### PR TITLE
fix(code-execution): preserve rich content through JS sandbox

### DIFF
--- a/crates/goose/src/agents/platform_extensions/code_execution.rs
+++ b/crates/goose/src/agents/platform_extensions/code_execution.rs
@@ -318,10 +318,13 @@ impl CodeExecutionClient {
                 .output
                 .as_ref()
                 .and_then(|v| v.get("text_result"))
-                .and_then(|v| v.as_str())
-                .filter(|s| !s.is_empty())
-                .unwrap_or("Tool returned rich content.");
-            let mut contents = vec![Content::text(text_fallback)];
+                .and_then(|v| match v {
+                    Value::String(s) if !s.is_empty() => Some(s.clone()),
+                    Value::Null | Value::String(_) => None,
+                    other => Some(other.to_string()),
+                })
+                .unwrap_or_else(|| "Tool returned rich content.".to_string());
+            let mut contents = vec![Content::text(&text_fallback)];
             contents.extend(rich_contents);
             Ok(contents)
         } else {

--- a/crates/goose/src/agents/platform_extensions/code_execution.rs
+++ b/crates/goose/src/agents/platform_extensions/code_execution.rs
@@ -310,7 +310,13 @@ impl CodeExecutionClient {
             });
 
         if is_pure_ref && !rich_contents.is_empty() {
-            Ok(rich_contents)
+            // Always include a text fallback so providers that only serialize
+            // text content (OpenAI, Codex, Anthropic) still produce a tool result
+            // for the model. The rich content carries audience metadata and will
+            // be filtered by downstream audience logic.
+            let mut contents = vec![Content::text("Tool returned rich content.")];
+            contents.extend(rich_contents);
+            Ok(contents)
         } else {
             let return_val = serde_json::to_string_pretty(&output.output)
                 .unwrap_or_else(|_| json!(&output.output).to_string());

--- a/crates/goose/src/agents/platform_extensions/code_execution.rs
+++ b/crates/goose/src/agents/platform_extensions/code_execution.rs
@@ -263,8 +263,7 @@ impl CodeExecutionClient {
             .ok_or("Missing arguments for execute_typescript")?;
 
         let code_mode = self.get_code_mode(session_id).await?;
-        let (registry, content_store) =
-            self.build_callback_registry(session_id, &code_mode)?;
+        let (registry, content_store) = self.build_callback_registry(session_id, &code_mode)?;
         let code = args.input.code.clone();
         let disclosure = self.disclosure;
 

--- a/crates/goose/src/agents/platform_extensions/code_execution.rs
+++ b/crates/goose/src/agents/platform_extensions/code_execution.rs
@@ -19,12 +19,21 @@ use schemars::{schema_for, JsonSchema};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
 use std::future::Future;
 use std::hash::{Hash, Hasher};
 use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
+
+/// Thread-safe store for non-text content captured during code execution.
+/// Maps token strings (e.g. "cref_1") to the original rich Content items.
+type ContentStore = Arc<std::sync::Mutex<HashMap<String, Vec<Content>>>>;
+
+/// Global counter for generating unique content reference tokens.
+static CONTENT_REF_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub static EXTENSION_NAME: &str = "code_execution";
 
@@ -140,12 +149,14 @@ impl CodeExecutionClient {
         Ok(code_mode)
     }
 
-    /// Build a PctxRegistry with all tool callbacks registered
+    /// Build a PctxRegistry with all tool callbacks registered.
+    /// Returns the registry and a ContentStore that will accumulate non-text content
+    /// produced by tool callbacks during execution.
     fn build_callback_registry(
         &self,
         session_id: &str,
         code_mode: &CodeMode,
-    ) -> Result<PctxRegistry, String> {
+    ) -> Result<(PctxRegistry, ContentStore), String> {
         let manager = self
             .context
             .extension_manager
@@ -153,6 +164,7 @@ impl CodeExecutionClient {
             .and_then(|w| w.upgrade())
             .ok_or("Extension manager not available")?;
 
+        let content_store: ContentStore = Arc::new(std::sync::Mutex::new(HashMap::new()));
         let registry = PctxRegistry::default();
         for cfg in code_mode.callbacks() {
             let full_name = format!(
@@ -163,13 +175,18 @@ impl CodeExecutionClient {
                     .unwrap_or_default(),
                 &cfg.name
             );
-            let callback = create_tool_callback(session_id.to_string(), full_name, manager.clone());
+            let callback = create_tool_callback(
+                session_id.to_string(),
+                full_name,
+                manager.clone(),
+                content_store.clone(),
+            );
             registry
                 .add_callback(&cfg.id(), callback)
                 .map_err(|e| format!("Failed to register callback: {e}"))?;
         }
 
-        Ok(registry)
+        Ok((registry, content_store))
     }
 
     /// Handle the list_functions tool call
@@ -246,7 +263,8 @@ impl CodeExecutionClient {
             .ok_or("Missing arguments for execute_typescript")?;
 
         let code_mode = self.get_code_mode(session_id).await?;
-        let registry = self.build_callback_registry(session_id, &code_mode)?;
+        let (registry, content_store) =
+            self.build_callback_registry(session_id, &code_mode)?;
         let code = args.input.code.clone();
         let disclosure = self.disclosure;
 
@@ -268,7 +286,35 @@ impl CodeExecutionClient {
         .await
         .map_err(|e| format!("Typescript execution task failed: {e}"))??;
 
-        Ok(vec![Content::text(output.markdown())])
+        // Collect any rich content referenced by tokens in the output
+        let mut rich_contents = Vec::new();
+        if let Some(ref val) = output.output {
+            let store = content_store.lock().unwrap();
+            collect_rich_content(val, &store, &mut rich_contents);
+        }
+
+        // If the entire return value was just a content ref, return only
+        // the resolved rich content. Otherwise return the text output
+        // (with refs intact) plus the rich content alongside it.
+        let is_top_level_ref = output
+            .output
+            .as_ref()
+            .and_then(|v| v.as_object())
+            .is_some_and(|m| m.contains_key("_goose_content_ref"));
+
+        if is_top_level_ref && !rich_contents.is_empty() {
+            Ok(rich_contents)
+        } else {
+            let return_val = serde_json::to_string_pretty(&output.output)
+                .unwrap_or_else(|_| json!(&output.output).to_string());
+            let mut contents = vec![Content::text(format_output(
+                output.success,
+                &return_val,
+                &output.stderr,
+            ))];
+            contents.extend(rich_contents);
+            Ok(contents)
+        }
     }
 }
 
@@ -276,11 +322,13 @@ fn create_tool_callback(
     session_id: String,
     full_name: String,
     manager: Arc<crate::agents::ExtensionManager>,
+    content_store: ContentStore,
 ) -> CallbackFn {
     Arc::new(move |args: Option<Value>| {
         let session_id = session_id.clone();
         let full_name = full_name.clone();
         let manager = manager.clone();
+        let content_store = content_store.clone();
         Box::pin(async move {
             let tool_call = {
                 let mut params = CallToolRequestParams::new(full_name);
@@ -299,24 +347,49 @@ fn create_tool_callback(
                         if let Some(sc) = &result.structured_content {
                             Ok(serde_json::to_value(sc).unwrap_or(Value::Null))
                         } else {
-                            // Filter to assistant-audience or no-audience content,
-                            // skipping user-only content to avoid duplicated output
-                            let text: String = result
-                                .content
-                                .iter()
-                                .filter(|c| {
-                                    c.audience().is_none_or(|audiences| {
-                                        audiences.is_empty() || audiences.contains(&Role::Assistant)
-                                    })
-                                })
-                                .filter_map(|c| match &c.raw {
-                                    RawContent::Text(t) => Some(t.text.clone()),
-                                    _ => None,
-                                })
-                                .collect::<Vec<_>>()
-                                .join("\n");
-                            // Try to parse as JSON, otherwise return as string
-                            Ok(serde_json::from_str(&text).unwrap_or(Value::String(text)))
+                            // Separate text content from non-text (resources, images, etc.)
+                            let mut text_parts = Vec::new();
+                            let mut rich_contents = Vec::new();
+
+                            for content in &result.content {
+                                match &content.raw {
+                                    RawContent::Text(t) => {
+                                        // Only include text meant for assistant
+                                        if content.audience().is_none_or(|audiences| {
+                                            audiences.is_empty()
+                                                || audiences.contains(&Role::Assistant)
+                                        }) {
+                                            text_parts.push(t.text.clone());
+                                        }
+                                    }
+                                    _ => {
+                                        // Non-text content (resources, images, blobs) — store for later
+                                        rich_contents.push(content.clone());
+                                    }
+                                }
+                            }
+
+                            let text = text_parts.join("\n");
+                            let text_value: Value =
+                                serde_json::from_str(&text).unwrap_or(Value::String(text));
+
+                            // If there's non-text content, store it and return a token reference
+                            if !rich_contents.is_empty() {
+                                let token = format!(
+                                    "cref_{}",
+                                    CONTENT_REF_COUNTER.fetch_add(1, Ordering::Relaxed)
+                                );
+                                content_store
+                                    .lock()
+                                    .unwrap()
+                                    .insert(token.clone(), rich_contents);
+                                Ok(json!({
+                                    "_goose_content_ref": token,
+                                    "text_result": text_value,
+                                }))
+                            } else {
+                                Ok(text_value)
+                            }
                         }
                     }
                     Err(e) => Err(format!("Tool error: {}", e.message)),
@@ -325,6 +398,44 @@ fn create_tool_callback(
             }
         }) as Pin<Box<dyn Future<Output = Result<Value, String>> + Send>>
     })
+}
+
+fn format_output(success: bool, return_val: &str, stderr: &str) -> String {
+    if success {
+        format!("Code Executed Successfully: true\n\n# Return Value\n```json\n{return_val}\n```\n")
+    } else {
+        format!(
+            "Code Executed Successfully: false\n\n# Return Value\n```json\n{return_val}\n```\n\n# STDERR\n{stderr}\n"
+        )
+    }
+}
+
+/// Recursively walk a JSON value, collecting rich content for any
+/// `_goose_content_ref` tokens found.
+fn collect_rich_content(
+    val: &Value,
+    store: &HashMap<String, Vec<Content>>,
+    rich: &mut Vec<Content>,
+) {
+    match val {
+        Value::Object(map) => {
+            if let Some(Value::String(token)) = map.get("_goose_content_ref") {
+                if let Some(stored) = store.get(token) {
+                    rich.extend(stored.iter().cloned());
+                }
+            } else {
+                for v in map.values() {
+                    collect_rich_content(v, store, rich);
+                }
+            }
+        }
+        Value::Array(arr) => {
+            for v in arr {
+                collect_rich_content(v, store, rich);
+            }
+        }
+        _ => {}
+    }
 }
 
 #[async_trait]

--- a/crates/goose/src/agents/platform_extensions/code_execution.rs
+++ b/crates/goose/src/agents/platform_extensions/code_execution.rs
@@ -296,14 +296,24 @@ impl CodeExecutionClient {
         // If the entire return value was just a content ref, return only
         // the resolved rich content. Otherwise return the text output
         // (with refs intact) plus the rich content alongside it.
-        // Only treat as a pure content ref if the wrapper has our sentinel key,
-        // which distinguishes it from real tool objects that happen to contain
-        // _goose_content_ref (injected) alongside their own fields.
+        // Only treat as a pure content ref if the wrapper has exactly the
+        // shape produced by `create_tool_callback`: {_goose_content_ref,
+        // _goose_pure_ref, text_result} and nothing else. This prevents
+        // the fast path from triggering when a script spreads the wrapper
+        // into a larger object (e.g. `return { ...r, status: "ok" }`),
+        // which would silently discard the caller-added fields.
         let is_pure_ref = output
             .output
             .as_ref()
-            .and_then(|v| v.get("_goose_pure_ref"))
-            .and_then(|v| v.as_bool())
+            .and_then(|v| v.as_object())
+            .map(|map| {
+                map.get("_goose_pure_ref")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
+                    && map.len() == 3
+                    && map.contains_key("_goose_content_ref")
+                    && map.contains_key("text_result")
+            })
             .unwrap_or(false);
 
         if is_pure_ref && !rich_contents.is_empty() {

--- a/crates/goose/src/agents/platform_extensions/code_execution.rs
+++ b/crates/goose/src/agents/platform_extensions/code_execution.rs
@@ -296,13 +296,19 @@ impl CodeExecutionClient {
         // If the entire return value was just a content ref, return only
         // the resolved rich content. Otherwise return the text output
         // (with refs intact) plus the rich content alongside it.
-        let is_top_level_ref = output
+        // Only treat as a pure content ref if the object is exactly the shape
+        // we created (just _goose_content_ref + text_result, nothing extra).
+        let is_pure_ref = output
             .output
             .as_ref()
             .and_then(|v| v.as_object())
-            .is_some_and(|m| m.contains_key("_goose_content_ref"));
+            .is_some_and(|m| {
+                m.contains_key("_goose_content_ref")
+                    && m.len() <= 2
+                    && m.keys().all(|k| k == "_goose_content_ref" || k == "text_result")
+            });
 
-        if is_top_level_ref && !rich_contents.is_empty() {
+        if is_pure_ref && !rich_contents.is_empty() {
             Ok(rich_contents)
         } else {
             let return_val = serde_json::to_string_pretty(&output.output)
@@ -423,10 +429,9 @@ fn collect_rich_content(
                 if let Some(stored) = store.get(token) {
                     rich.extend(stored.iter().cloned());
                 }
-            } else {
-                for v in map.values() {
-                    collect_rich_content(v, store, rich);
-                }
+            }
+            for v in map.values() {
+                collect_rich_content(v, store, rich);
             }
         }
         Value::Array(arr) => {

--- a/crates/goose/src/agents/platform_extensions/code_execution.rs
+++ b/crates/goose/src/agents/platform_extensions/code_execution.rs
@@ -290,24 +290,22 @@ impl CodeExecutionClient {
         let mut rich_contents = Vec::new();
         if let Some(ref val) = output.output {
             let store = content_store.lock().unwrap();
-            collect_rich_content(val, &store, &mut rich_contents);
+            let mut seen = std::collections::HashSet::new();
+            collect_rich_content(val, &store, &mut rich_contents, &mut seen);
         }
 
         // If the entire return value was just a content ref, return only
         // the resolved rich content. Otherwise return the text output
         // (with refs intact) plus the rich content alongside it.
-        // Only treat as a pure content ref if the object is exactly the shape
-        // we created (just _goose_content_ref + text_result, nothing extra).
+        // Only treat as a pure content ref if the wrapper has our sentinel key,
+        // which distinguishes it from real tool objects that happen to contain
+        // _goose_content_ref (injected) alongside their own fields.
         let is_pure_ref = output
             .output
             .as_ref()
-            .and_then(|v| v.as_object())
-            .is_some_and(|m| {
-                m.contains_key("_goose_content_ref")
-                    && m.len() <= 2
-                    && m.keys()
-                        .all(|k| k == "_goose_content_ref" || k == "text_result")
-            });
+            .and_then(|v| v.get("_goose_pure_ref"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
 
         if is_pure_ref && !rich_contents.is_empty() {
             // Always include a text fallback so providers that only serialize
@@ -418,6 +416,7 @@ fn create_tool_callback(
                                     }
                                     _ => Ok(json!({
                                         "_goose_content_ref": token,
+                                        "_goose_pure_ref": true,
                                         "text_result": text_value,
                                     })),
                                 }
@@ -445,26 +444,30 @@ fn format_output(success: bool, return_val: &str, stderr: &str) -> String {
 }
 
 /// Recursively walk a JSON value, collecting rich content for any
-/// `_goose_content_ref` tokens found.
+/// `_goose_content_ref` tokens found. Each token is only resolved once
+/// to avoid duplicating content when the same ref appears multiple times.
 fn collect_rich_content(
     val: &Value,
     store: &HashMap<String, Vec<Content>>,
     rich: &mut Vec<Content>,
+    seen: &mut std::collections::HashSet<String>,
 ) {
     match val {
         Value::Object(map) => {
             if let Some(Value::String(token)) = map.get("_goose_content_ref") {
-                if let Some(stored) = store.get(token) {
-                    rich.extend(stored.iter().cloned());
+                if seen.insert(token.clone()) {
+                    if let Some(stored) = store.get(token) {
+                        rich.extend(stored.iter().cloned());
+                    }
                 }
             }
             for v in map.values() {
-                collect_rich_content(v, store, rich);
+                collect_rich_content(v, store, rich, seen);
             }
         }
         Value::Array(arr) => {
             for v in arr {
-                collect_rich_content(v, store, rich);
+                collect_rich_content(v, store, rich, seen);
             }
         }
         _ => {}

--- a/crates/goose/src/agents/platform_extensions/code_execution.rs
+++ b/crates/goose/src/agents/platform_extensions/code_execution.rs
@@ -312,9 +312,16 @@ impl CodeExecutionClient {
         if is_pure_ref && !rich_contents.is_empty() {
             // Always include a text fallback so providers that only serialize
             // text content (OpenAI, Codex, Anthropic) still produce a tool result
-            // for the model. The rich content carries audience metadata and will
-            // be filtered by downstream audience logic.
-            let mut contents = vec![Content::text("Tool returned rich content.")];
+            // for the model. Preserve the original text_result if the callback
+            // returned one, so the model still sees meaningful textual data.
+            let text_fallback = output
+                .output
+                .as_ref()
+                .and_then(|v| v.get("text_result"))
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .unwrap_or("Tool returned rich content.");
+            let mut contents = vec![Content::text(text_fallback)];
             contents.extend(rich_contents);
             Ok(contents)
         } else {

--- a/crates/goose/src/agents/platform_extensions/code_execution.rs
+++ b/crates/goose/src/agents/platform_extensions/code_execution.rs
@@ -305,7 +305,8 @@ impl CodeExecutionClient {
             .is_some_and(|m| {
                 m.contains_key("_goose_content_ref")
                     && m.len() <= 2
-                    && m.keys().all(|k| k == "_goose_content_ref" || k == "text_result")
+                    && m.keys()
+                        .all(|k| k == "_goose_content_ref" || k == "text_result")
             });
 
         if is_pure_ref && !rich_contents.is_empty() {

--- a/crates/goose/src/agents/platform_extensions/code_execution.rs
+++ b/crates/goose/src/agents/platform_extensions/code_execution.rs
@@ -396,7 +396,9 @@ fn create_tool_callback(
                             let text_value: Value =
                                 serde_json::from_str(&text).unwrap_or(Value::String(text));
 
-                            // If there's non-text content, store it and return a token reference
+                            // If there's non-text content, store it and return a token reference.
+                            // When text_value is an object, inject the ref key into it so that
+                            // the original shape is preserved (e.g. r.items still works in JS).
                             if !rich_contents.is_empty() {
                                 let token = format!(
                                     "cref_{}",
@@ -406,10 +408,19 @@ fn create_tool_callback(
                                     .lock()
                                     .unwrap()
                                     .insert(token.clone(), rich_contents);
-                                Ok(json!({
-                                    "_goose_content_ref": token,
-                                    "text_result": text_value,
-                                }))
+                                match text_value {
+                                    Value::Object(mut map) => {
+                                        map.insert(
+                                            "_goose_content_ref".to_string(),
+                                            Value::String(token),
+                                        );
+                                        Ok(Value::Object(map))
+                                    }
+                                    _ => Ok(json!({
+                                        "_goose_content_ref": token,
+                                        "text_result": text_value,
+                                    })),
+                                }
                             } else {
                                 Ok(text_value)
                             }

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/goose/src/agents/prompt_manager.rs
-assertion_line: 441
 expression: system_prompt
 ---
 You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
@@ -103,10 +102,7 @@ Manage agent sessions: list, view, start, send messages, and interrupt agents.
 
 
 You have these skills at your disposal, when it is clear they can help you solve a problem or you are asked to use them:
-• agent-browser - Browser automation CLI for AI agents. Use when the user needs to interact with websites, including navigating pages, filling forms, clicking buttons, taking screenshots, extracting data, testing web apps, or automating any browser task. Triggers include requests to "open a website", "fill out a form", "click a button", "take a screenshot", "scrape data from a page", "test this web app", "login to a site", "automate browser actions", or any task requiring programmatic web interaction.
-• find-skills - Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.
 • goose-doc-guide - Reference goose documentation to create, configure, or explain goose-specific features like recipes, extensions, sessions, and providers. You MUST fetch relevant goose docs before answering. You MUST NOT rely on training data or assumptions for any goose-specific fields, values, names, syntax, or commands.
-• skill-management - Manage AI agent skills using the sq-agents CLI. Use when asked to find, search, discover, browse, install, list, show, or remove skills.
 ## todo
 
 ### Instructions

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
@@ -102,11 +102,7 @@ Manage agent sessions: list, view, start, send messages, and interrupt agents.
 
 
 You have these skills at your disposal, when it is clear they can help you solve a problem or you are asked to use them:
-• agent-browser - Debug visual bugs and interact with web apps using agent-browser CLI. Use when debugging, inspecting, navigating, filling forms, clicking buttons, taking screenshots, scraping data, testing web apps, or automating browser tasks. Supports desktop browsers and iOS Simulator (Mobile Safari). 93% less context than Playwright MCP.
-• codesearch - Use when searching, finding, locating, discovering, querying, looking up, or browsing code patterns, files, or implementations across all Square repositories via go/codesearch.
-• find-skills - Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.
 • goose-doc-guide - Reference goose documentation to create, configure, or explain goose-specific features like recipes, extensions, sessions, and providers. You MUST fetch relevant goose docs before answering. You MUST NOT rely on training data or assumptions for any goose-specific fields, values, names, syntax, or commands.
-• skill-management - Manage AI agent skills using the sq-agents CLI. Use when asked to find, search, discover, browse, install, list, show, or remove skills.
 ## todo
 
 ### Instructions

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/goose/src/agents/prompt_manager.rs
+assertion_line: 441
 expression: system_prompt
 ---
 You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.
@@ -102,7 +103,10 @@ Manage agent sessions: list, view, start, send messages, and interrupt agents.
 
 
 You have these skills at your disposal, when it is clear they can help you solve a problem or you are asked to use them:
+• agent-browser - Browser automation CLI for AI agents. Use when the user needs to interact with websites, including navigating pages, filling forms, clicking buttons, taking screenshots, extracting data, testing web apps, or automating any browser task. Triggers include requests to "open a website", "fill out a form", "click a button", "take a screenshot", "scrape data from a page", "test this web app", "login to a site", "automate browser actions", or any task requiring programmatic web interaction.
+• find-skills - Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.
 • goose-doc-guide - Reference goose documentation to create, configure, or explain goose-specific features like recipes, extensions, sessions, and providers. You MUST fetch relevant goose docs before answering. You MUST NOT rely on training data or assumptions for any goose-specific fields, values, names, syntax, or commands.
+• skill-management - Manage AI agent skills using the sq-agents CLI. Use when asked to find, search, discover, browse, install, list, show, or remove skills.
 ## todo
 
 ### Instructions

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
@@ -102,7 +102,11 @@ Manage agent sessions: list, view, start, send messages, and interrupt agents.
 
 
 You have these skills at your disposal, when it is clear they can help you solve a problem or you are asked to use them:
+• agent-browser - Debug visual bugs and interact with web apps using agent-browser CLI. Use when debugging, inspecting, navigating, filling forms, clicking buttons, taking screenshots, scraping data, testing web apps, or automating browser tasks. Supports desktop browsers and iOS Simulator (Mobile Safari). 93% less context than Playwright MCP.
+• codesearch - Use when searching, finding, locating, discovering, querying, looking up, or browsing code patterns, files, or implementations across all Square repositories via go/codesearch.
+• find-skills - Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.
 • goose-doc-guide - Reference goose documentation to create, configure, or explain goose-specific features like recipes, extensions, sessions, and providers. You MUST fetch relevant goose docs before answering. You MUST NOT rely on training data or assumptions for any goose-specific fields, values, names, syntax, or commands.
+• skill-management - Manage AI agent skills using the sq-agents CLI. Use when asked to find, search, discover, browse, install, list, show, or remove skills.
 ## todo
 
 ### Instructions


### PR DESCRIPTION
## Summary

Code mode wraps MCP tools in a JS sandbox, but non-text content (resources, images, blobs) couldn't survive the JSON boundary. This fix introduces a token-based reference system: non-text content is stored on the Rust side, token references are passed to JS, and the resolved content is restored after execution.

The model's return value remains intact with token refs visible in the JSON, while actual rich content is appended as separate Content items. Also removed stdout/stderr as a return channel—console.log is now ignored entirely. This simplifies the interface of Code Mode (one return channel rather than three) and means that the freeform text of stdout/stderr doesn't have to be scanned for possible Content refs.

### Type of Change
- [x] Bug fix
- [x] Refactor / Code quality

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing

Manual testing confirmed Autovisualiser now renders visualizations successfully when called through code mode, preserving the HTML blob through the JS sandbox boundary.

### Related Issues
Relates to #6167

🤖 Generated with Claude Code