### PR TITLE
fix(cli): always install linux binary when running script in WSL

### DIFF
--- a/download_cli.sh
+++ b/download_cli.sh
@@ -101,27 +101,8 @@ else
   if [[ "${WINDIR:-}" ]] || [[ "${windir:-}" ]] || [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
     OS="windows"
   elif [[ -f "/proc/version" ]] && grep -q "Microsoft\|WSL" /proc/version 2>/dev/null; then
-    # WSL detected. Prefer Linux unless there are clear signs we should install the Windows build:
-    # - running on a Windows-mounted path like /mnt/c/...   OR
-    # - Windows executables are available AND we're on a Windows mount
-    if [[ "$PWD" =~ ^/mnt/[a-zA-Z]/ ]]; then
-      OS="windows"
-    else
-      # If powershell/cmd exist, only treat as Windows when in a Windows mount
-      if command -v powershell.exe >/dev/null 2>&1 || command -v cmd.exe >/dev/null 2>&1; then
-        if [[ "$PWD" =~ ^/mnt/[a-zA-Z]/ ]] || [[ -d "/c" || -d "/d" || -d "/e" ]]; then
-          OS="windows"
-        else
-          OS="linux"
-        fi
-      else
-        # No strong Windows interop present — install Linux build inside WSL by default
-        OS="linux"
-      fi
-    fi
-  elif [[ "$PWD" =~ ^/mnt/[a-zA-Z]/ ]]; then
-    # WSL mount point detection (like /mnt/c/) outside of /proc/version check
-    OS="windows"
+    # WSL detected. Always install Linux build inside WSL since we use Linux binary paths.
+    OS="linux"
   elif [[ "$OSTYPE" == "darwin"* ]]; then
     OS="darwin"
   elif command -v powershell.exe >/dev/null 2>&1 || command -v cmd.exe >/dev/null 2>&1; then


### PR DESCRIPTION
**Category:** fix
**User Impact:** Linux installations inside WSL2 mounted drives will correctly install the Linux binary rather than erroneously attempting to install the Windows .exe to the Linux toolchain.
**Problem:** The download_cli.sh script contained logic that forced OS=windows if the user's PWD was inside a mounted drive (e.g. /mnt/c/...), even under WSL contexts. This resulted in the script downloading the Windows PE binary and failing to run.
**Solution:** Removed the mount heuristics that overrode the OS variable for WSL environments. Now, any installation executed within /proc/version matching Microsoft or WSL will securely default to linux, matching the expected behavior and ensuring functionality.

<details>
<summary>File changes</summary>

**download_cli.sh**
Stripped the complex heuristics that checked for /mnt/[a-zA-Z]/ inside the Microsoft/WSL branch and simplified it to forcefully assign OS=linux.

</details>

Fixes #8672
