### PR TITLE
cli: adjust default theme to address #1905

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -495,6 +495,10 @@ impl CliSession {
 
                     let current = output::get_theme();
                     let new_theme = match current {
+                        output::Theme::Ansi => {
+                            println!("Switching to Light theme");
+                            output::Theme::Light
+                        }
                         output::Theme::Light => {
                             println!("Switching to Dark theme");
                             output::Theme::Dark
@@ -502,10 +506,6 @@ impl CliSession {
                         output::Theme::Dark => {
                             println!("Switching to Ansi theme");
                             output::Theme::Ansi
-                        }
-                        output::Theme::Ansi => {
-                            println!("Switching to Light theme");
-                            output::Theme::Light
                         }
                     };
                     output::set_theme(new_theme);

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -60,7 +60,7 @@ thread_local! {
             .unwrap_or_else(||
                 Config::global().get_param::<String>("GOOSE_CLI_THEME").ok()
                     .map(|val| Theme::from_config_str(&val))
-                    .unwrap_or(Theme::Dark)
+                    .unwrap_or(Theme::Ansi)
             )
     );
 }


### PR DESCRIPTION
Using `Theme::Ansi` by default leads to better rendering in a range of common terminal themes

Fixes https://github.com/block/goose/issues/1905