### PR TITLE
refine left nav: project glyphs, activity indicators, and design tokens

### DIFF
--- a/ui/goose2/src/features/chat/ui/ChatInputToolbar.tsx
+++ b/ui/goose2/src/features/chat/ui/ChatInputToolbar.tsx
@@ -33,21 +33,13 @@ import {
   getCatalogEntry,
   resolveAgentProviderCatalogIdStrict,
 } from "@/features/providers/providerCatalog";
+import { ProjectGlyph } from "@/shared/ui/ProjectGlyph";
 
 const NO_PROJECT_VALUE = "__no_project__";
 const CREATE_PROJECT_VALUE = "__create_project__";
 
 function ProjectDot({ color }: { color?: string | null }) {
-  return (
-    <span
-      aria-hidden="true"
-      className={cn(
-        "inline-block size-2 rounded-full",
-        color ? "" : "bg-muted-foreground/40",
-      )}
-      style={color ? { backgroundColor: color } : undefined}
-    />
-  );
+  return <ProjectGlyph color={color} className="size-3.5" />;
 }
 
 interface ChatInputToolbarProps {

--- a/ui/goose2/src/features/projects/ui/CreateProjectDialog.tsx
+++ b/ui/goose2/src/features/projects/ui/CreateProjectDialog.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/shared/ui/button";
 import { Checkbox } from "@/shared/ui/checkbox";
 import { Input } from "@/shared/ui/input";
 import { Label } from "@/shared/ui/label";
+import { ProjectGlyph } from "@/shared/ui/ProjectGlyph";
 import {
   Dialog,
   DialogContent,
@@ -292,14 +293,15 @@ export function CreateProjectDialog({
                   type="button"
                   onClick={() => setColor(c)}
                   className={cn(
-                    "h-6 w-6 rounded-full border-2 transition-transform",
+                    "flex h-7 w-7 items-center justify-center rounded-md border transition-transform",
                     color === c
-                      ? "border-foreground scale-110"
-                      : "border-transparent hover:scale-105",
+                      ? "border-foreground bg-accent/30 scale-105"
+                      : "border-transparent hover:scale-105 hover:bg-accent/20",
                   )}
-                  style={{ backgroundColor: c }}
                   aria-label={t("dialog.colorAria", { color: c })}
-                />
+                >
+                  <ProjectGlyph color={c} className="size-4" />
+                </button>
               ))}
             </div>
           </div>

--- a/ui/goose2/src/features/projects/ui/ProjectsView.tsx
+++ b/ui/goose2/src/features/projects/ui/ProjectsView.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { SearchBar } from "@/shared/ui/SearchBar";
 import { Button, buttonVariants } from "@/shared/ui/button";
+import { ProjectGlyph } from "@/shared/ui/ProjectGlyph";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -215,9 +216,9 @@ export function ProjectsView({ onStartChat }: ProjectsViewProps) {
                   className="flex items-start justify-between gap-3 rounded-lg border border-border px-4 py-3"
                 >
                   <div className="min-w-0 flex-1 flex items-start gap-3">
-                    <span
-                      className="inline-block w-2.5 h-2.5 rounded-full mt-1.5 shrink-0"
-                      style={{ backgroundColor: project.color }}
+                    <ProjectGlyph
+                      color={project.color}
+                      className="mt-0.5 size-4 shrink-0"
                     />
                     <div className="min-w-0 flex-1">
                       <p className="text-sm font-medium">{project.name}</p>

--- a/ui/goose2/src/features/settings/ui/SettingsModal.tsx
+++ b/ui/goose2/src/features/settings/ui/SettingsModal.tsx
@@ -42,6 +42,7 @@ import {
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
 import { useProjectStore } from "@/features/projects/stores/projectStore";
 import { getDisplaySessionTitle } from "@/features/chat/lib/sessionTitle";
+import { ProjectGlyph } from "@/shared/ui/ProjectGlyph";
 
 import type { Session } from "@/shared/types/chat";
 
@@ -312,9 +313,9 @@ export function SettingsModal({
                         className="flex items-center justify-between gap-3 rounded-lg border border-border px-3 py-2"
                       >
                         <div className="flex items-center gap-2 min-w-0">
-                          <span
-                            className="inline-block w-2 h-2 rounded-full flex-shrink-0"
-                            style={{ backgroundColor: project.color }}
+                          <ProjectGlyph
+                            color={project.color}
+                            className="size-3.5 flex-shrink-0"
                           />
                           <span className="text-sm truncate">
                             {project.name}

--- a/ui/goose2/src/features/sidebar/ui/Sidebar.tsx
+++ b/ui/goose2/src/features/sidebar/ui/Sidebar.tsx
@@ -313,7 +313,7 @@ export function Sidebar({
               collapsed ? "justify-center" : "justify-between",
             )}
           >
-            <GooseIcon className="text-muted-foreground" />
+            <GooseIcon className="text-foreground" />
             {!collapsed && (
               <Button
                 type="button"
@@ -365,13 +365,13 @@ export function Sidebar({
 
             <div
               className={cn(
-                "flex items-center w-full rounded-md transition-all duration-300 ease-out",
+                "mb-4 flex items-center w-full rounded-md transition-all duration-300 ease-out",
                 collapsed
                   ? "justify-center p-3 text-muted-foreground"
                   : "gap-2 border border-border px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-transparent",
               )}
             >
-              <Search className="size-3.5 flex-shrink-0" />
+              <Search className="size-3.5 flex-shrink-0 text-[var(--text-placeholder)]" />
               {!collapsed && (
                 <>
                   <input
@@ -388,7 +388,7 @@ export function Sidebar({
                     }}
                     placeholder={t("search.placeholder")}
                     className={cn(
-                      "focus-override appearance-none bg-transparent border-none text-xs flex-1 min-w-0 placeholder:text-muted-foreground outline-none focus-visible:ring-0 focus-visible:ring-offset-0",
+                      "focus-override appearance-none bg-transparent border-none text-xs flex-1 min-w-0 placeholder:text-[var(--text-placeholder)] outline-none focus-visible:ring-0 focus-visible:ring-offset-0",
                       labelTransition,
                       labelVisible
                         ? "opacity-100 w-auto"
@@ -396,17 +396,6 @@ export function Sidebar({
                     )}
                     onClick={(e) => e.stopPropagation()}
                   />
-                  <kbd
-                    className={cn(
-                      "text-[10px] text-muted-foreground px-1 py-0.5 rounded font-mono flex-shrink-0",
-                      labelTransition,
-                      labelVisible
-                        ? "opacity-100 w-auto"
-                        : "opacity-0 w-0 overflow-hidden px-0",
-                    )}
-                  >
-                    ⌘K
-                  </kbd>
                 </>
               )}
             </div>
@@ -491,7 +480,7 @@ export function Sidebar({
 
           {!collapsed && (
             <>
-              <div className="relative z-10 my-2 -mx-1.5 bg-border h-px" />
+              <div className="relative z-10 my-3" />
 
               {sidebarSearch.submittedQuery ? (
                 <div className="relative z-10 space-y-2">

--- a/ui/goose2/src/features/sidebar/ui/SidebarChatRow.tsx
+++ b/ui/goose2/src/features/sidebar/ui/SidebarChatRow.tsx
@@ -28,6 +28,7 @@ interface SidebarChatRowProps {
   isActive: boolean;
   isRunning?: boolean;
   hasUnread?: boolean;
+  reserveActivitySpace?: boolean;
   className?: string;
   onSelect?: (id: string) => void;
   onRename?: (id: string, nextTitle: string) => void;
@@ -42,6 +43,7 @@ export function SidebarChatRow({
   isActive,
   isRunning = false,
   hasUnread = false,
+  reserveActivitySpace = false,
   className,
   onSelect,
   onRename,
@@ -64,6 +66,9 @@ export function SidebarChatRow({
     t("common:session.defaultTitle"),
   );
   const [draftTitle, setDraftTitle] = useState(editableTitle);
+  const showActivityIndicator = isRunning || hasUnread;
+  const shouldReserveActivitySpace =
+    reserveActivitySpace || showActivityIndicator;
 
   useEffect(() => {
     setDraftTitle(editableTitle);
@@ -186,10 +191,17 @@ export function SidebarChatRow({
           isActive ? ACTIVE_CHAT_ROW_CLASS : INACTIVE_CHAT_ROW_CLASS,
         )}
       >
+        {shouldReserveActivitySpace && (
+          <span className="flex h-3 w-3 shrink-0 items-center justify-center">
+            <SessionActivityIndicator
+              isRunning={isRunning}
+              hasUnread={hasUnread}
+            />
+          </span>
+        )}
         <span className="flex-1 min-w-0 truncate text-left">
           {displayTitle}
         </span>
-        <SessionActivityIndicator isRunning={isRunning} hasUnread={hasUnread} />
       </Button>
 
       <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>

--- a/ui/goose2/src/features/sidebar/ui/SidebarProjectsSection.tsx
+++ b/ui/goose2/src/features/sidebar/ui/SidebarProjectsSection.tsx
@@ -493,6 +493,7 @@ export function SidebarProjectsSection({
                     isActive={isActive}
                     isRunning={session.isRunning ?? false}
                     hasUnread={session.hasUnread ?? false}
+                    reserveActivitySpace={false}
                     onSelect={onSelectSession}
                     onRename={onRenameChat}
                     onArchive={onArchiveChat}

--- a/ui/goose2/src/features/sidebar/ui/SidebarProjectsSection.tsx
+++ b/ui/goose2/src/features/sidebar/ui/SidebarProjectsSection.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/shared/ui/button";
 import type { AppView } from "@/app/AppShell";
 import type { ProjectInfo } from "@/features/projects/api/projects";
 import { SessionActivityIndicator } from "@/shared/ui/SessionActivityIndicator";
+import { ProjectGlyph } from "@/shared/ui/ProjectGlyph";
 import { SidebarItemMenu } from "./SidebarItemMenu";
 import { SidebarChatRow } from "./SidebarChatRow";
 
@@ -152,15 +153,15 @@ function ProjectSection({
               : PROJECT_ROW_TEXT_CLASS,
           )}
         >
-          <span className="relative flex h-3 w-3 flex-shrink-0 items-center justify-center">
-            <span
-              className="absolute inline-block h-2 w-2 rounded-full transition-opacity duration-150 group-hover:opacity-0"
-              style={{ backgroundColor: project.color }}
+          <span className="relative flex h-4 w-4 flex-shrink-0 items-center justify-center">
+            <ProjectGlyph
+              color={project.color}
+              className="absolute size-4 transition-opacity duration-150 group-hover:opacity-0"
             />
             {isExpanded ? (
-              <IconChevronDown className="absolute h-3 w-3 opacity-0 transition-opacity duration-150 group-hover:opacity-100" />
+              <IconChevronDown className="absolute h-4 w-4 opacity-0 transition-opacity duration-150 group-hover:opacity-100" />
             ) : (
-              <IconChevronRight className="absolute h-3 w-3 opacity-0 transition-opacity duration-150 group-hover:opacity-100" />
+              <IconChevronRight className="absolute h-4 w-4 opacity-0 transition-opacity duration-150 group-hover:opacity-100" />
             )}
           </span>
           <span className="flex-1 min-w-0 truncate text-left">
@@ -368,10 +369,7 @@ export function SidebarProjectsSection({
               onClick={() => onNavigate?.("projects")}
               className="rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent/50"
             >
-              <span
-                className="inline-block size-2.5 rounded-full"
-                style={{ backgroundColor: project.color }}
-              />
+              <ProjectGlyph color={project.color} className="size-[18px]" />
             </Button>
           ))}
         </div>

--- a/ui/goose2/src/features/sidebar/ui/SidebarProjectsSection.tsx
+++ b/ui/goose2/src/features/sidebar/ui/SidebarProjectsSection.tsx
@@ -330,7 +330,7 @@ export function SidebarProjectsSection({
       >
         <span
           className={cn(
-            "text-xs font-light uppercase tracking-wider text-muted-foreground flex-1 pl-3",
+            "text-xs font-medium tracking-normal text-muted-foreground/60 flex-1 pl-3",
             labelTransition,
             labelVisible
               ? "opacity-100 w-auto"
@@ -411,8 +411,8 @@ export function SidebarProjectsSection({
       >
         <div
           className={cn(
-            "my-2 -mx-1.5 bg-border transition-all duration-300",
-            collapsed ? "w-5 mx-auto h-px" : "h-px",
+            "my-3 transition-all duration-300",
+            collapsed ? "my-2" : "",
           )}
         />
         <div
@@ -423,7 +423,7 @@ export function SidebarProjectsSection({
         >
           <span
             className={cn(
-              "text-xs font-light uppercase tracking-wider text-muted-foreground flex-1 pl-3",
+              "text-xs font-medium tracking-normal text-muted-foreground/60 flex-1 pl-3",
               labelTransition,
               labelVisible
                 ? "opacity-100 w-auto"

--- a/ui/goose2/src/features/sidebar/ui/__tests__/SidebarChatRow.test.tsx
+++ b/ui/goose2/src/features/sidebar/ui/__tests__/SidebarChatRow.test.tsx
@@ -108,6 +108,43 @@ describe("SidebarChatRow", () => {
     expect(screen.getByLabelText(/unread messages/i)).toBeInTheDocument();
   });
 
+  it("does not reserve activity space by default when idle", () => {
+    const { container } = render(
+      <SidebarChatRow id="session-1" title="Idle Chat" isActive={false} />,
+    );
+
+    expect(
+      container.querySelector(".h-3.w-3.shrink-0.items-center.justify-center"),
+    ).toBeNull();
+  });
+
+  it("does not reserve activity space for recents until activity exists", () => {
+    const { container, rerender } = render(
+      <SidebarChatRow
+        id="session-1"
+        title="Recent Chat"
+        isActive={false}
+        reserveActivitySpace={false}
+      />,
+    );
+
+    expect(
+      container.querySelector(".h-3.w-3.shrink-0.items-center.justify-center"),
+    ).toBeNull();
+
+    rerender(
+      <SidebarChatRow
+        id="session-1"
+        title="Recent Chat"
+        isActive={false}
+        hasUnread
+        reserveActivitySpace={false}
+      />,
+    );
+
+    expect(screen.getByLabelText(/unread messages/i)).toBeInTheDocument();
+  });
+
   it("keeps the localized default title in rename mode without persisting it", async () => {
     const user = userEvent.setup();
     const onRename = vi.fn();

--- a/ui/goose2/src/shared/i18n/locales/en/sidebar.json
+++ b/ui/goose2/src/shared/i18n/locales/en/sidebar.json
@@ -18,7 +18,7 @@
   },
   "search": {
     "error": "Message search failed. Showing metadata matches only.",
-    "placeholder": "Search chats by title, persona, project, or message...",
+    "placeholder": "Search conversations",
     "searching": "Searching chats..."
   },
   "sections": {

--- a/ui/goose2/src/shared/i18n/locales/es/sidebar.json
+++ b/ui/goose2/src/shared/i18n/locales/es/sidebar.json
@@ -18,7 +18,7 @@
   },
   "search": {
     "error": "La búsqueda de mensajes falló. Mostrando solo coincidencias de metadatos.",
-    "placeholder": "Busca chats por título, persona, proyecto o mensaje...",
+    "placeholder": "Buscar conversaciones",
     "searching": "Buscando chats..."
   },
   "sections": {

--- a/ui/goose2/src/shared/styles/globals.css
+++ b/ui/goose2/src/shared/styles/globals.css
@@ -32,6 +32,7 @@
 
   --color-blue-100: #7cacff;
   --color-blue-200: #5c98f9;
+  --color-blue-300: #0090ff;
 
   --color-green-100: #a3d795;
   --color-green-200: #91cb80;
@@ -98,6 +99,7 @@
   --background-danger: var(--color-red-200);
   --background-success: var(--color-green-200);
   --background-info: var(--color-blue-200);
+  --background-info-strong: var(--color-blue-300);
   --background-warning: var(--color-yellow-200);
 
   /* Semantic borders */
@@ -111,6 +113,7 @@
   --border-success: var(--color-green-300);
   --border-warning: var(--color-yellow-200);
   --border-info: var(--color-blue-200);
+  --border-info-strong: var(--color-blue-300);
 
   /* Semantic text */
   --text-default: var(--color-gray-900);
@@ -123,6 +126,7 @@
   --text-success: var(--color-green-300);
   --text-warning: var(--color-yellow-200);
   --text-info: var(--color-blue-200);
+  --text-info-strong: var(--color-blue-300);
 
   --ring: color-mix(in srgb, var(--border-strong) 20%, transparent);
 
@@ -281,6 +285,7 @@
   --background-danger: var(--color-red-100);
   --background-success: var(--color-green-100);
   --background-info: var(--color-blue-100);
+  --background-info-strong: var(--color-blue-300);
   --background-warning: var(--color-yellow-100);
 
   /* semantic borders */
@@ -294,6 +299,7 @@
   --border-success: var(--color-green-200);
   --border-warning: var(--color-yellow-200);
   --border-info: var(--color-blue-200);
+  --border-info-strong: var(--color-blue-300);
 
   /* semantic text */
   --text-default: var(--color-white);
@@ -306,6 +312,7 @@
   --text-success: var(--color-green-100);
   --text-warning: var(--color-yellow-100);
   --text-info: var(--color-blue-100);
+  --text-info-strong: var(--color-blue-300);
 
   --ring: color-mix(in srgb, var(--border-strong) 20%, transparent);
 
@@ -381,6 +388,7 @@
   --color-background-danger: var(--background-danger);
   --color-background-success: var(--background-success);
   --color-background-info: var(--background-info);
+  --color-background-info-strong: var(--background-info-strong);
   --color-background-warning: var(--background-warning);
 
   --color-background-accent: var(--background-accent);
@@ -398,6 +406,7 @@
   --color-border-success: var(--border-success);
   --color-border-warning: var(--border-warning);
   --color-border-info: var(--border-info);
+  --color-border-info-strong: var(--border-info-strong);
 
   /* semantic text */
   --color-text-default: var(--text-default);
@@ -410,6 +419,7 @@
   --color-text-success: var(--text-success);
   --color-text-warning: var(--text-warning);
   --color-text-info: var(--text-info);
+  --color-text-info-strong: var(--text-info-strong);
 
   /* alpha variants */
   --color-dark-10: var(--dark-10);

--- a/ui/goose2/src/shared/styles/globals.css
+++ b/ui/goose2/src/shared/styles/globals.css
@@ -116,6 +116,7 @@
   --text-default: var(--color-gray-900);
   --text-subtle: var(--color-gray-600);
   --text-muted: var(--color-gray-500);
+  --text-placeholder: var(--color-gray-400);
   --text-alt: var(--color-gray-600);
   --text-inverse: var(--color-white);
   --text-danger: var(--color-red-200);
@@ -298,6 +299,7 @@
   --text-default: var(--color-white);
   --text-subtle: var(--color-gray-400);
   --text-muted: var(--color-gray-500);
+  --text-placeholder: var(--color-gray-600);
   --text-alt: var(--color-gray-500);
   --text-inverse: var(--color-black);
   --text-danger: var(--color-red-100);
@@ -401,6 +403,7 @@
   --color-text-default: var(--text-default);
   --color-text-subtle: var(--text-subtle);
   --color-text-muted: var(--text-muted);
+  --color-text-placeholder: var(--text-placeholder);
   --color-text-alt: var(--text-alt);
   --color-text-inverse: var(--text-inverse);
   --color-text-danger: var(--text-danger);

--- a/ui/goose2/src/shared/ui/ProjectGlyph.tsx
+++ b/ui/goose2/src/shared/ui/ProjectGlyph.tsx
@@ -1,0 +1,22 @@
+import { Folder } from "lucide-react";
+import { cn } from "@/shared/lib/cn";
+
+interface ProjectGlyphProps {
+  color?: string | null;
+  className?: string;
+}
+
+export function ProjectGlyph({ color, className }: ProjectGlyphProps) {
+  return (
+    <Folder
+      aria-hidden="true"
+      strokeWidth={2}
+      className={cn(
+        "shrink-0",
+        color ? "" : "text-muted-foreground/50",
+        className,
+      )}
+      style={color ? { color } : undefined}
+    />
+  );
+}

--- a/ui/goose2/src/shared/ui/SessionActivityIndicator.test.tsx
+++ b/ui/goose2/src/shared/ui/SessionActivityIndicator.test.tsx
@@ -3,16 +3,20 @@ import { describe, expect, it } from "vitest";
 import { SessionActivityIndicator } from "./SessionActivityIndicator";
 
 describe("SessionActivityIndicator", () => {
-  it("renders a brand-colored inline spinner for running sessions", () => {
+  it("renders a strong-info inline spinner for running sessions", () => {
     render(<SessionActivityIndicator isRunning />);
 
-    expect(screen.getByLabelText(/chat active/i)).toHaveClass("text-brand");
+    expect(screen.getByLabelText(/chat active/i)).toHaveClass(
+      "text-[var(--color-text-info-strong)]",
+    );
   });
 
-  it("renders a brand-colored inline dot for unread sessions", () => {
+  it("renders a strong-info inline dot for unread sessions", () => {
     render(<SessionActivityIndicator hasUnread />);
 
-    expect(screen.getByLabelText(/unread messages/i)).toHaveClass("bg-brand");
+    expect(screen.getByLabelText(/unread messages/i)).toHaveClass(
+      "bg-[var(--color-background-info-strong)]",
+    );
   });
 
   it("renders an overlay spinner variant for running sessions", () => {
@@ -21,7 +25,9 @@ describe("SessionActivityIndicator", () => {
     );
 
     expect(screen.getByLabelText(/chat active/i)).toBeInTheDocument();
-    expect(container.querySelector(".text-brand")).toBeTruthy();
+    expect(
+      container.querySelector(".text-\\[var\\(--color-text-info-strong\\)\\]"),
+    ).toBeTruthy();
   });
 
   it("renders nothing when the session is idle and read", () => {

--- a/ui/goose2/src/shared/ui/SessionActivityIndicator.tsx
+++ b/ui/goose2/src/shared/ui/SessionActivityIndicator.tsx
@@ -21,13 +21,13 @@ export function SessionActivityIndicator({
           role="status"
           aria-label="Chat active"
           className={cn(
-            "absolute -right-1 -top-1 flex h-3.5 w-3.5 items-center justify-center rounded-full border border-background bg-background shadow-sm",
+            "absolute -right-1 -top-1 flex h-3.5 w-3.5 items-center justify-center rounded-full border border-background bg-background shadow-sm transition-opacity duration-200 ease-out animate-in fade-in-0",
             className,
           )}
         >
           <Loader2
             aria-hidden="true"
-            className="h-2.5 w-2.5 animate-spin text-brand"
+            className="h-2.5 w-2.5 animate-spin text-[var(--color-text-info-strong)]"
           />
         </span>
       );
@@ -37,7 +37,10 @@ export function SessionActivityIndicator({
       <Loader2
         role="status"
         aria-label="Chat active"
-        className={cn("h-3 w-3 shrink-0 animate-spin text-brand", className)}
+        className={cn(
+          "h-3 w-3 shrink-0 animate-in fade-in-0 animate-spin text-[var(--color-text-info-strong)] duration-200 ease-out",
+          className,
+        )}
       />
     );
   }
@@ -52,7 +55,7 @@ export function SessionActivityIndicator({
         role="status"
         aria-label="Unread messages"
         className={cn(
-          "absolute -right-0.5 -top-0.5 h-2.5 w-2.5 shrink-0 rounded-full border border-background bg-brand",
+          "absolute -right-0.5 -top-0.5 h-2 w-2 shrink-0 rounded-full border border-background bg-[var(--color-background-info-strong)] transition-opacity duration-200 ease-out animate-in fade-in-0",
           className,
         )}
       />
@@ -63,7 +66,10 @@ export function SessionActivityIndicator({
     <span
       role="status"
       aria-label="Unread messages"
-      className={cn("h-2 w-2 shrink-0 rounded-full bg-brand", className)}
+      className={cn(
+        "h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--color-background-info-strong)] transition-opacity duration-200 ease-out animate-in fade-in-0",
+        className,
+      )}
     />
   );
 }

--- a/ui/goose2/src/shared/ui/command.tsx
+++ b/ui/goose2/src/shared/ui/command.tsx
@@ -64,7 +64,7 @@ function CommandInput({
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden focus-visible:ring-0 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50",
+          "placeholder:text-[var(--text-placeholder)] flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden focus-visible:ring-0 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         {...props}

--- a/ui/goose2/src/shared/ui/input.tsx
+++ b/ui/goose2/src/shared/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input hover:border-border-input-hover focus-visible:border-ring focus-visible:ring-0 focus-visible:ring-offset-0 flex h-9 w-full min-w-0 rounded-input border bg-transparent px-3 py-1 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-[var(--text-placeholder)] selection:bg-primary selection:text-primary-foreground border-input hover:border-border-input-hover focus-visible:border-ring focus-visible:ring-0 focus-visible:ring-offset-0 flex h-9 w-full min-w-0 rounded-input border bg-transparent px-3 py-1 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className,

--- a/ui/goose2/src/shared/ui/textarea.tsx
+++ b/ui/goose2/src/shared/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-0 focus-visible:ring-offset-0 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base transition-[color,box-shadow] outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "border-input placeholder:text-[var(--text-placeholder)] focus-visible:border-ring focus-visible:ring-0 focus-visible:ring-offset-0 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base transition-[color,box-shadow] outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary

**Category:** improvement
**User Impact:** The sidebar navigation looks cleaner and more polished, with consistent folder icons for projects, subtler activity indicators, and softer placeholder text across the app.

**Problem:** The left nav had visual inconsistencies — projects used plain colored dots that didn't read as "project," activity indicators used a brand color that competed with the UI, section dividers were heavy visible lines, and placeholder text across inputs was too prominent.

**Solution:** Replace colored dots with colored folder icons via a shared `ProjectGlyph` component, switch activity indicators from `text-brand` to a new `--color-text-info-strong` semantic token for better visual hierarchy, remove the visible divider line and `⌘K` badge from the sidebar, and introduce a `--text-placeholder` token used consistently across all input components.

<details>
<summary>File changes</summary>

**ui/goose2/src/shared/ui/ProjectGlyph.tsx**
New shared component that renders a colored Lucide `Folder` icon, replacing the ad-hoc colored dots used to represent projects.

**ui/goose2/src/features/chat/ui/ChatInputToolbar.tsx**
Swapped the inline `ProjectDot` (colored `<span>`) for the new `ProjectGlyph` component.

**ui/goose2/src/features/projects/ui/CreateProjectDialog.tsx**
Color picker now shows `ProjectGlyph` icons inside rounded button containers instead of plain colored circles.

**ui/goose2/src/features/projects/ui/ProjectsView.tsx**
Project list cards now use `ProjectGlyph` instead of a colored dot span.

**ui/goose2/src/features/settings/ui/SettingsModal.tsx**
Project list in settings now uses `ProjectGlyph` instead of a colored dot span.

**ui/goose2/src/features/sidebar/ui/Sidebar.tsx**
Removed the `⌘K` keyboard hint from search, shortened the search placeholder, replaced the visible `bg-border` divider with spacing, updated the Goose icon to `text-foreground`, and added `mb-4` spacing below search.

**ui/goose2/src/features/sidebar/ui/SidebarChatRow.tsx**
Added `reserveActivitySpace` prop so the activity indicator column can be conditionally shown. Moved the indicator to the left of the title text.

**ui/goose2/src/features/sidebar/ui/SidebarProjectsSection.tsx**
Replaced colored dots with `ProjectGlyph` in both expanded and collapsed views. Updated section labels from uppercase/light to normal-case/medium with reduced opacity. Replaced visible divider lines with spacing.

**ui/goose2/src/features/sidebar/ui/__tests__/SidebarChatRow.test.tsx**
Added tests for the new `reserveActivitySpace` behavior — verifying space is not reserved for idle rows and appears only when activity exists.

**ui/goose2/src/shared/ui/SessionActivityIndicator.tsx**
Replaced `text-brand`/`bg-brand` with semantic `--color-text-info-strong`/`--color-background-info-strong` tokens. Added fade-in transitions for smoother appearance. Reduced unread dot size slightly.

**ui/goose2/src/shared/ui/SessionActivityIndicator.test.tsx**
Updated assertions to match the new semantic token class names.

**ui/goose2/src/shared/styles/globals.css**
Added new semantic tokens: `--text-placeholder`, `--color-blue-300`, `--background-info-strong`, `--border-info-strong`, and `--text-info-strong` for both light and dark themes.

**ui/goose2/src/shared/ui/command.tsx**
Updated placeholder color from `text-muted-foreground` to `var(--text-placeholder)`.

**ui/goose2/src/shared/ui/input.tsx**
Updated placeholder color from `text-muted-foreground` to `var(--text-placeholder)`.

**ui/goose2/src/shared/ui/textarea.tsx**
Updated placeholder color from `text-muted-foreground` to `var(--text-placeholder)`.

**ui/goose2/src/shared/i18n/locales/en/sidebar.json**
Shortened search placeholder to "Search conversations".

**ui/goose2/src/shared/i18n/locales/es/sidebar.json**
Shortened search placeholder to "Buscar conversaciones".

</details>

## Reproduction Steps

1. Open the app and look at the left sidebar — projects should show colored folder icons instead of colored dots
2. Expand a project section — chat rows with activity should show a spinner or unread dot to the left of the title
3. Note the section dividers are now spacing-only (no visible lines)
4. Click into any input field — placeholder text should be noticeably softer than before
5. Check the search bar — it should say "Search conversations" without a ⌘K badge
6. Toggle dark mode and verify all the above still looks correct

## Screenshots/Demos

<img width="292" height="892" alt="image" src="https://github.com/user-attachments/assets/d0265f3f-56cc-4b0a-a82b-19b6d0f74c56" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)