### PR TITLE
fix: actually set the working dir for extensions from session

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -634,6 +634,7 @@ impl Agent {
 
     /// Load extensions from session into the agent
     /// Skips extensions that are already loaded
+    /// Uses the session's working_dir for extension initialization
     pub async fn load_extensions_from_session(
         self: &Arc<Self>,
         session: &Session,
@@ -651,11 +652,15 @@ impl Agent {
             }
         };
 
+        // Capture the session's working_dir to pass to extensions
+        let working_dir = session.working_dir.clone();
+
         let extension_futures = enabled_configs
             .into_iter()
             .map(|config| {
                 let config_clone = config.clone();
                 let agent_ref = self.clone();
+                let working_dir_clone = working_dir.clone();
 
                 async move {
                     let name = config_clone.name().to_string();
@@ -674,7 +679,10 @@ impl Agent {
                         };
                     }
 
-                    match agent_ref.add_extension(config_clone).await {
+                    match agent_ref
+                        .add_extension_with_working_dir(config_clone, Some(working_dir_clone))
+                        .await
+                    {
                         Ok(_) => ExtensionLoadResult {
                             name,
                             success: true,
@@ -698,6 +706,14 @@ impl Agent {
     }
 
     pub async fn add_extension(&self, extension: ExtensionConfig) -> ExtensionResult<()> {
+        self.add_extension_with_working_dir(extension, None).await
+    }
+
+    pub async fn add_extension_with_working_dir(
+        &self,
+        extension: ExtensionConfig,
+        working_dir: Option<std::path::PathBuf>,
+    ) -> ExtensionResult<()> {
         match &extension {
             ExtensionConfig::Frontend {
                 tools,
@@ -726,7 +742,7 @@ impl Agent {
             }
             _ => {
                 self.extension_manager
-                    .add_extension(extension.clone())
+                    .add_extension_with_working_dir(extension.clone(), working_dir)
                     .await?;
             }
         }

--- a/crates/goose/src/agents/extension_manager_extension.rs
+++ b/crates/goose/src/agents/extension_manager_extension.rs
@@ -211,7 +211,7 @@ impl ExtensionManagerClient {
         };
 
         extension_manager
-            .add_extension(config)
+            .add_extension_with_working_dir(config, None)
             .await
             .map(|_| {
                 vec![Content::text(format!(

--- a/crates/goose/tests/mcp_integration_test.rs
+++ b/crates/goose/tests/mcp_integration_test.rs
@@ -264,7 +264,9 @@ async fn test_replayed_session(
 
     #[allow(clippy::redundant_closure_call)]
     let result = (async || -> Result<(), Box<dyn std::error::Error>> {
-        extension_manager.add_extension(extension_config).await?;
+        extension_manager
+            .add_extension_with_working_dir(extension_config, None)
+            .await?;
         let mut results = Vec::new();
         for tool_call in tool_calls {
             let tool_call = CallToolRequestParam {


### PR DESCRIPTION
## Summary
The root cause was two-fold: first, the ExtensionManager::add_extension method wasn't accepting a working directory parameter, so the session's working_dir was never propagated from Agent::load_extensions_from_session. Second, for builtin extensions like developer that run in-process (not as child processes), the GOOSE_WORKING_DIR environment variable wasn't being set in the current process's environment—it was only being set for child process extensions. The fix adds a working_dir parameter through the extension loading chain and ensures GOOSE_WORKING_DIR is set in the current process when loading builtin extensions, so that when you change the working directory in the UI and extensions are reloaded, the developer extension's shell commands now correctly use the new directory.

<img width="867" height="758" alt="image" src="https://github.com/user-attachments/assets/f42341ec-09ca-478e-a26f-6ed1a81dd5e0" />


closes https://github.com/block/goose/issues/6610
