### PR TITLE
[feat] MCP prompts

### DIFF
--- a/crates/goose-mcp/src/developer/prompts.rs
+++ b/crates/goose-mcp/src/developer/prompts.rs
@@ -23,6 +23,7 @@ pub fn create_prompts() -> Vec<Prompt> {
             .collect();
 
         prompts.push(Prompt::new(&template.id, &template.template, arguments));
+        println!("Loaded prompt: {}", template.id);
     }
 
     prompts

--- a/crates/goose-server/src/routes/mod.rs
+++ b/crates/goose-server/src/routes/mod.rs
@@ -1,6 +1,7 @@
 // Export route modules
 pub mod agent;
 pub mod health;
+pub mod prompts;
 pub mod reply;
 pub mod secrets;
 pub mod system;
@@ -14,5 +15,6 @@ pub fn configure(state: crate::state::AppState) -> Router {
         .merge(reply::routes(state.clone()))
         .merge(agent::routes(state.clone()))
         .merge(system::routes(state.clone()))
+        .merge(prompts::routes(state.clone()))
         .merge(secrets::routes(state))
 }

--- a/crates/goose-server/src/routes/prompts.rs
+++ b/crates/goose-server/src/routes/prompts.rs
@@ -2,12 +2,13 @@ use mcp_core::protocol::{GetPromptResult, ListPromptsResult};
 
 use crate::state::AppState;
 use axum::{
-    extract::{Path, State},
+    extract::State,
     http::{HeaderMap, StatusCode},
     routing::post,
     Json, Router,
 };
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 #[derive(Serialize, Deserialize)]
 struct Prompt {
@@ -17,14 +18,21 @@ struct Prompt {
 }
 
 #[derive(Serialize, Deserialize)]
+struct ListPromptRequest {
+    system: String
+}
+
+#[derive(Serialize, Deserialize)]
 struct PromptRequest {
     system: String,
+    name: String,
+    arguments: Value
 }
 
 async fn list_prompts_handler(
     State(state): State<AppState>,
     headers: HeaderMap,
-    Json(request): Json<PromptRequest>,
+    Json(request): Json<ListPromptRequest>,
 ) -> Result<Json<ListPromptsResult>, StatusCode> {
     // Verify secret key
     let secret_key = headers
@@ -41,21 +49,21 @@ async fn list_prompts_handler(
 
     // Get prompts through agent passthrough
     let result = agent
-        .passthrough(&request.system, "list_prompts", serde_json::json!({}))
+        .passthrough(&request.system, "prompts/list", serde_json::json!({}))
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     // Deserialize the result to ListPromptsResult
     let prompts_result: ListPromptsResult =
         serde_json::from_value(result).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
     Ok(Json(prompts_result))
 }
 
 async fn get_prompt_handler(
-    Path(prompt_name): Path<String>,
     State(state): State<AppState>,
     headers: HeaderMap,
-    Json(payload): Json<PromptRequest>,
+    Json(request): Json<PromptRequest>,
 ) -> Result<Json<GetPromptResult>, StatusCode> {
     // Verify secret key
     let secret_key = headers
@@ -73,10 +81,11 @@ async fn get_prompt_handler(
     // Get prompt through agent passthrough
     let result = agent
         .passthrough(
-            &payload.system,
-            "get_prompt",
+            &request.system,
+            "prompts/get",
             serde_json::json!({
-                "name": prompt_name
+                "name": &request.name,
+                "arguments": &request.arguments,
             }),
         )
         .await
@@ -91,6 +100,6 @@ async fn get_prompt_handler(
 pub fn routes(state: AppState) -> Router {
     Router::new()
         .route("/prompts/list", post(list_prompts_handler))
-        .route("/prompts/get/:prompt_name", post(get_prompt_handler))
+        .route("/prompts/get", post(get_prompt_handler))
         .with_state(state)
 }

--- a/crates/goose-server/src/routes/prompts.rs
+++ b/crates/goose-server/src/routes/prompts.rs
@@ -1,0 +1,98 @@
+use crate::state::AppState;
+use axum::{
+    extract::{State, Path},
+    http::{HeaderMap, StatusCode},
+    routing::post,
+    Json, Router,
+};
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct ListPromptsResponse {
+    prompts: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct GetPromptResponse {
+    name: String,
+    content: String,
+}
+
+async fn list_prompts(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<ListPromptsResponse>, StatusCode> {
+    // Verify secret key
+    let secret_key = headers
+        .get("X-Secret-Key")
+        .and_then(|value| value.to_str().ok())
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+
+    if secret_key != state.secret_key {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
+    let agent = state.agent.lock().await;
+    let agent = agent.as_ref().ok_or(StatusCode::NOT_FOUND)?;
+    
+    // Get prompts through agent passthrough
+    let result = agent
+        .passthrough("prompts", serde_json::json!({ "method": "list" }))
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    
+    let prompts = result
+        .as_array()
+        .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+        .unwrap_or_default();
+
+    Ok(Json(ListPromptsResponse { prompts }))
+}
+
+async fn get_prompt(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(prompt_name): Path<String>,
+) -> Result<Json<GetPromptResponse>, StatusCode> {
+    // Verify secret key
+    let secret_key = headers
+        .get("X-Secret-Key")
+        .and_then(|value| value.to_str().ok())
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+
+    if secret_key != state.secret_key {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
+    let agent = state.agent.lock().await;
+    let agent = agent.as_ref().ok_or(StatusCode::NOT_FOUND)?;
+    
+    // Get prompt through agent passthrough
+    let result = agent
+        .passthrough(
+            "prompts",
+            serde_json::json!({
+                "method": "get",
+                "name": prompt_name
+            })
+        )
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    
+    let content = result
+        .as_str()
+        .map(String::from)
+        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Json(GetPromptResponse {
+        name: prompt_name,
+        content,
+    }))
+}
+
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route("/prompts/list", post(list_prompts))
+        .route("/prompts/get/:prompt_name", post(get_prompt))
+        .with_state(state)
+}

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -24,7 +24,7 @@ pub trait Agent: Send + Sync {
     async fn list_systems(&self) -> Vec<String>;
 
     /// Pass through a JSON-RPC request to a specific system
-    async fn passthrough(&self, system: &str, request: Value) -> SystemResult<Value>;
+    async fn passthrough(&self, system: &str, method: &str, params: Value) -> SystemResult<Value>;
 
     /// Get the total usage of the agent
     async fn usage(&self) -> Vec<ProviderUsage>;

--- a/crates/goose/src/agents/capabilities.rs
+++ b/crates/goose/src/agents/capabilities.rs
@@ -314,4 +314,11 @@ impl Capabilities {
 
         result
     }
+
+    /// Retrieve a client by name, if it exists
+    pub async fn system(&self, system: &str) -> Option<Arc<Mutex<Box<dyn McpClientTrait>>>> {
+        // Use the clients hashmap to get the client associated with the system name
+        self.clients.get(system).cloned()
+    }
 }
+

--- a/crates/goose/src/agents/capabilities.rs
+++ b/crates/goose/src/agents/capabilities.rs
@@ -316,9 +316,8 @@ impl Capabilities {
     }
 
     /// Retrieve a client by name, if it exists
-    pub async fn system(&self, system: &str) -> Option<Arc<Mutex<Box<dyn McpClientTrait>>>> {
+    pub async fn get_system(&self, system: &str) -> Option<Arc<Mutex<Box<dyn McpClientTrait>>>> {
         // Use the clients hashmap to get the client associated with the system name
         self.clients.get(system).cloned()
     }
 }
-

--- a/crates/goose/src/agents/default.rs
+++ b/crates/goose/src/agents/default.rs
@@ -148,6 +148,7 @@ impl Agent for DefaultAgent {
     }
 
     async fn passthrough(&self, system: &str, method: &str, params: Value) -> SystemResult<Value> {
+        println!("in pass through");
         let capabilities = self.capabilities.lock().await;
         let client = capabilities
             .get_system(system)

--- a/crates/goose/src/agents/default.rs
+++ b/crates/goose/src/agents/default.rs
@@ -147,9 +147,11 @@ impl Agent for DefaultAgent {
             .expect("Failed to list systems")
     }
 
-    async fn passthrough(&self, _system: &str, _request: Value) -> SystemResult<Value> {
-        // TODO implement
-        Ok(Value::Null)
+    async fn passthrough(&self, system: &str, request: Value) -> SystemResult<Value> {
+        let capabilities = self.capabilities.lock().await;
+        
+        // Get the client/system that corresponds to the given system string
+       let system = capabilities.get_system(system).await?;
     }
 
     #[instrument(skip(self, messages), fields(user_message))]

--- a/crates/goose/src/agents/reference.rs
+++ b/crates/goose/src/agents/reference.rs
@@ -7,7 +7,7 @@ use tracing::{debug, instrument};
 
 use super::Agent;
 use crate::agents::capabilities::Capabilities;
-use crate::agents::system::{SystemConfig, SystemResult};
+use crate::agents::system::{SystemConfig, SystemError, SystemResult};
 use crate::message::{Message, ToolRequest};
 use crate::providers::base::Provider;
 use crate::providers::base::ProviderUsage;
@@ -52,21 +52,20 @@ impl Agent for ReferenceAgent {
             .expect("Failed to list systems")
     }
 
-    async fn passthrough(&self, system: &str, request: Value) -> SystemResult<Value> {
+    async fn passthrough(&self, system: &str, method: &str, params: Value) -> SystemResult<Value> {
         let capabilities = self.capabilities.lock().await;
-        
-        // Get the client by name
         let client = capabilities
-            .get_client_for_tool(&format!("{}__dummy", system))
-            .ok_or_else(|| SystemError::NotFound(system.to_string()))?;
-        
-        let client_guard = client.lock().await;
-        
-        // Forward the request to the client's execute endpoint
-        client_guard
-            .execute(request)
+            .get_system(system)
             .await
-            .map_err(|e| SystemError::ExecutionError(e.to_string()))
+            .unwrap_or_else(|| panic!("System not found: {}", system));
+        let client = client.lock().await;
+
+        let result: Value = client
+            .forward_request(method, params)
+            .await
+            .map_err(SystemError::Client)?;
+
+        Ok(result)
     }
 
     #[instrument(skip(self, messages), fields(user_message))]

--- a/crates/goose/src/agents/reference.rs
+++ b/crates/goose/src/agents/reference.rs
@@ -54,12 +54,14 @@ impl Agent for ReferenceAgent {
 
     async fn passthrough(&self, system: &str, method: &str, params: Value) -> SystemResult<Value> {
         let capabilities = self.capabilities.lock().await;
+        tracing::info!("passthrough" = system, method);
         let client = capabilities
             .get_system(system)
             .await
             .unwrap_or_else(|| panic!("System not found: {}", system));
         let client = client.lock().await;
 
+        tracing::info!("forwarding request" = method);
         let result: Value = client
             .forward_request(method, params)
             .await

--- a/crates/mcp-client/src/client.rs
+++ b/crates/mcp-client/src/client.rs
@@ -1,11 +1,8 @@
-use mcp_core::{
-    prompt::Prompt,
-    protocol::{
+use mcp_core::protocol::{
         CallToolResult, GetPromptResult, Implementation, InitializeResult, JsonRpcError,
         JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, ListPromptsResult,
         ListResourcesResult, ListToolsResult, ReadResourceResult, ServerCapabilities,
-        METHOD_NOT_FOUND,
-    },
+        METHOD_NOT_FOUND
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -135,10 +132,11 @@ where
     }
 
     /// Send a JSON-RPC request and check we don't get an error response.
-    pub async fn send_request<R>(&self, method: &str, params: Value) -> Result<R, Error>
+    async fn send_request<R>(&self, method: &str, params: Value) -> Result<R, Error>
     where
         R: for<'de> Deserialize<'de>,
     {
+        println!("send_request: method={:?}, params={:?}", method, params);
         let mut service = self.service.lock().await;
         service.ready().await.map_err(|_| Error::NotReady)?;
 
@@ -159,7 +157,7 @@ where
                 params: params.clone(),
                 source: Box::new(e.into()),
             })?;
-
+        println!("response_msg: {:?}", response_msg);
         match response_msg {
             JsonRpcMessage::Response(JsonRpcResponse {
                 id, result, error, ..
@@ -313,6 +311,7 @@ where
     }
 
     async fn list_tools(&self, next_cursor: Option<String>) -> Result<ListToolsResult, Error> {
+        println!("list_tools");
         if !self.completed_initialization() {
             return Err(Error::NotInitialized);
         }
@@ -384,6 +383,7 @@ where
     }
 
     async fn forward_request(&self, method: &str, params: Value) -> Result<Value, Error> {
+        println!("Forwarding request to server: method={}, params={}", method, params);
         self.send_request(method, params).await
     }
 }

--- a/crates/mcp-client/src/client.rs
+++ b/crates/mcp-client/src/client.rs
@@ -1,8 +1,6 @@
-use mcp_core::protocol::{
-    CallToolResult, Implementation, InitializeResult, JsonRpcError, JsonRpcMessage,
-    JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, ListResourcesResult, ListToolsResult,
-    ReadResourceResult, ServerCapabilities, METHOD_NOT_FOUND,
-};
+use mcp_core::{prompt::Prompt, protocol::{
+    CallToolResult, GetPromptResult, Implementation, InitializeResult, JsonRpcError, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, ListPromptsResult, ListResourcesResult, ListToolsResult, ReadResourceResult, ServerCapabilities, METHOD_NOT_FOUND
+}};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -94,6 +92,10 @@ pub trait McpClientTrait: Send + Sync {
     async fn list_tools(&self, next_cursor: Option<String>) -> Result<ListToolsResult, Error>;
 
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<CallToolResult, Error>;
+
+    async fn list_prompts(&self) -> Result<ListPromptsResult, Error>;
+
+    async fn get_prompt(&self, name: &str, arguments: Value) -> Result<GetPromptResult, Error>;
 }
 
 /// The MCP client is the interface for MCP operations.
@@ -125,7 +127,7 @@ where
     }
 
     /// Send a JSON-RPC request and check we don't get an error response.
-    async fn send_request<R>(&self, method: &str, params: Value) -> Result<R, Error>
+    pub async fn send_request<R>(&self, method: &str, params: Value) -> Result<R, Error>
     where
         R: for<'de> Deserialize<'de>,
     {
@@ -338,5 +340,38 @@ where
         // TODO ERROR: check that if there is an error, we send back is_error: true with msg
         // https://modelcontextprotocol.io/docs/concepts/tools#error-handling-2
         self.send_request("tools/call", params).await
+    }
+
+    async fn list_prompts(&self) -> Result<ListPromptsResult, Error> {
+        if !self.completed_initialization() {
+            return Err(Error::NotInitialized);
+        }
+        if self.server_capabilities.as_ref().unwrap().prompts.is_none() {
+            return Err(Error::RpcError {
+                code: METHOD_NOT_FOUND,
+                message: "Server does not support 'prompts' capability".to_string(),
+            });
+        }
+        
+        self.send_request("prompts/list", serde_json::json!({})).await
+    }
+    
+    async fn get_prompt(&self, name: &str, arguments: Value) -> Result<GetPromptResult, Error> {
+        if !self.completed_initialization() {
+            return Err(Error::NotInitialized);
+        }
+
+        if self.server_capabilities.as_ref().unwrap().prompts.is_none() {
+            return Err(Error::RpcError {
+                code: METHOD_NOT_FOUND,
+                message: "Server does not support 'prompts' capability".to_string(),
+            });
+        }
+
+        let params = serde_json::json!({ "name": name, "arguments": arguments });
+       // TODO ERROR: check that if there is an error, we send back is_error: true with msg
+        // https://modelcontextprotocol.io/docs/concepts/tools#error-handling-2
+        self.send_request("prompts/get", params).await
+    
     }
 }


### PR DESCRIPTION
Implement get_prompt and list_prompts per MCP: https://spec.modelcontextprotocol.io/specification/2024-11-05/server/prompts/

- add a prompts.rs to goose-server/routes with additional /prompts/list and /prompts/get/:prompt_name routes that call the passthrough respectively
- implement passthrough in agents
- add the list_prompts and get_prompt declarations on the mcpclienttrait
- implement list_prompts and get_prompt in mcp-client/client.rs