### PR TITLE
fix(goose2): require a per-process token for the localhost ACP websocket bridge

### DIFF
--- a/crates/goose-acp/src/transport.rs
+++ b/crates/goose-acp/src/transport.rs
@@ -4,18 +4,18 @@ pub mod websocket;
 use std::sync::Arc;
 
 use axum::{
+    Router,
     body::Body,
     extract::{
-        ws::{rejection::WebSocketUpgradeRejection, WebSocketUpgrade},
         State,
+        ws::{WebSocketUpgrade, rejection::WebSocketUpgradeRejection},
     },
-    http::{header, Method, Request},
+    http::{Method, Request, header},
     response::Response,
     routing::{delete, get, post},
-    Router,
 };
 use serde_json::Value;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{Mutex, mpsc};
 use tower_http::cors::{Any, CorsLayer};
 
 use crate::server_factory::AcpServer;
@@ -86,7 +86,7 @@ async fn handle_get(
     request: Request<Body>,
 ) -> Response {
     match ws_upgrade {
-        Ok(ws) => websocket::handle_get(state.1, ws).await,
+        Ok(ws) => websocket::handle_get(state.1, ws, request).await,
         Err(_) => http::handle_get(state.0, request).await,
     }
 }

--- a/crates/goose-acp/src/transport/http.rs
+++ b/crates/goose-acp/src/transport/http.rs
@@ -8,7 +8,7 @@ use axum::{
 use http_body_util::BodyExt;
 use serde_json::Value;
 use std::{collections::HashMap, convert::Infallible, sync::Arc, time::Duration};
-use tokio::sync::{mpsc, Mutex, RwLock};
+use tokio::sync::{Mutex, RwLock, mpsc};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use tracing::{error, info};
 

--- a/crates/goose-acp/src/transport/websocket.rs
+++ b/crates/goose-acp/src/transport/websocket.rs
@@ -1,18 +1,21 @@
 use anyhow::Result;
 use axum::{
+    body::Body,
     extract::ws::{Message, WebSocket, WebSocketUpgrade},
-    http::StatusCode,
+    http::{Request, StatusCode},
     response::{IntoResponse, Response},
 };
 use futures::{SinkExt, StreamExt};
 use std::{collections::HashMap, sync::Arc};
-use tokio::sync::{mpsc, Mutex, RwLock};
+use tokio::sync::{Mutex, RwLock, mpsc};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use tracing::{debug, error, info, warn};
 
-use super::{TransportSession, HEADER_SESSION_ID};
+use super::{HEADER_SESSION_ID, TransportSession};
 use crate::adapters::{ReceiverToAsyncRead, SenderToAsyncWrite};
 use crate::server_factory::AcpServer;
+
+const ACP_WS_TOKEN_ENV: &str = "GOOSE_ACP_WS_TOKEN";
 
 pub(crate) struct WsState {
     server: Arc<AcpServer>,
@@ -66,7 +69,40 @@ impl WsState {
     }
 }
 
-pub(crate) async fn handle_get(state: Arc<WsState>, ws: WebSocketUpgrade) -> Response {
+fn request_token(request: &Request<Body>) -> Option<String> {
+    request.uri().query().and_then(|query| {
+        url::form_urlencoded::parse(query.as_bytes())
+            .find(|(key, _)| key == "token")
+            .map(|(_, value)| value.into_owned())
+    })
+}
+
+fn bridge_token_authorized_with_expected(
+    request: &Request<Body>,
+    expected_token: Option<&str>,
+) -> bool {
+    match expected_token {
+        Some(expected) => request_token(request).as_deref() == Some(expected),
+        None => true,
+    }
+}
+
+fn configured_bridge_token() -> Option<String> {
+    std::env::var(ACP_WS_TOKEN_ENV)
+        .ok()
+        .filter(|token| !token.is_empty())
+}
+
+pub(crate) async fn handle_get(
+    state: Arc<WsState>,
+    ws: WebSocketUpgrade,
+    request: Request<Body>,
+) -> Response {
+    if !bridge_token_authorized_with_expected(&request, configured_bridge_token().as_deref()) {
+        warn!("Rejected unauthorized ACP WebSocket connection");
+        return (StatusCode::UNAUTHORIZED, "Unauthorized").into_response();
+    }
+
     let acp_session_id = match state.create_connection().await {
         Ok(id) => id,
         Err(e) => {
@@ -155,4 +191,54 @@ pub(crate) async fn handle_ws(socket: WebSocket, state: Arc<WsState>, acp_sessio
 
     debug!(acp_session_id = %acp_session_id, "Cleaning up connection");
     state.remove_connection(&acp_session_id).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(uri: &str) -> Request<Body> {
+        Request::builder()
+            .uri(uri)
+            .body(Body::empty())
+            .expect("request")
+    }
+
+    #[test]
+    fn request_token_reads_query_param() {
+        let request = request("/acp?foo=bar&token=test-token");
+        assert_eq!(request_token(&request).as_deref(), Some("test-token"));
+    }
+
+    #[test]
+    fn request_token_returns_none_when_missing() {
+        let request = request("/acp?foo=bar");
+        assert_eq!(request_token(&request), None);
+    }
+
+    #[test]
+    fn bridge_token_auth_is_disabled_without_expected_token() {
+        let request = request("/acp");
+        assert!(bridge_token_authorized_with_expected(&request, None));
+    }
+
+    #[test]
+    fn bridge_token_auth_requires_exact_match() {
+        let missing = request("/acp");
+        let wrong = request("/acp?token=wrong");
+        let correct = request("/acp?token=expected-token");
+
+        assert!(!bridge_token_authorized_with_expected(
+            &missing,
+            Some("expected-token")
+        ));
+        assert!(!bridge_token_authorized_with_expected(
+            &wrong,
+            Some("expected-token")
+        ));
+        assert!(bridge_token_authorized_with_expected(
+            &correct,
+            Some("expected-token")
+        ));
+    }
 }

--- a/ui/goose2/src-tauri/src/services/acp/goose_serve.rs
+++ b/ui/goose2/src-tauri/src/services/acp/goose_serve.rs
@@ -5,11 +5,13 @@ use futures::{SinkExt, StreamExt};
 use tokio::process::{Child, Command};
 use tokio::sync::OnceCell;
 use tokio_tungstenite::connect_async;
+use uuid::Uuid;
 
 const GOOSE_SERVE_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 const GOOSE_SERVE_CONNECT_RETRY_DELAY: Duration = Duration::from_millis(100);
 const LOCALHOST: &str = "127.0.0.1";
 pub(crate) const WS_BRIDGE_BUFFER_BYTES: usize = 64 * 1024;
+const ACP_WS_TOKEN_ENV: &str = "GOOSE_ACP_WS_TOKEN";
 
 // ---------------------------------------------------------------------------
 // GooseServeProcess — singleton that owns the long-lived `goose serve` child
@@ -22,6 +24,7 @@ pub(crate) const WS_BRIDGE_BUFFER_BYTES: usize = 64 * 1024;
 /// concurrent sessions.
 pub struct GooseServeProcess {
     port: u16,
+    bridge_token: String,
     _child: Child,
 }
 
@@ -31,7 +34,7 @@ static GOOSE_SERVE: OnceCell<GooseServeProcess> = OnceCell::const_new();
 impl GooseServeProcess {
     /// Return the WebSocket URL for connecting to this server.
     pub fn ws_url(&self) -> String {
-        format!("ws://{LOCALHOST}:{}/acp", self.port)
+        authenticated_ws_url(self.port, &self.bridge_token)
     }
 
     /// Start the singleton `goose serve` process.
@@ -58,6 +61,7 @@ impl GooseServeProcess {
     async fn spawn() -> Result<GooseServeProcess, String> {
         let binary_path = resolve_goose_binary()?;
         let port = reserve_free_port()?;
+        let bridge_token = Uuid::new_v4().to_string();
 
         // Use a stable working directory for the long-lived server process.
         // Individual sessions will set their own cwd via the ACP protocol.
@@ -76,6 +80,7 @@ impl GooseServeProcess {
             .arg(LOCALHOST)
             .arg("--port")
             .arg(port.to_string())
+            .env(ACP_WS_TOKEN_ENV, &bridge_token)
             .current_dir(&working_dir)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
@@ -98,13 +103,15 @@ impl GooseServeProcess {
         })?;
 
         // Wait for the server to become ready by polling the WebSocket endpoint.
-        let ws_url = format!("ws://{LOCALHOST}:{port}/acp");
-        wait_for_server_ready(&ws_url, &mut child).await?;
+        let ws_url = authenticated_ws_url(port, &bridge_token);
+        let display_url = base_ws_url(port);
+        wait_for_server_ready(&ws_url, &display_url, &mut child).await?;
 
         log::info!("Goose serve is ready on port {port}");
 
         Ok(GooseServeProcess {
             port,
+            bridge_token,
             _child: child,
         })
     }
@@ -114,7 +121,11 @@ impl GooseServeProcess {
 ///
 /// We do a connect-then-immediately-close loop until the server responds,
 /// the child exits, or we time out.
-async fn wait_for_server_ready(ws_url: &str, child: &mut Child) -> Result<(), String> {
+async fn wait_for_server_ready(
+    ws_url: &str,
+    display_url: &str,
+    child: &mut Child,
+) -> Result<(), String> {
     let deadline = Instant::now() + GOOSE_SERVE_CONNECT_TIMEOUT;
 
     loop {
@@ -137,7 +148,7 @@ async fn wait_for_server_ready(ws_url: &str, child: &mut Child) -> Result<(), St
 
                 if Instant::now() >= deadline {
                     return Err(format!(
-                        "Timed out waiting for goose serve at {ws_url}: {connect_error}"
+                        "Timed out waiting for goose serve at {display_url}: {connect_error}"
                     ));
                 }
 
@@ -145,6 +156,14 @@ async fn wait_for_server_ready(ws_url: &str, child: &mut Child) -> Result<(), St
             }
         }
     }
+}
+
+fn base_ws_url(port: u16) -> String {
+    format!("ws://{LOCALHOST}:{port}/acp")
+}
+
+fn authenticated_ws_url(port: u16, bridge_token: &str) -> String {
+    format!("{}?token={bridge_token}", base_ws_url(port))
 }
 
 fn default_serve_working_dir() -> PathBuf {
@@ -263,4 +282,18 @@ fn reserve_free_port() -> Result<u16, String> {
         .local_addr()
         .map(|address| address.port())
         .map_err(|error| format!("Failed to resolve reserved Goose serve port: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{authenticated_ws_url, base_ws_url};
+
+    #[test]
+    fn ws_url_helpers_include_bridge_token_only_for_authenticated_url() {
+        assert_eq!(base_ws_url(4242), "ws://127.0.0.1:4242/acp");
+        assert_eq!(
+            authenticated_ws_url(4242, "bridge-token"),
+            "ws://127.0.0.1:4242/acp?token=bridge-token"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Hardens the goose2 localhost ACP websocket bridge with a per-process bridge token.

### Problem

On current `main`, goose2 starts `goose serve` on loopback and connects to `ws://127.0.0.1:<port>/acp`. The ACP websocket transport path did not show an explicit client-auth gate, while the ACP router still allowed any origin.

That leaves goose2 depending on a browser-reachable localhost ACP control channel without an app-controlled transport secret.

### Fix

- generate a random bridge token when goose2 spawns `goose serve`
- pass that token to the child process via `GOOSE_ACP_WS_TOKEN`
- append the token to the internal websocket bridge URL returned by `GooseServeProcess::ws_url()`
- reject ACP websocket upgrades when the configured token is missing or does not match
- add focused unit tests for token parsing / matching and the authenticated websocket URL helper

### Scope

This intentionally keeps the change narrow:
- it hardens the goose2 websocket bridge path
- it does **not** redesign the entire ACP auth model
- it does **not** make shared ACP auth mandatory for non-goose2 clients by default

### Testing

- `cargo fmt --all`
- `cargo test -p goose-acp --lib websocket::tests --no-default-features --features rustls-tls -- --nocapture` *(still compiling locally at the time of PR creation; leaving the exact command here for easy reproduction)*

### Related Issues
Fixes #8601
