### PR TITLE
fix: unblock acp via databricks

### DIFF
--- a/crates/goose/src/providers/databricks.rs
+++ b/crates/goose/src/providers/databricks.rs
@@ -152,28 +152,24 @@ impl DatabricksProvider {
         };
 
         // Check if the default fast model exists in the workspace
-        let model_with_fast = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                if let Ok(Some(models)) = provider.fetch_supported_models().await {
-                    if models.contains(&DATABRICKS_DEFAULT_FAST_MODEL.to_string()) {
-                        tracing::debug!(
-                            "Found {} in Databricks workspace, setting as fast model",
-                            DATABRICKS_DEFAULT_FAST_MODEL
-                        );
-                        model.with_fast(DATABRICKS_DEFAULT_FAST_MODEL.to_string())
-                    } else {
-                        tracing::debug!(
-                            "{} not found in Databricks workspace, not setting fast model",
-                            DATABRICKS_DEFAULT_FAST_MODEL
-                        );
-                        model
-                    }
-                } else {
-                    tracing::debug!("Could not fetch Databricks models, not setting fast model");
-                    model
-                }
-            })
-        });
+        let model_with_fast = if let Ok(Some(models)) = provider.fetch_supported_models().await {
+            if models.contains(&DATABRICKS_DEFAULT_FAST_MODEL.to_string()) {
+                tracing::debug!(
+                    "Found {} in Databricks workspace, setting as fast model",
+                    DATABRICKS_DEFAULT_FAST_MODEL
+                );
+                model.with_fast(DATABRICKS_DEFAULT_FAST_MODEL.to_string())
+            } else {
+                tracing::debug!(
+                    "{} not found in Databricks workspace, not setting fast model",
+                    DATABRICKS_DEFAULT_FAST_MODEL
+                );
+                model
+            }
+        } else {
+            tracing::debug!("Could not fetch Databricks models, not setting fast model");
+            model
+        };
 
         provider.model = model_with_fast;
         Ok(provider)


### PR DESCRIPTION
When goose runs via `goose acp` we don't have a multi-threaded runtime available

https://github.com/block/goose/blob/5b93ee587feb4135146b27ad8683a9a9b6bd2feb/crates/goose-cli/src/commands/acp.rs#L680

Therefor, this bombs when goose is running via acp and with databricks

```
tokio::task::block_in_place(|| {
  tokio::runtime::Handle::current().block_on(async { ... })
}
```

Removing it doesn't seem to break anything I can find via normal usage, and unblocks using goose via acp and with databricks