### PR TITLE
fix: persist frontend extensions in session state

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -617,7 +617,7 @@ impl Agent {
     /// Save current extension state to session metadata
     /// Should be called after any extension add/remove operation
     pub async fn save_extension_state(&self, session: &SessionConfig) -> Result<()> {
-        let extension_configs = self.extension_manager.get_extension_configs().await;
+        let extension_configs = self.get_extension_configs().await;
 
         let extensions_state = EnabledExtensionsState::new(extension_configs);
 
@@ -640,7 +640,7 @@ impl Agent {
 
     /// Save current extension state to session by session_id
     pub async fn persist_extension_state(&self, session_id: &str) -> Result<()> {
-        let extension_configs = self.extension_manager.get_extension_configs().await;
+        let extension_configs = self.get_extension_configs().await;
         let extensions_state = EnabledExtensionsState::new(extension_configs);
 
         let session_manager = self.config.session_manager.clone();

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -930,7 +930,24 @@ impl Agent {
     }
 
     pub async fn get_extension_configs(&self) -> Vec<ExtensionConfig> {
-        self.extension_manager.get_extension_configs().await
+        let mut configs = self.extension_manager.get_extension_configs().await;
+
+        let frontend_tools = self.frontend_tools.lock().await;
+        if !frontend_tools.is_empty() {
+            let tools: Vec<Tool> = frontend_tools.values().map(|t| t.tool.clone()).collect();
+            let instructions = self.frontend_instructions.lock().await.clone();
+
+            configs.push(ExtensionConfig::Frontend {
+                name: "frontend".to_string(),
+                description: "Frontend-provided tools".to_string(),
+                tools,
+                instructions,
+                bundled: None,
+                available_tools: Vec::new(),
+            });
+        }
+
+        configs
     }
 
     /// Handle a confirmation response for a tool request


### PR DESCRIPTION
Resolves #8425. Fixes the bug where frontend extensions drop when persisting extensions to the session metadata by ensuring they are included in \Agent::get_extension_configs()\.