### PR TITLE
feat: add EUrouter as a declarative provider

### DIFF
--- a/crates/goose/src/providers/declarative/eurouter.json
+++ b/crates/goose/src/providers/declarative/eurouter.json
@@ -39,6 +39,7 @@
       "supports_cache_control": null
     }
   ],
+  "dynamic_models": true,
   "headers": null,
   "timeout_seconds": null,
   "supports_streaming": true

--- a/crates/goose/src/providers/declarative/eurouter.json
+++ b/crates/goose/src/providers/declarative/eurouter.json
@@ -1,0 +1,45 @@
+{
+  "name": "eurouter",
+  "engine": "openai",
+  "display_name": "EUrouter",
+  "description": "AI Gateway to European AI - EU-hosted, GDPR-friendly models via OpenAI-compatible API",
+  "api_key_env": "EUROUTER_API_KEY",
+  "base_url": "https://api.eurouter.ai/api/v1",
+  "models": [
+    {
+      "name": "deepseek-r1",
+      "context_limit": 65000,
+      "input_token_cost": null,
+      "output_token_cost": null,
+      "currency": null,
+      "supports_cache_control": null
+    },
+    {
+      "name": "kimi-k2.5",
+      "context_limit": 131000,
+      "input_token_cost": null,
+      "output_token_cost": null,
+      "currency": null,
+      "supports_cache_control": null
+    },
+    {
+      "name": "mistral-large-latest",
+      "context_limit": 131000,
+      "input_token_cost": null,
+      "output_token_cost": null,
+      "currency": null,
+      "supports_cache_control": null
+    },
+    {
+      "name": "minimax-m2.5",
+      "context_limit": 1048000,
+      "input_token_cost": null,
+      "output_token_cost": null,
+      "currency": null,
+      "supports_cache_control": null
+    }
+  ],
+  "headers": null,
+  "timeout_seconds": null,
+  "supports_streaming": true
+}

--- a/crates/goose/src/providers/declarative/eurouter.json
+++ b/crates/goose/src/providers/declarative/eurouter.json
@@ -5,40 +5,7 @@
   "description": "AI Gateway to European AI - EU-hosted, GDPR-friendly models via OpenAI-compatible API",
   "api_key_env": "EUROUTER_API_KEY",
   "base_url": "https://api.eurouter.ai/api/v1",
-  "models": [
-    {
-      "name": "deepseek-r1",
-      "context_limit": 65000,
-      "input_token_cost": null,
-      "output_token_cost": null,
-      "currency": null,
-      "supports_cache_control": null
-    },
-    {
-      "name": "kimi-k2.5",
-      "context_limit": 131000,
-      "input_token_cost": null,
-      "output_token_cost": null,
-      "currency": null,
-      "supports_cache_control": null
-    },
-    {
-      "name": "mistral-large-latest",
-      "context_limit": 131000,
-      "input_token_cost": null,
-      "output_token_cost": null,
-      "currency": null,
-      "supports_cache_control": null
-    },
-    {
-      "name": "minimax-m2.5",
-      "context_limit": 1048000,
-      "input_token_cost": null,
-      "output_token_cost": null,
-      "currency": null,
-      "supports_cache_control": null
-    }
-  ],
+  "models": [],
   "dynamic_models": true,
   "headers": null,
   "timeout_seconds": null,


### PR DESCRIPTION
## Summary

Adds [EUrouter](https://www.eurouter.ai) as a declarative provider, following the same JSON format as existing providers (Tensorix, Groq, Mistral, etc.).

EUrouter is an AI Gateway to European AI, providing a single OpenAI-compatible API endpoint for EU-hosted, GDPR-friendly models.

## Models Included

| Model | Context |
|-------|---------|
| `deepseek-r1` | 65K |
| `kimi-k2.5` | 131K |
| `mistral-large-latest` | 131K |
| `minimax-m2.5` | 1M |

And more. See all available modesl on `https://api.eurouter.ai/api/v1/models`

## Changes

- Added `crates/goose/src/providers/declarative/eurouter.json`

## Authentication

Users set `EUROUTER_API_KEY` in their environment, consistent with the `api_key_env` convention used by other declarative providers.

### Testing

The JSON file follows the exact schema of existing declarative providers and requires no code changes — just the new JSON file in the `declarative/` directory.

### Related Issues
N/A (new provider addition)