### PR TITLE
fix agent responding with repeating content

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -846,6 +846,24 @@ impl Agent {
 
                                 let num_tool_requests = frontend_requests.len() + remaining_requests.len();
                                 if num_tool_requests == 0 {
+                                    if let Some(final_output_tool) = self.final_output_tool.lock().await.as_ref() {
+                                        if final_output_tool.final_output.is_none() {
+                                            tracing::warn!("Final output tool has not been called yet. Continuing agent loop.");
+                                            let message = Message::user().with_text(FINAL_OUTPUT_CONTINUATION_MESSAGE);
+                                            messages.push(message.clone());
+                                            yield AgentEvent::Message(message);
+                                            continue;
+                                        } else {
+                                            let message = Message::assistant().with_text(final_output_tool.final_output.clone().unwrap());
+                                            messages.push(message.clone());
+                                            yield AgentEvent::Message(message);
+                                            // Set added_message to true and continue to end the current iteration
+                                            added_message = true;
+                                            push_message(&mut messages, response);
+                                            continue;
+                                        }
+                                    }
+                                    // If there's no final output tool and no tool requests, continue the loop
                                     continue;
                                 }
 


### PR DESCRIPTION
Noticed since streaming was added we're getting a lot of repeated "I found the issue!" type responses that loop over and over again repeating the same thing but with variations in the response text. The agent eventually recovers and continues but pretty sure it didn't do this before.

Here is an example:
<img width="777" height="775" alt="image" src="https://github.com/user-attachments/assets/7df2f53d-3a9f-4b7c-a2a5-b078a46b4bcd" />


From goose:

### The Problem
The current version is missing the final output tool handling when there are no tool requests. This means:

Agent generates a response with no tool calls
Instead of checking if it should end or continue, it just continues the loop
This causes the agent to generate another response to the same input
This repeats, causing the "multiple similar responses" you're seeing

### The Fix
The current version needs the final output tool handling logic from the original version. 

### The Root Cause
In the current version (line ~522), when there are no tool requests, the code simply does:

```
let num_tool_requests = frontend_requests.len() + remaining_requests.len();
if num_tool_requests == 0 {
    continue;  // This just continues the loop!
}
```

But in the original version, there's additional logic to handle the final_output_tool:

```
if num_tool_requests == 0 {
    if let Some(final_output_tool) = self.final_output_tool.lock().await.as_ref() {
        if final_output_tool.final_output.is_none() {
            // Continue the agent loop with a continuation message
            let message = Message::user().with_text(FINAL_OUTPUT_CONTINUATION_MESSAGE);
            messages.push(message.clone());
            yield AgentEvent::Message(message);
            continue;
        } else {
            // Return the final output and end
            let message = Message::assistant().with_text(final_output_tool.final_output.clone().unwrap());
            messages.push(message.clone());
            yield AgentEvent::Message(message);
            added_message = true;
            push_message(&mut messages, response);
            continue;
        }
    }
    continue;
}
```

### What's Happening
The current version is missing the final output tool handling logic. This means:

The agent responds to "hi"
When there are no tool requests, it just continues the loop
The agent loop continues indefinitely, causing the agent to keep responding to the same context
Each time it responds, it generates a slightly different response (which explains why you see different content each time)

### The Fix
I've added the missing logic from the original version. This should fix the repeated responses issue by properly handling the final output tool and breaking the loop when appropriate.

The key insight is that the agent was stuck in an infinite loop because it wasn't properly checking for completion conditions when there were no tool requests to process.

