### PR TITLE
test(prompt_manager): Force deterministic skills output in snapshot tests

### DIFF
--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -446,10 +446,14 @@ mod tests {
                     .and_then(|i| i.instructions.clone())
                     .unwrap_or_default();
 
-                // Force determinism for snapshot testing so local developer skills don't pollute the diff
+                // Force determinism for snapshot testing so host-specific extension instructions
+                // do not pollute the diff.
                 if def.name == "skills" {
                     instructions =
                         "<Deterministic skill instructions for snapshot tests>".to_string();
+                } else if def.name == "developer" {
+                    instructions =
+                        "<Deterministic developer instructions for snapshot tests>".to_string();
                 }
 
                 let has_resources = info

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -445,12 +445,13 @@ mod tests {
                 let mut instructions = info
                     .and_then(|i| i.instructions.clone())
                     .unwrap_or_default();
-                    
+
                 // Force determinism for snapshot testing so local developer skills don't pollute the diff
                 if def.name == "skills" {
-                    instructions = "<Deterministic skill instructions for snapshot tests>".to_string();
+                    instructions =
+                        "<Deterministic skill instructions for snapshot tests>".to_string();
                 }
-                
+
                 let has_resources = info
                     .and_then(|i| i.capabilities.resources.as_ref())
                     .is_some();

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -442,9 +442,15 @@ mod tests {
             .map(|def| {
                 let client = (def.client_factory)(context.clone());
                 let info = client.get_info();
-                let instructions = info
+                let mut instructions = info
                     .and_then(|i| i.instructions.clone())
                     .unwrap_or_default();
+                    
+                // Force determinism for snapshot testing so local developer skills don't pollute the diff
+                if def.name == "skills" {
+                    instructions = "<Deterministic skill instructions for snapshot tests>".to_string();
+                }
+                
                 let has_resources = info
                     .and_then(|i| i.capabilities.resources.as_ref())
                     .is_some();

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/goose/src/agents/prompt_manager.rs
-assertion_line: 458
+assertion_line: 474
 expression: system_prompt
 ---
 You are a general-purpose AI agent called goose, created by AAIF (Agentic AI Foundation).
@@ -78,18 +78,7 @@ WORKFLOW:
 ## developer
 
 ### Instructions
-Use the developer extension to build software and operate a terminal.
-
-Make sure to use the tools *efficiently* - reading all the content you need in as few
-iterations as possible and then making the requested edits or running commands. You are
-responsible for managing your context window, and to minimize unnecessary turns which
-cost the user money.
-
-For editing software, prefer the flow of using tree to understand the codebase structure
-and file sizes. When you need to search, prefer rg which correctly respects gitignored
-content. Then use cat or sed to gather the context you need, always reading before editing.
-Use write and edit to efficiently make changes. Test and verify as appropriate.
-
+<Deterministic developer instructions for snapshot tests>
 ## orchestrator
 
 ### Instructions

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
@@ -97,10 +97,7 @@ Manage agent sessions: list, view, start, send messages, and interrupt agents.
 ## skills
 
 ### Instructions
-
-
-You have these skills at your disposal, when it is clear they can help you solve a problem or you are asked to use them:
-• goose-doc-guide - Reference goose documentation to create, configure, or explain goose-specific features like recipes, extensions, sessions, and providers. You MUST fetch relevant goose docs before answering. You MUST NOT rely on training data or assumptions for any goose-specific fields, values, names, syntax, or commands.
+<Deterministic skill instructions for snapshot tests>
 ## summarize
 
 


### PR DESCRIPTION
﻿Resolves #8484

The \	est_all_platform_extensions\ test previously failed when developers had local skills installed (e.g. in \~/.agents/skills\) because the SkillsClient dynamically loaded them into the context, polluting the snapshot output diff.

This patch guarantees that the snapshot test generates identical deterministic output by safely hardcoding the \skills\ extension instructions inside the loop specifically for the snapshot.
