### PR TITLE
Update prompt injection detection metrics (due to errors exporting to datadog)

### DIFF
--- a/crates/goose/src/agents/tool_execution.rs
+++ b/crates/goose/src/agents/tool_execution.rs
@@ -87,9 +87,8 @@ impl Agent {
                                 tracing::info!(
                                     counter.goose.prompt_injection_user_decisions = 1,
                                     decision = ?confirmation.permission,
-                                    "🔒 User security decision: {:?} for finding ID: {}",
-                                    confirmation.permission,
-                                    finding_id
+                                    finding_id = %finding_id,
+                                    "User security decision"
                                 );
                             }
 

--- a/crates/goose/src/security/mod.rs
+++ b/crates/goose/src/security/mod.rs
@@ -49,7 +49,7 @@ impl SecurityManager {
         if !self.is_prompt_injection_detection_enabled() {
             tracing::debug!(
                 counter.goose.prompt_injection_scanner_disabled = 1,
-                "🔓 Security scanning disabled"
+                "Security scanning disabled"
             );
             return Ok(vec![]);
         }
@@ -57,7 +57,7 @@ impl SecurityManager {
         let scanner = self.scanner.get_or_init(|| {
             tracing::info!(
                 counter.goose.prompt_injection_scanner_enabled = 1,
-                "🔓 Security scanner initialized and enabled"
+                "Security scanner initialized and enabled"
             );
             PromptInjectionScanner::new()
         });
@@ -96,9 +96,9 @@ impl SecurityManager {
                         threshold = config_threshold,
                         "{}",
                         if above_threshold {
-                            "🔒 Current tool call flagged as malicious after security analysis (above threshold)"
+                            "Current tool call flagged as malicious after security analysis (above threshold)"
                         } else {
-                            "🔒 Security finding below threshold - logged but not blocking execution"
+                            "Security finding below threshold - logged but not blocking execution"
                         }
                     );
                     if above_threshold {


### PR DESCRIPTION
## Summary
There were errors exporting metrics to Datadog, although local testing didn't cause any issues which makes it harder to troubleshoot. Suspicion is that the issues may be due to formatted string messages with `{}` placeholders, `gauge.goose.*` as attribute keys, newlines in explanation strings, or emojis in message strings. 

Part of error log (not super descriptive):
```
Field | Value
-- | --
attributes.message | Failed to export metrics
attributes.reason | Metrics exporter otlp failed with http request failed with error sending request for url (xxx)
```

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
No AI assistance on this PR

### Testing
Manual testing - I set up a local Docker OTLP collector to capture and inspect the raw metric payloads from goose, which allowed me to verify that the prompt injection metrics were emitted correctly (along with looking at the already existing metrics). 


<img width="791" height="629" alt="Screenshot 2025-11-12 at 4 21 41 pm" src="https://github.com/user-attachments/assets/4679dddb-2f7b-4bf8-ba9d-e5af58ff2b82" />

