### PR TITLE
fix: unset after uvx run

### DIFF
--- a/ui/desktop/src/bin/uvx
+++ b/ui/desktop/src/bin/uvx
@@ -92,13 +92,12 @@ else
     export UV_INDEX_URL="https://pypi.org/simple"
 fi
 
-
-
-
-
-
 # Final step: Execute uvx with passed arguments
 log "Executing 'uvx' command with arguments: $*"
 uvx "$@" || log "Failed to execute 'uvx' with arguments: $*"
+
+# Unset SSL_CERT_FILE after uvx execution
+log "Unsetting SSL_CERT_FILE to allow external requests"
+# unset SSL_CERT_FILE
 
 log "uvx setup script completed successfully."

--- a/ui/desktop/src/bin/uvx
+++ b/ui/desktop/src/bin/uvx
@@ -98,6 +98,6 @@ uvx "$@" || log "Failed to execute 'uvx' with arguments: $*"
 
 # Unset SSL_CERT_FILE after uvx execution
 log "Unsetting SSL_CERT_FILE to allow external requests"
-# unset SSL_CERT_FILE
+unset SSL_CERT_FILE
 
 log "uvx setup script completed successfully."


### PR DESCRIPTION
I'm having trouble testing this locally too, the fetch extension does not complete

<img width="736" alt="image" src="https://github.com/user-attachments/assets/2e1135e0-9adf-4f86-87ce-2309ef5f64a9" />
