### PR TITLE
feat: log rotation

### DIFF
--- a/crates/goose-cli/src/logging.rs
+++ b/crates/goose-cli/src/logging.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Result};
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Once;
 use tokio::sync::Mutex;
@@ -15,12 +14,6 @@ use goose_bench::error_capture::ErrorCaptureLayer;
 
 // Used to ensure we only set up tracing once
 static INIT: Once = Once::new();
-
-/// Returns the directory where log files should be stored.
-/// Creates the directory structure if it doesn't exist.
-fn get_log_directory() -> Result<PathBuf> {
-    goose::logging::get_log_directory("cli", true)
-}
 
 /// Sets up the logging infrastructure for the application.
 /// This includes:
@@ -50,8 +43,9 @@ fn setup_logging_internal(
 
     let mut setup = || {
         result = (|| {
-            // Set up file appender for goose module logs
-            let log_dir = get_log_directory()?;
+            let _ = goose::logging::cleanup_old_logs("cli");
+            let _ = goose::logging::cleanup_old_logs("llm");
+            let log_dir = goose::logging::get_log_directory("cli", true)?;
             let timestamp = chrono::Local::now().format("%Y%m%d_%H%M%S").to_string();
 
             // Create log file name by prefixing with timestamp
@@ -61,9 +55,9 @@ fn setup_logging_internal(
                 format!("{}.log", timestamp)
             };
 
-            // Create non-rolling file appender for detailed logs
+            // Create daily rolling file appender for detailed logs
             let file_appender = tracing_appender::rolling::RollingFileAppender::new(
-                Rotation::NEVER,
+                Rotation::DAILY,
                 log_dir,
                 log_filename,
             );
@@ -177,7 +171,7 @@ mod tests {
     #[test]
     fn test_log_directory_creation() {
         let _temp_dir = setup_temp_home();
-        let log_dir = get_log_directory().unwrap();
+        let log_dir = goose::logging::get_log_directory("cli", true).unwrap();
         assert!(log_dir.exists());
         assert!(log_dir.is_dir());
 

--- a/crates/goose-cli/src/logging.rs
+++ b/crates/goose-cli/src/logging.rs
@@ -43,21 +43,15 @@ fn setup_logging_internal(
 
     let mut setup = || {
         result = (|| {
-            let _ = goose::logging::cleanup_old_logs("cli");
-            let _ = goose::logging::cleanup_old_logs("llm");
-            let log_dir = goose::logging::get_log_directory("cli", true)?;
+            let log_dir = goose::logging::prepare_log_directory("cli", true)?;
             let timestamp = chrono::Local::now().format("%Y%m%d_%H%M%S").to_string();
-
-            // Create log file name by prefixing with timestamp
             let log_filename = if name.is_some() {
                 format!("{}-{}.log", timestamp, name.unwrap())
             } else {
                 format!("{}.log", timestamp)
             };
-
-            // Create daily rolling file appender for detailed logs
             let file_appender = tracing_appender::rolling::RollingFileAppender::new(
-                Rotation::DAILY,
+                Rotation::NEVER, // we do manual rotation via file naming and cleanup_old_logs
                 log_dir,
                 log_filename,
             );
@@ -171,7 +165,7 @@ mod tests {
     #[test]
     fn test_log_directory_creation() {
         let _temp_dir = setup_temp_home();
-        let log_dir = goose::logging::get_log_directory("cli", true).unwrap();
+        let log_dir = goose::logging::prepare_log_directory("cli", true).unwrap();
         assert!(log_dir.exists());
         assert!(log_dir.is_dir());
 

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -1,6 +1,5 @@
 use super::base::Usage;
 use super::errors::GoogleErrorCode;
-use crate::config::paths::Paths;
 use crate::model::ModelConfig;
 use crate::providers::errors::{OpenAIError, ProviderError};
 use anyhow::{anyhow, Result};
@@ -471,8 +470,7 @@ impl RequestLog {
     where
         Payload: Serialize,
     {
-        let logs_dir = Paths::in_state_dir("logs").join("llm");
-        std::fs::create_dir_all(&logs_dir)?;
+        let logs_dir = crate::logging::prepare_log_directory("llm", true)?;
 
         let request_id = Uuid::new_v4();
         let temp_name = format!("llm_request.{request_id}.jsonl");
@@ -529,7 +527,7 @@ impl RequestLog {
     fn finish(&mut self) -> Result<()> {
         if let Some(mut writer) = self.writer.take() {
             writer.flush()?;
-            let logs_dir = Paths::in_state_dir("logs").join("llm");
+            let logs_dir = crate::logging::prepare_log_directory("llm", true)?;
             let log_path = |i| logs_dir.join(format!("llm_request.{}.jsonl", i));
 
             for i in (0..LOGS_TO_KEEP - 1).rev() {

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -471,7 +471,7 @@ impl RequestLog {
     where
         Payload: Serialize,
     {
-        let logs_dir = Paths::in_state_dir("logs");
+        let logs_dir = Paths::in_state_dir("logs").join("llm");
         std::fs::create_dir_all(&logs_dir)?;
 
         let request_id = Uuid::new_v4();
@@ -529,7 +529,7 @@ impl RequestLog {
     fn finish(&mut self) -> Result<()> {
         if let Some(mut writer) = self.writer.take() {
             writer.flush()?;
-            let logs_dir = Paths::in_state_dir("logs");
+            let logs_dir = Paths::in_state_dir("logs").join("llm");
             let log_path = |i| logs_dir.join(format!("llm_request.{}.jsonl", i));
 
             for i in (0..LOGS_TO_KEEP - 1).rev() {


### PR DESCRIPTION
Simple log rotation to prevent runaway log file storage. Will fix https://github.com/block/goose/issues/4965 and https://github.com/block/goose/issues/4365

Approach:

* Rotates log content to new files daily
* Deletes log files after two weeks
* Sets up a new `llm` subdirectory for `llm-request` logs so they can use the same cleanup strategy

Notes:

* There wasn't a super natural place to call the cleanup function for llm requests, so I coupled calls to it when we do cleanup for `cli` and `server` dirs
* This will require a one time manual `rm` of logs at the top level of the log dir, as I moved llm-requests to a new subdir, but after that should work for everything automatically