### PR TITLE
doc: Sharing sessions service and how to share sessions

### DIFF
--- a/documentation/docs/guides/managing-goose-sessions.md
+++ b/documentation/docs/guides/managing-goose-sessions.md
@@ -96,7 +96,7 @@ Note that sessions are automatically saved when you exit.
         To resume a specific session, run the following command: 
 
         ```
-        goose session -r --name <name>
+        goose session -r --name <n>
         ```
         For example, to resume the session named `react-migration`, you would run:
 
@@ -290,3 +290,63 @@ Search allows you to find specific content within your current session. The sear
         ```
     </TabItem>
 </Tabs>
+
+## Share Sessions with Others
+
+Goose runs locally on your computer and stores sessions on your machine. To share sessions with others, you need a service that can:
+- Store sessions in a central location
+- Make them accessible to other Goose users
+- Handle the sharing and retrieval of session data
+
+To implement this, you will need:
+- A storage method for the shared sessions
+- A hosted service to handle the sharing
+- API endpoints that match the [Goose Session Sharing API Reference](https://goosed.stage.sqprod.co/docs)
+
+### Configure Session Sharing
+
+Once you have a sharing service URL:
+
+1. Open Goose Desktop
+2. Click the three dots (...) in the top-right corner
+3. Select **Settings**
+4. Find the **Session Sharing** section
+5. Enable session sharing using the toggle
+6. Enter your sharing service URL in the **Base URL** field
+   - Example: `https://your-sharing-service.example.com`
+   - Do not include a trailing slash
+
+:::tip
+The sharing service URL must be accessible to anyone you want to share sessions with.
+:::
+
+### Share a Session
+
+Once sharing is configured, you can share sessions:
+
+1. Start or open a session you want to share
+2. Click the three dots (...) in the top-right corner
+3. Click **Share Session**
+4. Copy the generated share link
+
+Anyone with access to the same sharing service can view your shared session using this link.
+
+:::info
+Sessions are only shared when you explicitly choose to share them. Enabling session sharing does not automatically share all your sessions.
+:::
+
+### View Shared Sessions
+
+To view a session someone shared with you:
+
+1. Make sure you have configured the same sharing service URL
+2. Open the share link they provided
+3. The shared session will open in Goose Desktop
+
+You can also browse all shared sessions:
+
+1. Click the three dots (...) in the top-right corner
+2. Select **Previous Sessions**
+3. Click the **Shared** tab
+
+For details about implementing a sharing service, see the [API Reference Documentation](https://goosed.stage.sqprod.co/docs).

--- a/documentation/docs/guides/managing-goose-sessions.md
+++ b/documentation/docs/guides/managing-goose-sessions.md
@@ -96,7 +96,7 @@ Note that sessions are automatically saved when you exit.
         To resume a specific session, run the following command: 
 
         ```
-        goose session -r --name <n>
+        goose session -r --name <name>
         ```
         For example, to resume the session named `react-migration`, you would run:
 

--- a/documentation/docs/guides/managing-goose-sessions.md
+++ b/documentation/docs/guides/managing-goose-sessions.md
@@ -231,15 +231,13 @@ You can remove sessions using CLI commands. For detailed instructions on session
 
 ## Share Sessions
 
-Goose sessions can be shared with others, making it easy to document and distribute solutions to technical challenges or important project discussions. ecause Goose is local to your machine, by default, all your sessions are only available on your computer. 
-
-To make sessions shareable, you'll need to the Goose API to implement a session sharing service.
+Because Goose is local to your machine, by default, all your sessions are only available on your device. To make sessions shareable, you'll need to use a session sharing service.
 
 <Tabs groupId="interface">
     <TabItem value="ui" label="Goose Desktop" default>
         ### How to Implement a Session Sharing Service
 
-        To share sessions through Goose Desktop, you need to use a session sharing service that can:
+       Your session sharing service should:
         - Store sessions in a central location
         - Make them accessible to other Goose users
         - Handle the sharing and retrieval of session data
@@ -251,14 +249,14 @@ To make sessions shareable, you'll need to the Goose API to implement a session 
 
         ### Enable Session Sharing
 
-        Once your session sharing service is set up, you should have a base URL. This should be used by you and people you plan to exchange sessions with. Connect Goose to your session sharing service by:
+        Once your session sharing service is set up, you'll have a service URL. This URL should be used by you and anyone you plan to share sessions with. To connect Goose to the sharing service:
 
         1. Open Goose Desktop
         2. Click the three dots (...) in the top-right corner
-        3. Select **Advanced Settings**
+        3. Select **Settings**
         4. Find the **Session Sharing** section
         5. Enable session sharing using the toggle
-        6. Enter your sharing service URL in the **Base URL** field
+        6. Enter your service URL in the **Base URL** field
            - Example: `https://your-sharing-service.example.com`
            - Do not include a trailing slash
 
@@ -281,7 +279,7 @@ To make sessions shareable, you'll need to the Goose API to implement a session 
 
         To view a session someone shared with you:
 
-        1. Make sure you have configured the same sharing service URL
+        1. Make sure you have configured the same service URL
         2. Open the share link they provided
         3. The shared session will open in Goose Desktop
 
@@ -293,7 +291,6 @@ To make sessions shareable, you'll need to the Goose API to implement a session 
 </Tabs>
 
 ## Search Within Sessions
-
 Search allows you to find specific content within your current session. The search functionality is available in both CLI and Desktop interfaces.
 
 <Tabs>

--- a/documentation/docs/guides/managing-goose-sessions.md
+++ b/documentation/docs/guides/managing-goose-sessions.md
@@ -229,6 +229,69 @@ You can resume a CLI session in Desktop and vice versa.
 
 You can remove sessions using CLI commands. For detailed instructions on session removal, see the [CLI Commands documentation](/docs/guides/goose-cli-commands#session-remove-options).
 
+## Share Sessions
+
+Goose sessions can be shared with others, making it easy to document and distribute solutions to technical challenges or important project discussions. ecause Goose is local to your machine, by default, all your sessions are only available on your computer. 
+
+To make sessions shareable, you'll need to the Goose API to implement a session sharing service.
+
+<Tabs groupId="interface">
+    <TabItem value="ui" label="Goose Desktop" default>
+        ### How to Implement a Session Sharing Service
+
+        To share sessions through Goose Desktop, you need to use a session sharing service that can:
+        - Store sessions in a central location
+        - Make them accessible to other Goose users
+        - Handle the sharing and retrieval of session data
+
+        To implement this, you will need:
+        - A storage method for the shared sessions
+        - A hosted service to handle the sharing
+        - API endpoints that match the [Goose Session Sharing API Reference](https://goosed.stage.sqprod.co/docs)
+
+        ### Enable Session Sharing
+
+        Once your session sharing service is set up, you should have a base URL. This should be used by you and people you plan to exchange sessions with. Connect Goose to your session sharing service by:
+
+        1. Open Goose Desktop
+        2. Click the three dots (...) in the top-right corner
+        3. Select **Advanced Settings**
+        4. Find the **Session Sharing** section
+        5. Enable session sharing using the toggle
+        6. Enter your sharing service URL in the **Base URL** field
+           - Example: `https://your-sharing-service.example.com`
+           - Do not include a trailing slash
+
+        ### Share a Session
+
+        Once sharing is enabled, you can share sessions:
+
+        1. Start or open a session you want to share
+        2. Click the three dots (...) in the top-right corner
+        3. Click **Share Session**
+        4. Copy the generated share link
+
+        Anyone with access to the same sharing service can view your shared session using this link.
+
+        :::info
+        Sessions are only shared when you explicitly choose to share them. Enabling session sharing does not automatically share all your sessions.
+        :::
+
+        ### View Shared Sessions
+
+        To view a session someone shared with you:
+
+        1. Make sure you have configured the same sharing service URL
+        2. Open the share link they provided
+        3. The shared session will open in Goose Desktop
+
+        For details about implementing a sharing service, see the [API Reference Documentation](https://goosed.stage.sqprod.co/docs).
+    </TabItem>
+    <TabItem value="cli" label="Goose CLI">
+        In the CLI, sessions are stored as `.jsonl` files in `~/.local/share/goose/sessions/`. You can directly share these files with others.
+    </TabItem>
+</Tabs>
+
 ## Search Within Sessions
 
 Search allows you to find specific content within your current session. The search functionality is available in both CLI and Desktop interfaces.
@@ -291,97 +354,3 @@ Search allows you to find specific content within your current session. The sear
     </TabItem>
 </Tabs>
 
-## Share Sessions with Others
-
-Goose runs locally on your computer and stores sessions on your machine. 
-
-<Tabs groupId="interface">
-    <TabItem value="ui" label="Goose Desktop" default>
-        To share sessions through Goose Desktop, you need a service that can:
-        - Store sessions in a central location
-        - Make them accessible to other Goose users
-        - Handle the sharing and retrieval of session data
-
-        To implement this, you will need:
-        - A storage method for the shared sessions
-        - A hosted service to handle the sharing
-        - API endpoints that match the [Goose Session Sharing API Reference](https://goosed.stage.sqprod.co/docs)
-
-        ### Configure Session Sharing
-
-        Once you have a sharing service URL:
-
-        1. Open Goose Desktop
-        2. Click the three dots (...) in the top-right corner
-        3. Select **Settings**
-        4. Find the **Session Sharing** section
-        5. Enable session sharing using the toggle
-        6. Enter your sharing service URL in the **Base URL** field
-           - Example: `https://your-sharing-service.example.com`
-           - Do not include a trailing slash
-
-        :::tip
-        The sharing service URL must be accessible to anyone you want to share sessions with.
-        :::
-
-        ### Share a Session
-
-        Once sharing is configured, you can share sessions:
-
-        1. Start or open a session you want to share
-        2. Click the three dots (...) in the top-right corner
-        3. Click **Share Session**
-        4. Copy the generated share link
-
-        Anyone with access to the same sharing service can view your shared session using this link.
-
-        :::info
-        Sessions are only shared when you explicitly choose to share them. Enabling session sharing does not automatically share all your sessions.
-        :::
-
-        ### View Shared Sessions
-
-        To view a session someone shared with you:
-
-        1. Make sure you have configured the same sharing service URL
-        2. Open the share link they provided
-        3. The shared session will open in Goose Desktop
-
-        You can also browse all shared sessions:
-
-        1. Click the three dots (...) in the top-right corner
-        2. Select **Previous Sessions**
-        3. Click the **Shared** tab
-
-        For details about implementing a sharing service, see the [API Reference Documentation](https://goosed.stage.sqprod.co/docs).
-    </TabItem>
-    <TabItem value="cli" label="Goose CLI">
-        In the CLI, sessions are stored as `.jsonl` files in `~/.local/share/goose/sessions/`. You can directly share these files with others.
-
-        To share a session:
-        ```bash
-        # Copy the session file
-        cp ~/.local/share/goose/sessions/your-session.jsonl /path/to/shared/location
-        ```
-
-        To use a shared session file:
-        ```bash
-        # Copy the shared file to your sessions directory
-        cp /path/to/shared/session.jsonl ~/.local/share/goose/sessions/
-
-        # Resume the session
-        goose session -r --name session-name
-        ```
-
-        :::tip
-        The session filename (without .jsonl) is what you will use with the --name flag to resume it.
-        :::
-
-        :::warning
-        When sharing session files directly:
-        - Make sure to share both the file and its intended name
-        - Be aware that sessions might contain sensitive information
-        - The recipient will need the same extensions enabled to use any extension-specific features
-        :::
-    </TabItem>
-</Tabs>

--- a/documentation/docs/guides/managing-goose-sessions.md
+++ b/documentation/docs/guides/managing-goose-sessions.md
@@ -16,7 +16,7 @@ A session is a single, continuous interaction between you and Goose, providing a
     <TabItem value="ui" label="Goose Desktop" default>
         After choosing an LLM provider, you'll see the session interface ready for use. Type your questions, tasks, or instructions directly into the input field, and Goose will immediately get to work. 
 
-        To start a new session at any time, click the three dots in the top-right corner of the application and select **New Session** from the dropdown menu.
+        To start a new session at any time, click the gear icon in the top-right corner of the application and select **New Session** from the dropdown menu.
 
         You can also use keyboard shortcuts to start a new session or bring focus to open Goose windows.
         
@@ -252,7 +252,7 @@ Because Goose is local to your machine, by default, all your sessions are only a
         Once your session sharing service is set up, you'll have a service URL. This URL should be used by you and anyone you plan to share sessions with. To connect Goose to the sharing service:
 
         1. Open Goose Desktop
-        2. Click the three dots (...) in the top-right corner
+        2. Click the gear icon in the top-right corner
         3. Select **Settings**
         4. Find the **Session Sharing** section
         5. Enable session sharing using the toggle
@@ -265,7 +265,7 @@ Because Goose is local to your machine, by default, all your sessions are only a
         Once sharing is enabled, you can share sessions:
 
         1. Start or open a session you want to share
-        2. Click the three dots (...) in the top-right corner
+        2. Click the gear icon in the top-right corner
         3. Click **Share Session**
         4. Copy the generated share link
 

--- a/documentation/docs/guides/managing-goose-sessions.md
+++ b/documentation/docs/guides/managing-goose-sessions.md
@@ -293,60 +293,95 @@ Search allows you to find specific content within your current session. The sear
 
 ## Share Sessions with Others
 
-Goose runs locally on your computer and stores sessions on your machine. To share sessions with others, you need a service that can:
-- Store sessions in a central location
-- Make them accessible to other Goose users
-- Handle the sharing and retrieval of session data
+Goose runs locally on your computer and stores sessions on your machine. 
 
-To implement this, you will need:
-- A storage method for the shared sessions
-- A hosted service to handle the sharing
-- API endpoints that match the [Goose Session Sharing API Reference](https://goosed.stage.sqprod.co/docs)
+<Tabs groupId="interface">
+    <TabItem value="ui" label="Goose Desktop" default>
+        To share sessions through Goose Desktop, you need a service that can:
+        - Store sessions in a central location
+        - Make them accessible to other Goose users
+        - Handle the sharing and retrieval of session data
 
-### Configure Session Sharing
+        To implement this, you will need:
+        - A storage method for the shared sessions
+        - A hosted service to handle the sharing
+        - API endpoints that match the [Goose Session Sharing API Reference](https://goosed.stage.sqprod.co/docs)
 
-Once you have a sharing service URL:
+        ### Configure Session Sharing
 
-1. Open Goose Desktop
-2. Click the three dots (...) in the top-right corner
-3. Select **Settings**
-4. Find the **Session Sharing** section
-5. Enable session sharing using the toggle
-6. Enter your sharing service URL in the **Base URL** field
-   - Example: `https://your-sharing-service.example.com`
-   - Do not include a trailing slash
+        Once you have a sharing service URL:
 
-:::tip
-The sharing service URL must be accessible to anyone you want to share sessions with.
-:::
+        1. Open Goose Desktop
+        2. Click the three dots (...) in the top-right corner
+        3. Select **Settings**
+        4. Find the **Session Sharing** section
+        5. Enable session sharing using the toggle
+        6. Enter your sharing service URL in the **Base URL** field
+           - Example: `https://your-sharing-service.example.com`
+           - Do not include a trailing slash
 
-### Share a Session
+        :::tip
+        The sharing service URL must be accessible to anyone you want to share sessions with.
+        :::
 
-Once sharing is configured, you can share sessions:
+        ### Share a Session
 
-1. Start or open a session you want to share
-2. Click the three dots (...) in the top-right corner
-3. Click **Share Session**
-4. Copy the generated share link
+        Once sharing is configured, you can share sessions:
 
-Anyone with access to the same sharing service can view your shared session using this link.
+        1. Start or open a session you want to share
+        2. Click the three dots (...) in the top-right corner
+        3. Click **Share Session**
+        4. Copy the generated share link
 
-:::info
-Sessions are only shared when you explicitly choose to share them. Enabling session sharing does not automatically share all your sessions.
-:::
+        Anyone with access to the same sharing service can view your shared session using this link.
 
-### View Shared Sessions
+        :::info
+        Sessions are only shared when you explicitly choose to share them. Enabling session sharing does not automatically share all your sessions.
+        :::
 
-To view a session someone shared with you:
+        ### View Shared Sessions
 
-1. Make sure you have configured the same sharing service URL
-2. Open the share link they provided
-3. The shared session will open in Goose Desktop
+        To view a session someone shared with you:
 
-You can also browse all shared sessions:
+        1. Make sure you have configured the same sharing service URL
+        2. Open the share link they provided
+        3. The shared session will open in Goose Desktop
 
-1. Click the three dots (...) in the top-right corner
-2. Select **Previous Sessions**
-3. Click the **Shared** tab
+        You can also browse all shared sessions:
 
-For details about implementing a sharing service, see the [API Reference Documentation](https://goosed.stage.sqprod.co/docs).
+        1. Click the three dots (...) in the top-right corner
+        2. Select **Previous Sessions**
+        3. Click the **Shared** tab
+
+        For details about implementing a sharing service, see the [API Reference Documentation](https://goosed.stage.sqprod.co/docs).
+    </TabItem>
+    <TabItem value="cli" label="Goose CLI">
+        In the CLI, sessions are stored as `.jsonl` files in `~/.local/share/goose/sessions/`. You can directly share these files with others.
+
+        To share a session:
+        ```bash
+        # Copy the session file
+        cp ~/.local/share/goose/sessions/your-session.jsonl /path/to/shared/location
+        ```
+
+        To use a shared session file:
+        ```bash
+        # Copy the shared file to your sessions directory
+        cp /path/to/shared/session.jsonl ~/.local/share/goose/sessions/
+
+        # Resume the session
+        goose session -r --name session-name
+        ```
+
+        :::tip
+        The session filename (without .jsonl) is what you will use with the --name flag to resume it.
+        :::
+
+        :::warning
+        When sharing session files directly:
+        - Make sure to share both the file and its intended name
+        - Be aware that sessions might contain sensitive information
+        - The recipient will need the same extensions enabled to use any extension-specific features
+        :::
+    </TabItem>
+</Tabs>


### PR DESCRIPTION
This pull request updates the documentation for managing Goose sessions, focusing on improving clarity and adding new functionality for session sharing. Key changes include updating instructions for starting and resuming sessions, introducing a comprehensive section on sharing sessions, and minor adjustments to the structure of the guide.

### Updates to session management instructions:
* Updated the description for starting a new session in Goose Desktop to reflect the change from the "three dots" icon to the "gear" icon. (`[documentation/docs/guides/managing-goose-sessions.mdL19-R19](diffhunk://#diff-08b4b977d065693949daba778a60368ed3033df53b958ca3a73405f1ceb95c34L19-R19)`)
* Modified the CLI command for resuming sessions, changing the placeholder `<name>` to `<n>` for consistency. (`[documentation/docs/guides/managing-goose-sessions.mdL99-R99](diffhunk://#diff-08b4b977d065693949daba778a60368ed3033df53b958ca3a73405f1ceb95c34L99-R99)`)

### New functionality: Session sharing
* Added a detailed section on enabling and using session sharing in Goose Desktop, including setup instructions, sharing sessions, and viewing shared sessions. This includes requirements for implementing a session sharing service and links to the API reference documentation. (`[documentation/docs/guides/managing-goose-sessions.mdL232-R293](diffhunk://#diff-08b4b977d065693949daba778a60368ed3033df53b958ca3a73405f1ceb95c34L232-R293)`)

### Structural adjustments:
* Reorganized the guide by moving the "Search Within Sessions" section to follow the new "Share Sessions" section. (`[documentation/docs/guides/managing-goose-sessions.mdL232-R293](diffhunk://#diff-08b4b977d065693949daba778a60368ed3033df53b958ca3a73405f1ceb95c34L232-R293)`)