### PR TITLE
Match lower case

### DIFF
--- a/crates/goose-mcp/src/mcp_server_runner.rs
+++ b/crates/goose-mcp/src/mcp_server_runner.rs
@@ -17,7 +17,7 @@ pub async fn run_mcp_server(name: &str) -> Result<()> {
 
     tracing::info!("Starting MCP server");
 
-    match name {
+    match name.to_lowercase().as_str() {
         "autovisualiser" => serve_and_wait(AutoVisualiserRouter::new()).await,
         "computercontroller" => serve_and_wait(ComputerControllerServer::new()).await,
         "developer" => serve_and_wait(DeveloperServer::new()).await,


### PR DESCRIPTION
For some reason some people have the developer extension upper cased and in recent refactors we stopped accepting that.