### PR TITLE
Isolate agent by session

### DIFF
--- a/SESSION_ISOLATION.md
+++ b/SESSION_ISOLATION.md
@@ -1,0 +1,159 @@
+# Session Isolation Improvements
+
+## Overview
+
+This document describes the session isolation improvements implemented in the new Goose Desktop application to ensure proper separation of agent state between different chat sessions.
+
+## Problem
+
+The original issue was that when switching between sessions within the same window (e.g., through the history-resume function), the agent's internal state was not being reset, potentially causing information leakage between sessions.
+
+### Key Issues Identified:
+1. **Same Agent Instance**: The backend reused the same `Agent` instance for all sessions
+2. **Persistent State**: Agent contained stateful components that persisted across sessions:
+   - Extension manager state
+   - Sub-recipe manager state  
+   - Final output tool state
+   - Frontend tools and instructions
+   - Prompt manager modifications
+   - Tool usage tracking
+   - Subagent manager state
+
+## Solution
+
+### Backend Changes
+
+#### 1. Agent State Reset Method
+Added `reset_session_state()` method to the `Agent` struct that clears session-specific state:
+
+```rust
+/// Reset agent state for a new session to ensure isolation between sessions
+pub async fn reset_session_state(&self) -> Result<()> {
+    // Reset tool monitor to clear tool usage tracking
+    if let Some(monitor) = self.tool_monitor.lock().await.as_mut() {
+        monitor.reset();
+    }
+
+    // Clear final output tool state
+    *self.final_output_tool.lock().await = None;
+
+    // Reset sub-recipe manager to clear any loaded sub-recipes
+    *self.sub_recipe_manager.lock().await = SubRecipeManager::new();
+
+    // Reset prompt manager to clear any session-specific prompt modifications
+    *self.prompt_manager.lock().await = PromptManager::new();
+
+    // Clear frontend tools and instructions
+    self.frontend_tools.lock().await.clear();
+    *self.frontend_instructions.lock().await = None;
+
+    // Recreate MCP notification channel and reset subagent manager
+    let (mcp_tx, mcp_rx) = mpsc::channel(100);
+    *self.mcp_notification_rx.lock().await = mcp_rx;
+    *self.subagent_manager.lock().await = Some(SubAgentManager::new(mcp_tx));
+
+    Ok(())
+}
+```
+
+#### 2. Session Change Detection
+Modified `AppState` to track the current session ID and detect session changes:
+
+```rust
+pub struct AppState {
+    agent: Option<AgentRef>,
+    pub secret_key: String,
+    pub scheduler: Arc<Mutex<Option<Arc<dyn SchedulerTrait>>>>,
+    pub current_session_id: Arc<Mutex<Option<String>>>, // New field
+}
+
+/// Check if this is a new session and reset agent state if needed
+pub async fn handle_session_change(&self, new_session_id: &str) -> Result<bool, anyhow::Error> {
+    let mut current_session = self.current_session_id.lock().await;
+    
+    let session_changed = match current_session.as_ref() {
+        Some(current_id) => current_id != new_session_id,
+        None => true, // First session
+    };
+
+    if session_changed {
+        tracing::info!("Session change detected: {:?} -> {}", current_session.as_ref(), new_session_id);
+        
+        // Reset agent state for session isolation
+        if let Ok(agent) = self.get_agent().await {
+            agent.reset_session_state().await?;
+        }
+
+        *current_session = Some(new_session_id.to_string());
+    }
+
+    Ok(session_changed)
+}
+```
+
+#### 3. Request Handler Integration
+Modified both `/reply` and `/ask` endpoints to call session change detection:
+
+```rust
+// Handle session change detection and agent state reset
+if let Err(e) = state.handle_session_change(&session_id).await {
+    tracing::error!("Failed to handle session change: {}", e);
+    // Return error response
+}
+```
+
+### Frontend Changes
+
+The frontend changes are minimal since the session isolation happens primarily on the backend. The existing session management in the new app continues to work, but now with proper backend state isolation.
+
+## Behavior Comparison
+
+### Old App (goose/ui/desktop)
+- ✅ **New Windows**: Session switching created new windows with fresh goosed processes
+- ✅ **Complete Isolation**: Each window had its own agent instance and state
+- ✅ **No Cross-Session Contamination**: Guaranteed isolation through process separation
+
+### New App (goose-main/ui/desktop) - Before Fix
+- ⚠️ **Same Window**: Session switching happened within the same window/process
+- ⚠️ **Same Agent Instance**: Reused the same backend agent for all sessions
+- ⚠️ **State Persistence**: Agent's internal state persisted between sessions
+
+### New App (goose-main/ui/desktop) - After Fix
+- ✅ **Same Window**: Session switching still happens within the same window (by design)
+- ✅ **Same Process**: Uses the same goosed process (efficient)
+- ✅ **State Isolation**: Agent state is reset when switching sessions
+- ✅ **No Cross-Session Contamination**: Session-specific state is cleared between sessions
+
+## Testing
+
+A test script (`test_session_isolation.py`) is provided to verify the session isolation:
+
+```bash
+cd /Users/zane/Development/goose-main
+python3 test_session_isolation.py
+```
+
+The test verifies that:
+1. Information from one session doesn't leak to another session
+2. Each session maintains its own context correctly
+3. Session switching properly resets agent state
+
+## Benefits
+
+1. **Security**: Prevents information leakage between sessions
+2. **Consistency**: Matches user expectations from the old app behavior
+3. **Reliability**: Eliminates unknown-unknowns from persistent state
+4. **Performance**: More efficient than creating new processes (like old app)
+
+## Logging
+
+Session changes are logged for debugging:
+```
+INFO: Session change detected: Some("old_session_id") -> new_session_id
+INFO: Resetting agent session state for session isolation
+INFO: Agent session state reset completed
+```
+
+## Backward Compatibility
+
+This change is backward compatible and doesn't affect the API or user interface. It only improves the internal state management for better session isolation.

--- a/test_session_isolation.py
+++ b/test_session_isolation.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+Test script to verify session isolation in the new Goose app.
+This script tests that agent state is properly reset between sessions.
+"""
+
+import requests
+import json
+import time
+import sys
+
+# Configuration
+GOOSE_SERVER_URL = "http://localhost:8000"
+SECRET_KEY = "your-secret-key"  # Replace with actual secret key
+
+def send_chat_request(session_id, message, working_dir="/tmp"):
+    """Send a chat request to the Goose server"""
+    url = f"{GOOSE_SERVER_URL}/reply"
+    headers = {
+        "Content-Type": "application/json",
+        "X-Secret-Key": SECRET_KEY
+    }
+    
+    payload = {
+        "messages": [
+            {
+                "role": "user",
+                "created": int(time.time()),
+                "content": [{"type": "text", "text": message}]
+            }
+        ],
+        "session_id": session_id,
+        "session_working_dir": working_dir
+    }
+    
+    print(f"Sending request to session {session_id}: {message}")
+    
+    try:
+        response = requests.post(url, headers=headers, json=payload, stream=True)
+        response.raise_for_status()
+        
+        # Process SSE stream
+        messages = []
+        for line in response.iter_lines():
+            if line:
+                line = line.decode('utf-8')
+                if line.startswith('data: '):
+                    try:
+                        event_data = json.loads(line[6:])  # Remove 'data: ' prefix
+                        if event_data.get('type') == 'Message':
+                            message = event_data.get('message', {})
+                            if message.get('role') == 'assistant':
+                                content = message.get('content', [])
+                                for c in content:
+                                    if c.get('type') == 'text':
+                                        messages.append(c.get('text', ''))
+                        elif event_data.get('type') == 'Finish':
+                            break
+                        elif event_data.get('type') == 'Error':
+                            print(f"Error: {event_data.get('error')}")
+                            return None
+                    except json.JSONDecodeError:
+                        continue
+        
+        return ' '.join(messages).strip()
+        
+    except requests.exceptions.RequestException as e:
+        print(f"Request failed: {e}")
+        return None
+
+def test_session_isolation():
+    """Test that sessions are properly isolated"""
+    print("Testing session isolation...")
+    
+    # Test 1: Different sessions should not share state
+    session1_id = "test_session_1"
+    session2_id = "test_session_2"
+    
+    # Send a message to session 1 that might create some agent state
+    response1 = send_chat_request(
+        session1_id, 
+        "Remember that my favorite color is blue. What's my favorite color?"
+    )
+    
+    if response1:
+        print(f"Session 1 response: {response1}")
+    else:
+        print("Failed to get response from session 1")
+        return False
+    
+    time.sleep(1)  # Brief pause
+    
+    # Send a message to session 2 asking about the same thing
+    response2 = send_chat_request(
+        session2_id,
+        "What's my favorite color?"
+    )
+    
+    if response2:
+        print(f"Session 2 response: {response2}")
+    else:
+        print("Failed to get response from session 2")
+        return False
+    
+    # Session 2 should not know about the favorite color from session 1
+    if "blue" in response2.lower():
+        print("❌ FAILED: Session 2 remembered information from session 1")
+        return False
+    else:
+        print("✅ PASSED: Session 2 did not remember information from session 1")
+    
+    # Test 2: Switch back to session 1 - it should remember its own context
+    response1_again = send_chat_request(
+        session1_id,
+        "What's my favorite color again?"
+    )
+    
+    if response1_again:
+        print(f"Session 1 (second time) response: {response1_again}")
+        
+        if "blue" in response1_again.lower():
+            print("✅ PASSED: Session 1 remembered its own context")
+            return True
+        else:
+            print("❌ FAILED: Session 1 forgot its own context")
+            return False
+    else:
+        print("Failed to get second response from session 1")
+        return False
+
+def main():
+    """Main test function"""
+    print("Goose Session Isolation Test")
+    print("=" * 40)
+    
+    # Check if server is running
+    try:
+        response = requests.get(f"{GOOSE_SERVER_URL}/health", timeout=5)
+        print("✅ Goose server is running")
+    except requests.exceptions.RequestException:
+        print("❌ Goose server is not running or not accessible")
+        print(f"Please start the Goose server at {GOOSE_SERVER_URL}")
+        sys.exit(1)
+    
+    # Run the isolation test
+    if test_session_isolation():
+        print("\n🎉 All session isolation tests passed!")
+        sys.exit(0)
+    else:
+        print("\n💥 Session isolation tests failed!")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Since we are not launching a new window when resuming a session with the new ui there is a potential for cross session contamination. The previous ui always launched a new window to avoid this.

Left the docs and test for review purposes, will remove before merging.