### PR TITLE
chore: Add docker to allowed deeplink commands

### DIFF
--- a/documentation/src/utils/install-links.ts
+++ b/documentation/src/utils/install-links.ts
@@ -29,7 +29,7 @@ export function getGooseInstallLink(server: MCPServer): string {
   }
   
   const parts = server.command.split(" ");
-  const baseCmd = parts[0]; // jbang, npx or uvx
+  const baseCmd = parts[0]; // docker, jbang, npx or uvx
   const args = parts.slice(1); // remaining arguments
 
   const queryParams = [

--- a/ui/desktop/src/components/settings_v2/extensions/deeplink.ts
+++ b/ui/desktop/src/components/settings_v2/extensions/deeplink.ts
@@ -15,7 +15,7 @@ function getStdioConfig(
   timeout: number
 ) {
   // Validate that the command is one of the allowed commands
-  const allowedCommands = ['jbang', 'npx', 'uvx', 'goosed'];
+  const allowedCommands = ['docker', 'jbang', 'npx', 'uvx', 'goosed'];
   if (!allowedCommands.includes(cmd)) {
     toastService.handleError(
       'Invalid Command',

--- a/ui/desktop/src/components/settings_v2/extensions/utils.ts
+++ b/ui/desktop/src/components/settings_v2/extensions/utils.ts
@@ -168,7 +168,7 @@ export async function replaceWithShims(cmd: string) {
 
 export function removeShims(cmd: string) {
   // Only remove shims if the path matches our known shim patterns
-  const shimPatterns = [/goosed$/, /jbang$/, /npx$/, /uvx$/];
+  const shimPatterns = [/goosed$/, /docker$/, /jbang$/, /npx$/, /uvx$/];
 
   // Check if the command matches any shim pattern
   const isShim = shimPatterns.some((pattern) => pattern.test(cmd));

--- a/ui/desktop/src/extensions.tsx
+++ b/ui/desktop/src/extensions.tsx
@@ -362,7 +362,7 @@ function getStdioConfig(
   description: string,
   parsedTimeout: number
 ) {
-  const allowedCommands = ['jbang', 'npx', 'uvx', 'goosed'];
+  const allowedCommands = ['docker', 'jbang', 'npx', 'uvx', 'goosed'];
   if (!allowedCommands.includes(cmd)) {
     handleError(
       `Failed to install extension: Invalid command: ${cmd}. Only ${allowedCommands.join(', ')} are allowed.`,


### PR DESCRIPTION
I was trying to make deployment of MCPs simpler for our users, while avoiding local installation of Python/Node modules. To this end, I am using Docker.

I would like to use the `goose://` scheme to install (to avoid manual configuration of the `config.yaml`) - however, there is an allow-list which only permits `jbang`, `uvx`, `npx`, and `goosed`.

<img width="448" alt="image" src="https://github.com/user-attachments/assets/c03bf8db-4347-4315-9737-dc8625d9b108" />

There doesn't seem to be an overwhelming reason not to allow `docker` here - `jbang`, `uvx`, and `npx` all run arbitrary code that exists in a repository somewhere.

I do appreciate that this is "yet another command," but I feel like Docker is a pretty common and generic way to launch sandboxed MCP commands that Goose should support relatively cleanly.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210278353063201