### PR TITLE
Fix search covering scrollbar

### DIFF
--- a/ui/desktop/src/components/ChatView.tsx
+++ b/ui/desktop/src/components/ChatView.tsx
@@ -387,7 +387,8 @@ export default function ChatView({
             activities={botConfig?.activities || null}
           />
         ) : (
-          <ScrollArea ref={scrollRef} className="flex-1 px-4" autoScroll>
+          /* padding needs to be passed into the container inside ScrollArea to avoid pushing the scrollbar out */
+          <ScrollArea ref={scrollRef} className="flex-1" paddingX={4} autoScroll>
             <SearchView className="mt-[16px]" scrollAreaRef={scrollRef}>
               {filteredMessages.map((message, index) => (
                 <div key={message.id || index} className="mt-[16px] message-content">

--- a/ui/desktop/src/components/ChatView.tsx
+++ b/ui/desktop/src/components/ChatView.tsx
@@ -389,7 +389,7 @@ export default function ChatView({
         ) : (
           /* padding needs to be passed into the container inside ScrollArea to avoid pushing the scrollbar out */
           <ScrollArea ref={scrollRef} className="flex-1" paddingX={4} autoScroll>
-            <SearchView className="mt-[16px]" scrollAreaRef={scrollRef}>
+            <SearchView scrollAreaRef={scrollRef}>
               {filteredMessages.map((message, index) => (
                 <div key={message.id || index} className="mt-[16px] message-content">
                   {isUserMessage(message) ? (

--- a/ui/desktop/src/components/conversation/SearchBar.tsx
+++ b/ui/desktop/src/components/conversation/SearchBar.tsx
@@ -82,7 +82,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({
 
   return (
     <div
-      className={`fixed top-[36px] left-0 right-0 bg-bgAppInverse text-textProminentInverse z-50 ${
+      className={`sticky top-0 left-0 right-0 bg-bgAppInverse text-textProminentInverse z-50 ${
         isExiting ? 'search-bar-exit' : 'search-bar-enter'
       }`}
     >

--- a/ui/desktop/src/components/ui/scroll-area.tsx
+++ b/ui/desktop/src/components/ui/scroll-area.tsx
@@ -12,10 +12,13 @@ export interface ScrollAreaHandle {
 
 interface ScrollAreaProps extends React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> {
   autoScroll?: boolean;
+  /* padding needs to be passed into the container inside ScrollArea to avoid pushing the scrollbar out */
+  paddingX?: number;
+  paddingY?: number;
 }
 
 const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
-  ({ className, children, autoScroll = false, ...props }, ref) => {
+  ({ className, children, autoScroll = false, paddingX, paddingY, ...props }, ref) => {
     const rootRef = React.useRef<React.ElementRef<typeof ScrollAreaPrimitive.Root>>(null);
     const viewportRef = React.useRef<HTMLDivElement>(null);
     const viewportEndRef = React.useRef<HTMLDivElement>(null);
@@ -104,8 +107,10 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
           ref={viewportRef}
           className="h-full w-full rounded-[inherit] [&>div]:!block"
         >
-          {children}
-          {autoScroll && <div ref={viewportEndRef} style={{ height: '1px' }} />}
+          <div className={cn(paddingX ? `px-${paddingX}` : '', paddingY ? `py-${paddingY}` : '')}>
+            {children}
+            {autoScroll && <div ref={viewportEndRef} style={{ height: '1px' }} />}
+          </div>
         </ScrollAreaPrimitive.Viewport>
         <ScrollBar />
         <ScrollAreaPrimitive.Corner />


### PR DESCRIPTION
The new search component is over the scroll bar which can be problematic when the scrollbar is smaller and the user can't reach it. Changed to use `sticky` rather than `fixed` so it stays within its container. Not as pretty as full width but we'd need to add way more code to get `fixed` to respect all types of scrollbar widths on different OSs so this is a simple solution for now.

Before:
<img width="1074" alt="Screenshot 2025-03-31 at 6 10 44 PM" src="https://github.com/user-attachments/assets/6680f25d-f863-4094-8075-8c0807f6eb4a" />

After:
<img width="1074" alt="Screenshot 2025-03-31 at 6 08 42 PM" src="https://github.com/user-attachments/assets/22a6333d-e59d-47e8-958d-c47b5bbc75b2" />

