### PR TITLE
fix: handle commas within values for CUSTOM_HEADERS

### DIFF
--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -683,7 +683,7 @@ fn split_on_commas_outside_quotes(s: &str) -> Vec<String> {
 }
 
 fn parse_custom_headers(s: String) -> HashMap<String, String> {
-    fn unquote_and_unescape(val: &str) -> String {
+    fn normalize_header_value(val: &str) -> String {
         let trimmed = val.trim();
         let Some(inner) = trimmed.strip_prefix('"').and_then(|s| s.strip_suffix('"')) else {
             return trimmed.to_string();
@@ -710,7 +710,12 @@ fn parse_custom_headers(s: String) -> HashMap<String, String> {
                 out.push(c);
             }
         }
-        out
+
+        if inner.contains(',') {
+            out
+        } else {
+            format!("\"{}\"", out)
+        }
     }
 
     split_on_commas_outside_quotes(&s)
@@ -721,7 +726,7 @@ fn parse_custom_headers(s: String) -> HashMap<String, String> {
             if key.is_empty() {
                 return None;
             }
-            let value = unquote_and_unescape(v);
+            let value = normalize_header_value(v);
             Some((key.to_string(), value))
         })
         .collect()
@@ -824,7 +829,15 @@ mod tests {
     fn test_parse_custom_headers_supports_escaped_quotes() {
         let headers = r#"A="hello \"world\"",B=ok"#.to_string();
         let parsed = parse_custom_headers(headers);
-        assert_eq!(parsed.get("A").unwrap(), r#"hello "world""#);
+        assert_eq!(parsed.get("A").unwrap(), r#""hello "world"""#);
+        assert_eq!(parsed.get("B").unwrap(), "ok");
+    }
+
+    #[test]
+    fn test_parse_custom_headers_preserves_literal_quotes_without_commas() {
+        let headers = r#"If-None-Match="abc",B=ok"#.to_string();
+        let parsed = parse_custom_headers(headers);
+        assert_eq!(parsed.get("If-None-Match").unwrap(), r#""abc""#);
         assert_eq!(parsed.get("B").unwrap(), "ok");
     }
 

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -664,7 +664,7 @@ fn split_on_commas_outside_quotes(s: &str) -> Vec<String> {
         if escape_next {
             current.push(c);
             escape_next = false;
-        } else if c == '\\' {
+        } else if c == '\\' && in_quotes {
             current.push(c);
             escape_next = true;
         } else if c == '"' {
@@ -684,12 +684,9 @@ fn split_on_commas_outside_quotes(s: &str) -> Vec<String> {
 
 fn parse_custom_headers(s: String) -> HashMap<String, String> {
     fn unquote_and_unescape(val: &str) -> String {
-        let val = val.trim();
-        // check if it starts and ends with double quotes
-        let inner = if val.len() >= 2 && val.starts_with('"') && val.ends_with('"') {
-            &val[1..val.len() - 1]
-        } else {
-            val
+        let trimmed = val.trim();
+        let Some(inner) = trimmed.strip_prefix('"').and_then(|s| s.strip_suffix('"')) else {
+            return trimmed.to_string();
         };
 
         let mut out = String::with_capacity(inner.len());
@@ -829,6 +826,22 @@ mod tests {
         let parsed = parse_custom_headers(headers);
         assert_eq!(parsed.get("A").unwrap(), r#"hello "world""#);
         assert_eq!(parsed.get("B").unwrap(), "ok");
+    }
+
+    #[test]
+    fn test_parse_custom_headers_preserves_backslashes_in_unquoted_values() {
+        let headers = r#"X-Signature=a\\b,Y=ok"#.to_string();
+        let parsed = parse_custom_headers(headers);
+        assert_eq!(parsed.get("X-Signature").unwrap(), r#"a\\b"#);
+        assert_eq!(parsed.get("Y").unwrap(), "ok");
+    }
+
+    #[test]
+    fn test_parse_custom_headers_splits_on_commas_after_unquoted_backslashes() {
+        let headers = r#"X-Path=C:\,X-Env=prod"#.to_string();
+        let parsed = parse_custom_headers(headers);
+        assert_eq!(parsed.get("X-Path").unwrap(), "C:\\");
+        assert_eq!(parsed.get("X-Env").unwrap(), "prod");
     }
 
     #[test]

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -654,13 +654,78 @@ impl Provider for OpenAiProvider {
     }
 }
 
+fn split_on_commas_outside_quotes(s: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    let mut escape_next = false;
+
+    for c in s.chars() {
+        if escape_next {
+            current.push(c);
+            escape_next = false;
+        } else if c == '\\' {
+            current.push(c);
+            escape_next = true;
+        } else if c == '"' {
+            in_quotes = !in_quotes;
+            current.push(c);
+        } else if c == ',' && !in_quotes {
+            parts.push(current.clone());
+            current.clear();
+        } else {
+            current.push(c);
+        }
+    }
+
+    parts.push(current);
+    parts
+}
+
 fn parse_custom_headers(s: String) -> HashMap<String, String> {
-    s.split(',')
+    fn unquote_and_unescape(val: &str) -> String {
+        let val = val.trim();
+        // check if it starts and ends with double quotes
+        let inner = if val.len() >= 2 && val.starts_with('"') && val.ends_with('"') {
+            &val[1..val.len() - 1]
+        } else {
+            val
+        };
+
+        let mut out = String::with_capacity(inner.len());
+        let mut chars = inner.chars();
+        while let Some(c) = chars.next() {
+            if c == '\\' {
+                if let Some(next) = chars.next() {
+                    match next {
+                        '"' => out.push('"'),
+                        '\\' => out.push('\\'),
+                        // keep unknown escapes as-is (e.g., \n) rather than guessing
+                        other => {
+                            out.push('\\');
+                            out.push(other);
+                        }
+                    }
+                } else {
+                    out.push('\\');
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+
+    split_on_commas_outside_quotes(&s)
+        .into_iter()
         .filter_map(|header| {
-            let mut parts = header.splitn(2, '=');
-            let key = parts.next().map(|s| s.trim().to_string())?;
-            let value = parts.next().map(|s| s.trim().to_string())?;
-            Some((key, value))
+            let (k, v) = header.split_once('=')?;
+            let key = k.trim();
+            if key.is_empty() {
+                return None;
+            }
+            let value = unquote_and_unescape(v);
+            Some((key.to_string(), value))
         })
         .collect()
 }
@@ -740,6 +805,30 @@ mod tests {
             custom_models: None,
             skip_canonical_filtering: false,
         }
+    }
+
+    #[test]
+    fn test_parse_custom_headers_respects_commas_in_quotes() {
+        let headers = r#"A="1,2",B=3"#.to_string();
+        let parsed = parse_custom_headers(headers);
+        assert_eq!(parsed.get("A").unwrap(), "1,2");
+        assert_eq!(parsed.get("B").unwrap(), "3");
+    }
+
+    #[test]
+    fn test_parse_custom_headers_trims_and_unquotes() {
+        let headers = r#" A = "x, y" , B = z "#.to_string();
+        let parsed = parse_custom_headers(headers);
+        assert_eq!(parsed.get("A").unwrap(), "x, y");
+        assert_eq!(parsed.get("B").unwrap(), "z");
+    }
+
+    #[test]
+    fn test_parse_custom_headers_supports_escaped_quotes() {
+        let headers = r#"A="hello \"world\"",B=ok"#.to_string();
+        let parsed = parse_custom_headers(headers);
+        assert_eq!(parsed.get("A").unwrap(), r#"hello "world""#);
+        assert_eq!(parsed.get("B").unwrap(), "ok");
     }
 
     #[test]


### PR DESCRIPTION
Resolves #8495. Improves \parse_custom_headers\ to correctly handle commas inside quoted strings in \OPENAI_CUSTOM_HEADERS\ variables.