### PR TITLE
fix(gym): isolate scenario Cargo projects from parent workspace

### DIFF
--- a/evals/open-model-gym/suite/scenarios/file-editing.yaml
+++ b/evals/open-model-gym/suite/scenarios/file-editing.yaml
@@ -15,6 +15,8 @@ setup:
     version = "0.1.0"
     edition = "2021"
 
+    [workspace]
+
   src/main.rs: |
     mod models;
     mod utils;

--- a/evals/open-model-gym/suite/scenarios/multi-turn-edit.yaml
+++ b/evals/open-model-gym/suite/scenarios/multi-turn-edit.yaml
@@ -12,6 +12,8 @@ setup:
     version = "0.1.0"
     edition = "2021"
 
+    [workspace]
+
   src/main.rs: |
     mod models;
 


### PR DESCRIPTION
## Summary

Two open-model-gym scenarios (`file-editing` and `multi-turn-edit`) scaffold a Cargo project without declaring `[workspace]`. When the gym is run from inside a checkout of `goose` itself — which is the most natural place to run it — the final `cargo build` validation step fails before goose's output is even evaluated:

```
error: current package believes it's in a workspace when it's not:
current:   .../evals/open-model-gym/suite/.workdir/file-editing_.../Cargo.toml
workspace: .../goose/Cargo.toml
```

This causes the scenario to be scored as failed regardless of how well the agent performed the edit.

## Fix

Add an empty `[workspace]` table to the scaffolded `Cargo.toml` in each affected scenario. This makes the scenario project self-contained so `cargo build` works regardless of where the gym is executed.

```diff
  Cargo.toml: |
    [package]
    name = "user-service"
    version = "0.1.0"
    edition = "2021"
+
+   [workspace]
```

## Repro

From inside a goose checkout, with a model configured:

```bash
cd evals/open-model-gym
just install
just run  # or: npx tsx suite/src/runner.ts
```

Before this change, `file-editing` fails at the `cargo build` validation rule even when the agent produces the correct edit. After the change, the scenario runs to completion.

Verified locally on macOS with `databricks/goose-claude-4-7-opus` — the `file-editing` scenario now passes end-to-end (`1/1 tests passed` in ~27s).

## Scope

Minimal, two-line change. No behavior change for users who run the gym outside a Rust workspace.
