### PR TITLE
Add chat history search feature to navigation panel

### DIFF
--- a/ui/desktop/src/components/Layout/CondensedRenderer.tsx
+++ b/ui/desktop/src/components/Layout/CondensedRenderer.tsx
@@ -5,6 +5,7 @@ import { defineMessages, useIntl } from '../../i18n';
 import { cn } from '../../utils';
 import { DropdownMenu, DropdownMenuTrigger } from '../ui/dropdown-menu';
 import { ChatSessionsDropdown, SessionsList } from './navigation';
+import { ChatHistorySearch } from '../conversation/ChatHistorySearch';
 import type { NavigationRendererProps } from './navigation/types';
 
 const i18n = defineMessages({
@@ -74,6 +75,20 @@ export const CondensedRenderer: React.FC<NavigationRendererProps> = ({
       {/* Left spacer (horizontal top position only) */}
       {!isVertical && isTopPosition && (
         <div className="bg-background-primary rounded-lg self-stretch w-[160px] flex-shrink-0" />
+      )}
+
+      {/* Search bar — skip mount entirely in icon-only mode so the
+          document-level Cmd/Ctrl+K handler inside ChatHistorySearch
+          does not intercept the shortcut when no UI is visible. */}
+      {!isCondensedIconOnly && (
+        <div className={cn(isVertical ? 'w-full px-2 pb-1' : 'py-1.5 px-3')}>
+          <ChatHistorySearch
+            onSessionClick={onSessionClick}
+            getSessionStatus={getSessionStatus}
+            clearUnread={clearUnread}
+            activeSessionId={activeSessionId}
+          />
+        </div>
       )}
 
       {/* Navigation items */}

--- a/ui/desktop/src/components/Layout/ExpandedRenderer.tsx
+++ b/ui/desktop/src/components/Layout/ExpandedRenderer.tsx
@@ -5,6 +5,7 @@ import { Z_INDEX } from './constants';
 import { cn } from '../../utils';
 import { DropdownMenu, DropdownMenuTrigger } from '../ui/dropdown-menu';
 import { ChatSessionsDropdown } from './navigation';
+import { ChatHistorySearch } from '../conversation/ChatHistorySearch';
 import type { NavigationRendererProps } from './navigation/types';
 
 export const ExpandedRenderer: React.FC<NavigationRendererProps> = ({
@@ -141,6 +142,19 @@ export const ExpandedRenderer: React.FC<NavigationRendererProps> = ({
             alignContent: 'start',
           }}
         >
+          {/* Search bar spanning full width */}
+          <div
+            className="col-span-full p-2"
+            style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+          >
+            <ChatHistorySearch
+              onSessionClick={onSessionClick}
+              getSessionStatus={getSessionStatus}
+              clearUnread={clearUnread}
+              activeSessionId={activeSessionId}
+            />
+          </div>
+
           {visibleItems.map((item, index) => {
             const Icon = item.icon;
             const active = isActive(item.path);

--- a/ui/desktop/src/components/conversation/ChatHistorySearch.tsx
+++ b/ui/desktop/src/components/conversation/ChatHistorySearch.tsx
@@ -177,6 +177,18 @@ export const ChatHistorySearch: React.FC<ChatHistorySearchProps> = ({
     [onSessionClick, clearUnread]
   );
 
+  const handleContainerBlur = useCallback((event: React.FocusEvent<HTMLDivElement>) => {
+    const nextFocusedElement = event.relatedTarget;
+    if (!containerRef.current || !nextFocusedElement) {
+      setIsFocused(false);
+      return;
+    }
+
+    if (!containerRef.current.contains(nextFocusedElement)) {
+      setIsFocused(false);
+    }
+  }, []);
+
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
@@ -233,7 +245,7 @@ export const ChatHistorySearch: React.FC<ChatHistorySearchProps> = ({
   );
 
   return (
-    <div ref={containerRef} className={cn('relative', className)}>
+    <div ref={containerRef} className={cn('relative', className)} onBlur={handleContainerBlur}>
       <div className="relative group">
         <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-secondary group-focus-within:text-text-primary transition-colors" />
         <input

--- a/ui/desktop/src/components/conversation/ChatHistorySearch.tsx
+++ b/ui/desktop/src/components/conversation/ChatHistorySearch.tsx
@@ -28,9 +28,13 @@ const i18n = defineMessages({
     id: 'chatHistorySearch.messageCount',
     defaultMessage: '{count, plural, one {# message} other {# messages}}',
   },
-  keyboardHint: {
-    id: 'chatHistorySearch.keyboardHint',
+  keyboardHintMac: {
+    id: 'chatHistorySearch.keyboardHintMac',
     defaultMessage: '⌘K',
+  },
+  keyboardHintOther: {
+    id: 'chatHistorySearch.keyboardHintOther',
+    defaultMessage: 'Ctrl+K',
   },
 });
 
@@ -184,8 +188,9 @@ export const ChatHistorySearch: React.FC<ChatHistorySearchProps> = ({
   }, []);
 
   useEffect(() => {
+    const isMac = window.electron?.platform === 'darwin';
     const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      if ((isMac ? e.metaKey : e.ctrlKey) && !e.shiftKey && !e.altKey && e.key === 'k') {
         e.preventDefault();
         inputRef.current?.focus();
         setIsFocused(true);
@@ -262,7 +267,9 @@ export const ChatHistorySearch: React.FC<ChatHistorySearchProps> = ({
           </button>
         ) : (
           <kbd className="absolute right-2.5 top-1/2 -translate-y-1/2 text-[10px] text-text-secondary font-mono bg-background-primary px-1.5 py-0.5 rounded border border-border-primary">
-            {intl.formatMessage(i18n.keyboardHint)}
+            {intl.formatMessage(
+              window.electron?.platform === 'darwin' ? i18n.keyboardHintMac : i18n.keyboardHintOther
+            )}
           </kbd>
         )}
       </div>

--- a/ui/desktop/src/components/conversation/ChatHistorySearch.tsx
+++ b/ui/desktop/src/components/conversation/ChatHistorySearch.tsx
@@ -130,6 +130,13 @@ export const ChatHistorySearch: React.FC<ChatHistorySearchProps> = ({
     setHighlightedIndex(-1);
 
     if (query.trim()) {
+      // Drop previous results and flip to the searching state immediately
+      // so (a) an item from the previous query cannot be clicked during the
+      // 250ms debounce window and (b) the empty-state does not flicker
+      // before the new request actually runs.
+      setResults([]);
+      setHasError(false);
+      setIsSearching(true);
       searchTimeoutRef.current = setTimeout(() => {
         performSearch(query);
       }, 250);

--- a/ui/desktop/src/components/conversation/ChatHistorySearch.tsx
+++ b/ui/desktop/src/components/conversation/ChatHistorySearch.tsx
@@ -1,0 +1,367 @@
+import React, { useState, useCallback, useEffect, useRef } from 'react';
+import { Search, X, MessageSquare, ChefHat, Clock } from 'lucide-react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { defineMessages, useIntl } from '../../i18n';
+import { searchSessions } from '../../api';
+import { cn } from '../../utils';
+import { ScrollArea } from '../ui/scroll-area';
+import { Skeleton } from '../ui/skeleton';
+import { SessionIndicators } from '../SessionIndicators';
+import { getSessionDisplayName, truncateMessage } from '../../hooks/useNavigationSessions';
+import type { Session } from '../../api';
+import type { SessionStatus } from '../Layout/navigation/types';
+
+const i18n = defineMessages({
+  searchPlaceholder: {
+    id: 'chatHistorySearch.searchPlaceholder',
+    defaultMessage: 'Search chats…',
+  },
+  noResults: {
+    id: 'chatHistorySearch.noResults',
+    defaultMessage: 'No chats found',
+  },
+  searchError: {
+    id: 'chatHistorySearch.searchError',
+    defaultMessage: 'Search failed',
+  },
+  messageCount: {
+    id: 'chatHistorySearch.messageCount',
+    defaultMessage: '{count, plural, one {# message} other {# messages}}',
+  },
+  keyboardHint: {
+    id: 'chatHistorySearch.keyboardHint',
+    defaultMessage: '⌘K',
+  },
+});
+
+function formatRelativeTime(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  const diffHr = Math.floor(diffMs / 3600000);
+  const diffDay = Math.floor(diffMs / 86400000);
+
+  if (diffMin < 1) return 'just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHr < 24) return `${diffHr}h ago`;
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+interface ChatHistorySearchProps {
+  onSessionClick: (sessionId: string) => void;
+  getSessionStatus: (sessionId: string) => SessionStatus | undefined;
+  clearUnread: (sessionId: string) => void;
+  activeSessionId?: string;
+  className?: string;
+}
+
+const SEARCH_RESULTS_LIMIT = 8;
+
+export const ChatHistorySearch: React.FC<ChatHistorySearchProps> = ({
+  onSessionClick,
+  getSessionStatus,
+  clearUnread,
+  activeSessionId,
+  className,
+}) => {
+  const intl = useIntl();
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<Session[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [hasError, setHasError] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const latestRequestIdRef = useRef(0);
+
+  const showDropdown =
+    isFocused && (query.trim().length > 0 || isSearching || hasError || results.length > 0);
+
+  const performSearch = useCallback(async (searchQuery: string) => {
+    if (!searchQuery.trim()) {
+      latestRequestIdRef.current += 1;
+      setResults([]);
+      setHasError(false);
+      return;
+    }
+
+    const requestId = ++latestRequestIdRef.current;
+    setIsSearching(true);
+    setHasError(false);
+    try {
+      const response = await searchSessions({
+        query: { query: searchQuery, limit: SEARCH_RESULTS_LIMIT },
+        throwOnError: false,
+        client: undefined,
+      });
+
+      if (requestId !== latestRequestIdRef.current) return;
+
+      if (response.error || !response.data) {
+        setResults([]);
+        setHasError(true);
+      } else {
+        setResults(response.data);
+      }
+    } catch {
+      if (requestId !== latestRequestIdRef.current) return;
+      setResults([]);
+      setHasError(true);
+    } finally {
+      if (requestId === latestRequestIdRef.current) {
+        setIsSearching(false);
+        setHighlightedIndex(-1);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (searchTimeoutRef.current) {
+      clearTimeout(searchTimeoutRef.current);
+    }
+
+    // Invalidate any in-flight request and reset selection so Enter
+    // cannot pick a stale result during the debounce window.
+    latestRequestIdRef.current += 1;
+    setHighlightedIndex(-1);
+
+    if (query.trim()) {
+      searchTimeoutRef.current = setTimeout(() => {
+        performSearch(query);
+      }, 250);
+    } else {
+      setResults([]);
+      setHasError(false);
+      setIsSearching(false);
+    }
+
+    return () => {
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current);
+      }
+    };
+  }, [query, performSearch]);
+
+  const handleClear = useCallback(() => {
+    setQuery('');
+    setResults([]);
+    setHasError(false);
+    setHighlightedIndex(-1);
+    inputRef.current?.focus();
+  }, []);
+
+  const handleSelectSession = useCallback(
+    (sessionId: string) => {
+      clearUnread(sessionId);
+      onSessionClick(sessionId);
+      setQuery('');
+      setResults([]);
+      setHighlightedIndex(-1);
+      inputRef.current?.blur();
+    },
+    [onSessionClick, clearUnread]
+  );
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsFocused(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        inputRef.current?.focus();
+        setIsFocused(true);
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  const handleInputKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!showDropdown) return;
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setHighlightedIndex((prev) => (prev < results.length - 1 ? prev + 1 : 0));
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : results.length - 1));
+          break;
+        case 'Enter':
+          e.preventDefault();
+          // Ignore Enter while a search is pending/in-flight so we don't
+          // select a result from the previous query.
+          if (isSearching) break;
+          if (highlightedIndex >= 0 && highlightedIndex < results.length) {
+            handleSelectSession(results[highlightedIndex].id);
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          setIsFocused(false);
+          inputRef.current?.blur();
+          break;
+      }
+    },
+    [showDropdown, results, highlightedIndex, isSearching, handleSelectSession]
+  );
+
+  return (
+    <div ref={containerRef} className={cn('relative', className)}>
+      <div className="relative group">
+        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-secondary group-focus-within:text-text-primary transition-colors" />
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onFocus={() => setIsFocused(true)}
+          onKeyDown={handleInputKeyDown}
+          placeholder={intl.formatMessage(i18n.searchPlaceholder)}
+          aria-label={intl.formatMessage(i18n.searchPlaceholder)}
+          aria-expanded={showDropdown}
+          aria-autocomplete="list"
+          aria-controls="chat-search-results"
+          role="combobox"
+          className={cn(
+            'w-full pl-8 pr-14 py-1.5 text-sm',
+            'bg-background-secondary border border-border-primary rounded-lg',
+            'text-text-primary placeholder-text-secondary',
+            'focus:outline-none focus:ring-1 focus:ring-border-tertiary focus:border-border-tertiary',
+            'transition-all duration-150'
+          )}
+        />
+        {query ? (
+          <button
+            onClick={handleClear}
+            className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded text-text-secondary hover:text-text-primary transition-colors"
+            aria-label="Clear search"
+          >
+            <X className="w-3.5 h-3.5" />
+          </button>
+        ) : (
+          <kbd className="absolute right-2.5 top-1/2 -translate-y-1/2 text-[10px] text-text-secondary font-mono bg-background-primary px-1.5 py-0.5 rounded border border-border-primary">
+            {intl.formatMessage(i18n.keyboardHint)}
+          </kbd>
+        )}
+      </div>
+
+      <AnimatePresence>
+        {showDropdown && (
+          <motion.div
+            id="chat-search-results"
+            role="listbox"
+            initial={{ opacity: 0, y: -4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={{ duration: 0.12 }}
+            className={cn(
+              'absolute z-50 w-full mt-1.5',
+              'bg-background-primary border border-border-secondary rounded-lg shadow-lg',
+              'overflow-hidden'
+            )}
+          >
+            {isSearching ? (
+              <div className="p-2 space-y-2">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <div key={i} className="flex items-center gap-2 px-2 py-1.5">
+                    <Skeleton className="w-4 h-4 rounded" />
+                    <div className="flex-1 space-y-1">
+                      <Skeleton className="h-3 w-3/4 rounded" />
+                      <Skeleton className="h-2 w-1/2 rounded" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : hasError ? (
+              <div className="px-3 py-2.5 text-sm text-red-500">
+                {intl.formatMessage(i18n.searchError)}
+              </div>
+            ) : results.length > 0 ? (
+              <ScrollArea className="max-h-72">
+                <div className="p-1">
+                  {results.map((session, index) => {
+                    const status = getSessionStatus(session.id);
+                    const isStreaming = status?.streamState === 'streaming';
+                    const hasSessionError = status?.streamState === 'error';
+                    const hasUnread = status?.hasUnreadActivity ?? false;
+                    const isActive = session.id === activeSessionId;
+                    const isHighlighted = index === highlightedIndex;
+                    const displayName = truncateMessage(getSessionDisplayName(session), 40);
+                    const isRecipe = !!session.recipe;
+
+                    return (
+                      <button
+                        key={session.id}
+                        role="option"
+                        aria-selected={isHighlighted}
+                        onClick={() => handleSelectSession(session.id)}
+                        onMouseEnter={() => setHighlightedIndex(index)}
+                        className={cn(
+                          'w-full flex items-center gap-2 px-2.5 py-2 text-sm rounded-md',
+                          'text-left transition-colors duration-75',
+                          isHighlighted
+                            ? 'bg-background-tertiary'
+                            : isActive
+                              ? 'bg-background-secondary'
+                              : 'hover:bg-background-secondary'
+                        )}
+                      >
+                        {isRecipe ? (
+                          <ChefHat className="w-3.5 h-3.5 flex-shrink-0 text-text-secondary" />
+                        ) : (
+                          <MessageSquare className="w-3.5 h-3.5 flex-shrink-0 text-text-secondary" />
+                        )}
+                        <div className="flex-1 min-w-0">
+                          <div className="font-medium truncate text-text-primary">
+                            {displayName}
+                          </div>
+                          <div className="flex items-center gap-1.5 mt-0.5">
+                            {session.message_count > 0 && (
+                              <span className="text-[11px] text-text-secondary">
+                                {intl.formatMessage(i18n.messageCount, {
+                                  count: session.message_count,
+                                })}
+                              </span>
+                            )}
+                            <span className="text-[11px] text-text-secondary flex items-center gap-0.5">
+                              <Clock className="w-2.5 h-2.5" />
+                              {formatRelativeTime(session.updated_at)}
+                            </span>
+                          </div>
+                        </div>
+                        <SessionIndicators
+                          isStreaming={isStreaming}
+                          hasUnread={hasUnread}
+                          hasError={hasSessionError}
+                        />
+                      </button>
+                    );
+                  })}
+                </div>
+              </ScrollArea>
+            ) : query.trim() ? (
+              <div className="px-3 py-2.5 text-sm text-text-secondary">
+                {intl.formatMessage(i18n.noResults)}
+              </div>
+            ) : null}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -113,6 +113,7 @@
   "cardButtons.launch": {
     "defaultMessage": "Launch"
   },
+<<<<<<< HEAD
   "chat.notification.taskComplete.body": {
     "defaultMessage": "Click here to bring Goose back into focus."
   },
@@ -120,7 +121,13 @@
     "defaultMessage": "Goose finished the task."
   },
   "chatHistorySearch.keyboardHint": {
+=======
+  "chatHistorySearch.keyboardHintMac": {
+>>>>>>> 310bc157f1d (fix(ui): use platform-specific modifier for chat search shortcut)
     "defaultMessage": "⌘K"
+  },
+  "chatHistorySearch.keyboardHintOther": {
+    "defaultMessage": "Ctrl+K"
   },
   "chatHistorySearch.messageCount": {
     "defaultMessage": "{count,plural,one{# message} other{# messages}}"

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -113,17 +113,13 @@
   "cardButtons.launch": {
     "defaultMessage": "Launch"
   },
-<<<<<<< HEAD
   "chat.notification.taskComplete.body": {
     "defaultMessage": "Click here to bring Goose back into focus."
   },
   "chat.notification.taskComplete.title": {
     "defaultMessage": "Goose finished the task."
   },
-  "chatHistorySearch.keyboardHint": {
-=======
   "chatHistorySearch.keyboardHintMac": {
->>>>>>> 310bc157f1d (fix(ui): use platform-specific modifier for chat search shortcut)
     "defaultMessage": "⌘K"
   },
   "chatHistorySearch.keyboardHintOther": {

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -119,6 +119,21 @@
   "chat.notification.taskComplete.title": {
     "defaultMessage": "Goose finished the task."
   },
+  "chatHistorySearch.keyboardHint": {
+    "defaultMessage": "⌘K"
+  },
+  "chatHistorySearch.messageCount": {
+    "defaultMessage": "{count,plural,one{# message} other{# messages}}"
+  },
+  "chatHistorySearch.noResults": {
+    "defaultMessage": "No chats found"
+  },
+  "chatHistorySearch.searchError": {
+    "defaultMessage": "Search failed"
+  },
+  "chatHistorySearch.searchPlaceholder": {
+    "defaultMessage": "Search chats…"
+  },
   "chatInput.contextWindow": {
     "defaultMessage": "Context window"
   },


### PR DESCRIPTION
# Add chat history search to navigation panel

Implements a native search bar in the Goose navigation panel, allowing users to search through their chat history by keywords.

Resolves #8440

## Features

- **Debounced search** (250ms) via existing `/sessions/search` backend endpoint
- **Rich results dropdown** with session name, message count, and relative time
- **Session status indicators** — streaming, unread, and error states
- **Recipe/chat icon distinction** — ChefHat icon for recipe sessions, MessageSquare for chats
- **Full keyboard navigation** — ↑/↓ arrows, Enter to select, Escape to close
- **Global shortcut** — `Cmd/Ctrl+K` to focus the search input
- **Animated dropdown** — smooth open/close with framer-motion
- **Skeleton loading states** — 3-row shimmer while results load
- **ARIA accessibility** — combobox + listbox roles, `aria-expanded`, `aria-selected`
- **Responsive** — works in both expanded grid and condensed navigation layouts
- **Hidden in icon-only mode** — search bar collapses when navigation is minimized to icons

## Changes

| File | Status |
|------|--------|
| `components/conversation/ChatHistorySearch.tsx` | **New** (348 lines) |
| `components/Layout/ExpandedRenderer.tsx` | Modified (+11 lines) |
| `components/Layout/CondensedRenderer.tsx` | Modified (+16 lines) |

## Implementation Details

- Reuses shared UI components: `ScrollArea`, `Skeleton`, `SessionIndicators`
- Reuses existing utilities: `getSessionDisplayName`, `truncateMessage` from `useNavigationSessions`
- Uses `defineMessages`/`useIntl` i18n pattern consistent with codebase
- Follows existing navigation component patterns and Tailwind theme tokens
- No backend changes required — the `/sessions/search` endpoint already exists

## Preview

- Expanded navigation: search input renders above the session grid and the dropdown stays attached to the full-width search bar.
- Condensed navigation: search input renders inline above the session list and is not mounted in icon-only mode.
- Keyboard flow: Cmd+K on macOS / Ctrl+K elsewhere focuses the field, arrow keys move the active result, Enter selects, Escape closes, and Tab closes the dropdown when focus leaves the control.

## Quality Checks

- ✅ TypeScript compilation (no errors in changed files)
- ✅ ESLint (clean)
- ✅ Prettier formatted

## Testing

- `source bin/activate-hermit && cd ui/desktop && pnpm run lint:check`

