### PR TITLE
fix: mcp command error reporting on cli

### DIFF
--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -115,18 +115,15 @@ async fn child_process_client(
     #[cfg(unix)]
     command.process_group(0);
 
-    // Extract the command name for better error messages
     let cmd_name = command.as_std().get_program().to_string_lossy().to_string();
-
     let (transport, mut stderr) = TokioChildProcess::builder(command)
         .stderr(Stdio::piped())
         .spawn()
-        .map_err(|e| {
-            // Check if it's a "command not found" error
+        .map_err(|e| {            
             if e.kind() == std::io::ErrorKind::NotFound {
                 ExtensionError::SetupError(format!(
-                    "Command '{}' not found. Please ensure it is installed and available in PATH. Original error: {}",
-                    cmd_name, e
+                    "Command '{}' not found. Please ensure it is installed and available in PATH.",
+                    cmd_name
                 ))
             } else {
                 ExtensionError::IoError(e)

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -119,7 +119,7 @@ async fn child_process_client(
     let (transport, mut stderr) = TokioChildProcess::builder(command)
         .stderr(Stdio::piped())
         .spawn()
-        .map_err(|e| {            
+        .map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
                 ExtensionError::SetupError(format!(
                     "Command '{}' not found. Please ensure it is installed and available in PATH.",

--- a/crates/goose/src/agents/extension_manager_test.rs
+++ b/crates/goose/src/agents/extension_manager_test.rs
@@ -1,0 +1,59 @@
+#[cfg(test)]
+mod tests {
+    use super::super::extension::{ExtensionConfig, ExtensionError};
+    use super::super::extension_manager::*;
+    use tokio::process::Command;
+
+    #[tokio::test]
+    async fn test_missing_command_error_message() {
+        // Test that a missing command produces a helpful error message
+        let fake_cmd = "nonexistent_command_xyz_123";
+        let command = Command::new(fake_cmd);
+
+        let result = child_process_client(command, &None).await;
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        let error_msg = error.to_string();
+
+        // Check that the error message mentions the specific command
+        assert!(
+            error_msg.contains(fake_cmd),
+            "Error message should mention the command name '{}'. Got: {}",
+            fake_cmd,
+            error_msg
+        );
+        assert!(
+            error_msg.contains("not found"),
+            "Error message should indicate command not found. Got: {}",
+            error_msg
+        );
+        assert!(
+            error_msg.contains("PATH"),
+            "Error message should mention PATH. Got: {}",
+            error_msg
+        );
+    }
+
+    #[tokio::test]
+    async fn test_uvx_missing_error_hint() {
+        // Test that missing uvx produces a helpful installation hint
+        let mut manager = ExtensionManager::new();
+
+        let config = ExtensionConfig::InlinePython {
+            name: "test_python".to_string(),
+            code: "print('test')".to_string(),
+            description: Some("Test extension".to_string()),
+            timeout: Some(30),
+            dependencies: None,
+            bundled: None,
+        };
+
+        // This should fail if uvx is not installed
+        // We can't guarantee uvx isn't installed in test environment,
+        // but we can test the error path would work
+
+        // For now, just verify the code compiles with our changes
+        // Real integration testing would require a controlled environment
+    }
+}


### PR DESCRIPTION
when CLI launches mcp servers with stdio, if the command is missing it will not normally say what, this makes it explicit, maybe overkill, may save some debugging time (GUI packages up the commands needed usually): 

now shows: 
<img width="987" height="122" alt="Screenshot 2025-08-14 at 4 58 11 pm" src="https://github.com/user-attachments/assets/6b7a050a-6e64-4f3c-a8fc-0764fb8abd6f" />

fixes: https://github.com/block/goose/issues/3872 