### PR TITLE
PoC: make tool calling more compact in GUI

### DIFF
--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -14,6 +14,7 @@ import { ToastContainer } from 'react-toastify';
 import { toastService } from './toasts';
 import { settingsV2Enabled } from './flags';
 import { extractExtensionName } from './components/settings/extensions/utils';
+import { ToolCallViewProvider } from './components/ToolCallViewMode';
 import { GoosehintsModal } from './components/GoosehintsModal';
 import { SessionDetails } from './sessions';
 
@@ -738,117 +739,119 @@ export default function App() {
           onCancel={handleCancel}
         />
       )}
-      <div className="relative w-screen h-screen overflow-hidden bg-bgApp flex flex-col">
-        <div className="titlebar-drag-region" />
-        <div>
-          {view === 'loading' && <SuspenseLoader />}
-          {view === 'welcome' &&
-            (settingsV2Enabled ? (
-              <ProviderSettings onClose={() => setView('chat')} isOnboarding={true} />
-            ) : (
-              <WelcomeView
-                onSubmit={() => {
-                  setView('chat');
-                }}
-              />
-            ))}
-          {view === 'settings' &&
-            (settingsV2Enabled ? (
-              <SettingsViewV2
+      <ToolCallViewProvider>
+        <div className="relative w-screen h-screen overflow-hidden bg-bgApp flex flex-col">
+          <div className="titlebar-drag-region" />
+          <div>
+            {view === 'loading' && <SuspenseLoader />}
+            {view === 'welcome' &&
+              (settingsV2Enabled ? (
+                <ProviderSettings onClose={() => setView('chat')} isOnboarding={true} />
+              ) : (
+                <WelcomeView
+                  onSubmit={() => {
+                    setView('chat');
+                  }}
+                />
+              ))}
+            {view === 'settings' &&
+              (settingsV2Enabled ? (
+                <SettingsViewV2
+                  onClose={() => {
+                    setView('chat');
+                  }}
+                  setView={setView}
+                  viewOptions={viewOptions as SettingsViewOptions}
+                />
+              ) : (
+                <SettingsView
+                  onClose={() => {
+                    setView('chat');
+                  }}
+                  setView={setView}
+                  viewOptions={viewOptions as SettingsViewOptions}
+                />
+              ))}
+            {view === 'moreModels' && (
+              <MoreModelsView
                 onClose={() => {
-                  setView('chat');
+                  setView('settings');
                 }}
                 setView={setView}
-                viewOptions={viewOptions as SettingsViewOptions}
               />
-            ) : (
-              <SettingsView
+            )}
+            {view === 'configureProviders' && (
+              <ConfigureProvidersView
                 onClose={() => {
-                  setView('chat');
+                  setView('settings');
                 }}
-                setView={setView}
-                viewOptions={viewOptions as SettingsViewOptions}
               />
-            ))}
-          {view === 'moreModels' && (
-            <MoreModelsView
-              onClose={() => {
-                setView('settings');
-              }}
-              setView={setView}
-            />
-          )}
-          {view === 'configureProviders' && (
-            <ConfigureProvidersView
-              onClose={() => {
-                setView('settings');
-              }}
-            />
-          )}
-          {view === 'ConfigureProviders' && (
-            <ProviderSettings onClose={() => setView('chat')} isOnboarding={false} />
-          )}
-          {view === 'chat' && !isLoadingSession && (
-            <ChatView
-              chat={chat}
-              setChat={setChat}
-              setView={setView}
-              setIsGoosehintsModalOpen={setIsGoosehintsModalOpen}
-            />
-          )}
-          {view === 'sessions' && <SessionsView setView={setView} />}
-          {view === 'sharedSession' && (
-            <SharedSessionView
-              session={viewOptions?.sessionDetails}
-              isLoading={isLoadingSharedSession}
-              error={viewOptions?.error || sharedSessionError}
-              onBack={() => setView('sessions')}
-              onRetry={async () => {
-                if (viewOptions?.shareToken && viewOptions?.baseUrl) {
-                  setIsLoadingSharedSession(true);
-                  try {
-                    await openSharedSessionFromDeepLink(
-                      `goose://sessions/${viewOptions.shareToken}`,
-                      setView,
-                      viewOptions.baseUrl
-                    );
-                  } catch (error) {
-                    console.error('Failed to retry loading shared session:', error);
-                  } finally {
-                    setIsLoadingSharedSession(false);
+            )}
+            {view === 'ConfigureProviders' && (
+              <ProviderSettings onClose={() => setView('chat')} isOnboarding={false} />
+            )}
+            {view === 'chat' && !isLoadingSession && (
+              <ChatView
+                chat={chat}
+                setChat={setChat}
+                setView={setView}
+                setIsGoosehintsModalOpen={setIsGoosehintsModalOpen}
+              />
+            )}
+            {view === 'sessions' && <SessionsView setView={setView} />}
+            {view === 'sharedSession' && (
+              <SharedSessionView
+                session={viewOptions?.sessionDetails}
+                isLoading={isLoadingSharedSession}
+                error={viewOptions?.error || sharedSessionError}
+                onBack={() => setView('sessions')}
+                onRetry={async () => {
+                  if (viewOptions?.shareToken && viewOptions?.baseUrl) {
+                    setIsLoadingSharedSession(true);
+                    try {
+                      await openSharedSessionFromDeepLink(
+                        `goose://sessions/${viewOptions.shareToken}`,
+                        setView,
+                        viewOptions.baseUrl
+                      );
+                    } catch (error) {
+                      console.error('Failed to retry loading shared session:', error);
+                    } finally {
+                      setIsLoadingSharedSession(false);
+                    }
                   }
-                }
-              }}
-            />
-          )}
-          {view === 'recipeEditor' && (
-            <RecipeEditor
-              key={viewOptions?.config ? 'with-config' : 'no-config'}
-              config={viewOptions?.config || window.electron.getConfig().recipeConfig}
-              onClose={() => setView('chat')}
-              setView={setView}
-              onSave={(config) => {
-                console.log('Saving recipe config:', config);
-                window.electron.createChatWindow(
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  config,
-                  'recipeEditor',
-                  { config }
-                );
-                setView('chat');
-              }}
-            />
-          )}
-          {view === 'permission' && (
-            <PermissionSettingsView
-              onClose={() => setView((viewOptions as { parentView: View }).parentView)}
-            />
-          )}
+                }}
+              />
+            )}
+            {view === 'recipeEditor' && (
+              <RecipeEditor
+                key={viewOptions?.config ? 'with-config' : 'no-config'}
+                config={viewOptions?.config || window.electron.getConfig().recipeConfig}
+                onClose={() => setView('chat')}
+                setView={setView}
+                onSave={(config) => {
+                  console.log('Saving recipe config:', config);
+                  window.electron.createChatWindow(
+                    undefined,
+                    undefined,
+                    undefined,
+                    undefined,
+                    config,
+                    'recipeEditor',
+                    { config }
+                  );
+                  setView('chat');
+                }}
+              />
+            )}
+            {view === 'permission' && (
+              <PermissionSettingsView
+                onClose={() => setView((viewOptions as { parentView: View }).parentView)}
+              />
+            )}
+          </div>
         </div>
-      </div>
+      </ToolCallViewProvider>
       {isGoosehintsModalOpen && (
         <GoosehintsModal
           directory={window.appConfig.get('GOOSE_WORKING_DIR') as string}

--- a/ui/desktop/src/components/AdaptiveToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/AdaptiveToolCallWithResponse.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useToolCallViewMode } from './ToolCallViewMode';
+import OriginalToolCallWithResponse from './ToolCallWithResponse';
+import CompactToolCallWithResponse from './CompactToolCallWithResponse';
+import { ToolRequestMessageContent, ToolResponseMessageContent } from '../types/message';
+
+interface AdaptiveToolCallWithResponseProps {
+  isCancelledMessage: boolean;
+  toolRequest: ToolRequestMessageContent;
+  toolResponse?: ToolResponseMessageContent;
+}
+
+/**
+ * A wrapper component that renders either the compact or expanded tool call view
+ * based on the user's preference.
+ */
+export default function AdaptiveToolCallWithResponse(props: AdaptiveToolCallWithResponseProps) {
+  const { isCompactMode } = useToolCallViewMode();
+
+  return isCompactMode ? (
+    <CompactToolCallWithResponse {...props} />
+  ) : (
+    <OriginalToolCallWithResponse {...props} />
+  );
+}

--- a/ui/desktop/src/components/CompactToolCallArguments.tsx
+++ b/ui/desktop/src/components/CompactToolCallArguments.tsx
@@ -1,0 +1,119 @@
+import React, { useState } from 'react';
+import MarkdownContent from './MarkdownContent';
+import Expand from './ui/Expand';
+
+type ToolCallArgumentValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ToolCallArgumentValue[]
+  | { [key: string]: ToolCallArgumentValue };
+
+interface CompactToolCallArgumentsProps {
+  args: Record<string, ToolCallArgumentValue>;
+}
+
+export function CompactToolCallArguments({ args }: CompactToolCallArgumentsProps) {
+  const [expandedKeys, setExpandedKeys] = useState<Record<string, boolean>>({});
+
+  const toggleKey = (key: string) => {
+    setExpandedKeys((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const renderValue = (key: string, value: ToolCallArgumentValue) => {
+    if (typeof value === 'string') {
+      const needsExpansion = value.length > 40; // Reduced from 60 to 40 for more compact display
+      const isExpanded = expandedKeys[key];
+
+      if (!needsExpansion) {
+        return (
+          <div className="text-xs mb-1">
+            <div className="flex flex-row">
+              <span className="text-textSubtle min-w-[100px] font-medium">{key}</span>
+              <span className="text-textPlaceholder">{value}</span>
+            </div>
+          </div>
+        );
+      }
+
+      return (
+        <div className="text-xs mb-1">
+          <div className="flex flex-row">
+            <span className="text-textSubtle min-w-[100px] font-medium">{key}</span>
+            <div className="w-full flex justify-between items-start">
+              {isExpanded ? (
+                <div className="">
+                  <MarkdownContent content={value} className="text-xs text-textPlaceholder" />
+                </div>
+              ) : (
+                <span className="text-textPlaceholder mr-2">{value.slice(0, 40)}...</span>
+              )}
+              <button
+                onClick={() => toggleKey(key)}
+                className="hover:opacity-75 text-textPlaceholder"
+              >
+                <Expand size={4} isExpanded={isExpanded} />
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // Handle non-string values (arrays, objects, etc.)
+    const isComplex = typeof value === 'object' && value !== null;
+    const isExpanded = expandedKeys[key];
+
+    // Create a compact representation for complex objects
+    const compactContent = Array.isArray(value)
+      ? `[${value.length} items]`
+      : isComplex
+        ? `{${Object.keys(value as object).length} keys}`
+        : String(value);
+
+    // Full content for when expanded
+    const fullContent = Array.isArray(value)
+      ? value.map((item, index) => `${index + 1}. ${JSON.stringify(item)}`).join('\n')
+      : isComplex
+        ? JSON.stringify(value, null, 2)
+        : String(value);
+
+    return (
+      <div className="text-xs mb-1">
+        <div className="flex flex-row">
+          <span className="text-textSubtle min-w-[100px] font-medium">{key}</span>
+          <div className="w-full flex justify-between items-start">
+            {isComplex ? (
+              <>
+                {isExpanded ? (
+                  <pre className="whitespace-pre-wrap text-textPlaceholder text-xs">
+                    {fullContent}
+                  </pre>
+                ) : (
+                  <span className="text-textPlaceholder">{compactContent}</span>
+                )}
+                <button
+                  onClick={() => toggleKey(key)}
+                  className="hover:opacity-75 text-textPlaceholder ml-2"
+                >
+                  <Expand size={4} isExpanded={isExpanded} />
+                </button>
+              </>
+            ) : (
+              <span className="text-textPlaceholder">{compactContent}</span>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="my-1">
+      {Object.entries(args).map(([key, value]) => (
+        <div key={key}>{renderValue(key, value)}</div>
+      ))}
+    </div>
+  );
+}

--- a/ui/desktop/src/components/CompactToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/CompactToolCallWithResponse.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { Card } from './ui/card';
+import { ToolCallArguments } from './ToolCallArguments';
+import MarkdownContent from './MarkdownContent';
+import { Content, ToolRequestMessageContent, ToolResponseMessageContent } from '../types/message';
+import { snakeToTitleCase } from '../utils';
+import Dot, { LoadingStatus } from './ui/Dot';
+import Expand from './ui/Expand';
+
+interface CompactToolCallWithResponseProps {
+  isCancelledMessage: boolean;
+  toolRequest: ToolRequestMessageContent;
+  toolResponse?: ToolResponseMessageContent;
+}
+
+export default function CompactToolCallWithResponse({
+  isCancelledMessage,
+  toolRequest,
+  toolResponse,
+}: CompactToolCallWithResponseProps) {
+  const toolCall = toolRequest.toolCall.status === 'success' ? toolRequest.toolCall.value : null;
+  if (!toolCall) {
+    return null;
+  }
+
+  return (
+    <div className={'w-full text-textSubtle text-sm'}>
+      <Card className="">
+        <CompactToolCallView {...{ isCancelledMessage, toolCall, toolResponse }} />
+      </Card>
+    </div>
+  );
+}
+
+interface CompactToolCallViewProps {
+  isCancelledMessage: boolean;
+  toolCall: {
+    name: string;
+    arguments: Record<string, unknown>;
+  };
+  toolResponse?: ToolResponseMessageContent;
+}
+
+function CompactToolCallView({
+  isCancelledMessage,
+  toolCall,
+  toolResponse,
+}: CompactToolCallViewProps) {
+  const [isExpanded, setIsExpanded] = React.useState(false);
+  const toggleExpand = () => setIsExpanded((prev) => !prev);
+
+  const loadingStatus: LoadingStatus = !toolResponse?.toolResult.status
+    ? 'loading'
+    : toolResponse?.toolResult.status;
+
+  const toolResults: { result: Content; defaultExpanded: boolean }[] =
+    loadingStatus === 'success' && Array.isArray(toolResponse?.toolResult.value)
+      ? toolResponse.toolResult.value
+          .filter((item) => {
+            const audience = item.annotations?.audience as string[] | undefined;
+            return !audience || audience.includes('user');
+          })
+          .map((item) => ({
+            result: item,
+            defaultExpanded: false, // Always collapsed by default
+          }))
+      : [];
+
+  // Create a compact summary of the parameters
+  const paramSummary = getParameterSummary(toolCall.arguments);
+
+  return (
+    <div className="w-full">
+      {/* Compact Header - Always Visible */}
+      <div className="flex justify-between items-center w-full pr-2">
+        <div className="flex items-center flex-grow overflow-hidden">
+          <Dot size={2} loadingStatus={loadingStatus} />
+          <span className="ml-[10px] font-medium">
+            {snakeToTitleCase(toolCall.name.substring(toolCall.name.lastIndexOf('__') + 2))}
+          </span>
+          {/* Compact parameter summary */}
+          <span className="ml-2 text-textSubtle truncate text-xs opacity-70">{paramSummary}</span>
+        </div>
+        <button onClick={toggleExpand} className="flex-shrink-0 hover:opacity-75">
+          <Expand size={5} isExpanded={isExpanded} />
+        </button>
+      </div>
+
+      {/* Expanded Content */}
+      {isExpanded && (
+        <div className="mt-2">
+          {/* Tool Details */}
+          {Object.entries(toolCall.arguments).length > 0 && (
+            <div className="bg-bgStandard rounded-t mt-1 p-2">
+              <div className="text-xs font-medium mb-1">Tool Details</div>
+              <ToolCallArguments args={toolCall.arguments} />
+            </div>
+          )}
+
+          {/* Tool Output */}
+          {!isCancelledMessage && toolResults.length > 0 && (
+            <div className="bg-bgStandard mt-1 p-2">
+              <div className="text-xs font-medium mb-1">Output</div>
+              {toolResults.map(({ result }, index) => (
+                <div key={index} className="bg-bgApp rounded p-2 mt-1">
+                  {result.type === 'text' && result.text && (
+                    <MarkdownContent
+                      content={result.text}
+                      className="whitespace-pre-wrap max-w-full overflow-x-auto"
+                    />
+                  )}
+                  {result.type === 'image' && (
+                    <img
+                      src={`data:${result.mimeType};base64,${result.data}`}
+                      alt="Tool result"
+                      className="max-w-full h-auto rounded-md my-2"
+                      onError={(e) => {
+                        console.error('Failed to load image');
+                        e.currentTarget.style.display = 'none';
+                      }}
+                    />
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Helper function to create a compact summary of parameters
+function getParameterSummary(args: Record<string, unknown>): string {
+  const entries = Object.entries(args);
+  if (entries.length === 0) return '';
+
+  // For a single parameter, show key and truncated value
+  if (entries.length === 1) {
+    const [key, value] = entries[0];
+    const stringValue = typeof value === 'string' ? value : JSON.stringify(value);
+
+    const truncatedValue =
+      stringValue.length > 30 ? stringValue.substring(0, 30) + '...' : stringValue;
+
+    return `${key}: ${truncatedValue}`;
+  }
+
+  // For multiple parameters, just show the keys
+  return entries.map(([key]) => key).join(', ');
+}

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -4,7 +4,7 @@ import GooseResponseForm from './GooseResponseForm';
 import { extractUrls } from '../utils/urlUtils';
 import { formatMessageTimestamp } from '../utils/timeUtils';
 import MarkdownContent from './MarkdownContent';
-import ToolCallWithResponse from './ToolCallWithResponse';
+import AdaptiveToolCallWithResponse from './AdaptiveToolCallWithResponse';
 import {
   Message,
   getTextContent,
@@ -128,7 +128,7 @@ export default function GooseMessage({
           <div className="relative flex flex-col w-full">
             <div className={`goose-message-tool bg-bgSubtle rounded px-2 py-2 mt-2`}>
               {toolRequests.map((toolRequest) => (
-                <ToolCallWithResponse
+                <AdaptiveToolCallWithResponse
                   // If the message is resumed and not matched tool response, it means the tool is broken or cancelled.
                   isCancelledMessage={
                     messageIndex < messageHistoryIndex &&

--- a/ui/desktop/src/components/ToolCallViewMode.tsx
+++ b/ui/desktop/src/components/ToolCallViewMode.tsx
@@ -1,0 +1,59 @@
+import React, { createContext, useContext, useState } from 'react';
+import { Button } from './ui/button';
+import { Maximize2, Minimize2 } from 'lucide-react';
+
+// Create a context to store the compact mode state
+interface ToolCallViewContextType {
+  isCompactMode: boolean;
+  toggleCompactMode: () => void;
+}
+
+const ToolCallViewContext = createContext<ToolCallViewContextType>({
+  isCompactMode: true,
+  toggleCompactMode: () => {},
+});
+
+// Hook to use the compact mode context
+export const useToolCallViewMode = () => useContext(ToolCallViewContext);
+
+// Provider component to wrap around the application
+export function ToolCallViewProvider({ children }: { children: React.ReactNode }) {
+  const [isCompactMode, setIsCompactMode] = useState<boolean>(true);
+
+  const toggleCompactMode = () => {
+    setIsCompactMode((prev) => !prev);
+  };
+
+  return (
+    <ToolCallViewContext.Provider value={{ isCompactMode, toggleCompactMode }}>
+      {children}
+    </ToolCallViewContext.Provider>
+  );
+}
+
+// Toggle button component
+export function ToolCallViewToggle() {
+  const { isCompactMode, toggleCompactMode } = useToolCallViewMode();
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={toggleCompactMode}
+      className="flex items-center gap-1 text-xs"
+      title={isCompactMode ? 'Switch to expanded tool view' : 'Switch to compact tool view'}
+    >
+      {isCompactMode ? (
+        <>
+          <Maximize2 className="h-3 w-3" />
+          <span className="hidden sm:inline">Expand Tools</span>
+        </>
+      ) : (
+        <>
+          <Minimize2 className="h-3 w-3" />
+          <span className="hidden sm:inline">Compact Tools</span>
+        </>
+      )}
+    </Button>
+  );
+}

--- a/ui/desktop/src/components/more_menu/MoreMenuLayout.tsx
+++ b/ui/desktop/src/components/more_menu/MoreMenuLayout.tsx
@@ -3,6 +3,7 @@ import MoreMenu from './MoreMenu';
 import type { View, ViewOptions } from '../../App';
 import { Document } from '../icons';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/Tooltip';
+import { ToolCallViewToggle } from '../ToolCallViewMode';
 
 export default function MoreMenuLayout({
   hasMessages,
@@ -48,7 +49,10 @@ export default function MoreMenuLayout({
             </Tooltip>
           </TooltipProvider>
 
-          <MoreMenu setView={setView} setIsGoosehintsModalOpen={setIsGoosehintsModalOpen} />
+          <div className="flex items-center gap-2">
+            <ToolCallViewToggle />
+            <MoreMenu setView={setView} setIsGoosehintsModalOpen={setIsGoosehintsModalOpen} />
+          </div>
         </div>
       )}
     </div>

--- a/ui/desktop/src/components/sessions/SessionViewComponents.tsx
+++ b/ui/desktop/src/components/sessions/SessionViewComponents.tsx
@@ -5,7 +5,7 @@ import { Button } from '../ui/button';
 import BackButton from '../ui/BackButton';
 import { ScrollArea } from '../ui/scroll-area';
 import MarkdownContent from '../MarkdownContent';
-import ToolCallWithResponse from '../ToolCallWithResponse';
+import AdaptiveToolCallWithResponse from '../AdaptiveToolCallWithResponse';
 import { ToolRequestMessageContent, ToolResponseMessageContent } from '../../types/message';
 import { type Message } from '../../types/message';
 import { formatMessageTimestamp } from '../../utils/timeUtils';
@@ -158,7 +158,7 @@ export const SessionMessages: React.FC<SessionMessagesProps> = ({
                         {toolRequests.length > 0 && (
                           <div className="goose-message-tool bg-bgApp border border-borderSubtle dark:border-gray-700 rounded-b-2xl px-4 pt-4 pb-2 mt-1">
                             {toolRequests.map((toolRequest) => (
-                              <ToolCallWithResponse
+                              <AdaptiveToolCallWithResponse
                                 // In the session history page, if no tool response found for given request, it means the tool call
                                 // is broken or cancelled.
                                 isCancelledMessage={


### PR DESCRIPTION
GUI currently shows args, params and so on with tool calls and uses a lot of space (even with output folded away) which is visually prominent and noisy. 

This is a proposal to fold more away by default: 

Folded: 

<img width="736" alt="Screenshot 2025-05-07 at 1 57 20 pm" src="https://github.com/user-attachments/assets/c0da7a19-2f3c-4619-9d23-391c37f61b2a" />

Expanded: 

<img width="678" alt="Screenshot 2025-05-07 at 1 57 32 pm" src="https://github.com/user-attachments/assets/9d32f58e-b320-4a1e-bc11-8a374a06c747" />


originally: 

<img width="699" alt="image" src="https://github.com/user-attachments/assets/e6519771-82d8-49f2-908e-33d4e39612e8" />

