### PR TITLE
Fix build-cli workflow to use correct PR branch

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -9,6 +9,10 @@ on:
         required: false
         default: ""
         type: string
+      pr_number:
+        required: false
+        default: ""
+        type: string
       # Let's allow overriding the OSes and architectures in JSON array form:
       # e.g. '["ubuntu-latest","macos-latest"]'
       # If no input is provided, these defaults apply.
@@ -39,8 +43,26 @@ jobs:
             target-suffix: apple-darwin
 
     steps:
+      - name: Get PR details
+        if: ${{ inputs.pr_number != '' }}
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ inputs.pr_number }}
+            });
+            core.setOutput('head_ref', pr.data.head.ref);
+            core.setOutput('head_sha', pr.data.head.sha);
+            core.setOutput('head_repo', pr.data.head.repo.full_name);
+
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        with:
+          ref: ${{ inputs.pr_number != '' && steps.pr.outputs.head_sha || github.sha }}
+          repository: ${{ inputs.pr_number != '' && steps.pr.outputs.head_repo || github.repository }}
 
       - name: Update version in Cargo.toml
         if: ${{ inputs.version != '' }}

--- a/.github/workflows/pr-comment-build-cli.yml
+++ b/.github/workflows/pr-comment-build-cli.yml
@@ -41,6 +41,8 @@ jobs:
     needs: [trigger-on-command]
     if: ${{ needs.trigger-on-command.outputs.continue == 'true' }}
     uses: ./.github/workflows/build-cli.yml
+    with:
+      pr_number: ${{ needs.trigger-on-command.outputs.pr_number }}
 
   pr-comment-cli:
     name: PR Comment with CLI builds


### PR DESCRIPTION
## Problem

PR #2754 (Hermit integration) was reverted in PR #2759 due to build failures. The root cause was that the build-cli workflow was using main branch code instead of the PR branch code when triggered from PR comments.

## Solution

This PR fixes the GitHub Actions workflow to properly handle PR branch builds:

### Changes Made:
- **Enhanced pr-comment-build-cli.yml**: Pass PR number to reusable workflow
- **Enhanced build-cli.yml**: Fetch PR details and checkout correct branch
- **Backward Compatible**: Regular builds (release, canary) unchanged
- **Proper Branch Handling**: Uses PR's head SHA when building from comments

### Technical Details:
- Added `pr_number` input parameter to build-cli.yml workflow
- Added PR details fetching step using GitHub API
- Modified checkout step to use PR's head SHA and repository when building from PR
- Maintains backward compatibility for non-PR builds

## Testing

Once merged, this can be tested by:
1. Creating a test PR with some changes
2. Commenting `.build-cli` on the PR
3. Verifying the build uses the PR branch code (not main)

## Impact

- **Fixes Root Cause**: Resolves the issue that led to PR #2759 revert
- **Enables Hermit Re-integration**: Paves the way for safe re-introduction of Hermit toolchain management
- **Low Risk**: Changes are isolated to the problematic workflow
- **Backward Compatible**: Existing workflows continue to work unchanged

## Next Steps

After this fix is confirmed working:
1. **Gradual Hermit Re-integration**: Start with single workflow, then expand
2. **Monitor Builds**: Watch for stability after each integration step
3. **Team Communication**: Update team on fix progress

Fixes the core issue mentioned in PR #2759 revert.