### PR TITLE
feat: selective render

### DIFF
--- a/crates/goose-server/src/routes/reply.rs
+++ b/crates/goose-server/src/routes/reply.rs
@@ -270,6 +270,7 @@ async fn stream_message(
                 }
             }
         }
+        Role::Goose => (),
     }
     Ok(())
 }

--- a/crates/goose/src/agents/system.rs
+++ b/crates/goose/src/agents/system.rs
@@ -11,7 +11,7 @@ pub enum SystemError {
     Initialization(SystemConfig),
     #[error("Failed a client call to an MCP server: {0}")]
     Client(#[from] ClientError),
-    #[error("Messages exceeded context-limit and could not be truncated to fit.")]
+    #[error("User Message exceeded context-limit. History could not be truncated to accomodate.")]
     ContextLimit,
     #[error("Transport error: {0}")]
     Transport(#[from] mcp_client::transport::Error),

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -62,7 +62,6 @@ impl TruncateAgent {
             have been truncated to keep history within the LLM context-limit.";
             let alert_msg = Message::goose().with_text(alert_val);
             new_messages.push(alert_msg);
-
         }
 
         Ok(new_messages)

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -51,16 +51,6 @@ impl TruncateAgent {
 
         let mut new_messages = messages.to_vec();
         if approx_count > target_limit {
-            let user_msg_size = self.text_content_size(new_messages.last(), model);
-            if user_msg_size > target_limit {
-                debug!(
-                    "[WARNING] User message {} exceeds token budget {}.",
-                    user_msg_size,
-                    user_msg_size - target_limit
-                );
-                return Err(SystemError::ContextLimit);
-            }
-
             new_messages = self.chop_front_messages(messages, approx_count, target_limit, model);
             if new_messages.is_empty() {
                 return Err(SystemError::ContextLimit);

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -29,7 +29,7 @@ impl TruncateAgent {
         }
     }
 
-    async fn prepare_inference(
+    async fn enforce_ctx_limit_pre_flight(
         &self,
         system_prompt: &str,
         tools: &[Tool],
@@ -146,7 +146,7 @@ impl Agent for TruncateAgent {
 
         // Update conversation history for the start of the reply
         let mut messages = self
-            .prepare_inference(
+            .enforce_ctx_limit_pre_flight(
                 &system_prompt,
                 &tools,
                 messages,
@@ -203,15 +203,6 @@ impl Agent for TruncateAgent {
                 }
 
                 yield message_tool_response.clone();
-
-                messages = self.prepare_inference(
-                    &system_prompt,
-                    &tools,
-                    &messages,
-                    estimated_limit,
-                    &capabilities.provider().get_model_config().model_name,
-                    &mut capabilities.get_resources().await?
-                ).await?;
 
                 messages.push(response);
                 messages.push(message_tool_response);

--- a/crates/goose/src/message.rs
+++ b/crates/goose/src/message.rs
@@ -142,6 +142,15 @@ impl Message {
         }
     }
 
+    /// Create a new user message with the current timestamp
+    pub fn goose() -> Self {
+        Message {
+            role: Role::Goose,
+            created: Utc::now().timestamp(),
+            content: Vec::new(),
+        }
+    }
+
     /// Add any MessageContent to the message
     pub fn with_content(mut self, content: MessageContent) -> Self {
         self.content.push(content);

--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -73,6 +73,7 @@ impl AnthropicProvider {
             let role = match message.role {
                 Role::User => "user",
                 Role::Assistant => "assistant",
+                Role::Goose => continue,
             };
 
             let mut content = Vec::new();

--- a/crates/mcp-core/src/role.rs
+++ b/crates/mcp-core/src/role.rs
@@ -6,4 +6,5 @@ use serde::{Deserialize, Serialize};
 pub enum Role {
     User,
     Assistant,
+    Goose,
 }


### PR DESCRIPTION
This change allows "Goose" (not user, not assistant) to show information to the user which is outside of the user's conversation with the llm, and avoids sending those out-of-band messages to the llm.

ideally, visually, it would be nice to update the prompt so Goose-messages show as a third speaker.

changelist:
* add role Goose
* after truncation, create message to user from Role::Goose and append to the message history
* filter out these Goose-messages before sending to llm-preprocessing
* after llm response, render llm response, then render any goose response if one exists

this keeps the Goose messages in the message history.