### PR TITLE
feat: show live context window usage during multi-turn sessions

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -1070,6 +1070,9 @@ impl CliSession {
                         Some(Ok(AgentEvent::HistoryReplaced(updated_conversation))) => {
                             self.messages = updated_conversation;
                         }
+                        Some(Ok(AgentEvent::ContextUsage { used_tokens, total_tokens })) => {
+                            progress_bars.update_context(used_tokens, total_tokens);
+                        }
                         Some(Ok(AgentEvent::ModelChange { model, mode })) => {
                             if is_stream_json_mode {
                                 emit_stream_event(&StreamEvent::ModelChange { model: model.clone(), mode: mode.clone() });

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -1109,6 +1109,8 @@ impl CliSession {
             }
         }
 
+        let _ = progress_bars.hide_all();
+
         if !is_json_mode && !is_stream_json_mode {
             output::flush_markdown_buffer_current_theme(&mut markdown_buffer);
         }

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -1416,10 +1416,20 @@ pub fn display_cost_usage(provider: &str, model: &str, input_tokens: usize, outp
     }
 }
 
+fn format_tokens_short(n: usize) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.0}k", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
+}
+
 pub struct McpSpinners {
     bars: HashMap<String, ProgressBar>,
     log_spinner: Option<ProgressBar>,
-
+    context_bar: Option<ProgressBar>,
     multi_bar: MultiProgress,
 }
 
@@ -1428,8 +1438,41 @@ impl McpSpinners {
         McpSpinners {
             bars: HashMap::new(),
             log_spinner: None,
+            context_bar: None,
             multi_bar: MultiProgress::new(),
         }
+    }
+
+    pub fn update_context(&mut self, used: usize, total: usize) {
+        let pct = if total > 0 {
+            (used as f64 / total as f64 * 100.0) as u64
+        } else {
+            0
+        };
+
+        let color = if pct < 50 {
+            "green"
+        } else if pct < 85 {
+            "yellow"
+        } else {
+            "red"
+        };
+
+        let style = ProgressStyle::with_template(&format!("  {{bar:20.{color}}} {{pos}}% {{msg}}"))
+            .unwrap()
+            .progress_chars("━━╌");
+
+        let bar = self
+            .context_bar
+            .get_or_insert_with(|| self.multi_bar.add(ProgressBar::new(100)));
+
+        bar.set_style(style);
+        bar.set_position(pct);
+        bar.set_message(format!(
+            "{}/{} tokens",
+            format_tokens_short(used),
+            format_tokens_short(total)
+        ));
     }
 
     pub fn log(&mut self, message: &str) {
@@ -1476,6 +1519,7 @@ impl McpSpinners {
         if let Some(spinner) = self.log_spinner.as_mut() {
             spinner.disable_steady_tick();
         }
+        self.context_bar = None;
         self.multi_bar.clear()
     }
 }

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -1519,8 +1519,16 @@ impl McpSpinners {
         if let Some(spinner) = self.log_spinner.as_mut() {
             spinner.disable_steady_tick();
         }
+        // Keep context_bar alive — only clear MCP spinners
+        let context_bar = self.context_bar.take();
+        let result = self.multi_bar.clear();
+        self.context_bar = context_bar;
+        result
+    }
+
+    pub fn hide_all(&mut self) -> Result<(), Error> {
         self.context_bar = None;
-        self.multi_bar.clear()
+        self.hide()
     }
 }
 

--- a/crates/goose-server/src/routes/reply.rs
+++ b/crates/goose-server/src/routes/reply.rs
@@ -368,6 +368,7 @@ pub async fn reply(
                                 message: n,
                             }, &tx, &cancel_token).await;
                         }
+                        Ok(Some(Ok(AgentEvent::ContextUsage { .. }))) => {}
 
                         Ok(Some(Err(e))) => {
                             tracing::error!("Error processing message: {}", e);

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -155,8 +155,15 @@ pub struct Agent {
 pub enum AgentEvent {
     Message(Message),
     McpNotification((String, ServerNotification)),
-    ModelChange { model: String, mode: String },
+    ModelChange {
+        model: String,
+        mode: String,
+    },
     HistoryReplaced(Conversation),
+    ContextUsage {
+        used_tokens: usize,
+        total_tokens: usize,
+    },
 }
 
 impl Default for Agent {
@@ -1214,6 +1221,13 @@ impl Agent {
 
                             if let Some(ref usage) = usage {
                                 self.update_session_metrics(&session_config.id, session_config.schedule_id.clone(), usage, false).await?;
+                                if let Some(total) = usage.usage.total_tokens {
+                                    let context_limit = self.provider().await?.get_model_config().context_limit();
+                                    yield AgentEvent::ContextUsage {
+                                        used_tokens: total as usize,
+                                        total_tokens: context_limit,
+                                    };
+                                }
                             }
 
                             if let Some(response) = response {

--- a/crates/goose/src/agents/subagent_handler.rs
+++ b/crates/goose/src/agents/subagent_handler.rs
@@ -208,7 +208,9 @@ fn get_agent_messages(params: SubagentRunParams) -> AgentMessagesFuture {
                     }
                     conversation.push(msg);
                 }
-                Ok(AgentEvent::McpNotification(_)) | Ok(AgentEvent::ModelChange { .. }) => {}
+                Ok(AgentEvent::McpNotification(_))
+                | Ok(AgentEvent::ModelChange { .. })
+                | Ok(AgentEvent::ContextUsage { .. }) => {}
                 Ok(AgentEvent::HistoryReplaced(updated_conversation)) => {
                     conversation = updated_conversation;
                 }

--- a/crates/goose/src/gateway/handler.rs
+++ b/crates/goose/src/gateway/handler.rs
@@ -450,6 +450,7 @@ impl GatewayHandler {
                         "gateway stream: history replaced #{event_count}"
                     );
                 }
+                Ok(AgentEvent::ContextUsage { .. }) => {}
                 Err(e) => {
                     tracing::error!(session_id, error = %e, "gateway stream: error at event #{event_count}");
                     // Stop typing indicator before sending error.

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -463,6 +463,7 @@ mod tests {
                     }
                     Ok(AgentEvent::McpNotification(_)) => {}
                     Ok(AgentEvent::ModelChange { .. }) => {}
+                    Ok(AgentEvent::ContextUsage { .. }) => {}
                     Ok(AgentEvent::HistoryReplaced(_updated_conversation)) => {
                         // We should update the conversation here, but we're not reading it
                     }


### PR DESCRIPTION
## Summary

Adds a persistent status bar at the bottom of the terminal that shows context window usage in real-time during multi-turn tool-calling sessions.

```
  ━━━━━━╌╌╌╌╌╌╌╌╌╌╌╌╌╌ 30% 78k/262k tokens
```

## Problem

During long agentic sessions with many tool calls (e.g. codebase analysis with 30+ tool calls), there's no way to see how full the context window is getting. The existing `/context` command only works between turns at the REPL prompt, not during streaming multi-turn execution. Users only discover context overflow when the session fails.

## Implementation

- **New `AgentEvent::ContextUsage` variant** — emitted after each provider response with current token count and context limit
- **Persistent `ProgressBar`** in the existing `McpSpinners` `MultiProgress` — stays pinned at the bottom while output scrolls above
- **Color-coded** — green (<50%), yellow (50-85%), red (>85%) to quickly signal when compaction is approaching
- **Non-intrusive** — cleared when the session returns to the prompt; only appears during streaming

## Test plan

- [ ] Run a multi-turn tool-calling session and verify the bar appears and updates after each turn
- [ ] Verify color transitions from green → yellow → red as context fills
- [ ] Verify the bar clears when returning to the REPL prompt
- [ ] Verify non-streaming / single-turn responses don't show a stale bar
- [ ] Verify subagent and gateway paths handle the new event variant without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)