### PR TITLE
Add dependabot config for pnpm workspace, cargo, and actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  # pnpm workspace for the UI (desktop, acp, text, sdk, goose-binary/*, goose2).
+  # Point at the workspace ROOT where pnpm-lock.yaml lives so Dependabot updates
+  # both the child package.json AND ui/pnpm-lock.yaml in one PR.
+  - package-ecosystem: "npm"
+    directory: "/ui"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      ui-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Cargo workspace at the repo root.
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      cargo-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used by workflows in .github/workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Without a `.github/dependabot.yml`, Dependabot auto-discovery treats `ui/desktop/package.json` as a standalone npm project. Since the pnpm lockfile lives one level up at `ui/pnpm-lock.yaml`, Dependabot updates only the child `package.json` and leaves the lockfile stale, producing broken PRs (e.g. #8444).

This config points the npm ecosystem at `/ui` (the pnpm workspace root) so Dependabot updates the correct child `package.json` **and** regenerates `ui/pnpm-lock.yaml` in the same PR.

Also adds cargo updates at the repo root and github-actions updates, with minor/patch bumps grouped to cut PR noise.

Existing broken PRs (like #8444) won't self-heal — close them, or comment `@dependabot recreate` once this lands.