### PR TITLE
fix(ui): correct grammar typo in apps view description

### DIFF
--- a/ui/desktop/src/components/apps/AppsView.tsx
+++ b/ui/desktop/src/components/apps/AppsView.tsx
@@ -28,7 +28,7 @@ const i18n = defineMessages({
   description: {
     id: 'appsView.description',
     defaultMessage:
-      'Applications from your MCP servers and Apps build by goose itself. You can ask it to create new apps through the chat interface and they will appear here.',
+      'Applications from your MCP servers and Apps built by goose itself. You can ask it to create new apps through the chat interface and they will appear here.',
   },
   loading: {
     id: 'appsView.loading',

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -21,7 +21,7 @@
     "defaultMessage": "Custom app"
   },
   "appsView.description": {
-    "defaultMessage": "Applications from your MCP servers and Apps build by goose itself. You can ask it to create new apps through the chat interface and they will appear here."
+    "defaultMessage": "Applications from your MCP servers and Apps built by goose itself. You can ask it to create new apps through the chat interface and they will appear here."
   },
   "appsView.errorLoading": {
     "defaultMessage": "Error loading apps: {error}"


### PR DESCRIPTION
**Category:** fix
**User Impact:** Improves UI professionalism by fixing a minor spelling mistake in the Apps view descriptions.
**Problem:** The Apps view subtitle previously read "Apps build by goose itself" which used incorrect tense.
**Solution:** Changing "build" to "built" corrects the grammar error.

<details>
<summary>File changes</summary>

**AppsView.tsx**
Corrected the typo in the default description inline string.

**en.json**
Corrected the localization string for the respective App description block.

</details>

Fixes #8668
