### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/documentation/docs/mcp/exa-mcp.md
+++ b/documentation/docs/mcp/exa-mcp.md
@@ -1,0 +1,117 @@
+---
+title: Exa Search Extension
+description: Add Exa MCP Server as a goose Extension
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+
+This tutorial covers how to add the [Exa MCP Server](https://github.com/exa-labs/exa-mcp-server) as a goose extension to enable AI-powered web search functionality.
+
+:::tip Quick Install
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=exa-mcp-server&id=exa&name=Exa%20Search&description=AI-powered%20web%20search&env=EXA_API_KEY%3DExa%20API%20Key)
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+  **Command**
+  ```sh
+  npx -y exa-mcp-server
+  ```
+  </TabItem>
+</Tabs>
+  **Environment Variable**
+  ```
+  EXA_API_KEY: <YOUR_API_KEY>
+  ```
+:::
+
+## Configuration
+
+:::info
+Note that you'll need [Node.js](https://nodejs.org/) installed on your system to run this command, as it uses `npx`.
+:::
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  <GooseDesktopInstaller
+    extensionId="exa"
+    extensionName="Exa Search"
+    description="AI-powered web search"
+    command="npx"
+    args={["-y", "exa-mcp-server"]}
+    envVars={[
+      { name: "EXA_API_KEY", label: "Exa API Key" }
+    ]}
+    apiKeyLink="https://dashboard.exa.ai/api-keys"
+    apiKeyLinkText="Exa API Key"
+  />
+</TabItem>
+  <TabItem value="cli" label="goose CLI">
+    <CLIExtensionInstructions
+      name="Exa Search"
+      description="AI-powered web search"
+      command="npx -y exa-mcp-server"
+      envVars={[
+        { key: "EXA_API_KEY", value: "▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪" }
+      ]}
+      infoNote={
+        <>
+          Obtain your <a href="https://dashboard.exa.ai/api-keys" target="_blank" rel="noopener noreferrer">Exa API Key</a> and paste it in. You can get your API key by signing up at <a href="https://exa.ai" target="_blank" rel="noopener noreferrer">exa.ai</a> and navigating to the API keys page in the dashboard.
+        </>
+      }
+    />
+  </TabItem>
+</Tabs>
+
+## Example Usage
+
+The Exa MCP server enables AI-powered web search in your goose interactions. Exa offers advanced search capabilities including:
+
+1. Neural, keyword, and auto search modes
+2. Content retrieval with full text, highlights, or summaries
+3. Category filtering (news, research papers, companies, and more)
+4. Domain and date range filtering
+
+### goose Prompt
+
+```
+Find recent research papers about large language model reasoning capabilities and summarize the key findings.
+```
+
+### goose Output
+
+```
+I'll use Exa to search for recent research papers on LLM reasoning.
+
+─── web_search_exa | exa ──────────────────────────
+query: large language model reasoning capabilities research paper
+category: research paper
+
+
+Here are the key findings from recent research on LLM reasoning:
+
+1. Chain-of-Thought Reasoning:
+- Recent papers show that explicit chain-of-thought prompting significantly improves performance on multi-step reasoning tasks
+- Models trained with reasoning traces demonstrate better generalization to novel problem types
+
+2. Mathematical and Logical Reasoning:
+- New benchmarks reveal that while LLMs have improved at arithmetic and formal logic, they still struggle with compositional reasoning
+- Hybrid approaches combining neural methods with symbolic solvers show promising results
+
+3. Commonsense Reasoning:
+- Studies demonstrate that scaling model size continues to improve commonsense reasoning benchmarks
+- However, models still fail on tasks requiring physical intuition or temporal reasoning about everyday events
+
+4. Limitations and Future Directions:
+- Several papers identify "reasoning shortcuts" where models exploit dataset patterns rather than performing genuine inference
+- Research into retrieval-augmented reasoning shows potential for grounding model outputs in verified facts
+
+Would you like me to search for more details on any of these topics?
+```
+
+:::tip
+Exa supports multiple search types including neural search for semantic queries and auto mode that intelligently combines search strategies. You can also filter results by category, domain, and date range for more targeted research.
+:::

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -281,6 +281,23 @@
     ]
   },
   {
+    "id": "exa",
+    "name": "Exa Search",
+    "description": "AI-powered web search with neural and keyword capabilities",
+    "command": "npx -y exa-mcp-server",
+    "link": "https://github.com/exa-labs/exa-mcp-server",
+    "installation_notes": "Install using npx package manager. Requires Exa API key.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [
+      {
+        "name": "EXA_API_KEY",
+        "description": "API key for Exa web search service",
+        "required": true
+      }
+    ]
+  },
+  {
     "id": "excalidraw-mcp-app",
     "name": "Excalidraw",
     "description": "Excalidraw MCP App for diagrammin",


### PR DESCRIPTION
## Summary
- Add Exa as an extension in the server registry (`servers.json`) for AI-powered web search
- Add documentation page (`documentation/docs/mcp/exa-mcp.md`) with Desktop and CLI configuration instructions, environment variable setup, and example usage
- Exa offers neural, keyword, and auto search modes with content retrieval (text, highlights, summaries), category filtering, domain filtering, and date range filtering

## Usage

```sh
npx -y exa-mcp-server
```

Set `EXA_API_KEY` environment variable with your API key from [dashboard.exa.ai](https://dashboard.exa.ai/api-keys).

## Files Changed
- `documentation/static/servers.json` — added Exa entry to extension registry
- `documentation/docs/mcp/exa-mcp.md` — new extension documentation page

## Test Plan
- [ ] Verify `servers.json` is valid JSON and Exa entry appears in the extensions catalog
- [ ] Verify documentation page renders correctly with Desktop and CLI tabs
- [ ] Verify deep link installer URL works in goose Desktop
- [ ] Install extension via CLI and confirm `exa-mcp-server` starts with a valid API key