### PR TITLE
fix: overlay config writes onto symlinked paths

### DIFF
--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -34,6 +34,32 @@ fn write_secrets_file(path: &Path, content: &str) -> std::io::Result<()> {
     }
 }
 
+pub(crate) fn atomic_write_overlay(path: &Path, content: &[u8]) -> Result<(), ConfigError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| ConfigError::DirectoryError(e.to_string()))?;
+    }
+
+    let temp_path = path.with_extension("tmp");
+
+    {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&temp_path)?;
+
+        file.lock_exclusive()
+            .map_err(|e| ConfigError::LockError(e.to_string()))?;
+
+        file.write_all(content)?;
+        file.sync_all()?;
+    }
+
+    std::fs::rename(&temp_path, path)?;
+
+    Ok(())
+}
+
 const KEYRING_SERVICE: &str = "goose";
 const KEYRING_USERNAME: &str = "secrets";
 pub const CONFIG_YAML_NAME: &str = "config.yaml";
@@ -498,80 +524,14 @@ impl Config {
         load_init_config_from_workspace()
     }
 
-    fn config_write_target_path(&self) -> Result<PathBuf, ConfigError> {
-        let mut path = self.config_path.clone();
-
-        // Follow symlinks so we update the target file without replacing the link itself.
-        const MAX_SYMLINK_HOPS: usize = 1;
-        let mut hops = 0usize;
-        loop {
-            match std::fs::symlink_metadata(&path) {
-                Ok(meta) if meta.file_type().is_symlink() => {
-                    if hops >= MAX_SYMLINK_HOPS {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::InvalidInput,
-                            format!(
-                                "Too many symlink levels (or a cycle) while resolving config path: {:?}",
-                                self.config_path
-                            ),
-                        )
-                        .into());
-                    }
-                    hops += 1;
-
-                    let link = std::fs::read_link(&path)?;
-                    path = if link.is_absolute() {
-                        link
-                    } else {
-                        path.parent().unwrap_or_else(|| Path::new(".")).join(link)
-                    };
-                }
-                Ok(_) => return Ok(path),
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(path),
-                Err(e) => return Err(e.into()),
-            }
-        }
-    }
-
     fn save_values(&self, values: &Mapping) -> Result<(), ConfigError> {
         // Create backup before writing new config
         self.create_backup_if_needed()?;
 
-        let target_path = self.config_write_target_path()?;
-
         // Convert to YAML for storage
         let yaml_value = serde_yaml::to_string(values)?;
 
-        if let Some(parent) = target_path.parent() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| ConfigError::DirectoryError(e.to_string()))?;
-        }
-
-        // Write to a temporary file first for atomic operation
-        let temp_path = target_path.with_extension("tmp");
-
-        {
-            let mut file = OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(&temp_path)?;
-
-            // Acquire an exclusive lock
-            file.lock_exclusive()
-                .map_err(|e| ConfigError::LockError(e.to_string()))?;
-
-            // Write the contents using the same file handle
-            file.write_all(yaml_value.as_bytes())?;
-            file.sync_all()?;
-
-            // Unlock is handled automatically when file is dropped
-        }
-
-        // Atomically replace the original file
-        std::fs::rename(&temp_path, &target_path)?;
-
-        Ok(())
+        atomic_write_overlay(&self.config_path, yaml_value.as_bytes())
     }
 
     pub fn initialize_if_empty(&self, values: Mapping) -> Result<(), ConfigError> {
@@ -1333,7 +1293,7 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
-    fn test_write_follows_symlink() -> Result<(), ConfigError> {
+    fn test_write_replaces_symlink_with_overlay_file() -> Result<(), ConfigError> {
         use std::os::unix::fs as unix_fs;
 
         let dir = TempDir::new().unwrap();
@@ -1350,31 +1310,28 @@ mod tests {
 
         let meta = std::fs::symlink_metadata(&symlink_path)?;
         assert!(
-            meta.file_type().is_symlink(),
-            "config path should remain a symlink"
+            meta.file_type().is_file(),
+            "config path should become a regular overlay file"
         );
 
         let content = std::fs::read_to_string(&symlink_path)?;
         assert!(content.contains("key1: value1"));
 
         let content = std::fs::read_to_string(&target_path)?;
-        assert!(content.contains("key1: value1"));
+        assert_eq!(content, "{}\n");
 
         Ok(())
     }
 
     #[test]
     #[cfg(unix)]
-    fn test_write_fails_on_long_symlink_chain() -> Result<(), ConfigError> {
+    fn test_write_replaces_head_of_symlink_chain() -> Result<(), ConfigError> {
         use std::os::unix::fs as unix_fs;
 
         let dir = TempDir::new().unwrap();
         let target_path = dir.path().join("real_config.yaml");
         std::fs::write(&target_path, "{}\n")?;
 
-        // config.yaml -> link1.yaml -> real_config.yaml
-        // We only allow following one symlink hop. If there's another symlink, we should fail
-        // rather than overwrite the intermediate symlink.
         let config_symlink = dir.path().join("config.yaml");
         let link1 = dir.path().join("link1.yaml");
         unix_fs::symlink(&target_path, &link1)?;
@@ -1383,22 +1340,24 @@ mod tests {
         let secrets_file = NamedTempFile::new().unwrap();
         let config = Config::new_with_file_secrets(&config_symlink, secrets_file.path())?;
 
-        let err = config.set_param("key1", "value1").unwrap_err();
-        assert!(
-            err.to_string().contains("Too many symlink levels"),
-            "unexpected error: {err}"
-        );
+        config.set_param("key1", "value1")?;
 
         let meta = std::fs::symlink_metadata(&config_symlink)?;
         assert!(
-            meta.file_type().is_symlink(),
-            "config path should remain a symlink"
+            meta.file_type().is_file(),
+            "config path should become a regular overlay file"
         );
         let meta = std::fs::symlink_metadata(&link1)?;
         assert!(
             meta.file_type().is_symlink(),
             "intermediate link should remain a symlink"
         );
+
+        let content = std::fs::read_to_string(&config_symlink)?;
+        assert!(content.contains("key1: value1"));
+
+        let content = std::fs::read_to_string(&target_path)?;
+        assert_eq!(content, "{}\n");
 
         Ok(())
     }

--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -1,3 +1,4 @@
+use crate::config::base::atomic_write_overlay;
 use crate::config::paths::Paths;
 use crate::config::Config;
 use crate::providers::anthropic::AnthropicProvider;
@@ -26,6 +27,15 @@ static FIXED_PROVIDERS: Dir = include_dir!("$CARGO_MANIFEST_DIR/src/providers/de
 
 pub fn custom_providers_dir() -> std::path::PathBuf {
     Paths::config_dir().join("custom_providers")
+}
+
+fn write_custom_provider_file(
+    path: &Path,
+    provider_config: &DeclarativeProviderConfig,
+) -> Result<()> {
+    let json_content = serde_json::to_vec_pretty(provider_config)?;
+    atomic_write_overlay(path, &json_content)?;
+    Ok(())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -238,9 +248,8 @@ pub fn create_custom_provider(
     let custom_providers_dir = custom_providers_dir();
     std::fs::create_dir_all(&custom_providers_dir)?;
 
-    let json_content = serde_json::to_string_pretty(&provider_config)?;
     let file_path = custom_providers_dir.join(format!("{}.json", id));
-    std::fs::write(file_path, json_content)?;
+    write_custom_provider_file(&file_path, &provider_config)?;
 
     Ok(provider_config)
 }
@@ -303,8 +312,7 @@ pub fn update_custom_provider(params: UpdateCustomProviderParams) -> Result<()> 
         };
 
         let file_path = custom_providers_dir().join(format!("{}.json", updated_config.name));
-        let json_content = serde_json::to_string_pretty(&updated_config)?;
-        std::fs::write(file_path, json_content)?;
+        write_custom_provider_file(&file_path, &updated_config)?;
     }
     Ok(())
 }
@@ -500,6 +508,7 @@ pub fn register_declarative_provider(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     #[test]
     fn test_tanzu_json_deserializes() {
@@ -565,6 +574,72 @@ mod tests {
             serde_json::from_str(json).expect("groq.json should parse without env_vars");
         assert!(config.env_vars.is_none());
         assert!(config.dynamic_models.is_none());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_write_custom_provider_replaces_symlink_with_overlay_file() -> Result<()> {
+        use std::os::unix::fs as unix_fs;
+
+        let dir = TempDir::new().unwrap();
+        let target_path = dir.path().join("atlas_swap.json");
+        let symlink_path = dir.path().join("custom_provider.json");
+
+        let original = serde_json::json!({
+            "name": "atlas_swap",
+            "engine": "openai",
+            "display_name": "Atlas Swap",
+            "description": "Managed by Home Manager",
+            "api_key_env": "",
+            "base_url": "http://localhost:8013/v1/chat/completions",
+            "models": [],
+            "requires_auth": false,
+            "skip_canonical_filtering": true
+        });
+        std::fs::write(&target_path, serde_json::to_vec_pretty(&original)?)?;
+        unix_fs::symlink(&target_path, &symlink_path)?;
+
+        let provider_config = DeclarativeProviderConfig {
+            name: "atlas_swap".to_string(),
+            engine: ProviderEngine::OpenAI,
+            display_name: "Atlas Swap".to_string(),
+            description: Some("Editable overlay".to_string()),
+            api_key_env: String::new(),
+            base_url: "http://localhost:8013/v1/chat/completions".to_string(),
+            models: vec![ModelInfo::new("gemma4-31b", 32768)],
+            headers: None,
+            timeout_seconds: None,
+            supports_streaming: Some(true),
+            requires_auth: false,
+            catalog_provider_id: None,
+            base_path: None,
+            env_vars: None,
+            dynamic_models: Some(true),
+            skip_canonical_filtering: true,
+            fast_model: None,
+        };
+
+        write_custom_provider_file(&symlink_path, &provider_config)?;
+
+        let meta = std::fs::symlink_metadata(&symlink_path)?;
+        assert!(
+            meta.file_type().is_file(),
+            "custom provider path should become a regular overlay file"
+        );
+
+        let overlay: DeclarativeProviderConfig =
+            serde_json::from_str(&std::fs::read_to_string(&symlink_path)?)?;
+        assert_eq!(overlay.description, Some("Editable overlay".to_string()));
+        assert_eq!(overlay.models[0].name, "gemma4-31b");
+
+        let preserved_target: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&target_path)?)?;
+        assert_eq!(
+            preserved_target["description"],
+            serde_json::Value::String("Managed by Home Manager".to_string())
+        );
+
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fix Goose config writes for declarative config managers such as Home Manager. When `config.yaml` or a custom provider JSON lives at a symlinked logical path, Goose should write an overlay file at the logical location instead of following the symlink into an immutable target.

## Changes
- add a shared atomic helper that writes to the logical config path and replaces a symlink with a regular file overlay
- use that helper for `config.yaml` writes in `crates/goose/src/config/base.rs`
- use the same helper for writable custom-provider JSON files in `crates/goose/src/config/declarative_providers.rs`
- add regression tests for symlinked `config.yaml`, a short symlink chain, and symlinked custom-provider JSON files

## Validation
- `nix develop -c cargo fmt --all`
- `nix develop -c cargo test -p goose --no-default-features --features rustls-tls write_replaces_symlink_with_overlay_file -- --nocapture`
- `nix develop -c cargo test -p goose --no-default-features --features rustls-tls write_replaces_head_of_symlink_chain -- --nocapture`
- `nix develop -c cargo test -p goose --no-default-features --features rustls-tls write_custom_provider_replaces_symlink_with_overlay_file -- --nocapture`