### PR TITLE
fix(cli): always install linux binary when running script in WSL

### DIFF
--- a/download_cli.sh
+++ b/download_cli.sh
@@ -101,27 +101,8 @@ else
   if [[ "${WINDIR:-}" ]] || [[ "${windir:-}" ]] || [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
     OS="windows"
   elif [[ -f "/proc/version" ]] && grep -q "Microsoft\|WSL" /proc/version 2>/dev/null; then
-    # WSL detected. Prefer Linux unless there are clear signs we should install the Windows build:
-    # - running on a Windows-mounted path like /mnt/c/...   OR
-    # - Windows executables are available AND we're on a Windows mount
-    if [[ "$PWD" =~ ^/mnt/[a-zA-Z]/ ]]; then
-      OS="windows"
-    else
-      # If powershell/cmd exist, only treat as Windows when in a Windows mount
-      if command -v powershell.exe >/dev/null 2>&1 || command -v cmd.exe >/dev/null 2>&1; then
-        if [[ "$PWD" =~ ^/mnt/[a-zA-Z]/ ]] || [[ -d "/c" || -d "/d" || -d "/e" ]]; then
-          OS="windows"
-        else
-          OS="linux"
-        fi
-      else
-        # No strong Windows interop present — install Linux build inside WSL by default
-        OS="linux"
-      fi
-    fi
-  elif [[ "$PWD" =~ ^/mnt/[a-zA-Z]/ ]]; then
-    # WSL mount point detection (like /mnt/c/) outside of /proc/version check
-    OS="windows"
+    # WSL detected. Always install Linux build inside WSL since we use Linux binary paths.
+    OS="linux"
   elif [[ "$OSTYPE" == "darwin"* ]]; then
     OS="darwin"
   elif command -v powershell.exe >/dev/null 2>&1 || command -v cmd.exe >/dev/null 2>&1; then


### PR DESCRIPTION
��* * C a t e g o r y : * *   f i x 
 * * U s e r   I m p a c t : * *   L i n u x   i n s t a l l a t i o n s   i n s i d e   W S L 2   m o u n t e d   d r i v e s   w i l l   c o r r e c t l y   i n s t a l l   t h e   L i n u x   b i n a r y   r a t h e r   t h a n   e r r o n e o u s l y   a t t e m p t i n g   t o   i n s t a l l   t h e   W i n d o w s   . e x e   t o   t h e   L i n u x   t o o l c h a i n . 
 * * P r o b l e m : * *   T h e   d o w n l o a d _ c l i . s h   s c r i p t   c o n t a i n e d   l o g i c   t h a t   f o r c e d   O S = " w i n d o w s "   i f   t h e   u s e r ' s   P W D   w a s   i n s i d e   a   m o u n t e d   d r i v e   ( e . g .   / m n t / c / . . . ) ,   e v e n   u n d e r   W S L   c o n t e x t s .   T h i s   r e s u l t e d   i n   t h e   s c r i p t   d o w n l o a d i n g   t h e   W i n d o w s   P E   b i n a r y   a n d   f a i l i n g   t o   r u n . 
 * * S o l u t i o n : * *   R e m o v e d   t h e   m o u n t   h e u r i s t i c s   t h a t   o v e r r o d e   t h e   O S   v a r i a b l e   f o r   W S L   e n v i r o n m e n t s .   N o w ,   a n y   i n s t a l l a t i o n   e x e c u t e d   w i t h i n   / p r o c / v e r s i o n   m a t c h i n g   M i c r o s o f t | W S L   w i l l   s e c u r e l y   d e f a u l t   t o   l i n u x ,   m a t c h i n g   t h e   e x p e c t e d   b e h a v i o r   a n d   e n s u r i n g   f u n c t i o n a l i t y . 
 
 < d e t a i l s > 
 < s u m m a r y > F i l e   c h a n g e s < / s u m m a r y > 
 
 * * d o w n l o a d _ c l i . s h * * 
 S t r i p p e d   t h e   c o m p l e x   h e u r i s t i c s   t h a t   c h e c k e d   f o r   / m n t / [ a - z A - Z ] /   i n s i d e   t h e   M i c r o s o f t | W S L   b r a n c h   a n d   s i m p l i f i e d   i t   t o   f o r c e f u l l y   a s s i g n   O S = " l i n u x " . 
 
 < / d e t a i l s > 
 
 F i x e s   # 8 6 7 2  
 