### PR TITLE
feat(cli): add /skills command to list available skills

### DIFF
--- a/crates/goose-cli/src/session/completion.rs
+++ b/crates/goose-cli/src/session/completion.rs
@@ -135,6 +135,7 @@ impl GooseCompleter {
             "/prompts",
             "/prompt",
             "/mode",
+            "/skills",
             "/recipe",
         ];
 

--- a/crates/goose-cli/src/session/input.rs
+++ b/crates/goose-cli/src/session/input.rs
@@ -27,6 +27,7 @@ pub enum InputResult {
     Compact,
     ToggleFullToolOutput,
     Edit(Option<String>),
+    Skills,
 }
 
 #[derive(Debug)]
@@ -204,6 +205,7 @@ fn handle_slash_command(input: &str) -> Option<InputResult> {
     const CMD_SUMMARIZE_DEPRECATED: &str = "/summarize";
     const CMD_EDIT: &str = "/edit";
     const CMD_EDIT_WITH_SPACE: &str = "/edit ";
+    const CMD_SKILLS: &str = "/skills";
 
     match input {
         "/exit" | "/quit" => Some(InputResult::Exit),
@@ -284,6 +286,7 @@ fn handle_slash_command(input: &str) -> Option<InputResult> {
                 Some(InputResult::Edit(Some(prefill.to_string())))
             }
         }
+        s if s == CMD_SKILLS => Some(InputResult::Skills),
         _ => None,
     }
 }
@@ -412,6 +415,7 @@ fn print_help() {
                         The model is used based on $GOOSE_PLANNER_PROVIDER and $GOOSE_PLANNER_MODEL environment variables.
                         If no model is set, the default model is used.
 /endplan - Exit plan mode and return to 'normal' goose mode.
+/skills - List all available skills and their descriptions.
 /recipe [filepath] - Generate a recipe from the current conversation and save it to the specified filepath (must end with .yaml).
                        If no filepath is provided, it will be saved to ./recipe.yaml.
 /compact - Compact the current conversation to reduce context length while preserving key information.

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -798,9 +798,10 @@ impl CliSession {
     }
 
     async fn handle_skills(&mut self) -> Result<()> {
-        let skills = goose::agents::platform_extensions::skills::list_installed_skills(
+        let mut skills = goose::agents::platform_extensions::skills::list_installed_skills(
             std::env::current_dir().ok().as_deref(),
         );
+        skills.sort_by(|a, b| (&a.name, &a.path).cmp(&(&b.name, &b.path)));
         output::render_skills(&skills);
         Ok(())
     }

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -637,6 +637,10 @@ impl CliSession {
                 history.save(editor);
                 self.handle_compact().await?;
             }
+            InputResult::Skills => {
+                history.save(editor);
+                self.handle_skills().await?;
+            }
             InputResult::Edit(prefill) => {
                 history.save(editor);
                 match crate::session::editor::resolve_editor_command() {
@@ -790,6 +794,14 @@ impl CliSession {
         self.agent.update_goose_mode(mode, &self.session_id).await?;
         config.set_goose_mode(mode)?;
         output::goose_mode_message(&format!("Goose mode set to '{mode}'"));
+        Ok(())
+    }
+
+    async fn handle_skills(&mut self) -> Result<()> {
+        let skills = goose::agents::platform_extensions::skills::list_installed_skills(
+            std::env::current_dir().ok().as_deref(),
+        );
+        output::render_skills(&skills);
         Ok(())
     }
 

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -607,6 +607,22 @@ pub fn render_prompt_info(info: &PromptInfo) {
     println!();
 }
 
+pub fn render_skills(skills: &[goose::agents::platform_extensions::skills::Source]) {
+    println!();
+    if skills.is_empty() {
+        println!("  {}", style("No skills found.").dim());
+    } else {
+        println!("  {}", style("Available skills:").green().bold());
+        for skill in skills {
+            println!("  - {}", style(&skill.name).cyan());
+            if let Some(desc) = &skill.description {
+                println!("    {}", style(desc).dim());
+            }
+        }
+    }
+    println!();
+}
+
 fn render_arguments(info: &PromptInfo) {
     if let Some(args) = &info.arguments {
         println!("\n Arguments:");

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -607,7 +607,7 @@ pub fn render_prompt_info(info: &PromptInfo) {
     println!();
 }
 
-pub fn render_skills(skills: &[goose::agents::platform_extensions::skills::Source]) {
+pub fn render_skills(skills: &[goose::agents::platform_extensions::Source]) {
     println!();
     if skills.is_empty() {
         println!("  {}", style("No skills found.").dim());
@@ -615,8 +615,8 @@ pub fn render_skills(skills: &[goose::agents::platform_extensions::skills::Sourc
         println!("  {}", style("Available skills:").green().bold());
         for skill in skills {
             println!("  - {}", style(&skill.name).cyan());
-            if let Some(desc) = &skill.description {
-                println!("    {}", style(desc).dim());
+            if !skill.description.is_empty() {
+                println!("    {}", style(&skill.description).dim());
             }
         }
     }

--- a/crates/goose/src/agents/platform_extensions/skills.rs
+++ b/crates/goose/src/agents/platform_extensions/skills.rs
@@ -79,7 +79,10 @@ fn walk_files_recursively<F, G>(
         Err(_) => return,
     };
 
-    for entry in entries.flatten() {
+    let mut entries: Vec<_> = entries.flatten().collect();
+    entries.sort_by_key(|entry| entry.path());
+
+    for entry in entries {
         let path = entry.path();
         if path.is_dir() {
             if should_descend(&path) {


### PR DESCRIPTION
Resolves #8599. Added /skills command to deterministicly list all available skills with descriptions in the interactive CLI session.