### PR TITLE
fix(ui): improve chat history arrows styling in placeholder text

### DIFF
--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -272,7 +272,7 @@ export default function ChatInput({
           data-testid="chat-input"
           autoFocus
           id="dynamic-textarea"
-          placeholder="What can goose help with?   ⌘↑/⌘↓"
+          placeholder="What can goose help with? (⌘↑/↓ for history)"
           value={displayValue}
           onChange={handleChange}
           onCompositionStart={handleCompositionStart}


### PR DESCRIPTION
Fixes #1608

Makes the chat history keyboard shortcut indicators more visually appealing and clearer in the chat input placeholder text.

Changes:
- Updated placeholder text from '⌘↑/⌘↓' to '(⌘↑/↓ for history)'
- Made the shortcut text more descriptive and easier to understand
- Improved visual formatting with parentheses

Testing:
- Verified placeholder text displays correctly
- Confirmed linting passes
- Keyboard shortcuts continue to work as expected