### PR TITLE
don't need to serialize nulls

### DIFF
--- a/crates/goose/src/providers/configs.rs
+++ b/crates/goose/src/providers/configs.rs
@@ -24,13 +24,17 @@ pub struct ModelConfig {
     /// The name of the model to use
     pub model_name: String,
     /// Optional explicit context limit that overrides any defaults
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub context_limit: Option<usize>,
     /// Optional temperature setting (0.0 - 1.0)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f32>,
     /// Optional maximum tokens to generate
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tokens: Option<i32>,
     /// Factor used to estimate safe context window size (0.0 - 1.0)
     /// Defaults to 0.8 (80%) of the context limit to leave headroom for responses
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub estimate_factor: Option<f32>,
 }
 

--- a/ui/desktop/src/components/ApiKeyWarning.tsx
+++ b/ui/desktop/src/components/ApiKeyWarning.tsx
@@ -54,7 +54,7 @@ export GOOSE_PROVIDER__MODEL=claude-3-sonnet-2`;
 
 const OPENROUTER_CONFIG = `export GOOSE_PROVIDER__TYPE=openrouter
 export GOOSE_PROVIDER__HOST=https://openrouter.ai
-export GOOSE_PROVIDER__MODEL=anthropic/claude-3-sonnet
+export GOOSE_PROVIDER__MODEL="anthropic/claude-3.5-sonnet"
 export GOOSE_PROVIDER__API_KEY=your_api_key_here`;
 
 export function ApiKeyWarning({ className }: ApiKeyWarningProps) {


### PR DESCRIPTION
Was looking at making deepseek work on open router, and some models don't like having nulls passed in as metadata: 

![image](https://github.com/user-attachments/assets/cc4825e7-d5e9-4269-9661-b5ecf4f15264)


this helps that