### PR TITLE
feat: give synopsis get_hints tool to fetch relevant developer hints from local context store

### DIFF
--- a/.goosehints
+++ b/.goosehints
@@ -1,13 +1,5 @@
-This is a python CLI app that uses UV. Read CONTRIBUTING.md for information on how to build and test it as needed.
+Always show me the plan you intend to execute and ask for my confirmation before proceeding. 
 
-Some key concepts are that it is run as a command line interface, dependes on the "ai-exchange" package (which is in packages/exchange in this repo), and has the concept of toolkits which are ways that its behavior can be extended. Look in src/goose and tests.
+Always search for relevant developer hints before creating a plan.
 
-Assume the user has UV installed and ensure UV is used to run any python related commands.
-
-To run tests: 
-
-```sh
-uv sync && uv run pytest tests -m 'not integration' 
-```
-
-ideally after each change
+Always ask for confirmation at each step of coding or shell commands before executing it.

--- a/.goosehints
+++ b/.goosehints
@@ -1,5 +1,0 @@
-Always show me the plan you intend to execute and ask for my confirmation before proceeding. 
-
-Always search for relevant developer hints before creating a plan.
-
-Always ask for confirmation at each step of coding or shell commands before executing it.

--- a/packages/exchange/pyproject.toml
+++ b/packages/exchange/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "jinja2>=3.1.4",
     "tiktoken>=0.8.0",
     "httpx>=0.27.0",
-    "tenacity>=9.0.0",
+    "tenacity>=8.2.0,!=8.4.0,<9.0.0",
     "python-dotenv>=1.0.1",
     "langfuse>=2.38.2"
 ]

--- a/packages/exchange/src/exchange/moderators/summarizer.py
+++ b/packages/exchange/src/exchange/moderators/summarizer.py
@@ -7,7 +7,7 @@ class ContextSummarizer(ContextTruncate):
     def rewrite(self, exchange: type["exchange.exchange.Exchange"]) -> None:  # noqa: F821
         """Summarize the context history up to the last few messages in the exchange"""
 
-        self._update_system_prompt_token_count(exchange)
+        # self._update_system_prompt_token_count(exchange)
 
         # TODO: use an offset for summarization
         if exchange.checkpoint_data.total_token_count < self.max_tokens:

--- a/packages/exchange/src/exchange/moderators/truncate.py
+++ b/packages/exchange/src/exchange/moderators/truncate.py
@@ -30,7 +30,7 @@ class ContextTruncate(Moderator):
 
     def rewrite(self, exchange: Exchange) -> None:
         """Truncate the exchange messages with a FIFO strategy."""
-        self._update_system_prompt_token_count(exchange)
+        # self._update_system_prompt_token_count(exchange)
 
         if exchange.checkpoint_data.total_token_count < self.max_tokens:
             return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "selenium>=4.0.0",
     "beautifulsoup4>=4.9.3",
     "pyshadow<=0.0.5"
+    "goose-context-management",
 ]
 author = [{ name = "Block", email = "ai-oss-tools@block.xyz" }]
 packages = [{ include = "goose", from = "src" }]
@@ -79,6 +80,7 @@ dev-dependencies = [
 
 [tool.uv.sources]
 ai-exchange = { workspace = true }
+goose-context-management = { path = "../goose-context-store", editable = true }
 
 [tool.uv.workspace]
 members = ["packages/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
     "pyshadow<=0.0.5"
     "goose-plugins-block",
     "goose-context-management",
+    "selenium>=4.0.0",
+    "beautifulsoup4>=4.9.3",
+    "pyshadow<=0.0.5"
 ]
 author = [{ name = "Block", email = "ai-oss-tools@block.xyz" }]
 packages = [{ include = "goose", from = "src" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,10 @@ dependencies = [
     "langfuse>=2.38.2",
     "selenium>=4.0.0",
     "beautifulsoup4>=4.9.3",
-    "pyshadow<=0.0.5"
+    "pyshadow<=0.0.5",
     "goose-plugins-block",
     "goose-context-management",
     "selenium>=4.0.0",
-    "beautifulsoup4>=4.9.3",
-    "pyshadow<=0.0.5"
 ]
 author = [{ name = "Block", email = "ai-oss-tools@block.xyz" }]
 packages = [{ include = "goose", from = "src" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "selenium>=4.0.0",
     "beautifulsoup4>=4.9.3",
     "pyshadow<=0.0.5"
+    "goose-plugins-block",
     "goose-context-management",
 ]
 author = [{ name = "Block", email = "ai-oss-tools@block.xyz" }]
@@ -80,6 +81,7 @@ dev-dependencies = [
 
 [tool.uv.sources]
 ai-exchange = { workspace = true }
+goose-plugins-block = { path = "../goose-plugins-block", editable = true }
 goose-context-management = { path = "../goose-context-store", editable = true }
 
 [tool.uv.workspace]

--- a/src/goose/build.py
+++ b/src/goose/build.py
@@ -43,7 +43,7 @@ def build_exchange(profile: Profile, notifier: Notifier) -> Exchange:
             spec.name,
             {key: concrete_toolkits[val] for key, val in spec.requires.items()},
         )
-        toolkit = get_toolkit(spec.name)(notifier=notifier, requires=requires)
+        toolkit = get_toolkit(spec.name)(notifier=notifier, requires=requires, context=profile.context)
         toolkits.append(toolkit)
 
     # From the toolkits, we derive the exchange prompt and tools

--- a/src/goose/cli/session.py
+++ b/src/goose/cli/session.py
@@ -226,6 +226,8 @@ class Session:
                 for tool_use in response.tool_use:
                     tool_result = self.exchange.call_function(tool_use)
                     content.append(tool_result)
+                    if tool_use.name == "get_hints":  # todo find more elegant solution to inject hints into moderator
+                        self.exchange.moderator.hints += tool_result.output
                 message = Message(role="user", content=content)
                 committed.append(message)
                 self.exchange.add(message)

--- a/src/goose/cli/session.py
+++ b/src/goose/cli/session.py
@@ -4,6 +4,7 @@ import traceback
 from pathlib import Path
 from typing import Optional
 from git import Repo
+import json
 
 from exchange import Message, Text, ToolResult, ToolUse
 from exchange.langfuse_wrapper import auth_check, observe_wrapper
@@ -221,7 +222,7 @@ class Session:
             devhint_tags = get_all_tags(self.context_db)
             devhint_tags = [tag for tag in devhint_tags if tag not in init_tags]  # Updated line
 
-            self.exchange.moderator.hints += f"Available tags to search developer hints by are: {devhint_tags}"
+            self.exchange.moderator.hints += f"Available tags to search developer hints by are: {devhint_tags}\n\n"
 
         while message:  # Loop until no input (empty string).
             self.notifier.start()
@@ -271,7 +272,7 @@ class Session:
                     tool_result = self.exchange.call_function(tool_use)
                     content.append(tool_result)
                     if tool_use.name == "get_hints":  # TODO find more elegant solution to inject hints into moderator
-                        self.exchange.moderator.hints += tool_result.output
+                        self.exchange.moderator.dynamic_hints += json.loads(tool_result.output)
                 message = Message(role="user", content=content)
                 committed.append(message)
                 self.exchange.add(message)

--- a/src/goose/cli/session.py
+++ b/src/goose/cli/session.py
@@ -27,7 +27,7 @@ from goose.utils._create_exchange import create_exchange
 from goose.utils.session_file import is_empty_session, is_existing_session, log_messages, read_or_create_file
 
 from context_manager.developer_hints import get_all_tags, get_hints
-from context_manager.lancedb_interface import LanceDBInterface
+from context_manager.context_db import LanceDBContext
 
 RESUME_MESSAGE = "I see we were interrupted. How can I help you?"
 
@@ -109,7 +109,7 @@ class Session:
 
         self.prompt_session = GoosePromptSession()
 
-        self.context_db = LanceDBInterface(profile.context) if profile.context else None
+        self.context_db = LanceDBContext(profile.context) if profile.context else None
 
     def _get_initial_messages(self) -> list[Message]:
         messages = self.load_session()

--- a/src/goose/cli/session.py
+++ b/src/goose/cli/session.py
@@ -272,7 +272,7 @@ class Session:
                     tool_result = self.exchange.call_function(tool_use)
                     content.append(tool_result)
                     if tool_use.name == "get_hints":  # TODO find more elegant solution to inject hints into moderator
-                        self.exchange.moderator.dynamic_hints += json.loads(tool_result.output)
+                        self.exchange.moderator.dynamic_hints.add(json.loads(tool_result.output))
                 message = Message(role="user", content=content)
                 committed.append(message)
                 self.exchange.add(message)

--- a/src/goose/profile.py
+++ b/src/goose/profile.py
@@ -42,7 +42,10 @@ class Profile:
 
     def profile_info(self) -> str:
         tookit_names = [toolkit.name for toolkit in self.toolkits]
-        return f"provider:{self.provider}, processor:{self.processor} toolkits: {', '.join(tookit_names)} context: {self.context}"
+        return (
+            f"provider:{self.provider}, processor:{self.processor} "
+            f"toolkits: {', '.join(tookit_names)} context: {self.context}"
+        )
 
 
 def default_profile(provider: str, processor: str, accelerator: str, **kwargs: dict[str, any]) -> Profile:
@@ -57,4 +60,7 @@ def default_profile(provider: str, processor: str, accelerator: str, **kwargs: d
         moderator="synopsis",
         toolkits=[ToolkitSpec("synopsis")],
         context=None
+        moderator="truncate",
+        toolkits=[ToolkitSpec("developer")],
+        context=None,
     )

--- a/src/goose/profile.py
+++ b/src/goose/profile.py
@@ -21,6 +21,7 @@ class Profile:
     processor: str
     accelerator: str
     moderator: str
+    context: str = None
     toolkits: list[ToolkitSpec] = field(factory=list, converter=ensure_list(ToolkitSpec))
 
     @toolkits.validator
@@ -41,7 +42,7 @@ class Profile:
 
     def profile_info(self) -> str:
         tookit_names = [toolkit.name for toolkit in self.toolkits]
-        return f"provider:{self.provider}, processor:{self.processor} toolkits: {', '.join(tookit_names)}"
+        return f"provider:{self.provider}, processor:{self.processor} toolkits: {', '.join(tookit_names)} context: {self.context}"
 
 
 def default_profile(provider: str, processor: str, accelerator: str, **kwargs: dict[str, any]) -> Profile:
@@ -55,4 +56,5 @@ def default_profile(provider: str, processor: str, accelerator: str, **kwargs: d
         accelerator=accelerator,
         moderator="synopsis",
         toolkits=[ToolkitSpec("synopsis")],
+        context=None
     )

--- a/src/goose/profile.py
+++ b/src/goose/profile.py
@@ -60,7 +60,4 @@ def default_profile(provider: str, processor: str, accelerator: str, **kwargs: d
         moderator="synopsis",
         toolkits=[ToolkitSpec("synopsis")],
         context=None
-        moderator="truncate",
-        toolkits=[ToolkitSpec("developer")],
-        context=None,
     )

--- a/src/goose/synopsis/developer.md
+++ b/src/goose/synopsis/developer.md
@@ -30,3 +30,5 @@ as possible to execute.
 
 You'll receive a summary and a plan, and can immediately start using your tools and can directly
 reply to the user as needed.
+
+At the start of a plan, fetch developer hints first.

--- a/src/goose/synopsis/moderator.py
+++ b/src/goose/synopsis/moderator.py
@@ -47,6 +47,7 @@ class Synopsis(Moderator):
         if home_hints_path.is_file():
             hints.append(render_template(home_hints_path))
         self.hints = "\n".join(hints)
+        self.dynamic_hints = ""
 
     def rewrite(self, exchange: Exchange) -> None:
         # Get the last message, which would be either a user text or a user tool use

--- a/src/goose/synopsis/moderator.py
+++ b/src/goose/synopsis/moderator.py
@@ -47,7 +47,7 @@ class Synopsis(Moderator):
         if home_hints_path.is_file():
             hints.append(render_template(home_hints_path))
         self.hints = "\n".join(hints)
-        self.dynamic_hints = ""
+        self.dynamic_hints = set()
 
     def rewrite(self, exchange: Exchange) -> None:
         # Get the last message, which would be either a user text or a user tool use

--- a/src/goose/synopsis/plan.md
+++ b/src/goose/synopsis/plan.md
@@ -27,6 +27,13 @@ Your plan needs to use the following format, but can have any number of tasks.
 
 {{synopsis.hints}}
 
+# Dynamic Contextual Hints
+
+{% for hint in synopsis.dynamic_hints %}
+{{ hint }}
+
+{% endfor %}
+
 # Context
 
 The current state of the agent is:

--- a/src/goose/synopsis/synopsis.md
+++ b/src/goose/synopsis/synopsis.md
@@ -6,6 +6,10 @@
 
 {{synopsis.hints}}
 
+# Dynamic Contextual Hints
+
+{{synopsis.dynamic_hints}}
+
 # Relevant Files
 
 {% for file in system.active_files %}

--- a/src/goose/synopsis/synopsis.md
+++ b/src/goose/synopsis/synopsis.md
@@ -8,7 +8,10 @@
 
 # Dynamic Contextual Hints
 
-{{synopsis.dynamic_hints}}
+{% for hint in synopsis.dynamic_hints %}
+{{ hint }}
+
+{% endfor %}
 
 # Relevant Files
 

--- a/src/goose/synopsis/toolkit.py
+++ b/src/goose/synopsis/toolkit.py
@@ -187,7 +187,7 @@ class SynopsisDeveloper(Toolkit):
             self.notifier.log(f"Failed fetching with error: {str(exc)}")
 
     @tool
-    def get_hints(self, query: str, tags: list[str], limit: int) -> list[str]:
+    def get_hints(self, query: str, tags: list[str], limit: int) -> str:
         """Get developer hints that might help with completing the coding task. Fetch relevant hints at the beginning
            of any plan execution.
 

--- a/src/goose/synopsis/toolkit.py
+++ b/src/goose/synopsis/toolkit.py
@@ -23,6 +23,7 @@ class SynopsisDeveloper(Toolkit):
         self._file_history = defaultdict(list)
         if self.context:
             self.db = LanceDBContext(self.context)
+        self._file_history = defaultdict(list)
 
     def system(self) -> str:
         """Retrieve system configuration details for developer"""

--- a/src/goose/synopsis/toolkit.py
+++ b/src/goose/synopsis/toolkit.py
@@ -197,6 +197,7 @@ class SynopsisDeveloper(Toolkit):
             limit (int): Number of relevant documents to return.
         """
         # TODO do some additional filtering / reranking on returned results based on the task
+        # TODO make toolkit available only if context is passed in profiles config
         hints = get_hints(self.db, query, tags, lazy_load=True, limit=limit)
         return "## DEVELOPER HINTS:\n\n" + "\n\n".join(
             [f"### {h['file_name']} Hint File:\n{h['content']}" for h in hints]

--- a/src/goose/synopsis/toolkit.py
+++ b/src/goose/synopsis/toolkit.py
@@ -18,6 +18,8 @@ class SynopsisDeveloper(Toolkit):
     def __init__(self, *args: object, **kwargs: Dict[str, object]) -> None:
         super().__init__(*args, **kwargs)
         self._file_history = defaultdict(list)
+        if self.context:
+            self.db = LanceDBInterface(self.context)
 
     def system(self) -> str:
         """Retrieve system configuration details for developer"""
@@ -193,4 +195,6 @@ class SynopsisDeveloper(Toolkit):
             tags (list[str]): A list of metadata tags relevant to the search eg., ["java", "proto update", "unit tests"]
             limit (int): Number of relevant documents to return.
         """
-        return get_developer_hints(self.db, query, tags, limit)
+        # TODO do some additional filtering / reranking on returned results based on the task
+        hints = get_hints(self.db, query, tags, lazy_load=True, limit=limit)
+        return "## DEVELOPER HINTS:\n\n" + "\n\n".join([f"### {h['file_name']} Hint File:\n{h['content']}" for h in hints])

--- a/src/goose/synopsis/toolkit.py
+++ b/src/goose/synopsis/toolkit.py
@@ -12,6 +12,7 @@ from goose.synopsis.process_manager import ProcessManager, ProcessManagerCommand
 from goose.toolkit.base import Toolkit, tool
 
 
+
 class SynopsisDeveloper(Toolkit):
     """Provides shell and file operation tools using OperatingSystem."""
 
@@ -197,4 +198,6 @@ class SynopsisDeveloper(Toolkit):
         """
         # TODO do some additional filtering / reranking on returned results based on the task
         hints = get_hints(self.db, query, tags, lazy_load=True, limit=limit)
-        return "## DEVELOPER HINTS:\n\n" + "\n\n".join([f"### {h['file_name']} Hint File:\n{h['content']}" for h in hints])
+        return "## DEVELOPER HINTS:\n\n" + "\n\n".join(
+            [f"### {h['file_name']} Hint File:\n{h['content']}" for h in hints]
+        )

--- a/src/goose/synopsis/toolkit.py
+++ b/src/goose/synopsis/toolkit.py
@@ -182,3 +182,15 @@ class SynopsisDeveloper(Toolkit):
             self.notifier.log(f"Failed fetching with HTTP error: {exc.response.status_code}")
         except Exception as exc:
             self.notifier.log(f"Failed fetching with error: {str(exc)}")
+
+    @tool
+    def get_hints(self, query: str, tags: list[str], limit: int) -> list[str]:
+        """Get developer hints that might help with completing the coding task. Fetch relevant hints at the beginning
+           of any plan execution.
+
+        Args:
+            query (str): A query for relevant developer hints, e.g., "update proto files" or "generate unit tests"
+            tags (list[str]): A list of metadata tags relevant to the search eg., ["java", "proto update", "unit tests"]
+            limit (int): Number of relevant documents to return.
+        """
+        return get_developer_hints(self.db, query, tags, limit)

--- a/src/goose/synopsis/toolkit.py
+++ b/src/goose/synopsis/toolkit.py
@@ -11,6 +11,8 @@ from goose.synopsis.text_editor import TextEditor, TextEditorCommand
 from goose.synopsis.process_manager import ProcessManager, ProcessManagerCommand
 from goose.toolkit.base import Toolkit, tool
 
+from context_manager.developer_hints import get_hints
+from context_manager.context_db import LanceDBContext
 
 
 class SynopsisDeveloper(Toolkit):
@@ -20,7 +22,7 @@ class SynopsisDeveloper(Toolkit):
         super().__init__(*args, **kwargs)
         self._file_history = defaultdict(list)
         if self.context:
-            self.db = LanceDBInterface(self.context)
+            self.db = LanceDBContext(self.context)
 
     def system(self) -> str:
         """Retrieve system configuration details for developer"""
@@ -198,7 +200,10 @@ class SynopsisDeveloper(Toolkit):
         """
         # TODO do some additional filtering / reranking on returned results based on the task
         # TODO make toolkit available only if context is passed in profiles config
-        hints = get_hints(self.db, query, tags, lazy_load=True, limit=limit)
-        return "## DEVELOPER HINTS:\n\n" + "\n\n".join(
-            [f"### {h['file_name']} Hint File:\n{h['content']}" for h in hints]
-        )
+        hints = get_hints(db=self.db, query=query, tags=tags, lazy_load=True, limit=limit)
+        if len(hints) == 0:
+            return ""
+        else:
+            return "## DEVELOPER HINTS:\n\n" + "\n\n".join(
+                [f"### {h['file_name']} Hint File:\n{h['content']}" for h in hints]
+            )

--- a/src/goose/toolkit/base.py
+++ b/src/goose/toolkit/base.py
@@ -46,10 +46,11 @@ class Toolkit(ABC):
     empty if they are not required for the toolkit.
     """
 
-    def __init__(self, notifier: Notifier, requires: Optional[Requirements] = None) -> None:
+    def __init__(self, notifier: Notifier, context: str=None, requires: Optional[Requirements] = None) -> None:
         self.notifier = notifier
         # This needs to be updated after the fact via build_exchange
         self.exchange_view = None
+        self.context = context
 
     def system(self) -> str:
         """Get the addition to the system prompt for this toolkit."""

--- a/src/goose/toolkit/base.py
+++ b/src/goose/toolkit/base.py
@@ -46,7 +46,7 @@ class Toolkit(ABC):
     empty if they are not required for the toolkit.
     """
 
-    def __init__(self, notifier: Notifier, context: str=None, requires: Optional[Requirements] = None) -> None:
+    def __init__(self, notifier: Notifier, context: str = None, requires: Optional[Requirements] = None) -> None:
         self.notifier = notifier
         # This needs to be updated after the fact via build_exchange
         self.exchange_view = None

--- a/src/goose/utils/_create_exchange.py
+++ b/src/goose/utils/_create_exchange.py
@@ -19,6 +19,14 @@ from exchange.providers.base import MissingProviderEnvVariableError
 
 def create_exchange(profile: Profile, notifier: SessionNotifier) -> Exchange:
     try:
+        if profile.context:
+            openai_api_key = _get_api_key_from_keychain("OPENAI_API_KEY", "openai")
+            if openai_api_key is None or openai_api_key == "":
+                error_message = f"{e.message}. Please set the OpenAI environment variable required for LanceDB embeddings to use context store."
+                print(Panel(error_message, style="red"))
+                sys.exit(1)
+            else:
+                os.environ["OPENAI_API_KEY"] = openai_api_key
         return build_exchange(profile, notifier=notifier)
     except InvalidChoiceError as e:
         error_message = (


### PR DESCRIPTION
Beginning sketch of how Goose might retrieve context from a local context store via an additional tool call.

The local context store referenced is an interface to LanceDB as defined here: https://github.com/squareup/goose-context-store

The general idea is that based on a new task, Goose will first fetch relevant hints based on text and semantic queries to the local context store, and append those to its existing .goosehints as part of the system prompt.