### PR TITLE
Unlist VS Code extension tutorials from MCP and experimental sections

### DIFF
--- a/documentation/blog/2025-03-21-goose-vscode/index.mdx
+++ b/documentation/blog/2025-03-21-goose-vscode/index.mdx
@@ -9,7 +9,7 @@ import ArchivedExtensionWarning from '@site/src/components/ArchivedExtensionWarn
 
 ![blog cover](vscodestream.png)
 
-<ArchivedExtensionWarning extensionName="VS Code MCP" />
+<ArchivedExtensionWarning extensionName="VS Code MCP" repoUrl="https://github.com/block/vscode-mcp" />
 
 Want to use Goose in VS Code? On the recent [Wild Goose Case livestream](https://www.youtube.com/watch?v=hG7AnTw-GLU&ab_channel=BlockOpenSource), hosts [Ebony Louis](https://www.linkedin.com/in/ebonylouis/) and [Adewale Abati](https://www.linkedin.com/in/acekyd/) were joined by [Andrew Gertig](https://www.linkedin.com/in/andrewgertig/), Engineering Lead at Cash App, as he demonstrated the new VSCode MCP and how it brings powerful Goose-assisted coding capabilities directly into VS Code.
 

--- a/documentation/blog/2025-03-21-goose-vscode/index.mdx
+++ b/documentation/blog/2025-03-21-goose-vscode/index.mdx
@@ -5,7 +5,11 @@ authors:
     - tania
 ---
 
+import ArchivedExtensionWarning from '@site/src/components/ArchivedExtensionWarning';
+
 ![blog cover](vscodestream.png)
+
+<ArchivedExtensionWarning extensionName="VS Code MCP" />
 
 Want to use Goose in VS Code? On the recent [Wild Goose Case livestream](https://www.youtube.com/watch?v=hG7AnTw-GLU&ab_channel=BlockOpenSource), hosts [Ebony Louis](https://www.linkedin.com/in/ebonylouis/) and [Adewale Abati](https://www.linkedin.com/in/acekyd/) were joined by [Andrew Gertig](https://www.linkedin.com/in/andrewgertig/), Engineering Lead at Cash App, as he demonstrated the new VSCode MCP and how it brings powerful Goose-assisted coding capabilities directly into VS Code.
 
@@ -52,8 +56,6 @@ The features don't end here. The team is actively exploring several exciting fea
 
 # Community and Contributing
 The project is open source, and welcomes contributions from the community. If you'd like to support the project or directly contribute to it, you can check out [the VSCode MCP repo on GitHub](https://github.com/block/vscode-mcp), or [join the Block Open Source Discord](https://discord.gg/goose-oss) if you'd like to ask the team any questions or start discussions.
-
-You can also follow the [tutorial showing you how to integrate VS Code with Goose](/docs/mcp/vs-code-mcp).
 
 <head>
   <meta property="og:title" content="Cracking the Code in VS Code" />

--- a/documentation/blog/2025-03-26-mcp-security/index.md
+++ b/documentation/blog/2025-03-26-mcp-security/index.md
@@ -58,7 +58,7 @@ A quick glance at an MCP directory like Glama can save you from crying on your o
 <head>
   <meta property="og:title" content="How to Determine If An MCP Server Is Safe" />
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="https://block.github.io/goose/blog/2025/03/21/goose-vscode" />
+  <meta property="og:url" content="https://block.github.io/goose/blog/2025/03/26/mcp-security" />
   <meta property="og:description" content="Before you plug your AI agent into just any MCP server, here's how to check if it's actually safe." />
   <meta property="og:image" content="http://block.github.io/goose/assets/images/mcpsafety-87eb7ace7163a5edbe068ff75b79a199.png" />
   <meta name="twitter:card" content="summary_large_image" />

--- a/documentation/blog/2025-04-01-top-5-mcp-servers/index.mdx
+++ b/documentation/blog/2025-04-01-top-5-mcp-servers/index.mdx
@@ -65,7 +65,7 @@ This works differently from the Knowledge Graph extension even though they both 
 
 ## VS Code Extension: Your Favorite Editor, Connected
 
-<ArchivedExtensionWarning extensionName="VS Code Extension" />
+<ArchivedExtensionWarning extensionName="VS Code Extension" repoUrl="https://github.com/block/vscode-mcp" />
 
 One of the biggest points in conversations with people especially around vibe coding, is finding ways to track what changes are being made. While version control is always recommended, sometimes I want to be able to stop or change direction before going too far. The [VS Code Extension](https://github.com/block/vscode-mcp) alongside other features, allows me to preview the diff of my code changes before I commit them. 
 

--- a/documentation/blog/2025-04-01-top-5-mcp-servers/index.mdx
+++ b/documentation/blog/2025-04-01-top-5-mcp-servers/index.mdx
@@ -6,6 +6,8 @@ authors:
     - adewale
 ---
 
+import ArchivedExtensionWarning from '@site/src/components/ArchivedExtensionWarning';
+
 ![blog cover](mcp-servers-cover.png)
 
 As a developer, finding the right tools that seamlessly work together can feel like discovering a superpower. And when you have a working process, it can sometimes be difficult to try out new tools.
@@ -63,7 +65,9 @@ This works differently from the Knowledge Graph extension even though they both 
 
 ## VS Code Extension: Your Favorite Editor, Connected
 
-One of the biggest points in conversations with people especially around vibe coding, is finding ways to track what changes are being made. While version control is always recommended, sometimes I want to be able to stop or change direction before going too far. The [VS Code Extension](/docs/mcp/vs-code-mcp) alongside other features, allows me to preview the diff of my code changes before I commit them. 
+<ArchivedExtensionWarning extensionName="VS Code Extension" />
+
+One of the biggest points in conversations with people especially around vibe coding, is finding ways to track what changes are being made. While version control is always recommended, sometimes I want to be able to stop or change direction before going too far. The [VS Code Extension](https://github.com/block/vscode-mcp) alongside other features, allows me to preview the diff of my code changes before I commit them. 
 
 I can choose to accept or refuse these changes, or tell Goose to try something else before any actual changes are made.
 

--- a/documentation/docs/experimental/index.md
+++ b/documentation/docs/experimental/index.md
@@ -30,11 +30,6 @@ The list of experimental features may change as Goose development progresses. So
       link="/docs/experimental/goose-mobile"
     />
     <Card 
-      title="VS Code Extension"
-      description="An experimental extension enabling Goose to work within VS Code."
-      link="/docs/experimental/vs-code-extension"
-    />
-    <Card 
       title="Automatic Multi-Model Switching"
       description="Intelligent, context-aware switching between models based on conversation content, complexity, and tool usage patterns."
       link="/docs/guides/multi-model/autopilot"

--- a/documentation/docs/experimental/vs-code-extension.md
+++ b/documentation/docs/experimental/vs-code-extension.md
@@ -2,6 +2,7 @@
 title: VS Code Extension
 sidebar_label: VS Code Extension
 sidebar_position: 4
+unlisted: true
 ---
 
 import Tabs from '@theme/Tabs';

--- a/documentation/docs/mcp/vs-code-mcp.md
+++ b/documentation/docs/mcp/vs-code-mcp.md
@@ -1,6 +1,7 @@
 ---
 title: VS Code Extension
 description: Use VS Code MCP Server as a Goose Extension for file operations and VS Code integration
+unlisted: true
 ---
 
 import Tabs from '@theme/Tabs';

--- a/documentation/src/components/ArchivedExtensionWarning.tsx
+++ b/documentation/src/components/ArchivedExtensionWarning.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Admonition from '@theme/Admonition';
+
+interface ArchivedExtensionWarningProps {
+  extensionName?: string;
+}
+
+export default function ArchivedExtensionWarning({ extensionName }: ArchivedExtensionWarningProps) {
+  const message = extensionName 
+    ? `The ${extensionName} is no longer actively maintained. The repository remains available for reference, but may not be compatible with current versions of goose.`
+    : 'This extension is no longer actively maintained. The repository remains available for reference, but may not be compatible with current versions of goose.';
+
+  return (
+    <Admonition type="warning" title="Archived Extension">
+      {message}
+    </Admonition>
+  );
+}

--- a/documentation/src/components/ArchivedExtensionWarning.tsx
+++ b/documentation/src/components/ArchivedExtensionWarning.tsx
@@ -3,16 +3,23 @@ import Admonition from '@theme/Admonition';
 
 interface ArchivedExtensionWarningProps {
   extensionName?: string;
+  repoUrl?: string;
 }
 
-export default function ArchivedExtensionWarning({ extensionName }: ArchivedExtensionWarningProps) {
-  const message = extensionName 
-    ? `The ${extensionName} is no longer actively maintained. The repository remains available for reference, but may not be compatible with current versions of goose.`
-    : 'This extension is no longer actively maintained. The repository remains available for reference, but may not be compatible with current versions of goose.';
-
+export default function ArchivedExtensionWarning({ extensionName, repoUrl }: ArchivedExtensionWarningProps) {
+  const prefix = extensionName ? `The ${extensionName} is` : 'This extension is';
+  
   return (
     <Admonition type="warning" title="Archived Extension">
-      {message}
+      {prefix} no longer actively maintained. The{' '}
+      {repoUrl ? (
+        <a href={repoUrl} target="_blank" rel="noopener noreferrer">
+          repository
+        </a>
+      ) : (
+        'repository'
+      )}{' '}
+      remains available for reference, but may not be compatible with current versions of goose.
     </Admonition>
   );
 }

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -590,17 +590,6 @@
     "environmentVariables": []
   },
   {
-    "id": "vscode",
-    "name": "VSCode",
-    "description": "Provides a VSCode IDE integration for development workflows",
-    "command": "npx vscode-mcp-server",
-    "link": "https://github.com/block/vscode-mcp",
-    "installation_notes": "Install using npx package manager.",
-    "is_builtin": false,
-    "endorsed": true,
-    "environmentVariables": []
-  },
-  {
     "id": "youtube-transcript-mcp",
     "name": "YouTube Transcript",
     "description": "YouTube video transcript extraction",


### PR DESCRIPTION
## Summary
Getting a lot of people trying to use the VS Code MCP servers but they're archived. 



### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

