### PR TITLE
experiment: running developer tools in process vs MCP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3457,6 +3457,9 @@ dependencies = [
  "etcetera",
  "fs2",
  "futures",
+ "glob",
+ "ignore",
+ "image 0.24.9",
  "include_dir",
  "indoc 2.0.6",
  "jsonschema",
@@ -3480,6 +3483,7 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "sha2",
+ "shellexpand",
  "temp-env",
  "tempfile",
  "thiserror 1.0.69",
@@ -3497,6 +3501,7 @@ dependencies = [
  "webbrowser 0.8.15",
  "winapi",
  "wiremock",
+ "xcap",
 ]
 
 [[package]]

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -78,6 +78,13 @@ aws-sdk-sagemakerruntime = "1.62.0"
 # For GCP Vertex AI provider auth
 jsonwebtoken = "9.3.1"
 
+# For developer tools
+shellexpand = "3.1.0"
+xcap = "0.0.14"
+ignore = "0.4"
+image = "0.24.9"
+glob = "0.3"
+
 blake3 = "1.5"
 fs2 = "0.4.3"
 tokio-stream = "0.1.17"

--- a/crates/goose/src/agents/developer_tool_handlers.rs
+++ b/crates/goose/src/agents/developer_tool_handlers.rs
@@ -1,0 +1,671 @@
+//! Developer tool handlers implementation
+//!
+//! This module contains the actual implementation of developer tools handlers
+
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+use base64::Engine;
+use glob::glob;
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
+use mcp_core::{ToolError, ToolResult};
+use rmcp::model::Content;
+use tokio::process::Command;
+use xcap::{Monitor, Window};
+
+use super::developer_tools::*;
+use super::Agent;
+
+/// Shell command configuration helpers
+mod shell_config {
+    use std::env;
+    use std::path::PathBuf;
+
+    pub fn get_shell_config() -> (String, Vec<String>) {
+        if env::consts::OS == "windows" {
+            // On Windows, use cmd.exe for better compatibility
+            ("cmd".to_string(), vec!["/C".to_string()])
+        } else {
+            // On Unix-like systems, use the user's shell
+            let shell = env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+            (shell, vec!["-c".to_string()])
+        }
+    }
+
+    pub fn expand_path(path: &str) -> PathBuf {
+        PathBuf::from(shellexpand::tilde(path).to_string())
+    }
+
+    pub fn is_absolute_path(path: &str) -> bool {
+        PathBuf::from(path).is_absolute()
+    }
+
+    #[allow(dead_code)]
+    pub fn normalize_line_endings(text: &str) -> String {
+        text.replace("\r\n", "\n").replace('\r', "\n")
+    }
+}
+
+use shell_config::*;
+
+impl Agent {
+    /// Initialize developer tools state
+    #[allow(dead_code)]
+    pub(crate) fn init_developer_tools_state(&mut self) {
+        // This would be called during agent initialization
+        // For now, we'll handle state inline
+    }
+
+    /// Handle developer tool calls
+    pub async fn handle_developer_tool_call(
+        &self,
+        tool_name: &str,
+        arguments: serde_json::Value,
+    ) -> ToolResult<Vec<Content>> {
+        match tool_name {
+            DEVELOPER_SHELL_TOOL_NAME => self.handle_shell_command(arguments).await,
+            DEVELOPER_GLOB_TOOL_NAME => self.handle_glob_search(arguments).await,
+            DEVELOPER_GREP_TOOL_NAME => self.handle_grep_search(arguments).await,
+            DEVELOPER_TEXT_EDITOR_TOOL_NAME => self.handle_text_editor(arguments).await,
+            DEVELOPER_LIST_WINDOWS_TOOL_NAME => self.handle_list_windows().await,
+            DEVELOPER_SCREEN_CAPTURE_TOOL_NAME => self.handle_screen_capture(arguments).await,
+            DEVELOPER_IMAGE_PROCESSOR_TOOL_NAME => self.handle_image_processor(arguments).await,
+            _ => Err(ToolError::ExecutionError(format!(
+                "Unknown developer tool: {}",
+                tool_name
+            ))),
+        }
+    }
+
+    /// Execute a shell command
+    async fn handle_shell_command(&self, arguments: serde_json::Value) -> ToolResult<Vec<Content>> {
+        let command = arguments
+            .get("command")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolError::ExecutionError("Missing 'command' parameter".to_string()))?;
+
+        let (shell, shell_args) = get_shell_config();
+
+        let mut cmd = Command::new(&shell);
+        for arg in shell_args {
+            cmd.arg(arg);
+        }
+        cmd.arg(command);
+        cmd.current_dir(std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/")));
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+
+        let output = cmd
+            .output()
+            .await
+            .map_err(|e| ToolError::ExecutionError(format!("Failed to execute command: {}", e)))?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        let result = if output.status.success() {
+            format!("Command succeeded.\n\nOutput:\n{}", stdout)
+        } else {
+            format!(
+                "Command failed with exit code: {}\n\nStdout:\n{}\n\nStderr:\n{}",
+                output.status.code().unwrap_or(-1),
+                stdout,
+                stderr
+            )
+        };
+
+        Ok(vec![Content::text(result)])
+    }
+
+    /// Search for files using glob patterns
+    async fn handle_glob_search(&self, arguments: serde_json::Value) -> ToolResult<Vec<Content>> {
+        let pattern = arguments
+            .get("pattern")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolError::ExecutionError("Missing 'pattern' parameter".to_string()))?;
+
+        let search_path = arguments
+            .get("path")
+            .and_then(|v| v.as_str())
+            .unwrap_or(".");
+
+        let base_path = expand_path(search_path);
+        let full_pattern = if is_absolute_path(pattern) {
+            pattern.to_string()
+        } else {
+            base_path.join(pattern).to_string_lossy().to_string()
+        };
+
+        // Load .gooseignore patterns
+        let ignore_patterns = load_gooseignore_patterns(&base_path)?;
+
+        let mut matches = Vec::new();
+        for entry in glob(&full_pattern)
+            .map_err(|e| ToolError::ExecutionError(format!("Invalid glob pattern: {}", e)))?
+        {
+            match entry {
+                Ok(path) => {
+                    if !should_ignore_path(&path, &ignore_patterns) {
+                        matches.push(path.to_string_lossy().to_string());
+                    }
+                }
+                Err(e) => {
+                    // Log but don't fail on individual path errors
+                    eprintln!("Error accessing path: {}", e);
+                }
+            }
+        }
+
+        // Sort by modification time (newest first)
+        matches.sort_by(|a, b| {
+            let a_meta = std::fs::metadata(a).ok();
+            let b_meta = std::fs::metadata(b).ok();
+
+            match (a_meta, b_meta) {
+                (Some(a), Some(b)) => {
+                    let a_time = a.modified().ok();
+                    let b_time = b.modified().ok();
+                    b_time.cmp(&a_time)
+                }
+                _ => std::cmp::Ordering::Equal,
+            }
+        });
+
+        let result = if matches.is_empty() {
+            "No files found matching the pattern.".to_string()
+        } else {
+            format!("Found {} files:\n{}", matches.len(), matches.join("\n"))
+        };
+
+        Ok(vec![Content::text(result)])
+    }
+
+    /// Execute file content search
+    async fn handle_grep_search(&self, arguments: serde_json::Value) -> ToolResult<Vec<Content>> {
+        let command = arguments
+            .get("command")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolError::ExecutionError("Missing 'command' parameter".to_string()))?;
+
+        // Execute the search command
+        let (shell, shell_args) = get_shell_config();
+
+        let mut cmd = Command::new(&shell);
+        for arg in shell_args {
+            cmd.arg(arg);
+        }
+        cmd.arg(command);
+        cmd.current_dir(std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/")));
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+
+        let output = cmd.output().await.map_err(|e| {
+            ToolError::ExecutionError(format!("Failed to execute search command: {}", e))
+        })?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        // Filter results based on .gooseignore
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"));
+        let ignore_patterns = load_gooseignore_patterns(&cwd)?;
+
+        let filtered_output = stdout
+            .lines()
+            .filter(|line| {
+                // Try to extract file path from the line
+                // This is a simple heuristic that works for most grep/rg output
+                if let Some(path_end) = line.find(':') {
+                    let path_str = &line[..path_end];
+                    let path = PathBuf::from(path_str);
+                    !should_ignore_path(&path, &ignore_patterns)
+                } else {
+                    true // Keep lines that don't look like file paths
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let result = if output.status.success() {
+            if filtered_output.is_empty() {
+                "No matches found.".to_string()
+            } else {
+                filtered_output
+            }
+        } else {
+            format!("Search command failed:\nStderr:\n{}", stderr)
+        };
+
+        Ok(vec![Content::text(result)])
+    }
+
+    /// Handle text editor operations
+    async fn handle_text_editor(&self, arguments: serde_json::Value) -> ToolResult<Vec<Content>> {
+        let command = arguments
+            .get("command")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolError::ExecutionError("Missing 'command' parameter".to_string()))?;
+
+        let path = arguments
+            .get("path")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolError::ExecutionError("Missing 'path' parameter".to_string()))?;
+
+        let path = expand_path(path);
+
+        match command {
+            "view" => self.handle_view_file(&path, &arguments).await,
+            "write" => self.handle_write_file(&path, &arguments).await,
+            "str_replace" => self.handle_str_replace(&path, &arguments).await,
+            "insert" => self.handle_insert_text(&path, &arguments).await,
+            "undo_edit" => self.handle_undo_edit(&path).await,
+            _ => Err(ToolError::ExecutionError(format!(
+                "Unknown text editor command: {}",
+                command
+            ))),
+        }
+    }
+
+    /// View file contents
+    async fn handle_view_file(
+        &self,
+        path: &Path,
+        arguments: &serde_json::Value,
+    ) -> ToolResult<Vec<Content>> {
+        if path.is_dir() {
+            // List directory contents
+            let mut entries = Vec::new();
+            let read_dir = tokio::fs::read_dir(path).await.map_err(|e| {
+                ToolError::ExecutionError(format!("Failed to read directory: {}", e))
+            })?;
+
+            let mut read_dir = read_dir;
+            while let Some(entry) = read_dir.next_entry().await.map_err(|e| {
+                ToolError::ExecutionError(format!("Failed to read directory entry: {}", e))
+            })? {
+                let file_type = if entry
+                    .file_type()
+                    .await
+                    .map_err(|e| {
+                        ToolError::ExecutionError(format!("Failed to get file type: {}", e))
+                    })?
+                    .is_dir()
+                {
+                    "[DIR]"
+                } else {
+                    "[FILE]"
+                };
+                entries.push(format!(
+                    "{} {}",
+                    file_type,
+                    entry.file_name().to_string_lossy()
+                ));
+            }
+
+            entries.sort();
+            Ok(vec![Content::text(entries.join("\n"))])
+        } else {
+            // Read file contents
+            let content = tokio::fs::read_to_string(path)
+                .await
+                .map_err(|e| ToolError::ExecutionError(format!("Failed to read file: {}", e)))?;
+
+            // Handle view_range if specified
+            if let Some(range) = arguments.get("view_range") {
+                if let Some(range_array) = range.as_array() {
+                    if range_array.len() == 2 {
+                        let start = range_array[0].as_i64().unwrap_or(1) as usize;
+                        let end = range_array[1].as_i64().unwrap_or(-1) as isize;
+
+                        let lines: Vec<&str> = content.lines().collect();
+                        let total_lines = lines.len();
+
+                        let start_idx = if start > 0 { start - 1 } else { 0 };
+                        let end_idx = if end < 0 {
+                            total_lines
+                        } else {
+                            (end as usize).min(total_lines)
+                        };
+
+                        let selected_lines = lines[start_idx..end_idx].join("\n");
+                        return Ok(vec![Content::text(selected_lines)]);
+                    }
+                }
+            }
+
+            Ok(vec![Content::text(content)])
+        }
+    }
+
+    /// Write content to file
+    async fn handle_write_file(
+        &self,
+        path: &Path,
+        arguments: &serde_json::Value,
+    ) -> ToolResult<Vec<Content>> {
+        let content = arguments
+            .get("file_text")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                ToolError::ExecutionError("Missing 'file_text' parameter".to_string())
+            })?;
+
+        // Save current content to history (for undo)
+        self.save_file_history(path).await?;
+
+        // Create parent directories if they don't exist
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent).await.map_err(|e| {
+                ToolError::ExecutionError(format!("Failed to create directories: {}", e))
+            })?;
+        }
+
+        // Write the file
+        tokio::fs::write(path, content)
+            .await
+            .map_err(|e| ToolError::ExecutionError(format!("Failed to write file: {}", e)))?;
+
+        Ok(vec![Content::text(format!(
+            "Successfully wrote {} bytes to {}",
+            content.len(),
+            path.display()
+        ))])
+    }
+
+    /// Replace string in file
+    async fn handle_str_replace(
+        &self,
+        path: &Path,
+        arguments: &serde_json::Value,
+    ) -> ToolResult<Vec<Content>> {
+        let old_str = arguments
+            .get("old_str")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolError::ExecutionError("Missing 'old_str' parameter".to_string()))?;
+
+        let new_str = arguments
+            .get("new_str")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolError::ExecutionError("Missing 'new_str' parameter".to_string()))?;
+
+        // Read current content
+        let content = tokio::fs::read_to_string(path)
+            .await
+            .map_err(|e| ToolError::ExecutionError(format!("Failed to read file: {}", e)))?;
+
+        // Check if old_str exists in the file
+        if !content.contains(old_str) {
+            return Err(ToolError::ExecutionError(
+                "The specified 'old_str' was not found in the file".to_string(),
+            ));
+        }
+
+        // Check if old_str appears multiple times
+        let occurrences = content.matches(old_str).count();
+        if occurrences > 1 {
+            return Err(ToolError::ExecutionError(format!(
+                "The specified 'old_str' appears {} times in the file. Please make it more specific.",
+                occurrences
+            )));
+        }
+
+        // Save current content to history
+        self.save_file_history(path).await?;
+
+        // Perform replacement
+        let new_content = content.replace(old_str, new_str);
+
+        // Write the file
+        tokio::fs::write(path, &new_content)
+            .await
+            .map_err(|e| ToolError::ExecutionError(format!("Failed to write file: {}", e)))?;
+
+        Ok(vec![Content::text(format!(
+            "Successfully replaced string in {}",
+            path.display()
+        ))])
+    }
+
+    /// Insert text at specific line
+    async fn handle_insert_text(
+        &self,
+        path: &Path,
+        arguments: &serde_json::Value,
+    ) -> ToolResult<Vec<Content>> {
+        let insert_line = arguments
+            .get("insert_line")
+            .and_then(|v| v.as_i64())
+            .ok_or_else(|| {
+                ToolError::ExecutionError("Missing 'insert_line' parameter".to_string())
+            })? as usize;
+
+        let new_str = arguments
+            .get("new_str")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolError::ExecutionError("Missing 'new_str' parameter".to_string()))?;
+
+        // Read current content
+        let content = tokio::fs::read_to_string(path)
+            .await
+            .map_err(|e| ToolError::ExecutionError(format!("Failed to read file: {}", e)))?;
+
+        // Save current content to history
+        self.save_file_history(path).await?;
+
+        let mut lines: Vec<String> = content.lines().map(|l| l.to_string()).collect();
+
+        // Insert at the specified line
+        if insert_line == 0 {
+            lines.insert(0, new_str.to_string());
+        } else if insert_line <= lines.len() {
+            lines.insert(insert_line, new_str.to_string());
+        } else {
+            return Err(ToolError::ExecutionError(format!(
+                "Insert line {} is beyond the file length ({})",
+                insert_line,
+                lines.len()
+            )));
+        }
+
+        let new_content = lines.join("\n");
+
+        // Write the file
+        tokio::fs::write(path, &new_content)
+            .await
+            .map_err(|e| ToolError::ExecutionError(format!("Failed to write file: {}", e)))?;
+
+        Ok(vec![Content::text(format!(
+            "Successfully inserted text at line {} in {}",
+            insert_line,
+            path.display()
+        ))])
+    }
+
+    /// Undo last edit
+    async fn handle_undo_edit(&self, path: &Path) -> ToolResult<Vec<Content>> {
+        // Get file history from developer tools state
+        let content_to_restore = {
+            let file_history = self.developer_tools_state.lock().await;
+            let mut history = file_history.file_history.lock().unwrap();
+
+            if let Some(versions) = history.get_mut(path) {
+                versions.pop()
+            } else {
+                None
+            }
+        }; // All locks are dropped here
+
+        match content_to_restore {
+            Some(content) => {
+                tokio::fs::write(path, &content).await.map_err(|e| {
+                    ToolError::ExecutionError(format!("Failed to restore file: {}", e))
+                })?;
+
+                Ok(vec![Content::text(format!(
+                    "Successfully restored previous version of {}",
+                    path.display()
+                ))])
+            }
+            None => Err(ToolError::ExecutionError(
+                "No previous version available for undo".to_string(),
+            )),
+        }
+    }
+
+    /// Save file content to history for undo functionality
+    async fn save_file_history(&self, path: &Path) -> Result<(), ToolError> {
+        if path.exists() {
+            let content = tokio::fs::read_to_string(path).await.map_err(|e| {
+                ToolError::ExecutionError(format!("Failed to read file for history: {}", e))
+            })?;
+
+            let file_history = self.developer_tools_state.lock().await;
+            let mut history = file_history.file_history.lock().unwrap();
+
+            let versions = history.entry(path.to_path_buf()).or_insert_with(Vec::new);
+            versions.push(content);
+
+            // Keep only last 10 versions
+            if versions.len() > 10 {
+                versions.remove(0);
+            }
+        }
+        Ok(())
+    }
+
+    /// List available windows
+    async fn handle_list_windows(&self) -> ToolResult<Vec<Content>> {
+        let windows = Window::all()
+            .map_err(|e| ToolError::ExecutionError(format!("Failed to list windows: {}", e)))?;
+
+        let window_list: Vec<String> = windows
+            .into_iter()
+            .map(|w| w.title().to_string())
+            .filter(|title| !title.is_empty())
+            .collect();
+
+        let result = if window_list.is_empty() {
+            "No windows found".to_string()
+        } else {
+            format!("Available windows:\n{}", window_list.join("\n"))
+        };
+
+        Ok(vec![Content::text(result)])
+    }
+
+    /// Capture screenshot
+    async fn handle_screen_capture(
+        &self,
+        arguments: serde_json::Value,
+    ) -> ToolResult<Vec<Content>> {
+        let display = arguments.get("display").and_then(|v| v.as_i64());
+        let window_title = arguments.get("window_title").and_then(|v| v.as_str());
+
+        let image = if let Some(title) = window_title {
+            // Capture specific window
+            let windows = Window::all()
+                .map_err(|e| ToolError::ExecutionError(format!("Failed to list windows: {}", e)))?;
+
+            let window = windows
+                .into_iter()
+                .find(|w| w.title() == title)
+                .ok_or_else(|| {
+                    ToolError::ExecutionError(format!("Window '{}' not found", title))
+                })?;
+
+            window.capture_image().map_err(|e| {
+                ToolError::ExecutionError(format!("Failed to capture window: {}", e))
+            })?
+        } else {
+            // Capture display
+            let display_num = display.unwrap_or(0) as usize;
+            let monitors = Monitor::all().map_err(|e| {
+                ToolError::ExecutionError(format!("Failed to list monitors: {}", e))
+            })?;
+
+            let monitor = monitors.get(display_num).ok_or_else(|| {
+                ToolError::ExecutionError(format!("Display {} not found", display_num))
+            })?;
+
+            monitor.capture_image().map_err(|e| {
+                ToolError::ExecutionError(format!("Failed to capture display: {}", e))
+            })?
+        };
+
+        // Convert to PNG and encode as base64
+        let mut buffer = Vec::new();
+        image
+            .write_to(&mut Cursor::new(&mut buffer), xcap::image::ImageFormat::Png)
+            .map_err(|e| ToolError::ExecutionError(format!("Failed to encode image: {}", e)))?;
+
+        let base64_image = base64::engine::general_purpose::STANDARD.encode(&buffer);
+        let data_uri = format!("data:image/png;base64,{}", base64_image);
+
+        Ok(vec![Content::text(format!(
+            "Screenshot captured. Image data URI:\n{}",
+            data_uri
+        ))])
+    }
+
+    /// Process image file
+    async fn handle_image_processor(
+        &self,
+        arguments: serde_json::Value,
+    ) -> ToolResult<Vec<Content>> {
+        let path = arguments
+            .get("path")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolError::ExecutionError("Missing 'path' parameter".to_string()))?;
+
+        let path = expand_path(path);
+
+        // Load the image
+        let img = image::open(&path)
+            .map_err(|e| ToolError::ExecutionError(format!("Failed to load image: {}", e)))?;
+
+        // Resize if needed (max width 1920px)
+        const MAX_WIDTH: u32 = 1920;
+        let img = if img.width() > MAX_WIDTH {
+            let scale = MAX_WIDTH as f32 / img.width() as f32;
+            let new_height = (img.height() as f32 * scale) as u32;
+            img.resize(MAX_WIDTH, new_height, image::imageops::FilterType::Lanczos3)
+        } else {
+            img
+        };
+
+        // Convert to PNG and encode as base64
+        let mut buffer = Vec::new();
+        img.write_to(&mut Cursor::new(&mut buffer), image::ImageFormat::Png)
+            .map_err(|e| ToolError::ExecutionError(format!("Failed to encode image: {}", e)))?;
+
+        let base64_image = base64::engine::general_purpose::STANDARD.encode(&buffer);
+        let data_uri = format!("data:image/png;base64,{}", base64_image);
+
+        Ok(vec![Content::text(format!(
+            "Image processed. Dimensions: {}x{}. Data URI:\n{}",
+            img.width(),
+            img.height(),
+            data_uri
+        ))])
+    }
+}
+
+/// Load .gooseignore patterns
+fn load_gooseignore_patterns(base_path: &Path) -> Result<Gitignore, ToolError> {
+    let ignore_path = base_path.join(".gooseignore");
+    let mut builder = GitignoreBuilder::new(base_path);
+
+    if ignore_path.exists() {
+        builder.add(&ignore_path);
+    }
+
+    builder
+        .build()
+        .map_err(|e| ToolError::ExecutionError(format!("Failed to parse .gooseignore: {}", e)))
+}
+
+/// Check if a path should be ignored
+fn should_ignore_path(path: &Path, ignore: &Gitignore) -> bool {
+    ignore.matched(path, path.is_dir()).is_ignore()
+}

--- a/crates/goose/src/agents/developer_tools.rs
+++ b/crates/goose/src/agents/developer_tools.rs
@@ -1,0 +1,340 @@
+//! Developer tools for the Goose agent
+//!
+//! This module contains tools for shell execution, file editing, screen capture,
+//! and other developer-focused functionality.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use indoc::indoc;
+use mcp_core::tool::{Tool, ToolAnnotations};
+use serde_json::json;
+
+pub const DEVELOPER_SHELL_TOOL_NAME: &str = "developer__shell";
+pub const DEVELOPER_GLOB_TOOL_NAME: &str = "developer__glob";
+pub const DEVELOPER_GREP_TOOL_NAME: &str = "developer__grep";
+pub const DEVELOPER_TEXT_EDITOR_TOOL_NAME: &str = "developer__text_editor";
+pub const DEVELOPER_LIST_WINDOWS_TOOL_NAME: &str = "developer__list_windows";
+pub const DEVELOPER_SCREEN_CAPTURE_TOOL_NAME: &str = "developer__screen_capture";
+pub const DEVELOPER_IMAGE_PROCESSOR_TOOL_NAME: &str = "developer__image_processor";
+
+/// Create the shell tool definition
+pub fn shell_tool() -> Tool {
+    let shell_tool_desc = match std::env::consts::OS {
+        "windows" => indoc! {r#"
+            Execute a command in the shell.
+
+            This will return the output and error concatenated into a single string, as
+            you would see from running on the command line. There will also be an indication
+            of if the command succeeded or failed.
+
+            Avoid commands that produce a large amount of output, and consider piping those outputs to files.
+
+            **Important**: For searching files and code:
+
+            Preferred: Use ripgrep (`rg`) when available - it respects .gitignore and is fast:
+              - To locate a file by name: `rg --files | rg example.py`
+              - To locate content inside files: `rg 'class Example'`
+
+            Alternative Windows commands (if ripgrep is not installed):
+              - To locate a file by name: `dir /s /b example.py`
+              - To locate content inside files: `findstr /s /i "class Example" *.py`
+
+            Note: Alternative commands may show ignored/hidden files that should be excluded.
+        "#},
+        _ => indoc! {r#"
+            Execute a command in the shell.
+
+            This will return the output and error concatenated into a single string, as
+            you would see from running on the command line. There will also be an indication
+            of if the command succeeded or failed.
+
+            Avoid commands that produce a large amount of output, and consider piping those outputs to files.
+            If you need to run a long lived command, background it - e.g. `uvicorn main:app &` so that
+            this tool does not run indefinitely.
+
+            **Important**: Each shell command runs in its own process. Things like directory changes or
+            sourcing files do not persist between tool calls. So you may need to repeat them each time by
+            stringing together commands, e.g. `cd example && ls` or `source env/bin/activate && pip install numpy`
+
+            - Restrictions: Avoid find, grep, cat, head, tail, ls - use dedicated tools instead (Grep, Glob, Read, LS)
+            - Multiple commands: Use ; or && to chain commands, avoid newlines
+            - Pathnames: Use absolute paths and avoid cd unless explicitly requested
+        "#},
+    };
+
+    Tool::new(
+        DEVELOPER_SHELL_TOOL_NAME.to_string(),
+        shell_tool_desc.to_string(),
+        json!({
+            "type": "object",
+            "required": ["command"],
+            "properties": {
+                "command": {"type": "string", "description": "The shell command to execute"}
+            }
+        }),
+        None,
+    )
+}
+
+/// Create the glob tool definition
+pub fn glob_tool() -> Tool {
+    Tool::new(
+        DEVELOPER_GLOB_TOOL_NAME.to_string(),
+        indoc! {r#"
+            Search for files using glob patterns.
+            
+            This tool provides fast file pattern matching using glob syntax.
+            Returns matching file paths sorted by modification time.
+            Examples:
+            - `*.rs` - Find all Rust files in current directory
+            - `src/**/*.py` - Find all Python files recursively in src directory
+            - `**/test*.js` - Find all JavaScript test files recursively
+            
+            **Important**: Use this tool instead of shell commands like `find` or `ls -r` for file searching,
+            as it properly handles ignored files and is more efficient. This tool respects .gooseignore patterns.
+            
+            Use this tool when you need to locate files by name patterns rather than content.
+        "#}.to_string(),
+        json!({
+            "type": "object",
+            "required": ["pattern"],
+            "properties": {
+                "pattern": {"type": "string", "description": "The glob pattern to search for"},
+                "path": {"type": "string", "description": "The directory to search in (defaults to current directory)"}
+            }
+        }),
+        Some(ToolAnnotations {
+            title: Some("Search files by pattern".to_string()),
+            read_only_hint: true,
+            destructive_hint: false,
+            idempotent_hint: true,
+            open_world_hint: false,
+        }),
+    )
+}
+
+/// Create the grep tool definition
+pub fn grep_tool() -> Tool {
+    Tool::new(
+        DEVELOPER_GREP_TOOL_NAME.to_string(),
+        indoc! {r#"
+            Execute file content search commands using ripgrep, grep, or find.
+            
+            Use this tool to run search commands that look for content within files. The tool
+            executes your command directly and filters results to respect .gooseignore patterns.
+            
+            **Recommended tools and usage:**
+            
+            **ripgrep (rg)** - Fast, recommended for most searches:
+            - List files containing pattern: `rg -l "pattern"`
+            - Case-insensitive search: `rg -i "pattern"`
+            - Search specific file types: `rg "pattern" --glob "*.js"`
+            - Show matches with context: `rg "pattern" -C 3`
+            - List files by name: `rg --files | rg <filename>`
+            - List files that contain a regex: `rg '<regex>' -l`
+            - Sort by modification time: `rg -l "pattern" --sort modified`
+            
+            **grep** - Traditional Unix tool:
+            - Recursive search: `grep -r "pattern" .`
+            - List files only: `grep -rl "pattern" .`
+            - Include specific files: `grep -r "pattern" --include="*.py"`
+            
+            **find + grep** - When you need complex file filtering:
+            - `find . -name "*.py" -exec grep -l "pattern" {} \;`
+            - `find . -type f -newer file.txt -exec grep "pattern" {} \;`
+            
+            **Important**: Use this tool instead of the shell tool for search commands, as it
+            properly filters results to respect ignored files.
+        "#}
+        .to_string(),
+        json!({
+            "type": "object",
+            "required": ["command"],
+            "properties": {
+                "command": {"type": "string", "description": "The search command to execute (rg, grep, find, etc.)"}
+            }
+        }),
+        Some(ToolAnnotations {
+            title: Some("Search file contents".to_string()),
+            read_only_hint: true,
+            destructive_hint: false,
+            idempotent_hint: true,
+            open_world_hint: false,
+        }),
+    )
+}
+
+/// Create the text editor tool definition
+pub fn text_editor_tool() -> Tool {
+    Tool::new(
+        DEVELOPER_TEXT_EDITOR_TOOL_NAME.to_string(),
+        indoc! {r#"
+            Perform text editing operations on files.
+
+            The `command` parameter specifies the operation to perform. Allowed options are:
+            - `view`: View the content of a file.
+            - `write`: Create or overwrite a file with the given content
+            - `str_replace`: Replace a string in a file with a new string.
+            - `insert`: Insert text at a specific line location in the file.
+            - `undo_edit`: Undo the last edit made to a file.
+
+            To use the write command, you must specify `file_text` which will become the new content of the file. Be careful with
+            existing files! This is a full overwrite, so you must include everything - not just sections you are modifying.
+
+            To use the str_replace command, you must specify both `old_str` and `new_str` - the `old_str` needs to exactly match one
+            unique section of the original file, including any whitespace. Make sure to include enough context that the match is not
+            ambiguous. The entire original string will be replaced with `new_str`.
+
+            To use the insert command, you must specify both `insert_line` (the line number after which to insert, 0 for beginning) 
+            and `new_str` (the text to insert).
+        "#}.to_string(),
+        json!({
+            "type": "object",
+            "required": ["command", "path"],
+            "properties": {
+                "path": {
+                    "description": "Absolute path to file or directory, e.g. `/repo/file.py` or `/repo`.",
+                    "type": "string"
+                },
+                "command": {
+                    "type": "string",
+                    "enum": ["view", "write", "str_replace", "insert", "undo_edit"],
+                    "description": "Allowed options are: `view`, `write`, `str_replace`, `insert`, `undo_edit`."
+                },
+                "view_range": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "description": "Optional array of two integers specifying the start and end line numbers to view. Line numbers are 1-indexed, and -1 for the end line means read to the end of the file. This parameter only applies when viewing files, not directories."
+                },
+                "insert_line": {
+                    "type": "integer",
+                    "description": "The line number after which to insert the text (0 for beginning of file). This parameter is required when using the insert command."
+                },
+                "old_str": {"type": "string"},
+                "new_str": {"type": "string"},
+                "file_text": {"type": "string"}
+            }
+        }),
+        None,
+    )
+}
+
+/// Create the list windows tool definition
+pub fn list_windows_tool() -> Tool {
+    Tool::new(
+        DEVELOPER_LIST_WINDOWS_TOOL_NAME.to_string(),
+        indoc! {r#"
+            List all available window titles that can be used with screen_capture.
+            Returns a list of window titles that can be used with the window_title parameter
+            of the screen_capture tool.
+        "#}
+        .to_string(),
+        json!({
+            "type": "object",
+            "required": [],
+            "properties": {}
+        }),
+        Some(ToolAnnotations {
+            title: Some("List available windows".to_string()),
+            read_only_hint: true,
+            destructive_hint: false,
+            idempotent_hint: false,
+            open_world_hint: false,
+        }),
+    )
+}
+
+/// Create the screen capture tool definition
+pub fn screen_capture_tool() -> Tool {
+    Tool::new(
+        DEVELOPER_SCREEN_CAPTURE_TOOL_NAME.to_string(),
+        indoc! {r#"
+            Capture a screenshot of a specified display or window.
+            You can capture either:
+            1. A full display (monitor) using the display parameter
+            2. A specific window by its title using the window_title parameter
+
+            Only one of display or window_title should be specified.
+        "#}
+        .to_string(),
+        json!({
+            "type": "object",
+            "required": [],
+            "properties": {
+                "display": {
+                    "type": "integer",
+                    "default": 0,
+                    "description": "The display number to capture (0 is main display)"
+                },
+                "window_title": {
+                    "type": "string",
+                    "default": null,
+                    "description": "Optional: the exact title of the window to capture. use the list_windows tool to find the available windows."
+                }
+            }
+        }),
+        Some(ToolAnnotations {
+            title: Some("Capture a screenshot".to_string()),
+            read_only_hint: true,
+            destructive_hint: false,
+            idempotent_hint: false,
+            open_world_hint: false,
+        }),
+    )
+}
+
+/// Create the image processor tool definition
+pub fn image_processor_tool() -> Tool {
+    Tool::new(
+        DEVELOPER_IMAGE_PROCESSOR_TOOL_NAME.to_string(),
+        indoc! {r#"
+            Process an image file from disk. The image will be:
+            1. Resized if larger than max width while maintaining aspect ratio
+            2. Converted to PNG format
+            3. Returned as base64 encoded data
+
+            This allows processing image files for use in the conversation.
+        "#}
+        .to_string(),
+        json!({
+            "type": "object",
+            "required": ["path"],
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path to the image file to process"
+                }
+            }
+        }),
+        Some(ToolAnnotations {
+            title: Some("Process Image".to_string()),
+            read_only_hint: true,
+            destructive_hint: false,
+            idempotent_hint: true,
+            open_world_hint: false,
+        }),
+    )
+}
+
+/// Developer tools state management
+pub struct DeveloperToolsState {
+    pub file_history: Arc<Mutex<HashMap<PathBuf, Vec<String>>>>,
+}
+
+impl DeveloperToolsState {
+    pub fn new() -> Self {
+        Self {
+            file_history: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl Default for DeveloperToolsState {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/goose/src/agents/mod.rs
+++ b/crates/goose/src/agents/mod.rs
@@ -1,5 +1,7 @@
 mod agent;
 mod context;
+mod developer_tool_handlers;
+pub mod developer_tools;
 pub mod extension;
 pub mod extension_manager;
 pub mod final_output_tool;

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -18,6 +18,7 @@ use crate::session;
 use mcp_core::tool::Tool;
 
 use super::super::agents::Agent;
+use super::developer_tools;
 
 async fn toolshim_postprocess(
     response: Message,
@@ -61,6 +62,18 @@ impl Agent {
             }
             _ => self.list_tools(None).await,
         };
+
+        // Add developer tools directly
+        tools.extend([
+            developer_tools::shell_tool(),
+            developer_tools::glob_tool(),
+            developer_tools::grep_tool(),
+            developer_tools::text_editor_tool(),
+            developer_tools::list_windows_tool(),
+            developer_tools::screen_capture_tool(),
+            developer_tools::image_processor_tool(),
+        ]);
+
         // Add frontend tools
         let frontend_tools = self.frontend_tools.lock().await;
         for frontend_tool in frontend_tools.values() {


### PR DESCRIPTION
Trying out running developer tools alongside the agent, this results in just one goose process with defaults, not 2. 

Also means that crashes of the developer tool will be panics but makes them more visible (may be useful to help diagnose things). 

eg: 

<img width="875" height="190" alt="image" src="https://github.com/user-attachments/assets/4b3448a3-2ad0-438f-a024-7b0dbca9d264" />

likely would be swallowed when running as an MCP (if that bug existed). 

