### PR TITLE
Fix documentation-only change detection for push events

### DIFF
--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -33,11 +33,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
+          fetch-depth: 0
 
       - name: Check for code changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # pin@v3
         id: filter
         with:
+          base: ${{ github.event.before || github.event.pull_request.base.sha }}
           filters: |
             code:
               - '!documentation/**'


### PR DESCRIPTION
- Add fetch-depth: 0 to get full git history for proper comparison
- Add explicit base parameter to paths-filter for push events
- Ensures tests are skipped when doc-only PRs merge to main

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance


merging to main takes too long for docs PRs and blogs. Hoping this does the trick.