### PR TITLE
allow saving when a provider has no config

### DIFF
--- a/ui/desktop/src/components/settings/providers/ProviderGrid.tsx
+++ b/ui/desktop/src/components/settings/providers/ProviderGrid.tsx
@@ -36,10 +36,13 @@ const ProviderCards = memo(function ProviderCards({
             refreshProviders();
           }
         },
-        formProps: {},
+        formProps: {
+          isOnboarding,
+          onProviderLaunch,
+        },
       });
     },
-    [openModal, refreshProviders]
+    [openModal, refreshProviders, isOnboarding, onProviderLaunch]
   );
 
   const deleteProviderConfigViaModal = useCallback(

--- a/ui/desktop/src/components/settings/providers/modal/ProviderConfiguationModal.tsx
+++ b/ui/desktop/src/components/settings/providers/modal/ProviderConfiguationModal.tsx
@@ -98,6 +98,17 @@ export default function ProviderConfigurationModal() {
       // Wait for the submission to complete
       await SubmitHandler(upsert, currentProvider, configValues);
 
+      // Check if this provider has no required configuration and we're in onboarding mode
+      const hasNoRequiredConfig = parameters.filter(p => p.required).length === 0;
+      const isOnboardingMode = modalProps.formProps?.isOnboarding;
+      const onProviderLaunch = modalProps.formProps?.onProviderLaunch;
+
+      // If it's onboarding mode, has no required config, and we have a launch function, launch the provider
+      if (isOnboardingMode && hasNoRequiredConfig && onProviderLaunch) {
+        console.log('Launching provider after configuration:', currentProvider.name);
+        await onProviderLaunch(currentProvider);
+      }
+
       // Close the modal before triggering refreshes to avoid UI issues
       closeModal();
 

--- a/ui/desktop/src/components/settings/providers/modal/subcomponents/forms/DefaultProviderSetupForm.tsx
+++ b/ui/desktop/src/components/settings/providers/modal/subcomponents/forms/DefaultProviderSetupForm.tsx
@@ -12,6 +12,8 @@ interface DefaultProviderSetupFormProps {
   setConfigValues: React.Dispatch<React.SetStateAction<Record<string, string>>>;
   provider: ProviderDetails;
   validationErrors: ValidationErrors;
+  isOnboarding?: boolean;
+  onProviderLaunch?: (provider: ProviderDetails) => void;
 }
 
 export default function DefaultProviderSetupForm({
@@ -19,6 +21,8 @@ export default function DefaultProviderSetupForm({
   setConfigValues,
   provider,
   validationErrors = {},
+  isOnboarding,
+  onProviderLaunch,
 }: DefaultProviderSetupFormProps) {
   const parameters = useMemo(
     () => provider.metadata.config_keys || [],

--- a/ui/desktop/src/components/settings/providers/modal/subcomponents/handlers/DefaultSubmitHandler.tsx
+++ b/ui/desktop/src/components/settings/providers/modal/subcomponents/handlers/DefaultSubmitHandler.tsx
@@ -47,6 +47,18 @@ export const DefaultSubmitHandler = async (
     }
   );
 
+  // For providers with no required configuration, save optional parameters with defaults
+  // This ensures something gets saved to mark the provider as configured
+  if (parameters.length > 0 && parameters.every(p => !p.required)) {
+    parameters.forEach((parameter) => {
+      if (parameter.default !== undefined && parameter.default !== null) {
+        const configKey = `${parameter.name}`;
+        const isSecret = parameter.secret === true;
+        upsertPromises.push(upsertFn(configKey, parameter.default, isSecret));
+      }
+    });
+  }
+
   // Wait for all upsert operations to complete
   return Promise.all(upsertPromises);
 };


### PR DESCRIPTION
some providers have no actual config, so the GUI won't let you launch them (eg gemini). 

this is an attempt to fix that cc @zanesq probably can wait until after new GUI lands