### PR TITLE
[codex] fix declarative provider auth updates and Ollama Cloud model selection

### DIFF
--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -388,6 +388,7 @@ pub fn load_provider(id: &str) -> Result<LoadedProvider> {
 
     Err(anyhow::anyhow!("Provider not found: {}", id))
 }
+
 pub fn load_custom_providers(dir: &Path) -> Result<Vec<DeclarativeProviderConfig>> {
     if !dir.exists() {
         return Ok(Vec::new());

--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -302,22 +302,11 @@ pub fn update_custom_provider(params: UpdateCustomProviderParams) -> Result<()> 
             fast_model: existing_config.fast_model.clone(),
         })
     } else {
-        let custom_file = custom_providers_dir().join(format!("{}.json", params.id));
-        if params.requires_auth {
-            Some(DeclarativeProviderConfig {
-                requires_auth: true,
-                api_key_env,
-                ..existing_config
-            })
-        } else {
-            if !existing_config.api_key_env.is_empty() {
-                let _ = config.delete_secret(&existing_config.api_key_env);
-            }
-            if custom_file.exists() {
-                std::fs::remove_file(custom_file)?;
-            }
-            None
-        }
+        Some(build_fixed_provider_auth_override(
+            existing_config,
+            params.requires_auth,
+            api_key_env,
+        ))
     };
 
     if let Some(config_to_write) = updated_config {
@@ -329,6 +318,24 @@ pub fn update_custom_provider(params: UpdateCustomProviderParams) -> Result<()> 
     }
 
     Ok(())
+}
+
+fn build_fixed_provider_auth_override(
+    existing_config: DeclarativeProviderConfig,
+    requires_auth: bool,
+    api_key_env: String,
+) -> DeclarativeProviderConfig {
+    let api_key_env = if requires_auth {
+        api_key_env
+    } else {
+        existing_config.api_key_env.clone()
+    };
+
+    DeclarativeProviderConfig {
+        requires_auth,
+        api_key_env,
+        ..existing_config
+    }
 }
 
 pub fn remove_custom_provider(id: &str) -> Result<()> {
@@ -682,5 +689,63 @@ mod tests {
 
         let result = expand_env_vars("${TEST_EXPAND_OVERRIDE}/path", &env_vars).unwrap();
         assert_eq!(result, "https://from-env.com/path");
+    }
+
+    #[test]
+    fn test_build_fixed_provider_auth_override_preserves_api_key_env_when_disabling_auth() {
+        let existing = DeclarativeProviderConfig {
+            name: "ollama_cloud".to_string(),
+            engine: ProviderEngine::OpenAI,
+            display_name: "Ollama Cloud".to_string(),
+            description: None,
+            api_key_env: "OLLAMA_CLOUD_API_KEY".to_string(),
+            base_url: "https://ollama.com/v1/chat/completions".to_string(),
+            models: vec![],
+            headers: None,
+            timeout_seconds: None,
+            supports_streaming: Some(true),
+            requires_auth: true,
+            catalog_provider_id: None,
+            base_path: None,
+            env_vars: None,
+            dynamic_models: Some(true),
+            skip_canonical_filtering: true,
+            fast_model: None,
+        };
+
+        let override_config =
+            build_fixed_provider_auth_override(existing, false, "IGNORED_API_KEY_ENV".to_string());
+
+        assert!(!override_config.requires_auth);
+        assert_eq!(override_config.api_key_env, "OLLAMA_CLOUD_API_KEY");
+    }
+
+    #[test]
+    fn test_build_fixed_provider_auth_override_uses_updated_api_key_env_when_enabling_auth() {
+        let existing = DeclarativeProviderConfig {
+            name: "lmstudio".to_string(),
+            engine: ProviderEngine::OpenAI,
+            display_name: "LM Studio".to_string(),
+            description: None,
+            api_key_env: String::new(),
+            base_url: "http://localhost:1234/v1/chat/completions".to_string(),
+            models: vec![],
+            headers: None,
+            timeout_seconds: None,
+            supports_streaming: Some(true),
+            requires_auth: false,
+            catalog_provider_id: None,
+            base_path: None,
+            env_vars: None,
+            dynamic_models: Some(true),
+            skip_canonical_filtering: false,
+            fast_model: None,
+        };
+
+        let override_config =
+            build_fixed_provider_auth_override(existing, true, "LMSTUDIO_API_KEY".to_string());
+
+        assert!(override_config.requires_auth);
+        assert_eq!(override_config.api_key_env, "LMSTUDIO_API_KEY");
     }
 }

--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -266,14 +266,14 @@ pub fn update_custom_provider(params: UpdateCustomProviderParams) -> Result<()> 
         String::new()
     };
 
-    if editable {
+    let updated_config = if editable {
         let model_infos: Vec<ModelInfo> = params
             .models
             .into_iter()
             .map(|name| ModelInfo::new(name, 128000))
             .collect();
 
-        let updated_config = DeclarativeProviderConfig {
+        Some(DeclarativeProviderConfig {
             name: params.id.clone(),
             engine: match params.engine.as_str() {
                 "openai_compatible" => ProviderEngine::OpenAI,
@@ -300,12 +300,34 @@ pub fn update_custom_provider(params: UpdateCustomProviderParams) -> Result<()> 
             dynamic_models: existing_config.dynamic_models,
             skip_canonical_filtering: existing_config.skip_canonical_filtering,
             fast_model: existing_config.fast_model.clone(),
-        };
+        })
+    } else {
+        let custom_file = custom_providers_dir().join(format!("{}.json", params.id));
+        if params.requires_auth {
+            Some(DeclarativeProviderConfig {
+                requires_auth: true,
+                api_key_env,
+                ..existing_config
+            })
+        } else {
+            if !existing_config.api_key_env.is_empty() {
+                let _ = config.delete_secret(&existing_config.api_key_env);
+            }
+            if custom_file.exists() {
+                std::fs::remove_file(custom_file)?;
+            }
+            None
+        }
+    };
 
-        let file_path = custom_providers_dir().join(format!("{}.json", updated_config.name));
-        let json_content = serde_json::to_string_pretty(&updated_config)?;
+    if let Some(config_to_write) = updated_config {
+        let custom_dir = custom_providers_dir();
+        std::fs::create_dir_all(&custom_dir)?;
+        let file_path = custom_dir.join(format!("{}.json", config_to_write.name));
+        let json_content = serde_json::to_string_pretty(&config_to_write)?;
         std::fs::write(file_path, json_content)?;
     }
+
     Ok(())
 }
 
@@ -324,8 +346,36 @@ pub fn remove_custom_provider(id: &str) -> Result<()> {
     Ok(())
 }
 
+fn find_fixed_provider(id: &str) -> Option<DeclarativeProviderConfig> {
+    FIXED_PROVIDERS.files().find_map(|file| {
+        if file.path().extension().and_then(|s| s.to_str()) != Some("json") {
+            return None;
+        }
+        let config: DeclarativeProviderConfig = serde_json::from_str(file.contents_utf8()?).ok()?;
+        (config.name == id).then_some(config)
+    })
+}
+
 pub fn load_provider(id: &str) -> Result<LoadedProvider> {
     let custom_file_path = custom_providers_dir().join(format!("{}.json", id));
+
+    if let Some(fixed) = find_fixed_provider(id) {
+        let config = if custom_file_path.exists() {
+            let content = std::fs::read_to_string(&custom_file_path)?;
+            let shadow: DeclarativeProviderConfig = serde_json::from_str(&content)?;
+            DeclarativeProviderConfig {
+                requires_auth: shadow.requires_auth,
+                api_key_env: shadow.api_key_env,
+                ..fixed
+            }
+        } else {
+            fixed
+        };
+        return Ok(LoadedProvider {
+            config,
+            is_editable: false,
+        });
+    }
 
     if custom_file_path.exists() {
         let content = std::fs::read_to_string(&custom_file_path)?;
@@ -334,27 +384,6 @@ pub fn load_provider(id: &str) -> Result<LoadedProvider> {
             config,
             is_editable: true,
         });
-    }
-
-    for file in FIXED_PROVIDERS.files() {
-        if file.path().extension().and_then(|s| s.to_str()) != Some("json") {
-            continue;
-        }
-
-        let content = file
-            .contents_utf8()
-            .ok_or_else(|| anyhow::anyhow!("Failed to read file as UTF-8: {:?}", file.path()))?;
-
-        let config: DeclarativeProviderConfig = match serde_json::from_str(content) {
-            Ok(config) => config,
-            Err(_) => continue,
-        };
-        if config.name == id {
-            return Ok(LoadedProvider {
-                config,
-                is_editable: false,
-            });
-        }
     }
 
     Err(anyhow::anyhow!("Provider not found: {}", id))
@@ -409,11 +438,31 @@ pub fn register_declarative_providers(
     let dir = custom_providers_dir();
     let custom_providers = load_custom_providers(&dir)?;
     let fixed_providers = load_fixed_providers()?;
+
+    let fixed_names: std::collections::HashSet<&str> =
+        fixed_providers.iter().map(|c| c.name.as_str()).collect();
+
+    let (shadows, true_custom): (Vec<_>, Vec<_>) = custom_providers
+        .into_iter()
+        .partition(|c| fixed_names.contains(c.name.as_str()));
+
+    let shadow_map: HashMap<String, DeclarativeProviderConfig> =
+        shadows.into_iter().map(|c| (c.name.clone(), c)).collect();
+
     for config in fixed_providers {
+        let config = if let Some(shadow) = shadow_map.get(&config.name) {
+            DeclarativeProviderConfig {
+                requires_auth: shadow.requires_auth,
+                api_key_env: shadow.api_key_env.clone(),
+                ..config
+            }
+        } else {
+            config
+        };
         register_declarative_provider(registry, config, ProviderType::Declarative);
     }
 
-    for config in custom_providers {
+    for config in true_custom {
         register_declarative_provider(registry, config, ProviderType::Custom);
     }
 

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -461,6 +461,20 @@ mod tests {
         }
 
         #[test]
+        fn sets_limits_from_canonical_ollama_cloud_model() {
+            let _guard = env_lock::lock_env([
+                ("GOOSE_MAX_TOKENS", None::<&str>),
+                ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+            ]);
+            let config = ModelConfig::new_or_fail("gemini-3-flash-preview")
+                .with_canonical_limits("ollama_cloud");
+
+            assert_eq!(config.context_limit, Some(1_048_576));
+            assert_eq!(config.max_tokens, Some(65_536));
+            assert_eq!(config.reasoning, Some(true));
+        }
+
+        #[test]
         fn does_not_override_existing_context_limit() {
             let _guard = env_lock::lock_env([
                 ("GOOSE_MAX_TOKENS", None::<&str>),

--- a/crates/goose/src/providers/canonical/name_builder.rs
+++ b/crates/goose/src/providers/canonical/name_builder.rs
@@ -47,6 +47,7 @@ pub fn map_provider_name(provider: &str) -> &str {
         "aws_bedrock" => "amazon-bedrock",
         "gcp_vertex_ai" => "google-vertex",
         "gemini_oauth" => "google",
+        "ollama_cloud" => "ollama-cloud",
         "zhipu" => "zhipuai",
         _ => provider,
     }
@@ -303,6 +304,11 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_map_provider_name_for_ollama_cloud() {
+        assert_eq!(map_provider_name("ollama_cloud"), "ollama-cloud");
+    }
+
+    #[test]
     fn test_map_to_canonical_model() {
         let r = super::super::CanonicalModelRegistry::bundled().unwrap();
 
@@ -499,6 +505,16 @@ mod tests {
         assert_eq!(
             map_to_canonical_model("zhipu", "glm-5", r),
             Some("zhipuai/glm-5".to_string())
+        );
+
+        // === Ollama Cloud ===
+        assert_eq!(
+            map_to_canonical_model("ollama_cloud", "glm-5", r),
+            Some("ollama-cloud/glm-5".to_string())
+        );
+        assert_eq!(
+            map_to_canonical_model("ollama_cloud", "gemini-3-flash-preview", r),
+            Some("ollama-cloud/gemini-3-flash-preview".to_string())
         );
 
         // === GCP Vertex AI ===

--- a/crates/goose/src/providers/declarative/ollama_cloud.json
+++ b/crates/goose/src/providers/declarative/ollama_cloud.json
@@ -7,6 +7,7 @@
   "base_url": "https://ollama.com/v1/chat/completions",
   "models": [],
   "dynamic_models": true,
+  "skip_canonical_filtering": true,
   "headers": null,
   "timeout_seconds": null,
   "supports_streaming": true

--- a/ui/desktop/src/components/settings/providers/ProviderGrid.tsx
+++ b/ui/desktop/src/components/settings/providers/ProviderGrid.tsx
@@ -160,7 +160,7 @@ function ProviderCards({
       setShowCustomProviderModal(false);
       setEditingProvider(null);
       if (refreshProviders) {
-        refreshProviders();
+        await refreshProviders();
       }
       setSwitchModelProvider(providerId);
       setShowSwitchModelModal(true);
@@ -180,7 +180,7 @@ function ProviderCards({
     setEditingProvider(null);
     setIsActiveProvider(false);
     if (refreshProviders) {
-      refreshProviders();
+      await refreshProviders();
     }
   }, [editingProvider, refreshProviders]);
 

--- a/ui/desktop/src/components/settings/providers/modal/subcomponents/forms/CustomProviderForm.tsx
+++ b/ui/desktop/src/components/settings/providers/modal/subcomponents/forms/CustomProviderForm.tsx
@@ -408,11 +408,11 @@ export default function CustomProviderForm({
     setValidationErrors({});
 
     const errors: Record<string, string> = {};
-    if (!displayName) errors.displayName = intl.formatMessage(i18n.displayNameRequired);
-    if (!apiUrl) errors.apiUrl = intl.formatMessage(i18n.apiUrlRequired);
+    if (isEditable && !displayName) errors.displayName = intl.formatMessage(i18n.displayNameRequired);
+    if (isEditable && !apiUrl) errors.apiUrl = intl.formatMessage(i18n.apiUrlRequired);
     const existingHadAuth = initialData && (initialData.requires_auth ?? true);
     if (requiresAuth && !apiKey && !existingHadAuth) errors.apiKey = intl.formatMessage(i18n.apiKeyRequired);
-    if (!models) errors.models = intl.formatMessage(i18n.modelsRequired);
+    if (isEditable && !models) errors.models = intl.formatMessage(i18n.modelsRequired);
 
     if (Object.keys(errors).length > 0) {
       setValidationErrors(errors);


### PR DESCRIPTION
## Summary
This stacks the declarative-provider auth update flow with two follow-up fixes needed to make the Ollama Cloud configuration path work end to end.

Changes included:
- allow fixed declarative providers to save auth updates from the provider settings modal
- persist auth overrides for fixed declarative providers instead of treating them like fully editable custom providers
- await provider refresh before opening model selection after an update, so the model picker uses fresh provider state
- skip canonical filtering for `ollama_cloud` so the full live cloud model list is shown instead of an over-filtered subset

## Root cause
There were two separate issues in the provider flow:
- fixed declarative providers could accept an API key in the UI, but the update path did not fully persist and reload those auth overrides in a way the rest of Goose treated as configured
- after a successful update, the model picker could open against stale cached provider state, and Ollama Cloud's live model list was additionally being filtered too aggressively by canonical-model filtering

## Impact
This makes the Ollama Cloud provider flow usable from the desktop settings UI:
- `Update Provider` persists the API key for the fixed declarative provider
- the follow-up model picker opens with refreshed provider state
- the provider shows the live Ollama Cloud models instead of a nearly empty list

## Validation
- `source bin/activate-hermit && cd ui/desktop && pnpm run typecheck`
- rebuilt and packaged the macOS desktop app locally with `just package-ui`
- manually verified the desktop flow:
  - add/update Ollama Cloud API key
  - open model picker after update
  - see populated cloud models and select one successfully

## Notes
The first two commits are the `#8191`-equivalent declarative-provider fixes on top of `main`; the last commit is the follow-up for the refreshed model picker and Ollama Cloud model list behavior.