### PR TITLE
[MCP-UI] proxy add Referrer-Policy HTTP response header

### DIFF
--- a/crates/goose-server/src/routes/mcp_ui_proxy.rs
+++ b/crates/goose-server/src/routes/mcp_ui_proxy.rs
@@ -34,7 +34,13 @@ async fn mcp_ui_proxy(
     }
 
     (
-        [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+        [
+            (header::CONTENT_TYPE, "text/html; charset=utf-8"),
+            (
+                header::HeaderName::from_static("referrer-policy"),
+                "no-referrer",
+            ),
+        ],
         Html(MCP_UI_PROXY_HTML),
     )
         .into_response()

--- a/crates/goose-server/src/routes/templates/mcp_ui_proxy.html
+++ b/crates/goose-server/src/routes/templates/mcp_ui_proxy.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8"/>
+    <meta name="referrer" content="no-referrer"/>
     <!-- 
       Permissive CSP so nested content is not constrained by top-level Goose Desktop CSP
       - default-src: Fallback for other directives (allows same-origin)

--- a/ui/desktop/forge.config.ts
+++ b/ui/desktop/forge.config.ts
@@ -4,7 +4,7 @@ const { resolve } = require('path');
 
 let cfg = {
   asar: true,
-  extraResource: ['src/bin', 'src/images', 'static'],
+  extraResource: ['src/bin', 'src/images'],
   icon: 'src/images/icon',
   // Windows specific configuration
   win32: {


### PR DESCRIPTION
## Summary
From copilot review of https://github.com/block/goose/pull/5487
Add a Referrer-Policy header/meta tag (e.g. no-referrer) on the proxy HTML to help prevent accidental leak if secret is ever in the URL.

