### PR TITLE
Fix clippy uninlined_format_args warnings in build.rs

### DIFF
--- a/crates/goose/build.rs
+++ b/crates/goose/build.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Create base directory
     fs::create_dir_all(BASE_DIR)?;
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed={}", BASE_DIR);
+    println!("cargo:rerun-if-changed={BASE_DIR}");
 
     for tokenizer_name in TOKENIZERS {
         download_tokenizer(tokenizer_name).await?;
@@ -21,30 +21,26 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 async fn download_tokenizer(repo_id: &str) -> Result<(), Box<dyn Error>> {
     let dir_name = repo_id.replace('/', "--");
-    let download_dir = format!("{}/{}", BASE_DIR, dir_name);
-    let file_url = format!(
-        "https://huggingface.co/{}/resolve/main/tokenizer.json",
-        repo_id
-    );
-    let file_path = format!("{}/tokenizer.json", download_dir);
+    let download_dir = format!("{BASE_DIR}/{dir_name}");
+    let file_url = format!("https://huggingface.co/{repo_id}/resolve/main/tokenizer.json");
+    let file_path = format!("{download_dir}/tokenizer.json");
 
     // Create directory if it doesn't exist
     fs::create_dir_all(&download_dir)?;
 
     // Check if file already exists
     if Path::new(&file_path).exists() {
-        println!("Tokenizer for {} already exists, skipping...", repo_id);
+        println!("Tokenizer for {repo_id} already exists, skipping...");
         return Ok(());
     }
 
-    println!("Downloading tokenizer for {}...", repo_id);
+    println!("Downloading tokenizer for {repo_id}...");
 
     // Download the file
     let response = reqwest::get(&file_url).await?;
     if !response.status().is_success() {
         return Err(format!(
-            "Failed to download tokenizer for {}, status: {}",
-            repo_id,
+            "Failed to download tokenizer for {repo_id}, status: {}",
             response.status()
         )
         .into());
@@ -53,6 +49,6 @@ async fn download_tokenizer(repo_id: &str) -> Result<(), Box<dyn Error>> {
     let content = response.bytes().await?;
     fs::write(&file_path, content)?;
 
-    println!("Downloaded {} to {}", repo_id, file_path);
+    println!("Downloaded {repo_id} to {file_path}");
     Ok(())
 }

--- a/crates/goose/build.rs
+++ b/crates/goose/build.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Create base directory
     fs::create_dir_all(BASE_DIR)?;
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed={BASE_DIR}");
+    println!("cargo:rerun-if-changed={}", BASE_DIR);
 
     for tokenizer_name in TOKENIZERS {
         download_tokenizer(tokenizer_name).await?;
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 async fn download_tokenizer(repo_id: &str) -> Result<(), Box<dyn Error>> {
     let dir_name = repo_id.replace('/', "--");
-    let download_dir = format!("{BASE_DIR}/{dir_name}");
+    let download_dir = format!("{}/{}", BASE_DIR, dir_name);
     let file_url = format!("https://huggingface.co/{repo_id}/resolve/main/tokenizer.json");
     let file_path = format!("{download_dir}/tokenizer.json");
 

--- a/crates/goose/build.rs
+++ b/crates/goose/build.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Create base directory
     fs::create_dir_all(BASE_DIR)?;
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed={BASE_DIR}");
+    println!("cargo:rerun-if-changed={}", BASE_DIR);
 
     for tokenizer_name in TOKENIZERS {
         download_tokenizer(tokenizer_name).await?;
@@ -21,26 +21,30 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 async fn download_tokenizer(repo_id: &str) -> Result<(), Box<dyn Error>> {
     let dir_name = repo_id.replace('/', "--");
-    let download_dir = format!("{BASE_DIR}/{dir_name}");
-    let file_url = format!("https://huggingface.co/{repo_id}/resolve/main/tokenizer.json");
-    let file_path = format!("{download_dir}/tokenizer.json");
+    let download_dir = format!("{}/{}", BASE_DIR, dir_name);
+    let file_url = format!(
+        "https://huggingface.co/{}/resolve/main/tokenizer.json",
+        repo_id
+    );
+    let file_path = format!("{}/tokenizer.json", download_dir);
 
     // Create directory if it doesn't exist
     fs::create_dir_all(&download_dir)?;
 
     // Check if file already exists
     if Path::new(&file_path).exists() {
-        println!("Tokenizer for {repo_id} already exists, skipping...");
+        println!("Tokenizer for {} already exists, skipping...", repo_id);
         return Ok(());
     }
 
-    println!("Downloading tokenizer for {repo_id}...");
+    println!("Downloading tokenizer for {}...", repo_id);
 
     // Download the file
     let response = reqwest::get(&file_url).await?;
     if !response.status().is_success() {
         return Err(format!(
-            "Failed to download tokenizer for {repo_id}, status: {}",
+            "Failed to download tokenizer for {}, status: {}",
+            repo_id,
             response.status()
         )
         .into());
@@ -49,6 +53,6 @@ async fn download_tokenizer(repo_id: &str) -> Result<(), Box<dyn Error>> {
     let content = response.bytes().await?;
     fs::write(&file_path, content)?;
 
-    println!("Downloaded {repo_id} to {file_path}");
+    println!("Downloaded {} to {}", repo_id, file_path);
     Ok(())
 }

--- a/crates/goose/build.rs
+++ b/crates/goose/build.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Create base directory
     fs::create_dir_all(BASE_DIR)?;
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed={}", BASE_DIR);
+    println!("cargo:rerun-if-changed={BASE_DIR}");
 
     for tokenizer_name in TOKENIZERS {
         download_tokenizer(tokenizer_name).await?;
@@ -21,23 +21,20 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 async fn download_tokenizer(repo_id: &str) -> Result<(), Box<dyn Error>> {
     let dir_name = repo_id.replace('/', "--");
-    let download_dir = format!("{}/{}", BASE_DIR, dir_name);
-    let file_url = format!(
-        "https://huggingface.co/{}/resolve/main/tokenizer.json",
-        repo_id
-    );
-    let file_path = format!("{}/tokenizer.json", download_dir);
+    let download_dir = format!("{BASE_DIR}/{dir_name}");
+    let file_url = format!("https://huggingface.co/{repo_id}/resolve/main/tokenizer.json");
+    let file_path = format!("{download_dir}/tokenizer.json");
 
     // Create directory if it doesn't exist
     fs::create_dir_all(&download_dir)?;
 
     // Check if file already exists
     if Path::new(&file_path).exists() {
-        println!("Tokenizer for {} already exists, skipping...", repo_id);
+        println!("Tokenizer for {repo_id} already exists, skipping...");
         return Ok(());
     }
 
-    println!("Downloading tokenizer for {}...", repo_id);
+    println!("Downloading tokenizer for {repo_id}...");
 
     // Download the file
     let response = reqwest::get(&file_url).await?;
@@ -53,6 +50,6 @@ async fn download_tokenizer(repo_id: &str) -> Result<(), Box<dyn Error>> {
     let content = response.bytes().await?;
     fs::write(&file_path, content)?;
 
-    println!("Downloaded {} to {}", repo_id, file_path);
+    println!("Downloaded {repo_id} to {file_path}");
     Ok(())
 }

--- a/crates/mcp-client/src/transport/stdio.rs
+++ b/crates/mcp-client/src/transport/stdio.rs
@@ -134,10 +134,7 @@ impl StdioActor {
         while let Some(message_str) = receiver.recv().await {
             tracing::debug!(message = ?message_str, "Sending outgoing message");
 
-            if let Err(e) = stdin
-                .write_all(format!("{message_str}\n").as_bytes())
-                .await
-            {
+            if let Err(e) = stdin.write_all(format!("{message_str}\n").as_bytes()).await {
                 tracing::error!(error = ?e, "Error writing message to child process");
                 break;
             }

--- a/crates/mcp-client/src/transport/stdio.rs
+++ b/crates/mcp-client/src/transport/stdio.rs
@@ -135,7 +135,7 @@ impl StdioActor {
             tracing::debug!(message = ?message_str, "Sending outgoing message");
 
             if let Err(e) = stdin
-                .write_all(format!("{}\n", message_str).as_bytes())
+                .write_all(format!("{message_str}\n").as_bytes())
                 .await
             {
                 tracing::error!(error = ?e, "Error writing message to child process");


### PR DESCRIPTION
Fixes the 7 clippy uninlined_format_args warnings in crates/goose/build.rs that were causing CI failures.

This addresses the specific CI failure from https://github.com/block/goose/actions/runs/15909272756/job/44872229172 where the build script failed to compile due to clippy warnings being treated as errors.

Changes:
- Updated format strings in build.rs to use inline variable formatting (e.g., `format!("{variable}")` instead of `format!("{}", variable)`)
- Fixed one additional format string in mcp-client that was also failing the same clippy rule

The build script now compiles successfully and should pass CI.