### PR TITLE
feat: Make configuration ephemeral for goose

### DIFF
--- a/crates/goose-ffi/README.md
+++ b/crates/goose-ffi/README.md
@@ -69,6 +69,18 @@ You need to have Python 3.6+ installed with the `ctypes` module (included in sta
 
 The agent will respond with information about the Eiffel Tower.
 
+We also include a Dockerfile to run the example from the Dockerfile, this also enables testing in the read only mode
+```bash
+
+CROSS_BUILD_OPTS="--platform linux/amd64 --no-cache" CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build -p goose-ffi --release --target x86_64-unknown-linux-gnu
+docker build -t goose-agent --platform=linux/amd64 -f Dockerfile .
+
+docker run -it --read-only  --platform=linux/amd64 \
+    -e DATABRICKS_API_KEY=...\
+    -e DATABRICKS_HOST=... \
+    -e RUST_BACKTRACE=full \
+    goose-agent
+```
 ## Using from Other Languages
 
 The Goose FFI library can be used from many programming languages with C FFI support, including:

--- a/crates/goose-ffi/examples/Dockerfile
+++ b/crates/goose-ffi/examples/Dockerfile
@@ -1,0 +1,24 @@
+FROM --platform=linux/amd64 python:3.11-slim
+
+WORKDIR /app
+
+# Create a non-root user
+RUN useradd -m gooseuser
+
+# Copy the Python example and pre-built library
+COPY goose_agent.py /app/
+COPY ../../../target/x86_64-unknown-linux-gnu/release/libgoose_ffi.so /app/
+
+# Modify the Python script to use the local library path
+RUN sed -i 's|LIB_PATH = os.path.join(os.path.dirname(__file__), "../../..", "target", "debug", LIB_NAME)|LIB_PATH = "/app/libgoose_ffi.so"|g' /app/goose_agent.py && \
+    chmod +x /app/goose_agent.py
+
+# Set read-only filesystem for security
+VOLUME ["/tmp"]
+ENV PYTHONUNBUFFERED=1
+
+# Switch to non-root user
+USER gooseuser
+
+# Run the example with API key
+CMD ["python3", "goose_agent.py"]

--- a/crates/goose-ffi/examples/goose_agent.py
+++ b/crates/goose-ffi/examples/goose_agent.py
@@ -48,6 +48,7 @@ class ProviderConfig(Structure):
         ("api_key", c_char_p),
         ("model_name", c_char_p),
         ("host", c_char_p),
+        ("ephemeral", c_bool),
     ]
 
 class AsyncResult(Structure):
@@ -73,12 +74,13 @@ goose.goose_free_async_result.argtypes = [POINTER(AsyncResult)]
 goose.goose_free_async_result.restype = None
 
 class GooseAgent:
-    def __init__(self, provider_type=ProviderType.DATABRICKS, api_key=None, model_name=None, host=None):
+    def __init__(self, provider_type=ProviderType.DATABRICKS, api_key=None, model_name=None, host=None, ephemeral=False):
         self.config = ProviderConfig(
             provider_type=provider_type,
             api_key=api_key.encode("utf-8") if api_key else None,
             model_name=model_name.encode("utf-8") if model_name else None,
             host=host.encode("utf-8") if host else None,
+            ephemeral=ephemeral,
         )
         self.agent = goose.goose_agent_new(ctypes.byref(self.config))
         if not self.agent:
@@ -102,7 +104,9 @@ class GooseAgent:
 def main():
     api_key = os.getenv("DATABRICKS_API_KEY")
     host = os.getenv("DATABRICKS_HOST")
-    agent = GooseAgent(api_key=api_key, model_name="claude-3-7-sonnet", host=host)
+
+    # Create agent with ephemeral config
+    agent = GooseAgent(api_key=api_key, model_name="claude-3-7-sonnet", host=host, ephemeral=True)
 
     print("Type a message (or 'quit' to exit):")
     while True:

--- a/crates/goose-ffi/include/goose_ffi.h
+++ b/crates/goose-ffi/include/goose_ffi.h
@@ -46,12 +46,14 @@ typedef goose_Agent *goose_AgentPtr;
  - api_key: Provider API key (null for default from environment variables)
  - model_name: Model name to use (null for provider default)
  - host: Provider host URL (null for default from environment variables)
+ - ephemeral: Whether to use ephemeral in-memory configuration (true) or persistent configuration (false)
  */
 typedef struct goose_ProviderConfigFFI {
   goose_ProviderType provider_type;
   const char *api_key;
   const char *model_name;
   const char *host;
+  bool ephemeral;
 } goose_ProviderConfigFFI;
 
 /*

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -35,9 +35,10 @@ impl Agent {
         let model_name = &model_config.model_name;
 
         let mut system_prompt = self.prompt_manager.build_system_prompt(
+            &self.config,
             extensions_info,
             self.frontend_instructions.clone(),
-            Some(model_name),
+            Some(model_name.as_str()),
         );
 
         // Handle toolshim if enabled

--- a/crates/goose/src/config/mod.rs
+++ b/crates/goose/src/config/mod.rs
@@ -4,7 +4,7 @@ pub mod extensions;
 pub mod permission;
 
 pub use crate::agents::ExtensionConfig;
-pub use base::{Config, ConfigError, APP_STRATEGY};
+pub use base::{is_in_memory, set_in_memory, Config, ConfigError, APP_STRATEGY};
 pub use experiments::ExperimentManager;
 pub use extensions::{ExtensionConfigManager, ExtensionEntry};
 pub use permission::PermissionManager;

--- a/crates/goose/src/permission/permission_store.rs
+++ b/crates/goose/src/permission/permission_store.rs
@@ -1,3 +1,4 @@
+use crate::config::is_in_memory;
 use crate::message::ToolRequest;
 use anyhow::Result;
 use blake3::Hasher;
@@ -19,12 +20,38 @@ pub struct ToolPermissionRecord {
     expiry: Option<i64>, // Optional expiry timestamp
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+/// Storage type for permissions
+///
+/// This enum represents different storage backends for permissions:
+/// - Memory: Ephemeral in-memory storage that doesn't persist to disk
+/// - File: Persistent storage on disk
+///
+/// The Memory variant is thread-safe and can be safely shared across threads.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+enum StorageType {
+    #[serde(skip_serializing, skip_deserializing)]
+    Memory {
+        #[allow(dead_code)]
+        id: String, // Unique ID for debugging and distinguishing instances
+    },
+    #[serde(skip_serializing, skip_deserializing)]
+    File { permissions_dir: PathBuf },
+}
+
+impl Default for StorageType {
+    fn default() -> Self {
+        StorageType::File {
+            permissions_dir: PathBuf::from(".config/goose"),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ToolPermissionStore {
     permissions: HashMap<String, Vec<ToolPermissionRecord>>,
     version: u32, // For future schema migrations
     #[serde(skip)] // Don't serialize this field
-    permissions_dir: PathBuf,
+    storage: StorageType,
 }
 
 impl Default for ToolPermissionStore {
@@ -35,6 +62,17 @@ impl Default for ToolPermissionStore {
 
 impl ToolPermissionStore {
     pub fn new() -> Self {
+        // Check if we should use in-memory storage
+        if is_in_memory() {
+            // Generate a unique ID for this in-memory instance
+            let instance_id = format!("memory-{}", uuid::Uuid::new_v4());
+            return Self {
+                permissions: HashMap::new(),
+                version: 1,
+                storage: StorageType::Memory { id: instance_id },
+            };
+        }
+
         let permissions_dir = choose_app_strategy(crate::config::APP_STRATEGY.clone())
             .map(|strategy| strategy.config_dir())
             .unwrap_or_else(|_| PathBuf::from(".config/goose"));
@@ -42,13 +80,35 @@ impl ToolPermissionStore {
         Self {
             permissions: HashMap::new(),
             version: 1,
-            permissions_dir,
+            storage: StorageType::File { permissions_dir },
+        }
+    }
+
+    pub fn new_in_memory() -> Self {
+        // Generate a unique ID for this in-memory instance
+        let instance_id = format!("memory-{}", uuid::Uuid::new_v4());
+        Self {
+            permissions: HashMap::new(),
+            version: 1,
+            storage: StorageType::Memory { id: instance_id },
         }
     }
 
     pub fn load() -> Result<Self> {
         let store = Self::new();
-        let file_path = store.permissions_dir.join("tool_permissions.json");
+
+        // If using in-memory storage, just return the empty store
+        if let StorageType::Memory { .. } = &store.storage {
+            return Ok(store);
+        }
+
+        // Get the permissions directory from the File storage
+        let permissions_dir = match &store.storage {
+            StorageType::File { permissions_dir } => permissions_dir.clone(),
+            _ => unreachable!(), // We already checked for Memory above
+        };
+
+        let file_path = permissions_dir.join("tool_permissions.json");
 
         if !file_path.exists() {
             return Ok(store);
@@ -56,7 +116,9 @@ impl ToolPermissionStore {
 
         let file = File::open(file_path)?;
         let mut permissions: ToolPermissionStore = serde_json::from_reader(file)?;
-        permissions.permissions_dir = store.permissions_dir;
+
+        // Update the storage type to match the original store
+        permissions.storage = store.storage;
 
         // Clean up expired entries on load
         permissions.cleanup_expired()?;
@@ -65,9 +127,20 @@ impl ToolPermissionStore {
     }
 
     pub fn save(&self) -> anyhow::Result<()> {
-        std::fs::create_dir_all(&self.permissions_dir)?;
+        // If using in-memory storage, we don't need to save to disk
+        if let StorageType::Memory { .. } = &self.storage {
+            return Ok(());
+        }
 
-        let path = self.permissions_dir.join("tool_permissions.json");
+        // Get the permissions directory from the File storage
+        let permissions_dir = match &self.storage {
+            StorageType::File { permissions_dir } => permissions_dir,
+            _ => unreachable!(), // We already checked for Memory above
+        };
+
+        std::fs::create_dir_all(permissions_dir)?;
+
+        let path = permissions_dir.join("tool_permissions.json");
         let temp_path = path.with_extension("tmp");
 
         // Write complete content to temporary file
@@ -144,6 +217,161 @@ impl ToolPermissionStore {
         if changed {
             self.save()?;
         }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_in_memory_permission_store() -> anyhow::Result<()> {
+        // Create an in-memory store
+        let mut store = ToolPermissionStore::new_in_memory();
+
+        // Create a mock tool call
+        let tool_call = mcp_core::tool::ToolCall {
+            name: "test_tool".to_string(),
+            arguments: serde_json::json!({"key": "value"}),
+        };
+
+        // Create a mock tool request
+        let tool_request = ToolRequest {
+            id: "test_id".to_string(),
+            tool_call: Ok(tool_call),
+        };
+
+        // Record a permission
+        store.record_permission(&tool_request, true, None)?;
+
+        // Check if the permission was recorded
+        let permission = store.check_permission(&tool_request);
+        assert_eq!(permission, Some(true));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_permission_store_isolation() -> anyhow::Result<()> {
+        // Create two separate in-memory stores
+        let mut store1 = ToolPermissionStore::new_in_memory();
+        let store2 = ToolPermissionStore::new_in_memory();
+
+        // Create tool calls with different arguments to get different hashes
+        let tool_call1 = mcp_core::tool::ToolCall {
+            name: "test_tool".to_string(),
+            arguments: serde_json::json!({"key": "value1"}),
+        };
+
+        // Create the tool requests with different arguments
+        let tool_request1 = ToolRequest {
+            id: "test_id".to_string(),
+            tool_call: Ok(tool_call1.clone()),
+        };
+
+        // Record permissions in both stores
+        store1.record_permission(&tool_request1, true, None)?;
+
+        // Verify the first store has the permission record
+        assert_eq!(store1.check_permission(&tool_request1), Some(true));
+
+        // The second store shouldn't have any records for this request
+        // This verifies isolation between store instances
+        assert_eq!(store2.check_permission(&tool_request1), None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_in_memory_mode_permission_store() -> anyhow::Result<()> {
+        // Enable in-memory mode
+        crate::config::set_in_memory(true);
+
+        // Create a store - should be in-memory due to the flag
+        let mut store = ToolPermissionStore::new();
+
+        // Create a mock tool call
+        let tool_call = mcp_core::tool::ToolCall {
+            name: "test_tool".to_string(),
+            arguments: serde_json::json!({"key": "value"}),
+        };
+
+        // Create a mock tool request
+        let tool_request = ToolRequest {
+            id: "test_id".to_string(),
+            tool_call: Ok(tool_call),
+        };
+
+        // Record a permission
+        store.record_permission(&tool_request, true, None)?;
+
+        // Check if the permission was recorded
+        let permission = store.check_permission(&tool_request);
+        assert_eq!(permission, Some(true));
+
+        // Clean up
+        crate::config::set_in_memory(false);
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_permission_store_concurrent() -> anyhow::Result<()> {
+        let store1 = ToolPermissionStore::new_in_memory();
+        let store2 = ToolPermissionStore::new_in_memory();
+
+        // Clone the stores to move into threads
+        let store1_clone = store1.clone();
+        let store2_clone = store2.clone();
+
+        let t1 = tokio::spawn(async move {
+            let mut store = store1_clone;
+
+            // Create tool call inside the thread
+            let tool_call = mcp_core::tool::ToolCall {
+                name: "test_tool".to_string(),
+                arguments: serde_json::json!({"key": "value1"}),
+            };
+
+            let tool_request = ToolRequest {
+                id: "test_id1".to_string(),
+                tool_call: Ok(tool_call),
+            };
+
+            store.record_permission(&tool_request, true, None)?;
+            let permission = store.check_permission(&tool_request);
+            assert_eq!(permission, Some(true));
+
+            Ok::<(), anyhow::Error>(())
+        });
+
+        let t2 = tokio::spawn(async move {
+            let mut store = store2_clone;
+
+            // Create a separate tool call inside the thread
+            let tool_call = mcp_core::tool::ToolCall {
+                name: "test_tool".to_string(),
+                arguments: serde_json::json!({"key": "value2"}),
+            };
+
+            let tool_request = ToolRequest {
+                id: "test_id2".to_string(),
+                tool_call: Ok(tool_call),
+            };
+
+            store.record_permission(&tool_request, false, None)?;
+            let permission = store.check_permission(&tool_request);
+            assert_eq!(permission, Some(false));
+
+            Ok::<(), anyhow::Error>(())
+        });
+
+        let res1 = t1.await.unwrap();
+        let res2 = t2.await.unwrap();
+        res1?;
+        res2?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
This is to allow ffi interfaces to use goose in ephemeral mode, I have tested this in a read only docker environment