### PR TITLE
Fix session history scroll jumpy when virtual scrolling

### DIFF
--- a/ui/desktop/src/components/conversation/SearchBar.tsx
+++ b/ui/desktop/src/components/conversation/SearchBar.tsx
@@ -22,6 +22,8 @@ interface SearchBarProps {
   inputRef?: React.RefObject<HTMLInputElement>;
   /** Initial search term */
   initialSearchTerm?: string;
+  /** Placeholder text for the search input */
+  placeholder?: string;
 }
 
 /**
@@ -34,6 +36,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({
   searchResults,
   inputRef: externalInputRef,
   initialSearchTerm = '',
+  placeholder = 'Search conversation...', // Default placeholder
 }: SearchBarProps) => {
   const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
   const [caseSensitive, setCaseSensitive] = useState(false);
@@ -157,7 +160,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({
               value={searchTerm}
               onChange={handleSearch}
               onKeyDown={handleKeyDown}
-              placeholder="Search conversation..."
+              placeholder={placeholder}
               className="w-full text-sm pl-9 pr-24 py-3 bg-bgAppInverse
                       placeholder:text-textSubtleInverse focus:outline-none 
                        active:border-borderProminent"

--- a/ui/desktop/src/components/conversation/SearchView.tsx
+++ b/ui/desktop/src/components/conversation/SearchView.tsx
@@ -19,6 +19,8 @@ interface SearchViewProps {
     count: number;
     currentIndex: number;
   } | null;
+  /** Placeholder text for the search input */
+  placeholder?: string;
 }
 
 interface SearchContainerElement extends HTMLDivElement {
@@ -36,6 +38,7 @@ export const SearchView: React.FC<PropsWithChildren<SearchViewProps>> = ({
   onSearch,
   onNavigate,
   searchResults,
+  placeholder = 'Search conversation...', // Default placeholder
 }) => {
   const [isSearchVisible, setIsSearchVisible] = useState(false);
   const [initialSearchTerm, setInitialSearchTerm] = useState('');
@@ -329,6 +332,7 @@ export const SearchView: React.FC<PropsWithChildren<SearchViewProps>> = ({
           searchResults={searchResults || internalSearchResults || undefined}
           inputRef={searchInputRef}
           initialSearchTerm={initialSearchTerm}
+          placeholder={placeholder}
         />
       )}
       {children}

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -346,7 +346,6 @@ const SessionListView: React.FC<SessionListViewProps> = ({ setView, onSelectSess
                 top: position.top,
                 left: 0,
                 right: 0,
-                // Remove fixed height - let content determine height naturally
               }}
             />
           );

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
 import {
   MessageSquareText,
   Target,
@@ -28,8 +28,10 @@ interface SessionListViewProps {
   onSelectSession: (sessionId: string) => void;
 }
 
-const ITEM_HEIGHT = 90; // Adjust based on your card height
+// Virtual scrolling constants
+const ITEM_HEIGHT = 68; // Fixed height for all session items
 const BUFFER_SIZE = 5; // Number of items to render above/below viewport
+const OVERSCAN = 3; // Additional items to render for smoother scrolling
 
 const SessionListView: React.FC<SessionListViewProps> = ({ setView, onSelectSession }) => {
   const [sessions, setSessions] = useState<Session[]>([]);
@@ -41,45 +43,113 @@ const SessionListView: React.FC<SessionListViewProps> = ({ setView, onSelectSess
     currentIndex: number;
   } | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const scrollElementRef = useRef<HTMLDivElement | null>(null);
   const [visibleRange, setVisibleRange] = useState({ start: 0, end: 20 });
+  const shouldScrollToTop = useRef(false);
 
   useEffect(() => {
     loadSessions();
   }, []);
 
-  // Handle scroll events to update visible range
-  useEffect(() => {
-    const viewportEl = containerRef.current?.closest('[data-radix-scroll-area-viewport]');
-    if (!viewportEl) return;
+  // Calculate item positions with fixed height
+  const calculateItemPositions = (sessions: Session[]) => {
+    const totalHeight = sessions.length * ITEM_HEIGHT;
+    const positions: { top: number; height: number }[] = [];
 
-    const handleScroll = () => {
-      const scrollTop = viewportEl.scrollTop;
-      const viewportHeight = viewportEl.clientHeight;
+    for (let i = 0; i < sessions.length; i++) {
+      positions.push({
+        top: i * ITEM_HEIGHT,
+        height: ITEM_HEIGHT,
+      });
+    }
 
-      const start = Math.max(0, Math.floor(scrollTop / ITEM_HEIGHT) - BUFFER_SIZE);
+    return { positions, totalHeight };
+  };
+
+  // Update visible range based on scroll position with fixed heights
+  const updateVisibleRange = useCallback(
+    (scrollTop: number, viewportHeight: number) => {
+      if (filteredSessions.length === 0) return;
+
+      // Simple calculation with fixed heights
+      const start = Math.max(0, Math.floor(scrollTop / ITEM_HEIGHT) - OVERSCAN - BUFFER_SIZE);
+      const visibleCount = Math.ceil(viewportHeight / ITEM_HEIGHT);
       const end = Math.min(
         filteredSessions.length,
-        Math.ceil((scrollTop + viewportHeight) / ITEM_HEIGHT) + BUFFER_SIZE
+        start + visibleCount + OVERSCAN + BUFFER_SIZE * 2
       );
 
       setVisibleRange({ start, end });
+    },
+    [filteredSessions.length]
+  );
+
+  // Handle scroll events
+  useEffect(() => {
+    // Find the Radix ScrollArea viewport
+    const scrollElement = containerRef.current?.closest(
+      '[data-radix-scroll-area-viewport]'
+    ) as HTMLDivElement;
+    if (!scrollElement) return;
+
+    // Store reference for other functions
+    scrollElementRef.current = scrollElement;
+
+    const handleScroll = () => {
+      const scrollTop = scrollElement.scrollTop;
+      const viewportHeight = scrollElement.clientHeight;
+
+      updateVisibleRange(scrollTop, viewportHeight);
     };
 
-    handleScroll(); // Initial calculation
-    viewportEl.addEventListener('scroll', handleScroll);
+    // Initial calculation
+    handleScroll();
 
-    const resizeObserver = new ResizeObserver(handleScroll);
-    resizeObserver.observe(viewportEl);
+    // Add scroll listener with throttling
+    let ticking = false;
+    const throttledScroll = () => {
+      if (!ticking) {
+        requestAnimationFrame(() => {
+          handleScroll();
+          ticking = false;
+        });
+        ticking = true;
+      }
+    };
+
+    scrollElement.addEventListener('scroll', throttledScroll, { passive: true });
+
+    // Handle resize
+    const resizeObserver = new ResizeObserver(() => {
+      handleScroll();
+    });
+    resizeObserver.observe(scrollElement);
 
     return () => {
-      viewportEl.removeEventListener('scroll', handleScroll);
+      scrollElement.removeEventListener('scroll', throttledScroll);
       resizeObserver.disconnect();
     };
-  }, [filteredSessions.length]);
+  }, [filteredSessions.length, updateVisibleRange]);
+
+  // Update visible range when filtered sessions change
+  useEffect(() => {
+    const scrollElement = scrollElementRef.current;
+    if (scrollElement) {
+      // If we should scroll to top (after clearing search), do it now
+      if (shouldScrollToTop.current) {
+        scrollElement.scrollTop = 0;
+        setVisibleRange({ start: 0, end: 20 });
+        shouldScrollToTop.current = false;
+      }
+      updateVisibleRange(scrollElement.scrollTop, scrollElement.clientHeight);
+    }
+  }, [filteredSessions, updateVisibleRange]);
 
   // Filter sessions when search term or case sensitivity changes
   const handleSearch = (term: string, caseSensitive: boolean) => {
     if (!term) {
+      // Mark that we should scroll to top after the state updates
+      shouldScrollToTop.current = true;
       setFilteredSessions(sessions);
       setSearchResults(null);
       return;
@@ -110,11 +180,12 @@ const SessionListView: React.FC<SessionListViewProps> = ({ setView, onSelectSess
     setSearchResults(filtered.length > 0 ? { count: filtered.length, currentIndex: 1 } : null);
 
     // Reset scroll position when search changes
-    const viewportEl = containerRef.current?.closest('[data-radix-scroll-area-viewport]');
-    if (viewportEl) {
-      viewportEl.scrollTop = 0;
-    }
-    setVisibleRange({ start: 0, end: 20 });
+    setTimeout(() => {
+      if (scrollElementRef.current) {
+        scrollElementRef.current.scrollTop = 0;
+      }
+      setVisibleRange({ start: 0, end: 20 });
+    }, 0);
   };
 
   const loadSessions = async () => {
@@ -157,52 +228,61 @@ const SessionListView: React.FC<SessionListViewProps> = ({ setView, onSelectSess
     }
   };
 
-  // Render a session item
-  const SessionItem = React.memo(function SessionItem({ session }: { session: Session }) {
+  // Render a session item (simplified without height measurement)
+  const SessionItem = React.memo(function SessionItem({
+    session,
+    style,
+  }: {
+    session: Session;
+    style?: React.CSSProperties;
+  }) {
     return (
-      <Card
-        onClick={() => onSelectSession(session.id)}
-        className="p-2 mx-4 mb-2 bg-bgSecondary hover:bg-bgSubtle cursor-pointer transition-all duration-150"
-      >
-        <div className="flex justify-between items-start gap-4">
-          <div className="min-w-0 flex-1">
-            <h3 className="text-base font-medium text-textStandard truncate max-w-[50vw]">
-              {session.metadata.description || session.id}
-            </h3>
-            <div className="flex gap-3 min-w-0">
-              <div className="flex items-center text-textSubtle text-sm shrink-0">
-                <Calendar className="w-3 h-3 mr-1 flex-shrink-0" />
-                <span>{formatMessageTimestamp(Date.parse(session.modified) / 1000)}</span>
-              </div>
-              <div className="flex items-center text-textSubtle text-sm min-w-0">
-                <Folder className="w-3 h-3 mr-1 flex-shrink-0" />
-                <span className="truncate">{session.metadata.working_dir}</span>
-              </div>
-            </div>
-          </div>
-
-          <div className="flex items-center gap-3 shrink-0">
-            <div className="flex flex-col items-end">
-              <div className="flex items-center text-sm text-textSubtle">
-                <span>{session.path.split('/').pop() || session.path}</span>
-              </div>
-              <div className="flex items-center mt-1 space-x-3 text-sm text-textSubtle">
-                <div className="flex items-center">
-                  <MessageSquareText className="w-3 h-3 mr-1" />
-                  <span>{session.metadata.message_count}</span>
+      <div style={style}>
+        <Card
+          onClick={() => onSelectSession(session.id)}
+          className="p-2 mx-4 mb-2 bg-bgSecondary hover:bg-bgSubtle cursor-pointer transition-all duration-150 will-change-transform"
+          style={{ transform: 'translateZ(0)' }}
+        >
+          <div className="flex justify-between items-start gap-4">
+            <div className="min-w-0 flex-1">
+              <h3 className="text-base font-medium text-textStandard truncate max-w-[50vw]">
+                {session.metadata.description || session.id}
+              </h3>
+              <div className="flex gap-3 min-w-0">
+                <div className="flex items-center text-textSubtle text-sm shrink-0">
+                  <Calendar className="w-3 h-3 mr-1 flex-shrink-0" />
+                  <span>{formatMessageTimestamp(Date.parse(session.modified) / 1000)}</span>
                 </div>
-                {session.metadata.total_tokens !== null && (
-                  <div className="flex items-center">
-                    <Target className="w-3 h-3 mr-1" />
-                    <span>{session.metadata.total_tokens.toLocaleString()}</span>
-                  </div>
-                )}
+                <div className="flex items-center text-textSubtle text-sm min-w-0">
+                  <Folder className="w-3 h-3 mr-1 flex-shrink-0" />
+                  <span className="truncate">{session.metadata.working_dir}</span>
+                </div>
               </div>
             </div>
-            <ChevronRight className="w-8 h-5 text-textSubtle" />
+
+            <div className="flex items-center gap-3 shrink-0">
+              <div className="flex flex-col items-end">
+                <div className="flex items-center text-sm text-textSubtle">
+                  <span>{session.path.split('/').pop() || session.path}</span>
+                </div>
+                <div className="flex items-center mt-1 space-x-3 text-sm text-textSubtle">
+                  <div className="flex items-center">
+                    <MessageSquareText className="w-3 h-3 mr-1" />
+                    <span>{session.metadata.message_count}</span>
+                  </div>
+                  {session.metadata.total_tokens !== null && (
+                    <div className="flex items-center">
+                      <Target className="w-3 h-3 mr-1" />
+                      <span>{session.metadata.total_tokens.toLocaleString()}</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+              <ChevronRight className="w-8 h-5 text-textSubtle" />
+            </div>
           </div>
-        </div>
-      </Card>
+        </Card>
+      </div>
     );
   });
 
@@ -247,21 +327,30 @@ const SessionListView: React.FC<SessionListViewProps> = ({ setView, onSelectSess
       );
     }
 
+    // Calculate positions and total height for virtual scrolling
+    const { positions, totalHeight } = calculateItemPositions(filteredSessions);
     const visibleSessions = filteredSessions.slice(visibleRange.start, visibleRange.end);
 
     return (
-      <div style={{ height: filteredSessions.length * ITEM_HEIGHT }} className="relative">
-        <div
-          style={{
-            position: 'absolute',
-            top: visibleRange.start * ITEM_HEIGHT,
-            width: '100%',
-          }}
-        >
-          {visibleSessions.map((session) => (
-            <SessionItem key={session.id} session={session} />
-          ))}
-        </div>
+      <div style={{ height: totalHeight, position: 'relative' }}>
+        {visibleSessions.map((session, index) => {
+          const actualIndex = visibleRange.start + index;
+          const position = positions[actualIndex];
+
+          return (
+            <SessionItem
+              key={session.id}
+              session={session}
+              style={{
+                position: 'absolute',
+                top: position.top,
+                left: 0,
+                right: 0,
+                // Remove fixed height - let content determine height naturally
+              }}
+            />
+          );
+        })}
       </div>
     );
   };
@@ -279,17 +368,23 @@ const SessionListView: React.FC<SessionListViewProps> = ({ setView, onSelectSess
         <div className="flex flex-col mb-6 px-8">
           <h1 className="text-3xl font-medium text-textStandard">Previous goose sessions</h1>
           <h3 className="text-sm text-textSubtle mt-2">
-            View previous goose sessions and their contents to pick up where you left off.
+            View previous goose sessions and their contents to pick up where you left off. ⌘F to
+            search
           </h3>
         </div>
 
         <div className="flex-1 min-h-0 relative">
           <ScrollArea className="h-full" data-search-scroll-area>
-            <div ref={containerRef} className="h-full relative">
+            <div
+              ref={containerRef}
+              className="h-full relative"
+              style={{ transform: 'translateZ(0)' }}
+            >
               <SearchView
                 onSearch={handleSearch}
                 onNavigate={handleSearchNavigation}
                 searchResults={searchResults}
+                placeholder="Search session history..."
                 className="relative"
               >
                 {renderContent()}


### PR DESCRIPTION
Noticed session history was jumpy when scrolling. This fixes the jumpiness and also adds more efficient rendering and loading of session items. Also updated search placeholder to be more specific for session history search and added a note about cmd+F to search.