### PR TITLE
[goose-llm] expose helpers to serialize and deserialize Message

### DIFF
--- a/bindings/kotlin/example/Usage.kt
+++ b/bindings/kotlin/example/Usage.kt
@@ -135,6 +135,13 @@ fun main() = runBlocking {
     )
 
     val response = completion(req)
-    println("\nCompletion Response:")
-    println(response.message)
+    println("\nCompletion Response: $response")
+
+    println("\n---\n")
+
+    val serialized = serializeMessage(response.message)
+    println("Serialized Message: $serialized")
+
+    val deserialized = deserializeMessage(serialized)
+    println("Deserialized Message: $deserialized")
 }

--- a/bindings/kotlin/uniffi/goose_llm/goose_llm.kt
+++ b/bindings/kotlin/uniffi/goose_llm/goose_llm.kt
@@ -773,11 +773,15 @@ internal interface IntegrityCheckingUniffiLib : Library {
 
     fun uniffi_goose_llm_checksum_func_create_tool_config(): Short
 
+    fun uniffi_goose_llm_checksum_func_deserialize_message(): Short
+
     fun uniffi_goose_llm_checksum_func_generate_session_name(): Short
 
     fun uniffi_goose_llm_checksum_func_generate_tooltip(): Short
 
     fun uniffi_goose_llm_checksum_func_print_messages(): Short
+
+    fun uniffi_goose_llm_checksum_func_serialize_message(): Short
 
     fun ffi_goose_llm_uniffi_contract_version(): Int
 }
@@ -841,6 +845,11 @@ internal interface UniffiLib : Library {
         uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
 
+    fun uniffi_goose_llm_fn_func_deserialize_message(
+        `jsonValue`: RustBuffer.ByValue,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
+
     fun uniffi_goose_llm_fn_func_generate_session_name(
         `providerName`: RustBuffer.ByValue,
         `providerConfig`: RustBuffer.ByValue,
@@ -857,6 +866,11 @@ internal interface UniffiLib : Library {
         `messages`: RustBuffer.ByValue,
         uniffi_out_err: UniffiRustCallStatus,
     ): Unit
+
+    fun uniffi_goose_llm_fn_func_serialize_message(
+        `message`: RustBuffer.ByValue,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
 
     fun ffi_goose_llm_rustbuffer_alloc(
         `size`: Long,
@@ -1096,6 +1110,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_goose_llm_checksum_func_create_tool_config() != 22809.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_goose_llm_checksum_func_deserialize_message() != 57344.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_goose_llm_checksum_func_generate_session_name() != 9810.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -1103,6 +1120,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_goose_llm_checksum_func_print_messages() != 30278.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_goose_llm_checksum_func_serialize_message() != 24354.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
 }
@@ -2898,6 +2918,16 @@ fun `createToolConfig`(
         },
     )
 
+fun `deserializeMessage`(`jsonValue`: JsonValueFfi): Message =
+    FfiConverterTypeMessage.lift(
+        uniffiRustCall { _status ->
+            UniffiLib.INSTANCE.uniffi_goose_llm_fn_func_deserialize_message(
+                FfiConverterTypeJsonValueFfi.lower(`jsonValue`),
+                _status,
+            )
+        },
+    )
+
 /**
  * Generates a short (≤4 words) session name
  */
@@ -2956,3 +2986,13 @@ fun `printMessages`(`messages`: List<Message>) =
             _status,
         )
     }
+
+fun `serializeMessage`(`message`: Message): kotlin.String =
+    FfiConverterString.lift(
+        uniffiRustCall { _status ->
+            UniffiLib.INSTANCE.uniffi_goose_llm_fn_func_serialize_message(
+                FfiConverterTypeMessage.lower(`message`),
+                _status,
+            )
+        },
+    )

--- a/crates/goose-llm/src/message/mod.rs
+++ b/crates/goose-llm/src/message/mod.rs
@@ -20,7 +20,7 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
-use crate::types::core::Role;
+use crate::types::{core::Role, json_value_ffi};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, uniffi::Record)]
 /// A message to or from an LLM
@@ -29,6 +29,24 @@ pub struct Message {
     pub role: Role,
     pub created: i64,
     pub content: Contents,
+}
+
+#[uniffi::export]
+pub fn serialize_message(message: &Message) -> String {
+    let result = serde_json::to_string(message);
+    match result {
+        Ok(json_str) => json_str,
+        Err(e) => panic!("Failed to serialize message: {}", e),
+    }
+}
+
+#[uniffi::export]
+pub fn deserialize_message(json_value: json_value_ffi::JsonValueFfi) -> Message {
+    let result = serde_json::from_value::<Message>(json_value.into());
+    match result {
+        Ok(message) => message,
+        Err(e) => panic!("Failed to deserialize message: {}", e),
+    }
 }
 
 impl Message {


### PR DESCRIPTION
see `Usage.kt`

output:
```
...
Completion Response: CompletionResponse(message=Message(role=ASSISTANT, created=1746824998085, content=[Text(v1=TextContent(text=7 × 6 = 42))]), model=gpt-4.1-2025-04-14, usage=Usage(inputTokens=443, outputTokens=9, totalTokens=452), runtimeMetrics=RuntimeMetrics(totalTimeSec=1.3730228, totalTimeSecProvider=1.2091802, tokensPerSecond=373.8069698745157))

---

Serialized Message: {"role":"assistant","created":1746824998085,"content":[{"type":"text","text":"7 × 6 = 42"}]}

Deserialized Message: Message(role=ASSISTANT, created=1746824998085, content=[Text(v1=TextContent(text=7 × 6 = 42))])

```