### PR TITLE
ci: declare and enforce MSRV of 1.91.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,43 @@ jobs:
         env:
           CARGO_INCREMENTAL: "0"
 
+  rust-msrv:
+    name: Check MSRV
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
+      - name: Read MSRV from Cargo.toml
+        id: msrv
+        run: |
+          msrv=$(sed -n 's/^rust-version = "\(.*\)"$/\1/p' Cargo.toml)
+          if [ -z "$msrv" ]; then
+            echo "Could not find rust-version in workspace Cargo.toml" >&2
+            exit 1
+          fi
+          echo "msrv=$msrv" >> "$GITHUB_OUTPUT"
+          echo "MSRV: $msrv"
+
+      - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606  # v1
+        with:
+          toolchain: ${{ steps.msrv.outputs.msrv }}
+
+      - name: Install Dependencies
+        run: |
+          sudo apt update -y
+          sudo apt install -y libdbus-1-dev libxcb1-dev
+
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae  # v2
+        with:
+          key: msrv
+
+      - name: Check with MSRV toolchain
+        run: cargo check --workspace --locked --all-targets
+        env:
+          CARGO_INCREMENTAL: "0"
+
   rust-lint:
     name: Lint Rust Code
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 version = "1.31.0"
+rust-version = "1.91.1"
 authors = ["AAIF <ai-oss-tools@block.xyz>"]
 license = "Apache-2.0"
 repository = "https://github.com/aaif-goose/goose"

--- a/crates/goose-acp-macros/Cargo.toml
+++ b/crates/goose-acp-macros/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "goose-acp-macros"
 edition.workspace = true
+rust-version.workspace = true
 version.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/goose-acp/Cargo.toml
+++ b/crates/goose-acp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "goose-acp"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "goose-cli"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/goose-mcp/Cargo.toml
+++ b/crates/goose-mcp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "goose-mcp"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/goose-sdk/Cargo.toml
+++ b/crates/goose-sdk/Cargo.toml
@@ -2,6 +2,7 @@
 name = "goose-sdk"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/goose-server/Cargo.toml
+++ b/crates/goose-server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "goose-server"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/goose-test-support/Cargo.toml
+++ b/crates/goose-test-support/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "goose-test-support"
 edition.workspace = true
+rust-version.workspace = true
 version.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/goose-test/Cargo.toml
+++ b/crates/goose-test/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "goose-test"
 edition.workspace = true
+rust-version.workspace = true
 version.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -2,6 +2,7 @@
 name = "goose"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
**Category:** infrastructure
**User Impact:** Distro packagers (Fedora, Debian, etc.) now have a documented minimum Rust version to target, and the project will no longer silently drift above it.

**Problem:** A Red Hat engineer packaging goose for Fedora hit a build failure because a transitive dependency had jumped its MSRV past Fedora's packaged rustc. goose had no declared MSRV and no CI enforcement, so any `cargo update` could silently raise the floor and break downstream packagers without us noticing.

**Solution:** Declare `rust-version = "1.91.1"` in the workspace `Cargo.toml` (this matches the current effective floor, driven by `aws-smithy-xml 0.60.15` among others) and propagate it to every member crate. Add a `rust-msrv` CI job that reads the version out of `Cargo.toml` and runs `cargo check --workspace --locked --all-targets` against exactly that toolchain, so MSRV violations fail CI on the offending PR. The version lives in one place; CI extracts it, so future bumps are a one-line change.

<details>
<summary>File changes</summary>

**Cargo.toml**
Added `rust-version = "1.91.1"` to `[workspace.package]` as the single source of truth for the MSRV.

**crates/\*/Cargo.toml** (9 files)
Added `rust-version.workspace = true` so each member crate inherits the workspace MSRV and reports it in `cargo metadata`.

**.github/workflows/ci.yml**
Added a new `rust-msrv` job that extracts the MSRV from `Cargo.toml` via `sed`, installs that exact toolchain, and runs `cargo check --workspace --locked --all-targets`. Uses a dedicated `Swatinem/rust-cache` key so it doesn't evict the main build cache.

</details>

### Reproduction Steps

1. Run \`cargo metadata --format-version 1 --no-deps | jq '.packages[] | {name, rust_version}'\` and confirm every goose crate reports \`"1.91.1"\`.
2. Install the MSRV toolchain locally: \`rustup toolchain install 1.91.1 --profile minimal\`.
3. Run \`cargo +1.91.1 check --workspace --locked --all-targets\` and confirm it builds cleanly.
4. In CI, observe the new \`Check MSRV\` job running alongside the existing lint and build jobs.