### PR TITLE
Fetch less and use the right SHA

### DIFF
--- a/.github/actions/generate-release-pr-body/action.yaml
+++ b/.github/actions/generate-release-pr-body/action.yaml
@@ -29,7 +29,7 @@ runs:
         PRIOR_REF: ${{ inputs.prior_ref }}
         TEMPLATE_FILE: "${{ github.action_path }}/pr_body_template.txt"
       run: |
-        git fetch origin --tags
+        git fetch origin "$HEAD_REF" "$PRIOR_REF"
 
         {
           sed -e "s/{{VERSION}}/${VERSION}/g" \

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -58,7 +58,9 @@ jobs:
 
         just prepare-release $VERSION
         BRANCH_NAME=$(git branch --show-current)
+        HEAD_REF=$(git rev-parse HEAD)
         echo "branch_name=$BRANCH_NAME" >> $GITHUB_ENV
+        echo "head_ref=$HEAD_REF" >> $GITHUB_ENV
         echo "Branch: $BRANCH_NAME"
 
     - name: push release branch
@@ -69,7 +71,7 @@ jobs:
       uses: ./.github/actions/generate-release-pr-body
       with:
         version: ${{ env.version }}
-        head_ref: ${{ github.event.pull_request.head.sha || github.sha }}
+        head_ref: ${{ env.head_ref }}
         prior_ref: ${{ env.prior_ref }}
 
     - name: Create Pull Request

--- a/.github/workflows/merge-release-pr-on-tag.yaml
+++ b/.github/workflows/merge-release-pr-on-tag.yaml
@@ -114,7 +114,7 @@ jobs:
       env:
         BRANCH: ${{ steps.version.outputs.branch }}
       run: |
-        git fetch origin
+        git fetch origin "$BRANCH"
 
         BRANCH_SHA=$(git rev-parse "origin/$BRANCH")
         echo "branch_sha=$BRANCH_SHA" >> $GITHUB_OUTPUT


### PR DESCRIPTION
- speed up fetches by only fetching what we need
- set the right head SHA when generating the release log