### PR TITLE
feat: providers filter goose messages

### DIFF
--- a/crates/goose-server/src/routes/reply.rs
+++ b/crates/goose-server/src/routes/reply.rs
@@ -270,6 +270,7 @@ async fn stream_message(
                 }
             }
         }
+        Role::Goose => (),
     }
     Ok(())
 }

--- a/crates/goose/src/agents/system.rs
+++ b/crates/goose/src/agents/system.rs
@@ -11,7 +11,7 @@ pub enum SystemError {
     Initialization(SystemConfig),
     #[error("Failed a client call to an MCP server: {0}")]
     Client(#[from] ClientError),
-    #[error("Messages exceeded context-limit and could not be truncated to fit.")]
+    #[error("User Message exceeded context-limit. History could not be truncated to accomodate.")]
     ContextLimit,
     #[error("Transport error: {0}")]
     Transport(#[from] mcp_client::transport::Error),

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -62,7 +62,6 @@ impl TruncateAgent {
             have been truncated to keep history within the LLM context-limit.";
             let alert_msg = Message::goose().with_text(alert_val);
             new_messages.push(alert_msg);
-
         }
 
         Ok(new_messages)

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -51,16 +51,6 @@ impl TruncateAgent {
 
         let mut new_messages = messages.to_vec();
         if approx_count > target_limit {
-            let user_msg_size = self.text_content_size(new_messages.last(), model);
-            if user_msg_size > target_limit {
-                debug!(
-                    "[WARNING] User message {} exceeds token budget {}.",
-                    user_msg_size,
-                    user_msg_size - target_limit
-                );
-                return Err(SystemError::ContextLimit);
-            }
-
             new_messages = self.chop_front_messages(messages, approx_count, target_limit, model);
             if new_messages.is_empty() {
                 return Err(SystemError::ContextLimit);

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -29,7 +29,7 @@ impl TruncateAgent {
         }
     }
 
-    async fn prepare_inference(
+    async fn enforce_ctx_limit_pre_flight(
         &self,
         system_prompt: &str,
         tools: &[Tool],
@@ -146,7 +146,7 @@ impl Agent for TruncateAgent {
 
         // Update conversation history for the start of the reply
         let mut messages = self
-            .prepare_inference(
+            .enforce_ctx_limit_pre_flight(
                 &system_prompt,
                 &tools,
                 messages,
@@ -203,15 +203,6 @@ impl Agent for TruncateAgent {
                 }
 
                 yield message_tool_response.clone();
-
-                messages = self.prepare_inference(
-                    &system_prompt,
-                    &tools,
-                    &messages,
-                    estimated_limit,
-                    &capabilities.provider().get_model_config().model_name,
-                    &mut capabilities.get_resources().await?
-                ).await?;
 
                 messages.push(response);
                 messages.push(message_tool_response);

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -156,14 +156,10 @@ impl Agent for TruncateAgent {
         Ok(Box::pin(async_stream::try_stream! {
             let _reply_guard = reply_span.enter();
             loop {
-                // keep goose messages in the history but dont send them to llm
-                let mut conv_history = messages.clone();
-                conv_history = conv_history.into_iter().filter(|msg| msg.role != Role::Goose).collect();
-
                 // Get completion from provider
                 let (response, usage) = capabilities.provider().complete(
                     &system_prompt,
-                    &conv_history,
+                    &messages,
                     &tools,
                 ).await?;
                 capabilities.record_usage(usage).await;

--- a/crates/goose/src/message.rs
+++ b/crates/goose/src/message.rs
@@ -142,6 +142,15 @@ impl Message {
         }
     }
 
+    /// Create a new user message with the current timestamp
+    pub fn goose() -> Self {
+        Message {
+            role: Role::Goose,
+            created: Utc::now().timestamp(),
+            content: Vec::new(),
+        }
+    }
+
     /// Add any MessageContent to the message
     pub fn with_content(mut self, content: MessageContent) -> Self {
         self.content.push(content);

--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -73,6 +73,7 @@ impl AnthropicProvider {
             let role = match message.role {
                 Role::User => "user",
                 Role::Assistant => "assistant",
+                Role::Goose => continue,
             };
 
             let mut content = Vec::new();

--- a/crates/goose/src/providers/google.rs
+++ b/crates/goose/src/providers/google.rs
@@ -65,6 +65,7 @@ impl GoogleProvider {
     fn messages_to_google_spec(&self, messages: &[Message]) -> Vec<Value> {
         messages
             .iter()
+            .filter(|message| message.role != Role::Goose)
             .map(|message| {
                 let role = if message.role == Role::User {
                     "user"
@@ -457,6 +458,7 @@ mod tests {
         let messages = vec![
             set_up_text_message("Hello", Role::User),
             set_up_text_message("World", Role::Assistant),
+            set_up_text_message("Please don't notice me.", Role::Goose),
         ];
         let payload = provider.messages_to_google_spec(&messages);
         assert_eq!(payload.len(), 2);

--- a/crates/goose/src/providers/openai_utils.rs
+++ b/crates/goose/src/providers/openai_utils.rs
@@ -20,7 +20,9 @@ pub fn messages_to_openai_spec(
 ) -> Vec<Value> {
     let mut messages_spec = Vec::new();
     for message in messages {
-        if message.role == Role::Goose { continue; }
+        if message.role == Role::Goose {
+            continue;
+        }
 
         let mut converted = json!({
             "role": message.role
@@ -382,7 +384,7 @@ mod tests {
     fn test_messages_to_openai_spec() -> anyhow::Result<()> {
         let messages = vec![
             Message::user().with_text("Hello"),
-            Message::goose().with_text("Please don't notice me.")
+            Message::goose().with_text("Please don't notice me."),
         ];
         let spec = messages_to_openai_spec(&messages, &ImageFormat::OpenAi, false);
 

--- a/crates/goose/src/providers/openai_utils.rs
+++ b/crates/goose/src/providers/openai_utils.rs
@@ -20,6 +20,8 @@ pub fn messages_to_openai_spec(
 ) -> Vec<Value> {
     let mut messages_spec = Vec::new();
     for message in messages {
+        if message.role == Role::Goose { continue; }
+
         let mut converted = json!({
             "role": message.role
         });
@@ -378,8 +380,11 @@ mod tests {
 
     #[test]
     fn test_messages_to_openai_spec() -> anyhow::Result<()> {
-        let message = Message::user().with_text("Hello");
-        let spec = messages_to_openai_spec(&[message], &ImageFormat::OpenAi, false);
+        let messages = vec![
+            Message::user().with_text("Hello"),
+            Message::goose().with_text("Please don't notice me.")
+        ];
+        let spec = messages_to_openai_spec(&messages, &ImageFormat::OpenAi, false);
 
         assert_eq!(spec.len(), 1);
         assert_eq!(spec[0]["role"], "user");

--- a/crates/mcp-core/src/role.rs
+++ b/crates/mcp-core/src/role.rs
@@ -6,4 +6,5 @@ use serde::{Deserialize, Serialize};
 pub enum Role {
     User,
     Assistant,
+    Goose,
 }


### PR DESCRIPTION
Assuming messages sent to provider-specific pre-processing contain a mixture of messages from Role::Goose, and the other expected roles, update provider-code to ignore Role::Goose messages when converting from Message -> Provider-Specific-Spec