### PR TITLE
docs: add access control section to Developer tutorial

### DIFF
--- a/documentation/docs/getting-started/using-extensions.md
+++ b/documentation/docs/getting-started/using-extensions.md
@@ -28,7 +28,7 @@ goose includes several built-in extensions you can start using out of the box:
 - [Auto Visualiser](/docs/mcp/autovisualiser-mcp): Automatically generates graphical data visualizations in conversations.
 
 :::warning Access Control
-goose operates autonomously by default. Combined with the Developer extension's tools, this means goose can execute commands and modify files without your approval. If you want more control over this behavior, you can configure the [goose permission mode](/docs/guides/goose-permissions), [tool permissions](/docs/guides/managing-tools/tool-permissions), and [.gooseignore files](/docs/guides/using-gooseignore). See [Configuring Access Controls](/docs/mcp/developer-mcp##configuring-access-controls) for a brief overview.
+goose operates autonomously by default. Combined with the Developer extension's tools, this means goose can execute commands and modify files without your approval. If you want more control over this behavior, you can configure the [goose permission mode](/docs/guides/goose-permissions), [tool permissions](/docs/guides/managing-tools/tool-permissions), and [.gooseignore files](/docs/guides/using-gooseignore). See [Configuring Access Controls](/docs/mcp/developer-mcp#configuring-access-controls) for a brief overview.
 :::
 
 In addition, these platform extensions provide core goose functionality. They are also always available and enabled by default:

--- a/documentation/docs/getting-started/using-extensions.md
+++ b/documentation/docs/getting-started/using-extensions.md
@@ -28,7 +28,7 @@ goose includes several built-in extensions you can start using out of the box:
 - [Auto Visualiser](/docs/mcp/autovisualiser-mcp): Automatically generates graphical data visualizations in conversations.
 
 :::warning Access Control
-goose operates autonomously by default. Combined with the Developer extension's tools, this means goose can execute commands and modify files without your approval. If you want more control over this behavior, you can configure the [goose permission mode](/docs/guides/goose-permissions), [tool permissions](/docs/guides/managing-tools/tool-permissions), and [.gooseignore files](/docs/guides/using-gooseignore). See [Configuruing Access Controls](/docs/mcp/developer-mcp##configuring-access-controls) for a brief overview.
+goose operates autonomously by default. Combined with the Developer extension's tools, this means goose can execute commands and modify files without your approval. If you want more control over this behavior, you can configure the [goose permission mode](/docs/guides/goose-permissions), [tool permissions](/docs/guides/managing-tools/tool-permissions), and [.gooseignore files](/docs/guides/using-gooseignore). See [Configuring Access Controls](/docs/mcp/developer-mcp##configuring-access-controls) for a brief overview.
 :::
 
 In addition, these platform extensions provide core goose functionality. They are also always available and enabled by default:

--- a/documentation/docs/getting-started/using-extensions.md
+++ b/documentation/docs/getting-started/using-extensions.md
@@ -7,28 +7,34 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import { PanelLeft, Settings } from 'lucide-react';
 
-Extensions are add-ons that provide a way to extend the functionality of Goose by connecting with applications and tools you already use in your workflow. These extensions can be used to add new features, access data and resources, or integrate with other systems.
+Extensions are add-ons that provide a way to extend the functionality of goose by connecting with applications and tools you already use in your workflow. These extensions can be used to add new features, access data and resources, or integrate with other systems.
 
 Extensions are based on the [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol), so you can connect
-Goose to a wide ecosystem of capabilities.
+goose to a wide ecosystem of capabilities.
 
-Goose automatically checks external extensions for known malware before activation. If a malicious package is detected, the [extension will be blocked](/docs/troubleshooting/known-issues#malicious-package-detected) with a clear error message.
+goose automatically checks external extensions for known malware before activation. If a malicious package is detected, the [extension will be blocked](/docs/troubleshooting/known-issues#malicious-package-detected) with a clear error message.
 
 :::tip Tutorials
-Check out the [step-by-step tutorials](/docs/category/mcp-servers) for adding and using several Goose Extensions
+Check out the [step-by-step tutorials](/docs/category/mcp-servers) for adding and using various goose extensions
 :::
 
 ## Built-in Extensions
-Out of the box, Goose is installed with a few extensions but with only the `Developer` extension enabled by default.
+goose includes several built-in extensions you can start using out of the box:
 
-Here are the built-in extensions:
-
-- [Developer](/docs/mcp/developer-mcp): Provides a set of general development tools that are useful for software development.
+- [Developer](/docs/mcp/developer-mcp): Provides a set of general development tools that are useful for software development. The Developer extension is **enabled by default**.
 - [Computer Controller](/docs/mcp/computer-controller-mcp): Provides general computer control tools for webscraping, file caching, and automations.
-- [Memory](/docs/mcp/memory-mcp): Teaches Goose to remember your preferences as you use it.
-- [Tutorial](/docs/mcp/tutorial-mcp): Provides interactive tutorials for learning about Goose.
+- [Memory](/docs/mcp/memory-mcp): Teaches goose to remember your preferences as you use it.
+- [Tutorial](/docs/mcp/tutorial-mcp): Provides interactive tutorials for learning about goose.
 - [Auto Visualiser](/docs/mcp/autovisualiser-mcp): Automatically generates graphical data visualizations in conversations.
 
+:::warning Access Control
+goose operates autonomously by default. Combined with the Developer extension's tools, this means goose can execute commands and modify files without your approval. If you want more control over this behavior, you can configure the [goose permission mode](/docs/guides/goose-permissions), [tool permissions](/docs/guides/managing-tools/tool-permissions), and [.gooseignore files](/docs/guides/using-gooseignore). See [Configuruing Access Controls](/docs/mcp/developer-mcp##configuring-access-controls) for a brief overview.
+:::
+
+In addition, these platform extensions provide core goose functionality. They are also always available and enabled by default:
+
+- Extension Manager: Discover, enable, and disable extensions dynamically during sessions
+- [Todo](/docs/mcp/todo-mcp): Manage task lists and track progress across sessions
 
 #### Toggling Built-in Extensions
 
@@ -50,20 +56,16 @@ Here are the built-in extensions:
     To navigate through available extensions:
 
     1. Run the following command:
-    ```sh
-    goose configure
-    ```
-    2. Select `Add Extension` from the menu.
-    3. Choose the type of extension you'd like to add:
-        - `Built-In Extension`: Use an extension that comes pre-installed with Goose.
-        - `Command-Line Extension`: Add a local command or script to run as an extension.
-        - `Remote Extension (SSE)`: Connect to a remote system via SSE (Server-Sent Events).
-        - `Remote Extension (Streaming HTTP)`: Connect to a remote system via Streaming HTTP
-    4. Follow the prompts based on the type of extension you selected.
+        ```sh
+        goose configure
+        ```
+    2. Select `Add Extension` from the menu. Use the up and down keys to highlight your choice then press `Enter`.
+    3. Select `Built-In Extension`.
+    4. Select the extension to enable.
+    5. Provide a timeout for the extension (in seconds).
+    6. Press `Enter`.
 
     **Example: Adding Built-in Extension**
-
-    To select an option during configuration, hover over it and press Enter.
 
     ```
     ┌   goose-configure 
@@ -74,33 +76,29 @@ Here are the built-in extensions:
     ◇  What type of extension would you like to add?
     │  Built-in Extension 
     │
-    ◆  Which built-in extension would you like to enable?
-    │  ○ Developer Tools 
-    │  ○ Computer Controller (controls for webscraping, file caching, and automations)
-    │  ○ Google Drive 
-    │  ○ Memory 
-    │  ● JetBrains 
+    ◇  Which built-in extension would you like to enable?
+    │  Auto Visualiser
     │        
     ◇  Please set the timeout for this tool (in secs):
     │  300
     │ 
-    └  Enabled jetbrains extension    
+    └  Enabled Auto Visualiser extension    
     ```
   </TabItem>
 </Tabs>
 
 
 :::info
-All of Goose's built-in extensions are MCP servers in their own right. If you'd like
-to use the MCP servers included with Goose with any other agent, you are free to do so.
+goose's built-in extensions are MCP servers in their own right. If you'd like
+to use the MCP servers included with goose with any other agent, you are free to do so.
 :::
 
 
 ## Discovering Extensions
 
-Goose provides a [central directory][extensions-directory] of extensions that you can install and use. 
+goose provides a [central directory][extensions-directory] of extensions that you can install and use. 
 
-You can also add any other [MCP Server](#mcp-servers) as a Goose extension, even if it's not listed in our directory.
+You can also add any other [MCP Server](#mcp-servers) as a goose extension, even if it's not listed in our directory.
 
 
 ## Adding Extensions
@@ -113,7 +111,7 @@ If you're in a corporate or airgapped environment and extensions fail to activat
 
 ### MCP Servers
 
-You can install any MCP server as a Goose extension. 
+You can install any MCP server as a goose extension. 
 
 :::tip MCP Server Directory
 See available servers in the **[MCP Server Directory](https://www.pulsemcp.com/servers)**.
@@ -127,7 +125,7 @@ See available servers in the **[MCP Server Directory](https://www.pulsemcp.com/s
   3. Under `Extensions`, click `Add custom extension`.
   4. On the `Add custom extension` modal, enter the necessary details
      - If adding an environment variable, click `Add` button to the right of the variable
-     - The `Timeout` field lets you set how long Goose should wait for a tool call from this extension to complete
+     - The `Timeout` field lets you set how long goose should wait for a tool call from this extension to complete
   5. Click `Add` button
   
   #### Example of adding the [Knowledge Graph Memory MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/memory):
@@ -149,7 +147,7 @@ See available servers in the **[MCP Server Directory](https://www.pulsemcp.com/s
   2. Select `Add Extension` from the menu.
 
   3. Choose the type of extension you'd like to add:
-      - `Built-In Extension`: Use an extension that comes pre-installed with Goose.
+      - `Built-In Extension`: Use an extension that comes pre-installed with goose.
       - `Command-Line Extension`: Add a local command or script to run as an extension.
       - `Remote Extension (SSE)`: Connect to a remote system via SSE (Server-Sent Events).
       - `Remote Extension (Streaming HTTP)`: Connect to a remote system via Streaming HTTP
@@ -258,7 +256,7 @@ Note: Java and Kotlin extensions are only support on Linux and macOS
 
 ### Deeplinks
 
-Extensions can be installed using Goose's deep link protocol. The URL format varies based on the extension type:
+Extensions can be installed using goose's deep link protocol. The URL format varies based on the extension type:
 
 <Tabs groupId="interface">
   <TabItem value="stdio" label="StandardIO" default>
@@ -357,7 +355,7 @@ You can enable or disable installed extensions based on your workflow needs.
   </TabItem>
 
   <TabItem value="cli" label="goose CLI">
-    1. Run the following command to open up Goose's configurations:
+    1. Run the following command to open up goose's configurations:
     ```sh
     goose configure
     ```
@@ -383,9 +381,9 @@ You can enable or disable installed extensions based on your workflow needs.
 
 ## Automatically Enabled Extensions
 
-The Smart Extension Recommendation system in Goose automatically identifies and suggests relevant extensions based on your tasks and needs. This section explains how to use this feature effectively and understand its capabilities and limitations.
+The Smart Extension Recommendation system in goose automatically identifies and suggests relevant extensions based on your tasks and needs. This section explains how to use this feature effectively and understand its capabilities and limitations.
 
-When you request a task, Goose checks its enabled extensions and their tools to determine if it can fulfill the request. If not, it suggests or enables additional extensions as needed. You can also request specific extensions by name.
+When you request a task, goose checks its enabled extensions and their tools to determine if it can fulfill the request. If not, it suggests or enables additional extensions as needed. You can also request specific extensions by name.
 
 
 :::warning
@@ -394,17 +392,17 @@ Any extensions enabled dynamically are only enabled for the current session. To 
 
 ### Automatic Detection
 
-Goose automatically detects when an extension is needed based on your task requirements. Here's an example of how Goose identifies and enables a needed extension during a conversation:
+goose automatically detects when an extension is needed based on your task requirements. Here's an example of how goose identifies and enables a needed extension during a conversation:
 
 <Tabs groupId="interface">
 <TabItem value="ui" label="goose Desktop" default>
 
-#### Goose Prompt
+#### goose Prompt
 ```plaintext
 Find all orders with pending status from our production database
 ```
 
-#### Goose Output
+#### goose Output
 
 ```plaintext
 I'll help you search for available extensions that might help us interact with PostgreSQL databases.
@@ -426,12 +424,12 @@ Great! Now I can help you query the database...
 </TabItem>
 <TabItem value="cli" label="goose CLI">
 
-#### Goose Prompt
+#### goose Prompt
 ```plaintext
 Find all orders with pending status from our production database
 ```
 
-#### Goose Output
+#### goose Output
 
 ```sh
 I apologize, but I notice that I don't currently have access to your database. Let me search if there are any database-related extensions available.
@@ -442,7 +440,7 @@ I see that there is a "postgresql" extension available. Let me enable it so I ca
 extension_name: postgresql
 
 
-■  Goose would like to enable the following extension, do you approve?
+■  goose would like to enable the following extension, do you approve?
 // highlight-start
 | ● Yes, for this session 
 // highlight-end
@@ -454,18 +452,18 @@ extension_name: postgresql
 
 ### Direct Request
 
-Goose responds to explicit requests for extensions, allowing users to manually enable specific tools they need. Here's an example of how Goose handles a direct request to enable an extension:
+goose responds to explicit requests for extensions, allowing users to manually enable specific tools they need. Here's an example of how goose handles a direct request to enable an extension:
 
 <Tabs groupId="interface">
 <TabItem value="ui" label="goose Desktop" default>
 
-#### Goose Prompt
+#### goose Prompt
 
 ```plaintext
 Use PostgreSQL extension
 ```
 
-#### Goose Output
+#### goose Output
 
 ```plaintext
 I'll help enable the PostgreSQL extension for you.
@@ -482,13 +480,13 @@ The PostgreSQL extension is now ready to use. What would you like to do with it?
 </TabItem>
 <TabItem value="cli" label="goose CLI">
 
-#### Goose Prompt
+#### goose Prompt
 
 ```sh
 Use the PostgreSQL extension
 ```
 
-#### Goose Output
+#### goose Output
 
 ```sh
 I'll help enable the PostgreSQL extension for you.
@@ -496,7 +494,7 @@ I'll help enable the PostgreSQL extension for you.
 extension_name: postgresql
 
 
-■  Goose would like to enable the following extension, do you approve?
+■  goose would like to enable the following extension, do you approve?
 // highlight-start
 | ● Yes, for this session 
 // highlight-end
@@ -508,7 +506,7 @@ extension_name: postgresql
 
 ## Updating Extension Properties
 
-Goose relies on extension properties to determine how to handle an extension. You can edit these properties if you want to change the extension's display settings and behavior, such as the name, timeout, or environment variables.
+goose relies on extension properties to determine how to handle an extension. You can edit these properties if you want to change the extension's display settings and behavior, such as the name, timeout, or environment variables.
 
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
@@ -523,7 +521,7 @@ Goose relies on extension properties to determine how to handle an extension. Yo
 
   <TabItem value="cli" label="Config file">
   
-  1. Navigate to the Goose [configuration file](/docs/guides/config-files). For example, navigate to `~/.config/goose/config.yaml` on macOS.
+  1. Navigate to the goose [configuration file](/docs/guides/config-files). For example, navigate to `~/.config/goose/config.yaml` on macOS.
   2. Edit the extension properties as needed and save your changes.
 
   </TabItem>
@@ -548,7 +546,7 @@ You can remove installed extensions.
   To remove an extension, you must [disable](#enablingdisabling-extensions) it first.
   :::
 
-    1. Run the following command to open up Goose's configurations:
+    1. Run the following command to open up goose's configurations:
     ```sh
     goose configure
     ```
@@ -572,7 +570,7 @@ You can remove installed extensions.
 
 ## Starting Session with Extensions
 
-You can start a tailored Goose session with specific extensions directly from the CLI. 
+You can start a tailored goose session with specific extensions directly from the CLI. 
 
 :::info Notes
 * The extension will not be installed. It will only be enabled for the current session.
@@ -664,6 +662,6 @@ goose session --with-streamable-http-extension "https://example.com/streamable"
 
 ## Developing Extensions
 
-Goose extensions are implemented with MCP, a standard protocol that allows AI models and agents to securely connect with local or remote resources. Learn how to build your own [extension as an MCP server](https://modelcontextprotocol.io/quickstart/server).
+goose extensions are implemented with MCP, a standard protocol that allows AI models and agents to securely connect with local or remote resources. Learn how to build your own [extension as an MCP server](https://modelcontextprotocol.io/quickstart/server).
 
 [extensions-directory]: /extensions

--- a/documentation/docs/guides/config-files.md
+++ b/documentation/docs/guides/config-files.md
@@ -29,7 +29,7 @@ The following settings can be configured at the root level of your config.yaml f
 | `GOOSE_PROVIDER` | Primary [LLM provider](/docs/getting-started/providers) | "anthropic", "openai", etc. | None | Yes |
 | `GOOSE_MODEL` | Default model to use | Model name (e.g., "claude-3.5-sonnet", "gpt-4") | None | Yes |
 | `GOOSE_TEMPERATURE` | Model response randomness | Float between 0.0 and 1.0 | Model-specific | No |
-| `GOOSE_MODE` | [Tool execution behavior](/docs/guides/goose-permissions) | "auto", "approve", "chat", "smart_approve" | "smart_approve" | No |
+| `GOOSE_MODE` | [Tool execution behavior](/docs/guides/goose-permissions) | "auto", "approve", "chat", "smart_approve" | "auto" | No |
 | `GOOSE_MAX_TURNS` | [Maximum number of turns](/docs/guides/sessions/smart-context-management#maximum-turns) allowed without user input | Integer (e.g., 10, 50, 100) | 1000 | No |
 | `GOOSE_LEAD_PROVIDER` | Provider for lead model in [lead/worker mode](/docs/guides/environment-variables#leadworker-model-configuration) | Same as `GOOSE_PROVIDER` options | Falls back to `GOOSE_PROVIDER` | No |
 | `GOOSE_LEAD_MODEL` | Lead model for lead/worker mode | Model name | None | No |

--- a/documentation/docs/guides/goose-permissions.md
+++ b/documentation/docs/guides/goose-permissions.md
@@ -1,14 +1,14 @@
 ---
 sidebar_position: 25
-title: Goose Permission Modes
-sidebar_label: Goose Permissions
+title: goose Permission Modes
+sidebar_label: goose Permissions
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import { PanelLeft } from 'lucide-react';
+import { PanelLeft, Tornado } from 'lucide-react';
 
-Goose’s permissions determine how much autonomy it has when modifying files, using extensions, and performing automated actions. By selecting a permission mode, you have full control over how Goose interacts with your development environment.
+goose’s permissions determine how much autonomy it has when modifying files, using extensions, and performing automated actions. By selecting a permission mode, you have full control over how goose interacts with your development environment.
 
 <details>
   <summary>Permission Modes Video Walkthrough</summary>
@@ -24,19 +24,18 @@ Goose’s permissions determine how much autonomy it has when modifying files, u
 
 ## Permission Modes
 
-| Mode               | Description                                                                                           | Best For                                                                                   |
-|--------------------|-------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
-| **Completely Autonomous**           | Goose can modify files, use extensions, and delete files **without requiring approval**.              | Users who want **full automation** and seamless integration into their workflow.           |
-| **Manual Approval**| Goose **asks for confirmation** before using any tools or extensions.                                 | Users who want to **review and approve** every change and tool usage.                      |
-| **Smart Approval** | Goose uses a risk-based approach to **automatically approve low-risk actions** and **flag others** for approval. | Users who want a **balanced mix of autonomy and oversight** based on the action’s impact. |
-| **Chat Only**      | Goose **only engages in chat**, with no extension use or file modifications.                          | Users who prefer a **conversational AI experience** for analysis, writing, and reasoning tasks without automation.                    |
-       |
+| Mode | Description | Best For |
+|------|-------------|----------|
+| **Completely Autonomous** | goose can modify files, use extensions, and delete files **without requiring approval** | Users who want **full automation** and seamless integration into their workflow |
+| **Manual Approval** | goose **asks for confirmation** before using any tools or extensions (supports granular [tool permissions](/docs/guides/managing-tools/tool-permissions)) | Users who want to **review and approve** every change and tool usage |
+| **Smart Approval** | goose uses a risk-based approach to **automatically approve low-risk actions** and **flag others** for approval (supports granular [tool permissions](/docs/guides/managing-tools/tool-permissions))  | Users who want a **balanced mix of autonomy and oversight** based on the action’s impact |
+| **Chat Only** | goose **only engages in chat**, with no extension use or file modifications | Users who prefer a **conversational AI experience** for analysis, writing, and reasoning tasks without automation |
 
 :::warning
 `Autonomous Mode` is applied by default.
 :::
 
-## Configuring Goose Mode
+## Configuring goose mode
 
 Here's how to configure:
 
@@ -48,7 +47,7 @@ Here's how to configure:
      <Tabs groupId="method">
       <TabItem value="session" label="In Session" default>
 
-      Click the Goose Mode option from the bottom menu. 
+      Click the <Tornado className="inline" size={16} /> mode button from the bottom menu. 
       </TabItem>
       <TabItem value="settings" label="From Settings">
         1. Click the <PanelLeft className="inline" size={16} /> button on the top-left to open the sidebar.
@@ -76,7 +75,7 @@ Here's how to configure:
         goose configure
         ```
 
-        2. Select `Goose Settings` from the menu and press Enter.
+        2. Select `goose settings` from the menu and press Enter.
 
         ```sh
         ┌ goose-configure
@@ -87,41 +86,47 @@ Here's how to configure:
         | ○ Toggle Extensions
         | ○ Remove Extension
         // highlight-start
-        | ● Goose Settings (Set the Goose Mode, Tool Output, Experiment and more)
+        | ● goose settings (Set the goose mode, Tool Output, Tool Permissions, Experiment, goose recipe github repo and more)
         // highlight-end
         └
         ```
 
-        3. Choose `Goose Mode` from the menu and press Enter.
+        3. Choose `goose mode` from the menu and press Enter.
 
         ```sh
         ┌   goose-configure
         │
         ◇  What would you like to configure?
-        │  Goose Settings
+        │  goose settings 
         │
         ◆  What setting would you like to configure?
         // highlight-start
-        │  ● Goose Mode (Configure Goose mode)
+        │  ● goose mode (Configure goose mode)
         // highlight-end
-        |  ○ Tool Output
+        │  ○ Router Tool Selection Strategy 
+        │  ○ Tool Permission 
+        │  ○ Tool Output 
+        │  ○ Max Turns 
+        │  ○ Toggle Experiment 
+        │  ○ goose recipe github repo 
+        │  ○ Scheduler Type 
         └
         ```
 
-        4.  Choose the Goose mode you would like to configure.
+        4.  Choose the goose mode you would like to configure.
 
         ```sh
         ┌   goose-configure
         │
         ◇  What would you like to configure?
-        │  Goose Settings
+        │  goose settings
         │
         ◇  What setting would you like to configure?
-        │  Goose Mode
+        │  goose mode
         │
-        ◆  Which Goose mode would you like to configure?
+        ◆  Which goose mode would you like to configure?
         // highlight-start
-        │  ● Auto Mode
+        │  ● Auto Mode (Full file modification, extension usage, edit, create and delete files freely)
         // highlight-end
         |  ○ Approve Mode
         |  ○ Smart Approve Mode    
@@ -135,8 +140,8 @@ Here's how to configure:
 </Tabs>
 
   :::info
-  If you choose `Manual` (in Goose Desktop) or `Approve Mode` (in Goose CLI), you will see "Allow" and "Deny" buttons in your session windows during tool calls. 
-  Goose will only ask for permission for tools that it deems are 'write' tools, e.g. any 'text editor write', 'text editor edit', 'bash - rm, cp, mv' commands. 
+  In manual and smart approval modes, you will see "Allow" and "Deny" buttons in your session windows during tool calls. 
+  goose will only ask for permission for tools that it deems are 'write' tools, e.g. any 'text editor write', 'text editor edit', 'bash - rm, cp, mv' commands. 
   
   Read/write approval makes best effort attempt at classifying read or write tools. This is interpreted by your LLM provider. 
   :::

--- a/documentation/docs/guides/subagents.mdx
+++ b/documentation/docs/guides/subagents.mdx
@@ -21,7 +21,7 @@ Subagents are independent instances that execute tasks while keeping your main c
 ## How to Use Subagents
 
 :::tip Autonomous Subagent Creation
-goose can autonomously decide to use subagents when it determines they would be beneficial for your task - you don't always need to explicitly request them. This happens automatically in autonomous mode (the default). Subagents are disabled in chat-only mode.
+goose can autonomously decide to use subagents when it determines they would be beneficial for your task - you don't always need to explicitly request them. This happens automatically in autonomous [permission mode](/docs/guides/goose-permissions) (the default). Subagents are disabled in manual approval, smart approval, and chat-only modes.
 :::
 
 To use subagents, ask goose to delegate tasks using natural language. goose automatically decides when to spawn subagents and handles their lifecycle. You can:

--- a/documentation/docs/mcp/developer-mcp.md
+++ b/documentation/docs/mcp/developer-mcp.md
@@ -1,24 +1,25 @@
 ---
 title: Developer Extension
-description: Use Developer MCP Server as a Goose Extension
+description: Use Developer MCP Server as a goose Extension
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 import GooseBuiltinInstaller from '@site/src/components/GooseBuiltinInstaller';
+import { Tornado } from 'lucide-react';
 
 <YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/on_p-LeIrak" />
 
-The Developer extension allows Goose to automate developer-centric tasks such as file editing, shell command execution, and project setup. It also provides tools for [enhanced code editing](/docs/guides/enhanced-code-editing) and [codebase analysis](/docs/guides/codebase-analysis).
+The Developer extension allows goose to automate developer-centric tasks such as file editing, shell command execution, and project setup. It also provides tools for [enhanced code editing](/docs/guides/enhanced-code-editing) and [codebase analysis](/docs/guides/codebase-analysis).
 
-This tutorial will cover enabling and using the Developer MCP Server, which is a built-in Goose extension. 
+This tutorial will cover enabling and using the Developer MCP Server, which is a built-in goose extension. 
 
 
 ## Configuration
 
 :::info
-The Developer extension is already enabled by default when Goose is installed.
+The Developer extension is already enabled by default when goose is installed.
 :::
 
 <Tabs groupId="interface">
@@ -53,7 +54,7 @@ The Developer extension is already enabled by default when Goose is installed.
 
 ## Example Usage
 
-In this example, I'm going to have Goose automate setting up my JavaScript developer environment with Express, Mongoose, Nodemon, Dotenv and initialize Git.
+In this example, I'm going to have goose automate setting up my JavaScript developer environment with Express, Mongoose, Nodemon, Dotenv and initialize Git.
 
 :::info LLM
 Anthropic's Claude 4 Sonnet was used for this task.
@@ -62,7 +63,7 @@ Anthropic's Claude 4 Sonnet was used for this task.
 
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
-   1. Open a new session in Goose Desktop
+   1. Open a new session in goose Desktop
   </TabItem>
   <TabItem value="cli" label="goose CLI">
 
@@ -75,14 +76,14 @@ Anthropic's Claude 4 Sonnet was used for this task.
   </TabItem>
 </Tabs>
 
-### Goose Prompt
+### goose Prompt
 ```
 set up a new JavaScript project with Express, Mongoose, Nodemon, and Dotenv? Fetch the latest package versions, generate a README with those versions, and initialize Git
 ```
 
 After 1 minute, Goose was done setting up my entire dev environment! 🎉
 
-### Goose Output
+### goose Output
 
 ```md
 I'll help you set up a new JavaScript project with those dependencies. I'll break this down into steps:
@@ -154,3 +155,75 @@ curl x POST http://localhost:3000/api/users \
 
 Would you like me to add any additional features or make other improvements to the setup?
 ```
+
+## Configuring Access Controls
+
+By default, goose can run system commands with your user privileges and edit any accessible file **without your approval**. This is because goose runs in Autonomous permission mode by default and has access to the Developer extension's shell and file editing tools. While this configuration allows goose to work quickly and independently, there's potential for unexpected outcomes. Understanding the available access control features can help you configure goose to match your comfort level and specific needs.
+
+:::tip
+See the [Quick Setup Example](#quick-setup-example) below for some ways to configure more control over goose's behavior.
+:::
+
+### Developer Extension Tools
+
+The Developer extension provides these tools:
+
+| Tool | Description | Use Cases | Risk Level |
+|------|-------------|-----------|------------|
+| `shell` | Execute shell commands | Running tests, installing packages, git operations | ⚠️ High<br />Can run any system command with your user privileges |
+| `text_editor` | Read, write, and edit files | Code refactoring, creating files, updating configs | ⚠️ High<br />Can modify any accessible file |
+| `analyze` | Analyze code structure | Understanding codebase, finding dependencies | ✅ Low<br />Read-only code analysis |
+| `screen_capture` | Take screenshots | Debugging UI issues, documenting state | ✅ Low<br />Visual information only |
+| `image_processor` | Process and resize images | Optimizing assets, format conversion | ✅ Low<br />Image manipulation only |
+
+### Access Control Features
+
+You can layer multiple controls to match your risk tolerance and workflow:
+
+- **[goose Permission Modes](/docs/guides/goose-permissions)** control when goose asks for approval:
+
+  | Mode | Description | Use Cases |
+  |------|-------------|-----------|
+  | Autonomous<br />CLI: `auto` | No approval required | Best for experienced users in safe environments |
+  | Manual Approval<br />CLI: `approve` | Review every action | Recommended for sensitive work or when you want maximum control |
+  | Smart Approval<br />CLI: `smart_approve` | AI decides what needs review | Balanced approach |
+  | Chat Only<br />CLI: `chat` | Disable all tools | For maximum security and models that don't support tool-calling |
+
+- **[Tool Permissions](/docs/guides/managing-tools/tool-permissions)** let you set `Always allow`, `Ask before`, and `Never allow` permissions for individual extension tools when in Manual Approval or Smart Approval modes
+
+- **[.gooseignore files](/docs/guides/using-gooseignore)** restrict which files and directories goose can access (`.gitignore` files are fallback)
+
+:::tip Changing Modes In-Session
+You can change goose permission modes during a session without restarting:
+- **CLI**: Use the `/mode` command (e.g. `/mode approve`)
+- **Desktop**: Use the <Tornado className="inline" size={16} /> mode selector button in the bottom menu
+:::
+
+#### Quick Setup Example
+
+You might want more control over goose's operations when working with sensitive systems, exploring unfamiliar codebases, using untrusted models, or simply preferring to review actions before execution.
+
+Here's an example configuration that enables oversight:
+
+1. **Set the [permission mode](/docs/guides/goose-permissions)** to Smart Approval or Manual Approval:
+   ```yaml
+   # ~/.config/goose/config.yaml
+   GOOSE_MODE: smart_approve  # or approve
+   ```
+
+2. **Create a [`.gooseignore` file](/docs/guides/using-gooseignore)** in your project to protect sensitive files:
+   ```
+   .env*
+   secrets.*
+   *.key
+   *.pem
+   .git/
+   ```
+
+3. **Configure [tool permissions](/docs/guides/managing-tools/tool-permissions)** based on your needs
+
+As you become more comfortable with goose's behavior, you can adjust these settings to reduce friction while maintaining appropriate safeguards for your environment.
+
+:::info
+Also see the [Security Guide](/docs/guides/security/) for information about using goose safely.
+:::

--- a/documentation/docs/mcp/developer-mcp.md
+++ b/documentation/docs/mcp/developer-mcp.md
@@ -81,7 +81,7 @@ Anthropic's Claude 4 Sonnet was used for this task.
 set up a new JavaScript project with Express, Mongoose, Nodemon, and Dotenv? Fetch the latest package versions, generate a README with those versions, and initialize Git
 ```
 
-After 1 minute, Goose was done setting up my entire dev environment! 🎉
+After 1 minute, goose was done setting up my entire dev environment! 🎉
 
 ### goose Output
 

--- a/documentation/docs/quickstart.md
+++ b/documentation/docs/quickstart.md
@@ -305,4 +305,4 @@ Here are some ideas for next steps:
 * Continue your session with goose and improve your game (styling, functionality, etc).
 * Browse other available [extensions](/extensions) and install more to enhance goose's functionality even further.
 * Provide goose with a [set of hints](/docs/guides/using-goosehints) to use within your sessions.
-
+* See how you can set up [access controls](/docs/mcp/developer-mcp#configuring-access-controls) if you don't want goose to work autonomously.


### PR DESCRIPTION
## Summary
This PR document access controls in the context of the default autonomous mode and Developer extension. Also lowercase "goose".

## Documentation updates:

- `documentation/docs/getting-started/using-extensions.md`: 
  - Add Access Control warning with link to access controls section
  - Mention Todo and Extension Manager platform extensions
- `documentation/docs/guides/config-files.md`:
  - Changed `GOOSE_MODE` default from "smart_approve" to "auto" (per [agent.rs](https://github.com/block/goose/blob/main/crates/goose/src/agents/agent.rs#L265))
- `documentation/docs/guides/goose-permissions.md`: 
  - Clarify that Manual and Smart Approval modes support tool permissions (per [permission_inspector.rs](https://github.com/block/goose/blob/main/crates/goose/src/permission/permission_inspector.rs#L144-L170)) and prompt for approval
- `documentation/docs/guides/subagents.mdx`:
  - Clarify subagents aren't available in manual, smart, or chat modes (per [reply_parts.rs](https://github.com/block/goose/blob/main/crates/goose/src/agents/reply_parts.rs#L123-L127))
- `documentation/docs/mcp/developer-mcp.md`: 
  - Add "Configuring Access Controls" section
- `documentation/docs/quickstart.md`:
  - Add "Next Steps" bullet with link to access controls section

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [X] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
Manual testing with goose codebase analysis

### Related Issues
Relates to #5142

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211843573790824