### PR TITLE
Run smoke tests on a free runner

### DIFF
--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -46,7 +46,7 @@ jobs:
 
   build-binary:
     name: Build Release Binary
-    runs-on: goose
+    runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.code == 'true' || github.event_name == 'workflow_dispatch'
     steps:


### PR DESCRIPTION
The goal is to remove the `goose` runner from the project, as it really isn't needed.