### PR TITLE
persist and reliably apply chat model selection

### DIFF
--- a/ui/goose2/src/app/AppShell.tsx
+++ b/ui/goose2/src/app/AppShell.tsx
@@ -206,9 +206,6 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
             ) ?? null)
           : null;
         const workingDir = await resolveSessionCwd(project);
-        sessionStore.updateSession(homeSession.id, {
-          providerId: sessionModelPreference.providerId,
-        });
         await acpPrepareSession(
           homeSession.id,
           sessionModelPreference.providerId,
@@ -217,6 +214,9 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
             personaId: homeSession.personaId,
           },
         );
+        sessionStore.updateSession(homeSession.id, {
+          providerId: sessionModelPreference.providerId,
+        });
         if (sessionModelPreference.modelId) {
           await acpSetModel(homeSession.id, sessionModelPreference.modelId);
           sessionStore.updateSession(homeSession.id, {

--- a/ui/goose2/src/app/AppShell.tsx
+++ b/ui/goose2/src/app/AppShell.tsx
@@ -10,19 +10,16 @@ import { TopBar } from "./ui/TopBar";
 import { useChatStore } from "@/features/chat/stores/chatStore";
 import {
   type ChatSession,
-  hasSessionStarted,
   useChatSessionStore,
 } from "@/features/chat/stores/chatSessionStore";
 import { useAgentStore } from "@/features/agents/stores/agentStore";
 import { useProjectStore } from "@/features/projects/stores/projectStore";
 import { findExistingDraft } from "@/features/chat/lib/newChat";
-import { resolveSessionModelPreference } from "@/features/chat/lib/sessionModelPreference";
 import { DEFAULT_CHAT_TITLE } from "@/features/chat/lib/sessionTitle";
 import { useAppStartup } from "./hooks/useAppStartup";
-import {
-  loadStoredHomeSessionId,
-  persistHomeSessionId,
-} from "./lib/homeSessionStorage";
+import { useHomeSessionStateSync } from "./hooks/useHomeSessionStateSync";
+import { loadStoredHomeSessionId } from "./lib/homeSessionStorage";
+import { resolveSupportedSessionModelPreference } from "./lib/resolveSupportedSessionModelPreference";
 import { AppShellContent } from "./ui/AppShellContent";
 import { acpPrepareSession, acpSetModel } from "@/shared/api/acp";
 import {
@@ -31,6 +28,7 @@ import {
 } from "@/features/chat/hooks/replayBuffer";
 import { resolveSessionCwd } from "@/features/projects/lib/sessionCwdSelection";
 import { perfLog } from "@/shared/lib/perfLog";
+import { useProviderInventoryStore } from "@/features/providers/stores/providerInventoryStore";
 
 export type AppView =
   | "home"
@@ -67,6 +65,7 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
   const sessionStore = useChatSessionStore();
   const agentStore = useAgentStore();
   const projectStore = useProjectStore();
+  const providerInventoryEntries = useProviderInventoryStore((s) => s.entries);
 
   const pendingProjectCreatedRef = useRef<((projectId: string) => void) | null>(
     null,
@@ -150,37 +149,14 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
     ? sessionStore.getSession(homeSessionId)
     : undefined;
 
-  useEffect(() => {
-    if (
-      !homeSessionId ||
-      !sessionStore.hasHydratedSessions ||
-      sessionStore.isLoading
-    ) {
-      return;
-    }
-    if (
-      !homeSession ||
-      homeSession.archivedAt ||
-      hasSessionStarted(
-        homeSession,
-        chatStore.messagesBySession[homeSession.id],
-      )
-    ) {
-      setHomeSessionId(null);
-    }
-  }, [
-    chatStore.messagesBySession,
-    homeSession,
-    homeSession?.archivedAt,
-    homeSession?.messageCount,
+  useHomeSessionStateSync({
     homeSessionId,
-    sessionStore.hasHydratedSessions,
-    sessionStore.isLoading,
-  ]);
-
-  useEffect(() => {
-    persistHomeSessionId(homeSessionId);
-  }, [homeSessionId]);
+    homeSession,
+    messagesBySession: chatStore.messagesBySession,
+    hasHydratedSessions: sessionStore.hasHydratedSessions,
+    isLoading: sessionStore.isLoading,
+    setHomeSessionId,
+  });
 
   const ensureHomeSession = useCallback(async () => {
     if (!sessionStore.hasHydratedSessions || sessionStore.isLoading) {
@@ -197,9 +173,11 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
         !homeSession.archivedAt &&
         homeSession.messageCount === 0
       ) {
-        const sessionModelPreference = resolveSessionModelPreference({
-          providerId: agentStore.selectedProvider ?? "goose",
-        });
+        const sessionModelPreference =
+          await resolveSupportedSessionModelPreference(
+            agentStore.selectedProvider ?? "goose",
+            providerInventoryEntries,
+          );
         const project = homeSession.projectId
           ? (projectStore.projects.find(
               (candidate) => candidate.id === homeSession.projectId,
@@ -233,9 +211,11 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
       }
 
       const workingDir = await resolveSessionCwd(null);
-      const sessionModelPreference = resolveSessionModelPreference({
-        providerId: agentStore.selectedProvider ?? "goose",
-      });
+      const sessionModelPreference =
+        await resolveSupportedSessionModelPreference(
+          agentStore.selectedProvider ?? "goose",
+          providerInventoryEntries,
+        );
       const session = await sessionStore.createSession({
         title: DEFAULT_CHAT_TITLE,
         providerId: sessionModelPreference.providerId,
@@ -258,6 +238,7 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
   }, [
     agentStore.selectedProvider,
     homeSession,
+    providerInventoryEntries,
     projectStore.projects,
     sessionStore.hasHydratedSessions,
     sessionStore,
@@ -282,10 +263,12 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
       const agentId = agentStore.activeAgentId ?? undefined;
       const providerId =
         project?.preferredProvider ?? agentStore.selectedProvider ?? "goose";
-      const sessionModelPreference = resolveSessionModelPreference({
-        providerId,
-        preferredModel: project?.preferredModel ?? undefined,
-      });
+      const sessionModelPreference =
+        await resolveSupportedSessionModelPreference(
+          providerId,
+          providerInventoryEntries,
+          project?.preferredModel ?? undefined,
+        );
       const sessionState = useChatSessionStore.getState();
       const chatState = useChatStore.getState();
       const existingDraft = findExistingDraft({
@@ -331,6 +314,7 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
       agentStore.activeAgentId,
       agentStore.selectedProvider,
       chatStore,
+      providerInventoryEntries,
       sessionStore,
     ],
   );

--- a/ui/goose2/src/app/AppShell.tsx
+++ b/ui/goose2/src/app/AppShell.tsx
@@ -24,7 +24,7 @@ import {
   persistHomeSessionId,
 } from "./lib/homeSessionStorage";
 import { AppShellContent } from "./ui/AppShellContent";
-import { acpPrepareSession } from "@/shared/api/acp";
+import { acpPrepareSession, acpSetModel } from "@/shared/api/acp";
 import {
   clearReplayBuffer,
   getAndDeleteReplayBuffer,
@@ -208,8 +208,6 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
         const workingDir = await resolveSessionCwd(project);
         sessionStore.updateSession(homeSession.id, {
           providerId: sessionModelPreference.providerId,
-          modelId: sessionModelPreference.modelId,
-          modelName: sessionModelPreference.modelName,
         });
         await acpPrepareSession(
           homeSession.id,
@@ -219,6 +217,13 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
             personaId: homeSession.personaId,
           },
         );
+        if (sessionModelPreference.modelId) {
+          await acpSetModel(homeSession.id, sessionModelPreference.modelId);
+          sessionStore.updateSession(homeSession.id, {
+            modelId: sessionModelPreference.modelId,
+            modelName: sessionModelPreference.modelName,
+          });
+        }
         return homeSession;
       }
 

--- a/ui/goose2/src/app/AppShell.tsx
+++ b/ui/goose2/src/app/AppShell.tsx
@@ -16,8 +16,13 @@ import {
 import { useAgentStore } from "@/features/agents/stores/agentStore";
 import { useProjectStore } from "@/features/projects/stores/projectStore";
 import { findExistingDraft } from "@/features/chat/lib/newChat";
+import { resolveSessionModelPreference } from "@/features/chat/lib/sessionModelPreference";
 import { DEFAULT_CHAT_TITLE } from "@/features/chat/lib/sessionTitle";
 import { useAppStartup } from "./hooks/useAppStartup";
+import {
+  loadStoredHomeSessionId,
+  persistHomeSessionId,
+} from "./lib/homeSessionStorage";
 import { AppShellContent } from "./ui/AppShellContent";
 import { acpPrepareSession } from "@/shared/api/acp";
 import {
@@ -40,34 +45,6 @@ const SIDEBAR_MIN_WIDTH = 180;
 const SIDEBAR_MAX_WIDTH = 380;
 const SIDEBAR_SNAP_COLLAPSE_THRESHOLD = 100;
 const SIDEBAR_COLLAPSED_WIDTH = 48;
-const HOME_SESSION_STORAGE_KEY = "goose:home-session-id";
-
-function loadStoredHomeSessionId(): string | null {
-  if (typeof window === "undefined") {
-    return null;
-  }
-  try {
-    return window.localStorage.getItem(HOME_SESSION_STORAGE_KEY);
-  } catch {
-    return null;
-  }
-}
-
-function persistHomeSessionId(sessionId: string | null): void {
-  if (typeof window === "undefined") {
-    return;
-  }
-  try {
-    if (sessionId) {
-      window.localStorage.setItem(HOME_SESSION_STORAGE_KEY, sessionId);
-      return;
-    }
-    window.localStorage.removeItem(HOME_SESSION_STORAGE_KEY);
-  } catch {
-    // localStorage may be unavailable
-  }
-}
-
 export function AppShell({ children }: { children?: React.ReactNode }) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [sidebarWidth, setSidebarWidth] = useState(SIDEBAR_DEFAULT_WIDTH);
@@ -220,15 +197,23 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
         !homeSession.archivedAt &&
         homeSession.messageCount === 0
       ) {
+        const sessionModelPreference = resolveSessionModelPreference({
+          providerId: agentStore.selectedProvider ?? "goose",
+        });
         const project = homeSession.projectId
           ? (projectStore.projects.find(
               (candidate) => candidate.id === homeSession.projectId,
             ) ?? null)
           : null;
         const workingDir = await resolveSessionCwd(project);
+        sessionStore.updateSession(homeSession.id, {
+          providerId: sessionModelPreference.providerId,
+          modelId: sessionModelPreference.modelId,
+          modelName: sessionModelPreference.modelName,
+        });
         await acpPrepareSession(
           homeSession.id,
-          homeSession.providerId ?? agentStore.selectedProvider ?? "goose",
+          sessionModelPreference.providerId,
           workingDir,
           {
             personaId: homeSession.personaId,
@@ -238,10 +223,15 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
       }
 
       const workingDir = await resolveSessionCwd(null);
+      const sessionModelPreference = resolveSessionModelPreference({
+        providerId: agentStore.selectedProvider ?? "goose",
+      });
       const session = await sessionStore.createSession({
         title: DEFAULT_CHAT_TITLE,
-        providerId: agentStore.selectedProvider ?? "goose",
+        providerId: sessionModelPreference.providerId,
         workingDir,
+        modelId: sessionModelPreference.modelId,
+        modelName: sessionModelPreference.modelName,
       });
       setHomeSessionId(session.id);
       return session;
@@ -282,7 +272,10 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
       const agentId = agentStore.activeAgentId ?? undefined;
       const providerId =
         project?.preferredProvider ?? agentStore.selectedProvider ?? "goose";
-      const modelId = project?.preferredModel ?? undefined;
+      const sessionModelPreference = resolveSessionModelPreference({
+        providerId,
+        preferredModel: project?.preferredModel ?? undefined,
+      });
       const sessionState = useChatSessionStore.getState();
       const chatState = useChatStore.getState();
       const existingDraft = findExistingDraft({
@@ -311,10 +304,10 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
         title,
         projectId: project?.id,
         agentId,
-        providerId,
+        providerId: sessionModelPreference.providerId,
         workingDir,
-        modelId,
-        modelName: modelId,
+        modelId: sessionModelPreference.modelId,
+        modelName: sessionModelPreference.modelName,
       });
       sessionStore.setActiveSession(session.id);
       setActiveView("chat");

--- a/ui/goose2/src/app/AppShell.tsx
+++ b/ui/goose2/src/app/AppShell.tsx
@@ -214,8 +214,13 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
             personaId: homeSession.personaId,
           },
         );
+        const shouldClearHomeModel =
+          sessionModelPreference.providerId !== homeSession.providerId ||
+          !sessionModelPreference.modelId;
         sessionStore.updateSession(homeSession.id, {
           providerId: sessionModelPreference.providerId,
+          modelId: shouldClearHomeModel ? undefined : homeSession.modelId,
+          modelName: shouldClearHomeModel ? undefined : homeSession.modelName,
         });
         if (sessionModelPreference.modelId) {
           await acpSetModel(homeSession.id, sessionModelPreference.modelId);

--- a/ui/goose2/src/app/hooks/useHomeSessionStateSync.ts
+++ b/ui/goose2/src/app/hooks/useHomeSessionStateSync.ts
@@ -1,0 +1,51 @@
+import { useEffect } from "react";
+import {
+  hasSessionStarted,
+  type ChatSession,
+} from "@/features/chat/stores/chatSessionStore";
+import { persistHomeSessionId } from "../lib/homeSessionStorage";
+
+interface UseHomeSessionStateSyncOptions {
+  homeSessionId: string | null;
+  homeSession?: ChatSession;
+  messagesBySession: Record<string, ArrayLike<unknown> | undefined>;
+  hasHydratedSessions: boolean;
+  isLoading: boolean;
+  setHomeSessionId: (sessionId: string | null) => void;
+}
+
+export function useHomeSessionStateSync({
+  homeSessionId,
+  homeSession,
+  messagesBySession,
+  hasHydratedSessions,
+  isLoading,
+  setHomeSessionId,
+}: UseHomeSessionStateSyncOptions): void {
+  useEffect(() => {
+    if (!homeSessionId || !hasHydratedSessions || isLoading) {
+      return;
+    }
+
+    if (
+      !homeSession ||
+      homeSession.archivedAt ||
+      hasSessionStarted(homeSession, messagesBySession[homeSession.id])
+    ) {
+      setHomeSessionId(null);
+    }
+  }, [
+    hasHydratedSessions,
+    homeSession,
+    homeSession?.archivedAt,
+    homeSession?.messageCount,
+    homeSessionId,
+    isLoading,
+    messagesBySession,
+    setHomeSessionId,
+  ]);
+
+  useEffect(() => {
+    persistHomeSessionId(homeSessionId);
+  }, [homeSessionId]);
+}

--- a/ui/goose2/src/app/lib/homeSessionStorage.ts
+++ b/ui/goose2/src/app/lib/homeSessionStorage.ts
@@ -1,0 +1,27 @@
+const HOME_SESSION_STORAGE_KEY = "goose:home-session-id";
+
+export function loadStoredHomeSessionId(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    return window.localStorage.getItem(HOME_SESSION_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function persistHomeSessionId(sessionId: string | null): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    if (sessionId) {
+      window.localStorage.setItem(HOME_SESSION_STORAGE_KEY, sessionId);
+      return;
+    }
+    window.localStorage.removeItem(HOME_SESSION_STORAGE_KEY);
+  } catch {
+    // localStorage may be unavailable
+  }
+}

--- a/ui/goose2/src/app/lib/resolveSupportedSessionModelPreference.test.ts
+++ b/ui/goose2/src/app/lib/resolveSupportedSessionModelPreference.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveSupportedSessionModelPreference } from "./resolveSupportedSessionModelPreference";
+
+const mockGetProviderInventory = vi.fn();
+
+vi.mock("@/features/providers/api/inventory", () => ({
+  getProviderInventory: (...args: unknown[]) =>
+    mockGetProviderInventory(...args),
+}));
+
+describe("resolveSupportedSessionModelPreference", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+  });
+
+  it("drops the model when provider inventory lookup fails", async () => {
+    window.localStorage.setItem(
+      "goose:preferredModelsByAgent",
+      JSON.stringify({
+        goose: {
+          modelId: "gpt-5.4",
+          modelName: "GPT-5.4",
+          providerId: "openai",
+        },
+      }),
+    );
+    mockGetProviderInventory.mockRejectedValue(
+      new Error("inventory unavailable"),
+    );
+
+    await expect(
+      resolveSupportedSessionModelPreference("goose", new Map()),
+    ).resolves.toEqual({
+      providerId: "openai",
+    });
+  });
+
+  it("drops the model when provider inventory has no matching entry", async () => {
+    window.localStorage.setItem(
+      "goose:preferredModelsByAgent",
+      JSON.stringify({
+        goose: {
+          modelId: "gpt-5.4",
+          modelName: "GPT-5.4",
+          providerId: "openai",
+        },
+      }),
+    );
+    mockGetProviderInventory.mockResolvedValue([]);
+
+    await expect(
+      resolveSupportedSessionModelPreference("goose", new Map()),
+    ).resolves.toEqual({
+      providerId: "openai",
+    });
+  });
+});

--- a/ui/goose2/src/app/lib/resolveSupportedSessionModelPreference.ts
+++ b/ui/goose2/src/app/lib/resolveSupportedSessionModelPreference.ts
@@ -1,0 +1,28 @@
+import type { ProviderInventoryEntryDto } from "@aaif/goose-sdk";
+import { getProviderInventory } from "@/features/providers/api/inventory";
+import {
+  resolveSessionModelPreference,
+  sanitizeSessionModelPreference,
+  type SessionModelPreference,
+} from "@/features/chat/lib/sessionModelPreference";
+
+export async function resolveSupportedSessionModelPreference(
+  providerId: string,
+  inventoryEntries: Map<string, ProviderInventoryEntryDto>,
+  preferredModel?: string,
+): Promise<SessionModelPreference> {
+  const sessionModelPreference = resolveSessionModelPreference({
+    providerId,
+    preferredModel,
+  });
+
+  if (!sessionModelPreference.modelId) {
+    return sessionModelPreference;
+  }
+
+  const inventoryEntry =
+    inventoryEntries.get(sessionModelPreference.providerId) ??
+    (await getProviderInventory([sessionModelPreference.providerId]))[0];
+
+  return sanitizeSessionModelPreference(sessionModelPreference, inventoryEntry);
+}

--- a/ui/goose2/src/app/lib/resolveSupportedSessionModelPreference.ts
+++ b/ui/goose2/src/app/lib/resolveSupportedSessionModelPreference.ts
@@ -22,7 +22,15 @@ export async function resolveSupportedSessionModelPreference(
 
   const inventoryEntry =
     inventoryEntries.get(sessionModelPreference.providerId) ??
-    (await getProviderInventory([sessionModelPreference.providerId]))[0];
+    (await getProviderInventory([sessionModelPreference.providerId])
+      .then(([entry]) => entry)
+      .catch(() => undefined));
+
+  if (!inventoryEntry) {
+    return {
+      providerId: sessionModelPreference.providerId,
+    };
+  }
 
   return sanitizeSessionModelPreference(sessionModelPreference, inventoryEntry);
 }

--- a/ui/goose2/src/features/chat/hooks/__tests__/useChatSessionController.test.ts
+++ b/ui/goose2/src/features/chat/hooks/__tests__/useChatSessionController.test.ts
@@ -213,6 +213,50 @@ describe("useChatSessionController", () => {
     });
   });
 
+  it("restores the previous stored model preference when setting a model fails", async () => {
+    window.localStorage.setItem(
+      "goose:preferredModelsByAgent",
+      JSON.stringify({
+        goose: {
+          modelId: "gpt-4o",
+          modelName: "GPT-4o",
+          providerId: "openai",
+        },
+      }),
+    );
+    mockAcpSetModel.mockRejectedValueOnce(new Error("set model failed"));
+
+    const { result } = renderHook(() =>
+      useChatSessionController({ sessionId: "session-1" }),
+    );
+
+    act(() => {
+      result.current.handleModelChange("claude-sonnet-4");
+    });
+
+    await waitFor(() => {
+      expect(
+        useChatSessionStore.getState().getSession("session-1"),
+      ).toMatchObject({
+        providerId: "openai",
+        modelId: "gpt-4o",
+        modelName: "GPT-4o",
+      });
+    });
+
+    expect(
+      JSON.parse(
+        window.localStorage.getItem("goose:preferredModelsByAgent") ?? "{}",
+      ),
+    ).toEqual({
+      goose: {
+        modelId: "gpt-4o",
+        modelName: "GPT-4o",
+        providerId: "openai",
+      },
+    });
+  });
+
   it("shows the stored explicit model for new chats", async () => {
     window.localStorage.setItem(
       "goose:preferredModelsByAgent",
@@ -263,5 +307,59 @@ describe("useChatSessionController", () => {
       expect(result.current.currentModelId).toBe("goose-claude-4-6-opus");
     });
     expect(result.current.currentModelName).toBe("Claude 4.6 Opus");
+  });
+
+  it("applies the pending Home model to ACP when a real session becomes active", async () => {
+    const { result, rerender } = renderHook(
+      ({ sessionId }: { sessionId: string | null }) =>
+        useChatSessionController({ sessionId }),
+      {
+        initialProps: { sessionId: null as string | null },
+      },
+    );
+
+    act(() => {
+      result.current.handleModelChange("claude-sonnet-4");
+    });
+
+    useChatSessionStore.setState((state) => ({
+      sessions: [
+        {
+          id: "session-2",
+          title: "Chat",
+          providerId: "openai",
+          createdAt: "2026-04-21T00:00:00.000Z",
+          updatedAt: "2026-04-21T00:00:00.000Z",
+          messageCount: 0,
+        },
+        ...state.sessions,
+      ],
+    }));
+
+    rerender({ sessionId: "session-2" });
+
+    await waitFor(() => {
+      expect(mockAcpPrepareSession).toHaveBeenCalledWith(
+        "session-2",
+        "anthropic",
+        "/tmp/project",
+        { personaId: undefined },
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockAcpSetModel).toHaveBeenCalledWith(
+        "session-2",
+        "claude-sonnet-4",
+      );
+    });
+
+    expect(
+      useChatSessionStore.getState().getSession("session-2"),
+    ).toMatchObject({
+      providerId: "anthropic",
+      modelId: "claude-sonnet-4",
+      modelName: "Claude Sonnet 4",
+    });
   });
 });

--- a/ui/goose2/src/features/chat/hooks/__tests__/useChatSessionController.test.ts
+++ b/ui/goose2/src/features/chat/hooks/__tests__/useChatSessionController.test.ts
@@ -9,10 +9,35 @@ const mockAcpPrepareSession = vi.fn();
 const mockAcpSetModel = vi.fn();
 const mockSetSelectedProvider = vi.fn();
 const mockResolveSessionCwd = vi.fn();
+const mockGooseConfigRead = vi.fn();
+const mockUseProviderInventory = vi.fn();
+const mockPickerState = {
+  pickerAgents: [{ id: "goose", label: "Goose" }],
+  availableModels: [] as Array<{
+    id: string;
+    name: string;
+    displayName?: string;
+    providerId?: string;
+  }>,
+  modelsLoading: false,
+  modelStatusMessage: null as string | null,
+};
 
 vi.mock("@/shared/api/acp", () => ({
   acpPrepareSession: (...args: unknown[]) => mockAcpPrepareSession(...args),
   acpSetModel: (...args: unknown[]) => mockAcpSetModel(...args),
+}));
+
+vi.mock("@/shared/api/acpConnection", () => ({
+  getClient: async () => ({
+    goose: {
+      GooseConfigRead: (...args: unknown[]) => mockGooseConfigRead(...args),
+    },
+  }),
+}));
+
+vi.mock("@/features/providers/hooks/useProviderInventory", () => ({
+  useProviderInventory: () => mockUseProviderInventory(),
 }));
 
 vi.mock("../useChat", () => ({
@@ -63,10 +88,10 @@ vi.mock("../useAgentModelPickerState", () => ({
     }) => void;
   }) => ({
     selectedAgentId: "goose",
-    pickerAgents: [{ id: "goose", label: "Goose" }],
-    availableModels: [],
-    modelsLoading: false,
-    modelStatusMessage: null,
+    pickerAgents: mockPickerState.pickerAgents,
+    availableModels: mockPickerState.availableModels,
+    modelsLoading: mockPickerState.modelsLoading,
+    modelStatusMessage: mockPickerState.modelStatusMessage,
     handleProviderChange: vi.fn(),
     handleModelChange: (modelId: string) => {
       if (modelId === "claude-sonnet-4") {
@@ -86,9 +111,18 @@ import { useChatSessionController } from "../useChatSessionController";
 describe("useChatSessionController", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.localStorage.clear();
     mockAcpPrepareSession.mockResolvedValue(undefined);
     mockAcpSetModel.mockResolvedValue(undefined);
     mockResolveSessionCwd.mockResolvedValue("/tmp/project");
+    mockGooseConfigRead.mockResolvedValue({ value: null });
+    mockUseProviderInventory.mockReturnValue({
+      getEntry: () => undefined,
+    });
+    mockPickerState.pickerAgents = [{ id: "goose", label: "Goose" }];
+    mockPickerState.availableModels = [];
+    mockPickerState.modelsLoading = false;
+    mockPickerState.modelStatusMessage = null;
 
     useAgentStore.setState({
       personas: [],
@@ -177,5 +211,57 @@ describe("useChatSessionController", () => {
       modelId: "claude-sonnet-4",
       modelName: "Claude Sonnet 4",
     });
+  });
+
+  it("shows the stored explicit model for new chats", async () => {
+    window.localStorage.setItem(
+      "goose:preferredModelsByAgent",
+      JSON.stringify({
+        goose: {
+          modelId: "claude-sonnet-4",
+          modelName: "Claude Sonnet 4",
+          providerId: "anthropic",
+        },
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useChatSessionController({ sessionId: null }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.currentModelId).toBe("claude-sonnet-4");
+    });
+    expect(result.current.currentModelName).toBe("Claude Sonnet 4");
+  });
+
+  it("falls back to the configured goose default model when no explicit model is stored", async () => {
+    mockGooseConfigRead.mockImplementation(
+      async ({ key }: { key: string }): Promise<{ value: string | null }> => {
+        if (key === "GOOSE_PROVIDER") {
+          return { value: "databricks" };
+        }
+        if (key === "GOOSE_MODEL") {
+          return { value: "goose-claude-4-6-opus" };
+        }
+        return { value: null };
+      },
+    );
+    mockPickerState.availableModels = [
+      {
+        id: "goose-claude-4-6-opus",
+        name: "Claude 4.6 Opus",
+        providerId: "databricks",
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      useChatSessionController({ sessionId: null }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.currentModelId).toBe("goose-claude-4-6-opus");
+    });
+    expect(result.current.currentModelName).toBe("Claude 4.6 Opus");
   });
 });

--- a/ui/goose2/src/features/chat/hooks/__tests__/useChatSessionController.test.ts
+++ b/ui/goose2/src/features/chat/hooks/__tests__/useChatSessionController.test.ts
@@ -66,7 +66,7 @@ vi.mock("@/features/agents/hooks/useProviderSelection", () => ({
       { id: "anthropic", label: "Anthropic" },
     ],
     providersLoading: false,
-    selectedProvider: "openai",
+    selectedProvider: useAgentStore.getState().selectedProvider ?? "openai",
     setSelectedProvider: (...args: unknown[]) =>
       mockSetSelectedProvider(...args),
   }),
@@ -258,6 +258,7 @@ describe("useChatSessionController", () => {
   });
 
   it("shows the stored explicit model for new chats", async () => {
+    useAgentStore.setState({ selectedProvider: "goose" });
     window.localStorage.setItem(
       "goose:preferredModelsByAgent",
       JSON.stringify({
@@ -280,6 +281,7 @@ describe("useChatSessionController", () => {
   });
 
   it("falls back to the configured goose default model when no explicit model is stored", async () => {
+    useAgentStore.setState({ selectedProvider: "goose" });
     mockGooseConfigRead.mockImplementation(
       async ({ key }: { key: string }): Promise<{ value: string | null }> => {
         if (key === "GOOSE_PROVIDER") {

--- a/ui/goose2/src/features/chat/hooks/__tests__/useChatSessionController.test.ts
+++ b/ui/goose2/src/features/chat/hooks/__tests__/useChatSessionController.test.ts
@@ -362,4 +362,65 @@ describe("useChatSessionController", () => {
       modelName: "Claude Sonnet 4",
     });
   });
+
+  it("does not persist or record a pending Home model when ACP rejects it", async () => {
+    mockAcpSetModel.mockRejectedValueOnce(new Error("set model failed"));
+
+    const { result, rerender } = renderHook(
+      ({ sessionId }: { sessionId: string | null }) =>
+        useChatSessionController({ sessionId }),
+      {
+        initialProps: { sessionId: null as string | null },
+      },
+    );
+
+    act(() => {
+      result.current.handleModelChange("claude-sonnet-4");
+    });
+
+    expect(
+      window.localStorage.getItem("goose:preferredModelsByAgent"),
+    ).toBeNull();
+
+    useChatSessionStore.setState((state) => ({
+      sessions: [
+        {
+          id: "session-3",
+          title: "Chat",
+          providerId: "openai",
+          createdAt: "2026-04-21T00:00:00.000Z",
+          updatedAt: "2026-04-21T00:00:00.000Z",
+          messageCount: 0,
+        },
+        ...state.sessions,
+      ],
+    }));
+
+    rerender({ sessionId: "session-3" });
+
+    await waitFor(() => {
+      expect(mockAcpSetModel).toHaveBeenCalledWith(
+        "session-3",
+        "claude-sonnet-4",
+      );
+    });
+
+    await waitFor(() => {
+      expect(
+        useChatSessionStore.getState().getSession("session-3"),
+      ).toMatchObject({
+        providerId: "anthropic",
+      });
+    });
+
+    expect(
+      useChatSessionStore.getState().getSession("session-3"),
+    ).not.toMatchObject({
+      modelId: "claude-sonnet-4",
+      modelName: "Claude Sonnet 4",
+    });
+    expect(
+      window.localStorage.getItem("goose:preferredModelsByAgent"),
+    ).toBeNull();
+  });
 });

--- a/ui/goose2/src/features/chat/hooks/__tests__/useResolvedAgentModelPicker.test.ts
+++ b/ui/goose2/src/features/chat/hooks/__tests__/useResolvedAgentModelPicker.test.ts
@@ -36,6 +36,13 @@ describe("useResolvedAgentModelPicker", () => {
           ? {
               providerId: "codex-acp",
               defaultModel: "gpt-5.4",
+              models: [
+                {
+                  id: "gpt-5.4",
+                  name: "GPT-5.4",
+                  recommended: true,
+                },
+              ],
             }
           : undefined,
     });
@@ -90,7 +97,7 @@ describe("useResolvedAgentModelPicker", () => {
     expect(setPendingProviderId).toHaveBeenCalledWith("codex-acp");
     expect(setPendingModelSelection).toHaveBeenCalledWith({
       id: "gpt-5.4",
-      name: "gpt-5.4",
+      name: "GPT-5.4",
       providerId: "codex-acp",
       source: "default",
     });
@@ -140,6 +147,139 @@ describe("useResolvedAgentModelPicker", () => {
       name: "GPT-5.4 mini",
       providerId: "codex-acp",
       source: "explicit",
+    });
+  });
+
+  it("resolves ACP alias defaults to a concrete model when switching agents", () => {
+    mockUseProviderInventory.mockReturnValue({
+      getEntry: (providerId: string) =>
+        providerId === "claude-acp"
+          ? {
+              providerId: "claude-acp",
+              defaultModel: "current",
+              models: [
+                {
+                  id: "sonnet",
+                  name: "Claude Sonnet",
+                  recommended: true,
+                },
+                {
+                  id: "opus",
+                  name: "Claude Opus",
+                  recommended: false,
+                },
+              ],
+            }
+          : undefined,
+    });
+
+    const setPendingProviderId = vi.fn();
+    const setPendingModelSelection = vi.fn();
+    const setGlobalSelectedProvider = vi.fn();
+
+    const { result } = renderHook(() =>
+      useResolvedAgentModelPicker({
+        providers: [
+          { id: "goose", label: "Goose" },
+          { id: "claude-acp", label: "Claude Code" },
+        ],
+        selectedProvider: "goose",
+        sessionId: null,
+        session: undefined,
+        pendingModelSelection: undefined,
+        setPendingProviderId,
+        setPendingModelSelection,
+        setGlobalSelectedProvider,
+        prepareSelectedProvider: vi.fn(),
+      }),
+    );
+
+    act(() => {
+      result.current.handleProviderChange("claude-acp");
+    });
+
+    expect(setPendingModelSelection).toHaveBeenCalledWith({
+      id: "sonnet",
+      name: "Claude Sonnet",
+      providerId: "claude-acp",
+      source: "default",
+    });
+  });
+
+  it("prefers a concrete default model over a session alias like current", () => {
+    mockUseProviderInventory.mockReturnValue({
+      getEntry: (providerId: string) =>
+        providerId === "claude-acp"
+          ? {
+              providerId: "claude-acp",
+              defaultModel: "current",
+              models: [
+                {
+                  id: "sonnet",
+                  name: "Claude Sonnet",
+                  recommended: true,
+                },
+              ],
+            }
+          : undefined,
+    });
+
+    mockUseAgentModelPickerState.mockImplementation(
+      ({
+        onProviderSelected,
+      }: {
+        onProviderSelected: (providerId: string) => void;
+      }) => ({
+        pickerAgents: [
+          { id: "goose", label: "Goose" },
+          { id: "claude-acp", label: "Claude Code" },
+        ],
+        availableModels: [
+          {
+            id: "sonnet",
+            name: "Claude Sonnet",
+            recommended: true,
+          },
+        ],
+        modelsLoading: false,
+        modelStatusMessage: null,
+        handleProviderChange: (providerId: string) =>
+          onProviderSelected(providerId),
+        handleModelChange: vi.fn(),
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useResolvedAgentModelPicker({
+        providers: [
+          { id: "goose", label: "Goose" },
+          { id: "claude-acp", label: "Claude Code" },
+        ],
+        selectedProvider: "claude-acp",
+        sessionId: "session-1",
+        session: {
+          id: "session-1",
+          title: "Chat",
+          providerId: "claude-acp",
+          modelId: "current",
+          modelName: "current",
+          createdAt: "2026-04-21T00:00:00.000Z",
+          updatedAt: "2026-04-21T00:00:00.000Z",
+          messageCount: 0,
+        },
+        pendingModelSelection: undefined,
+        setPendingProviderId: vi.fn(),
+        setPendingModelSelection: vi.fn(),
+        setGlobalSelectedProvider: vi.fn(),
+        prepareSelectedProvider: vi.fn(),
+      }),
+    );
+
+    expect(result.current.effectiveModelSelection).toEqual({
+      id: "sonnet",
+      name: "Claude Sonnet",
+      providerId: "claude-acp",
+      source: "default",
     });
   });
 });

--- a/ui/goose2/src/features/chat/hooks/__tests__/useResolvedAgentModelPicker.test.ts
+++ b/ui/goose2/src/features/chat/hooks/__tests__/useResolvedAgentModelPicker.test.ts
@@ -1,0 +1,145 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useResolvedAgentModelPicker } from "../useResolvedAgentModelPicker";
+
+const mockUseProviderInventory = vi.fn();
+const mockUseAgentModelPickerState = vi.fn();
+const mockGetClient = vi.fn();
+
+vi.mock("@/features/providers/hooks/useProviderInventory", () => ({
+  useProviderInventory: () => mockUseProviderInventory(),
+}));
+
+vi.mock("../useAgentModelPickerState", () => ({
+  useAgentModelPickerState: (args: unknown) =>
+    mockUseAgentModelPickerState(args),
+}));
+
+vi.mock("@/shared/api/acpConnection", () => ({
+  getClient: (...args: unknown[]) => mockGetClient(...args),
+}));
+
+describe("useResolvedAgentModelPicker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+
+    mockGetClient.mockResolvedValue({
+      goose: {
+        GooseConfigRead: vi.fn().mockResolvedValue({ value: null }),
+      },
+    });
+
+    mockUseProviderInventory.mockReturnValue({
+      getEntry: (providerId: string) =>
+        providerId === "codex-acp"
+          ? {
+              providerId: "codex-acp",
+              defaultModel: "gpt-5.4",
+            }
+          : undefined,
+    });
+
+    mockUseAgentModelPickerState.mockImplementation(
+      ({
+        onProviderSelected,
+      }: {
+        onProviderSelected: (providerId: string) => void;
+      }) => ({
+        pickerAgents: [
+          { id: "goose", label: "Goose" },
+          { id: "codex-acp", label: "Codex" },
+        ],
+        availableModels: [],
+        modelsLoading: false,
+        modelStatusMessage: null,
+        handleProviderChange: (providerId: string) =>
+          onProviderSelected(providerId),
+        handleModelChange: vi.fn(),
+      }),
+    );
+  });
+
+  it("selects the agent default model when switching to a provider without a saved model", () => {
+    const setPendingProviderId = vi.fn();
+    const setPendingModelSelection = vi.fn();
+    const setGlobalSelectedProvider = vi.fn();
+
+    const { result } = renderHook(() =>
+      useResolvedAgentModelPicker({
+        providers: [
+          { id: "goose", label: "Goose" },
+          { id: "codex-acp", label: "Codex" },
+        ],
+        selectedProvider: "goose",
+        sessionId: null,
+        session: undefined,
+        pendingModelSelection: undefined,
+        setPendingProviderId,
+        setPendingModelSelection,
+        setGlobalSelectedProvider,
+        prepareSelectedProvider: vi.fn(),
+      }),
+    );
+
+    act(() => {
+      result.current.handleProviderChange("codex-acp");
+    });
+
+    expect(setGlobalSelectedProvider).toHaveBeenCalledWith("codex-acp");
+    expect(setPendingProviderId).toHaveBeenCalledWith("codex-acp");
+    expect(setPendingModelSelection).toHaveBeenCalledWith({
+      id: "gpt-5.4",
+      name: "gpt-5.4",
+      providerId: "codex-acp",
+      source: "default",
+    });
+  });
+
+  it("selects the saved model when switching back to an agent", () => {
+    window.localStorage.setItem(
+      "goose:preferredModelsByAgent",
+      JSON.stringify({
+        "codex-acp": {
+          modelId: "gpt-5.4-mini",
+          modelName: "GPT-5.4 mini",
+          providerId: "codex-acp",
+        },
+      }),
+    );
+
+    const setPendingProviderId = vi.fn();
+    const setPendingModelSelection = vi.fn();
+    const setGlobalSelectedProvider = vi.fn();
+
+    const { result } = renderHook(() =>
+      useResolvedAgentModelPicker({
+        providers: [
+          { id: "goose", label: "Goose" },
+          { id: "codex-acp", label: "Codex" },
+        ],
+        selectedProvider: "goose",
+        sessionId: null,
+        session: undefined,
+        pendingModelSelection: undefined,
+        setPendingProviderId,
+        setPendingModelSelection,
+        setGlobalSelectedProvider,
+        prepareSelectedProvider: vi.fn(),
+      }),
+    );
+
+    act(() => {
+      result.current.handleProviderChange("codex-acp");
+    });
+
+    expect(setGlobalSelectedProvider).toHaveBeenCalledWith("codex-acp");
+    expect(setPendingProviderId).toHaveBeenCalledWith("codex-acp");
+    expect(setPendingModelSelection).toHaveBeenCalledWith({
+      id: "gpt-5.4-mini",
+      name: "GPT-5.4 mini",
+      providerId: "codex-acp",
+      source: "explicit",
+    });
+  });
+});

--- a/ui/goose2/src/features/chat/hooks/__tests__/useResolvedAgentModelPicker.test.ts
+++ b/ui/goose2/src/features/chat/hooks/__tests__/useResolvedAgentModelPicker.test.ts
@@ -324,4 +324,73 @@ describe("useResolvedAgentModelPicker", () => {
       source: "default",
     });
   });
+
+  it("drops Goose fallback models that are incompatible with a concrete provider", () => {
+    window.localStorage.setItem(
+      "goose:preferredModelsByAgent",
+      JSON.stringify({
+        goose: {
+          modelId: "claude-sonnet-4",
+          modelName: "Claude Sonnet 4",
+          providerId: "anthropic",
+        },
+      }),
+    );
+
+    mockUseAgentModelPickerState.mockImplementation(
+      ({
+        onProviderSelected,
+      }: {
+        onProviderSelected: (providerId: string) => void;
+      }) => ({
+        pickerAgents: [
+          { id: "goose", label: "Goose" },
+          { id: "openai", label: "OpenAI" },
+        ],
+        availableModels: [
+          {
+            id: "gpt-5.4",
+            name: "GPT-5.4",
+            providerId: "openai",
+          },
+          {
+            id: "claude-sonnet-4",
+            name: "Claude Sonnet 4",
+            providerId: "anthropic",
+          },
+        ],
+        modelsLoading: false,
+        modelStatusMessage: null,
+        handleProviderChange: (providerId: string) =>
+          onProviderSelected(providerId),
+        handleModelChange: vi.fn(),
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useResolvedAgentModelPicker({
+        providers: [
+          { id: "goose", label: "Goose" },
+          { id: "openai", label: "OpenAI" },
+        ],
+        selectedProvider: "openai",
+        sessionId: "session-1",
+        session: {
+          id: "session-1",
+          title: "Chat",
+          providerId: "openai",
+          createdAt: "2026-04-21T00:00:00.000Z",
+          updatedAt: "2026-04-21T00:00:00.000Z",
+          messageCount: 0,
+        },
+        pendingModelSelection: undefined,
+        setPendingProviderId: vi.fn(),
+        setPendingModelSelection: vi.fn(),
+        setGlobalSelectedProvider: vi.fn(),
+        prepareSelectedProvider: vi.fn(),
+      }),
+    );
+
+    expect(result.current.effectiveModelSelection).toBeNull();
+  });
 });

--- a/ui/goose2/src/features/chat/hooks/__tests__/useResolvedAgentModelPicker.test.ts
+++ b/ui/goose2/src/features/chat/hooks/__tests__/useResolvedAgentModelPicker.test.ts
@@ -150,6 +150,48 @@ describe("useResolvedAgentModelPicker", () => {
     });
   });
 
+  it("keeps explicit concrete provider requests authoritative", () => {
+    window.localStorage.setItem(
+      "goose:preferredModelsByAgent",
+      JSON.stringify({
+        goose: {
+          modelId: "claude-sonnet-4",
+          modelName: "Claude Sonnet 4",
+          providerId: "anthropic",
+        },
+      }),
+    );
+
+    const setPendingProviderId = vi.fn();
+    const setPendingModelSelection = vi.fn();
+    const setGlobalSelectedProvider = vi.fn();
+
+    const { result } = renderHook(() =>
+      useResolvedAgentModelPicker({
+        providers: [
+          { id: "goose", label: "Goose" },
+          { id: "openai", label: "OpenAI" },
+        ],
+        selectedProvider: "anthropic",
+        sessionId: null,
+        session: undefined,
+        pendingModelSelection: undefined,
+        setPendingProviderId,
+        setPendingModelSelection,
+        setGlobalSelectedProvider,
+        prepareSelectedProvider: vi.fn(),
+      }),
+    );
+
+    act(() => {
+      result.current.handleProviderChange("openai");
+    });
+
+    expect(setGlobalSelectedProvider).toHaveBeenCalledWith("openai");
+    expect(setPendingProviderId).toHaveBeenCalledWith("openai");
+    expect(setPendingModelSelection).toHaveBeenCalledWith(undefined);
+  });
+
   it("resolves ACP alias defaults to a concrete model when switching agents", () => {
     mockUseProviderInventory.mockReturnValue({
       getEntry: (providerId: string) =>

--- a/ui/goose2/src/features/chat/hooks/useChatSessionController.ts
+++ b/ui/goose2/src/features/chat/hooks/useChatSessionController.ts
@@ -7,7 +7,6 @@ import { useChatSessionStore } from "../stores/chatSessionStore";
 import { useAgentStore } from "@/features/agents/stores/agentStore";
 import { useProviderSelection } from "@/features/agents/hooks/useProviderSelection";
 import { useProjectStore } from "@/features/projects/stores/projectStore";
-import { useAgentModelPickerState } from "./useAgentModelPickerState";
 import {
   buildProjectSystemPrompt,
   composeSystemPrompt,
@@ -16,6 +15,10 @@ import {
 } from "@/features/projects/lib/chatProjectContext";
 import { resolveSessionCwd } from "@/features/projects/lib/sessionCwdSelection";
 import { acpPrepareSession, acpSetModel } from "@/shared/api/acp";
+import {
+  useResolvedAgentModelPicker,
+  type PreferredModelSelection,
+} from "./useResolvedAgentModelPicker";
 
 interface UseChatSessionControllerOptions {
   sessionId: string | null;
@@ -52,11 +55,8 @@ export function useChatSessionController({
   const [pendingPersonaId, setPendingPersonaId] = useState<string | null>();
   const [pendingProjectId, setPendingProjectId] = useState<string | null>();
   const [pendingProviderId, setPendingProviderId] = useState<string>();
-  const [pendingModelSelection, setPendingModelSelection] = useState<{
-    id: string;
-    name: string;
-    providerId?: string;
-  } | null>();
+  const [pendingModelSelection, setPendingModelSelection] =
+    useState<PreferredModelSelection | null>();
   const pendingDraftValue = useChatStore(
     (s) => s.draftsBySession[PENDING_HOME_SESSION_ID] ?? "",
   );
@@ -140,6 +140,7 @@ export function useChatSessionController({
       nextProject = project,
       nextWorkspacePath = activeWorkspace?.path,
       personaId = selectedPersonaId ?? undefined,
+      modelSelection?: PreferredModelSelection | null,
     ) => {
       if (!sessionId) {
         return;
@@ -149,8 +150,38 @@ export function useChatSessionController({
         nextWorkspacePath,
       );
       await acpPrepareSession(sessionId, providerId, workingDir, { personaId });
+      if (!modelSelection?.id) {
+        return;
+      }
+
+      const sessionStore = useChatSessionStore.getState();
+      const liveSession = sessionStore.getSession(sessionId);
+      const modelAlreadyApplied =
+        liveSession?.modelId === modelSelection.id &&
+        liveSession?.modelName === modelSelection.name;
+
+      if (modelAlreadyApplied) {
+        return;
+      }
+
+      sessionStore.updateSession(sessionId, {
+        modelId: modelSelection.id,
+        modelName: modelSelection.name,
+      });
+      await acpSetModel(sessionId, modelSelection.id);
     },
     [activeWorkspace?.path, project, selectedPersonaId, sessionId],
+  );
+  const prepareSelectedProvider = useCallback(
+    (providerId: string, modelSelection?: PreferredModelSelection | null) =>
+      prepareCurrentSession(
+        providerId,
+        project,
+        activeWorkspace?.path,
+        selectedPersonaId ?? undefined,
+        modelSelection,
+      ),
+    [activeWorkspace?.path, prepareCurrentSession, project, selectedPersonaId],
   );
 
   const prevProjectIdRef = useRef(session?.projectId);
@@ -168,6 +199,27 @@ export function useChatSessionController({
     }
   }, [clearActiveWorkspace, session?.projectId, sessionId]);
 
+  const {
+    selectedAgentId,
+    pickerAgents,
+    availableModels,
+    modelsLoading,
+    modelStatusMessage,
+    handleProviderChange,
+    handleModelChange,
+    effectiveModelSelection,
+  } = useResolvedAgentModelPicker({
+    providers,
+    selectedProvider,
+    sessionId,
+    session,
+    pendingModelSelection,
+    setPendingProviderId,
+    setPendingModelSelection,
+    setGlobalSelectedProvider,
+    prepareSelectedProvider,
+  });
+
   const prevWorkspaceRef = useRef(activeWorkspace);
   useEffect(() => {
     const previousWorkspace = prevWorkspaceRef.current;
@@ -183,114 +235,19 @@ export function useChatSessionController({
     if (previousWorkspace?.path === activeWorkspace.path) {
       return;
     }
-    void prepareCurrentSession(selectedProvider).catch((error) => {
+    void prepareSelectedProvider(
+      selectedProvider,
+      effectiveModelSelection,
+    ).catch((error) => {
       console.error("Failed to prepare ACP session:", error);
     });
-  }, [activeWorkspace, prepareCurrentSession, selectedProvider, sessionId]);
-
-  const {
-    selectedAgentId,
-    pickerAgents,
-    availableModels,
-    modelsLoading,
-    modelStatusMessage,
-    handleProviderChange,
-    handleModelChange,
-  } = useAgentModelPickerState({
-    providers,
+  }, [
+    activeWorkspace,
+    effectiveModelSelection,
+    prepareSelectedProvider,
     selectedProvider,
-    onProviderSelected: (providerId) => {
-      if (!sessionId) {
-        setGlobalSelectedProvider(providerId);
-        setPendingProviderId(providerId);
-        setPendingModelSelection(null);
-        return;
-      }
-      useChatSessionStore
-        .getState()
-        .switchSessionProvider(sessionId, providerId);
-      setGlobalSelectedProvider(providerId);
-      void prepareCurrentSession(providerId).catch((error) => {
-        console.error("Failed to update ACP session provider:", error);
-      });
-    },
-    onModelSelected: (model) => {
-      const modelId = model.id;
-      const modelName = model.displayName ?? model.name ?? model.id;
-      const nextProviderId = model.providerId ?? selectedProvider;
-
-      if (!sessionId) {
-        if (nextProviderId && nextProviderId !== selectedProvider) {
-          setPendingProviderId(nextProviderId);
-          setGlobalSelectedProvider(nextProviderId);
-        }
-        setPendingModelSelection({
-          id: modelId,
-          name: modelName,
-          providerId: nextProviderId,
-        });
-        return;
-      }
-      if (
-        !session ||
-        (modelId === session.modelId &&
-          (!nextProviderId || nextProviderId === session.providerId))
-      ) {
-        return;
-      }
-      const previousProviderId = session.providerId;
-      const previousModelId = session.modelId;
-      const previousModelName = session.modelName;
-      const providerChanged =
-        Boolean(nextProviderId) && nextProviderId !== session.providerId;
-
-      if (providerChanged && nextProviderId) {
-        useChatSessionStore
-          .getState()
-          .switchSessionProvider(sessionId, nextProviderId);
-        setGlobalSelectedProvider(nextProviderId);
-      }
-
-      useChatSessionStore.getState().updateSession(sessionId, {
-        modelId,
-        modelName,
-      });
-
-      void (async () => {
-        try {
-          if (providerChanged && nextProviderId) {
-            await prepareCurrentSession(nextProviderId);
-          }
-          await acpSetModel(sessionId, modelId);
-        } catch (error) {
-          console.error("Failed to set model:", error);
-          if (providerChanged && previousProviderId) {
-            setGlobalSelectedProvider(previousProviderId);
-          }
-          useChatSessionStore.getState().updateSession(sessionId, {
-            providerId: previousProviderId,
-            modelId: previousModelId,
-            modelName: previousModelName,
-          });
-          void (async () => {
-            try {
-              if (providerChanged && previousProviderId) {
-                await prepareCurrentSession(previousProviderId);
-              }
-              if (previousModelId) {
-                await acpSetModel(sessionId, previousModelId);
-              }
-            } catch (rollbackError) {
-              console.error(
-                "Failed to restore previous provider/model after setModel failure:",
-                rollbackError,
-              );
-            }
-          })();
-        }
-      })();
-    },
-  });
+    sessionId,
+  ]);
 
   const handleProjectChange = useCallback(
     (projectId: string | null) => {
@@ -310,16 +267,24 @@ export function useChatSessionController({
       if (!selectedProvider) {
         return;
       }
-      void prepareCurrentSession(selectedProvider, nextProject).catch(
-        (error) => {
-          console.error(
-            "Failed to update ACP session working directory:",
-            error,
-          );
-        },
-      );
+      void prepareCurrentSession(
+        selectedProvider,
+        nextProject,
+        activeWorkspace?.path,
+        selectedPersonaId ?? undefined,
+        effectiveModelSelection,
+      ).catch((error) => {
+        console.error("Failed to update ACP session working directory:", error);
+      });
     },
-    [prepareCurrentSession, selectedProvider, sessionId],
+    [
+      activeWorkspace?.path,
+      effectiveModelSelection,
+      prepareCurrentSession,
+      selectedPersonaId,
+      selectedProvider,
+      sessionId,
+    ],
   );
 
   const handlePersonaChange = useCallback(
@@ -334,7 +299,7 @@ export function useChatSessionController({
         if (matchingProvider) {
           if (!sessionId) {
             setPendingProviderId(matchingProvider.id);
-            setPendingModelSelection(null);
+            setPendingModelSelection(undefined);
             setGlobalSelectedProvider(matchingProvider.id);
           } else {
             handleProviderChange(matchingProvider.id);
@@ -399,7 +364,8 @@ export function useChatSessionController({
     {
       onMessageAccepted: sessionId ? onMessageAccepted : undefined,
       ensurePrepared: selectedProvider
-        ? () => prepareCurrentSession(selectedProvider)
+        ? () =>
+            prepareSelectedProvider(selectedProvider, effectiveModelSelection)
         : undefined,
     },
   );
@@ -582,15 +548,10 @@ export function useChatSessionController({
             nextProject,
             activeWorkspace?.path,
             nextPersonaId,
+            pendingModelSelection,
           );
           if (cancelled) {
             return;
-          }
-          if (pendingModelSelection?.id) {
-            await acpSetModel(sessionId, pendingModelSelection.id);
-            if (cancelled) {
-              return;
-            }
           }
         } catch (error) {
           console.error("Failed to sync pending Home state:", error);
@@ -663,14 +624,8 @@ export function useChatSessionController({
     providersLoading,
     selectedProvider: selectedAgentId,
     handleProviderChange,
-    currentModelId:
-      pendingModelSelection !== undefined
-        ? (pendingModelSelection?.id ?? null)
-        : (session?.modelId ?? null),
-    currentModelName:
-      pendingModelSelection !== undefined
-        ? (pendingModelSelection?.name ?? null)
-        : session?.modelName,
+    currentModelId: effectiveModelSelection?.id ?? null,
+    currentModelName: effectiveModelSelection?.name ?? null,
     availableModels,
     modelsLoading,
     modelStatusMessage,

--- a/ui/goose2/src/features/chat/hooks/useChatSessionController.ts
+++ b/ui/goose2/src/features/chat/hooks/useChatSessionController.ts
@@ -7,12 +7,14 @@ import { useChatSessionStore } from "../stores/chatSessionStore";
 import { useAgentStore } from "@/features/agents/stores/agentStore";
 import { useProviderSelection } from "@/features/agents/hooks/useProviderSelection";
 import { useProjectStore } from "@/features/projects/stores/projectStore";
+import { resolveAgentProviderCatalogIdStrict } from "@/features/providers/providerCatalog";
 import {
   buildProjectSystemPrompt,
   composeSystemPrompt,
   getProjectArtifactRoots,
   resolveProjectDefaultArtifactRoot,
 } from "@/features/projects/lib/chatProjectContext";
+import { setStoredModelPreference } from "../lib/modelPreferences";
 import { resolveSessionCwd } from "@/features/projects/lib/sessionCwdSelection";
 import { acpPrepareSession, acpSetModel } from "@/shared/api/acp";
 import {
@@ -164,11 +166,11 @@ export function useChatSessionController({
         return;
       }
 
+      await acpSetModel(sessionId, modelSelection.id);
       sessionStore.updateSession(sessionId, {
         modelId: modelSelection.id,
         modelName: modelSelection.name,
       });
-      await acpSetModel(sessionId, modelSelection.id);
     },
     [activeWorkspace?.path, project, selectedPersonaId, sessionId],
   );
@@ -548,6 +550,17 @@ export function useChatSessionController({
           );
           if (cancelled) {
             return;
+          }
+          if (pendingModelSelection?.source === "explicit") {
+            const agentId =
+              resolveAgentProviderCatalogIdStrict(
+                pendingModelSelection.providerId ?? nextProviderId,
+              ) ?? "goose";
+            setStoredModelPreference(agentId, {
+              modelId: pendingModelSelection.id,
+              modelName: pendingModelSelection.name,
+              providerId: pendingModelSelection.providerId ?? nextProviderId,
+            });
           }
         } catch (error) {
           console.error("Failed to sync pending Home state:", error);

--- a/ui/goose2/src/features/chat/hooks/useChatSessionController.ts
+++ b/ui/goose2/src/features/chat/hooks/useChatSessionController.ts
@@ -535,10 +535,6 @@ export function useChatSessionController({
         if (hasPendingProject) {
           patch.projectId = nextProjectId ?? null;
         }
-        if (hasPendingModel) {
-          patch.modelId = pendingModelSelection?.id;
-          patch.modelName = pendingModelSelection?.name;
-        }
 
         useChatSessionStore.getState().updateSession(sessionId, patch);
 

--- a/ui/goose2/src/features/chat/hooks/useResolvedAgentModelPicker.ts
+++ b/ui/goose2/src/features/chat/hooks/useResolvedAgentModelPicker.ts
@@ -17,6 +17,7 @@ import {
 
 const GOOSE_PROVIDER_CONFIG_KEY = "GOOSE_PROVIDER";
 const GOOSE_MODEL_CONFIG_KEY = "GOOSE_MODEL";
+const MODEL_ALIAS_IDS = new Set(["current", "default"]);
 
 export type PreferredModelSelection = {
   id: string;
@@ -40,6 +41,10 @@ interface UseResolvedAgentModelPickerOptions {
     providerId: string,
     modelSelection?: PreferredModelSelection | null,
   ) => Promise<void>;
+}
+
+function isModelAlias(modelId?: string | null): boolean {
+  return modelId != null && MODEL_ALIAS_IDS.has(modelId);
 }
 
 export function useResolvedAgentModelPicker({
@@ -90,6 +95,30 @@ export function useResolvedAgentModelPicker({
       const inventoryEntry = getProviderInventoryEntry(agentId);
       if (!inventoryEntry?.defaultModel) {
         return null;
+      }
+
+      const resolvedInventoryModel =
+        inventoryEntry.models.find(
+          (model) =>
+            model.id === inventoryEntry.defaultModel && !isModelAlias(model.id),
+        ) ??
+        inventoryEntry.models.find((model) => model.recommended) ??
+        inventoryEntry.models.find((model) => !isModelAlias(model.id)) ??
+        inventoryEntry.models.find(
+          (model) => model.id === inventoryEntry.defaultModel,
+        ) ??
+        inventoryEntry.models[0];
+
+      if (resolvedInventoryModel) {
+        return {
+          id: resolvedInventoryModel.id,
+          name: resolvedInventoryModel.name,
+          providerId:
+            inventoryEntry.providerId === agentId
+              ? inventoryEntry.providerId
+              : fallbackProviderId,
+          source: "default" as const,
+        };
       }
 
       return {
@@ -362,17 +391,49 @@ export function useResolvedAgentModelPicker({
       storedModelPreference,
     ]);
 
+  const sessionModelSelection = useMemo<PreferredModelSelection | null>(() => {
+    if (!session?.modelId) {
+      return null;
+    }
+
+    const matchingSessionModel =
+      availableModels.find(
+        (model) =>
+          model.id === session.modelId &&
+          (!session.providerId ||
+            !model.providerId ||
+            model.providerId === session.providerId),
+      ) ?? null;
+
+    if (matchingSessionModel) {
+      return {
+        id: matchingSessionModel.id,
+        name:
+          matchingSessionModel.displayName ??
+          matchingSessionModel.name ??
+          session.modelName ??
+          session.modelId,
+        providerId: matchingSessionModel.providerId ?? session.providerId,
+        source: "explicit",
+      };
+    }
+
+    if (isModelAlias(session.modelId)) {
+      return null;
+    }
+
+    return {
+      id: session.modelId,
+      name: session.modelName ?? session.modelId,
+      providerId: session.providerId,
+      source: "explicit",
+    };
+  }, [availableModels, session]);
+
   const effectiveModelSelection =
     pendingModelSelection !== undefined
       ? pendingModelSelection
-      : session?.modelId
-        ? {
-            id: session.modelId,
-            name: session.modelName ?? session.modelId,
-            providerId: session.providerId,
-            source: "explicit" as const,
-          }
-        : preferredModelSelection;
+      : (sessionModelSelection ?? preferredModelSelection);
 
   return {
     selectedAgentId,

--- a/ui/goose2/src/features/chat/hooks/useResolvedAgentModelPicker.ts
+++ b/ui/goose2/src/features/chat/hooks/useResolvedAgentModelPicker.ts
@@ -64,6 +64,10 @@ export function useResolvedAgentModelPicker({
 
   const selectedAgentId =
     resolveAgentProviderCatalogIdStrict(selectedProvider) ?? "goose";
+  const concreteSelectedProviderId =
+    resolveAgentProviderCatalogIdStrict(selectedProvider) == null
+      ? selectedProvider
+      : null;
   const storedModelPreference = useMemo(
     () => getStoredModelPreference(selectedAgentId),
     [selectedAgentId],
@@ -345,13 +349,19 @@ export function useResolvedAgentModelPicker({
               model.id === storedModelPreference.modelId &&
               (!storedModelPreference.providerId ||
                 !model.providerId ||
-                model.providerId === storedModelPreference.providerId),
+                model.providerId === storedModelPreference.providerId) &&
+              (!concreteSelectedProviderId ||
+                !model.providerId ||
+                model.providerId === concreteSelectedProviderId),
           ) ?? null;
+        const storedSelectionCompatible =
+          !concreteSelectedProviderId ||
+          storedModelPreference.providerId === concreteSelectedProviderId;
 
         if (
           matchingStoredModel ||
-          availableModels.length === 0 ||
-          modelsLoading
+          ((availableModels.length === 0 || modelsLoading) &&
+            storedSelectionCompatible)
         ) {
           return {
             id: storedModelPreference.modelId,
@@ -382,8 +392,18 @@ export function useResolvedAgentModelPicker({
             model.id === inventoryDefaultSelection.id &&
             (!inventoryDefaultSelection.providerId ||
               !model.providerId ||
-              model.providerId === inventoryDefaultSelection.providerId),
+              model.providerId === inventoryDefaultSelection.providerId) &&
+            (!concreteSelectedProviderId ||
+              !model.providerId ||
+              model.providerId === concreteSelectedProviderId),
         ) ?? null;
+      const defaultSelectionCompatible =
+        !concreteSelectedProviderId ||
+        inventoryDefaultSelection.providerId === concreteSelectedProviderId;
+
+      if (!matchingDefaultModel && !defaultSelectionCompatible) {
+        return null;
+      }
 
       return {
         id: inventoryDefaultSelection.id,
@@ -400,6 +420,7 @@ export function useResolvedAgentModelPicker({
       availableModels,
       getPreferredSelectionForAgent,
       modelsLoading,
+      concreteSelectedProviderId,
       selectedProvider,
       selectedAgentId,
       storedModelPreference,

--- a/ui/goose2/src/features/chat/hooks/useResolvedAgentModelPicker.ts
+++ b/ui/goose2/src/features/chat/hooks/useResolvedAgentModelPicker.ts
@@ -10,6 +10,7 @@ import {
 } from "../stores/chatSessionStore";
 import { useAgentModelPickerState } from "./useAgentModelPickerState";
 import {
+  clearStoredModelPreference,
   getStoredModelPreference,
   setStoredModelPreference,
 } from "../lib/modelPreferences";
@@ -171,13 +172,14 @@ export function useResolvedAgentModelPicker({
       const modelId = model.id;
       const modelName = model.displayName ?? model.name ?? model.id;
       const nextProviderId = model.providerId ?? selectedProvider;
-      setStoredModelPreference(selectedAgentId, {
+      const nextStoredModelPreference = {
         modelId,
         modelName,
         providerId: nextProviderId,
-      });
+      };
 
       if (!sessionId) {
+        setStoredModelPreference(selectedAgentId, nextStoredModelPreference);
         if (nextProviderId && nextProviderId !== selectedProvider) {
           setPendingProviderId(nextProviderId);
           setGlobalSelectedProvider(nextProviderId);
@@ -199,6 +201,8 @@ export function useResolvedAgentModelPicker({
         return;
       }
 
+      const previousStoredModelPreference =
+        getStoredModelPreference(selectedAgentId);
       const previousProviderId = session.providerId;
       const previousModelId = session.modelId;
       const previousModelName = session.modelName;
@@ -223,10 +227,19 @@ export function useResolvedAgentModelPicker({
             await prepareSelectedProvider(nextProviderId);
           }
           await acpSetModel(sessionId, modelId);
+          setStoredModelPreference(selectedAgentId, nextStoredModelPreference);
         } catch (error) {
           console.error("Failed to set model:", error);
           if (providerChanged && previousProviderId) {
             setGlobalSelectedProvider(previousProviderId);
+          }
+          if (previousStoredModelPreference) {
+            setStoredModelPreference(
+              selectedAgentId,
+              previousStoredModelPreference,
+            );
+          } else {
+            clearStoredModelPreference(selectedAgentId);
           }
           useChatSessionStore.getState().updateSession(sessionId, {
             providerId: previousProviderId,

--- a/ui/goose2/src/features/chat/hooks/useResolvedAgentModelPicker.ts
+++ b/ui/goose2/src/features/chat/hooks/useResolvedAgentModelPicker.ts
@@ -179,7 +179,6 @@ export function useResolvedAgentModelPicker({
       };
 
       if (!sessionId) {
-        setStoredModelPreference(selectedAgentId, nextStoredModelPreference);
         if (nextProviderId && nextProviderId !== selectedProvider) {
           setPendingProviderId(nextProviderId);
           setGlobalSelectedProvider(nextProviderId);

--- a/ui/goose2/src/features/chat/hooks/useResolvedAgentModelPicker.ts
+++ b/ui/goose2/src/features/chat/hooks/useResolvedAgentModelPicker.ts
@@ -199,18 +199,33 @@ export function useResolvedAgentModelPicker({
     providers,
     selectedProvider,
     onProviderSelected: (providerId) => {
-      const nextAgentId =
-        resolveAgentProviderCatalogIdStrict(providerId) ?? "goose";
+      const requestedAgentId = resolveAgentProviderCatalogIdStrict(providerId);
       const preferredModelSelection = getPreferredSelectionForAgent(
-        nextAgentId,
+        requestedAgentId ?? "goose",
         providerId,
       );
-      const nextProviderId = preferredModelSelection?.providerId ?? providerId;
+      const nextProviderId = requestedAgentId
+        ? (preferredModelSelection?.providerId ?? providerId)
+        : providerId;
+      const nextModelSelection =
+        !requestedAgentId &&
+        preferredModelSelection?.providerId &&
+        preferredModelSelection.providerId !== providerId
+          ? undefined
+          : preferredModelSelection
+            ? {
+                ...preferredModelSelection,
+                providerId:
+                  requestedAgentId == null
+                    ? providerId
+                    : preferredModelSelection.providerId,
+              }
+            : undefined;
 
       if (!sessionId) {
         setGlobalSelectedProvider(nextProviderId);
         setPendingProviderId(nextProviderId);
-        setPendingModelSelection(preferredModelSelection ?? undefined);
+        setPendingModelSelection(nextModelSelection);
         return;
       }
 
@@ -218,12 +233,11 @@ export function useResolvedAgentModelPicker({
         .getState()
         .switchSessionProvider(sessionId, nextProviderId);
       setGlobalSelectedProvider(nextProviderId);
-      void prepareSelectedProvider(
-        nextProviderId,
-        preferredModelSelection,
-      ).catch((error) => {
-        console.error("Failed to update ACP session provider:", error);
-      });
+      void prepareSelectedProvider(nextProviderId, nextModelSelection).catch(
+        (error) => {
+          console.error("Failed to update ACP session provider:", error);
+        },
+      );
     },
     onModelSelected: (model) => {
       const modelId = model.id;

--- a/ui/goose2/src/features/chat/hooks/useResolvedAgentModelPicker.ts
+++ b/ui/goose2/src/features/chat/hooks/useResolvedAgentModelPicker.ts
@@ -64,6 +64,47 @@ export function useResolvedAgentModelPicker({
     [selectedAgentId],
   );
 
+  const getPreferredSelectionForAgent = useMemo(
+    () => (agentId: string, fallbackProviderId?: string) => {
+      const preferredModel = getStoredModelPreference(agentId);
+      if (preferredModel) {
+        return {
+          id: preferredModel.modelId,
+          name: preferredModel.modelName,
+          providerId: preferredModel.providerId ?? fallbackProviderId,
+          source: "explicit" as const,
+        };
+      }
+
+      if (agentId === "goose") {
+        if (!gooseDefaultSelection) {
+          return null;
+        }
+
+        return {
+          ...gooseDefaultSelection,
+          providerId: gooseDefaultSelection.providerId ?? fallbackProviderId,
+        };
+      }
+
+      const inventoryEntry = getProviderInventoryEntry(agentId);
+      if (!inventoryEntry?.defaultModel) {
+        return null;
+      }
+
+      return {
+        id: inventoryEntry.defaultModel,
+        name: inventoryEntry.defaultModel,
+        providerId:
+          inventoryEntry.providerId === agentId
+            ? inventoryEntry.providerId
+            : fallbackProviderId,
+        source: "default" as const,
+      };
+    },
+    [getProviderInventoryEntry, gooseDefaultSelection],
+  );
+
   useEffect(() => {
     if (selectedAgentId !== "goose") {
       setGooseDefaultSelection(null);
@@ -131,22 +172,16 @@ export function useResolvedAgentModelPicker({
     onProviderSelected: (providerId) => {
       const nextAgentId =
         resolveAgentProviderCatalogIdStrict(providerId) ?? "goose";
-      const preferredModel = getStoredModelPreference(nextAgentId);
-      const nextProviderId = preferredModel?.providerId ?? providerId;
+      const preferredModelSelection = getPreferredSelectionForAgent(
+        nextAgentId,
+        providerId,
+      );
+      const nextProviderId = preferredModelSelection?.providerId ?? providerId;
 
       if (!sessionId) {
         setGlobalSelectedProvider(nextProviderId);
         setPendingProviderId(nextProviderId);
-        setPendingModelSelection(
-          preferredModel
-            ? {
-                id: preferredModel.modelId,
-                name: preferredModel.modelName,
-                providerId: preferredModel.providerId,
-                source: "explicit",
-              }
-            : undefined,
-        );
+        setPendingModelSelection(preferredModelSelection ?? undefined);
         return;
       }
 
@@ -156,14 +191,7 @@ export function useResolvedAgentModelPicker({
       setGlobalSelectedProvider(nextProviderId);
       void prepareSelectedProvider(
         nextProviderId,
-        preferredModel
-          ? {
-              id: preferredModel.modelId,
-              name: preferredModel.modelName,
-              providerId: preferredModel.providerId,
-              source: "explicit",
-            }
-          : null,
+        preferredModelSelection,
       ).catch((error) => {
         console.error("Failed to update ACP session provider:", error);
       });
@@ -296,25 +324,10 @@ export function useResolvedAgentModelPicker({
         }
       }
 
-      const inventoryDefaultSelection =
-        selectedAgentId === "goose"
-          ? gooseDefaultSelection
-          : (() => {
-              const inventoryEntry = getProviderInventoryEntry(selectedAgentId);
-              if (!inventoryEntry?.defaultModel) {
-                return null;
-              }
-
-              return {
-                id: inventoryEntry.defaultModel,
-                name: inventoryEntry.defaultModel,
-                providerId:
-                  inventoryEntry.providerId === selectedAgentId
-                    ? inventoryEntry.providerId
-                    : undefined,
-                source: "default" as const,
-              };
-            })();
+      const inventoryDefaultSelection = getPreferredSelectionForAgent(
+        selectedAgentId,
+        selectedProvider,
+      );
 
       if (!inventoryDefaultSelection) {
         return null;
@@ -342,9 +355,9 @@ export function useResolvedAgentModelPicker({
       };
     }, [
       availableModels,
-      getProviderInventoryEntry,
-      gooseDefaultSelection,
+      getPreferredSelectionForAgent,
       modelsLoading,
+      selectedProvider,
       selectedAgentId,
       storedModelPreference,
     ]);

--- a/ui/goose2/src/features/chat/hooks/useResolvedAgentModelPicker.ts
+++ b/ui/goose2/src/features/chat/hooks/useResolvedAgentModelPicker.ts
@@ -1,0 +1,362 @@
+import { useEffect, useMemo, useState } from "react";
+import type { AcpProvider } from "@/shared/api/acp";
+import { useProviderInventory } from "@/features/providers/hooks/useProviderInventory";
+import { resolveAgentProviderCatalogIdStrict } from "@/features/providers/providerCatalog";
+import { getClient } from "@/shared/api/acpConnection";
+import { acpSetModel } from "@/shared/api/acp";
+import {
+  useChatSessionStore,
+  type ChatSession,
+} from "../stores/chatSessionStore";
+import { useAgentModelPickerState } from "./useAgentModelPickerState";
+import {
+  getStoredModelPreference,
+  setStoredModelPreference,
+} from "../lib/modelPreferences";
+
+const GOOSE_PROVIDER_CONFIG_KEY = "GOOSE_PROVIDER";
+const GOOSE_MODEL_CONFIG_KEY = "GOOSE_MODEL";
+
+export type PreferredModelSelection = {
+  id: string;
+  name: string;
+  providerId?: string;
+  source: "default" | "explicit";
+};
+
+interface UseResolvedAgentModelPickerOptions {
+  providers: AcpProvider[];
+  selectedProvider: string;
+  sessionId: string | null;
+  session?: ChatSession;
+  pendingModelSelection: PreferredModelSelection | null | undefined;
+  setPendingProviderId: (providerId: string | undefined) => void;
+  setPendingModelSelection: (
+    selection: PreferredModelSelection | null | undefined,
+  ) => void;
+  setGlobalSelectedProvider: (providerId: string) => void;
+  prepareSelectedProvider: (
+    providerId: string,
+    modelSelection?: PreferredModelSelection | null,
+  ) => Promise<void>;
+}
+
+export function useResolvedAgentModelPicker({
+  providers,
+  selectedProvider,
+  sessionId,
+  session,
+  pendingModelSelection,
+  setPendingProviderId,
+  setPendingModelSelection,
+  setGlobalSelectedProvider,
+  prepareSelectedProvider,
+}: UseResolvedAgentModelPickerOptions) {
+  const { getEntry: getProviderInventoryEntry } = useProviderInventory();
+  const [gooseDefaultSelection, setGooseDefaultSelection] =
+    useState<PreferredModelSelection | null>(null);
+
+  const selectedAgentId =
+    resolveAgentProviderCatalogIdStrict(selectedProvider) ?? "goose";
+  const storedModelPreference = useMemo(
+    () => getStoredModelPreference(selectedAgentId),
+    [selectedAgentId],
+  );
+
+  useEffect(() => {
+    if (selectedAgentId !== "goose") {
+      setGooseDefaultSelection(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadGooseDefaultSelection = async () => {
+      try {
+        const client = await getClient();
+        const [providerResponse, modelResponse] = await Promise.all([
+          client.goose.GooseConfigRead({ key: GOOSE_PROVIDER_CONFIG_KEY }),
+          client.goose.GooseConfigRead({ key: GOOSE_MODEL_CONFIG_KEY }),
+        ]);
+
+        if (cancelled) {
+          return;
+        }
+
+        const providerId =
+          typeof providerResponse.value === "string"
+            ? providerResponse.value
+            : undefined;
+        const modelId =
+          typeof modelResponse.value === "string"
+            ? modelResponse.value
+            : undefined;
+
+        if (!modelId) {
+          setGooseDefaultSelection(null);
+          return;
+        }
+
+        setGooseDefaultSelection({
+          id: modelId,
+          name: modelId,
+          providerId,
+          source: "default",
+        });
+      } catch {
+        if (!cancelled) {
+          setGooseDefaultSelection(null);
+        }
+      }
+    };
+
+    void loadGooseDefaultSelection();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedAgentId]);
+
+  const {
+    pickerAgents,
+    availableModels,
+    modelsLoading,
+    modelStatusMessage,
+    handleProviderChange,
+    handleModelChange,
+  } = useAgentModelPickerState({
+    providers,
+    selectedProvider,
+    onProviderSelected: (providerId) => {
+      const nextAgentId =
+        resolveAgentProviderCatalogIdStrict(providerId) ?? "goose";
+      const preferredModel = getStoredModelPreference(nextAgentId);
+      const nextProviderId = preferredModel?.providerId ?? providerId;
+
+      if (!sessionId) {
+        setGlobalSelectedProvider(nextProviderId);
+        setPendingProviderId(nextProviderId);
+        setPendingModelSelection(
+          preferredModel
+            ? {
+                id: preferredModel.modelId,
+                name: preferredModel.modelName,
+                providerId: preferredModel.providerId,
+                source: "explicit",
+              }
+            : undefined,
+        );
+        return;
+      }
+
+      useChatSessionStore
+        .getState()
+        .switchSessionProvider(sessionId, nextProviderId);
+      setGlobalSelectedProvider(nextProviderId);
+      void prepareSelectedProvider(
+        nextProviderId,
+        preferredModel
+          ? {
+              id: preferredModel.modelId,
+              name: preferredModel.modelName,
+              providerId: preferredModel.providerId,
+              source: "explicit",
+            }
+          : null,
+      ).catch((error) => {
+        console.error("Failed to update ACP session provider:", error);
+      });
+    },
+    onModelSelected: (model) => {
+      const modelId = model.id;
+      const modelName = model.displayName ?? model.name ?? model.id;
+      const nextProviderId = model.providerId ?? selectedProvider;
+      setStoredModelPreference(selectedAgentId, {
+        modelId,
+        modelName,
+        providerId: nextProviderId,
+      });
+
+      if (!sessionId) {
+        if (nextProviderId && nextProviderId !== selectedProvider) {
+          setPendingProviderId(nextProviderId);
+          setGlobalSelectedProvider(nextProviderId);
+        }
+        setPendingModelSelection({
+          id: modelId,
+          name: modelName,
+          providerId: nextProviderId,
+          source: "explicit",
+        });
+        return;
+      }
+
+      if (
+        !session ||
+        (modelId === session.modelId &&
+          (!nextProviderId || nextProviderId === session.providerId))
+      ) {
+        return;
+      }
+
+      const previousProviderId = session.providerId;
+      const previousModelId = session.modelId;
+      const previousModelName = session.modelName;
+      const providerChanged =
+        Boolean(nextProviderId) && nextProviderId !== session.providerId;
+
+      if (providerChanged && nextProviderId) {
+        useChatSessionStore
+          .getState()
+          .switchSessionProvider(sessionId, nextProviderId);
+        setGlobalSelectedProvider(nextProviderId);
+      }
+
+      useChatSessionStore.getState().updateSession(sessionId, {
+        modelId,
+        modelName,
+      });
+
+      void (async () => {
+        try {
+          if (providerChanged && nextProviderId) {
+            await prepareSelectedProvider(nextProviderId);
+          }
+          await acpSetModel(sessionId, modelId);
+        } catch (error) {
+          console.error("Failed to set model:", error);
+          if (providerChanged && previousProviderId) {
+            setGlobalSelectedProvider(previousProviderId);
+          }
+          useChatSessionStore.getState().updateSession(sessionId, {
+            providerId: previousProviderId,
+            modelId: previousModelId,
+            modelName: previousModelName,
+          });
+          void (async () => {
+            try {
+              if (providerChanged && previousProviderId) {
+                await prepareSelectedProvider(previousProviderId);
+              }
+              if (previousModelId) {
+                await acpSetModel(sessionId, previousModelId);
+              }
+            } catch (rollbackError) {
+              console.error(
+                "Failed to restore previous provider/model after setModel failure:",
+                rollbackError,
+              );
+            }
+          })();
+        }
+      })();
+    },
+  });
+
+  const preferredModelSelection =
+    useMemo<PreferredModelSelection | null>(() => {
+      if (storedModelPreference) {
+        const matchingStoredModel =
+          availableModels.find(
+            (model) =>
+              model.id === storedModelPreference.modelId &&
+              (!storedModelPreference.providerId ||
+                !model.providerId ||
+                model.providerId === storedModelPreference.providerId),
+          ) ?? null;
+
+        if (
+          matchingStoredModel ||
+          availableModels.length === 0 ||
+          modelsLoading
+        ) {
+          return {
+            id: storedModelPreference.modelId,
+            name:
+              matchingStoredModel?.displayName ??
+              matchingStoredModel?.name ??
+              storedModelPreference.modelName,
+            providerId:
+              matchingStoredModel?.providerId ??
+              storedModelPreference.providerId,
+            source: "explicit",
+          };
+        }
+      }
+
+      const inventoryDefaultSelection =
+        selectedAgentId === "goose"
+          ? gooseDefaultSelection
+          : (() => {
+              const inventoryEntry = getProviderInventoryEntry(selectedAgentId);
+              if (!inventoryEntry?.defaultModel) {
+                return null;
+              }
+
+              return {
+                id: inventoryEntry.defaultModel,
+                name: inventoryEntry.defaultModel,
+                providerId:
+                  inventoryEntry.providerId === selectedAgentId
+                    ? inventoryEntry.providerId
+                    : undefined,
+                source: "default" as const,
+              };
+            })();
+
+      if (!inventoryDefaultSelection) {
+        return null;
+      }
+
+      const matchingDefaultModel =
+        availableModels.find(
+          (model) =>
+            model.id === inventoryDefaultSelection.id &&
+            (!inventoryDefaultSelection.providerId ||
+              !model.providerId ||
+              model.providerId === inventoryDefaultSelection.providerId),
+        ) ?? null;
+
+      return {
+        id: inventoryDefaultSelection.id,
+        name:
+          matchingDefaultModel?.displayName ??
+          matchingDefaultModel?.name ??
+          inventoryDefaultSelection.name,
+        providerId:
+          matchingDefaultModel?.providerId ??
+          inventoryDefaultSelection.providerId,
+        source: "default",
+      };
+    }, [
+      availableModels,
+      getProviderInventoryEntry,
+      gooseDefaultSelection,
+      modelsLoading,
+      selectedAgentId,
+      storedModelPreference,
+    ]);
+
+  const effectiveModelSelection =
+    pendingModelSelection !== undefined
+      ? pendingModelSelection
+      : session?.modelId
+        ? {
+            id: session.modelId,
+            name: session.modelName ?? session.modelId,
+            providerId: session.providerId,
+            source: "explicit" as const,
+          }
+        : preferredModelSelection;
+
+  return {
+    selectedAgentId,
+    pickerAgents,
+    availableModels,
+    modelsLoading,
+    modelStatusMessage,
+    handleProviderChange,
+    handleModelChange,
+    effectiveModelSelection,
+  };
+}

--- a/ui/goose2/src/features/chat/lib/modelPreferences.ts
+++ b/ui/goose2/src/features/chat/lib/modelPreferences.ts
@@ -1,0 +1,86 @@
+import { resolveAgentProviderCatalogIdStrict } from "@/features/providers/providerCatalog";
+
+const MODEL_PREFERENCES_STORAGE_KEY = "goose:preferredModelsByAgent";
+
+export interface StoredModelPreference {
+  modelId: string;
+  modelName: string;
+  providerId?: string;
+}
+
+type StoredModelPreferences = Record<string, StoredModelPreference>;
+
+function readStoredModelPreferences(): StoredModelPreferences {
+  if (typeof window === "undefined") {
+    return {};
+  }
+
+  try {
+    const stored = window.localStorage.getItem(MODEL_PREFERENCES_STORAGE_KEY);
+    if (!stored) {
+      return {};
+    }
+
+    const parsed = JSON.parse(stored);
+    if (!parsed || typeof parsed !== "object") {
+      return {};
+    }
+
+    return parsed as StoredModelPreferences;
+  } catch {
+    return {};
+  }
+}
+
+function persistStoredModelPreferences(
+  preferences: StoredModelPreferences,
+): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    if (Object.keys(preferences).length === 0) {
+      window.localStorage.removeItem(MODEL_PREFERENCES_STORAGE_KEY);
+      return;
+    }
+
+    window.localStorage.setItem(
+      MODEL_PREFERENCES_STORAGE_KEY,
+      JSON.stringify(preferences),
+    );
+  } catch {
+    // localStorage may be unavailable
+  }
+}
+
+export function getStoredModelPreference(
+  agentId: string,
+): StoredModelPreference | null {
+  return readStoredModelPreferences()[agentId] ?? null;
+}
+
+export function getStoredModelPreferenceForProvider(
+  providerId: string,
+): StoredModelPreference | null {
+  const agentId = resolveAgentProviderCatalogIdStrict(providerId) ?? "goose";
+  return getStoredModelPreference(agentId);
+}
+
+export function setStoredModelPreference(
+  agentId: string,
+  preference: StoredModelPreference,
+): void {
+  const next = readStoredModelPreferences();
+  next[agentId] = preference;
+  persistStoredModelPreferences(next);
+}
+
+export function clearStoredModelPreference(agentId: string): void {
+  const next = readStoredModelPreferences();
+  if (!(agentId in next)) {
+    return;
+  }
+  delete next[agentId];
+  persistStoredModelPreferences(next);
+}

--- a/ui/goose2/src/features/chat/lib/sessionModelPreference.test.ts
+++ b/ui/goose2/src/features/chat/lib/sessionModelPreference.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { resolveSessionModelPreference } from "./sessionModelPreference";
+
+describe("resolveSessionModelPreference", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("keeps a requested concrete provider when the stored preference uses a different provider", () => {
+    window.localStorage.setItem(
+      "goose:preferredModelsByAgent",
+      JSON.stringify({
+        goose: {
+          modelId: "claude-sonnet-4",
+          modelName: "Claude Sonnet 4",
+          providerId: "anthropic",
+        },
+      }),
+    );
+
+    expect(
+      resolveSessionModelPreference({
+        providerId: "openai",
+      }),
+    ).toEqual({
+      providerId: "openai",
+    });
+  });
+
+  it("reuses a stored model when it matches the requested concrete provider", () => {
+    window.localStorage.setItem(
+      "goose:preferredModelsByAgent",
+      JSON.stringify({
+        goose: {
+          modelId: "gpt-5.4",
+          modelName: "GPT-5.4",
+          providerId: "openai",
+        },
+      }),
+    );
+
+    expect(
+      resolveSessionModelPreference({
+        providerId: "openai",
+      }),
+    ).toEqual({
+      providerId: "openai",
+      modelId: "gpt-5.4",
+      modelName: "GPT-5.4",
+    });
+  });
+
+  it("resolves an agent provider to the stored concrete provider and model", () => {
+    window.localStorage.setItem(
+      "goose:preferredModelsByAgent",
+      JSON.stringify({
+        goose: {
+          modelId: "claude-sonnet-4",
+          modelName: "Claude Sonnet 4",
+          providerId: "anthropic",
+        },
+      }),
+    );
+
+    expect(
+      resolveSessionModelPreference({
+        providerId: "goose",
+      }),
+    ).toEqual({
+      providerId: "anthropic",
+      modelId: "claude-sonnet-4",
+      modelName: "Claude Sonnet 4",
+    });
+  });
+});

--- a/ui/goose2/src/features/chat/lib/sessionModelPreference.test.ts
+++ b/ui/goose2/src/features/chat/lib/sessionModelPreference.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { resolveSessionModelPreference } from "./sessionModelPreference";
+import {
+  resolveSessionModelPreference,
+  sanitizeSessionModelPreference,
+} from "./sessionModelPreference";
 
 describe("resolveSessionModelPreference", () => {
   beforeEach(() => {
@@ -70,6 +73,42 @@ describe("resolveSessionModelPreference", () => {
       providerId: "anthropic",
       modelId: "claude-sonnet-4",
       modelName: "Claude Sonnet 4",
+    });
+  });
+
+  it("keeps a stored model when the provider inventory still contains it", () => {
+    expect(
+      sanitizeSessionModelPreference(
+        {
+          providerId: "openai",
+          modelId: "gpt-5.4",
+          modelName: "GPT-5.4",
+        },
+        {
+          models: [{ id: "gpt-5.4" }, { id: "gpt-5.4-mini" }],
+        },
+      ),
+    ).toEqual({
+      providerId: "openai",
+      modelId: "gpt-5.4",
+      modelName: "GPT-5.4",
+    });
+  });
+
+  it("drops a stored model when the provider inventory no longer contains it", () => {
+    expect(
+      sanitizeSessionModelPreference(
+        {
+          providerId: "openai",
+          modelId: "gpt-4.1",
+          modelName: "GPT-4.1",
+        },
+        {
+          models: [{ id: "gpt-5.4" }, { id: "gpt-5.4-mini" }],
+        },
+      ),
+    ).toEqual({
+      providerId: "openai",
     });
   });
 });

--- a/ui/goose2/src/features/chat/lib/sessionModelPreference.ts
+++ b/ui/goose2/src/features/chat/lib/sessionModelPreference.ts
@@ -12,6 +12,12 @@ export interface SessionModelPreference {
   modelName?: string;
 }
 
+interface ProviderInventoryEntryLike {
+  models: Array<{
+    id: string;
+  }>;
+}
+
 export function resolveSessionModelPreference({
   providerId,
   preferredModel,
@@ -48,5 +54,22 @@ export function resolveSessionModelPreference({
     providerId,
     modelId: storedModelPreference.modelId,
     modelName: storedModelPreference.modelName,
+  };
+}
+
+export function sanitizeSessionModelPreference(
+  preference: SessionModelPreference,
+  inventoryEntry?: ProviderInventoryEntryLike | null,
+): SessionModelPreference {
+  if (!preference.modelId || !inventoryEntry) {
+    return preference;
+  }
+
+  if (inventoryEntry.models.some((model) => model.id === preference.modelId)) {
+    return preference;
+  }
+
+  return {
+    providerId: preference.providerId,
   };
 }

--- a/ui/goose2/src/features/chat/lib/sessionModelPreference.ts
+++ b/ui/goose2/src/features/chat/lib/sessionModelPreference.ts
@@ -1,3 +1,4 @@
+import { resolveAgentProviderCatalogIdStrict } from "@/features/providers/providerCatalog";
 import { getStoredModelPreferenceForProvider } from "./modelPreferences";
 
 interface SessionModelPreferenceOptions {
@@ -24,9 +25,28 @@ export function resolveSessionModelPreference({
   }
 
   const storedModelPreference = getStoredModelPreferenceForProvider(providerId);
+  if (!storedModelPreference) {
+    return { providerId };
+  }
+
+  if (resolveAgentProviderCatalogIdStrict(providerId)) {
+    return {
+      providerId: storedModelPreference.providerId ?? providerId,
+      modelId: storedModelPreference.modelId,
+      modelName: storedModelPreference.modelName,
+    };
+  }
+
+  if (
+    storedModelPreference.providerId &&
+    storedModelPreference.providerId !== providerId
+  ) {
+    return { providerId };
+  }
+
   return {
-    providerId: storedModelPreference?.providerId ?? providerId,
-    modelId: storedModelPreference?.modelId,
-    modelName: storedModelPreference?.modelName,
+    providerId,
+    modelId: storedModelPreference.modelId,
+    modelName: storedModelPreference.modelName,
   };
 }

--- a/ui/goose2/src/features/chat/lib/sessionModelPreference.ts
+++ b/ui/goose2/src/features/chat/lib/sessionModelPreference.ts
@@ -1,0 +1,32 @@
+import { getStoredModelPreferenceForProvider } from "./modelPreferences";
+
+interface SessionModelPreferenceOptions {
+  providerId: string;
+  preferredModel?: string;
+}
+
+export interface SessionModelPreference {
+  providerId: string;
+  modelId?: string;
+  modelName?: string;
+}
+
+export function resolveSessionModelPreference({
+  providerId,
+  preferredModel,
+}: SessionModelPreferenceOptions): SessionModelPreference {
+  if (preferredModel) {
+    return {
+      providerId,
+      modelId: preferredModel,
+      modelName: preferredModel,
+    };
+  }
+
+  const storedModelPreference = getStoredModelPreferenceForProvider(providerId);
+  return {
+    providerId: storedModelPreference?.providerId ?? providerId,
+    modelId: storedModelPreference?.modelId,
+    modelName: storedModelPreference?.modelName,
+  };
+}


### PR DESCRIPTION
**Category:** fix
**User Impact:** New chats now remember and visibly use the selected Goose model instead of quietly falling back to a different one.
**Problem:** Goose could appear selected without any model shown, even though ACP would still resolve one at send time. After a user chose a model, new chats and Home-session handoffs did not consistently inherit it, and failed model switches could leave the UI showing a sticky preference that never actually took effect.
**Solution:** This change resolves an effective model for the picker, seeds new chats from either the user's last explicit choice or Goose's configured default, and only persists model state after ACP has accepted it. The model-resolution logic is centralized so Home sessions, provider switches, and new-chat creation all stay in sync.

<details>
<summary>File changes</summary>

**ui/goose2/src/app/AppShell.tsx**
Seeds Home sessions and brand-new chats from a resolved provider/model preference instead of leaving Goose visually blank. Reused Home drafts now apply the chosen model to ACP before session state says that model is active.

**ui/goose2/src/app/lib/homeSessionStorage.ts**
Extracts Home-session localStorage helpers so AppShell stays focused on session orchestration instead of storage plumbing.

**ui/goose2/src/features/chat/hooks/__tests__/useChatSessionController.test.ts**
Adds coverage for stored model defaults, Goose config fallback behavior, pending Home-session handoff, and rollback after a failed model switch. These tests lock in the UX expectations behind the picker changes.

**ui/goose2/src/features/chat/hooks/useChatSessionController.ts**
Moves session controller model handling onto a resolved effective-model state and ensures pending Home state is prepared in ACP before the session records the model. This keeps first-send behavior aligned with what the composer shows.

**ui/goose2/src/features/chat/hooks/useResolvedAgentModelPicker.ts**
Introduces a dedicated hook to resolve the current picker model from session state, stored preferences, provider inventory defaults, and Goose config defaults. It also makes explicit model selections sticky per agent and restores the prior preference if ACP rejects a model switch.

**ui/goose2/src/features/chat/lib/modelPreferences.ts**
Adds localStorage-backed persistence for per-agent model choices so new chats can inherit the last successful explicit selection.

**ui/goose2/src/features/chat/lib/sessionModelPreference.ts**
Adds a small resolver for turning provider/project context into the provider/model pair that new sessions should start with.

</details>

1. Open Goose 2 on Home with `Goose` selected in the composer.
2. Verify the composer shows an actual model for Goose instead of leaving the model state blank.
3. Choose a different Goose-backed model, then start a chat and return to Home or open another new chat.
4. Verify the next new chat inherits that chosen model automatically and the visible provider/model match the backend session that gets prepared.
5. If you simulate a failed model switch, verify the previous stored model remains the sticky default instead of the failed choice.
