### PR TITLE
fix: relax CSP for MCP-UI webviews to allow fonts and safe media sources

### DIFF
--- a/ui/desktop/index.html
+++ b/ui/desktop/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8"/>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' http://127.0.0.1:* https:; object-src 'none'; font-src 'self' data: https:; media-src 'self' mediastream:; form-action 'none'; base-uri 'self'; manifest-src 'self'; worker-src 'self'; frame-src 'self' https: http:;"/>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline' https:; style-src-elem 'self' 'unsafe-inline' https:; script-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' http://127.0.0.1:* https:; object-src 'none'; font-src 'self' data: https:; media-src 'self' https: blob: data: mediastream:; media-src-elem 'self' https: blob: data: mediastream:; form-action 'none'; base-uri 'self'; manifest-src 'self'; worker-src 'self'; frame-src 'self' https: http:;"/>
     <title>Goose</title>
     <script>
       // Initialize theme before any content loads
@@ -14,7 +14,7 @@
               const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
               const savedTheme = localStorage.getItem('theme');
               const isDark = useSystemTheme ? systemPrefersDark : (savedTheme ? savedTheme === 'dark' : systemPrefersDark);
-              
+
               if (isDark) {
                 document.documentElement.classList.add('dark');
               } else {

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -1701,8 +1701,10 @@ app.whenReady().then(async () => {
         ...details.responseHeaders,
         'Content-Security-Policy':
           "default-src 'self';" +
-          // Allow inline styles since we use them in our React components
-          "style-src 'self' 'unsafe-inline';" +
+          // Allow inline styles (since we use them in our React components) and external stylesheets (for MCP-UI)
+          "style-src 'self' 'unsafe-inline' https:;" +
+          // Explicitly allow external stylesheet elements
+          "style-src-elem 'self' 'unsafe-inline' https:;" +
           // Scripts from our app and inline scripts (for theme initialization)
           "script-src 'self' 'unsafe-inline';" +
           // Images from our app and data: URLs (for base64 images)
@@ -1715,8 +1717,10 @@ app.whenReady().then(async () => {
           "frame-src 'self' https: http:;" +
           // Font sources - allow self, data URLs, and external fonts
           "font-src 'self' data: https:;" +
-          // Media sources - allow microphone
-          "media-src 'self' mediastream:;" +
+          // Media sources - allow microphone, https media, and blobs/data URLs
+          "media-src 'self' https: blob: data: mediastream:;" +
+          // Explicitly allow media elements (CSP3) for data/blob/https
+          "media-src-elem 'self' https: blob: data: mediastream:;" +
           // Form actions
           "form-action 'none';" +
           // Base URI restriction


### PR DESCRIPTION
## Summary
This PR updates Goose’s Content Security Policy (CSP) for the MCP-UI host environment to resolve CSP blocks encountered when loading MCP-UIs in Goose. We now permit fonts (stylesheet and font assets as required by MCP-UIs) and expand `media-src` to cover safe media sources commonly used by MCP-UIs, while keeping the policy as tight as possible.

## Background
Users loading MCP-UIs in Goose hit CSP violations, preventing external stylesheets and media from loading. Example console errors:

- `about:srcdoc:11 Refused to load the stylesheet 'https://…/inter.css' because it violates the following Content Security Policy directive: "style-src 'self' 'unsafe-inline'". Note that 'style-src-elem' was not explicitly set, so 'style-src' is used as a fallback.`
- `Refused to load media from '<URL>' because it violates the following Content Security Policy directive: "media-src 'self' mediastream:".`

## Root cause
- The host CSP for the embedded MCP-UI context only allowed `self` and inline styles. External stylesheets (e.g., for Inter) were blocked.
- `media-src` allowed only `self` and `mediastream:`, blocking `blob:`, `data:`, and `https:` media commonly used by MCP-UIs.

## What’s changed
- Enable font styling and assets:
  - Allow external stylesheets via `https:` and explicitly include `style-src-elem` to scope stylesheet elements.
  - Ensure `font-src` permits external fonts via `https:` and `data:` for Inter font files (e.g., woff/woff2) as needed.
- Expand `media-src` to support safe, commonly used sources:
  - Add `blob:` and `data:` to allow in-memory media.
  - Add `https:` to allow remote media loaded by MCP-UIs.
- No changes to `default-src`. No `'unsafe-eval'` added. Inline styles remain as previously configured.

## Before (effective)
Note: Representative excerpt for clarity.
```text
Content-Security-Policy:
  default-src 'self';
  style-src 'self' 'unsafe-inline';
  script-src 'self' 'unsafe-inline';
  img-src 'self' data: https:;
  connect-src 'self' http://127.0.0.1:* https:;
  object-src 'none';
  font-src 'self' data: https:;
  media-src 'self' mediastream:;
  form-action 'none';
  base-uri 'self';
  manifest-src 'self';
  worker-src 'self';
  frame-src 'self' https: http:;
```

## After (exact)
These values match the PR diff.
```text
Content-Security-Policy:
  default-src 'self';
  style-src 'self' 'unsafe-inline' https:;
  style-src-elem 'self' 'unsafe-inline' https:;
  script-src 'self' 'unsafe-inline';
  img-src 'self' data: https:;
  connect-src 'self' http://127.0.0.1:* https:;
  object-src 'none';
  font-src 'self' data: https:;
  media-src 'self' https: blob: data: mediastream:;
  media-src-elem 'self' https: blob: data: mediastream:;
  form-action 'none';
  base-uri 'self';
  manifest-src 'self';
  worker-src 'self';
  frame-src 'self' https: http:;
```

## Security considerations
- Avoid wildcards and keep the allowlist minimal.
- External stylesheet usage is allowed over `https:` and scoped with `style-src-elem` rather than relying solely on `style-src`.
- `media-src`/`media-src-elem` now include `https:`, `blob:`, and `data:` to support typical MCP-UI media patterns; if we can enumerate domains later, we can replace `https:` with a stricter allowlist.
- No changes to `script-src` and no additional execution primitives are enabled.

## Testing/Verification
1) Repro on main:
   - Load an MCP-UI that references Inter and attempts to play media.
   - Observe the two CSP errors above in DevTools console and broken styling/media.
2) Build/run this branch:
   - Load the same MCP-UI.
   - Verify no CSP errors for Inter stylesheet/font or media.
   - Verify Inter renders as expected; media loads/plays correctly.



