### PR TITLE
Document New Window menu in macOS dock

### DIFF
--- a/documentation/docs/guides/sessions/session-management.md
+++ b/documentation/docs/guides/sessions/session-management.md
@@ -46,7 +46,9 @@ In your first session, goose prompts you to [set up an LLM (Large Language Model
         </Tabs>
 
         :::tip
-        On macOS, you can drag and drop a folder onto the goose icon in the dock to open a new session in that directory.
+        On macOS, you can use the goose dock icon to quickly start sessions:
+            - **Drag and drop** a folder onto the goose icon to open a new session in that directory
+            - **Right-click** the goose icon and select `New Window` to open a new session in your most recent directory
         :::
 
         You can also use keyboard shortcuts to start a new session or manage goose windows.


### PR DESCRIPTION
## Summary
Expand the tip in the goose Session Management doc to include new Right click -> New Window functionality in macOS dock.
Feature PR: https://github.com/block/goose/pull/5099


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance
