### PR TITLE
feat: use a file lock for oauth

### DIFF
--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -60,6 +60,7 @@ serde_yaml = "0.9.34"
 once_cell = "1.20.2"
 etcetera = "0.8.0"
 rand = "0.8.5"
+fs2 = "0.4.3"
 
 # For Bedrock provider
 aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }

--- a/crates/goose/src/providers/oauth.rs
+++ b/crates/goose/src/providers/oauth.rs
@@ -7,8 +7,8 @@ use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::Digest;
-use std::{collections::HashMap, fs, net::SocketAddr, path::PathBuf, sync::Arc};
 use std::fs::OpenOptions;
+use std::{collections::HashMap, fs, net::SocketAddr, path::PathBuf, sync::Arc};
 use tokio::sync::oneshot;
 use url::Url;
 
@@ -51,7 +51,7 @@ impl TokenCache {
         let cache_path = get_base_path().join(format!("{}.json", hash));
         let lock_path = get_base_path().join(format!("{}.lock", hash));
 
-        Self { 
+        Self {
             cache_path,
             lock_path,
         }

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -253,8 +253,8 @@ pub fn emit_debug_trace<T: serde::Serialize>(
 mod tests {
     use super::*;
     use serde_json::json;
-    use std::io::Write;
-    use tempfile::NamedTempFile;
+    
+    
 
     #[test]
     fn test_detect_image_path() {
@@ -266,7 +266,7 @@ mod tests {
             0x0D, 0x0A, 0x1A, 0x0A, // PNG header
             0x00, 0x00, 0x00, 0x0D, // Rest of fake PNG data
         ];
-        std::fs::write(&png_path, &png_data).unwrap();
+        std::fs::write(&png_path, png_data).unwrap();
         let png_path_str = png_path.to_str().unwrap();
 
         // Create a fake PNG (wrong magic numbers)
@@ -304,7 +304,7 @@ mod tests {
             0x0D, 0x0A, 0x1A, 0x0A, // PNG header
             0x00, 0x00, 0x00, 0x0D, // Rest of fake PNG data
         ];
-        std::fs::write(&png_path, &png_data).unwrap();
+        std::fs::write(&png_path, png_data).unwrap();
         let png_path_str = png_path.to_str().unwrap();
 
         // Create a fake PNG (wrong magic numbers)


### PR DESCRIPTION
This means that the oauth lock will be respected
across processes, which is an error we see coming up somewhat regularly now