### PR TITLE
openai: support xhigh reasoning suffix for gpt-5 models

### DIFF
--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -1798,6 +1798,47 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn test_create_request_gpt_5_4_xhigh_reasoning_effort() -> anyhow::Result<()> {
+        let model_config = ModelConfig {
+            model_name: "gpt-5.4-xhigh".to_string(),
+            context_limit: Some(4096),
+            temperature: None,
+            max_tokens: Some(1024),
+            toolshim: false,
+            toolshim_model: None,
+            fast_model_config: None,
+            request_params: None,
+            reasoning: None,
+        };
+        let request = create_request(
+            &model_config,
+            "system",
+            &[],
+            &[],
+            &ImageFormat::OpenAi,
+            false,
+        )?;
+        let obj = request.as_object().unwrap();
+        let expected = json!({
+            "model": "gpt-5.4",
+            "messages": [
+                {
+                    "role": "developer",
+                    "content": "system"
+                }
+            ],
+            "reasoning_effort": "xhigh",
+            "max_completion_tokens": 1024
+        });
+
+        for (key, value) in expected.as_object().unwrap() {
+            assert_eq!(obj.get(key).unwrap(), value);
+        }
+
+        Ok(())
+    }
+
     struct StreamingUsageTestResult {
         usage_count: usize,
         usage: Option<ProviderUsage>,

--- a/crates/goose/src/providers/formats/openai_responses.rs
+++ b/crates/goose/src/providers/formats/openai_responses.rs
@@ -854,6 +854,29 @@ mod tests {
     }
 
     #[test]
+    fn test_create_responses_request_gpt_5_4_xhigh_reasoning_effort() -> anyhow::Result<()> {
+        let model_config = ModelConfig {
+            model_name: "gpt-5.4-xhigh".to_string(),
+            context_limit: Some(4096),
+            temperature: None,
+            max_tokens: Some(1024),
+            toolshim: false,
+            toolshim_model: None,
+            fast_model_config: None,
+            request_params: None,
+            reasoning: None,
+        };
+
+        let request = create_responses_request(&model_config, "system", &[], &[])?;
+
+        assert_eq!(request["model"], "gpt-5.4");
+        assert_eq!(request["reasoning"]["effort"], "xhigh");
+        assert_eq!(request["reasoning"]["summary"], "auto");
+
+        Ok(())
+    }
+
+    #[test]
     fn test_responses_api_to_message_captures_reasoning_summary() -> anyhow::Result<()> {
         let response: ResponsesApiResponse = serde_json::from_value(serde_json::json!({
             "id": "resp_1",

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -807,6 +807,14 @@ mod tests {
     }
 
     #[test]
+    fn gpt_5_4_xhigh_uses_responses() {
+        assert!(OpenAiProvider::should_use_responses_api(
+            "gpt-5.4-xhigh",
+            "v1/chat/completions"
+        ));
+    }
+
+    #[test]
     fn gpt_4o_does_not_use_responses() {
         assert!(!OpenAiProvider::should_use_responses_api(
             "gpt-4o",

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -207,7 +207,7 @@ pub fn extract_reasoning_effort(model_name: &str) -> (String, Option<String>) {
     let parts: Vec<&str> = model_name.split('-').collect();
     let last_part = parts.last().unwrap();
     match *last_part {
-        "low" | "medium" | "high" => {
+        "low" | "medium" | "high" | "xhigh" => {
             let base_name = parts[..parts.len() - 1].join("-");
             (base_name, Some(last_part.to_string()))
         }


### PR DESCRIPTION
## Summary
- Support `xhigh` in the existing OpenAI reasoning suffix parser.
- Before, `GOOSE_MODEL=gpt-5.4-xhigh` was sent to OpenAI as an invalid model name and failed with 400.
- After, Goose normalizes the model to `gpt-5.4` and forwards `xhigh`.

### Follow-ups
- This suffix-based reasoning effort behavior is not currently documented in user-facing docs. I plan to follow up with a separate docs-only PR describing that model names like `gpt-5.4-xhigh` are accepted and normalized to `model = gpt-5.4` with `reasoning.effort = xhigh`.
- As a follow-up UX improvement, it may also be worth extending `goose configure` so reasoning effort can be set directly for the
built-in OpenAI provider, instead of requiring users to encode it in the model suffix.

### Testing
- `source bin/activate-hermit && cargo test -p goose xhigh`
- Manual check with built `before` / `after` binaries using `GOOSE_MODEL=gpt-5.4-xhigh`

### Related Issues
Relates to: none  
Discussion: none

### Screenshots/Demos (for UX changes)
Before:

```sh
$ cat ~/.config/goose/config.yaml
GOOSE_PROVIDER: openai
GOOSE_MODEL: gpt-5.4-xhigh

$ goose session
# effective request to OpenAI Responses API:
# model = gpt-5.4-xhigh
# reasoning.effort = medium
# result: 400 The requested model 'gpt-5.4-xhigh' does not exist
```

After:

```sh
$ cat ~/.config/goose/config.yaml
GOOSE_PROVIDER: openai
GOOSE_MODEL: gpt-5.4-xhigh

$ goose run -t "say hi"
Hi! 👋

# effective request to OpenAI Responses API:
# model = gpt-5.4
# reasoning.effort = xhigh
```
