### PR TITLE
hotfix: orphaned `goosed` processes with `just run-ui`

### DIFF
--- a/ui/desktop/src/goosed.ts
+++ b/ui/desktop/src/goosed.ts
@@ -291,9 +291,25 @@ export const startGoosed = async (
 
   // Ensure goosed is terminated when the app quits
   // TODO will need to do it at tab level next
-  app.on('will-quit', () => {
+  const quitHandler = () => {
     log.info('App quitting, terminating goosed server');
     try_kill_goose();
+  };
+
+  app.on('will-quit', quitHandler);
+  app.on('before-quit', quitHandler);
+
+  // Also handle SIGINT/SIGTERM for development mode when electron-forge kills the process
+  process.on('SIGINT', () => {
+    log.info('Received SIGINT, terminating goosed server');
+    try_kill_goose();
+    process.exit(0);
+  });
+
+  process.on('SIGTERM', () => {
+    log.info('Received SIGTERM, terminating goosed server');
+    try_kill_goose();
+    process.exit(0);
   });
 
   log.info(`Goosed server successfully started on port ${port}`);


### PR DESCRIPTION
This is a speculative fix for cases when you end up with unkillable `goosed` on macos after a while running `just run-ui`

in theory if it is quickly killed than the parent goes away and the goosed process never gets told