### PR TITLE
bump openapi version directly

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -300,9 +300,12 @@ prepare-release version:
     # see --workspace flag https://doc.rust-lang.org/cargo/commands/cargo-update.html
     # used to update Cargo.lock after we've bumped versions in Cargo.toml
     @cargo update --workspace
-    @just generate-openapi
+    @just set-openapi-version {{ version }}
     @git add Cargo.toml Cargo.lock ui/desktop/package.json ui/desktop/package-lock.json ui/desktop/openapi.json
     @git commit --message "chore(release): release version {{ version }}"
+
+set-openapi-version version:
+    @jq '.info.version |= "{{ version }}"' ui/desktop/openapi.json > ui/desktop/openapi.json.tmp && mv ui/desktop/openapi.json.tmp ui/desktop/openapi.json
 
 # extract version from Cargo.toml
 get-tag-version:

--- a/crates/goose-server/src/bin/generate_schema.rs
+++ b/crates/goose-server/src/bin/generate_schema.rs
@@ -19,7 +19,7 @@ fn main() {
         fs::create_dir_all(parent).unwrap();
     }
 
-    fs::write(&output_path, &schema).unwrap();
+    fs::write(&output_path, format!("{schema}\n")).unwrap();
     eprintln!(
         "Successfully generated OpenAPI schema at {}",
         output_path.canonicalize().unwrap().display()

--- a/scripts/check-openapi-schema.sh
+++ b/scripts/check-openapi-schema.sh
@@ -8,7 +8,7 @@ echo "🔍 Checking OpenAPI schema is up-to-date..."
 
 # Check if the generated schema differs from the committed version
 echo "🔍 Comparing generated schema with committed version..."
-if ! git diff --exit-code ui/desktop/openapi.json ui/desktop/src/api/; then
+if ! git diff --ignore-space-change --exit-code ui/desktop/openapi.json ui/desktop/src/api/; then
   echo ""
   echo "❌ OpenAPI schema is out of date!"
   echo ""


### PR DESCRIPTION
In the release branch workflow, we need to bump the openapi version. Doing so by regenerating the schema means doing a rust build plus installing the open-api-ts packages that generate our sdk. But we only want to bump the version -- the usual CI pipeline should handle the type regeneration.