### PR TITLE
feat: implement notifications handling for extension logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3255,6 +3255,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
  "eventsource-client",
  "futures",
  "mcp-core",

--- a/crates/goose-server/src/routes/reply.rs
+++ b/crates/goose-server/src/routes/reply.rs
@@ -91,6 +91,7 @@ async fn handler(
     headers: HeaderMap,
     Json(request): Json<ChatRequest>,
 ) -> Result<SseResponse, StatusCode> {
+    println!("hello there!");
     // Verify secret key
     let secret_key = headers
         .get("X-Secret-Key")

--- a/crates/goose-server/src/routes/reply.rs
+++ b/crates/goose-server/src/routes/reply.rs
@@ -91,7 +91,6 @@ async fn handler(
     headers: HeaderMap,
     Json(request): Json<ChatRequest>,
 ) -> Result<SseResponse, StatusCode> {
-    println!("hello there!");
     // Verify secret key
     let secret_key = headers
         .get("X-Secret-Key")

--- a/crates/goose/src/agents/capabilities.rs
+++ b/crates/goose/src/agents/capabilities.rs
@@ -114,6 +114,18 @@ impl Capabilities {
             } => {
                 let transport = StdioTransport::new(cmd, args.to_vec(), envs.get_env());
                 let handle = transport.start().await?;
+                eprintln!("added this extension");
+                
+                // Set up logging in the default cache directory
+                let log_path = format!("{}/.cache/goose/logs/{}.log", 
+                    std::env::var("HOME").unwrap_or_else(|_| "~".to_string()),
+                    config.name());
+                if let Err(e) = handle.enable_file_logging(&log_path).await {
+                    tracing::warn!("Failed to enable file logging for {}: {}", config.name(), e);
+                } else {
+                    tracing::info!("Enabled logging for {} at {}", config.name(), log_path);
+                }
+                
                 let service = McpService::with_timeout(handle, Duration::from_secs(300));
                 Box::new(McpClient::new(service))
             }

--- a/crates/goose/src/agents/capabilities.rs
+++ b/crates/goose/src/agents/capabilities.rs
@@ -117,13 +117,21 @@ impl Capabilities {
                 eprintln!("added this extension");
                 
                 // Set up logging in the default cache directory
+                println!("Setting up logging for extension {}", config.name());
                 let log_path = format!("{}/.cache/goose/logs/{}.log", 
                     std::env::var("HOME").unwrap_or_else(|_| "~".to_string()),
                     config.name());
+                println!("Will attempt to create log file at: {}", log_path);
                 if let Err(e) = handle.enable_file_logging(&log_path).await {
-                    tracing::warn!("Failed to enable file logging for {}: {}", config.name(), e);
+                    println!("Failed to enable file logging for {}: {}", config.name(), e);
                 } else {
-                    tracing::info!("Enabled logging for {} at {}", config.name(), log_path);
+                    println!("Enabled logging for {} at {}", config.name(), log_path);
+                    // Verify the file exists
+                    if std::path::Path::new(&log_path).exists() {
+                        println!("Confirmed log file was created at {}", log_path);
+                    } else {
+                        println!("Log file does not exist at {} after setup", log_path);
+                    }
                 }
                 
                 let service = McpService::with_timeout(handle, Duration::from_secs(300));

--- a/crates/mcp-client/Cargo.toml
+++ b/crates/mcp-client/Cargo.toml
@@ -20,5 +20,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tower = { version = "0.4", features = ["timeout", "util"] }
 tower-service = "0.3"
 rand = "0.8"
+chrono = "0.4.39"
 
 [dev-dependencies]

--- a/crates/mcp-client/src/transport/logging/file_logger.rs
+++ b/crates/mcp-client/src/transport/logging/file_logger.rs
@@ -1,0 +1,48 @@
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use chrono::Local;
+
+use super::LogMessage;
+
+pub struct FileLogger {
+    file: Arc<Mutex<File>>,
+}
+
+impl FileLogger {
+    pub fn new(path: PathBuf) -> std::io::Result<Self> {
+        // Create parent directories if they don't exist
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .write(true)
+            .open(path)?;
+
+        Ok(Self {
+            file: Arc::new(Mutex::new(file)),
+        })
+    }
+
+    pub async fn log(&self, message: &LogMessage) -> std::io::Result<()> {
+        let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
+        let log_line = format!(
+            "[{}] [{}] {}: {}\n",
+            timestamp,
+            message.level,
+            message.logger.as_deref().unwrap_or("unknown"),
+            message.message
+        );
+
+        let mut file = self.file.lock().await;
+        file.write_all(log_line.as_bytes())?;
+        file.flush()?;
+
+        Ok(())
+    }
+}

--- a/crates/mcp-client/src/transport/logging/file_logger.rs
+++ b/crates/mcp-client/src/transport/logging/file_logger.rs
@@ -13,17 +13,21 @@ pub struct FileLogger {
 
 impl FileLogger {
     pub fn new(path: PathBuf) -> std::io::Result<Self> {
+        println!("Creating new FileLogger for path: {:?}", path);
         // Create parent directories if they don't exist
         if let Some(parent) = path.parent() {
+            println!("Creating parent directories: {:?}", parent);
             std::fs::create_dir_all(parent)?;
         }
 
+        println!("Opening log file...");
         let file = OpenOptions::new()
             .create(true)
             .append(true)
             .write(true)
-            .open(path)?;
+            .open(&path)?;
 
+        println!("FileLogger successfully created");
         Ok(Self {
             file: Arc::new(Mutex::new(file)),
         })
@@ -39,9 +43,11 @@ impl FileLogger {
             message.message
         );
 
+        println!("Writing log line: {}", log_line.trim());
         let mut file = self.file.lock().await;
         file.write_all(log_line.as_bytes())?;
         file.flush()?;
+        println!("Successfully wrote and flushed log line");
 
         Ok(())
     }

--- a/crates/mcp-client/src/transport/logging/manager.rs
+++ b/crates/mcp-client/src/transport/logging/manager.rs
@@ -1,0 +1,202 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use crate::transport::Error;
+use mcp_core::protocol::{JsonRpcMessage, JsonRpcNotification, JsonRpcRequest};
+
+/// Log levels supported by the MCP protocol
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    Debug,
+    Info,
+    Notice,
+    Warning,
+    Error,
+    Critical,
+    Alert,
+    Emergency,
+}
+
+impl std::fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LogLevel::Debug => write!(f, "DEBUG"),
+            LogLevel::Info => write!(f, "INFO"),
+            LogLevel::Notice => write!(f, "NOTICE"),
+            LogLevel::Warning => write!(f, "WARN"),
+            LogLevel::Error => write!(f, "ERROR"),
+            LogLevel::Critical => write!(f, "CRIT"),
+            LogLevel::Alert => write!(f, "ALERT"),
+            LogLevel::Emergency => write!(f, "EMERG"),
+        }
+    }
+}
+
+/// Logging capability for client/server capability negotiation
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct LoggingCapability {}
+
+/// Parameters for setting the log level
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetLevelParams {
+    pub level: LogLevel,
+}
+
+/// Parameters for logging message notifications
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoggingMessageParams {
+    pub level: LogLevel,
+    pub logger: Option<String>,
+    pub data: Value,
+}
+
+/// A log message received from the server
+#[derive(Debug, Clone)]
+pub struct LogMessage {
+    pub level: LogLevel,
+    pub logger: Option<String>,
+    pub message: String,
+}
+
+/// Handler type for log messages
+pub type LogHandler = Box<dyn Fn(LogMessage) + Send + Sync>;
+
+/// Manages logging state and handlers
+#[derive(Clone)]
+pub struct LoggingManager {
+    handlers: Arc<RwLock<Vec<LogHandler>>>,
+}
+
+impl Default for LoggingManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LoggingManager {
+    pub fn new() -> Self {
+        Self {
+            handlers: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+
+    /// Register a new handler for log messages
+    pub async fn add_handler<F>(&self, handler: F)
+    where
+        F: Fn(LogMessage) + Send + Sync + 'static,
+    {
+        self.handlers.write().await.push(Box::new(handler));
+    }
+
+    /// Handle a logging notification message
+    pub async fn handle_notification(&self, notification: JsonRpcNotification) -> Result<(), Error> {
+        tracing::debug!("LoggingManager handling notification: {:?}", notification);
+        // Parse notification parameters
+        let params: LoggingMessageParams = serde_json::from_value(
+            notification.params.ok_or_else(|| Error::UnsupportedMessage)?,
+        )
+        .map_err(|e| Error::Serialization(e))?;
+
+        // Convert data to string - handle both string and structured data
+        let message = match params.data {
+            Value::String(s) => s,
+            _ => serde_json::to_string(&params.data)
+                .map_err(|e| Error::Serialization(e))?,
+        };
+
+        let log_message = LogMessage {
+            level: params.level,
+            logger: params.logger,
+            message,
+        };
+
+        tracing::debug!("Created log message: {:?}", log_message);
+
+        // Notify all registered handlers
+        for handler in self.handlers.read().await.iter() {
+            handler(log_message.clone());
+        }
+
+        Ok(())
+    }
+}
+
+/// Helper function to handle incoming notifications in the transport
+pub async fn handle_notification(
+    notification: JsonRpcNotification,
+    logging_manager: &LoggingManager,
+) -> Result<(), Error> {
+    match notification.method.as_str() {
+        "notifications/message" => {
+            logging_manager.handle_notification(notification).await?;
+        }
+        _ => {
+            // Ignore other notification types
+            tracing::debug!("Ignoring unknown notification: {}", notification.method);
+        }
+    }
+    Ok(())
+}
+
+/// Helper function to create a setLevel request
+pub fn create_set_level_request(level: LogLevel) -> JsonRpcMessage {
+    JsonRpcMessage::Request(JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: Some(0), // The transport will set the actual ID
+        method: "logging/setLevel".to_string(),
+        params: Some(serde_json::to_value(SetLevelParams { level }).unwrap()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test]
+    async fn test_logging_manager() {
+        let manager = LoggingManager::new();
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_clone = counter.clone();
+
+        // Add a test handler
+        manager
+            .add_handler(move |msg| {
+                assert_eq!(msg.level, LogLevel::Info);
+                assert_eq!(msg.message, "test message");
+                counter_clone.fetch_add(1, Ordering::SeqCst);
+            })
+            .await;
+
+        // Create a test notification
+        let notification = JsonRpcNotification {
+            jsonrpc: "2.0".to_string(),
+            method: "notifications/message".to_string(),
+            params: Some(serde_json::json!({
+                "level": "info",
+                "data": "test message"
+            })),
+        };
+
+        // Handle the notification
+        manager.handle_notification(notification).await.unwrap();
+
+        // Verify the handler was called
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn test_create_set_level_request() {
+        let request = create_set_level_request(LogLevel::Debug);
+        match request {
+            JsonRpcMessage::Request(req) => {
+                assert_eq!(req.method, "logging/setLevel");
+                assert!(req.params.is_some());
+            }
+            _ => panic!("Expected Request"),
+        }
+    }
+}

--- a/crates/mcp-client/src/transport/logging/mod.rs
+++ b/crates/mcp-client/src/transport/logging/mod.rs
@@ -1,0 +1,8 @@
+pub(crate) mod file_logger;
+mod manager;
+
+pub use file_logger::FileLogger;
+pub use manager::{
+    LogLevel, LogMessage, LoggingCapability, LoggingManager, LoggingMessageParams, SetLevelParams,
+    create_set_level_request, handle_notification,
+};

--- a/crates/mcp-client/src/transport/mod.rs
+++ b/crates/mcp-client/src/transport/mod.rs
@@ -125,3 +125,6 @@ pub use stdio::StdioTransport;
 
 pub mod sse;
 pub use sse::SseTransport;
+
+pub mod logging;
+pub use logging::{LogLevel, LogMessage, LoggingManager};

--- a/crates/mcp-client/src/transport/stdio.rs
+++ b/crates/mcp-client/src/transport/stdio.rs
@@ -99,22 +99,25 @@ impl StdioActor {
                             "Received incoming message"
                         );
 
-                        match &message {
+                    match &message {
                             JsonRpcMessage::Response(response) => {
-                                eprintln!("Got response message with id: {:?}", response.id);
+                                tracing::debug!("Got response message with id: {:?}", response.id);
                                 if let Some(id) = &response.id {
                                     pending_requests.respond(&id.to_string(), Ok(message)).await;
                                 }
                             }
                             JsonRpcMessage::Notification(n) => {
-                                eprintln!("Got notification message with method: {}", n.method);
+                                tracing::debug!("Got notification message with method: {}", n.method);
                                 let notification: JsonRpcNotification = n.clone();
+                                if n.method == "notifications/message" {
+                                    println!("Processing log notification with params: {:?}", n.params);
+                                }
                                 if let Err(e) = handle_notification(notification, &logging_manager).await {
                                     tracing::error!("Error handling notification: {:?}", e);
                                 }
                             }
                             _ => {
-                                eprintln!("Got other message type");
+                                tracing::debug!("Got other message type: {:?}", message);
                             }
                         }
                     } else {

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "Apache-2.0"
     },
-    "version": "1.0.9"
+    "version": "1.0.10"
   },
   "paths": {
     "/config": {

--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -96,7 +96,7 @@ function ToolResultView({ result }: ToolResultViewProps) {
 
   const shouldShowExpanded = (item: Content, index: number) => {
     return (
-      (item.annotations.priority !== undefined && item.annotations.priority >= 0.5) ||
+      (item.annotations?.priority !== undefined && item.annotations.priority >= 0.5) ||
       expandedItems.includes(index)
     );
   };
@@ -106,7 +106,7 @@ function ToolResultView({ result }: ToolResultViewProps) {
       {filteredResults.map((item, index) => {
         const isExpanded = shouldShowExpanded(item, index);
         const shouldMinimize =
-          item.annotations.priority === undefined || item.annotations.priority < 0.5;
+          item.annotations?.priority === undefined || item.annotations.priority < 0.5;
         return (
           <div key={index} className="relative">
             {shouldMinimize && (


### PR DESCRIPTION
This will allow developers to view logs from their extensions (servers). For the MCP protocol, logs are emitted as notification-type messages, so this PR expands how we handle server responses to include notifications. 