### PR TITLE
fix: improve server error messages to include HTTP status code

### DIFF
--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -70,7 +70,7 @@ fn check_context_length_exceeded(text: &str) -> bool {
 
 fn format_server_error_message(status_code: u16, payload: Option<&Value>) -> String {
     if let Some(p) = payload {
-        format!("HTTP {}: {:?}", status_code, p)
+        format!("HTTP {}: {}", status_code, p.to_string())
     } else {
         format!(
             "HTTP {}: No response body received from server",
@@ -90,7 +90,7 @@ pub fn map_http_error_to_provider_error(
                 "Authentication failed. Please ensure your API keys are valid and have the required permissions. \
         Status: {}{}",
                 status,
-                payload.as_ref().map(|p| format!(". Response: {:?}", p)).unwrap_or_default()
+                payload.as_ref().map(|p| format!(". Response: {}", p.to_string())).unwrap_or_default()
             );
             ProviderError::Authentication(message)
         }
@@ -1075,7 +1075,7 @@ mod tests {
                 StatusCode::UNAUTHORIZED,
                 Some(json!({"error": "auth failed"})),
                 ProviderError::Authentication(
-                    "Authentication failed. Please ensure your API keys are valid and have the required permissions. Status: 401 Unauthorized. Response: Object {\"error\": String(\"auth failed\")}".to_string(),
+                    "Authentication failed. Please ensure your API keys are valid and have the required permissions. Status: 401 Unauthorized. Response: {\"error\":\"auth failed\"}".to_string(),
                 ),
             ),
             // UNAUTHORIZED/FORBIDDEN - without payload
@@ -1129,7 +1129,7 @@ mod tests {
             (
                 StatusCode::BAD_GATEWAY,
                 Some(json!({"error": "upstream error"})),
-                ProviderError::ServerError("HTTP 502: Object {\"error\": String(\"upstream error\")}".to_string()),
+                ProviderError::ServerError("HTTP 502: {\"error\":\"upstream error\"}".to_string()),
             ),
             // Default - any other status code
             (

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -1068,7 +1068,6 @@ mod tests {
     #[test]
     fn test_map_http_error_to_provider_error() {
         let test_cases = vec![
-            // UNAUTHORIZED/FORBIDDEN - with payload
             (
                 StatusCode::UNAUTHORIZED,
                 Some(json!({"error": "auth failed"})),
@@ -1076,7 +1075,6 @@ mod tests {
                     "Authentication failed. Please ensure your API keys are valid and have the required permissions. Status: 401 Unauthorized. Response: {\"error\":\"auth failed\"}".to_string(),
                 ),
             ),
-            // UNAUTHORIZED/FORBIDDEN - without payload
             (
                 StatusCode::FORBIDDEN,
                 None,
@@ -1084,7 +1082,6 @@ mod tests {
                     "Authentication failed. Please ensure your API keys are valid and have the required permissions. Status: 403 Forbidden".to_string(),
                 ),
             ),
-            // BAD_REQUEST - with context_length_exceeded detection
             (
                 StatusCode::BAD_REQUEST,
                 Some(json!({"error": {"message": "context_length_exceeded"}})),
@@ -1092,7 +1089,6 @@ mod tests {
                     "{\"error\":{\"message\":\"context_length_exceeded\"}}".to_string(),
                 ),
             ),
-            // BAD_REQUEST - with error.message extraction
             (
                 StatusCode::BAD_REQUEST,
                 Some(json!({"error": {"message": "Custom error"}})),
@@ -1100,7 +1096,6 @@ mod tests {
                     "Request failed with status: 400 Bad Request. Message: Custom error".to_string(),
                 ),
             ),
-            // BAD_REQUEST - without payload
             (
                 StatusCode::BAD_REQUEST,
                 None,
@@ -1108,7 +1103,6 @@ mod tests {
                     "Request failed with status: 400 Bad Request".to_string(),
                 ),
             ),
-            // TOO_MANY_REQUESTS
             (
                 StatusCode::TOO_MANY_REQUESTS,
                 Some(json!({"retry_after": 60})),
@@ -1117,7 +1111,6 @@ mod tests {
                     retry_delay: None,
                 },
             ),
-            // is_server_error() without payload
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 None,
@@ -1126,7 +1119,6 @@ mod tests {
                     None,
                 )),
             ),
-            // is_server_error() with null payload (the "Server error: None" bug)
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Some(Value::Null),
@@ -1135,7 +1127,6 @@ mod tests {
                     Some(&Value::Null),
                 )),
             ),
-            // is_server_error() with payload
             (
                 StatusCode::BAD_GATEWAY,
                 Some(json!({"error": "upstream error"})),

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -1122,19 +1122,28 @@ mod tests {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 None,
-                ProviderError::ServerError("HTTP 500: No response body received from server".to_string()),
+                ProviderError::ServerError(format_server_error_message(
+                    StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+                    None,
+                )),
             ),
             // is_server_error() with null payload (the "Server error: None" bug)
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Some(Value::Null),
-                ProviderError::ServerError("HTTP 500: No response body received from server".to_string()),
+                ProviderError::ServerError(format_server_error_message(
+                    StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+                    Some(&Value::Null),
+                )),
             ),
             // is_server_error() with payload
             (
                 StatusCode::BAD_GATEWAY,
                 Some(json!({"error": "upstream error"})),
-                ProviderError::ServerError("HTTP 502: {\"error\":\"upstream error\"}".to_string()),
+                ProviderError::ServerError(format_server_error_message(
+                    StatusCode::BAD_GATEWAY.as_u16(),
+                    Some(&json!({"error": "upstream error"})),
+                )),
             ),
             // Default - any other status code
             (

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -313,14 +313,6 @@ pub async fn handle_response_google_compat(response: Response) -> Result<Value, 
             };
             Err(ProviderError::ServerError(msg))
         }
-        StatusCode::INTERNAL_SERVER_ERROR | StatusCode::SERVICE_UNAVAILABLE => {
-            let msg = if let Some(p) = &payload {
-                format!("HTTP {}: {:?}", final_status.as_u16(), p)
-            } else {
-                format!("HTTP {}: No response body received from server", final_status.as_u16())
-            };
-            Err(ProviderError::ServerError(msg))
-        }
         _ => {
             tracing::debug!(
                 "{}", format!("Provider request failed with status: {}. Payload: {:?}", final_status, payload)

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -309,7 +309,7 @@ pub async fn handle_response_google_compat(response: Response) -> Result<Value, 
             let msg = if let Some(p) = &payload {
                 format!("HTTP {}: {:?}", final_status.as_u16(), p)
             } else {
-                format!(NO_RESPONSE_BODY_ERROR_FMT, final_status.as_u16())
+                format!("HTTP {}: No response body received from server", final_status.as_u16())
             };
             Err(ProviderError::ServerError(msg))
         }

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -68,6 +68,17 @@ fn check_context_length_exceeded(text: &str) -> bool {
         .any(|phrase| text_lower.contains(phrase))
 }
 
+fn format_server_error_message(status_code: u16, payload: Option<&Value>) -> String {
+    if let Some(p) = payload {
+        format!("HTTP {}: {:?}", status_code, p)
+    } else {
+        format!(
+            "HTTP {}: No response body received from server",
+            status_code
+        )
+    }
+}
+
 pub fn map_http_error_to_provider_error(
     status: StatusCode,
     payload: Option<Value>,
@@ -116,17 +127,10 @@ pub fn map_http_error_to_provider_error(
             details: format!("{:?}", payload),
             retry_delay: None,
         },
-        _ if status.is_server_error() => {
-            let msg = if let Some(p) = &payload {
-                format!("HTTP {}: {:?}", status.as_u16(), p)
-            } else {
-                format!(
-                    "HTTP {}: No response body received from server",
-                    status.as_u16()
-                )
-            };
-            ProviderError::ServerError(msg)
-        }
+        _ if status.is_server_error() => ProviderError::ServerError(format_server_error_message(
+            status.as_u16(),
+            payload.as_ref(),
+        )),
         _ => ProviderError::RequestFailed(format!("Request failed with status: {}", status)),
     };
 
@@ -305,14 +309,9 @@ pub async fn handle_response_google_compat(response: Response) -> Result<Value, 
                 retry_delay,
             })
         }
-        _ if final_status.is_server_error() => {
-            let msg = if let Some(p) = &payload {
-                format!("HTTP {}: {:?}", final_status.as_u16(), p)
-            } else {
-                format!("HTTP {}: No response body received from server", final_status.as_u16())
-            };
-            Err(ProviderError::ServerError(msg))
-        }
+        _ if final_status.is_server_error() => Err(ProviderError::ServerError(
+            format_server_error_message(final_status.as_u16(), payload.as_ref()),
+        )),
         _ => {
             tracing::debug!(
                 "{}", format!("Provider request failed with status: {}. Payload: {:?}", final_status, payload)

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -69,13 +69,12 @@ fn check_context_length_exceeded(text: &str) -> bool {
 }
 
 fn format_server_error_message(status_code: u16, payload: Option<&Value>) -> String {
-    if let Some(p) = payload {
-        format!("HTTP {}: {}", status_code, p)
-    } else {
-        format!(
+    match payload {
+        Some(Value::Null) | None => format!(
             "HTTP {}: No response body received from server",
             status_code
-        )
+        ),
+        Some(p) => format!("HTTP {}: {}", status_code, p),
     }
 }
 
@@ -1123,6 +1122,12 @@ mod tests {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 None,
+                ProviderError::ServerError("HTTP 500: No response body received from server".to_string()),
+            ),
+            // is_server_error() with null payload (the "Server error: None" bug)
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Some(Value::Null),
                 ProviderError::ServerError("HTTP 500: No response body received from server".to_string()),
             ),
             // is_server_error() with payload

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -309,7 +309,7 @@ pub async fn handle_response_google_compat(response: Response) -> Result<Value, 
             let msg = if let Some(p) = &payload {
                 format!("HTTP {}: {:?}", final_status.as_u16(), p)
             } else {
-                format!("HTTP {}: No response body received from server", final_status.as_u16())
+                format!(NO_RESPONSE_BODY_ERROR_FMT, final_status.as_u16())
             };
             Err(ProviderError::ServerError(msg))
         }

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -70,7 +70,7 @@ fn check_context_length_exceeded(text: &str) -> bool {
 
 fn format_server_error_message(status_code: u16, payload: Option<&Value>) -> String {
     if let Some(p) = payload {
-        format!("HTTP {}: {}", status_code, p.to_string())
+        format!("HTTP {}: {}", status_code, p)
     } else {
         format!(
             "HTTP {}: No response body received from server",
@@ -90,7 +90,7 @@ pub fn map_http_error_to_provider_error(
                 "Authentication failed. Please ensure your API keys are valid and have the required permissions. \
         Status: {}{}",
                 status,
-                payload.as_ref().map(|p| format!(". Response: {}", p.to_string())).unwrap_or_default()
+                payload.as_ref().map(|p| format!(". Response: {}", p)).unwrap_or_default()
             );
             ProviderError::Authentication(message)
         }


### PR DESCRIPTION
## Summary

Previously, when a server error (5xx) occurred without a response body, the error message would display 'Server error: None', which was not helpful for debugging.

This change improves error messages by:
- Including the HTTP status code (e.g., 'HTTP 500')
- Providing a clear message when no response body is received
- Maintaining detailed error info when a response body is present

Example error messages:
- Before: 'Server error: None'
- After: 'HTTP 500: No response body received from server'

This affects all OpenAI-compatible providers (OpenAI, Claude, Google, Ollama, Azure, Databricks, GitHub Copilot, etc.) and Google-compatible endpoints.


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [X] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
ran all the tests in the utils module, and updated them to match new response

### Related Issues
related to #5528. this gives a better message but doesn't solve the problem of frequently running into 500 errors.

