### PR TITLE
maguire: attempt to speed up windows build, keep mingw dlls

### DIFF
--- a/.github/workflows/bundle-desktop-windows.yml
+++ b/.github/workflows/bundle-desktop-windows.yml
@@ -35,7 +35,10 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@38b70195107dddab2c7bbd522bcf763bac00963b
         with:
-          targets: ${{ matrix.target }}
+          toolchain: stable
+          profile: minimal
+          override: true
+          target: x86_64-pc-windows-msvc
 
       # 3) Set up Node.js
       - name: Set up Node.js
@@ -43,8 +46,31 @@ jobs:
         with:
           node-version: 16
 
-      # 4) Cache dependencies
-      - name: Cache Dependencies
+      # 4) Install protobuf
+      - name: Install protobuf
+        run: |
+          choco install protoc --yes
+          refreshenv
+          protoc --version
+          echo "PROTOC=C:/ProgramData/chocolatey/bin/protoc.exe" >> $env:GITHUB_ENV
+        shell: powershell
+
+      # 5) Install MinGW
+      - name: Install MinGW
+        run: |
+          choco install mingw --version=8.1.0 --yes
+          refreshenv
+
+      # 6) Cache dependencies
+      - name: Calculate source hash
+        id: source_hash
+        shell: bash
+        run: |
+          SOURCE_HASH=$(find . -type f -name "*.rs" -exec sha256sum {} \; | sort | sha256sum | cut -d ' ' -f1)
+          echo "hash=${SOURCE_HASH}" >> $GITHUB_OUTPUT
+
+      - name: Cache Cargo
+        id: cargo-cache
         uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # pin@v3
         with:
           path: |
@@ -53,45 +79,19 @@ jobs:
             target
             node_modules
             ui/desktop/node_modules
-          key: ${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock', '**/package-lock.json') }}
+          key: ${{ runner.os }}-cargo-v2-msvc-${{ hashFiles('**/Cargo.lock') }}-${{ steps.source_hash.outputs.hash }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.target }}-
-
-      # 5) Install top-level dependencies if a package.json is in root
-      - name: Install top-level deps
-        run: |
-          if (Test-Path package.json) {
-            npm install
-          }
-
-      # 6) Install MinGW and Protobuf
-      - name: Install build dependencies
-        run: |
-          # Install MinGW
-          choco install mingw --version=8.1.0
-          
-          # Install protobuf compiler
-          choco install protoc
-          
-          # Debug - check installations
-          Write-Host "Checking MinGW installation..."
-          Get-ChildItem -Path "C:\ProgramData\chocolatey\lib\mingw" -Recurse -Filter "*.dll" | ForEach-Object {
-            Write-Host $_.FullName
-          }
-          Get-ChildItem -Path "C:\tools" -Recurse -Filter "*.dll" | ForEach-Object {
-            Write-Host $_.FullName
-          }
-          
-          # Verify protoc installation
-          Write-Host "Checking protoc version..."
-          protoc --version
+            ${{ runner.os }}-cargo-v2-msvc-${{ hashFiles('**/Cargo.lock') }}-
+            ${{ runner.os }}-cargo-v2-msvc-
 
       # 7) Build rust with MSVC toolchain
-      - name: Cargo build for Windows
+      - name: Build Release Binary
         run: |
-          # Set PROTOC environment variable explicitly
-          $env:PROTOC = "protoc"
-          cargo build --release --target ${{ matrix.target }}
+          cargo build --release --target x86_64-pc-windows-msvc -j 4
+        env:
+          CARGO_BUILD_JOBS: "4"
+          RUSTFLAGS: "-C opt-level=3"
+          CARGO_INCREMENTAL: "0"
 
       # 8) Check that the compiled goosed.exe exists and copy to ui/desktop/src/bin
       - name: Prepare Windows binary and DLLs

--- a/.github/workflows/bundle-desktop-windows.yml
+++ b/.github/workflows/bundle-desktop-windows.yml
@@ -49,53 +49,62 @@ jobs:
       # 4) Install protobuf
       - name: Install protobuf
         run: |
-          # Install protoc using chocolatey
-          choco install protoc --yes
-          refreshenv
+          # Get latest protoc release info from GitHub API
+          Write-Host "Fetching latest protoc release information..."
+          $latestRelease = (Invoke-RestMethod -Uri "https://api.github.com/repos/protocolbuffers/protobuf/releases/latest")
+          $windowsAsset = $latestRelease.assets | Where-Object { $_.name -like "*win64.zip" }
+          $PROTOC_VERSION = $latestRelease.tag_name -replace 'v', ''
           
-          # Verify protoc installation and location
-          $protocPath = (Get-Command protoc -ErrorAction SilentlyContinue).Path
-          if ($protocPath) {
-            Write-Host "Found protoc at: $protocPath"
-          } else {
-            Write-Host "protoc not found in PATH, checking common locations..."
-            $possiblePaths = @(
-              "C:\ProgramData\chocolatey\bin\protoc.exe",
-              "C:\Program Files\protoc\bin\protoc.exe",
-              "C:\protoc\bin\protoc.exe"
-            )
-            foreach ($path in $possiblePaths) {
-              if (Test-Path $path) {
-                $protocPath = $path
-                Write-Host "Found protoc at: $path"
-                break
-              }
-            }
-          }
+          Write-Host "Latest protoc version: $PROTOC_VERSION"
+          Write-Host "Downloading: $($windowsAsset.name)"
           
-          if (-not $protocPath) {
-            Write-Error "protoc not found in any expected location"
-            exit 1
-          }
+          $PROTOC_DIR = "C:\protoc"
           
-          # Set environment variables for both the current process and GITHUB_ENV
-          $env:PROTOC = $protocPath
+          Write-Host "Creating protoc directory..."
+          New-Item -ItemType Directory -Force -Path $PROTOC_DIR
+          
+          Write-Host "Downloading protoc..."
+          Invoke-WebRequest -Uri $windowsAsset.browser_download_url -OutFile "$PROTOC_DIR\protoc.zip"
+          
+          Write-Host "Extracting protoc..."
+          Expand-Archive -Path "$PROTOC_DIR\protoc.zip" -DestinationPath $PROTOC_DIR -Force
+          
+          # Add to PATH and set PROTOC env var
+          $env:Path = "$PROTOC_DIR\bin;" + $env:Path
+          echo "$PROTOC_DIR\bin" >> $env:GITHUB_PATH
+          
+          $protocPath = "$PROTOC_DIR\bin\protoc.exe"
           echo "PROTOC=$protocPath" >> $env:GITHUB_ENV
+          $env:PROTOC = $protocPath
           
-          # Verify protoc works
+          # Verify installation
           Write-Host "Verifying protoc installation..."
-          & $protocPath --version
-          if ($LASTEXITCODE -ne 0) {
-            Write-Error "protoc verification failed"
-            exit 1
-          }
+          Write-Host "PROTOC env var: $env:PROTOC"
+          Write-Host "protoc location:"
+          Get-ChildItem -Path "$PROTOC_DIR\bin\protoc.exe"
           
-          # List contents of protoc installation directory
-          $protocDir = Split-Path $protocPath -Parent
+          Write-Host "protoc version:"
+          & $protocPath --version
+          
+          # List contents of protoc directory
           Write-Host "Contents of protoc directory:"
-          Get-ChildItem -Path $protocDir -Recurse | ForEach-Object {
+          Get-ChildItem -Path $PROTOC_DIR -Recurse | ForEach-Object {
             Write-Host $_.FullName
           }
+          
+          # Test protoc functionality
+          Write-Host "Testing protoc functionality..."
+          $testProto = @"
+          syntax = "proto3";
+          package test;
+          message Test {
+            string test_field = 1;
+          }
+          "@
+          
+          $testProto | Out-File -FilePath "$PROTOC_DIR\test.proto"
+          & $protocPath --version
+          & $protocPath --proto_path="$PROTOC_DIR" "$PROTOC_DIR\test.proto"
         shell: powershell
 
       # 5) Install MinGW
@@ -130,15 +139,22 @@ jobs:
       # 7) Build rust with MSVC toolchain
       - name: Build Release Binary
         run: |
-          Write-Host "Using PROTOC from: $env:PROTOC"
-          Write-Host "Current PATH: $env:PATH"
+          Write-Host "Environment Check:"
+          Write-Host "PROTOC: $env:PROTOC"
+          Write-Host "PATH: $env:PATH"
+          Write-Host "Testing protoc directly:"
+          & $env:PROTOC --version
+          
+          Write-Host "Building with Cargo..."
+          $env:RUST_LOG = "debug"
           cargo build --release --target x86_64-pc-windows-msvc -j 4 -vv
         env:
           CARGO_BUILD_JOBS: "4"
           RUSTFLAGS: "-C opt-level=3"
           CARGO_INCREMENTAL: "0"
-          PROTOC: ${{ env.PROTOC }}
-          RUST_BACKTRACE: "1"
+          PROTOC: "C:\\protoc\\bin\\protoc.exe"
+          RUST_BACKTRACE: "full"
+          RUST_LOG: "debug"
 
       # 8) Check that the compiled goosed.exe exists and copy to ui/desktop/src/bin
       - name: Prepare Windows binary and DLLs

--- a/.github/workflows/bundle-desktop-windows.yml
+++ b/.github/workflows/bundle-desktop-windows.yml
@@ -49,10 +49,47 @@ jobs:
       # 4) Install protobuf
       - name: Install protobuf
         run: |
+          # Install protoc using chocolatey
           choco install protoc --yes
           refreshenv
-          protoc --version
-          echo "PROTOC=C:/ProgramData/chocolatey/bin/protoc.exe" >> $env:GITHUB_ENV
+          
+          # Get the protoc path and verify it exists
+          $protocPath = "C:/ProgramData/chocolatey/bin/protoc.exe"
+          if (!(Test-Path $protocPath)) {
+            Write-Error "Protoc not found at expected path: $protocPath"
+            exit 1
+          }
+          
+          # Add to system PATH
+          $env:Path = "C:/ProgramData/chocolatey/bin;" + $env:Path
+          echo "C:/ProgramData/chocolatey/bin" >> $env:GITHUB_PATH
+          
+          # Set PROTOC environment variable
+          $env:PROTOC = $protocPath
+          echo "PROTOC=$protocPath" >> $env:GITHUB_ENV
+          
+          # Verify installation
+          Write-Host "Protoc version:"
+          & $protocPath --version
+          
+          Write-Host "Protoc location:"
+          Get-Command protoc | Format-List *
+          
+          Write-Host "Testing protoc functionality..."
+          $testProto = @"
+          syntax = "proto3";
+          package test;
+          message Test {
+            string test_field = 1;
+          }
+          "@
+          
+          $testProto | Out-File -FilePath "test.proto"
+          & $protocPath test.proto
+          
+          Write-Host "Environment variables:"
+          Write-Host "PROTOC: $env:PROTOC"
+          Write-Host "PATH: $env:Path"
         shell: powershell
 
       # 6) Install MinGW
@@ -87,11 +124,20 @@ jobs:
       # 7) Build rust with MSVC toolchain
       - name: Build Release Binary
         run: |
+          # Verify protoc is still accessible
+          Write-Host "Verifying protoc before build:"
+          Write-Host "PROTOC: $env:PROTOC"
+          Write-Host "PATH: $env:Path"
+          protoc --version
+          
+          # Run the build
           cargo build --release --target x86_64-pc-windows-msvc -j 4
         env:
           CARGO_BUILD_JOBS: "4"
           RUSTFLAGS: "-C opt-level=3"
           CARGO_INCREMENTAL: "0"
+          PROTOC: "C:/ProgramData/chocolatey/bin/protoc.exe"
+          PATH: "C:/ProgramData/chocolatey/bin;${{ env.PATH }}"
 
       # 8) Check that the compiled goosed.exe exists and copy to ui/desktop/src/bin
       - name: Prepare Windows binary and DLLs

--- a/.github/workflows/bundle-desktop-windows.yml
+++ b/.github/workflows/bundle-desktop-windows.yml
@@ -48,7 +48,7 @@ jobs:
 
       # 4) Install protobuf using a dedicated action
       - name: Install Protobuf
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@c0a85a5c3a8a595570507253d2ae2c121e1c5a95 # pin@v2
         with:
           version: "24.x"
           repo-token: ${{ github.token }}

--- a/.github/workflows/bundle-desktop-windows.yml
+++ b/.github/workflows/bundle-desktop-windows.yml
@@ -53,19 +53,32 @@ jobs:
           version: "24.x"
           repo-token: ${{ github.token }}
 
-      # 5) Verify protoc installation
+      # 5) Verify protoc installation and setup environment
       - name: Verify Protobuf Installation
         run: |
           Write-Host "Verifying protoc installation..."
           protoc --version
           
-          # Get the protoc path
+          # Get the full path to protoc and convert to Windows path format
           $protocPath = (Get-Command protoc).Path
+          $protocPath = $protocPath -replace '/', '\'
           Write-Host "Found protoc at: $protocPath"
           
+          # Create .cargo/config.toml with the protoc path
+          $cargoConfig = @"
+          [env]
+          PROTOC = "$protocPath"
+          "@
+          
+          New-Item -ItemType Directory -Force -Path ".cargo"
+          $cargoConfig | Out-File -FilePath ".cargo/config.toml" -Encoding utf8
+          
+          Write-Host "Created .cargo/config.toml:"
+          Get-Content ".cargo/config.toml"
+          
           # Set environment variables
-          echo "PROTOC=$protocPath" >> $env:GITHUB_ENV
           $env:PROTOC = $protocPath
+          echo "PROTOC=$protocPath" >> $env:GITHUB_ENV
           
           # Test protoc functionality
           $testProto = @"
@@ -77,17 +90,25 @@ jobs:
           "@
           
           $testProto | Out-File -FilePath "test.proto"
-          & $protocPath --version
           & $protocPath test.proto
+          
+          # List contents of lance-encoding source directory if it exists
+          Write-Host "Checking lance-encoding directory..."
+          $lanceDir = "target/release/build/lance-encoding-*"
+          if (Test-Path $lanceDir) {
+            Get-ChildItem -Path $lanceDir -Recurse | ForEach-Object {
+              Write-Host $_.FullName
+            }
+          }
         shell: powershell
 
-      # 5) Install MinGW
+      # 6) Install MinGW
       - name: Install MinGW
         run: |
           choco install mingw --version=8.1.0 --yes
           refreshenv
 
-      # 6) Cache dependencies
+      # 7) Cache dependencies
       - name: Calculate source hash
         id: source_hash
         shell: bash
@@ -110,18 +131,25 @@ jobs:
             ${{ runner.os }}-cargo-v2-msvc-${{ hashFiles('**/Cargo.lock') }}-
             ${{ runner.os }}-cargo-v2-msvc-
 
-      # 7) Build rust with MSVC toolchain
+      # 8) Build rust with MSVC toolchain
       - name: Build Release Binary
         run: |
           Write-Host "Environment Check:"
           Write-Host "PROTOC: $env:PROTOC"
           Write-Host "PATH: $env:Path"
+          Write-Host "Current Directory: $PWD"
           
           Write-Host "Testing protoc directly:"
           protoc --version
           
+          Write-Host ".cargo/config.toml contents:"
+          Get-Content ".cargo/config.toml"
+          
           Write-Host "Building with Cargo..."
           $env:RUST_LOG = "debug"
+          
+          # Clean the lance-encoding build directory
+          Remove-Item -Path "target/release/build/lance-encoding-*" -Recurse -ErrorAction SilentlyContinue
           
           cargo build --release --target x86_64-pc-windows-msvc -j 4 -vv
         env:
@@ -130,6 +158,9 @@ jobs:
           CARGO_INCREMENTAL: "0"
           RUST_BACKTRACE: "full"
           RUST_LOG: "debug"
+          # Set both environment variables to be extra sure
+          PROTOC: $env:PROTOC
+          PROTOC_NO_VENDOR: "1"
 
       # 8) Check that the compiled goosed.exe exists and copy to ui/desktop/src/bin
       - name: Prepare Windows binary and DLLs

--- a/.github/workflows/bundle-desktop-windows.yml
+++ b/.github/workflows/bundle-desktop-windows.yml
@@ -64,11 +64,16 @@ jobs:
             npm install
           }
 
-      # 6) Install MinGW for DLLs
-      - name: Install MinGW dependencies
+      # 6) Install MinGW and Protobuf
+      - name: Install build dependencies
         run: |
+          # Install MinGW
           choco install mingw --version=8.1.0
-          # Debug - check installation paths
+          
+          # Install protobuf compiler
+          choco install protoc
+          
+          # Debug - check installations
           Write-Host "Checking MinGW installation..."
           Get-ChildItem -Path "C:\ProgramData\chocolatey\lib\mingw" -Recurse -Filter "*.dll" | ForEach-Object {
             Write-Host $_.FullName
@@ -76,10 +81,16 @@ jobs:
           Get-ChildItem -Path "C:\tools" -Recurse -Filter "*.dll" | ForEach-Object {
             Write-Host $_.FullName
           }
+          
+          # Verify protoc installation
+          Write-Host "Checking protoc version..."
+          protoc --version
 
       # 7) Build rust with MSVC toolchain
       - name: Cargo build for Windows
         run: |
+          # Set PROTOC environment variable explicitly
+          $env:PROTOC = "protoc"
           cargo build --release --target ${{ matrix.target }}
 
       # 8) Check that the compiled goosed.exe exists and copy to ui/desktop/src/bin

--- a/.github/workflows/bundle-desktop-windows.yml
+++ b/.github/workflows/bundle-desktop-windows.yml
@@ -46,60 +46,13 @@ jobs:
         with:
           node-version: 16
 
-      # 4) Install protobuf using a dedicated action
-      - name: Install Protobuf
-        uses: arduino/setup-protoc@c0a85a5c3a8a595570507253d2ae2c121e1c5a95 # pin@v2
-        with:
-          version: "24.x"
-          repo-token: ${{ github.token }}
-
-      # 5) Verify protoc installation and setup environment
-      - name: Verify Protobuf Installation
+      # 4) Install protobuf
+      - name: Install protobuf
         run: |
-          Write-Host "Verifying protoc installation..."
+          choco install protoc --yes
+          refreshenv
           protoc --version
-          
-          # Get the full path to protoc and convert to Windows path format
-          $protocPath = (Get-Command protoc).Path
-          $protocPath = $protocPath -replace '/', '\'
-          Write-Host "Found protoc at: $protocPath"
-          
-          # Create .cargo/config.toml with the protoc path
-          $cargoConfig = @"
-          [env]
-          PROTOC = "$protocPath"
-          "@
-          
-          New-Item -ItemType Directory -Force -Path ".cargo"
-          $cargoConfig | Out-File -FilePath ".cargo/config.toml" -Encoding utf8
-          
-          Write-Host "Created .cargo/config.toml:"
-          Get-Content ".cargo/config.toml"
-          
-          # Set environment variables
-          $env:PROTOC = $protocPath
-          echo "PROTOC=$protocPath" >> $env:GITHUB_ENV
-          
-          # Test protoc functionality
-          $testProto = @"
-          syntax = "proto3";
-          package test;
-          message Test {
-            string test_field = 1;
-          }
-          "@
-          
-          $testProto | Out-File -FilePath "test.proto"
-          & $protocPath test.proto
-          
-          # List contents of lance-encoding source directory if it exists
-          Write-Host "Checking lance-encoding directory..."
-          $lanceDir = "target/release/build/lance-encoding-*"
-          if (Test-Path $lanceDir) {
-            Get-ChildItem -Path $lanceDir -Recurse | ForEach-Object {
-              Write-Host $_.FullName
-            }
-          }
+          echo "PROTOC=C:/ProgramData/chocolatey/bin/protoc.exe" >> $env:GITHUB_ENV
         shell: powershell
 
       # 6) Install MinGW
@@ -131,36 +84,14 @@ jobs:
             ${{ runner.os }}-cargo-v2-msvc-${{ hashFiles('**/Cargo.lock') }}-
             ${{ runner.os }}-cargo-v2-msvc-
 
-      # 8) Build rust with MSVC toolchain
+      # 7) Build rust with MSVC toolchain
       - name: Build Release Binary
         run: |
-          Write-Host "Environment Check:"
-          Write-Host "PROTOC: $env:PROTOC"
-          Write-Host "PATH: $env:Path"
-          Write-Host "Current Directory: $PWD"
-          
-          Write-Host "Testing protoc directly:"
-          protoc --version
-          
-          Write-Host ".cargo/config.toml contents:"
-          Get-Content ".cargo/config.toml"
-          
-          Write-Host "Building with Cargo..."
-          $env:RUST_LOG = "debug"
-          
-          # Clean the lance-encoding build directory
-          Remove-Item -Path "target/release/build/lance-encoding-*" -Recurse -ErrorAction SilentlyContinue
-          
-          cargo build --release --target x86_64-pc-windows-msvc -j 4 -vv
+          cargo build --release --target x86_64-pc-windows-msvc -j 4
         env:
           CARGO_BUILD_JOBS: "4"
           RUSTFLAGS: "-C opt-level=3"
           CARGO_INCREMENTAL: "0"
-          RUST_BACKTRACE: "full"
-          RUST_LOG: "debug"
-          # Set both environment variables to be extra sure
-          PROTOC: $env:PROTOC
-          PROTOC_NO_VENDOR: "1"
 
       # 8) Check that the compiled goosed.exe exists and copy to ui/desktop/src/bin
       - name: Prepare Windows binary and DLLs

--- a/.github/workflows/bundle-desktop-windows.yml
+++ b/.github/workflows/bundle-desktop-windows.yml
@@ -49,10 +49,53 @@ jobs:
       # 4) Install protobuf
       - name: Install protobuf
         run: |
+          # Install protoc using chocolatey
           choco install protoc --yes
           refreshenv
-          protoc --version
-          echo "PROTOC=C:/ProgramData/chocolatey/bin/protoc.exe" >> $env:GITHUB_ENV
+          
+          # Verify protoc installation and location
+          $protocPath = (Get-Command protoc -ErrorAction SilentlyContinue).Path
+          if ($protocPath) {
+            Write-Host "Found protoc at: $protocPath"
+          } else {
+            Write-Host "protoc not found in PATH, checking common locations..."
+            $possiblePaths = @(
+              "C:\ProgramData\chocolatey\bin\protoc.exe",
+              "C:\Program Files\protoc\bin\protoc.exe",
+              "C:\protoc\bin\protoc.exe"
+            )
+            foreach ($path in $possiblePaths) {
+              if (Test-Path $path) {
+                $protocPath = $path
+                Write-Host "Found protoc at: $path"
+                break
+              }
+            }
+          }
+          
+          if (-not $protocPath) {
+            Write-Error "protoc not found in any expected location"
+            exit 1
+          }
+          
+          # Set environment variables for both the current process and GITHUB_ENV
+          $env:PROTOC = $protocPath
+          echo "PROTOC=$protocPath" >> $env:GITHUB_ENV
+          
+          # Verify protoc works
+          Write-Host "Verifying protoc installation..."
+          & $protocPath --version
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "protoc verification failed"
+            exit 1
+          }
+          
+          # List contents of protoc installation directory
+          $protocDir = Split-Path $protocPath -Parent
+          Write-Host "Contents of protoc directory:"
+          Get-ChildItem -Path $protocDir -Recurse | ForEach-Object {
+            Write-Host $_.FullName
+          }
         shell: powershell
 
       # 5) Install MinGW
@@ -87,11 +130,15 @@ jobs:
       # 7) Build rust with MSVC toolchain
       - name: Build Release Binary
         run: |
-          cargo build --release --target x86_64-pc-windows-msvc -j 4
+          Write-Host "Using PROTOC from: $env:PROTOC"
+          Write-Host "Current PATH: $env:PATH"
+          cargo build --release --target x86_64-pc-windows-msvc -j 4 -vv
         env:
           CARGO_BUILD_JOBS: "4"
           RUSTFLAGS: "-C opt-level=3"
           CARGO_INCREMENTAL: "0"
+          PROTOC: ${{ env.PROTOC }}
+          RUST_BACKTRACE: "1"
 
       # 8) Check that the compiled goosed.exe exists and copy to ui/desktop/src/bin
       - name: Prepare Windows binary and DLLs

--- a/.github/workflows/bundle-desktop-windows.yml
+++ b/.github/workflows/bundle-desktop-windows.yml
@@ -46,8 +46,9 @@ jobs:
         with:
           node-version: 16
 
-      # 4) Install protobuf
+      # 4) Install protobuf and set environment
       - name: Install protobuf
+        id: install-protobuf
         run: |
           # Get latest protoc release info from GitHub API
           Write-Host "Fetching latest protoc release information..."
@@ -69,13 +70,28 @@ jobs:
           Write-Host "Extracting protoc..."
           Expand-Archive -Path "$PROTOC_DIR\protoc.zip" -DestinationPath $PROTOC_DIR -Force
           
-          # Add to PATH and set PROTOC env var
+          # Set environment variables for the current process and future steps
+          $protocPath = "$PROTOC_DIR\bin\protoc.exe"
+          
+          # Set for current process
+          $env:PROTOC = $protocPath
           $env:Path = "$PROTOC_DIR\bin;" + $env:Path
+          
+          # Set for future steps
+          echo "PROTOC=$protocPath" >> $env:GITHUB_ENV
           echo "$PROTOC_DIR\bin" >> $env:GITHUB_PATH
           
-          $protocPath = "$PROTOC_DIR\bin\protoc.exe"
-          echo "PROTOC=$protocPath" >> $env:GITHUB_ENV
-          $env:PROTOC = $protocPath
+          # Create a .cargo/config.toml to set environment variables for cargo
+          $cargoConfig = @"
+          [env]
+          PROTOC = "$protocPath"
+          "@
+          
+          New-Item -ItemType Directory -Force -Path ".cargo"
+          $cargoConfig | Out-File -FilePath ".cargo/config.toml" -Encoding utf8
+          
+          Write-Host "Created .cargo/config.toml:"
+          Get-Content ".cargo/config.toml"
           
           # Verify installation
           Write-Host "Verifying protoc installation..."
@@ -85,12 +101,6 @@ jobs:
           
           Write-Host "protoc version:"
           & $protocPath --version
-          
-          # List contents of protoc directory
-          Write-Host "Contents of protoc directory:"
-          Get-ChildItem -Path $PROTOC_DIR -Recurse | ForEach-Object {
-            Write-Host $_.FullName
-          }
           
           # Test protoc functionality
           Write-Host "Testing protoc functionality..."
@@ -103,8 +113,10 @@ jobs:
           "@
           
           $testProto | Out-File -FilePath "$PROTOC_DIR\test.proto"
-          & $protocPath --version
           & $protocPath --proto_path="$PROTOC_DIR" "$PROTOC_DIR\test.proto"
+          
+          # Export the protoc path for other steps
+          echo "::set-output name=protoc_path::$protocPath"
         shell: powershell
 
       # 5) Install MinGW
@@ -141,20 +153,29 @@ jobs:
         run: |
           Write-Host "Environment Check:"
           Write-Host "PROTOC: $env:PROTOC"
-          Write-Host "PATH: $env:PATH"
+          Write-Host "PATH: $env:Path"
+          
           Write-Host "Testing protoc directly:"
           & $env:PROTOC --version
           
+          Write-Host ".cargo/config.toml contents:"
+          Get-Content ".cargo/config.toml"
+          
           Write-Host "Building with Cargo..."
           $env:RUST_LOG = "debug"
+          
+          # Set PROTOC explicitly in the environment again
+          $env:PROTOC = "${{ steps.install-protobuf.outputs.protoc_path }}"
+          
+          cargo clean
           cargo build --release --target x86_64-pc-windows-msvc -j 4 -vv
         env:
           CARGO_BUILD_JOBS: "4"
           RUSTFLAGS: "-C opt-level=3"
           CARGO_INCREMENTAL: "0"
-          PROTOC: "C:\\protoc\\bin\\protoc.exe"
           RUST_BACKTRACE: "full"
           RUST_LOG: "debug"
+          PROTOC: "${{ steps.install-protobuf.outputs.protoc_path }}"
 
       # 8) Check that the compiled goosed.exe exists and copy to ui/desktop/src/bin
       - name: Prepare Windows binary and DLLs

--- a/.github/workflows/bundle-desktop-windows.yml
+++ b/.github/workflows/bundle-desktop-windows.yml
@@ -46,64 +46,28 @@ jobs:
         with:
           node-version: 16
 
-      # 4) Install protobuf and set environment
-      - name: Install protobuf
-        id: install-protobuf
+      # 4) Install protobuf using a dedicated action
+      - name: Install Protobuf
+        uses: arduino/setup-protoc@v2
+        with:
+          version: "24.x"
+          repo-token: ${{ github.token }}
+
+      # 5) Verify protoc installation
+      - name: Verify Protobuf Installation
         run: |
-          # Get latest protoc release info from GitHub API
-          Write-Host "Fetching latest protoc release information..."
-          $latestRelease = (Invoke-RestMethod -Uri "https://api.github.com/repos/protocolbuffers/protobuf/releases/latest")
-          $windowsAsset = $latestRelease.assets | Where-Object { $_.name -like "*win64.zip" }
-          $PROTOC_VERSION = $latestRelease.tag_name -replace 'v', ''
-          
-          Write-Host "Latest protoc version: $PROTOC_VERSION"
-          Write-Host "Downloading: $($windowsAsset.name)"
-          
-          $PROTOC_DIR = "C:\protoc"
-          
-          Write-Host "Creating protoc directory..."
-          New-Item -ItemType Directory -Force -Path $PROTOC_DIR
-          
-          Write-Host "Downloading protoc..."
-          Invoke-WebRequest -Uri $windowsAsset.browser_download_url -OutFile "$PROTOC_DIR\protoc.zip"
-          
-          Write-Host "Extracting protoc..."
-          Expand-Archive -Path "$PROTOC_DIR\protoc.zip" -DestinationPath $PROTOC_DIR -Force
-          
-          # Set environment variables for the current process and future steps
-          $protocPath = "$PROTOC_DIR\bin\protoc.exe"
-          
-          # Set for current process
-          $env:PROTOC = $protocPath
-          $env:Path = "$PROTOC_DIR\bin;" + $env:Path
-          
-          # Set for future steps
-          echo "PROTOC=$protocPath" >> $env:GITHUB_ENV
-          echo "$PROTOC_DIR\bin" >> $env:GITHUB_PATH
-          
-          # Create a .cargo/config.toml to set environment variables for cargo
-          $cargoConfig = @"
-          [env]
-          PROTOC = "$protocPath"
-          "@
-          
-          New-Item -ItemType Directory -Force -Path ".cargo"
-          $cargoConfig | Out-File -FilePath ".cargo/config.toml" -Encoding utf8
-          
-          Write-Host "Created .cargo/config.toml:"
-          Get-Content ".cargo/config.toml"
-          
-          # Verify installation
           Write-Host "Verifying protoc installation..."
-          Write-Host "PROTOC env var: $env:PROTOC"
-          Write-Host "protoc location:"
-          Get-ChildItem -Path "$PROTOC_DIR\bin\protoc.exe"
+          protoc --version
           
-          Write-Host "protoc version:"
-          & $protocPath --version
+          # Get the protoc path
+          $protocPath = (Get-Command protoc).Path
+          Write-Host "Found protoc at: $protocPath"
+          
+          # Set environment variables
+          echo "PROTOC=$protocPath" >> $env:GITHUB_ENV
+          $env:PROTOC = $protocPath
           
           # Test protoc functionality
-          Write-Host "Testing protoc functionality..."
           $testProto = @"
           syntax = "proto3";
           package test;
@@ -112,11 +76,9 @@ jobs:
           }
           "@
           
-          $testProto | Out-File -FilePath "$PROTOC_DIR\test.proto"
-          & $protocPath --proto_path="$PROTOC_DIR" "$PROTOC_DIR\test.proto"
-          
-          # Export the protoc path for other steps
-          echo "::set-output name=protoc_path::$protocPath"
+          $testProto | Out-File -FilePath "test.proto"
+          & $protocPath --version
+          & $protocPath test.proto
         shell: powershell
 
       # 5) Install MinGW
@@ -156,18 +118,11 @@ jobs:
           Write-Host "PATH: $env:Path"
           
           Write-Host "Testing protoc directly:"
-          & $env:PROTOC --version
-          
-          Write-Host ".cargo/config.toml contents:"
-          Get-Content ".cargo/config.toml"
+          protoc --version
           
           Write-Host "Building with Cargo..."
           $env:RUST_LOG = "debug"
           
-          # Set PROTOC explicitly in the environment again
-          $env:PROTOC = "${{ steps.install-protobuf.outputs.protoc_path }}"
-          
-          cargo clean
           cargo build --release --target x86_64-pc-windows-msvc -j 4 -vv
         env:
           CARGO_BUILD_JOBS: "4"
@@ -175,7 +130,6 @@ jobs:
           CARGO_INCREMENTAL: "0"
           RUST_BACKTRACE: "full"
           RUST_LOG: "debug"
-          PROTOC: "${{ steps.install-protobuf.outputs.protoc_path }}"
 
       # 8) Check that the compiled goosed.exe exists and copy to ui/desktop/src/bin
       - name: Prepare Windows binary and DLLs

--- a/.github/workflows/bundle-desktop-windows.yml
+++ b/.github/workflows/bundle-desktop-windows.yml
@@ -22,19 +22,20 @@ jobs:
   build-desktop-windows:
     name: Build Desktop (Windows)
     runs-on: windows-latest
+    strategy:
+      matrix:
+        target: [x86_64-pc-windows-msvc]  # Using MSVC for better Windows compatibility
 
     steps:
       # 1) Check out source
       - name: Checkout repository
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 
-      # 2) Set up Rust
+      # 2) Set up Rust with specific target
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@38b70195107dddab2c7bbd522bcf763bac00963b
-        # If you need a specific version, you could do:
-        # or uses: actions/setup-rust@v1
-        # with:
-        #   rust-version: 1.73.0
+        with:
+          targets: ${{ matrix.target }}
 
       # 3) Set up Node.js
       - name: Set up Node.js
@@ -42,16 +43,19 @@ jobs:
         with:
           node-version: 16
 
-      # 4) Cache dependencies (optional, can add more paths if needed)
-      - name: Cache node_modules
+      # 4) Cache dependencies
+      - name: Cache Dependencies
         uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # pin@v3
         with:
           path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
             node_modules
             ui/desktop/node_modules
-          key: ${{ runner.os }}-build-desktop-windows-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock', '**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-build-desktop-windows-
+            ${{ runner.os }}-${{ matrix.target }}-
 
       # 5) Install top-level dependencies if a package.json is in root
       - name: Install top-level deps
@@ -60,7 +64,7 @@ jobs:
             npm install
           }
 
-      # 6) Build rust for x86_64-pc-windows-gnu
+      # 6) Install MinGW for DLLs
       - name: Install MinGW dependencies
         run: |
           choco install mingw --version=8.1.0
@@ -73,21 +77,24 @@ jobs:
             Write-Host $_.FullName
           }
 
+      # 7) Build rust with MSVC toolchain
       - name: Cargo build for Windows
         run: |
-          cargo build --release --target x86_64-pc-windows-gnu
+          cargo build --release --target ${{ matrix.target }}
 
-      # 7) Check that the compiled goosed.exe exists and copy exe/dll to ui/desktop/src/bin
+      # 8) Check that the compiled goosed.exe exists and copy to ui/desktop/src/bin
       - name: Prepare Windows binary and DLLs
         run: |
-          if (!(Test-Path .\target\x86_64-pc-windows-gnu\release\goosed.exe)) {
-            Write-Error "Windows binary not found."; exit 1;
+          $binaryPath = ".\target\${{ matrix.target }}\release\goosed.exe"
+          if (!(Test-Path $binaryPath)) {
+            Write-Error "Windows binary not found at $binaryPath"; exit 1;
           }
+          
           Write-Host "Copying Windows binary and DLLs to ui/desktop/src/bin..."
           if (!(Test-Path ui\desktop\src\bin)) {
             New-Item -ItemType Directory -Path ui\desktop\src\bin | Out-Null
           }
-          Copy-Item .\target\x86_64-pc-windows-gnu\release\goosed.exe ui\desktop\src\bin\
+          Copy-Item $binaryPath ui\desktop\src\bin\
           
           # Copy MinGW DLLs - try both possible locations
           $mingwPaths = @(
@@ -106,18 +113,18 @@ jobs:
           }
           
           # Copy any other DLLs from the release directory
-          ls .\target\x86_64-pc-windows-gnu\release\*.dll | ForEach-Object {
-            Copy-Item $_ ui\desktop\src\bin\
+          Get-ChildItem ".\target\${{ matrix.target }}\release\*.dll" -ErrorAction SilentlyContinue | ForEach-Object {
+            Copy-Item $_.FullName ui\desktop\src\bin\
           }
 
-      # 8) Install & build UI desktop
+      # 9) Install & build UI desktop
       - name: Build desktop UI with npm
         run: |
           cd ui\desktop
           npm install
           npm run bundle:windows
 
-      # 9) Copy exe/dll to final out/Goose-win32-x64/resources/bin
+      # 10) Copy exe/dll to final out/Goose-win32-x64/resources/bin
       - name: Copy exe/dll to out folder
         run: |
           cd ui\desktop
@@ -125,13 +132,12 @@ jobs:
             New-Item -ItemType Directory -Path .\out\Goose-win32-x64\resources\bin | Out-Null
           }
           Copy-Item .\src\bin\goosed.exe .\out\Goose-win32-x64\resources\bin\
-          ls .\src\bin\*.dll | ForEach-Object {
-            Copy-Item $_ .\out\Goose-win32-x64\resources\bin\
+          Get-ChildItem .\src\bin\*.dll -ErrorAction SilentlyContinue | ForEach-Object {
+            Copy-Item $_.FullName .\out\Goose-win32-x64\resources\bin\
           }
 
-      # 10) Code signing (if enabled)
+      # 11) Code signing (if enabled)
       - name: Sign Windows executable
-        # Skip this step by default - enable when we have a certificate
         if: inputs.signing && inputs.signing == true
         env:
           WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
@@ -149,7 +155,7 @@ jobs:
           # Clean up the certificate
           Remove-Item -Path $certPath
 
-      # 11) Upload the final Windows build
+      # 12) Upload the final Windows build
       - name: Upload Windows build artifacts
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # pin@v4
         with:


### PR DESCRIPTION
attempting to speed up bundle-desktop-windows.yml per @Kvadratni.

tl;dr:
- changes build target to x86_64-pc-windows-msvc which is the preferred toolchain
- adds an explicit target specification in rust toolchain setup
- adds more comprehensive caching paths
- keeps mingw dependencies and dlls

should make more reliable with faster build times due to improved caching.

creating PR to trigger the workflow through a PR comment.