### PR TITLE
feat: add dynamic authentication for custom providers

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -1926,6 +1926,9 @@ fn add_provider() -> anyhow::Result<()> {
         supports_streaming: Some(supports_streaming),
         headers,
         requires_auth,
+        api_key_command: None,
+        api_key_file: None,
+        api_key_file_field: None,
     })?;
 
     cliclack::outro(format!("Custom provider added: {}", display_name))?;

--- a/crates/goose-server/src/routes/config_management.rs
+++ b/crates/goose-server/src/routes/config_management.rs
@@ -94,6 +94,9 @@ pub struct UpdateCustomProviderRequest {
     pub headers: Option<std::collections::HashMap<String, String>>,
     #[serde(default = "default_requires_auth")]
     pub requires_auth: bool,
+    pub api_key_command: Option<String>,
+    pub api_key_file: Option<String>,
+    pub api_key_file_field: Option<String>,
 }
 
 fn default_requires_auth() -> bool {
@@ -675,6 +678,9 @@ pub async fn create_custom_provider(
             supports_streaming: request.supports_streaming,
             headers: request.headers,
             requires_auth: request.requires_auth,
+            api_key_command: request.api_key_command,
+            api_key_file: request.api_key_file,
+            api_key_file_field: request.api_key_file_field,
         },
     )?;
 
@@ -745,6 +751,9 @@ pub async fn update_custom_provider(
             supports_streaming: request.supports_streaming,
             headers: request.headers,
             requires_auth: request.requires_auth,
+            api_key_command: request.api_key_command,
+            api_key_file: request.api_key_file,
+            api_key_file_field: request.api_key_file_field,
         },
     )?;
 

--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -95,7 +95,7 @@ impl DeclarativeProviderConfig {
 
         if self.requires_auth && !self.api_key_env.is_empty() {
             let global_config = Config::global();
-            if let Ok(key) = global_config.get_secret(&self.api_key_env) {
+            if let Ok(key) = global_config.get_secret::<String>(&self.api_key_env) {
                 if !key.is_empty() {
                     return Ok(match engine {
                         ProviderEngine::Anthropic => AuthMethod::ApiKey {

--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -272,7 +272,9 @@ pub fn update_custom_provider(params: UpdateCustomProviderParams) -> Result<()> 
             requires_auth: params.requires_auth,
             api_key_command: params.api_key_command.or(existing_config.api_key_command),
             api_key_file: params.api_key_file.or(existing_config.api_key_file),
-            api_key_file_field: params.api_key_file_field.or(existing_config.api_key_file_field),
+            api_key_file_field: params
+                .api_key_file_field
+                .or(existing_config.api_key_file_field),
         };
 
         let file_path = custom_providers_dir().join(format!("{}.json", updated_config.name));

--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -87,15 +87,7 @@ impl AnthropicProvider {
         model: ModelConfig,
         config: DeclarativeProviderConfig,
     ) -> Result<Self> {
-        let global_config = crate::config::Config::global();
-        let api_key: String = global_config
-            .get_secret(&config.api_key_env)
-            .map_err(|_| anyhow::anyhow!("Missing API key: {}", config.api_key_env))?;
-
-        let auth = AuthMethod::ApiKey {
-            header_name: "x-api-key".to_string(),
-            key: api_key,
-        };
+        let auth = config.resolve_auth_method(&config.engine)?;
 
         let mut api_client = ApiClient::new(config.base_url, auth)?
             .with_header("anthropic-version", ANTHROPIC_API_VERSION)?;

--- a/crates/goose/src/providers/dynamic_auth.rs
+++ b/crates/goose/src/providers/dynamic_auth.rs
@@ -112,8 +112,8 @@ impl FileAuthProvider {
 #[async_trait]
 impl AuthProvider for FileAuthProvider {
     async fn get_auth_header(&self) -> Result<(String, String)> {
-        let expanded = shellexpand::tilde(&self.path);
-        let content = tokio::fs::read_to_string(expanded.as_ref())
+        let expanded = shellexpand::tilde(&self.path).into_owned();
+        let content = tokio::fs::read_to_string(&expanded)
             .await
             .with_context(|| format!("Failed to read api_key_file: {}", self.path))?;
 

--- a/crates/goose/src/providers/dynamic_auth.rs
+++ b/crates/goose/src/providers/dynamic_auth.rs
@@ -1,0 +1,261 @@
+use super::api_client::AuthProvider;
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+
+const COMMAND_CACHE_TTL: Duration = Duration::from_secs(300);
+
+/// How the resolved token should be sent in the HTTP request.
+#[derive(Debug, Clone)]
+pub enum AuthHeaderStyle {
+    /// Standard `Authorization: Bearer <token>` header.
+    BearerToken,
+    /// Custom header name (e.g. Anthropic's `x-api-key`).
+    CustomHeader { header_name: String },
+}
+
+/// Executes a shell command at runtime and uses stdout as the auth token.
+/// The result is cached with a 5-minute TTL.
+pub struct CommandAuthProvider {
+    command: String,
+    header_style: AuthHeaderStyle,
+    cache: Arc<RwLock<Option<(String, Instant)>>>,
+}
+
+impl CommandAuthProvider {
+    pub fn new(command: String, header_style: AuthHeaderStyle) -> Self {
+        Self {
+            command,
+            header_style,
+            cache: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    async fn execute_command(&self) -> Result<String> {
+        let output = tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg(&self.command)
+            .output()
+            .await
+            .with_context(|| format!("Failed to execute api_key_command: {}", self.command))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!(
+                "api_key_command exited with status {}: {}",
+                output.status,
+                stderr.trim()
+            );
+        }
+
+        let token = String::from_utf8(output.stdout)
+            .context("api_key_command output is not valid UTF-8")?
+            .trim()
+            .to_string();
+
+        if token.is_empty() {
+            anyhow::bail!("api_key_command produced empty output");
+        }
+
+        Ok(token)
+    }
+}
+
+#[async_trait]
+impl AuthProvider for CommandAuthProvider {
+    async fn get_auth_header(&self) -> Result<(String, String)> {
+        // Fast path: check if cache is still valid
+        {
+            let cache = self.cache.read().await;
+            if let Some((ref token, ref timestamp)) = *cache {
+                if timestamp.elapsed() < COMMAND_CACHE_TTL {
+                    return Ok(header_pair(&self.header_style, token));
+                }
+            }
+        }
+
+        // Slow path: acquire write lock and double-check
+        let mut cache = self.cache.write().await;
+        if let Some((ref token, ref timestamp)) = *cache {
+            if timestamp.elapsed() < COMMAND_CACHE_TTL {
+                return Ok(header_pair(&self.header_style, token));
+            }
+        }
+
+        let token = self.execute_command().await?;
+        let pair = header_pair(&self.header_style, &token);
+        *cache = Some((token, Instant::now()));
+        Ok(pair)
+    }
+}
+
+/// Reads an auth token from a file on each call.
+/// If `field` is set, the file is parsed as JSON and the named field is extracted.
+pub struct FileAuthProvider {
+    path: String,
+    field: Option<String>,
+    header_style: AuthHeaderStyle,
+}
+
+impl FileAuthProvider {
+    pub fn new(path: String, field: Option<String>, header_style: AuthHeaderStyle) -> Self {
+        Self {
+            path,
+            field,
+            header_style,
+        }
+    }
+}
+
+#[async_trait]
+impl AuthProvider for FileAuthProvider {
+    async fn get_auth_header(&self) -> Result<(String, String)> {
+        let expanded = shellexpand::tilde(&self.path);
+        let content = tokio::fs::read_to_string(expanded.as_ref())
+            .await
+            .with_context(|| format!("Failed to read api_key_file: {}", self.path))?;
+
+        let token = match &self.field {
+            Some(field_name) => {
+                let json: serde_json::Value = serde_json::from_str(&content)
+                    .with_context(|| format!("api_key_file is not valid JSON: {}", self.path))?;
+                json.get(field_name)
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Field '{}' not found or not a string in {}",
+                            field_name,
+                            self.path
+                        )
+                    })?
+                    .to_string()
+            }
+            None => content.trim().to_string(),
+        };
+
+        if token.is_empty() {
+            anyhow::bail!("api_key_file produced empty token: {}", self.path);
+        }
+
+        Ok(header_pair(&self.header_style, &token))
+    }
+}
+
+fn header_pair(style: &AuthHeaderStyle, token: &str) -> (String, String) {
+    match style {
+        AuthHeaderStyle::BearerToken => {
+            ("Authorization".to_string(), format!("Bearer {}", token))
+        }
+        AuthHeaderStyle::CustomHeader { header_name } => {
+            (header_name.clone(), token.to_string())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_command_auth_provider_echo() {
+        let provider =
+            CommandAuthProvider::new("echo test-token".to_string(), AuthHeaderStyle::BearerToken);
+        let (header, value) = provider.get_auth_header().await.unwrap();
+        assert_eq!(header, "Authorization");
+        assert_eq!(value, "Bearer test-token");
+    }
+
+    #[tokio::test]
+    async fn test_command_auth_provider_caching() {
+        let provider = CommandAuthProvider::new(
+            "echo cached-token".to_string(),
+            AuthHeaderStyle::BearerToken,
+        );
+
+        let (_, v1) = provider.get_auth_header().await.unwrap();
+        let (_, v2) = provider.get_auth_header().await.unwrap();
+        assert_eq!(v1, v2);
+        assert_eq!(v1, "Bearer cached-token");
+    }
+
+    #[tokio::test]
+    async fn test_command_auth_provider_failure() {
+        let provider = CommandAuthProvider::new(
+            "exit 1".to_string(),
+            AuthHeaderStyle::BearerToken,
+        );
+        let result = provider.get_auth_header().await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("exited with status"));
+    }
+
+    #[tokio::test]
+    async fn test_command_auth_provider_custom_header() {
+        let provider = CommandAuthProvider::new(
+            "echo my-key".to_string(),
+            AuthHeaderStyle::CustomHeader {
+                header_name: "x-api-key".to_string(),
+            },
+        );
+        let (header, value) = provider.get_auth_header().await.unwrap();
+        assert_eq!(header, "x-api-key");
+        assert_eq!(value, "my-key");
+    }
+
+    #[tokio::test]
+    async fn test_file_auth_provider_plain_text() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("token.txt");
+        std::fs::write(&file_path, "file-token\n").unwrap();
+
+        let provider = FileAuthProvider::new(
+            file_path.to_string_lossy().to_string(),
+            None,
+            AuthHeaderStyle::BearerToken,
+        );
+        let (header, value) = provider.get_auth_header().await.unwrap();
+        assert_eq!(header, "Authorization");
+        assert_eq!(value, "Bearer file-token");
+    }
+
+    #[tokio::test]
+    async fn test_file_auth_provider_json_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("creds.json");
+        std::fs::write(
+            &file_path,
+            r#"{"access_token": "json-token", "expires": 3600}"#,
+        )
+        .unwrap();
+
+        let provider = FileAuthProvider::new(
+            file_path.to_string_lossy().to_string(),
+            Some("access_token".to_string()),
+            AuthHeaderStyle::BearerToken,
+        );
+        let (header, value) = provider.get_auth_header().await.unwrap();
+        assert_eq!(header, "Authorization");
+        assert_eq!(value, "Bearer json-token");
+    }
+
+    #[tokio::test]
+    async fn test_file_auth_provider_missing_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("creds.json");
+        std::fs::write(&file_path, r#"{"other_field": "value"}"#).unwrap();
+
+        let provider = FileAuthProvider::new(
+            file_path.to_string_lossy().to_string(),
+            Some("access_token".to_string()),
+            AuthHeaderStyle::BearerToken,
+        );
+        let result = provider.get_auth_header().await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Field 'access_token' not found"));
+    }
+}

--- a/crates/goose/src/providers/dynamic_auth.rs
+++ b/crates/goose/src/providers/dynamic_auth.rs
@@ -145,12 +145,8 @@ impl AuthProvider for FileAuthProvider {
 
 fn header_pair(style: &AuthHeaderStyle, token: &str) -> (String, String) {
     match style {
-        AuthHeaderStyle::BearerToken => {
-            ("Authorization".to_string(), format!("Bearer {}", token))
-        }
-        AuthHeaderStyle::CustomHeader { header_name } => {
-            (header_name.clone(), token.to_string())
-        }
+        AuthHeaderStyle::BearerToken => ("Authorization".to_string(), format!("Bearer {}", token)),
+        AuthHeaderStyle::CustomHeader { header_name } => (header_name.clone(), token.to_string()),
     }
 }
 
@@ -182,13 +178,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_command_auth_provider_failure() {
-        let provider = CommandAuthProvider::new(
-            "exit 1".to_string(),
-            AuthHeaderStyle::BearerToken,
-        );
+        let provider = CommandAuthProvider::new("exit 1".to_string(), AuthHeaderStyle::BearerToken);
         let result = provider.get_auth_header().await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("exited with status"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("exited with status"));
     }
 
     #[tokio::test]

--- a/crates/goose/src/providers/mod.rs
+++ b/crates/goose/src/providers/mod.rs
@@ -11,6 +11,7 @@ pub mod claude_code;
 pub mod codex;
 pub mod cursor_agent;
 pub mod databricks;
+pub mod dynamic_auth;
 pub mod embedding;
 pub mod errors;
 pub mod formats;

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -118,8 +118,9 @@ impl OllamaProvider {
                 .map_err(|_| anyhow::anyhow!("Failed to set default port"))?;
         }
 
+        let auth = config.resolve_auth_method(&config.engine)?;
         let mut api_client =
-            ApiClient::with_timeout(base_url.to_string(), AuthMethod::NoAuth, timeout)?;
+            ApiClient::with_timeout(base_url.to_string(), auth, timeout)?;
 
         if let Some(headers) = &config.headers {
             let mut header_map = reqwest::header::HeaderMap::new();

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -119,8 +119,7 @@ impl OllamaProvider {
         }
 
         let auth = config.resolve_auth_method(&config.engine)?;
-        let mut api_client =
-            ApiClient::with_timeout(base_url.to_string(), auth, timeout)?;
+        let mut api_client = ApiClient::with_timeout(base_url.to_string(), auth, timeout)?;
 
         if let Some(headers) = &config.headers {
             let mut header_map = reqwest::header::HeaderMap::new();

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -3779,8 +3779,20 @@
           "models"
         ],
         "properties": {
+          "api_key_command": {
+            "type": "string",
+            "nullable": true
+          },
           "api_key_env": {
             "type": "string"
+          },
+          "api_key_file": {
+            "type": "string",
+            "nullable": true
+          },
+          "api_key_file_field": {
+            "type": "string",
+            "nullable": true
           },
           "base_url": {
             "type": "string"
@@ -7154,6 +7166,18 @@
         "properties": {
           "api_key": {
             "type": "string"
+          },
+          "api_key_command": {
+            "type": "string",
+            "nullable": true
+          },
+          "api_key_file": {
+            "type": "string",
+            "nullable": true
+          },
+          "api_key_file_field": {
+            "type": "string",
+            "nullable": true
           },
           "api_url": {
             "type": "string"

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -154,7 +154,10 @@ export type CspMetadata = {
 };
 
 export type DeclarativeProviderConfig = {
+    api_key_command?: string | null;
     api_key_env?: string;
+    api_key_file?: string | null;
+    api_key_file_field?: string | null;
     base_url: string;
     description?: string | null;
     display_name: string;
@@ -1308,6 +1311,9 @@ export type UiMetadata = {
 
 export type UpdateCustomProviderRequest = {
     api_key: string;
+    api_key_command?: string | null;
+    api_key_file?: string | null;
+    api_key_file_field?: string | null;
     api_url: string;
     display_name: string;
     engine: string;

--- a/ui/desktop/src/components/settings/providers/ProviderGrid.tsx
+++ b/ui/desktop/src/components/settings/providers/ProviderGrid.tsx
@@ -238,6 +238,9 @@ function ProviderCards({
     models: editingProvider.config.models.map((m) => m.name),
     supports_streaming: editingProvider.config.supports_streaming ?? true,
     requires_auth: editingProvider.config.requires_auth ?? true,
+    api_key_command: editingProvider.config.api_key_command ?? null,
+    api_key_file: editingProvider.config.api_key_file ?? null,
+    api_key_file_field: editingProvider.config.api_key_file_field ?? null,
   };
 
   const editable = editingProvider ? editingProvider.isEditable : true;

--- a/ui/desktop/src/components/settings/providers/modal/subcomponents/forms/CustomProviderForm.tsx
+++ b/ui/desktop/src/components/settings/providers/modal/subcomponents/forms/CustomProviderForm.tsx
@@ -4,7 +4,7 @@ import { Select } from '../../../../../ui/Select';
 import { Button } from '../../../../../ui/button';
 import { SecureStorageNotice } from '../SecureStorageNotice';
 import { UpdateCustomProviderRequest } from '../../../../../../api';
-import { Trash2, AlertTriangle } from 'lucide-react';
+import { Trash2, AlertTriangle, ChevronDown, ChevronRight } from 'lucide-react';
 
 interface CustomProviderFormProps {
   onSubmit: (data: UpdateCustomProviderRequest) => void;
@@ -30,6 +30,10 @@ export default function CustomProviderForm({
   const [models, setModels] = useState('');
   const [requiresApiKey, setRequiresApiKey] = useState(false);
   const [supportsStreaming, setSupportsStreaming] = useState(true);
+  const [apiKeyCommand, setApiKeyCommand] = useState('');
+  const [apiKeyFile, setApiKeyFile] = useState('');
+  const [apiKeyFileField, setApiKeyFileField] = useState('');
+  const [showAdvancedAuth, setShowAdvancedAuth] = useState(false);
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
 
@@ -46,6 +50,12 @@ export default function CustomProviderForm({
       setModels(initialData.models.join(', '));
       setSupportsStreaming(initialData.supports_streaming ?? true);
       setRequiresApiKey(initialData.requires_auth ?? true);
+      setApiKeyCommand(initialData.api_key_command ?? '');
+      setApiKeyFile(initialData.api_key_file ?? '');
+      setApiKeyFileField(initialData.api_key_file_field ?? '');
+      if (initialData.api_key_command || initialData.api_key_file) {
+        setShowAdvancedAuth(true);
+      }
     }
   }, [initialData]);
 
@@ -84,6 +94,9 @@ export default function CustomProviderForm({
       models: modelList,
       supports_streaming: supportsStreaming,
       requires_auth: requiresApiKey,
+      api_key_command: apiKeyCommand || null,
+      api_key_file: apiKeyFile || null,
+      api_key_file_field: apiKeyFileField || null,
     });
   };
 
@@ -222,6 +235,81 @@ export default function CustomProviderForm({
             )}
           </div>
         )}
+
+        <div className="mt-3">
+          <button
+            type="button"
+            className="flex items-center text-sm text-text-muted hover:text-text-default"
+            onClick={() => setShowAdvancedAuth(!showAdvancedAuth)}
+          >
+            {showAdvancedAuth ? (
+              <ChevronDown className="h-4 w-4 mr-1" />
+            ) : (
+              <ChevronRight className="h-4 w-4 mr-1" />
+            )}
+            Dynamic Authentication
+          </button>
+
+          {showAdvancedAuth && (
+            <div className="mt-3 space-y-3 pl-2 border-l-2 border-border-default">
+              <p className="text-xs text-text-muted">
+                For JWT refresh, credential files, or external auth tools. These take priority over a static API key.
+              </p>
+              <div>
+                <label
+                  htmlFor="api-key-command"
+                  className="block text-sm font-medium text-text-default mb-1"
+                >
+                  Auth Command
+                </label>
+                <Input
+                  id="api-key-command"
+                  value={apiKeyCommand}
+                  onChange={(e) => setApiKeyCommand(e.target.value)}
+                  placeholder="e.g. gcloud auth print-access-token"
+                />
+                <p className="text-xs text-text-muted mt-1">
+                  Shell command whose stdout is used as the bearer token (cached 5 min).
+                </p>
+              </div>
+              <div>
+                <label
+                  htmlFor="api-key-file"
+                  className="block text-sm font-medium text-text-default mb-1"
+                >
+                  Auth File Path
+                </label>
+                <Input
+                  id="api-key-file"
+                  value={apiKeyFile}
+                  onChange={(e) => setApiKeyFile(e.target.value)}
+                  placeholder="e.g. ~/.config/my-tool/credentials.json"
+                />
+                <p className="text-xs text-text-muted mt-1">
+                  File to read the token from. Supports ~ expansion.
+                </p>
+              </div>
+              <div>
+                <label
+                  htmlFor="api-key-file-field"
+                  className="block text-sm font-medium text-text-default mb-1"
+                >
+                  JSON Field Name
+                </label>
+                <Input
+                  id="api-key-file-field"
+                  value={apiKeyFileField}
+                  onChange={(e) => setApiKeyFileField(e.target.value)}
+                  placeholder="e.g. access_token"
+                  disabled={!apiKeyFile}
+                />
+                <p className="text-xs text-text-muted mt-1">
+                  If the file is JSON, extract this field as the token.
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
       {isEditable && (
         <>


### PR DESCRIPTION
Closed as I didn't read the HOWTOAI properly, this touches authentication

## Summary

Custom/declarative providers currently only support static API keys (from env vars or keyring). Users who need dynamic authentication — such as JWT token refresh, credential files managed by external tools, or CLI-based auth flows — must run a separate local proxy to handle token management.

This PR adds two new authentication methods to eliminate that workaround:

- **`api_key_command`** — Shell command executed at runtime whose stdout is used as the bearer token (cached with 5-minute TTL using double-checked locking)
- **`api_key_file`** + **`api_key_file_field`** — Read token from a file (with `~` expansion), optionally extracting a named field from a JSON credential file

**Priority order:** `api_key_command` > `api_key_file` > `api_key_env` > `NoAuth`

These new fields are fully backward-compatible — existing provider JSON files continue to work unchanged since all new fields default to `None` via `#[serde(default)]`.

### Changes

| File | Change |
|------|--------|
| `crates/goose/src/providers/dynamic_auth.rs` | **New** — `CommandAuthProvider`, `FileAuthProvider`, `AuthHeaderStyle` + 7 unit tests |
| `crates/goose/src/providers/mod.rs` | Register `dynamic_auth` module |
| `crates/goose/src/config/declarative_providers.rs` | Add 3 optional fields, `resolve_auth_method()` helper, update param structs |
| `crates/goose/src/providers/openai.rs` | Simplify `from_custom_config` to use `resolve_auth_method()` |
| `crates/goose/src/providers/anthropic.rs` | Simplify `from_custom_config` to use `resolve_auth_method()` (removes hard error on missing key) |
| `crates/goose/src/providers/ollama.rs` | Replace hardcoded `NoAuth` with `resolve_auth_method()` |
| `crates/goose-server/src/routes/config_management.rs` | Add fields to `UpdateCustomProviderRequest`, pass through in create/update handlers |
| `crates/goose-cli/src/commands/configure.rs` | Add `None` defaults for new fields in CLI create path |
| `ui/desktop/src/api/types.gen.ts` | Add fields to TypeScript types |
| `ui/desktop/src/components/.../CustomProviderForm.tsx` | Collapsible "Dynamic Authentication" section in provider form |
| `ui/desktop/src/components/.../ProviderGrid.tsx` | Pass through new fields for edit/create flows |
| `ui/desktop/openapi.json` | Regenerated with new fields |

### Example usage

```json
{
  "name": "my_provider",
  "engine": "openai",
  "display_name": "My Provider",
  "base_url": "https://api.example.com/v1/chat/completions",
  "api_key_command": "my-auth-tool get-token",
  "models": [{"name": "my-model", "context_limit": 128000}],
  "requires_auth": true,
  "supports_streaming": true
}
```

### Type of Change
- [x] Feature
- [x] Refactor / Code quality

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

**Validation per [HOWTOAI](https://github.com/block/goose/blob/main/HOWTOAI.md):**
- The `dynamic_auth.rs` module handles credential-sensitive operations (shell command execution, file reading) — reviewed for security: commands run via `sh -c`, file paths use `shellexpand::tilde()`, empty tokens are rejected, and errors are properly propagated
- Follows existing project patterns: implements the existing `AuthProvider` trait and `AuthMethod::Custom` variant already in `api_client.rs`
- No changes to core authentication/authorization flows — this adds new auth *resolution* paths alongside existing ones
- All existing tests continue to pass; 7 new unit tests cover the new functionality

### Testing

- `cargo build` — compiles cleanly
- 578 goose lib tests pass
- 8 goose-server tests pass
- 7 new `dynamic_auth` unit tests pass (command echo, caching, failure, custom header, plain text file, JSON field extraction, missing field)
- `tsc --noEmit` and `eslint` pass for frontend
- Existing declarative provider JSONs (groq, deepseek, etc.) still deserialize correctly
- Manual end-to-end test: created a custom provider with `api_key_command` pointing to a token refresh script, verified it connects directly without a proxy

### Related Issues
N/A — this addresses a common pain point where users need dynamic auth for corporate/enterprise API endpoints that use rotating tokens or external credential management.

### Screenshots/Demos (for UX changes)

The Desktop UI adds a collapsible **"Dynamic Authentication"** section to the custom provider form (both create and edit flows):

- Collapsed by default, expandable via a chevron toggle
- Contains three fields: **Auth Command**, **Auth File Path**, and **JSON Field Name**
- The JSON Field Name input is disabled when no file path is set
- Auto-expands when editing a provider that already has dynamic auth configured
- Helper text explains each field's purpose (e.g., "Shell command whose stdout is used as the bearer token (cached 5 min)")