### PR TITLE
Custom goose distros without re-builds

### DIFF
--- a/CUSTOM_DISTROS.md
+++ b/CUSTOM_DISTROS.md
@@ -45,6 +45,7 @@ goose's architecture is designed for extensibility. Organizations can create "re
 | What You Want | Where to Look | Complexity |
 |---------------|---------------|------------|
 | Preconfigure a model/provider | `config.yaml`, `init-config.yaml`, environment variables | Low |
+| Customize the desktop app without rebuilding | Distro overlay (`distro/` directory) | Low |
 | Add custom AI providers | `crates/goose/src/providers/declarative/` | Low |
 | Bundle custom MCP extensions | `config.yaml` extensions section, `ui/desktop/src/built-in-extensions.json`, `ui/desktop/src/components/settings/extensions/bundled-extensions.json` | Medium |
 | Modify system prompts | `crates/goose/src/prompts/` | Low |
@@ -64,6 +65,7 @@ cd goose
 
 ### 2. Choose Your Customization Strategy
 
+- **Distro overlay**: Drop config files alongside a stock goose release (no fork, no rebuild — see [Appendix J](#j-distro-overlay-no-fork-no-rebuild))
 - **Configuration-only**: Modify config files and environment variables (no code changes)
 - **Extension-based**: Add custom MCP servers for your tools (minimal core changes)
 - **Deep customization**: Modify core behavior, UI, or add new providers
@@ -828,3 +830,201 @@ prompt: |
 - Subagent execution: `crates/goose/src/agents/subagent_handler.rs`
 - Recipe sub_recipes field: `crates/goose/src/recipe/mod.rs` (SubRecipe struct)
 - Template rendering: `crates/goose/src/recipe/template_recipe.rs`
+
+---
+
+## J. Distro Overlay (No Fork, No Rebuild)
+
+**Goal**: Customize the Goose desktop app for your organization — preconfigured provider, custom extensions, internal registries, feature flags — without forking the repo, rebuilding from source, or re-signing the application.
+
+### How It Works
+
+On startup, the Goose desktop app looks for a `distro/` directory containing a `distro.json` file. If found, configuration is applied before the app finishes initializing. If not found, Goose behaves as the stock open-source release with zero changes.
+
+### Overlay Location
+
+The overlay lives inside the app bundle at `<app>/Contents/Resources/distro/` (macOS) or the equivalent `resources/distro/` on other platforms. Because it's inside the bundle, it's covered by the code signature — tampering breaks the signature and the OS refuses to launch the app.
+
+### Directory Structure
+
+```
+distro/
+├── distro.json                 # Required. Env vars + feature flags.
+├── bundled-extensions.json     # Optional. Replaces the default extension catalog.
+├── init-config.yaml            # Optional. First-run config for new users.
+├── bin/                        # Optional. Shell shims prepended to PATH.
+│   ├── uvx
+│   └── npx
+└── announcements/              # Optional. In-app announcement modals.
+    ├── index.json
+    └── content/
+        └── *.md
+```
+
+Every file except `distro.json` is optional. Include whichever subset you need.
+
+### `distro.json`
+
+Two top-level keys: `env` and `features`.
+
+**`env`** — key-value pairs injected into `process.env` before any other module reads them:
+
+```json
+{
+  "env": {
+    "GOOSE_DEFAULT_PROVIDER": "databricks",
+    "GOOSE_DEFAULT_MODEL": "my-model",
+    "DATABRICKS_HOST": "https://my-instance.cloud.databricks.com/",
+    "GOOSE_PREDEFINED_MODELS": "[{\"id\":1,\"name\":\"my-model\",\"provider\":\"databricks\",\"alias\":\"My Model\",\"subtext\":\"Custom\"}]",
+    "GOOSE_NPM_REGISTRY": "https://registry.example.com/npm/",
+    "GOOSE_UV_REGISTRY": "https://registry.example.com/pypi/simple",
+    "GOOSE_VERSION": "1.0.0-custom",
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "https://telemetry.example.com/"
+  }
+}
+```
+
+**`features`** — UI feature flags (all default to stock values when omitted):
+
+| Key | Type | Default | Effect |
+|-----|------|---------|--------|
+| `updatesEnabled` | `boolean` | `true` | Auto-update checks and prompts |
+| `costTrackingEnabled` | `boolean` | `true` | Token cost tracking UI |
+| `announcementsEnabled` | `boolean` | `false` | In-app announcement modals |
+| `configurationEnabled` | `boolean` | `true` | Provider/model configuration UI |
+| `telemetryUiEnabled` | `boolean` | `true` | Telemetry settings in the UI |
+| `dictationAllowedProviders` | `string[] \| null` | `null` | Restrict dictation to listed providers |
+
+```json
+{
+  "features": {
+    "updatesEnabled": false,
+    "configurationEnabled": false
+  }
+}
+```
+
+### `bundled-extensions.json`
+
+Replaces the default extension catalog in Settings → Extensions. Same format as `ui/desktop/src/components/settings/extensions/bundled-extensions.json`:
+
+```json
+[
+  {
+    "id": "developer",
+    "name": "developer",
+    "display_name": "Developer",
+    "description": "General development tools.",
+    "enabled": true,
+    "type": "builtin",
+    "env_keys": [],
+    "timeout": 300,
+    "bundled": true
+  }
+]
+```
+
+### `init-config.yaml`
+
+Applied when a user has no existing config (first run). Sets default provider, model, and extensions:
+
+```yaml
+GOOSE_MODEL: my-model
+GOOSE_PROVIDER: databricks
+DATABRICKS_HOST: https://my-instance.cloud.databricks.com/
+extensions:
+  developer:
+    display_name: Developer
+    enabled: true
+    name: developer
+    timeout: 300
+    type: builtin
+```
+
+Existing users with a `~/.config/goose/config.yaml` are not affected.
+
+### `bin/`
+
+Executable scripts here are prepended to `PATH` when spawning the `goosed` backend. Use this to override `uvx`, `npx`, or other commands with shims that route through internal registries.
+
+### `announcements/`
+
+In-app modals shown to users. Requires `"announcementsEnabled": true` in features.
+
+`announcements/index.json`:
+```json
+[
+  {
+    "id": "2024-q1-welcome",
+    "version": "1.0.0",
+    "title": "Welcome",
+    "file": "welcome.md",
+    "contentFile": "welcome.md"
+  }
+]
+```
+
+`announcements/content/welcome.md`: standard markdown.
+
+Each announcement is shown once per user (tracked by `id`). The `version` field gates the announcement to users on that version or later.
+
+### Quick Start
+
+```bash
+# 1. Download and unpack the stock Goose release
+unzip Goose-darwin-arm64.zip
+
+# 2. Create the distro overlay
+mkdir -p Goose.app/Contents/Resources/distro
+
+cat > Goose.app/Contents/Resources/distro/distro.json << 'EOF'
+{
+  "env": {
+    "GOOSE_DEFAULT_PROVIDER": "openai"
+  },
+  "features": {
+    "updatesEnabled": false
+  }
+}
+EOF
+
+# 3. Re-sign (required on macOS after modifying the bundle)
+codesign --deep --force --sign "Developer ID Application: Your Org" Goose.app
+
+# 4. Notarize
+xcrun notarytool submit Goose.zip --apple-id ... --team-id ... --password ...
+
+# 5. Distribute the re-signed app
+```
+
+For development/testing, you can skip signing and run unsigned:
+```bash
+# Place overlay in the Electron resources path used by `npm run dev`
+mkdir -p ui/desktop/src/distro
+cp distro.json ui/desktop/src/distro/
+# Add 'src/distro' to extraResource in forge.config.ts for dev builds
+```
+
+### Error Handling
+
+A malformed `distro.json` is logged and ignored — the app starts with stock defaults.
+
+### Deployment
+
+The recommended workflow is **repackage + re-sign** (no rebuild):
+
+1. Download the stock Goose release artifact.
+2. Unpack the `.app` bundle.
+3. Copy your `distro/` directory into `Contents/Resources/`.
+4. Re-sign and notarize.
+5. Distribute.
+
+No Rust compilation, no Node bundling. The overlay is versioned with the app it ships in, scoped to that specific build, and protected by the code signature.
+
+### Technical Details
+
+- Overlay loader: `ui/desktop/src/distro.ts`
+- Feature flag plumbing: `ui/desktop/src/main.ts` (appConfig), `ui/desktop/src/updates.ts` (renderer)
+- Extensions override: `ui/desktop/src/components/settings/extensions/bundled-extensions.ts`
+- Init config: `crates/goose/src/config/base.rs` (`GOOSE_INIT_CONFIG` env var)
+- PATH injection: `ui/desktop/src/goosed.ts` (`buildGoosedEnv`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4573,7 +4573,7 @@ dependencies = [
 
 [[package]]
 name = "goose-sdk"
-version = "1.29.0"
+version = "1.30.0"
 dependencies = [
  "agent-client-protocol-schema",
  "sacp",

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -1086,7 +1086,6 @@ fn find_workspace_or_exe_root() -> Option<PathBuf> {
 }
 
 pub fn load_init_config_from_workspace() -> Result<Mapping, ConfigError> {
-    // Check for distro-provided init config first
     if let Ok(init_config_path) = std::env::var("GOOSE_INIT_CONFIG") {
         let path = PathBuf::from(&init_config_path);
         if path.exists() {
@@ -1095,7 +1094,6 @@ pub fn load_init_config_from_workspace() -> Result<Mapping, ConfigError> {
         }
     }
 
-    // Fall through to existing workspace root logic
     let root = find_workspace_or_exe_root().ok_or_else(|| {
         ConfigError::FileError(std::io::Error::new(
             std::io::ErrorKind::NotFound,

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -1086,6 +1086,16 @@ fn find_workspace_or_exe_root() -> Option<PathBuf> {
 }
 
 pub fn load_init_config_from_workspace() -> Result<Mapping, ConfigError> {
+    // Check for distro-provided init config first
+    if let Ok(init_config_path) = std::env::var("GOOSE_INIT_CONFIG") {
+        let path = PathBuf::from(&init_config_path);
+        if path.exists() {
+            let content = std::fs::read_to_string(&path)?;
+            return parse_yaml_content(&content);
+        }
+    }
+
+    // Fall through to existing workspace root logic
     let root = find_workspace_or_exe_root().ok_or_else(|| {
         ConfigError::FileError(std::io::Error::new(
             std::io::ErrorKind::NotFound,

--- a/ui/desktop/src/components/AnnouncementModal.tsx
+++ b/ui/desktop/src/components/AnnouncementModal.tsx
@@ -57,9 +57,20 @@ export default function AnnouncementModal() {
       }
 
       try {
-        // Load the announcements index
-        const indexModule = await import('../../announcements/index.json');
-        const announcements = indexModule.default as AnnouncementMeta[];
+        // Try distro announcements first, then fall back to bundled
+        let announcements: AnnouncementMeta[];
+        try {
+          const distroAnnouncements = await window.electron.getDistroAnnouncements();
+          if (distroAnnouncements) {
+            announcements = distroAnnouncements as AnnouncementMeta[];
+          } else {
+            const indexModule = await import('../../announcements/index.json');
+            announcements = indexModule.default as AnnouncementMeta[];
+          }
+        } catch {
+          const indexModule = await import('../../announcements/index.json');
+          announcements = indexModule.default as AnnouncementMeta[];
+        }
 
         // Get current app version
         const currentVersion = packageJson.version;
@@ -82,7 +93,10 @@ export default function AnnouncementModal() {
         if (unseenAnnouncementsList.length > 0) {
           // Load content for all unseen announcements
           const contentPromises = unseenAnnouncementsList.map(async (announcement) => {
-            const content = getAnnouncementContent(announcement.file);
+            // Distro announcements may have content inlined; fall back to bundled loader
+            const content =
+              (announcement as AnnouncementMeta & { content?: string }).content ||
+              getAnnouncementContent(announcement.file);
             return { announcement, content };
           });
 

--- a/ui/desktop/src/components/AnnouncementModal.tsx
+++ b/ui/desktop/src/components/AnnouncementModal.tsx
@@ -57,7 +57,6 @@ export default function AnnouncementModal() {
       }
 
       try {
-        // Try distro announcements first, then fall back to bundled
         let announcements: AnnouncementMeta[];
         try {
           const distroAnnouncements = await window.electron.getDistroAnnouncements();

--- a/ui/desktop/src/components/settings/extensions/bundled-extensions.ts
+++ b/ui/desktop/src/components/settings/extensions/bundled-extensions.ts
@@ -26,7 +26,9 @@ async function loadBundledExtensions(): Promise<BundledExtension[]> {
   if (bundledExtensionsOverride !== null) return bundledExtensionsOverride;
 
   try {
-    const distroExtensions = await window.electron.getDistroBundledExtensions();
+    const distroExtensions = (await window.electron.getDistroBundledExtensions()) as
+      | BundledExtension[]
+      | null;
     if (distroExtensions) {
       bundledExtensionsOverride = distroExtensions;
       return distroExtensions;

--- a/ui/desktop/src/components/settings/extensions/bundled-extensions.ts
+++ b/ui/desktop/src/components/settings/extensions/bundled-extensions.ts
@@ -32,7 +32,7 @@ async function loadBundledExtensions(): Promise<BundledExtension[]> {
       return distroExtensions;
     }
   } catch {
-    // Fall through to default
+    // use default
   }
   return defaultBundledExtensionsData as BundledExtension[];
 }
@@ -75,7 +75,6 @@ export async function syncBundledExtensions(
   addExtensionFn: (name: string, config: ExtensionConfig, enabled: boolean) => Promise<void>
 ): Promise<void> {
   try {
-    // Load bundled extensions (may be overridden by distro overlay)
     const bundledExtensions = await loadBundledExtensions();
 
     // Process each bundled extension

--- a/ui/desktop/src/components/settings/extensions/bundled-extensions.ts
+++ b/ui/desktop/src/components/settings/extensions/bundled-extensions.ts
@@ -1,6 +1,6 @@
 import type { ExtensionConfig } from '../../../api/types.gen';
 import { FixedExtensionEntry } from '../../ConfigContext';
-import bundledExtensionsData from './bundled-extensions.json';
+import defaultBundledExtensionsData from './bundled-extensions.json';
 import { nameToKey } from './utils';
 
 // Type definition for built-in extensions from JSON
@@ -19,6 +19,23 @@ type BundledExtension = {
   timeout?: number;
   allow_configure?: boolean;
 };
+
+let bundledExtensionsOverride: BundledExtension[] | null = null;
+
+async function loadBundledExtensions(): Promise<BundledExtension[]> {
+  if (bundledExtensionsOverride !== null) return bundledExtensionsOverride;
+
+  try {
+    const distroExtensions = await window.electron.getDistroBundledExtensions();
+    if (distroExtensions) {
+      bundledExtensionsOverride = distroExtensions;
+      return distroExtensions;
+    }
+  } catch {
+    // Fall through to default
+  }
+  return defaultBundledExtensionsData as BundledExtension[];
+}
 
 const DEPRECATED_GOOGLE_DRIVE_IDS = ['googledrive', 'google_drive'];
 const DEPRECATED_GOOGLE_DRIVE_ENV_KEYS = [
@@ -58,8 +75,8 @@ export async function syncBundledExtensions(
   addExtensionFn: (name: string, config: ExtensionConfig, enabled: boolean) => Promise<void>
 ): Promise<void> {
   try {
-    // Cast the imported JSON data to the expected type
-    const bundledExtensions = bundledExtensionsData as BundledExtension[];
+    // Load bundled extensions (may be overridden by distro overlay)
+    const bundledExtensions = await loadBundledExtensions();
 
     // Process each bundled extension
     for (const bundledExt of bundledExtensions) {

--- a/ui/desktop/src/components/settings/reset_provider/ResetProviderSection.tsx
+++ b/ui/desktop/src/components/settings/reset_provider/ResetProviderSection.tsx
@@ -9,9 +9,17 @@ const i18n = defineMessages({
     id: 'resetProviderSection.resetButton',
     defaultMessage: 'Reset Provider and Model',
   },
+  resetButtonDistro: {
+    id: 'resetProviderSection.resetButtonDistro',
+    defaultMessage: 'Reset to {distroName} Defaults',
+  },
   resetDescription: {
     id: 'resetProviderSection.resetDescription',
     defaultMessage: "This will clear your selected model and provider settings. If no defaults are available, you'll be taken to the welcome screen to set them up again.",
+  },
+  resetDescriptionDistro: {
+    id: 'resetProviderSection.resetDescriptionDistro',
+    defaultMessage: 'This will reset your model and provider settings to the {distroName} defaults.',
   },
 });
 
@@ -22,6 +30,10 @@ interface ResetProviderSectionProps {
 export default function ResetProviderSection(_props: ResetProviderSectionProps) {
   const intl = useIntl();
   const { remove } = useConfig();
+
+  const distroName = window.appConfig.get('DISTRO_NAME') as string | null;
+  const hasDistroDefaults =
+    distroName && window.appConfig.get('GOOSE_DEFAULT_PROVIDER');
 
   const handleResetProvider = async () => {
     try {
@@ -42,10 +54,14 @@ export default function ResetProviderSection(_props: ResetProviderSectionProps) 
         className="flex items-center justify-center gap-2"
       >
         <RefreshCw className="h-4 w-4" />
-        {intl.formatMessage(i18n.resetButton)}
+        {hasDistroDefaults
+          ? intl.formatMessage(i18n.resetButtonDistro, { distroName })
+          : intl.formatMessage(i18n.resetButton)}
       </Button>
       <p className="text-xs text-text-secondary mt-2">
-        {intl.formatMessage(i18n.resetDescription)}
+        {hasDistroDefaults
+          ? intl.formatMessage(i18n.resetDescriptionDistro, { distroName })
+          : intl.formatMessage(i18n.resetDescription)}
       </p>
     </div>
   );

--- a/ui/desktop/src/distro.ts
+++ b/ui/desktop/src/distro.ts
@@ -1,6 +1,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { app } from 'electron';
+
+let app: Electron.App | undefined;
+try {
+  app = require('electron').app;
+} catch {
+  // Not running inside Electron (e.g. tests importing goosed.ts)
+}
 
 interface DistroConfig {
   env?: Record<string, string>;
@@ -11,14 +17,24 @@ let distroDir: string | null = null;
 let distroConfig: DistroConfig = {};
 
 function findDistroDir(): string | null {
-  const externalPath = path.join(app.getPath('userData'), 'distro');
-  if (fs.existsSync(path.join(externalPath, 'distro.json'))) {
-    return externalPath;
+  if (!app) return null;
+
+  try {
+    const externalPath = path.join(app.getPath('userData'), 'distro');
+    if (fs.existsSync(path.join(externalPath, 'distro.json'))) {
+      return externalPath;
+    }
+  } catch {
+    // app.getPath may throw outside a fully initialized Electron context
   }
 
-  const bundlePath = path.join(process.resourcesPath, 'distro');
-  if (fs.existsSync(path.join(bundlePath, 'distro.json'))) {
-    return bundlePath;
+  try {
+    const bundlePath = path.join(process.resourcesPath, 'distro');
+    if (fs.existsSync(path.join(bundlePath, 'distro.json'))) {
+      return bundlePath;
+    }
+  } catch {
+    // process.resourcesPath may be undefined outside Electron
   }
 
   return null;

--- a/ui/desktop/src/distro.ts
+++ b/ui/desktop/src/distro.ts
@@ -11,13 +11,11 @@ let distroDir: string | null = null;
 let distroConfig: DistroConfig = {};
 
 function findDistroDir(): string | null {
-  // 1. Check external path (no re-signing needed)
   const externalPath = path.join(app.getPath('userData'), 'distro');
   if (fs.existsSync(path.join(externalPath, 'distro.json'))) {
     return externalPath;
   }
 
-  // 2. Check in-bundle path
   const bundlePath = path.join(process.resourcesPath, 'distro');
   if (fs.existsSync(path.join(bundlePath, 'distro.json'))) {
     return bundlePath;
@@ -32,7 +30,6 @@ if (distroDir) {
   const configPath = path.join(distroDir, 'distro.json');
   distroConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
 
-  // Apply env var overrides immediately
   if (distroConfig.env) {
     for (const [key, value] of Object.entries(distroConfig.env)) {
       process.env[key] = value;

--- a/ui/desktop/src/distro.ts
+++ b/ui/desktop/src/distro.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { app } from 'electron';
 
 interface DistroConfig {
   env?: Record<string, string>;
@@ -11,17 +10,6 @@ let distroDir: string | null = null;
 let distroConfig: DistroConfig = {};
 
 function findDistroDir(): string | null {
-  if (!app) return null;
-
-  try {
-    const externalPath = path.join(app.getPath('userData'), 'distro');
-    if (fs.existsSync(path.join(externalPath, 'distro.json'))) {
-      return externalPath;
-    }
-  } catch {
-    // app.getPath may throw outside a fully initialized Electron context
-  }
-
   try {
     const bundlePath = path.join(process.resourcesPath, 'distro');
     if (fs.existsSync(path.join(bundlePath, 'distro.json'))) {

--- a/ui/desktop/src/distro.ts
+++ b/ui/desktop/src/distro.ts
@@ -27,13 +27,19 @@ function findDistroDir(): string | null {
 // Executes on import — must be imported before anything that reads process.env
 distroDir = findDistroDir();
 if (distroDir) {
-  const configPath = path.join(distroDir, 'distro.json');
-  distroConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  try {
+    const configPath = path.join(distroDir, 'distro.json');
+    distroConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
 
-  if (distroConfig.env) {
-    for (const [key, value] of Object.entries(distroConfig.env)) {
-      process.env[key] = value;
+    if (distroConfig.env) {
+      for (const [key, value] of Object.entries(distroConfig.env)) {
+        process.env[key] = value;
+      }
     }
+  } catch (err) {
+    console.error('Failed to load distro.json, falling back to stock defaults:', err);
+    distroDir = null;
+    distroConfig = {};
   }
 }
 

--- a/ui/desktop/src/distro.ts
+++ b/ui/desktop/src/distro.ts
@@ -1,0 +1,58 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { app } from 'electron';
+
+interface DistroConfig {
+  env?: Record<string, string>;
+  features?: Record<string, unknown>;
+}
+
+let distroDir: string | null = null;
+let distroConfig: DistroConfig = {};
+
+function findDistroDir(): string | null {
+  // 1. Check external path (no re-signing needed)
+  const externalPath = path.join(app.getPath('userData'), 'distro');
+  if (fs.existsSync(path.join(externalPath, 'distro.json'))) {
+    return externalPath;
+  }
+
+  // 2. Check in-bundle path
+  const bundlePath = path.join(process.resourcesPath, 'distro');
+  if (fs.existsSync(path.join(bundlePath, 'distro.json'))) {
+    return bundlePath;
+  }
+
+  return null;
+}
+
+// Executes on import — must be imported before anything that reads process.env
+distroDir = findDistroDir();
+if (distroDir) {
+  const configPath = path.join(distroDir, 'distro.json');
+  distroConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+
+  // Apply env var overrides immediately
+  if (distroConfig.env) {
+    for (const [key, value] of Object.entries(distroConfig.env)) {
+      process.env[key] = value;
+    }
+  }
+}
+
+export function getDistroFeature<T>(key: string, defaultValue: T): T {
+  if (distroConfig.features && key in distroConfig.features) {
+    return distroConfig.features[key] as T;
+  }
+  return defaultValue;
+}
+
+export function getDistroDir(): string | null {
+  return distroDir;
+}
+
+export function getDistroFilePath(relativePath: string): string | null {
+  if (!distroDir) return null;
+  const fullPath = path.join(distroDir, relativePath);
+  return fs.existsSync(fullPath) ? fullPath : null;
+}

--- a/ui/desktop/src/distro.ts
+++ b/ui/desktop/src/distro.ts
@@ -1,12 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-
-let app: Electron.App | undefined;
-try {
-  app = require('electron').app;
-} catch {
-  // Not running inside Electron (e.g. tests importing goosed.ts)
-}
+import { app } from 'electron';
 
 interface DistroConfig {
   env?: Record<string, string>;

--- a/ui/desktop/src/distro.ts
+++ b/ui/desktop/src/distro.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 interface DistroConfig {
+  name?: string;
   env?: Record<string, string>;
   features?: Record<string, unknown>;
 }
@@ -46,6 +47,10 @@ export function getDistroFeature<T>(key: string, defaultValue: T): T {
     return distroConfig.features[key] as T;
   }
   return defaultValue;
+}
+
+export function getDistroName(): string | null {
+  return distroConfig.name || null;
 }
 
 export function getDistroDir(): string | null {

--- a/ui/desktop/src/goosed.ts
+++ b/ui/desktop/src/goosed.ts
@@ -6,6 +6,7 @@ import { createServer } from 'net';
 import { Buffer } from 'node:buffer';
 import { status } from './api';
 import { Client, createClient, createConfig } from './api/client';
+import { getDistroFilePath } from './distro';
 
 export interface Logger {
   info: (...args: unknown[]) => void;
@@ -128,10 +129,20 @@ export const buildGoosedEnv = (
   // Add binary directory to PATH for any dependencies
   const pathKey = process.platform === 'win32' ? 'Path' : 'PATH';
   const currentPath = process.env[pathKey] || '';
+  let newPath = currentPath;
+
   if (binaryPath) {
-    env[pathKey] = `${path.dirname(binaryPath)}${path.delimiter}${currentPath}`;
-  } else if (currentPath) {
-    env[pathKey] = currentPath;
+    newPath = `${path.dirname(binaryPath)}${path.delimiter}${newPath}`;
+  }
+
+  // Prepend distro bin path (takes precedence over default shims)
+  const distroBinPath = getDistroFilePath('bin');
+  if (distroBinPath) {
+    newPath = `${distroBinPath}${path.delimiter}${newPath}`;
+  }
+
+  if (newPath) {
+    env[pathKey] = newPath;
   }
 
   return env;
@@ -244,6 +255,12 @@ export const startGoosed = async (options: StartGoosedOptions): Promise<GoosedRe
     if (value !== undefined) {
       spawnEnv[key] = value;
     }
+  }
+
+  // Pass distro init-config path to goosed if available
+  const initConfigPath = getDistroFilePath('init-config.yaml');
+  if (initConfigPath) {
+    spawnEnv.GOOSE_INIT_CONFIG = initConfigPath;
   }
 
   const spawnCommand = goosedPath;

--- a/ui/desktop/src/goosed.ts
+++ b/ui/desktop/src/goosed.ts
@@ -257,7 +257,6 @@ export const startGoosed = async (options: StartGoosedOptions): Promise<GoosedRe
     }
   }
 
-  // Pass distro init-config path to goosed if available
   const initConfigPath = getDistroFilePath('init-config.yaml');
   if (initConfigPath) {
     spawnEnv.GOOSE_INIT_CONFIG = initConfigPath;

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -3251,8 +3251,14 @@
   "resetProviderSection.resetButton": {
     "defaultMessage": "Reset Provider and Model"
   },
+  "resetProviderSection.resetButtonDistro": {
+    "defaultMessage": "Reset to {distroName} Defaults"
+  },
   "resetProviderSection.resetDescription": {
     "defaultMessage": "This will clear your selected model and provider settings. If no defaults are available, you'll be taken to the welcome screen to set them up again."
+  },
+  "resetProviderSection.resetDescriptionDistro": {
+    "defaultMessage": "This will reset your model and provider settings to the {distroName} defaults."
   },
   "responseStyle.conciseDescription": {
     "defaultMessage": "Tool calls are by default closed and only show the tool used"

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -1,3 +1,4 @@
+import './distro'; // Must be first — sets process.env before other modules load
 import type { OpenDialogOptions, OpenDialogReturnValue } from 'electron';
 import {
   app,
@@ -45,7 +46,9 @@ import {
   setupAutoUpdater,
   updateTrayMenu,
 } from './utils/autoUpdater';
-import { UPDATES_ENABLED } from './updates';
+import { getDistroFeature, getDistroFilePath, getDistroDir } from './distro';
+
+const UPDATES_ENABLED = getDistroFeature('updatesEnabled', true);
 import './utils/recipeHash';
 import { Client } from './api/client';
 import { GooseApp } from './api';
@@ -539,6 +542,15 @@ let appConfig = {
   GOOSE_LOCALE: process.env.GOOSE_LOCALE || undefined,
   // If GOOSE_ALLOWLIST_WARNING env var is not set, defaults to false (strict blocking mode)
   GOOSE_ALLOWLIST_WARNING: process.env.GOOSE_ALLOWLIST_WARNING === 'true',
+  DISTRO_UPDATES_ENABLED: getDistroFeature('updatesEnabled', true),
+  DISTRO_COST_TRACKING_ENABLED: getDistroFeature('costTrackingEnabled', true),
+  DISTRO_ANNOUNCEMENTS_ENABLED: getDistroFeature('announcementsEnabled', false),
+  DISTRO_CONFIGURATION_ENABLED: getDistroFeature('configurationEnabled', true),
+  DISTRO_TELEMETRY_UI_ENABLED: getDistroFeature('telemetryUiEnabled', true),
+  DISTRO_DICTATION_ALLOWED_PROVIDERS: getDistroFeature<string[] | null>(
+    'dictationAllowedProviders',
+    null
+  ),
 };
 
 const windowMap = new Map<number, BrowserWindow>();
@@ -1728,6 +1740,32 @@ ipcMain.handle('show-save-dialog', async (_event, options) => {
 
 ipcMain.handle('get-allowed-extensions', async () => {
   return await getAllowList();
+});
+
+ipcMain.handle('get-distro-bundled-extensions', async () => {
+  const extensionsPath = getDistroFilePath('bundled-extensions.json');
+  if (extensionsPath) {
+    const data = fsSync.readFileSync(extensionsPath, 'utf-8');
+    return JSON.parse(data);
+  }
+  return null;
+});
+
+ipcMain.handle('get-distro-announcements', async () => {
+  const indexPath = getDistroFilePath('announcements/index.json');
+  if (!indexPath) return null;
+
+  const index = JSON.parse(fsSync.readFileSync(indexPath, 'utf-8'));
+  const distroPath = getDistroDir()!;
+  for (const entry of index) {
+    if (entry.contentFile) {
+      const mdPath = path.join(distroPath, 'announcements', 'content', entry.contentFile);
+      if (fsSync.existsSync(mdPath)) {
+        entry.content = fsSync.readFileSync(mdPath, 'utf-8');
+      }
+    }
+  }
+  return index;
 });
 
 const createNewWindow = async (app: App, dir?: string | null) => {

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -46,7 +46,7 @@ import {
   setupAutoUpdater,
   updateTrayMenu,
 } from './utils/autoUpdater';
-import { getDistroFeature, getDistroFilePath, getDistroDir } from './distro';
+import { getDistroFeature, getDistroFilePath, getDistroDir, getDistroName } from './distro';
 
 const UPDATES_ENABLED = getDistroFeature('updatesEnabled', true);
 import './utils/recipeHash';
@@ -551,6 +551,7 @@ let appConfig = {
     'dictationAllowedProviders',
     null
   ),
+  DISTRO_NAME: getDistroName(),
 };
 
 const windowMap = new Map<number, BrowserWindow>();

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -183,7 +183,6 @@ type ElectronAPI = {
   refreshApp: (app: GooseApp) => Promise<void>;
   closeApp: (appName: string) => Promise<void>;
   addRecentDir: (dir: string) => Promise<boolean>;
-  // Distro overlay functions
   getDistroBundledExtensions: () => Promise<unknown[] | null>;
   getDistroAnnouncements: () => Promise<unknown[] | null>;
 };

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -183,6 +183,9 @@ type ElectronAPI = {
   refreshApp: (app: GooseApp) => Promise<void>;
   closeApp: (appName: string) => Promise<void>;
   addRecentDir: (dir: string) => Promise<boolean>;
+  // Distro overlay functions
+  getDistroBundledExtensions: () => Promise<unknown[] | null>;
+  getDistroAnnouncements: () => Promise<unknown[] | null>;
 };
 
 type AppConfigAPI = {
@@ -336,6 +339,8 @@ const electronAPI: ElectronAPI = {
   refreshApp: (app: GooseApp) => ipcRenderer.invoke('refresh-app', app),
   closeApp: (appName: string) => ipcRenderer.invoke('close-app', appName),
   addRecentDir: (dir: string) => ipcRenderer.invoke('add-recent-dir', dir),
+  getDistroBundledExtensions: () => ipcRenderer.invoke('get-distro-bundled-extensions'),
+  getDistroAnnouncements: () => ipcRenderer.invoke('get-distro-announcements'),
 };
 
 const appConfigAPI: AppConfigAPI = {

--- a/ui/desktop/src/updates.ts
+++ b/ui/desktop/src/updates.ts
@@ -1,6 +1,9 @@
-export const UPDATES_ENABLED = true;
-export const COST_TRACKING_ENABLED = true;
-export const ANNOUNCEMENTS_ENABLED = false;
-export const CONFIGURATION_ENABLED = true;
-export const TELEMETRY_UI_ENABLED = true;
-export const DICTATION_ALLOWED_PROVIDERS: string[] | null = null;
+export const UPDATES_ENABLED = window.appConfig?.get('DISTRO_UPDATES_ENABLED') ?? true;
+export const COST_TRACKING_ENABLED = window.appConfig?.get('DISTRO_COST_TRACKING_ENABLED') ?? true;
+export const ANNOUNCEMENTS_ENABLED =
+  window.appConfig?.get('DISTRO_ANNOUNCEMENTS_ENABLED') ?? false;
+export const CONFIGURATION_ENABLED =
+  window.appConfig?.get('DISTRO_CONFIGURATION_ENABLED') ?? true;
+export const TELEMETRY_UI_ENABLED = window.appConfig?.get('DISTRO_TELEMETRY_UI_ENABLED') ?? true;
+export const DICTATION_ALLOWED_PROVIDERS: string[] | null =
+  (window.appConfig?.get('DISTRO_DICTATION_ALLOWED_PROVIDERS') as string[] | null) ?? null;


### PR DESCRIPTION
Allows customizing a goose distribution without re-building. Can be done either within the electron package (resources dir) or externally in user data (e.g. `~/Library/Application\ Support/Goose/distro`)