### PR TITLE
RFC: Web UI via goose-web binary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,7 @@ cargo clippy --all-targets -- -D warnings # run the linter
 
 ### Node
 
-To run the app:
+To run the Electron desktop app:
 
 ```
 just run-ui
@@ -172,6 +172,34 @@ This command builds a release build of Rust (equivalent to `cargo build -r`) and
 The app opens a window and displays first-time setup. After completing setup, goose is ready for use.
 
 Make GUI changes in `ui/desktop`.
+
+### Web UI
+
+The same React UI can run in a regular browser via `goose-web`, a standalone binary
+that embeds the static files and reverse-proxies API calls to `goosed`.
+
+1. Build the web-specific static files:
+
+```bash
+cd ui/desktop
+pnpm install
+pnpm run build:web   # outputs to dist-web/
+```
+
+2. Build and run the web server:
+
+```bash
+cargo run -p goose-web -- --port 3000
+```
+
+This spawns `goosed` as a child process automatically and opens the UI at
+`http://localhost:3000`. You can also connect to an existing goosed instance:
+
+```bash
+cargo run -p goose-web -- --goosed-url https://127.0.0.1:PORT --secret-key YOUR_KEY
+```
+
+See `cargo run -p goose-web -- --help` for all options.
 
 ### Regenerating the OpenAPI schema
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4652,6 +4652,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "goose-web"
+version = "1.29.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "hex",
+ "include_dir",
+ "mime_guess",
+ "rand 0.8.5",
+ "reqwest 0.13.2",
+ "tokio",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "which 8.0.2",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4573,7 +4573,7 @@ dependencies = [
 
 [[package]]
 name = "goose-sdk"
-version = "1.29.0"
+version = "1.30.0"
 dependencies = [
  "agent-client-protocol-schema",
  "sacp",
@@ -4653,7 +4653,7 @@ dependencies = [
 
 [[package]]
 name = "goose-web"
-version = "1.29.0"
+version = "1.30.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/goose-web/Cargo.toml
+++ b/crates/goose-web/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "goose-web"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Web UI frontend for Goose — embeds static files and reverse-proxies to goosed"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+axum = { workspace = true }
+clap = { workspace = true, features = ["env"] }
+hex = "0.4"
+include_dir = { workspace = true }
+mime_guess = "2"
+rand = { workspace = true }
+reqwest = { workspace = true, features = ["json", "rustls"], default-features = false }
+tokio = { workspace = true }
+tower-http = { workspace = true, features = ["cors"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+which = { workspace = true }
+
+[[bin]]
+name = "goose-web"
+path = "src/main.rs"

--- a/crates/goose-web/Cargo.toml
+++ b/crates/goose-web/Cargo.toml
@@ -18,7 +18,7 @@ hex = "0.4"
 include_dir = { workspace = true }
 mime_guess = "2"
 rand = { workspace = true }
-reqwest = { workspace = true, features = ["json", "rustls"], default-features = false }
+reqwest = { workspace = true, features = ["json", "rustls", "stream"], default-features = false }
 tokio = { workspace = true }
 tower-http = { workspace = true, features = ["cors"] }
 tracing = { workspace = true }

--- a/crates/goose-web/build.rs
+++ b/crates/goose-web/build.rs
@@ -1,0 +1,10 @@
+use std::path::PathBuf;
+
+fn main() {
+    // Ensure dist-web directory exists so include_dir! does not panic.
+    // In CI or fresh checkouts the web build may not have run yet.
+    let dist_web = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../ui/desktop/dist-web");
+    if !dist_web.exists() {
+        std::fs::create_dir_all(&dist_web).expect("failed to create dist-web placeholder");
+    }
+}

--- a/crates/goose-web/src/main.rs
+++ b/crates/goose-web/src/main.rs
@@ -37,12 +37,17 @@ struct Cli {
     /// Path to goosed binary (auto-detected if not specified)
     #[arg(long, env = "GOOSED_BINARY")]
     goosed_binary: Option<PathBuf>,
+
+    /// Working directory for goose sessions (defaults to current directory)
+    #[arg(long, env = "GOOSE_WORKING_DIR")]
+    dir: Option<PathBuf>,
 }
 
 #[derive(Clone)]
 struct AppState {
     goosed_base_url: String,
     secret_key: String,
+    working_dir: String,
 }
 
 #[tokio::main]
@@ -70,9 +75,16 @@ async fn main() -> anyhow::Result<()> {
             (url, secret, Some(child))
         };
 
+    let working_dir = cli
+        .dir
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_default())
+        .to_string_lossy()
+        .to_string();
+
     let state = AppState {
         goosed_base_url,
         secret_key,
+        working_dir,
     };
 
     let cors = CorsLayer::new()
@@ -103,19 +115,22 @@ async fn main() -> anyhow::Result<()> {
 }
 
 /// Serve index.html with injected meta tags for API config
-async fn serve_index(State(_state): State<AppState>) -> impl IntoResponse {
+async fn serve_index(State(state): State<AppState>) -> impl IntoResponse {
     let index_html = WEB_ASSETS
         .get_file("index.html")
         .map(|f| f.contents_utf8().unwrap_or(""))
         .unwrap_or("<html><body>dist-web not found — run pnpm build:web first</body></html>");
 
-    // Inject goosed connection info as meta tags before </head>.
-    // API is proxied through same origin, so base is empty.
+    // Inject config as meta tags before </head>.
     let injected = index_html.replace(
         "</head>",
-        "<meta name=\"goose:api-base\" content=\"\">\n\
-         <meta name=\"goose:secret-key\" content=\"\">\n\
-         </head>",
+        &format!(
+            "<meta name=\"goose:api-base\" content=\"\">\n\
+             <meta name=\"goose:secret-key\" content=\"\">\n\
+             <meta name=\"goose:working-dir\" content=\"{}\">\n\
+             </head>",
+            state.working_dir.replace('"', "&quot;")
+        ),
     );
 
     Html(injected)

--- a/crates/goose-web/src/main.rs
+++ b/crates/goose-web/src/main.rs
@@ -98,7 +98,7 @@ async fn main() -> anyhow::Result<()> {
         .layer(cors)
         .with_state(state);
 
-    let addr = SocketAddr::from(([0, 0, 0, 0], cli.port));
+    let addr = SocketAddr::from(([127, 0, 0, 1], cli.port));
     tracing::info!("Goose Web UI listening on http://{}", addr);
 
     let listener = tokio::net::TcpListener::bind(addr).await?;

--- a/crates/goose-web/src/main.rs
+++ b/crates/goose-web/src/main.rs
@@ -126,11 +126,14 @@ async fn serve_static_or_proxy(
     State(state): State<AppState>,
     req: Request<Body>,
 ) -> impl IntoResponse {
-    let path = req.uri().path().trim_start_matches('/');
+    let method = req.method().clone();
+    let path = req.uri().path().to_string();
+    let path_trimmed = path.trim_start_matches('/');
 
     // Try static file first
-    if let Some(file) = WEB_ASSETS.get_file(path) {
-        let mime = mime_guess::from_path(path)
+    if let Some(file) = WEB_ASSETS.get_file(path_trimmed) {
+        tracing::debug!("{} /{} -> static ({})", method, path_trimmed, file.contents().len());
+        let mime = mime_guess::from_path(path_trimmed)
             .first_or_octet_stream()
             .to_string();
         return Response::builder()
@@ -146,7 +149,9 @@ async fn serve_static_or_proxy(
     }
 
     // Not a static file — proxy to goosed
-    proxy_to_goosed(state, req).await.into_response()
+    let resp = proxy_to_goosed(state, req).await.into_response();
+    tracing::info!("{} {} -> proxy {}", method, path, resp.status());
+    resp
 }
 
 /// Forward a request to the goosed backend, injecting the secret key
@@ -171,13 +176,14 @@ async fn proxy_to_goosed(state: AppState, req: Request<Body>) -> impl IntoRespon
         }
     };
 
+    let secret_header = header::HeaderName::from_static("x-secret-key");
     let mut proxy_req = client.request(method, &uri);
     for (key, value) in headers.iter() {
-        if key != header::HOST {
+        if key != header::HOST && key != secret_header {
             proxy_req = proxy_req.header(key, value);
         }
     }
-    proxy_req = proxy_req.header("X-Secret-Key", &state.secret_key);
+    proxy_req = proxy_req.header(&secret_header, &state.secret_key);
     proxy_req = proxy_req.body(body_bytes);
 
     match proxy_req.send().await {

--- a/crates/goose-web/src/main.rs
+++ b/crates/goose-web/src/main.rs
@@ -20,7 +20,11 @@ use tower_http::cors::{Any, CorsLayer};
 static WEB_ASSETS: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../../ui/desktop/dist-web");
 
 #[derive(Parser)]
-#[command(author, version, about = "Goose Web UI — serves the browser frontend and proxies API calls to goosed")]
+#[command(
+    author,
+    version,
+    about = "Goose Web UI — serves the browser frontend and proxies API calls to goosed"
+)]
 struct Cli {
     /// Port to listen on for the web UI
     #[arg(long, default_value = "3000", env = "GOOSE_WEB_PORT")]
@@ -147,17 +151,19 @@ async fn serve_static_or_proxy(
 
     // Try static file first
     if let Some(file) = WEB_ASSETS.get_file(path_trimmed) {
-        tracing::debug!("{} /{} -> static ({})", method, path_trimmed, file.contents().len());
+        tracing::debug!(
+            "{} /{} -> static ({})",
+            method,
+            path_trimmed,
+            file.contents().len()
+        );
         let mime = mime_guess::from_path(path_trimmed)
             .first_or_octet_stream()
             .to_string();
         return Response::builder()
             .status(StatusCode::OK)
             .header(header::CONTENT_TYPE, mime)
-            .header(
-                header::CACHE_CONTROL,
-                "public, max-age=31536000, immutable",
-            )
+            .header(header::CACHE_CONTROL, "public, max-age=31536000, immutable")
             .body(Body::from(file.contents().to_vec()))
             .unwrap()
             .into_response();

--- a/crates/goose-web/src/main.rs
+++ b/crates/goose-web/src/main.rs
@@ -192,13 +192,16 @@ async fn proxy_to_goosed(state: AppState, req: Request<Body>) -> impl IntoRespon
             let status = StatusCode::from_u16(resp.status().as_u16())
                 .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
             let resp_headers = resp.headers().clone();
-            let body = resp.bytes().await.unwrap_or_default();
+
+            // Stream the response body instead of buffering — required for SSE
+            let body_stream = resp.bytes_stream();
+            let body = Body::from_stream(body_stream);
 
             let mut builder = Response::builder().status(status);
             for (key, value) in resp_headers.iter() {
                 builder = builder.header(key, value);
             }
-            builder.body(Body::from(body)).unwrap().into_response()
+            builder.body(body).unwrap().into_response()
         }
         Err(e) => {
             tracing::error!("Proxy error: {}", e);

--- a/crates/goose-web/src/main.rs
+++ b/crates/goose-web/src/main.rs
@@ -1,0 +1,316 @@
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::process::Stdio;
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{header, Request, Response, StatusCode},
+    response::{Html, IntoResponse},
+    routing::get,
+    Router,
+};
+use clap::Parser;
+use include_dir::{include_dir, Dir};
+use tokio::process::{Child, Command};
+use tower_http::cors::{Any, CorsLayer};
+
+/// Embedded web UI static files, built by `pnpm build:web` in ui/desktop/.
+/// At compile time this directory must exist; use an empty dir for dev builds.
+static WEB_ASSETS: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../../ui/desktop/dist-web");
+
+#[derive(Parser)]
+#[command(author, version, about = "Goose Web UI — serves the browser frontend and proxies API calls to goosed")]
+struct Cli {
+    /// Port to listen on for the web UI
+    #[arg(long, default_value = "3000", env = "GOOSE_WEB_PORT")]
+    port: u16,
+
+    /// Connect to an existing goosed instance instead of spawning one
+    #[arg(long, env = "GOOSE_WEB_GOOSED_URL")]
+    goosed_url: Option<String>,
+
+    /// Secret key for goosed authentication (generated automatically if spawning)
+    #[arg(long, env = "GOOSE_SERVER__SECRET_KEY")]
+    secret_key: Option<String>,
+
+    /// Path to goosed binary (auto-detected if not specified)
+    #[arg(long, env = "GOOSED_BINARY")]
+    goosed_binary: Option<PathBuf>,
+}
+
+#[derive(Clone)]
+struct AppState {
+    goosed_base_url: String,
+    secret_key: String,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "goose_web=info".into()),
+        )
+        .init();
+
+    let cli = Cli::parse();
+
+    let (goosed_base_url, secret_key, _child): (String, String, Option<Child>) =
+        if let Some(url) = cli.goosed_url {
+            let secret = cli
+                .secret_key
+                .expect("--secret-key is required when using --goosed-url");
+            (url, secret, None)
+        } else {
+            let secret = cli
+                .secret_key
+                .unwrap_or_else(|| hex::encode(rand::random::<[u8; 32]>()));
+            let (url, child) = spawn_goosed(&cli.goosed_binary, &secret).await?;
+            (url, secret, Some(child))
+        };
+
+    let state = AppState {
+        goosed_base_url,
+        secret_key,
+    };
+
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods(Any)
+        .allow_headers(Any);
+
+    let app = Router::new()
+        .route("/", get(serve_index))
+        .fallback(serve_static_or_proxy)
+        .layer(cors)
+        .with_state(state);
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], cli.port));
+    tracing::info!("Goose Web UI listening on http://{}", addr);
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+
+    if let Some(mut child) = _child {
+        tracing::info!("Stopping goosed child process");
+        let _ = child.kill().await;
+    }
+
+    Ok(())
+}
+
+/// Serve index.html with injected meta tags for API config
+async fn serve_index(State(_state): State<AppState>) -> impl IntoResponse {
+    let index_html = WEB_ASSETS
+        .get_file("index.html")
+        .map(|f| f.contents_utf8().unwrap_or(""))
+        .unwrap_or("<html><body>dist-web not found — run pnpm build:web first</body></html>");
+
+    // Inject goosed connection info as meta tags before </head>.
+    // API is proxied through same origin, so base is empty.
+    let injected = index_html.replace(
+        "</head>",
+        "<meta name=\"goose:api-base\" content=\"\">\n\
+         <meta name=\"goose:secret-key\" content=\"\">\n\
+         </head>",
+    );
+
+    Html(injected)
+}
+
+/// Try to serve a static file; if not found, proxy to goosed API
+async fn serve_static_or_proxy(
+    State(state): State<AppState>,
+    req: Request<Body>,
+) -> impl IntoResponse {
+    let path = req.uri().path().trim_start_matches('/');
+
+    // Try static file first
+    if let Some(file) = WEB_ASSETS.get_file(path) {
+        let mime = mime_guess::from_path(path)
+            .first_or_octet_stream()
+            .to_string();
+        return Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, mime)
+            .header(
+                header::CACHE_CONTROL,
+                "public, max-age=31536000, immutable",
+            )
+            .body(Body::from(file.contents().to_vec()))
+            .unwrap()
+            .into_response();
+    }
+
+    // Not a static file — proxy to goosed
+    proxy_to_goosed(state, req).await.into_response()
+}
+
+/// Forward a request to the goosed backend, injecting the secret key
+async fn proxy_to_goosed(state: AppState, req: Request<Body>) -> impl IntoResponse {
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true) // goosed uses self-signed TLS
+        .build()
+        .unwrap();
+
+    let method = req.method().clone();
+    let uri = format!("{}{}", state.goosed_base_url, req.uri());
+    let headers = req.headers().clone();
+
+    let body_bytes = match axum::body::to_bytes(req.into_body(), 50 * 1024 * 1024).await {
+        Ok(b) => b,
+        Err(_) => {
+            return Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .body(Body::from("Failed to read request body"))
+                .unwrap()
+                .into_response();
+        }
+    };
+
+    let mut proxy_req = client.request(method, &uri);
+    for (key, value) in headers.iter() {
+        if key != header::HOST {
+            proxy_req = proxy_req.header(key, value);
+        }
+    }
+    proxy_req = proxy_req.header("X-Secret-Key", &state.secret_key);
+    proxy_req = proxy_req.body(body_bytes);
+
+    match proxy_req.send().await {
+        Ok(resp) => {
+            let resp: reqwest::Response = resp;
+            let status = StatusCode::from_u16(resp.status().as_u16())
+                .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+            let resp_headers = resp.headers().clone();
+            let body = resp.bytes().await.unwrap_or_default();
+
+            let mut builder = Response::builder().status(status);
+            for (key, value) in resp_headers.iter() {
+                builder = builder.header(key, value);
+            }
+            builder.body(Body::from(body)).unwrap().into_response()
+        }
+        Err(e) => {
+            tracing::error!("Proxy error: {}", e);
+            Response::builder()
+                .status(StatusCode::BAD_GATEWAY)
+                .body(Body::from(format!("Failed to reach goosed: {}", e)))
+                .unwrap()
+                .into_response()
+        }
+    }
+}
+
+/// Find and spawn goosed, returning (base_url, child_process)
+async fn spawn_goosed(
+    binary_path: &Option<PathBuf>,
+    secret_key: &str,
+) -> anyhow::Result<(String, Child)> {
+    let goosed_path = if let Some(p) = binary_path {
+        p.clone()
+    } else {
+        find_goosed_binary()?
+    };
+
+    // Find a free port for goosed
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+
+    tracing::info!(
+        "Spawning goosed from {} on port {}",
+        goosed_path.display(),
+        port
+    );
+
+    let child = Command::new(&goosed_path)
+        .arg("agent")
+        .env("GOOSE_PORT", port.to_string())
+        .env("GOOSE_SERVER__SECRET_KEY", secret_key)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()?;
+
+    let base_url = format!("https://127.0.0.1:{}", port);
+
+    // Wait for goosed to become healthy
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .build()?;
+
+    let status_url = format!("{}/status", base_url);
+    for attempt in 1..=100 {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        let result: Result<reqwest::Response, _> = client.get(&status_url).send().await;
+        if result.is_ok() {
+            tracing::info!("goosed is healthy after {} attempts", attempt);
+            return Ok((base_url, child));
+        }
+    }
+
+    anyhow::bail!("goosed did not become healthy within 10 seconds");
+}
+
+fn find_goosed_binary() -> anyhow::Result<PathBuf> {
+    // Check GOOSED_BINARY env
+    if let Ok(p) = std::env::var("GOOSED_BINARY") {
+        let path = PathBuf::from(p);
+        if path.is_file() {
+            return Ok(path);
+        }
+    }
+
+    // Check common build paths relative to workspace root
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|p| p.to_path_buf())
+        .unwrap_or_default();
+
+    let binary_name = if cfg!(windows) {
+        "goosed.exe"
+    } else {
+        "goosed"
+    };
+
+    for subdir in &["target/release", "target/debug"] {
+        let candidate = workspace_root.join(subdir).join(binary_name);
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+    }
+
+    // Try PATH
+    if let Ok(path) = which::which("goosed") {
+        return Ok(path);
+    }
+
+    anyhow::bail!(
+        "Could not find goosed binary. Build it with `cargo build -p goose-server` \
+         or set GOOSED_BINARY env var."
+    );
+}
+
+#[cfg(unix)]
+async fn shutdown_signal() {
+    use tokio::signal::unix::{signal, SignalKind};
+
+    let mut sigint = signal(SignalKind::interrupt()).expect("failed to install SIGINT handler");
+    let mut sigterm = signal(SignalKind::terminate()).expect("failed to install SIGTERM handler");
+
+    tokio::select! {
+        _ = sigint.recv() => {},
+        _ = sigterm.recv() => {},
+    }
+}
+
+#[cfg(not(unix))]
+async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+}

--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -378,6 +378,18 @@ You can change your LLM provider and/or model or update your API key at any time
         goose session
         ```
     </TabItem>
+    <TabItem value="web" label="goose Web UI">
+        The web UI serves the same React interface in a regular browser. Build from source:
+
+        ```sh
+        cd ui/desktop && pnpm install && pnpm run build:web && cd ../..
+        cargo run -p goose-web -- --port 3000
+        ```
+
+        Then open `http://localhost:3000`. The `goose-web` binary spawns `goosed` automatically and proxies API calls, so the browser never needs direct access to the backend.
+
+        See the [environment variables guide](/docs/guides/environment-variables#web-ui-goose-web) for configuration options.
+    </TabItem>
 </Tabs>
 
 ## Shared Configuration Settings

--- a/documentation/docs/goose-architecture/goose-architecture.md
+++ b/documentation/docs/goose-architecture/goose-architecture.md
@@ -10,7 +10,7 @@ goose, an open source AI Agent, builds upon the basic interaction framework of L
 ## goose Components
 goose operates using three main components, the **interface**, the **agent**, and the **connected [extensions](/docs/getting-started/using-extensions)**.
 
-* **Interface**: This is the desktop application or CLI that the user is using to run goose. It collects input from the user and displays outputs to the user
+* **Interface**: This is the desktop application, CLI, or web UI that the user is using to run goose. It collects input from the user and displays outputs to the user. The web UI (`goose-web`) serves the same React frontend in a regular browser via a reverse proxy to `goosed`.
 
 * **Agent**: The agent runs goose's core logic, managing the interactive loop. 
 

--- a/documentation/docs/guides/environment-variables.md
+++ b/documentation/docs/guides/environment-variables.md
@@ -604,6 +604,32 @@ export GOOSE_RECIPE_RETRY_TIMEOUT_SECONDS=300
 export GOOSE_RECIPE_ON_FAILURE_TIMEOUT_SECONDS=60
 ```
 
+## Web UI (`goose-web`)
+
+These variables configure the `goose-web` binary, which serves the browser-based UI and proxies API calls to `goosed`.
+
+| Variable | Purpose | Values | Default |
+|----------|---------|---------|---------|
+| `GOOSE_WEB_PORT` | Port for the web UI HTTP server | Integer | `3000` |
+| `GOOSE_WEB_GOOSED_URL` | Connect to an existing `goosed` instance instead of spawning one | URL (e.g., `https://127.0.0.1:3001`) | None (spawns automatically) |
+| `GOOSE_SERVER__SECRET_KEY` | Secret key for `goosed` authentication (generated automatically when spawning) | String | Auto-generated |
+| `GOOSED_BINARY` | Path to the `goosed` binary | File path | Auto-detected from build dir or PATH |
+| `GOOSE_WORKING_DIR` | Working directory for goose sessions | Directory path | Current directory |
+
+**Examples**
+
+```bash
+# Run web UI on a custom port
+export GOOSE_WEB_PORT=8080
+
+# Connect to an existing goosed instance
+export GOOSE_WEB_GOOSED_URL="https://127.0.0.1:3001"
+export GOOSE_SERVER__SECRET_KEY="your-secret-key"
+
+# Specify goosed binary location
+export GOOSED_BINARY="/usr/local/bin/goosed"
+```
+
 ## Development & Testing
 
 These variables are primarily used for development, testing, and debugging goose itself.

--- a/ui/desktop/.gitignore
+++ b/ui/desktop/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 .vite/
 out
+dist-web/
 src/bin/goosed
 src/bin/goose-npm/
 /src/bin/*.exe

--- a/ui/desktop/README.md
+++ b/ui/desktop/README.md
@@ -90,6 +90,41 @@ The built application will be available in:
 Use the existing Windows build process as documented.
 
 
+# Web UI (browser mode)
+
+The same React UI can run in a regular browser without Electron, served by
+the `goose-web` binary. A platform abstraction layer (`src/platform/`) switches
+between Electron IPC and browser-native APIs at runtime.
+
+## Building
+
+```bash
+pnpm run build:web   # outputs static files to dist-web/
+```
+
+## Running
+
+```bash
+# From the project root:
+cargo run -p goose-web -- --port 3000
+```
+
+This embeds the `dist-web/` files, spawns `goosed` as a child process, and
+serves the UI at `http://localhost:3000`. The reverse proxy injects the secret
+key server-side so the browser never needs it.
+
+See `cargo run -p goose-web -- --help` for all options (custom goosed URL,
+working directory, etc.).
+
+## Platform abstraction
+
+- `src/platform/types.ts` — `PlatformAPI` interface
+- `src/platform/electron.ts` — delegates to `window.electron.*`
+- `src/platform/web.ts` — browser implementations (localStorage settings, Web Notifications, etc.)
+- `src/platform/index.ts` — runtime detection, exports `platform`
+
+All renderer code imports `platform` instead of accessing `window.electron` directly.
+
 # Running with goosed server from source
 
 Set `VITE_START_EMBEDDED_SERVER=yes` to no in `.env`.

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -41,7 +41,8 @@
     "start-alpha-gui": "ALPHA=true pnpm run start-gui",
     "i18n:extract": "formatjs extract 'src/**/*.{ts,tsx}' --out-file src/i18n/messages/en.json --flatten && pnpm run i18n:compile",
     "i18n:check": "node scripts/i18n-check.js",
-    "i18n:compile": "node scripts/i18n-compile.js"
+    "i18n:compile": "node scripts/i18n-compile.js",
+    "build:web": "pnpm run generate-api && pnpm run i18n:compile && vite build --config vite.web.config.mts"
   },
   "dependencies": {
     "@aaif/goose-acp": "workspace:*",

--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react';
-import { IpcRendererEvent } from 'electron';
+import { platform } from './platform';
 import {
   HashRouter,
   Routes,
@@ -395,7 +395,7 @@ export function AppInner() {
 
   useEffect(() => {
     try {
-      window.electron.reactReady();
+      platform.reactReady();
     } catch (error) {
       console.error('Error sending reactReady:', error);
       setFatalError(`React ready notification failed: ${errorMessage(error, 'Unknown error')}`);
@@ -403,9 +403,9 @@ export function AppInner() {
   }, []);
 
   useEffect(() => {
-    const handleOpenSharedSession = async (_event: IpcRendererEvent, ...args: unknown[]) => {
+    const handleOpenSharedSession = async (_event: unknown, ...args: unknown[]) => {
       const link = args[0] as string;
-      window.electron.logInfo(`Opening shared session from deep link ${link}`);
+      platform.logInfo(`Opening shared session from deep link ${link}`);
       setIsLoadingSharedSession(true);
       setSharedSessionError(null);
       try {
@@ -431,19 +431,19 @@ export function AppInner() {
         setIsLoadingSharedSession(false);
       }
     };
-    window.electron.on('open-shared-session', handleOpenSharedSession);
+    platform.on('open-shared-session', handleOpenSharedSession);
     return () => {
-      window.electron.off('open-shared-session', handleOpenSharedSession);
+      platform.off('open-shared-session', handleOpenSharedSession);
     };
   }, [navigate]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      const isMac = window.electron.platform === 'darwin';
+      const isMac = platform.platform === 'darwin';
       if ((isMac ? event.metaKey : event.ctrlKey) && event.key === 'n') {
         event.preventDefault();
         try {
-          window.electron.createChatWindow({ dir: getInitialWorkingDir() });
+          platform.createChatWindow({ dir: getInitialWorkingDir() });
         } catch (error) {
           console.error('Error creating new window:', error);
         }
@@ -463,8 +463,8 @@ export function AppInner() {
         toastId: 'mesh-not-running',
       });
     };
-    window.electron.on('mesh-not-running', handler);
-    return () => { window.electron.off('mesh-not-running', handler); };
+    platform.on('mesh-not-running', handler);
+    return () => { platform.off('mesh-not-running', handler); };
   }, []);
 
   // Prevent default drag and drop behavior globally to avoid opening files in new windows
@@ -513,19 +513,19 @@ export function AppInner() {
   }, []);
 
   useEffect(() => {
-    const handleFatalError = (_event: IpcRendererEvent, ...args: unknown[]) => {
+    const handleFatalError = (_event: unknown, ...args: unknown[]) => {
       const errorMessage = args[0] as string;
       console.error('Encountered a fatal error:', errorMessage);
       setFatalError(errorMessage);
     };
-    window.electron.on('fatal-error', handleFatalError);
+    platform.on('fatal-error', handleFatalError);
     return () => {
-      window.electron.off('fatal-error', handleFatalError);
+      platform.off('fatal-error', handleFatalError);
     };
   }, []);
 
   useEffect(() => {
-    const handleSetView = (_event: IpcRendererEvent, ...args: unknown[]) => {
+    const handleSetView = (_event: unknown, ...args: unknown[]) => {
       const newView = args[0] as View;
       const section = args[1] as string | undefined;
 
@@ -536,29 +536,29 @@ export function AppInner() {
       }
     };
 
-    window.electron.on('set-view', handleSetView);
-    return () => window.electron.off('set-view', handleSetView);
+    platform.on('set-view', handleSetView);
+    return () => platform.off('set-view', handleSetView);
   }, [navigate]);
 
   useEffect(() => {
-    const handleNewChat = (_event: IpcRendererEvent, ..._args: unknown[]) => {
+    const handleNewChat = (_event: unknown, ..._args: unknown[]) => {
       window.dispatchEvent(new CustomEvent(AppEvents.TRIGGER_NEW_CHAT));
     };
 
-    window.electron.on('new-chat', handleNewChat);
-    return () => window.electron.off('new-chat', handleNewChat);
+    platform.on('new-chat', handleNewChat);
+    return () => platform.off('new-chat', handleNewChat);
   }, []);
 
   useEffect(() => {
-    const handleFocusInput = (_event: IpcRendererEvent, ..._args: unknown[]) => {
+    const handleFocusInput = (_event: unknown, ..._args: unknown[]) => {
       const inputField = document.querySelector('input[type="text"], textarea') as HTMLInputElement;
       if (inputField) {
         inputField.focus();
       }
     };
-    window.electron.on('focus-input', handleFocusInput);
+    platform.on('focus-input', handleFocusInput);
     return () => {
-      window.electron.off('focus-input', handleFocusInput);
+      platform.off('focus-input', handleFocusInput);
     };
   }, []);
 
@@ -566,7 +566,7 @@ export function AppInner() {
   const isProcessingRef = useRef(false);
 
   useEffect(() => {
-    const handleSetInitialMessage = async (_event: IpcRendererEvent, ...args: unknown[]) => {
+    const handleSetInitialMessage = async (_event: unknown, ...args: unknown[]) => {
       const initialMessage = args[0] as string;
 
       if (initialMessage && !isProcessingRef.current) {
@@ -581,9 +581,9 @@ export function AppInner() {
         }, 1000);
       }
     };
-    window.electron.on('set-initial-message', handleSetInitialMessage);
+    platform.on('set-initial-message', handleSetInitialMessage);
     return () => {
-      window.electron.off('set-initial-message', handleSetInitialMessage);
+      platform.off('set-initial-message', handleSetInitialMessage);
     };
   }, [navigate]);
 

--- a/ui/desktop/src/components/AnnouncementModal.tsx
+++ b/ui/desktop/src/components/AnnouncementModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { platform } from '../platform';
 import { BaseModal } from './ui/BaseModal';
 import MarkdownContent from './MarkdownContent';
 import { ANNOUNCEMENTS_ENABLED } from '../updates';
@@ -72,7 +73,7 @@ export default function AnnouncementModal() {
         });
 
         // Get list of seen announcement IDs
-        const seenAnnouncementIds = await window.electron.getSetting('seenAnnouncementIds');
+        const seenAnnouncementIds = await platform.getSetting('seenAnnouncementIds');
 
         // Find ALL unseen announcements (in order)
         const unseenAnnouncementsList = applicableAnnouncements.filter(
@@ -112,7 +113,7 @@ export default function AnnouncementModal() {
     if (unseenAnnouncements.length === 0) return;
 
     // Get existing seen announcement IDs
-    const seenAnnouncementIds = await window.electron.getSetting('seenAnnouncementIds');
+    const seenAnnouncementIds = await platform.getSetting('seenAnnouncementIds');
 
     // Add all unseen announcement IDs to the seen list
     const newSeenIds = [...seenAnnouncementIds];
@@ -122,7 +123,7 @@ export default function AnnouncementModal() {
       }
     });
 
-    await window.electron.setSetting('seenAnnouncementIds', newSeenIds);
+    await platform.setSetting('seenAnnouncementIds', newSeenIds);
     setShowAnnouncementModal(false);
   };
 

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -6,6 +6,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { platform } from '../platform';
 import { defineMessages, useIntl } from '../i18n';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { SearchView } from './conversation/SearchView';
@@ -209,7 +210,7 @@ export default function BaseChat({
     if (!recipe) return;
 
     (async () => {
-      const accepted = await window.electron.hasAcceptedRecipeBefore(recipe);
+      const accepted = await platform.hasAcceptedRecipeBefore(recipe);
       setHasNotAcceptedRecipe(!accepted);
 
       if (!accepted) {
@@ -221,7 +222,7 @@ export default function BaseChat({
 
   const handleRecipeAccept = async (accept: boolean) => {
     if (recipe && accept) {
-      await window.electron.recordRecipeHash(recipe);
+      await platform.recordRecipeHash(recipe);
       setHasNotAcceptedRecipe(false);
     } else {
       setView('chat');

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -1,5 +1,6 @@
 import { AppEvents } from '../constants/events';
 import React, { useRef, useState, useEffect, useMemo, useCallback } from 'react';
+import { platform } from '../platform';
 import { Bug, ChefHat, ScrollText } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/Tooltip';
 import { Button } from './ui/button';
@@ -1152,7 +1153,7 @@ export default function ChatInput({
       reader.readAsDataURL(file);
     } else {
       trackFileAttached('file');
-      const path = window.electron.getPathForFile(file);
+      const path = platform.getPathForFile(file);
       const newValue = displayValue.trim() ? `${displayValue.trim()} ${path}` : path;
       setDisplayValue(newValue);
       setValue(newValue);

--- a/ui/desktop/src/components/ErrorBoundary.tsx
+++ b/ui/desktop/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { platform } from '../platform';
 import { Button } from './ui/button';
 import { AlertTriangle } from 'lucide-react';
 import { errorMessage, formatErrorForLogging } from '../utils/conversionUtils';
@@ -31,7 +32,7 @@ function getCurrentPage(): string {
 // Capture unhandled promise rejections
 window.addEventListener('unhandledrejection', (event) => {
   const reasonStr = formatErrorForLogging(event.reason);
-  window.electron.logInfo(`[UNHANDLED REJECTION] ${reasonStr}`);
+  platform.logInfo(`[UNHANDLED REJECTION] ${reasonStr}`);
   trackErrorWithContext(event.reason, {
     component: 'global',
     page: getCurrentPage(),
@@ -42,7 +43,7 @@ window.addEventListener('unhandledrejection', (event) => {
 
 // Capture global errors
 window.addEventListener('error', (event) => {
-  window.electron.logInfo(
+  platform.logInfo(
     `[GLOBAL ERROR] ${event.message} at ${event.filename}:${event.lineno}:${event.colno}`
   );
   trackErrorWithContext(event.error || event.message, {
@@ -60,7 +61,7 @@ export function ErrorUI({ error }: { error: string }) {
       name: 'app_reloaded',
       properties: { reason: 'error_recovery' },
     });
-    window.electron.reloadApp();
+    platform.reloadApp();
   };
 
   const version = window?.appConfig?.get('GOOSE_VERSION') as string | undefined;
@@ -105,7 +106,7 @@ export class ErrorBoundary extends React.Component<
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     // Send error to main process
-    window.electron.logInfo(`[ERROR] ${error.toString()}\n${errorInfo.componentStack}`);
+    platform.logInfo(`[ERROR] ${error.toString()}\n${errorInfo.componentStack}`);
 
     const componentMatch = errorInfo.componentStack?.match(/^\s*at\s+(\w+)/);
     const componentName = componentMatch ? componentMatch[1] : undefined;

--- a/ui/desktop/src/components/ExtensionInstallModal.tsx
+++ b/ui/desktop/src/components/ExtensionInstallModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
-import { IpcRendererEvent } from 'electron';
+import { platform } from '../platform';
 import {
   Dialog,
   DialogContent,
@@ -165,14 +165,14 @@ export function ExtensionInstallModal({ addExtension, setView }: ExtensionInstal
     _remoteUrl: string | null
   ): Promise<ModalType> => {
     try {
-      const config = window.electron.getConfig();
+      const config = platform.getConfig();
       const ALLOWLIST_WARNING_MODE = config.GOOSE_ALLOWLIST_WARNING === true;
 
       if (ALLOWLIST_WARNING_MODE) {
         return 'untrusted';
       }
 
-      const allowedCommands = await window.electron.getAllowedExtensions();
+      const allowedCommands = await platform.getAllowedExtensions();
 
       if (!allowedCommands || allowedCommands.length === 0) {
         return 'trusted';
@@ -277,7 +277,7 @@ export function ExtensionInstallModal({ addExtension, setView }: ExtensionInstal
 
       setPendingLink(modalType === 'blocked' ? null : link);
 
-      window.electron.logInfo(`Extension modal opened: ${modalType} for ${extName}`);
+      platform.logInfo(`Extension modal opened: ${modalType} for ${extName}`);
     } catch (error) {
       console.error('Error processing extension request:', error);
       setModalState((prev) => ({
@@ -332,15 +332,15 @@ export function ExtensionInstallModal({ addExtension, setView }: ExtensionInstal
 
   useEffect(() => {
 
-    const handleAddExtension = async (_event: IpcRendererEvent, ...args: unknown[]) => {
+    const handleAddExtension = async (_event: unknown, ...args: unknown[]) => {
       const link = args[0] as string;
       await handleExtensionRequest(link);
     };
 
-    window.electron.on('add-extension', handleAddExtension);
+    platform.on('add-extension', handleAddExtension);
 
     return () => {
-      window.electron.off('add-extension', handleAddExtension);
+      platform.off('add-extension', handleAddExtension);
     };
   }, [handleExtensionRequest]);
 

--- a/ui/desktop/src/components/LauncherView.tsx
+++ b/ui/desktop/src/components/LauncherView.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react';
+import { platform } from '../platform';
 import { defineMessages, useIntl } from '../i18n';
 import { getInitialWorkingDir } from '../utils/workingDir';
 
@@ -19,9 +20,9 @@ export default function LauncherView() {
     if (query.trim()) {
       const initialMessage = query;
       setQuery('');
-      window.electron.createChatWindow({ query: initialMessage, dir: getInitialWorkingDir() });
+      platform.createChatWindow({ query: initialMessage, dir: getInitialWorkingDir() });
       setTimeout(() => {
-        window.electron.closeWindow();
+        platform.closeWindow();
       }, 200);
     }
   };
@@ -29,7 +30,7 @@ export default function LauncherView() {
   const handleKeyDown = (e: React.KeyboardEvent) => {
     // Close on Escape
     if (e.key === 'Escape') {
-      window.electron.closeWindow();
+      platform.closeWindow();
     }
   };
 

--- a/ui/desktop/src/components/Layout/AppLayout.tsx
+++ b/ui/desktop/src/components/Layout/AppLayout.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { platform } from '../../platform';
 import { Outlet, useLocation } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { Menu } from 'lucide-react';
@@ -51,7 +52,7 @@ const AppLayoutContent: React.FC<AppLayoutContentProps> = ({ activeSessions }) =
   const navWidthRef = useRef<number | null>(null);
 
   useEffect(() => {
-    window.electron.getSetting('navExpandedWidth').then((delta) => {
+    platform.getSetting('navExpandedWidth').then((delta) => {
       if (delta !== null) {
         setNavWidth(
           Math.min(
@@ -89,7 +90,7 @@ const AppLayoutContent: React.FC<AppLayoutContentProps> = ({ activeSessions }) =
     window.removeEventListener('mousemove', onMouseMove);
     window.removeEventListener('mouseup', onMouseUp);
     if (navWidthRef.current !== null) {
-      window.electron.setSetting(
+      platform.setSetting(
         'navExpandedWidth',
         navWidthRef.current - NAV_DIMENSIONS.CONDENSED_WIDTH
       );

--- a/ui/desktop/src/components/Layout/NavigationContext.tsx
+++ b/ui/desktop/src/components/Layout/NavigationContext.tsx
@@ -7,6 +7,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { platform } from '../../platform';
 
 export type NavigationMode = 'push' | 'overlay';
 export type NavigationStyle = 'expanded' | 'condensed';
@@ -165,9 +166,9 @@ export const NavigationProvider: React.FC<NavigationProviderProps> = ({ children
     const handleToggleNavigation = () => {
       setIsNavExpanded(!isNavExpandedRef.current);
     };
-    window.electron.on('toggle-navigation', handleToggleNavigation);
+    platform.on('toggle-navigation', handleToggleNavigation);
     return () => {
-      window.electron.off('toggle-navigation', handleToggleNavigation);
+      platform.off('toggle-navigation', handleToggleNavigation);
     };
   }, [setIsNavExpanded]);
 

--- a/ui/desktop/src/components/MCPUIResourceRenderer.tsx
+++ b/ui/desktop/src/components/MCPUIResourceRenderer.tsx
@@ -1,4 +1,5 @@
 import { AppEvents } from '../constants/events';
+import { platform } from '../platform';
 import {
   UIResourceRenderer,
   UIActionResultIntent,
@@ -142,8 +143,8 @@ export default function MCPUIResourceRenderer({
   useEffect(() => {
     const fetchProxyUrl = async () => {
       try {
-        const gooseApiHost = await window.electron.getGoosedHostPort();
-        const secretKey = await window.electron.getSecretKey();
+        const gooseApiHost = await platform.getGoosedHostPort();
+        const secretKey = await platform.getSecretKey();
         if (gooseApiHost && secretKey) {
           setProxyUrl(`${gooseApiHost}/mcp-ui-proxy?secret=${encodeURIComponent(secretKey)}`);
         } else {
@@ -222,7 +223,7 @@ export default function MCPUIResourceRenderer({
         // Safe protocols open directly, unknown protocols require user confirmation
         // Dangerous protocols are blocked by main.ts in the open-external handler
         if (isProtocolSafe(url)) {
-          await window.electron.openExternal(url);
+          await platform.openExternal(url);
           return {
             status: 'success' as const,
             message: `Opened ${url} in default application`,
@@ -242,7 +243,7 @@ export default function MCPUIResourceRenderer({
           };
         }
 
-        const result = await window.electron.showMessageBox({
+        const result = await platform.showMessageBox({
           type: 'question',
           buttons: [
             intl.formatMessage(i18n.cancelButton),
@@ -265,7 +266,7 @@ export default function MCPUIResourceRenderer({
           };
         }
 
-        await window.electron.openExternal(url);
+        await platform.openExternal(url);
         return {
           status: 'success' as const,
           message: `Opened ${url} in default application`,

--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, memo, useMemo, useCallback } from 'react';
+import { platform } from '../platform';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
@@ -218,9 +219,9 @@ const MarkdownContent = memo(function MarkdownContent({
   const handleConfirmOpen = useCallback(async () => {
     if (pendingLink) {
       try {
-        await window.electron.openExternal(pendingLink.href);
+        await platform.openExternal(pendingLink.href);
       } catch {
-        await window.electron.showMessageBox({
+        await platform.showMessageBox({
           type: 'error',
           buttons: ['OK'],
           title: intl.formatMessage(i18n.failedToOpenLink),
@@ -282,7 +283,7 @@ const MarkdownContent = memo(function MarkdownContent({
                     if (!props.href) return;
 
                     if (isProtocolSafe(props.href)) {
-                      window.electron.openExternal(props.href);
+                      platform.openExternal(props.href);
                     } else {
                       const protocol = getProtocol(props.href);
                       if (!protocol) return;

--- a/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
+++ b/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
@@ -15,6 +15,7 @@
  * - "standalone" — Goose-specific mode for dedicated Electron windows
  */
 
+import { platform } from '../../platform';
 import { AppRenderer, type RequestHandlerExtra } from '@mcp-ui/client';
 import type {
   McpUiDisplayMode,
@@ -175,8 +176,8 @@ function getContainerDimensions(
 
 async function fetchMcpAppProxyUrl(csp: McpUiResourceCsp | null): Promise<string | null> {
   try {
-    const baseUrl = await window.electron.getGoosedHostPort();
-    const secretKey = await window.electron.getSecretKey();
+    const baseUrl = await platform.getGoosedHostPort();
+    const secretKey = await platform.getSecretKey();
 
     if (!baseUrl || !secretKey) {
       console.error('[McpAppRenderer] Failed to get goosed host/port or secret key');
@@ -421,8 +422,8 @@ export default function McpAppRenderer({
   const [secretKey, setSecretKey] = useState<string | null>(null);
 
   useEffect(() => {
-    window.electron.getGoosedHostPort().then(setApiHost);
-    window.electron.getSecretKey().then(setSecretKey);
+    platform.getGoosedHostPort().then(setApiHost);
+    platform.getSecretKey().then(setSecretKey);
   }, []);
 
   // Fetch the resource from the extension to get HTML and metadata (CSP, permissions, etc.).
@@ -550,7 +551,7 @@ export default function McpAppRenderer({
 
   const handleOpenLink = useCallback(async ({ url }: { url: string }) => {
     if (isProtocolSafe(url)) {
-      await window.electron.openExternal(url);
+      await platform.openExternal(url);
       return { status: 'success' as const };
     }
 
@@ -559,7 +560,7 @@ export default function McpAppRenderer({
       return { status: 'error' as const, message: intl.formatMessage(i18n.invalidUrl) };
     }
 
-    const result = await window.electron.showMessageBox({
+    const result = await platform.showMessageBox({
       type: 'question',
       buttons: [intl.formatMessage(i18n.cancelButton), intl.formatMessage(i18n.openButton)],
       defaultId: 0,
@@ -572,7 +573,7 @@ export default function McpAppRenderer({
       return { status: 'error' as const, message: 'User cancelled' };
     }
 
-    await window.electron.openExternal(url);
+    await platform.openExternal(url);
     return { status: 'success' as const };
   }, [intl]);
 

--- a/ui/desktop/src/components/MentionPopover.tsx
+++ b/ui/desktop/src/components/MentionPopover.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { platform } from '../platform';
 import { ItemIcon } from './ItemIcon';
 import { CommandType, getSlashCommands } from '../api';
 import { getInitialWorkingDir } from '../utils/workingDir';
@@ -157,7 +158,7 @@ const MentionPopover = forwardRef<
         if (depth > 5) return [];
 
         try {
-          const items = await window.electron.listFiles(dirPath);
+          const items = await platform.listFiles(dirPath);
           const results: DisplayItem[] = [];
 
           // Common directories to prioritize or skip
@@ -345,7 +346,7 @@ const MentionPopover = forwardRef<
 
             // Otherwise, try to determine if it's a directory
             try {
-              await window.electron.listFiles(fullPath);
+              await platform.listFiles(fullPath);
 
               results.push({
                 name: item,
@@ -380,9 +381,9 @@ const MentionPopover = forwardRef<
         let startPath = currentWorkingDir;
 
         if (!startPath) {
-          if (window.electron.platform === 'win32') {
+          if (platform.platform === 'win32') {
             startPath = 'C:\\Users';
-          } else if (window.electron.platform === 'linux') {
+          } else if (platform.platform === 'linux') {
             startPath = '/home';
           } else {
             startPath = '/Users'; // Default to macOS

--- a/ui/desktop/src/components/ParameterInputModal.tsx
+++ b/ui/desktop/src/components/ParameterInputModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { platform } from '../platform';
 import { Parameter } from '../recipe';
 import { Button } from './ui/button';
 import { getInitialWorkingDir } from '../utils/workingDir';
@@ -128,8 +129,8 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
     if (option === 'new-chat') {
       try {
         const workingDir = getInitialWorkingDir();
-        window.electron.createChatWindow({ dir: workingDir });
-        window.electron.hideWindow();
+        platform.createChatWindow({ dir: workingDir });
+        platform.hideWindow();
       } catch (error) {
         console.error('Error creating new window:', error);
         onClose();

--- a/ui/desktop/src/components/ProgressiveMessageList.tsx
+++ b/ui/desktop/src/components/ProgressiveMessageList.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { platform } from '../platform';
 import { defineMessages, useIntl } from '../i18n';
 import { Message, SystemNotificationContent } from '../api';
 import GooseMessage from './GooseMessage';
@@ -175,7 +176,7 @@ export default function ProgressiveMessageList({
     }
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      const isMac = window.electron.platform === 'darwin';
+      const isMac = platform.platform === 'darwin';
       const isSearchShortcut = (isMac ? e.metaKey : e.ctrlKey) && e.key === 'f';
 
       if (isSearchShortcut) {

--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -1,4 +1,5 @@
 import { AppEvents } from '../constants/events';
+import { platform } from '../platform';
 import { ToolIconWithStatus, ToolCallStatus } from './ToolCallStatusIndicator';
 import { getToolCallIcon } from '../utils/toolIconMapping';
 import React, { useEffect, useRef, useState } from 'react';
@@ -510,10 +511,10 @@ function ToolCallView({
 
   useEffect(() => {
     // Load initial value from settings
-    window.electron.getSetting('responseStyle').then(setResponseStyle);
+    platform.getSetting('responseStyle').then(setResponseStyle);
 
     const handleStyleChange = () => {
-      window.electron.getSetting('responseStyle').then(setResponseStyle);
+      platform.getSetting('responseStyle').then(setResponseStyle);
     };
 
     window.addEventListener(AppEvents.RESPONSE_STYLE_CHANGED, handleStyleChange);
@@ -888,7 +889,7 @@ function ToolCallView({
           <div className="border-t border-border-primary">
             <button
               onClick={() => {
-                window.electron.createChatWindow({
+                platform.createChatWindow({
                   resumeSessionId: subagentSessionId,
                   viewType: 'pair',
                 });

--- a/ui/desktop/src/components/UserMessage.tsx
+++ b/ui/desktop/src/components/UserMessage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { platform } from '../platform';
 import ImagePreview from './ImagePreview';
 import MarkdownContent from './MarkdownContent';
 import { getTextAndImageContent } from '../types/message';
@@ -100,7 +101,7 @@ export default function UserMessage({ message, onMessageUpdate }: UserMessagePro
   const initializeEditMode = useCallback(() => {
     setEditContent(textContent);
     setError(null);
-    window.electron.logInfo(`Entering edit mode with content: ${textContent}`);
+    platform.logInfo(`Entering edit mode with content: ${textContent}`);
   }, [textContent]);
 
   // Handle edit button click
@@ -111,7 +112,7 @@ export default function UserMessage({ message, onMessageUpdate }: UserMessagePro
     // Initialize edit content when entering edit mode
     if (newEditingState) {
       initializeEditMode();
-      window.electron.logInfo(`Edit interface shown for message: ${message.id}`);
+      platform.logInfo(`Edit interface shown for message: ${message.id}`);
 
       // Focus the textarea after a brief delay to ensure it's rendered
       setTimeout(() => {
@@ -125,7 +126,7 @@ export default function UserMessage({ message, onMessageUpdate }: UserMessagePro
       }, 50);
     }
 
-    window.electron.logInfo(`Edit state toggled: ${newEditingState} for message: ${message.id}`);
+    platform.logInfo(`Edit state toggled: ${newEditingState} for message: ${message.id}`);
   }, [isEditing, initializeEditMode, message.id]);
 
   // Handle content changes in edit mode
@@ -133,7 +134,7 @@ export default function UserMessage({ message, onMessageUpdate }: UserMessagePro
     const newContent = e.target.value;
     setEditContent(newContent);
     setError(null); // Clear any previous errors
-    window.electron.logInfo(`Content changed: ${newContent}`);
+    platform.logInfo(`Content changed: ${newContent}`);
   }, []);
 
   const handleSave = useCallback(
@@ -158,7 +159,7 @@ export default function UserMessage({ message, onMessageUpdate }: UserMessagePro
 
   // Handle cancel action
   const handleCancel = useCallback(() => {
-    window.electron.logInfo('Cancel clicked - reverting to original content');
+    platform.logInfo('Cancel clicked - reverting to original content');
     setIsEditing(false);
     setEditContent(textContent); // Reset to original content
     setError(null);
@@ -167,7 +168,7 @@ export default function UserMessage({ message, onMessageUpdate }: UserMessagePro
   // Handle keyboard events for accessibility
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      window.electron.logInfo(
+      platform.logInfo(
         `Key pressed: ${e.key}, metaKey: ${e.metaKey}, ctrlKey: ${e.ctrlKey}`
       );
 
@@ -176,7 +177,7 @@ export default function UserMessage({ message, onMessageUpdate }: UserMessagePro
         handleCancel();
       } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
-        window.electron.logInfo('Cmd+Enter detected, calling handleSave');
+        platform.logInfo('Cmd+Enter detected, calling handleSave');
         handleSave();
       }
     },

--- a/ui/desktop/src/components/apps/AppsView.tsx
+++ b/ui/desktop/src/components/apps/AppsView.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { platform } from '../../platform';
 import { MainPanelLayout } from '../Layout/MainPanelLayout';
 import { Button } from '../ui/button';
 import { Download, Play, Upload } from 'lucide-react';
@@ -175,7 +176,7 @@ export default function AppsView() {
 
   const handleLaunchApp = async (app: GooseApp) => {
     try {
-      await window.electron.launchApp(app);
+      await platform.launchApp(app);
     } catch (err) {
       console.error('Failed to launch app:', err);
       // App launch errors shouldn't hide the apps list, just log it

--- a/ui/desktop/src/components/bottom_menu/CostTracker.tsx
+++ b/ui/desktop/src/components/bottom_menu/CostTracker.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { platform } from '../../platform';
 import { CoinIcon } from '../icons';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/Tooltip';
 import { fetchCanonicalModelInfo } from '../../utils/canonical';
@@ -58,7 +59,7 @@ export function CostTracker({
   // Check if pricing is enabled
   useEffect(() => {
     const loadPricingSetting = async () => {
-      const enabled = await window.electron.getSetting('showPricing');
+      const enabled = await platform.getSetting('showPricing');
       setShowPricing(enabled);
     };
 

--- a/ui/desktop/src/components/bottom_menu/DirSwitcher.tsx
+++ b/ui/desktop/src/components/bottom_menu/DirSwitcher.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { platform } from '../../platform';
 import { FolderDot } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/Tooltip';
 import { updateWorkingDir } from '../../api';
@@ -39,7 +40,7 @@ export const DirSwitcher: React.FC<DirSwitcherProps> = ({
 
     let result;
     try {
-      result = await window.electron.directoryChooser();
+      result = await platform.directoryChooser();
     } finally {
       setIsDirectoryChooserOpen(false);
     }
@@ -50,7 +51,7 @@ export const DirSwitcher: React.FC<DirSwitcherProps> = ({
 
     const newDir = result.filePaths[0];
 
-    window.electron.addRecentDir(newDir);
+    platform.addRecentDir(newDir);
 
     if (sessionId) {
       onWorkingDirChange?.(newDir);
@@ -82,7 +83,7 @@ export const DirSwitcher: React.FC<DirSwitcherProps> = ({
     if (isCmdOrCtrlClick) {
       event.preventDefault();
       event.stopPropagation();
-      await window.electron.openDirectoryInExplorer(workingDir);
+      await platform.openDirectoryInExplorer(workingDir);
     } else {
       await handleDirectoryChange();
     }

--- a/ui/desktop/src/components/context_management/CreditsExhaustedNotification.tsx
+++ b/ui/desktop/src/components/context_management/CreditsExhaustedNotification.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { platform } from '../../platform';
 import { AlertTriangle, ExternalLink } from 'lucide-react';
 import { Message, SystemNotificationContent } from '../../api';
 import { WEB_PROTOCOLS } from '../../utils/urlSecurity';
@@ -53,7 +54,7 @@ export const CreditsExhaustedNotification: React.FC<CreditsExhaustedNotification
 
   const handleTopUp = () => {
     if (topUpUrl) {
-      window.electron.openExternal(topUpUrl);
+      platform.openExternal(topUpUrl);
     }
   };
 

--- a/ui/desktop/src/components/conversation/SearchView.tsx
+++ b/ui/desktop/src/components/conversation/SearchView.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, PropsWithChildren, useCallback, useRef } from 'react';
+import { platform } from '../../platform';
 import SearchBar from './SearchBar';
 import { SearchHighlighter } from '../../utils/searchHighlighter';
 import debounce from 'lodash/debounce';
@@ -296,7 +297,7 @@ export const SearchView: React.FC<PropsWithChildren<SearchViewProps>> = ({
   // Listen for keyboard events
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      const isMac = window.electron.platform === 'darwin';
+      const isMac = platform.platform === 'darwin';
 
       // Handle ⌘F/Ctrl+F to show/focus search
       if ((isMac ? e.metaKey : e.ctrlKey) && !e.shiftKey && e.key === 'f') {
@@ -345,16 +346,16 @@ export const SearchView: React.FC<PropsWithChildren<SearchViewProps>> = ({
 
   // Listen for Find menu commands
   useEffect(() => {
-    window.electron.on('find-command', handleFindCommand);
-    window.electron.on('find-next', handleFindNext);
-    window.electron.on('find-previous', handleFindPrevious);
-    window.electron.on('use-selection-find', handleUseSelectionFind);
+    platform.on('find-command', handleFindCommand);
+    platform.on('find-next', handleFindNext);
+    platform.on('find-previous', handleFindPrevious);
+    platform.on('use-selection-find', handleUseSelectionFind);
 
     return () => {
-      window.electron.off('find-command', handleFindCommand);
-      window.electron.off('find-next', handleFindNext);
-      window.electron.off('find-previous', handleFindPrevious);
-      window.electron.off('use-selection-find', handleUseSelectionFind);
+      platform.off('find-command', handleFindCommand);
+      platform.off('find-next', handleFindNext);
+      platform.off('find-previous', handleFindPrevious);
+      platform.off('use-selection-find', handleUseSelectionFind);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Empty dependency array - handlers are stable due to useCallback and useRef

--- a/ui/desktop/src/components/onboarding/ProviderConfigForm.tsx
+++ b/ui/desktop/src/components/onboarding/ProviderConfigForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { platform } from '../../platform';
 import { configureProviderOauth, ProviderDetails } from '../../api';
 import { useConfig } from '../ConfigContext';
 import DefaultProviderSetupForm, {
@@ -51,7 +52,7 @@ function parseLinks(text: string) {
         href="#"
         onClick={(e) => {
           e.preventDefault();
-          window.electron.openExternal(part);
+          platform.openExternal(part);
         }}
         className="underline hover:text-text-default cursor-pointer"
       >

--- a/ui/desktop/src/components/recipes/CreateEditRecipeModal.tsx
+++ b/ui/desktop/src/components/recipes/CreateEditRecipeModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import { platform } from '../../platform';
 import { useForm } from '@tanstack/react-form';
 import { Recipe, generateDeepLink, Parameter } from '../../recipe';
 import { Check, ExternalLink, Play, Save, X } from 'lucide-react';
@@ -458,7 +459,7 @@ export default function CreateEditRecipeModal({
 
       onClose(true);
 
-      window.electron.createChatWindow({ recipeId: savedId });
+      platform.createChatWindow({ recipeId: savedId });
 
       toastSuccess({
         title: recipe.title,

--- a/ui/desktop/src/components/recipes/CreateRecipeFromSessionModal.tsx
+++ b/ui/desktop/src/components/recipes/CreateRecipeFromSessionModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { platform } from '../../platform';
 import { useForm } from '@tanstack/react-form';
 import { Recipe } from '../../recipe';
 import { Geese } from '../icons/Geese';
@@ -273,7 +274,7 @@ export default function CreateRecipeFromSessionModal({
       onClose();
 
       if (runAfterSave) {
-        window.electron.createChatWindow({ recipeId });
+        platform.createChatWindow({ recipeId });
       }
     } catch (error) {
       console.error('Failed to create recipe:', error);

--- a/ui/desktop/src/components/recipes/RecipesView.tsx
+++ b/ui/desktop/src/components/recipes/RecipesView.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
+import { platform } from '../../platform';
 import { listSavedRecipes, convertToLocaleDateString } from '../../recipe/recipe_management';
 import {
   FileText,
@@ -407,7 +408,7 @@ export default function RecipesView() {
 
   const handleStartRecipeChatInNewWindow = async (recipeId: string) => {
     try {
-      window.electron.createChatWindow({
+      platform.createChatWindow({
         dir: getInitialWorkingDir(),
         viewType: 'pair',
         recipeId,
@@ -420,7 +421,7 @@ export default function RecipesView() {
   };
 
   const handleDeleteRecipe = async (recipeManifest: RecipeManifest) => {
-    const result = await window.electron.showMessageBox({
+    const result = await platform.showMessageBox({
       type: 'warning',
       buttons: [intl.formatMessage(i18n.cancel), 'Delete'],
       defaultId: 0,
@@ -526,7 +527,7 @@ export default function RecipesView() {
 
       const filename = `${sanitizedTitle}.yaml`;
 
-      const result = await window.electron.showSaveDialog({
+      const result = await platform.showSaveDialog({
         title: intl.formatMessage(i18n.exportRecipeDialogTitle),
         defaultPath: filename,
         filters: [
@@ -536,7 +537,7 @@ export default function RecipesView() {
       });
 
       if (!result.canceled && result.filePath) {
-        await window.electron.writeFile(result.filePath, response.data.yaml);
+        await platform.writeFile(result.filePath, response.data.yaml);
         trackRecipeExportedToFile(true);
         toastSuccess({
           title: intl.formatMessage(i18n.recipeExportedTitle),

--- a/ui/desktop/src/components/recipes/shared/SubRecipeModal.tsx
+++ b/ui/desktop/src/components/recipes/shared/SubRecipeModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { platform } from '../../../platform';
 import { X, FolderOpen } from 'lucide-react';
 import { Button } from '../../ui/button';
 import { SubRecipeFormData } from './recipeFormSchema';
@@ -154,7 +155,7 @@ export default function SubRecipeModal({
 
   const handleBrowseFile = async () => {
     try {
-      const selectedPath = await window.electron.selectFileOrDirectory();
+      const selectedPath = await platform.selectFileOrDirectory();
       if (selectedPath) {
         if (!selectedPath.endsWith('.yaml') && !selectedPath.endsWith('.yml')) {
           toastError({

--- a/ui/desktop/src/components/schedule/ScheduleModal.tsx
+++ b/ui/desktop/src/components/schedule/ScheduleModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, FormEvent, useCallback } from 'react';
+import { platform } from '../../platform';
 import { Card } from '../ui/card';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
@@ -130,14 +131,14 @@ export const ScheduleModal: React.FC<ScheduleModalProps> = ({
 
   const handleBrowseFile = async () => {
     const defaultPath = getStorageDirectory(true);
-    const filePath = await window.electron.selectFileOrDirectory(defaultPath);
+    const filePath = await platform.selectFileOrDirectory(defaultPath);
     if (filePath) {
       if (filePath.endsWith('.yaml') || filePath.endsWith('.yml')) {
         setRecipeSourcePath(filePath);
         setInternalValidationError(null);
 
         try {
-          const fileResponse = await window.electron.readFile(filePath);
+          const fileResponse = await platform.readFile(filePath);
           if (!fileResponse.found || fileResponse.error) {
             throw new Error(intl.formatMessage(i18n.failedReadFile));
           }

--- a/ui/desktop/src/components/sessions/SessionHistoryView.tsx
+++ b/ui/desktop/src/components/sessions/SessionHistoryView.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { platform } from '../../platform';
 import {
   Calendar,
   MessageSquareText,
@@ -225,7 +226,7 @@ const SessionHistoryView: React.FC<SessionHistoryViewProps> = ({
   const setView = useNavigation();
 
   useEffect(() => {
-    window.electron.getSetting('sessionSharing').then((config) => {
+    platform.getSetting('sessionSharing').then((config) => {
       if (config.enabled && config.baseUrl) {
         setCanShare(true);
       }
@@ -236,7 +237,7 @@ const SessionHistoryView: React.FC<SessionHistoryViewProps> = ({
     setIsSharing(true);
 
     try {
-      const config = await window.electron.getSetting('sessionSharing');
+      const config = await platform.getSetting('sessionSharing');
       if (!config.enabled || !config.baseUrl) {
         throw new Error('Session sharing is not enabled or base URL is not configured.');
       }

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -1,5 +1,6 @@
 import { AppEvents } from '../../constants/events';
 import React, { useEffect, useState, useRef, useCallback, useMemo, startTransition } from 'react';
+import { platform } from '../../platform';
 import { defineMessages, useIntl } from '../../i18n';
 import {
   MessageSquareText,
@@ -573,7 +574,7 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
 
     const handleOpenInNewWindow = useCallback((session: Session, e: React.MouseEvent) => {
       e.stopPropagation();
-      window.electron.createChatWindow({
+      platform.createChatWindow({
         dir: session.working_dir,
         resumeSessionId: session.id,
         viewType: 'pair',

--- a/ui/desktop/src/components/settings/app/AppSettingsSection.tsx
+++ b/ui/desktop/src/components/settings/app/AppSettingsSection.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { platform } from '../../../platform';
 import { defineMessages, useIntl } from '../../../i18n';
 import { Switch } from '../../ui/switch';
 import { Button } from '../../ui/button';
@@ -215,10 +216,10 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
   const [showPricing, setShowPricing] = useState(true);
   const [isDarkMode, setIsDarkMode] = useState(false);
   const updateSectionRef = useRef<HTMLDivElement>(null);
-  const shouldShowUpdates = !window.appConfig.get('GOOSE_VERSION');
+  const shouldShowUpdates = !platform.isWeb && !window.appConfig?.get('GOOSE_VERSION');
 
   useEffect(() => {
-    setIsMacOS(window.electron.platform === 'darwin');
+    setIsMacOS(platform.platform === 'darwin');
   }, []);
 
   useEffect(() => {
@@ -238,7 +239,7 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
   }, []);
 
   useEffect(() => {
-    window.electron.getSetting('showPricing').then(setShowPricing);
+    platform.getSetting('showPricing').then(setShowPricing);
   }, []);
 
   useEffect(() => {
@@ -250,16 +251,16 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
   }, [scrollToSection]);
 
   useEffect(() => {
-    window.electron.getMenuBarIconState().then((enabled) => {
+    platform.getMenuBarIconState().then((enabled) => {
       setMenuBarIconEnabled(enabled);
     });
 
-    window.electron.getWakelockState().then((enabled) => {
+    platform.getWakelockState().then((enabled) => {
       setWakelockEnabled(enabled);
     });
 
     if (isMacOS) {
-      window.electron.getDockIconState().then((enabled) => {
+      platform.getDockIconState().then((enabled) => {
         setDockIconEnabled(enabled);
       });
     }
@@ -270,12 +271,12 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
     // If we're turning off the menu bar icon and the dock icon is hidden,
     // we need to show the dock icon to maintain accessibility
     if (!newState && !dockIconEnabled && isMacOS) {
-      const success = await window.electron.setDockIcon(true);
+      const success = await platform.setDockIcon(true);
       if (success) {
         setDockIconEnabled(true);
       }
     }
-    const success = await window.electron.setMenuBarIcon(newState);
+    const success = await platform.setMenuBarIcon(newState);
     if (success) {
       setMenuBarIconEnabled(newState);
       trackSettingToggled('menu_bar_icon', newState);
@@ -287,7 +288,7 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
     // If we're turning off the dock icon and the menu bar icon is hidden,
     // we need to show the menu bar icon to maintain accessibility
     if (!newState && !menuBarIconEnabled) {
-      const success = await window.electron.setMenuBarIcon(true);
+      const success = await platform.setMenuBarIcon(true);
       if (success) {
         setMenuBarIconEnabled(true);
       }
@@ -300,7 +301,7 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
     }, 1000);
 
     // Set the dock icon state
-    const success = await window.electron.setDockIcon(newState);
+    const success = await platform.setDockIcon(newState);
     if (success) {
       setDockIconEnabled(newState);
       trackSettingToggled('dock_icon', newState);
@@ -309,7 +310,7 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
 
   const handleWakelockToggle = async () => {
     const newState = !wakelockEnabled;
-    const success = await window.electron.setWakelock(newState);
+    const success = await platform.setWakelock(newState);
     if (success) {
       setWakelockEnabled(newState);
       trackSettingToggled('prevent_sleep', newState);
@@ -318,7 +319,7 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
 
   const handleShowPricingToggle = async (checked: boolean) => {
     setShowPricing(checked);
-    await window.electron.setSetting('showPricing', checked);
+    await platform.setSetting('showPricing', checked);
     trackSettingToggled('cost_tracking', checked);
     // Trigger event for other components
     window.dispatchEvent(new CustomEvent('showPricingChanged'));
@@ -334,60 +335,64 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
           <CardDescription>{intl.formatMessage(i18n.appearanceDesc)}</CardDescription>
         </CardHeader>
         <CardContent className="pt-4 space-y-4 px-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <h3 className="text-text-primary text-xs">
-                {intl.formatMessage(i18n.notifications)}
-              </h3>
-              <p className="text-xs text-text-secondary max-w-md mt-[2px]">
-                {intl.formatMessage(i18n.notificationsDesc, {
-                  link: (
-                    <span
-                      className="underline hover:cursor-pointer"
-                      onClick={() => setShowNotificationModal(true)}
-                    >
-                      {intl.formatMessage(i18n.configGuide)}
-                    </span>
-                  ),
-                })}
-              </p>
+          {!platform.isWeb && (
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="text-text-primary text-xs">
+                  {intl.formatMessage(i18n.notifications)}
+                </h3>
+                <p className="text-xs text-text-secondary max-w-md mt-[2px]">
+                  {intl.formatMessage(i18n.notificationsDesc, {
+                    link: (
+                      <span
+                        className="underline hover:cursor-pointer"
+                        onClick={() => setShowNotificationModal(true)}
+                      >
+                        {intl.formatMessage(i18n.configGuide)}
+                      </span>
+                    ),
+                  })}
+                </p>
+              </div>
+              <div className="flex items-center">
+                <Button
+                  className="flex items-center gap-2 justify-center"
+                  variant="secondary"
+                  size="sm"
+                  onClick={async () => {
+                    try {
+                      await platform.openNotificationsSettings();
+                    } catch (error) {
+                      console.error('Failed to open notification settings:', error);
+                    }
+                  }}
+                >
+                  <Settings />
+                  {intl.formatMessage(i18n.openSettings)}
+                </Button>
+              </div>
             </div>
-            <div className="flex items-center">
-              <Button
-                className="flex items-center gap-2 justify-center"
-                variant="secondary"
-                size="sm"
-                onClick={async () => {
-                  try {
-                    await window.electron.openNotificationsSettings();
-                  } catch (error) {
-                    console.error('Failed to open notification settings:', error);
-                  }
-                }}
-              >
-                <Settings />
-                {intl.formatMessage(i18n.openSettings)}
-              </Button>
-            </div>
-          </div>
+          )}
 
-          <div className="flex items-center justify-between">
-            <div>
-              <h3 className="text-text-primary text-xs">{intl.formatMessage(i18n.menuBarIcon)}</h3>
-              <p className="text-xs text-text-secondary max-w-md mt-[2px]">
-                {intl.formatMessage(i18n.menuBarIconDesc)}
-              </p>
+          {!platform.isWeb && (
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="text-text-primary text-xs">{intl.formatMessage(i18n.menuBarIcon)}</h3>
+                <p className="text-xs text-text-secondary max-w-md mt-[2px]">
+                  {intl.formatMessage(i18n.menuBarIconDesc)}
+                </p>
+              </div>
+              <div className="flex items-center">
+                <Switch
+                  checked={menuBarIconEnabled}
+                  onCheckedChange={handleMenuBarIconToggle}
+                  variant="mono"
+                />
+              </div>
             </div>
-            <div className="flex items-center">
-              <Switch
-                checked={menuBarIconEnabled}
-                onCheckedChange={handleMenuBarIconToggle}
-                variant="mono"
-              />
-            </div>
-          </div>
+          )}
 
-          {isMacOS && (
+          {!platform.isWeb && isMacOS && (
             <div className="flex items-center justify-between">
               <div>
                 <h3 className="text-text-primary text-xs">{intl.formatMessage(i18n.dockIcon)}</h3>
@@ -508,7 +513,7 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
                 className="h-8 w-auto"
               />
               <span className="text-2xl font-mono text-black dark:text-white">
-                {String(window.appConfig.get('GOOSE_VERSION') || 'Development')}
+                {String(window.appConfig?.get('GOOSE_VERSION') || 'Development')}
               </span>
             </div>
           </CardContent>

--- a/ui/desktop/src/components/settings/app/ExternalBackendSection.tsx
+++ b/ui/desktop/src/components/settings/app/ExternalBackendSection.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { platform } from '../../../platform';
 import { Switch } from '../../ui/switch';
 import { Input } from '../../ui/input';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../ui/card';
@@ -64,7 +65,7 @@ export default function ExternalBackendSection() {
 
   useEffect(() => {
     const loadSettings = async () => {
-      const externalGoosed = await window.electron.getSetting('externalGoosed');
+      const externalGoosed = await platform.getSetting('externalGoosed');
       setConfig(externalGoosed);
     };
     loadSettings();
@@ -92,7 +93,7 @@ export default function ExternalBackendSection() {
   const saveConfig = async (newConfig: ExternalGoosedConfig): Promise<void> => {
     setIsSaving(true);
     try {
-      await window.electron.setSetting('externalGoosed', newConfig);
+      await platform.setSetting('externalGoosed', newConfig);
     } catch (error) {
       console.error('Failed to save external backend settings:', error);
     } finally {

--- a/ui/desktop/src/components/settings/app/UpdateSection.tsx
+++ b/ui/desktop/src/components/settings/app/UpdateSection.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { platform } from '../../../platform';
 import { Button } from '../../ui/button';
 import { Loader2, Download, CheckCircle, AlertCircle } from 'lucide-react';
 import { errorMessage } from '../../../utils/conversionUtils';
@@ -121,11 +122,11 @@ export default function UpdateSection() {
 
   useEffect(() => {
     // Get current version on mount
-    const currentVersion = window.electron.getVersion();
+    const currentVersion = platform.getVersion();
     setUpdateInfo((prev) => ({ ...prev, currentVersion }));
 
     // Check if there's already an update state from the auto-check
-    window.electron.getUpdateState().then((state) => {
+    platform.getUpdateState().then((state) => {
       if (state) {
         setUpdateInfo((prev) => ({
           ...prev,
@@ -136,12 +137,12 @@ export default function UpdateSection() {
     });
 
     // Check if using GitHub fallback
-    window.electron.isUsingGitHubFallback().then((isGitHub) => {
+    platform.isUsingGitHubFallback().then((isGitHub) => {
       setIsUsingGitHubFallback(isGitHub);
     });
 
     // Listen for updater events
-    window.electron.onUpdaterEvent((event) => {
+    platform.onUpdaterEvent((event) => {
 
       switch (event.event) {
         case 'checking-for-update':
@@ -156,7 +157,7 @@ export default function UpdateSection() {
             isUpdateAvailable: true,
           }));
           // Check if GitHub fallback is being used
-          window.electron.isUsingGitHubFallback().then((isGitHub) => {
+          platform.isUsingGitHubFallback().then((isGitHub) => {
             setIsUsingGitHubFallback(isGitHub);
           });
           break;
@@ -222,7 +223,7 @@ export default function UpdateSection() {
     lastProgressRef.current = 0; // Reset progress tracking for new download
 
     try {
-      const result = await window.electron.checkForUpdates();
+      const result = await platform.checkForUpdates();
 
       if (result.error) {
         throw new Error(result.error);
@@ -246,7 +247,7 @@ export default function UpdateSection() {
   };
 
   const installUpdate = () => {
-    window.electron.installUpdate();
+    platform.installUpdate();
   };
 
   const getStatusMessage = () => {

--- a/ui/desktop/src/components/settings/chat/GoosehintsModal.tsx
+++ b/ui/desktop/src/components/settings/chat/GoosehintsModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { platform } from '../../../platform';
 import { Button } from '../../ui/button';
 import { Check } from '../../icons';
 import {
@@ -148,7 +149,7 @@ const FileInfo = ({ filePath, found }: { filePath: string; found: boolean }) => 
   );
 };
 
-const getGoosehintsFile = async (filePath: string) => await window.electron.readFile(filePath);
+const getGoosehintsFile = async (filePath: string) => await platform.readFile(filePath);
 
 interface GoosehintsModalProps {
   directory: string;
@@ -183,7 +184,7 @@ export const GoosehintsModal = ({ directory, setIsGoosehintsModalOpen }: Goosehi
     setIsSaving(true);
     setSaveSuccess(false);
     try {
-      await window.electron.writeFile(goosehintsFilePath, goosehintsFile);
+      await platform.writeFile(goosehintsFilePath, goosehintsFile);
       setSaveSuccess(true);
       setGoosehintsFileFound(true);
       setTimeout(() => setSaveSuccess(false), 3000);

--- a/ui/desktop/src/components/settings/chat/SpellcheckToggle.tsx
+++ b/ui/desktop/src/components/settings/chat/SpellcheckToggle.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { platform } from '../../../platform';
 import { Switch } from '../../ui/switch';
 import { defineMessages, useIntl } from '../../../i18n';
 
@@ -19,7 +20,7 @@ export const SpellcheckToggle = () => {
 
   useEffect(() => {
     const loadState = async () => {
-      const state = await window.electron.getSpellcheckState();
+      const state = await platform.getSpellcheckState();
       setEnabled(state);
     };
     loadState();
@@ -27,7 +28,7 @@ export const SpellcheckToggle = () => {
 
   const handleToggle = async (checked: boolean) => {
     setEnabled(checked);
-    await window.electron.setSpellcheck(checked);
+    await platform.setSpellcheck(checked);
   };
 
   return (

--- a/ui/desktop/src/components/settings/gateways/GatewaySettingsSection.tsx
+++ b/ui/desktop/src/components/settings/gateways/GatewaySettingsSection.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { platform } from '../../../platform';
 import { Button } from '../../ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card';
 import { Input } from '../../ui/input';
@@ -113,7 +114,7 @@ interface PairingCodeResponse {
 }
 
 async function gatewayFetch(endpoint: string, options: globalThis.RequestInit = {}) {
-  const secretKey = await window.electron.getSecretKey();
+  const secretKey = await platform.getSecretKey();
   const url = getApiUrl(endpoint);
   return fetch(url, {
     ...options,

--- a/ui/desktop/src/components/settings/keyboard/KeyboardShortcutsSection.tsx
+++ b/ui/desktop/src/components/settings/keyboard/KeyboardShortcutsSection.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { platform } from '../../../platform';
 import { type MessageDescriptor } from 'react-intl';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../ui/card';
 import { Button } from '../../ui/button';
@@ -310,7 +311,7 @@ export const getShortcutLabel = (
 };
 
 export const formatShortcut = (shortcut: string): string => {
-  const isMac = window.electron.platform === 'darwin';
+  const isMac = platform.platform === 'darwin';
   return shortcut
     .replace('CommandOrControl', isMac ? '⌘' : 'Ctrl')
     .replace('Command', '⌘')
@@ -340,7 +341,7 @@ export default function KeyboardShortcutsSection() {
   const [showRestartNotice, setShowRestartNotice] = useState(false);
 
   const loadShortcuts = useCallback(async () => {
-    const keyboardShortcuts = await window.electron.getSetting('keyboardShortcuts');
+    const keyboardShortcuts = await platform.getSetting('keyboardShortcuts');
     setShortcuts({ ...defaultKeyboardShortcuts, ...keyboardShortcuts });
   }, []);
 
@@ -360,7 +361,7 @@ export default function KeyboardShortcutsSection() {
       )?.[0];
 
       if (conflictingKey) {
-        const confirmed = await window.electron.showMessageBox({
+        const confirmed = await platform.showMessageBox({
           type: 'warning',
           title: intl.formatMessage(i18n.shortcutConflictTitle),
           message: intl.formatMessage(i18n.shortcutConflictToggleMessage, {
@@ -390,7 +391,7 @@ export default function KeyboardShortcutsSection() {
       newShortcuts[key] = null;
     }
 
-    await window.electron.setSetting('keyboardShortcuts', newShortcuts);
+    await platform.setSetting('keyboardShortcuts', newShortcuts);
     setShortcuts(newShortcuts);
     trackSettingToggled(`shortcut_${key}`, enabled);
     if (needsRestart.has(key)) {
@@ -410,7 +411,7 @@ export default function KeyboardShortcutsSection() {
     )?.[0];
 
     if (conflictingKey) {
-      const confirmed = await window.electron.showMessageBox({
+      const confirmed = await platform.showMessageBox({
         type: 'warning',
         title: intl.formatMessage(i18n.shortcutConflictTitle),
         message: intl.formatMessage(i18n.shortcutConflictToggleMessage, {
@@ -441,7 +442,7 @@ export default function KeyboardShortcutsSection() {
 
     newShortcuts[editingKey] = shortcut || null;
 
-    await window.electron.setSetting('keyboardShortcuts', newShortcuts);
+    await platform.setSetting('keyboardShortcuts', newShortcuts);
     setShortcuts(newShortcuts);
     setEditingKey(null);
     if (needsRestart.has(editingKey)) {
@@ -454,7 +455,7 @@ export default function KeyboardShortcutsSection() {
   };
 
   const handleResetToDefaults = async () => {
-    const confirmed = await window.electron.showMessageBox({
+    const confirmed = await platform.showMessageBox({
       type: 'question',
       title: intl.formatMessage(i18n.resetShortcutsTitle),
       message: intl.formatMessage(i18n.resetShortcutsMessage),
@@ -467,7 +468,7 @@ export default function KeyboardShortcutsSection() {
     });
 
     if (confirmed.response === 0) {
-      await window.electron.setSetting('keyboardShortcuts', { ...defaultKeyboardShortcuts });
+      await platform.setSetting('keyboardShortcuts', { ...defaultKeyboardShortcuts });
       setShortcuts({ ...defaultKeyboardShortcuts });
       setShowRestartNotice(true);
       trackSettingToggled('shortcuts_reset', true);

--- a/ui/desktop/src/components/settings/mesh/MeshSettings.tsx
+++ b/ui/desktop/src/components/settings/mesh/MeshSettings.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { platform } from '../../../platform';
 import {
   RefreshCw,
   ExternalLink,
@@ -46,7 +47,7 @@ interface MeshStatusInfo {
 
 export const MeshSettings = () => {
   const { refreshCurrentModelAndProvider } = useModelAndProvider();
-  const isMacOS = window.electron.platform === 'darwin' && window.electron.arch === 'arm64';
+  const isMacOS = platform.platform === 'darwin' && platform.arch === 'arm64';
   const [status, setStatus] = useState<MeshStatus>('unknown');
   const [statusInfo, setStatusInfo] = useState<MeshStatusInfo>({
     running: false,
@@ -75,7 +76,7 @@ export const MeshSettings = () => {
   const checkStatus = useCallback(async () => {
     setChecking(true);
     try {
-      const result = await window.electron.checkMesh();
+      const result = await platform.checkMesh();
       if (result.running) {
         setStatus('running');
         setStatusInfo(result);
@@ -191,7 +192,7 @@ export const MeshSettings = () => {
         }
       }
 
-      const result = await window.electron.startMesh(args);
+      const result = await platform.startMesh(args);
       if (!result.started) {
         setError(result.error || 'Failed to start mesh-llm');
         setStatus('stopped');
@@ -221,7 +222,7 @@ export const MeshSettings = () => {
 
   const stopMesh = async () => {
     try {
-      const result = await window.electron.stopMesh();
+      const result = await platform.stopMesh();
       if (result.stopped) {
         setStatus('stopped');
         setStatusInfo((prev) => ({ ...prev, running: false, models: [], token: undefined }));

--- a/ui/desktop/src/components/settings/providers/modal/ProviderConfiguationModal.tsx
+++ b/ui/desktop/src/components/settings/providers/modal/ProviderConfiguationModal.tsx
@@ -1,4 +1,5 @@
 import { useState, Fragment } from 'react';
+import { platform } from '../../../../platform';
 import {
   Dialog,
   DialogContent,
@@ -433,7 +434,7 @@ export default function ProviderConfigurationModal({
                               href="#"
                               onClick={(e) => {
                                 e.preventDefault();
-                                window.electron.openExternal(provider.metadata.model_doc_link);
+                                platform.openExternal(provider.metadata.model_doc_link);
                               }}
                               className="underline hover:text-text-primary"
                             >

--- a/ui/desktop/src/components/settings/response_styles/ResponseStylesSection.tsx
+++ b/ui/desktop/src/components/settings/response_styles/ResponseStylesSection.tsx
@@ -1,5 +1,6 @@
 import { AppEvents } from '../../../constants/events';
 import { useEffect, useState } from 'react';
+import { platform } from '../../../platform';
 import { all_response_styles, ResponseStyleSelectionItem } from './ResponseStyleSelectionItem';
 
 export const ResponseStylesSection = () => {
@@ -8,7 +9,7 @@ export const ResponseStylesSection = () => {
   useEffect(() => {
     async function loadResponseStyle() {
       try {
-        const savedStyle = await window.electron.getSetting('responseStyle');
+        const savedStyle = await platform.getSetting('responseStyle');
         setCurrentStyle(savedStyle);
       } catch (error) {
         console.error('Error loading response style:', error);
@@ -20,7 +21,7 @@ export const ResponseStylesSection = () => {
   const handleStyleChange = async (newStyle: string) => {
     setCurrentStyle(newStyle);
     try {
-      await window.electron.setSetting('responseStyle', newStyle);
+      await platform.setSetting('responseStyle', newStyle);
     } catch (error) {
       console.error('Error saving response style:', error);
     }

--- a/ui/desktop/src/components/settings/sessions/SessionSharingSection.tsx
+++ b/ui/desktop/src/components/settings/sessions/SessionSharingSection.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { platform } from '../../../platform';
 import { Input } from '../../ui/input';
 import { Check, Lock, Loader2, AlertCircle } from 'lucide-react';
 import { Switch } from '../../ui/switch';
@@ -111,9 +112,9 @@ export default function SessionSharingSection() {
         enabled: true,
         baseUrl: typeof envBaseUrlShare === 'string' ? envBaseUrlShare : '',
       };
-      window.electron.setSetting('sessionSharing', forcedConfig);
+      platform.setSetting('sessionSharing', forcedConfig);
     } else {
-      window.electron.getSetting('sessionSharing').then((config) => {
+      platform.getSetting('sessionSharing').then((config) => {
         setSessionSharingConfig(config);
       });
     }
@@ -137,7 +138,7 @@ export default function SessionSharingSection() {
     }
     const updated = { ...sessionSharingConfig, enabled: !sessionSharingConfig.enabled };
     setSessionSharingConfig(updated);
-    await window.electron.setSetting('sessionSharing', updated);
+    await platform.setSetting('sessionSharing', updated);
     trackSettingToggled('session_sharing', updated.enabled);
   };
 
@@ -155,7 +156,7 @@ export default function SessionSharingSection() {
     if (isValidUrl(newBaseUrl)) {
       setUrlError('');
       const updated = { ...sessionSharingConfig, baseUrl: newBaseUrl };
-      await window.electron.setSetting('sessionSharing', updated);
+      await platform.setSetting('sessionSharing', updated);
     } else {
       setUrlError(intl.formatMessage(i18n.invalidUrl));
     }

--- a/ui/desktop/src/components/ui/BackButton.tsx
+++ b/ui/desktop/src/components/ui/BackButton.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useCallback } from 'react';
 import { ArrowLeft } from 'lucide-react';
+import { platform } from '../../platform';
 import { Button } from './button';
 import type { VariantProps } from 'class-variance-authority';
 import { buttonVariants } from './button';
@@ -46,7 +47,7 @@ const BackButton: React.FC<BackButtonProps> = ({
       handleExit();
     };
 
-    if (window.electron) {
+    if (platform) {
       const mouseBackHandler = (e: MouseEvent) => {
         // MouseButton 3 or 4 is typically back button.
         if (e.button === 3 || e.button === 4) {
@@ -55,14 +56,14 @@ const BackButton: React.FC<BackButtonProps> = ({
         }
       };
 
-      window.electron.on('mouse-back-button-clicked', handleMouseBack);
+      platform.on('mouse-back-button-clicked', handleMouseBack);
 
       // Also listen for mouseup events directly, for better OS compatibility.
       document.addEventListener('mouseup', mouseBackHandler);
 
       return () => {
-        if (window.electron) {
-          window.electron.off('mouse-back-button-clicked', handleMouseBack);
+        if (platform) {
+          platform.off('mouse-back-button-clicked', handleMouseBack);
         }
         document.removeEventListener('mouseup', mouseBackHandler);
       };

--- a/ui/desktop/src/contexts/ThemeContext.tsx
+++ b/ui/desktop/src/contexts/ThemeContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
 import { applyThemeTokens, buildMcpHostStyles } from '../theme/theme-tokens';
 import type { McpUiHostStyles } from '@modelcontextprotocol/ext-apps/app-bridge';
+import { platform } from '../platform';
 
 type ThemePreference = 'light' | 'dark' | 'system';
 type ResolvedTheme = 'light' | 'dark';
@@ -48,8 +49,8 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     async function loadThemeFromSettings() {
       try {
         const [useSystemTheme, savedTheme] = await Promise.all([
-          window.electron.getSetting('useSystemTheme'),
-          window.electron.getSetting('theme'),
+          platform.getSetting('useSystemTheme'),
+          platform.getSetting('theme'),
         ]);
 
         let preference: ThemePreference;
@@ -78,17 +79,17 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     // Save to settings
     try {
       if (preference === 'system') {
-        await window.electron.setSetting('useSystemTheme', true);
+        await platform.setSetting('useSystemTheme', true);
       } else {
-        await window.electron.setSetting('useSystemTheme', false);
-        await window.electron.setSetting('theme', preference);
+        await platform.setSetting('useSystemTheme', false);
+        await platform.setSetting('theme', preference);
       }
     } catch (error) {
       console.warn('[ThemeContext] Failed to save theme settings:', error);
     }
 
     // Broadcast to other windows via Electron
-    window.electron?.broadcastThemeChange({
+    platform?.broadcastThemeChange({
       mode: resolved,
       useSystemTheme: preference === 'system',
       theme: resolved,
@@ -111,7 +112,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
 
   // Listen for theme changes from other windows (via Electron IPC)
   useEffect(() => {
-    if (!window.electron) return;
+    if (!platform) return;
 
     const handleThemeChanged = (_event: unknown, ...args: unknown[]) => {
       const themeData = args[0] as { useSystemTheme: boolean; theme: string };
@@ -126,16 +127,16 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
 
       // Save to settings (don't await, fire and forget)
       if (newPreference === 'system') {
-        window.electron.setSetting('useSystemTheme', true);
+        platform.setSetting('useSystemTheme', true);
       } else {
-        window.electron.setSetting('useSystemTheme', false);
-        window.electron.setSetting('theme', newPreference);
+        platform.setSetting('useSystemTheme', false);
+        platform.setSetting('theme', newPreference);
       }
     };
 
-    window.electron.on('theme-changed', handleThemeChanged);
+    platform.on('theme-changed', handleThemeChanged);
     return () => {
-      window.electron.off('theme-changed', handleThemeChanged);
+      platform.off('theme-changed', handleThemeChanged);
     };
   }, []);
 

--- a/ui/desktop/src/hooks/useChatStream.ts
+++ b/ui/desktop/src/hooks/useChatStream.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
 import { v7 as uuidv7 } from 'uuid';
 import { AppEvents } from '../constants/events';
 import { ChatState } from '../types/chatState';
+import { platform } from '../platform';
 
 import {
   getSession,
@@ -401,7 +402,7 @@ export function useChatStream({
 
       const timeSinceLastInteraction = Date.now() - lastInteractionTimeRef.current;
       if (!error && timeSinceLastInteraction > 60000) {
-        window.electron.showNotification({
+        platform.showNotification({
           title: 'goose finished the task.',
           body: 'Click here to expand.',
         });
@@ -998,7 +999,7 @@ export function useChatStream({
             },
           });
           window.dispatchEvent(event);
-          window.electron.logInfo(`Dispatched session-forked event for session ${targetSessionId}`);
+          platform.logInfo(`Dispatched session-forked event for session ${targetSessionId}`);
         } else {
           const { getSession } = await import('../api');
           const sessionResponse = await getSession({

--- a/ui/desktop/src/hooks/useFileDrop.ts
+++ b/ui/desktop/src/hooks/useFileDrop.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState, useRef, useEffect } from 'react';
 import { compressImageDataUrl, errorMessage } from '../utils/conversionUtils';
+import { platform } from '../platform';
 
 export interface DroppedFile {
   id: string;
@@ -45,7 +46,7 @@ export const useFileDrop = () => {
         let droppedFile: DroppedFile;
 
         try {
-          const path = window.electron.getPathForFile(file);
+          const path = platform.getPathForFile(file);
           const isImage = file.type.startsWith('image/');
 
           droppedFile = {

--- a/ui/desktop/src/platform/electron.ts
+++ b/ui/desktop/src/platform/electron.ts
@@ -1,0 +1,91 @@
+import type { PlatformAPI } from './types';
+
+/**
+ * Electron implementation — delegates everything to window.electron
+ * which is set up by preload.ts via contextBridge.
+ */
+export const electronPlatform: PlatformAPI = {
+  isWeb: false,
+
+  get platform() {
+    return window.electron.platform;
+  },
+  get arch() {
+    return window.electron.arch;
+  },
+
+  reactReady: () => window.electron.reactReady(),
+  getConfig: () => window.electron.getConfig(),
+  reloadApp: () => window.electron.reloadApp(),
+
+  getSecretKey: () => window.electron.getSecretKey(),
+  getGoosedHostPort: () => window.electron.getGoosedHostPort(),
+
+  hideWindow: () => window.electron.hideWindow(),
+  closeWindow: () => window.electron.closeWindow(),
+  createChatWindow: (options) => window.electron.createChatWindow(options),
+
+  directoryChooser: () => window.electron.directoryChooser(),
+  showMessageBox: (options) => window.electron.showMessageBox(options),
+  showSaveDialog: (options) => window.electron.showSaveDialog(options),
+  selectFileOrDirectory: (defaultPath) => window.electron.selectFileOrDirectory(defaultPath),
+
+  readFile: (filePath) => window.electron.readFile(filePath),
+  writeFile: (filePath, content) => window.electron.writeFile(filePath, content),
+  ensureDirectory: (dirPath) => window.electron.ensureDirectory(dirPath),
+  listFiles: (dirPath, extension) => window.electron.listFiles(dirPath, extension),
+  getBinaryPath: (name) => window.electron.getBinaryPath(name),
+  getPathForFile: (file) => window.electron.getPathForFile(file),
+  getAllowedExtensions: () => window.electron.getAllowedExtensions(),
+  openDirectoryInExplorer: (dir) => window.electron.openDirectoryInExplorer(dir),
+
+  showNotification: (data) => window.electron.showNotification(data),
+  logInfo: (txt) => window.electron.logInfo(txt),
+
+  openExternal: (url) => window.electron.openExternal(url),
+  openInChrome: (url) => window.electron.openInChrome(url),
+  fetchMetadata: (url) => window.electron.fetchMetadata(url),
+
+  getSetting: (key) => window.electron.getSetting(key),
+  setSetting: (key, value) => window.electron.setSetting(key, value),
+
+  setMenuBarIcon: (show) => window.electron.setMenuBarIcon(show),
+  getMenuBarIconState: () => window.electron.getMenuBarIconState(),
+  setDockIcon: (show) => window.electron.setDockIcon(show),
+  getDockIconState: () => window.electron.getDockIconState(),
+  setWakelock: (enable) => window.electron.setWakelock(enable),
+  getWakelockState: () => window.electron.getWakelockState(),
+  setSpellcheck: (enable) => window.electron.setSpellcheck(enable),
+  getSpellcheckState: () => window.electron.getSpellcheckState(),
+  openNotificationsSettings: () => window.electron.openNotificationsSettings(),
+
+  on: (channel, callback) => window.electron.on(channel, callback as never),
+  off: (channel, callback) => window.electron.off(channel, callback as never),
+  emit: (channel, ...args) => window.electron.emit(channel, ...args),
+  broadcastThemeChange: (data) => window.electron.broadcastThemeChange(data),
+  onMouseBackButtonClicked: (cb) => window.electron.onMouseBackButtonClicked(cb),
+  offMouseBackButtonClicked: (cb) => window.electron.offMouseBackButtonClicked(cb),
+
+  getVersion: () => window.electron.getVersion(),
+  checkForUpdates: () => window.electron.checkForUpdates(),
+  downloadUpdate: () => window.electron.downloadUpdate(),
+  installUpdate: () => window.electron.installUpdate(),
+  restartApp: () => window.electron.restartApp(),
+  onUpdaterEvent: (cb) => window.electron.onUpdaterEvent(cb),
+  getUpdateState: () => window.electron.getUpdateState(),
+  isUsingGitHubFallback: () => window.electron.isUsingGitHubFallback(),
+
+  checkForOllama: () => window.electron.checkForOllama(),
+  checkMesh: () => window.electron.checkMesh(),
+  startMesh: (args) => window.electron.startMesh(args),
+  stopMesh: () => window.electron.stopMesh(),
+
+  hasAcceptedRecipeBefore: (recipe) => window.electron.hasAcceptedRecipeBefore(recipe),
+  recordRecipeHash: (recipe) => window.electron.recordRecipeHash(recipe),
+
+  launchApp: (app) => window.electron.launchApp(app),
+  refreshApp: (app) => window.electron.refreshApp(app),
+  closeApp: (name) => window.electron.closeApp(name),
+
+  addRecentDir: (dir) => window.electron.addRecentDir(dir),
+};

--- a/ui/desktop/src/platform/index.ts
+++ b/ui/desktop/src/platform/index.ts
@@ -1,0 +1,23 @@
+import type { PlatformAPI } from './types';
+import { electronPlatform } from './electron';
+import { webPlatform } from './web';
+
+export type { PlatformAPI } from './types';
+export type {
+  NotificationData,
+  MessageBoxOptions,
+  MessageBoxResponse,
+  SaveDialogOptions,
+  SaveDialogResponse,
+  FileResponse,
+  OpenDialogReturnValue,
+  CreateChatWindowOptions,
+  UpdaterEvent,
+  PlatformEventCallback,
+} from './types';
+
+const isElectron =
+  typeof window !== 'undefined' &&
+  typeof window.electron !== 'undefined';
+
+export const platform: PlatformAPI = isElectron ? electronPlatform : webPlatform;

--- a/ui/desktop/src/platform/types.ts
+++ b/ui/desktop/src/platform/types.ts
@@ -1,0 +1,174 @@
+import type { Settings, SettingKey } from '../utils/settings';
+import type { Recipe } from '../recipe';
+import type { GooseApp } from '../api';
+
+export interface NotificationData {
+  title: string;
+  body: string;
+}
+
+export interface MessageBoxOptions {
+  type?: 'none' | 'info' | 'error' | 'question' | 'warning';
+  buttons?: string[];
+  defaultId?: number;
+  title?: string;
+  message: string;
+  detail?: string;
+}
+
+export interface MessageBoxResponse {
+  response: number;
+  checkboxChecked?: boolean;
+}
+
+export interface SaveDialogOptions {
+  title?: string;
+  defaultPath?: string;
+  buttonLabel?: string;
+  filters?: Array<{ name: string; extensions: string[] }>;
+  message?: string;
+  nameFieldLabel?: string;
+  showsTagField?: boolean;
+}
+
+export interface SaveDialogResponse {
+  canceled: boolean;
+  filePath?: string;
+}
+
+export interface FileResponse {
+  file: string;
+  filePath: string;
+  error: string | null;
+  found: boolean;
+}
+
+export interface OpenDialogReturnValue {
+  canceled: boolean;
+  filePaths: string[];
+}
+
+export interface CreateChatWindowOptions {
+  query?: string;
+  dir?: string;
+  version?: string;
+  resumeSessionId?: string;
+  viewType?: string;
+  recipeId?: string;
+}
+
+export interface UpdaterEvent {
+  event: string;
+  data?: unknown;
+}
+
+export type PlatformEventCallback = (...args: unknown[]) => void;
+
+export interface PlatformAPI {
+  isWeb: boolean;
+  platform: string;
+  arch: string;
+
+  // Lifecycle
+  reactReady: () => void;
+  getConfig: () => Record<string, unknown>;
+  reloadApp: () => void;
+
+  // Backend connection
+  getSecretKey: () => Promise<string>;
+  getGoosedHostPort: () => Promise<string | null>;
+
+  // Window management
+  hideWindow: () => void;
+  closeWindow: () => void;
+  createChatWindow: (options?: CreateChatWindowOptions) => void;
+
+  // Dialogs
+  directoryChooser: () => Promise<OpenDialogReturnValue>;
+  showMessageBox: (options: MessageBoxOptions) => Promise<MessageBoxResponse>;
+  showSaveDialog: (options: SaveDialogOptions) => Promise<SaveDialogResponse>;
+  selectFileOrDirectory: (defaultPath?: string) => Promise<string | null>;
+
+  // File system
+  readFile: (filePath: string) => Promise<FileResponse>;
+  writeFile: (filePath: string, content: string) => Promise<boolean>;
+  ensureDirectory: (dirPath: string) => Promise<boolean>;
+  listFiles: (dirPath: string, extension?: string) => Promise<string[]>;
+  getBinaryPath: (binaryName: string) => Promise<string>;
+  getPathForFile: (file: File) => string;
+  getAllowedExtensions: () => Promise<string[]>;
+  openDirectoryInExplorer: (directoryPath: string) => Promise<boolean>;
+
+  // Notifications
+  showNotification: (data: NotificationData) => void;
+  logInfo: (txt: string) => void;
+
+  // External links
+  openExternal: (url: string) => Promise<void>;
+  openInChrome: (url: string) => void;
+  fetchMetadata: (url: string) => Promise<string>;
+
+  // Settings
+  getSetting: <K extends SettingKey>(key: K) => Promise<Settings[K]>;
+  setSetting: <K extends SettingKey>(key: K, value: Settings[K]) => Promise<void>;
+
+  // System toggles
+  setMenuBarIcon: (show: boolean) => Promise<boolean>;
+  getMenuBarIconState: () => Promise<boolean>;
+  setDockIcon: (show: boolean) => Promise<boolean>;
+  getDockIconState: () => Promise<boolean>;
+  setWakelock: (enable: boolean) => Promise<boolean>;
+  getWakelockState: () => Promise<boolean>;
+  setSpellcheck: (enable: boolean) => Promise<boolean>;
+  getSpellcheckState: () => Promise<boolean>;
+  openNotificationsSettings: () => Promise<boolean>;
+
+  // Events (IPC bridge)
+  on: (channel: string, callback: PlatformEventCallback) => void;
+  off: (channel: string, callback: PlatformEventCallback) => void;
+  emit: (channel: string, ...args: unknown[]) => void;
+  broadcastThemeChange: (themeData: {
+    mode: string;
+    useSystemTheme: boolean;
+    theme: string;
+    tokensUpdated?: boolean;
+  }) => void;
+  onMouseBackButtonClicked: (callback: () => void) => void;
+  offMouseBackButtonClicked: (callback: () => void) => void;
+
+  // Auto-update
+  getVersion: () => string;
+  checkForUpdates: () => Promise<{ updateInfo: unknown; error: string | null }>;
+  downloadUpdate: () => Promise<{ success: boolean; error: string | null }>;
+  installUpdate: () => void;
+  restartApp: () => void;
+  onUpdaterEvent: (callback: (event: UpdaterEvent) => void) => void;
+  getUpdateState: () => Promise<{ updateAvailable: boolean; latestVersion?: string } | null>;
+  isUsingGitHubFallback: () => Promise<boolean>;
+
+  // Mesh / local inference
+  checkForOllama: () => Promise<boolean>;
+  checkMesh: () => Promise<{
+    running: boolean;
+    installed: boolean;
+    models: string[];
+    token?: string;
+    peerCount?: number;
+    nodeStatus?: string;
+    binaryPath?: string;
+  }>;
+  startMesh: (args: string[]) => Promise<{ started: boolean; error?: string; pid?: number }>;
+  stopMesh: () => Promise<{ stopped: boolean }>;
+
+  // Recipes
+  hasAcceptedRecipeBefore: (recipe: Recipe) => Promise<boolean>;
+  recordRecipeHash: (recipe: Recipe) => Promise<boolean>;
+
+  // MCP apps
+  launchApp: (app: GooseApp) => Promise<void>;
+  refreshApp: (app: GooseApp) => Promise<void>;
+  closeApp: (appName: string) => Promise<void>;
+
+  // Recent dirs
+  addRecentDir: (dir: string) => Promise<boolean>;
+}

--- a/ui/desktop/src/platform/web.ts
+++ b/ui/desktop/src/platform/web.ts
@@ -1,3 +1,4 @@
+/* global location, Notification */
 import type { PlatformAPI, PlatformEventCallback } from './types';
 import { defaultSettings } from '../utils/settings';
 import type { Settings, SettingKey } from '../utils/settings';

--- a/ui/desktop/src/platform/web.ts
+++ b/ui/desktop/src/platform/web.ts
@@ -1,0 +1,239 @@
+import type { PlatformAPI, PlatformEventCallback } from './types';
+import { defaultSettings } from '../utils/settings';
+import type { Settings, SettingKey } from '../utils/settings';
+
+// Polyfill window.appConfig for web mode (Electron preload normally sets this)
+if (typeof window !== 'undefined' && !window.appConfig) {
+  (window as unknown as Record<string, unknown>).appConfig = {
+    get: () => undefined,
+    getAll: () => ({}),
+  };
+}
+
+const SETTINGS_STORAGE_KEY = 'goose_settings';
+
+function loadSettings(): Settings {
+  try {
+    const raw = localStorage.getItem(SETTINGS_STORAGE_KEY);
+    if (raw) return { ...defaultSettings, ...JSON.parse(raw) };
+  } catch {
+    // fall through
+  }
+  return { ...defaultSettings };
+}
+
+function saveSettings(settings: Settings): void {
+  localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings));
+}
+
+/** Simple in-page event bus to replace Electron IPC */
+class EventBus {
+  private listeners = new Map<string, Set<PlatformEventCallback>>();
+
+  on(channel: string, callback: PlatformEventCallback) {
+    if (!this.listeners.has(channel)) {
+      this.listeners.set(channel, new Set());
+    }
+    this.listeners.get(channel)!.add(callback);
+  }
+
+  off(channel: string, callback: PlatformEventCallback) {
+    this.listeners.get(channel)?.delete(callback);
+  }
+
+  emit(channel: string, ...args: unknown[]) {
+    this.listeners.get(channel)?.forEach((cb) => {
+      try {
+        cb(...args);
+      } catch (e) {
+        console.error(`[EventBus] error in "${channel}" listener:`, e);
+      }
+    });
+  }
+}
+
+const bus = new EventBus();
+
+function detectPlatform(): string {
+  const ua = navigator.userAgent.toLowerCase();
+  if (ua.includes('win')) return 'win32';
+  if (ua.includes('mac')) return 'darwin';
+  return 'linux';
+}
+
+function detectArch(): string {
+  const ua = navigator.userAgent.toLowerCase();
+  if (ua.includes('arm') || ua.includes('aarch64')) return 'arm64';
+  return 'x64';
+}
+
+/**
+ * Read a `<meta name="goose:KEY" content="VALUE">` tag injected by the server.
+ */
+function getMeta(name: string): string | null {
+  const el = document.querySelector(`meta[name="goose:${name}"]`);
+  return el?.getAttribute('content') ?? null;
+}
+
+export const webPlatform: PlatformAPI = {
+  isWeb: true,
+  platform: detectPlatform(),
+  arch: detectArch(),
+
+  reactReady: () => {},
+  getConfig: () => ({}),
+  reloadApp: () => location.reload(),
+
+  getSecretKey: async () => {
+    // In web mode the reverse proxy injects the secret server-side;
+    // the browser never needs to know it. Return empty string so the
+    // API client header is present but valueless (proxy adds the real one).
+    return getMeta('secret-key') ?? '';
+  },
+
+  getGoosedHostPort: async () => {
+    // When served through goose-web reverse proxy, API is on same origin.
+    return getMeta('api-base') ?? '';
+  },
+
+  // Window management — limited in browser
+  hideWindow: () => {},
+  closeWindow: () => window.close(),
+  createChatWindow: () => {
+    window.open(window.location.href, '_blank');
+  },
+
+  // Dialogs
+  directoryChooser: async () => {
+    // No native directory picker on all browsers, return cancelled
+    return { canceled: true, filePaths: [] };
+  },
+
+  showMessageBox: async (options) => {
+    const ok = window.confirm(options.message + (options.detail ? `\n\n${options.detail}` : ''));
+    return { response: ok ? 0 : 1 };
+  },
+
+  showSaveDialog: async (options) => {
+    const name = options.defaultPath ?? 'download';
+    return { canceled: false, filePath: name };
+  },
+
+  selectFileOrDirectory: async () => {
+    return new Promise((resolve) => {
+      const input = document.createElement('input');
+      input.type = 'file';
+      input.onchange = () => {
+        const file = input.files?.[0];
+        resolve(file ? file.name : null);
+      };
+      input.oncancel = () => resolve(null);
+      input.click();
+    });
+  },
+
+  // File system — not available in browser; return safe defaults
+  readFile: async (filePath) => ({
+    file: '',
+    filePath,
+    error: 'File system access not available in web mode',
+    found: false,
+  }),
+  writeFile: async () => false,
+  ensureDirectory: async () => false,
+  listFiles: async () => [],
+  getBinaryPath: async () => '',
+  getPathForFile: (file) => URL.createObjectURL(file),
+  getAllowedExtensions: async () => [],
+  openDirectoryInExplorer: async () => false,
+
+  // Notifications
+  showNotification: (data) => {
+    if ('Notification' in window && Notification.permission === 'granted') {
+      new Notification(data.title, { body: data.body });
+    } else if ('Notification' in window && Notification.permission !== 'denied') {
+      Notification.requestPermission().then((perm) => {
+        if (perm === 'granted') new Notification(data.title, { body: data.body });
+      });
+    }
+  },
+  logInfo: (txt) => console.log('[goose]', txt),
+
+  // External links
+  openExternal: async (url) => {
+    window.open(url, '_blank', 'noopener');
+  },
+  openInChrome: (url) => {
+    window.open(url, '_blank', 'noopener');
+  },
+  fetchMetadata: async (url) => {
+    const resp = await fetch(url);
+    return resp.text();
+  },
+
+  // Settings via localStorage
+  getSetting: async <K extends SettingKey>(key: K): Promise<Settings[K]> => {
+    return loadSettings()[key];
+  },
+  setSetting: async <K extends SettingKey>(key: K, value: Settings[K]): Promise<void> => {
+    const s = loadSettings();
+    s[key] = value;
+    saveSettings(s);
+  },
+
+  // System toggles — no-op in browser
+  setMenuBarIcon: async () => false,
+  getMenuBarIconState: async () => false,
+  setDockIcon: async () => false,
+  getDockIconState: async () => false,
+  setWakelock: async (enable) => {
+    try {
+      if (enable && 'wakeLock' in navigator) {
+        await (navigator as never as { wakeLock: { request: (t: string) => Promise<unknown> } }).wakeLock.request('screen');
+        return true;
+      }
+    } catch {
+      // not supported
+    }
+    return false;
+  },
+  getWakelockState: async () => false,
+  setSpellcheck: async () => false,
+  getSpellcheckState: async () => true,
+  openNotificationsSettings: async () => false,
+
+  // Event bus
+  on: (channel, callback) => bus.on(channel, callback),
+  off: (channel, callback) => bus.off(channel, callback),
+  emit: (channel, ...args) => bus.emit(channel, ...args),
+  broadcastThemeChange: () => {},
+  onMouseBackButtonClicked: () => {},
+  offMouseBackButtonClicked: () => {},
+
+  // Auto-update — not applicable in web
+  getVersion: () => import.meta.env.VITE_GOOSE_VERSION ?? 'web',
+  checkForUpdates: async () => ({ updateInfo: null, error: null }),
+  downloadUpdate: async () => ({ success: false, error: 'Not available in web mode' }),
+  installUpdate: () => {},
+  restartApp: () => location.reload(),
+  onUpdaterEvent: () => {},
+  getUpdateState: async () => null,
+  isUsingGitHubFallback: async () => false,
+
+  // Mesh / Ollama — no-op in web
+  checkForOllama: async () => false,
+  checkMesh: async () => ({ running: false, installed: false, models: [] }),
+  startMesh: async () => ({ started: false, error: 'Not available in web mode' }),
+  stopMesh: async () => ({ stopped: false }),
+
+  // Recipes — use localStorage
+  hasAcceptedRecipeBefore: async () => false,
+  recordRecipeHash: async () => true,
+
+  // MCP apps — no-op
+  launchApp: async () => {},
+  refreshApp: async () => {},
+  closeApp: async () => {},
+
+  addRecentDir: async () => false,
+};

--- a/ui/desktop/src/platform/web.ts
+++ b/ui/desktop/src/platform/web.ts
@@ -2,11 +2,17 @@ import type { PlatformAPI, PlatformEventCallback } from './types';
 import { defaultSettings } from '../utils/settings';
 import type { Settings, SettingKey } from '../utils/settings';
 
-// Polyfill window.appConfig for web mode (Electron preload normally sets this)
+// Polyfill window.appConfig for web mode (Electron preload normally sets this).
+// Config values are injected by goose-web as <meta name="goose:KEY"> tags.
 if (typeof window !== 'undefined' && !window.appConfig) {
+  const readMeta = (name: string) =>
+    document.querySelector(`meta[name="goose:${name}"]`)?.getAttribute('content') ?? undefined;
+  const webConfig: Record<string, unknown> = {
+    GOOSE_WORKING_DIR: readMeta('working-dir') ?? '',
+  };
   (window as unknown as Record<string, unknown>).appConfig = {
-    get: () => undefined,
-    getAll: () => ({}),
+    get: (key: string) => webConfig[key],
+    getAll: () => webConfig,
   };
 }
 
@@ -105,7 +111,10 @@ export const webPlatform: PlatformAPI = {
 
   // Dialogs
   directoryChooser: async () => {
-    // No native directory picker on all browsers, return cancelled
+    const path = window.prompt('Enter working directory path:');
+    if (path) {
+      return { canceled: false, filePaths: [path] };
+    }
     return { canceled: true, filePaths: [] };
   },
 

--- a/ui/desktop/src/renderer.tsx
+++ b/ui/desktop/src/renderer.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense, lazy } from 'react';
 import ReactDOM from 'react-dom/client';
 import { IntlProvider } from 'react-intl';
+import { platform } from './platform';
 import { ConfigProvider } from './components/ConfigContext';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import SuspenseLoader from './suspense-loader';
@@ -22,7 +23,7 @@ const TELEMETRY_CONFIG_KEY = 'GOOSE_TELEMETRY_ENABLED';
   const isLauncher = window.location.hash === '#/launcher';
 
   if (!isLauncher) {
-    const gooseApiHost = await window.electron.getGoosedHostPort();
+    const gooseApiHost = await platform.getGoosedHostPort();
     if (gooseApiHost === null) {
       window.alert('failed to start goose backend process');
       return;
@@ -31,7 +32,7 @@ const TELEMETRY_CONFIG_KEY = 'GOOSE_TELEMETRY_ENABLED';
       baseUrl: gooseApiHost,
       headers: {
         'Content-Type': 'application/json',
-        'X-Secret-Key': await window.electron.getSecretKey(),
+        'X-Secret-Key': await platform.getSecretKey(),
       },
     });
 

--- a/ui/desktop/src/sessionLinks.ts
+++ b/ui/desktop/src/sessionLinks.ts
@@ -1,6 +1,7 @@
 import { fetchSharedSessionDetails, SharedSessionDetails } from './sharedSessions';
 import { View, ViewOptions } from './utils/navigationUtils';
 import { errorMessage } from './utils/conversionUtils';
+import { platform } from './platform';
 
 /**
  * Handles opening a shared session from a deep link
@@ -28,7 +29,7 @@ export async function openSharedSessionFromDeepLink(
 
     // If no baseUrl is provided, check if there's one in settings
     if (!baseUrl) {
-      const config = await window.electron.getSetting('sessionSharing');
+      const config = await platform.getSetting('sessionSharing');
       if (config.enabled && config.baseUrl) {
         baseUrl = config.baseUrl;
       } else {

--- a/ui/desktop/src/utils/keyboardShortcuts.ts
+++ b/ui/desktop/src/utils/keyboardShortcuts.ts
@@ -1,5 +1,7 @@
+import { platform } from '../platform';
+
 function isMac(): boolean {
-  return window.electron?.platform === 'darwin';
+  return platform.platform === 'darwin';
 }
 
 export function getNavigationShortcutText(): string {

--- a/ui/desktop/src/utils/platform_events.ts
+++ b/ui/desktop/src/utils/platform_events.ts
@@ -1,4 +1,5 @@
 import { listApps, GooseApp } from '../api';
+import { platform } from '../platform';
 
 interface PlatformEventData {
   extension: string;
@@ -33,7 +34,7 @@ async function handleAppsEvent(eventType: string, eventData: PlatformEventData):
   switch (eventType) {
     case 'app_created':
       if (targetApp) {
-        await window.electron.launchApp(targetApp).catch((err) => {
+        await platform.launchApp(targetApp).catch((err) => {
           console.error('Failed to launch newly created app:', err);
         });
       }
@@ -41,7 +42,7 @@ async function handleAppsEvent(eventType: string, eventData: PlatformEventData):
 
     case 'app_updated':
       if (targetApp) {
-        await window.electron.refreshApp(targetApp).catch((err) => {
+        await platform.refreshApp(targetApp).catch((err) => {
           console.error('Failed to refresh updated app:', err);
         });
       }
@@ -49,7 +50,7 @@ async function handleAppsEvent(eventType: string, eventData: PlatformEventData):
 
     case 'app_deleted':
       if (app_name) {
-        await window.electron.closeApp(app_name).catch((err) => {
+        await platform.closeApp(app_name).catch((err) => {
           console.error('Failed to close deleted app:', err);
         });
       }

--- a/ui/desktop/vite.web.config.mts
+++ b/ui/desktop/vite.web.config.mts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vite';
+import tailwindcss from '@tailwindcss/vite';
+import path from 'path';
+
+// Web-only Vite config — builds the React UI as static files
+// for serving via goose-web (no Electron, no preload).
+export default defineConfig({
+  define: {
+    'process.env.ALPHA': JSON.stringify(false),
+    'process.env.GOOSE_TUNNEL': JSON.stringify(false),
+  },
+
+  plugins: [tailwindcss()],
+
+  resolve: {
+    alias: {
+      // Ensure the same src root as electron renderer
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+
+  build: {
+    target: 'esnext',
+    outDir: 'dist-web',
+    emptyOutDir: true,
+  },
+});


### PR DESCRIPTION
## Summary

This PR adds browser-based access to the existing goose React UI, without changing the Electron desktop app.

**What's included:**

- **Platform abstraction layer** (`ui/desktop/src/platform/`) — runtime detection switches between Electron IPC and browser-native APIs. All ~50 renderer files now import `platform` instead of `window.electron` directly.
- **`goose-web` binary** (`crates/goose-web/`) — standalone Rust server that embeds the static web build, spawns `goosed` as a child process, and reverse-proxies API calls with secret key injection. Single binary, zero runtime deps.
- **Web Vite build** (`vite.web.config.mts`, `pnpm build:web`) — separate build target outputting to `dist-web/`.
- **Documentation** updates across CONTRIBUTING.md, ui/desktop/README.md, architecture docs, installation guide, and environment variables reference.

**How it works:**

```
Browser → goose-web (HTTP, localhost:3000) → goosed (HTTPS, child process)
              ↑ static files                      ↑ X-Secret-Key injected server-side
              ↑ meta tag config                   ↑ SSE streaming proxied
```

`goose-web --port 3000` is all you need — it finds/spawns goosed, generates a secret key, waits for health check, and serves the UI. Binds to `127.0.0.1` by default.

## Open questions — feedback wanted

### Working directory handling

Currently the working directory is set via `--dir` flag and injected as a `<meta>` tag. The directory chooser in web mode falls back to `window.prompt()` for entering a path string. This needs a proper solution:
- Should there be a server-side directory browser API?
- Should working directory changes be restricted to subdirectories of the initial `--dir`?
- How should this interact with sessions that change working directory mid-conversation?

### Security implications

- **Secret key**: The reverse proxy strips any client-sent `X-Secret-Key` and injects the real one server-side, so the browser never sees it. The `<meta>` tag for secret-key is intentionally left empty.
- **Network binding**: Defaults to `127.0.0.1` (localhost only). For remote access, authentication beyond the goosed secret key would need to be added.
- **File system access**: Most file system operations return safe defaults in web mode (read/write/list return errors or empty). The `directoryChooser` prompt accepting arbitrary paths is a UX concern.
- **CORS**: Currently wide open (`Any` origin) since the proxy is same-origin. May need tightening.

### What's NOT included (potential follow-ups)

- Auth for the web UI itself (login, OAuth, etc.)
- Server-side file browser for directory selection
- Docker image / deployment guide
- CI build step for `pnpm build:web`
- PWA / service worker support

Looking for feedback on the overall approach and the security/working-directory questions above. Is this a direction the project wants to go?

---

*This PR was generated with [Claude Code](https://claude.ai/code)*