### PR TITLE
[draft - failing] claude3.7 sonnet with databricks provider

### DIFF
--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -100,6 +100,17 @@ pub fn render_message(message: &Message) {
             MessageContent::Image(image) => {
                 println!("Image: [data: {}, type: {}]", image.data, image.mime_type);
             }
+            MessageContent::Thinking(thinking) => {
+                if let Ok(show_thinking) = std::env::var("GOOSE_CLI_SHOW_THINKING") {
+                    println!("\n{}", style("Thinking:").dim().italic());
+                    print_markdown(&thinking.thinking, theme);
+                }
+            }
+            MessageContent::RedactedThinking(_) => {
+                // For redacted thinking, print thinking was redacted
+                println!("\n{}", style("Thinking:").dim().italic());
+                print_markdown("Thinking was redacted", theme);
+            }
         }
     }
     println!();

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -101,7 +101,7 @@ pub fn render_message(message: &Message) {
                 println!("Image: [data: {}, type: {}]", image.data, image.mime_type);
             }
             MessageContent::Thinking(thinking) => {
-                if let Ok(show_thinking) = std::env::var("GOOSE_CLI_SHOW_THINKING") {
+                if std::env::var("GOOSE_CLI_SHOW_THINKING").is_ok() {
                     println!("\n{}", style("Thinking:").dim().italic());
                     print_markdown(&thinking.thinking, theme);
                 }

--- a/crates/goose-server/src/routes/reply.rs
+++ b/crates/goose-server/src/routes/reply.rs
@@ -10,10 +10,7 @@ use bytes::Bytes;
 use futures::{stream::StreamExt, Stream};
 use goose::message::{Message, MessageContent};
 
-use mcp_core::{
-    content::{self, Content},
-    role::Role,
-};
+use mcp_core::{content::Content, role::Role};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::{

--- a/crates/goose-server/src/routes/reply.rs
+++ b/crates/goose-server/src/routes/reply.rs
@@ -256,6 +256,12 @@ async fn stream_message(
                     MessageContent::ToolResponse(_) => {
                         // skip tool responses
                     }
+                    MessageContent::Thinking(_) => {
+                        // skip thinking content in the protocol output
+                    }
+                    MessageContent::RedactedThinking(_) => {
+                        // skip redacted thinking content in the protocol output
+                    }
                 }
             }
         }

--- a/crates/goose/src/message.rs
+++ b/crates/goose/src/message.rs
@@ -35,6 +35,17 @@ pub struct ToolConfirmationRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ThinkingContent {
+    pub thinking: String,
+    pub signature: String,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct RedactedThinkingContent {
+    pub data: String,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 /// Content passed inside a message, which can be both simple content and tool content
 pub enum MessageContent {
     Text(TextContent),
@@ -42,6 +53,8 @@ pub enum MessageContent {
     ToolRequest(ToolRequest),
     ToolResponse(ToolResponse),
     ToolConfirmationRequest(ToolConfirmationRequest),
+    Thinking(ThinkingContent),
+    RedactedThinking(RedactedThinkingContent),
 }
 
 impl MessageContent {
@@ -87,6 +100,17 @@ impl MessageContent {
             prompt,
         })
     }
+
+    pub fn thinking<S1: Into<String>, S2: Into<String>>(thinking: S1, signature: S2) -> Self {
+        MessageContent::Thinking(ThinkingContent {
+            thinking: thinking.into(),
+            signature: signature.into(),
+        })
+    }
+
+    pub fn redacted_thinking<S: Into<String>>(data: S) -> Self {
+        MessageContent::RedactedThinking(RedactedThinkingContent { data: data.into() })
+    }
     pub fn as_tool_request(&self) -> Option<&ToolRequest> {
         if let MessageContent::ToolRequest(ref tool_request) = self {
             Some(tool_request)
@@ -130,6 +154,22 @@ impl MessageContent {
     pub fn as_text(&self) -> Option<&str> {
         match self {
             MessageContent::Text(text) => Some(&text.text),
+            _ => None,
+        }
+    }
+
+    /// Get the thinking content if this is a ThinkingContent variant
+    pub fn as_thinking(&self) -> Option<&ThinkingContent> {
+        match self {
+            MessageContent::Thinking(thinking) => Some(thinking),
+            _ => None,
+        }
+    }
+
+    /// Get the redacted thinking content if this is a RedactedThinkingContent variant
+    pub fn as_redacted_thinking(&self) -> Option<&RedactedThinkingContent> {
+        match self {
+            MessageContent::RedactedThinking(redacted) => Some(redacted),
             _ => None,
         }
     }
@@ -220,6 +260,20 @@ impl Message {
         self.with_content(MessageContent::tool_confirmation_request(
             id, tool_name, arguments, prompt,
         ))
+    }
+
+    /// Add thinking content to the message
+    pub fn with_thinking<S1: Into<String>, S2: Into<String>>(
+        self,
+        thinking: S1,
+        signature: S2,
+    ) -> Self {
+        self.with_content(MessageContent::thinking(thinking, signature))
+    }
+
+    /// Add redacted thinking content to the message
+    pub fn with_redacted_thinking<S: Into<String>>(self, data: S) -> Self {
+        self.with_content(MessageContent::redacted_thinking(data))
     }
 
     /// Get the concatenated text content of the message, separated by newlines

--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -87,7 +87,7 @@ impl AnthropicProvider {
 
         if std::env::var("GOOSE_DEBUG").is_ok() {
             println!(
-                "\nResponse:\n{}\n",
+                "\nResponse [ {status} ]:\n{}\n",
                 serde_json::to_string_pretty(&payload).unwrap()
             );
         }

--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -66,6 +66,13 @@ impl AnthropicProvider {
             ProviderError::RequestFailed(format!("Failed to construct endpoint URL: {e}"))
         })?;
 
+        if std::env::var("GOOSE_DEBUG").is_ok() {
+            println!(
+                "\nRequest:\n{}\n",
+                serde_json::to_string_pretty(&payload).unwrap()
+            );
+        }
+
         let response = self
             .client
             .post(url)
@@ -77,6 +84,13 @@ impl AnthropicProvider {
 
         let status = response.status();
         let payload: Option<Value> = response.json().await.ok();
+
+        if std::env::var("GOOSE_DEBUG").is_ok() {
+            println!(
+                "\nResponse:\n{}\n",
+                serde_json::to_string_pretty(&payload).unwrap()
+            );
+        }
 
         // https://docs.anthropic.com/en/api/errors
         match status {

--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -17,6 +17,8 @@ pub const ANTHROPIC_KNOWN_MODELS: &[&str] = &[
     "claude-3-5-sonnet-latest",
     "claude-3-5-haiku-latest",
     "claude-3-opus-latest",
+    "claude-3-7-sonnet-20250219",
+    "claude-3-7-sonnet-latest",
 ];
 
 pub const ANTHROPIC_DOC_URL: &str = "https://docs.anthropic.com/en/docs/about-claude/models";

--- a/crates/goose/src/providers/databricks.rs
+++ b/crates/goose/src/providers/databricks.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use super::base::{ConfigKey, Provider, ProviderMetadata, ProviderUsage, Usage};
 use super::errors::ProviderError;
-use super::formats::openai::{create_request, get_usage, response_to_message};
+use super::formats::databricks::{create_request, get_usage, response_to_message};
 use super::oauth;
 use super::utils::{get_model, ImageFormat};
 use crate::config::ConfigError;

--- a/crates/goose/src/providers/databricks.rs
+++ b/crates/goose/src/providers/databricks.rs
@@ -145,6 +145,13 @@ impl DatabricksProvider {
             ProviderError::RequestFailed(format!("Failed to construct endpoint URL: {e}"))
         })?;
 
+        if std::env::var("GOOSE_DEBUG").is_ok() {
+            println!(
+                "\nRequest:\n{}\n",
+                serde_json::to_string_pretty(&payload).unwrap()
+            );
+        }
+
         let auth_header = self.ensure_auth_header().await?;
         let response = self
             .client
@@ -156,6 +163,13 @@ impl DatabricksProvider {
 
         let status = response.status();
         let payload: Option<Value> = response.json().await.ok();
+
+        if std::env::var("GOOSE_DEBUG").is_ok() {
+            println!(
+                "\nResponse [ {status} ]:\n{}\n",
+                serde_json::to_string_pretty(&payload).unwrap()
+            );
+        }
 
         match status {
             StatusCode::OK => payload.ok_or_else( || ProviderError::RequestFailed("Response body is not valid JSON".to_string()) ),

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -274,7 +274,9 @@ pub fn create_request(
         return Err(anyhow!("No valid messages to send to Anthropic API"));
     }
 
-    let max_tokens = model_config.max_tokens.unwrap_or(4096);
+    // https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table
+    // Claude 3.7 supports max output tokens up to 8192
+    let max_tokens = model_config.max_tokens.unwrap_or(8192);
     let mut payload = json!({
         "model": model_config.model_name,
         "messages": anthropic_messages,

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -60,6 +60,19 @@ pub fn format_messages(messages: &[Message]) -> Vec<Value> {
                 MessageContent::ToolConfirmationRequest(_tool_confirmation_request) => {
                     // Skip tool confirmation requests
                 }
+                MessageContent::Thinking(thinking) => {
+                    content.push(json!({
+                        "type": "thinking",
+                        "thinking": thinking.thinking,
+                        "signature": thinking.signature
+                    }));
+                }
+                MessageContent::RedactedThinking(redacted) => {
+                    content.push(json!({
+                        "type": "redacted_thinking",
+                        "data": redacted.data
+                    }));
+                }
                 MessageContent::Image(_) => continue, // Anthropic doesn't support image content yet
             }
         }
@@ -179,6 +192,24 @@ pub fn response_to_message(response: Value) -> Result<Message> {
                 let tool_call = ToolCall::new(name, input.clone());
                 message = message.with_tool_request(id, Ok(tool_call));
             }
+            Some("thinking") => {
+                let thinking = block
+                    .get("thinking")
+                    .and_then(|t| t.as_str())
+                    .ok_or_else(|| anyhow!("Missing thinking content"))?;
+                let signature = block
+                    .get("signature")
+                    .and_then(|s| s.as_str())
+                    .ok_or_else(|| anyhow!("Missing thinking signature"))?;
+                message = message.with_thinking(thinking, signature);
+            }
+            Some("redacted_thinking") => {
+                let data = block
+                    .get("data")
+                    .and_then(|d| d.as_str())
+                    .ok_or_else(|| anyhow!("Missing redacted_thinking data"))?;
+                message = message.with_redacted_thinking(data);
+            }
             _ => continue,
         }
     }
@@ -243,10 +274,11 @@ pub fn create_request(
         return Err(anyhow!("No valid messages to send to Anthropic API"));
     }
 
+    let max_tokens = model_config.max_tokens.unwrap_or(4096);
     let mut payload = json!({
         "model": model_config.model_name,
         "messages": anthropic_messages,
-        "max_tokens": model_config.max_tokens.unwrap_or(4096)
+        "max_tokens": max_tokens,
     });
 
     // Add system message if present
@@ -265,12 +297,38 @@ pub fn create_request(
             .insert("tools".to_string(), json!(tool_specs));
     }
 
-    // Add temperature if specified
+    // Add temperature if specified and not using extended thinking model
     if let Some(temp) = model_config.temperature {
+        // Claude 3.7 models with thinking enabled don't support temperature
+        if !model_config.model_name.starts_with("claude-3-7-sonnet-") {
+            payload
+                .as_object_mut()
+                .unwrap()
+                .insert("temperature".to_string(), json!(temp));
+        }
+    }
+
+    // Add thinking parameters for claude-3-7-sonnet model
+    let is_thinking_enabled = std::env::var("ANTHROPIC_THINKING_ENABLED").is_ok();
+    if model_config.model_name.starts_with("claude-3-7-sonnet-") && is_thinking_enabled {
+        // Minimum budget_tokens is 1024
+        let budget_tokens = std::env::var("ANTHROPIC_THINKING_BUDGET")
+            .unwrap_or_else(|_| "16000".to_string())
+            .parse()
+            .unwrap_or(16000);
+
         payload
             .as_object_mut()
             .unwrap()
-            .insert("temperature".to_string(), json!(temp));
+            .insert("max_tokens".to_string(), json!(max_tokens + budget_tokens));
+
+        payload.as_object_mut().unwrap().insert(
+            "thinking".to_string(),
+            json!({
+                "type": "enabled",
+                "budget_tokens": budget_tokens
+            }),
+        );
     }
 
     Ok(payload)
@@ -362,6 +420,80 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_thinking_response() -> Result<()> {
+        let response = json!({
+            "id": "msg_456",
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "thinking",
+                    "thinking": "This is a step-by-step thought process...",
+                    "signature": "EuYBCkQYAiJAVbJNBoH7HQiDcMwwAMhWqNyoe4G2xHRprK8ICM8gZzu16i7Se4EiEbmlKqNH1GtwcX1BMK6iLu8bxWn5wPVIFBIMnptdlVal7ZX5iNPFGgwWjX+BntcEOHky4HciMFVef7FpQeqnuiL1Xt7J4OLHZSyu4tcr809AxAbclcJ5dm1xE5gZrUO+/v60cnJM2ipQp4B8/3eHI03KSV6bZR/vMrBSYCV+aa/f5KHX2cRtLGp/Ba+3Tk/efbsg01WSduwAIbR4coVrZLnGJXNyVTFW/Be2kLy/ECZnx8cqvU3oQOg="
+                },
+                {
+                    "type": "redacted_thinking",
+                    "data": "EmwKAhgBEgy3va3pzix/LafPsn4aDFIT2Xlxh0L5L8rLVyIwxtE3rAFBa8cr3qpP"
+                },
+                {
+                    "type": "text",
+                    "text": "I've analyzed the problem and here's the solution."
+                }
+            ],
+            "model": "claude-3-7-sonnet-20250219",
+            "stop_reason": "end_turn",
+            "stop_sequence": null,
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 45,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            }
+        });
+
+        let message = response_to_message(response.clone())?;
+        let usage = get_usage(&response)?;
+
+        assert_eq!(message.content.len(), 3);
+
+        if let MessageContent::Thinking(thinking) = &message.content[0] {
+            assert_eq!(
+                thinking.thinking,
+                "This is a step-by-step thought process..."
+            );
+            assert!(thinking
+                .signature
+                .starts_with("EuYBCkQYAiJAVbJNBoH7HQiDcMwwAMhWqNyoe4G2xHRprK8ICM8g"));
+        } else {
+            panic!("Expected Thinking content at index 0");
+        }
+
+        if let MessageContent::RedactedThinking(redacted) = &message.content[1] {
+            assert_eq!(
+                redacted.data,
+                "EmwKAhgBEgy3va3pzix/LafPsn4aDFIT2Xlxh0L5L8rLVyIwxtE3rAFBa8cr3qpP"
+            );
+        } else {
+            panic!("Expected RedactedThinking content at index 1");
+        }
+
+        if let MessageContent::Text(text) = &message.content[2] {
+            assert_eq!(
+                text.text,
+                "I've analyzed the problem and here's the solution."
+            );
+        } else {
+            panic!("Expected Text content at index 2");
+        }
+
+        assert_eq!(usage.input_tokens, Some(10));
+        assert_eq!(usage.output_tokens, Some(45));
+        assert_eq!(usage.total_tokens, Some(55));
+
+        Ok(())
+    }
+
+    #[test]
     fn test_message_to_anthropic_spec() {
         let messages = vec![
             Message::user().with_text("Hello"),
@@ -435,5 +567,30 @@ mod tests {
         assert_eq!(spec_array[0]["type"], "text");
         assert_eq!(spec_array[0]["text"], system);
         assert!(spec_array[0].get("cache_control").is_some());
+    }
+
+    #[test]
+    fn test_create_request_with_thinking() -> Result<()> {
+        let model_config = ModelConfig::new("claude-3-7-sonnet-20250219".to_string());
+        let system = "You are a helpful assistant.";
+        let messages = vec![Message::user().with_text("Hello")];
+        let tools = vec![];
+
+        let payload = create_request(&model_config, system, &messages, &tools)?;
+
+        // Verify basic structure
+        assert_eq!(payload["model"], "claude-3-7-sonnet-20250219");
+        assert_eq!(payload["messages"][0]["role"], "user");
+        assert_eq!(payload["messages"][0]["content"][0]["text"], "Hello");
+
+        // Verify thinking parameters
+        assert!(payload.get("thinking").is_some());
+        assert_eq!(payload["thinking"]["type"], "enabled");
+        assert!(payload["thinking"]["budget_tokens"].as_i64().unwrap() >= 1024);
+
+        // Temperature should not be present for 3.7 models with thinking
+        assert!(payload.get("temperature").is_none());
+
+        Ok(())
     }
 }

--- a/crates/goose/src/providers/formats/bedrock.rs
+++ b/crates/goose/src/providers/formats/bedrock.rs
@@ -34,6 +34,14 @@ pub fn to_bedrock_message_content(content: &MessageContent) -> Result<bedrock::C
         MessageContent::Image(_) => {
             bail!("Image content is not supported by Bedrock provider yet")
         }
+        MessageContent::Thinking(_) => {
+            // Thinking blocks are not supported in Bedrock - skip
+            bedrock::ContentBlock::Text("".to_string())
+        }
+        MessageContent::RedactedThinking(_) => {
+            // Redacted thinking blocks are not supported in Bedrock - skip
+            bedrock::ContentBlock::Text("".to_string())
+        }
         MessageContent::ToolRequest(tool_req) => {
             let tool_use_id = tool_req.id.to_string();
             let tool_use = if let Ok(call) = tool_req.tool_call.as_ref() {

--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -492,7 +492,7 @@ pub fn create_request(
         // Default to 8192 (Claude max output) + budget if not specified
         let max_completion_tokens = model_config.max_tokens.unwrap_or(8192);
         payload.as_object_mut().unwrap().insert(
-            "max_completion_tokens".to_string(),
+            "max_tokens".to_string(),
             json!(max_completion_tokens + budget_tokens),
         );
 
@@ -1039,7 +1039,7 @@ mod tests {
                 model_name: "claude-3-7-sonnet-20250219".to_string(),
                 tokenizer_name: "claude-3-7-sonnet".to_string(),
                 context_limit: Some(200000),
-                temperature: Some(1.5),
+                temperature: None,
                 max_tokens: Some(4000),
             };
 
@@ -1051,7 +1051,7 @@ mod tests {
             assert_eq!(obj["thinking"]["type"], "enabled");
             assert_eq!(obj["thinking"]["budget_tokens"], 12000);
             assert_eq!(obj["max_tokens"], 16000); // 4000 (max_tokens) + 12000 (budget)
-            assert_eq!(obj["temperature"], 1.5);
+            assert_eq!(obj["temperature"], 2); // fixed
 
             let messages = obj["messages"].as_array().unwrap();
             assert_eq!(messages[0]["role"], "system");

--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -1,0 +1,1180 @@
+use crate::message::{Message, MessageContent};
+use crate::model::ModelConfig;
+use crate::providers::base::Usage;
+use crate::providers::errors::ProviderError;
+use crate::providers::utils::{
+    convert_image, detect_image_path, is_valid_function_name, load_image_file,
+    sanitize_function_name, ImageFormat,
+};
+use anyhow::{anyhow, Error};
+use mcp_core::ToolError;
+use mcp_core::{Content, Role, Tool, ToolCall};
+use serde_json::{json, Value};
+
+/// Convert internal Message format to OpenAI's API message specification
+///   some openai compatible endpoints use the anthropic image spec at the content level
+///   even though the message structure is otherwise following openai, the enum switches this
+pub fn format_messages(messages: &[Message], image_format: &ImageFormat) -> Vec<Value> {
+    let mut messages_spec = Vec::new();
+    for message in messages {
+        let mut converted = json!({
+            "role": message.role
+        });
+
+        let mut output = Vec::new();
+
+        for content in &message.content {
+            match content {
+                MessageContent::Text(text) => {
+                    if !text.text.is_empty() {
+                        // Check for image paths in the text
+                        if let Some(image_path) = detect_image_path(&text.text) {
+                            // Try to load and convert the image
+                            if let Ok(image) = load_image_file(image_path) {
+                                converted["content"] = json!([
+                                    {"type": "text", "text": text.text},
+                                    convert_image(&image, image_format)
+                                ]);
+                            } else {
+                                // If image loading fails, just use the text
+                                converted["content"] = json!(text.text);
+                            }
+                        } else {
+                            converted["content"] = json!(text.text);
+                        }
+                    }
+                }
+                MessageContent::Thinking(_) => {
+                    // Thinking blocks are not directly used in OpenAI format
+                    continue;
+                }
+                MessageContent::RedactedThinking(_) => {
+                    // Redacted thinking blocks are not directly used in OpenAI format
+                    continue;
+                }
+                MessageContent::ToolRequest(request) => match &request.tool_call {
+                    Ok(tool_call) => {
+                        let sanitized_name = sanitize_function_name(&tool_call.name);
+                        let tool_calls = converted
+                            .as_object_mut()
+                            .unwrap()
+                            .entry("tool_calls")
+                            .or_insert(json!([]));
+
+                        tool_calls.as_array_mut().unwrap().push(json!({
+                            "id": request.id,
+                            "type": "function",
+                            "function": {
+                                "name": sanitized_name,
+                                "arguments": tool_call.arguments.to_string(),
+                            }
+                        }));
+                    }
+                    Err(e) => {
+                        output.push(json!({
+                            "role": "tool",
+                            "content": format!("Error: {}", e),
+                            "tool_call_id": request.id
+                        }));
+                    }
+                },
+                MessageContent::ToolResponse(response) => {
+                    match &response.tool_result {
+                        Ok(contents) => {
+                            // Send only contents with no audience or with Assistant in the audience
+                            let abridged: Vec<_> = contents
+                                .iter()
+                                .filter(|content| {
+                                    content
+                                        .audience()
+                                        .is_none_or(|audience| audience.contains(&Role::Assistant))
+                                })
+                                .map(|content| content.unannotated())
+                                .collect();
+
+                            // Process all content, replacing images with placeholder text
+                            let mut tool_content = Vec::new();
+                            let mut image_messages = Vec::new();
+
+                            for content in abridged {
+                                match content {
+                                    Content::Image(image) => {
+                                        // Add placeholder text in the tool response
+                                        tool_content.push(Content::text("This tool result included an image that is uploaded in the next message."));
+
+                                        // Create a separate image message
+                                        image_messages.push(json!({
+                                            "role": "user",
+                                            "content": [convert_image(&image, image_format)]
+                                        }));
+                                    }
+                                    Content::Resource(resource) => {
+                                        tool_content.push(Content::text(resource.get_text()));
+                                    }
+                                    _ => {
+                                        tool_content.push(content);
+                                    }
+                                }
+                            }
+                            let tool_response_content: Value = json!(tool_content
+                                .iter()
+                                .map(|content| match content {
+                                    Content::Text(text) => text.text.clone(),
+                                    _ => String::new(),
+                                })
+                                .collect::<Vec<String>>()
+                                .join(" "));
+
+                            // First add the tool response with all content
+                            output.push(json!({
+                                "role": "tool",
+                                "content": tool_response_content,
+                                "tool_call_id": response.id
+                            }));
+                            // Then add any image messages that need to follow
+                            output.extend(image_messages);
+                        }
+                        Err(e) => {
+                            // A tool result error is shown as output so the model can interpret the error message
+                            output.push(json!({
+                                "role": "tool",
+                                "content": format!("The tool call returned the following error:\n{}", e),
+                                "tool_call_id": response.id
+                            }));
+                        }
+                    }
+                }
+                MessageContent::ToolConfirmationRequest(_) => {
+                    // Skip tool confirmation requests
+                }
+                MessageContent::Image(image) => {
+                    // Handle direct image content
+                    converted["content"] = json!([convert_image(image, image_format)]);
+                }
+            }
+        }
+
+        if converted.get("content").is_some() || converted.get("tool_calls").is_some() {
+            output.insert(0, converted);
+        }
+        messages_spec.extend(output);
+    }
+
+    messages_spec
+}
+
+/// Convert internal Tool format to OpenAI's API tool specification
+pub fn format_tools(tools: &[Tool]) -> anyhow::Result<Vec<Value>> {
+    let mut tool_names = std::collections::HashSet::new();
+    let mut result = Vec::new();
+
+    for tool in tools {
+        if !tool_names.insert(&tool.name) {
+            return Err(anyhow!("Duplicate tool name: {}", tool.name));
+        }
+
+        let mut description = tool.description.clone();
+        description.truncate(1024);
+
+        // OpenAI's tool description max str len is 1024
+        result.push(json!({
+            "type": "function",
+            "function": {
+                "name": tool.name,
+                "description": description,
+                "parameters": tool.input_schema,
+            }
+        }));
+    }
+
+    Ok(result)
+}
+
+/// Convert OpenAI's API response to internal Message format
+pub fn response_to_message(response: Value) -> anyhow::Result<Message> {
+    let original = response["choices"][0]["message"].clone();
+    let mut content = Vec::new();
+
+    // Check if this is an Anthropic response with thinking
+    // When thinking mode is enabled with Claude, there are multiple entries in the choices array
+    // The first one (index 0) contains thinking responses, the second one (index 1) contains the final message
+    if response["choices"]
+        .as_array()
+        .map_or(false, |choices| choices.len() > 1)
+    {
+        // This might be an Anthropic thinking response
+        if let Some(thinking_msg) = response["choices"][0]["message"].as_object() {
+            // For thinking messages, content is null
+            if thinking_msg.get("content").map_or(false, |c| c.is_null()) {
+                // The actual message is in the second choice
+                if let Some(final_msg) = response["choices"]
+                    .as_array()
+                    .and_then(|choices| choices.get(1))
+                    .and_then(|choice| choice.get("message"))
+                {
+                    if let Some(msg_content) = final_msg.get("content") {
+                        if let Some(text_str) = msg_content.as_str() {
+                            content.push(MessageContent::text(text_str));
+                        }
+                    }
+
+                    // Process tool calls if present
+                    if let Some(tool_calls) = final_msg.get("tool_calls") {
+                        if let Some(tool_calls_array) = tool_calls.as_array() {
+                            for tool_call in tool_calls_array {
+                                let id = tool_call["id"].as_str().unwrap_or_default().to_string();
+                                let function_name = tool_call["function"]["name"]
+                                    .as_str()
+                                    .unwrap_or_default()
+                                    .to_string();
+                                let mut arguments = tool_call["function"]["arguments"]
+                                    .as_str()
+                                    .unwrap_or_default()
+                                    .to_string();
+                                // If arguments is empty, we will have invalid json parsing error later.
+                                if arguments.is_empty() {
+                                    arguments = "{}".to_string();
+                                }
+
+                                if !is_valid_function_name(&function_name) {
+                                    let error = ToolError::NotFound(format!(
+                                        "The provided function name '{}' had invalid characters, it must match this regex [a-zA-Z0-9_-]+",
+                                        function_name
+                                    ));
+                                    content.push(MessageContent::tool_request(id, Err(error)));
+                                } else {
+                                    match serde_json::from_str::<Value>(&arguments) {
+                                        Ok(params) => {
+                                            content.push(MessageContent::tool_request(
+                                                id,
+                                                Ok(ToolCall::new(&function_name, params)),
+                                            ));
+                                        }
+                                        Err(e) => {
+                                            let error = ToolError::InvalidParameters(format!(
+                                                "Could not interpret tool use parameters for id {}: {}",
+                                                id, e
+                                            ));
+                                            content
+                                                .push(MessageContent::tool_request(id, Err(error)));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                return Ok(Message {
+                    role: Role::Assistant,
+                    created: chrono::Utc::now().timestamp(),
+                    content,
+                });
+            }
+        }
+    }
+
+    // Standard OpenAI-like response format handling
+    if let Some(text) = original.get("content") {
+        if let Some(text_str) = text.as_str() {
+            content.push(MessageContent::text(text_str));
+        }
+    }
+
+    if let Some(tool_calls) = original.get("tool_calls") {
+        if let Some(tool_calls_array) = tool_calls.as_array() {
+            for tool_call in tool_calls_array {
+                let id = tool_call["id"].as_str().unwrap_or_default().to_string();
+                let function_name = tool_call["function"]["name"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string();
+                let mut arguments = tool_call["function"]["arguments"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string();
+                // If arguments is empty, we will have invalid json parsing error later.
+                if arguments.is_empty() {
+                    arguments = "{}".to_string();
+                }
+
+                if !is_valid_function_name(&function_name) {
+                    let error = ToolError::NotFound(format!(
+                        "The provided function name '{}' had invalid characters, it must match this regex [a-zA-Z0-9_-]+",
+                        function_name
+                    ));
+                    content.push(MessageContent::tool_request(id, Err(error)));
+                } else {
+                    match serde_json::from_str::<Value>(&arguments) {
+                        Ok(params) => {
+                            content.push(MessageContent::tool_request(
+                                id,
+                                Ok(ToolCall::new(&function_name, params)),
+                            ));
+                        }
+                        Err(e) => {
+                            let error = ToolError::InvalidParameters(format!(
+                                "Could not interpret tool use parameters for id {}: {}",
+                                id, e
+                            ));
+                            content.push(MessageContent::tool_request(id, Err(error)));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(Message {
+        role: Role::Assistant,
+        created: chrono::Utc::now().timestamp(),
+        content,
+    })
+}
+
+pub fn get_usage(data: &Value) -> Result<Usage, ProviderError> {
+    let usage = data
+        .get("usage")
+        .ok_or_else(|| ProviderError::UsageError("No usage data in response".to_string()))?;
+
+    let input_tokens = usage
+        .get("prompt_tokens")
+        .and_then(|v| v.as_i64())
+        .map(|v| v as i32);
+
+    let output_tokens = usage
+        .get("completion_tokens")
+        .and_then(|v| v.as_i64())
+        .map(|v| v as i32);
+
+    let total_tokens = usage
+        .get("total_tokens")
+        .and_then(|v| v.as_i64())
+        .map(|v| v as i32)
+        .or_else(|| match (input_tokens, output_tokens) {
+            (Some(input), Some(output)) => Some(input + output),
+            _ => None,
+        });
+
+    Ok(Usage::new(input_tokens, output_tokens, total_tokens))
+}
+
+/// Validates and fixes tool schemas to ensure they have proper parameter structure.
+/// If parameters exist, ensures they have properties and required fields, or removes parameters entirely.
+pub fn validate_tool_schemas(tools: &mut [Value]) {
+    for tool in tools.iter_mut() {
+        if let Some(function) = tool.get_mut("function") {
+            if let Some(parameters) = function.get_mut("parameters") {
+                if parameters.is_object() {
+                    ensure_valid_json_schema(parameters);
+                }
+            }
+        }
+    }
+}
+
+/// Ensures that the given JSON value follows the expected JSON Schema structure.
+fn ensure_valid_json_schema(schema: &mut Value) {
+    if let Some(params_obj) = schema.as_object_mut() {
+        // Check if this is meant to be an object type schema
+        let is_object_type = params_obj
+            .get("type")
+            .and_then(|t| t.as_str())
+            .is_none_or(|t| t == "object"); // Default to true if no type is specified
+
+        // Only apply full schema validation to object types
+        if is_object_type {
+            // Ensure required fields exist with default values
+            params_obj.entry("properties").or_insert_with(|| json!({}));
+            params_obj.entry("required").or_insert_with(|| json!([]));
+            params_obj.entry("type").or_insert_with(|| json!("object"));
+
+            // Recursively validate properties if it exists
+            if let Some(properties) = params_obj.get_mut("properties") {
+                if let Some(properties_obj) = properties.as_object_mut() {
+                    for (_key, prop) in properties_obj.iter_mut() {
+                        if prop.is_object()
+                            && prop.get("type").and_then(|t| t.as_str()) == Some("object")
+                        {
+                            ensure_valid_json_schema(prop);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub fn create_request(
+    model_config: &ModelConfig,
+    system: &str,
+    messages: &[Message],
+    tools: &[Tool],
+    image_format: &ImageFormat,
+) -> anyhow::Result<Value, Error> {
+    if model_config.model_name.starts_with("o1-mini") {
+        return Err(anyhow!(
+            "o1-mini model is not currently supported since Goose uses tool calling and o1-mini does not support it. Please use o1 or o3 models instead."
+        ));
+    }
+
+    let is_o1 = model_config.model_name.starts_with("o1");
+    let is_o3 = model_config.model_name.starts_with("o3");
+    let is_claude_3_7_sonnet = model_config.model_name.contains("claude-3-7-sonnet");
+
+    // Only extract reasoning effort for O1/O3 models
+    let (model_name, reasoning_effort) = if is_o1 || is_o3 {
+        let parts: Vec<&str> = model_config.model_name.split('-').collect();
+        let last_part = parts.last().unwrap();
+
+        match *last_part {
+            "low" | "medium" | "high" => {
+                let base_name = parts[..parts.len() - 1].join("-");
+                (base_name, Some(last_part.to_string()))
+            }
+            _ => (
+                model_config.model_name.to_string(),
+                Some("medium".to_string()),
+            ),
+        }
+    } else {
+        // For non-O family models, use the model name as is and no reasoning effort
+        (model_config.model_name.to_string(), None)
+    };
+
+    let system_message = json!({
+        "role": if is_o1 || is_o3 { "developer" } else { "system" },
+        "content": system
+    });
+
+    let messages_spec = format_messages(messages, image_format);
+    let mut tools_spec = if !tools.is_empty() {
+        format_tools(tools)?
+    } else {
+        vec![]
+    };
+
+    // Validate tool schemas
+    validate_tool_schemas(&mut tools_spec);
+
+    let mut messages_array = vec![system_message];
+    messages_array.extend(messages_spec);
+
+    let mut payload = json!({
+        "model": model_name,
+        "messages": messages_array
+    });
+
+    if let Some(effort) = reasoning_effort {
+        payload
+            .as_object_mut()
+            .unwrap()
+            .insert("reasoning_effort".to_string(), json!(effort));
+    }
+
+    if !tools_spec.is_empty() {
+        payload
+            .as_object_mut()
+            .unwrap()
+            .insert("tools".to_string(), json!(tools_spec));
+    }
+
+    // Add thinking parameters for Claude 3.7 Sonnet model when requested
+    let is_thinking_enabled = std::env::var("ANTHROPIC_THINKING_ENABLED").is_ok();
+    if is_claude_3_7_sonnet && is_thinking_enabled {
+        // Minimum budget_tokens is 1024
+        let budget_tokens = std::env::var("ANTHROPIC_THINKING_BUDGET")
+            .unwrap_or_else(|_| "16000".to_string())
+            .parse()
+            .unwrap_or(16000);
+
+        // For Claude models with thinking enabled, we need to add max_tokens + budget_tokens
+        // Default to 8192 (Claude max output) + budget if not specified
+        let max_completion_tokens = model_config.max_tokens.unwrap_or(8192);
+        payload.as_object_mut().unwrap().insert(
+            "max_completion_tokens".to_string(),
+            json!(max_completion_tokens + budget_tokens),
+        );
+
+        payload.as_object_mut().unwrap().insert(
+            "thinking".to_string(),
+            json!({
+                "type": "enabled",
+                "budget_tokens": budget_tokens
+            }),
+        );
+
+        // Temperature is fixed to 2 when using claude 3.7 thinking with Databricks
+        payload
+            .as_object_mut()
+            .unwrap()
+            .insert("temperature".to_string(), json!(2));
+    } else {
+        // o1, o3 models currently don't support temperature
+        if !is_o1 && !is_o3 {
+            if let Some(temp) = model_config.temperature {
+                payload
+                    .as_object_mut()
+                    .unwrap()
+                    .insert("temperature".to_string(), json!(temp));
+            }
+        }
+
+        // o1 models use max_completion_tokens instead of max_tokens
+        if let Some(tokens) = model_config.max_tokens {
+            let key = if is_o1 || is_o3 {
+                "max_completion_tokens"
+            } else {
+                "max_tokens"
+            };
+            payload
+                .as_object_mut()
+                .unwrap()
+                .insert(key.to_string(), json!(tokens));
+        }
+    }
+
+    Ok(payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mcp_core::content::Content;
+    use serde_json::json;
+
+    #[test]
+    fn test_validate_tool_schemas() {
+        // Test case 1: Empty parameters object
+        // Input JSON with an incomplete parameters object
+        let mut actual = vec![json!({
+            "type": "function",
+            "function": {
+                "name": "test_func",
+                "description": "test description",
+                "parameters": {
+                    "type": "object"
+                }
+            }
+        })];
+
+        // Run the function to validate and update schemas
+        validate_tool_schemas(&mut actual);
+
+        // Expected JSON after validation
+        let expected = vec![json!({
+            "type": "function",
+            "function": {
+                "name": "test_func",
+                "description": "test description",
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }
+            }
+        })];
+
+        // Compare entire JSON structures instead of individual fields
+        assert_eq!(actual, expected);
+
+        // Test case 2: Missing type field
+        let mut tools = vec![json!({
+            "type": "function",
+            "function": {
+                "name": "test_func",
+                "description": "test description",
+                "parameters": {
+                    "properties": {}
+                }
+            }
+        })];
+
+        validate_tool_schemas(&mut tools);
+
+        let params = tools[0]["function"]["parameters"].as_object().unwrap();
+        assert_eq!(params["type"], "object");
+
+        // Test case 3: Complete valid schema should remain unchanged
+        let original_schema = json!({
+            "type": "function",
+            "function": {
+                "name": "test_func",
+                "description": "test description",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": "City and country"
+                        }
+                    },
+                    "required": ["location"]
+                }
+            }
+        });
+
+        let mut tools = vec![original_schema.clone()];
+        validate_tool_schemas(&mut tools);
+        assert_eq!(tools[0], original_schema);
+    }
+
+    const OPENAI_TOOL_USE_RESPONSE: &str = r#"{
+        "choices": [{
+            "role": "assistant",
+            "message": {
+                "tool_calls": [{
+                    "id": "1",
+                    "function": {
+                        "name": "example_fn",
+                        "arguments": "{\"param\": \"value\"}"
+                    }
+                }]
+            }
+        }],
+        "usage": {
+            "input_tokens": 10,
+            "output_tokens": 25,
+            "total_tokens": 35
+        }
+    }"#;
+
+    #[test]
+    fn test_format_messages() -> anyhow::Result<()> {
+        let message = Message::user().with_text("Hello");
+        let spec = format_messages(&[message], &ImageFormat::OpenAi);
+
+        assert_eq!(spec.len(), 1);
+        assert_eq!(spec[0]["role"], "user");
+        assert_eq!(spec[0]["content"], "Hello");
+        Ok(())
+    }
+
+    #[test]
+    fn test_format_tools() -> anyhow::Result<()> {
+        let tool = Tool::new(
+            "test_tool",
+            "A test tool",
+            json!({
+                "type": "object",
+                "properties": {
+                    "input": {
+                        "type": "string",
+                        "description": "Test parameter"
+                    }
+                },
+                "required": ["input"]
+            }),
+        );
+
+        let spec = format_tools(&[tool])?;
+
+        assert_eq!(spec.len(), 1);
+        assert_eq!(spec[0]["type"], "function");
+        assert_eq!(spec[0]["function"]["name"], "test_tool");
+        Ok(())
+    }
+
+    #[test]
+    fn test_format_messages_complex() -> anyhow::Result<()> {
+        let mut messages = vec![
+            Message::assistant().with_text("Hello!"),
+            Message::user().with_text("How are you?"),
+            Message::assistant().with_tool_request(
+                "tool1",
+                Ok(ToolCall::new("example", json!({"param1": "value1"}))),
+            ),
+        ];
+
+        // Get the ID from the tool request to use in the response
+        let tool_id = if let MessageContent::ToolRequest(request) = &messages[2].content[0] {
+            request.id.clone()
+        } else {
+            panic!("should be tool request");
+        };
+
+        messages
+            .push(Message::user().with_tool_response(tool_id, Ok(vec![Content::text("Result")])));
+
+        let spec = format_messages(&messages, &ImageFormat::OpenAi);
+
+        assert_eq!(spec.len(), 4);
+        assert_eq!(spec[0]["role"], "assistant");
+        assert_eq!(spec[0]["content"], "Hello!");
+        assert_eq!(spec[1]["role"], "user");
+        assert_eq!(spec[1]["content"], "How are you?");
+        assert_eq!(spec[2]["role"], "assistant");
+        assert!(spec[2]["tool_calls"].is_array());
+        assert_eq!(spec[3]["role"], "tool");
+        assert_eq!(spec[3]["content"], "Result");
+        assert_eq!(spec[3]["tool_call_id"], spec[2]["tool_calls"][0]["id"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_format_messages_multiple_content() -> anyhow::Result<()> {
+        let mut messages = vec![Message::assistant().with_tool_request(
+            "tool1",
+            Ok(ToolCall::new("example", json!({"param1": "value1"}))),
+        )];
+
+        // Get the ID from the tool request to use in the response
+        let tool_id = if let MessageContent::ToolRequest(request) = &messages[0].content[0] {
+            request.id.clone()
+        } else {
+            panic!("should be tool request");
+        };
+
+        messages
+            .push(Message::user().with_tool_response(tool_id, Ok(vec![Content::text("Result")])));
+
+        let spec = format_messages(&messages, &ImageFormat::OpenAi);
+
+        assert_eq!(spec.len(), 2);
+        assert_eq!(spec[0]["role"], "assistant");
+        assert!(spec[0]["tool_calls"].is_array());
+        assert_eq!(spec[1]["role"], "tool");
+        assert_eq!(spec[1]["content"], "Result");
+        assert_eq!(spec[1]["tool_call_id"], spec[0]["tool_calls"][0]["id"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_format_tools_duplicate() -> anyhow::Result<()> {
+        let tool1 = Tool::new(
+            "test_tool",
+            "Test tool",
+            json!({
+                "type": "object",
+                "properties": {
+                    "input": {
+                        "type": "string",
+                        "description": "Test parameter"
+                    }
+                },
+                "required": ["input"]
+            }),
+        );
+
+        let tool2 = Tool::new(
+            "test_tool",
+            "Test tool",
+            json!({
+                "type": "object",
+                "properties": {
+                    "input": {
+                        "type": "string",
+                        "description": "Test parameter"
+                    }
+                },
+                "required": ["input"]
+            }),
+        );
+
+        let result = format_tools(&[tool1, tool2]);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Duplicate tool name"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_format_tools_empty() -> anyhow::Result<()> {
+        let spec = format_tools(&[])?;
+        assert!(spec.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_format_messages_with_image_path() -> anyhow::Result<()> {
+        // Create a temporary PNG file with valid PNG magic numbers
+        let temp_dir = tempfile::tempdir()?;
+        let png_path = temp_dir.path().join("test.png");
+        let png_data = [
+            0x89, 0x50, 0x4E, 0x47, // PNG magic number
+            0x0D, 0x0A, 0x1A, 0x0A, // PNG header
+            0x00, 0x00, 0x00, 0x0D, // Rest of fake PNG data
+        ];
+        std::fs::write(&png_path, &png_data)?;
+        let png_path_str = png_path.to_str().unwrap();
+
+        // Create message with image path
+        let message = Message::user().with_text(format!("Here is an image: {}", png_path_str));
+        let spec = format_messages(&[message], &ImageFormat::OpenAi);
+
+        assert_eq!(spec.len(), 1);
+        assert_eq!(spec[0]["role"], "user");
+
+        // Content should be an array with text and image
+        let content = spec[0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 2);
+        assert_eq!(content[0]["type"], "text");
+        assert!(content[0]["text"].as_str().unwrap().contains(png_path_str));
+        assert_eq!(content[1]["type"], "image_url");
+        assert!(content[1]["image_url"]["url"]
+            .as_str()
+            .unwrap()
+            .starts_with("data:image/png;base64,"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_response_to_message_text() -> anyhow::Result<()> {
+        let response = json!({
+            "choices": [{
+                "role": "assistant",
+                "message": {
+                    "content": "Hello from John Cena!"
+                }
+            }],
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 25,
+                "total_tokens": 35
+            }
+        });
+
+        let message = response_to_message(response)?;
+        assert_eq!(message.content.len(), 1);
+        if let MessageContent::Text(text) = &message.content[0] {
+            assert_eq!(text.text, "Hello from John Cena!");
+        } else {
+            panic!("Expected Text content");
+        }
+        assert!(matches!(message.role, Role::Assistant));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_response_to_message_valid_toolrequest() -> anyhow::Result<()> {
+        let response: Value = serde_json::from_str(OPENAI_TOOL_USE_RESPONSE)?;
+        let message = response_to_message(response)?;
+
+        assert_eq!(message.content.len(), 1);
+        if let MessageContent::ToolRequest(request) = &message.content[0] {
+            let tool_call = request.tool_call.as_ref().unwrap();
+            assert_eq!(tool_call.name, "example_fn");
+            assert_eq!(tool_call.arguments, json!({"param": "value"}));
+        } else {
+            panic!("Expected ToolRequest content");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_response_to_message_invalid_func_name() -> anyhow::Result<()> {
+        let mut response: Value = serde_json::from_str(OPENAI_TOOL_USE_RESPONSE)?;
+        response["choices"][0]["message"]["tool_calls"][0]["function"]["name"] =
+            json!("invalid fn");
+
+        let message = response_to_message(response)?;
+
+        if let MessageContent::ToolRequest(request) = &message.content[0] {
+            match &request.tool_call {
+                Err(ToolError::NotFound(msg)) => {
+                    assert!(msg.starts_with("The provided function name"));
+                }
+                _ => panic!("Expected ToolNotFound error"),
+            }
+        } else {
+            panic!("Expected ToolRequest content");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_response_to_message_json_decode_error() -> anyhow::Result<()> {
+        let mut response: Value = serde_json::from_str(OPENAI_TOOL_USE_RESPONSE)?;
+        response["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"] =
+            json!("invalid json {");
+
+        let message = response_to_message(response)?;
+
+        if let MessageContent::ToolRequest(request) = &message.content[0] {
+            match &request.tool_call {
+                Err(ToolError::InvalidParameters(msg)) => {
+                    assert!(msg.starts_with("Could not interpret tool use parameters"));
+                }
+                _ => panic!("Expected InvalidParameters error"),
+            }
+        } else {
+            panic!("Expected ToolRequest content");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_response_to_message_empty_argument() -> anyhow::Result<()> {
+        let mut response: Value = serde_json::from_str(OPENAI_TOOL_USE_RESPONSE)?;
+        response["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"] =
+            serde_json::Value::String("".to_string());
+
+        let message = response_to_message(response)?;
+
+        if let MessageContent::ToolRequest(request) = &message.content[0] {
+            let tool_call = request.tool_call.as_ref().unwrap();
+            assert_eq!(tool_call.name, "example_fn");
+            assert_eq!(tool_call.arguments, json!({}));
+        } else {
+            panic!("Expected ToolRequest content");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_request_gpt_4o() -> anyhow::Result<()> {
+        // Test default medium reasoning effort for O3 model
+        let model_config = ModelConfig {
+            model_name: "gpt-4o".to_string(),
+            tokenizer_name: "gpt-4o".to_string(),
+            context_limit: Some(4096),
+            temperature: None,
+            max_tokens: Some(1024),
+        };
+        let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
+        let obj = request.as_object().unwrap();
+        let expected = json!({
+            "model": "gpt-4o",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "system"
+                }
+            ],
+            "max_tokens": 1024
+        });
+
+        for (key, value) in expected.as_object().unwrap() {
+            assert_eq!(obj.get(key).unwrap(), value);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_request_o1_default() -> anyhow::Result<()> {
+        // Test default medium reasoning effort for O1 model
+        let model_config = ModelConfig {
+            model_name: "o1".to_string(),
+            tokenizer_name: "o1".to_string(),
+            context_limit: Some(4096),
+            temperature: None,
+            max_tokens: Some(1024),
+        };
+        let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
+        let obj = request.as_object().unwrap();
+        let expected = json!({
+            "model": "o1",
+            "messages": [
+                {
+                    "role": "developer",
+                    "content": "system"
+                }
+            ],
+            "reasoning_effort": "medium",
+            "max_completion_tokens": 1024
+        });
+
+        for (key, value) in expected.as_object().unwrap() {
+            assert_eq!(obj.get(key).unwrap(), value);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_request_o3_custom_reasoning_effort() -> anyhow::Result<()> {
+        // Test custom reasoning effort for O3 model
+        let model_config = ModelConfig {
+            model_name: "o3-mini-high".to_string(),
+            tokenizer_name: "o3-mini".to_string(),
+            context_limit: Some(4096),
+            temperature: None,
+            max_tokens: Some(1024),
+        };
+        let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
+        let obj = request.as_object().unwrap();
+        let expected = json!({
+            "model": "o3-mini",
+            "messages": [
+                {
+                    "role": "developer",
+                    "content": "system"
+                }
+            ],
+            "reasoning_effort": "high",
+            "max_completion_tokens": 1024
+        });
+
+        for (key, value) in expected.as_object().unwrap() {
+            assert_eq!(obj.get(key).unwrap(), value);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_request_claude_with_thinking() -> anyhow::Result<()> {
+        // Save original env variable state
+        let original_thinking_enabled = std::env::var("ANTHROPIC_THINKING_ENABLED").ok();
+        let original_thinking_budget = std::env::var("ANTHROPIC_THINKING_BUDGET").ok();
+
+        // Set up environment for testing
+        std::env::set_var("ANTHROPIC_THINKING_ENABLED", "true");
+        std::env::set_var("ANTHROPIC_THINKING_BUDGET", "12000");
+
+        let result = (|| {
+            let model_config = ModelConfig {
+                model_name: "claude-3-7-sonnet-20250219".to_string(),
+                tokenizer_name: "claude-3-7-sonnet".to_string(),
+                context_limit: Some(200000),
+                temperature: Some(1.5),
+                max_tokens: Some(4000),
+            };
+
+            let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
+            let obj = request.as_object().unwrap();
+
+            // Check that thinking parameters are correctly added
+            assert_eq!(obj["model"], "claude-3-7-sonnet-20250219");
+            assert_eq!(obj["thinking"]["type"], "enabled");
+            assert_eq!(obj["thinking"]["budget_tokens"], 12000);
+            assert_eq!(obj["max_tokens"], 16000); // 4000 (max_tokens) + 12000 (budget)
+            assert_eq!(obj["temperature"], 1.5);
+
+            let messages = obj["messages"].as_array().unwrap();
+            assert_eq!(messages[0]["role"], "system");
+            assert_eq!(messages[0]["content"], "system");
+
+            Ok(())
+        })();
+
+        // Restore original env variable state
+        match original_thinking_enabled {
+            Some(val) => std::env::set_var("ANTHROPIC_THINKING_ENABLED", val),
+            None => std::env::remove_var("ANTHROPIC_THINKING_ENABLED"),
+        }
+
+        match original_thinking_budget {
+            Some(val) => std::env::set_var("ANTHROPIC_THINKING_BUDGET", val),
+            None => std::env::remove_var("ANTHROPIC_THINKING_BUDGET"),
+        }
+
+        result
+    }
+
+    #[test]
+    fn test_response_to_message_anthropic_thinking() -> anyhow::Result<()> {
+        // This represents a response from Claude 3.7 with thinking enabled
+        let response = json!({
+            "model": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": null
+                    },
+                    "index": 0,
+                    "finish_reason": "stop"
+                },
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "# Databricks\n\nDatabricks is a unified data analytics platform founded in 2013 by the creators of Apache Spark. It's designed to help organizations process massive quantities of data and build AI applications."
+                    },
+                    "index": 0,
+                    "finish_reason": "stop"
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 58,
+                "completion_tokens": 682,
+                "total_tokens": 740
+            },
+            "object": "chat.completion",
+            "id": "msg_bdrk_01EFhg8GDohjCLRzqaQSKC2b",
+            "created": 1740586881
+        });
+
+        let message = response_to_message(response)?;
+
+        // Check that we properly extracted the text from the second choice
+        assert_eq!(message.content.len(), 1);
+        if let MessageContent::Text(text) = &message.content[0] {
+            assert!(text
+                .text
+                .contains("Databricks is a unified data analytics platform"));
+        } else {
+            panic!("Expected Text content");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_response_to_message_anthropic_thinking_with_tool_calls() -> anyhow::Result<()> {
+        // This represents a response from Claude 3.7 with thinking enabled and tool calls
+        let response = json!({
+            "model": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": null
+                    },
+                    "index": 0,
+                    "finish_reason": "stop"
+                },
+                {
+                    "message": {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {
+                                "id": "tool_1",
+                                "function": {
+                                    "name": "search_database",
+                                    "arguments": "{\"query\": \"Databricks history\"}"
+                                }
+                            }
+                        ]
+                    },
+                    "index": 0,
+                    "finish_reason": "stop"
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 58,
+                "completion_tokens": 682,
+                "total_tokens": 740
+            },
+            "object": "chat.completion",
+            "id": "msg_bdrk_01EFhg8GDohjCLRzqaQSKC2b",
+            "created": 1740586881
+        });
+
+        let message = response_to_message(response)?;
+
+        // Check that we properly extracted the tool call from the second choice
+        assert_eq!(message.content.len(), 1);
+        if let MessageContent::ToolRequest(request) = &message.content[0] {
+            let tool_call = request.tool_call.as_ref().unwrap();
+            assert_eq!(tool_call.name, "search_database");
+            assert_eq!(tool_call.arguments, json!({"query": "Databricks history"}));
+        } else {
+            panic!("Expected ToolRequest content");
+        }
+
+        Ok(())
+    }
+}

--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -200,12 +200,12 @@ pub fn response_to_message(response: Value) -> anyhow::Result<Message> {
     // The first one (index 0) contains thinking responses, the second one (index 1) contains the final message
     if response["choices"]
         .as_array()
-        .map_or(false, |choices| choices.len() > 1)
+        .is_some_and(|choices| choices.len() > 1)
     {
         // This might be an Anthropic thinking response
         if let Some(thinking_msg) = response["choices"][0]["message"].as_object() {
             // For thinking messages, content is null
-            if thinking_msg.get("content").map_or(false, |c| c.is_null()) {
+            if thinking_msg.get("content").is_some_and(|c| c.is_null()) {
                 // The actual message is in the second choice
                 if let Some(final_msg) = response["choices"]
                     .as_array()

--- a/crates/goose/src/providers/formats/mod.rs
+++ b/crates/goose/src/providers/formats/mod.rs
@@ -1,4 +1,5 @@
 pub mod anthropic;
 pub mod bedrock;
+pub mod databricks;
 pub mod google;
 pub mod openai;

--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -44,6 +44,14 @@ pub fn format_messages(messages: &[Message], image_format: &ImageFormat) -> Vec<
                         }
                     }
                 }
+                MessageContent::Thinking(_) => {
+                    // Thinking blocks are not directly used in OpenAI format
+                    continue;
+                }
+                MessageContent::RedactedThinking(_) => {
+                    // Redacted thinking blocks are not directly used in OpenAI format
+                    continue;
+                }
                 MessageContent::ToolRequest(request) => match &request.tool_call {
                     Ok(tool_call) => {
                         let sanitized_name = sanitize_function_name(&tool_call.name);


### PR DESCRIPTION
builds on top of https://github.com/block/goose/pull/1370 

This currently fails for the 2nd tool call in agent loop because Databricks uses Open AI SDK and doesn't expose `thinking` & `redacted_thinking` content types which are required by Anthropic. 

To run locally:
```
cargo build

goose configure   # setup Databricks provider with 'claude-3-7-sonnet' model

GOOSE_DEBUG=true GOOSE_CLI_SHOW_THINKING=true ANTHROPIC_THINKING_ENABLED=true ./target/debug/goose session
```

1st tool call will work, then you'll see this error for the 2nd tool call:
```
Response [ 400 Bad Request ]:
{
  "error": "Received error from amazon-bedrock",
  "external_model_message": {
    "message": "messages.3.content.0.type: Expected `thinking` or `redacted_thinking`, but found `tool_use`. When `thinking` is enabled, a final `assistant` message must start with a thinking block (preceeding the lastmost set of `tool_use` and `tool_result` blocks). We recommend you include thinking blocks from previous turns. To avoid this requirement, disable `thinking`."
  }
}

  2025-02-26T16:51:57.885058Z ERROR goose::agents::truncate: Error: Request failed: Request failed with status: 400 Bad Request. Message: messages.3.content.0.type: Expected `thinking` or `redacted_thinking`, but found `tool_use`. When `thinking` is enabled, a final `assistant` message must start with a thinking block (preceeding the lastmost set of `tool_use` and `tool_result` blocks). We recommend you include thinking blocks from previous turns. To avoid this requirement, disable `thinking`.
    at crates/goose/src/agents/truncate.rs:360
```