### PR TITLE
fix: lockfile fix for aws bedrock breakage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,9 +1627,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.54"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+checksum = "e24a03c8b52922d68a1589ad61032f2c1aa5a8158d2aa0d93c6e9534944bbad6"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
No idea what went on - but things are not in a great state building on macos

I don't like that we have to roll back the cmake version, however. https://github.com/block/goose/pull/4811 reverting the aws change may be better... 