### PR TITLE
feat(ui): make sidebar session count configurable

### DIFF
--- a/ui/desktop/src/components/Layout/NavigationContext.tsx
+++ b/ui/desktop/src/components/Layout/NavigationContext.tsx
@@ -15,7 +15,10 @@ export type NavigationPosition = 'top' | 'bottom' | 'left' | 'right';
 export interface NavigationPreferences {
   itemOrder: string[];
   enabledItems: string[];
+  maxRecentSessions?: number;
 }
+
+export const DEFAULT_MAX_RECENT_SESSIONS = 5;
 
 export const DEFAULT_ITEM_ORDER = [
   'home',

--- a/ui/desktop/src/components/Layout/NavigationPanel.tsx
+++ b/ui/desktop/src/components/Layout/NavigationPanel.tsx
@@ -51,6 +51,7 @@ export const Navigation: React.FC<{ className?: string }> = ({ className }) => {
     handleSessionClick,
   } = useNavigationSessions({
     onNavigate: isOverlayMode ? () => setIsNavExpanded(false) : undefined,
+    maxRecentSessions: preferences.maxRecentSessions,
   });
 
   const [draggedItem, setDraggedItem] = useState<string | null>(null);

--- a/ui/desktop/src/components/sessions/SessionsInsights.tsx
+++ b/ui/desktop/src/components/sessions/SessionsInsights.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { defineMessages, useIntl } from '../../i18n';
+import { DEFAULT_MAX_RECENT_SESSIONS, useNavigationContext } from '../Layout/NavigationContext';
 import { errorMessage } from '../../utils/conversionUtils';
 import { Card, CardContent, CardDescription } from '../ui/card';
 import { Greeting } from '../common/Greeting';
@@ -53,6 +54,8 @@ export function SessionInsights() {
   const [isLoadingSessions, setIsLoadingSessions] = useState(true);
   const navigate = useNavigate();
   const setView = useNavigation();
+  const { preferences } = useNavigationContext();
+  const maxRecentSessions = preferences.maxRecentSessions ?? DEFAULT_MAX_RECENT_SESSIONS;
 
   useEffect(() => {
     let loadingTimeout: ReturnType<typeof setTimeout>;
@@ -77,7 +80,8 @@ export function SessionInsights() {
     const loadRecentSessions = async () => {
       try {
         const response = await listSessions<true>({ throwOnError: true });
-        setRecentSessions(response.data.sessions.slice(0, 3));
+        // Home page shows half the sidebar session count, minimum 3
+        setRecentSessions(response.data.sessions.slice(0, Math.max(3, Math.floor(maxRecentSessions / 2))));
       } finally {
         setIsLoadingSessions(false);
       }
@@ -113,7 +117,7 @@ export function SessionInsights() {
         window.clearTimeout(loadingTimeout);
       }
     };
-  }, []);
+  }, [maxRecentSessions]);
 
   const handleSessionClick = async (session: Session) => {
     try {

--- a/ui/desktop/src/components/settings/app/NavigationCustomizationSettings.tsx
+++ b/ui/desktop/src/components/settings/app/NavigationCustomizationSettings.tsx
@@ -5,8 +5,13 @@ import {
   useNavigationContext,
   DEFAULT_ITEM_ORDER,
   DEFAULT_ENABLED_ITEMS,
+  DEFAULT_MAX_RECENT_SESSIONS,
 } from '../../Layout/NavigationContext';
+import { Input } from '../../ui/input';
 import { cn } from '../../../utils';
+
+const MIN_RECENT_SESSIONS = 1;
+const MAX_RECENT_SESSIONS = 50;
 
 const i18n = defineMessages({
   dragInstructions: {
@@ -24,6 +29,14 @@ const i18n = defineMessages({
   showItem: {
     id: 'navigationCustomization.showItem',
     defaultMessage: 'Show item',
+  },
+  recentSessionsLabel: {
+    id: 'navigationCustomization.recentSessionsLabel',
+    defaultMessage: 'Recent sessions shown',
+  },
+  recentSessionsDescription: {
+    id: 'navigationCustomization.recentSessionsDescription',
+    defaultMessage: 'Number of recent sessions displayed in the sidebar',
   },
   itemHome: {
     id: 'navigationCustomization.itemHome',
@@ -76,6 +89,18 @@ export const NavigationCustomizationSettings: React.FC<NavigationCustomizationSe
   const [draggedItem, setDraggedItem] = useState<string | null>(null);
   const [dragOverItem, setDragOverItem] = useState<string | null>(null);
   const intl = useIntl();
+
+  const currentMaxSessions = preferences.maxRecentSessions ?? DEFAULT_MAX_RECENT_SESSIONS;
+
+  const handleMaxSessionsChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = parseInt(e.target.value, 10);
+    if (isNaN(raw)) return;
+    const clamped = Math.min(MAX_RECENT_SESSIONS, Math.max(MIN_RECENT_SESSIONS, raw));
+    updatePreferences({
+      ...preferences,
+      maxRecentSessions: clamped,
+    });
+  };
 
   const handleDragStart = (e: React.DragEvent, itemId: string) => {
     setDraggedItem(itemId);
@@ -131,6 +156,7 @@ export const NavigationCustomizationSettings: React.FC<NavigationCustomizationSe
     updatePreferences({
       itemOrder: DEFAULT_ITEM_ORDER,
       enabledItems: DEFAULT_ENABLED_ITEMS,
+      maxRecentSessions: DEFAULT_MAX_RECENT_SESSIONS,
     });
   };
 
@@ -145,6 +171,27 @@ export const NavigationCustomizationSettings: React.FC<NavigationCustomizationSe
   return (
     <div className={className}>
       <div className="space-y-3">
+        {/* Recent sessions count */}
+        <div className="flex items-center justify-between py-2 px-3 bg-background-secondary rounded-lg">
+          <div>
+            <h4 className="text-text-primary text-sm">
+              {intl.formatMessage(i18n.recentSessionsLabel)}
+            </h4>
+            <p className="text-xs text-text-secondary mt-[2px]">
+              {intl.formatMessage(i18n.recentSessionsDescription)}
+            </p>
+          </div>
+          <Input
+            type="number"
+            min={MIN_RECENT_SESSIONS}
+            max={MAX_RECENT_SESSIONS}
+            value={currentMaxSessions}
+            onChange={handleMaxSessionsChange}
+            className="w-20"
+          />
+        </div>
+
+        {/* Item ordering */}
         <div className="flex items-center justify-between mb-4">
           <p className="text-sm text-text-secondary">
             {intl.formatMessage(i18n.dragInstructions)}

--- a/ui/desktop/src/hooks/useNavigationSessions.ts
+++ b/ui/desktop/src/hooks/useNavigationSessions.ts
@@ -8,16 +8,16 @@ import { startNewSession, resumeSession, shouldShowNewChatTitle } from '../sessi
 import { getInitialWorkingDir } from '../utils/workingDir';
 import { AppEvents } from '../constants/events';
 import type { Session } from '../api';
-
-const MAX_RECENT_SESSIONS = 5;
+import { DEFAULT_MAX_RECENT_SESSIONS } from '../components/Layout/NavigationContext';
 
 interface UseNavigationSessionsOptions {
   onNavigate?: () => void;
   fetchOnMount?: boolean;
+  maxRecentSessions?: number;
 }
 
 export function useNavigationSessions(options: UseNavigationSessionsOptions = {}) {
-  const { onNavigate, fetchOnMount = false } = options;
+  const { onNavigate, fetchOnMount = false, maxRecentSessions = DEFAULT_MAX_RECENT_SESSIONS } = options;
 
   const navigate = useNavigate();
   const location = useLocation();
@@ -51,14 +51,14 @@ export function useNavigationSessions(options: UseNavigationSessionsOptions = {}
       if (response.data) {
         const sorted = [...response.data.sessions]
           .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
-          .slice(0, MAX_RECENT_SESSIONS);
+          .slice(0, maxRecentSessions);
         setRecentSessions(sorted);
         sessionsRef.current = response.data.sessions;
       }
     } catch (error) {
       console.error('Failed to fetch sessions:', error);
     }
-  }, []);
+  }, [maxRecentSessions]);
 
   useEffect(() => {
     if (fetchOnMount) {
@@ -74,10 +74,10 @@ export function useNavigationSessions(options: UseNavigationSessionsOptions = {}
       if (!response.data) return;
       setRecentSessions((prev) => {
         if (prev.some((s) => s.id === activeSessionId)) return prev;
-        return [response.data as Session, ...prev].slice(0, MAX_RECENT_SESSIONS);
+        return [response.data as Session, ...prev].slice(0, maxRecentSessions);
       });
     });
-  }, [activeSessionId, recentSessions]);
+  }, [activeSessionId, recentSessions, maxRecentSessions]);
 
   useEffect(() => {
     let pollingTimeouts: ReturnType<typeof setTimeout>[] = [];
@@ -88,7 +88,7 @@ export function useNavigationSessions(options: UseNavigationSessionsOptions = {}
       if (session) {
         setRecentSessions((prev) => {
           if (prev.some((s) => s.id === session.id)) return prev;
-          return [session, ...prev].slice(0, MAX_RECENT_SESSIONS);
+          return [session, ...prev].slice(0, maxRecentSessions);
         });
         sessionsRef.current = [session, ...sessionsRef.current.filter((s) => s.id !== session.id)];
       }
@@ -106,13 +106,13 @@ export function useNavigationSessions(options: UseNavigationSessionsOptions = {}
         try {
           const response = await listSessions({ throwOnError: false });
           if (response.data) {
-            const apiSessions = response.data.sessions.slice(0, MAX_RECENT_SESSIONS);
+            const apiSessions = response.data.sessions.slice(0, maxRecentSessions);
             setRecentSessions((prev) => {
               const emptyLocalSessions = prev.filter(
                 (local) =>
                   local.message_count === 0 && !apiSessions.some((api) => api.id === local.id)
               );
-              return [...emptyLocalSessions, ...apiSessions].slice(0, MAX_RECENT_SESSIONS);
+              return [...emptyLocalSessions, ...apiSessions].slice(0, maxRecentSessions);
             });
             sessionsRef.current = response.data.sessions;
           }
@@ -136,7 +136,7 @@ export function useNavigationSessions(options: UseNavigationSessionsOptions = {}
       window.removeEventListener(AppEvents.SESSION_CREATED, handleSessionCreated);
       pollingTimeouts.forEach(clearTimeout);
     };
-  }, []);
+  }, [maxRecentSessions]);
 
   const handleNavClick = useCallback(
     (path: string) => {

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -2339,6 +2339,12 @@
   "navigationCustomization.itemSettings": {
     "defaultMessage": "Settings"
   },
+  "navigationCustomization.recentSessionsDescription": {
+    "defaultMessage": "Number of recent sessions displayed in the sidebar"
+  },
+  "navigationCustomization.recentSessionsLabel": {
+    "defaultMessage": "Recent sessions shown"
+  },
   "navigationCustomization.resetToDefaults": {
     "defaultMessage": "Reset to defaults"
   },


### PR DESCRIPTION
## Summary

Make the sidebar session count configurable via Settings UI, instead of hardcoded to 5.

### What changed

1. **NavigationContext** — added `maxRecentSessions` to `NavigationPreferences` (persisted in localStorage), with `DEFAULT_MAX_RECENT_SESSIONS = 5`
2. **useNavigationSessions** — accepts optional `maxRecentSessions` param, defaults to the constant
3. **NavigationPanel** — wires `preferences.maxRecentSessions` into the hook
4. **SessionsInsights** — reads preference for the home page session list
5. **NavigationCustomizationSettings** — **Settings UI**: number input (1–50, default 5) under Navigation > Customize Items, matching the existing `ConversationLimitsDropdown` pattern
6. **Reset to defaults** — now correctly resets `maxRecentSessions` alongside `itemOrder` and `enabledItems`

### How to test

1. Open Settings → Navigation → expand → Customize Items
2. "Recent sessions shown" input appears above the drag-to-reorder list
3. Change the value → sidebar session list updates immediately
4. Click "Reset to defaults" → value returns to 5
5. Reload the app → value persists (localStorage)

### Screenshots

Settings UI adds a number input matching the existing navigation customisation style:

```
┌─ Customize Items ──────────────────────────────┐
│ Recent sessions shown                    [ 5 ] │
│ Number of recent sessions displayed...         │
│                                                │
│ Drag to reorder...              Reset defaults │
│ ≡ Home                                    👁   │
│ ≡ Chat                                    👁   │
│ ...                                            │
└────────────────────────────────────────────────┘
```
