### PR TITLE
[experiment] feat: implement nested streaming for tool approval requests

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -352,6 +352,7 @@ impl Agent {
                         // Reset truncation attempt
                         truncation_attempt = 0;
 
+                        // categorize the type of requests we need to handle
                         let (frontend_requests,
                             enable_extension_requests,
                             search_extension_requests,
@@ -379,7 +380,9 @@ impl Agent {
                             message_tool_response.clone()
                         );
 
-                        // we have a stream of frontend tools to handle, yield each back to the caller
+                        // we have a stream of frontend tools to handle, inside the stream
+                        // execution is yeield back to this reply loop, and is of the same Message
+                        // type, so we can yield that back up to be handled
                         while let Some(msg) = frontend_tool_stream.try_next().await? {
                             yield msg;
                         }
@@ -433,7 +436,10 @@ impl Agent {
                             message_tool_response.clone()
                         );
 
-                        // we have a stream of enable_extension_requests to handle, yield each back to the caller
+                        // we have a stream of enable_extension_requests to handle
+                        // execution is yeield back to this reply loop, and is of the same Message
+                        // type, so we can yield the Message back up to be handled and grab and
+                        // confirmations or denials
                         while let Some(msg) = enable_extension_stream.try_next().await? {
                             yield msg;
                         }
@@ -481,6 +487,10 @@ impl Agent {
                             message_tool_response.clone()
                         );
 
+                        // we have a stream of tool_approval_requests to handle
+                        // execution is yeield back to this reply loop, and is of the same Message
+                        // type, so we can yield the Message back up to be handled and grab and
+                        // confirmations or denials
                         while let Some(msg) = tool_approval_stream.try_next().await? {
                             yield msg;
                         }

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -31,6 +31,7 @@ use mcp_core::{
     prompt::Prompt, protocol::GetPromptResult, tool::Tool, Content, ToolError, ToolResult,
 };
 
+use super::tool_execution::ExtensionInstallResult;
 use super::tool_execution::ToolFuture;
 
 const MAX_TRUNCATION_ATTEMPTS: usize = 3;
@@ -423,7 +424,7 @@ impl Agent {
 
                         // Handle pre-approved and read-only tools in parallel
                         let mut tool_futures: Vec<ToolFuture> = Vec::new();
-                        let mut install_results: Vec<(String, Result<Vec<Content>, ToolError>)> = Vec::new();
+                        let mut install_results: Vec<ExtensionInstallResult> = Vec::new();
                         let install_results_arc = Arc::new(Mutex::new(install_results));
 
                         let mut enable_extension_stream = self.handle_enable_extension_requests(

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
@@ -33,6 +31,8 @@ use crate::agents::types::{FrontendTool, ToolResultReceiver};
 use mcp_core::{
     prompt::Prompt, protocol::GetPromptResult, tool::Tool, Content, ToolError, ToolResult,
 };
+
+use super::tool_execution::ToolFuture;
 
 const MAX_TRUNCATION_ATTEMPTS: usize = 3;
 const ESTIMATE_FACTOR_DECAY: f32 = 0.9;
@@ -444,7 +444,7 @@ impl Agent {
                                                             self.provider()).await;
 
                             // Handle pre-approved and read-only tools in parallel
-                            let mut tool_futures: Vec<Pin<Box<dyn Future<Output = (String, Result<Vec<mcp_core::Content>, ToolError>)> + Send>>> = Vec::new();
+                            let mut tool_futures: Vec<ToolFuture> = Vec::new();
                             let mut install_results = Vec::new();
 
                             let denied_content_text = Content::text(

--- a/crates/goose/src/agents/categorize.rs
+++ b/crates/goose/src/agents/categorize.rs
@@ -1,0 +1,124 @@
+use std::collections::HashSet;
+
+use crate::agents::platform_tools::PLATFORM_ENABLE_EXTENSION_TOOL_NAME;
+use crate::agents::platform_tools::PLATFORM_SEARCH_AVAILABLE_EXTENSIONS_TOOL_NAME;
+use crate::agents::Agent;
+use crate::config::PermissionManager;
+use crate::message::{Message, MessageContent, ToolRequest};
+use crate::permission::permission_judge::check_tool_permissions;
+
+impl Agent {
+    /// Categorize tool requests from the response into different types
+    /// Returns:
+    /// - frontend_requests: Tool requests that should be handled by the frontend
+    /// - enable_extension_requests: Requests to enable extensions
+    /// - search_extension_requests: Requests to search for extensions
+    /// - other_requests: All other tool requests
+    /// - filtered_message: The original message with tool requests removed
+    pub(crate) fn categorize_tool_requests(
+        &self,
+        response: &Message,
+    ) -> (
+        Vec<ToolRequest>,
+        Vec<ToolRequest>,
+        Vec<ToolRequest>,
+        Vec<ToolRequest>,
+        Message,
+    ) {
+        // First collect any tool requests
+        let tool_requests: Vec<ToolRequest> = response
+            .content
+            .iter()
+            .filter_map(|content| {
+                if let MessageContent::ToolRequest(req) = content {
+                    Some(req.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // Create a filtered message with tool requests removed
+        let filtered_content = response
+            .content
+            .iter()
+            .filter(|c| !matches!(c, MessageContent::ToolRequest(_)))
+            .cloned()
+            .collect();
+
+        let filtered_message = Message {
+            role: response.role.clone(),
+            created: response.created,
+            content: filtered_content,
+        };
+
+        // Categorize tool requests
+        let mut frontend_requests = Vec::new();
+        let mut enable_extension_requests = Vec::new();
+        let mut search_extension_requests = Vec::new();
+        let mut other_requests = Vec::new();
+
+        for request in tool_requests {
+            if let Ok(tool_call) = &request.tool_call {
+                if self.is_frontend_tool(&tool_call.name) {
+                    frontend_requests.push(request);
+                } else if tool_call.name == PLATFORM_ENABLE_EXTENSION_TOOL_NAME {
+                    enable_extension_requests.push(request);
+                } else if tool_call.name == PLATFORM_SEARCH_AVAILABLE_EXTENSIONS_TOOL_NAME {
+                    search_extension_requests.push(request);
+                } else {
+                    other_requests.push(request);
+                }
+            } else {
+                // If there's an error in the tool call, add it to other_requests
+                other_requests.push(request);
+            }
+        }
+
+        (
+            frontend_requests,
+            enable_extension_requests,
+            search_extension_requests,
+            other_requests,
+            filtered_message,
+        )
+    }
+
+    pub(crate) async fn categorize_regular_tool_requests(
+        &self,
+        tool_requests: &[ToolRequest],
+        mode: &str,
+        tools_with_readonly_annotation: HashSet<String>,
+        tools_without_annotation: HashSet<String>,
+    ) -> (Vec<ToolRequest>, Vec<ToolRequest>, Vec<ToolRequest>) {
+        let mut permission_manager = PermissionManager::default();
+
+        // Skip the platform tools for permission checks
+        let filtered_requests: Vec<&ToolRequest> = tool_requests
+            .iter()
+            .filter(|req| {
+                if let Ok(tool_call) = &req.tool_call {
+                    !tool_call.name.starts_with("platform__")
+                } else {
+                    true // If there's an error (Err), don't skip the request
+                }
+            })
+            .collect();
+
+        let permission_check_result = check_tool_permissions(
+            filtered_requests,
+            mode,
+            tools_with_readonly_annotation.clone(),
+            tools_without_annotation.clone(),
+            &mut permission_manager,
+            self.provider(),
+        )
+        .await;
+
+        (
+            permission_check_result.approved,
+            permission_check_result.denied,
+            permission_check_result.needs_approval,
+        )
+    }
+}

--- a/crates/goose/src/agents/mod.rs
+++ b/crates/goose/src/agents/mod.rs
@@ -4,6 +4,7 @@ pub mod extension_manager;
 pub mod platform_tools;
 pub mod prompt_manager;
 mod reply_parts;
+mod tool_execution;
 mod types;
 
 pub use agent::Agent;

--- a/crates/goose/src/agents/mod.rs
+++ b/crates/goose/src/agents/mod.rs
@@ -1,4 +1,5 @@
 mod agent;
+mod categorize;
 pub mod extension;
 pub mod extension_manager;
 pub mod platform_tools;

--- a/crates/goose/src/agents/tool_execution.rs
+++ b/crates/goose/src/agents/tool_execution.rs
@@ -1,0 +1,86 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use async_stream::try_stream;
+use futures::stream::BoxStream;
+use futures::stream::StreamExt;
+use tokio::sync::Mutex;
+
+use crate::config::permission::PermissionLevel;
+use crate::config::PermissionManager;
+use crate::message::{Message, ToolRequest};
+use crate::permission::Permission;
+use mcp_core::{Content, ToolError};
+
+use crate::agents::Agent;
+
+impl Agent {
+    pub(crate) fn handle_approval_tool_requests<'a>(
+        &'a self,
+        tool_requests: &'a [ToolRequest],
+        tool_futures: Arc<
+            Mutex<
+                Vec<
+                    Pin<
+                        Box<
+                            dyn Future<Output = (String, Result<Vec<mcp_core::Content>, ToolError>)>
+                                + Send
+                                + 'a,
+                        >,
+                    >,
+                >,
+            >,
+        >,
+        permission_manager: &'a mut PermissionManager,
+        message_tool_response: Arc<Mutex<Message>>,
+    ) -> BoxStream<'a, anyhow::Result<Message>> {
+        try_stream! {
+
+            for request in tool_requests {
+                if let Ok(tool_call) = request.tool_call.clone() {
+                    let confirmation = Message::user().with_tool_confirmation_request(
+                        request.id.clone(),
+                        tool_call.name.clone(),
+                        tool_call.arguments.clone(),
+                        Some("Goose would like to call the above tool. Allow? (y/n):".to_string()),
+                    );
+
+                    yield confirmation;
+
+                    let mut rx = self.confirmation_rx.lock().await;
+                    while let Some((req_id, tool_confirmation)) = rx.recv().await {
+                        if req_id == request.id {
+                            let confirmed = tool_confirmation.permission == Permission::AllowOnce|| tool_confirmation.permission == Permission::AlwaysAllow;
+                            if confirmed {
+                                // Add this tool call to the futures collection
+                                let tool_future = self.dispatch_tool_call(tool_call.clone(), request.id.clone());
+                                let mut futures = tool_futures.lock().await;
+                                futures.push(Box::pin(tool_future));
+
+                                if tool_confirmation.permission == Permission::AlwaysAllow {
+                                    permission_manager.update_user_permission(&tool_call.name, PermissionLevel::AlwaysAllow);
+                                }
+                            } else {
+                                // User declined - add declined response
+                                let denied_content_text = Content::text(
+                                    "The user has declined to run this tool. \
+                                    DO NOT attempt to call this tool again. \
+                                    If there are no alternative methods to proceed, clearly explain the situation and STOP.");
+                                let mut response = message_tool_response.lock().await;
+                                *response = response.clone().with_tool_response(
+                                    request.id.clone(),
+                                    Ok(vec![denied_content_text.clone()]),
+                                );
+                            }
+                            break; // Exit the loop once the matching `req_id` is found
+                        }
+                    }
+                }
+
+            }
+
+        }
+        .boxed()
+    }
+}

--- a/crates/goose/src/agents/tool_execution.rs
+++ b/crates/goose/src/agents/tool_execution.rs
@@ -23,6 +23,9 @@ use mcp_core::{Content, ToolError};
 pub(crate) type ToolFuture<'a> =
     Pin<Box<dyn Future<Output = (String, Result<Vec<Content>, ToolError>)> + Send + 'a>>;
 pub(crate) type ToolFuturesVec<'a> = Arc<Mutex<Vec<ToolFuture<'a>>>>;
+// Type alias for extension installation results
+pub(crate) type ExtensionInstallResult = (String, Result<Vec<Content>, ToolError>);
+pub(crate) type ExtensionInstallResults = Arc<Mutex<Vec<ExtensionInstallResult>>>;
 
 use crate::agents::Agent;
 
@@ -112,7 +115,7 @@ impl Agent {
     pub(crate) fn handle_enable_extension_requests<'a>(
         &'a self,
         tool_requests: &'a [ToolRequest],
-        install_results: Arc<Mutex<Vec<(String, Result<Vec<Content>, ToolError>)>>>,
+        install_results: ExtensionInstallResults,
         message_tool_response: Arc<Mutex<Message>>,
     ) -> BoxStream<'a, anyhow::Result<Message>> {
         let denied_content_text = Content::text(

--- a/crates/goose/src/agents/tool_execution.rs
+++ b/crates/goose/src/agents/tool_execution.rs
@@ -1,29 +1,38 @@
+use mcp_core::ToolCall;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use tracing::debug;
 
 use async_stream::try_stream;
 use futures::stream::BoxStream;
 use futures::stream::StreamExt;
 use tokio::sync::Mutex;
 
+use crate::agents::platform_tools::{
+    PLATFORM_LIST_RESOURCES_TOOL_NAME, PLATFORM_READ_RESOURCE_TOOL_NAME,
+    PLATFORM_SEARCH_AVAILABLE_EXTENSIONS_TOOL_NAME,
+};
 use crate::config::permission::PermissionLevel;
 use crate::config::PermissionManager;
 use crate::message::{Message, ToolRequest};
 use crate::permission::Permission;
 use mcp_core::{Content, ToolError};
 
-// Type alias to reduce complexity
+// Type alias for ToolFutures - used in the agent loop to join all futures together
 pub(crate) type ToolFuture<'a> =
     Pin<Box<dyn Future<Output = (String, Result<Vec<Content>, ToolError>)> + Send + 'a>>;
 pub(crate) type ToolFuturesVec<'a> = Arc<Mutex<Vec<ToolFuture<'a>>>>;
 
 use crate::agents::Agent;
 
+use super::ExtensionManager;
+
 impl Agent {
     pub(crate) fn handle_approval_tool_requests<'a>(
         &'a self,
-        tool_requests: &'a [ToolRequest],
+        //tool_requests: &'a [ToolRequest],
+        tool_requests: Vec<ToolRequest>,
         tool_futures: ToolFuturesVec<'a>,
         permission_manager: &'a mut PermissionManager,
         message_tool_response: Arc<Mutex<Message>>,
@@ -72,5 +81,160 @@ impl Agent {
             }
         }
         .boxed()
+    }
+
+    pub(crate) fn handle_frontend_tool_requests<'a>(
+        &'a self,
+        tool_requests: &'a [ToolRequest],
+        message_tool_response: Arc<Mutex<Message>>,
+    ) -> BoxStream<'a, anyhow::Result<Message>> {
+        try_stream! {
+            for request in tool_requests {
+                if let Ok(tool_call) = request.tool_call.clone() {
+                    if self.is_frontend_tool(&tool_call.name) {
+                        // Send frontend tool request and wait for response
+                        yield Message::assistant().with_frontend_tool_request(
+                            request.id.clone(),
+                            Ok(tool_call.clone())
+                        );
+
+                        if let Some((id, result)) = self.tool_result_rx.lock().await.recv().await {
+                            let mut response = message_tool_response.lock().await;
+                            *response = response.clone().with_tool_response(id, result);
+                        }
+                    }
+                }
+            }
+        }
+        .boxed()
+    }
+
+    pub(crate) fn handle_enable_extension_requests<'a>(
+        &'a self,
+        tool_requests: &'a [ToolRequest],
+        install_results: Arc<Mutex<Vec<(String, Result<Vec<Content>, ToolError>)>>>,
+        message_tool_response: Arc<Mutex<Message>>,
+    ) -> BoxStream<'a, anyhow::Result<Message>> {
+        let denied_content_text = Content::text(
+                                "The user has declined to run this tool. \
+                                DO NOT attempt to call this tool again. \
+                                If there are no alternative methods to proceed, clearly explain the situation and STOP.");
+        try_stream! {
+            for extension_request in tool_requests {
+                if let Ok(tool_call) = extension_request.tool_call.clone() {
+                    let confirmation = Message::user().with_enable_extension_request(
+                        extension_request.id.clone(),
+                        tool_call
+                            .arguments
+                            .get("extension_name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string(),
+                    );
+
+                    yield confirmation;
+
+                    let mut rx = self.confirmation_rx.lock().await;
+                    while let Some((req_id, extension_confirmation)) = rx.recv().await {
+                        if req_id == extension_request.id {
+                            if extension_confirmation.permission == Permission::AllowOnce || extension_confirmation.permission == Permission::AlwaysAllow {
+                                let extension_name = tool_call
+                                    .arguments
+                                    .get("extension_name")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("")
+                                    .to_string();
+
+                                let mut results = install_results.lock().await;
+
+                                let install_result = self.enable_extension(
+                                    extension_name.clone(),
+                                    extension_request.id.clone(),
+                                ).await;
+
+                                results.push(install_result);
+                            } else {
+                                // User declined - add declined response
+                                let mut response = message_tool_response.lock().await;
+                                *response = response.clone().with_tool_response(
+                                    extension_request.id.clone(),
+                                    Ok(vec![denied_content_text.clone()]),
+                                );
+                            }
+                            break; // Exit the loop once the matching `req_id` is found
+                        }
+                    }
+                }
+            }
+        }
+        .boxed()
+    }
+
+    pub(crate) async fn handle_search_extension_requests<'a>(
+        &'a self,
+        tool_requests: &'a [ToolRequest],
+        message_tool_response: Arc<Mutex<Message>>,
+    ) {
+        let extension_manager = self.extension_manager.lock().await;
+        let mut tool_futures = Vec::new();
+
+        for search_request in tool_requests {
+            if let Ok(tool_call) = search_request.tool_call.clone() {
+                let is_frontend_tool = self.is_frontend_tool(&tool_call.name);
+
+                let tool_future = Self::create_tool_future(
+                    &extension_manager,
+                    tool_call,
+                    is_frontend_tool,
+                    search_request.id.clone(),
+                );
+
+                tool_futures.push(tool_future);
+            }
+        }
+
+        // Wait for all tool calls to complete
+        let results = futures::future::join_all(tool_futures).await;
+        for (request_id, output) in results {
+            let mut response = message_tool_response.lock().await;
+            *response = response.clone().with_tool_response(request_id, output);
+        }
+    }
+
+    /// Create a future that will execute a tool call
+    pub(crate) async fn create_tool_future(
+        extension_manager: &ExtensionManager,
+        tool_call: ToolCall,
+        is_frontend_tool: bool,
+        request_id: String,
+    ) -> (String, Result<Vec<Content>, ToolError>) {
+        let result = if tool_call.name == PLATFORM_READ_RESOURCE_TOOL_NAME {
+            // Check if the tool is read_resource and handle it separately
+            extension_manager
+                .read_resource(tool_call.arguments.clone())
+                .await
+        } else if tool_call.name == PLATFORM_LIST_RESOURCES_TOOL_NAME {
+            extension_manager
+                .list_resources(tool_call.arguments.clone())
+                .await
+        } else if tool_call.name == PLATFORM_SEARCH_AVAILABLE_EXTENSIONS_TOOL_NAME {
+            extension_manager.search_available_extensions().await
+        } else if is_frontend_tool {
+            // For frontend tools, return an error indicating we need frontend execution
+            Err(ToolError::ExecutionError(
+                "Frontend tool execution required".to_string(),
+            ))
+        } else {
+            extension_manager
+                .dispatch_tool_call(tool_call.clone())
+                .await
+        };
+
+        debug!(
+            "input" = serde_json::to_string(&tool_call).unwrap(),
+            "output" = serde_json::to_string(&result).unwrap(),
+        );
+
+        (request_id, result)
     }
 }


### PR DESCRIPTION
- extracts tool approval request handling to a separate nested stream function
- we need a lot of Arc<Mutex<>> for thread-safe interior mutability across functions
- test implementing try_stream pattern for handling approval tool requests

chore: cleanup old section as example

- [ ] gonna need some type definitions for the input to `handle_approval_tool_requests` its pretty gnarly 