### PR TITLE
docs: Add desktop session deletion documentation

### DIFF
--- a/documentation/docs/guides/sessions/session-management.md
+++ b/documentation/docs/guides/sessions/session-management.md
@@ -309,7 +309,7 @@ You can resume a CLI session in Desktop.
         6. Confirm the deletion in the modal that appears
 
         :::warning Permanent deletion
-        Deleting a session permanently removes it from your system. This action cannot be undone.
+        Deleting a session permanently removes it from your system and from both Desktop and CLI interfaces. This action cannot be undone.
         :::
 
         The session will be immediately removed from your session history and the underlying session file will be deleted from your local storage.

--- a/documentation/docs/guides/sessions/session-management.md
+++ b/documentation/docs/guides/sessions/session-management.md
@@ -309,7 +309,7 @@ You can resume a CLI session in Desktop.
         6. Confirm the deletion in the modal that appears
 
         :::warning Permanent deletion
-        Deleting a session permanently removes it from your system and from both Desktop and CLI interfaces. This action cannot be undone.
+        Deleting a session from Goose Desktop will also delete it from the CLI. This action cannot be undone.
         :::
 
         The session will be immediately removed from your session history and the underlying session file will be deleted from your local storage.

--- a/documentation/docs/guides/sessions/session-management.md
+++ b/documentation/docs/guides/sessions/session-management.md
@@ -5,7 +5,7 @@ sidebar_label: Session Management
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import { AppWindow, PanelLeft, FolderDot, Paperclip, Copy, Edit2 } from 'lucide-react';
+import { AppWindow, PanelLeft, FolderDot, Paperclip, Copy, Edit2, Trash2 } from 'lucide-react';
 
 
 A session is a single, continuous interaction between you and Goose, providing a space to ask questions and prompt action. This guide covers how to manage the session lifecycle.
@@ -295,11 +295,24 @@ You can resume a CLI session in Desktop.
     </TabItem>
 </Tabs>
 
-## Remove Sessions
+## Delete Sessions
 
 <Tabs groupId="interface">
     <TabItem value="ui" label="Goose Desktop" default>
-        Removing sessions is only available through the CLI.
+        You can delete sessions directly from the Desktop app:
+
+        1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar
+        2. Click `History` in the sidebar
+        3. Find the session you want to delete
+        4. Hover over the session card to reveal the action buttons
+        5. Click the <Trash2 className="inline" size={16} /> button that appears
+        6. Confirm the deletion in the modal that appears
+
+        :::warning Permanent deletion
+        Deleting a session permanently removes it from your system. This action cannot be undone.
+        :::
+
+        The session will be immediately removed from your session history and the underlying session file will be deleted from your local storage.
     </TabItem>
     <TabItem value="cli" label="Goose CLI">
         You can remove sessions using CLI commands. For detailed instructions on session removal, see the [CLI Commands documentation](/docs/guides/goose-cli-commands#session-remove-options).


### PR DESCRIPTION
## Summary

This PR adds documentation for the session deletion functionality in the Goose Desktop '

The changes make the process more user-friendly and explicit, and introduce a warning about permanent deletion.

Improvements to session deletion documentation:

* Updated the instructions for deleting sessions in the Goose Desktop app, providing a step-by-step guide with UI references and icons, including the new `Trash2` icon for deletion actions.
* Added a warning callout to emphasize that session deletion is permanent and cannot be undone.
