### PR TITLE
draft: track subagent tokens

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -1510,8 +1510,19 @@ impl Session {
         match self.get_metadata() {
             Ok(metadata) => {
                 let total_tokens = metadata.total_tokens.unwrap_or(0) as usize;
+                let subagent_tokens = metadata
+                    .accumulated_total_tokens_subagent_only
+                    .map(|t| t as usize);
+                let total_session_tokens = metadata
+                    .accumulated_total_tokens_with_subagents
+                    .map(|t| t as usize);
 
-                output::display_context_usage(total_tokens, context_limit);
+                output::display_context_usage(
+                    total_tokens,
+                    context_limit,
+                    subagent_tokens,
+                    total_session_tokens,
+                );
 
                 if show_cost {
                     let input_tokens = metadata.input_tokens.unwrap_or(0) as usize;
@@ -1526,7 +1537,7 @@ impl Session {
                 }
             }
             Err(_) => {
-                output::display_context_usage(0, context_limit);
+                output::display_context_usage(0, context_limit, None, None);
             }
         }
 

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -724,7 +724,12 @@ pub fn display_greeting() {
 }
 
 /// Display context window usage with both current and session totals
-pub fn display_context_usage(total_tokens: usize, context_limit: usize) {
+pub fn display_context_usage(
+    total_tokens: usize,
+    context_limit: usize,
+    subagent_tokens: Option<usize>,
+    total_session_tokens: Option<usize>,
+) {
     use console::style;
 
     if context_limit == 0 {
@@ -760,6 +765,22 @@ pub fn display_context_usage(total_tokens: usize, context_limit: usize) {
         "Context: {} {}% ({}/{} tokens)",
         colored_dots, percentage, total_tokens, context_limit
     );
+
+    // Display subagent token information if available
+    if let (Some(subagent_tokens), Some(total_session_tokens)) =
+        (subagent_tokens, total_session_tokens)
+    {
+        if subagent_tokens > 0 && total_session_tokens > 0 {
+            let subagent_percentage =
+                ((subagent_tokens as f64 / total_session_tokens as f64) * 100.0).round() as usize;
+            println!(
+                "Session: {} subagent tokens ({}% of {} total session tokens)",
+                style(subagent_tokens.to_string()).cyan(),
+                style(subagent_percentage.to_string()).cyan(),
+                total_session_tokens
+            );
+        }
+    }
 }
 
 fn normalize_model_name(model: &str) -> String {

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -774,10 +774,9 @@ pub fn display_context_usage(
             let subagent_percentage =
                 ((subagent_tokens as f64 / total_session_tokens as f64) * 100.0).round() as usize;
             println!(
-                "Session: {} subagent tokens ({}% of {} total session tokens)",
+                "Delegated: {} tokens handled by subagents ({}% of total tokens)",
                 style(subagent_tokens.to_string()).cyan(),
-                style(subagent_percentage.to_string()).cyan(),
-                total_session_tokens
+                style(subagent_percentage.to_string()).cyan()
             );
         }
     }

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -334,43 +334,4 @@ impl Agent {
 
         Ok(())
     }
-
-    /// Update session metadata with subagent token usage
-    pub(crate) async fn update_session_metrics_subagent(
-        session_config: &crate::agents::types::SessionConfig,
-        usage: &ProviderUsage,
-    ) -> Result<()> {
-        let session_file_path = match session::storage::get_path(session_config.id.clone()) {
-            Ok(path) => path,
-            Err(e) => {
-                return Err(anyhow::anyhow!("Failed to get session file path: {}", e));
-            }
-        };
-        let mut metadata = session::storage::read_metadata(&session_file_path)?;
-
-        metadata.schedule_id = session_config.schedule_id.clone();
-
-        let accumulate = |a: Option<i32>, b: Option<i32>| -> Option<i32> {
-            match (a, b) {
-                (Some(x), Some(y)) => Some(x + y),
-                _ => a.or(b),
-            }
-        };
-
-        // Add subagent tokens to the subagent-only counter
-        metadata.accumulated_total_tokens_subagent_only = accumulate(
-            metadata.accumulated_total_tokens_subagent_only,
-            usage.usage.total_tokens,
-        );
-
-        // Update combined totals: accumulated_total_tokens_with_subagents = accumulated_total_tokens + accumulated_total_tokens_subagent_only
-        metadata.accumulated_total_tokens_with_subagents = accumulate(
-            metadata.accumulated_total_tokens,
-            metadata.accumulated_total_tokens_subagent_only,
-        );
-
-        session::storage::update_metadata(&session_file_path, &metadata).await?;
-
-        Ok(())
-    }
 }

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -324,6 +324,51 @@ impl Agent {
             usage.usage.output_tokens,
         );
 
+        // Update combined totals: accumulated_total_tokens_with_subagents = accumulated_total_tokens + accumulated_total_tokens_subagent_only
+        metadata.accumulated_total_tokens_with_subagents = accumulate(
+            metadata.accumulated_total_tokens,
+            metadata.accumulated_total_tokens_subagent_only,
+        );
+
+        session::storage::update_metadata(&session_file_path, &metadata).await?;
+
+        Ok(())
+    }
+
+    /// Update session metadata with subagent token usage
+    pub(crate) async fn update_session_metrics_subagent(
+        session_config: &crate::agents::types::SessionConfig,
+        usage: &ProviderUsage,
+    ) -> Result<()> {
+        let session_file_path = match session::storage::get_path(session_config.id.clone()) {
+            Ok(path) => path,
+            Err(e) => {
+                return Err(anyhow::anyhow!("Failed to get session file path: {}", e));
+            }
+        };
+        let mut metadata = session::storage::read_metadata(&session_file_path)?;
+
+        metadata.schedule_id = session_config.schedule_id.clone();
+
+        let accumulate = |a: Option<i32>, b: Option<i32>| -> Option<i32> {
+            match (a, b) {
+                (Some(x), Some(y)) => Some(x + y),
+                _ => a.or(b),
+            }
+        };
+
+        // Add subagent tokens to the subagent-only counter
+        metadata.accumulated_total_tokens_subagent_only = accumulate(
+            metadata.accumulated_total_tokens_subagent_only,
+            usage.usage.total_tokens,
+        );
+
+        // Update combined totals: accumulated_total_tokens_with_subagents = accumulated_total_tokens + accumulated_total_tokens_subagent_only
+        metadata.accumulated_total_tokens_with_subagents = accumulate(
+            metadata.accumulated_total_tokens,
+            metadata.accumulated_total_tokens_subagent_only,
+        );
+
         session::storage::update_metadata(&session_file_path, &metadata).await?;
 
         Ok(())

--- a/crates/goose/src/agents/subagent.rs
+++ b/crates/goose/src/agents/subagent.rs
@@ -188,13 +188,14 @@ impl SubAgent {
 
                         // Track subagent token usage if session config is provided
                         if let Some(ref session_config) = session_config {
-                            if let Some(ref usage) = usage {
-                                if let Err(e) = crate::agents::reply_parts::Agent::update_session_metrics_subagent(
+                            if let Err(e) =
+                                crate::session::storage::update_session_metrics_subagent(
                                     session_config,
-                                    usage,
-                                ).await {
-                                    debug!("Failed to update subagent token metrics: {}", e);
-                                }
+                                    &usage,
+                                )
+                                .await
+                            {
+                                debug!("Failed to update subagent token metrics: {}", e);
                             }
                         }
 
@@ -209,13 +210,13 @@ impl SubAgent {
 
                     // Track subagent token usage for intermediate responses if session config is provided
                     if let Some(ref session_config) = session_config {
-                        if let Some(ref usage) = usage {
-                            if let Err(e) = crate::agents::reply_parts::Agent::update_session_metrics_subagent(
-                                session_config,
-                                usage,
-                            ).await {
-                                debug!("Failed to update subagent token metrics: {}", e);
-                            }
+                        if let Err(e) = crate::session::storage::update_session_metrics_subagent(
+                            session_config,
+                            &usage,
+                        )
+                        .await
+                        {
+                            debug!("Failed to update subagent token metrics: {}", e);
                         }
                     }
 

--- a/crates/goose/src/agents/subagent_execution_tool/tasks.rs
+++ b/crates/goose/src/agents/subagent_execution_tool/tasks.rs
@@ -8,7 +8,6 @@ use tokio_util::sync::CancellationToken;
 use crate::agents::subagent_execution_tool::task_execution_tracker::TaskExecutionTracker;
 use crate::agents::subagent_execution_tool::task_types::{Task, TaskResult, TaskStatus};
 use crate::agents::subagent_execution_tool::utils::strip_ansi_codes;
-use crate::agents::subagent_handler::run_complete_subagent_task;
 use crate::agents::subagent_task_config::TaskConfig;
 
 pub async fn process_task(
@@ -89,7 +88,11 @@ async fn handle_text_instruction_task(
     task_execution_tracker.start_task(&task.id).await;
 
     let result = tokio::select! {
-        result = run_complete_subagent_task(text_instruction.to_string(), task_config) => result,
+        result = crate::agents::subagent_handler::run_complete_subagent_task_with_session(
+            text_instruction.to_string(),
+            task_config.clone(),
+            task_config.session_config.clone()
+        ) => result,
         _ = cancellation_token.cancelled() => {
             return Err("Task cancelled".to_string());
         }

--- a/crates/goose/src/agents/subagent_handler.rs
+++ b/crates/goose/src/agents/subagent_handler.rs
@@ -1,5 +1,6 @@
 use crate::agents::subagent::SubAgent;
 use crate::agents::subagent_task_config::TaskConfig;
+use crate::agents::types::SessionConfig;
 use anyhow::Result;
 use rmcp::model::{ErrorCode, ErrorData};
 
@@ -7,6 +8,15 @@ use rmcp::model::{ErrorCode, ErrorData};
 pub async fn run_complete_subagent_task(
     text_instruction: String,
     task_config: TaskConfig,
+) -> Result<String, anyhow::Error> {
+    run_complete_subagent_task_with_session(text_instruction, task_config, None).await
+}
+
+/// Standalone function to run a complete subagent task with optional session tracking
+pub async fn run_complete_subagent_task_with_session(
+    text_instruction: String,
+    task_config: TaskConfig,
+    session_config: Option<SessionConfig>,
 ) -> Result<String, anyhow::Error> {
     // Create the subagent with the parent agent's provider
     let subagent = SubAgent::new(task_config.clone()).await.map_err(|e| {
@@ -19,7 +29,7 @@ pub async fn run_complete_subagent_task(
 
     // Execute the subagent task
     let messages = subagent
-        .reply_subagent(text_instruction, task_config)
+        .reply_subagent(text_instruction, task_config, session_config)
         .await?;
 
     // Extract all text content from all messages

--- a/crates/goose/src/agents/subagent_task_config.rs
+++ b/crates/goose/src/agents/subagent_task_config.rs
@@ -1,3 +1,4 @@
+use crate::agents::types::SessionConfig;
 use crate::providers::base::Provider;
 use std::env;
 use std::fmt;
@@ -16,6 +17,7 @@ pub struct TaskConfig {
     pub id: String,
     pub provider: Option<Arc<dyn Provider>>,
     pub max_turns: Option<usize>,
+    pub session_config: Option<SessionConfig>,
 }
 
 impl fmt::Debug for TaskConfig {
@@ -24,6 +26,7 @@ impl fmt::Debug for TaskConfig {
             .field("id", &self.id)
             .field("provider", &"<dyn Provider>")
             .field("max_turns", &self.max_turns)
+            .field("session_config", &self.session_config)
             .finish()
     }
 }
@@ -40,6 +43,25 @@ impl TaskConfig {
                     .and_then(|val| val.parse::<usize>().ok())
                     .unwrap_or(DEFAULT_SUBAGENT_MAX_TURNS),
             ),
+            session_config: None,
+        }
+    }
+
+    /// Create a new TaskConfig with session config for token tracking
+    pub fn new_with_session(
+        provider: Option<Arc<dyn Provider>>,
+        session_config: Option<SessionConfig>,
+    ) -> Self {
+        Self {
+            id: Uuid::new_v4().to_string(),
+            provider,
+            max_turns: Some(
+                env::var(GOOSE_SUBAGENT_MAX_TURNS_ENV_VAR)
+                    .ok()
+                    .and_then(|val| val.parse::<usize>().ok())
+                    .unwrap_or(DEFAULT_SUBAGENT_MAX_TURNS),
+            ),
+            session_config,
         }
     }
 

--- a/crates/goose/src/context_mgmt/auto_compact.rs
+++ b/crates/goose/src/context_mgmt/auto_compact.rs
@@ -268,6 +268,8 @@ mod tests {
             accumulated_total_tokens: Some(100),
             accumulated_input_tokens: Some(50),
             accumulated_output_tokens: Some(50),
+            accumulated_total_tokens_subagent_only: None,
+            accumulated_total_tokens_with_subagents: Some(100),
         }
     }
 

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -1298,6 +1298,8 @@ async fn run_scheduled_job_internal(
                             accumulated_total_tokens: None,
                             accumulated_input_tokens: None,
                             accumulated_output_tokens: None,
+                            accumulated_total_tokens_subagent_only: None,
+                            accumulated_total_tokens_with_subagents: None,
                         };
                         if let Err(e_fb) = crate::session::storage::save_messages_with_metadata(
                             &session_file_path,

--- a/crates/goose/src/session/storage.rs
+++ b/crates/goose/src/session/storage.rs
@@ -64,6 +64,10 @@ pub struct SessionMetadata {
     pub accumulated_input_tokens: Option<i32>,
     /// The number of output tokens used in the session. Accumulated across all messages.
     pub accumulated_output_tokens: Option<i32>,
+    /// The total number of tokens used by subagents only. Accumulated across all subagent interactions.
+    pub accumulated_total_tokens_subagent_only: Option<i32>,
+    /// The total number of tokens used by both main agent and subagents. This equals accumulated_total_tokens + accumulated_total_tokens_subagent_only.
+    pub accumulated_total_tokens_with_subagents: Option<i32>,
 }
 
 // Custom deserializer to handle old sessions without working_dir
@@ -83,6 +87,8 @@ impl<'de> Deserialize<'de> for SessionMetadata {
             accumulated_total_tokens: Option<i32>,
             accumulated_input_tokens: Option<i32>,
             accumulated_output_tokens: Option<i32>,
+            accumulated_total_tokens_subagent_only: Option<i32>,
+            accumulated_total_tokens_with_subagents: Option<i32>,
             working_dir: Option<PathBuf>,
         }
 
@@ -104,6 +110,8 @@ impl<'de> Deserialize<'de> for SessionMetadata {
             accumulated_total_tokens: helper.accumulated_total_tokens,
             accumulated_input_tokens: helper.accumulated_input_tokens,
             accumulated_output_tokens: helper.accumulated_output_tokens,
+            accumulated_total_tokens_subagent_only: helper.accumulated_total_tokens_subagent_only,
+            accumulated_total_tokens_with_subagents: helper.accumulated_total_tokens_with_subagents,
             working_dir,
         })
     }
@@ -129,6 +137,8 @@ impl SessionMetadata {
             accumulated_total_tokens: None,
             accumulated_input_tokens: None,
             accumulated_output_tokens: None,
+            accumulated_total_tokens_subagent_only: None,
+            accumulated_total_tokens_with_subagents: None,
         }
     }
 }

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -619,7 +619,7 @@ mod final_output_tool_tests {
             }),
         );
         let (_, result) = agent
-            .dispatch_tool_call(tool_call, "request_id".to_string(), None)
+            .dispatch_tool_call(tool_call, "request_id".to_string(), None, None)
             .await;
 
         assert!(result.is_ok(), "Tool call should succeed");

--- a/crates/goose/tests/private_tests.rs
+++ b/crates/goose/tests/private_tests.rs
@@ -895,7 +895,7 @@ async fn test_schedule_tool_dispatch() {
     };
 
     let (request_id, result) = agent
-        .dispatch_tool_call(tool_call, "test_dispatch".to_string(), None)
+        .dispatch_tool_call(tool_call, "test_dispatch".to_string(), None, None)
         .await;
     assert_eq!(request_id, "test_dispatch");
     assert!(result.is_ok());

--- a/crates/goose/tests/test_support.rs
+++ b/crates/goose/tests/test_support.rs
@@ -411,5 +411,7 @@ pub fn create_test_session_metadata(message_count: usize, working_dir: &str) -> 
         accumulated_total_tokens: Some(100),
         accumulated_input_tokens: Some(50),
         accumulated_output_tokens: Some(50),
+        accumulated_total_tokens_subagent_only: None,
+        accumulated_total_tokens_with_subagents: Some(100),
     }
 }

--- a/crates/goose/tests/todo_tools_test.rs
+++ b/crates/goose/tests/todo_tools_test.rs
@@ -42,7 +42,7 @@ async fn test_todo_write_and_read() {
     };
 
     let (_, write_result) = agent
-        .dispatch_tool_call(write_call, "test-write-1".to_string(), None)
+        .dispatch_tool_call(write_call, "test-write-1".to_string(), None, None)
         .await;
     assert!(write_result.is_ok(), "Write should succeed");
 
@@ -53,7 +53,7 @@ async fn test_todo_write_and_read() {
     };
 
     let (_, read_result) = agent
-        .dispatch_tool_call(read_call, "test-read-1".to_string(), None)
+        .dispatch_tool_call(read_call, "test-read-1".to_string(), None, None)
         .await;
     assert!(read_result.is_ok(), "Read should succeed");
 
@@ -83,7 +83,7 @@ async fn test_todo_empty_initially() {
     };
 
     let (_, read_result) = agent
-        .dispatch_tool_call(read_call, "test-read-empty".to_string(), None)
+        .dispatch_tool_call(read_call, "test-read-empty".to_string(), None, None)
         .await;
     assert!(read_result.is_ok(), "Read should succeed even when empty");
 
@@ -115,7 +115,7 @@ async fn test_todo_overwrite() {
         }),
     };
     let (_, write_result1) = agent
-        .dispatch_tool_call(write_call1, "test-write-1".to_string(), None)
+        .dispatch_tool_call(write_call1, "test-write-1".to_string(), None, None)
         .await;
     assert!(write_result1.is_ok(), "First write should succeed");
 
@@ -127,7 +127,7 @@ async fn test_todo_overwrite() {
         }),
     };
     let (_, write_result2) = agent
-        .dispatch_tool_call(write_call2, "test-write-2".to_string(), None)
+        .dispatch_tool_call(write_call2, "test-write-2".to_string(), None, None)
         .await;
     assert!(write_result2.is_ok(), "Second write should succeed");
 
@@ -138,7 +138,7 @@ async fn test_todo_overwrite() {
     };
 
     let (_, read_result) = agent
-        .dispatch_tool_call(read_call, "test-read-2".to_string(), None)
+        .dispatch_tool_call(read_call, "test-read-2".to_string(), None, None)
         .await;
 
     if let Ok(result) = read_result {
@@ -172,7 +172,7 @@ async fn test_todo_concurrent_access() {
                 }),
             };
             agent_clone
-                .dispatch_tool_call(write_call, format!("concurrent-{}", i), None)
+                .dispatch_tool_call(write_call, format!("concurrent-{}", i), None, None)
                 .await
         });
         handles.push(handle);
@@ -190,7 +190,7 @@ async fn test_todo_concurrent_access() {
     };
 
     let (_, read_result) = agent
-        .dispatch_tool_call(read_call, "final-read".to_string(), None)
+        .dispatch_tool_call(read_call, "final-read".to_string(), None, None)
         .await;
 
     if let Ok(result) = read_result {
@@ -227,7 +227,7 @@ async fn test_todo_large_content() {
     };
 
     let (_, write_result) = agent
-        .dispatch_tool_call(write_call, "large-write".to_string(), None)
+        .dispatch_tool_call(write_call, "large-write".to_string(), None, None)
         .await;
 
     // Should fail because it exceeds the 50,000 character limit
@@ -258,7 +258,7 @@ async fn test_todo_large_content() {
     };
 
     let (_, write_result) = agent
-        .dispatch_tool_call(write_call, "valid-write".to_string(), None)
+        .dispatch_tool_call(write_call, "valid-write".to_string(), None, None)
         .await;
     assert!(write_result.is_ok(), "Should handle content within limit");
 
@@ -269,7 +269,7 @@ async fn test_todo_large_content() {
     };
 
     let (_, read_result) = agent
-        .dispatch_tool_call(read_call, "valid-read".to_string(), None)
+        .dispatch_tool_call(read_call, "valid-read".to_string(), None, None)
         .await;
 
     if let Ok(result) = read_result {
@@ -305,7 +305,7 @@ async fn test_todo_unicode_content() {
     };
 
     let (_, write_result) = agent
-        .dispatch_tool_call(write_call, "unicode-write".to_string(), None)
+        .dispatch_tool_call(write_call, "unicode-write".to_string(), None, None)
         .await;
     assert!(write_result.is_ok(), "Write should succeed");
 
@@ -315,7 +315,7 @@ async fn test_todo_unicode_content() {
     };
 
     let (_, read_result) = agent
-        .dispatch_tool_call(read_call, "unicode-read".to_string(), None)
+        .dispatch_tool_call(read_call, "unicode-read".to_string(), None, None)
         .await;
 
     if let Ok(result) = read_result {
@@ -349,7 +349,7 @@ async fn test_todo_character_limit_enforcement() {
     };
 
     let (_, result) = agent
-        .dispatch_tool_call(write_call, "test-limit".to_string(), None)
+        .dispatch_tool_call(write_call, "test-limit".to_string(), None, None)
         .await;
 
     // Should fail with error
@@ -395,7 +395,7 @@ async fn test_todo_character_count_in_write_response() {
     };
 
     let (_, result) = agent
-        .dispatch_tool_call(write_call, "test-count".to_string(), None)
+        .dispatch_tool_call(write_call, "test-count".to_string(), None, None)
         .await;
 
     assert!(result.is_ok());
@@ -424,7 +424,7 @@ async fn test_todo_read_returns_clean_content() {
     };
 
     let (_, write_result) = agent
-        .dispatch_tool_call(write_call, "test-write".to_string(), None)
+        .dispatch_tool_call(write_call, "test-write".to_string(), None, None)
         .await;
     assert!(write_result.is_ok(), "Write should succeed");
 
@@ -435,7 +435,7 @@ async fn test_todo_read_returns_clean_content() {
     };
 
     let (_, result) = agent
-        .dispatch_tool_call(read_call, "test-read".to_string(), None)
+        .dispatch_tool_call(read_call, "test-read".to_string(), None, None)
         .await;
 
     assert!(result.is_ok());
@@ -469,7 +469,7 @@ async fn test_todo_unlimited_with_zero_limit() {
     };
 
     let (_, result) = agent
-        .dispatch_tool_call(write_call, "test-unlimited".to_string(), None)
+        .dispatch_tool_call(write_call, "test-unlimited".to_string(), None, None)
         .await;
 
     // Should succeed
@@ -497,7 +497,7 @@ async fn test_todo_unicode_character_counting() {
     };
 
     let (_, result) = agent
-        .dispatch_tool_call(write_call, "test-unicode".to_string(), None)
+        .dispatch_tool_call(write_call, "test-unicode".to_string(), None, None)
         .await;
 
     // Should fail as it's 11 chars


### PR DESCRIPTION
- Allows user to view what % of total tokens were delegated to subagents
- Shows approximately how many tokens were freed up from main agent context.



🐶 food

```
# How to use subagents effectively: 

Subagents are good for delegating small, tight-nit tasks such as gathering context. 

When used effectively, subagents allow you as the operator to command at a higher level and free up tokens from the main agent.

## How to trigger subagents:
To trigger dynamic subagents in goose, use the trigger words 'dynamic tasks'. Note: do not enable taskqueue extension. 

## Examples:

( O)> create two dynamic tasks, each to tell a random fact
I'll create two dynamic tasks, each to tell a random fact.
─── create_task | dynamic_task ──────────────────────────
task_parameters:
    -
        text_instruction: Tell me a random interesting fact
    -
        text_instruction: Tell me a random interesting fact

( O)> create dynamic tasks to explore and understand the code base
I'll create dynamic tasks to explore and understand the codebase. Let me start by creating tasks that will systematically examine different aspects of this Rust project.
─── create_task | dynamic_task ──────────────────────────
task_parameters:
    -
        text_instruction: Explore the main goose crate structure and understand its core functionality by examining the src directory and key files
    -
        text_instruction: Analyze the goose-cli crate to understand how the command line interface works and its relationship to the main goose crate
...

## How to track usage:

Once you've invoked subagents, you should see the total tokens handled by subagents and % of your total session usage.

Context: ●●○○○○○○○○ 15% (29376/200000 tokens)
Delegated: 134925 tokens handled by subagents (75% of total tokens)

```

