### PR TITLE
feat: adding oauth for gemini

### DIFF
--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -60,6 +60,7 @@ serde_yaml = "0.9.34"
 once_cell = "1.20.2"
 dirs = "6.0.0"
 rand = "0.8.5"
+oauth2 = { version = "4.4", features = ["reqwest"] }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/crates/goose/src/providers/google.rs
+++ b/crates/goose/src/providers/google.rs
@@ -175,9 +175,7 @@ impl GoogleProvider {
             .header("Content-Type", "application/json");
 
         match &self.auth {
-            GoogleAuth::ApiKey(_) => {
-                // Remove "Bearer " prefix for API key and pass as query param
-                let api_key = auth.trim_start_matches("Bearer ").to_string();
+            GoogleAuth::ApiKey(api_key) => {
                 request = request.query(&[("key", api_key)]);
             }
             GoogleAuth::OAuth { .. } => {

--- a/crates/goose/src/providers/google.rs
+++ b/crates/goose/src/providers/google.rs
@@ -239,16 +239,10 @@ impl Provider for GoogleProvider {
             GOOGLE_KNOWN_MODELS.iter().map(|&s| s.to_string()).collect(),
             GOOGLE_DOC_URL,
             vec![
-                ConfigKey::new("GOOGLE_API_KEY", false, true, None),
+                ConfigKey::new("GOOGLE_API_KEY", true, true, None),
                 ConfigKey::new("GOOGLE_HOST", false, false, Some(GOOGLE_API_HOST)),
                 ConfigKey::new("GOOGLE_CLIENT_ID", false, false, None),
                 ConfigKey::new("GOOGLE_CLIENT_SECRET", false, true, None),
-                ConfigKey::new(
-                    "GOOGLE_REDIRECT_URL",
-                    false,
-                    false,
-                    Some(DEFAULT_REDIRECT_URL),
-                ),
             ],
         )
     }


### PR DESCRIPTION
This enables use of Gemini with either an API token, and oauth by setting `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`