### PR TITLE
Don't show update tray icon if GOOSE_VERSION is set

### DIFF
--- a/ui/desktop/src/utils/autoUpdater.ts
+++ b/ui/desktop/src/utils/autoUpdater.ts
@@ -469,6 +469,10 @@ function sendStatusToWindow(event: string, data?: unknown) {
 function updateTrayIcon(hasUpdate: boolean) {
   if (!trayRef) return;
 
+  if (process.env.GOOSE_VERSION) {
+    hasUpdate = false;
+  }
+
   const isDev = !app.isPackaged;
   let iconPath: string;
 


### PR DESCRIPTION
## Summary
Follows logic of the settings app updates by not showing an update in the tray icon if GOOSE_VERSION is set.
fixes https://github.com/block/goose/issues/5424
