### PR TITLE
docs: acp clients

### DIFF
--- a/documentation/docs/guides/acp-clients.md
+++ b/documentation/docs/guides/acp-clients.md
@@ -59,7 +59,7 @@ Add goose to your Zed settings:
 ```json
 {
   "agent_servers": {
-    "goose CLI 🪿": {
+    "goose": {
       "command": "goose",
       "args": ["acp"],
       "env": {}
@@ -75,7 +75,7 @@ You should now be able to interact with goose directly in Zed. Your ACP sessions
 
 1. **Open the Agent Panel**: Click the sparkles agent icon in Zed's status bar
 2. **Create New Thread**: Click the `+` button to show thread options
-3. **Select goose**: Choose `New goose CLI 🪿` to start a new conversation with goose
+3. **Select goose**: Choose `New goose` to start a new conversation with goose
 4. **Start Chatting**: Interact with goose directly from the agent panel
 
 #### Advanced Configuration
@@ -89,12 +89,12 @@ The following Zed settings example configures two goose agent instances. This is
 ```json
 {
   "agent_servers": {
-    "goose CLI 🪿": {
+    "goose": {
       "command": "goose",
       "args": ["acp"],
       "env": {}
     },
-    "goose CLI (GPT-4o)": {
+    "goose (GPT-4o)": {
       "command": "goose",
       "args": ["acp"],
       "env": {
@@ -106,3 +106,31 @@ The following Zed settings example configures two goose agent instances. This is
   // more settings
 }
 ```
+
+## Additional Resources
+
+import ContentCardCarousel from '@site/src/components/ContentCardCarousel';
+import chooseYourIde from '@site/blog/2025-10-24-intro-to-agent-client-protocol-acp/choose-your-ide.png';
+
+<ContentCardCarousel
+  items={[
+    {
+      type: 'video',
+      title: 'Intro to Agent Client Protocol (ACP) | Vibe Code with goose',
+      description: 'Watch how ACP lets you seamlessly integrate goose into your code editor to streamline fragmented workflows.',
+      thumbnailUrl: 'https://img.youtube.com/vi/Hvu5KDTb6JE/maxresdefault.jpg',
+      linkUrl: 'https://www.youtube.com/watch?v=Hvu5KDTb6JE',
+      date: '2025-10-16',
+      duration: '50:23'
+    },
+   {
+      type: 'blog',
+      title: 'Intro to Agent Client Protocol (ACP): The Standard for AI Agent-Editor Integration',
+      description: 'Learn how to integrate AI agents like goose directly into your code editor via ACP, eliminating window-switching and vendor lock-in.',
+      thumbnailUrl: chooseYourIde,
+      linkUrl: '/goose/blog/2025/10/24/intro-to-agent-client-protocol-acp',
+      date: '2025-10-24',
+      duration: '7 min read'
+    }
+  ]}
+/>

--- a/documentation/docs/guides/acp-clients.md
+++ b/documentation/docs/guides/acp-clients.md
@@ -1,40 +1,43 @@
 ---
 sidebar_position: 105
-title: Using Goose in ACP Clients
-sidebar_label: Goose in ACP Clients
+title: Using goose in ACP Clients
+sidebar_label: goose in ACP Clients
 ---
 
-Client applications that support the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) can connect natively to Goose. This integration allows you to seamlessly interact with Goose directly from the client.
+Client applications that support the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) can connect natively to goose. This integration allows you to seamlessly interact with goose directly from the client.
 
 :::warning Experimental Feature
-ACP is an emerging specification that enables clients to communicate with AI agents like Goose. This feature has limited adoption and may evolve as the protocol develops.
+ACP is an emerging specification that enables clients to communicate with AI agents like goose. This feature has limited adoption and may evolve as the protocol develops.
 :::
 
 ## How It Works
-After you configure Goose as an agent in the ACP client, you gain access to Goose's core agent functionality, including its extensions and tools. 
+After you configure goose as an agent in the ACP client, you gain access to goose's core agent functionality, including its extensions and tools. 
 
-The client manages the Goose lifecycle automatically, including:
+The client manages the goose lifecycle automatically, including:
 
 - **Initialization**: The client runs the `goose acp` command to initialize the connection
-- **Communication**: The client communicates with Goose over stdio using JSON-RPC
-- **Multiple Sessions**: The client manages multiple concurrent Goose conversations simultaneously
+- **Communication**: The client communicates with goose over stdio using JSON-RPC
+- **Multiple Sessions**: The client manages multiple concurrent goose conversations simultaneously
 
 :::info Session Persistence
-ACP sessions are not currently persisted between client restarts or accessible from Goose session history.
+ACP sessions are saved to goose's session history where you can access and manage them using goose. However, these sessions aren't persisted in ACP clients, so you'll need to start a new conversation each time you restart the client.
 :::
 
-## Zed Editor Setup
+## Setup in ACP Clients
+Any editor or IDE that supports ACP can connect to goose as an agent server. Check the [official ACP clients list](https://agentclientprotocol.com/overview/clients) for available clients with links to their documentation.
 
-[Zed](https://zed.dev/) is the primary ACP-compatible editor. Here's how to integrate Goose:
+### Example: Zed Editor Setup
 
-### 1. Prerequisites
+ACP was originally developed by [Zed](https://zed.dev/). Here's how to configure goose in Zed:
 
-Ensure you have both Zed and Goose CLI installed:
+#### 1. Prerequisites
+
+Ensure you have both Zed and goose CLI installed:
 
 - **Zed**: Download from [zed.dev](https://zed.dev/)
-- **Goose CLI**: Follow the [installation guide](/docs/getting-started/installation)
+- **goose CLI**: Follow the [installation guide](/docs/getting-started/installation)
 
-  - ACP support requires version 1.8.0 or later - check with `goose --version`. 
+  - ACP support works best with version 1.14.2 or later - check with `goose --version`.
 
   - Temporarily run `goose acp` to test that ACP support is working:
 
@@ -45,18 +48,18 @@ Ensure you have both Zed and Goose CLI installed:
 
     Press `Ctrl+C` to exit the test.
 
-### 2. Configure Goose as a Custom Agent
+#### 2. Configure goose as a Custom Agent
 
-Add Goose to your Zed settings:
+Add goose to your Zed settings:
 
 1. Open Zed
-2. Press `Cmd+,` (macOS) or `Ctrl+,` (Linux/Windows) to open settings
+2. Press `Cmd+Option+,` (macOS) or `Ctrl+Alt+,` (Linux/Windows) to open the settings file
 3. Add the following configuration:
 
 ```json
 {
   "agent_servers": {
-    "Goose 🪿": {
+    "goose CLI 🪿": {
       "command": "goose",
       "args": ["acp"],
       "env": {}
@@ -66,32 +69,32 @@ Add Goose to your Zed settings:
 }
 ```
 
-You should now be able to interact with Goose directly in Zed. Your ACP sessions use the same extensions that are enabled in your Goose configuration, and your tools (Developer, Computer Controller, etc.) work the same way as in regular Goose sessions.
+You should now be able to interact with goose directly in Zed. Your ACP sessions use the same extensions that are enabled in your goose configuration, and your tools (Developer, Computer Controller, etc.) work the same way as in regular goose sessions.
 
-### 3. Start Using Goose in Zed
+#### 3. Start Using goose in Zed
 
 1. **Open the Agent Panel**: Click the sparkles agent icon in Zed's status bar
 2. **Create New Thread**: Click the `+` button to show thread options
-3. **Select Goose**: Choose `New Goose 🪿 Thread` to start a new conversation with Goose
-4. **Start Chatting**: Interact with Goose directly from the agent panel
+3. **Select goose**: Choose `New goose CLI 🪿` to start a new conversation with goose
+4. **Start Chatting**: Interact with goose directly from the agent panel
 
-### Advanced Configuration
+#### Advanced Configuration
 
-By default, Goose will use the provider and model defined in your [configuration file](/docs/guides/config-files). You can override this for specific ACP configurations using the `GOOSE_PROVIDER` and `GOOSE_MODEL` environment variables.
+By default, goose will use the provider and model defined in your [configuration file](/docs/guides/config-files). You can override this for specific ACP configurations using the `GOOSE_PROVIDER` and `GOOSE_MODEL` environment variables.
 
-The following Zed settings example configures two Goose agent instances. This is useful for:
+The following Zed settings example configures two goose agent instances. This is useful for:
 - Comparing model performance on the same task
 - Using cost-effective models for simple tasks and powerful models for complex ones
 
 ```json
 {
   "agent_servers": {
-    "Goose 🪿": {
+    "goose CLI 🪿": {
       "command": "goose",
       "args": ["acp"],
       "env": {}
     },
-    "Goose (GPT-4o)": {
+    "goose CLI (GPT-4o)": {
       "command": "goose",
       "args": ["acp"],
       "env": {


### PR DESCRIPTION
## Summary
This PR updates the "Using goose in ACP Clients" topic to reflect session persistence improvements and broader adoption.

Documentation updates:
- `documentation/docs/guides/acp-clients.md`: 
  - Update session persistence note to reflect that ACP sessions are saved to goose's session history (but not persisted in ACP clients)
  - Add "Setup in ACP Clients" section with link to official ACP clients list
  - Update minimum version recommendation to 1.14.2 for best experience (session persistence)
  - Update to sync with misc Zed editor changes
  - Lowercase "goose"

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
Manual testing

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211968427179928