### PR TITLE
handle full node paths in goose2 kill recipe

### DIFF
--- a/ui/goose2/justfile
+++ b/ui/goose2/justfile
@@ -192,7 +192,8 @@ kill:
     fi
 
     PROC_NAME=$(ps -p "$PID" -o comm= 2>/dev/null) || true
-    if [[ "$PROC_NAME" != "node" ]]; then
+    PROC_BASENAME="${PROC_NAME##*/}"
+    if [[ "$PROC_BASENAME" != "node" ]]; then
         echo "Process on port $VITE_PORT is '$PROC_NAME', not 'node' — refusing to kill"
         exit 1
     fi


### PR DESCRIPTION
## Overview

**Category:** fix
**User Impact:** Developers can stop the Goose 2 Vite server even when `ps` reports Node with a full executable path.
**Problem:** The `kill` recipe only accepted `node` exactly. On systems where `ps -o comm=` returns a path like `/opt/homebrew/bin/node`, the safety check rejects the Vite process and refuses to stop it.
**Solution:** Normalize the process name to its basename before comparing it to `node`, while still preserving the original value in the refusal message. This keeps the guardrail in place and makes the recipe work across command-name formats.

## Changes

<details>
<summary>File changes</summary>

**ui/goose2/justfile**
Updated the `kill` recipe to derive a basename from the `ps` command output before checking whether the process is Node. This keeps the existing safety behavior but handles environments where `ps` returns a full executable path.

</details>

## Reproduction Steps

1. Start the Goose 2 Vite dev server in an environment where `ps -o comm=` returns a full path for Node.
2. Run the `kill` recipe from `ui/goose2`.
3. Confirm the recipe stops the server instead of refusing with a message that the process is not `node`.
