### PR TITLE
feat(providers): Add support for generic OpenRouter API parameters

### DIFF
--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -166,6 +166,7 @@ impl ProviderDef for OpenRouterProvider {
                     Some("https://openrouter.ai"),
                     false,
                 ),
+                ConfigKey::new("OPENROUTER_PARAMETERS", false, false, None, false),
             ],
         )
         .with_setup_steps(vec![
@@ -281,6 +282,19 @@ impl Provider for OpenRouterProvider {
 
         if let Some(obj) = payload.as_object_mut() {
             obj.insert("transforms".to_string(), json!(["middle-out"]));
+        }
+
+        let config = crate::config::Config::global();
+        if let Ok(params) =
+            config.get_param::<serde_json::Map<String, Value>>("OPENROUTER_PARAMETERS")
+        {
+            if let Some(obj) = payload.as_object_mut() {
+                for (k, v) in params {
+                    if !obj.contains_key(&k) {
+                        obj.insert(k, v);
+                    }
+                }
+            }
         }
 
         let mut log = RequestLog::start(model_config, &payload)?;

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -1221,6 +1221,28 @@ Here are some local providers we support:
 
 
 
+## OpenRouter Advanced Configuration
+
+OpenRouter supports a variety of advanced configuration options in their API, such as `verbosity`, [plugins](https://openrouter.ai/docs/plugins), and `require_parameters`. You can pass these generic API parameters directly to OpenRouter by modifying your `config.yaml` file to include an `OPENROUTER_PARAMETERS` dictionary.
+
+1. Open your `~/.config/goose/config.yaml` file.
+2. Add the `OPENROUTER_PARAMETERS` key with your desired OpenRouter payload attributes. 
+
+You can format it as a YAML object:
+```yaml
+OPENROUTER_PARAMETERS:
+  verbosity: xhigh
+  plugins:
+    - id: web
+```
+
+Or as a JSON string:
+```yaml
+OPENROUTER_PARAMETERS: '{"verbosity": "xhigh", "plugins": [{"id": "web"}]}'
+```
+
+goose will automatically parse these values and append them directly to the OpenRouter inference request payload.
+
 ## GitHub Copilot Authentication
 
 GitHub Copilot uses a device flow for authentication, so no API keys are required:


### PR DESCRIPTION
﻿Resolves #8646

This PR adds support for configuring arbitrary advanced OpenRouter parameters (e.g. `verbosity`, `plugins`, `reasoning-tokens`) by defining `OPENROUTER_PARAMETERS` in `config.yaml`.

- Injects payload properties directly into OpenRouter JSON HTTP request body.
- Fallback/ignore logic safely handles non-existing configurations.
- Added usage documentation pointing out JSON & YAML format support under the OpenRouter getting started section.

Testing:
- Deployed documentation locally using `just run-docs` equivalent validation.
- Ran `cargo clippy --all-targets -- -D warnings`
