### PR TITLE
Add unified thinking effort control across all providers

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -24,7 +24,6 @@ use goose::model::ModelConfig;
 use goose::posthog::{get_telemetry_choice, TELEMETRY_ENABLED_KEY};
 use goose::providers::base::ConfigKey;
 use goose::providers::chatgpt_codex::reasoning_levels_for_model;
-use goose::providers::formats::anthropic::supports_adaptive_thinking;
 use goose::providers::provider_test::test_provider_configuration;
 use goose::providers::{create, providers, retry_operation, RetryConfig};
 use goose::session::SessionType;
@@ -758,58 +757,21 @@ pub async fn configure_provider_dialog() -> anyhow::Result<bool> {
         }
     };
 
-    if model.to_lowercase().starts_with("gemini-3") {
-        let thinking_level: &str = cliclack::select("Select thinking level for Gemini 3:")
-            .item("low", "Low - Better latency, lighter reasoning", "")
-            .item("high", "High - Deeper reasoning, higher latency", "")
-            .interact()?;
-        config.set_gemini3_thinking_level(thinking_level)?;
-    }
+    {
+        let supports_thinking = model.to_lowercase().starts_with("gemini-3")
+            || model.to_lowercase().contains("claude")
+            || goose::model::ModelConfig::new_or_fail(&model).is_openai_reasoning_model();
 
-    if model.to_lowercase().starts_with("claude-") {
-        let supports_adaptive = supports_adaptive_thinking(&model);
-
-        let mut thinking_select = cliclack::select("Select extended thinking mode for Claude:");
-        if supports_adaptive {
-            thinking_select = thinking_select.item(
-                "adaptive",
-                "Adaptive - Claude decides when and how much to think (recommended)",
-                "",
-            );
-        }
-        thinking_select = thinking_select
-            .item("enabled", "Enabled - Fixed token budget for thinking", "")
-            .item("disabled", "Disabled - No extended thinking", "");
-        if supports_adaptive {
-            thinking_select = thinking_select.initial_value("adaptive");
-        } else {
-            thinking_select = thinking_select.initial_value("disabled");
-        }
-        let thinking_type: &str = thinking_select.interact()?;
-        config.set_claude_thinking_type(thinking_type)?;
-
-        if thinking_type == "adaptive" {
-            let effort: &str = cliclack::select("Select adaptive thinking effort level:")
-                .item("low", "Low - Minimal thinking, fastest responses", "")
+        if supports_thinking {
+            let effort: &str = cliclack::select("Select thinking effort:")
+                .item("off", "Off - No extended thinking", "")
+                .item("low", "Low - Better latency, lighter reasoning", "")
                 .item("medium", "Medium - Moderate thinking", "")
-                .item("high", "High - Deep reasoning (default)", "")
-                .item(
-                    "max",
-                    "Max - No constraints on thinking depth (Opus 4.6 only)",
-                    "",
-                )
-                .initial_value("high")
+                .item("high", "High - Deep reasoning", "")
+                .item("max", "Max - No constraints on thinking depth", "")
+                .initial_value("off")
                 .interact()?;
-            config.set_claude_thinking_effort(effort)?;
-        } else if thinking_type == "enabled" {
-            let budget: String = cliclack::input("Enter thinking budget (tokens):")
-                .default_input("16000")
-                .validate(|input: &String| match input.parse::<i32>() {
-                    Ok(n) if n > 0 => Ok(()),
-                    _ => Err("Please enter a valid positive number"),
-                })
-                .interact()?;
-            config.set_claude_thinking_budget(budget.parse::<i32>()?)?;
+            config.set_goose_thinking_effort(effort)?;
         }
     }
 

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -760,7 +760,9 @@ pub async fn configure_provider_dialog() -> anyhow::Result<bool> {
     {
         let supports_thinking = model.to_lowercase().starts_with("gemini-3")
             || model.to_lowercase().contains("claude")
-            || goose::model::ModelConfig::new_or_fail(&model).is_openai_reasoning_model();
+            || goose::model::ModelConfig::new(&model)
+                .map(|c| c.is_openai_reasoning_model())
+                .unwrap_or(false);
 
         if supports_thinking {
             let effort: &str = cliclack::select("Select thinking effort:")

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -758,8 +758,10 @@ pub async fn configure_provider_dialog() -> anyhow::Result<bool> {
     };
 
     {
+        let claude_thinking_providers = ["anthropic", "databricks"];
         let supports_thinking = model.to_lowercase().starts_with("gemini-3")
-            || model.to_lowercase().contains("claude")
+            || (model.to_lowercase().contains("claude")
+                && claude_thinking_providers.contains(&provider_name.as_str()))
             || goose::model::ModelConfig::new(&model)
                 .map(|c| c.is_openai_reasoning_model())
                 .unwrap_or(false);

--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -375,6 +375,7 @@ fn resolve_provider_and_model(
             .is_some_and(|mc| mc.model_name == model_name)
     {
         let mut config = saved_model_config.unwrap();
+        config.normalize_effort_suffix();
         if let Some(temp) = recipe_settings.and_then(|s| s.temperature) {
             config = config.with_temperature(Some(temp));
         }

--- a/crates/goose-server/src/routes/agent.rs
+++ b/crates/goose-server/src/routes/agent.rs
@@ -595,7 +595,7 @@ async fn update_agent_provider(
         }
     };
 
-    let model_config = ModelConfig::new(&model)
+    let mut model_config = ModelConfig::new(&model)
         .map_err(|e| {
             (
                 StatusCode::BAD_REQUEST,
@@ -603,8 +603,11 @@ async fn update_agent_provider(
             )
         })?
         .with_canonical_limits(&payload.provider)
-        .with_context_limit(payload.context_limit)
-        .with_request_params(payload.request_params);
+        .with_context_limit(payload.context_limit);
+
+    if let Some(request_params) = payload.request_params {
+        model_config = model_config.with_merged_request_params(request_params);
+    }
 
     let extensions =
         EnabledExtensionsState::for_session(state.session_manager(), &payload.session_id, config)

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/goose/src/agents/prompt_manager.rs
+assertion_line: 454
 expression: system_prompt
 ---
 You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
@@ -102,7 +103,11 @@ Manage agent sessions: list, view, start, send messages, and interrupt agents.
 
 
 You have these skills at your disposal, when it is clear they can help you solve a problem or you are asked to use them:
+• agent-browser - Debug visual bugs and interact with web apps using agent-browser CLI. Use when debugging, inspecting, navigating, filling forms, clicking buttons, taking screenshots, scraping data, testing web apps, or automating browser tasks. Supports desktop browsers and iOS Simulator (Mobile Safari). 93% less context than Playwright MCP.
+• codesearch - Use when searching, finding, locating, discovering, querying, looking up, or browsing code patterns, files, or implementations across all Square repositories via go/codesearch.
+• find-skills - Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.
 • goose-doc-guide - Reference goose documentation to create, configure, or explain goose-specific features like recipes, extensions, sessions, and providers. You MUST fetch relevant goose docs before answering. You MUST NOT rely on training data or assumptions for any goose-specific fields, values, names, syntax, or commands.
+• skill-management - Manage AI agent skills using the sq-agents CLI. Use when asked to find, search, discover, browse, install, list, show, or remove skills.
 ## todo
 
 ### Instructions

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -1029,7 +1029,6 @@ config_value!(CLAUDE_CODE_COMMAND, String, "claude");
 config_value!(GEMINI_CLI_COMMAND, String, "gemini");
 config_value!(CURSOR_AGENT_COMMAND, String, "cursor-agent");
 config_value!(CODEX_COMMAND, String, "codex");
-config_value!(CODEX_REASONING_EFFORT, String, "high");
 config_value!(CODEX_ENABLE_SKILLS, String, "true");
 config_value!(CODEX_SKIP_GIT_CHECK, String, "false");
 config_value!(CHATGPT_CODEX_REASONING_EFFORT, String, "medium");

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -1041,10 +1041,7 @@ config_value!(GOOSE_MODEL, String);
 config_value!(GOOSE_PROMPT_EDITOR, Option<String>);
 config_value!(GOOSE_MAX_ACTIVE_AGENTS, usize);
 config_value!(GOOSE_DISABLE_SESSION_NAMING, bool);
-config_value!(GEMINI3_THINKING_LEVEL, String);
-config_value!(CLAUDE_THINKING_TYPE, String);
-config_value!(CLAUDE_THINKING_EFFORT, String);
-config_value!(CLAUDE_THINKING_BUDGET, i32);
+config_value!(GOOSE_THINKING_EFFORT, String);
 
 fn find_workspace_or_exe_root() -> Option<PathBuf> {
     let exe = std::env::current_exe().ok()?;

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -300,17 +300,16 @@ impl ModelConfig {
         Ok(self)
     }
 
-    pub fn with_request_params(mut self, params: Option<HashMap<String, Value>>) -> Self {
-        match (self.request_params.as_mut(), params) {
-            (Some(existing), Some(new)) => {
-                for (k, v) in new {
+    pub fn with_merged_request_params(mut self, params: HashMap<String, Value>) -> Self {
+        match self.request_params.as_mut() {
+            Some(existing) => {
+                for (k, v) in params {
                     existing.insert(k, v);
                 }
             }
-            (None, Some(new)) => {
-                self.request_params = Some(new);
+            None => {
+                self.request_params = Some(params);
             }
-            _ => {}
         }
         self
     }

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -347,7 +347,7 @@ impl ModelConfig {
         4_096
     }
 
-    fn normalize_effort_suffix(&mut self) {
+    pub fn normalize_effort_suffix(&mut self) {
         if !self.is_openai_reasoning_model() {
             return;
         }

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -1,4 +1,5 @@
 use once_cell::sync::Lazy;
+use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -82,7 +83,7 @@ pub enum ConfigError {
     InvalidRange(String, String),
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Default, Serialize, ToSchema)]
 pub struct ModelConfig {
     pub model_name: String,
     pub context_limit: Option<usize>,
@@ -97,6 +98,42 @@ pub struct ModelConfig {
     pub request_params: Option<HashMap<String, Value>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<bool>,
+}
+
+impl<'de> Deserialize<'de> for ModelConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawModelConfig {
+            model_name: String,
+            context_limit: Option<usize>,
+            temperature: Option<f32>,
+            max_tokens: Option<i32>,
+            toolshim: bool,
+            toolshim_model: Option<String>,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            request_params: Option<HashMap<String, Value>>,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            reasoning: Option<bool>,
+        }
+
+        let raw = RawModelConfig::deserialize(deserializer)?;
+        let mut config = Self {
+            model_name: raw.model_name,
+            context_limit: raw.context_limit,
+            temperature: raw.temperature,
+            max_tokens: raw.max_tokens,
+            toolshim: raw.toolshim,
+            toolshim_model: raw.toolshim_model,
+            fast_model_config: None,
+            request_params: raw.request_params,
+            reasoning: raw.reasoning,
+        };
+        config.normalize_effort_suffix();
+        Ok(config)
+    }
 }
 
 impl ModelConfig {

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -135,7 +135,7 @@ impl ModelConfig {
         let predefined = find_predefined_model(&model_name);
         let request_params = predefined.and_then(|pm| pm.request_params);
 
-        Ok(Self {
+        let mut config = Self {
             model_name,
             context_limit,
             temperature,
@@ -145,7 +145,9 @@ impl ModelConfig {
             fast_model_config: None,
             request_params,
             reasoning: None,
-        })
+        };
+        config.normalize_effort_suffix();
+        Ok(config)
     }
 
     pub fn with_canonical_limits(mut self, provider_name: &str) -> Self {
@@ -335,6 +337,37 @@ impl ModelConfig {
         4_096
     }
 
+    fn normalize_effort_suffix(&mut self) {
+        if !self.is_openai_reasoning_model() {
+            return;
+        }
+        let has_explicit_effort = self
+            .request_params
+            .as_ref()
+            .and_then(|p| p.get("thinking_effort"))
+            .is_some();
+        if has_explicit_effort {
+            return;
+        }
+        let parts: Vec<&str> = self.model_name.split('-').collect();
+        let last = match parts.last() {
+            Some(l) => *l,
+            None => return,
+        };
+        let effort = match last {
+            "low" => ThinkingEffort::Low,
+            "medium" => ThinkingEffort::Medium,
+            "high" => ThinkingEffort::High,
+            _ => return,
+        };
+        self.model_name = parts[..parts.len() - 1].join("-");
+        let params = self.request_params.get_or_insert_with(HashMap::new);
+        params.insert(
+            "thinking_effort".to_string(),
+            serde_json::json!(effort.to_string()),
+        );
+    }
+
     pub fn thinking_effort(&self) -> Option<ThinkingEffort> {
         self.get_config_param::<String>("thinking_effort", "GOOSE_THINKING_EFFORT")
             .and_then(|s| s.parse::<ThinkingEffort>().ok())
@@ -502,6 +535,72 @@ mod tests {
                 ..Default::default()
             };
             assert_eq!(config.thinking_effort(), Some(ThinkingEffort::Low));
+        }
+
+        #[test]
+        fn effort_suffix_stripped_from_model_name() {
+            let _guard = env_lock::lock_env([
+                ("GOOSE_THINKING_EFFORT", None::<&str>),
+                ("GOOSE_MAX_TOKENS", None::<&str>),
+                ("GOOSE_TEMPERATURE", None::<&str>),
+                ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+                ("GOOSE_TOOLSHIM", None::<&str>),
+                ("GOOSE_TOOLSHIM_OLLAMA_MODEL", None::<&str>),
+            ]);
+            let config = ModelConfig::new("o3-mini-high").unwrap();
+            assert_eq!(config.model_name, "o3-mini");
+            assert_eq!(config.thinking_effort(), Some(ThinkingEffort::High));
+        }
+
+        #[test]
+        fn effort_suffix_not_stripped_when_thinking_effort_set() {
+            let _guard = env_lock::lock_env([
+                ("GOOSE_THINKING_EFFORT", None::<&str>),
+                ("GOOSE_MAX_TOKENS", None::<&str>),
+                ("GOOSE_TEMPERATURE", None::<&str>),
+                ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+                ("GOOSE_TOOLSHIM", None::<&str>),
+                ("GOOSE_TOOLSHIM_OLLAMA_MODEL", None::<&str>),
+            ]);
+            let mut params = HashMap::new();
+            params.insert("thinking_effort".to_string(), serde_json::json!("low"));
+            let mut config = ModelConfig::new("o3-mini-high").unwrap();
+            // Suffix was already normalized during new(), but if request_params
+            // were set before construction, the suffix would not be stripped.
+            // Verify the normalized state:
+            assert_eq!(config.model_name, "o3-mini");
+
+            // Now simulate setting explicit effort after construction
+            config.request_params = Some(params);
+            assert_eq!(config.thinking_effort(), Some(ThinkingEffort::Low));
+        }
+
+        #[test]
+        fn no_suffix_no_change() {
+            let _guard = env_lock::lock_env([
+                ("GOOSE_THINKING_EFFORT", None::<&str>),
+                ("GOOSE_MAX_TOKENS", None::<&str>),
+                ("GOOSE_TEMPERATURE", None::<&str>),
+                ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+                ("GOOSE_TOOLSHIM", None::<&str>),
+                ("GOOSE_TOOLSHIM_OLLAMA_MODEL", None::<&str>),
+            ]);
+            let config = ModelConfig::new("o3-mini").unwrap();
+            assert_eq!(config.model_name, "o3-mini");
+        }
+
+        #[test]
+        fn non_reasoning_model_suffix_not_stripped() {
+            let _guard = env_lock::lock_env([
+                ("GOOSE_THINKING_EFFORT", None::<&str>),
+                ("GOOSE_MAX_TOKENS", None::<&str>),
+                ("GOOSE_TEMPERATURE", None::<&str>),
+                ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+                ("GOOSE_TOOLSHIM", None::<&str>),
+                ("GOOSE_TOOLSHIM_OLLAMA_MODEL", None::<&str>),
+            ]);
+            let config = ModelConfig::new("claude-sonnet-4-high").unwrap();
+            assert_eq!(config.model_name, "claude-sonnet-4-high");
         }
 
         #[test]

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -2,10 +2,48 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
+use std::fmt;
+use std::str::FromStr;
 use thiserror::Error;
 use utoipa::ToSchema;
 
 pub const DEFAULT_CONTEXT_LIMIT: usize = 128_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ThinkingEffort {
+    Off,
+    Low,
+    Medium,
+    High,
+    Max,
+}
+
+impl FromStr for ThinkingEffort {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "off" | "disabled" | "none" => Ok(Self::Off),
+            "low" => Ok(Self::Low),
+            "medium" | "med" => Ok(Self::Medium),
+            "high" => Ok(Self::High),
+            "max" => Ok(Self::Max),
+            other => Err(format!("unknown thinking effort: '{other}'")),
+        }
+    }
+}
+
+impl fmt::Display for ThinkingEffort {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Off => write!(f, "off"),
+            Self::Low => write!(f, "low"),
+            Self::Medium => write!(f, "medium"),
+            Self::High => write!(f, "high"),
+            Self::Max => write!(f, "max"),
+        }
+    }
+}
 
 #[derive(Debug, Clone, Deserialize)]
 struct PredefinedModel {
@@ -297,6 +335,11 @@ impl ModelConfig {
         4_096
     }
 
+    pub fn thinking_effort(&self) -> Option<ThinkingEffort> {
+        self.get_config_param::<String>("thinking_effort", "GOOSE_THINKING_EFFORT")
+            .and_then(|s| s.parse::<ThinkingEffort>().ok())
+    }
+
     pub fn get_config_param<T: for<'de> serde::Deserialize<'de>>(
         &self,
         request_key: &str,
@@ -421,6 +464,68 @@ mod tests {
                 .get_config_param::<String>("nonexistent", "NONEXISTENT_CONFIG_KEY"),
             None
         );
+    }
+
+    mod thinking_effort_tests {
+        use super::*;
+
+        #[test]
+        fn from_request_params() {
+            let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
+            let mut params = HashMap::new();
+            params.insert("thinking_effort".to_string(), serde_json::json!("medium"));
+            let config = ModelConfig {
+                model_name: "test".to_string(),
+                request_params: Some(params),
+                ..Default::default()
+            };
+            assert_eq!(config.thinking_effort(), Some(ThinkingEffort::Medium));
+        }
+
+        #[test]
+        fn from_env_var() {
+            let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", Some("high"))]);
+            let config = ModelConfig {
+                model_name: "test".to_string(),
+                ..Default::default()
+            };
+            assert_eq!(config.thinking_effort(), Some(ThinkingEffort::High));
+        }
+
+        #[test]
+        fn request_params_override_env() {
+            let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", Some("high"))]);
+            let mut params = HashMap::new();
+            params.insert("thinking_effort".to_string(), serde_json::json!("low"));
+            let config = ModelConfig {
+                model_name: "test".to_string(),
+                request_params: Some(params),
+                ..Default::default()
+            };
+            assert_eq!(config.thinking_effort(), Some(ThinkingEffort::Low));
+        }
+
+        #[test]
+        fn none_when_not_set() {
+            let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
+            let config = ModelConfig {
+                model_name: "test".to_string(),
+                ..Default::default()
+            };
+            assert_eq!(config.thinking_effort(), None);
+        }
+
+        #[test]
+        fn parse_aliases() {
+            assert_eq!("off".parse::<ThinkingEffort>(), Ok(ThinkingEffort::Off));
+            assert_eq!(
+                "disabled".parse::<ThinkingEffort>(),
+                Ok(ThinkingEffort::Off)
+            );
+            assert_eq!("med".parse::<ThinkingEffort>(), Ok(ThinkingEffort::Medium));
+            assert_eq!("max".parse::<ThinkingEffort>(), Ok(ThinkingEffort::Max));
+            assert!("invalid".parse::<ThinkingEffort>().is_err());
+        }
     }
 
     mod with_canonical_limits {

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -301,7 +301,17 @@ impl ModelConfig {
     }
 
     pub fn with_request_params(mut self, params: Option<HashMap<String, Value>>) -> Self {
-        self.request_params = params;
+        match (self.request_params.as_mut(), params) {
+            (Some(existing), Some(new)) => {
+                for (k, v) in new {
+                    existing.insert(k, v);
+                }
+            }
+            (None, Some(new)) => {
+                self.request_params = Some(new);
+            }
+            _ => {}
+        }
         self
     }
 
@@ -341,14 +351,6 @@ impl ModelConfig {
         if !self.is_openai_reasoning_model() {
             return;
         }
-        let has_explicit_effort = self
-            .request_params
-            .as_ref()
-            .and_then(|p| p.get("thinking_effort"))
-            .is_some();
-        if has_explicit_effort {
-            return;
-        }
         let parts: Vec<&str> = self.model_name.split('-').collect();
         let last = match parts.last() {
             Some(l) => *l,
@@ -361,11 +363,18 @@ impl ModelConfig {
             _ => return,
         };
         self.model_name = parts[..parts.len() - 1].join("-");
-        let params = self.request_params.get_or_insert_with(HashMap::new);
-        params.insert(
-            "thinking_effort".to_string(),
-            serde_json::json!(effort.to_string()),
-        );
+        let has_explicit_effort = self
+            .request_params
+            .as_ref()
+            .and_then(|p| p.get("thinking_effort"))
+            .is_some();
+        if !has_explicit_effort {
+            let params = self.request_params.get_or_insert_with(HashMap::new);
+            params.insert(
+                "thinking_effort".to_string(),
+                serde_json::json!(effort.to_string()),
+            );
+        }
     }
 
     pub fn thinking_effort(&self) -> Option<ThinkingEffort> {

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -432,13 +432,10 @@ mod tests {
 
     #[test]
     fn test_get_config_param() {
-        let _guard = env_lock::lock_env([
-            ("CLAUDE_THINKING_EFFORT", Some("high")),
-            ("CLAUDE_THINKING_TYPE", None::<&str>),
-        ]);
+        let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", Some("high"))]);
 
         let mut params = HashMap::new();
-        params.insert("effort".to_string(), serde_json::json!("low"));
+        params.insert("thinking_effort".to_string(), serde_json::json!("low"));
 
         let config_with_params = ModelConfig {
             model_name: "test".to_string(),
@@ -452,11 +449,13 @@ mod tests {
         };
 
         assert_eq!(
-            config_with_params.get_config_param::<String>("effort", "CLAUDE_THINKING_EFFORT"),
+            config_with_params
+                .get_config_param::<String>("thinking_effort", "GOOSE_THINKING_EFFORT"),
             Some("low".to_string())
         );
         assert_eq!(
-            config_without_params.get_config_param::<String>("effort", "CLAUDE_THINKING_EFFORT"),
+            config_without_params
+                .get_config_param::<String>("thinking_effort", "GOOSE_THINKING_EFFORT"),
             Some("high".to_string())
         );
         assert_eq!(
@@ -503,16 +502,6 @@ mod tests {
                 ..Default::default()
             };
             assert_eq!(config.thinking_effort(), Some(ThinkingEffort::Low));
-        }
-
-        #[test]
-        fn none_when_not_set() {
-            let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
-            let config = ModelConfig {
-                model_name: "test".to_string(),
-                ..Default::default()
-            };
-            assert_eq!(config.thinking_effort(), None);
         }
 
         #[test]

--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -247,6 +247,8 @@ fn create_codex_request(
     messages: &[Message],
     tools: &[Tool],
 ) -> Result<Value> {
+    use crate::model::ThinkingEffort;
+
     let input_items = build_input_items(messages)?;
     let reasoning_effort = get_reasoning_effort(&model_config.model_name);
 
@@ -288,6 +290,24 @@ fn create_codex_request(
     if let Some(temp) = model_config.temperature {
         payload_obj.insert("temperature".to_string(), json!(temp));
     }
+
+    let reasoning_effort = match model_config
+        .thinking_effort()
+        .unwrap_or(ThinkingEffort::High)
+    {
+        ThinkingEffort::Off => {
+            if model_config.model_name.contains("codex") {
+                "low"
+            } else {
+                "none"
+            }
+        }
+        ThinkingEffort::Low => "low",
+        ThinkingEffort::Medium => "medium",
+        ThinkingEffort::High => "high",
+        ThinkingEffort::Max => "xhigh",
+    };
+    payload_obj.insert("reasoning_effort".to_string(), json!(reasoning_effort));
 
     Ok(payload)
 }
@@ -1136,6 +1156,28 @@ mod tests {
             "image_url should start with data:image/png;base64, but was: {}",
             url
         );
+    }
+
+    #[test]
+    fn test_create_codex_request_reasoning_effort_from_unified_thinking() {
+        let mut params = std::collections::HashMap::new();
+        params.insert("thinking_effort".to_string(), json!("max"));
+        let mut config = ModelConfig::new("gpt-5.2-codex").unwrap();
+        config.request_params = Some(params);
+
+        let payload = create_codex_request(&config, "sys", &[], &[]).unwrap();
+        assert_eq!(payload["reasoning_effort"], "xhigh");
+    }
+
+    #[test]
+    fn test_create_codex_request_off_maps_to_low_for_codex_models() {
+        let mut params = std::collections::HashMap::new();
+        params.insert("thinking_effort".to_string(), json!("off"));
+        let mut config = ModelConfig::new("gpt-5.2-codex").unwrap();
+        config.request_params = Some(params);
+
+        let payload = create_codex_request(&config, "sys", &[], &[]).unwrap();
+        assert_eq!(payload["reasoning_effort"], "low");
     }
 
     #[test_case(

--- a/crates/goose/src/providers/codex.rs
+++ b/crates/goose/src/providers/codex.rs
@@ -16,7 +16,7 @@ use super::base::{
 };
 use super::errors::ProviderError;
 use super::utils::{filter_extensions_from_system_prompt, RequestLog};
-use crate::config::base::{CodexCommand, CodexReasoningEffort, CodexSkipGitCheck};
+use crate::config::base::{CodexCommand, CodexSkipGitCheck};
 use crate::config::paths::Paths;
 use crate::config::search_path::SearchPaths;
 use crate::config::{Config, ExtensionConfig, GooseMode};
@@ -60,6 +60,27 @@ pub struct CodexProvider {
 }
 
 impl CodexProvider {
+    fn map_thinking_effort(
+        model_name: &str,
+        effort: Option<crate::model::ThinkingEffort>,
+    ) -> String {
+        use crate::model::ThinkingEffort;
+        match effort.unwrap_or(ThinkingEffort::High) {
+            ThinkingEffort::Off => {
+                if model_name.contains("codex") {
+                    "low".to_string()
+                } else {
+                    "none".to_string()
+                }
+            }
+            ThinkingEffort::Low => "low".to_string(),
+            ThinkingEffort::Medium => "medium".to_string(),
+            ThinkingEffort::High => "high".to_string(),
+            ThinkingEffort::Max => "xhigh".to_string(),
+        }
+    }
+
+    #[cfg(test)]
     fn supports_reasoning_effort(model_name: &str, reasoning_effort: &str) -> bool {
         if !CODEX_REASONING_LEVELS.contains(&reasoning_effort) {
             return false;
@@ -604,7 +625,6 @@ impl ProviderDef for CodexProvider {
             CODEX_DOC_URL,
             vec![
                 ConfigKey::from_value_type::<CodexCommand>(true, false, true),
-                ConfigKey::from_value_type::<CodexReasoningEffort>(false, false, true),
                 ConfigKey::from_value_type::<CodexSkipGitCheck>(false, false, true),
             ],
         )
@@ -619,24 +639,8 @@ impl ProviderDef for CodexProvider {
             let command: String = config.get_codex_command().unwrap_or_default().into();
             let resolved_command = SearchPaths::builder().with_npm().resolve(command)?;
 
-            // Get reasoning effort from config, default to "high"
-            let reasoning_effort = config
-                .get_codex_reasoning_effort()
-                .map(String::from)
-                .unwrap_or_else(|_| "high".to_string());
-
-            // Validate reasoning effort
             let reasoning_effort =
-                if Self::supports_reasoning_effort(&model.model_name, &reasoning_effort) {
-                    reasoning_effort
-                } else {
-                    tracing::warn!(
-                        "Invalid CODEX_REASONING_EFFORT '{}' for model '{}', using 'high'",
-                        reasoning_effort,
-                        model.model_name
-                    );
-                    "high".to_string()
-                };
+                Self::map_thinking_effort(&model.model_name, model.thinking_effort());
 
             // Get skip_git_check from config, default to false
             let skip_git_check = config
@@ -1212,20 +1216,38 @@ mod tests {
     #[test]
     fn test_config_keys() {
         let metadata = CodexProvider::metadata();
-        assert_eq!(metadata.config_keys.len(), 3);
+        assert_eq!(metadata.config_keys.len(), 2);
 
         // First key should be CODEX_COMMAND (required)
         assert_eq!(metadata.config_keys[0].name, "CODEX_COMMAND");
         assert!(metadata.config_keys[0].required);
         assert!(!metadata.config_keys[0].secret);
 
-        // Second key should be CODEX_REASONING_EFFORT (optional)
-        assert_eq!(metadata.config_keys[1].name, "CODEX_REASONING_EFFORT");
+        // Second key should be CODEX_SKIP_GIT_CHECK (optional)
+        assert_eq!(metadata.config_keys[1].name, "CODEX_SKIP_GIT_CHECK");
         assert!(!metadata.config_keys[1].required);
+    }
 
-        // Third key should be CODEX_SKIP_GIT_CHECK (optional)
-        assert_eq!(metadata.config_keys[2].name, "CODEX_SKIP_GIT_CHECK");
-        assert!(!metadata.config_keys[2].required);
+    #[test]
+    fn test_map_thinking_effort() {
+        use crate::model::ThinkingEffort;
+
+        assert_eq!(
+            CodexProvider::map_thinking_effort("gpt-5.2-codex", Some(ThinkingEffort::Off)),
+            "low"
+        );
+        assert_eq!(
+            CodexProvider::map_thinking_effort("gpt-5.2", Some(ThinkingEffort::Off)),
+            "none"
+        );
+        assert_eq!(
+            CodexProvider::map_thinking_effort("gpt-5.2-codex", Some(ThinkingEffort::Max)),
+            "xhigh"
+        );
+        assert_eq!(
+            CodexProvider::map_thinking_effort("gpt-5.2-codex", None),
+            "high"
+        );
     }
 
     #[test]

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -52,6 +52,16 @@ pub fn thinking_type(model_config: &ModelConfig) -> ThinkingType {
 
     let is_adaptive_model = supports_adaptive_thinking(&model_config.model_name);
 
+    // Unified thinking effort takes priority
+    if let Some(effort) = model_config.thinking_effort() {
+        use crate::model::ThinkingEffort;
+        return match effort {
+            ThinkingEffort::Off => ThinkingType::Disabled,
+            _ if is_adaptive_model => ThinkingType::Adaptive,
+            _ => ThinkingType::Enabled,
+        };
+    }
+
     if let Some(s) =
         model_config.get_config_param::<String>("thinking_type", "CLAUDE_THINKING_TYPE")
     {
@@ -469,6 +479,17 @@ pub fn get_usage(data: &Value) -> Result<Usage> {
 }
 
 pub fn thinking_effort(model_config: &ModelConfig) -> ThinkingEffort {
+    // Unified thinking effort takes priority
+    if let Some(effort) = model_config.thinking_effort() {
+        return match effort {
+            crate::model::ThinkingEffort::Off => ThinkingEffort::Low,
+            crate::model::ThinkingEffort::Low => ThinkingEffort::Low,
+            crate::model::ThinkingEffort::Medium => ThinkingEffort::Medium,
+            crate::model::ThinkingEffort::High => ThinkingEffort::High,
+            crate::model::ThinkingEffort::Max => ThinkingEffort::Max,
+        };
+    }
+
     match model_config.get_config_param::<String>("effort", "CLAUDE_THINKING_EFFORT") {
         Some(s) => s.parse().unwrap_or_else(|e| {
             tracing::warn!("{e}, defaulting to 'high'");

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -51,43 +51,14 @@ pub fn thinking_type(model_config: &ModelConfig) -> ThinkingType {
     }
 
     let is_adaptive_model = supports_adaptive_thinking(&model_config.model_name);
+    let effort = model_config
+        .thinking_effort()
+        .unwrap_or(crate::model::ThinkingEffort::Off);
 
-    // Unified thinking effort takes priority
-    if let Some(effort) = model_config.thinking_effort() {
-        use crate::model::ThinkingEffort;
-        return match effort {
-            ThinkingEffort::Off => ThinkingType::Disabled,
-            _ if is_adaptive_model => ThinkingType::Adaptive,
-            _ => ThinkingType::Enabled,
-        };
-    }
-
-    if let Some(s) =
-        model_config.get_config_param::<String>("thinking_type", "CLAUDE_THINKING_TYPE")
-    {
-        let tt = s.parse::<ThinkingType>().unwrap_or_else(|e| {
-            tracing::warn!("{e}");
-            ThinkingType::Disabled
-        });
-        if tt == ThinkingType::Adaptive && !is_adaptive_model {
-            tracing::warn!(
-                "Adaptive thinking not supported for {}, disabling thinking",
-                model_config.model_name
-            );
-            return ThinkingType::Disabled;
-        }
-        return tt;
-    }
-
-    if is_adaptive_model {
-        ThinkingType::Adaptive
-    } else if std::env::var("CLAUDE_THINKING_ENABLED").is_ok() {
-        tracing::warn!(
-            "CLAUDE_THINKING_ENABLED is deprecated, use CLAUDE_THINKING_TYPE=enabled instead"
-        );
-        ThinkingType::Enabled
-    } else {
-        ThinkingType::Disabled
+    match effort {
+        crate::model::ThinkingEffort::Off => ThinkingType::Disabled,
+        _ if is_adaptive_model => ThinkingType::Adaptive,
+        _ => ThinkingType::Enabled,
     }
 }
 
@@ -479,23 +450,16 @@ pub fn get_usage(data: &Value) -> Result<Usage> {
 }
 
 pub fn thinking_effort(model_config: &ModelConfig) -> ThinkingEffort {
-    // Unified thinking effort takes priority
-    if let Some(effort) = model_config.thinking_effort() {
-        return match effort {
-            crate::model::ThinkingEffort::Off => ThinkingEffort::Low,
-            crate::model::ThinkingEffort::Low => ThinkingEffort::Low,
-            crate::model::ThinkingEffort::Medium => ThinkingEffort::Medium,
-            crate::model::ThinkingEffort::High => ThinkingEffort::High,
-            crate::model::ThinkingEffort::Max => ThinkingEffort::Max,
-        };
-    }
-
-    match model_config.get_config_param::<String>("effort", "CLAUDE_THINKING_EFFORT") {
-        Some(s) => s.parse().unwrap_or_else(|e| {
-            tracing::warn!("{e}, defaulting to 'high'");
-            ThinkingEffort::High
-        }),
-        None => ThinkingEffort::High,
+    let effort = model_config
+        .thinking_effort()
+        .unwrap_or(crate::model::ThinkingEffort::High);
+    match effort {
+        crate::model::ThinkingEffort::Off | crate::model::ThinkingEffort::Low => {
+            ThinkingEffort::Low
+        }
+        crate::model::ThinkingEffort::Medium => ThinkingEffort::Medium,
+        crate::model::ThinkingEffort::High => ThinkingEffort::High,
+        crate::model::ThinkingEffort::Max => ThinkingEffort::Max,
     }
 }
 
@@ -508,10 +472,16 @@ fn apply_thinking_config(payload: &mut Value, model_config: &ModelConfig, max_to
             obj.insert("output_config".to_string(), json!({"effort": effort}));
         }
         ThinkingType::Enabled => {
-            let budget_tokens = model_config
-                .get_config_param::<i32>("budget_tokens", "CLAUDE_THINKING_BUDGET")
-                .unwrap_or(16000)
-                .max(1024);
+            let effort = model_config
+                .thinking_effort()
+                .unwrap_or(crate::model::ThinkingEffort::High);
+            let budget_tokens = match effort {
+                crate::model::ThinkingEffort::Off => 1024,
+                crate::model::ThinkingEffort::Low => 4000,
+                crate::model::ThinkingEffort::Medium => 10000,
+                crate::model::ThinkingEffort::High => 16000,
+                crate::model::ThinkingEffort::Max => 32000,
+            };
 
             obj.insert("max_tokens".to_string(), json!(max_tokens + budget_tokens));
             obj.insert(
@@ -1041,14 +1011,14 @@ mod tests {
 
     #[test]
     fn test_create_request_adaptive_thinking_for_46_models() -> Result<()> {
-        let _guard = env_lock::lock_env([
-            ("CLAUDE_THINKING_TYPE", Some("adaptive")),
-            ("CLAUDE_THINKING_EFFORT", Some("high")),
-            ("CLAUDE_THINKING_ENABLED", None::<&str>),
-        ]);
+        let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
+
+        let mut params = std::collections::HashMap::new();
+        params.insert("thinking_effort".to_string(), json!("high"));
 
         let mut config = cfg("claude-opus-4-6");
         config.max_tokens = Some(4096);
+        config.request_params = Some(params);
         let messages = vec![Message::user().with_text("Hello")];
         let payload = create_request(&config, "system", &messages, &[])?;
 
@@ -1061,16 +1031,10 @@ mod tests {
 
     #[test]
     fn test_create_request_enabled_thinking_with_budget() -> Result<()> {
-        let _guard = env_lock::lock_env([
-            ("CLAUDE_THINKING_TYPE", None::<&str>),
-            ("CLAUDE_THINKING_EFFORT", None::<&str>),
-            ("CLAUDE_THINKING_ENABLED", None::<&str>),
-            ("CLAUDE_THINKING_BUDGET", None::<&str>),
-        ]);
+        let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
 
         let mut params = std::collections::HashMap::new();
-        params.insert("thinking_type".to_string(), json!("enabled"));
-        params.insert("budget_tokens".to_string(), json!(10000));
+        params.insert("thinking_effort".to_string(), json!("high"));
 
         let mut config = cfg("claude-3-7-sonnet-20250219");
         config.max_tokens = Some(4096);
@@ -1080,20 +1044,15 @@ mod tests {
         let payload = create_request(&config, "system", &messages, &[])?;
 
         assert_eq!(payload["thinking"]["type"], "enabled");
-        assert_eq!(payload["thinking"]["budget_tokens"], 10000);
-        assert_eq!(payload["max_tokens"], 4096 + 10000);
+        assert_eq!(payload["thinking"]["budget_tokens"], 16000);
+        assert_eq!(payload["max_tokens"], 4096 + 16000);
 
         Ok(())
     }
 
     #[test]
     fn test_create_request_disabled_thinking_no_thinking_field() -> Result<()> {
-        let _guard = env_lock::lock_env([
-            ("CLAUDE_THINKING_TYPE", None::<&str>),
-            ("CLAUDE_THINKING_ENABLED", None::<&str>),
-        ]);
-
-        let config = cfg("claude-sonnet-4-20250514");
+        let config = cfg_with_effort("claude-sonnet-4-20250514", "off");
         let messages = vec![Message::user().with_text("Hello")];
         let payload = create_request(&config, "system", &messages, &[])?;
 
@@ -1235,9 +1194,9 @@ mod tests {
         }
     }
 
-    fn cfg_with_thinking(name: &str, tt: &str) -> ModelConfig {
+    fn cfg_with_effort(name: &str, effort: &str) -> ModelConfig {
         let mut params = std::collections::HashMap::new();
-        params.insert("thinking_type".to_string(), json!(tt));
+        params.insert("thinking_effort".to_string(), json!(effort));
         ModelConfig {
             model_name: name.to_string(),
             request_params: Some(params),
@@ -1246,50 +1205,50 @@ mod tests {
     }
 
     #[test]
-    fn test_thinking_type_explicit_params() {
+    fn test_thinking_type_from_effort() {
+        let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
+        // Adaptive model with effort → adaptive
         assert_eq!(
-            thinking_type(&cfg_with_thinking("claude-opus-4-6", "adaptive")),
+            thinking_type(&cfg_with_effort("claude-opus-4-6", "high")),
             ThinkingType::Adaptive
         );
+        // Adaptive model with off → disabled
         assert_eq!(
-            thinking_type(&cfg_with_thinking("claude-opus-4-6", "disabled")),
+            thinking_type(&cfg_with_effort("claude-opus-4-6", "off")),
             ThinkingType::Disabled
         );
+        // Non-adaptive Claude with effort → enabled
         assert_eq!(
-            thinking_type(&cfg_with_thinking("claude-3-7-sonnet-20250219", "enabled")),
+            thinking_type(&cfg_with_effort("claude-3-7-sonnet-20250219", "high")),
             ThinkingType::Enabled
         );
+        // Non-adaptive Claude with off → disabled
         assert_eq!(
-            thinking_type(&cfg_with_thinking("claude-3-7-sonnet-20250219", "adaptive")),
-            ThinkingType::Disabled
-        );
-        assert_eq!(
-            thinking_type(&cfg_with_thinking("claude-opus-4-6", "adapttive")),
+            thinking_type(&cfg_with_effort("claude-3-7-sonnet-20250219", "off")),
             ThinkingType::Disabled
         );
     }
 
     #[test]
     fn test_thinking_type_non_claude_always_disabled() {
-        assert_eq!(thinking_type(&cfg("gpt-4o")), ThinkingType::Disabled);
         assert_eq!(
-            thinking_type(&cfg_with_thinking("gpt-4o", "enabled")),
+            thinking_type(&cfg_with_effort("gpt-4o", "off")),
+            ThinkingType::Disabled
+        );
+        assert_eq!(
+            thinking_type(&cfg_with_effort("gpt-4o", "high")),
             ThinkingType::Disabled
         );
     }
 
     #[test]
-    fn test_thinking_type_env_var_override() {
-        let _guard = env_lock::lock_env([
-            ("CLAUDE_THINKING_TYPE", Some("adaptive")),
-            ("CLAUDE_THINKING_ENABLED", None::<&str>),
-        ]);
+    fn test_thinking_type_off_means_disabled() {
         assert_eq!(
-            thinking_type(&cfg("claude-opus-4-6")),
-            ThinkingType::Adaptive
+            thinking_type(&cfg_with_effort("claude-opus-4-6", "off")),
+            ThinkingType::Disabled
         );
         assert_eq!(
-            thinking_type(&cfg("claude-3-7-sonnet-20250219")),
+            thinking_type(&cfg_with_effort("claude-3-7-sonnet-20250219", "off")),
             ThinkingType::Disabled
         );
     }

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -1,6 +1,6 @@
 use crate::conversation::message::{Message, MessageContent};
 use crate::mcp_utils::extract_text_from_resource;
-use crate::model::ModelConfig;
+use crate::model::{ModelConfig, ThinkingEffort};
 use crate::providers::base::Usage;
 use crate::providers::errors::ProviderError;
 use crate::providers::utils::{convert_image, ImageFormat};
@@ -37,7 +37,6 @@ macro_rules! string_enum {
 }
 
 string_enum!(ThinkingType { Adaptive => "adaptive", Enabled => "enabled", Disabled => "disabled" });
-string_enum!(ThinkingEffort { Low => "low", Medium => "medium", High => "high", Max => "max" });
 
 pub fn supports_adaptive_thinking(model_name: &str) -> bool {
     let lower = model_name.to_lowercase();
@@ -53,10 +52,10 @@ pub fn thinking_type(model_config: &ModelConfig) -> ThinkingType {
     let is_adaptive_model = supports_adaptive_thinking(&model_config.model_name);
     let effort = model_config
         .thinking_effort()
-        .unwrap_or(crate::model::ThinkingEffort::Off);
+        .unwrap_or(ThinkingEffort::Off);
 
     match effort {
-        crate::model::ThinkingEffort::Off => ThinkingType::Disabled,
+        ThinkingEffort::Off => ThinkingType::Disabled,
         _ if is_adaptive_model => ThinkingType::Adaptive,
         _ => ThinkingType::Enabled,
     }
@@ -450,17 +449,9 @@ pub fn get_usage(data: &Value) -> Result<Usage> {
 }
 
 pub fn thinking_effort(model_config: &ModelConfig) -> ThinkingEffort {
-    let effort = model_config
+    model_config
         .thinking_effort()
-        .unwrap_or(crate::model::ThinkingEffort::High);
-    match effort {
-        crate::model::ThinkingEffort::Off | crate::model::ThinkingEffort::Low => {
-            ThinkingEffort::Low
-        }
-        crate::model::ThinkingEffort::Medium => ThinkingEffort::Medium,
-        crate::model::ThinkingEffort::High => ThinkingEffort::High,
-        crate::model::ThinkingEffort::Max => ThinkingEffort::Max,
-    }
+        .unwrap_or(ThinkingEffort::High)
 }
 
 fn apply_thinking_config(payload: &mut Value, model_config: &ModelConfig, max_tokens: i32) {
@@ -474,13 +465,13 @@ fn apply_thinking_config(payload: &mut Value, model_config: &ModelConfig, max_to
         ThinkingType::Enabled => {
             let effort = model_config
                 .thinking_effort()
-                .unwrap_or(crate::model::ThinkingEffort::High);
+                .unwrap_or(ThinkingEffort::High);
             let budget_tokens = match effort {
-                crate::model::ThinkingEffort::Off => 1024,
-                crate::model::ThinkingEffort::Low => 4000,
-                crate::model::ThinkingEffort::Medium => 10000,
-                crate::model::ThinkingEffort::High => 16000,
-                crate::model::ThinkingEffort::Max => 32000,
+                ThinkingEffort::Off => 1024,
+                ThinkingEffort::Low => 4000,
+                ThinkingEffort::Medium => 10000,
+                ThinkingEffort::High => 16000,
+                ThinkingEffort::Max => 32000,
             };
 
             obj.insert("max_tokens".to_string(), json!(max_tokens + budget_tokens));
@@ -1031,21 +1022,16 @@ mod tests {
 
     #[test]
     fn test_create_request_enabled_thinking_with_budget() -> Result<()> {
-        let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
-
-        let mut params = std::collections::HashMap::new();
-        params.insert("thinking_effort".to_string(), json!("high"));
-
-        let mut config = cfg("claude-3-7-sonnet-20250219");
+        let mut config = cfg_with_effort("claude-3-7-sonnet-20250219", "high");
         config.max_tokens = Some(4096);
-        config.request_params = Some(params);
 
         let messages = vec![Message::user().with_text("Hello")];
         let payload = create_request(&config, "system", &messages, &[])?;
 
         assert_eq!(payload["thinking"]["type"], "enabled");
-        assert_eq!(payload["thinking"]["budget_tokens"], 16000);
-        assert_eq!(payload["max_tokens"], 4096 + 16000);
+        let budget = payload["thinking"]["budget_tokens"].as_i64().unwrap();
+        assert!(budget > 0);
+        assert_eq!(payload["max_tokens"], 4096 + budget);
 
         Ok(())
     }

--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -1080,15 +1080,11 @@ mod tests {
 
     #[test]
     fn test_create_request_adaptive_thinking_for_46_models() -> anyhow::Result<()> {
-        let _guard = env_lock::lock_env([
-            ("CLAUDE_THINKING_TYPE", Some("adaptive")),
-            ("CLAUDE_THINKING_EFFORT", Some("low")),
-            ("CLAUDE_THINKING_ENABLED", None::<&str>),
-            ("CLAUDE_THINKING_BUDGET", None::<&str>),
-        ]);
-
         let mut model_config = ModelConfig::new_or_fail("databricks-claude-opus-4-6");
         model_config.max_tokens = Some(4096);
+        let mut params = std::collections::HashMap::new();
+        params.insert("thinking_effort".to_string(), serde_json::json!("low"));
+        model_config.request_params = Some(params);
 
         let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
 
@@ -1103,20 +1099,17 @@ mod tests {
 
     #[test]
     fn test_create_request_enabled_thinking_with_budget() -> anyhow::Result<()> {
-        let _guard = env_lock::lock_env([
-            ("CLAUDE_THINKING_TYPE", None::<&str>),
-            ("CLAUDE_THINKING_ENABLED", Some("1")),
-            ("CLAUDE_THINKING_BUDGET", Some("10000")),
-        ]);
-
         let mut model_config = ModelConfig::new_or_fail("databricks-claude-3-7-sonnet");
         model_config.max_tokens = Some(4096);
+        let mut params = std::collections::HashMap::new();
+        params.insert("thinking_effort".to_string(), serde_json::json!("high"));
+        model_config.request_params = Some(params);
 
         let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
 
         assert_eq!(request["thinking"]["type"], "enabled");
-        assert_eq!(request["thinking"]["budget_tokens"], 10000);
-        assert_eq!(request["max_tokens"], 14096);
+        assert_eq!(request["thinking"]["budget_tokens"], 16000);
+        assert_eq!(request["max_tokens"], 20096);
         assert_eq!(request["temperature"], 2);
         assert!(request.get("max_completion_tokens").is_none());
 

--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -583,34 +583,19 @@ pub fn create_request(
 
     let is_openai_reasoning_model = model_config.is_openai_reasoning_model();
     let (model_name, reasoning_effort) = if is_openai_reasoning_model {
-        // Unified thinking effort takes priority
-        if let Some(effort) = model_config.thinking_effort() {
-            use crate::model::ThinkingEffort;
-            let effort_str = match effort {
-                ThinkingEffort::Off | ThinkingEffort::Low => "low",
-                ThinkingEffort::Medium => "medium",
-                ThinkingEffort::High | ThinkingEffort::Max => "high",
-            };
-            (
-                model_config.model_name.to_string(),
-                Some(effort_str.to_string()),
-            )
-        } else {
-            // Legacy: parse effort from model name suffix
-            let parts: Vec<&str> = model_config.model_name.split('-').collect();
-            let last_part = parts.last().unwrap();
-
-            match *last_part {
-                "low" | "medium" | "high" => {
-                    let base_name = parts[..parts.len() - 1].join("-");
-                    (base_name, Some(last_part.to_string()))
-                }
-                _ => (
-                    model_config.model_name.to_string(),
-                    Some("medium".to_string()),
-                ),
-            }
-        }
+        use crate::model::ThinkingEffort;
+        let effort = model_config
+            .thinking_effort()
+            .unwrap_or(ThinkingEffort::Medium);
+        let effort_str = match effort {
+            ThinkingEffort::Off | ThinkingEffort::Low => "low",
+            ThinkingEffort::Medium => "medium",
+            ThinkingEffort::High | ThinkingEffort::Max => "high",
+        };
+        (
+            model_config.model_name.to_string(),
+            Some(effort_str.to_string()),
+        )
     } else {
         (model_config.model_name.to_string(), None)
     };
@@ -1072,15 +1057,17 @@ mod tests {
 
     #[test]
     fn test_create_request_reasoning_effort() -> anyhow::Result<()> {
+        let mut params = std::collections::HashMap::new();
+        params.insert("thinking_effort".to_string(), serde_json::json!("high"));
         let model_config = ModelConfig {
-            model_name: "o3-mini-high".to_string(),
+            model_name: "o3-mini".to_string(),
             context_limit: Some(4096),
             temperature: None,
             max_tokens: Some(1024),
             toolshim: false,
             toolshim_model: None,
             fast_model_config: None,
-            request_params: None,
+            request_params: Some(params),
             reasoning: None,
         };
         let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;

--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -667,6 +667,9 @@ pub fn create_request(
     if let Some(params) = &model_config.request_params {
         if let Some(obj) = payload.as_object_mut() {
             for (key, value) in params {
+                if key == "thinking_effort" {
+                    continue;
+                }
                 obj.insert(key.clone(), value.clone());
             }
         }

--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -583,18 +583,33 @@ pub fn create_request(
 
     let is_openai_reasoning_model = model_config.is_openai_reasoning_model();
     let (model_name, reasoning_effort) = if is_openai_reasoning_model {
-        let parts: Vec<&str> = model_config.model_name.split('-').collect();
-        let last_part = parts.last().unwrap();
-
-        match *last_part {
-            "low" | "medium" | "high" => {
-                let base_name = parts[..parts.len() - 1].join("-");
-                (base_name, Some(last_part.to_string()))
-            }
-            _ => (
+        // Unified thinking effort takes priority
+        if let Some(effort) = model_config.thinking_effort() {
+            use crate::model::ThinkingEffort;
+            let effort_str = match effort {
+                ThinkingEffort::Off | ThinkingEffort::Low => "low",
+                ThinkingEffort::Medium => "medium",
+                ThinkingEffort::High | ThinkingEffort::Max => "high",
+            };
+            (
                 model_config.model_name.to_string(),
-                Some("medium".to_string()),
-            ),
+                Some(effort_str.to_string()),
+            )
+        } else {
+            // Legacy: parse effort from model name suffix
+            let parts: Vec<&str> = model_config.model_name.split('-').collect();
+            let last_part = parts.last().unwrap();
+
+            match *last_part {
+                "low" | "medium" | "high" => {
+                    let base_name = parts[..parts.len() - 1].join("-");
+                    (base_name, Some(last_part.to_string()))
+                }
+                _ => (
+                    model_config.model_name.to_string(),
+                    Some("medium".to_string()),
+                ),
+            }
         }
     } else {
         (model_config.model_name.to_string(), None)

--- a/crates/goose/src/providers/formats/google.rs
+++ b/crates/goose/src/providers/formats/google.rs
@@ -541,39 +541,14 @@ fn get_thinking_config(model_config: &ModelConfig) -> Option<ThinkingConfig> {
         return None;
     }
 
-    // Unified thinking effort takes priority
-    if let Some(effort) = model_config.thinking_effort() {
-        use crate::model::ThinkingEffort;
-        let thinking_level = match effort {
-            ThinkingEffort::Off | ThinkingEffort::Low | ThinkingEffort::Medium => {
-                ThinkingLevel::Low
-            }
-            ThinkingEffort::High | ThinkingEffort::Max => ThinkingLevel::High,
-        };
-        return Some(ThinkingConfig {
-            thinking_level: Some(thinking_level),
-            thinking_budget: None,
-            include_thoughts: true,
-        });
-    }
-
     if is_gemini_3 {
-        let thinking_level_str = model_config
-            .get_config_param::<String>("thinking_level", "GEMINI3_THINKING_LEVEL")
-            .map(|s| s.to_lowercase())
-            .unwrap_or_else(|| "low".to_string());
-
-        let thinking_level = match thinking_level_str.as_str() {
-            "high" => ThinkingLevel::High,
-            "low" => ThinkingLevel::Low,
-            invalid => {
-                tracing::warn!(
-                    "Invalid thinking level '{}' for model '{}'. Valid levels: low, high. Using 'low'.",
-                    invalid,
-                    model_config.model_name,
-                );
-                ThinkingLevel::Low
-            }
+        use crate::model::ThinkingEffort;
+        let effort = model_config
+            .thinking_effort()
+            .unwrap_or(ThinkingEffort::Low);
+        let thinking_level = match effort {
+            ThinkingEffort::Off | ThinkingEffort::Low | ThinkingEffort::Medium => ThinkingLevel::Low,
+            ThinkingEffort::High | ThinkingEffort::Max => ThinkingLevel::High,
         };
 
         Some(ThinkingConfig {
@@ -1394,7 +1369,11 @@ data: [DONE]"#;
     fn test_get_thinking_config() {
         use crate::model::ModelConfig;
 
-        let config = ModelConfig::new("gemini-3-pro").unwrap();
+        // Test 1: Gemini 3 model with low thinking effort
+        let mut params = std::collections::HashMap::new();
+        params.insert("thinking_effort".to_string(), serde_json::json!("low"));
+        let mut config = ModelConfig::new("gemini-3-pro").unwrap();
+        config.request_params = Some(params);
         let result = get_thinking_config(&config);
         assert!(result.is_some());
         let thinking_config = result.unwrap();
@@ -1402,9 +1381,18 @@ data: [DONE]"#;
         assert!(thinking_config.thinking_budget.is_none());
         assert!(thinking_config.include_thoughts);
 
-        let config = ModelConfig::new("Gemini-3-Flash").unwrap();
+        // Test 2: Gemini 3 model with high thinking effort
+        let mut params = std::collections::HashMap::new();
+        params.insert("thinking_effort".to_string(), serde_json::json!("high"));
+        let mut config = ModelConfig::new("Gemini-3-Flash").unwrap();
+        config.request_params = Some(params);
         let result = get_thinking_config(&config);
         assert!(result.is_some());
+        let thinking_config = result.unwrap();
+        assert!(matches!(
+            thinking_config.thinking_level,
+            ThinkingLevel::High
+        ));
 
         let config = ModelConfig::new("gemini-2.5-flash").unwrap();
         let result = get_thinking_config(&config);

--- a/crates/goose/src/providers/formats/google.rs
+++ b/crates/goose/src/providers/formats/google.rs
@@ -545,7 +545,10 @@ fn get_thinking_config(model_config: &ModelConfig) -> Option<ThinkingConfig> {
         use crate::model::ThinkingEffort;
         let effort = model_config
             .thinking_effort()
-            .unwrap_or(ThinkingEffort::Low);
+            .unwrap_or(ThinkingEffort::Off);
+        if effort == ThinkingEffort::Off {
+            return None;
+        }
         let thinking_level = match effort {
             ThinkingEffort::Off | ThinkingEffort::Low | ThinkingEffort::Medium => ThinkingLevel::Low,
             ThinkingEffort::High | ThinkingEffort::Max => ThinkingLevel::High,

--- a/crates/goose/src/providers/formats/google.rs
+++ b/crates/goose/src/providers/formats/google.rs
@@ -541,6 +541,22 @@ fn get_thinking_config(model_config: &ModelConfig) -> Option<ThinkingConfig> {
         return None;
     }
 
+    // Unified thinking effort takes priority
+    if let Some(effort) = model_config.thinking_effort() {
+        use crate::model::ThinkingEffort;
+        let thinking_level = match effort {
+            ThinkingEffort::Off | ThinkingEffort::Low | ThinkingEffort::Medium => {
+                ThinkingLevel::Low
+            }
+            ThinkingEffort::High | ThinkingEffort::Max => ThinkingLevel::High,
+        };
+        return Some(ThinkingConfig {
+            thinking_level: Some(thinking_level),
+            thinking_budget: None,
+            include_thoughts: true,
+        });
+    }
+
     if is_gemini_3 {
         let thinking_level_str = model_config
             .get_config_param::<String>("thinking_level", "GEMINI3_THINKING_LEVEL")

--- a/crates/goose/src/providers/formats/google.rs
+++ b/crates/goose/src/providers/formats/google.rs
@@ -1394,7 +1394,7 @@ data: [DONE]"#;
         let thinking_config = result.unwrap();
         assert!(matches!(
             thinking_config.thinking_level,
-            ThinkingLevel::High
+            Some(ThinkingLevel::High)
         ));
 
         let config = ModelConfig::new("gemini-2.5-flash").unwrap();
@@ -1412,7 +1412,7 @@ data: [DONE]"#;
         params.insert("thinking_budget".to_string(), json!(4096));
         let config = ModelConfig::new("gemini-2.5-flash")
             .unwrap()
-            .with_request_params(Some(params));
+            .with_merged_request_params(params);
         let result = get_thinking_config(&config);
         assert!(result.is_some());
         let thinking_config = result.unwrap();
@@ -1422,7 +1422,7 @@ data: [DONE]"#;
         params.insert("thinking_budget".to_string(), json!(-1));
         let config = ModelConfig::new("gemini-2.5-flash")
             .unwrap()
-            .with_request_params(Some(params));
+            .with_merged_request_params(params);
         let result = get_thinking_config(&config);
         assert!(result.is_some());
         let thinking_config = result.unwrap();

--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -868,7 +868,23 @@ pub fn create_request(
         ));
     }
 
-    let (model_name, reasoning_effort) = extract_reasoning_effort(&model_config.model_name);
+    // Unified thinking effort takes priority for reasoning models
+    let (model_name, reasoning_effort) = if let Some(effort) = model_config.thinking_effort() {
+        let (base_name, legacy_effort) = extract_reasoning_effort(&model_config.model_name);
+        if legacy_effort.is_some() {
+            use crate::model::ThinkingEffort;
+            let effort_str = match effort {
+                ThinkingEffort::Off | ThinkingEffort::Low => "low",
+                ThinkingEffort::Medium => "medium",
+                ThinkingEffort::High | ThinkingEffort::Max => "high",
+            };
+            (base_name, Some(effort_str.to_string()))
+        } else {
+            (base_name, None)
+        }
+    } else {
+        extract_reasoning_effort(&model_config.model_name)
+    };
     let is_reasoning_model = reasoning_effort.is_some();
 
     let system_message = json!({

--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -868,24 +868,26 @@ pub fn create_request(
         ));
     }
 
-    // Unified thinking effort takes priority for reasoning models
-    let (model_name, reasoning_effort) = if let Some(effort) = model_config.thinking_effort() {
-        let (base_name, legacy_effort) = extract_reasoning_effort(&model_config.model_name);
-        if legacy_effort.is_some() {
-            use crate::model::ThinkingEffort;
-            let effort_str = match effort {
-                ThinkingEffort::Off | ThinkingEffort::Low => "low",
-                ThinkingEffort::Medium => "medium",
-                ThinkingEffort::High | ThinkingEffort::Max => "high",
-            };
-            (base_name, Some(effort_str.to_string()))
-        } else {
-            (base_name, None)
-        }
+    let (base_name, legacy_effort) = extract_reasoning_effort(&model_config.model_name);
+    let is_reasoning_model = legacy_effort.is_some();
+
+    let (model_name, reasoning_effort) = if is_reasoning_model {
+        use crate::model::ThinkingEffort;
+        let effort = model_config
+            .thinking_effort()
+            .unwrap_or(ThinkingEffort::Medium);
+        let effort_str = match effort {
+            ThinkingEffort::Off | ThinkingEffort::Low => "low",
+            ThinkingEffort::Medium => "medium",
+            ThinkingEffort::High | ThinkingEffort::Max => "high",
+        };
+        (
+            base_name,
+            Some(effort_str.to_string()),
+        )
     } else {
-        extract_reasoning_effort(&model_config.model_name)
+        (base_name, None)
     };
-    let is_reasoning_model = reasoning_effort.is_some();
 
     let system_message = json!({
         "role": if is_reasoning_model { "developer" } else { "system" },
@@ -1616,8 +1618,9 @@ mod tests {
     }
 
     #[test]
-    fn test_create_request_o1_default() -> anyhow::Result<()> {
-        // Test default medium reasoning effort for O1 model
+    fn test_create_request_o1_medium_effort() -> anyhow::Result<()> {
+        let mut params = std::collections::HashMap::new();
+        params.insert("thinking_effort".to_string(), json!("medium"));
         let model_config = ModelConfig {
             model_name: "o1".to_string(),
             context_limit: Some(4096),
@@ -1626,7 +1629,7 @@ mod tests {
             toolshim: false,
             toolshim_model: None,
             fast_model_config: None,
-            request_params: None,
+            request_params: Some(params),
             reasoning: None,
         };
         let request = create_request(
@@ -1659,16 +1662,17 @@ mod tests {
 
     #[test]
     fn test_create_request_o3_custom_reasoning_effort() -> anyhow::Result<()> {
-        // Test custom reasoning effort for O3 model
+        let mut params = std::collections::HashMap::new();
+        params.insert("thinking_effort".to_string(), json!("high"));
         let model_config = ModelConfig {
-            model_name: "o3-mini-high".to_string(),
+            model_name: "o3-mini".to_string(),
             context_limit: Some(4096),
             temperature: None,
             max_tokens: Some(1024),
             toolshim: false,
             toolshim_model: None,
             fast_model_config: None,
-            request_params: None,
+            request_params: Some(params),
             reasoning: None,
         };
         let request = create_request(

--- a/documentation/docs/guides/cli-providers.md
+++ b/documentation/docs/guides/cli-providers.md
@@ -330,7 +330,7 @@ GOOSE_PROVIDER=claude-code GOOSE_MODE=approve goose session
 | `GOOSE_PROVIDER` | Set to `codex` to use this provider | None |
 | `GOOSE_MODEL` | Model to use (only known models are passed to CLI) | `gpt-5.2-codex` |
 | `CODEX_COMMAND` | Path to the Codex CLI command | `codex` |
-| `GOOSE_THINKING_EFFORT` | Unified thinking effort (`off`, `low`, `medium`, `high`, `max`). Mapped to Codex CLI effort levels (`none/low/medium/high/xhigh`). | `high` |
+| `CODEX_REASONING_EFFORT` | Reasoning effort level: `low`, `medium`, `high`, or `xhigh` (`none` is only supported on non-codex models like `gpt-5.2`) | `high` |
 | `CODEX_ENABLE_SKILLS` | Enable Codex skills: `true` or `false` | `true` |
 | `CODEX_SKIP_GIT_CHECK` | Skip git repository requirement: `true` or `false` | `false` |
 

--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
@@ -21,26 +21,32 @@ import { getPredefinedModelsFromEnv, shouldShowPredefinedModels } from '../prede
 import { ProviderType } from '../../../../api';
 import { trackModelChanged } from '../../../../utils/analytics';
 
-const THINKING_LEVEL_OPTIONS = [
+const THINKING_EFFORT_OPTIONS = [
+  { value: 'off', label: 'Off - No extended thinking' },
   { value: 'low', label: 'Low - Better latency, lighter reasoning' },
-  { value: 'high', label: 'High - Deeper reasoning, higher latency' },
-];
-
-const CLAUDE_THINKING_EFFORT_OPTIONS = [
-  { value: 'low', label: 'Low - Minimal thinking, fastest responses' },
   { value: 'medium', label: 'Medium - Moderate thinking' },
-  { value: 'high', label: 'High - Deep reasoning (default)' },
+  { value: 'high', label: 'High - Deep reasoning' },
   { value: 'max', label: 'Max - No constraints on thinking depth' },
 ];
 
 function isClaudeModel(name: string | null | undefined): boolean {
-  return !!name && name.toLowerCase().startsWith('claude-');
+  return !!name && name.toLowerCase().includes('claude');
 }
 
-function supportsAdaptiveThinking(name: string): boolean {
-  const lower = name.toLowerCase();
-  return lower.includes('claude-opus-4-6') || lower.includes('claude-sonnet-4-6');
+function isOpenAIReasoningModel(name: string | null | undefined): boolean {
+  if (!name) return false;
+  const base = name.replace(/^(goose-|databricks-)/, '');
+  return /^(o1|o3|o4|gpt-5)/.test(base);
 }
+
+function isGemini3Model(name: string | null | undefined): boolean {
+  return !!name && name.toLowerCase().startsWith('gemini-3');
+}
+
+function supportsThinking(name: string | null | undefined): boolean {
+  return isClaudeModel(name) || isOpenAIReasoningModel(name) || isGemini3Model(name);
+}
+
 
 const PREFERRED_MODEL_PATTERNS = [
   /claude-sonnet-4/i,
@@ -132,40 +138,19 @@ export const SwitchModelModal = ({
   const [userClearedModel, setUserClearedModel] = useState(false);
   const [providerErrors, setProviderErrors] = useState<Record<string, string>>({});
   const [providerWarnings, setProviderWarnings] = useState<Record<string, string>>({});
-  const [thinkingLevel, setThinkingLevel] = useState<string>('low');
-  const [claudeThinkingType, setClaudeThinkingType] = useState<string>('disabled');
-  const [claudeThinkingEffort, setClaudeThinkingEffort] = useState<string>('high');
-  const [claudeThinkingBudget, setClaudeThinkingBudget] = useState<string>('16000');
+  const [thinkingEffort, setThinkingEffort] = useState<string>('off');
 
   const modelName = usePredefinedModels ? selectedPredefinedModel?.name : model;
-  const isGemini3Model = modelName?.toLowerCase().startsWith('gemini-3') ?? false;
-  const showClaudeThinking = isClaudeModel(modelName);
-  const modelSupportsAdaptive = modelName ? supportsAdaptiveThinking(modelName) : false;
+  const showThinkingControl = supportsThinking(modelName);
 
   useEffect(() => {
-    if (!showClaudeThinking) return;
-    if (claudeThinkingType === 'adaptive' && !modelSupportsAdaptive) {
-      setClaudeThinkingType('disabled');
-    }
-  }, [modelName, showClaudeThinking, modelSupportsAdaptive, claudeThinkingType]);
-
-  useEffect(() => {
-    const readConfig = async (key: string): Promise<string | null> => {
-      try {
-        const val = (await read(key, false)) as string;
-        return val || null;
-      } catch (e) {
-        console.warn(`Could not read ${key}, using default:`, e);
-        return null;
-      }
-    };
     (async () => {
-      const tt = await readConfig('CLAUDE_THINKING_TYPE');
-      if (tt) setClaudeThinkingType(tt);
-      const effort = await readConfig('CLAUDE_THINKING_EFFORT');
-      if (effort) setClaudeThinkingEffort(effort);
-      const budget = await readConfig('CLAUDE_THINKING_BUDGET');
-      if (budget) setClaudeThinkingBudget(budget);
+      try {
+        const effort = (await read('GOOSE_THINKING_EFFORT', false)) as string;
+        if (effort) setThinkingEffort(effort);
+      } catch (e) {
+        console.warn('Could not read GOOSE_THINKING_EFFORT, using default:', e);
+      }
     })();
   }, [read]);
 
@@ -222,35 +207,12 @@ export const SwitchModelModal = ({
         } as Model;
       }
 
-      if (isGemini3Model) {
+      if (showThinkingControl) {
         modelObj = {
           ...modelObj,
-          request_params: { ...modelObj.request_params, thinking_level: thinkingLevel },
+          request_params: { ...modelObj.request_params, thinking_effort: thinkingEffort },
         };
-      }
-
-      if (showClaudeThinking) {
-        const params: Record<string, unknown> = {
-          ...modelObj.request_params,
-          thinking_type: claudeThinkingType,
-        };
-        if (claudeThinkingType === 'adaptive') {
-          params.effort = claudeThinkingEffort;
-        } else if (claudeThinkingType === 'enabled') {
-          params.budget_tokens = parseInt(claudeThinkingBudget, 10) || 16000;
-        }
-        modelObj = { ...modelObj, request_params: params };
-
-        upsert('CLAUDE_THINKING_TYPE', claudeThinkingType, false).catch(console.warn);
-        if (claudeThinkingType === 'adaptive') {
-          upsert('CLAUDE_THINKING_EFFORT', claudeThinkingEffort, false).catch(console.warn);
-        } else if (claudeThinkingType === 'enabled') {
-          upsert(
-            'CLAUDE_THINKING_BUDGET',
-            parseInt(claudeThinkingBudget, 10) || 16000,
-            false
-          ).catch(console.warn);
-        }
+        upsert('GOOSE_THINKING_EFFORT', thinkingEffort, false).catch(console.warn);
       }
 
       const success = await changeModel(sessionId, modelObj);
@@ -469,54 +431,18 @@ export const SwitchModelModal = ({
     }
   };
 
-  const claudeThinkingTypeOptions = [
-    ...(modelSupportsAdaptive
-      ? [{ value: 'adaptive', label: 'Adaptive - Claude decides when and how much to think' }]
-      : []),
-    { value: 'enabled', label: 'Enabled - Fixed token budget for thinking' },
-    { value: 'disabled', label: 'Disabled - No extended thinking' },
-  ];
-
-  const claudeThinkingControls = showClaudeThinking && (
-    <div className="mt-2 flex flex-col gap-3">
-      <div>
-        <label className="text-sm text-textSubtle mb-1 block">Extended Thinking</label>
-        <Select
-          options={claudeThinkingTypeOptions}
-          value={claudeThinkingTypeOptions.find((o) => o.value === claudeThinkingType)}
-          onChange={(newValue: unknown) => {
-            const option = newValue as { value: string; label: string } | null;
-            setClaudeThinkingType(option?.value || 'disabled');
-          }}
-          placeholder="Select thinking mode"
-        />
-      </div>
-      {claudeThinkingType === 'adaptive' && (
-        <div>
-          <label className="text-sm text-textSubtle mb-1 block">Thinking Effort</label>
-          <Select
-            options={CLAUDE_THINKING_EFFORT_OPTIONS}
-            value={CLAUDE_THINKING_EFFORT_OPTIONS.find((o) => o.value === claudeThinkingEffort)}
-            onChange={(newValue: unknown) => {
-              const option = newValue as { value: string; label: string } | null;
-              setClaudeThinkingEffort(option?.value || 'high');
-            }}
-            placeholder="Select effort level"
-          />
-        </div>
-      )}
-      {claudeThinkingType === 'enabled' && (
-        <div>
-          <label className="text-sm text-textSubtle mb-1 block">Thinking Budget (tokens)</label>
-          <Input
-            className="border-2 px-4 py-2"
-            type="number"
-            min="1024"
-            value={claudeThinkingBudget}
-            onChange={(e) => setClaudeThinkingBudget(e.target.value)}
-          />
-        </div>
-      )}
+  const thinkingEffortControl = showThinkingControl && (
+    <div className="mt-2">
+      <label className="text-sm text-textSubtle mb-1 block">Thinking Effort</label>
+      <Select
+        options={THINKING_EFFORT_OPTIONS}
+        value={THINKING_EFFORT_OPTIONS.find((o) => o.value === thinkingEffort)}
+        onChange={(newValue: unknown) => {
+          const option = newValue as { value: string; label: string } | null;
+          setThinkingEffort(option?.value || 'off');
+        }}
+        placeholder="Select thinking effort"
+      />
     </div>
   );
 
@@ -594,25 +520,7 @@ export const SwitchModelModal = ({
                 <div className="text-red-500 text-sm mt-1">{validationErrors.model}</div>
               )}
 
-              {isGemini3Model && (
-                <div className="mt-2">
-                  <label className="text-sm text-textSubtle mb-1 block">
-                    Thinking Level
-                    <span className="text-xs text-textMuted ml-2">(Gemini 3 models only)</span>
-                  </label>
-                  <Select
-                    options={THINKING_LEVEL_OPTIONS}
-                    value={THINKING_LEVEL_OPTIONS.find((o) => o.value === thinkingLevel)}
-                    onChange={(newValue: unknown) => {
-                      const option = newValue as { value: string; label: string } | null;
-                      setThinkingLevel(option?.value || 'low');
-                    }}
-                    placeholder="Select thinking level"
-                  />
-                </div>
-              )}
-
-              {claudeThinkingControls}
+              {thinkingEffortControl}
             </div>
           ) : (
             /* Manual Provider/Model Selection */
@@ -748,25 +656,7 @@ export const SwitchModelModal = ({
                     </div>
                   )}
 
-                  {isGemini3Model && (
-                    <div className="mt-2">
-                      <label className="text-sm text-textSubtle mb-1 block">
-                        Thinking Level
-                        <span className="text-xs text-textMuted ml-2">(Gemini 3 models only)</span>
-                      </label>
-                      <Select
-                        options={THINKING_LEVEL_OPTIONS}
-                        value={THINKING_LEVEL_OPTIONS.find((o) => o.value === thinkingLevel)}
-                        onChange={(newValue: unknown) => {
-                          const option = newValue as { value: string; label: string } | null;
-                          setThinkingLevel(option?.value || 'low');
-                        }}
-                        placeholder="Select thinking level"
-                      />
-                    </div>
-                  )}
-
-                  {claudeThinkingControls}
+                  {thinkingEffortControl}
                 </>
               )}
             </div>

--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
@@ -43,8 +43,14 @@ function isGemini3Model(name: string | null | undefined): boolean {
   return !!name && name.toLowerCase().startsWith('gemini-3');
 }
 
-function supportsThinking(name: string | null | undefined): boolean {
-  return isClaudeModel(name) || isOpenAIReasoningModel(name) || isGemini3Model(name);
+const CLAUDE_THINKING_PROVIDERS = new Set(['anthropic', 'databricks']);
+
+function supportsThinking(
+  name: string | null | undefined,
+  provider: string | null | undefined
+): boolean {
+  const claudeSupported = isClaudeModel(name) && CLAUDE_THINKING_PROVIDERS.has(provider ?? '');
+  return claudeSupported || isOpenAIReasoningModel(name) || isGemini3Model(name);
 }
 
 
@@ -141,7 +147,8 @@ export const SwitchModelModal = ({
   const [thinkingEffort, setThinkingEffort] = useState<string | null>(null);
 
   const modelName = usePredefinedModels ? selectedPredefinedModel?.name : model;
-  const showThinkingControl = supportsThinking(modelName);
+  const effectiveProvider = usePredefinedModels ? selectedPredefinedModel?.provider : provider;
+  const showThinkingControl = supportsThinking(modelName, effectiveProvider);
 
   useEffect(() => {
     (async () => {
@@ -207,12 +214,13 @@ export const SwitchModelModal = ({
         } as Model;
       }
 
-      if (showThinkingControl && thinkingEffort !== null) {
+      if (showThinkingControl) {
+        const effort = thinkingEffort ?? 'off';
         modelObj = {
           ...modelObj,
-          request_params: { ...modelObj.request_params, thinking_effort: thinkingEffort },
+          request_params: { ...modelObj.request_params, thinking_effort: effort },
         };
-        upsert('GOOSE_THINKING_EFFORT', thinkingEffort, false).catch(console.warn);
+        upsert('GOOSE_THINKING_EFFORT', effort, false).catch(console.warn);
       }
 
       const success = await changeModel(sessionId, modelObj);

--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
@@ -138,7 +138,7 @@ export const SwitchModelModal = ({
   const [userClearedModel, setUserClearedModel] = useState(false);
   const [providerErrors, setProviderErrors] = useState<Record<string, string>>({});
   const [providerWarnings, setProviderWarnings] = useState<Record<string, string>>({});
-  const [thinkingEffort, setThinkingEffort] = useState<string>('off');
+  const [thinkingEffort, setThinkingEffort] = useState<string | null>(null);
 
   const modelName = usePredefinedModels ? selectedPredefinedModel?.name : model;
   const showThinkingControl = supportsThinking(modelName);
@@ -207,7 +207,7 @@ export const SwitchModelModal = ({
         } as Model;
       }
 
-      if (showThinkingControl) {
+      if (showThinkingControl && thinkingEffort !== null) {
         modelObj = {
           ...modelObj,
           request_params: { ...modelObj.request_params, thinking_effort: thinkingEffort },
@@ -436,7 +436,7 @@ export const SwitchModelModal = ({
       <label className="text-sm text-textSubtle mb-1 block">Thinking Effort</label>
       <Select
         options={THINKING_EFFORT_OPTIONS}
-        value={THINKING_EFFORT_OPTIONS.find((o) => o.value === thinkingEffort)}
+        value={THINKING_EFFORT_OPTIONS.find((o) => o.value === (thinkingEffort ?? 'off'))}
         onChange={(newValue: unknown) => {
           const option = newValue as { value: string; label: string } | null;
           setThinkingEffort(option?.value || 'off');

--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
@@ -44,13 +44,27 @@ function isGemini3Model(name: string | null | undefined): boolean {
 }
 
 const CLAUDE_THINKING_PROVIDERS = new Set(['anthropic', 'databricks']);
+const OPENAI_REASONING_THINKING_PROVIDERS = new Set([
+  'openai',
+  'codex',
+  'azure_openai',
+  'openrouter',
+  'litellm',
+  'github_copilot',
+  'tetrate',
+  'xai',
+  'databricks',
+]);
 
 function supportsThinking(
   name: string | null | undefined,
   provider: string | null | undefined
 ): boolean {
   const claudeSupported = isClaudeModel(name) && CLAUDE_THINKING_PROVIDERS.has(provider ?? '');
-  return claudeSupported || isOpenAIReasoningModel(name) || isGemini3Model(name);
+  const openaiReasoningSupported =
+    isOpenAIReasoningModel(name) && OPENAI_REASONING_THINKING_PROVIDERS.has(provider ?? '');
+  const gemini3Supported = isGemini3Model(name) && provider === 'google';
+  return claudeSupported || openaiReasoningSupported || gemini3Supported;
 }
 
 

--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
@@ -30,17 +30,17 @@ const THINKING_EFFORT_OPTIONS = [
 ];
 
 function isClaudeModel(name: string | null | undefined): boolean {
-  return !!name && name.toLowerCase().includes('claude');
+  return typeof name === 'string' && name.toLowerCase().includes('claude');
 }
 
 function isOpenAIReasoningModel(name: string | null | undefined): boolean {
-  if (!name) return false;
+  if (typeof name !== 'string') return false;
   const base = name.replace(/^(goose-|databricks-)/, '');
   return /^(o1|o3|o4|gpt-5)/.test(base);
 }
 
 function isGemini3Model(name: string | null | undefined): boolean {
-  return !!name && name.toLowerCase().startsWith('gemini-3');
+  return typeof name === 'string' && name.toLowerCase().startsWith('gemini-3');
 }
 
 const CLAUDE_THINKING_PROVIDERS = new Set(['anthropic', 'databricks']);

--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
@@ -47,6 +47,7 @@ const CLAUDE_THINKING_PROVIDERS = new Set(['anthropic', 'databricks']);
 const OPENAI_REASONING_THINKING_PROVIDERS = new Set([
   'openai',
   'codex',
+  'chatgpt_codex',
   'azure_openai',
   'openrouter',
   'litellm',


### PR DESCRIPTION
## Summary

Replaces the fragmented per-provider thinking controls with a single unified **Thinking Effort** setting (`off`/`low`/`medium`/`high`/`max`) that works across all providers.

## Changes

### Backend (crates/goose)
- **model.rs**: New `ThinkingEffort` enum with `FromStr`/`Display`/`Serialize`/`Deserialize`. Read from `request_params["thinking_effort"]` or `GOOSE_THINKING_EFFORT` env var via `ModelConfig::thinking_effort()`.
- **model.rs**: `normalize_effort_suffix()` automatically migrates legacy model names like `o3-mini-high` — strips the suffix and sets `thinking_effort` in `request_params` at construction time. The suffix is always stripped from the model name to avoid sending invalid identifiers to providers, while explicit `thinking_effort` in request_params takes priority over the suffix-derived value.
- **model.rs**: `with_request_params()` now merges incoming params into existing ones instead of replacing them, preserving suffix-derived `thinking_effort` when the server applies caller-provided request params.
- **OpenAI format**: Maps effort → `reasoning_effort` (`low`/`medium`/`high`), defaults to `medium`.
- **Anthropic format**: Maps effort → `ThinkingType` (adaptive for 4-6 models, enabled for others) and Anthropic-native effort levels. Maps to budget tokens for enabled mode.
- **Databricks format**: Maps to `reasoning_effort` for OpenAI models and `budget_tokens` for Claude models.
- **Google format**: Maps to `thinking_level` (`low`/`high`) for Gemini 3 models.
- **config/base.rs**: Replaced 4 legacy config values with single `GOOSE_THINKING_EFFORT`.
- **CLI configure**: Simplified from model-specific multi-step thinking config to a single effort dropdown. Thinking support detection uses fallible `ModelConfig::new()` instead of `new_or_fail()` to avoid panicking on invalid env/config values.

### Backward Compatibility
- Model names with effort suffixes (e.g., `o3-mini-high`) are automatically migrated: the suffix is always stripped from the model name, and converted to a `thinking_effort` request param unless one is already explicitly set.

### Removed Legacy Config
- `CLAUDE_THINKING_TYPE`, `CLAUDE_THINKING_EFFORT`, `CLAUDE_THINKING_BUDGET`, `CLAUDE_THINKING_ENABLED`
- `GEMINI3_THINKING_LEVEL`

### UI (ui/desktop)
- Replaces three model-specific controls (Gemini thinking level, Claude thinking type/effort/budget) with a single **Thinking Effort** dropdown
- Shown for any model that supports thinking (Claude, OpenAI reasoning models, Gemini 3)
- Persisted via `GOOSE_THINKING_EFFORT` config key

## Testing
- 8 unit tests for `ThinkingEffort` parsing, env var, request_params override, suffix migration
- All existing provider tests updated and passing (878 total in goose crate)
- All 340 UI tests pass