### PR TITLE
disable RPM build-ID generation to prevent package conflicts

### DIFF
--- a/ui/desktop/forge.config.ts
+++ b/ui/desktop/forge.config.ts
@@ -26,12 +26,12 @@ let cfg = {
     // Document types for drag-and-drop support onto dock icon
     CFBundleDocumentTypes: [
       {
-        CFBundleTypeName: "Folders",
-        CFBundleTypeRole: "Viewer",
-        LSHandlerRank: "Alternate",
-        LSItemContentTypes: ["public.directory", "public.folder"]
-      }
-    ]
+        CFBundleTypeName: 'Folders',
+        CFBundleTypeRole: 'Viewer',
+        LSHandlerRank: 'Alternate',
+        LSItemContentTypes: ['public.directory', 'public.folder'],
+      },
+    ],
   },
 };
 
@@ -73,8 +73,8 @@ module.exports = {
         desktopTemplate: './forge.deb.desktop',
         options: {
           icon: 'src/images/icon.png',
-          prefix: '/opt'
-        }
+          prefix: '/opt',
+        },
       },
     },
     {
@@ -88,8 +88,9 @@ module.exports = {
         desktopTemplate: './forge.rpm.desktop',
         options: {
           icon: 'src/images/icon.png',
-          prefix: '/opt'
-        }
+          prefix: '/opt',
+          fpm: ['--rpm-rpmbuild-define', '_build_id_links none'],
+        },
       },
     },
   ],


### PR DESCRIPTION
Fixes #5432

I haven't tested this though, this is what the LLMs said we should do
