### PR TITLE
fix: run setup before dev and dev-debug in goose2 justfile

### DIFF
--- a/ui/goose2/justfile
+++ b/ui/goose2/justfile
@@ -78,7 +78,7 @@ test-e2e-all:
 # ── Run ──────────────────────────────────────────────────────
 
 # Start the desktop app in dev mode
-dev:
+dev: setup
     #!/usr/bin/env bash
     set -euo pipefail
 

--- a/ui/goose2/justfile
+++ b/ui/goose2/justfile
@@ -127,7 +127,7 @@ dev: setup
     pnpm tauri dev --features app-test-driver --config src-tauri/tauri.dev.conf.json "${EXTRA_CONFIG_ARGS[@]}"
 
 # Start the desktop app with dev config
-dev-debug:
+dev-debug: setup
     #!/usr/bin/env bash
     set -euo pipefail
 


### PR DESCRIPTION
## Summary
- Add `setup` as a dependency for the `dev` and `dev-debug` recipes in the goose2 justfile, ensuring the environment is properly initialized before starting the desktop app in dev mode.

## Test plan
- [x] Run `just dev` and verify `setup` runs first
- [x] Run `just dev-debug` and verify `setup` runs first

🤖 Generated with [Claude Code](https://claude.com/claude-code)