### PR TITLE
feat(goose2): detect stale goose binary via git SHA stamp file

### DIFF
--- a/ui/goose2/justfile
+++ b/ui/goose2/justfile
@@ -10,9 +10,65 @@ default:
 
 # Install dependencies and build workspace packages
 setup:
+    #!/usr/bin/env bash
+    set -euo pipefail
     cd ../ && pnpm install
     cd ../sdk && pnpm build
     cargo build --manifest-path ../../Cargo.toml -p goose-cli --bin goose
+    SHA=$(git rev-parse HEAD)
+    if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
+        SHA="${SHA}-dirty"
+    fi
+    echo "${SHA}" > ../../target/debug/.goose-build-sha
+
+# Check if the goose binary matches the current git state
+check-binary bin_path="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    GOOSE_BIN="{{ bin_path }}"
+    if [[ -z "${GOOSE_BIN}" ]]; then
+        REPO_ROOT=$(cd ../.. && pwd)
+        if [[ -x "${REPO_ROOT}/target/debug/goose" ]]; then
+            GOOSE_BIN="${REPO_ROOT}/target/debug/goose"
+        elif [[ -x "${REPO_ROOT}/target/release/goose" ]]; then
+            GOOSE_BIN="${REPO_ROOT}/target/release/goose"
+        else
+            echo "No local goose binary found; skipping build check"
+            exit 0
+        fi
+    fi
+
+    STAMP_FILE="${GOOSE_BIN%/*}/.goose-build-sha"
+    CURRENT_SHA=$(git rev-parse HEAD)
+    CURRENT_DIRTY=""
+    if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
+        CURRENT_DIRTY="-dirty"
+    fi
+
+    if [[ ! -f "${STAMP_FILE}" ]]; then
+        echo "ERROR: no build stamp found — goose binary may be stale"
+        echo "   Run: just goose2 setup"
+        exit 1
+    fi
+
+    BUILD_REF=$(cat "${STAMP_FILE}")
+    BUILD_BASE="${BUILD_REF%-dirty}"
+    BUILD_DIRTY=""
+    [[ "${BUILD_REF}" == *-dirty ]] && BUILD_DIRTY="-dirty"
+
+    if [[ "${BUILD_BASE}" != "${CURRENT_SHA}" ]]; then
+        echo "ERROR: goose binary is from a different commit"
+        echo "   Binary built from: ${BUILD_REF}"
+        echo "   Current HEAD:      ${CURRENT_SHA}${CURRENT_DIRTY}"
+        echo "   Run: just goose2 setup"
+        exit 1
+    elif [[ "${BUILD_DIRTY}" != "${CURRENT_DIRTY}" ]]; then
+        echo "WARNING: goose binary dirty state differs from working tree"
+        echo "   Binary built from: ${BUILD_REF}"
+        echo "   Current HEAD:      ${CURRENT_SHA}${CURRENT_DIRTY}"
+        echo "   Consider running: just goose2 setup"
+    fi
 
 # ── Build & Check ────────────────────────────────────────────
 
@@ -102,6 +158,7 @@ dev:
 
     if [[ -n "${GOOSE_BIN:-}" ]]; then
         echo "Using local goose binary: ${GOOSE_BIN}"
+        just check-binary "${GOOSE_BIN}"
     else
         echo "No local goose binary found under ${REPO_ROOT}/target; falling back to PATH"
     fi
@@ -150,6 +207,7 @@ dev-debug:
 
     if [[ -n "${GOOSE_BIN:-}" ]]; then
         echo "Using local goose binary: ${GOOSE_BIN}"
+        just check-binary "${GOOSE_BIN}"
     else
         echo "No local goose binary found under ${REPO_ROOT}/target; falling back to PATH"
     fi

--- a/ui/goose2/justfile
+++ b/ui/goose2/justfile
@@ -2,6 +2,10 @@
 # always gets the same port.
 vite_port := `python3 -c "import hashlib,os; h=int(hashlib.sha256(os.getcwd().encode()).hexdigest(),16); print(10000 + h % 55000)"`
 
+# Paths that affect the goose binary — used to filter git diff/status.
+# NOTE: if you add a new crate dependency to goose-cli, add its path here.
+backend_paths := "crates/goose-cli crates/goose crates/goose-acp crates/goose-acp-macros crates/goose-mcp crates/goose-server Cargo.toml Cargo.lock vendor"
+
 # Default recipe
 default:
     @just --list
@@ -16,15 +20,13 @@ setup:
     cd sdk && pnpm build
     cargo build --manifest-path ../../Cargo.toml -p goose-cli --bin goose
     SHA=$(git rev-parse HEAD)
-    BACKEND_PATHS="crates/goose-cli crates/goose crates/goose-acp crates/goose-acp-macros crates/goose-mcp crates/goose-server Cargo.toml Cargo.lock vendor"
-    if [[ -n "$(git status --porcelain -- $BACKEND_PATHS 2>/dev/null)" ]]; then
+    if [[ -n "$(git status --porcelain -- {{ backend_paths }} 2>/dev/null)" ]]; then
         SHA="${SHA}-dirty"
     fi
     echo "${SHA}" > ../../target/debug/.goose-build-sha
 
 # Check if the goose binary matches the current git state.
 # Only flags staleness when paths that affect the binary have changed.
-# NOTE: if you add a new crate dependency to goose-cli, add its path here.
 check-binary bin_path="":
     #!/usr/bin/env bash
     set -euo pipefail
@@ -42,13 +44,10 @@ check-binary bin_path="":
         fi
     fi
 
-    # Paths that affect the goose binary — used to filter git diff/status.
-    BACKEND_PATHS="crates/goose-cli crates/goose crates/goose-acp crates/goose-acp-macros crates/goose-mcp crates/goose-server Cargo.toml Cargo.lock vendor"
-
     STAMP_FILE="${GOOSE_BIN%/*}/.goose-build-sha"
     CURRENT_SHA=$(git rev-parse HEAD)
     CURRENT_DIRTY=""
-    if [[ -n "$(git status --porcelain -- $BACKEND_PATHS 2>/dev/null)" ]]; then
+    if [[ -n "$(git status --porcelain -- {{ backend_paths }} 2>/dev/null)" ]]; then
         CURRENT_DIRTY="-dirty"
     fi
 
@@ -65,7 +64,7 @@ check-binary bin_path="":
 
     if [[ "${BUILD_BASE}" != "${CURRENT_SHA}" ]]; then
         # SHAs differ — check whether any backend-relevant paths changed.
-        if ! RELEVANT_CHANGES=$(git diff --name-only "${BUILD_BASE}" "${CURRENT_SHA}" -- $BACKEND_PATHS 2>/dev/null); then
+        if ! RELEVANT_CHANGES=$(git diff --name-only "${BUILD_BASE}" "${CURRENT_SHA}" -- {{ backend_paths }} 2>/dev/null); then
             # Build SHA is no longer reachable (e.g. after rebase/force-push).
             echo "ERROR: goose binary build SHA is no longer in history — binary may be stale"
             echo "   Binary built from: ${BUILD_REF}"

--- a/ui/goose2/justfile
+++ b/ui/goose2/justfile
@@ -13,7 +13,7 @@ setup:
     #!/usr/bin/env bash
     set -euo pipefail
     cd ../ && pnpm install
-    cd ../sdk && pnpm build
+    cd sdk && pnpm build
     cargo build --manifest-path ../../Cargo.toml -p goose-cli --bin goose
     SHA=$(git rev-parse HEAD)
     if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then

--- a/ui/goose2/justfile
+++ b/ui/goose2/justfile
@@ -16,12 +16,15 @@ setup:
     cd sdk && pnpm build
     cargo build --manifest-path ../../Cargo.toml -p goose-cli --bin goose
     SHA=$(git rev-parse HEAD)
-    if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
+    BACKEND_PATHS="crates/goose-cli crates/goose crates/goose-acp crates/goose-acp-macros crates/goose-mcp crates/goose-server Cargo.toml Cargo.lock vendor"
+    if [[ -n "$(git status --porcelain -- $BACKEND_PATHS 2>/dev/null)" ]]; then
         SHA="${SHA}-dirty"
     fi
     echo "${SHA}" > ../../target/debug/.goose-build-sha
 
-# Check if the goose binary matches the current git state
+# Check if the goose binary matches the current git state.
+# Only flags staleness when paths that affect the binary have changed.
+# NOTE: if you add a new crate dependency to goose-cli, add its path here.
 check-binary bin_path="":
     #!/usr/bin/env bash
     set -euo pipefail
@@ -39,10 +42,13 @@ check-binary bin_path="":
         fi
     fi
 
+    # Paths that affect the goose binary — used to filter git diff/status.
+    BACKEND_PATHS="crates/goose-cli crates/goose crates/goose-acp crates/goose-acp-macros crates/goose-mcp crates/goose-server Cargo.toml Cargo.lock vendor"
+
     STAMP_FILE="${GOOSE_BIN%/*}/.goose-build-sha"
     CURRENT_SHA=$(git rev-parse HEAD)
     CURRENT_DIRTY=""
-    if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
+    if [[ -n "$(git status --porcelain -- $BACKEND_PATHS 2>/dev/null)" ]]; then
         CURRENT_DIRTY="-dirty"
     fi
 
@@ -58,11 +64,24 @@ check-binary bin_path="":
     [[ "${BUILD_REF}" == *-dirty ]] && BUILD_DIRTY="-dirty"
 
     if [[ "${BUILD_BASE}" != "${CURRENT_SHA}" ]]; then
-        echo "ERROR: goose binary is from a different commit"
-        echo "   Binary built from: ${BUILD_REF}"
-        echo "   Current HEAD:      ${CURRENT_SHA}${CURRENT_DIRTY}"
-        echo "   Run: just goose2 setup"
-        exit 1
+        # SHAs differ — check whether any backend-relevant paths changed.
+        if ! RELEVANT_CHANGES=$(git diff --name-only "${BUILD_BASE}" "${CURRENT_SHA}" -- $BACKEND_PATHS 2>/dev/null); then
+            # Build SHA is no longer reachable (e.g. after rebase/force-push).
+            echo "ERROR: goose binary build SHA is no longer in history — binary may be stale"
+            echo "   Binary built from: ${BUILD_REF}"
+            echo "   Current HEAD:      ${CURRENT_SHA}${CURRENT_DIRTY}"
+            echo "   Run: just goose2 setup"
+            exit 1
+        fi
+        if [[ -n "${RELEVANT_CHANGES}" ]]; then
+            echo "ERROR: goose binary is stale — backend code changed since last build"
+            echo "   Binary built from: ${BUILD_REF}"
+            echo "   Current HEAD:      ${CURRENT_SHA}${CURRENT_DIRTY}"
+            echo "   Changed paths:"
+            echo "${RELEVANT_CHANGES}" | sed 's/^/      /'
+            echo "   Run: just goose2 setup"
+            exit 1
+        fi
     elif [[ "${BUILD_DIRTY}" != "${CURRENT_DIRTY}" ]]; then
         echo "WARNING: goose binary dirty state differs from working tree"
         echo "   Binary built from: ${BUILD_REF}"

--- a/ui/sdk/package.json
+++ b/ui/sdk/package.json
@@ -31,7 +31,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "npm run generate && npm run build:ts",
+    "build": "pnpm run generate && pnpm run build:ts",
     "build:ts": "tsc",
     "build:native": "tsx scripts/build-native.ts",
     "build:native:all": "tsx scripts/build-native.ts --all",
@@ -54,9 +54,9 @@
   },
   "devDependencies": {
     "@agentclientprotocol/sdk": "^0.14.1",
-    "@hey-api/openapi-ts": "^0.92.3",
-    "@types/node": "^20.0.0",
-    "prettier": "^3.8.1",
+    "@hey-api/openapi-ts": "^0.92.4",
+    "@types/node": "^20.19.37",
+    "prettier": "^3.8.3",
     "tsx": "^4.21.0",
     "typescript": "~5.9.3"
   }


### PR DESCRIPTION
## Summary

- Adds a `check-binary` recipe that detects when the local goose binary is stale by comparing a build-time git SHA stamp against the current HEAD, filtered to backend-relevant paths only
- Updates `setup` to write a `.goose-build-sha` stamp file after building, and `dev`/`dev-debug` to call `check-binary` before launching
- Fixes sdk build script to use `pnpm` instead of `npm`, and corrects the sdk path in the setup recipe

## Test plan

- [ ] Run `just goose2 setup` and verify `.goose-build-sha` is written to `target/debug/`
- [ ] Run `just goose2 dev` with a fresh build — should show no staleness warning
- [ ] Modify a file in `crates/goose-cli/` and run `just goose2 dev` — should error about stale binary
- [ ] Modify a file outside backend paths (e.g. `ui/`) and run `just goose2 dev` — should not warn

🤖 Generated with [Claude Code](https://claude.com/claude-code)