### PR TITLE
Fix popular topics not starting chat when clicked

### DIFF
--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -402,7 +402,15 @@ function BaseChatContent({
                 <div className="block h-8" />
               </>
             ) : !recipe && showPopularTopics ? (
-              <PopularChatTopics append={(text: string) => handleSubmit(text)} />
+              <PopularChatTopics
+                append={(text: string) => {
+                  const syntheticEvent = {
+                    detail: { value: text },
+                    preventDefault: () => {},
+                  } as unknown as React.FormEvent;
+                  handleFormSubmit(syntheticEvent);
+                }}
+              />
             ) : null}
           </ScrollArea>
 


### PR DESCRIPTION
## Summary
Needed to use `handleFormSubmit` rather than `handleSubmit` because the former creates a session
Tested locally

Closes https://github.com/block/goose/issues/6501

