### PR TITLE
fix: do not build unsigned desktop app bundles on every PR in ci. add manual option.

### DIFF
--- a/.github/workflows/bundle-desktop-manual.yml
+++ b/.github/workflows/bundle-desktop-manual.yml
@@ -1,0 +1,19 @@
+name: Manual Desktop Bundle (Unsigned)
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch name to bundle app from'
+        required: true
+        type: string
+
+jobs:
+  bundle-desktop-unsigned:
+    uses: ./.github/workflows/bundle-desktop.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      signing: false
+      ref: ${{ inputs.branch }}

--- a/.github/workflows/bundle-desktop.yml
+++ b/.github/workflows/bundle-desktop.yml
@@ -3,6 +3,7 @@
 #  - release.yml
 #  - canary.yml
 #  - pr-comment-bundle-desktop.yml
+#  - bundle-desktop-manual.yml
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,13 +131,4 @@ jobs:
         run: source ../../bin/activate-hermit && npm run test:run
         working-directory: ui/desktop
 
-  # Faster Desktop App build for PRs only
-  bundle-desktop-unsigned:
-    uses: ./.github/workflows/bundle-desktop.yml
-    permissions:
-      id-token: write
-      contents: read
-    needs: changes
-    if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request')
-    with:
-      signing: false
+


### PR DESCRIPTION
Bundling the desktop app takes ~20mins and right now we do it on every PR that touches code. The check for whether a changeset touches code is also a bit faulty, but that's a separate matter.

We rarely need these app builds so in this PR I propose removing this step from CI and adding an option with a manually triggered `workflow_dispatch` for anyone who wants to build an unsigned copy of the desktop app from a branch.

This will save a significant amount of time waiting for builds in CI, while still letting us build a version of the app this way for any branch when needed.