### PR TITLE
feat: implement dynamic tool discovery via MCP notifications/tools/li…

### DIFF
--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::Duration;
 use tempfile::{tempdir, TempDir};
 use tokio::io::AsyncReadExt;
@@ -34,7 +34,9 @@ use super::tool_execution::{ToolCallContext, ToolCallResult};
 use super::types::SharedProvider;
 use crate::agents::extension::{Envs, ProcessExit};
 use crate::agents::extension_malware_check;
-use crate::agents::mcp_client::{GooseMcpClientCapabilities, McpClient, McpClientTrait};
+use crate::agents::mcp_client::{
+    GooseMcpClientCapabilities, McpClient, McpClientTrait, ToolCacheInvalidator,
+};
 use crate::builtin_extension::get_builtin_extension;
 use crate::config::extensions::name_to_key;
 use crate::config::search_path::SearchPaths;
@@ -235,6 +237,7 @@ struct ResolvedTool {
     client: McpClientBox,
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn child_process_client(
     mut command: Command,
     timeout: &Option<u64>,
@@ -243,6 +246,7 @@ async fn child_process_client(
     docker_container: Option<String>,
     client_name: String,
     capabilities: GooseMcpClientCapabilities,
+    tool_cache_invalidator: Option<Weak<dyn ToolCacheInvalidator>>,
 ) -> ExtensionResult<McpClient> {
     configure_subprocess(&mut command);
 
@@ -281,6 +285,7 @@ async fn child_process_client(
         client_name,
         capabilities,
         working_dir.clone(),
+        tool_cache_invalidator,
     )
     .await;
 
@@ -413,6 +418,7 @@ async fn create_streamable_http_client(
     client_name: String,
     capabilities: GooseMcpClientCapabilities,
     roots_dir: &std::path::Path,
+    tool_cache_invalidator: Option<Weak<dyn ToolCacheInvalidator>>,
 ) -> ExtensionResult<Box<dyn McpClientTrait>> {
     let mut default_headers = HeaderMap::new();
 
@@ -451,6 +457,7 @@ async fn create_streamable_http_client(
         client_name.clone(),
         capabilities.clone(),
         roots_dir.to_path_buf(),
+        tool_cache_invalidator.clone(),
     )
     .await;
 
@@ -481,6 +488,7 @@ async fn create_streamable_http_client(
                         client_name,
                         capabilities,
                         roots_dir.to_path_buf(),
+                        tool_cache_invalidator,
                     )
                     .await?,
                 ))
@@ -601,6 +609,9 @@ impl ExtensionManager {
                     mcpui: self.capabilities.mcpui,
                 };
 
+                let invalidator: Option<Weak<dyn ToolCacheInvalidator>> =
+                    Some(Arc::downgrade(self) as Weak<dyn ToolCacheInvalidator>);
+
                 create_streamable_http_client(
                     &resolved_uri,
                     *timeout,
@@ -610,6 +621,7 @@ impl ExtensionManager {
                     self.client_name.clone(),
                     capability,
                     &effective_working_dir,
+                    invalidator,
                 )
                 .await?
             }
@@ -621,6 +633,8 @@ impl ExtensionManager {
                     None
                 };
                 let normalized_name = name_to_key(name);
+                let invalidator: Option<Weak<dyn ToolCacheInvalidator>> =
+                    Some(Arc::downgrade(self) as Weak<dyn ToolCacheInvalidator>);
 
                 if let Some(def) = PLATFORM_EXTENSIONS.get(normalized_name.as_str()) {
                     // Platform extension: create via in-process client factory
@@ -671,6 +685,7 @@ impl ExtensionManager {
                             Some(container_id.to_string()),
                             self.client_name.clone(),
                             capabilities,
+                            invalidator.clone(),
                         )
                         .await?;
                         Box::new(client)
@@ -691,6 +706,7 @@ impl ExtensionManager {
                                 self.client_name.clone(),
                                 capabilities,
                                 effective_working_dir.clone(),
+                                invalidator,
                             )
                             .await?,
                         )
@@ -742,6 +758,8 @@ impl ExtensionManager {
                 let capabilities = GooseMcpClientCapabilities {
                     mcpui: self.capabilities.mcpui,
                 };
+                let invalidator: Option<Weak<dyn ToolCacheInvalidator>> =
+                    Some(Arc::downgrade(self) as Weak<dyn ToolCacheInvalidator>);
                 let client = child_process_client(
                     command,
                     timeout,
@@ -750,6 +768,7 @@ impl ExtensionManager {
                     container.map(|c| c.id().to_string()),
                     self.client_name.clone(),
                     capabilities,
+                    invalidator,
                 )
                 .await?;
                 Box::new(client)
@@ -778,6 +797,9 @@ impl ExtensionManager {
                     mcpui: self.capabilities.mcpui,
                 };
 
+                let invalidator: Option<Weak<dyn ToolCacheInvalidator>> =
+                    Some(Arc::downgrade(self) as Weak<dyn ToolCacheInvalidator>);
+
                 let client = child_process_client(
                     command,
                     timeout,
@@ -786,6 +808,7 @@ impl ExtensionManager {
                     container.map(|c| c.id().to_string()),
                     self.client_name.clone(),
                     capabilities,
+                    invalidator,
                 )
                 .await?;
 
@@ -1702,6 +1725,13 @@ impl ExtensionManager {
         content.push_str("\n</info-msg>");
 
         Some(content)
+    }
+}
+
+#[async_trait::async_trait]
+impl ToolCacheInvalidator for ExtensionManager {
+    async fn invalidate_tools(&self) {
+        self.invalidate_tools_cache_and_bump_version().await;
     }
 }
 

--- a/crates/goose/src/agents/mcp_client.rs
+++ b/crates/goose/src/agents/mcp_client.rs
@@ -26,7 +26,7 @@ use rmcp::{
     ClientHandler, ErrorData, Peer, RoleClient, ServiceError, ServiceExt,
 };
 use serde_json::Value;
-use std::{path::PathBuf, sync::Arc, time::Duration};
+use std::{path::PathBuf, sync::Arc, sync::Weak, time::Duration};
 use tokio::sync::{
     mpsc::{self, Sender},
     Mutex,
@@ -36,6 +36,14 @@ use tokio_util::sync::CancellationToken;
 pub type BoxError = Box<dyn std::error::Error + Sync + Send>;
 
 pub type Error = rmcp::ServiceError;
+
+/// Trait for invalidating the tool cache in the ExtensionManager.
+/// Used by GooseClient to trigger cache invalidation when an MCP server
+/// sends `notifications/tools/list_changed`.
+#[async_trait::async_trait]
+pub trait ToolCacheInvalidator: Send + Sync {
+    async fn invalidate_tools(&self);
+}
 
 #[async_trait::async_trait]
 pub trait McpClientTrait: Send + Sync {
@@ -113,6 +121,7 @@ pub struct GooseClient {
     client_name: String,
     capabilities: GooseMcpClientCapabilities,
     working_dir: Arc<tokio::sync::RwLock<PathBuf>>,
+    tool_cache_invalidator: Option<Weak<dyn ToolCacheInvalidator>>,
 }
 
 impl GooseClient {
@@ -123,6 +132,24 @@ impl GooseClient {
         capabilities: GooseMcpClientCapabilities,
         working_dir: PathBuf,
     ) -> Self {
+        Self::new_with_invalidator(
+            handlers,
+            provider,
+            client_name,
+            capabilities,
+            working_dir,
+            None,
+        )
+    }
+
+    pub fn new_with_invalidator(
+        handlers: Arc<Mutex<Vec<Sender<ServerNotification>>>>,
+        provider: SharedProvider,
+        client_name: String,
+        capabilities: GooseMcpClientCapabilities,
+        working_dir: PathBuf,
+        tool_cache_invalidator: Option<Weak<dyn ToolCacheInvalidator>>,
+    ) -> Self {
         GooseClient {
             notification_handlers: handlers,
             provider,
@@ -130,6 +157,7 @@ impl GooseClient {
             client_name,
             capabilities,
             working_dir: Arc::new(tokio::sync::RwLock::new(working_dir)),
+            tool_cache_invalidator,
         }
     }
 
@@ -163,6 +191,20 @@ impl GooseClient {
             .find(|(key, _)| key.eq_ignore_ascii_case(SESSION_ID_HEADER))
             .and_then(|(_, value)| value.as_str())
             .map(|value| value.to_string())
+    }
+
+    /// Handles the tools/list_changed notification by upgrading the weak reference
+    /// to the cache invalidator and calling `invalidate_tools()`.
+    /// Returns `true` if the invalidator was successfully called, `false` if the
+    /// weak reference had been dropped.
+    async fn handle_tool_list_changed(&self) -> bool {
+        if let Some(ref invalidator) = self.tool_cache_invalidator {
+            if let Some(invalidator) = invalidator.upgrade() {
+                invalidator.invalidate_tools().await;
+                return true;
+            }
+        }
+        false
     }
 }
 
@@ -212,6 +254,14 @@ impl ClientHandler for GooseClient {
                 let _ =
                     handler.try_send(ServerNotification::LoggingMessageNotification(notification));
             });
+    }
+
+    async fn on_tool_list_changed(
+        &self,
+        _context: rmcp::service::NotificationContext<rmcp::RoleClient>,
+    ) {
+        tracing::info!("Received tools/list_changed notification from MCP server");
+        self.handle_tool_list_changed().await;
     }
 
     async fn create_message(
@@ -396,6 +446,7 @@ impl McpClient {
         client_name: String,
         capabilities: GooseMcpClientCapabilities,
         working_dir: PathBuf,
+        tool_cache_invalidator: Option<Weak<dyn ToolCacheInvalidator>>,
     ) -> Result<Self, ClientInitializeError>
     where
         T: IntoTransport<RoleClient, E, A>,
@@ -409,10 +460,12 @@ impl McpClient {
             client_name,
             capabilities,
             working_dir,
+            tool_cache_invalidator,
         )
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn connect_with_container<T, E, A>(
         transport: T,
         timeout: std::time::Duration,
@@ -421,6 +474,7 @@ impl McpClient {
         client_name: String,
         capabilities: GooseMcpClientCapabilities,
         working_dir: PathBuf,
+        tool_cache_invalidator: Option<Weak<dyn ToolCacheInvalidator>>,
     ) -> Result<Self, ClientInitializeError>
     where
         T: IntoTransport<RoleClient, E, A>,
@@ -429,12 +483,13 @@ impl McpClient {
         let notification_subscribers =
             Arc::new(Mutex::new(Vec::<mpsc::Sender<ServerNotification>>::new()));
 
-        let client = GooseClient::new(
+        let client = GooseClient::new_with_invalidator(
             notification_subscribers.clone(),
             provider,
             client_name.clone(),
             capabilities.clone(),
             working_dir,
+            tool_cache_invalidator,
         );
         let client: rmcp::service::RunningService<rmcp::RoleClient, GooseClient> =
             client.serve(transport).await?;
@@ -1008,5 +1063,91 @@ mod tests {
         assert_eq!(result.roots.len(), 1);
         assert_eq!(result.roots[0].uri, "file:///tmp/test-project");
         assert_eq!(result.roots[0].name.as_deref(), Some("working_directory"));
+    }
+
+    #[test]
+    fn test_on_tool_list_changed_calls_invalidator() {
+        struct MockInvalidator {
+            call_count: std::sync::atomic::AtomicUsize,
+        }
+
+        #[async_trait::async_trait]
+        impl ToolCacheInvalidator for MockInvalidator {
+            async fn invalidate_tools(&self) {
+                self.call_count
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let invalidator = Arc::new(MockInvalidator {
+                call_count: std::sync::atomic::AtomicUsize::new(0),
+            });
+
+            let capabilities = GooseMcpClientCapabilities { mcpui: false };
+            let client = GooseClient::new_with_invalidator(
+                Arc::new(Mutex::new(Vec::new())),
+                Arc::new(Mutex::new(None)),
+                "test".to_string(),
+                capabilities,
+                std::env::current_dir().unwrap_or_default(),
+                Some(Arc::downgrade(&invalidator) as Weak<dyn ToolCacheInvalidator>),
+            );
+
+            // Exercise the actual code path that handles tool_list_changed.
+            // This tests the weak-ref upgrade and invalidation call.
+            let result1 = client.handle_tool_list_changed().await;
+            let result2 = client.handle_tool_list_changed().await;
+
+            assert!(result1, "should return true when invalidator is alive");
+            assert!(result2, "should return true when invalidator is alive");
+            assert_eq!(
+                invalidator
+                    .call_count
+                    .load(std::sync::atomic::Ordering::SeqCst),
+                2,
+                "invalidate_tools should have been called twice"
+            );
+        });
+    }
+
+    #[test]
+    fn test_on_tool_list_changed_noop_when_invalidator_dropped() {
+        struct MockInvalidator {
+            call_count: std::sync::atomic::AtomicUsize,
+        }
+
+        #[async_trait::async_trait]
+        impl ToolCacheInvalidator for MockInvalidator {
+            async fn invalidate_tools(&self) {
+                self.call_count
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let invalidator = Arc::new(MockInvalidator {
+                call_count: std::sync::atomic::AtomicUsize::new(0),
+            });
+
+            let capabilities = GooseMcpClientCapabilities { mcpui: false };
+            let client = GooseClient::new_with_invalidator(
+                Arc::new(Mutex::new(Vec::new())),
+                Arc::new(Mutex::new(None)),
+                "test".to_string(),
+                capabilities,
+                std::env::current_dir().unwrap_or_default(),
+                Some(Arc::downgrade(&invalidator) as Weak<dyn ToolCacheInvalidator>),
+            );
+
+            // Drop the Arc so the weak ref becomes stale.
+            drop(invalidator);
+
+            // handle_tool_list_changed should return false (weak upgrade fails).
+            let result = client.handle_tool_list_changed().await;
+            assert!(!result, "should return false when invalidator is dropped");
+        });
     }
 }


### PR DESCRIPTION
# Pull Request

## Title
feat: implement dynamic tool discovery via MCP notifications/tools/list_changed

## URL
https://github.com/block/goose/compare/main...makanilani:goose:dynamic-tool-discovery

---

## Description

### Summary

When MCP servers send `notifications/tools/list_changed` (e.g., Google Colab servers that register tools dynamically), Goose now invalidates its tool cache so the next agent turn sees the updated tool set.

### Problem

Currently, Goose calls `tools/list` once during initialization and never checks for updates. The `rmcp` crate's `ClientHandler` trait provides `on_tool_list_changed()` with a default no-op implementation, and `GooseClient` does not override it — so the notification is silently dropped.

### Changes

- Add `ToolCacheInvalidator` trait in `mcp_client.rs`
- Implement `ToolCacheInvalidator` for `ExtensionManager`
- Add `tool_cache_invalidator` field to `GooseClient`
- Implement `on_tool_list_changed` handler in `GooseClient`'s `ClientHandler` impl (overrides rmcp's default no-op)
- Thread invalidator reference through all MCP client construction paths (StreamableHttp, Stdio, Builtin, InlinePython)

### Architecture

```
MCP Server → notifications/tools/list_changed
  → GooseClient::on_tool_list_changed() (new)
    → ExtensionManager::invalidate_tools_cache_and_bump_version() (existing)
      → Agent reads fresh tools on next turn via get_prefixed_tools()
```

### Files Changed

- `Cargo.lock`
- `crates/goose/src/agents/mcp_client.rs`
- `crates/goose/src/agents/extension_manager.rs`


### Testing
Observed  Google colab mcp server works after the change.

---
Co-authored-by: Qwen-Coder <qwen-coder@alibabacloud.com>
