### PR TITLE
feat: optionally enforce path confinement in developer extension

### DIFF
--- a/crates/goose-acp/src/fs.rs
+++ b/crates/goose-acp/src/fs.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use fs_err as fs;
 use goose::agents::mcp_client::{Error as McpError, McpClientTrait};
 use goose::agents::platform_extensions::developer::edit::{
-    resolve_path, string_replace, FileEditParams, FileReadParams, FileWriteParams,
+    string_replace, validate_and_resolve_path, FileEditParams, FileReadParams, FileWriteParams,
 };
 use goose::agents::platform_extensions::developer::shell::{ShellParams, OUTPUT_LIMIT_BYTES};
 use goose::agents::platform_extensions::developer::DeveloperClient;
@@ -131,7 +131,14 @@ impl AcpTools {
             Ok(p) => p,
             Err(e) => return Ok(error_result(e)),
         };
-        let path = resolve_path(&params.path, ctx.working_dir.as_deref());
+        let path = match validate_and_resolve_path(
+            &params.path,
+            ctx.working_dir.as_deref(),
+            ctx.allowed_paths.as_ref(),
+        ) {
+            Ok(p) => p,
+            Err(msg) => return Ok(error_result(msg)),
+        };
         self.update_tool_call(
             ctx,
             ToolCallUpdateFields::new()
@@ -156,7 +163,14 @@ impl AcpTools {
             Ok(p) => p,
             Err(e) => return Ok(error_result(e)),
         };
-        let path = resolve_path(&params.path, ctx.working_dir.as_deref());
+        let path = match validate_and_resolve_path(
+            &params.path,
+            ctx.working_dir.as_deref(),
+            ctx.allowed_paths.as_ref(),
+        ) {
+            Ok(p) => p,
+            Err(msg) => return Ok(error_result(msg)),
+        };
         self.update_tool_call(
             ctx,
             ToolCallUpdateFields::new()
@@ -193,7 +207,14 @@ impl AcpTools {
             Ok(p) => p,
             Err(e) => return Ok(error_result(e)),
         };
-        let path = resolve_path(&params.path, ctx.working_dir.as_deref());
+        let path = match validate_and_resolve_path(
+            &params.path,
+            ctx.working_dir.as_deref(),
+            ctx.allowed_paths.as_ref(),
+        ) {
+            Ok(p) => p,
+            Err(msg) => return Ok(error_result(msg)),
+        };
         self.update_tool_call(
             ctx,
             ToolCallUpdateFields::new()

--- a/crates/goose-acp/tests/common_tests/mod.rs
+++ b/crates/goose-acp/tests/common_tests/mod.rs
@@ -187,12 +187,12 @@ pub async fn run_fs_read_text_file_true<C: Connection>() {
     fs::write(temp_dir.path().join(CONFIG_YAML_NAME), config_yaml).unwrap();
 
     let expected_session_id = C::expected_session_id();
-    let prompt = "Use the read tool to read /tmp/test_acp_read.txt and output only its contents.";
+    let prompt = "Use the read tool to read test_acp_read.txt and output only its contents.";
     let openai = OpenAiFixture::new(
         vec![
             (
                 prompt.to_string(),
-                include_str!("../test_data/openai_fs_read_tool_call.txt"),
+                include_str!("../test_data/openai_fs_read_relative_tool_call.txt"),
             ),
             (
                 r#""content":"test-read-content-12345""#.into(),
@@ -205,7 +205,7 @@ pub async fn run_fs_read_text_file_true<C: Connection>() {
 
     let fs = FsFixture::new();
     let config = TestConnectionConfig {
-        read_text_file: Some(fs.read_handler("/tmp/test_acp_read.txt", "test-read-content-12345")),
+        read_text_file: Some(fs.read_handler("test_acp_read.txt", "test-read-content-12345")),
         data_root: temp_dir.path().to_path_buf(),
         ..Default::default()
     };
@@ -232,19 +232,16 @@ pub async fn run_fs_read_text_file_true<C: Connection>() {
 }
 
 pub async fn run_fs_write_text_file_false<C: Connection>() {
-    let _ = fs::remove_file("/tmp/test_acp_write.txt");
-
     let expected_session_id = C::expected_session_id();
-    let prompt =
-        "Use the write tool to write 'test-write-content-67890' to /tmp/test_acp_write.txt";
+    let prompt = "Use the write tool to write 'test-write-content-67890' to test_acp_write.txt";
     let openai = OpenAiFixture::new(
         vec![
             (
                 prompt.to_string(),
-                include_str!("../test_data/openai_fs_write_tool_call.txt"),
+                include_str!("../test_data/openai_fs_write_relative_tool_call.txt"),
             ),
             (
-                r#"Created /tmp/test_acp_write.txt"#.into(),
+                r#"Created test_acp_write.txt"#.into(),
                 include_str!("../test_data/openai_fs_write_tool_result.txt"),
             ),
         ],
@@ -265,8 +262,9 @@ pub async fn run_fs_write_text_file_false<C: Connection>() {
         .await
         .unwrap();
     assert!(!output.text.is_empty());
+    let written = session.work_dir().join("test_acp_write.txt");
     assert_eq!(
-        fs::read_to_string("/tmp/test_acp_write.txt").unwrap(),
+        fs::read_to_string(&written).unwrap(),
         "test-write-content-67890"
     );
     assert_notifications(
@@ -283,16 +281,15 @@ pub async fn run_fs_write_text_file_false<C: Connection>() {
 
 pub async fn run_fs_write_text_file_true<C: Connection>() {
     let expected_session_id = C::expected_session_id();
-    let prompt =
-        "Use the write tool to write 'test-write-content-67890' to /tmp/test_acp_write.txt";
+    let prompt = "Use the write tool to write 'test-write-content-67890' to test_acp_write.txt";
     let openai = OpenAiFixture::new(
         vec![
             (
                 prompt.to_string(),
-                include_str!("../test_data/openai_fs_write_tool_call.txt"),
+                include_str!("../test_data/openai_fs_write_relative_tool_call.txt"),
             ),
             (
-                r#"Created /tmp/test_acp_write.txt"#.into(),
+                r#"Created test_acp_write.txt"#.into(),
                 include_str!("../test_data/openai_fs_write_tool_result.txt"),
             ),
         ],
@@ -303,9 +300,7 @@ pub async fn run_fs_write_text_file_true<C: Connection>() {
     let fs = FsFixture::new();
     let config = TestConnectionConfig {
         builtins: vec!["developer".to_string()],
-        write_text_file: Some(
-            fs.write_handler("/tmp/test_acp_write.txt", "test-write-content-67890"),
-        ),
+        write_text_file: Some(fs.write_handler("test_acp_write.txt", "test-write-content-67890")),
         ..Default::default()
     };
     let mut conn = C::new(config, openai).await;

--- a/crates/goose-acp/tests/fixtures/mod.rs
+++ b/crates/goose-acp/tests/fixtures/mod.rs
@@ -298,8 +298,8 @@ impl FsFixture {
         let content = content.to_string();
         Arc::new(move |req: &ReadTextFileRequest| {
             let path = req.path.to_str().unwrap_or("");
-            if path != expected_path {
-                let err = format!("expected path {expected_path}, got {path}");
+            if !path.ends_with(&expected_path) {
+                let err = format!("expected path ending with {expected_path}, got {path}");
                 calls.lock().unwrap().push(Err(err.clone()));
                 return Err(err);
             }
@@ -318,8 +318,8 @@ impl FsFixture {
         let expected_content = expected_content.to_string();
         Arc::new(move |req: &WriteTextFileRequest| {
             let path = req.path.to_str().unwrap_or("");
-            if path != expected_path {
-                let err = format!("expected path {expected_path}, got {path}");
+            if !path.ends_with(&expected_path) {
+                let err = format!("expected path ending with {expected_path}, got {path}");
                 calls.lock().unwrap().push(Err(err.clone()));
                 return Err(err);
             }

--- a/crates/goose-acp/tests/test_data/openai_fs_read_relative_tool_call.txt
+++ b/crates/goose-acp/tests/test_data/openai_fs_read_relative_tool_call.txt
@@ -1,0 +1,27 @@
+data: {"id":"chatcmpl-DFS7Z5WU3Km0oi1oFGiFSCLRPlriu","object":"chat.completion.chunk","created":1772575389,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_ihWQp56Fq7txY7HHZJiNwzdy","type":"function","function":{"name":"read","arguments":""}}],"refusal":null},"finish_reason":null}],"usage":null,"obfuscation":"arnej9G"}
+
+data: {"id":"chatcmpl-DFS7Z5WU3Km0oi1oFGiFSCLRPlriu","object":"chat.completion.chunk","created":1772575389,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"finish_reason":null}],"usage":null,"obfuscation":"M6pPn6sMuZ"}
+
+data: {"id":"chatcmpl-DFS7Z5WU3Km0oi1oFGiFSCLRPlriu","object":"chat.completion.chunk","created":1772575389,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"path"}}]},"finish_reason":null}],"usage":null,"obfuscation":"7mHQMw0OR"}
+
+data: {"id":"chatcmpl-DFS7Z5WU3Km0oi1oFGiFSCLRPlriu","object":"chat.completion.chunk","created":1772575389,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":"}}]},"finish_reason":null}],"usage":null,"obfuscation":"UktUfC37dd"}
+
+data: {"id":"chatcmpl-DFS7Z5WU3Km0oi1oFGiFSCLRPlriu","object":"chat.completion.chunk","created":1772575389,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"test"}}]},"finish_reason":null}],"usage":null,"obfuscation":"kkR18xflju"}
+
+data: {"id":"chatcmpl-DFS7Z5WU3Km0oi1oFGiFSCLRPlriu","object":"chat.completion.chunk","created":1772575389,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"_ac"}}]},"finish_reason":null}],"usage":null,"obfuscation":"3eLyGhC3LQ"}
+
+data: {"id":"chatcmpl-DFS7Z5WU3Km0oi1oFGiFSCLRPlriu","object":"chat.completion.chunk","created":1772575389,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"p"}}]},"finish_reason":null}],"usage":null,"obfuscation":"NXUnZPCSiGnn"}
+
+data: {"id":"chatcmpl-DFS7Z5WU3Km0oi1oFGiFSCLRPlriu","object":"chat.completion.chunk","created":1772575389,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"_read"}}]},"finish_reason":null}],"usage":null,"obfuscation":"mCuJG2UV"}
+
+data: {"id":"chatcmpl-DFS7Z5WU3Km0oi1oFGiFSCLRPlriu","object":"chat.completion.chunk","created":1772575389,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":".txt"}}]},"finish_reason":null}],"usage":null,"obfuscation":"KjZS3z8R5"}
+
+data: {"id":"chatcmpl-DFS7Z5WU3Km0oi1oFGiFSCLRPlriu","object":"chat.completion.chunk","created":1772575389,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"finish_reason":null}],"usage":null,"obfuscation":"Pe4UZ56QwD"}
+
+data: {"id":"chatcmpl-DFS7Z5WU3Km0oi1oFGiFSCLRPlriu","object":"chat.completion.chunk","created":1772575389,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":null,"obfuscation":"5hgvg2ilskM"}
+
+data: {"id":"chatcmpl-DFS7Z5WU3Km0oi1oFGiFSCLRPlriu","object":"chat.completion.chunk","created":1772575389,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[],"usage":{"prompt_tokens":7010,"completion_tokens":156,"total_tokens":7166,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":128,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"bxKDPI1dGxmTdwd"}
+
+data: [DONE]
+
+

--- a/crates/goose-acp/tests/test_data/openai_fs_write_relative_tool_call.txt
+++ b/crates/goose-acp/tests/test_data/openai_fs_write_relative_tool_call.txt
@@ -1,0 +1,53 @@
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_AmzdRa1JlDxMgwoFQ3W9Y6bf","type":"function","function":{"name":"write","arguments":""}}],"refusal":null},"finish_reason":null}],"usage":null,"obfuscation":"RgiRu2"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{"}}]},"finish_reason":null}],"usage":null,"obfuscation":"c0QxkX9w4RWN"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":" \""}}]},"finish_reason":null}],"usage":null,"obfuscation":"guqW44RQ65"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"path"}}]},"finish_reason":null}],"usage":null,"obfuscation":"U4psai0wZ"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":"}}]},"finish_reason":null}],"usage":null,"obfuscation":"VmwxuO12qp"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":" \"test"}}]},"finish_reason":null}],"usage":null,"obfuscation":"u6VUDV4LA"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"_ac"}}]},"finish_reason":null}],"usage":null,"obfuscation":"67j2bDOpM3"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"p"}}]},"finish_reason":null}],"usage":null,"obfuscation":"tqT1vbnWapFk"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"_write"}}]},"finish_reason":null}],"usage":null,"obfuscation":"35yX5yg"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":".txt"}}]},"finish_reason":null}],"usage":null,"obfuscation":"2OmZyuL8W"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\","}}]},"finish_reason":null}],"usage":null,"obfuscation":"D4bVfN7m5M"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":" \""}}]},"finish_reason":null}],"usage":null,"obfuscation":"TtPSCtq6VV"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"content"}}]},"finish_reason":null}],"usage":null,"obfuscation":"EqSkfr"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":"}}]},"finish_reason":null}],"usage":null,"obfuscation":"ubKsA67ljm"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":" \""}}]},"finish_reason":null}],"usage":null,"obfuscation":"H6lzd69n6V"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"test"}}]},"finish_reason":null}],"usage":null,"obfuscation":"v0IFOBPju"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-write"}}]},"finish_reason":null}],"usage":null,"obfuscation":"jzyuAat"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-content"}}]},"finish_reason":null}],"usage":null,"obfuscation":"6p3tY"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"finish_reason":null}],"usage":null,"obfuscation":"R4PFCfWGWwQO"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"678"}}]},"finish_reason":null}],"usage":null,"obfuscation":"BHRNUazkpJ"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"90"}}]},"finish_reason":null}],"usage":null,"obfuscation":"085WWflBbh1"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\""}}]},"finish_reason":null}],"usage":null,"obfuscation":"zu9irR3Bf58"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":" }"}}]},"finish_reason":null}],"usage":null,"obfuscation":"m4lW5kBYPNx"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":null,"obfuscation":"Ptpd2etx9L8"}
+
+data: {"id":"chatcmpl-DFS9ySulK0wZhiU0Qbcdrr7vqTth2","object":"chat.completion.chunk","created":1772575538,"model":"gpt-5-nano-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[],"usage":{"prompt_tokens":7013,"completion_tokens":233,"total_tokens":7246,"prompt_tokens_details":{"cached_tokens":6784,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":192,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"K1gClbYIVju8"}
+
+data: [DONE]
+
+

--- a/crates/goose/src/agents/platform_extensions/analyze/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/analyze/mod.rs
@@ -3,6 +3,7 @@ pub mod graph;
 pub mod languages;
 pub mod parser;
 
+use super::developer::edit::validate_and_resolve_path;
 use crate::agents::extension::PlatformExtensionContext;
 use crate::agents::mcp_client::{Error, McpClientTrait};
 use crate::agents::tool_execution::ToolCallContext;
@@ -84,17 +85,6 @@ impl AnalyzeClient {
             .map(Value::Object)
             .ok_or_else(|| "Missing arguments".to_string())?;
         serde_json::from_value(value).map_err(|e| format!("Failed to parse arguments: {e}"))
-    }
-
-    fn resolve_path(path: &str, working_dir: Option<&Path>) -> PathBuf {
-        let p = PathBuf::from(path);
-        if p.is_absolute() {
-            p
-        } else if let Some(cwd) = working_dir {
-            cwd.join(p)
-        } else {
-            p
-        }
     }
 
     fn analyze(&self, params: AnalyzeParams, path: PathBuf) -> CallToolResult {
@@ -244,7 +234,18 @@ impl McpClientTrait for AnalyzeClient {
         match name {
             "analyze" => match Self::parse_args::<AnalyzeParams>(arguments) {
                 Ok(params) => {
-                    let path = Self::resolve_path(&params.path, working_dir);
+                    let path = match validate_and_resolve_path(
+                        &params.path,
+                        working_dir,
+                        ctx.allowed_paths.as_ref(),
+                    ) {
+                        Ok(p) => p,
+                        Err(msg) => {
+                            return Ok(CallToolResult::error(vec![
+                                Content::text(msg).with_priority(0.0)
+                            ]))
+                        }
+                    };
                     Ok(self.analyze(params, path))
                 }
                 Err(error) => Ok(CallToolResult::error(vec![Content::text(format!(

--- a/crates/goose/src/agents/platform_extensions/developer/edit.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/edit.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -42,8 +43,12 @@ impl EditTools {
         &self,
         params: FileReadParams,
         working_dir: Option<&Path>,
+        allowed_paths: Option<&HashSet<PathBuf>>,
     ) -> CallToolResult {
-        let path = resolve_path(&params.path, working_dir);
+        let path = match validate_and_resolve_path(&params.path, working_dir, allowed_paths) {
+            Ok(p) => p,
+            Err(msg) => return CallToolResult::error(vec![Content::text(msg).with_priority(0.0)]),
+        };
 
         match fs::read_to_string(&path) {
             Ok(content) => {
@@ -59,15 +64,19 @@ impl EditTools {
     }
 
     pub fn file_write(&self, params: FileWriteParams) -> CallToolResult {
-        self.file_write_with_cwd(params, None)
+        self.file_write_with_cwd(params, None, None)
     }
 
     pub fn file_write_with_cwd(
         &self,
         params: FileWriteParams,
         working_dir: Option<&Path>,
+        allowed_paths: Option<&HashSet<PathBuf>>,
     ) -> CallToolResult {
-        let path = resolve_path(&params.path, working_dir);
+        let path = match validate_and_resolve_path(&params.path, working_dir, allowed_paths) {
+            Ok(p) => p,
+            Err(msg) => return CallToolResult::error(vec![Content::text(msg).with_priority(0.0)]),
+        };
 
         if let Some(parent) = path.parent() {
             if !parent.as_os_str().is_empty() && !parent.exists() {
@@ -103,15 +112,19 @@ impl EditTools {
     }
 
     pub fn file_edit(&self, params: FileEditParams) -> CallToolResult {
-        self.file_edit_with_cwd(params, None)
+        self.file_edit_with_cwd(params, None, None)
     }
 
     pub fn file_edit_with_cwd(
         &self,
         params: FileEditParams,
         working_dir: Option<&Path>,
+        allowed_paths: Option<&HashSet<PathBuf>>,
     ) -> CallToolResult {
-        let path = resolve_path(&params.path, working_dir);
+        let path = match validate_and_resolve_path(&params.path, working_dir, allowed_paths) {
+            Ok(p) => p,
+            Err(msg) => return CallToolResult::error(vec![Content::text(msg).with_priority(0.0)]),
+        };
 
         let content = match fs::read_to_string(&path) {
             Ok(c) => c,
@@ -212,17 +225,103 @@ fn apply_line_limit(content: &str, line: Option<u32>, limit: Option<u32>) -> Str
     lines[start..end].concat()
 }
 
-pub fn resolve_path(path: &str, working_dir: Option<&Path>) -> PathBuf {
-    let path = PathBuf::from(path);
-    if path.is_absolute() {
-        path
+/// Resolve a user-supplied path, optionally enforcing confinement to a set of allowed base paths.
+///
+/// * `working_dir` — used to resolve relative paths. Falls back to `cwd` when `None`.
+/// * `allowed_paths` — when `Some`, the resolved path must be inside at least one of the
+///   listed base directories. When `None`, no confinement is enforced.
+pub fn validate_and_resolve_path(
+    path: &str,
+    working_dir: Option<&Path>,
+    allowed_paths: Option<&HashSet<PathBuf>>,
+) -> Result<PathBuf, String> {
+    let path_buf = PathBuf::from(path);
+
+    // Resolve relative paths against working_dir (or cwd).
+    let cwd_fallback;
+    let base = match working_dir {
+        Some(dir) => dir,
+        None => {
+            cwd_fallback = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+            cwd_fallback.as_path()
+        }
+    };
+    let joined = if path_buf.is_absolute() {
+        path_buf
     } else {
-        working_dir
-            .map(Path::to_path_buf)
-            .or_else(|| std::env::current_dir().ok())
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join(path)
+        base.join(&path_buf)
+    };
+
+    // If no confinement, just resolve and return.
+    let Some(bases) = allowed_paths else {
+        return Ok(joined);
+    };
+
+    // Build the set of canonical base paths for confinement checks.
+    let canonical_bases: Vec<PathBuf> =
+        bases.iter().filter_map(|b| b.canonicalize().ok()).collect();
+    if canonical_bases.is_empty() && !bases.is_empty() {
+        return Err("Failed to resolve allowed base directories for confinement".to_string());
     }
+
+    let is_within_bases = |p: &Path| canonical_bases.iter().any(|cb| p.starts_with(cb));
+
+    // Walk the path component-by-component through the filesystem,
+    // then validate the result against allowed base directories.
+    let resolved = resolve_confined(&joined, path)?;
+
+    if !is_within_bases(&resolved) {
+        return Err(format!("Path escapes allowed directories: {path}"));
+    }
+    Ok(resolved)
+}
+
+/// Walk path components, resolving each through the filesystem where possible.
+///
+/// Existing components are canonicalized (following symlinks). Once a non-existent
+/// component is encountered, subsequent `..` and `.` are rejected outright — they
+/// are ambiguous without the filesystem and create path-confusion escapes. Dangling
+/// symlinks (exist but can't be canonicalized) are also rejected since their targets
+/// cannot be verified.
+fn resolve_confined(joined: &Path, original_path: &str) -> Result<PathBuf, String> {
+    let mut resolved = PathBuf::new();
+    let mut past_fs = false;
+
+    for component in joined.components() {
+        if past_fs {
+            // Beyond the filesystem boundary: only plain names are safe.
+            match component {
+                std::path::Component::ParentDir | std::path::Component::CurDir => {
+                    return Err(format!(
+                        "Path contains traversal after non-existent segment: {original_path}"
+                    ));
+                }
+                _ => resolved.push(component),
+            }
+            continue;
+        }
+
+        let candidate = resolved.join(component.as_os_str());
+        if candidate.symlink_metadata().is_ok() {
+            // Component exists — canonicalize to follow symlinks.
+            match candidate.canonicalize() {
+                Ok(canonical) => resolved = canonical,
+                Err(_) => {
+                    // Exists but can't canonicalize (dangling symlink). We cannot
+                    // verify where it points, so reject under confinement.
+                    return Err(format!(
+                        "Path contains an unresolvable symlink: {original_path}"
+                    ));
+                }
+            }
+        } else {
+            // Component doesn't exist on the filesystem.
+            resolved.push(component);
+            past_fs = true;
+        }
+    }
+
+    Ok(resolved)
 }
 
 fn count_lines_before(content: &str, byte_pos: usize) -> usize {
@@ -323,6 +422,7 @@ mod tests {
                 limit: None,
             },
             None,
+            None,
         );
 
         assert!(!result.is_error.unwrap_or(false));
@@ -342,6 +442,7 @@ mod tests {
                 line: Some(2),
                 limit: Some(1),
             },
+            None,
             None,
         );
 
@@ -480,6 +581,7 @@ mod tests {
                 content: "relative write".to_string(),
             },
             Some(dir.path()),
+            None,
         );
 
         assert!(!result.is_error.unwrap_or(false));
@@ -502,6 +604,7 @@ mod tests {
                 after: "after".to_string(),
             },
             Some(dir.path()),
+            None,
         );
 
         assert!(!result.is_error.unwrap_or(false));
@@ -509,5 +612,206 @@ mod tests {
             fs::read_to_string(dir.path().join("relative-edit.txt")).unwrap(),
             "after"
         );
+    }
+
+    // --- Path confinement tests ---
+
+    /// Helper: create a confined set containing just the given directory.
+    fn confined(dir: &Path) -> HashSet<PathBuf> {
+        HashSet::from([dir.to_path_buf()])
+    }
+
+    #[test]
+    fn test_absolute_path_outside_allowed_dirs_rejected() {
+        let dir = setup();
+        let allowed = confined(dir.path());
+        let result = validate_and_resolve_path("/etc/passwd", Some(dir.path()), Some(&allowed));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("escapes allowed directories"));
+    }
+
+    #[test]
+    fn test_absolute_path_inside_allowed_dir_allowed() {
+        let dir = setup();
+        let file = dir.path().join("allowed.txt");
+        fs::write(&file, "ok").unwrap();
+        let abs_path = file.to_string_lossy().to_string();
+        let allowed = confined(dir.path());
+        let result = validate_and_resolve_path(&abs_path, Some(dir.path()), Some(&allowed));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_dotdot_traversal_rejected() {
+        let dir = setup();
+        let allowed = confined(dir.path());
+        let result =
+            validate_and_resolve_path("../../etc/passwd", Some(dir.path()), Some(&allowed));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("escapes allowed directories"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_symlink_outside_allowed_dir_rejected() {
+        let dir = setup();
+        let outside = setup();
+        let target = outside.path().join("outside.txt");
+        fs::write(&target, "secret").unwrap();
+
+        std::os::unix::fs::symlink(&target, dir.path().join("link.txt")).unwrap();
+
+        let allowed = confined(dir.path());
+        let result = validate_and_resolve_path("link.txt", Some(dir.path()), Some(&allowed));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("escapes allowed directories"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_symlink_inside_allowed_dir_allowed() {
+        let dir = setup();
+        let target = dir.path().join("real.txt");
+        fs::write(&target, "ok").unwrap();
+
+        std::os::unix::fs::symlink(&target, dir.path().join("link.txt")).unwrap();
+
+        let allowed = confined(dir.path());
+        let result = validate_and_resolve_path("link.txt", Some(dir.path()), Some(&allowed));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_write_new_file_within_allowed_dir() {
+        let dir = setup();
+        fs::create_dir_all(dir.path().join("subdir")).unwrap();
+        let allowed = confined(dir.path());
+        let result =
+            validate_and_resolve_path("subdir/new_file.txt", Some(dir.path()), Some(&allowed));
+        assert!(result.is_ok());
+        assert!(result
+            .unwrap()
+            .starts_with(dir.path().canonicalize().unwrap()));
+    }
+
+    #[test]
+    fn test_write_new_file_dotdot_escape_rejected() {
+        let dir = setup();
+        let allowed = confined(dir.path());
+        let result = validate_and_resolve_path("../escape.txt", Some(dir.path()), Some(&allowed));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("escapes allowed directories"));
+    }
+
+    #[test]
+    fn test_no_confinement_allows_absolute_paths() {
+        let result = validate_and_resolve_path("/tmp/some_file.txt", None, None);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), PathBuf::from("/tmp/some_file.txt"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_symlink_ancestor_escape_on_new_file_rejected() {
+        // A symlink dir inside the workspace pointing outside: link -> /outside
+        // Writing to link/newdir/file.txt should be rejected because the ancestor
+        // "link" resolves outside the allowed directory.
+        let dir = setup();
+        let outside = setup();
+        std::os::unix::fs::symlink(outside.path(), dir.path().join("link")).unwrap();
+
+        let allowed = confined(dir.path());
+        let result =
+            validate_and_resolve_path("link/newdir/file.txt", Some(dir.path()), Some(&allowed));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("escapes allowed directories"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_dangling_symlink_outside_allowed_dir_rejected() {
+        // A dangling symlink (target doesn't exist) pointing outside the workspace
+        // should be rejected even though the parent dir is inside.
+        let dir = setup();
+        std::os::unix::fs::symlink("/tmp/nonexistent_target.txt", dir.path().join("link.txt"))
+            .unwrap();
+
+        let allowed = confined(dir.path());
+        let result = validate_and_resolve_path("link.txt", Some(dir.path()), Some(&allowed));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("symlink"));
+    }
+
+    #[test]
+    fn test_dotdot_traversal_with_nonexistent_prefix_rejected() {
+        // a/../../escape.txt should be rejected even when "a" doesn't exist,
+        // because .. after a non-existent component is always rejected.
+        let dir = setup();
+        let allowed = confined(dir.path());
+        let result =
+            validate_and_resolve_path("a/../../escape.txt", Some(dir.path()), Some(&allowed));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("traversal after non-existent"));
+    }
+
+    #[test]
+    fn test_multiple_allowed_paths() {
+        let dir1 = setup();
+        let dir2 = setup();
+        let file1 = dir1.path().join("file1.txt");
+        let file2 = dir2.path().join("file2.txt");
+        fs::write(&file1, "ok").unwrap();
+        fs::write(&file2, "ok").unwrap();
+
+        let allowed = HashSet::from([dir1.path().to_path_buf(), dir2.path().to_path_buf()]);
+
+        // File in dir1 is allowed
+        let result =
+            validate_and_resolve_path(&file1.to_string_lossy(), Some(dir1.path()), Some(&allowed));
+        assert!(result.is_ok());
+
+        // File in dir2 is also allowed
+        let result =
+            validate_and_resolve_path(&file2.to_string_lossy(), Some(dir1.path()), Some(&allowed));
+        assert!(result.is_ok());
+
+        // File outside both is rejected
+        let result = validate_and_resolve_path("/etc/passwd", Some(dir1.path()), Some(&allowed));
+        assert!(result.is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_dotdot_across_symlink_rejected() {
+        // link -> /tmp/outside, then "link/../newdir/file.txt" should be rejected
+        // because `link/..` resolves through the symlink to /tmp, escaping the workspace.
+        let dir = setup();
+        let outside = setup();
+        std::os::unix::fs::symlink(outside.path(), dir.path().join("link")).unwrap();
+
+        let allowed = confined(dir.path());
+        let result =
+            validate_and_resolve_path("link/../newdir/file.txt", Some(dir.path()), Some(&allowed));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("escapes allowed directories"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_dotdot_rewind_into_symlink_after_missing_rejected() {
+        // missing/../link/new/file.txt — "missing" doesn't exist so `..` after it
+        // is rejected outright (traversal after non-existent segment).
+        let dir = setup();
+        let outside = setup();
+        std::os::unix::fs::symlink(outside.path(), dir.path().join("link")).unwrap();
+
+        let allowed = confined(dir.path());
+        let result = validate_and_resolve_path(
+            "missing/../link/new/file.txt",
+            Some(dir.path()),
+            Some(&allowed),
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("traversal after non-existent"));
     }
 }

--- a/crates/goose/src/agents/platform_extensions/developer/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/mod.rs
@@ -152,27 +152,50 @@ impl McpClientTrait for DeveloperClient {
         _cancel_token: CancellationToken,
     ) -> Result<CallToolResult, Error> {
         let working_dir = ctx.working_dir.as_deref();
+        let allowed_paths = ctx.allowed_paths.as_ref();
         match name {
             "shell" => match Self::parse_args::<ShellParams>(arguments) {
                 Ok(params) => Ok(self.shell_tool.shell_with_cwd(params, working_dir).await),
                 Err(error) => Ok(ShellTool::error_result(&format!("Error: {error}"), None)),
             },
             "write" => match Self::parse_args::<FileWriteParams>(arguments) {
-                Ok(params) => Ok(self.edit_tools.file_write_with_cwd(params, working_dir)),
+                Ok(params) => {
+                    Ok(self
+                        .edit_tools
+                        .file_write_with_cwd(params, working_dir, allowed_paths))
+                }
                 Err(error) => Ok(CallToolResult::error(vec![Content::text(format!(
                     "Error: {error}"
                 ))
                 .with_priority(0.0)])),
             },
             "edit" => match Self::parse_args::<FileEditParams>(arguments) {
-                Ok(params) => Ok(self.edit_tools.file_edit_with_cwd(params, working_dir)),
+                Ok(params) => {
+                    Ok(self
+                        .edit_tools
+                        .file_edit_with_cwd(params, working_dir, allowed_paths))
+                }
                 Err(error) => Ok(CallToolResult::error(vec![Content::text(format!(
                     "Error: {error}"
                 ))
                 .with_priority(0.0)])),
             },
             "tree" => match Self::parse_args::<TreeParams>(arguments) {
-                Ok(params) => Ok(self.tree_tool.tree_with_cwd(params, working_dir)),
+                Ok(params) => {
+                    let path = match edit::validate_and_resolve_path(
+                        &params.path,
+                        working_dir,
+                        allowed_paths,
+                    ) {
+                        Ok(p) => p,
+                        Err(msg) => {
+                            return Ok(CallToolResult::error(vec![
+                                Content::text(msg).with_priority(0.0)
+                            ]))
+                        }
+                    };
+                    Ok(self.tree_tool.tree_at_depth(path, params.depth))
+                }
                 Err(error) => Ok(CallToolResult::error(vec![Content::text(format!(
                     "Error: {error}"
                 ))

--- a/crates/goose/src/agents/platform_extensions/developer/tree.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/tree.rs
@@ -27,7 +27,7 @@ impl TreeTool {
 
     pub fn tree(&self, params: TreeParams) -> CallToolResult {
         let root = PathBuf::from(&params.path);
-        self.tree_at(root, params.depth)
+        self.tree_at_depth(root, params.depth)
     }
 
     pub fn tree_with_cwd(&self, params: TreeParams, working_dir: Option<&Path>) -> CallToolResult {
@@ -41,10 +41,10 @@ impl TreeTool {
                 .unwrap_or_else(|| PathBuf::from("."))
                 .join(path)
         };
-        self.tree_at(root, params.depth)
+        self.tree_at_depth(root, params.depth)
     }
 
-    fn tree_at(&self, root: PathBuf, depth: u32) -> CallToolResult {
+    pub fn tree_at_depth(&self, root: PathBuf, depth: u32) -> CallToolResult {
         if !root.exists() {
             return CallToolResult::error(vec![Content::text(format!(
                 "Path does not exist: {}",

--- a/crates/goose/src/agents/tool_execution.rs
+++ b/crates/goose/src/agents/tool_execution.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use std::future::Future;
 use tokio_util::sync::CancellationToken;
 
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use crate::config::permission::PermissionLevel;
@@ -18,6 +19,9 @@ pub struct ToolCallContext {
     pub session_id: String,
     pub working_dir: Option<PathBuf>,
     pub tool_call_request_id: Option<String>,
+    /// When `Some`, file operations are confined to these base paths.
+    /// When `None`, all paths are allowed (no confinement).
+    pub allowed_paths: Option<HashSet<PathBuf>>,
 }
 
 impl ToolCallContext {
@@ -26,11 +30,30 @@ impl ToolCallContext {
         working_dir: Option<PathBuf>,
         tool_call_request_id: Option<String>,
     ) -> Self {
+        let allowed_paths = Self::build_allowed_paths(&working_dir);
         Self {
             session_id,
             working_dir,
             tool_call_request_id,
+            allowed_paths,
         }
+    }
+
+    /// Build the allowed paths set based on the confinement config.
+    /// Returns `None` (no confinement) when the config key is absent or false.
+    /// Returns `Some({working_dir})` when confinement is enabled.
+    fn build_allowed_paths(working_dir: &Option<PathBuf>) -> Option<HashSet<PathBuf>> {
+        let confinement_enabled = crate::config::Config::global()
+            .get_param::<bool>("GOOSE_CONFINEMENT")
+            .unwrap_or(false);
+        if !confinement_enabled {
+            return None;
+        }
+        // Only confine when we have a working directory to confine to.
+        // Without one (e.g. server tool-callback contexts) confinement
+        // is not meaningful, so allow all paths.
+        let dir = working_dir.as_ref()?;
+        Some(HashSet::from([dir.clone()]))
     }
 
     pub fn working_dir_str(&self) -> Option<&str> {


### PR DESCRIPTION
## Summary

Replaces the unchecked `resolve_path` with `validate_and_resolve_path` that enforces confinement to the working directory (allowance is made for a future feature that allows paths to be added to the allowed set). This prevents absolute path escape (`/etc/passwd`), `..` traversal (`../../etc/passwd`), and symlink-based escapes from reaching files outside the working directory.

Confinement is off by default to match the existing behaviour where working directory is just a base path. It can be enabled by setting the GOOSE_CONFINEMENT config key to true.

### Testing

New unit tests covering: absolute path rejection, `..` traversal rejection, symlink escape rejection, symlink within working dir allowed, new file write within working dir, `..` escape on write, and no-confinement mode.

### Related Issues

Fixes #7587