### PR TITLE
docs: add GOOSE_PATH_ROOT environment variable documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,6 +252,21 @@ reuse it. For things like automations or to test without doing official setup, y
 set the relevant env vars for that provider. For example `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
 or `DATABRICKS_HOST`. Refer to the provider details for more info on required keys.
 
+### Isolating Test Environments
+
+When testing changes or running multiple goose configurations, use `GOOSE_PATH_ROOT` to isolate your data:
+
+```bash
+# Test with a clean environment
+export GOOSE_PATH_ROOT="/tmp/goose-test"
+./target/debug/goose session
+
+# Or for a single command
+GOOSE_PATH_ROOT="/tmp/goose-dev" cargo run -p goose-cli -- session
+```
+
+This creates isolated `config/`, `data/`, and `state/` directories under the specified path, preventing your test sessions from affecting your main goose installation. See the [environment variables guide](./documentation/docs/guides/environment-variables.md#development--testing) for more details.
+
 ## Enable traces in goose with [locally hosted Langfuse](https://langfuse.com/docs/deployment/self-host)
 
 - Start a local Langfuse using the docs [here](https://langfuse.com/self-hosting/docker-compose). Create an organization and project and create API credentials.

--- a/documentation/docs/guides/environment-variables.md
+++ b/documentation/docs/guides/environment-variables.md
@@ -380,6 +380,37 @@ export ALPHA_FEATURES=true
 ALPHA_FEATURES=true goose session
 ```
 
+## Development & Testing
+
+These variables are primarily used for development, testing, and debugging goose itself.
+
+| Variable | Purpose | Values | Default |
+|----------|---------|---------|---------|
+| `GOOSE_PATH_ROOT` | Override the root directory for all goose data, config, and state files | Absolute path to directory | Platform-specific defaults |
+
+**Default locations:**
+- macOS: `~/Library/Application Support/Block/goose/`
+- Linux: `~/.local/share/goose/`
+- Windows: `%APPDATA%\Block\goose\`
+
+When set, goose creates `config/`, `data/`, and `state/` subdirectories under the specified path. Useful for isolating test environments, running multiple configurations, or CI/CD pipelines.
+
+**Examples**
+
+```bash
+# Temporary test environment
+export GOOSE_PATH_ROOT="/tmp/goose-test"
+
+# Isolated environment for a single command
+GOOSE_PATH_ROOT="/tmp/goose-isolated" goose run --recipe my-recipe.yaml
+
+# CI/CD usage
+GOOSE_PATH_ROOT="$(mktemp -d)" goose run --recipe integration-test.yaml
+
+# Use with developer tools
+GOOSE_PATH_ROOT="/tmp/goose-test" ./scripts/goose-db-helper.sh status
+```
+
 ## Variables Controlled by goose
 
 These variables are automatically set by goose during command execution.


### PR DESCRIPTION
Add documentation for the GOOSE_PATH_ROOT environment variable in the Development & Testing section of the environment variables guide.

This variable allows users to override the default directory structure for goose data, config, and state files - useful for testing, development, CI/CD pipelines, and running multiple isolated configurations.




### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

