### PR TITLE
Reset ChatGPT Codex auth during OAuth setup

### DIFF
--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -1015,7 +1015,9 @@ impl Provider for ChatGptCodexProvider {
 
         if let Err(e) = result {
             if let Some(previous_token) = previous_token.as_ref() {
-                let _ = self.auth_provider.cache.save(previous_token);
+                if self.auth_provider.cache.load().is_none() {
+                    let _ = self.auth_provider.cache.save(previous_token);
+                }
             }
             return Err(ProviderError::Authentication(format!(
                 "OAuth flow failed: {}",

--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -806,6 +806,10 @@ impl ChatGptCodexAuthProvider {
         }
     }
 
+    fn clear_cached_tokens(&self) {
+        self.cache.clear();
+    }
+
     async fn get_valid_token(&self) -> Result<TokenData> {
         if let Some(mut token_data) = self.cache.load() {
             if token_data.expires_at > Utc::now() + chrono::Duration::seconds(60) {
@@ -865,6 +869,11 @@ pub struct ChatGptCodexProvider {
 }
 
 impl ChatGptCodexProvider {
+    pub async fn cleanup() -> Result<()> {
+        TokenCache::new().clear();
+        Ok(())
+    }
+
     pub async fn from_env(model: ModelConfig) -> Result<Self> {
         let auth_provider = Arc::new(ChatGptCodexAuthProvider::new(
             ChatGptCodexAuthState::instance(),
@@ -997,10 +1006,20 @@ impl Provider for ChatGptCodexProvider {
     }
 
     async fn configure_oauth(&self) -> Result<(), ProviderError> {
-        self.auth_provider
-            .get_valid_token()
+        let previous_token = self.auth_provider.cache.load();
+        self.auth_provider.clear_cached_tokens();
+
+        let result = perform_oauth_flow(self.auth_provider.state.as_ref())
             .await
-            .map_err(|e| ProviderError::Authentication(format!("OAuth flow failed: {}", e)))?;
+            .and_then(|token_data| self.auth_provider.cache.save(&token_data));
+
+        if let Err(e) = result {
+            if let Some(previous_token) = previous_token.as_ref() {
+                let _ = self.auth_provider.cache.save(previous_token);
+            }
+            return Err(ProviderError::Authentication(format!("OAuth flow failed: {}", e)));
+        }
+
         Ok(())
     }
 

--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -1017,7 +1017,10 @@ impl Provider for ChatGptCodexProvider {
             if let Some(previous_token) = previous_token.as_ref() {
                 let _ = self.auth_provider.cache.save(previous_token);
             }
-            return Err(ProviderError::Authentication(format!("OAuth flow failed: {}", e)));
+            return Err(ProviderError::Authentication(format!(
+                "OAuth flow failed: {}",
+                e
+            )));
         }
 
         Ok(())

--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -100,6 +100,10 @@ async fn init_registry() -> RwLock<ProviderRegistry> {
         "kimi_code",
         Arc::new(|| Box::pin(KimiCodeProvider::cleanup())),
     );
+    registry.set_cleanup(
+        "chatgpt_codex",
+        Arc::new(|| Box::pin(ChatGptCodexProvider::cleanup())),
+    );
 
     if let Err(e) = load_custom_providers_into_registry(&mut registry) {
         tracing::warn!("Failed to load custom providers: {}", e);


### PR DESCRIPTION
## Summary
- force `chatgpt_codex` reconfiguration to start a fresh OAuth flow instead of silently reusing cached tokens
- restore the previous cached token if the new OAuth attempt fails or is cancelled
- register `chatgpt_codex` cleanup so deleting the provider clears cached OAuth state

## Review Notes
- Production-safety review passed (3 rounds)
- Focus area: explicit re-auth should let users switch ChatGPT subscriptions without breaking existing auth on failed relogin

## Test plan
- [x] `cargo test -p goose chatgpt_codex --no-default-features --features rustls-tls -- --nocapture`
- [x] `cargo clippy -p goose --no-default-features --features rustls-tls --lib -- -D warnings`
- [ ] CI passes
- [ ] Reconfigure ChatGPT Codex after existing login and verify browser flow prompts for a fresh login
- [ ] Cancel reconfigure midway and verify the previous login still works
