### PR TITLE
Listen for ctrl-c during provider request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7055,6 +7055,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -54,7 +54,7 @@ tower-http = { version = "0.5", features = ["cors", "fs", "auth"] }
 http = "1.0"
 webbrowser = "1.0"
 indicatif = "0.17.11"
-tokio-util = { version = "0.7.15", features = ["compat"] }
+tokio-util = { version = "0.7.15", features = ["compat", "rt"] }
 is-terminal = "0.4.16"
 anstream = "0.6.18"
 url = "2.5.7"

--- a/crates/goose-cli/src/session/input.rs
+++ b/crates/goose-cli/src/session/input.rs
@@ -74,6 +74,7 @@ pub fn get_input(
         Ok(text) => text,
         Err(e) => match e {
             rustyline::error::ReadlineError::Interrupted => return Ok(InputResult::Exit),
+            rustyline::error::ReadlineError::Eof => return Ok(InputResult::Exit),
             _ => return Err(e.into()),
         },
     };


### PR DESCRIPTION
Prior, we'd only start listening during the stream. So if the user hit ctrl-c while we waited for the provider response (before any streaming started), we wouldn't handle it.

fixes #4265

Also treats ctrl-D as exit, so we don't print "Error: EOF" when you exit this way.