### PR TITLE
Drop file system MCP

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -335,17 +335,6 @@
     ]
   },
   {
-    "id": "filesystem-mcp",
-    "name": "Filesystem",
-    "description": "File system operations and management",
-    "command": "uvx mcp-server-filesystem",
-    "link": "https://github.com/modelcontextprotocol/servers",
-    "installation_notes": "Install using uvx package manager.",
-    "is_builtin": false,
-    "endorsed": true,
-    "environmentVariables": []
-  },
-  {
     "id": "github-mcp",
     "name": "GitHub",
     "description": "GitHub repository management and operations",


### PR DESCRIPTION
this is actually a node mcp, not a python one. but worse, it requires specifying which folders to mount. also we already have internal file system support, so dropping it seems reasonable