### PR TITLE
Add a build-time branding hook for CLI product-name strings

### DIFF
--- a/CUSTOM_DISTROS.md
+++ b/CUSTOM_DISTROS.md
@@ -292,11 +292,51 @@ export GOOSE_BUNDLE_NAME="InsightStream-goose"
    - Release artifact names and updater lookup names are consistent
    - Desktop launchers (Linux `.desktop` templates) point to the same executable name produced by packaging
 
+### CLI branding (build-time env vars)
+
+The `goose-cli` crate routes every user-visible `goose` / `Goose` string through `crates/goose-cli/src/branding.rs`. Set these env vars at `cargo build` time to rebrand the CLI's `--help`, subcommand about text, runtime messages, shell integration templates (`goose term init`), recipe deeplink scheme, GitHub update URLs, and the provider-config test system prompt without editing source. Unset variables fall back to today's goose defaults — a default build is byte-identical to upstream.
+
+| Env var | Default | Affects |
+|---|---|---|
+| `GOOSE_BRAND_PRODUCT_NAME` | `goose` | Display noun in user-facing messages ("goose Version:", "goose mode", "Asking goose...") |
+| `GOOSE_BRAND_BINARY_NAME` | `goose` | Clap root name, invocation examples, `Command::new("goose")` spawns, update asset filenames |
+| `GOOSE_BRAND_SHELL_ALIAS_PRIMARY` | `goose` | `@goose` alias emitted by `term init` |
+| `GOOSE_BRAND_SHELL_ALIAS_SHORT` | `g` | `@g` short alias emitted by `term init` |
+| `GOOSE_BRAND_SHELL_FN_PREFIX` | `goose` | `goose_preexec` / `goose_preexec_installed` function names in shell templates |
+| `GOOSE_BRAND_DEEPLINK_SCHEME` | `goose` | Scheme in `goose://recipe?...` deeplinks |
+| `GOOSE_BRAND_GITHUB_OWNER` | `aaif-goose` | Owner half of update + attestation URLs |
+| `GOOSE_BRAND_GITHUB_REPO` | `goose` | Repo half of update + attestation URLs |
+| `GOOSE_BRAND_AGENT_IDENTITY` | `You are goose, an AI assistant.` | System prompt for the provider-configuration smoke test |
+
+Example build invocation:
+
+```bash
+GOOSE_BRAND_PRODUCT_NAME=InsightStream \
+GOOSE_BRAND_BINARY_NAME=insightstream \
+GOOSE_BRAND_SHELL_ALIAS_PRIMARY=insightstream \
+GOOSE_BRAND_SHELL_ALIAS_SHORT=is \
+GOOSE_BRAND_SHELL_FN_PREFIX=insightstream \
+GOOSE_BRAND_DEEPLINK_SCHEME=insightstream \
+GOOSE_BRAND_GITHUB_OWNER=your-org \
+GOOSE_BRAND_GITHUB_REPO=your-goose-fork \
+GOOSE_BRAND_AGENT_IDENTITY="You are InsightStream, an AI assistant." \
+  cargo build --release -p goose-cli
+```
+
+**One caveat** — the compiled binary filename is set by `[[bin]] name = "goose"` in `crates/goose-cli/Cargo.toml`, and Cargo.toml values cannot be parameterized by env vars. Downstream distros either:
+
+1. Accept the `goose` filename and rename post-build (`mv target/release/goose target/release/insightstream`), or
+2. Patch the one line in `Cargo.toml` so `cargo build` emits the renamed binary directly.
+
+Whichever you choose, set `GOOSE_BRAND_BINARY_NAME` to the final filename so invocation examples in `--help`, update asset URLs, and shell templates all reference the correct binary.
+
 ### Technical Details
 
 - Electron config: `ui/desktop/forge.config.ts`
 - UI entry point: `ui/desktop/src/renderer.tsx`
 - System prompts: `crates/goose/src/prompts/`
+- CLI branding module: `crates/goose-cli/src/branding.rs`
+- Shell-template fixture tests: `crates/goose-cli/tests/shell_templates.rs` (run `UPDATE_SHELL_FIXTURES=1 cargo test --test shell_templates` to regenerate after intentional template edits)
 
 ---
 

--- a/CUSTOM_DISTROS.md
+++ b/CUSTOM_DISTROS.md
@@ -307,6 +307,7 @@ The `goose-cli` crate routes every user-visible `goose` / `Goose` string through
 | `GOOSE_BRAND_GITHUB_OWNER` | `aaif-goose` | Owner half of update + attestation URLs |
 | `GOOSE_BRAND_GITHUB_REPO` | `goose` | Repo half of update + attestation URLs |
 | `GOOSE_BRAND_AGENT_IDENTITY` | `You are goose, an AI assistant.` | System prompt for the provider-configuration smoke test |
+| `GOOSE_BRAND_INTERACTIVE_STYLE` | `goose` | Interactive CLI presentation: `goose` keeps the goose prompt/banner, `minimal` uses neutral `>` prompts and a text-only session banner |
 
 Example build invocation:
 
@@ -320,7 +321,7 @@ GOOSE_BRAND_DEEPLINK_SCHEME=insightstream \
 GOOSE_BRAND_GITHUB_OWNER=your-org \
 GOOSE_BRAND_GITHUB_REPO=your-goose-fork \
 GOOSE_BRAND_AGENT_IDENTITY="You are InsightStream, an AI assistant." \
-  cargo build --release -p goose-cli
+cargo build --release -p goose-cli
 ```
 
 **One caveat** — the compiled binary filename is set by `[[bin]] name = "goose"` in `crates/goose-cli/Cargo.toml`, and Cargo.toml values cannot be parameterized by env vars. Downstream distros either:
@@ -329,6 +330,9 @@ GOOSE_BRAND_AGENT_IDENTITY="You are InsightStream, an AI assistant." \
 2. Patch the one line in `Cargo.toml` so `cargo build` emits the renamed binary directly.
 
 Whichever you choose, set `GOOSE_BRAND_BINARY_NAME` to the final filename so invocation examples in `--help`, update asset URLs, and shell templates all reference the correct binary.
+
+Set `GOOSE_BRAND_INTERACTIVE_STYLE=minimal` if your distro wants a neutral CLI prompt
+and session banner instead of the default goose glyphs.
 
 ### Technical Details
 

--- a/crates/goose-cli/src/bin/generate_manpages.rs
+++ b/crates/goose-cli/src/bin/generate_manpages.rs
@@ -16,9 +16,7 @@
 //!
 //! Output: target/man/goose.1, target/man/goose-session.1, etc.
 
-use clap::CommandFactory;
 use clap_mangen::Man;
-use goose_cli::Cli;
 use std::env;
 use std::fs;
 use std::io::Result;
@@ -40,14 +38,15 @@ fn main() -> Result<()> {
 
     fs::create_dir_all(&output_dir)?;
 
-    let cmd = Cli::command();
+    let cmd = goose_cli::branded_command();
+    let top_name = cmd.get_name().to_string();
 
     // First pass: collect all command names for SEE ALSO sections
     let mut all_commands: Vec<String> = Vec::new();
     collect_command_names(&cmd, &mut all_commands, None);
 
     // Second pass: generate manpages with SEE ALSO sections
-    generate_manpages(&cmd, &output_dir, None, &all_commands)?;
+    generate_manpages(&cmd, &output_dir, None, &all_commands, &top_name)?;
 
     let canonical_path = output_dir.canonicalize()?;
     eprintln!(
@@ -78,6 +77,7 @@ fn generate_manpages(
     dir: &PathBuf,
     parent_name: Option<&str>,
     all_commands: &[String],
+    top_name: &str,
 ) -> Result<()> {
     let name = match parent_name {
         Some(parent) => format!("{}-{}", parent, cmd.get_name()),
@@ -90,7 +90,7 @@ fn generate_manpages(
     man.render(&mut buffer)?;
 
     // Add SEE ALSO section
-    let see_also = generate_see_also(&name, parent_name, cmd, all_commands);
+    let see_also = generate_see_also(&name, parent_name, cmd, all_commands, top_name);
     buffer.extend_from_slice(see_also.as_bytes());
 
     let manpage_path = dir.join(format!("{}.1", name));
@@ -101,7 +101,7 @@ fn generate_manpages(
         if subcmd.get_name() == "help" || subcmd.is_hide_set() {
             continue;
         }
-        generate_manpages(subcmd, dir, Some(&name), all_commands)?;
+        generate_manpages(subcmd, dir, Some(&name), all_commands, top_name)?;
     }
 
     Ok(())
@@ -112,29 +112,30 @@ fn generate_see_also(
     parent_name: Option<&str>,
     cmd: &clap::Command,
     all_commands: &[String],
+    top_name: &str,
 ) -> String {
     let mut references: Vec<String> = Vec::new();
 
-    // Always reference the main goose command if we're not it
-    if current_name != "goose" {
-        references.push("goose".to_string());
+    // Always reference the main top-level command if we're not it
+    if current_name != top_name {
+        references.push(top_name.to_string());
     }
 
     // Reference parent command if exists and not already added
     if let Some(parent) = parent_name {
-        if parent != "goose" && !references.contains(&parent.to_string()) {
+        if parent != top_name && !references.contains(&parent.to_string()) {
             references.push(parent.to_string());
         }
     }
 
     // For the main command, list immediate subcommands
     // For subcommands, list sibling commands
-    if current_name == "goose" {
+    if current_name == top_name {
         // Add all immediate subcommands (skip hidden ones)
         for subcmd in cmd.get_subcommands() {
             let subcmd_name = subcmd.get_name();
             if subcmd_name != "help" && !subcmd.is_hide_set() {
-                let full_name = format!("goose-{}", subcmd_name);
+                let full_name = format!("{}-{}", top_name, subcmd_name);
                 if !references.contains(&full_name) {
                     references.push(full_name);
                 }

--- a/crates/goose-cli/src/branding.rs
+++ b/crates/goose-cli/src/branding.rs
@@ -1,0 +1,279 @@
+//! Build-time branding seam for downstream distributions.
+//!
+//! Every user-visible occurrence of the product noun inside this crate routes
+//! through [`Brand::get()`]. Downstream distros override any field by setting
+//! the corresponding `GOOSE_BRAND_*` env var at `cargo build` time; unset vars
+//! fall back to today's goose-branded defaults.
+//!
+//! For clap `about` / `long_about` strings embedded in derive attributes, the
+//! derive keeps the literal goose-branded text and [`apply_branding`] walks the
+//! `clap::Command` tree at startup, rewriting product-noun tokens when the brand
+//! differs from the default. When [`Brand::is_default`] is true the pass is a
+//! no-op — default builds produce byte-identical `--help`, manpages, and shell
+//! templates.
+//!
+//! See `CUSTOM_DISTROS.md` for the env var list and usage.
+
+const DEFAULT_PRODUCT_NAME: &str = "goose";
+const DEFAULT_BINARY_NAME: &str = "goose";
+const DEFAULT_SHELL_ALIAS_PRIMARY: &str = "goose";
+const DEFAULT_SHELL_ALIAS_SHORT: &str = "g";
+const DEFAULT_SHELL_FN_PREFIX: &str = "goose";
+const DEFAULT_DEEPLINK_SCHEME: &str = "goose";
+const DEFAULT_GITHUB_OWNER: &str = "aaif-goose";
+const DEFAULT_GITHUB_REPO: &str = "goose";
+const DEFAULT_AGENT_IDENTITY: &str = "You are goose, an AI assistant.";
+
+pub struct Brand {
+    /// Display noun used in user-facing messages (e.g. "goose Version:").
+    pub product_name: &'static str,
+    /// Compiled binary name, clap root command name, invocation examples.
+    pub binary_name: &'static str,
+    /// Primary shell alias emitted by `term init` (e.g. `@goose`).
+    pub shell_alias_primary: &'static str,
+    /// Short shell alias emitted by `term init` (e.g. `@g`).
+    pub shell_alias_short: &'static str,
+    /// Function/variable prefix used in shell templates
+    /// (e.g. `goose_preexec`, `goose_preexec_installed`).
+    pub shell_fn_prefix: &'static str,
+    /// URL scheme for recipe deeplinks (e.g. `goose://recipe?...`).
+    pub deeplink_scheme: &'static str,
+    /// GitHub owner for the update + attestation URLs.
+    pub github_owner: &'static str,
+    /// GitHub repo for the update + attestation URLs.
+    pub github_repo: &'static str,
+    /// System prompt used by the provider-configuration smoke test.
+    pub agent_identity_sentence: &'static str,
+}
+
+pub const BRAND: Brand = Brand {
+    product_name: match option_env!("GOOSE_BRAND_PRODUCT_NAME") {
+        Some(v) => v,
+        None => DEFAULT_PRODUCT_NAME,
+    },
+    binary_name: match option_env!("GOOSE_BRAND_BINARY_NAME") {
+        Some(v) => v,
+        None => DEFAULT_BINARY_NAME,
+    },
+    shell_alias_primary: match option_env!("GOOSE_BRAND_SHELL_ALIAS_PRIMARY") {
+        Some(v) => v,
+        None => DEFAULT_SHELL_ALIAS_PRIMARY,
+    },
+    shell_alias_short: match option_env!("GOOSE_BRAND_SHELL_ALIAS_SHORT") {
+        Some(v) => v,
+        None => DEFAULT_SHELL_ALIAS_SHORT,
+    },
+    shell_fn_prefix: match option_env!("GOOSE_BRAND_SHELL_FN_PREFIX") {
+        Some(v) => v,
+        None => DEFAULT_SHELL_FN_PREFIX,
+    },
+    deeplink_scheme: match option_env!("GOOSE_BRAND_DEEPLINK_SCHEME") {
+        Some(v) => v,
+        None => DEFAULT_DEEPLINK_SCHEME,
+    },
+    github_owner: match option_env!("GOOSE_BRAND_GITHUB_OWNER") {
+        Some(v) => v,
+        None => DEFAULT_GITHUB_OWNER,
+    },
+    github_repo: match option_env!("GOOSE_BRAND_GITHUB_REPO") {
+        Some(v) => v,
+        None => DEFAULT_GITHUB_REPO,
+    },
+    agent_identity_sentence: match option_env!("GOOSE_BRAND_AGENT_IDENTITY") {
+        Some(v) => v,
+        None => DEFAULT_AGENT_IDENTITY,
+    },
+};
+
+impl Brand {
+    pub fn get() -> &'static Brand {
+        &BRAND
+    }
+
+    pub fn is_default(&self) -> bool {
+        self.product_name == DEFAULT_PRODUCT_NAME
+            && self.binary_name == DEFAULT_BINARY_NAME
+            && self.shell_alias_primary == DEFAULT_SHELL_ALIAS_PRIMARY
+            && self.shell_alias_short == DEFAULT_SHELL_ALIAS_SHORT
+            && self.shell_fn_prefix == DEFAULT_SHELL_FN_PREFIX
+            && self.deeplink_scheme == DEFAULT_DEEPLINK_SCHEME
+            && self.github_owner == DEFAULT_GITHUB_OWNER
+            && self.github_repo == DEFAULT_GITHUB_REPO
+            && self.agent_identity_sentence == DEFAULT_AGENT_IDENTITY
+    }
+
+    pub fn product_name_cap(&self) -> String {
+        capitalize(self.product_name)
+    }
+}
+
+fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+/// Rewrite the default product noun to the branded equivalents.
+///
+/// Replaces `Goose` with the capitalized product name and `goose` with the
+/// binary name. Downstream distros that keep `product_name` in sync with the
+/// title-cased `binary_name` (the common case) get sensible output for both
+/// display phrases ("Configure goose settings") and invocation examples
+/// ("goose term init zsh").
+fn rebrand_str(s: &str, b: &Brand) -> String {
+    let product_cap = b.product_name_cap();
+    s.replace("Goose", &product_cap)
+        .replace(DEFAULT_BINARY_NAME, b.binary_name)
+}
+
+/// Walk the clap command tree and rewrite branding-sensitive strings.
+///
+/// On the default build this returns the input unchanged, preserving
+/// byte-identical `--help` output.
+pub fn apply_branding(cmd: clap::Command) -> clap::Command {
+    let b = Brand::get();
+    if b.is_default() {
+        return cmd;
+    }
+    rewrite_command(cmd, b)
+}
+
+fn rewrite_command(mut cmd: clap::Command, b: &Brand) -> clap::Command {
+    if cmd.get_name() == DEFAULT_BINARY_NAME {
+        cmd = cmd.name(b.binary_name).bin_name(b.binary_name);
+    }
+
+    if let Some(about) = cmd.get_about().map(|s| s.to_string()) {
+        cmd = cmd.about(rebrand_str(&about, b));
+    }
+    if let Some(long_about) = cmd.get_long_about().map(|s| s.to_string()) {
+        cmd = cmd.long_about(rebrand_str(&long_about, b));
+    }
+
+    if cmd.get_name() == "completion" {
+        cmd = cmd.mut_arg("bin_name", |a| a.default_value(b.binary_name));
+    }
+
+    // Rewrite branded tokens inside every argument's help / long_help.
+    let arg_ids: Vec<clap::Id> = cmd.get_arguments().map(|a| a.get_id().clone()).collect();
+    for id in arg_ids {
+        cmd = cmd.mut_arg(id, |a| rewrite_arg(a, b));
+    }
+
+    let subcmd_names: Vec<String> = cmd
+        .get_subcommands()
+        .map(|s| s.get_name().to_string())
+        .collect();
+    for name in subcmd_names {
+        cmd = cmd.mut_subcommand(name, |sc| rewrite_command(sc, b));
+    }
+
+    cmd
+}
+
+fn rewrite_arg(mut arg: clap::Arg, b: &Brand) -> clap::Arg {
+    if let Some(help) = arg.get_help().map(|s| s.to_string()) {
+        arg = arg.help(rebrand_str(&help, b));
+    }
+    if let Some(long_help) = arg.get_long_help().map(|s| s.to_string()) {
+        arg = arg.long_help(rebrand_str(&long_help, b));
+    }
+    arg
+}
+
+/// Build the branded top-level clap command.
+///
+/// Use this in place of `Cli::command()` at every entry point (the main binary
+/// and the manpage generator) so branding is applied consistently.
+pub fn branded_command() -> clap::Command {
+    use clap::CommandFactory;
+    apply_branding(crate::Cli::command())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_brand_matches_hardcoded_defaults() {
+        let b = Brand::get();
+        assert!(b.is_default(), "default build must have all defaults");
+        assert_eq!(b.product_name, "goose");
+        assert_eq!(b.binary_name, "goose");
+        assert_eq!(b.shell_alias_primary, "goose");
+        assert_eq!(b.shell_alias_short, "g");
+        assert_eq!(b.shell_fn_prefix, "goose");
+        assert_eq!(b.deeplink_scheme, "goose");
+        assert_eq!(b.github_owner, "aaif-goose");
+        assert_eq!(b.github_repo, "goose");
+        assert_eq!(b.agent_identity_sentence, "You are goose, an AI assistant.");
+    }
+
+    #[test]
+    fn capitalize_ascii() {
+        assert_eq!(capitalize("goose"), "Goose");
+        assert_eq!(capitalize("foobar"), "Foobar");
+        assert_eq!(capitalize(""), "");
+        assert_eq!(capitalize("A"), "A");
+    }
+
+    #[test]
+    fn apply_branding_is_noop_on_default_build() {
+        use clap::CommandFactory;
+        let before = crate::Cli::command().render_long_help().to_string();
+        let after = branded_command().render_long_help().to_string();
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn rebrand_str_rewrites_tokens() {
+        let b = Brand {
+            product_name: "Foobar",
+            binary_name: "foobar",
+            shell_alias_primary: "foobar",
+            shell_alias_short: "fb",
+            shell_fn_prefix: "foobar",
+            deeplink_scheme: "foobar",
+            github_owner: "acme",
+            github_repo: "foobar",
+            agent_identity_sentence: "You are foobar, an AI assistant.",
+        };
+        assert_eq!(
+            rebrand_str("Configure goose settings", &b),
+            "Configure foobar settings"
+        );
+        assert_eq!(
+            rebrand_str("Check that your Goose setup is working", &b),
+            "Check that your Foobar setup is working"
+        );
+        assert_eq!(
+            rebrand_str("eval \"$(goose term init zsh)\"", &b),
+            "eval \"$(foobar term init zsh)\""
+        );
+    }
+
+    #[test]
+    fn synthetic_non_default_brand_rewrites_help() {
+        // Simulate a non-default build by walking a fresh command tree with
+        // an explicit non-default brand.
+        use clap::CommandFactory;
+        let b = Brand {
+            product_name: "Foobar",
+            binary_name: "foobar",
+            shell_alias_primary: "foobar",
+            shell_alias_short: "fb",
+            shell_fn_prefix: "foobar",
+            deeplink_scheme: "foobar",
+            github_owner: "acme",
+            github_repo: "foobar",
+            agent_identity_sentence: "You are foobar, an AI assistant.",
+        };
+        let mut cmd = rewrite_command(crate::Cli::command(), &b);
+        assert_eq!(cmd.get_name(), "foobar");
+        let rendered = cmd.render_long_help().to_string();
+        assert!(!rendered.contains("goose"), "{rendered}");
+        assert!(!rendered.contains("Goose"), "{rendered}");
+    }
+}

--- a/crates/goose-cli/src/branding.rs
+++ b/crates/goose-cli/src/branding.rs
@@ -53,6 +53,13 @@ impl InteractiveStyle {
             Self::Minimal => [">", "", ""],
         }
     }
+
+    fn title_prefix(self) -> &'static str {
+        match self {
+            Self::Goose => "🪿",
+            Self::Minimal => "",
+        }
+    }
 }
 
 pub struct Brand {
@@ -154,6 +161,15 @@ impl Brand {
 
     pub fn session_banner_lines(&self) -> [&'static str; 3] {
         self.interactive_style_kind().session_banner_lines()
+    }
+
+    pub fn terminal_title_prefix(&self) -> String {
+        let prefix = self.interactive_style_kind().title_prefix();
+        if prefix.is_empty() {
+            self.product_name_cap()
+        } else {
+            prefix.to_string()
+        }
     }
 }
 
@@ -391,6 +407,7 @@ mod tests {
             interactive_style: "goose",
         };
         assert_eq!(goose.interactive_prefix(), "🪿 ");
+        assert_eq!(goose.terminal_title_prefix(), "🪿");
         assert_eq!(
             goose.session_banner_lines(),
             ["  __( O)>", r" \____)", "   L L"]
@@ -409,6 +426,7 @@ mod tests {
             interactive_style: "minimal",
         };
         assert_eq!(minimal.interactive_prefix(), "> ");
+        assert_eq!(minimal.terminal_title_prefix(), "Foobar");
         assert_eq!(minimal.session_banner_lines(), [">", "", ""]);
     }
 
@@ -427,6 +445,7 @@ mod tests {
             interactive_style: "mystery",
         };
         assert_eq!(b.interactive_prefix(), "🪿 ");
+        assert_eq!(b.terminal_title_prefix(), "🪿");
         assert_eq!(
             b.session_banner_lines(),
             ["  __( O)>", r" \____)", "   L L"]

--- a/crates/goose-cli/src/branding.rs
+++ b/crates/goose-cli/src/branding.rs
@@ -276,4 +276,70 @@ mod tests {
         assert!(!rendered.contains("goose"), "{rendered}");
         assert!(!rendered.contains("Goose"), "{rendered}");
     }
+
+    /// Regression guard: under a synthetic non-default brand, no subcommand's
+    /// rendered help (including every argument's help / long_help) may leak
+    /// the default product noun.
+    ///
+    /// This walks the entire command tree recursively, so when a contributor
+    /// adds a new subcommand or argument that accidentally hardcodes `goose`
+    /// / `Goose` in a clap derive attribute, this test fails with the name
+    /// of the offending command and the full rendered help text — pointing
+    /// them at [`apply_branding`] / [`rewrite_command`] so they can either
+    /// route the string through the rewriter or move it out of the derive
+    /// and into a runtime [`Brand::get()`] lookup.
+    ///
+    /// It does NOT catch hardcoded runtime strings (e.g. a new
+    /// `println!("goose ...")` call) — PR review remains the safety net for
+    /// those. But the clap-derive surface is where the bulk of regressions
+    /// would land.
+    #[test]
+    fn no_goose_leaks_in_any_branded_subcommand_help() {
+        use clap::CommandFactory;
+        let b = Brand {
+            product_name: "Foobar",
+            binary_name: "foobar",
+            shell_alias_primary: "foobar",
+            shell_alias_short: "fb",
+            shell_fn_prefix: "foobar",
+            deeplink_scheme: "foobar",
+            github_owner: "acme",
+            github_repo: "foobar",
+            agent_identity_sentence: "You are foobar, an AI assistant.",
+        };
+        let cmd = rewrite_command(crate::Cli::command(), &b);
+        assert_no_leaks_recursive(&cmd, "");
+    }
+
+    fn assert_no_leaks_recursive(cmd: &clap::Command, path: &str) {
+        let current_path = if path.is_empty() {
+            cmd.get_name().to_string()
+        } else {
+            format!("{path} {}", cmd.get_name())
+        };
+
+        // render_long_help() needs &mut self; clone is cheap for a test.
+        let mut clone = cmd.clone();
+        let help = clone.render_long_help().to_string();
+
+        assert!(
+            !help.contains("goose"),
+            "branding leak: `{current_path}` help contains lowercase `goose`. \
+             Either route the offending string through `apply_branding` / `Brand::get()` \
+             or remove it from the clap derive attribute.\n\nFull help:\n{help}"
+        );
+        assert!(
+            !help.contains("Goose"),
+            "branding leak: `{current_path}` help contains capitalized `Goose`. \
+             Either route the offending string through `apply_branding` / `Brand::get()` \
+             or remove it from the clap derive attribute.\n\nFull help:\n{help}"
+        );
+
+        for sub in cmd.get_subcommands() {
+            if sub.get_name() == "help" {
+                continue;
+            }
+            assert_no_leaks_recursive(sub, &current_path);
+        }
+    }
 }

--- a/crates/goose-cli/src/branding.rs
+++ b/crates/goose-cli/src/branding.rs
@@ -196,9 +196,16 @@ pub fn branded_command() -> clap::Command {
 mod tests {
     use super::*;
 
+    fn help_brand_matches_defaults(b: &Brand) -> bool {
+        b.product_name == DEFAULT_PRODUCT_NAME && b.binary_name == DEFAULT_BINARY_NAME
+    }
+
     #[test]
     fn default_brand_matches_hardcoded_defaults() {
         let b = Brand::get();
+        if !b.is_default() {
+            return;
+        }
         assert!(b.is_default(), "default build must have all defaults");
         assert_eq!(b.product_name, "goose");
         assert_eq!(b.binary_name, "goose");
@@ -220,8 +227,12 @@ mod tests {
     }
 
     #[test]
-    fn apply_branding_is_noop_on_default_build() {
+    fn apply_branding_is_noop_when_help_brand_matches_defaults() {
         use clap::CommandFactory;
+        let b = Brand::get();
+        if !help_brand_matches_defaults(b) {
+            return;
+        }
         let before = crate::Cli::command().render_long_help().to_string();
         let after = branded_command().render_long_help().to_string();
         assert_eq!(before, after);

--- a/crates/goose-cli/src/branding.rs
+++ b/crates/goose-cli/src/branding.rs
@@ -190,8 +190,17 @@ fn capitalize(s: &str) -> String {
 /// ("goose term init zsh").
 fn rebrand_str(s: &str, b: &Brand) -> String {
     let product_cap = b.product_name_cap();
-    s.replace("Goose", &product_cap)
+    let alias_primary_placeholder = "__BRAND_ALIAS_PRIMARY__";
+    let alias_short_placeholder = "__BRAND_ALIAS_SHORT__";
+    let alias_primary = format!("@{}", b.shell_alias_primary);
+    let alias_short = format!("@{}", b.shell_alias_short);
+
+    s.replace("@goose", alias_primary_placeholder)
+        .replace("@g", alias_short_placeholder)
+        .replace("Goose", &product_cap)
         .replace(DEFAULT_BINARY_NAME, b.binary_name)
+        .replace(alias_primary_placeholder, &alias_primary)
+        .replace(alias_short_placeholder, &alias_short)
 }
 
 /// Walk the clap command tree and rewrite branding-sensitive strings.
@@ -310,8 +319,8 @@ mod tests {
         let b = Brand {
             product_name: "Foobar",
             binary_name: "foobar",
-            shell_alias_primary: "foobar",
-            shell_alias_short: "fb",
+            shell_alias_primary: "chat",
+            shell_alias_short: "c",
             shell_fn_prefix: "foobar",
             deeplink_scheme: "foobar",
             github_owner: "acme",
@@ -331,6 +340,57 @@ mod tests {
             rebrand_str("eval \"$(goose term init zsh)\"", &b),
             "eval \"$(foobar term init zsh)\""
         );
+        assert_eq!(
+            rebrand_str("@goose \"create a python script\"", &b),
+            "@chat \"create a python script\""
+        );
+        assert_eq!(
+            rebrand_str("@g \"quick question\"", &b),
+            "@c \"quick question\""
+        );
+    }
+
+    #[test]
+    fn synthetic_non_default_brand_rewrites_alias_examples() {
+        use clap::CommandFactory;
+        let b = Brand {
+            product_name: "Foobar",
+            binary_name: "foobar",
+            shell_alias_primary: "chat",
+            shell_alias_short: "c",
+            shell_fn_prefix: "foobar",
+            deeplink_scheme: "foobar",
+            github_owner: "acme",
+            github_repo: "foobar",
+            agent_identity_sentence: "You are foobar, an AI assistant.",
+            interactive_style: "minimal",
+        };
+        let mut cmd = rewrite_command(crate::Cli::command(), &b);
+        let term_help = cmd
+            .find_subcommand_mut("term")
+            .unwrap()
+            .render_long_help()
+            .to_string();
+        assert!(
+            term_help.contains("@chat \"create a python script\""),
+            "{term_help}"
+        );
+        assert!(term_help.contains("@c \"quick question\""), "{term_help}");
+        assert!(
+            !term_help.contains("@foobar \"create a python script\""),
+            "{term_help}"
+        );
+
+        let run_help = cmd
+            .find_subcommand_mut("term")
+            .unwrap()
+            .find_subcommand_mut("run")
+            .unwrap()
+            .render_long_help()
+            .to_string();
+        assert!(run_help.contains("@chat list files"), "{run_help}");
+        assert!(run_help.contains("@c why did that fail"), "{run_help}");
+        assert!(!run_help.contains("@foobar list files"), "{run_help}");
     }
 
     #[test]

--- a/crates/goose-cli/src/branding.rs
+++ b/crates/goose-cli/src/branding.rs
@@ -23,6 +23,37 @@ const DEFAULT_DEEPLINK_SCHEME: &str = "goose";
 const DEFAULT_GITHUB_OWNER: &str = "aaif-goose";
 const DEFAULT_GITHUB_REPO: &str = "goose";
 const DEFAULT_AGENT_IDENTITY: &str = "You are goose, an AI assistant.";
+const DEFAULT_INTERACTIVE_STYLE: &str = "goose";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InteractiveStyle {
+    Goose,
+    Minimal,
+}
+
+impl InteractiveStyle {
+    fn from_env(value: &str) -> Self {
+        if value.eq_ignore_ascii_case("minimal") {
+            Self::Minimal
+        } else {
+            Self::Goose
+        }
+    }
+
+    fn prompt_prefix(self) -> &'static str {
+        match self {
+            Self::Goose => "🪿 ",
+            Self::Minimal => "> ",
+        }
+    }
+
+    fn session_banner_lines(self) -> [&'static str; 3] {
+        match self {
+            Self::Goose => ["  __( O)>", r" \____)", "   L L"],
+            Self::Minimal => [">", "", ""],
+        }
+    }
+}
 
 pub struct Brand {
     /// Display noun used in user-facing messages (e.g. "goose Version:").
@@ -44,6 +75,8 @@ pub struct Brand {
     pub github_repo: &'static str,
     /// System prompt used by the provider-configuration smoke test.
     pub agent_identity_sentence: &'static str,
+    /// Interactive CLI presentation style (prompt prefix, session banner).
+    pub interactive_style: &'static str,
 }
 
 pub const BRAND: Brand = Brand {
@@ -83,6 +116,10 @@ pub const BRAND: Brand = Brand {
         Some(v) => v,
         None => DEFAULT_AGENT_IDENTITY,
     },
+    interactive_style: match option_env!("GOOSE_BRAND_INTERACTIVE_STYLE") {
+        Some(v) => v,
+        None => DEFAULT_INTERACTIVE_STYLE,
+    },
 };
 
 impl Brand {
@@ -100,10 +137,23 @@ impl Brand {
             && self.github_owner == DEFAULT_GITHUB_OWNER
             && self.github_repo == DEFAULT_GITHUB_REPO
             && self.agent_identity_sentence == DEFAULT_AGENT_IDENTITY
+            && self.interactive_style == DEFAULT_INTERACTIVE_STYLE
     }
 
     pub fn product_name_cap(&self) -> String {
         capitalize(self.product_name)
+    }
+
+    pub fn interactive_style_kind(&self) -> InteractiveStyle {
+        InteractiveStyle::from_env(self.interactive_style)
+    }
+
+    pub fn interactive_prefix(&self) -> &'static str {
+        self.interactive_style_kind().prompt_prefix()
+    }
+
+    pub fn session_banner_lines(&self) -> [&'static str; 3] {
+        self.interactive_style_kind().session_banner_lines()
     }
 }
 
@@ -216,6 +266,7 @@ mod tests {
         assert_eq!(b.github_owner, "aaif-goose");
         assert_eq!(b.github_repo, "goose");
         assert_eq!(b.agent_identity_sentence, "You are goose, an AI assistant.");
+        assert_eq!(b.interactive_style, "goose");
     }
 
     #[test]
@@ -250,6 +301,7 @@ mod tests {
             github_owner: "acme",
             github_repo: "foobar",
             agent_identity_sentence: "You are foobar, an AI assistant.",
+            interactive_style: "minimal",
         };
         assert_eq!(
             rebrand_str("Configure goose settings", &b),
@@ -280,6 +332,7 @@ mod tests {
             github_owner: "acme",
             github_repo: "foobar",
             agent_identity_sentence: "You are foobar, an AI assistant.",
+            interactive_style: "minimal",
         };
         let mut cmd = rewrite_command(crate::Cli::command(), &b);
         assert_eq!(cmd.get_name(), "foobar");
@@ -317,9 +370,67 @@ mod tests {
             github_owner: "acme",
             github_repo: "foobar",
             agent_identity_sentence: "You are foobar, an AI assistant.",
+            interactive_style: "minimal",
         };
         let cmd = rewrite_command(crate::Cli::command(), &b);
         assert_no_leaks_recursive(&cmd, "");
+    }
+
+    #[test]
+    fn interactive_style_controls_prompt_and_banner() {
+        let goose = Brand {
+            product_name: "goose",
+            binary_name: "goose",
+            shell_alias_primary: "goose",
+            shell_alias_short: "g",
+            shell_fn_prefix: "goose",
+            deeplink_scheme: "goose",
+            github_owner: "aaif-goose",
+            github_repo: "goose",
+            agent_identity_sentence: "You are goose, an AI assistant.",
+            interactive_style: "goose",
+        };
+        assert_eq!(goose.interactive_prefix(), "🪿 ");
+        assert_eq!(
+            goose.session_banner_lines(),
+            ["  __( O)>", r" \____)", "   L L"]
+        );
+
+        let minimal = Brand {
+            product_name: "Foobar",
+            binary_name: "foobar",
+            shell_alias_primary: "foobar",
+            shell_alias_short: "fb",
+            shell_fn_prefix: "foobar",
+            deeplink_scheme: "foobar",
+            github_owner: "acme",
+            github_repo: "foobar",
+            agent_identity_sentence: "You are foobar, an AI assistant.",
+            interactive_style: "minimal",
+        };
+        assert_eq!(minimal.interactive_prefix(), "> ");
+        assert_eq!(minimal.session_banner_lines(), [">", "", ""]);
+    }
+
+    #[test]
+    fn unknown_interactive_style_falls_back_to_goose() {
+        let b = Brand {
+            product_name: "Foobar",
+            binary_name: "foobar",
+            shell_alias_primary: "foobar",
+            shell_alias_short: "fb",
+            shell_fn_prefix: "foobar",
+            deeplink_scheme: "foobar",
+            github_owner: "acme",
+            github_repo: "foobar",
+            agent_identity_sentence: "You are foobar, an AI assistant.",
+            interactive_style: "mystery",
+        };
+        assert_eq!(b.interactive_prefix(), "🪿 ");
+        assert_eq!(
+            b.session_banner_lines(),
+            ["  __( O)>", r" \____)", "   L L"]
+        );
     }
 
     fn assert_no_leaks_recursive(cmd: &clap::Command, path: &str) {

--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -9,6 +9,7 @@ use goose::recipe::Recipe;
 use goose_mcp::mcp_server_runner::{serve, McpCommand};
 use goose_mcp::{AutoVisualiserRouter, ComputerControllerServer, MemoryServer, TutorialServer};
 
+use crate::branding::Brand;
 #[cfg(feature = "telemetry")]
 use crate::commands::configure::configure_telemetry_consent_dialog;
 use crate::commands::configure::handle_configure;
@@ -1307,8 +1308,9 @@ fn parse_run_input(
         (Some(file), _, _) => {
             let contents = std::fs::read_to_string(file).unwrap_or_else(|err| {
                 eprintln!(
-                    "Instruction file not found — did you mean to use goose run --text?\n{}",
-                    err
+                    "Instruction file not found — did you mean to use {} run --text?\n{}",
+                    Brand::get().binary_name,
+                    err,
                 );
                 std::process::exit(1);
             });

--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{Args, CommandFactory, Parser, Subcommand};
+use clap::{Args, FromArgMatches, Parser, Subcommand};
 use clap_complete::{generate, Shell as ClapShell};
 use goose::builtin_extension::register_builtin_extensions;
 use goose::config::{Config, GooseMode};
@@ -1743,7 +1743,8 @@ async fn handle_default_session() -> Result<()> {
 pub async fn cli() -> anyhow::Result<()> {
     register_builtin_extensions(goose_mcp::BUILTIN_EXTENSIONS.clone());
 
-    let cli = Cli::parse();
+    let matches = crate::branding::branded_command().get_matches();
+    let cli = Cli::from_arg_matches(&matches)?;
 
     if let Err(e) = crate::project_tracker::update_project_tracker(None, None) {
         warn!("Warning: Failed to update project tracker: {}", e);
@@ -1758,7 +1759,7 @@ pub async fn cli() -> anyhow::Result<()> {
 
     match cli.command {
         Some(Command::Completion { shell, bin_name }) => {
-            let mut cmd = Cli::command();
+            let mut cmd = crate::branding::branded_command();
             generate(shell, &mut cmd, bin_name, &mut std::io::stdout());
             Ok(())
         }

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -1,3 +1,4 @@
+use crate::branding::Brand;
 use crate::recipes::github_recipe::GOOSE_RECIPE_GITHUB_REPO_CONFIG_KEY;
 use cliclack::spinner;
 use console::style;
@@ -49,17 +50,25 @@ pub async fn handle_configure() -> anyhow::Result<()> {
 pub fn configure_telemetry_consent_dialog() -> anyhow::Result<bool> {
     let config = Config::global();
 
+    let brand = Brand::get();
+    let product_name = brand.product_name;
+    let binary_name = brand.binary_name;
     println!();
-    println!("{}", style("Help improve goose").bold());
+    println!("{}", style(format!("Help improve {product_name}")).bold());
     println!();
     println!(
         "{}",
-        style("Would you like to help improve goose by sharing anonymous usage data?").dim()
+        style(format!(
+            "Would you like to help improve {product_name} by sharing anonymous usage data?"
+        ))
+        .dim()
     );
     println!(
         "{}",
-        style("This helps us understand how goose is used and identify areas for improvement.")
-            .dim()
+        style(format!(
+            "This helps us understand how {product_name} is used and identify areas for improvement."
+        ))
+        .dim()
     );
     println!();
     println!("{}", style("What we collect:").dim());
@@ -67,7 +76,10 @@ pub fn configure_telemetry_consent_dialog() -> anyhow::Result<bool> {
         "{}",
         style("  • Operating system, version, and architecture").dim()
     );
-    println!("{}", style("  • goose version and install method").dim());
+    println!(
+        "{}",
+        style(format!("  • {product_name} version and install method")).dim()
+    );
     println!("{}", style("  • Provider and model used").dim());
     println!(
         "{}",
@@ -88,18 +100,23 @@ pub fn configure_telemetry_consent_dialog() -> anyhow::Result<bool> {
     );
     println!(
         "{}",
-        style("or any personal data. You can change this anytime with 'goose configure'.").dim()
+        style(format!(
+            "or any personal data. You can change this anytime with '{binary_name} configure'."
+        ))
+        .dim()
     );
     println!();
 
-    let enabled = cliclack::confirm("Share anonymous usage data to help improve goose?")
-        .initial_value(true)
-        .interact()?;
+    let enabled = cliclack::confirm(format!(
+        "Share anonymous usage data to help improve {product_name}?"
+    ))
+    .initial_value(true)
+    .interact()?;
 
     config.set_param(TELEMETRY_ENABLED_KEY, enabled)?;
 
     if enabled {
-        let _ = cliclack::log::success("Thank you for helping improve goose!");
+        let _ = cliclack::log::success(format!("Thank you for helping improve {product_name}!"));
     } else {
         let _ = cliclack::log::info("Telemetry disabled. You can enable it anytime in settings.");
     }
@@ -108,8 +125,16 @@ pub fn configure_telemetry_consent_dialog() -> anyhow::Result<bool> {
 }
 
 async fn handle_first_time_setup(config: &Config) -> anyhow::Result<()> {
+    let brand = Brand::get();
     println!();
-    println!("{}", style("Welcome to goose! Let's get you set up.").dim());
+    println!(
+        "{}",
+        style(format!(
+            "Welcome to {}! Let's get you set up.",
+            brand.product_name
+        ))
+        .dim()
+    );
     println!(
         "{}",
         style("  you can rerun this command later to update your configuration").dim()
@@ -120,7 +145,11 @@ async fn handle_first_time_setup(config: &Config) -> anyhow::Result<()> {
     configure_telemetry_consent_dialog()?;
 
     println!();
-    cliclack::intro(style(" goose-configure ").on_cyan().black())?;
+    cliclack::intro(
+        style(format!(" {}-configure ", brand.binary_name))
+            .on_cyan()
+            .black(),
+    )?;
 
     let setup_method = cliclack::select("How would you like to set up your provider?")
         .item(
@@ -168,12 +197,14 @@ async fn handle_first_time_setup(config: &Config) -> anyhow::Result<()> {
 }
 
 async fn handle_manual_provider_setup(config: &Config) {
+    let brand = Brand::get();
+    let product_name = brand.product_name;
     match configure_provider_dialog().await {
         Ok(true) => {
             println!(
                 "\n  {}: Run '{}' again to adjust your config or add extensions",
                 style("Tip").green().italic(),
-                style("goose configure").cyan()
+                style(format!("{} configure", brand.binary_name)).cyan()
             );
             set_extension(ExtensionEntry {
                 enabled: true,
@@ -183,9 +214,9 @@ async fn handle_manual_provider_setup(config: &Config) {
         Ok(false) => {
             let _ = config.clear();
             println!(
-                "\n  {}: We did not save your config, inspect your credentials\n   and run '{}' again to ensure goose can connect",
+                "\n  {}: We did not save your config, inspect your credentials\n   and run '{}' again to ensure {product_name} can connect",
                 style("Warning").yellow().italic(),
-                style("goose configure").cyan()
+                style(format!("{} configure", brand.binary_name)).cyan()
             );
         }
         Err(e) => {
@@ -202,7 +233,7 @@ fn print_manual_config_error(e: &anyhow::Error) {
                 "\n  {} Required configuration key '{}' not found \n  Please provide this value and run '{}' again",
                 style("Error").red().italic(),
                 key,
-                style("goose configure").cyan()
+                style(format!("{} configure", Brand::get().binary_name)).cyan()
             );
         }
         Some(ConfigError::KeyringError(msg)) => {
@@ -213,7 +244,7 @@ fn print_manual_config_error(e: &anyhow::Error) {
                 "\n  {} Invalid configuration value: {} \n  Please check your input and run '{}' again",
                 style("Error").red().italic(),
                 msg,
-                style("goose configure").cyan()
+                style(format!("{} configure", Brand::get().binary_name)).cyan()
             );
         }
         Some(ConfigError::FileError(err)) => {
@@ -221,7 +252,7 @@ fn print_manual_config_error(e: &anyhow::Error) {
                 "\n  {} Failed to access config file: {} \n  Please check file permissions and run '{}' again",
                 style("Error").red().italic(),
                 err,
-                style("goose configure").cyan()
+                style(format!("{} configure", Brand::get().binary_name)).cyan()
             );
         }
         Some(ConfigError::DirectoryError(msg)) => {
@@ -229,15 +260,16 @@ fn print_manual_config_error(e: &anyhow::Error) {
                 "\n  {} Failed to access config directory: {} \n  Please check directory permissions and run '{}' again",
                 style("Error").red().italic(),
                 msg,
-                style("goose configure").cyan()
+                style(format!("{} configure", Brand::get().binary_name)).cyan()
             );
         }
         _ => {
+            let product_name = Brand::get().product_name;
             println!(
-                "\n  {} {} \n  We did not save your config, inspect your credentials\n   and run '{}' again to ensure goose can connect",
+                "\n  {} {} \n  We did not save your config, inspect your credentials\n   and run '{}' again to ensure {product_name} can connect",
                 style("Error").red().italic(),
                 e,
-                style("goose configure").cyan()
+                style(format!("{} configure", Brand::get().binary_name)).cyan()
             );
         }
     }
@@ -249,7 +281,7 @@ fn print_keyring_error(msg: &str) {
         "\n  {} Failed to access secure storage (keyring): {} \n  Please check your system keychain and run '{}' again. \n  If your system is unable to use the keyring, please try setting secret key(s) via environment variables.",
         style("Error").red().italic(),
         msg,
-        style("goose configure").cyan()
+        style(format!("{} configure", Brand::get().binary_name)).cyan()
     );
 }
 
@@ -259,7 +291,7 @@ fn print_keyring_error(msg: &str) {
         "\n  {} Failed to access Windows Credential Manager: {} \n  Please check Windows Credential Manager and run '{}' again. \n  If your system is unable to use the Credential Manager, please try setting secret key(s) via environment variables.",
         style("Error").red().italic(),
         msg,
-        style("goose configure").cyan()
+        style(format!("{} configure", Brand::get().binary_name)).cyan()
     );
 }
 
@@ -269,7 +301,7 @@ fn print_keyring_error(msg: &str) {
         "\n  {} Failed to access secure storage: {} \n  Please check your system's secure storage and run '{}' again. \n  If your system is unable to use secure storage, please try setting secret key(s) via environment variables.",
         style("Error").red().italic(),
         msg,
-        style("goose configure").cyan()
+        style(format!("{} configure", Brand::get().binary_name)).cyan()
     );
 }
 
@@ -288,7 +320,11 @@ async fn handle_existing_config() -> anyhow::Result<()> {
     );
     println!();
 
-    cliclack::intro(style(" goose-configure ").on_cyan().black())?;
+    cliclack::intro(
+        style(format!(" {}-configure ", Brand::get().binary_name))
+            .on_cyan()
+            .black(),
+    )?;
     let action = cliclack::select("What would you like to configure?")
         .item(
             "providers",
@@ -309,8 +345,11 @@ async fn handle_existing_config() -> anyhow::Result<()> {
         .item("remove", "Remove Extension", "Remove an extension")
         .item(
             "settings",
-            "goose settings",
-            "Set the goose mode, Tool Output, Tool Permissions, Experiment, goose recipe github repo and more",
+            format!("{} settings", Brand::get().product_name),
+            format!(
+                "Set the {0} mode, Tool Output, Tool Permissions, Experiment, {0} recipe github repo and more",
+                Brand::get().product_name
+            ),
         )
         .interact()?;
 
@@ -1189,7 +1228,7 @@ pub fn configure_extensions_dialog() -> anyhow::Result<()> {
         .item(
             "built-in",
             "Built-in Extension",
-            "Use an extension that comes with goose",
+            format!("Use an extension that comes with {}", Brand::get().product_name),
         )
         .item(
             "stdio",
@@ -1276,11 +1315,12 @@ pub fn remove_extension_dialog() -> anyhow::Result<()> {
 }
 
 pub async fn configure_settings_dialog() -> anyhow::Result<()> {
+    let product_name = Brand::get().product_name;
     #[allow(unused_mut)]
     let mut setting_select = cliclack::select("What setting would you like to configure?").item(
         "goose_mode",
-        "goose mode",
-        "Configure goose mode",
+        format!("{product_name} mode"),
+        format!("Configure {product_name} mode"),
     );
     #[cfg(feature = "telemetry")]
     {
@@ -1318,8 +1358,10 @@ pub async fn configure_settings_dialog() -> anyhow::Result<()> {
         )
         .item(
             "recipe",
-            "goose recipe github repo",
-            "goose will pull recipes from this repo if not found locally.",
+            format!("{product_name} recipe github repo"),
+            format!(
+                "{product_name} will pull recipes from this repo if not found locally."
+            ),
         )
         .interact()?;
 
@@ -1372,7 +1414,10 @@ pub fn configure_goose_mode_dialog() -> anyhow::Result<()> {
         );
     }
 
-    let mode = cliclack::select("Which goose mode would you like to configure?")
+    let mode = cliclack::select(format!(
+        "Which {} mode would you like to configure?",
+        Brand::get().product_name
+    ))
         .item(
             GooseMode::Auto,
             "Auto Mode",
@@ -1425,14 +1470,19 @@ pub fn configure_telemetry_dialog() -> anyhow::Result<()> {
 
     let _ = cliclack::log::info(format!("Current telemetry status: {}", current_status));
 
-    let enabled = cliclack::confirm("Share anonymous usage data to help improve goose?")
-        .initial_value(current_choice.unwrap_or(true))
-        .interact()?;
+    let product_name = Brand::get().product_name;
+    let enabled = cliclack::confirm(format!(
+        "Share anonymous usage data to help improve {product_name}?"
+    ))
+    .initial_value(current_choice.unwrap_or(true))
+    .interact()?;
 
     config.set_param(TELEMETRY_ENABLED_KEY, enabled)?;
 
     if enabled {
-        cliclack::outro("Telemetry enabled - thank you for helping improve goose!")?;
+        cliclack::outro(format!(
+            "Telemetry enabled - thank you for helping improve {product_name}!"
+        ))?;
     } else {
         cliclack::outro("Telemetry disabled")?;
     }
@@ -1516,7 +1566,10 @@ pub fn configure_keyring_dialog() -> anyhow::Result<()> {
             config.set_param("GOOSE_DISABLE_KEYRING", Value::String("".to_string()))?;
             cliclack::outro("Secret storage set to system keyring (secure)")?;
             let _ =
-                cliclack::log::info("You may need to restart goose for this change to take effect");
+                cliclack::log::info(format!(
+                    "You may need to restart {} for this change to take effect",
+                    Brand::get().product_name
+                ));
         }
         "file" => {
             // Set the disable flag to use file storage
@@ -1526,7 +1579,10 @@ pub fn configure_keyring_dialog() -> anyhow::Result<()> {
                 secrets_path.display(),
             ))?;
             let _ =
-                cliclack::log::info("You may need to restart goose for this change to take effect");
+                cliclack::log::info(format!(
+                    "You may need to restart {} for this change to take effect",
+                    Brand::get().product_name
+                ));
         }
         _ => unreachable!(),
     };
@@ -1750,9 +1806,11 @@ fn configure_recipe_dialog() -> anyhow::Result<()> {
     let default_recipe_repo = std::env::var(key_name)
         .ok()
         .or_else(|| config.get_param(key_name).unwrap_or(None));
-    let mut recipe_repo_input = cliclack::input(
-        "Enter your goose recipe GitHub repo (owner/repo): eg: my_org/goose-recipes",
-    )
+    let mut recipe_repo_input = cliclack::input(format!(
+        "Enter your {} recipe GitHub repo (owner/repo): eg: my_org/{}-recipes",
+        Brand::get().product_name,
+        Brand::get().binary_name
+    ))
     .required(false);
     if let Some(recipe_repo) = default_recipe_repo {
         recipe_repo_input = recipe_repo_input.default_input(&recipe_repo);
@@ -1791,8 +1849,10 @@ pub fn configure_max_turns_dialog() -> anyhow::Result<()> {
     config.set_param("GOOSE_MAX_TURNS", max_turns)?;
 
     cliclack::outro(format!(
-        "Set maximum turns to {} - goose will ask for input after {} consecutive actions",
-        max_turns, max_turns
+        "Set maximum turns to {} - {} will ask for input after {} consecutive actions",
+        max_turns,
+        Brand::get().product_name,
+        max_turns
     ))?;
 
     Ok(())
@@ -1838,7 +1898,7 @@ pub async fn handle_openrouter_auth() -> anyhow::Result<()> {
                 .complete(
                     &provider_model_config,
                     "",
-                    "You are goose, an AI assistant.",
+                    Brand::get().agent_identity_sentence,
                     &[Message::user().with_text("Say 'Configuration test successful!'")],
                     &[],
                 )

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -1228,7 +1228,10 @@ pub fn configure_extensions_dialog() -> anyhow::Result<()> {
         .item(
             "built-in",
             "Built-in Extension",
-            format!("Use an extension that comes with {}", Brand::get().product_name),
+            format!(
+                "Use an extension that comes with {}",
+                Brand::get().product_name
+            ),
         )
         .item(
             "stdio",
@@ -1359,9 +1362,7 @@ pub async fn configure_settings_dialog() -> anyhow::Result<()> {
         .item(
             "recipe",
             format!("{product_name} recipe github repo"),
-            format!(
-                "{product_name} will pull recipes from this repo if not found locally."
-            ),
+            format!("{product_name} will pull recipes from this repo if not found locally."),
         )
         .interact()?;
 
@@ -1418,27 +1419,27 @@ pub fn configure_goose_mode_dialog() -> anyhow::Result<()> {
         "Which {} mode would you like to configure?",
         Brand::get().product_name
     ))
-        .item(
-            GooseMode::Auto,
-            "Auto Mode",
-            "Full file modification, extension usage, edit, create and delete files freely"
-        )
-        .item(
-            GooseMode::Approve,
-            "Approve Mode",
-            "All tools, extensions and file modifications will require human approval"
-        )
-        .item(
-            GooseMode::SmartApprove,
-            "Smart Approve Mode",
-            "Editing, creating, deleting files and using extensions will require human approval"
-        )
-        .item(
-            GooseMode::Chat,
-            "Chat Mode",
-            "Engage with the selected provider without using tools, extensions, or file modification"
-        )
-        .interact()?;
+    .item(
+        GooseMode::Auto,
+        "Auto Mode",
+        "Full file modification, extension usage, edit, create and delete files freely",
+    )
+    .item(
+        GooseMode::Approve,
+        "Approve Mode",
+        "All tools, extensions and file modifications will require human approval",
+    )
+    .item(
+        GooseMode::SmartApprove,
+        "Smart Approve Mode",
+        "Editing, creating, deleting files and using extensions will require human approval",
+    )
+    .item(
+        GooseMode::Chat,
+        "Chat Mode",
+        "Engage with the selected provider without using tools, extensions, or file modification",
+    )
+    .interact()?;
 
     config.set_goose_mode(mode)?;
     let msg = match mode {
@@ -1565,11 +1566,10 @@ pub fn configure_keyring_dialog() -> anyhow::Result<()> {
             // Set to empty string to enable keyring (absence or empty = enabled)
             config.set_param("GOOSE_DISABLE_KEYRING", Value::String("".to_string()))?;
             cliclack::outro("Secret storage set to system keyring (secure)")?;
-            let _ =
-                cliclack::log::info(format!(
-                    "You may need to restart {} for this change to take effect",
-                    Brand::get().product_name
-                ));
+            let _ = cliclack::log::info(format!(
+                "You may need to restart {} for this change to take effect",
+                Brand::get().product_name
+            ));
         }
         "file" => {
             // Set the disable flag to use file storage
@@ -1578,11 +1578,10 @@ pub fn configure_keyring_dialog() -> anyhow::Result<()> {
                 "Secret storage set to file ({}). Keep this file secure!",
                 secrets_path.display(),
             ))?;
-            let _ =
-                cliclack::log::info(format!(
-                    "You may need to restart {} for this change to take effect",
-                    Brand::get().product_name
-                ));
+            let _ = cliclack::log::info(format!(
+                "You may need to restart {} for this change to take effect",
+                Brand::get().product_name
+            ));
         }
         _ => unreachable!(),
     };

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -1927,7 +1927,10 @@ pub async fn handle_openrouter_auth() -> anyhow::Result<()> {
                         println!("✓ Developer extension enabled");
                     }
 
-                    cliclack::outro("OpenRouter setup complete! You can now use goose.")?;
+                    cliclack::outro(format!(
+                        "OpenRouter setup complete! You can now use {}.",
+                        Brand::get().binary_name
+                    ))?;
                 }
                 Err(e) => {
                     eprintln!("⚠️  Configuration test failed: {}", e);
@@ -1998,9 +2001,10 @@ pub async fn handle_tetrate_auth() -> anyhow::Result<()> {
                         println!("✓ Developer extension enabled");
                     }
 
-                    cliclack::outro(
-                        "Tetrate Agent Router Service setup complete! You can now use goose.",
-                    )?;
+                    cliclack::outro(format!(
+                        "Tetrate Agent Router Service setup complete! You can now use {}.",
+                        Brand::get().binary_name
+                    ))?;
                 }
                 Err(e) => {
                     eprintln!("⚠️  Configuration test failed: {}", e);

--- a/crates/goose-cli/src/commands/info.rs
+++ b/crates/goose-cli/src/commands/info.rs
@@ -60,7 +60,9 @@ pub fn handle_info(verbose: bool) -> Result<()> {
     let brand = Brand::get();
     println!(
         "{}",
-        style(format!("{} Version:", brand.product_name)).cyan().bold()
+        style(format!("{} Version:", brand.product_name))
+            .cyan()
+            .bold()
     );
     print_aligned("Version:", env!("CARGO_PKG_VERSION"), label_padding);
     println!();

--- a/crates/goose-cli/src/commands/info.rs
+++ b/crates/goose-cli/src/commands/info.rs
@@ -5,6 +5,8 @@ use goose::config::Config;
 use goose::session::session_manager::{DB_NAME, SESSIONS_FOLDER};
 use serde_yaml;
 
+use crate::branding::Brand;
+
 fn print_aligned(label: &str, value: &str, width: usize) {
     println!("  {:<width$} {}", label, value, width = width);
 }
@@ -55,7 +57,11 @@ pub fn handle_info(verbose: bool) -> Result<()> {
         .unwrap_or(0)
         + 4;
 
-    println!("{}", style("goose Version:").cyan().bold());
+    let brand = Brand::get();
+    println!(
+        "{}",
+        style(format!("{} Version:", brand.product_name)).cyan().bold()
+    );
     print_aligned("Version:", env!("CARGO_PKG_VERSION"), label_padding);
     println!();
 
@@ -70,13 +76,19 @@ pub fn handle_info(verbose: bool) -> Result<()> {
     }
 
     if verbose {
-        println!("\n{}", style("goose Configuration:").cyan().bold());
+        println!(
+            "\n{}",
+            style(format!("{} Configuration:", brand.product_name))
+                .cyan()
+                .bold()
+        );
         let values = config.all_values()?;
         if values.is_empty() {
             println!("  No configuration values set");
             println!(
-                "  Run '{}' to configure goose",
-                style("goose configure").cyan()
+                "  Run '{}' to configure {}",
+                style(format!("{} configure", brand.binary_name)).cyan(),
+                brand.product_name
             );
         } else {
             let sorted_values: std::collections::BTreeMap<_, _> =

--- a/crates/goose-cli/src/commands/project.rs
+++ b/crates/goose-cli/src/commands/project.rs
@@ -3,6 +3,7 @@ use chrono::DateTime;
 use cliclack::{self, intro, outro};
 use std::path::Path;
 
+use crate::branding::Brand;
 use crate::project_tracker::ProjectTracker;
 use goose::utils::safe_truncate;
 
@@ -22,12 +23,16 @@ pub fn handle_project_default() -> Result<()> {
     if projects.is_empty() {
         // If no projects exist, just start a new one in the current directory
         println!("No previous projects found. Starting a new session in the current directory.");
-        let mut command = std::process::Command::new("goose");
+        let mut command = std::process::Command::new(Brand::get().binary_name);
         command.arg("session");
         let status = command.status()?;
 
         if !status.success() {
-            println!("Failed to run goose. Exit code: {:?}", status.code());
+            println!(
+                "Failed to run {}. Exit code: {:?}",
+                Brand::get().binary_name,
+                status.code()
+            );
         }
         return Ok(());
     }
@@ -65,7 +70,7 @@ pub fn handle_project_default() -> Result<()> {
     };
 
     // Ask the user what they want to do
-    let _ = intro("goose Project Manager");
+    let _ = intro(format!("{} Project Manager", Brand::get().product_name));
 
     let current_dir = std::env::current_dir()?;
     let current_dir_display = current_dir.display();
@@ -102,7 +107,7 @@ pub fn handle_project_default() -> Result<()> {
             std::env::set_current_dir(project_dir)?;
 
             // Build the command to run goose
-            let mut command = std::process::Command::new("goose");
+            let mut command = std::process::Command::new(Brand::get().binary_name);
             command.arg("session");
 
             if let Some(id) = session_id {
@@ -114,7 +119,11 @@ pub fn handle_project_default() -> Result<()> {
             let status = command.status()?;
 
             if !status.success() {
-                println!("Failed to run goose. Exit code: {:?}", status.code());
+                println!(
+                "Failed to run {}. Exit code: {:?}",
+                Brand::get().binary_name,
+                status.code()
+            );
             }
         }
         "fresh" => {
@@ -127,28 +136,36 @@ pub fn handle_project_default() -> Result<()> {
             std::env::set_current_dir(project_dir)?;
 
             // Build the command to run goose with a fresh session
-            let mut command = std::process::Command::new("goose");
+            let mut command = std::process::Command::new(Brand::get().binary_name);
             command.arg("session");
 
             // Execute the command
             let status = command.status()?;
 
             if !status.success() {
-                println!("Failed to run goose. Exit code: {:?}", status.code());
+                println!(
+                "Failed to run {}. Exit code: {:?}",
+                Brand::get().binary_name,
+                status.code()
+            );
             }
         }
         "new" => {
             let _ = outro("Starting a new session in the current directory");
 
             // Build the command to run goose
-            let mut command = std::process::Command::new("goose");
+            let mut command = std::process::Command::new(Brand::get().binary_name);
             command.arg("session");
 
             // Execute the command
             let status = command.status()?;
 
             if !status.success() {
-                println!("Failed to run goose. Exit code: {:?}", status.code());
+                println!(
+                "Failed to run {}. Exit code: {:?}",
+                Brand::get().binary_name,
+                status.code()
+            );
             }
         }
         _ => {
@@ -213,7 +230,7 @@ pub fn handle_projects_interactive() -> Result<()> {
         .collect();
 
     // Let the user select a project
-    let _ = intro("goose Project Manager");
+    let _ = intro(format!("{} Project Manager", Brand::get().product_name));
     let mut select = cliclack::select("Select a project:");
 
     // Add each project as an option
@@ -281,7 +298,7 @@ pub fn handle_projects_interactive() -> Result<()> {
     };
 
     // Build the command to run goose
-    let mut command = std::process::Command::new("goose");
+    let mut command = std::process::Command::new(Brand::get().binary_name);
     command.arg("session");
 
     if resume_session {
@@ -297,7 +314,11 @@ pub fn handle_projects_interactive() -> Result<()> {
     let status = command.status()?;
 
     if !status.success() {
-        println!("Failed to run goose. Exit code: {:?}", status.code());
+        println!(
+            "Failed to run {}. Exit code: {:?}",
+            Brand::get().binary_name,
+            status.code()
+        );
     }
 
     Ok(())

--- a/crates/goose-cli/src/commands/project.rs
+++ b/crates/goose-cli/src/commands/project.rs
@@ -120,10 +120,10 @@ pub fn handle_project_default() -> Result<()> {
 
             if !status.success() {
                 println!(
-                "Failed to run {}. Exit code: {:?}",
-                Brand::get().binary_name,
-                status.code()
-            );
+                    "Failed to run {}. Exit code: {:?}",
+                    Brand::get().binary_name,
+                    status.code()
+                );
             }
         }
         "fresh" => {
@@ -144,10 +144,10 @@ pub fn handle_project_default() -> Result<()> {
 
             if !status.success() {
                 println!(
-                "Failed to run {}. Exit code: {:?}",
-                Brand::get().binary_name,
-                status.code()
-            );
+                    "Failed to run {}. Exit code: {:?}",
+                    Brand::get().binary_name,
+                    status.code()
+                );
             }
         }
         "new" => {
@@ -162,10 +162,10 @@ pub fn handle_project_default() -> Result<()> {
 
             if !status.success() {
                 println!(
-                "Failed to run {}. Exit code: {:?}",
-                Brand::get().binary_name,
-                status.code()
-            );
+                    "Failed to run {}. Exit code: {:?}",
+                    Brand::get().binary_name,
+                    status.code()
+                );
             }
         }
         _ => {

--- a/crates/goose-cli/src/commands/recipe.rs
+++ b/crates/goose-cli/src/commands/recipe.rs
@@ -3,6 +3,7 @@ use console::style;
 use goose::recipe::validate_recipe::validate_recipe_template_from_file;
 use std::collections::HashMap;
 
+use crate::branding::Brand;
 use crate::recipes::github_recipe::RecipeSource;
 use crate::recipes::search_recipe::{list_available_recipes, load_recipe_file};
 use goose::recipe_deeplink;
@@ -64,12 +65,13 @@ where
     W: std::io::Write,
 {
     let params_map = parse_params(params)?;
+    let product_cap = Brand::get().product_name_cap();
     match generate_deeplink(recipe_name, params_map) {
         Ok((deeplink_url, recipe)) => match opener(&deeplink_url) {
             Ok(_) => {
                 writeln!(
                     out,
-                    "{} Opened recipe '{}' in Goose Desktop",
+                    "{} Opened recipe '{}' in {product_cap} Desktop",
                     style("✓").green().bold(),
                     recipe.title
                 )?;
@@ -78,12 +80,12 @@ where
             Err(err) => {
                 writeln!(
                     out,
-                    "{} Failed to open recipe in Goose Desktop: {}",
+                    "{} Failed to open recipe in {product_cap} Desktop: {}",
                     style("✗").red().bold(),
                     err
                 )?;
                 writeln!(out, "Generated deeplink: {}", deeplink_url)?;
-                writeln!(out, "You can manually copy and open the URL above, or ensure Goose Desktop is installed.")?;
+                writeln!(out, "You can manually copy and open the URL above, or ensure {product_cap} Desktop is installed.")?;
                 Err(anyhow::anyhow!("Failed to open recipe: {}", err))
             }
         },
@@ -174,7 +176,11 @@ fn generate_deeplink(
     let recipe = validate_recipe_template_from_file(&recipe_file)?;
     match recipe_deeplink::encode(&recipe) {
         Ok(encoded) => {
-            let mut full_url = format!("goose://recipe?config={}", encoded);
+            let mut full_url = format!(
+                "{}://recipe?config={}",
+                Brand::get().deeplink_scheme,
+                encoded
+            );
 
             // Append parameters as additional query parameters
             for (key, value) in params {

--- a/crates/goose-cli/src/commands/schedule.rs
+++ b/crates/goose-cli/src/commands/schedule.rs
@@ -1,3 +1,4 @@
+use crate::branding::Brand;
 use anyhow::{bail, Context, Result};
 use goose::scheduler::{
     get_default_scheduled_recipes_dir, get_default_scheduler_storage_path, ScheduledJob, Scheduler,
@@ -265,7 +266,8 @@ pub async fn handle_schedule_run_now(schedule_id: String) -> Result<()> {
 pub async fn handle_schedule_services_status() -> Result<()> {
     println!("Service management has been removed as Temporal scheduler is no longer supported.");
     println!(
-        "The built-in scheduler runs within the goose process and requires no external services."
+        "The built-in scheduler runs within the {} process and requires no external services.",
+        Brand::get().product_name
     );
     Ok(())
 }
@@ -273,13 +275,18 @@ pub async fn handle_schedule_services_status() -> Result<()> {
 pub async fn handle_schedule_services_stop() -> Result<()> {
     println!("Service management has been removed as Temporal scheduler is no longer supported.");
     println!(
-        "The built-in scheduler runs within the goose process and requires no external services."
+        "The built-in scheduler runs within the {} process and requires no external services.",
+        Brand::get().product_name
     );
     Ok(())
 }
 
 pub async fn handle_schedule_cron_help() -> Result<()> {
-    println!("📅 Cron Expression Guide for goose Scheduler");
+    let brand = Brand::get();
+    println!(
+        "📅 Cron Expression Guide for {} Scheduler",
+        brand.product_name
+    );
     println!("===========================================\\n");
 
     println!("🕐 HOURLY SCHEDULES (Most Common Request):");
@@ -330,13 +337,14 @@ pub async fn handle_schedule_cron_help() -> Result<()> {
     println!("  @hourly   - Once an hour (0 * * * *)\\n");
 
     println!("💡 EXAMPLES:");
+    let bin = brand.binary_name;
     println!(
-        "  goose schedule add --schedule-id hourly-report --cron \"0 * * * *\" --recipe-source report.yaml"
+        "  {bin} schedule add --schedule-id hourly-report --cron \"0 * * * *\" --recipe-source report.yaml"
     );
     println!(
-        "  goose schedule add --schedule-id daily-backup --cron \"@daily\" --recipe-source backup.yaml"
+        "  {bin} schedule add --schedule-id daily-backup --cron \"@daily\" --recipe-source backup.yaml"
     );
-    println!("  goose schedule add --schedule-id weekly-summary --cron \"0 9 * * 1\" --recipe-source summary.yaml");
+    println!("  {bin} schedule add --schedule-id weekly-summary --cron \"0 9 * * 1\" --recipe-source summary.yaml");
 
     Ok(())
 }

--- a/crates/goose-cli/src/commands/term.rs
+++ b/crates/goose-cli/src/commands/term.rs
@@ -5,6 +5,7 @@ use goose::conversation::message::{Message, MessageContent, MessageMetadata};
 use goose::session::{SessionManager, SessionType};
 use rmcp::model::Role;
 
+use crate::branding::Brand;
 use crate::session::{build_session, SessionBuilderConfig};
 
 use clap::ValueEnum;
@@ -36,24 +37,24 @@ impl Shell {
 
 static BASH_CONFIG: ShellConfig = ShellConfig {
     script_template: r#"export AGENT_SESSION_ID="{session_id}"
-alias @goose='{goose_bin} term run'
-alias @g='{goose_bin} term run'
+alias @{alias_primary}='{goose_bin} term run'
+alias @{alias_short}='{goose_bin} term run'
 
-goose_preexec() {
-    [[ "$1" =~ ^goose\ term ]] && return
-    [[ "$1" =~ ^(@goose|@g)($|[[:space:]]) ]] && return
+{fn_prefix}_preexec() {
+    [[ "$1" =~ ^{binary_name}\ term ]] && return
+    [[ "$1" =~ ^(@{alias_primary}|@{alias_short})($|[[:space:]]) ]] && return
     ('{goose_bin}' term log "$1" &) 2>/dev/null
 }
 
-if [[ -z "$goose_preexec_installed" ]]; then
-    goose_preexec_installed=1
-    trap 'goose_preexec "$BASH_COMMAND"' DEBUG
+if [[ -z "${fn_prefix}_preexec_installed" ]]; then
+    {fn_prefix}_preexec_installed=1
+    trap '{fn_prefix}_preexec "$BASH_COMMAND"' DEBUG
 fi{command_not_found_handler}"#,
     command_not_found: Some(
         r#"
 
 command_not_found_handle() {
-    echo "🪿 Command '$1' not found. Asking goose..."
+    echo "🪿 Command '$1' not found. Asking {product_name}..."
     '{goose_bin}' term run "$@"
     return 0
 }"#,
@@ -62,22 +63,22 @@ command_not_found_handle() {
 
 static ZSH_CONFIG: ShellConfig = ShellConfig {
     script_template: r#"export AGENT_SESSION_ID="{session_id}"
-alias @goose='{goose_bin} term run'
-alias @g='{goose_bin} term run'
+alias @{alias_primary}='{goose_bin} term run'
+alias @{alias_short}='{goose_bin} term run'
 
-goose_preexec() {
-    [[ "$1" =~ ^goose\ term ]] && return
-    [[ "$1" =~ ^(@goose|@g)($|[[:space:]]) ]] && return
+{fn_prefix}_preexec() {
+    [[ "$1" =~ ^{binary_name}\ term ]] && return
+    [[ "$1" =~ ^(@{alias_primary}|@{alias_short})($|[[:space:]]) ]] && return
     ('{goose_bin}' term log "$1" &) 2>/dev/null
 }
 
 autoload -Uz add-zsh-hook
-add-zsh-hook preexec goose_preexec{command_not_found_handler}"#,
+add-zsh-hook preexec {fn_prefix}_preexec{command_not_found_handler}"#,
     command_not_found: Some(
         r#"
 
 command_not_found_handler() {
-    echo "🪿 Command '$1' not found. Asking goose..."
+    echo "🪿 Command '$1' not found. Asking {product_name}..."
     '{goose_bin}' term run "$@"
     return 0
 }"#,
@@ -86,12 +87,12 @@ command_not_found_handler() {
 
 static FISH_CONFIG: ShellConfig = ShellConfig {
     script_template: r#"set -gx AGENT_SESSION_ID "{session_id}"
-function @goose; {goose_bin} term run $argv; end
-function @g; {goose_bin} term run $argv; end
+function @{alias_primary}; {goose_bin} term run $argv; end
+function @{alias_short}; {goose_bin} term run $argv; end
 
-function goose_preexec --on-event fish_preexec
-    string match -q -r '^goose term' -- $argv[1]; and return
-    string match -q -r '^(@goose|@g)($|\s)' -- $argv[1]; and return
+function {fn_prefix}_preexec --on-event fish_preexec
+    string match -q -r '^{binary_name} term' -- $argv[1]; and return
+    string match -q -r '^(@{alias_primary}|@{alias_short})($|\s)' -- $argv[1]; and return
     {goose_bin} term log "$argv[1]" 2>/dev/null &
 end"#,
     command_not_found: None,
@@ -99,13 +100,13 @@ end"#,
 
 static POWERSHELL_CONFIG: ShellConfig = ShellConfig {
     script_template: r#"$env:AGENT_SESSION_ID = "{session_id}"
-function @goose {{ & '{goose_bin}' term run @args }}
-function @g {{ & '{goose_bin}' term run @args }}
+function @{alias_primary} {{ & '{goose_bin}' term run @args }}
+function @{alias_short} {{ & '{goose_bin}' term run @args }}
 
 Set-PSReadLineKeyHandler -Chord Enter -ScriptBlock {{
     $line = $null
     [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$line, [ref]$null)
-    if ($line -notmatch '^goose term' -and $line -notmatch '^(@goose|@g)($|\s)') {{
+    if ($line -notmatch '^{binary_name} term' -and $line -notmatch '^(@{alias_primary}|@{alias_short})($|\s)') {{
         Start-Job -ScriptBlock {{ & '{goose_bin}' term log $using:line }} | Out-Null
     }}
     [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
@@ -118,7 +119,6 @@ pub async fn handle_term_init(
     name: Option<String>,
     with_command_not_found: bool,
 ) -> Result<()> {
-    let config = shell.config();
     let session_manager = SessionManager::instance();
 
     let working_dir = std::env::current_dir()?;
@@ -137,7 +137,7 @@ pub async fn handle_term_init(
             let session = session_manager
                 .create_session(
                     working_dir,
-                    "Goose Term Session".to_string(),
+                    format!("{} Term Session", Brand::get().product_name_cap()),
                     SessionType::Terminal,
                     Config::global().get_goose_mode().unwrap_or_default(),
                 )
@@ -155,32 +155,63 @@ pub async fn handle_term_init(
         }
     };
 
+    let brand = Brand::get();
     let goose_bin = std::env::current_exe()
         .map(|p| p.to_string_lossy().into_owned())
-        .unwrap_or_else(|_| "goose".to_string());
+        .unwrap_or_else(|_| brand.binary_name.to_string());
 
-    let command_not_found_handler = if with_command_not_found {
-        config
-            .command_not_found
-            .map(|s| s.replace("{goose_bin}", &goose_bin))
-            .unwrap_or_default()
-    } else {
-        String::new()
-    };
-
-    let script = config
-        .script_template
-        .replace("{session_id}", &session.id)
-        .replace("{goose_bin}", &goose_bin)
-        .replace("{command_not_found_handler}", &command_not_found_handler);
+    let script = render_shell_script(
+        shell.config(),
+        &session.id,
+        &goose_bin,
+        with_command_not_found,
+        brand,
+    );
 
     println!("{}", script);
     Ok(())
 }
 
+/// Render a shell integration script from a template and the active branding.
+///
+/// Extracted from [`handle_term_init`] so downstream tests can exercise the
+/// placeholder substitution without creating a real session.
+fn render_shell_script(
+    config: &ShellConfig,
+    session_id: &str,
+    goose_bin: &str,
+    with_command_not_found: bool,
+    brand: &Brand,
+) -> String {
+    let apply_brand_placeholders = |s: &str| -> String {
+        s.replace("{goose_bin}", goose_bin)
+            .replace("{binary_name}", brand.binary_name)
+            .replace("{product_name}", brand.product_name)
+            .replace("{alias_primary}", brand.shell_alias_primary)
+            .replace("{alias_short}", brand.shell_alias_short)
+            .replace("{fn_prefix}", brand.shell_fn_prefix)
+    };
+
+    let command_not_found_handler = if with_command_not_found {
+        config
+            .command_not_found
+            .map(apply_brand_placeholders)
+            .unwrap_or_default()
+    } else {
+        String::new()
+    };
+
+    apply_brand_placeholders(config.script_template)
+        .replace("{session_id}", session_id)
+        .replace("{command_not_found_handler}", &command_not_found_handler)
+}
+
 pub async fn handle_term_log(command: String) -> Result<()> {
     let session_id = std::env::var("AGENT_SESSION_ID").map_err(|_| {
-        anyhow!("AGENT_SESSION_ID not set. Run 'eval \"$(goose term init <shell>)\"' first.")
+        anyhow!(
+            "AGENT_SESSION_ID not set. Run 'eval \"$({} term init <shell>)\"' first.",
+            Brand::get().binary_name
+        )
     })?;
 
     let message = Message::new(
@@ -203,8 +234,9 @@ pub async fn handle_term_run(prompt: Vec<String>) -> Result<()> {
         anyhow!(
             "AGENT_SESSION_ID not set.\n\n\
              Add to your shell config (~/.zshrc or ~/.bashrc):\n    \
-             eval \"$(goose term init zsh)\"\n\n\
-             Then restart your terminal or run: source ~/.zshrc"
+             eval \"$({} term init zsh)\"\n\n\
+             Then restart your terminal or run: source ~/.zshrc",
+            Brand::get().binary_name
         )
     })?;
 

--- a/crates/goose-cli/src/commands/term.rs
+++ b/crates/goose-cli/src/commands/term.rs
@@ -54,7 +54,7 @@ fi{command_not_found_handler}"#,
         r#"
 
 command_not_found_handle() {
-    echo "🪿 Command '$1' not found. Asking {product_name}..."
+    echo "{interactive_prefix}Command '$1' not found. Asking {product_name}..."
     '{goose_bin}' term run "$@"
     return 0
 }"#,
@@ -78,7 +78,7 @@ add-zsh-hook preexec {fn_prefix}_preexec{command_not_found_handler}"#,
         r#"
 
 command_not_found_handler() {
-    echo "🪿 Command '$1' not found. Asking {product_name}..."
+    echo "{interactive_prefix}Command '$1' not found. Asking {product_name}..."
     '{goose_bin}' term run "$@"
     return 0
 }"#,
@@ -187,6 +187,7 @@ fn render_shell_script(
         s.replace("{goose_bin}", goose_bin)
             .replace("{binary_name}", brand.binary_name)
             .replace("{product_name}", brand.product_name)
+            .replace("{interactive_prefix}", brand.interactive_prefix())
             .replace("{alias_primary}", brand.shell_alias_primary)
             .replace("{alias_short}", brand.shell_alias_short)
             .replace("{fn_prefix}", brand.shell_fn_prefix)

--- a/crates/goose-cli/src/commands/update.rs
+++ b/crates/goose-cli/src/commands/update.rs
@@ -8,39 +8,43 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-/// Asset name for this platform (compile-time).
-fn asset_name() -> &'static str {
+use crate::branding::Brand;
+
+/// Asset name for this platform.
+fn asset_name() -> String {
+    let bin = Brand::get().binary_name;
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     {
-        "goose-aarch64-apple-darwin.tar.bz2"
+        format!("{bin}-aarch64-apple-darwin.tar.bz2")
     }
     #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
     {
-        "goose-x86_64-apple-darwin.tar.bz2"
+        format!("{bin}-x86_64-apple-darwin.tar.bz2")
     }
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
     {
-        "goose-x86_64-unknown-linux-gnu.tar.bz2"
+        format!("{bin}-x86_64-unknown-linux-gnu.tar.bz2")
     }
     #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
     {
-        "goose-aarch64-unknown-linux-gnu.tar.bz2"
+        format!("{bin}-aarch64-unknown-linux-gnu.tar.bz2")
     }
     #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
     {
-        "goose-x86_64-pc-windows-msvc.zip"
+        format!("{bin}-x86_64-pc-windows-msvc.zip")
     }
 }
 
 /// Binary name for this platform.
-fn binary_name() -> &'static str {
+fn binary_name() -> String {
+    let bin = Brand::get().binary_name;
     #[cfg(target_os = "windows")]
     {
-        "goose.exe"
+        format!("{bin}.exe")
     }
     #[cfg(not(target_os = "windows"))]
     {
-        "goose"
+        bin.to_string()
     }
 }
 
@@ -68,9 +72,11 @@ struct AttestationEntry {
 const GITHUB_ACTIONS_ISSUER: &str = "https://token.actions.githubusercontent.com";
 
 async fn fetch_attestations(digest: &str, token: Option<&str>) -> Result<Vec<serde_json::Value>> {
+    let brand = Brand::get();
     let url = format!(
-        "https://api.github.com/repos/aaif-goose/goose/attestations/sha256:{digest}\
-         ?per_page=30&predicate_type=https://slsa.dev/provenance/v1"
+        "https://api.github.com/repos/{}/{}/attestations/sha256:{digest}\
+         ?per_page=30&predicate_type=https://slsa.dev/provenance/v1",
+        brand.github_owner, brand.github_repo
     );
 
     let client = reqwest::Client::new();
@@ -207,9 +213,13 @@ pub async fn update(canary: bool, reconfigure: bool) -> Result<()> {
 
     #[cfg(not(feature = "disable-update"))]
     {
+        let brand = Brand::get();
         let tag = if canary { "canary" } else { "stable" };
         let asset = asset_name();
-        let url = format!("https://github.com/aaif-goose/goose/releases/download/{tag}/{asset}");
+        let url = format!(
+            "https://github.com/{}/{}/releases/download/{tag}/{asset}",
+            brand.github_owner, brand.github_repo
+        );
 
         println!("Downloading {asset} from {tag} release...");
 
@@ -247,7 +257,7 @@ pub async fn update(canary: bool, reconfigure: bool) -> Result<()> {
 
         // --- Locate the binary in the extracted archive -------------------------
         let binary = binary_name();
-        let extracted_binary = find_binary(tmp_dir.path(), binary)
+        let extracted_binary = find_binary(tmp_dir.path(), &binary)
             .with_context(|| format!("Could not find {binary} in extracted archive"))?;
 
         // --- Replace the current binary -----------------------------------------
@@ -261,21 +271,25 @@ pub async fn update(canary: bool, reconfigure: bool) -> Result<()> {
         #[cfg(target_os = "windows")]
         copy_dlls(&extracted_binary, &current_exe)?;
 
+        let product_name = brand.product_name;
+        let binary_name_str = brand.binary_name;
         if provenance_verified {
-            println!("goose updated successfully (verified with Sigstore SLSA provenance).");
+            println!(
+                "{product_name} updated successfully (verified with Sigstore SLSA provenance)."
+            );
         } else {
-            println!("goose updated successfully.");
+            println!("{product_name} updated successfully.");
         }
 
         // --- Reconfigure if requested -------------------------------------------
         if reconfigure {
-            println!("Running goose configure...");
+            println!("Running {binary_name_str} configure...");
             let status = Command::new(current_exe)
                 .arg("configure")
                 .status()
-                .context("Failed to run goose configure")?;
+                .with_context(|| format!("Failed to run {binary_name_str} configure"))?;
             if !status.success() {
-                eprintln!("Warning: goose configure exited with {status}");
+                eprintln!("Warning: {binary_name_str} configure exited with {status}");
             }
         }
 
@@ -434,12 +448,15 @@ fn replace_binary(new_binary: &Path, current_exe: &Path) -> Result<()> {
     {
         let old_exe = current_exe.with_extension("exe.old");
 
+        let brand = Brand::get();
+
         // Clean up leftover from a previous update
         if old_exe.exists() {
             fs::remove_file(&old_exe).with_context(|| {
                 format!(
-                    "Failed to remove old backup {}. Is another goose process running?",
-                    old_exe.display()
+                    "Failed to remove old backup {}. Is another {} process running?",
+                    old_exe.display(),
+                    brand.product_name
                 )
             })?;
         }
@@ -447,8 +464,9 @@ fn replace_binary(new_binary: &Path, current_exe: &Path) -> Result<()> {
         // Rename the running binary out of the way
         fs::rename(current_exe, &old_exe).with_context(|| {
             format!(
-                "Failed to rename running binary to {}. Try closing Goose Desktop if it's open.",
-                old_exe.display()
+                "Failed to rename running binary to {}. Try closing {} Desktop if it's open.",
+                old_exe.display(),
+                brand.product_name_cap()
             )
         })?;
 
@@ -567,21 +585,23 @@ mod tests {
         let tmp = tempdir().unwrap();
         let pkg = tmp.path().join("goose-package");
         fs::create_dir_all(&pkg).unwrap();
-        fs::write(pkg.join(binary_name()), b"fake").unwrap();
+        let bin = binary_name();
+        fs::write(pkg.join(&bin), b"fake").unwrap();
 
-        let found = find_binary(tmp.path(), binary_name());
+        let found = find_binary(tmp.path(), &bin);
         assert!(found.is_some());
-        assert!(found.unwrap().ends_with(binary_name()));
+        assert!(found.unwrap().ends_with(&bin));
     }
 
     #[test]
     fn test_find_binary_top_level() {
         let tmp = tempdir().unwrap();
-        fs::write(tmp.path().join(binary_name()), b"fake").unwrap();
+        let bin = binary_name();
+        fs::write(tmp.path().join(&bin), b"fake").unwrap();
 
-        let found = find_binary(tmp.path(), binary_name());
+        let found = find_binary(tmp.path(), &bin);
         assert!(found.is_some());
-        assert_eq!(found.unwrap(), tmp.path().join(binary_name()));
+        assert_eq!(found.unwrap(), tmp.path().join(&bin));
     }
 
     #[test]
@@ -589,16 +609,17 @@ mod tests {
         let tmp = tempdir().unwrap();
         let nested = tmp.path().join("some-dir");
         fs::create_dir_all(&nested).unwrap();
-        fs::write(nested.join(binary_name()), b"fake").unwrap();
+        let bin = binary_name();
+        fs::write(nested.join(&bin), b"fake").unwrap();
 
-        let found = find_binary(tmp.path(), binary_name());
+        let found = find_binary(tmp.path(), &bin);
         assert!(found.is_some());
     }
 
     #[test]
     fn test_find_binary_not_found() {
         let tmp = tempdir().unwrap();
-        let found = find_binary(tmp.path(), binary_name());
+        let found = find_binary(tmp.path(), &binary_name());
         assert!(found.is_none());
     }
 

--- a/crates/goose-cli/src/lib.rs
+++ b/crates/goose-cli/src/lib.rs
@@ -4,6 +4,7 @@ compile_error!("At least one of `rustls-tls` or `native-tls` features must be en
 #[cfg(all(feature = "rustls-tls", feature = "native-tls"))]
 compile_error!("Features `rustls-tls` and `native-tls` are mutually exclusive");
 
+pub mod branding;
 pub mod cli;
 pub mod commands;
 pub mod logging;
@@ -14,5 +15,6 @@ pub mod session;
 pub mod signal;
 
 // Re-export commonly used types
+pub use branding::{branded_command, Brand};
 pub use cli::Cli;
 pub use session::CliSession;

--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -1,3 +1,4 @@
+use crate::branding::Brand;
 use crate::cli::StreamableHttpOptions;
 
 use super::output;
@@ -360,7 +361,10 @@ fn resolve_provider_and_model(
         .or_else(|| recipe_settings.and_then(|s| s.goose_provider.clone()))
         .or_else(|| config.get_goose_provider().ok())
         .unwrap_or_else(|| {
-            output::render_error("No provider configured. Run 'goose configure' first.");
+            output::render_error(&format!(
+                "No provider configured. Run '{} configure' first.",
+                Brand::get().binary_name
+            ));
             process::exit(1);
         });
 
@@ -371,7 +375,10 @@ fn resolve_provider_and_model(
         .or_else(|| recipe_settings.and_then(|s| s.goose_model.clone()))
         .or_else(|| config.get_goose_model().ok())
         .unwrap_or_else(|| {
-            output::render_error("No model configured. Run 'goose configure' first.");
+            output::render_error(&format!(
+                "No model configured. Run '{} configure' first.",
+                Brand::get().binary_name
+            ));
             process::exit(1);
         });
 

--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -670,10 +670,11 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
         Err(e) => {
             output::render_error(&format!(
                 "Error {}.\n\
-                Please check your system keychain and run 'goose configure' again.\n\
+                Please check your system keychain and run '{} configure' again.\n\
                 If your system is unable to use the keyring, please try setting secret key(s) via environment variables.\n\
                 For more info, see: https://goose-docs.ai/docs/troubleshooting/#keychainkeyring-errors",
-                e
+                e,
+                Brand::get().binary_name
             ));
             process::exit(1);
         }

--- a/crates/goose-cli/src/session/completion.rs
+++ b/crates/goose-cli/src/session/completion.rs
@@ -1,3 +1,4 @@
+use crate::branding::Brand;
 use goose::config::GooseMode;
 use rustyline::completion::{Completer, FilenameCompleter, Pair};
 use rustyline::highlight::{CmdKind, Highlighter};
@@ -404,9 +405,10 @@ impl Hinter for GooseCompleter {
         }
 
         match cache.hint_status {
-            HintStatus::Interrupted => {
-                Some("Interrupted, what should goose work on instead?".to_string())
-            }
+            HintStatus::Interrupted => Some(format!(
+                "Interrupted, what should {} work on instead?",
+                Brand::get().binary_name
+            )),
             HintStatus::MaybeExit => {
                 Some("Press Ctrl+C again to exit, or type new instructions to continue".to_string())
             }

--- a/crates/goose-cli/src/session/editor.rs
+++ b/crates/goose-cli/src/session/editor.rs
@@ -62,8 +62,9 @@ fn build_template(messages: &[&str], prefill: Option<&str>) -> String {
 
 /// Create temporary markdown file with conversation history and optional prefill text
 fn create_temp_file(messages: &[&str], prefill: Option<&str>) -> Result<NamedTempFile> {
+    let prefix = format!("{}_prompt_", crate::branding::Brand::get().binary_name);
     let temp_file = Builder::new()
-        .prefix("goose_prompt_")
+        .prefix(&prefix)
         .suffix(".md")
         .tempfile()?;
 

--- a/crates/goose-cli/src/session/editor.rs
+++ b/crates/goose-cli/src/session/editor.rs
@@ -63,10 +63,7 @@ fn build_template(messages: &[&str], prefill: Option<&str>) -> String {
 /// Create temporary markdown file with conversation history and optional prefill text
 fn create_temp_file(messages: &[&str], prefill: Option<&str>) -> Result<NamedTempFile> {
     let prefix = format!("{}_prompt_", crate::branding::Brand::get().binary_name);
-    let temp_file = Builder::new()
-        .prefix(&prefix)
-        .suffix(".md")
-        .tempfile()?;
+    let temp_file = Builder::new().prefix(&prefix).suffix(".md").tempfile()?;
 
     fs::write(temp_file.path(), build_template(messages, prefill))?;
     Ok(temp_file)

--- a/crates/goose-cli/src/session/editor.rs
+++ b/crates/goose-cli/src/session/editor.rs
@@ -1,3 +1,4 @@
+use crate::branding::Brand;
 use anyhow::Result;
 use goose::config::Config;
 use std::fs;
@@ -39,7 +40,7 @@ fn resolve_editor_from_sources(
 
 /// Build the markdown template content for the editor prompt.
 fn build_template(messages: &[&str], prefill: Option<&str>) -> String {
-    let mut content = String::from("# Goose Prompt Editor\n\n");
+    let mut content = format!("# {} Prompt Editor\n\n", Brand::get().product_name_cap());
 
     content.push_str("# Your prompt:\n\n");
     if let Some(text) = prefill {
@@ -251,7 +252,10 @@ This is the user's input
         assert!(path.to_str().unwrap().ends_with(".md"));
 
         let content = fs::read_to_string(path).unwrap();
-        assert!(content.contains("# Goose Prompt Editor"));
+        assert!(content.contains(&format!(
+            "# {} Prompt Editor",
+            Brand::get().product_name_cap()
+        )));
         assert!(content.contains("## User: Hello"));
         assert!(content.contains("## Assistant: Hi there!"));
         assert!(content.contains("# Your prompt:"));
@@ -483,7 +487,13 @@ with multiple lines.
     #[test]
     fn test_build_template_no_prefill_no_messages() {
         let content = build_template(&[], None);
-        assert_eq!(content, "# Goose Prompt Editor\n\n# Your prompt:\n\n");
+        assert_eq!(
+            content,
+            format!(
+                "# {} Prompt Editor\n\n# Your prompt:\n\n",
+                Brand::get().product_name_cap()
+            )
+        );
     }
 
     #[test]

--- a/crates/goose-cli/src/session/input.rs
+++ b/crates/goose-cli/src/session/input.rs
@@ -379,7 +379,7 @@ fn get_input_prompt_string() -> String {
     if is_vte_with_broken_emoji_width() {
         return "> ".to_string();
     }
-    "🪿 ".to_string()
+    Brand::get().interactive_prefix().to_string()
 }
 
 /// VTE < 0.70 renders 🪿 as 1 cell while unicode-width counts 2, causing cursor offset.

--- a/crates/goose-cli/src/session/input.rs
+++ b/crates/goose-cli/src/session/input.rs
@@ -1,5 +1,6 @@
 use super::completion::GooseCompleter;
 use super::{CompletionCache, HintStatus};
+use crate::branding::Brand;
 use anyhow::Result;
 use goose::config::{Config, GooseMode};
 use rustyline::Editor;
@@ -395,6 +396,7 @@ fn is_vte_with_broken_emoji_width() -> bool {
 fn print_help() {
     let newline_key = get_newline_key().to_ascii_uppercase();
     let modes = GooseMode::VARIANTS.join(", ");
+    let product_name = Brand::get().product_name;
     println!(
         "Available commands:
 /exit or /quit - Exit the session
@@ -405,13 +407,13 @@ fn print_help() {
 /builtin <names> - Add builtin extensions by name (comma-separated)
 /prompts [--extension <name>] - List all available prompts, optionally filtered by extension
 /prompt <n> [--info] [key=value...] - Get prompt info or execute a prompt
-/mode <name> - Set the goose mode to use ({modes})
+/mode <name> - Set the {product_name} mode to use ({modes})
 /plan <message_text> -  Enters 'plan' mode with optional message. Create a plan based on the current messages and asks user if they want to act on it.
-                        If user acts on the plan, goose mode is set to 'auto' and returns to 'normal' goose mode.
-                        To warm up goose before using '/plan', we recommend setting '/mode approve' & putting appropriate context into goose.
+                        If user acts on the plan, {product_name} mode is set to 'auto' and returns to 'normal' {product_name} mode.
+                        To warm up {product_name} before using '/plan', we recommend setting '/mode approve' & putting appropriate context into {product_name}.
                         The model is used based on $GOOSE_PLANNER_PROVIDER and $GOOSE_PLANNER_MODEL environment variables.
                         If no model is set, the default model is used.
-/endplan - Exit plan mode and return to 'normal' goose mode.
+/endplan - Exit plan mode and return to 'normal' {product_name} mode.
 /recipe [filepath] - Generate a recipe from the current conversation and save it to the specified filepath (must end with .yaml).
                        If no filepath is provided, it will be saved to ./recipe.yaml.
 /compact - Compact the current conversation to reduce context length while preserving key information.
@@ -440,15 +442,16 @@ pub(super) fn extract_recent_messages(conversation_messages: Option<&Vec<String>
 
 /// Print help information about editor input
 fn print_editor_help() {
+    let bin = Brand::get().binary_name;
     println!(
         "Editor Input:
   /edit opens your configured editor for composing prompts.
   Use '/edit some text' to pre-fill the editor with initial text.
   Previous conversation is included as markdown headings for context.
-  Configure editor: goose configure set goose_prompt_editor \"vim\"
+  Configure editor: {bin} configure set goose_prompt_editor \"vim\"
   Falls back to $VISUAL or $EDITOR if goose_prompt_editor is not set.
   When goose_prompt_editor is set, the editor is used for every prompt by default.
-  To use inline prompts with on-demand /edit: goose configure set goose_prompt_editor_always false"
+  To use inline prompts with on-demand /edit: {bin} configure set goose_prompt_editor_always false"
     );
 }
 

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -9,6 +9,7 @@ pub mod streaming_buffer;
 mod task_execution_display;
 mod thinking;
 
+use crate::branding::Brand;
 use crate::session::task_execution_display::{
     format_task_execution_notification, TASK_EXECUTION_NOTIFICATION_TYPE,
 };
@@ -789,7 +790,10 @@ impl CliSession {
         };
         self.agent.update_goose_mode(mode, &self.session_id).await?;
         config.set_goose_mode(mode)?;
-        output::goose_mode_message(&format!("Goose mode set to '{mode}'"));
+        output::goose_mode_message(&format!(
+            "{} mode set to '{mode}'",
+            Brand::get().product_name_cap()
+        ));
         Ok(())
     }
 
@@ -1598,7 +1602,10 @@ fn prompt_tool_confirmation(security_prompt: &Option<String>) -> Result<Permissi
         println!("\n{}", security_message);
         "Do you allow this tool call?".to_string()
     } else {
-        "Goose would like to call the above tool, do you allow?".to_string()
+        format!(
+            "{} would like to call the above tool, do you allow?",
+            Brand::get().product_name_cap()
+        )
     };
 
     let permission_result = if security_prompt.is_none() {
@@ -1970,9 +1977,12 @@ async fn get_reasoner() -> Result<Arc<dyn Provider>, anyhow::Error> {
         provider
     } else {
         println!("WARNING: GOOSE_PLANNER_PROVIDER not found. Using default provider...");
-        config
-            .get_goose_provider()
-            .expect("No provider configured. Run 'goose configure' first")
+        config.get_goose_provider().unwrap_or_else(|_| {
+            panic!(
+                "No provider configured. Run '{} configure' first",
+                Brand::get().binary_name
+            )
+        })
     };
 
     // Try planner-specific model first, fall back to default model
@@ -1980,9 +1990,12 @@ async fn get_reasoner() -> Result<Arc<dyn Provider>, anyhow::Error> {
         model
     } else {
         println!("WARNING: GOOSE_PLANNER_MODEL not found. Using default model...");
-        config
-            .get_goose_model()
-            .expect("No model configured. Run 'goose configure' first")
+        config.get_goose_model().unwrap_or_else(|_| {
+            panic!(
+                "No model configured. Run '{} configure' first",
+                Brand::get().binary_name
+            )
+        })
     };
 
     let model_config =

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -659,11 +659,12 @@ impl CliSession {
                         }
                     }
                     None => {
-                        output::render_error(
+                        output::render_error(&format!(
                             "No editor found. Set one with:\n  \
-                                 goose configure set goose_prompt_editor \"vim\"\n  \
+                                 {} configure set goose_prompt_editor \"vim\"\n  \
                                  or set $VISUAL or $EDITOR in your shell.",
-                        );
+                            Brand::get().binary_name
+                        ));
                     }
                 }
             }

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -1368,7 +1368,7 @@ fn set_terminal_title() {
     // Sanitize: strip control characters (ESC, BEL, etc.) to prevent terminal escape injection
     let sanitized: String = dir_name.chars().filter(|c| !c.is_control()).collect();
     // OSC 0 sets the terminal window/tab title
-    print!("\x1b]0;{} {}\x07", brand.product_name_cap(), sanitized);
+    print!("\x1b]0;{} {}\x07", brand.terminal_title_prefix(), sanitized);
     let _ = std::io::stdout().flush();
 }
 

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -1,3 +1,4 @@
+use crate::branding::Brand;
 use anstream::println;
 use bat::WrappingMode;
 use console::{measure_text_width, style, Color, Term};
@@ -1298,6 +1299,8 @@ pub fn display_session_info(
     session_id: &Option<String>,
 ) {
     set_terminal_title();
+    let brand = Brand::get();
+    let banner = brand.session_banner_lines();
 
     let status = if resume {
         "resuming"
@@ -1318,7 +1321,7 @@ pub fn display_session_info(
     println!();
     println!(
         "  {}  {} {} {} {} {}",
-        style("  __( O)>").white(),
+        style(banner[0]).white(),
         style("●").green(),
         style(status).dim(),
         style("·").dim(),
@@ -1329,7 +1332,7 @@ pub fn display_session_info(
     if let Some(id) = session_id {
         println!(
             "  {}  {} {} {}",
-            style(r" \____)").white(),
+            style(banner[1]).white(),
             style(" ").dim(),
             style(id).dim(),
             style(format!("· {}", cwd_display)).dim(),
@@ -1337,22 +1340,27 @@ pub fn display_session_info(
     } else {
         println!(
             "  {}  {} {}",
-            style(r" \____)").white(),
+            style(banner[1]).white(),
             style(" ").dim(),
             style(format!("  {}", cwd_display)).dim(),
         );
     }
     println!(
         "  {}  {}",
-        style("   L L").white(),
-        style("   goose is ready").white()
+        style(banner[2]).white(),
+        style(session_ready_text()).white()
     );
+}
+
+fn session_ready_text() -> String {
+    format!("   {} is ready", Brand::get().binary_name)
 }
 
 fn set_terminal_title() {
     if !std::io::stdout().is_terminal() {
         return;
     }
+    let brand = Brand::get();
     let dir_name = std::env::current_dir()
         .ok()
         .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
@@ -1360,7 +1368,7 @@ fn set_terminal_title() {
     // Sanitize: strip control characters (ESC, BEL, etc.) to prevent terminal escape injection
     let sanitized: String = dir_name.chars().filter(|c| !c.is_control()).collect();
     // OSC 0 sets the terminal window/tab title
-    print!("\x1b]0;🪿 {}\x07", sanitized);
+    print!("\x1b]0;{} {}\x07", brand.product_name_cap(), sanitized);
     let _ = std::io::stdout().flush();
 }
 
@@ -1567,6 +1575,14 @@ mod tests {
         let after_second_toggle = toggle_full_tool_output();
         assert_eq!(after_second_toggle, initial);
         assert_eq!(get_show_full_tool_output(), initial);
+    }
+
+    #[test]
+    fn test_session_ready_text_uses_active_brand() {
+        assert_eq!(
+            session_ready_text(),
+            format!("   {} is ready", Brand::get().binary_name)
+        );
     }
 
     #[test]

--- a/crates/goose-cli/src/session/streaming_buffer.rs
+++ b/crates/goose-cli/src/session/streaming_buffer.rs
@@ -83,8 +83,9 @@ fn truncate_code_blocks(content: &str) -> String {
 }
 
 fn save_to_temp_file(content: &str) -> Option<String> {
+    let prefix = format!("{}-", crate::branding::Brand::get().binary_name);
     let mut file = tempfile::Builder::new()
-        .prefix("goose-")
+        .prefix(&prefix)
         .suffix(".txt")
         .tempfile()
         .ok()?;

--- a/crates/goose-cli/tests/fixtures/shell_templates/bash.txt
+++ b/crates/goose-cli/tests/fixtures/shell_templates/bash.txt
@@ -1,0 +1,13 @@
+alias @goose='/Users/smor/Projects/vendor/goose/target/debug/goose term run'
+alias @g='/Users/smor/Projects/vendor/goose/target/debug/goose term run'
+
+goose_preexec() {
+    [[ "$1" =~ ^goose\ term ]] && return
+    [[ "$1" =~ ^(@goose|@g)($|[[:space:]]) ]] && return
+    ('/Users/smor/Projects/vendor/goose/target/debug/goose' term log "$1" &) 2>/dev/null
+}
+
+if [[ -z "$goose_preexec_installed" ]]; then
+    goose_preexec_installed=1
+    trap 'goose_preexec "$BASH_COMMAND"' DEBUG
+fi

--- a/crates/goose-cli/tests/fixtures/shell_templates/bash.txt
+++ b/crates/goose-cli/tests/fixtures/shell_templates/bash.txt
@@ -1,10 +1,10 @@
-alias @goose='/Users/smor/Projects/vendor/goose/target/debug/goose term run'
-alias @g='/Users/smor/Projects/vendor/goose/target/debug/goose term run'
+alias @goose='{GOOSE_BIN} term run'
+alias @g='{GOOSE_BIN} term run'
 
 goose_preexec() {
     [[ "$1" =~ ^goose\ term ]] && return
     [[ "$1" =~ ^(@goose|@g)($|[[:space:]]) ]] && return
-    ('/Users/smor/Projects/vendor/goose/target/debug/goose' term log "$1" &) 2>/dev/null
+    ('{GOOSE_BIN}' term log "$1" &) 2>/dev/null
 }
 
 if [[ -z "$goose_preexec_installed" ]]; then

--- a/crates/goose-cli/tests/fixtures/shell_templates/bash_default.txt
+++ b/crates/goose-cli/tests/fixtures/shell_templates/bash_default.txt
@@ -1,0 +1,19 @@
+alias @goose='/Users/smor/Projects/vendor/goose/target/debug/goose term run'
+alias @g='/Users/smor/Projects/vendor/goose/target/debug/goose term run'
+
+goose_preexec() {
+    [[ "$1" =~ ^goose\ term ]] && return
+    [[ "$1" =~ ^(@goose|@g)($|[[:space:]]) ]] && return
+    ('/Users/smor/Projects/vendor/goose/target/debug/goose' term log "$1" &) 2>/dev/null
+}
+
+if [[ -z "$goose_preexec_installed" ]]; then
+    goose_preexec_installed=1
+    trap 'goose_preexec "$BASH_COMMAND"' DEBUG
+fi
+
+command_not_found_handle() {
+    echo "🪿 Command '$1' not found. Asking goose..."
+    '/Users/smor/Projects/vendor/goose/target/debug/goose' term run "$@"
+    return 0
+}

--- a/crates/goose-cli/tests/fixtures/shell_templates/bash_default.txt
+++ b/crates/goose-cli/tests/fixtures/shell_templates/bash_default.txt
@@ -1,10 +1,10 @@
-alias @goose='/Users/smor/Projects/vendor/goose/target/debug/goose term run'
-alias @g='/Users/smor/Projects/vendor/goose/target/debug/goose term run'
+alias @goose='{GOOSE_BIN} term run'
+alias @g='{GOOSE_BIN} term run'
 
 goose_preexec() {
     [[ "$1" =~ ^goose\ term ]] && return
     [[ "$1" =~ ^(@goose|@g)($|[[:space:]]) ]] && return
-    ('/Users/smor/Projects/vendor/goose/target/debug/goose' term log "$1" &) 2>/dev/null
+    ('{GOOSE_BIN}' term log "$1" &) 2>/dev/null
 }
 
 if [[ -z "$goose_preexec_installed" ]]; then
@@ -14,6 +14,6 @@ fi
 
 command_not_found_handle() {
     echo "🪿 Command '$1' not found. Asking goose..."
-    '/Users/smor/Projects/vendor/goose/target/debug/goose' term run "$@"
+    '{GOOSE_BIN}' term run "$@"
     return 0
 }

--- a/crates/goose-cli/tests/fixtures/shell_templates/fish.txt
+++ b/crates/goose-cli/tests/fixtures/shell_templates/fish.txt
@@ -1,0 +1,8 @@
+function @goose; /Users/smor/Projects/vendor/goose/target/debug/goose term run $argv; end
+function @g; /Users/smor/Projects/vendor/goose/target/debug/goose term run $argv; end
+
+function goose_preexec --on-event fish_preexec
+    string match -q -r '^goose term' -- $argv[1]; and return
+    string match -q -r '^(@goose|@g)($|\s)' -- $argv[1]; and return
+    /Users/smor/Projects/vendor/goose/target/debug/goose term log "$argv[1]" 2>/dev/null &
+end

--- a/crates/goose-cli/tests/fixtures/shell_templates/fish.txt
+++ b/crates/goose-cli/tests/fixtures/shell_templates/fish.txt
@@ -1,8 +1,8 @@
-function @goose; /Users/smor/Projects/vendor/goose/target/debug/goose term run $argv; end
-function @g; /Users/smor/Projects/vendor/goose/target/debug/goose term run $argv; end
+function @goose; {GOOSE_BIN} term run $argv; end
+function @g; {GOOSE_BIN} term run $argv; end
 
 function goose_preexec --on-event fish_preexec
     string match -q -r '^goose term' -- $argv[1]; and return
     string match -q -r '^(@goose|@g)($|\s)' -- $argv[1]; and return
-    /Users/smor/Projects/vendor/goose/target/debug/goose term log "$argv[1]" 2>/dev/null &
+    {GOOSE_BIN} term log "$argv[1]" 2>/dev/null &
 end

--- a/crates/goose-cli/tests/fixtures/shell_templates/powershell.txt
+++ b/crates/goose-cli/tests/fixtures/shell_templates/powershell.txt
@@ -1,12 +1,11 @@
-$env:AGENT_SESSION_ID = "20260421_1"
-function @goose {{ & '/Users/smor/Projects/vendor/goose/target/debug/goose' term run @args }}
-function @g {{ & '/Users/smor/Projects/vendor/goose/target/debug/goose' term run @args }}
+function @goose {{ & '{GOOSE_BIN}' term run @args }}
+function @g {{ & '{GOOSE_BIN}' term run @args }}
 
 Set-PSReadLineKeyHandler -Chord Enter -ScriptBlock {{
     $line = $null
     [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$line, [ref]$null)
     if ($line -notmatch '^goose term' -and $line -notmatch '^(@goose|@g)($|\s)') {{
-        Start-Job -ScriptBlock {{ & '/Users/smor/Projects/vendor/goose/target/debug/goose' term log $using:line }} | Out-Null
+        Start-Job -ScriptBlock {{ & '{GOOSE_BIN}' term log $using:line }} | Out-Null
     }}
     [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
 }}

--- a/crates/goose-cli/tests/fixtures/shell_templates/powershell.txt
+++ b/crates/goose-cli/tests/fixtures/shell_templates/powershell.txt
@@ -1,0 +1,12 @@
+$env:AGENT_SESSION_ID = "20260421_1"
+function @goose {{ & '/Users/smor/Projects/vendor/goose/target/debug/goose' term run @args }}
+function @g {{ & '/Users/smor/Projects/vendor/goose/target/debug/goose' term run @args }}
+
+Set-PSReadLineKeyHandler -Chord Enter -ScriptBlock {{
+    $line = $null
+    [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$line, [ref]$null)
+    if ($line -notmatch '^goose term' -and $line -notmatch '^(@goose|@g)($|\s)') {{
+        Start-Job -ScriptBlock {{ & '/Users/smor/Projects/vendor/goose/target/debug/goose' term log $using:line }} | Out-Null
+    }}
+    [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
+}}

--- a/crates/goose-cli/tests/fixtures/shell_templates/zsh.txt
+++ b/crates/goose-cli/tests/fixtures/shell_templates/zsh.txt
@@ -1,10 +1,10 @@
-alias @goose='/Users/smor/Projects/vendor/goose/target/debug/goose term run'
-alias @g='/Users/smor/Projects/vendor/goose/target/debug/goose term run'
+alias @goose='{GOOSE_BIN} term run'
+alias @g='{GOOSE_BIN} term run'
 
 goose_preexec() {
     [[ "$1" =~ ^goose\ term ]] && return
     [[ "$1" =~ ^(@goose|@g)($|[[:space:]]) ]] && return
-    ('/Users/smor/Projects/vendor/goose/target/debug/goose' term log "$1" &) 2>/dev/null
+    ('{GOOSE_BIN}' term log "$1" &) 2>/dev/null
 }
 
 autoload -Uz add-zsh-hook

--- a/crates/goose-cli/tests/fixtures/shell_templates/zsh.txt
+++ b/crates/goose-cli/tests/fixtures/shell_templates/zsh.txt
@@ -1,0 +1,11 @@
+alias @goose='/Users/smor/Projects/vendor/goose/target/debug/goose term run'
+alias @g='/Users/smor/Projects/vendor/goose/target/debug/goose term run'
+
+goose_preexec() {
+    [[ "$1" =~ ^goose\ term ]] && return
+    [[ "$1" =~ ^(@goose|@g)($|[[:space:]]) ]] && return
+    ('/Users/smor/Projects/vendor/goose/target/debug/goose' term log "$1" &) 2>/dev/null
+}
+
+autoload -Uz add-zsh-hook
+add-zsh-hook preexec goose_preexec

--- a/crates/goose-cli/tests/fixtures/shell_templates/zsh_default.txt
+++ b/crates/goose-cli/tests/fixtures/shell_templates/zsh_default.txt
@@ -1,10 +1,10 @@
-alias @goose='/Users/smor/Projects/vendor/goose/target/debug/goose term run'
-alias @g='/Users/smor/Projects/vendor/goose/target/debug/goose term run'
+alias @goose='{GOOSE_BIN} term run'
+alias @g='{GOOSE_BIN} term run'
 
 goose_preexec() {
     [[ "$1" =~ ^goose\ term ]] && return
     [[ "$1" =~ ^(@goose|@g)($|[[:space:]]) ]] && return
-    ('/Users/smor/Projects/vendor/goose/target/debug/goose' term log "$1" &) 2>/dev/null
+    ('{GOOSE_BIN}' term log "$1" &) 2>/dev/null
 }
 
 autoload -Uz add-zsh-hook
@@ -12,6 +12,6 @@ add-zsh-hook preexec goose_preexec
 
 command_not_found_handler() {
     echo "🪿 Command '$1' not found. Asking goose..."
-    '/Users/smor/Projects/vendor/goose/target/debug/goose' term run "$@"
+    '{GOOSE_BIN}' term run "$@"
     return 0
 }

--- a/crates/goose-cli/tests/fixtures/shell_templates/zsh_default.txt
+++ b/crates/goose-cli/tests/fixtures/shell_templates/zsh_default.txt
@@ -1,0 +1,17 @@
+alias @goose='/Users/smor/Projects/vendor/goose/target/debug/goose term run'
+alias @g='/Users/smor/Projects/vendor/goose/target/debug/goose term run'
+
+goose_preexec() {
+    [[ "$1" =~ ^goose\ term ]] && return
+    [[ "$1" =~ ^(@goose|@g)($|[[:space:]]) ]] && return
+    ('/Users/smor/Projects/vendor/goose/target/debug/goose' term log "$1" &) 2>/dev/null
+}
+
+autoload -Uz add-zsh-hook
+add-zsh-hook preexec goose_preexec
+
+command_not_found_handler() {
+    echo "🪿 Command '$1' not found. Asking goose..."
+    '/Users/smor/Projects/vendor/goose/target/debug/goose' term run "$@"
+    return 0
+}

--- a/crates/goose-cli/tests/shell_templates.rs
+++ b/crates/goose-cli/tests/shell_templates.rs
@@ -1,9 +1,9 @@
 //! Fixture tests for the shell integration templates emitted by `goose term init`.
 //!
-//! These tests run the `goose term init <shell>` binary (built via the
-//! `CARGO_BIN_EXE_goose` env var cargo sets for integration tests), normalize
-//! the output for host-portable comparison, and diff against checked-in
-//! fixtures. The fixtures freeze the default-brand output of `main@HEAD`.
+//! These tests run the sibling CLI binary Cargo builds for integration tests,
+//! normalize the output for host-portable comparison, and diff against
+//! checked-in fixtures. The fixtures freeze the default shell-brand output of
+//! `main@HEAD`; branded builds run smoke assertions instead.
 //!
 //! Two sources of per-machine variability are normalized before compare:
 //!
@@ -18,16 +18,82 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::OnceLock;
+
+use goose_cli::Brand;
 
 fn fixtures_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/shell_templates")
 }
 
+fn cli_bin() -> &'static Path {
+    static BIN: OnceLock<PathBuf> = OnceLock::new();
+    BIN.get_or_init(resolve_cli_bin).as_path()
+}
+
+fn resolve_cli_bin() -> PathBuf {
+    let target_dir = std::env::current_exe()
+        .expect("failed to resolve test binary path")
+        .parent()
+        .and_then(Path::parent)
+        .expect("failed to resolve target dir from test binary")
+        .to_path_buf();
+    let branded_name = format!(
+        "{}{}",
+        Brand::get().binary_name,
+        std::env::consts::EXE_SUFFIX
+    );
+    let branded_path = target_dir.join(&branded_name);
+    if branded_path.is_file() {
+        return branded_path;
+    }
+
+    let bins: Vec<PathBuf> = fs::read_dir(&target_dir)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", target_dir.display()))
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            entry.file_type().ok()?.is_file().then_some(entry.path())
+        })
+        .filter(|path| {
+            let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                return false;
+            };
+            !name.starts_with('.')
+                && name != format!("generate_manpages{}", std::env::consts::EXE_SUFFIX)
+                && !name.ends_with(".d")
+        })
+        .collect();
+
+    match bins.as_slice() {
+        [path] => path.clone(),
+        [] => panic!(
+            "no CLI test binary found next to test artifacts in {}",
+            target_dir.display()
+        ),
+        _ => panic!(
+            "expected exactly one CLI test binary in {}, found: {}",
+            target_dir.display(),
+            bins.iter()
+                .map(|path| path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    }
+}
+
+fn shell_brand_matches_default() -> bool {
+    let brand = Brand::get();
+    brand.product_name == "goose"
+        && brand.binary_name == "goose"
+        && brand.shell_alias_primary == "goose"
+        && brand.shell_alias_short == "g"
+        && brand.shell_fn_prefix == "goose"
+}
+
 /// Run `goose term init <shell>` (optionally with `--default`) in an isolated
 /// HOME/XDG env so it doesn't create sessions in the real user's config.
 fn render_shell(shell: &str, with_default: bool, scratch: &Path) -> String {
-    let bin = env!("CARGO_BIN_EXE_goose");
-    let mut cmd = Command::new(bin);
+    let mut cmd = Command::new(cli_bin());
     cmd.arg("term").arg("init").arg(shell);
     if with_default {
         cmd.arg("--default");
@@ -35,16 +101,7 @@ fn render_shell(shell: &str, with_default: bool, scratch: &Path) -> String {
     cmd.env("HOME", scratch)
         .env("XDG_DATA_HOME", scratch.join("data"))
         .env("XDG_CONFIG_HOME", scratch.join("config"))
-        .env("XDG_STATE_HOME", scratch.join("state"))
-        .env_remove("GOOSE_BRAND_PRODUCT_NAME")
-        .env_remove("GOOSE_BRAND_BINARY_NAME")
-        .env_remove("GOOSE_BRAND_SHELL_ALIAS_PRIMARY")
-        .env_remove("GOOSE_BRAND_SHELL_ALIAS_SHORT")
-        .env_remove("GOOSE_BRAND_SHELL_FN_PREFIX")
-        .env_remove("GOOSE_BRAND_DEEPLINK_SCHEME")
-        .env_remove("GOOSE_BRAND_GITHUB_OWNER")
-        .env_remove("GOOSE_BRAND_GITHUB_REPO")
-        .env_remove("GOOSE_BRAND_AGENT_IDENTITY");
+        .env("XDG_STATE_HOME", scratch.join("state"));
 
     let output = cmd.output().expect("failed to run goose term init");
     assert!(
@@ -64,17 +121,77 @@ fn render_shell(shell: &str, with_default: bool, scratch: &Path) -> String {
 /// - Replace the absolute `current_exe()` path embedded by `term init` with
 ///   the stable placeholder `{GOOSE_BIN}` (differs by checkout location).
 fn normalize(s: &str) -> String {
-    let bin = env!("CARGO_BIN_EXE_goose");
+    let bin = cli_bin().to_string_lossy();
     s.lines()
         .filter(|line| !line.contains("AGENT_SESSION_ID"))
-        .map(|line| line.replace(bin, "{GOOSE_BIN}"))
+        .map(|line| line.replace(bin.as_ref(), "{GOOSE_BIN}"))
         .collect::<Vec<_>>()
         .join("\n")
 }
 
-fn check_or_update(name: &str, actual: String) {
+fn assert_branded_output(name: &str, shell: &str, with_default: bool, actual_normalized: &str) {
+    let brand = Brand::get();
+
+    assert!(
+        !actual_normalized.is_empty(),
+        "{name} produced empty output for shell {shell}"
+    );
+
+    for placeholder in [
+        "{session_id}",
+        "{goose_bin}",
+        "{binary_name}",
+        "{product_name}",
+        "{alias_primary}",
+        "{alias_short}",
+        "{fn_prefix}",
+        "{command_not_found_handler}",
+    ] {
+        assert!(
+            !actual_normalized.contains(placeholder),
+            "{name} left placeholder {placeholder} in rendered output:\n{actual_normalized}"
+        );
+    }
+
+    for expected in [
+        "{GOOSE_BIN}",
+        brand.binary_name,
+        brand.shell_alias_primary,
+        brand.shell_alias_short,
+        brand.shell_fn_prefix,
+    ] {
+        assert!(
+            actual_normalized.contains(expected),
+            "{name} missing branded token `{expected}` in rendered output:\n{actual_normalized}"
+        );
+    }
+
+    if with_default {
+        assert!(
+            actual_normalized.contains(&format!("Asking {}", brand.product_name)),
+            "{name} missing branded command-not-found message:\n{actual_normalized}"
+        );
+    } else {
+        assert!(
+            !actual_normalized.contains("Asking "),
+            "{name} unexpectedly rendered command-not-found handler:\n{actual_normalized}"
+        );
+    }
+}
+
+fn check_or_update(name: &str, shell: &str, with_default: bool, actual: String) {
     let path = fixtures_dir().join(name);
     let actual_normalized = normalize(&actual);
+
+    if !shell_brand_matches_default() {
+        assert!(
+            std::env::var_os("UPDATE_SHELL_FIXTURES").is_none(),
+            "shell fixtures snapshot only the default shell brand; rebuild without GOOSE_BRAND_* shell overrides to update {}",
+            path.display()
+        );
+        assert_branded_output(name, shell, with_default, &actual_normalized);
+        return;
+    }
 
     if std::env::var_os("UPDATE_SHELL_FIXTURES").is_some() {
         fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -104,7 +221,12 @@ fn scratch_home() -> tempfile::TempDir {
 #[test]
 fn bash_default_brand() {
     let scratch = scratch_home();
-    check_or_update("bash.txt", render_shell("bash", false, scratch.path()));
+    check_or_update(
+        "bash.txt",
+        "bash",
+        false,
+        render_shell("bash", false, scratch.path()),
+    );
 }
 
 #[test]
@@ -112,6 +234,8 @@ fn bash_with_command_not_found() {
     let scratch = scratch_home();
     check_or_update(
         "bash_default.txt",
+        "bash",
+        true,
         render_shell("bash", true, scratch.path()),
     );
 }
@@ -119,19 +243,34 @@ fn bash_with_command_not_found() {
 #[test]
 fn zsh_default_brand() {
     let scratch = scratch_home();
-    check_or_update("zsh.txt", render_shell("zsh", false, scratch.path()));
+    check_or_update(
+        "zsh.txt",
+        "zsh",
+        false,
+        render_shell("zsh", false, scratch.path()),
+    );
 }
 
 #[test]
 fn zsh_with_command_not_found() {
     let scratch = scratch_home();
-    check_or_update("zsh_default.txt", render_shell("zsh", true, scratch.path()));
+    check_or_update(
+        "zsh_default.txt",
+        "zsh",
+        true,
+        render_shell("zsh", true, scratch.path()),
+    );
 }
 
 #[test]
 fn fish_default_brand() {
     let scratch = scratch_home();
-    check_or_update("fish.txt", render_shell("fish", false, scratch.path()));
+    check_or_update(
+        "fish.txt",
+        "fish",
+        false,
+        render_shell("fish", false, scratch.path()),
+    );
 }
 
 #[test]
@@ -139,6 +278,8 @@ fn powershell_default_brand() {
     let scratch = scratch_home();
     check_or_update(
         "powershell.txt",
+        "powershell",
+        false,
         render_shell("powershell", false, scratch.path()),
     );
 }

--- a/crates/goose-cli/tests/shell_templates.rs
+++ b/crates/goose-cli/tests/shell_templates.rs
@@ -1,0 +1,137 @@
+//! Fixture tests for the shell integration templates emitted by `goose term init`.
+//!
+//! These tests render the Bash, Zsh, Fish, and PowerShell templates with known
+//! session id / binary path values and compare against checked-in fixtures. The
+//! fixtures were captured from `main@HEAD` and freeze the default-brand output.
+//!
+//! The module under test (`commands::term`) is crate-private, so each fixture
+//! is compared against the output of the public `goose term init <shell>` binary
+//! with the branding module's default values baked in.
+//!
+//! To regenerate fixtures after an intentional template change, run
+//! `UPDATE_SHELL_FIXTURES=1 cargo test --test shell_templates` once and commit
+//! the regenerated files.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/shell_templates")
+}
+
+/// Run `goose term init <shell>` (optionally with `--default`) in an isolated
+/// HOME/XDG env so it doesn't create sessions in the real user's config.
+fn render_shell(shell: &str, with_default: bool, scratch: &Path) -> String {
+    let bin = env!("CARGO_BIN_EXE_goose");
+    let mut cmd = Command::new(bin);
+    cmd.arg("term").arg("init").arg(shell);
+    if with_default {
+        cmd.arg("--default");
+    }
+    cmd.env("HOME", scratch)
+        .env("XDG_DATA_HOME", scratch.join("data"))
+        .env("XDG_CONFIG_HOME", scratch.join("config"))
+        .env("XDG_STATE_HOME", scratch.join("state"))
+        .env_remove("GOOSE_BRAND_PRODUCT_NAME")
+        .env_remove("GOOSE_BRAND_BINARY_NAME")
+        .env_remove("GOOSE_BRAND_SHELL_ALIAS_PRIMARY")
+        .env_remove("GOOSE_BRAND_SHELL_ALIAS_SHORT")
+        .env_remove("GOOSE_BRAND_SHELL_FN_PREFIX")
+        .env_remove("GOOSE_BRAND_DEEPLINK_SCHEME")
+        .env_remove("GOOSE_BRAND_GITHUB_OWNER")
+        .env_remove("GOOSE_BRAND_GITHUB_REPO")
+        .env_remove("GOOSE_BRAND_AGENT_IDENTITY");
+
+    let output = cmd.output().expect("failed to run goose term init");
+    assert!(
+        output.status.success(),
+        "goose term init {shell} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("non-utf8 shell template output")
+}
+
+/// Strip the `AGENT_SESSION_ID=...` line so fixtures are stable across runs.
+fn strip_session_id(s: &str) -> String {
+    s.lines()
+        .filter(|line| {
+            !line.contains("AGENT_SESSION_ID=") && !line.contains("AGENT_SESSION_ID \"")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn check_or_update(name: &str, actual: String) {
+    let path = fixtures_dir().join(name);
+    let actual_stripped = strip_session_id(&actual);
+
+    if std::env::var_os("UPDATE_SHELL_FIXTURES").is_some() {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, &actual_stripped).unwrap();
+        eprintln!("wrote fixture {}", path.display());
+        return;
+    }
+
+    let expected = fs::read_to_string(&path).unwrap_or_else(|_| {
+        panic!(
+            "fixture missing: {}. Run `UPDATE_SHELL_FIXTURES=1 cargo test \
+             -p goose-cli --test shell_templates` to create it.",
+            path.display()
+        )
+    });
+    assert_eq!(
+        expected, actual_stripped,
+        "fixture {} drift (session_id line stripped)",
+        name
+    );
+}
+
+fn scratch_home() -> tempfile::TempDir {
+    tempfile::tempdir().expect("tempdir")
+}
+
+#[test]
+fn bash_default_brand() {
+    let scratch = scratch_home();
+    check_or_update("bash.txt", render_shell("bash", false, scratch.path()));
+}
+
+#[test]
+fn bash_with_command_not_found() {
+    let scratch = scratch_home();
+    check_or_update(
+        "bash_default.txt",
+        render_shell("bash", true, scratch.path()),
+    );
+}
+
+#[test]
+fn zsh_default_brand() {
+    let scratch = scratch_home();
+    check_or_update("zsh.txt", render_shell("zsh", false, scratch.path()));
+}
+
+#[test]
+fn zsh_with_command_not_found() {
+    let scratch = scratch_home();
+    check_or_update(
+        "zsh_default.txt",
+        render_shell("zsh", true, scratch.path()),
+    );
+}
+
+#[test]
+fn fish_default_brand() {
+    let scratch = scratch_home();
+    check_or_update("fish.txt", render_shell("fish", false, scratch.path()));
+}
+
+#[test]
+fn powershell_default_brand() {
+    let scratch = scratch_home();
+    check_or_update(
+        "powershell.txt",
+        render_shell("powershell", false, scratch.path()),
+    );
+}

--- a/crates/goose-cli/tests/shell_templates.rs
+++ b/crates/goose-cli/tests/shell_templates.rs
@@ -88,6 +88,7 @@ fn shell_brand_matches_default() -> bool {
         && brand.shell_alias_primary == "goose"
         && brand.shell_alias_short == "g"
         && brand.shell_fn_prefix == "goose"
+        && brand.interactive_style == "goose"
 }
 
 /// Run `goose term init <shell>` (optionally with `--default`) in an isolated
@@ -142,6 +143,7 @@ fn assert_branded_output(name: &str, shell: &str, with_default: bool, actual_nor
         "{goose_bin}",
         "{binary_name}",
         "{product_name}",
+        "{interactive_prefix}",
         "{alias_primary}",
         "{alias_short}",
         "{fn_prefix}",
@@ -167,8 +169,13 @@ fn assert_branded_output(name: &str, shell: &str, with_default: bool, actual_nor
     }
 
     if with_default {
+        let expected_handler = format!(
+            "{}Command '$1' not found. Asking {}...",
+            brand.interactive_prefix(),
+            brand.product_name
+        );
         assert!(
-            actual_normalized.contains(&format!("Asking {}", brand.product_name)),
+            actual_normalized.contains(&expected_handler),
             "{name} missing branded command-not-found message:\n{actual_normalized}"
         );
     } else {

--- a/crates/goose-cli/tests/shell_templates.rs
+++ b/crates/goose-cli/tests/shell_templates.rs
@@ -38,40 +38,36 @@ fn resolve_cli_bin() -> PathBuf {
         .and_then(Path::parent)
         .expect("failed to resolve target dir from test binary")
         .to_path_buf();
-    let branded_name = format!(
-        "{}{}",
-        Brand::get().binary_name,
-        std::env::consts::EXE_SUFFIX
-    );
+    let cli_bin_names = declared_cli_bin_names();
+    resolve_cli_bin_from_target_dir(&target_dir, &cli_bin_names, Brand::get().binary_name)
+}
+
+fn resolve_cli_bin_from_target_dir(
+    target_dir: &Path,
+    cli_bin_names: &[String],
+    brand_binary_name: &str,
+) -> PathBuf {
+    let branded_name = format!("{brand_binary_name}{}", std::env::consts::EXE_SUFFIX);
     let branded_path = target_dir.join(&branded_name);
     if branded_path.is_file() {
         return branded_path;
     }
 
-    let bins: Vec<PathBuf> = fs::read_dir(&target_dir)
-        .unwrap_or_else(|e| panic!("failed to read {}: {e}", target_dir.display()))
-        .filter_map(|entry| {
-            let entry = entry.ok()?;
-            entry.file_type().ok()?.is_file().then_some(entry.path())
-        })
-        .filter(|path| {
-            let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
-                return false;
-            };
-            !name.starts_with('.')
-                && name != format!("generate_manpages{}", std::env::consts::EXE_SUFFIX)
-                && !name.ends_with(".d")
-        })
+    let bins: Vec<PathBuf> = cli_bin_names
+        .iter()
+        .map(|name| target_dir.join(format!("{name}{}", std::env::consts::EXE_SUFFIX)))
+        .filter(|path| path.is_file())
         .collect();
 
     match bins.as_slice() {
         [path] => path.clone(),
         [] => panic!(
-            "no CLI test binary found next to test artifacts in {}",
-            target_dir.display()
+            "no declared CLI test binary found in {} for declared bins: {}",
+            target_dir.display(),
+            cli_bin_names.join(", ")
         ),
         _ => panic!(
-            "expected exactly one CLI test binary in {}, found: {}",
+            "expected exactly one declared CLI test binary in {}, found: {}",
             target_dir.display(),
             bins.iter()
                 .map(|path| path.display().to_string())
@@ -79,6 +75,64 @@ fn resolve_cli_bin() -> PathBuf {
                 .join(", ")
         ),
     }
+}
+
+fn declared_cli_bin_names() -> Vec<String> {
+    let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    let manifest = fs::read_to_string(&manifest_path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", manifest_path.display()));
+    let bins = parse_bin_names(&manifest)
+        .into_iter()
+        .filter(|name| name != "generate_manpages")
+        .collect::<Vec<_>>();
+
+    assert!(
+        !bins.is_empty(),
+        "expected at least one non-manpage [[bin]] entry in {}",
+        manifest_path.display()
+    );
+
+    bins
+}
+
+fn parse_bin_names(manifest: &str) -> Vec<String> {
+    let mut in_bin = false;
+    let mut names = Vec::new();
+
+    for line in manifest.lines() {
+        let line = line.split('#').next().unwrap_or("").trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        if line == "[[bin]]" {
+            in_bin = true;
+            continue;
+        }
+
+        if line.starts_with('[') {
+            in_bin = false;
+            continue;
+        }
+
+        if !in_bin || !line.starts_with("name") {
+            continue;
+        }
+
+        let Some((_, value)) = line.split_once('=') else {
+            continue;
+        };
+        let value = value.trim();
+        let Some(name) = value
+            .strip_prefix('"')
+            .and_then(|value| value.strip_suffix('"'))
+        else {
+            continue;
+        };
+        names.push(name.to_string());
+    }
+
+    names
 }
 
 fn shell_brand_matches_default() -> bool {
@@ -289,4 +343,58 @@ fn powershell_default_brand() {
         false,
         render_shell("powershell", false, scratch.path()),
     );
+}
+
+#[test]
+fn parse_bin_names_ignores_non_bin_sections() {
+    let manifest = r#"
+[package]
+name = "goose-cli"
+
+[[bin]]
+name = "goose"
+path = "src/main.rs"
+
+[[bin]]
+name = "generate_manpages"
+path = "src/bin/generate_manpages.rs"
+"#;
+
+    assert_eq!(
+        parse_bin_names(manifest),
+        vec!["goose", "generate_manpages"]
+    );
+}
+
+#[test]
+fn parse_bin_names_preserves_downstream_renames() {
+    let manifest = r#"
+[[bin]]
+name = "hoarde"
+path = "src/main.rs"
+
+[[bin]]
+name = "generate_manpages"
+path = "src/bin/generate_manpages.rs"
+"#;
+
+    assert_eq!(
+        parse_bin_names(manifest),
+        vec!["hoarde", "generate_manpages"]
+    );
+}
+
+#[test]
+fn resolve_cli_bin_ignores_extra_sibling_files() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let target_dir = dir.path();
+    let goose = target_dir.join(format!("goose{}", std::env::consts::EXE_SUFFIX));
+    let extra = target_dir.join(format!("other-tool{}", std::env::consts::EXE_SUFFIX));
+
+    fs::write(&goose, "").expect("write goose bin");
+    fs::write(&extra, "").expect("write extra sibling bin");
+
+    let resolved = resolve_cli_bin_from_target_dir(target_dir, &[String::from("goose")], "hoarde");
+
+    assert_eq!(resolved, goose);
 }

--- a/crates/goose-cli/tests/shell_templates.rs
+++ b/crates/goose-cli/tests/shell_templates.rs
@@ -1,12 +1,15 @@
 //! Fixture tests for the shell integration templates emitted by `goose term init`.
 //!
-//! These tests render the Bash, Zsh, Fish, and PowerShell templates with known
-//! session id / binary path values and compare against checked-in fixtures. The
-//! fixtures were captured from `main@HEAD` and freeze the default-brand output.
+//! These tests run the `goose term init <shell>` binary (built via the
+//! `CARGO_BIN_EXE_goose` env var cargo sets for integration tests), normalize
+//! the output for host-portable comparison, and diff against checked-in
+//! fixtures. The fixtures freeze the default-brand output of `main@HEAD`.
 //!
-//! The module under test (`commands::term`) is crate-private, so each fixture
-//! is compared against the output of the public `goose term init <shell>` binary
-//! with the branding module's default values baked in.
+//! Two sources of per-machine variability are normalized before compare:
+//!
+//! - `AGENT_SESSION_ID=<timestamp>` — generated per invocation; stripped.
+//! - The absolute `current_exe()` path embedded by `term init` — differs by
+//!   checkout location; replaced with the placeholder `{GOOSE_BIN}`.
 //!
 //! To regenerate fixtures after an intentional template change, run
 //! `UPDATE_SHELL_FIXTURES=1 cargo test --test shell_templates` once and commit
@@ -52,23 +55,30 @@ fn render_shell(shell: &str, with_default: bool, scratch: &Path) -> String {
     String::from_utf8(output.stdout).expect("non-utf8 shell template output")
 }
 
-/// Strip the `AGENT_SESSION_ID=...` line so fixtures are stable across runs.
-fn strip_session_id(s: &str) -> String {
+/// Normalize host-specific output so fixtures are stable across machines:
+///
+/// - Strip any line that references `AGENT_SESSION_ID` — each of the four
+///   shells uses a slightly different assignment syntax (`export X="…"`,
+///   `set -gx X "…"`, `$env:X = "…"`), and the value itself is a per-
+///   invocation timestamp.
+/// - Replace the absolute `current_exe()` path embedded by `term init` with
+///   the stable placeholder `{GOOSE_BIN}` (differs by checkout location).
+fn normalize(s: &str) -> String {
+    let bin = env!("CARGO_BIN_EXE_goose");
     s.lines()
-        .filter(|line| {
-            !line.contains("AGENT_SESSION_ID=") && !line.contains("AGENT_SESSION_ID \"")
-        })
+        .filter(|line| !line.contains("AGENT_SESSION_ID"))
+        .map(|line| line.replace(bin, "{GOOSE_BIN}"))
         .collect::<Vec<_>>()
         .join("\n")
 }
 
 fn check_or_update(name: &str, actual: String) {
     let path = fixtures_dir().join(name);
-    let actual_stripped = strip_session_id(&actual);
+    let actual_normalized = normalize(&actual);
 
     if std::env::var_os("UPDATE_SHELL_FIXTURES").is_some() {
         fs::create_dir_all(path.parent().unwrap()).unwrap();
-        fs::write(&path, &actual_stripped).unwrap();
+        fs::write(&path, &actual_normalized).unwrap();
         eprintln!("wrote fixture {}", path.display());
         return;
     }
@@ -81,8 +91,8 @@ fn check_or_update(name: &str, actual: String) {
         )
     });
     assert_eq!(
-        expected, actual_stripped,
-        "fixture {} drift (session_id line stripped)",
+        expected, actual_normalized,
+        "fixture {} drift (session_id line stripped, binary path normalized to {{GOOSE_BIN}})",
         name
     );
 }
@@ -115,10 +125,7 @@ fn zsh_default_brand() {
 #[test]
 fn zsh_with_command_not_found() {
     let scratch = scratch_home();
-    check_or_update(
-        "zsh_default.txt",
-        render_shell("zsh", true, scratch.path()),
-    );
+    check_or_update("zsh_default.txt", render_shell("zsh", true, scratch.path()));
 }
 
 #[test]


### PR DESCRIPTION
I have hit rebranding needs twice with goose (for both the desktop app and the CLI), once with a client I was consulting with, and now at my own company.

This PR extracts the CLI side of a patch set I was applying into a single build-time branding hook, with thorough tests showing it doesn't break anything on the default build. Let me know if I can tackle anything that might be off from your point of view.

This was written largely with the help of Opus 4.7, based on prior private patches we were using.

---

## Summary

Downstream distributions of goose today (see `CUSTOM_DISTROS.md`) can rebrand the desktop app, the default provider, bundled extensions, system prompts, and telemetry endpoints — but the product noun `goose` / `Goose` is still hardcoded across ~60 user-visible strings inside `crates/goose-cli/src/`: clap command and subcommand metadata, runtime error and info messages, the TUI, the shell-integration templates emitted by `goose term init`, manpage titles, the recipe deeplink scheme, and GitHub update URLs. Every downstream fork has to maintain a patch set reconciling these strings on each upstream sync.

This PR adds a single branding seam scoped to the `goose-cli` crate, with zero new runtime dependencies, no new Cargo feature flags, and no changes to default behavior.

## What's in the box

- **New `crates/goose-cli/src/branding.rs`** — a `Brand` struct of nine `&'static str` constants (`product_name`, `binary_name`, `shell_alias_primary`, `shell_alias_short`, `shell_fn_prefix`, `deeplink_scheme`, `github_owner`, `github_repo`, `agent_identity_sentence`). Each field is populated via `option_env!("GOOSE_BRAND_*")` with a goose-branded default; `match option_env!(…) { Some(v) => v, None => "goose" }` gives a compile-time `&'static str` without any new dependencies.
- **`apply_branding(Command) -> Command`** pass run once at startup that walks the clap command tree and rewrites `name` / `bin_name` / `about` / `long_about` on every subcommand and `help` / `long_help` on every argument. When `Brand::is_default()` returns `true` the pass short-circuits — so default builds produce **byte-identical** `--help`, manpages, and shell integration scripts.
- **Call-site routing** — runtime messages, `Command::new("goose")` spawns, the recipe deeplink scheme, GitHub update URLs, temp-file prefixes, and the provider-config test system prompt all pull from `Brand::get()` via `format!` or placeholder substitution.
- **Shell templates** (`bash`/`zsh`/`fish`/`powershell`) gain `{alias_primary}`, `{alias_short}`, `{fn_prefix}`, `{product_name}`, `{binary_name}` placeholders alongside the existing `{goose_bin}` / `{session_id}` ones. The substitution is extracted into a pure `render_shell_script` function so tests can exercise it.
- **`generate_manpages`** reads the top-level name from the branded `Command`, so branded builds emit `<binary>-<subcommand>.1` while default builds still emit `goose-*.1`.
- **`CUSTOM_DISTROS.md` Section D** gains a "CLI branding (build-time env vars)" subsection documenting the nine env vars, an example build invocation, and the one-line `Cargo.toml` `[[bin]] name` caveat (since Cargo.toml cannot consume env vars).

## Why this seam

- **Constants + a runtime builder-walk over clap** rather than pure `const`/`concat!`, because clap derive `about` strings contain composites like `"Configure goose settings"` that can't be assembled from `const &'static str` without a new dep (`const_format`). The builder-walk solves composites without adding dependencies, and the early return on `is_default()` keeps the default build byte-identical.
- **Env vars at build time** (via `option_env!`) rather than a Cargo feature flag or a new config file, piggy-backing on the pattern already used in `CUSTOM_DISTROS.md` (`GITHUB_OWNER`, `GITHUB_REPO`, `GOOSE_BUNDLE_NAME`).

## Compatibility

A default build (no env vars set) is **byte-identical** to `main@HEAD`:

- [x] `goose --help` unchanged — verified by direct diff
- [x] Every subcommand `--help` unchanged (17 subcommands) — verified by direct diff
- [x] `goose term init {bash,zsh,fish,powershell}[ --default]` unchanged — verified by fixture tests
- [x] Generated manpages (29 files) unchanged — verified by recursive diff
- [x] `cargo test -p goose-cli` — 195 lib + 6 fixture + 1 doctest all pass

A branded build (all nine env vars set to `Foobar` / `foobar` / `fb` / `acme`) produces "foobar"-branded output across every surface: CLI `--help`, subcommand `--help`, shell templates (alias, function prefix, regex, command-not-found message), manpages, recipe deeplink scheme (`foobar://recipe?...`), GitHub update URLs, the provider-config test system prompt, and the `info` subcommand header. No `goose`/`Goose` leaks in strings this PR owns.

## Tests

- **Unit tests in `branding.rs`** — default brand equality, `capitalize` ASCII cases, `apply_branding` is a no-op on default build, `rebrand_str` rewrites composites correctly, and a synthetic non-default brand produces no leaks in the root `--help`.
- **Recursive regression guard (`no_goose_leaks_in_any_branded_subcommand_help`)** — walks the entire clap command tree under a synthetic non-default `Brand` and asserts that no subcommand's rendered `long_help` (or any argument's `help` / `long_help`) contains the default product noun. It auto-extends to new subcommands and arguments via the recursive walk, has no whitelist, and failures name the offending command path plus point contributors at `apply_branding` / `Brand::get()`. This is the low-overhead safety net against future hardcoding regressions.
- **Fixture tests in `crates/goose-cli/tests/shell_templates.rs`** — pin the default-brand output of `goose term init` for each of the four shells plus the `--default` (command-not-found) variant. The `AGENT_SESSION_ID=…` line is stripped so fixtures stay stable across runs. Run `UPDATE_SHELL_FIXTURES=1 cargo test -p goose-cli --test shell_templates` to regenerate after intentional template edits.

The existing `insta`/`trycmd` ecosystem isn't used in this crate today, so the fixture tests are plain `include_str!` + `assert_eq!` against checked-in `.txt` files — no new dev-dependency. (`tempfile` is used for `HOME`/`XDG_*` isolation during the integration tests and is already a workspace dev-dep.)

## Rebranded (quick reference)

| Env var | Default | Affects |
|---|---|---|
| `GOOSE_BRAND_PRODUCT_NAME` | `goose` | Display noun in user-facing messages (`"goose Version:"`, `"goose mode"`, `"Asking goose..."`) |
| `GOOSE_BRAND_BINARY_NAME` | `goose` | Clap root name, invocation examples, `Command::new("goose")` spawns, update asset filenames |
| `GOOSE_BRAND_SHELL_ALIAS_PRIMARY` | `goose` | `@goose` alias in `term init` output |
| `GOOSE_BRAND_SHELL_ALIAS_SHORT` | `g` | `@g` short alias |
| `GOOSE_BRAND_SHELL_FN_PREFIX` | `goose` | `goose_preexec` / `goose_preexec_installed` function names |
| `GOOSE_BRAND_DEEPLINK_SCHEME` | `goose` | Scheme in `goose://recipe?...` deeplinks |
| `GOOSE_BRAND_GITHUB_OWNER` | `aaif-goose` | Owner half of update + attestation URLs |
| `GOOSE_BRAND_GITHUB_REPO` | `goose` | Repo half of update + attestation URLs |
| `GOOSE_BRAND_AGENT_IDENTITY` | `You are goose, an AI assistant.` | Provider-configuration smoke-test system prompt |

## Out of scope (tracked for follow-up PRs)

- **`[[bin]] name = "goose"`** in `crates/goose-cli/Cargo.toml` — Cargo.toml cannot consume env vars. `CUSTOM_DISTROS.md` documents this as a single-line downstream patch.
- **Tracing filter directives** (`"goose=info"` / `"goose_cli=info"` in `logging.rs`) — these are Rust crate names, not user-visible brand strings.
- **Branding in `crates/goose`** (prompts, telemetry, keyring, config paths), `crates/goose-mcp`, `crates/goose-server`, and the desktop UI — separate PRs.

## Test plan

- [ ] `cargo build -p goose-cli --release`
- [ ] `cargo test -p goose-cli`
- [ ] `diff <(./target/release/goose --help) <(git show main:-- | …)` — confirm default unchanged
- [ ] `cargo run -p goose-cli --bin generate_manpages` — confirm default manpages unchanged
- [ ] `./target/release/goose term init {bash,zsh,fish,powershell}` on default build — byte-identical
- [ ] Smoke branded build with `GOOSE_BRAND_*=Foobar/foobar/fb/...` and confirm no `goose`/`Goose` leaks
