### PR TITLE
(experiment) sub-recipes prototype

### DIFF
--- a/crates/goose-cli/src/recipes/recipe.rs
+++ b/crates/goose-cli/src/recipes/recipe.rs
@@ -1,12 +1,14 @@
 use anyhow::Result;
 use console::style;
+use goose::agents::extension::Envs;
+use goose::config::ExtensionConfig;
 
 use crate::recipes::print_recipe::{
     missing_parameters_command_line, print_parameters_with_values, print_recipe_explanation,
     print_required_parameters_for_template,
 };
 use crate::recipes::search_recipe::retrieve_recipe_file;
-use goose::recipe::{Recipe, RecipeParameter, RecipeParameterRequirement};
+use goose::recipe::{Recipe, RecipeParameter, RecipeParameterRequirement, SubRecipe};
 use minijinja::{Environment, Error, Template, UndefinedBehavior};
 use serde_json::Value as JsonValue;
 use serde_yaml::Value as YamlValue;
@@ -258,6 +260,24 @@ fn render_content_with_params(content: &str, params: &HashMap<String, String>) -
             e.to_string()
         )
     })
+}
+
+pub fn subrecipe_extension(subrecipes: &Vec<SubRecipe>) -> ExtensionConfig {
+    let json = serde_json::to_string(subrecipes).expect("Failed to serialize subrecipes");
+    ExtensionConfig::Stdio {
+        name: String::from("subrecipes"),
+        cmd: String::from("uvx"),
+        args: vec![
+            String::from("subrecipes-mcp"),
+            String::from("--subrecipes-json"),
+            json,
+        ],
+        envs: Envs::default(),
+        timeout: None,
+        env_keys: vec![],
+        description: Some(String::from("Execute sub-recipes using the provided tools")),
+        bundled: None,
+    }
 }
 
 #[cfg(test)]

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -258,6 +258,8 @@ impl ExtensionManager {
             .await
             .map_err(|e| ExtensionError::Initialization(config.clone(), e))?;
 
+        // dbg!(&init_result);
+
         if let Some(instructions) = init_result.instructions {
             self.instructions
                 .insert(sanitized_name.clone(), instructions);

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -63,6 +63,7 @@ impl Agent {
             Some(model_name),
             tool_selection_strategy,
         );
+        // println!("Using system prompt: {}", system_prompt);
 
         // Handle toolshim if enabled
         let mut toolshim_tools = vec![];

--- a/crates/goose/src/recipe/mod.rs
+++ b/crates/goose/src/recipe/mod.rs
@@ -85,6 +85,9 @@ pub struct Recipe {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parameters: Option<Vec<RecipeParameter>>, // any additional parameters for the recipe
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subrecipes: Option<Vec<SubRecipe>>, // any sub-recipes that this recipe depends on
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -144,6 +147,11 @@ pub struct RecipeParameter {
     pub default: Option<String>,
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SubRecipe {
+    pub path: String, // path to the sub-recipe file
+}
+
 /// Builder for creating Recipe instances
 pub struct RecipeBuilder {
     // Required fields with default values
@@ -159,6 +167,7 @@ pub struct RecipeBuilder {
     activities: Option<Vec<String>>,
     author: Option<Author>,
     parameters: Option<Vec<RecipeParameter>>,
+    subrecipes: Option<Vec<SubRecipe>>,
 }
 
 impl Recipe {
@@ -188,6 +197,7 @@ impl Recipe {
             activities: None,
             author: None,
             parameters: None,
+            subrecipes: None,
         }
     }
 }
@@ -252,6 +262,12 @@ impl RecipeBuilder {
         self
     }
 
+    /// Sets the sub-recipes for the Recipe
+    pub fn subrecipes(mut self, subrecipes: Vec<SubRecipe>) -> Self {
+        self.subrecipes = Some(subrecipes);
+        self
+    }
+
     /// Builds the Recipe instance
     ///
     /// Returns an error if any required fields are missing
@@ -274,6 +290,7 @@ impl RecipeBuilder {
             activities: self.activities,
             author: self.author,
             parameters: self.parameters,
+            subrecipes: self.subrecipes,
         })
     }
 }

--- a/subrecipes-mcp/.gitignore
+++ b/subrecipes-mcp/.gitignore
@@ -1,0 +1,2 @@
+build
+subrecipes_mcp.egg-info/

--- a/subrecipes-mcp/README.md
+++ b/subrecipes-mcp/README.md
@@ -1,0 +1,5 @@
+an MCP server that runs goose recipes, to be used in a prototype for subrecipe implementaiton.
+
+install using:
+
+  uv tool install -e .

--- a/subrecipes-mcp/main.py
+++ b/subrecipes-mcp/main.py
@@ -1,0 +1,83 @@
+import argparse
+import asyncio
+import json
+from typing import Awaitable, Callable
+from pathlib import Path
+from fastmcp import FastMCP, Context
+from mcp import types
+
+server = FastMCP(
+    "Subrecipes 🚀",
+    instructions="This extension allows you to run subrecipes.",
+)
+
+del server._mcp_server.request_handlers[
+    types.ListResourcesRequest
+]  # Otherwise the Goose system prompt says this supports resources
+
+
+def runner(subrecipe: dict) -> tuple[str, Callable[[Context], Awaitable[str]]]:
+    path = Path(subrecipe["path"])
+    name = (
+        "_".join(path.parts[-2:])
+        .removesuffix(".yaml")
+        .removesuffix(".yml")
+        .removesuffix(".json")
+    )[:64]  # Claude rejected a name for being longer than 64 characters
+    name = name.replace(".", "_").replace(" ", "_")
+
+    async def tool_func(ctx: Context) -> str:
+        await ctx.info(f"Running subrecipe {name}")
+
+        # shell out to the subrecipe and stream stdout/stderr
+        process = await asyncio.create_subprocess_exec(
+            "goose",
+            "run",
+            "--recipe",
+            path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        output = []
+
+        async def read_stream(stream, name):
+            while True:
+                line = await stream.readline()
+                if not line:
+                    break
+                if line := line.decode("utf-8").rstrip():
+                    await ctx.log(f"{name}: {line}")
+                    output.append(line)
+
+        await asyncio.gather(
+            read_stream(process.stdout, "stdout"),
+            read_stream(process.stderr, "stderr"),
+        )
+
+        return_code = await process.wait()
+        return f"Subrecipe {name} finished with return code {return_code}"
+
+    return name, tool_func
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--subrecipes-json", type=str, required=True)
+    args = parser.parse_args()
+
+    subrecipes_json = json.loads(args.subrecipes_json)
+
+    for subrecipe in subrecipes_json:
+        name, tool_func = runner(subrecipe)
+        server.tool(
+            tool_func,
+            name=name,
+            description=f"Run {name}",
+        )
+
+    server.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/subrecipes-mcp/pyproject.toml
+++ b/subrecipes-mcp/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "subrecipes-mcp"
+version = "0.1.0"
+description = "Add your description here"
+requires-python = ">=3.13"
+dependencies = [
+    "fastmcp>=2.3.4",
+]
+
+[project.scripts]
+subrecipes-mcp = "main:main"

--- a/subrecipes.yaml
+++ b/subrecipes.yaml
@@ -1,0 +1,25 @@
+version: 1.0.0
+title: "Goose Recipe Handler"
+description: "A simple request router using sub-recipes"
+
+prompt: |
+  You are tasked with answering incoming requests and taking action.
+  Read the oldest file in 'inbox' and see if you can help.
+
+  Use the tools available to you to process the request.
+
+  Write replies to the 'oubox' folder, with the same name as the file you read from 'inbox'.
+
+  If there is no appropriate action to take, just reply stating that you cannot help.
+
+  If you can help, respond with the result of your action.
+
+  Then "touch" the file in 'inbox' to mark it as processed.
+
+extensions:
+  - type: builtin # just to read the file
+    name: developer
+
+subrecipes:
+  - path: ../goose-recipes/joke-of-the-day/recipe.yaml
+  - path: ../goose-recipes/tutorial-trip-planner/recipe.yaml


### PR DESCRIPTION
(not to merge)

This is a minimal prototype of sub-recipes. You can add a `subrecipes` field to your recipe, and Goose will add tool calls representing each sub-recipe. No parameters are supported in this prototype.

To get it working, cd into the `subrecipes-mcp` directory and run `uv tool install -e .`.