### PR TITLE
feat: mcp UI sidecar (WIP)

### DIFF
--- a/ui/desktop/src/components/Layout/MainPanelLayout.tsx
+++ b/ui/desktop/src/components/Layout/MainPanelLayout.tsx
@@ -1,18 +1,92 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
+import SidecarPanel from '../Sidecar/SidecarPanel';
+import { SidecarProvider, useSidecar } from '../Sidecar/SidecarContext';
 
 export const MainPanelLayout: React.FC<{
   children: React.ReactNode;
   removeTopPadding?: boolean;
   backgroundColor?: string;
 }> = ({ children, removeTopPadding = false, backgroundColor = 'bg-background-default' }) => {
-  return (
-    <div className={`h-dvh`}>
-      {/* Padding top matches the app toolbar drag area height - can be removed for full bleed */}
-      <div
-        className={`flex flex-col ${backgroundColor} flex-1 min-w-0 h-full min-h-0 ${removeTopPadding ? '' : 'pt-[32px]'}`}
-      >
-        {children}
+  const ResizableSeparator = () => {
+    const { isOpen, setWidthPct, close } = useSidecar();
+    const dragging = useRef(false);
+
+    const onMouseDown = useCallback(
+      (e: React.MouseEvent) => {
+        if (!isOpen) return;
+        dragging.current = true;
+        document.body.style.cursor = 'col-resize';
+        e.preventDefault();
+        e.stopPropagation();
+      },
+      [isOpen]
+    );
+
+    const onMouseMove = useCallback(
+      (e: MouseEvent) => {
+        if (!dragging.current) return;
+        const container = document.querySelector('#main-panel-layout-container') as HTMLDivElement;
+        if (!container) return;
+        const rect = container.getBoundingClientRect();
+        const totalWidth = rect.width || 1;
+        const distanceFromRight = Math.max(0, Math.min(rect.width, rect.right - e.clientX));
+        const next = distanceFromRight / totalWidth; // fraction of container taken by sidecar
+        // Auto-collapse if below 12% (similar feel to left rail)
+        if (next < 0.12) {
+          setWidthPct(0.3); // store a sensible default when re-opened
+          close();
+          dragging.current = false;
+          document.body.style.cursor = '';
+          return;
+        }
+        setWidthPct(next);
+      },
+      [setWidthPct, close]
+    );
+
+    const onMouseUp = useCallback(() => {
+      if (!dragging.current) return;
+      dragging.current = false;
+      document.body.style.cursor = '';
+    }, []);
+
+    React.useEffect(() => {
+      window.addEventListener('mousemove', onMouseMove);
+      window.addEventListener('mouseup', onMouseUp);
+      return () => {
+        window.removeEventListener('mousemove', onMouseMove);
+        window.removeEventListener('mouseup', onMouseUp);
+      };
+    }, [onMouseMove, onMouseUp]);
+
+    return (
+      <div className={`relative ${isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}>
+        <div className="absolute inset-y-0 -left-[3px] w-[6px]" />
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          className={`w-[6px] cursor-col-resize bg-transparent hover:bg-borderSubtle/60 active:bg-borderSubtle transition-colors`}
+          onMouseDown={onMouseDown}
+          title="Resize side panel"
+        />
       </div>
-    </div>
+    );
+  };
+
+  return (
+    <SidecarProvider>
+      <div className={`h-dvh`}>
+        <div
+          id="main-panel-layout-container"
+          className={`flex ${backgroundColor} flex-1 min-w-0 h-full min-h-0`}
+        >
+          <div className={`flex flex-col flex-1 min-w-0 ${removeTopPadding ? '' : 'pt-[32px]'}`}>
+            {children}
+          </div>
+          <ResizableSeparator />
+          <SidecarPanel />
+        </div>
+      </div>
+    </SidecarProvider>
   );
 };

--- a/ui/desktop/src/components/MCPUIResourceRenderer.tsx
+++ b/ui/desktop/src/components/MCPUIResourceRenderer.tsx
@@ -160,9 +160,21 @@ export default function MCPUIResourceRenderer({
     ): Promise<UIActionHandlerResult> => {
       const { prompt } = actionEvent.payload;
 
+      // Validate prompt before forwarding
+      if (typeof prompt !== 'string' || prompt.trim().length === 0) {
+        return {
+          status: 'error' as const,
+          error: {
+            code: UIActionErrorCode.INVALID_PARAMS,
+            message: 'Prompt must be a non-empty string',
+            details: actionEvent.payload,
+          },
+        };
+      }
+
       if (appendPromptToChat) {
         try {
-          appendPromptToChat(prompt);
+          appendPromptToChat(prompt.trim());
           window.dispatchEvent(new CustomEvent('scroll-chat-to-bottom'));
           return {
             status: 'success' as const,

--- a/ui/desktop/src/components/Sidecar/SidecarContext.tsx
+++ b/ui/desktop/src/components/Sidecar/SidecarContext.tsx
@@ -15,6 +15,10 @@ type SidecarContextValue = {
     resource: ResourceContent;
     appendPromptToChat?: (value: string) => void;
   }) => void;
+  toggleMCPUI: (payload: {
+    resource: ResourceContent;
+    appendPromptToChat?: (value: string) => void;
+  }) => void;
   close: () => void;
 };
 
@@ -82,9 +86,22 @@ export function SidecarProvider({ children }: { children: React.ReactNode }) {
     []
   );
 
+  const toggleMCPUI = useCallback(
+    (payload: { resource: ResourceContent; appendPromptToChat?: (value: string) => void }) => {
+      const currentUri = content.kind === 'mcp-ui' ? content.resource.resource.uri : undefined;
+      const nextUri = payload.resource.resource.uri;
+      if (isOpen && currentUri && nextUri && currentUri === nextUri) {
+        close();
+        return;
+      }
+      openWithMCPUI(payload);
+    },
+    [content, isOpen, close, openWithMCPUI]
+  );
+
   const value = useMemo<SidecarContextValue>(
-    () => ({ isOpen, content, widthPct, setWidthPct, open, openWithMCPUI, close }),
-    [isOpen, content, widthPct, setWidthPct, open, openWithMCPUI, close]
+    () => ({ isOpen, content, widthPct, setWidthPct, open, openWithMCPUI, toggleMCPUI, close }),
+    [isOpen, content, widthPct, setWidthPct, open, openWithMCPUI, toggleMCPUI, close]
   );
 
   return <SidecarContext.Provider value={value}>{children}</SidecarContext.Provider>;

--- a/ui/desktop/src/components/Sidecar/SidecarContext.tsx
+++ b/ui/desktop/src/components/Sidecar/SidecarContext.tsx
@@ -1,0 +1,91 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import type { ResourceContent } from '../../types/message';
+
+export type SidecarContent =
+  | { kind: 'none' }
+  | { kind: 'mcp-ui'; resource: ResourceContent; appendPromptToChat?: (value: string) => void };
+
+type SidecarContextValue = {
+  isOpen: boolean;
+  content: SidecarContent;
+  widthPct: number;
+  setWidthPct: (pct: number) => void;
+  open: () => void;
+  openWithMCPUI: (payload: {
+    resource: ResourceContent;
+    appendPromptToChat?: (value: string) => void;
+  }) => void;
+  close: () => void;
+};
+
+const SidecarContext = createContext<SidecarContextValue | null>(null);
+
+export function useSidecar() {
+  const ctx = useContext(SidecarContext);
+  if (!ctx) throw new Error('useSidecar must be used within SidecarProvider');
+  return ctx;
+}
+
+export function SidecarProvider({ children }: { children: React.ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [content, setContent] = useState<SidecarContent>({ kind: 'none' });
+  const [widthPct, _setWidthPct] = useState<number>(() => {
+    const stored = localStorage.getItem('sidecar_width_pct');
+    const value = stored ? parseFloat(stored) : 0.5;
+    if (Number.isFinite(value) && value > 0 && value < 1) return value;
+    return 0.5; // initial 50%
+  });
+
+  const setWidthPct = useCallback((pct: number) => {
+    // clamp between 0.1 and 0.75 (min enforced in panel by minWidth too)
+    const clamped = Math.max(0.1, Math.min(0.75, pct));
+    _setWidthPct(clamped);
+    try {
+      localStorage.setItem('sidecar_width_pct', String(clamped));
+    } catch {
+      /* ignore storage failures (private mode, etc.) */
+    }
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    if (window?.electron && 'setSidecarOpen' in window.electron) {
+      // notify main process to restore window size
+      // @ts-expect-error exposed in preload
+      window.electron.setSidecarOpen(false);
+    }
+  }, []);
+
+  const open = useCallback(() => {
+    setIsOpen(true);
+    if (window?.electron && 'setSidecarOpen' in window.electron) {
+      // notify main process to enlarge window
+      // @ts-expect-error exposed in preload
+      window.electron.setSidecarOpen(true);
+    }
+  }, []);
+
+  const openWithMCPUI = useCallback(
+    (payload: { resource: ResourceContent; appendPromptToChat?: (value: string) => void }) => {
+      setContent({
+        kind: 'mcp-ui',
+        resource: payload.resource,
+        appendPromptToChat: payload.appendPromptToChat,
+      });
+      setIsOpen(true);
+      if (window?.electron && 'setSidecarOpen' in window.electron) {
+        // notify main process to enlarge window
+        // @ts-expect-error exposed in preload
+        window.electron.setSidecarOpen(true);
+      }
+    },
+    []
+  );
+
+  const value = useMemo<SidecarContextValue>(
+    () => ({ isOpen, content, widthPct, setWidthPct, open, openWithMCPUI, close }),
+    [isOpen, content, widthPct, setWidthPct, open, openWithMCPUI, close]
+  );
+
+  return <SidecarContext.Provider value={value}>{children}</SidecarContext.Provider>;
+}

--- a/ui/desktop/src/components/Sidecar/SidecarContext.tsx
+++ b/ui/desktop/src/components/Sidecar/SidecarContext.tsx
@@ -76,14 +76,16 @@ export function SidecarProvider({ children }: { children: React.ReactNode }) {
         resource: payload.resource,
         appendPromptToChat: payload.appendPromptToChat,
       });
-      setIsOpen(true);
-      if (window?.electron && 'setSidecarOpen' in window.electron) {
+      // Only resize window if sidecar wasn't already open
+      if (!isOpen && window?.electron && 'setSidecarOpen' in window.electron) {
+        console.log('Resizing window for sidecar open');
         // notify main process to enlarge window
         // @ts-expect-error exposed in preload
         window.electron.setSidecarOpen(true);
       }
+      setIsOpen(true);
     },
-    []
+    [isOpen]
   );
 
   const toggleMCPUI = useCallback(

--- a/ui/desktop/src/components/Sidecar/SidecarPanel.tsx
+++ b/ui/desktop/src/components/Sidecar/SidecarPanel.tsx
@@ -16,7 +16,7 @@ export default function SidecarPanel() {
 
   return (
     <div
-      className={`transition-all duration-200 ease-in-out bg-background-default border-l border-borderSubtle h-full ${
+      className={`transition-[width,opacity] duration-200 ease-in-out bg-background-default border-l border-borderSubtle h-full ${
         isOpen ? 'opacity-100' : 'opacity-0'
       } overflow-hidden flex-shrink-0`}
       style={style as React.CSSProperties}

--- a/ui/desktop/src/components/Sidecar/SidecarPanel.tsx
+++ b/ui/desktop/src/components/Sidecar/SidecarPanel.tsx
@@ -1,0 +1,52 @@
+import React, { useMemo } from 'react';
+import { useSidecar } from './SidecarContext';
+import MCPUIResourceRenderer from '../MCPUIResourceRenderer';
+
+export default function SidecarPanel() {
+  const { isOpen, content, close, widthPct } = useSidecar();
+
+  const style = useMemo(() => {
+    return isOpen
+      ? {
+          width: `${Math.min(75, Math.max(10, widthPct * 100))}%`,
+          minWidth: 320,
+        }
+      : { width: 0 };
+  }, [isOpen, widthPct]);
+
+  return (
+    <div
+      className={`transition-all duration-200 ease-in-out bg-background-default border-l border-borderSubtle h-full ${
+        isOpen ? 'opacity-100' : 'opacity-0'
+      } overflow-hidden flex-shrink-0`}
+      style={style as React.CSSProperties}
+      aria-hidden={!isOpen}
+    >
+      {isOpen && (
+        <div className="h-full flex flex-col">
+          <div className="sticky top-0 z-10 flex items-center justify-between px-3 py-2 border-b border-borderSubtle bg-background-default/95 backdrop-blur supports-[backdrop-filter]:bg-background-default/70">
+            <div className="text-xs font-sans text-textSubtle uppercase tracking-wide">
+              MCP‑UI sidecar
+            </div>
+            <button
+              className="inline-flex items-center justify-center w-6 h-6 rounded hover:bg-bgSubtle text-textSubtle hover:text-textStandard"
+              onClick={close}
+              aria-label="Close side panel"
+              title="Close"
+            >
+              ×
+            </button>
+          </div>
+          <div className="flex-1 min-h-0 overflow-auto p-3">
+            {content.kind === 'mcp-ui' && (
+              <MCPUIResourceRenderer
+                content={content.resource}
+                appendPromptToChat={content.appendPromptToChat}
+              />
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/desktop/src/components/Sidecar/SidecarPanel.tsx
+++ b/ui/desktop/src/components/Sidecar/SidecarPanel.tsx
@@ -24,12 +24,12 @@ export default function SidecarPanel() {
     >
       {isOpen && (
         <div className="h-full flex flex-col">
-          <div className="sticky top-0 z-10 flex items-center justify-between px-3 py-2 border-b border-borderSubtle bg-background-default/95 backdrop-blur supports-[backdrop-filter]:bg-background-default/70">
+          <div className="sticky top-0 z-100 flex items-center justify-between px-3 py-2 border-b border-borderSubtle bg-background-default/95 backdrop-blur supports-[backdrop-filter]:bg-background-default/70">
             <div className="text-xs font-sans text-textSubtle uppercase tracking-wide">
               MCP‑UI sidecar
             </div>
             <button
-              className="inline-flex items-center justify-center w-6 h-6 rounded hover:bg-bgSubtle text-textSubtle hover:text-textStandard"
+              className="no-drag inline-flex items-center justify-center w-6 h-6 cursor-pointer rounded hover:bg-bgSubtle text-textSubtle hover:text-textStandard relative z-50 pointer-events-auto"
               onClick={close}
               aria-label="Close side panel"
               title="Close"

--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -13,7 +13,7 @@ import {
 import { cn, snakeToTitleCase } from '../utils';
 import { LoadingStatus } from './ui/Dot';
 import { NotificationEvent } from '../hooks/useMessageStream';
-import { ChevronRight, LoaderCircle, SquareArrowOutUpRight } from 'lucide-react';
+import { ChevronRight, SquareArrowOutUpRight } from 'lucide-react';
 import { TooltipWrapper } from './settings/providers/subcomponents/buttons/TooltipWrapper';
 // Inline MCP-UI renderer is unused now (sidecar only)
 import { isUIResource } from '@mcp-ui/client';

--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -13,7 +13,7 @@ import {
 import { cn, snakeToTitleCase } from '../utils';
 import { LoadingStatus } from './ui/Dot';
 import { NotificationEvent } from '../hooks/useMessageStream';
-import { ChevronRight, LoaderCircle } from 'lucide-react';
+import { ChevronRight, LoaderCircle, SquareArrowOutUpRight } from 'lucide-react';
 import { TooltipWrapper } from './settings/providers/subcomponents/buttons/TooltipWrapper';
 // Inline MCP-UI renderer is unused now (sidecar only)
 import { isUIResource } from '@mcp-ui/client';
@@ -46,22 +46,47 @@ export default function ToolCallWithResponse({
   return (
     <>
       {shouldRender && (
-        <div
-          className={cn(
-            'w-full text-sm font-sans rounded-lg overflow-hidden border-borderSubtle border bg-background-muted'
-          )}
-        >
-          <ToolCallView
-            {...{
-              isCancelledMessage,
-              toolCall: toolCall!,
-              toolResponse,
-              notifications,
-              isStreamingMessage,
-              openInSidecar: (resource: ResourceContent) =>
-                sidecar.openWithMCPUI({ resource, appendPromptToChat: append }),
-            }}
-          />
+        <div className="relative">
+          <div
+            className={cn(
+              'w-full text-sm font-sans rounded-lg overflow-hidden border-borderSubtle border bg-background-default p-3'
+            )}
+          >
+            <ToolCallView
+              {...{
+                isCancelledMessage,
+                toolCall: toolCall!,
+                toolResponse,
+                notifications,
+                isStreamingMessage,
+                openInSidecar: (resource: ResourceContent) =>
+                  sidecar.toggleMCPUI({ resource, appendPromptToChat: append }),
+              }}
+            />
+          </div>
+          {(() => {
+            const ui = (toolResponse?.toolResult?.value || []).find((c) => isUIResource(c));
+            return ui && isUIResource(ui) ? (
+              <button
+                className="absolute z-10 rounded bg-background-default/95 border border-borderSubtle shadow hover:bg-bgSubtle"
+                title={sidecar.isOpen ? 'Close side panel' : 'Open in side panel'}
+                aria-label={sidecar.isOpen ? 'Close side panel' : 'Open in side panel'}
+                onClick={() =>
+                  sidecar.toggleMCPUI({
+                    resource: ui as ResourceContent,
+                    appendPromptToChat: append,
+                  })
+                }
+                style={{
+                  right: 'calc(var(--spacing) * -21)',
+                  top: 'calc(var(--spacing) * 1)',
+                  padding: '6px',
+                }}
+              >
+                <SquareArrowOutUpRight size={14} />
+              </button>
+            ) : null;
+          })()}
         </div>
       )}
     </>
@@ -119,7 +144,6 @@ interface ToolCallViewProps {
   toolResponse?: ToolResponseMessageContent;
   notifications?: NotificationEvent[];
   isStreamingMessage?: boolean;
-  openInSidecar: (resource: ResourceContent) => void;
 }
 
 interface Progress {
@@ -166,7 +190,6 @@ function ToolCallView({
   toolResponse,
   notifications,
   isStreamingMessage = false,
-  openInSidecar,
 }: ToolCallViewProps) {
   const [responseStyle, setResponseStyle] = useState(() => localStorage.getItem('response_style'));
 
@@ -508,15 +531,7 @@ function ToolCallView({
           {toolResults.map(({ result, isExpandToolResults }, index) => {
             return (
               <div key={index} className={cn('border-t border-borderSubtle')}>
-                <ToolResultView
-                  result={result}
-                  isStartExpanded={isExpandToolResults}
-                  onOpenInSidecar={
-                    result.type === 'resource' && isUIResource(result)
-                      ? () => openInSidecar(result as ResourceContent)
-                      : undefined
-                  }
-                />
+                <ToolResultView result={result} isStartExpanded={isExpandToolResults} />
               </div>
             );
           })}
@@ -552,27 +567,15 @@ function ToolDetailsView({ toolCall, isStartExpanded }: ToolDetailsViewProps) {
 interface ToolResultViewProps {
   result: Content;
   isStartExpanded: boolean;
-  onOpenInSidecar?: () => void;
 }
 
-function ToolResultView({ result, isStartExpanded, onOpenInSidecar }: ToolResultViewProps) {
+function ToolResultView({ result, isStartExpanded }: ToolResultViewProps) {
   return (
     <ToolCallExpandable
       label={<span className="pl-4 py-1 font-sans text-sm">Output</span>}
       isStartExpanded={isStartExpanded}
     >
       <div className="pl-4 pr-4 py-4">
-        {onOpenInSidecar && (
-          <div className="flex justify-end mb-2">
-            <button
-              className="text-xs font-sans px-2 py-1 rounded border border-borderSubtle hover:bg-bgSubtle"
-              onClick={onOpenInSidecar}
-              title="Open in side panel"
-            >
-              Open in sidecar
-            </button>
-          </div>
-        )}
         {result.type === 'text' && result.text && (
           <MarkdownContent
             content={result.text}

--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -41,12 +41,41 @@ export default function ToolCallWithResponse({
   // Always mount the component to keep hooks order consistent. Render nothing if no toolCall.
   const shouldRender = !!toolCall;
 
-  // Manual open via per-result action; no auto-open to allow selection
+  // Find UI resource in tool response
+  const ui = (toolResponse?.toolResult?.value || []).find((c) => isUIResource(c));
+
+  // Track if we've already auto-opened for this tool call to prevent double-firing
+  const hasAutoOpened = React.useRef(false);
+
+  // Auto-open sidecar when tool finishes and contains UI resource
+  React.useEffect(() => {
+    // Reset flag when streaming starts (new tool call)
+    if (isStreamingMessage) {
+      hasAutoOpened.current = false;
+      return;
+    }
+
+    // Auto-open when tool finishes with UI resource
+    if (ui && isUIResource(ui) && !hasAutoOpened.current) {
+      hasAutoOpened.current = true;
+      // Small delay to ensure the tool response is fully processed
+      const timer = setTimeout(() => {
+        sidecar.openWithMCPUI({
+          resource: ui as ResourceContent,
+          appendPromptToChat: append,
+        });
+      }, 100);
+      return () => clearTimeout(timer);
+    }
+
+    // Explicit return for TypeScript when no conditions are met
+    return undefined;
+  }, [ui, isStreamingMessage, append, sidecar]);
 
   return (
     <>
       {shouldRender && (
-        <div className="relative">
+        <div className="relative ">
           <div
             className={cn(
               'w-full text-sm font-sans rounded-lg overflow-hidden border-borderSubtle border bg-background-default p-3'
@@ -60,33 +89,25 @@ export default function ToolCallWithResponse({
                 notifications,
                 isStreamingMessage,
                 openInSidecar: (resource: ResourceContent) =>
-                  sidecar.toggleMCPUI({ resource, appendPromptToChat: append }),
+                  sidecar.openWithMCPUI({ resource, appendPromptToChat: append }),
               }}
             />
           </div>
-          {(() => {
-            const ui = (toolResponse?.toolResult?.value || []).find((c) => isUIResource(c));
-            return ui && isUIResource(ui) ? (
-              <button
-                className="absolute z-10 rounded bg-background-default/95 border border-borderSubtle shadow hover:bg-bgSubtle"
-                title={sidecar.isOpen ? 'Close side panel' : 'Open in side panel'}
-                aria-label={sidecar.isOpen ? 'Close side panel' : 'Open in side panel'}
-                onClick={() =>
-                  sidecar.toggleMCPUI({
-                    resource: ui as ResourceContent,
-                    appendPromptToChat: append,
-                  })
-                }
-                style={{
-                  right: 'calc(var(--spacing) * -21)',
-                  top: 'calc(var(--spacing) * 1)',
-                  padding: '6px',
-                }}
-              >
-                <SquareArrowOutUpRight size={14} />
-              </button>
-            ) : null;
-          })()}
+          {ui && isUIResource(ui) ? (
+            <button
+              className="absolute right-[-40px] top-0 z-10 p-2 rounded bg-background-default/95 border border-borderSubtle shadow hover:bg-bgSubtle cursor-pointer"
+              title="Open in side panel"
+              aria-label="Open in side panel"
+              onClick={() => {
+                sidecar.openWithMCPUI({
+                  resource: ui as ResourceContent,
+                  appendPromptToChat: append,
+                });
+              }}
+            >
+              <SquareArrowOutUpRight size={14} />
+            </button>
+          ) : null}
         </div>
       )}
     </>

--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -4,14 +4,20 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Button } from './ui/button';
 import { ToolCallArguments, ToolCallArgumentValue } from './ToolCallArguments';
 import MarkdownContent from './MarkdownContent';
-import { Content, ToolRequestMessageContent, ToolResponseMessageContent } from '../types/message';
+import {
+  Content,
+  ToolRequestMessageContent,
+  ToolResponseMessageContent,
+  ResourceContent,
+} from '../types/message';
 import { cn, snakeToTitleCase } from '../utils';
 import { LoadingStatus } from './ui/Dot';
 import { NotificationEvent } from '../hooks/useMessageStream';
-import { ChevronRight, FlaskConical } from 'lucide-react';
+import { ChevronRight, LoaderCircle } from 'lucide-react';
 import { TooltipWrapper } from './settings/providers/subcomponents/buttons/TooltipWrapper';
-import MCPUIResourceRenderer from './MCPUIResourceRenderer';
+// Inline MCP-UI renderer is unused now (sidecar only)
 import { isUIResource } from '@mcp-ui/client';
+import { useSidecar } from './Sidecar/SidecarContext';
 
 interface ToolCallWithResponseProps {
   isCancelledMessage: boolean;
@@ -30,47 +36,34 @@ export default function ToolCallWithResponse({
   isStreamingMessage = false,
   append,
 }: ToolCallWithResponseProps) {
+  const sidecar = useSidecar();
   const toolCall = toolRequest.toolCall.status === 'success' ? toolRequest.toolCall.value : null;
-  if (!toolCall) {
-    return null;
-  }
+  // Always mount the component to keep hooks order consistent. Render nothing if no toolCall.
+  const shouldRender = !!toolCall;
+
+  // Manual open via per-result action; no auto-open to allow selection
 
   return (
     <>
-      <div
-        className={cn(
-          'w-full text-sm font-sans rounded-lg overflow-hidden border-borderSubtle border bg-background-muted'
-        )}
-      >
-        <ToolCallView
-          {...{
-            isCancelledMessage,
-            toolCall,
-            toolResponse,
-            notifications,
-            isStreamingMessage,
-          }}
-        />
-      </div>
-      {/* MCP UI — Inline */}
-      {toolResponse?.toolResult?.value &&
-        toolResponse.toolResult.value.map((content, index) => {
-          if (isUIResource(content)) {
-            return (
-              <div key={`${content.type}-${index}`} className="mt-3">
-                <MCPUIResourceRenderer content={content} appendPromptToChat={append} />
-                <div className="mt-3 p-4 py-3 border border-borderSubtle rounded-lg bg-background-muted flex items-center">
-                  <FlaskConical className="mr-2" size={20} />
-                  <div className="text-sm font-sans">
-                    MCP UI is experimental and may change at any time.
-                  </div>
-                </div>
-              </div>
-            );
-          } else {
-            return null;
-          }
-        })}
+      {shouldRender && (
+        <div
+          className={cn(
+            'w-full text-sm font-sans rounded-lg overflow-hidden border-borderSubtle border bg-background-muted'
+          )}
+        >
+          <ToolCallView
+            {...{
+              isCancelledMessage,
+              toolCall: toolCall!,
+              toolResponse,
+              notifications,
+              isStreamingMessage,
+              openInSidecar: (resource: ResourceContent) =>
+                sidecar.openWithMCPUI({ resource, appendPromptToChat: append }),
+            }}
+          />
+        </div>
+      )}
     </>
   );
 }
@@ -126,6 +119,7 @@ interface ToolCallViewProps {
   toolResponse?: ToolResponseMessageContent;
   notifications?: NotificationEvent[];
   isStreamingMessage?: boolean;
+  openInSidecar: (resource: ResourceContent) => void;
 }
 
 interface Progress {
@@ -172,6 +166,7 @@ function ToolCallView({
   toolResponse,
   notifications,
   isStreamingMessage = false,
+  openInSidecar,
 }: ToolCallViewProps) {
   const [responseStyle, setResponseStyle] = useState(() => localStorage.getItem('response_style'));
 
@@ -513,7 +508,15 @@ function ToolCallView({
           {toolResults.map(({ result, isExpandToolResults }, index) => {
             return (
               <div key={index} className={cn('border-t border-borderSubtle')}>
-                <ToolResultView result={result} isStartExpanded={isExpandToolResults} />
+                <ToolResultView
+                  result={result}
+                  isStartExpanded={isExpandToolResults}
+                  onOpenInSidecar={
+                    result.type === 'resource' && isUIResource(result)
+                      ? () => openInSidecar(result as ResourceContent)
+                      : undefined
+                  }
+                />
               </div>
             );
           })}
@@ -549,15 +552,27 @@ function ToolDetailsView({ toolCall, isStartExpanded }: ToolDetailsViewProps) {
 interface ToolResultViewProps {
   result: Content;
   isStartExpanded: boolean;
+  onOpenInSidecar?: () => void;
 }
 
-function ToolResultView({ result, isStartExpanded }: ToolResultViewProps) {
+function ToolResultView({ result, isStartExpanded, onOpenInSidecar }: ToolResultViewProps) {
   return (
     <ToolCallExpandable
       label={<span className="pl-4 py-1 font-sans text-sm">Output</span>}
       isStartExpanded={isStartExpanded}
     >
       <div className="pl-4 pr-4 py-4">
+        {onOpenInSidecar && (
+          <div className="flex justify-end mb-2">
+            <button
+              className="text-xs font-sans px-2 py-1 rounded border border-borderSubtle hover:bg-bgSubtle"
+              onClick={onOpenInSidecar}
+              title="Open in side panel"
+            >
+              Open in sidecar
+            </button>
+          </div>
+        )}
         {result.type === 'text' && result.text && (
           <MarkdownContent
             content={result.text}

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -2153,12 +2153,12 @@ app.whenReady().then(async () => {
         const maxWidth = display.workArea.width;
         const newWidth = Math.min(bounds.width + TARGET_DELTA, maxWidth);
         if (newWidth !== bounds.width) {
-          win.setBounds({ ...bounds, width: newWidth });
+          win.setSize(newWidth, bounds.height, true);
         }
       } else {
         const newWidth = Math.max(bounds.width - TARGET_DELTA, 750);
         if (newWidth !== bounds.width) {
-          win.setBounds({ ...bounds, width: newWidth });
+          win.setSize(newWidth, bounds.height, true);
         }
       }
     } catch (e) {

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -15,6 +15,7 @@ import {
   Tray,
 } from 'electron';
 import { Buffer } from 'node:buffer';
+import { screen } from 'electron';
 import fs from 'node:fs/promises';
 import fsSync from 'node:fs';
 import started from 'electron-squirrel-startup';
@@ -2137,6 +2138,32 @@ app.whenReady().then(async () => {
   ipcMain.on('restart-app', () => {
     app.relaunch();
     app.exit(0);
+  });
+
+  // Handle sidecar toggling to resize window
+  ipcMain.on('sidecar-toggled', (event, isOpen: boolean) => {
+    try {
+      const win = BrowserWindow.fromWebContents(event.sender);
+      if (!win) return;
+      const bounds = win.getBounds();
+      const TARGET_DELTA = 420; // pixels reserved for sidecar
+      if (isOpen) {
+        // Enlarge window width by TARGET_DELTA up to available screen
+        const display = screen.getDisplayMatching(bounds);
+        const maxWidth = display.workArea.width;
+        const newWidth = Math.min(bounds.width + TARGET_DELTA, maxWidth);
+        if (newWidth !== bounds.width) {
+          win.setBounds({ ...bounds, width: newWidth });
+        }
+      } else {
+        const newWidth = Math.max(bounds.width - TARGET_DELTA, 750);
+        if (newWidth !== bounds.width) {
+          win.setBounds({ ...bounds, width: newWidth });
+        }
+      }
+    } catch (e) {
+      console.error('Failed to handle sidecar toggle resize', e);
+    }
   });
 
   // Handler for getting app version

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -113,6 +113,8 @@ type ElectronAPI = {
   hasAcceptedRecipeBefore: (recipeConfig: Recipe) => Promise<boolean>;
   recordRecipeHash: (recipeConfig: Recipe) => Promise<boolean>;
   openDirectoryInExplorer: (directoryPath: string) => Promise<boolean>;
+  // Sidecar sizing
+  setSidecarOpen?: (isOpen: boolean) => void;
 };
 
 type AppConfigAPI = {
@@ -236,6 +238,9 @@ const electronAPI: ElectronAPI = {
     ipcRenderer.invoke('record-recipe-hash', recipeConfig),
   openDirectoryInExplorer: (directoryPath: string) =>
     ipcRenderer.invoke('open-directory-in-explorer', directoryPath),
+  setSidecarOpen: (isOpen: boolean) => {
+    ipcRenderer.send('sidecar-toggled', isOpen);
+  },
 };
 
 const appConfigAPI: AppConfigAPI = {


### PR DESCRIPTION
Add MCP UI sidecar panel for interactive tool interfaces

This PR introduces a collapsible sidecar panel that displays MCP UI resources alongside the main chat interface. When tools return UI resources (like forms, visualizations, or interactive components), users can open them in a dedicated side panel for better interaction.

**Key Features:**
- Toggle button appears on tool responses with UI resources
- Sidecar panel slides in from the right with smooth animations
- Window automatically resizes to accommodate the panel
- Context shared between main chat and sidecar for seamless interaction
- Clean separation of concerns with dedicated SidecarContext

**Technical Implementation:**
- New SidecarContext manages panel state and UI resource handling
- MainPanelLayout updated to support flexible width with sidecar
- IPC communication for window resizing when panel opens/closes
- Responsive design maintains usability across different screen sizes


https://github.com/user-attachments/assets/b9d3c564-2607-4c44-990b-7f0fed1395d3

