### PR TITLE
fix: allow manual model entry when provider model listing fails

### DIFF
--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
@@ -115,14 +115,6 @@ const i18n = defineMessages({
     id: 'switchModelModal.checkProviderConfig',
     defaultMessage: 'Check your provider configuration in Settings → Providers',
   },
-  couldNotFetchModels: {
-    id: 'switchModelModal.couldNotFetchModels',
-    defaultMessage: 'Could not fetch models from provider',
-  },
-  manualEntryHint: {
-    id: 'switchModelModal.manualEntryHint',
-    defaultMessage: 'You can still enter a model name manually, or check your provider configuration in Settings → Providers.',
-  },
   loadingModels: {
     id: 'switchModelModal.loadingModels',
     defaultMessage: 'Loading models…',
@@ -855,13 +847,13 @@ export const SwitchModelModal = ({
                         <div className="flex items-start">
                           <div className="flex-1">
                             <h3 className="text-sm font-medium text-yellow-800 dark:text-yellow-200">
-                              {intl.formatMessage(i18n.couldNotFetchModels)}
+                              {intl.formatMessage(i18n.couldNotContactProvider)}
                             </h3>
                             <div className="mt-1 text-sm text-yellow-700 dark:text-yellow-300">
                               {providerErrors[provider]}
                             </div>
                             <div className="mt-2 text-xs text-yellow-600 dark:text-yellow-400">
-                              {intl.formatMessage(i18n.manualEntryHint)}
+                              {intl.formatMessage(i18n.checkProviderConfig)}
                             </div>
                           </div>
                         </div>

--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
@@ -115,6 +115,14 @@ const i18n = defineMessages({
     id: 'switchModelModal.checkProviderConfig',
     defaultMessage: 'Check your provider configuration in Settings → Providers',
   },
+  couldNotFetchModels: {
+    id: 'switchModelModal.couldNotFetchModels',
+    defaultMessage: 'Could not fetch models from provider',
+  },
+  manualEntryHint: {
+    id: 'switchModelModal.manualEntryHint',
+    defaultMessage: 'You can still enter a model name manually, or check your provider configuration in Settings → Providers.',
+  },
   loadingModels: {
     id: 'switchModelModal.loadingModels',
     defaultMessage: 'Loading models…',
@@ -841,21 +849,33 @@ export const SwitchModelModal = ({
                       </div>
                     </div>
                   ) : providerErrors[provider] ? (
-                    /* Show error message when provider failed to connect */
-                    <div className="rounded-md bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-3">
-                      <div className="flex items-start">
-                        <div className="flex-1">
-                          <h3 className="text-sm font-medium text-red-800 dark:text-red-200">
-                            {intl.formatMessage(i18n.couldNotContactProvider)}
-                          </h3>
-                          <div className="mt-1 text-sm text-red-700 dark:text-red-300">
-                            {providerErrors[provider]}
-                          </div>
-                          <div className="mt-2 text-xs text-red-600 dark:text-red-400">
-                            {intl.formatMessage(i18n.checkProviderConfig)}
+                    /* Show error with custom model input so users aren't stuck */
+                    <div className="flex flex-col gap-2">
+                      <div className="rounded-md bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 p-3">
+                        <div className="flex items-start">
+                          <div className="flex-1">
+                            <h3 className="text-sm font-medium text-yellow-800 dark:text-yellow-200">
+                              {intl.formatMessage(i18n.couldNotFetchModels)}
+                            </h3>
+                            <div className="mt-1 text-sm text-yellow-700 dark:text-yellow-300">
+                              {providerErrors[provider]}
+                            </div>
+                            <div className="mt-2 text-xs text-yellow-600 dark:text-yellow-400">
+                              {intl.formatMessage(i18n.manualEntryHint)}
+                            </div>
                           </div>
                         </div>
                       </div>
+                      <label className="text-sm text-text-secondary">{intl.formatMessage(i18n.customModelName)}</label>
+                      <Input
+                        className="border-2 px-4 py-5"
+                        placeholder={intl.formatMessage(i18n.typeModelName)}
+                        onChange={(event) => setModel(event.target.value)}
+                        value={model}
+                      />
+                      {attemptedSubmit && validationErrors.model && (
+                        <div className="text-red-500 text-sm mt-1">{validationErrors.model}</div>
+                      )}
                     </div>
                   ) : !isCustomModel ? (
                     <div>


### PR DESCRIPTION
Closes https://github.com/block/goose/issues/7636

## Summary
- When a provider's model listing API fails (e.g., `/v1/models` returns 404 through a proxy like Azure AI Foundry), the Switch Models dialog showed a dead-end red error banner with no way to proceed
- Replace the blocking error with a yellow warning banner + text input so users can still type a model name manually
- **Pure UI escape hatch — no backend changes, no health check bypass.** The `/v1/models` health check still runs and the error is still surfaced to the user as a warning. This does not restore the `known_models` fallback or touch `modelInterface.ts` at all.

### Note on prior PR #7649
That PR was closed because it restored the `known_models` fallback for all providers in `modelInterface.ts`, which subverted the health check introduced in PR #6744. This PR takes a different approach — it only changes the UI layer (`SwitchModelModal.tsx`) to add a manual input alongside the existing warning, so the health check behavior is fully preserved.

## Test plan
- [x] Set `ANTHROPIC_HOST` to a bad endpoint (e.g., `http://localhost:9999`) in `~/.config/goose/config.yaml`
- [x] Open Switch Models → select Anthropic
- [x] **Before**: red dead-end error, no model input, user is stuck
- [x] **After**: yellow warning banner with text input to manually enter a model name
- [x] Verify normal providers (with working model listing) still show the dropdown as usual
- [x] Verify local provider still shows the "download models" UI when no models are downloaded