### PR TITLE
fix windows cli build

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -200,6 +200,8 @@ jobs:
               ls -la target/x86_64-pc-windows-gnu/release/
             "
 
+          sudo chown -R $USER:$USER target/
+
           # Verify build succeeded
           if [ ! -f "./target/x86_64-pc-windows-gnu/release/goose.exe" ]; then
             echo "❌ Windows CLI binary not found."


### PR DESCRIPTION
The docker step is creating the target/ directory, and it runs as root. I think this worked before most of the time because we cached something in target/ so the directory was pre-existing. It would also explain why it sometimes failed.