### PR TITLE
Bump auto scroll threshold

### DIFF
--- a/ui/desktop/src/components/ui/scroll-area.tsx
+++ b/ui/desktop/src/components/ui/scroll-area.tsx
@@ -46,7 +46,7 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
     const isActivelyScrollingRef = React.useRef(false);
     const scrollTimeoutRef = React.useRef<number | null>(null);
 
-    const BOTTOM_SCROLL_THRESHOLD = 100;
+    const BOTTOM_SCROLL_THRESHOLD = 200;
 
     const isAtBottom = React.useCallback(() => {
       if (!viewportRef.current) return false;


### PR DESCRIPTION
## Summary
Noticed sometimes the auto scroll would get out of sync if the streaming response pushed the cursor higher than 100 pixels. Bumping it to 200 helps avoid this.

Tested locally works much better.
