### PR TITLE
Add Diagnostics Info to Q&A and Bug Report Templates

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/qa.yml
+++ b/.github/DISCUSSION_TEMPLATE/qa.yml
@@ -1,0 +1,26 @@
+title: "❓ Question: [Brief summary]"
+labels:
+  - help
+body:
+  - type: markdown
+    attributes:
+      value: |
+        💡 Before posting, please attach your **diagnostics zip** — it helps the Goose team debug faster and saves everyone time.  
+        [How to capture and share diagnostics](https://block.github.io/goose/docs/troubleshooting/diagnostics-and-reporting/)
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Describe the issue in detail and attach your diagnostics zip if possible.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Tell us how to reproduce the issue — commands, steps, or context.
+  - type: textarea
+    id: version
+    attributes:
+      label: Goose version and environment
+      description: Include your Goose version and operating system if known.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,16 +2,21 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: bug
 assignees: ''
-
 ---
 
 **Describe the bug**
 
-Note: Please check the common issues on https://block.github.io/goose/docs/troubleshooting before filing a report
+💡 Before filing, please check common issues:  
+https://block.github.io/goose/docs/troubleshooting  
+
+📦 To help us debug faster, attach your **diagnostics zip** if possible.  
+👉 How to capture it: https://block.github.io/goose/docs/troubleshooting/diagnostics-and-reporting/
 
 A clear and concise description of what the bug is.
+
+---
 
 **To Reproduce**
 Steps to reproduce the behavior:
@@ -20,18 +25,26 @@ Steps to reproduce the behavior:
 3. Scroll down to '....'
 4. See error
 
+---
+
 **Expected behavior**
 A clear and concise description of what you expected to happen.
+
+---
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Please provide following information:**
- - **OS & Arch:** [e.g. Ubuntu 22.04 x86]
- - **Interface:** [UI/CLI]
- - **Version:** [e.g. v1.0.2]
- - **Extensions enabled:** [e.g. Computer Controller, Figma]
- - **Provider & Model:** [e.g. Google - gemini-1.5-pro]
+---
+
+**Please provide the following information**
+- **OS & Arch:** [e.g. Ubuntu 22.04 x86]
+- **Interface:** [UI / CLI]
+- **Version:** [e.g. v1.0.2]
+- **Extensions enabled:** [e.g. Computer Controller, Figma]
+- **Provider & Model:** [e.g. Google – gemini-1.5-pro]
+
+---
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
This PR improves how users report and troubleshoot issues by adding clear guidance on attaching **diagnostics zips** in both Discussions and Issue templates.

#### 🧩 What’s New
- **Added** a new `.github/DISCUSSION_TEMPLATE/qa.yml` file for the Q&A category.
  - Includes a friendly reminder to attach diagnostics zips.
  - Provides a direct link to the official diagnostics guide.
  - Adds structured fields for steps, version, and environment details.
- **Updated** the `.github/ISSUE_TEMPLATE/bug_report.md` template.
  - Added links to troubleshooting docs.
  - Added instructions for attaching diagnostics zips.
  - Cleaned up formatting for clarity and consistency.

#### 💡 Why
Encourages users to proactively include diagnostics data when asking for help or reporting bugs, making it faster and easier for maintainers to debug issues.

#### 🧠 Docs Reference
[Diagnostics and Reporting Guide](https://block.github.io/goose/docs/troubleshooting/diagnostics-and-reporting/)
