### PR TITLE
fix(providers): handle missing delta field in streaming chunks

### DIFF
--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -64,7 +64,7 @@ struct ContentPart {
     thought_signature: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 struct Delta {
     #[serde(default)]
     content: Option<DeltaContent>,
@@ -77,6 +77,7 @@ struct Delta {
 
 #[derive(Serialize, Deserialize, Debug)]
 struct StreamingChoice {
+    #[serde(default)]
     delta: Delta,
     index: Option<i32>,
     finish_reason: Option<String>,
@@ -953,11 +954,7 @@ where
 
                     yield (
                         Some(msg),
-                        if chunk.choices[0].finish_reason.is_some() {
-                            usage
-                        } else {
-                            None
-                        },
+                        usage,
                     )
                 } else if usage.is_some() {
                     yield (None, usage)

--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -954,7 +954,11 @@ where
 
                     yield (
                         Some(msg),
-                        usage,
+                        if chunk.choices[0].finish_reason.is_some() {
+                            usage
+                        } else {
+                            None
+                        },
                     )
                 } else if usage.is_some() {
                     yield (None, usage)
@@ -1991,6 +1995,23 @@ data: [DONE]
         assert_eq!(result.tool_calls.len(), 1, "Expected 1 tool call");
         assert_eq!(result.tool_calls[0], "developer__shell");
         assert_usage_yielded_once(&result, 12376, 79, 12455);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_azure_annotation_chunk_without_delta_does_not_fail() -> anyhow::Result<()> {
+        let response_lines = r#"
+data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1234567890,"model":"gpt-5.4","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":null}],"usage":null}
+data: {"choices":[{"content_filter_offsets":{"check_offset":5,"start_offset":5,"end_offset":5},"content_filter_results":{"hate":{"filtered":false,"severity":"safe"},"self_harm":{"filtered":false,"severity":"safe"},"sexual":{"filtered":false,"severity":"safe"},"violence":{"filtered":false,"severity":"safe"}},"finish_reason":null,"index":0}],"created":0,"id":"","model":"","object":""}
+data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1234567891,"model":"gpt-5.4","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":1,"total_tokens":11}}
+data: [DONE]
+"#;
+
+        let result = run_streaming_test(response_lines).await?;
+
+        assert!(result.has_text_content, "Expected text content in response");
+        assert_usage_yielded_once(&result, 10, 1, 11);
 
         Ok(())
     }


### PR DESCRIPTION
**Category:** fix
**User Impact:** Users will no longer encounter streaming crashes with providers (like Azure OpenAI) that omit the delta object in filtering or final chunks.
**Problem:** Some providers conform to the streaming format but omit the delta field entirely when yielding final content-filter results rather than yielding delta: {}. This caused a direct serde validation failure during stream parsing.
**Solution:** Added #[serde(default)] to the delta field and derived Default for the schema so omitted fields safely deserialize to a null delta message, allowing the stream to complete successfully.

<details>
<summary>File changes</summary>

**openai.rs**
Derived Default on Delta and relaxed the validation on StreamingChoice::delta so it uses the default (null content) fallback if the field is missing from the provider's chunk.

</details>

Fixes #8641