### PR TITLE
Avoid web double write

### DIFF
--- a/crates/goose-cli/src/commands/web.rs
+++ b/crates/goose-cli/src/commands/web.rs
@@ -483,8 +483,6 @@ async fn process_message_streaming(
             while let Some(result) = stream.next().await {
                 match result {
                     Ok(AgentEvent::Message(message)) => {
-                        SessionManager::add_message(&session_id, &message).await?;
-
                         for content in &message.content {
                             match content {
                                 MessageContent::Text(text) => {


### PR DESCRIPTION
Goose web was writing incoming messages to the session, rather than relying on the agent to do it
