### PR TITLE
WIP: Draft of recipe retry functionality

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -708,6 +708,7 @@ pub async fn cli() -> Result<()> {
                         quiet: false,
                         sub_recipes: None,
                         final_output_response: None,
+                        retry_config: None,
                     })
                     .await;
                     setup_logging(
@@ -762,7 +763,7 @@ pub async fn cli() -> Result<()> {
             quiet,
             additional_sub_recipes,
         }) => {
-            let (input_config, session_settings, sub_recipes, final_output_response) = match (
+            let (input_config, session_settings, sub_recipes, final_output_response, retry_config) = match (
                 instructions,
                 input_text,
                 recipe,
@@ -779,6 +780,7 @@ pub async fn cli() -> Result<()> {
                             extensions_override: None,
                             additional_system_prompt: system,
                         },
+                        None,
                         None,
                         None,
                         None,
@@ -801,6 +803,7 @@ pub async fn cli() -> Result<()> {
                         None,
                         None,
                         None,
+                        None,
                     )
                 }
                 (_, Some(text), _) => (
@@ -809,6 +812,7 @@ pub async fn cli() -> Result<()> {
                         extensions_override: None,
                         additional_system_prompt: system,
                     },
+                    None,
                     None,
                     None,
                     None,
@@ -853,6 +857,7 @@ pub async fn cli() -> Result<()> {
                 quiet,
                 sub_recipes,
                 final_output_response,
+                retry_config,
             })
             .await;
 
@@ -978,6 +983,7 @@ pub async fn cli() -> Result<()> {
                     quiet: false,
                     sub_recipes: None,
                     final_output_response: None,
+                    retry_config: None,
                 })
                 .await;
                 setup_logging(

--- a/crates/goose-cli/src/commands/bench.rs
+++ b/crates/goose-cli/src/commands/bench.rs
@@ -49,6 +49,7 @@ pub async fn agent_generator(
         quiet: false,
         sub_recipes: None,
         final_output_response: None,
+        retry_config: None,
     })
     .await;
 

--- a/crates/goose-cli/src/commands/web.rs
+++ b/crates/goose-cli/src/commands/web.rs
@@ -484,6 +484,7 @@ async fn process_message_streaming(
         schedule_id: None,
         execution_mode: None,
         max_turns: None,
+        retry_config: None,
     };
 
     // Get response from agent

--- a/crates/goose-cli/src/recipes/extract_from_cli.rs
+++ b/crates/goose-cli/src/recipes/extract_from_cli.rs
@@ -16,6 +16,7 @@ pub fn extract_recipe_info_from_cli(
     Option<SessionSettings>,
     Option<Vec<SubRecipe>>,
     Option<Response>,
+    Option<goose::recipe::RetryConfig>,
 )> {
     let recipe = load_recipe_as_template(&recipe_name, params).unwrap_or_else(|err| {
         eprintln!("{}: {}", console::style("Error").red().bold(), err);
@@ -58,6 +59,7 @@ pub fn extract_recipe_info_from_cli(
         }),
         Some(all_sub_recipes),
         recipe.response,
+        recipe.retry,
     ))
 }
 
@@ -89,7 +91,7 @@ mod tests {
         let params = vec![("name".to_string(), "my_value".to_string())];
         let recipe_name = recipe_path.to_str().unwrap().to_string();
 
-        let (input_config, settings, sub_recipes, response) =
+        let (input_config, settings, sub_recipes, response, retry_config) =
             extract_recipe_info_from_cli(recipe_name, params, Vec::new()).unwrap();
 
         assert_eq!(input_config.contents, Some("test_prompt".to_string()));
@@ -145,7 +147,7 @@ mod tests {
             sub_recipe2_path.to_string_lossy().to_string(),
         ];
 
-        let (input_config, settings, sub_recipes, response) =
+        let (input_config, settings, sub_recipes, response, retry_config) =
             extract_recipe_info_from_cli(recipe_name, params, additional_sub_recipes).unwrap();
 
         assert_eq!(input_config.contents, Some("test_prompt".to_string()));

--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -53,6 +53,8 @@ pub struct SessionBuilderConfig {
     pub sub_recipes: Option<Vec<SubRecipe>>,
     /// Final output expected response
     pub final_output_response: Option<Response>,
+    /// Retry configuration
+    pub retry_config: Option<goose::recipe::RetryConfig>,
 }
 
 /// Offers to help debug an extension failure by creating a minimal debugging session
@@ -128,6 +130,7 @@ async fn offer_extension_debugging_help(
         debug_agent,
         Some(temp_session_file.clone()),
         false,
+        None,
         None,
         None,
     );
@@ -376,6 +379,7 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> Session {
         session_config.debug,
         session_config.scheduled_job_id.clone(),
         session_config.max_turns,
+        session_config.retry_config.clone(),
     );
 
     // Add extensions if provided
@@ -531,6 +535,7 @@ mod tests {
             quiet: false,
             sub_recipes: None,
             final_output_response: None,
+            retry_config: None,
         };
 
         assert_eq!(config.extensions.len(), 1);

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -53,6 +53,7 @@ pub struct Session {
     run_mode: RunMode,
     scheduled_job_id: Option<String>, // ID of the scheduled job that triggered this session
     max_turns: Option<u32>,
+    retry_config: Option<goose::recipe::RetryConfig>,
 }
 
 // Cache structure for completion data
@@ -115,6 +116,7 @@ impl Session {
         debug: bool,
         scheduled_job_id: Option<String>,
         max_turns: Option<u32>,
+        retry_config: Option<goose::recipe::RetryConfig>,
     ) -> Self {
         let messages = if let Some(session_file) = &session_file {
             match session::read_messages(session_file) {
@@ -138,6 +140,7 @@ impl Session {
             run_mode: RunMode::Normal,
             scheduled_job_id,
             max_turns,
+            retry_config,
         }
     }
 
@@ -761,6 +764,7 @@ impl Session {
                 schedule_id: self.scheduled_job_id.clone(),
                 execution_mode: None,
                 max_turns: self.max_turns,
+                retry_config: self.retry_config.clone(),
             }
         });
         let mut stream = self

--- a/crates/goose-server/src/routes/reply.rs
+++ b/crates/goose-server/src/routes/reply.rs
@@ -185,6 +185,7 @@ async fn handler(
                     schedule_id: request.scheduled_job_id.clone(),
                     execution_mode: None,
                     max_turns: None,
+                    retry_config: None,
                 }),
             )
             .await
@@ -360,6 +361,7 @@ async fn ask_handler(
                 schedule_id: request.scheduled_job_id.clone(),
                 execution_mode: None,
                 max_turns: None,
+                retry_config: None,
             }),
         )
         .await

--- a/crates/goose/src/agents/final_output_tool.rs
+++ b/crates/goose/src/agents/final_output_tool.rs
@@ -87,6 +87,10 @@ impl FinalOutputTool {
         "#, serde_json::to_string_pretty(self.response.json_schema.as_ref().unwrap()).unwrap()}
     }
 
+    pub fn reset(&mut self) {
+        self.final_output = None;
+    }
+
     async fn validate_json_output(&self, output: &Value) -> Result<Value, String> {
         let compiled_schema =
             match jsonschema::validator_for(self.response.json_schema.as_ref().unwrap()) {

--- a/crates/goose/src/agents/types.rs
+++ b/crates/goose/src/agents/types.rs
@@ -28,4 +28,6 @@ pub struct SessionConfig {
     pub execution_mode: Option<String>,
     /// Maximum number of turns (iterations) allowed without user input
     pub max_turns: Option<u32>,
+    /// Retry configuration for the session (from recipe)
+    pub retry_config: Option<crate::recipe::RetryConfig>,
 }

--- a/crates/goose/src/recipe/mod.rs
+++ b/crates/goose/src/recipe/mod.rs
@@ -102,6 +102,9 @@ pub struct Recipe {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sub_recipes: Option<Vec<SubRecipe>>, // sub-recipes for the recipe
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry: Option<RetryConfig>, // retry configuration for the recipe
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -129,6 +132,14 @@ pub struct Settings {
 pub struct Response {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub json_schema: Option<serde_json::Value>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RetryConfig {
+    pub max_retries: u32,
+    pub success_check: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub on_failure: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -230,6 +241,7 @@ pub struct RecipeBuilder {
     parameters: Option<Vec<RecipeParameter>>,
     response: Option<Response>,
     sub_recipes: Option<Vec<SubRecipe>>,
+    retry: Option<RetryConfig>,
 }
 
 impl Recipe {
@@ -262,6 +274,7 @@ impl Recipe {
             parameters: None,
             response: None,
             sub_recipes: None,
+            retry: None,
         }
     }
     pub fn from_content(content: &str) -> Result<Self> {
@@ -352,6 +365,11 @@ impl RecipeBuilder {
         self
     }
 
+    pub fn retry(mut self, retry: RetryConfig) -> Self {
+        self.retry = Some(retry);
+        self
+    }
+
     /// Builds the Recipe instance
     ///
     /// Returns an error if any required fields are missing
@@ -377,6 +395,7 @@ impl RecipeBuilder {
             parameters: self.parameters,
             response: self.response,
             sub_recipes: self.sub_recipes,
+            retry: self.retry,
         })
     }
 }

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -1204,6 +1204,7 @@ async fn run_scheduled_job_internal(
             schedule_id: Some(job.id.clone()),
             execution_mode: job.execution_mode.clone(),
             max_turns: None,
+            retry_config: recipe.retry.clone(),
         };
 
         match agent
@@ -1420,6 +1421,7 @@ mod tests {
             settings: None,
             response: None,
             sub_recipes: None,
+            retry: None,
         };
         let mut recipe_file = File::create(&recipe_filename)?;
         writeln!(

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -709,6 +709,7 @@ mod max_turns_tests {
             schedule_id: None,
             execution_mode: None,
             max_turns: Some(1),
+            retry_config: None,
         };
         let messages = vec![Message::user().with_text("Hello")];
 

--- a/documentation/docs/guides/recipes/recipe-reference.md
+++ b/documentation/docs/guides/recipes/recipe-reference.md
@@ -37,6 +37,7 @@ After creating recipe files, you can use [`goose` CLI commands](/docs/guides/goo
 | `parameters` | Array | List of parameter definitions |
 | `extensions` | Array | List of extension configurations |
 | `response` | Object | Configuration for structured output validation |
+| `retry` | Object | Configuration for automatic retry functionality |
 
 ## Parameters
 
@@ -105,6 +106,25 @@ extensions:
     args:
       - 'mcp_presidio@latest'
     description: "For searching logs using Presidio"
+```
+
+## Retry Configuration
+
+The `retry` field lets recipes automatically retry execution when they don't meet success criteria. This is useful for handling non-deterministic LLM behavior.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `max_retries` | Number | Maximum number of retry attempts |
+| `success_check` | String | Shell command that verifies successful execution (exit code 0 = success) |
+| `on_failure` | String | (Optional) Shell command to run before each retry for cleanup |
+
+When used, the recipe runs to completion, executes the success_check command, and if it fails, cleans up with on_failure (if provided) and starts again with a fresh message history.
+
+```yaml
+retry:
+  max_retries: 3
+  success_check: "cargo test"
+  on_failure: "git clean -df"
 ```
 
 ## Structured Output with `response`
@@ -213,6 +233,11 @@ extensions:
     timeout: 300
     bundled: true
     description: "Query codesearch directly from goose"
+
+retry:
+  max_retries: 3
+  success_check: "cargo test"
+  on_failure: "git clean -df"
 
 response:
   json_schema:

--- a/documentation/docs/guides/recipes/session-recipes.md
+++ b/documentation/docs/guides/recipes/session-recipes.md
@@ -65,6 +65,10 @@ You can turn your current Goose session into a reusable recipe that includes the
      goose_provider: $provider    # Provider to use for this recipe
      goose_model: $model          # Specific model to use for this recipe
      temperature: $temperature    # Model temperature setting for this recipe (0.0 to 1.0)
+   retry:                         # Optional retry configuration
+     max_retries: 3               # Maximum retry attempts
+     success_check: $cmd          # Shell command to validate success
+     on_failure: $cleanup_cmd     # Optional cleanup before retry
    ```
    </details>
 


### PR DESCRIPTION
This is a draft pr still wip for exploring adding retry functionality for recipes.

`success_check` is a shell command to run. If it returns a failure status code then `on_failure` shell command will run.

```
pub struct RetryConfig {
    pub max_retries: u32,
    pub success_check: String,
    #[serde(skip_serializing_if = "Option::is_none")]
    pub on_failure: Option<String>,
}
```