### PR TITLE
Add uv for uvx in Justfile

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -31,6 +31,7 @@ jobs:
         fetch-depth: 0 # to generate complete release log
 
     - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
+    - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 
     - name: Validate input and set old version
       run: |

--- a/.github/workflows/update-release-pr.yaml
+++ b/.github/workflows/update-release-pr.yaml
@@ -27,6 +27,7 @@ jobs:
         path: './prior-version'
 
     - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
+    - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 
     - name: Extract version from branch name
       env:


### PR DESCRIPTION
The Justfile recipes `get-tag-version` and `prepare-release` need uvx, and we don't manage uv with hermit. Any of those other things could arguably change, but for now, just add it where we need it.