### PR TITLE
feat: remove hints from recipe prompts

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1330,7 +1330,6 @@ impl Agent {
             .with_extensions(extensions_info.into_iter())
             .with_frontend_instructions(self.frontend_instructions.lock().await.clone())
             .with_extension_and_tool_counts(extension_count, tool_count)
-            .with_hints(&std::env::current_dir()?)
             .build();
 
         let recipe_prompt = prompt_manager.get_recipe_prompt().await;


### PR DESCRIPTION
Right now hints are included in the prompt for recipes. I think it makes sense for recipes to be as consistent as possible in any dir, so this change removes hints.

Anything we should consider here?