### PR TITLE
Stop load openai fast model for openapi compatible custom endpoint

### DIFF
--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -84,7 +84,7 @@ impl OpenAiProvider {
         let is_openai = url::Url::parse(&host)
             .ok()
             .and_then(|u| u.host_str().map(|h| h.to_ascii_lowercase()))
-            .map(|h| h == "api.openai.com")
+            .map(|h| h == "api.openai.com" || h.ends_with(".api.openai.com"))
             .unwrap_or(false);
         let model = if is_openai {
             model.with_fast(OPEN_AI_DEFAULT_FAST_MODEL, OPEN_AI_PROVIDER_NAME)?

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -79,7 +79,14 @@ impl OpenAiProvider {
         // Only apply the default fast model when talking to OpenAI directly.
         // Custom/compatible endpoints likely don't serve gpt-4o-mini, so
         // leave fast_model unset (complete_fast will fall back to the main model).
-        let model = if host.contains("api.openai.com") {
+        // Parse the URL and compare the hostname exactly to avoid false positives
+        // (e.g. https://api.openai.com.local:8000 or proxy paths containing api.openai.com).
+        let is_openai = url::Url::parse(&host)
+            .ok()
+            .and_then(|u| u.host_str().map(|h| h.to_ascii_lowercase()))
+            .map(|h| h == "api.openai.com")
+            .unwrap_or(false);
+        let model = if is_openai {
             model.with_fast(OPEN_AI_DEFAULT_FAST_MODEL, OPEN_AI_PROVIDER_NAME)?
         } else {
             model

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -71,12 +71,19 @@ pub struct OpenAiProvider {
 
 impl OpenAiProvider {
     pub async fn from_env(model: ModelConfig) -> Result<Self> {
-        let model = model.with_fast(OPEN_AI_DEFAULT_FAST_MODEL, OPEN_AI_PROVIDER_NAME)?;
-
         let config = crate::config::Config::global();
         let host: String = config
             .get_param("OPENAI_HOST")
             .unwrap_or_else(|_| "https://api.openai.com".to_string());
+
+        // Only apply the default fast model when talking to OpenAI directly.
+        // Custom/compatible endpoints likely don't serve gpt-4o-mini, so
+        // leave fast_model unset (complete_fast will fall back to the main model).
+        let model = if host.contains("api.openai.com") {
+            model.with_fast(OPEN_AI_DEFAULT_FAST_MODEL, OPEN_AI_PROVIDER_NAME)?
+        } else {
+            model
+        };
 
         let secrets = config
             .get_secrets("OPENAI_API_KEY", &["OPENAI_CUSTOM_HEADERS"])


### PR DESCRIPTION
## Summary

When using custom OPENAI compatible endpoint, `gpt-4o-mini` is always tried to be loaded automatically even it didn't exist.

There are always warnings in the log like this:

```
{"timestamp":"2026-04-19T00:48:34.916138Z","level":"WARN","fields":{"message":"Provider request failed with status: 404 Not Found. Payload: Some(Object {\"error\": Object\
 {\"message\": String(\"The model `gpt-4o-mini` does not exist.\"), \"type\": String(\"NotFoundError\"), \"param\": String(\"model\"), \"code\": Number(404)}}). Returning\
 error: RequestFailed(\"Resource not found (404): The model `gpt-4o-mini` does not exist.\")"},"target":"goose::providers::openai_compatible","span":{"gen_ai.request.mode\
l":"gpt-4o-mini","session.id":"20260419_4","name":"complete"},"spans":[{"gen_ai.request.model":"gpt-4o-mini","session.id":"20260419_4","name":"complete"}]}
```

```
{"timestamp":"2026-04-19T00:48:34.916189Z","level":"WARN","fields":{"message":"Request failed, retrying (1/3): RequestFailed(\"Resource not found (404): The model `gpt-4o\
-mini` does not exist.\")"},"target":"goose::providers::retry","span":{"gen_ai.request.model":"gpt-4o-mini","session.id":"20260419_4","name":"complete"},"spans":[{"gen_ai\
.request.model":"gpt-4o-mini","session.id":"20260419_4","name":"complete"}]}
```

### ANALYSIS 

`OpenAiProvider::from_env()` read `OPENAI_HOST` only after unconditionally calling `model.with_fast("gpt-4o-mini", ...)`. So any user pointing the openai provider at a custom endpoint (like `http://localhost:8000`) always got `gpt-4o-mini` baked in as the fast model — which then fails with 404 at runtime whenever `complete_fast()` is called (MOIM summarization, context compaction, orchestrator).

### FIX

The fix (`openai.rs:73-86`): read OPENAI_HOST first, then only set the default fast model when the host contains api.openai.com. For any other host, fast_model_config stays None, so use_fast_model() falls back to the main model instead of attempting a non-existent `gpt-4o-mini`.

With `OPENAI_HOST: http://localhost:8000`, the fast model will now silently use `/models/Qwen3.5-35B-A3B-FP8` for MOIM/summarization calls instead of retrying `gpt-4o-mini` 3× and then falling back. If you later want a dedicated fast model on your local server, you can set it via a custom provider config with fast_model: "your-fast-model".


### Testing

Tested with local VLLM hosted QWEN3.5:35B and OpenAI API Endpoints. The WARN message disappeared after the fix.