### PR TITLE
feat: improved UX for tool calls via execute_code

### DIFF
--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -271,6 +271,7 @@ fn render_tool_request(req: &ToolRequest, theme: Theme, debug: bool) {
         Ok(call) => match call.name.to_string().as_str() {
             "developer__text_editor" => render_text_editor_request(call, debug),
             "developer__shell" => render_shell_request(call, debug),
+            "code_execution__execute_code" => render_execute_code_request(call, debug),
             "subagent" => render_subagent_request(call, debug),
             "todo__write" => render_todo_request(call, debug),
             _ => render_default_request(call, debug),
@@ -442,6 +443,61 @@ fn render_text_editor_request(call: &CallToolRequestParam, debug: bool) {
 fn render_shell_request(call: &CallToolRequestParam, debug: bool) {
     print_tool_header(call);
     print_params(&call.arguments, 0, debug);
+    println!();
+}
+
+fn render_execute_code_request(call: &CallToolRequestParam, debug: bool) {
+    let tool_graph = call
+        .arguments
+        .as_ref()
+        .and_then(|args| args.get("tool_graph"))
+        .and_then(Value::as_array)
+        .filter(|arr| !arr.is_empty());
+
+    let Some(tool_graph) = tool_graph else {
+        return render_default_request(call, debug);
+    };
+
+    let count = tool_graph.len();
+    let plural = if count == 1 { "" } else { "s" };
+    println!();
+    println!(
+        "─── {} tool call{} | {} ──────────────────────────",
+        style(count).cyan(),
+        plural,
+        style("execute_code").magenta().dim()
+    );
+
+    for (i, node) in tool_graph.iter().filter_map(Value::as_object).enumerate() {
+        let tool = node
+            .get("tool")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let desc = node
+            .get("description")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let deps: Vec<_> = node
+            .get("depends_on")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_u64)
+            .map(|d| (d + 1).to_string())
+            .collect();
+        let deps_str = if deps.is_empty() {
+            String::new()
+        } else {
+            format!(" (uses {})", deps.join(", "))
+        };
+        println!(
+            "  {}. {}: {}{}",
+            style(i + 1).dim(),
+            style(tool).cyan(),
+            style(desc).green(),
+            style(deps_str).dim()
+        );
+    }
     println!();
 }
 

--- a/crates/goose/src/providers/canonical/build_canonical_models.rs
+++ b/crates/goose/src/providers/canonical/build_canonical_models.rs
@@ -289,6 +289,7 @@ impl MappingReport {
     }
 }
 
+#[allow(clippy::too_many_lines)]
 async fn build_canonical_models() -> Result<()> {
     println!("Fetching models from OpenRouter API...");
 

--- a/scripts/test_providers.sh
+++ b/scripts/test_providers.sh
@@ -55,8 +55,10 @@ fi
 if [ "$CODE_EXEC_MODE" = true ]; then
   echo "Mode: code_execution (JS batching)"
   BUILTINS="developer,code_execution"
-  # Match "execute_code | code_execution" or "read_module | code_execution" in output
-  SUCCESS_PATTERN="(execute_code \| code_execution)|(read_module \| code_execution)"
+  # Match code_execution tool usage:
+  # - "execute_code | code_execution" or "read_module | code_execution" (fallback format)
+  # - "tool call | execute_code" or "tool calls | execute_code" (new format with tool_graph)
+  SUCCESS_PATTERN="(execute_code \| code_execution)|(read_module \| code_execution)|(tool calls? \| execute_code)"
   SUCCESS_MSG="code_execution tool called"
   FAILURE_MSG="no code_execution tools called"
 else


### PR DESCRIPTION
**Change**

Improves the UX when in code mode. Makes a new `tool_graph` argument the model will provide to outline the flow of execution that will occur with the code it wrote. The client then uses this to render information about what the code it wrote will do (how many tools were called, what tools were called, etc) still with an option to see the code.

**Demos**

Desktop:
<img width="1389" height="1033" alt="Screenshot 2025-12-19 at 3 39 52 PM" src="https://github.com/user-attachments/assets/94194e65-8c86-4b16-923a-9271afd2ba3f" />

CLI:
<img width="1302" height="882" alt="Screenshot 2025-12-19 at 3 56 45 PM" src="https://github.com/user-attachments/assets/48bd84ab-06ce-4d88-9c19-2867e30932cc" />