### PR TITLE
refactor: split text_editor into read/edit/write tools with fuzzy matching and unified diffs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4492,6 +4492,7 @@ dependencies = [
  "serial_test",
  "shell-words",
  "shellexpand",
+ "similar",
  "tempfile",
  "tokio",
  "tokio-stream",

--- a/crates/goose-cli/src/session/export.rs
+++ b/crates/goose-cli/src/session/export.rs
@@ -157,7 +157,10 @@ pub fn tool_request_to_markdown(req: &ToolRequest, export_all_content: bool) -> 
                         ));
                     }
                 }
-                "developer__text_editor" => {
+                "developer__text_editor"
+                | "developer__read_file"
+                | "developer__edit_file"
+                | "developer__write_file" => {
                     if let Some(Value::String(path)) =
                         call.arguments.as_ref().and_then(|args| args.get("path"))
                     {

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -485,7 +485,10 @@ fn render_thinking_streaming(
 fn render_tool_request(req: &ToolRequest, theme: Theme, debug: bool) {
     match &req.tool_call {
         Ok(call) => match call.name.to_string().as_str() {
-            "developer__text_editor" => render_text_editor_request(call, debug),
+            "developer__text_editor"
+            | "developer__read_file"
+            | "developer__edit_file"
+            | "developer__write_file" => render_text_editor_request(call, debug),
             "developer__shell" => render_shell_request(call, debug),
             "execute" | "execute_code" => render_execute_code_request(call, debug),
             "delegate" => render_delegate_request(call, debug),

--- a/crates/goose-mcp/Cargo.toml
+++ b/crates/goose-mcp/Cargo.toml
@@ -67,6 +67,7 @@ libc = "0.2"
 mpatch = "=0.2.0"
 tokio-util = { workspace = true }
 shell-words = "1.1.1"
+similar = "2.7.0"
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/crates/goose-mcp/src/developer/shell.rs
+++ b/crates/goose-mcp/src/developer/shell.rs
@@ -92,16 +92,6 @@ pub fn is_absolute_path(path_str: &str) -> bool {
     }
 }
 
-pub fn normalize_line_endings(text: &str) -> String {
-    if cfg!(windows) {
-        // Ensure CRLF line endings on Windows
-        text.replace("\r\n", "\n").replace("\n", "\r\n")
-    } else {
-        // Ensure LF line endings on Unix
-        text.replace("\r\n", "\n")
-    }
-}
-
 /// Configure a shell command with process group support for proper child process tracking.
 ///
 /// On Unix systems, creates a new process group so child processes can be killed together.


### PR DESCRIPTION
## Summary

Ports key ideas from pi's text editor implementation to improve goose's developer tools.

### Tool split
- Replaces the monolithic `text_editor` tool (with `command` subparam and 7 optional fields) with three focused tools: `read_file`, `edit_file`, `write_file`
- Simpler schemas mean fewer LLM errors — each tool only has the parameters it needs
- Removes `insert` (line-number-based insertion is error-prone) and `undo_edit` (rarely used effectively)
- Removes in-memory `file_history` state

### Fuzzy text matching
- Tries exact match first, falls back to fuzzy normalization
- Strips trailing whitespace per line
- Normalizes smart quotes (`\u201C\u201D\u2018\u2019` → `"'`), Unicode dashes (em-dash, en-dash → `-`), and special spaces (NBSP etc → ` `)
- Fixes common LLM-introduced character differences that previously caused match failures

### Encoding preservation
- BOM stripping/preservation for UTF-8 files
- Detects and preserves original line endings (CRLF/LF) instead of forcing platform default

### Unified diff output
- User-facing edit output now shows a proper unified diff with line numbers and context (using `similar` crate) instead of a raw code snippet

### Downstream updates
- CLI output rendering, export, and ACP server updated to recognize new tool names alongside legacy `developer__text_editor`
