### PR TITLE
Fix debug UI connection to external goosed server

### DIFF
--- a/ui/desktop/src/goosed.ts
+++ b/ui/desktop/src/goosed.ts
@@ -47,9 +47,19 @@ const checkServerStatus = async (): Promise<boolean> => {
 
 const connectToExternalBackend = async (
   workingDir: string,
-  port: number = 3000
+  port: number = 3000,
+  serverSecret: string
 ): Promise<[number, string, ChildProcess]> => {
   log.info(`Using external goosed backend on port ${port}`);
+
+  // Configure client for external backend before checking status
+  client.setConfig({
+    baseUrl: `http://127.0.0.1:${port}`,
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Secret-Key': serverSecret,
+    },
+  });
 
   const isReady = await checkServerStatus();
   if (!isReady) {
@@ -94,7 +104,7 @@ export const startGoosed = async (
   dir = path.resolve(path.normalize(dir));
 
   if (process.env.GOOSE_EXTERNAL_BACKEND) {
-    return connectToExternalBackend(dir, 3000);
+    return connectToExternalBackend(dir, 3000, serverSecret);
   }
 
   // Validate that the directory actually exists and is a directory


### PR DESCRIPTION
## Problem
The UI fails to connect when using an external goosed backend for debugging, timing out after 20 seconds even though the server is running.

## Root Cause
The checkServerStatus() call happens before the API client is configured with authentication headers.

## Solution
Configure the client with auth headers before checking status in connectToExternalBackend().

## Testing
Start goosed: GOOSE_SERVER__SECRET_KEY=test GOOSE_PORT=3000 ./target/release/goosed agent
Connect UI: just debug-ui