### PR TITLE
Bump openapi in prepare-release

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -286,7 +286,8 @@ prepare-release version:
     # see --workspace flag https://doc.rust-lang.org/cargo/commands/cargo-update.html
     # used to update Cargo.lock after we've bumped versions in Cargo.toml
     @cargo update --workspace
-    @git add Cargo.toml Cargo.lock ui/desktop/package.json ui/desktop/package-lock.json
+    @just generate-openapi
+    @git add Cargo.toml Cargo.lock ui/desktop/package.json ui/desktop/package-lock.json ui/desktop/openapi.json
     @git commit --message "chore(release): release version {{ version }}"
 
 # extract version from Cargo.toml


### PR DESCRIPTION
The prepare-release Just recipe should do everything to bump the version, but it wasn't bumping it int he openapi spec.