### PR TITLE
fix: remove qwen3-coder from provider/mcp smoke tests

### DIFF
--- a/scripts/test_mcp.sh
+++ b/scripts/test_mcp.sh
@@ -20,7 +20,7 @@ JUDGE_MODEL=${GOOSE_JUDGE_MODEL:-google/gemini-2.5-flash}
 PROVIDERS=(
   "anthropic:claude-haiku-4-5-20251001"
   "google:gemini-2.5-flash"
-  "openrouter:qwen/qwen3-coder"
+  "openrouter:google/gemini-2.5-flash"
   "openai:gpt-5-mini"
 )
 

--- a/scripts/test_providers.sh
+++ b/scripts/test_providers.sh
@@ -15,7 +15,7 @@ fi
 SCRIPT_DIR=$(pwd)
 
 PROVIDERS=(
-  "openrouter:google/gemini-2.5-pro:google/gemini-2.5-flash:anthropic/claude-sonnet-4.5:qwen/qwen3-coder"
+  "openrouter:google/gemini-2.5-pro:google/gemini-2.5-flash:anthropic/claude-sonnet-4.5"
   "openai:gpt-4o:gpt-4o-mini:gpt-3.5-turbo:gpt-5"
   "anthropic:claude-sonnet-4-5-20250929:claude-opus-4-1-20250805"
   "google:gemini-2.5-pro:gemini-2.5-flash"


### PR DESCRIPTION
Noticing the `qwen3-coder` often produces failing test results in test_providers.sh an test_mcp.sh because it doesn't reliably call the tools we expect

Most recent example where it simply didn't call the `sampleLLM` tool when it is directly told to do so by the test script https://github.com/block/goose/actions/runs/19044249135/job/54389311803?pr=5550