### PR TITLE
fix: gate code-mode tool filtering behind cfg(feature) for --no-defau…

### DIFF
--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -154,6 +154,7 @@ impl Agent {
             .await;
         #[cfg(not(feature = "code-mode"))]
         let code_execution_active = false;
+        #[cfg(feature = "code-mode")]
         if code_execution_active {
             let disclosure_style =
                 crate::agents::platform_extensions::code_execution::get_tool_disclosure();


### PR DESCRIPTION
## Summary
The `if code_execution_active` block references `code_execution` and `pctx_code_mode` symbols that only exist when the `code-mode` feature is enabled. Without the compile-time gate, `cargo check --no-default-features` fails with unresolved module errors even though the branch is dead at runtime.

### Testing
`cargo check --no-default-features`

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

