### PR TITLE
Handle spaces in extension names also

### DIFF
--- a/crates/goose-mcp/src/mcp_server_runner.rs
+++ b/crates/goose-mcp/src/mcp_server_runner.rs
@@ -17,7 +17,7 @@ pub async fn run_mcp_server(name: &str) -> Result<()> {
 
     tracing::info!("Starting MCP server");
 
-    match name.to_lowercase().as_str() {
+    match name.to_lowercase().replace(' ', "").as_str() {
         "autovisualiser" => serve_and_wait(AutoVisualiserRouter::new()).await,
         "computercontroller" => serve_and_wait(ComputerControllerServer::new()).await,
         "developer" => serve_and_wait(DeveloperServer::new()).await,


### PR DESCRIPTION
## Summary
Follow up for https://github.com/block/goose/pull/5763 to add removing spaces also like "Computer Controller" to "computercontroller"

