### PR TITLE
fix: disallow runaway subagent chains

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -412,6 +412,20 @@ impl Agent {
         cancellation_token: Option<CancellationToken>,
         session: &Session,
     ) -> (String, Result<ToolCallResult, ErrorData>) {
+        if session.session_type == crate::session::SessionType::SubAgent
+            && (tool_call.name == DYNAMIC_TASK_TOOL_NAME_PREFIX
+                || tool_call.name == SUBAGENT_EXECUTE_TASK_TOOL_NAME)
+        {
+            return (
+                request_id,
+                Err(ErrorData::new(
+                    ErrorCode::INVALID_REQUEST,
+                    "Subagents cannot create other subagents".to_string(),
+                    None,
+                )),
+            );
+        }
+
         if tool_call.name == PLATFORM_MANAGE_SCHEDULE_TOOL_NAME {
             let arguments = tool_call
                 .arguments


### PR DESCRIPTION
We need to disable subagents being able to create other subagents. It might be cleaner to not even advertise the tool, but looks like it would be a bigger refactor to do so

@tlongwell-block @DOsinga Let me know if this looks like a good fix to you for the immediate term

Demo:

<img width="3552" height="1430" alt="Screenshot 2025-11-10 at 4 27 06 PM" src="https://github.com/user-attachments/assets/bc712a10-909f-4f02-b6c5-bbd8f74e8da8" />
