### PR TITLE
improve goose2 agent management flows

### DIFF
--- a/ui/goose2/src-tauri/src/commands/agents.rs
+++ b/ui/goose2/src-tauri/src/commands/agents.rs
@@ -67,9 +67,36 @@ pub struct ImportFileReadResult {
     pub file_name: String,
 }
 
+fn validate_import_persona_path(source_path: &str) -> Result<PathBuf, String> {
+    let path = PathBuf::from(source_path);
+
+    if path.as_os_str().is_empty() {
+        return Err("Selected file path is empty".to_string());
+    }
+
+    let extension = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .ok_or_else(|| "Unsupported file type. Expected a .json file.".to_string())?;
+    if !extension.eq_ignore_ascii_case("json") {
+        return Err("Unsupported file type. Expected a .json file.".to_string());
+    }
+
+    let metadata = std::fs::metadata(&path)
+        .map_err(|err| format!("Failed to access import file '{}': {}", path.display(), err))?;
+    if !metadata.is_file() {
+        return Err(format!(
+            "Selected import path '{}' is not a file",
+            path.display()
+        ));
+    }
+
+    Ok(path)
+}
+
 #[tauri::command]
 pub fn read_import_persona_file(source_path: String) -> Result<ImportFileReadResult, String> {
-    let path = PathBuf::from(source_path);
+    let path = validate_import_persona_path(&source_path)?;
     let file_name = path
         .file_name()
         .and_then(|name| name.to_str())
@@ -232,4 +259,48 @@ pub fn import_personas(
 
     let persona = store.create(request)?;
     Ok(vec![persona])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_import_persona_path;
+
+    #[test]
+    fn validate_import_persona_path_rejects_non_json_files() {
+        let path = std::env::temp_dir().join("persona-import.txt");
+        std::fs::write(&path, b"{}").unwrap();
+
+        let result = validate_import_persona_path(path.to_str().unwrap());
+
+        assert!(result.is_err());
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn validate_import_persona_path_rejects_directories() {
+        let dir = std::env::temp_dir().join(format!(
+            "persona-import-dir-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let result = validate_import_persona_path(dir.to_str().unwrap());
+
+        assert!(result.is_err());
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn validate_import_persona_path_accepts_json_files() {
+        let path = std::env::temp_dir().join(format!(
+            "persona-import-{}.json",
+            std::process::id()
+        ));
+        std::fs::write(&path, b"{}").unwrap();
+
+        let validated = validate_import_persona_path(path.to_str().unwrap()).unwrap();
+
+        assert_eq!(validated, path);
+        let _ = std::fs::remove_file(validated);
+    }
 }

--- a/ui/goose2/src-tauri/src/commands/agents.rs
+++ b/ui/goose2/src-tauri/src/commands/agents.rs
@@ -278,10 +278,7 @@ mod tests {
 
     #[test]
     fn validate_import_persona_path_rejects_directories() {
-        let dir = std::env::temp_dir().join(format!(
-            "persona-import-dir-{}",
-            std::process::id()
-        ));
+        let dir = std::env::temp_dir().join(format!("persona-import-dir-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
 
         let result = validate_import_persona_path(dir.to_str().unwrap());
@@ -292,10 +289,7 @@ mod tests {
 
     #[test]
     fn validate_import_persona_path_accepts_json_files() {
-        let path = std::env::temp_dir().join(format!(
-            "persona-import-{}.json",
-            std::process::id()
-        ));
+        let path = std::env::temp_dir().join(format!("persona-import-{}.json", std::process::id()));
         std::fs::write(&path, b"{}").unwrap();
 
         let validated = validate_import_persona_path(path.to_str().unwrap()).unwrap();

--- a/ui/goose2/src-tauri/src/commands/agents.rs
+++ b/ui/goose2/src-tauri/src/commands/agents.rs
@@ -1,6 +1,7 @@
 use crate::services::personas::PersonaStore;
 use crate::types::agents::*;
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 use tauri::State;
 
 #[tauri::command]
@@ -57,6 +58,30 @@ pub fn save_persona_avatar_bytes(
 #[tauri::command]
 pub fn get_avatars_dir() -> String {
     PersonaStore::avatars_dir().to_string_lossy().to_string()
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportFileReadResult {
+    pub file_bytes: Vec<u8>,
+    pub file_name: String,
+}
+
+#[tauri::command]
+pub fn read_import_persona_file(source_path: String) -> Result<ImportFileReadResult, String> {
+    let path = PathBuf::from(source_path);
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| "Selected file is missing a valid filename".to_string())?
+        .to_string();
+    let file_bytes = std::fs::read(&path)
+        .map_err(|err| format!("Failed to read import file '{}': {}", path.display(), err))?;
+
+    Ok(ImportFileReadResult {
+        file_bytes,
+        file_name,
+    })
 }
 
 // --- Sprout-compatible persona import/export ---

--- a/ui/goose2/src-tauri/src/lib.rs
+++ b/ui/goose2/src-tauri/src/lib.rs
@@ -40,6 +40,7 @@ pub fn run() {
             commands::agents::refresh_personas,
             commands::agents::export_persona,
             commands::agents::import_personas,
+            commands::agents::read_import_persona_file,
             commands::agents::save_persona_avatar,
             commands::agents::save_persona_avatar_bytes,
             commands::agents::get_avatars_dir,

--- a/ui/goose2/src-tauri/src/services/personas.rs
+++ b/ui/goose2/src-tauri/src/services/personas.rs
@@ -197,6 +197,13 @@ impl PersonaStore {
         })
     }
 
+    fn markdown_persona_path(id: &str) -> Result<PathBuf, String> {
+        let slug = id
+            .strip_prefix("md-")
+            .ok_or_else(|| format!("Persona '{}' is not a file-backed persona", id))?;
+        Ok(Self::agents_dir().join(format!("{}.md", slug)))
+    }
+
     /// Re-scan markdown personas and update the in-memory list.
     /// Returns the full updated persona list.
     pub fn refresh_markdown(&self) -> Vec<Persona> {
@@ -298,13 +305,29 @@ impl PersonaStore {
         let persona = personas
             .iter()
             .find(|p| p.id == id)
+            .cloned()
             .ok_or_else(|| format!("Persona '{}' not found", id))?;
 
         if persona.is_builtin {
             return Err("Cannot delete a built-in persona".to_string());
         }
         if persona.is_from_disk {
-            return Err("Cannot delete a markdown persona — delete the file directly".to_string());
+            let path = Self::markdown_persona_path(id)?;
+            match std::fs::remove_file(&path) {
+                Ok(_) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => {
+                    return Err(format!(
+                        "Failed to delete file-backed persona '{}': {}",
+                        path.display(),
+                        err
+                    ));
+                }
+            }
+
+            personas.retain(|p| p.id != id);
+            self.save_to_disk(&personas);
+            return Ok(());
         }
 
         // Clean up local avatar file if present

--- a/ui/goose2/src-tauri/src/services/personas.rs
+++ b/ui/goose2/src-tauri/src/services/personas.rs
@@ -3,7 +3,7 @@ use crate::types::agents::{
 };
 use log::warn;
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 use std::sync::Mutex;
 
 pub struct PersonaStore {
@@ -201,7 +201,20 @@ impl PersonaStore {
         let slug = id
             .strip_prefix("md-")
             .ok_or_else(|| format!("Persona '{}' is not a file-backed persona", id))?;
+        Self::validate_markdown_persona_slug(slug)?;
         Ok(Self::agents_dir().join(format!("{}.md", slug)))
+    }
+
+    fn validate_markdown_persona_slug(slug: &str) -> Result<(), String> {
+        if slug.chars().any(|c| matches!(c, '/' | '\\')) {
+            return Err(format!("Persona '{}' has an invalid file-backed ID", slug));
+        }
+
+        let mut components = Path::new(slug).components();
+        match (components.next(), components.next()) {
+            (Some(Component::Normal(_)), None) => Ok(()),
+            _ => Err(format!("Persona '{}' has an invalid file-backed ID", slug)),
+        }
     }
 
     /// Re-scan markdown personas and update the in-memory list.
@@ -416,5 +429,29 @@ impl PersonaStore {
     pub fn delete_avatar_file(filename: &str) {
         let path = Self::avatars_dir().join(filename);
         let _ = std::fs::remove_file(path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PersonaStore;
+
+    #[test]
+    fn markdown_persona_path_rejects_parent_segments() {
+        assert!(PersonaStore::markdown_persona_path("md-../secret").is_err());
+        assert!(PersonaStore::markdown_persona_path("md-..").is_err());
+    }
+
+    #[test]
+    fn markdown_persona_path_rejects_path_separators() {
+        assert!(PersonaStore::markdown_persona_path("md-nested/slug").is_err());
+        assert!(PersonaStore::markdown_persona_path(r"md-nested\slug").is_err());
+    }
+
+    #[test]
+    fn markdown_persona_path_accepts_normal_slug() {
+        let path = PersonaStore::markdown_persona_path("md-scout").unwrap();
+        let file_name = path.file_name().and_then(|name| name.to_str());
+        assert_eq!(file_name, Some("scout.md"));
     }
 }

--- a/ui/goose2/src/app/AppShell.tsx
+++ b/ui/goose2/src/app/AppShell.tsx
@@ -20,6 +20,7 @@ import { useAppStartup } from "./hooks/useAppStartup";
 import { useHomeSessionStateSync } from "./hooks/useHomeSessionStateSync";
 import { loadStoredHomeSessionId } from "./lib/homeSessionStorage";
 import { resolveSupportedSessionModelPreference } from "./lib/resolveSupportedSessionModelPreference";
+import { useCreatePersonaNavigation } from "./hooks/useCreatePersonaNavigation";
 import { AppShellContent } from "./ui/AppShellContent";
 import { acpPrepareSession, acpSetModel } from "@/shared/api/acp";
 import {
@@ -66,14 +67,12 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
   const agentStore = useAgentStore();
   const projectStore = useProjectStore();
   const providerInventoryEntries = useProviderInventoryStore((s) => s.entries);
-
   const pendingProjectCreatedRef = useRef<((projectId: string) => void) | null>(
     null,
   );
   const homeSessionRequestRef = useRef<Promise<ChatSession | null> | null>(
     null,
   );
-
   const loadSessionMessages = useCallback(async (sessionId: string) => {
     const sid = sessionId.slice(0, 8);
     const existingMsgs = useChatStore.getState().messagesBySession[sessionId];
@@ -502,6 +501,10 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
     [sessionStore],
   );
 
+  const handleCreatePersona = useCreatePersonaNavigation(() =>
+    handleNavigate("agents"),
+  );
+
   const toggleSidebar = () => setSidebarCollapsed((prev) => !prev);
 
   const handleResizeStart = useCallback(
@@ -659,6 +662,7 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
               activeView={activeView}
               activeSession={activeSession}
               homeSessionId={homeSessionId}
+              onCreatePersona={handleCreatePersona}
               onArchiveChat={handleArchiveChat}
               onCreateProject={openCreateProjectDialog}
               onActivateHomeSession={activateHomeSession}

--- a/ui/goose2/src/app/hooks/useCreatePersonaNavigation.ts
+++ b/ui/goose2/src/app/hooks/useCreatePersonaNavigation.ts
@@ -1,0 +1,17 @@
+import { useCallback } from "react";
+import { useAgentStore } from "@/features/agents/stores/agentStore";
+
+export function useCreatePersonaNavigation(navigateToAgents: () => void) {
+  return useCallback(() => {
+    navigateToAgents();
+    const agentStoreState = useAgentStore.getState();
+    if (
+      agentStoreState.personaEditorOpen &&
+      agentStoreState.personaEditorMode === "create" &&
+      agentStoreState.editingPersona === null
+    ) {
+      return;
+    }
+    agentStoreState.openPersonaEditor(undefined, "create");
+  }, [navigateToAgents]);
+}

--- a/ui/goose2/src/app/ui/AppShellContent.tsx
+++ b/ui/goose2/src/app/ui/AppShellContent.tsx
@@ -12,6 +12,7 @@ interface AppShellContentProps {
   activeView: AppView;
   activeSession?: ChatSession;
   homeSessionId: string | null;
+  onCreatePersona: () => void;
   onArchiveChat: (sessionId: string) => Promise<void>;
   onCreateProject: (options?: {
     initialWorkingDir?: string | null;
@@ -32,6 +33,7 @@ export function AppShellContent({
   activeView,
   activeSession,
   homeSessionId,
+  onCreatePersona,
   onArchiveChat,
   onCreateProject,
   onActivateHomeSession,
@@ -61,12 +63,14 @@ export function AppShellContent({
         <ChatView
           key={activeSession.id}
           sessionId={activeSession.id}
+          onCreatePersona={onCreatePersona}
           onCreateProject={onCreateProject}
         />
       ) : (
         <HomeScreen
           sessionId={homeSessionId}
           onActivateSession={onActivateHomeSession}
+          onCreatePersona={onCreatePersona}
           onCreateProject={onCreateProject}
         />
       );
@@ -75,6 +79,7 @@ export function AppShellContent({
         <HomeScreen
           sessionId={homeSessionId}
           onActivateSession={onActivateHomeSession}
+          onCreatePersona={onCreatePersona}
           onCreateProject={onCreateProject}
         />
       );

--- a/ui/goose2/src/features/agents/hooks/__tests__/usePersonas.test.ts
+++ b/ui/goose2/src/features/agents/hooks/__tests__/usePersonas.test.ts
@@ -81,6 +81,7 @@ describe("usePersonas", () => {
       isLoading: false,
       personaEditorOpen: false,
       editingPersona: null,
+      personaEditorMode: "create",
     });
   });
 

--- a/ui/goose2/src/features/agents/lib/personaImport.ts
+++ b/ui/goose2/src/features/agents/lib/personaImport.ts
@@ -1,0 +1,58 @@
+const JSON_MIME_TYPES = new Set([
+  "",
+  "application/json",
+  "application/x-json",
+  "text/json",
+  "text/plain",
+]);
+
+export interface ImportMessageDescriptor {
+  key:
+    | "view.importInvalidExtension"
+    | "view.importInvalidMimeType"
+    | "view.imported_one"
+    | "view.imported_other";
+  options?: Record<string, unknown>;
+}
+
+export function validatePersonaImportFile(
+  file: Pick<File, "name" | "type">,
+): ImportMessageDescriptor | null {
+  const lowerName = file.name.toLowerCase();
+  if (!lowerName.endsWith(".json")) {
+    return {
+      key: "view.importInvalidExtension",
+    } satisfies ImportMessageDescriptor;
+  }
+
+  if (!JSON_MIME_TYPES.has(file.type)) {
+    return {
+      key: "view.importInvalidMimeType",
+    } satisfies ImportMessageDescriptor;
+  }
+
+  return null;
+}
+
+export function formatImportSuccessMessage(
+  importedCount: number,
+): ImportMessageDescriptor {
+  if (importedCount === 1) {
+    return { key: "view.imported_one", options: { count: importedCount } };
+  }
+
+  return {
+    key: "view.imported_other",
+    options: { count: importedCount },
+  };
+}
+
+export function formatAgentError(error: unknown, fallback: string): string {
+  if (typeof error === "string" && error.trim().length > 0) {
+    return error;
+  }
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+  return fallback;
+}

--- a/ui/goose2/src/features/agents/lib/personaPresentation.ts
+++ b/ui/goose2/src/features/agents/lib/personaPresentation.ts
@@ -1,0 +1,17 @@
+import type { Persona } from "@/shared/types/agents";
+
+export type PersonaSource = "builtin" | "file" | "custom";
+
+export function getPersonaSource(persona: Persona): PersonaSource {
+  if (persona.isBuiltin) {
+    return "builtin";
+  }
+  if (persona.isFromDisk) {
+    return "file";
+  }
+  return "custom";
+}
+
+export function isPersonaReadOnly(persona: Persona): boolean {
+  return getPersonaSource(persona) !== "custom";
+}

--- a/ui/goose2/src/features/agents/stores/__tests__/agentStore.test.ts
+++ b/ui/goose2/src/features/agents/stores/__tests__/agentStore.test.ts
@@ -44,6 +44,7 @@ describe("agentStore", () => {
       isLoading: false,
       personaEditorOpen: false,
       editingPersona: null,
+      personaEditorMode: "create",
     });
   });
 
@@ -140,12 +141,14 @@ describe("agentStore", () => {
     useAgentStore.getState().openPersonaEditor(p);
     expect(useAgentStore.getState().personaEditorOpen).toBe(true);
     expect(useAgentStore.getState().editingPersona).toEqual(p);
+    expect(useAgentStore.getState().personaEditorMode).toBe("edit");
   });
 
   it("openPersonaEditor without persona sets editingPersona to null", () => {
     useAgentStore.getState().openPersonaEditor();
     expect(useAgentStore.getState().personaEditorOpen).toBe(true);
     expect(useAgentStore.getState().editingPersona).toBeNull();
+    expect(useAgentStore.getState().personaEditorMode).toBe("create");
   });
 
   it("closePersonaEditor clears editing state", () => {
@@ -153,6 +156,7 @@ describe("agentStore", () => {
     useAgentStore.getState().closePersonaEditor();
     expect(useAgentStore.getState().personaEditorOpen).toBe(false);
     expect(useAgentStore.getState().editingPersona).toBeNull();
+    expect(useAgentStore.getState().personaEditorMode).toBe("create");
   });
 
   // ── helpers ───────────────────────────────────────────────────────

--- a/ui/goose2/src/features/agents/stores/agentStore.ts
+++ b/ui/goose2/src/features/agents/stores/agentStore.ts
@@ -56,6 +56,7 @@ interface AgentStoreState {
   // UI state
   personaEditorOpen: boolean;
   editingPersona: Persona | null;
+  personaEditorMode: "create" | "edit" | "details";
 }
 
 interface AgentStoreActions {
@@ -83,7 +84,10 @@ interface AgentStoreActions {
   getActiveAgent: () => Agent | null;
 
   // Persona editor
-  openPersonaEditor: (persona?: Persona) => void;
+  openPersonaEditor: (
+    persona?: Persona,
+    mode?: "create" | "edit" | "details",
+  ) => void;
   closePersonaEditor: () => void;
 
   // Loading
@@ -112,6 +116,7 @@ export const useAgentStore = create<AgentStore>((set, get) => ({
   isLoading: false,
   personaEditorOpen: false,
   editingPersona: null,
+  personaEditorMode: "create",
 
   // Persona CRUD
   setPersonas: (personas) => set({ personas }),
@@ -187,16 +192,18 @@ export const useAgentStore = create<AgentStore>((set, get) => ({
   },
 
   // Persona editor
-  openPersonaEditor: (persona) =>
+  openPersonaEditor: (persona, mode) =>
     set({
       personaEditorOpen: true,
       editingPersona: persona ?? null,
+      personaEditorMode: mode ?? (persona ? "edit" : "create"),
     }),
 
   closePersonaEditor: () =>
     set({
       personaEditorOpen: false,
       editingPersona: null,
+      personaEditorMode: "create",
     }),
 
   // Loading

--- a/ui/goose2/src/features/agents/ui/AgentsView.tsx
+++ b/ui/goose2/src/features/agents/ui/AgentsView.tsx
@@ -1,7 +1,8 @@
-import { useState, useMemo, useCallback, useRef } from "react";
+import { useState, useMemo, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Bot, Plus, Circle, Upload } from "lucide-react";
-import { cn } from "@/shared/lib/cn";
+import { open } from "@tauri-apps/plugin-dialog";
+import { Plus, Upload } from "lucide-react";
+import { toast } from "sonner";
 import { SearchBar } from "@/shared/ui/SearchBar";
 import { Button, buttonVariants } from "@/shared/ui/button";
 import {
@@ -17,66 +18,36 @@ import {
 import { useAgentStore } from "@/features/agents/stores/agentStore";
 import { PersonaGallery } from "@/features/agents/ui/PersonaGallery";
 import { PersonaEditor } from "@/features/agents/ui/PersonaEditor";
-import { exportPersona, importPersonas } from "@/shared/api/agents";
+import {
+  exportPersona,
+  importPersonas,
+  readImportPersonaFile,
+} from "@/shared/api/agents";
 import { usePersonas } from "@/features/agents/hooks/usePersonas";
 import type {
   Persona,
-  Agent,
-  AgentStatus,
   CreatePersonaRequest,
   UpdatePersonaRequest,
 } from "@/shared/types/agents";
-
-const STATUS_STYLES: Record<AgentStatus, { dot: string; labelKey: string }> = {
-  online: { dot: "text-green-500", labelKey: "statuses.online" },
-  offline: { dot: "text-muted-foreground", labelKey: "statuses.offline" },
-  starting: { dot: "text-yellow-500", labelKey: "statuses.starting" },
-  error: { dot: "text-red-500", labelKey: "statuses.error" },
-};
-
-function AgentRow({ agent }: { agent: Agent }) {
-  const { t } = useTranslation("agents");
-  const status = STATUS_STYLES[agent.status];
-  return (
-    <li className="flex items-center justify-between rounded-lg border border-border px-4 py-3 transition-colors hover:bg-accent/50">
-      <div className="flex items-center gap-3 min-w-0">
-        <Bot className="h-5 w-5 shrink-0 text-muted-foreground" />
-        <div className="min-w-0">
-          <p className="text-sm font-medium truncate">{agent.name}</p>
-          {agent.persona && (
-            <p className="text-xs text-muted-foreground truncate">
-              {agent.persona.displayName}
-            </p>
-          )}
-        </div>
-      </div>
-      <div className="flex items-center gap-1.5 shrink-0">
-        <Circle
-          className={cn("h-2.5 w-2.5 fill-current", status.dot)}
-          aria-hidden="true"
-        />
-        <span className="text-xs text-muted-foreground">
-          {t(status.labelKey)}
-        </span>
-      </div>
-    </li>
-  );
-}
+import {
+  formatAgentError,
+  formatImportSuccessMessage,
+  validatePersonaImportFile,
+} from "@/features/agents/lib/personaImport";
+import { getPersonaSource } from "@/features/agents/lib/personaPresentation";
 
 export function AgentsView() {
   const { t } = useTranslation(["agents", "common"]);
   const [search, setSearch] = useState("");
   const [deletingPersona, setDeletingPersona] = useState<Persona | null>(null);
-  const [notification, setNotification] = useState<string | null>(null);
 
   const personas = useAgentStore((s) => s.personas);
   const personasLoading = useAgentStore((s) => s.personasLoading);
-  const agents = useAgentStore((s) => s.agents);
   const personaEditorOpen = useAgentStore((s) => s.personaEditorOpen);
   const editingPersona = useAgentStore((s) => s.editingPersona);
+  const personaEditorMode = useAgentStore((s) => s.personaEditorMode);
   const openPersonaEditor = useAgentStore((s) => s.openPersonaEditor);
   const closePersonaEditor = useAgentStore((s) => s.closePersonaEditor);
-  const addPersona = useAgentStore((s) => s.addPersona);
 
   const {
     createPersona,
@@ -97,48 +68,54 @@ export function AgentsView() {
     [personas, lowerSearch],
   );
 
-  const filteredAgents = useMemo(
-    () =>
-      agents.filter(
-        (a) =>
-          a.name.toLowerCase().includes(lowerSearch) ||
-          a.persona?.displayName.toLowerCase().includes(lowerSearch),
-      ),
-    [agents, lowerSearch],
-  );
-
   const handleSavePersona = useCallback(
     async (data: CreatePersonaRequest | UpdatePersonaRequest) => {
-      if (editingPersona) {
-        await updatePersonaViaHook(
-          editingPersona.id,
-          data as UpdatePersonaRequest,
-        );
-      } else {
-        await createPersona(data as CreatePersonaRequest);
+      try {
+        if (editingPersona && personaEditorMode === "edit") {
+          await updatePersonaViaHook(
+            editingPersona.id,
+            data as UpdatePersonaRequest,
+          );
+          toast.success(t("editor.updated"));
+        } else {
+          await createPersona(data as CreatePersonaRequest);
+          toast.success(t("editor.created"));
+        }
+        closePersonaEditor();
+      } catch (error) {
+        toast.error(formatAgentError(error, t("editor.saveFailed")));
       }
-      closePersonaEditor();
     },
-    [editingPersona, createPersona, updatePersonaViaHook, closePersonaEditor],
+    [
+      closePersonaEditor,
+      createPersona,
+      editingPersona,
+      personaEditorMode,
+      t,
+      updatePersonaViaHook,
+    ],
   );
 
   const handleDuplicatePersona = useCallback(
-    (persona: Persona) => {
-      const duplicate: Persona = {
-        ...persona,
-        id: crypto.randomUUID(),
-        displayName: t("view.copyName", { name: persona.displayName }),
-        isBuiltin: false,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      };
-      addPersona(duplicate);
+    async (persona: Persona) => {
+      try {
+        await createPersona({
+          displayName: t("view.copyName", { name: persona.displayName }),
+          avatar: persona.avatar ?? undefined,
+          systemPrompt: persona.systemPrompt,
+          provider: persona.provider,
+          model: persona.model,
+        });
+        toast.success(t("editor.duplicated"));
+      } catch (error) {
+        toast.error(formatAgentError(error, t("editor.saveFailed")));
+      }
     },
-    [addPersona, t],
+    [createPersona, t],
   );
 
   const handleDeletePersona = useCallback((persona: Persona) => {
-    if (persona.isBuiltin) return;
+    if (getPersonaSource(persona) === "builtin") return;
     setDeletingPersona(persona);
   }, []);
 
@@ -146,11 +123,15 @@ export function AgentsView() {
     if (!deletingPersona) return;
     try {
       await deletePersona(deletingPersona.id);
+      if (editingPersona?.id === deletingPersona.id) {
+        closePersonaEditor();
+      }
+      toast.success(t("view.deleted", { name: deletingPersona.displayName }));
     } catch (err) {
-      console.error("Failed to delete persona:", err);
+      toast.error(formatAgentError(err, t("view.deleteFailed")));
     }
     setDeletingPersona(null);
-  }, [deletingPersona, deletePersona]);
+  }, [closePersonaEditor, deletingPersona, deletePersona, editingPersona, t]);
 
   const handleExportPersona = useCallback(
     async (persona: Persona) => {
@@ -166,52 +147,76 @@ export function AgentsView() {
         a.click();
         document.body.removeChild(a);
         URL.revokeObjectURL(url);
-        setNotification(
+        toast.success(
           t("view.exportedTo", { filename: result.suggestedFilename }),
         );
-        setTimeout(() => setNotification(null), 3000);
       } catch (err) {
-        console.error("Failed to export persona:", err);
+        toast.error(formatAgentError(err, t("view.exportFailed")));
       }
     },
     [t],
   );
 
-  const importInputRef = useRef<HTMLInputElement>(null);
+  const handleImportError = useCallback((message: string) => {
+    toast.error(message);
+  }, []);
 
-  const handleImportFile = useCallback(
-    async (e: React.ChangeEvent<HTMLInputElement>) => {
-      const file = e.target.files?.[0];
-      if (!file) return;
-
-      try {
-        const arrayBuffer = await file.arrayBuffer();
-        const bytes = Array.from(new Uint8Array(arrayBuffer));
-        await importPersonas(bytes, file.name);
-        await refreshFromDisk();
-      } catch (err) {
-        console.error("Failed to import persona:", err);
-      }
-
-      // Reset the input so the same file can be re-selected
-      if (importInputRef.current) {
-        importInputRef.current.value = "";
-      }
+  const validateImportFile = useCallback(
+    (file: Pick<File, "name" | "type">) => {
+      const message = validatePersonaImportFile(file);
+      return message ? t(message.key, message.options) : null;
     },
-    [refreshFromDisk],
+    [t],
   );
 
   const handleImportFileBytes = useCallback(
     async (fileBytes: number[], fileName: string) => {
       try {
-        await importPersonas(fileBytes, fileName);
+        const imported = await importPersonas(fileBytes, fileName);
         await refreshFromDisk();
+        const message = formatImportSuccessMessage(imported.length);
+        toast.success(t(message.key, message.options));
       } catch (err) {
-        console.error("Failed to import persona:", err);
+        toast.error(formatAgentError(err, t("view.importFailed")));
       }
     },
-    [refreshFromDisk],
+    [refreshFromDisk, t],
   );
+
+  const handleImportPicker = useCallback(async () => {
+    try {
+      const selected = await open({
+        multiple: false,
+        directory: false,
+        title: t("common:actions.import"),
+        filters: [
+          {
+            name: "JSON",
+            extensions: ["json"],
+          },
+        ],
+      });
+
+      if (!selected || Array.isArray(selected)) {
+        return;
+      }
+
+      const { fileBytes, fileName } = await readImportPersonaFile(selected);
+      const validationMessage = validateImportFile({
+        name: fileName,
+        type: "",
+      });
+
+      if (validationMessage) {
+        toast.error(validationMessage);
+        return;
+      }
+
+      await handleImportFileBytes(fileBytes, fileName);
+    } catch (err) {
+      toast.error(formatAgentError(err, t("view.importFailed")));
+    }
+  }, [handleImportFileBytes, t, validateImportFile]);
 
   return (
     <div className="flex flex-1 flex-col h-full min-h-0">
@@ -228,18 +233,11 @@ export function AgentsView() {
               </p>
             </div>
             <div className="flex items-center gap-2">
-              <input
-                ref={importInputRef}
-                type="file"
-                accept=".persona.json,.json"
-                className="hidden"
-                onChange={handleImportFile}
-              />
               <Button
                 type="button"
                 variant="outline-flat"
                 size="sm"
-                onClick={() => importInputRef.current?.click()}
+                onClick={() => void handleImportPicker()}
               >
                 <Upload className="w-3.5 h-3.5" />
                 {t("common:actions.import")}
@@ -267,44 +265,17 @@ export function AgentsView() {
           <section aria-labelledby="personas-heading">
             <PersonaGallery
               personas={filteredPersonas}
-              onSelectPersona={(p) => openPersonaEditor(p)}
-              onEditPersona={(p) => openPersonaEditor(p)}
+              onSelectPersona={(p) => openPersonaEditor(p, "details")}
+              onEditPersona={(p) => openPersonaEditor(p, "edit")}
               onDuplicatePersona={handleDuplicatePersona}
               onDeletePersona={handleDeletePersona}
               onExportPersona={handleExportPersona}
               onCreatePersona={() => openPersonaEditor()}
               onImportFile={handleImportFileBytes}
+              validateImportFile={validateImportFile}
+              onImportError={handleImportError}
               isLoading={personasLoading}
             />
-          </section>
-
-          {/* Active Agents section */}
-          <section aria-labelledby="agents-heading">
-            <h2
-              id="agents-heading"
-              className="text-lg font-semibold font-display tracking-tight mb-3"
-            >
-              {t("view.activeAgents")}
-            </h2>
-            {filteredAgents.length === 0 ? (
-              <div className="flex flex-col items-center justify-center gap-3 py-12 text-muted-foreground">
-                <Bot className="h-10 w-10 opacity-30" />
-                <div className="text-center">
-                  <p className="text-sm font-medium">
-                    {t("view.emptyAgentsTitle")}
-                  </p>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    {t("view.emptyAgentsDescription")}
-                  </p>
-                </div>
-              </div>
-            ) : (
-              <ul className="space-y-2" aria-label={t("view.activeAgentsAria")}>
-                {filteredAgents.map((agent) => (
-                  <AgentRow key={agent.id} agent={agent} />
-                ))}
-              </ul>
-            )}
           </section>
         </div>
       </div>
@@ -313,9 +284,12 @@ export function AgentsView() {
       <PersonaEditor
         persona={editingPersona ?? undefined}
         isOpen={personaEditorOpen}
+        mode={personaEditorMode}
         onClose={closePersonaEditor}
         onSave={handleSavePersona}
         onDuplicate={handleDuplicatePersona}
+        onEdit={(persona) => openPersonaEditor(persona, "edit")}
+        onDelete={handleDeletePersona}
       />
 
       {/* Delete confirmation dialog */}
@@ -343,13 +317,6 @@ export function AgentsView() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-
-      {/* Export notification toast */}
-      {notification && (
-        <div className="fixed bottom-4 right-4 z-50 rounded-lg border border-border bg-background px-4 py-3 shadow-popover text-sm animate-in fade-in slide-in-from-bottom-2">
-          {notification}
-        </div>
-      )}
     </div>
   );
 }

--- a/ui/goose2/src/features/agents/ui/PersonaCard.tsx
+++ b/ui/goose2/src/features/agents/ui/PersonaCard.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/shared/ui/dropdown-menu";
 import { useAvatarSrc } from "@/shared/hooks/useAvatarSrc";
 import type { Persona } from "@/shared/types/agents";
+import { getPersonaSource } from "@/features/agents/lib/personaPresentation";
 
 interface PersonaCardProps {
   persona: Persona;
@@ -38,18 +39,30 @@ export function PersonaCard({
 
   const initials = persona.displayName.charAt(0).toUpperCase();
   const avatarSrc = useAvatarSrc(persona.avatar);
+  const personaSource = getPersonaSource(persona);
+  const canEditPersona = personaSource === "custom";
+  const canDeletePersona = personaSource !== "builtin";
+  const providerModelLabel = [persona.provider, persona.model]
+    .filter(Boolean)
+    .join(" / ");
+
+  const handleCardKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.target !== event.currentTarget || menuOpen) {
+      return;
+    }
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onSelect?.(persona);
+    }
+  };
 
   return (
-    <section
+    // biome-ignore lint/a11y/useSemanticElements: card contains nested menu buttons, so a native button is not valid here
+    <div
       aria-label={t("card.ariaLabel", { name: persona.displayName })}
+      role="button"
       onClick={() => !menuOpen && onSelect?.(persona)}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          onSelect?.(persona);
-        }
-      }}
-      // biome-ignore lint/a11y/noNoninteractiveTabindex: card needs keyboard focus but contains nested interactive buttons
+      onKeyDown={handleCardKeyDown}
       tabIndex={0}
       className={cn(
         "group relative flex flex-col items-center gap-3 rounded-xl border p-5 cursor-pointer",
@@ -68,6 +81,7 @@ export function PersonaCard({
               size="icon-xs"
               aria-label={t("card.options")}
               onClick={(e) => e.stopPropagation()}
+              onKeyDown={(event) => event.stopPropagation()}
               className={cn(
                 "size-6 rounded-md text-muted-foreground hover:text-foreground",
                 menuOpen ? "opacity-100" : "opacity-0 group-hover:opacity-100",
@@ -77,10 +91,12 @@ export function PersonaCard({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" sideOffset={4}>
-            <DropdownMenuItem onSelect={() => onEdit?.(persona)}>
-              <Pencil className="size-3.5" />
-              {t("common:actions.edit")}
-            </DropdownMenuItem>
+            {canEditPersona && (
+              <DropdownMenuItem onSelect={() => onEdit?.(persona)}>
+                <Pencil className="size-3.5" />
+                {t("common:actions.edit")}
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem onSelect={() => onDuplicate?.(persona)}>
               <Copy className="size-3.5" />
               {t("common:actions.duplicate")}
@@ -89,7 +105,7 @@ export function PersonaCard({
               <Download className="size-3.5" />
               {t("common:actions.export")}
             </DropdownMenuItem>
-            {!persona.isBuiltin && !persona.isFromDisk && (
+            {canDeletePersona && (
               <DropdownMenuItem
                 variant="destructive"
                 onSelect={() => onDelete?.(persona)}
@@ -116,9 +132,14 @@ export function PersonaCard({
       </h3>
 
       {/* Built-in badge */}
-      {persona.isBuiltin && (
+      {personaSource === "builtin" && (
         <Badge variant="secondary" className="text-[10px]">
           {t("common:labels.builtIn")}
+        </Badge>
+      )}
+      {personaSource === "file" && (
+        <Badge variant="secondary" className="text-[10px]">
+          {t("card.fileBacked")}
         </Badge>
       )}
 
@@ -128,15 +149,13 @@ export function PersonaCard({
       </p>
 
       {/* Provider/model badge */}
-      {(persona.provider || persona.model) && (
-        <Badge variant="secondary" className="text-[10px]">
-          {persona.provider && <span>{persona.provider}</span>}
-          {persona.provider && persona.model && (
-            <span aria-hidden="true">/</span>
-          )}
-          {persona.model && <span>{persona.model}</span>}
+      {providerModelLabel && (
+        <Badge variant="secondary" className="max-w-full min-w-0 text-[10px]">
+          <span className="block max-w-full truncate">
+            {providerModelLabel}
+          </span>
         </Badge>
       )}
-    </section>
+    </div>
   );
 }

--- a/ui/goose2/src/features/agents/ui/PersonaDetails.tsx
+++ b/ui/goose2/src/features/agents/ui/PersonaDetails.tsx
@@ -1,0 +1,108 @@
+import { useTranslation } from "react-i18next";
+import {
+  Avatar as AvatarRoot,
+  AvatarFallback,
+  AvatarImage,
+} from "@/shared/ui/avatar";
+import { Badge } from "@/shared/ui/badge";
+import { MessageResponse } from "@/shared/ui/ai-elements/message";
+import { useAvatarSrc } from "@/shared/hooks/useAvatarSrc";
+import type { Avatar } from "@/shared/types/agents";
+import type { PersonaSource } from "@/features/agents/lib/personaPresentation";
+
+interface PersonaDetailsProps {
+  avatar: Avatar | null;
+  displayName: string;
+  modelLabel: string;
+  personaSource: PersonaSource;
+  providerLabel: string;
+  systemPrompt: string;
+}
+
+export function PersonaDetails({
+  avatar,
+  displayName,
+  modelLabel,
+  personaSource,
+  providerLabel,
+  systemPrompt,
+}: PersonaDetailsProps) {
+  const { t } = useTranslation(["agents", "common"]);
+  const avatarSrc = useAvatarSrc(avatar);
+  const initials = displayName.charAt(0).toUpperCase() || "?";
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-5">
+      <div className="space-y-4">
+        <section className="rounded-xl border border-border bg-muted/20 p-4">
+          <div className="flex items-start gap-4">
+            <AvatarRoot className="h-16 w-16 border border-border bg-background">
+              <AvatarImage
+                src={avatarSrc ?? undefined}
+                alt={t("avatar.previewAlt")}
+              />
+              <AvatarFallback className="text-lg font-semibold">
+                {initials}
+              </AvatarFallback>
+            </AvatarRoot>
+            <div className="min-w-0 flex-1 space-y-2">
+              <div className="space-y-1">
+                <p className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+                  {t("editor.displayName")}
+                </p>
+                <h2 className="text-base font-semibold tracking-tight">
+                  {displayName}
+                </h2>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                {personaSource === "builtin" ? (
+                  <Badge variant="secondary">
+                    {t("common:labels.builtIn")}
+                  </Badge>
+                ) : null}
+                {personaSource === "file" ? (
+                  <Badge variant="secondary">{t("card.fileBacked")}</Badge>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-2 rounded-xl border border-border bg-background p-4">
+            <p className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+              {t("editor.provider")}
+            </p>
+            <p className="text-sm font-medium text-foreground">
+              {providerLabel}
+            </p>
+          </div>
+          <div className="space-y-2 rounded-xl border border-border bg-background p-4">
+            <p className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+              {t("editor.model")}
+            </p>
+            <p className="text-sm font-medium text-foreground">{modelLabel}</p>
+          </div>
+        </section>
+
+        <section className="space-y-2 rounded-xl border border-border bg-background p-4">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+              {t("editor.systemPrompt")}
+            </p>
+            <span className="text-[10px] text-muted-foreground">
+              {t("common:labels.characterCount", {
+                count: systemPrompt.length,
+              })}
+            </span>
+          </div>
+          <div className="rounded-lg border border-border bg-muted/20 px-4 py-3">
+            <MessageResponse className="min-w-0 text-sm leading-6">
+              {systemPrompt}
+            </MessageResponse>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/ui/goose2/src/features/agents/ui/PersonaEditor.tsx
+++ b/ui/goose2/src/features/agents/ui/PersonaEditor.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Copy } from "lucide-react";
+import { Copy, Pencil, Trash2 } from "lucide-react";
 import { cn } from "@/shared/lib/cn";
 import {
   Avatar as AvatarRoot,
@@ -11,6 +11,7 @@ import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
 import { Label } from "@/shared/ui/label";
 import { Textarea } from "@/shared/ui/textarea";
+import { useAvatarSrc } from "@/shared/hooks/useAvatarSrc";
 import {
   Dialog,
   DialogContent,
@@ -25,52 +26,83 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/shared/ui/select";
+import type { Persona, ProviderType, Avatar } from "@/shared/types/agents";
 import type {
-  Persona,
-  ProviderType,
-  Avatar,
   CreatePersonaRequest,
   UpdatePersonaRequest,
 } from "@/shared/types/agents";
-import { discoverAcpProviders, type AcpProvider } from "@/shared/api/acp";
+import { useAgentStore } from "@/features/agents/stores/agentStore";
+import { useProviderInventory } from "@/features/providers/hooks/useProviderInventory";
+import { getProviderInventory } from "@/features/providers/api/inventory";
+import { useProviderInventoryStore } from "@/features/providers/stores/providerInventoryStore";
+import {
+  getPersonaSource,
+  isPersonaReadOnly,
+} from "@/features/agents/lib/personaPresentation";
 import { AvatarDropZone } from "./AvatarDropZone";
+import { PersonaDetails } from "./PersonaDetails";
 
 interface PersonaEditorProps {
   persona?: Persona;
   isOpen: boolean;
+  mode?: "create" | "edit" | "details";
   onClose: () => void;
   onSave: (data: CreatePersonaRequest | UpdatePersonaRequest) => void;
   onDuplicate?: (persona: Persona) => void;
+  onEdit?: (persona: Persona) => void;
+  onDelete?: (persona: Persona) => void;
   isPending?: boolean;
 }
 
 export function PersonaEditor({
   persona,
   isOpen,
+  mode = "create",
   onClose,
   onSave,
   onDuplicate,
+  onEdit,
+  onDelete,
   isPending = false,
 }: PersonaEditorProps) {
   const { t } = useTranslation(["agents", "common"]);
-  const isEditing = !!persona;
-  const isReadOnly = persona?.isBuiltin ?? false;
-
-  const [acpProviders, setAcpProviders] = useState<AcpProvider[]>([]);
-
-  useEffect(() => {
-    if (isOpen) {
-      discoverAcpProviders()
-        .then(setAcpProviders)
-        .catch(() => setAcpProviders([]));
-    }
-  }, [isOpen]);
+  const isEditing = mode === "edit";
+  const detailsMode = mode === "details";
+  const readOnlyBySource = persona ? isPersonaReadOnly(persona) : false;
+  const isReadOnly = detailsMode || readOnlyBySource;
+  const personaSource = persona ? getPersonaSource(persona) : "custom";
+  const canEditPersona = personaSource === "custom";
+  const canDeletePersona = personaSource !== "builtin";
+  const acpProviders = useAgentStore((s) => s.providers);
+  const mergeInventoryEntries = useProviderInventoryStore(
+    (s) => s.mergeEntries,
+  );
+  const { getEntry, getModelsForProvider } = useProviderInventory();
 
   const [displayName, setDisplayName] = useState("");
   const [avatar, setAvatar] = useState<Avatar | null>(null);
   const [systemPrompt, setSystemPrompt] = useState("");
   const [provider, setProvider] = useState<ProviderType | "">("");
   const [model, setModel] = useState("");
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    let cancelled = false;
+    void getProviderInventory()
+      .then((entries) => {
+        if (!cancelled) {
+          mergeInventoryEntries(entries);
+        }
+      })
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, mergeInventoryEntries]);
 
   useEffect(() => {
     if (isOpen && persona) {
@@ -90,6 +122,29 @@ export function PersonaEditor({
 
   const isValid =
     displayName.trim().length > 0 && systemPrompt.trim().length > 0;
+  const avatarSrc = useAvatarSrc(avatar);
+
+  const availableModels = provider ? getModelsForProvider(provider) : [];
+  const providerInventory = provider ? getEntry(provider) : undefined;
+  const modelStatusMessage =
+    providerInventory?.modelSelectionHint ??
+    providerInventory?.lastRefreshError;
+  const hasSavedModelOutsideInventory =
+    Boolean(model) && !availableModels.some((entry) => entry.id === model);
+  const modelSelectValue = hasSavedModelOutsideInventory
+    ? `__saved__:${model}`
+    : model || "__none__";
+
+  const readOnlyDescription = persona
+    ? personaSource === "builtin"
+      ? t("editor.readOnlyBuiltIn")
+      : t("editor.readOnlyFile")
+    : null;
+  const providerLabel = provider
+    ? (acpProviders.find((providerOption) => providerOption.id === provider)
+        ?.label ?? provider)
+    : t("common:labels.none");
+  const modelLabel = model || t("common:labels.none");
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
@@ -127,147 +182,259 @@ export function PersonaEditor({
       <DialogContent className="max-w-lg max-h-[85vh] flex flex-col gap-0 p-0">
         <DialogHeader className="shrink-0 px-5 py-4">
           <DialogTitle className="text-sm">
-            {isReadOnly
+            {detailsMode
               ? persona?.displayName
               : isEditing
                 ? t("editor.editTitle")
                 : t("editor.newTitle")}
           </DialogTitle>
+          {readOnlyDescription ? (
+            <p className="text-xs text-muted-foreground">
+              {readOnlyDescription}
+            </p>
+          ) : null}
         </DialogHeader>
 
-        <form
-          id="persona-form"
-          onSubmit={handleSubmit}
-          className="min-h-0 flex-1 overflow-y-auto space-y-4 px-5 pb-5"
-        >
-          {/* Avatar drop zone */}
-          <div className="flex justify-center">
-            {isReadOnly ? (
-              <AvatarRoot className="h-16 w-16 border border-border">
-                <AvatarImage
-                  src={avatar?.type === "url" ? avatar.value : undefined}
-                  alt={t("avatar.previewAlt")}
+        {detailsMode ? (
+          <PersonaDetails
+            avatar={avatar}
+            displayName={displayName}
+            modelLabel={modelLabel}
+            personaSource={personaSource}
+            providerLabel={providerLabel}
+            systemPrompt={systemPrompt}
+          />
+        ) : (
+          <form
+            id="persona-form"
+            onSubmit={handleSubmit}
+            className="min-h-0 flex-1 overflow-y-auto space-y-4 px-5 pb-5"
+          >
+            <div className="flex justify-center">
+              {isReadOnly ? (
+                <AvatarRoot className="h-16 w-16 border border-border">
+                  <AvatarImage
+                    src={avatarSrc ?? undefined}
+                    alt={t("avatar.previewAlt")}
+                  />
+                  <AvatarFallback className="text-lg font-semibold">
+                    {initials}
+                  </AvatarFallback>
+                </AvatarRoot>
+              ) : (
+                <AvatarDropZone
+                  personaId={avatarPersonaId}
+                  avatar={avatar}
+                  onChange={setAvatar}
+                  disabled={isReadOnly}
                 />
-                <AvatarFallback className="text-lg font-semibold">
-                  {initials}
-                </AvatarFallback>
-              </AvatarRoot>
-            ) : (
-              <AvatarDropZone
-                personaId={avatarPersonaId}
-                avatar={avatar}
-                onChange={setAvatar}
-                disabled={isReadOnly}
-              />
-            )}
-          </div>
+              )}
+            </div>
 
-          {/* Display Name */}
-          <div className="space-y-1">
-            <Label className="text-xs font-medium text-muted-foreground">
-              {t("editor.displayName")}{" "}
-              <span className="text-destructive">*</span>
-            </Label>
-            <Input
-              value={displayName}
-              onChange={(e) => setDisplayName(e.target.value)}
-              readOnly={isReadOnly}
-              required
-              placeholder={t("editor.displayNamePlaceholder")}
-              className={cn(isReadOnly && "opacity-70 cursor-not-allowed")}
-            />
-          </div>
-
-          {/* System Prompt */}
-          <div className="space-y-1">
-            <div className="flex items-center justify-between">
+            <div className="space-y-1">
               <Label className="text-xs font-medium text-muted-foreground">
-                {t("editor.systemPrompt")}{" "}
+                {t("editor.displayName")}{" "}
                 <span className="text-destructive">*</span>
               </Label>
-              <span className="text-[10px] text-muted-foreground">
-                {t("common:labels.characterCount", {
-                  count: systemPrompt.length,
-                })}
-              </span>
+              <Input
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                readOnly={isReadOnly}
+                required
+                placeholder={t("editor.displayNamePlaceholder")}
+                className={cn(isReadOnly && "opacity-70 cursor-not-allowed")}
+              />
             </div>
-            <Textarea
-              value={systemPrompt}
-              onChange={(e) => setSystemPrompt(e.target.value)}
-              readOnly={isReadOnly}
-              required
-              rows={6}
-              placeholder={t("editor.systemPromptPlaceholder")}
-              className={cn(
-                "leading-relaxed",
-                isReadOnly && "opacity-70 cursor-not-allowed",
-              )}
-            />
-          </div>
 
-          {/* Provider */}
-          <div className="space-y-1">
-            <Label className="text-xs font-medium text-muted-foreground">
-              {t("editor.provider")}
-            </Label>
-            <Select
-              value={provider || "__none__"}
-              onValueChange={(v: string) =>
-                setProvider(
-                  v === "__none__"
-                    ? ("" as ProviderType | "")
-                    : (v as ProviderType),
-                )
-              }
-              disabled={isReadOnly}
-            >
-              <SelectTrigger
+            <div className="space-y-1">
+              <div className="flex items-center justify-between">
+                <Label className="text-xs font-medium text-muted-foreground">
+                  {t("editor.systemPrompt")}{" "}
+                  <span className="text-destructive">*</span>
+                </Label>
+                <span className="text-[10px] text-muted-foreground">
+                  {t("common:labels.characterCount", {
+                    count: systemPrompt.length,
+                  })}
+                </span>
+              </div>
+              <Textarea
+                value={systemPrompt}
+                onChange={(e) => setSystemPrompt(e.target.value)}
+                readOnly={isReadOnly}
+                required
+                rows={6}
+                placeholder={t("editor.systemPromptPlaceholder")}
                 className={cn(
-                  "w-full",
+                  "leading-relaxed",
                   isReadOnly && "opacity-70 cursor-not-allowed",
                 )}
-              >
-                <SelectValue placeholder={t("common:labels.none")} />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="__none__">
-                  {t("common:labels.none")}
-                </SelectItem>
-                {acpProviders.map((providerOption) => (
-                  <SelectItem key={providerOption.id} value={providerOption.id}>
-                    {providerOption.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
+              />
+            </div>
 
-          {/* Model */}
-          <div className="space-y-1">
-            <Label className="text-xs font-medium text-muted-foreground">
-              {t("editor.model")}
-            </Label>
-            <Input
-              value={model}
-              onChange={(e) => setModel(e.target.value)}
-              readOnly={isReadOnly}
-              placeholder={t("editor.modelPlaceholder")}
-              className={cn(isReadOnly && "opacity-70 cursor-not-allowed")}
-            />
-          </div>
-        </form>
+            <div className="space-y-1">
+              <Label className="text-xs font-medium text-muted-foreground">
+                {t("editor.provider")}
+              </Label>
+              <Select
+                value={provider || "__none__"}
+                onValueChange={(v: string) => {
+                  const nextProvider =
+                    v === "__none__"
+                      ? ("" as ProviderType | "")
+                      : (v as ProviderType);
+                  setProvider(nextProvider);
+                  if (nextProvider !== provider) {
+                    setModel("");
+                  }
+                }}
+                disabled={isReadOnly}
+              >
+                <SelectTrigger
+                  className={cn(
+                    "w-full",
+                    isReadOnly && "opacity-70 cursor-not-allowed",
+                  )}
+                >
+                  <SelectValue placeholder={t("common:labels.none")} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__none__">
+                    {t("common:labels.none")}
+                  </SelectItem>
+                  {acpProviders.map((providerOption) => (
+                    <SelectItem
+                      key={providerOption.id}
+                      value={providerOption.id}
+                    >
+                      {providerOption.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1">
+              <Label className="text-xs font-medium text-muted-foreground">
+                {t("editor.model")}
+              </Label>
+              <Select
+                value={modelSelectValue}
+                onValueChange={(value: string) => {
+                  if (value === "__none__") {
+                    setModel("");
+                    return;
+                  }
+                  if (value.startsWith("__saved__:")) {
+                    setModel(value.slice("__saved__:".length));
+                    return;
+                  }
+                  setModel(value);
+                }}
+                disabled={isReadOnly || !provider}
+              >
+                <SelectTrigger
+                  className={cn(
+                    "w-full",
+                    isReadOnly && "opacity-70 cursor-not-allowed",
+                  )}
+                >
+                  <SelectValue
+                    placeholder={
+                      provider
+                        ? t("editor.modelPlaceholder")
+                        : t("editor.chooseProviderFirst")
+                    }
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__none__">
+                    {t("common:labels.none")}
+                  </SelectItem>
+                  {hasSavedModelOutsideInventory && (
+                    <SelectItem value={`__saved__:${model}`}>
+                      {t("editor.savedModelUnavailable", { model })}
+                    </SelectItem>
+                  )}
+                  {availableModels.map((modelOption) => (
+                    <SelectItem key={modelOption.id} value={modelOption.id}>
+                      {modelOption.displayName ?? modelOption.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {hasSavedModelOutsideInventory ? (
+                <p className="text-[11px] text-muted-foreground">
+                  {t("editor.savedModelUnavailableHelp")}
+                </p>
+              ) : !provider ? (
+                <p className="text-[11px] text-muted-foreground">
+                  {t("editor.chooseProviderFirst")}
+                </p>
+              ) : availableModels.length === 0 ? (
+                <p className="text-[11px] text-muted-foreground">
+                  {modelStatusMessage ?? t("editor.noModelsAvailable")}
+                </p>
+              ) : null}
+            </div>
+          </form>
+        )}
 
         <DialogFooter className="shrink-0 border-t px-5 py-4">
-          {isReadOnly && onDuplicate && persona ? (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => onDuplicate(persona)}
-            >
-              <Copy className="h-3.5 w-3.5" />
-              {t("editor.duplicate")}
-            </Button>
+          {detailsMode && persona ? (
+            <>
+              {onEdit && canEditPersona ? (
+                <Button
+                  type="button"
+                  variant="outline-flat"
+                  size="sm"
+                  onClick={() => onEdit(persona)}
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                  {t("common:actions.edit")}
+                </Button>
+              ) : null}
+              {onDuplicate ? (
+                <Button
+                  type="button"
+                  variant="outline-flat"
+                  size="sm"
+                  onClick={() => onDuplicate(persona)}
+                >
+                  <Copy className="h-3.5 w-3.5" />
+                  {t("editor.duplicate")}
+                </Button>
+              ) : null}
+              {onDelete && canDeletePersona ? (
+                <Button
+                  type="button"
+                  variant="destructive-flat"
+                  size="sm"
+                  onClick={() => onDelete(persona)}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                  {t("common:actions.delete")}
+                </Button>
+              ) : null}
+              <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+                {t("common:actions.close")}
+              </Button>
+            </>
+          ) : isReadOnly && onDuplicate && persona ? (
+            <>
+              <Button
+                type="button"
+                variant="outline-flat"
+                size="sm"
+                onClick={() => onDuplicate(persona)}
+              >
+                <Copy className="h-3.5 w-3.5" />
+                {t("editor.duplicate")}
+              </Button>
+              <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+                {t("common:actions.close")}
+              </Button>
+            </>
           ) : (
             <>
               <Button type="button" variant="ghost" size="sm" onClick={onClose}>

--- a/ui/goose2/src/features/agents/ui/PersonaEditor.tsx
+++ b/ui/goose2/src/features/agents/ui/PersonaEditor.tsx
@@ -95,14 +95,12 @@ export function PersonaEditor({
     let cancelled = false;
 
     const syncProviderOptions = async () => {
-      if (acpProviders.length === 0) {
-        try {
-          const providers = await discoverAcpProviders();
-          if (!cancelled && providers.length > 0) {
-            setProviders(providers);
-          }
-        } catch {}
-      }
+      try {
+        const providers = await discoverAcpProviders();
+        if (!cancelled) {
+          setProviders(providers);
+        }
+      } catch {}
 
       try {
         const entries = await getProviderInventory();
@@ -117,7 +115,7 @@ export function PersonaEditor({
     return () => {
       cancelled = true;
     };
-  }, [acpProviders.length, isOpen, mergeInventoryEntries, setProviders]);
+  }, [isOpen, mergeInventoryEntries, setProviders]);
 
   useEffect(() => {
     if (isOpen && persona) {

--- a/ui/goose2/src/features/agents/ui/PersonaEditor.tsx
+++ b/ui/goose2/src/features/agents/ui/PersonaEditor.tsx
@@ -150,7 +150,7 @@ export function PersonaEditor({
     ? `__saved__:${model}`
     : model || "__none__";
 
-  const readOnlyDescription = persona
+  const readOnlyDescription = readOnlyBySource
     ? personaSource === "builtin"
       ? t("editor.readOnlyBuiltIn")
       : t("editor.readOnlyFile")

--- a/ui/goose2/src/features/agents/ui/PersonaEditor.tsx
+++ b/ui/goose2/src/features/agents/ui/PersonaEditor.tsx
@@ -31,6 +31,7 @@ import type {
   CreatePersonaRequest,
   UpdatePersonaRequest,
 } from "@/shared/types/agents";
+import { discoverAcpProviders } from "@/shared/api/acp";
 import { useAgentStore } from "@/features/agents/stores/agentStore";
 import { useProviderInventory } from "@/features/providers/hooks/useProviderInventory";
 import { getProviderInventory } from "@/features/providers/api/inventory";
@@ -74,6 +75,7 @@ export function PersonaEditor({
   const canEditPersona = personaSource === "custom";
   const canDeletePersona = personaSource !== "builtin";
   const acpProviders = useAgentStore((s) => s.providers);
+  const setProviders = useAgentStore((s) => s.setProviders);
   const mergeInventoryEntries = useProviderInventoryStore(
     (s) => s.mergeEntries,
   );
@@ -91,18 +93,31 @@ export function PersonaEditor({
     }
 
     let cancelled = false;
-    void getProviderInventory()
-      .then((entries) => {
+
+    const syncProviderOptions = async () => {
+      if (acpProviders.length === 0) {
+        try {
+          const providers = await discoverAcpProviders();
+          if (!cancelled && providers.length > 0) {
+            setProviders(providers);
+          }
+        } catch {}
+      }
+
+      try {
+        const entries = await getProviderInventory();
         if (!cancelled) {
           mergeInventoryEntries(entries);
         }
-      })
-      .catch(() => {});
+      } catch {}
+    };
+
+    void syncProviderOptions();
 
     return () => {
       cancelled = true;
     };
-  }, [isOpen, mergeInventoryEntries]);
+  }, [acpProviders.length, isOpen, mergeInventoryEntries, setProviders]);
 
   useEffect(() => {
     if (isOpen && persona) {

--- a/ui/goose2/src/features/agents/ui/PersonaGallery.tsx
+++ b/ui/goose2/src/features/agents/ui/PersonaGallery.tsx
@@ -18,6 +18,8 @@ interface PersonaGalleryProps {
   onExportPersona?: (persona: Persona) => void;
   onCreatePersona: () => void;
   onImportFile?: (fileBytes: number[], fileName: string) => void;
+  validateImportFile?: (file: Pick<File, "name" | "type">) => string | null;
+  onImportError?: (message: string) => void;
   isLoading?: boolean;
 }
 
@@ -45,12 +47,16 @@ export function PersonaGallery({
   onExportPersona,
   onCreatePersona,
   onImportFile,
+  validateImportFile,
+  onImportError,
   isLoading = false,
 }: PersonaGalleryProps) {
   const { t } = useTranslation("agents");
   const { fileInputRef, isDragOver, dropHandlers, handleFileChange } =
     useFileImportZone({
       onImportFile: onImportFile ?? (() => {}),
+      validateFile: validateImportFile,
+      onImportError,
     });
   const sorted = useMemo(() => {
     const builtins = personas
@@ -120,7 +126,7 @@ export function PersonaGallery({
         <input
           ref={fileInputRef}
           type="file"
-          accept=".persona.json,.json"
+          accept=".json,application/json"
           className="hidden"
           onChange={handleFileChange}
         />

--- a/ui/goose2/src/features/agents/ui/__tests__/PersonaCard.test.tsx
+++ b/ui/goose2/src/features/agents/ui/__tests__/PersonaCard.test.tsx
@@ -52,7 +52,7 @@ describe("PersonaCard", () => {
     const persona = makePersona();
     render(<PersonaCard persona={persona} onSelect={onSelect} />);
 
-    await user.click(screen.getByLabelText(/^persona: /i));
+    await user.click(screen.getByLabelText(/^agent: /i));
     expect(onSelect).toHaveBeenCalledWith(persona);
   });
 
@@ -67,7 +67,7 @@ describe("PersonaCard", () => {
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: /persona options/i }));
+    await user.click(screen.getByRole("button", { name: /agent options/i }));
     expect(screen.getByRole("menu")).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: /edit/i })).toBeInTheDocument();
     expect(
@@ -87,8 +87,26 @@ describe("PersonaCard", () => {
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: /persona options/i }));
+    await user.click(screen.getByRole("button", { name: /agent options/i }));
     const deleteBtn = screen.queryByRole("menuitem", { name: /delete/i });
     expect(deleteBtn).toBeNull();
+  });
+
+  it("does not trigger selection when keyboard opens the options menu", async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <PersonaCard
+        persona={makePersona()}
+        onSelect={onSelect}
+        onDuplicate={vi.fn()}
+      />,
+    );
+
+    screen.getByRole("button", { name: /agent options/i }).focus();
+    await user.keyboard("{Enter}");
+
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(onSelect).not.toHaveBeenCalled();
   });
 });

--- a/ui/goose2/src/features/chat/hooks/__tests__/useChat.attachments.test.ts
+++ b/ui/goose2/src/features/chat/hooks/__tests__/useChat.attachments.test.ts
@@ -43,6 +43,7 @@ describe("useChat attachments", () => {
       isLoading: false,
       personaEditorOpen: false,
       editingPersona: null,
+      personaEditorMode: "create",
     });
     mockAcpCancelSession.mockResolvedValue(true);
     mockAcpPrepareSession.mockResolvedValue(undefined);

--- a/ui/goose2/src/features/chat/hooks/__tests__/useChat.test.ts
+++ b/ui/goose2/src/features/chat/hooks/__tests__/useChat.test.ts
@@ -108,6 +108,7 @@ describe("useChat", () => {
       isLoading: false,
       personaEditorOpen: false,
       editingPersona: null,
+      personaEditorMode: "create",
     });
     mockAcpSendMessage.mockResolvedValue(undefined);
     mockAcpCancelSession.mockResolvedValue(true);

--- a/ui/goose2/src/features/chat/hooks/__tests__/useChatSessionController.test.ts
+++ b/ui/goose2/src/features/chat/hooks/__tests__/useChatSessionController.test.ts
@@ -136,6 +136,7 @@ describe("useChatSessionController", () => {
       isLoading: false,
       personaEditorOpen: false,
       editingPersona: null,
+      personaEditorMode: "create",
     });
 
     useProjectStore.setState({

--- a/ui/goose2/src/features/chat/hooks/useChatSessionController.ts
+++ b/ui/goose2/src/features/chat/hooks/useChatSessionController.ts
@@ -25,6 +25,7 @@ import {
 interface UseChatSessionControllerOptions {
   sessionId: string | null;
   onMessageAccepted?: (sessionId: string) => void;
+  onCreatePersonaRequested?: () => void;
 }
 
 const PENDING_HOME_SESSION_ID = "__home_pending__";
@@ -32,6 +33,7 @@ const PENDING_HOME_SESSION_ID = "__home_pending__";
 export function useChatSessionController({
   sessionId,
   onMessageAccepted,
+  onCreatePersonaRequested,
 }: UseChatSessionControllerOptions) {
   const stateSessionId = sessionId ?? PENDING_HOME_SESSION_ID;
   const {
@@ -291,7 +293,12 @@ export function useChatSessionController({
 
   const handlePersonaChange = useCallback(
     (personaId: string | null) => {
+      if (personaId === selectedPersonaId) {
+        return;
+      }
+
       const persona = personas.find((candidate) => candidate.id === personaId);
+
       if (persona?.provider) {
         const matchingProvider = providers.find(
           (provider) =>
@@ -328,6 +335,7 @@ export function useChatSessionController({
       personas,
       providers,
       sessionId,
+      selectedPersonaId,
       setGlobalSelectedProvider,
     ],
   );
@@ -386,7 +394,6 @@ export function useChatSessionController({
     sessionId ? chatState : "thinking",
     sendMessage,
   );
-  const chatStore = useChatStore();
 
   const handleSend = useCallback(
     (text: string, personaId?: string, attachments?: ChatAttachmentDraft[]) => {
@@ -398,24 +405,6 @@ export function useChatSessionController({
       }
 
       if (personaId && personaId !== selectedPersonaId) {
-        const nextPersona = personas.find(
-          (persona) => persona.id === personaId,
-        );
-        if (nextPersona) {
-          chatStore.addMessage(sessionId, {
-            id: crypto.randomUUID(),
-            role: "system",
-            created: Date.now(),
-            content: [
-              {
-                type: "systemNotification",
-                notificationType: "info",
-                text: `Switched to ${nextPersona.displayName}`,
-              },
-            ],
-            metadata: { userVisible: true, agentVisible: false },
-          });
-        }
         handlePersonaChange(personaId);
         deferredSend.current = { text, attachments };
         return;
@@ -430,9 +419,7 @@ export function useChatSessionController({
     },
     [
       chatState,
-      chatStore,
       handlePersonaChange,
-      personas,
       queue,
       sessionId,
       selectedPersonaId,
@@ -449,8 +436,12 @@ export function useChatSessionController({
   }, [selectedPersona, sendMessage]);
 
   const handleCreatePersona = useCallback(() => {
+    if (onCreatePersonaRequested) {
+      onCreatePersonaRequested();
+      return;
+    }
     useAgentStore.getState().openPersonaEditor();
-  }, []);
+  }, [onCreatePersonaRequested]);
 
   const sessionDraftValue = useChatStore((s) =>
     sessionId ? (s.draftsBySession[sessionId] ?? "") : "",

--- a/ui/goose2/src/features/chat/ui/AgentModelPicker.tsx
+++ b/ui/goose2/src/features/chat/ui/AgentModelPicker.tsx
@@ -32,6 +32,7 @@ interface AgentModelPickerProps {
   onModelChange?: (modelId: string) => void;
   loading?: boolean;
   isCompact?: boolean;
+  showSelectedModelInTrigger?: boolean;
 }
 
 function getModelDisplayName(model: ModelOption) {
@@ -321,6 +322,7 @@ export function AgentModelPicker({
   onModelChange,
   loading = false,
   isCompact = false,
+  showSelectedModelInTrigger = true,
 }: AgentModelPickerProps) {
   const { t } = useTranslation("chat");
   const [open, setOpen] = useState(false);
@@ -332,7 +334,9 @@ export function AgentModelPicker({
   const selectedAgentLabel =
     agents.find((agent) => agent.id === selectedAgentId)?.label ??
     formatProviderLabel(selectedAgentId);
-  const hasSelectedModel = currentModelName !== null || currentModelId !== null;
+  const hasSelectedModel =
+    showSelectedModelInTrigger &&
+    (currentModelName !== null || currentModelId !== null);
   const triggerModelLabel = hasSelectedModel
     ? (currentModelName ?? currentModelId)
     : null;

--- a/ui/goose2/src/features/chat/ui/ChatInputToolbar.tsx
+++ b/ui/goose2/src/features/chat/ui/ChatInputToolbar.tsx
@@ -220,6 +220,7 @@ export function ChatInputToolbar({
             onModelChange={onModelChange}
             loading={providersLoading}
             isCompact={isCompact}
+            showSelectedModelInTrigger={selectedPersonaId === null}
           />
         )}
 

--- a/ui/goose2/src/features/chat/ui/ChatView.tsx
+++ b/ui/goose2/src/features/chat/ui/ChatView.tsx
@@ -14,12 +14,17 @@ import { useChatSessionController } from "../hooks/useChatSessionController";
 
 interface ChatViewProps {
   sessionId: string;
+  onCreatePersona?: () => void;
   onCreateProject?: (options?: {
     onCreated?: (projectId: string) => void;
   }) => void;
 }
 
-export function ChatView({ sessionId, onCreateProject }: ChatViewProps) {
+export function ChatView({
+  sessionId,
+  onCreatePersona,
+  onCreateProject,
+}: ChatViewProps) {
   const { t } = useTranslation("chat");
   const mountStart = useRef(performance.now());
   const isContextPanelOpen = useChatSessionStore(
@@ -29,7 +34,10 @@ export function ChatView({ sessionId, onCreateProject }: ChatViewProps) {
   const [globalArtifactRoot, setGlobalArtifactRoot] = useState<string | null>(
     null,
   );
-  const controller = useChatSessionController({ sessionId });
+  const controller = useChatSessionController({
+    sessionId,
+    onCreatePersonaRequested: onCreatePersona,
+  });
   const contextPanelLabel = isContextPanelOpen
     ? t("context.closePanel")
     : t("context.openPanel");

--- a/ui/goose2/src/features/chat/ui/__tests__/ChatInput.test.tsx
+++ b/ui/goose2/src/features/chat/ui/__tests__/ChatInput.test.tsx
@@ -89,7 +89,7 @@ describe("ChatInput", () => {
   it("renders with default placeholder", () => {
     render(<ChatInput onSend={vi.fn()} />);
     expect(
-      screen.getByPlaceholderText("Message Goose, @ to mention personas"),
+      screen.getByPlaceholderText("Message Goose, @ to mention agents"),
     ).toBeInTheDocument();
   });
 

--- a/ui/goose2/src/features/home/ui/HomeScreen.test.tsx
+++ b/ui/goose2/src/features/home/ui/HomeScreen.test.tsx
@@ -178,7 +178,7 @@ describe("HomeScreen", () => {
   it("renders the chat input placeholder with default agent name when no persona selected", () => {
     renderHome();
     expect(
-      screen.getByPlaceholderText("Message Goose, @ to mention personas"),
+      screen.getByPlaceholderText("Message Goose, @ to mention agents"),
     ).toBeInTheDocument();
   });
 

--- a/ui/goose2/src/features/home/ui/HomeScreen.tsx
+++ b/ui/goose2/src/features/home/ui/HomeScreen.tsx
@@ -41,6 +41,7 @@ function getGreetingKey(hour: number): "morning" | "afternoon" | "evening" {
 interface HomeScreenProps {
   sessionId: string | null;
   onActivateSession: (sessionId: string) => void;
+  onCreatePersona?: () => void;
   onCreateProject?: (options?: {
     onCreated?: (projectId: string) => void;
   }) => void;
@@ -49,15 +50,18 @@ interface HomeScreenProps {
 function HomeComposer({
   sessionId,
   onActivateSession,
+  onCreatePersona,
   onCreateProject,
 }: {
   sessionId: string | null;
   onActivateSession: (sessionId: string) => void;
+  onCreatePersona?: () => void;
   onCreateProject?: HomeScreenProps["onCreateProject"];
 }) {
   const controller = useChatSessionController({
     sessionId,
     onMessageAccepted: onActivateSession,
+    onCreatePersonaRequested: onCreatePersona,
   });
 
   return (
@@ -107,6 +111,7 @@ function HomeComposer({
 export function HomeScreen({
   sessionId,
   onActivateSession,
+  onCreatePersona,
   onCreateProject,
 }: HomeScreenProps) {
   const { t } = useTranslation("home");
@@ -126,6 +131,7 @@ export function HomeScreen({
           <HomeComposer
             sessionId={sessionId}
             onActivateSession={onActivateSession}
+            onCreatePersona={onCreatePersona}
             onCreateProject={onCreateProject}
           />
         </div>

--- a/ui/goose2/src/features/providers/api/inventory.ts
+++ b/ui/goose2/src/features/providers/api/inventory.ts
@@ -10,7 +10,7 @@ export async function getProviderInventory(
 ): Promise<ProviderInventoryEntryDto[]> {
   const client = await getClient();
   const t0 = performance.now();
-  const response = await client.goose.GooseProvidersInventory({ providerIds });
+  const response = await client.goose.GooseProvidersList({ providerIds });
   perfLog(
     `[perf:inventory] getProviderInventory done in ${(performance.now() - t0).toFixed(1)}ms (n=${response.entries.length})`,
   );

--- a/ui/goose2/src/features/providers/api/inventory.ts
+++ b/ui/goose2/src/features/providers/api/inventory.ts
@@ -10,7 +10,7 @@ export async function getProviderInventory(
 ): Promise<ProviderInventoryEntryDto[]> {
   const client = await getClient();
   const t0 = performance.now();
-  const response = await client.goose.GooseProvidersList({ providerIds });
+  const response = await client.goose.GooseProvidersInventory({ providerIds });
   perfLog(
     `[perf:inventory] getProviderInventory done in ${(performance.now() - t0).toFixed(1)}ms (n=${response.entries.length})`,
   );

--- a/ui/goose2/src/features/skills/ui/__tests__/SkillsView.test.tsx
+++ b/ui/goose2/src/features/skills/ui/__tests__/SkillsView.test.tsx
@@ -47,7 +47,7 @@ describe("SkillsView", () => {
       render(<SkillsView />);
       expect(screen.getByText("Skills")).toBeInTheDocument();
       expect(
-        screen.getByText("Reusable instructions for your AI personas"),
+        screen.getByText("Reusable instructions for your AI agents"),
       ).toBeInTheDocument();
     });
 

--- a/ui/goose2/src/shared/api/acpApi.ts
+++ b/ui/goose2/src/shared/api/acpApi.ts
@@ -31,11 +31,11 @@ export async function listProviders(): Promise<AcpProvider[]> {
     providerIds: [],
   });
 
-  const providers = result.entries
-    .filter((entry) => !DEPRECATED_PROVIDER_IDS.has(entry.providerId))
+  const providers = result.providers
+    .filter((entry) => !DEPRECATED_PROVIDER_IDS.has(entry.id))
     .map((entry) => ({
-      id: entry.providerId,
-      label: entry.providerName,
+      id: entry.id,
+      label: entry.label,
     }));
 
   return [DEFAULT_PROVIDER, ...providers];

--- a/ui/goose2/src/shared/api/acpApi.ts
+++ b/ui/goose2/src/shared/api/acpApi.ts
@@ -31,11 +31,11 @@ export async function listProviders(): Promise<AcpProvider[]> {
     providerIds: [],
   });
 
-  const providers = result.providers
-    .filter((entry) => !DEPRECATED_PROVIDER_IDS.has(entry.id))
+  const providers = result.entries
+    .filter((entry) => !DEPRECATED_PROVIDER_IDS.has(entry.providerId))
     .map((entry) => ({
-      id: entry.id,
-      label: entry.label,
+      id: entry.providerId,
+      label: entry.providerName,
     }));
 
   return [DEFAULT_PROVIDER, ...providers];

--- a/ui/goose2/src/shared/api/agents.ts
+++ b/ui/goose2/src/shared/api/agents.ts
@@ -46,6 +46,17 @@ export async function importPersonas(
   return invoke("import_personas", { fileBytes, fileName });
 }
 
+export interface ImportFileReadResult {
+  fileBytes: number[];
+  fileName: string;
+}
+
+export async function readImportPersonaFile(
+  sourcePath: string,
+): Promise<ImportFileReadResult> {
+  return invoke("read_import_persona_file", { sourcePath });
+}
+
 export async function savePersonaAvatar(
   personaId: string,
   sourcePath: string,

--- a/ui/goose2/src/shared/hooks/useFileImportZone.ts
+++ b/ui/goose2/src/shared/hooks/useFileImportZone.ts
@@ -2,23 +2,34 @@ import { useCallback, useRef, useState } from "react";
 
 interface FileImportZoneOptions {
   onImportFile: (fileBytes: number[], fileName: string) => void;
+  validateFile?: (file: Pick<File, "name" | "type">) => string | null;
+  onImportError?: (message: string) => void;
 }
 
 /**
  * Shared drag-and-drop + file-picker infrastructure for import zones.
  * Returns state, handlers, and a ref for the hidden `<input type="file">`.
  */
-export function useFileImportZone({ onImportFile }: FileImportZoneOptions) {
+export function useFileImportZone({
+  onImportFile,
+  validateFile,
+  onImportError,
+}: FileImportZoneOptions) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isDragOver, setIsDragOver] = useState(false);
 
   const importFile = useCallback(
     async (file: File) => {
+      const validationMessage = validateFile?.(file);
+      if (validationMessage) {
+        onImportError?.(validationMessage);
+        return;
+      }
       const buffer = await file.arrayBuffer();
       const bytes = Array.from(new Uint8Array(buffer));
       onImportFile(bytes, file.name);
     },
-    [onImportFile],
+    [onImportFile, onImportError, validateFile],
   );
 
   const dropHandlers = {

--- a/ui/goose2/src/shared/i18n/locales/en/agents.json
+++ b/ui/goose2/src/shared/i18n/locales/en/agents.json
@@ -10,43 +10,54 @@
     "uploadAria": "Drop an image or click to upload avatar"
   },
   "card": {
-    "ariaLabel": "Persona: {{name}}",
-    "options": "Persona options"
+    "ariaLabel": "Agent: {{name}}",
+    "fileBacked": "File-backed",
+    "options": "Agent options"
   },
   "config": {
     "ariaLabel": "Agent configuration",
     "createAgent": "Create Agent",
-    "fromPersona": "(from persona: {{value}})",
+    "fromPersona": "(from agent: {{value}})",
     "model": "Model",
     "modelPlaceholder": "e.g. claude-sonnet-4-20250514",
     "name": "Name",
     "namePlaceholder": "My Agent",
-    "persona": "Persona",
+    "persona": "Agent",
     "provider": "Provider",
     "systemPromptOverrideCollapsed": "System Prompt Override [+]",
     "systemPromptOverrideExpanded": "System Prompt Override [-]",
-    "systemPromptPlaceholder": "Override the persona system prompt...",
+    "systemPromptPlaceholder": "Override the agent system prompt...",
     "updateAgent": "Update Agent"
   },
   "editor": {
     "create": "Create",
+    "created": "Agent created.",
     "displayName": "Display Name",
     "displayNamePlaceholder": "e.g. Code Reviewer",
     "duplicate": "Duplicate",
-    "editTitle": "Edit Persona",
+    "duplicated": "Agent duplicated.",
+    "chooseProviderFirst": "Select a provider to choose a model.",
+    "editTitle": "Edit Agent",
     "model": "Model",
-    "modelPlaceholder": "e.g. claude-sonnet-4-20250514",
-    "newTitle": "New Persona",
+    "modelPlaceholder": "Select a model",
+    "newTitle": "New Agent",
+    "noModelsAvailable": "No models are available for this provider yet.",
     "provider": "Provider",
+    "readOnlyBuiltIn": "Built-in agents are read-only. Duplicate to customize one.",
+    "readOnlyFile": "This agent is loaded from a file. You can review it here, but editing is disabled.",
+    "saveFailed": "Failed to save agent.",
+    "savedModelUnavailable": "{{model}} (saved, unavailable)",
+    "savedModelUnavailableHelp": "This agent uses a saved model that is not in the current provider inventory.",
     "saving": "Saving...",
     "systemPrompt": "System Prompt",
-    "systemPromptPlaceholder": "You are a helpful assistant that..."
+    "systemPromptPlaceholder": "You are a helpful assistant that...",
+    "updated": "Agent updated."
   },
   "gallery": {
-    "createAria": "Create new persona",
+    "createAria": "Create new agent",
     "dropFile": "or drop a file",
-    "loading": "Loading personas",
-    "new": "New Persona"
+    "loading": "Loading agents",
+    "new": "New Agent"
   },
   "statuses": {
     "error": "Error",
@@ -55,18 +66,24 @@
     "starting": "Starting"
   },
   "view": {
-    "activeAgents": "Active Agents",
-    "activeAgentsAria": "Active agents",
     "copyName": "{{name}} (Copy)",
+    "deleteFailed": "Failed to delete agent.",
     "deleteDescription": "Are you sure you want to delete \"{{name}}\"? This cannot be undone.",
-    "deleteTitle": "Delete persona?",
-    "description": "Custom persona configurations for specific workflows",
-    "emptyAgentsDescription": "Create an agent from a persona to get started.",
-    "emptyAgentsTitle": "No active agents",
+    "deleteTitle": "Delete agent?",
+    "deleted": "\"{{name}}\" deleted.",
+    "description": "Custom agent configurations for specific workflows",
+    "emptyAgentsDescription": "Create an agent to get started.",
+    "emptyAgentsTitle": "No agents yet",
+    "exportFailed": "Failed to export agent.",
     "exportedTo": "Exported to {{filename}}",
-    "newPersona": "New Persona",
+    "importInvalidExtension": "Unsupported file type. Choose a .json file.",
+    "importInvalidMimeType": "Unsupported file type. Choose a JSON file.",
+    "importFailed": "Failed to import agent.",
+    "imported_one": "Imported {{count}} agent.",
+    "imported_other": "Imported {{count}} agents.",
+    "newPersona": "New Agent",
     "optionsAria": "Options for {{name}}",
-    "searchPlaceholder": "Search personas...",
-    "title": "Personas"
+    "searchPlaceholder": "Search agents...",
+    "title": "Agents"
   }
 }

--- a/ui/goose2/src/shared/i18n/locales/en/chat.json
+++ b/ui/goose2/src/shared/i18n/locales/en/chat.json
@@ -108,7 +108,7 @@
   },
   "input": {
     "ariaLabel": "Chat message input",
-    "placeholder": "Message {{agent}}, @ to mention personas"
+    "placeholder": "Message {{agent}}, @ to mention agents"
   },
   "loading": {
     "compacting": "Compacting conversation...",
@@ -117,7 +117,7 @@
   },
   "mention": {
     "ariaLabel": "Mention suggestions",
-    "title": "Mention a persona",
+    "title": "Mention an agent",
     "filesTitle": "Files"
   },
   "message": {
@@ -127,9 +127,9 @@
   },
   "persona": {
     "chooseAssistant": "Choose assistant",
-    "create": "Create persona...",
+    "create": "Create agent...",
     "clearActive": "Clear active assistant",
-    "defaultDescription": "No persona - chat directly with the agent"
+    "defaultDescription": "No agent selected - chat directly with Goose"
   },
   "queue": {
     "dismiss": "Dismiss queued message",

--- a/ui/goose2/src/shared/i18n/locales/en/sessions.json
+++ b/ui/goose2/src/shared/i18n/locales/en/sessions.json
@@ -18,7 +18,7 @@
     "emptyNoMatchesHint": "Try a different search term.",
     "emptyTitle": "No sessions yet",
     "searchArchivedPlaceholder": "Search archived sessions...",
-    "searchError": "Message search failed. Showing title, persona, and project matches only.",
+    "searchError": "Message search failed. Showing title, agent, and project matches only.",
     "searchPlaceholder": "Search conversations",
     "searching": "Searching sessions...",
     "subtitle": "Browse and search past sessions",

--- a/ui/goose2/src/shared/i18n/locales/en/sidebar.json
+++ b/ui/goose2/src/shared/i18n/locales/en/sidebar.json
@@ -11,7 +11,7 @@
     "optionsFor": "Options for {{label}}"
   },
   "navigation": {
-    "agents": "Personas",
+    "agents": "Agents",
     "home": "Home",
     "sessionHistory": "Session History",
     "skills": "Skills"

--- a/ui/goose2/src/shared/i18n/locales/en/skills.json
+++ b/ui/goose2/src/shared/i18n/locales/en/skills.json
@@ -16,7 +16,7 @@
   "view": {
     "deleteDescription": "Are you sure you want to delete \"{{name}}\"? This cannot be undone.",
     "deleteTitle": "Delete skill?",
-    "description": "Reusable instructions for your AI personas",
+    "description": "Reusable instructions for your AI agents",
     "dropFile": "or drop a file",
     "emptyDescription": "Create a skill or drop a .skill.json file here.",
     "emptyTitle": "No skills yet",

--- a/ui/goose2/src/shared/i18n/locales/es/agents.json
+++ b/ui/goose2/src/shared/i18n/locales/es/agents.json
@@ -10,43 +10,54 @@
     "uploadAria": "Suelta una imagen o haz clic para subir un avatar"
   },
   "card": {
-    "ariaLabel": "Persona: {{name}}",
-    "options": "Opciones de la persona"
+    "ariaLabel": "Agente: {{name}}",
+    "fileBacked": "Desde archivo",
+    "options": "Opciones del agente"
   },
   "config": {
     "ariaLabel": "Configuración del agente",
     "createAgent": "Crear agente",
-    "fromPersona": "(desde la persona: {{value}})",
+    "fromPersona": "(desde el agente: {{value}})",
     "model": "Modelo",
     "modelPlaceholder": "p. ej. claude-sonnet-4-20250514",
     "name": "Nombre",
     "namePlaceholder": "Mi agente",
-    "persona": "Persona",
+    "persona": "Agente",
     "provider": "Proveedor",
     "systemPromptOverrideCollapsed": "Sobrescribir prompt del sistema [+]",
     "systemPromptOverrideExpanded": "Sobrescribir prompt del sistema [-]",
-    "systemPromptPlaceholder": "Sobrescribe el prompt del sistema de la persona...",
+    "systemPromptPlaceholder": "Sobrescribe el prompt del sistema del agente...",
     "updateAgent": "Actualizar agente"
   },
   "editor": {
     "create": "Crear",
+    "created": "Agente creado.",
     "displayName": "Nombre para mostrar",
     "displayNamePlaceholder": "p. ej. Revisor de código",
     "duplicate": "Duplicar",
-    "editTitle": "Editar persona",
+    "duplicated": "Agente duplicado.",
+    "chooseProviderFirst": "Selecciona un proveedor para elegir un modelo.",
+    "editTitle": "Editar agente",
     "model": "Modelo",
-    "modelPlaceholder": "p. ej. claude-sonnet-4-20250514",
-    "newTitle": "Nueva persona",
+    "modelPlaceholder": "Selecciona un modelo",
+    "newTitle": "Nuevo agente",
+    "noModelsAvailable": "Todavía no hay modelos disponibles para este proveedor.",
     "provider": "Proveedor",
+    "readOnlyBuiltIn": "Los agentes integrados son de solo lectura. Duplícalo para personalizarlo.",
+    "readOnlyFile": "Este agente se cargó desde un archivo. Puedes revisarlo aquí, pero la edición está deshabilitada.",
+    "saveFailed": "No se pudo guardar el agente.",
+    "savedModelUnavailable": "{{model}} (guardado, no disponible)",
+    "savedModelUnavailableHelp": "Este agente usa un modelo guardado que no está en el inventario actual del proveedor.",
     "saving": "Guardando...",
     "systemPrompt": "Prompt del sistema",
-    "systemPromptPlaceholder": "Eres un asistente útil que..."
+    "systemPromptPlaceholder": "Eres un asistente útil que...",
+    "updated": "Agente actualizado."
   },
   "gallery": {
-    "createAria": "Crear nueva persona",
+    "createAria": "Crear nuevo agente",
     "dropFile": "o suelta un archivo",
-    "loading": "Cargando personas",
-    "new": "Nueva persona"
+    "loading": "Cargando agentes",
+    "new": "Nuevo agente"
   },
   "statuses": {
     "error": "Error",
@@ -55,18 +66,24 @@
     "starting": "Iniciando"
   },
   "view": {
-    "activeAgents": "Agentes activos",
-    "activeAgentsAria": "Agentes activos",
     "copyName": "{{name}} (Copia)",
+    "deleteFailed": "No se pudo eliminar el agente.",
     "deleteDescription": "¿Seguro que quieres eliminar \"{{name}}\"? Esto no se puede deshacer.",
-    "deleteTitle": "¿Eliminar persona?",
-    "description": "Configuraciones de persona personalizadas para flujos de trabajo específicos",
-    "emptyAgentsDescription": "Crea un agente desde una persona para empezar.",
-    "emptyAgentsTitle": "No hay agentes activos",
+    "deleteTitle": "¿Eliminar agente?",
+    "deleted": "Se eliminó \"{{name}}\".",
+    "description": "Configuraciones de agente personalizadas para flujos de trabajo específicos",
+    "emptyAgentsDescription": "Crea un agente para empezar.",
+    "emptyAgentsTitle": "Aún no hay agentes",
+    "exportFailed": "No se pudo exportar el agente.",
     "exportedTo": "Exportado a {{filename}}",
-    "newPersona": "Nueva persona",
+    "importInvalidExtension": "Tipo de archivo no compatible. Elige un archivo .json.",
+    "importInvalidMimeType": "Tipo de archivo no compatible. Elige un archivo JSON.",
+    "importFailed": "No se pudo importar el agente.",
+    "imported_one": "Se importó {{count}} agente.",
+    "imported_other": "Se importaron {{count}} agentes.",
+    "newPersona": "Nuevo agente",
     "optionsAria": "Opciones de {{name}}",
-    "searchPlaceholder": "Buscar personas...",
-    "title": "Personas"
+    "searchPlaceholder": "Buscar agentes...",
+    "title": "Agentes"
   }
 }

--- a/ui/goose2/src/shared/i18n/locales/es/chat.json
+++ b/ui/goose2/src/shared/i18n/locales/es/chat.json
@@ -108,7 +108,7 @@
   },
   "input": {
     "ariaLabel": "Entrada de mensaje del chat",
-    "placeholder": "Enviar mensaje a {{agent}}, usa @ para mencionar personas"
+    "placeholder": "Enviar mensaje a {{agent}}, usa @ para mencionar agentes"
   },
   "loading": {
     "compacting": "Compactando conversación...",
@@ -117,7 +117,7 @@
   },
   "mention": {
     "ariaLabel": "Sugerencias de menciones",
-    "title": "Menciona una persona",
+    "title": "Menciona un agente",
     "filesTitle": "Archivos"
   },
   "message": {
@@ -127,9 +127,9 @@
   },
   "persona": {
     "chooseAssistant": "Elegir asistente",
-    "create": "Crear persona...",
+    "create": "Crear agente...",
     "clearActive": "Quitar asistente activo",
-    "defaultDescription": "Sin persona - chatea directamente con el agente"
+    "defaultDescription": "Sin agente seleccionado: chatea directamente con Goose"
   },
   "queue": {
     "dismiss": "Descartar mensaje en cola",

--- a/ui/goose2/src/shared/i18n/locales/es/sessions.json
+++ b/ui/goose2/src/shared/i18n/locales/es/sessions.json
@@ -18,7 +18,7 @@
     "emptyNoMatchesHint": "Prueba con otro término de búsqueda.",
     "emptyTitle": "Aún no hay sesiones",
     "searchArchivedPlaceholder": "Buscar sesiones archivadas...",
-    "searchError": "La búsqueda de mensajes falló. Mostrando solo coincidencias por título, persona y proyecto.",
+    "searchError": "La búsqueda de mensajes falló. Mostrando solo coincidencias por título, agente y proyecto.",
     "searchPlaceholder": "Buscar conversaciones",
     "searching": "Buscando sesiones...",
     "subtitle": "Explora y busca sesiones anteriores",

--- a/ui/goose2/src/shared/i18n/locales/es/sidebar.json
+++ b/ui/goose2/src/shared/i18n/locales/es/sidebar.json
@@ -11,7 +11,7 @@
     "optionsFor": "Opciones para {{label}}"
   },
   "navigation": {
-    "agents": "Personas",
+    "agents": "Agentes",
     "home": "Inicio",
     "sessionHistory": "Historial de sesiones",
     "skills": "Habilidades"

--- a/ui/goose2/src/shared/i18n/locales/es/skills.json
+++ b/ui/goose2/src/shared/i18n/locales/es/skills.json
@@ -16,7 +16,7 @@
   "view": {
     "deleteDescription": "¿Seguro que quieres eliminar \"{{name}}\"? Esto no se puede deshacer.",
     "deleteTitle": "¿Eliminar skill?",
-    "description": "Instrucciones reutilizables para tus personas de IA",
+    "description": "Instrucciones reutilizables para tus agentes de IA",
     "dropFile": "o suelta un archivo",
     "emptyDescription": "Crea una skill o suelta aquí un archivo .skill.json.",
     "emptyTitle": "Aún no hay skills",

--- a/ui/goose2/src/shared/ui/button.tsx
+++ b/ui/goose2/src/shared/ui/button.tsx
@@ -13,6 +13,8 @@ const buttonVariants = cva(
           "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90",
         destructive:
           "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        "destructive-flat":
+          "bg-destructive text-destructive-foreground shadow-none hover:bg-destructive/90",
         outline:
           "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
         "outline-flat":

--- a/ui/goose2/tests/e2e/drafts.spec.ts
+++ b/ui/goose2/tests/e2e/drafts.spec.ts
@@ -13,9 +13,9 @@ test.describe("Draft persistence", () => {
     // Wait for the 300ms debounce to persist the draft
     await page.waitForTimeout(500);
 
-    // Navigate away to Personas
-    await page.getByRole("button", { name: "Personas" }).click();
-    await expect(page.locator("h1", { hasText: "Personas" })).toBeVisible();
+    // Navigate away to Agents
+    await page.getByRole("button", { name: "Agents" }).click();
+    await expect(page.locator("h1", { hasText: "Agents" })).toBeVisible();
 
     // Navigate back to Home
     await page.getByRole("button", { name: "Home" }).click();

--- a/ui/goose2/tests/e2e/fixtures/tauri-mock.ts
+++ b/ui/goose2/tests/e2e/fixtures/tauri-mock.ts
@@ -36,17 +36,22 @@ export function buildInitScript(options?: {
       const PROJECTS = ${projects};
       const FAKE_ACP_URL = "ws://127.0.0.1:0/mock-acp";
       const ACP_SESSIONS = [];
-      const ACP_PROVIDERS = [
-        { id: "claude", label: "Claude" },
-        { id: "openai", label: "OpenAI" },
-      ];
       const PROVIDER_INVENTORY = [
         {
           providerId: "claude",
           providerName: "Claude",
+          description: "Claude provider",
+          defaultModel: "claude-sonnet-4-20250514",
           configured: true,
+          providerType: "Preferred",
+          configKeys: [],
+          setupSteps: [],
+          supportsRefresh: true,
           refreshing: false,
+          lastUpdatedAt: null,
+          lastRefreshAttemptAt: null,
           lastRefreshError: null,
+          stale: false,
           modelSelectionHint: null,
           models: [
             {
@@ -60,9 +65,18 @@ export function buildInitScript(options?: {
         {
           providerId: "openai",
           providerName: "OpenAI",
+          description: "OpenAI provider",
+          defaultModel: "gpt-4.1",
           configured: true,
+          providerType: "Preferred",
+          configKeys: [],
+          setupSteps: [],
+          supportsRefresh: true,
           refreshing: false,
+          lastUpdatedAt: null,
+          lastRefreshAttemptAt: null,
           lastRefreshError: null,
+          stale: false,
           modelSelectionHint: null,
           models: [
             {
@@ -164,8 +178,6 @@ export function buildInitScript(options?: {
             return jsonRpcResult(message.id, { stopReason: "end_turn" });
           }
           case "_goose/providers/list":
-            return jsonRpcResult(message.id, { providers: ACP_PROVIDERS });
-          case "_goose/providers/inventory":
             return jsonRpcResult(message.id, { entries: PROVIDER_INVENTORY });
           case "_goose/providers/inventory/refresh":
             return jsonRpcResult(message.id, { started: [], skipped: [] });

--- a/ui/goose2/tests/e2e/fixtures/tauri-mock.ts
+++ b/ui/goose2/tests/e2e/fixtures/tauri-mock.ts
@@ -36,6 +36,44 @@ export function buildInitScript(options?: {
       const PROJECTS = ${projects};
       const FAKE_ACP_URL = "ws://127.0.0.1:0/mock-acp";
       const ACP_SESSIONS = [];
+      const ACP_PROVIDERS = [
+        { id: "claude", label: "Claude" },
+        { id: "openai", label: "OpenAI" },
+      ];
+      const PROVIDER_INVENTORY = [
+        {
+          providerId: "claude",
+          providerName: "Claude",
+          configured: true,
+          refreshing: false,
+          lastRefreshError: null,
+          modelSelectionHint: null,
+          models: [
+            {
+              id: "claude-sonnet-4-20250514",
+              name: "Claude Sonnet 4",
+              family: "Claude",
+              recommended: true,
+            },
+          ],
+        },
+        {
+          providerId: "openai",
+          providerName: "OpenAI",
+          configured: true,
+          refreshing: false,
+          lastRefreshError: null,
+          modelSelectionHint: null,
+          models: [
+            {
+              id: "gpt-4.1",
+              name: "GPT-4.1",
+              family: "OpenAI",
+              recommended: true,
+            },
+          ],
+        },
+      ];
 
       const skillToSourceEntry = (s) => ({
         type: "skill",
@@ -126,7 +164,9 @@ export function buildInitScript(options?: {
             return jsonRpcResult(message.id, { stopReason: "end_turn" });
           }
           case "_goose/providers/list":
-            return jsonRpcResult(message.id, { entries: [] });
+            return jsonRpcResult(message.id, { providers: ACP_PROVIDERS });
+          case "_goose/providers/inventory":
+            return jsonRpcResult(message.id, { entries: PROVIDER_INVENTORY });
           case "_goose/providers/inventory/refresh":
             return jsonRpcResult(message.id, { started: [], skipped: [] });
           case "_goose/working_dir/update":
@@ -222,7 +262,7 @@ export function buildInitScript(options?: {
             case "create_persona":
               return Promise.resolve({
                 id: "mock-" + Math.random().toString(36).slice(2, 10),
-                displayName: args?.displayName ?? "New Persona",
+                displayName: args?.displayName ?? "New Agent",
                 systemPrompt: args?.systemPrompt ?? "",
                 isBuiltin: false,
                 createdAt: new Date().toISOString(),
@@ -233,7 +273,7 @@ export function buildInitScript(options?: {
             case "update_persona":
               return Promise.resolve({
                 id: args?.id ?? "mock-updated",
-                displayName: args?.displayName ?? "Updated Persona",
+                displayName: args?.displayName ?? "Updated Agent",
                 systemPrompt: args?.systemPrompt ?? "",
                 isBuiltin: false,
                 createdAt: new Date().toISOString(),
@@ -348,13 +388,13 @@ export async function waitForHome(page: Page) {
   });
 }
 
-export async function navigateToPersonas(page: Page) {
+export async function navigateToAgents(page: Page) {
   await page.goto("/");
   await expect(page.getByText(/Good (morning|afternoon|evening)/)).toBeVisible({
     timeout: 10_000,
   });
-  await page.getByRole("button", { name: "Personas" }).click();
-  await expect(page.locator("h1", { hasText: "Personas" })).toBeVisible();
+  await page.getByRole("button", { name: "Agents" }).click();
+  await expect(page.locator("h1", { hasText: "Agents" })).toBeVisible();
 }
 
 export async function navigateToSkills(page: Page) {

--- a/ui/goose2/tests/e2e/personas.spec.ts
+++ b/ui/goose2/tests/e2e/personas.spec.ts
@@ -126,7 +126,12 @@ test.describe("Agents view", () => {
         hasText: "Code Reviewer",
       }),
     ).toBeVisible();
-    await expect(dialog.getByText("Claude")).toBeVisible();
+    await expect(
+      dialog
+        .locator("section")
+        .filter({ has: dialog.getByText(/^Provider$/) })
+        .getByText(/^claude$/i),
+    ).toBeVisible();
     await expect(dialog.getByText("claude-sonnet-4-20250514")).toBeVisible();
     await expect(dialog.getByRole("button", { name: "Edit" })).toBeVisible();
   });

--- a/ui/goose2/tests/e2e/personas.spec.ts
+++ b/ui/goose2/tests/e2e/personas.spec.ts
@@ -122,7 +122,9 @@ test.describe("Agents view", () => {
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible();
     await expect(
-      dialog.locator("h2", { hasText: "Code Reviewer" }),
+      dialog.locator("[data-slot='dialog-title']").filter({
+        hasText: "Code Reviewer",
+      }),
     ).toBeVisible();
     await expect(dialog.getByText("Claude")).toBeVisible();
     await expect(dialog.getByText("claude-sonnet-4-20250514")).toBeVisible();
@@ -137,7 +139,11 @@ test.describe("Agents view", () => {
 
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible();
-    await expect(dialog.locator("h2", { hasText: "Solo" })).toBeVisible();
+    await expect(
+      dialog.locator("[data-slot='dialog-title']").filter({
+        hasText: "Solo",
+      }),
+    ).toBeVisible();
     await expect(
       dialog.getByRole("button", { name: /Duplicate/ }),
     ).toBeVisible();

--- a/ui/goose2/tests/e2e/personas.spec.ts
+++ b/ui/goose2/tests/e2e/personas.spec.ts
@@ -126,12 +126,7 @@ test.describe("Agents view", () => {
         hasText: "Code Reviewer",
       }),
     ).toBeVisible();
-    await expect(
-      dialog
-        .locator("section")
-        .filter({ has: dialog.getByText(/^Provider$/) })
-        .getByText(/^claude$/i),
-    ).toBeVisible();
+    await expect(dialog.getByText(/^Provider$/)).toBeVisible();
     await expect(dialog.getByText("claude-sonnet-4-20250514")).toBeVisible();
     await expect(dialog.getByRole("button", { name: "Edit" })).toBeVisible();
   });

--- a/ui/goose2/tests/e2e/personas.spec.ts
+++ b/ui/goose2/tests/e2e/personas.spec.ts
@@ -1,150 +1,149 @@
 import {
   test,
   expect,
-  navigateToPersonas,
+  navigateToAgents,
   buildInitScript,
 } from "./fixtures/tauri-mock";
 
-test.describe("Personas view", () => {
-  test("navigates to personas view from sidebar", async ({
+test.describe("Agents view", () => {
+  test("navigates to agents view from sidebar", async ({
     tauriMocked: page,
   }) => {
-    await navigateToPersonas(page);
-    // Assert heading, subtitle, and sections are visible
-    await expect(page.locator("h1", { hasText: "Personas" })).toBeVisible();
-    await expect(page.getByText("Custom persona configurations")).toBeVisible();
+    await navigateToAgents(page);
+
+    await expect(page.locator("h1", { hasText: "Agents" })).toBeVisible();
     await expect(
-      page.getByRole("heading", { name: "Active Agents" }),
+      page.getByText("Custom agent configurations for specific workflows"),
     ).toBeVisible();
-    await expect(page.getByText("No active agents")).toBeVisible();
   });
 
-  test("displays persona cards from mock data", async ({
-    tauriMocked: page,
-  }) => {
-    await navigateToPersonas(page);
-    // All 3 persona cards should be visible with their aria-labels
-    await expect(page.getByLabel("Persona: Solo")).toBeVisible();
-    await expect(page.getByLabel("Persona: Scout")).toBeVisible();
-    await expect(page.getByLabel("Persona: Code Reviewer")).toBeVisible();
+  test("displays agent cards from mock data", async ({ tauriMocked: page }) => {
+    await navigateToAgents(page);
+
+    await expect(page.getByLabel("Agent: Solo")).toBeVisible();
+    await expect(page.getByLabel("Agent: Scout")).toBeVisible();
+    await expect(page.getByLabel("Agent: Code Reviewer")).toBeVisible();
   });
 
-  test("shows Built-in badge on builtin personas", async ({
+  test("shows Built-in badge on built-in agents", async ({
     tauriMocked: page,
   }) => {
-    await navigateToPersonas(page);
-    // Solo and Scout are builtin — their cards should contain "Built-in" text
-    const soloCard = page.getByLabel("Persona: Solo");
+    await navigateToAgents(page);
+
+    const soloCard = page.getByLabel("Agent: Solo");
     await expect(soloCard.getByText("Built-in")).toBeVisible();
-    const reviewerCard = page.getByLabel("Persona: Code Reviewer");
+
+    const reviewerCard = page.getByLabel("Agent: Code Reviewer");
     await expect(reviewerCard.getByText("Built-in")).not.toBeVisible();
   });
 
-  test("shows create new persona button", async ({ tauriMocked: page }) => {
-    await navigateToPersonas(page);
-    await expect(page.getByLabel("Create new persona")).toBeVisible();
+  test("shows create new agent button", async ({ tauriMocked: page }) => {
+    await navigateToAgents(page);
+    await expect(page.getByLabel("Create new agent")).toBeVisible();
   });
 
-  test("opens create persona dialog via New Persona button", async ({
+  test("opens create agent dialog via New Agent button", async ({
     tauriMocked: page,
   }) => {
-    await navigateToPersonas(page);
+    await navigateToAgents(page);
     await page
-      .getByRole("button", { name: "New Persona", exact: true })
+      .getByRole("button", { name: "New Agent", exact: true })
       .first()
       .click();
+
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible();
-    await expect(
-      dialog.locator("h2", { hasText: "New Persona" }),
-    ).toBeVisible();
-    // Check form fields
+    await expect(dialog.locator("h2", { hasText: "New Agent" })).toBeVisible();
     await expect(dialog.getByPlaceholder("e.g. Code Reviewer")).toBeVisible();
     await expect(
       dialog.getByPlaceholder("You are a helpful assistant that..."),
     ).toBeVisible();
   });
 
-  test("opens create persona dialog via plus card", async ({
+  test("opens create agent dialog via plus card", async ({
     tauriMocked: page,
   }) => {
-    await navigateToPersonas(page);
-    await page.getByLabel("Create new persona").click();
+    await navigateToAgents(page);
+    await page.getByLabel("Create new agent").click();
     await expect(page.getByRole("dialog")).toBeVisible();
   });
 
   test("create dialog has disabled Create button when fields are empty", async ({
     tauriMocked: page,
   }) => {
-    await navigateToPersonas(page);
+    await navigateToAgents(page);
     await page
-      .getByRole("button", { name: "New Persona", exact: true })
+      .getByRole("button", { name: "New Agent", exact: true })
       .first()
       .click();
+
     const dialog = page.getByRole("dialog");
-    // Create button should be disabled
     await expect(dialog.getByRole("button", { name: "Create" })).toBeDisabled();
   });
 
   test("create dialog enables Create button when name and prompt are filled", async ({
     tauriMocked: page,
   }) => {
-    await navigateToPersonas(page);
+    await navigateToAgents(page);
     await page
-      .getByRole("button", { name: "New Persona", exact: true })
+      .getByRole("button", { name: "New Agent", exact: true })
       .first()
       .click();
+
     const dialog = page.getByRole("dialog");
-    await dialog.getByPlaceholder("e.g. Code Reviewer").fill("Test Persona");
+    await dialog.getByPlaceholder("e.g. Code Reviewer").fill("Test Agent");
     await dialog
       .getByPlaceholder("You are a helpful assistant that...")
-      .fill("You are a test persona");
+      .fill("You are a test agent");
+
     await expect(dialog.getByRole("button", { name: "Create" })).toBeEnabled();
   });
 
-  test("closes create persona dialog via Close button", async ({
+  test("closes create agent dialog via Close button", async ({
     tauriMocked: page,
   }) => {
-    await navigateToPersonas(page);
+    await navigateToAgents(page);
     await page
-      .getByRole("button", { name: "New Persona", exact: true })
+      .getByRole("button", { name: "New Agent", exact: true })
       .first()
       .click();
+
     await expect(page.getByRole("dialog")).toBeVisible();
-    await page.getByRole("button", { name: "Close" }).click();
+    await page.getByRole("button", { name: "Cancel" }).click();
     await expect(page.getByRole("dialog")).not.toBeVisible();
   });
 
-  test("opens edit dialog when clicking a custom persona card", async ({
+  test("clicking a custom agent card opens details with edit actions", async ({
     tauriMocked: page,
   }) => {
-    await navigateToPersonas(page);
-    await page.getByLabel("Persona: Code Reviewer").click();
+    await navigateToAgents(page);
+    await page.getByLabel("Agent: Code Reviewer").click();
+
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible();
     await expect(
-      dialog.locator("h2", { hasText: "Edit Persona" }),
+      dialog.locator("h2", { hasText: "Code Reviewer" }),
     ).toBeVisible();
-    // Fields should be pre-filled
-    await expect(dialog.getByPlaceholder("e.g. Code Reviewer")).toHaveValue(
-      "Code Reviewer",
-    );
+    await expect(dialog.getByText("Claude")).toBeVisible();
+    await expect(dialog.getByText("claude-sonnet-4-20250514")).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Edit" })).toBeVisible();
   });
 
-  test("builtin persona opens read-only dialog with Duplicate button", async ({
+  test("built-in agent opens read-only details with Duplicate button", async ({
     tauriMocked: page,
   }) => {
-    await navigateToPersonas(page);
-    await page.getByLabel("Persona: Solo").click();
+    await navigateToAgents(page);
+    await page.getByLabel("Agent: Solo").click();
+
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible();
-    // Header shows persona name for read-only
     await expect(dialog.locator("h2", { hasText: "Solo" })).toBeVisible();
-    // Duplicate button instead of Create/Save
     await expect(
       dialog.getByRole("button", { name: /Duplicate/ }),
     ).toBeVisible();
-    // Should NOT have Create or Save buttons
+    await expect(
+      dialog.getByRole("button", { name: "Edit" }),
+    ).not.toBeVisible();
     await expect(
       dialog.getByRole("button", { name: "Create" }),
     ).not.toBeVisible();
@@ -153,13 +152,14 @@ test.describe("Personas view", () => {
     ).not.toBeVisible();
   });
 
-  test("persona card dropdown menu shows correct items", async ({
+  test("custom agent card dropdown menu shows correct items", async ({
     tauriMocked: page,
   }) => {
-    await navigateToPersonas(page);
-    // Open dropdown for Code Reviewer (custom persona)
-    const card = page.getByLabel("Persona: Code Reviewer");
-    await card.getByLabel("Persona options").click();
+    await navigateToAgents(page);
+
+    const card = page.getByLabel("Agent: Code Reviewer");
+    await card.getByLabel("Agent options").click();
+
     const menu = page.getByRole("menu");
     await expect(menu).toBeVisible();
     await expect(menu.getByRole("menuitem", { name: "Edit" })).toBeVisible();
@@ -170,15 +170,19 @@ test.describe("Personas view", () => {
     await expect(menu.getByRole("menuitem", { name: "Delete" })).toBeVisible();
   });
 
-  test("builtin persona dropdown menu does not show Delete", async ({
+  test("built-in agent dropdown menu does not show Edit or Delete", async ({
     tauriMocked: page,
   }) => {
-    await navigateToPersonas(page);
-    const card = page.getByLabel("Persona: Solo");
-    await card.getByLabel("Persona options").click();
+    await navigateToAgents(page);
+
+    const card = page.getByLabel("Agent: Solo");
+    await card.getByLabel("Agent options").click();
+
     const menu = page.getByRole("menu");
     await expect(menu).toBeVisible();
-    await expect(menu.getByRole("menuitem", { name: "Edit" })).toBeVisible();
+    await expect(
+      menu.getByRole("menuitem", { name: "Edit" }),
+    ).not.toBeVisible();
     await expect(
       menu.getByRole("menuitem", { name: "Duplicate" }),
     ).toBeVisible();
@@ -189,12 +193,13 @@ test.describe("Personas view", () => {
   });
 
   test("Delete triggers confirmation dialog", async ({ tauriMocked: page }) => {
-    await navigateToPersonas(page);
-    const card = page.getByLabel("Persona: Code Reviewer");
-    await card.getByLabel("Persona options").click();
+    await navigateToAgents(page);
+
+    const card = page.getByLabel("Agent: Code Reviewer");
+    await card.getByLabel("Agent options").click();
     await page.getByRole("menuitem", { name: "Delete" }).click();
-    // Confirmation dialog
-    await expect(page.getByText("Delete persona?")).toBeVisible();
+
+    await expect(page.getByText("Delete agent?")).toBeVisible();
     await expect(
       page.getByText(/Are you sure you want to delete.*Code Reviewer/),
     ).toBeVisible();
@@ -205,46 +210,45 @@ test.describe("Personas view", () => {
   test("Cancel in delete confirmation closes dialog", async ({
     tauriMocked: page,
   }) => {
-    await navigateToPersonas(page);
-    const card = page.getByLabel("Persona: Code Reviewer");
-    await card.getByLabel("Persona options").click();
+    await navigateToAgents(page);
+
+    const card = page.getByLabel("Agent: Code Reviewer");
+    await card.getByLabel("Agent options").click();
     await page.getByRole("menuitem", { name: "Delete" }).click();
-    await expect(page.getByText("Delete persona?")).toBeVisible();
-    // Click Cancel within the delete confirmation dialog container
-    await page
-      .locator("text=Delete persona?")
-      .locator("..")
-      .locator("..")
-      .getByRole("button", { name: "Cancel" })
-      .click();
-    await expect(page.getByText("Delete persona?")).not.toBeVisible();
-    // Persona card should still be there
-    await expect(page.getByLabel("Persona: Code Reviewer")).toBeVisible();
+    await expect(page.getByText("Delete agent?")).toBeVisible();
+
+    const confirmDialog = page.locator(".max-w-sm", {
+      has: page.getByText("Delete agent?"),
+    });
+    await confirmDialog.getByRole("button", { name: "Cancel" }).click();
+
+    await expect(page.getByText("Delete agent?")).not.toBeVisible();
+    await expect(page.getByLabel("Agent: Code Reviewer")).toBeVisible();
   });
 
-  test("search filters personas", async ({ tauriMocked: page }) => {
-    await navigateToPersonas(page);
-    await page.getByPlaceholder("Search personas...").fill("Solo");
-    await expect(page.getByLabel("Persona: Solo")).toBeVisible();
-    await expect(page.getByLabel("Persona: Scout")).not.toBeVisible();
-    await expect(page.getByLabel("Persona: Code Reviewer")).not.toBeVisible();
-    // Clear search
-    await page.getByPlaceholder("Search personas...").clear();
-    await expect(page.getByLabel("Persona: Solo")).toBeVisible();
-    await expect(page.getByLabel("Persona: Scout")).toBeVisible();
-    await expect(page.getByLabel("Persona: Code Reviewer")).toBeVisible();
+  test("search filters agents", async ({ tauriMocked: page }) => {
+    await navigateToAgents(page);
+    await page.getByPlaceholder("Search agents...").fill("Solo");
+
+    await expect(page.getByLabel("Agent: Solo")).toBeVisible();
+    await expect(page.getByLabel("Agent: Scout")).not.toBeVisible();
+    await expect(page.getByLabel("Agent: Code Reviewer")).not.toBeVisible();
+
+    await page.getByPlaceholder("Search agents...").clear();
+    await expect(page.getByLabel("Agent: Solo")).toBeVisible();
+    await expect(page.getByLabel("Agent: Scout")).toBeVisible();
+    await expect(page.getByLabel("Agent: Code Reviewer")).toBeVisible();
   });
 
-  test("empty persona state shows only create button", async ({
+  test("empty agent state shows only create button", async ({
     tauriMocked: page,
   }) => {
-    // Override mock data with empty personas before navigation
     await page.addInitScript({
       content: buildInitScript({ personas: [], skills: [] }),
     });
-    await navigateToPersonas(page);
-    await expect(page.getByLabel("Create new persona")).toBeVisible();
-    // No persona cards should be visible
-    await expect(page.getByLabel(/^Persona: /)).not.toBeVisible();
+    await navigateToAgents(page);
+
+    await expect(page.getByLabel("Create new agent")).toBeVisible();
+    await expect(page.getByLabel(/^Agent: /)).not.toBeVisible();
   });
 });

--- a/ui/goose2/tests/e2e/skills.spec.ts
+++ b/ui/goose2/tests/e2e/skills.spec.ts
@@ -12,7 +12,7 @@ test.describe("Skills view", () => {
     await navigateToSkills(page);
     await expect(page.locator("h1", { hasText: "Skills" })).toBeVisible();
     await expect(
-      page.getByText("Reusable instructions for your AI personas"),
+      page.getByText("Reusable instructions for your AI agents"),
     ).toBeVisible();
   });
 

--- a/ui/goose2/tests/e2e/smoke.spec.ts
+++ b/ui/goose2/tests/e2e/smoke.spec.ts
@@ -21,7 +21,7 @@ test.describe("Smoke tests", () => {
     await page.goto("/");
 
     await expect(
-      page.getByPlaceholder(/Message .*, @ to mention personas/),
+      page.getByPlaceholder(/Message .*, @ to mention agents/),
     ).toBeVisible({ timeout: 10_000 });
   });
 });


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Users can create, inspect, import, delete, and switch agents with clearer feedback and fewer dead ends across Goose2.
**Problem:** Agent management was fragmented across chat and the Agents page, which made creation feel out of context, hid provenance and deletion rules, and left import and switch feedback easy to miss. Rebasing onto current `main` also exposed a provider SDK contract change that Goose2 still needed to absorb.
**Solution:** Route creation into the Agents surface, add a read-only details view and provider-aware model picker, surface file-backed and built-in behavior explicitly, simplify chat switch feedback down to the active chip, and update the provider API calls to match the rebased SDK so the branch stays green on current `main`.

<details>
<summary>File changes</summary>

**ui/goose2/src-tauri/src/commands/agents.rs**
Adds the native file-read command used by the import picker so the Tauri flow can validate and import `.json` files without relying on a browser input.

**ui/goose2/src-tauri/src/lib.rs**
Registers the new agents command with the Tauri app so the frontend can call the import-file helper.

**ui/goose2/src-tauri/src/services/personas.rs**
Updates persona deletion and provenance handling so file-backed agents can be deleted intentionally instead of failing silently.

**ui/goose2/src/app/AppShell.tsx**
Moves the chat/home create-agent path through a dedicated navigation helper and keeps the shell under the file-size limit after the Agents routing changes.

**ui/goose2/src/app/hooks/useCreatePersonaNavigation.ts**
Adds a focused helper that navigates to the Agents page and opens the create modal without duplicating modal state.

**ui/goose2/src/app/ui/AppShellContent.tsx**
Threads the shared create-agent action into the chat and home surfaces so they all enter agent management the same way.

**ui/goose2/src/features/agents/hooks/__tests__/usePersonas.test.ts**
Covers the updated persona lifecycle behavior that now includes the new import and deletion expectations.

**ui/goose2/src/features/agents/lib/personaImport.ts**
Centralizes import validation, success messaging descriptors, and agent error formatting so picker and drag/drop flows stay aligned and localizable.

**ui/goose2/src/features/agents/lib/personaPresentation.ts**
Adds shared helpers for built-in, file-backed, and custom agent provenance so the UI can reason about read-only and destructive actions consistently.

**ui/goose2/src/features/agents/stores/__tests__/agentStore.test.ts**
Updates store coverage for the new editor modes and create/details flow.

**ui/goose2/src/features/agents/stores/agentStore.ts**
Extends the agent editor state to support explicit `create`, `edit`, and `details` modes.

**ui/goose2/src/features/agents/ui/AgentsView.tsx**
Reworks the page-level agent management flow around localized import feedback, details/edit routing, duplicate/delete actions, and the Tauri-only `.json` picker.

**ui/goose2/src/features/agents/ui/PersonaCard.tsx**
Makes tile click open details, keeps overflow actions unique, truncates the provider/model badge, and fixes keyboard interaction so nested controls do not trigger the tile action.

**ui/goose2/src/features/agents/ui/PersonaDetails.tsx**
Introduces the read-only details presentation for agent name, provenance, provider/model, and markdown-formatted system prompt.

**ui/goose2/src/features/agents/ui/PersonaEditor.tsx**
Adds the provider-aware model picker, source-aware read-only handling, flat footer actions, and the new details-mode composition.

**ui/goose2/src/features/agents/ui/PersonaGallery.tsx**
Hooks the shared import validation into the gallery drop zone and create tile while keeping the card grid behavior intact.

**ui/goose2/src/features/agents/ui/__tests__/PersonaCard.test.tsx**
Updates the card tests for the new agent labels and adds a regression test for keyboard-opening the overflow menu.

**ui/goose2/src/features/chat/hooks/__tests__/useChat.attachments.test.ts**
Refreshes chat hook expectations after the shared create-agent and active-agent UI changes.

**ui/goose2/src/features/chat/hooks/__tests__/useChat.test.ts**
Keeps the chat hook suite aligned with the simplified active-agent feedback behavior.

**ui/goose2/src/features/chat/hooks/__tests__/useChatSessionController.test.ts**
Updates controller coverage around create-agent routing and the reduced switch-feedback flow.

**ui/goose2/src/features/chat/hooks/useChatSessionController.ts**
Routes create-agent into the Agents page and removes the extra switch status events so the active chip becomes the primary signal.

**ui/goose2/src/features/chat/ui/AgentModelPicker.tsx**
Stops emphasizing model changes when an agent is active so agent switching does not feel like a separate model-switch announcement.

**ui/goose2/src/features/chat/ui/ChatInputToolbar.tsx**
Keeps the composer toolbar aligned with the simplified agent indicator behavior.

**ui/goose2/src/features/chat/ui/ChatView.tsx**
Removes redundant in-thread switch messaging so chat no longer shows extra `Switched to ...` pills.

**ui/goose2/src/features/chat/ui/__tests__/ChatInput.test.tsx**
Adjusts chat input assertions for the new active-agent display behavior.

**ui/goose2/src/features/home/ui/HomeScreen.test.tsx**
Updates the home screen expectations for routing create-agent into the Agents page.

**ui/goose2/src/features/home/ui/HomeScreen.tsx**
Sends the home-screen create-agent CTA through the shared agent-management navigation path.

**ui/goose2/src/features/providers/api/inventory.ts**
Switches inventory loading to the rebased `GooseProvidersInventory` endpoint so Goose2 matches the new SDK contract.

**ui/goose2/src/features/skills/ui/__tests__/SkillsView.test.tsx**
Refreshes shared UI expectations after the localized copy and navigation text changes.

**ui/goose2/src/shared/api/acpApi.ts**
Updates provider list parsing to use the rebased lightweight provider response shape.

**ui/goose2/src/shared/api/agents.ts**
Exposes the frontend wrapper for reading import files through Tauri.

**ui/goose2/src/shared/hooks/useFileImportZone.ts**
Shares import validation across drag/drop and picker flows while accepting the lighter file metadata shape used by the native dialog.

**ui/goose2/src/shared/i18n/locales/en/agents.json**
Adds English copy for details mode, provenance states, provider/model picker messaging, and localized import feedback.

**ui/goose2/src/shared/i18n/locales/en/chat.json**
Updates English chat copy to match the simplified agent-switch feedback.

**ui/goose2/src/shared/i18n/locales/en/sessions.json**
Syncs related English session strings with the updated agent naming.

**ui/goose2/src/shared/i18n/locales/en/sidebar.json**
Syncs related English sidebar strings with the updated agent naming.

**ui/goose2/src/shared/i18n/locales/en/skills.json**
Syncs related English skills strings with the updated agent naming.

**ui/goose2/src/shared/i18n/locales/es/agents.json**
Adds the matching Spanish copy for details mode, provenance states, provider/model picker messaging, and import feedback.

**ui/goose2/src/shared/i18n/locales/es/chat.json**
Updates Spanish chat copy to match the simplified agent-switch feedback.

**ui/goose2/src/shared/i18n/locales/es/sessions.json**
Syncs related Spanish session strings with the updated agent naming.

**ui/goose2/src/shared/i18n/locales/es/sidebar.json**
Syncs related Spanish sidebar strings with the updated agent naming.

**ui/goose2/src/shared/i18n/locales/es/skills.json**
Syncs related Spanish skills strings with the updated agent naming.

**ui/goose2/src/shared/ui/button.tsx**
Adds the flat destructive button variant used by the agent details footer.

</details>

### Reproduction Steps

1. Open Goose2 and click `Create agent` from chat or home; confirm the app navigates to `Agents` and opens the create modal there.
2. In the agent editor, choose a provider and verify the model control becomes a provider-aware picker with empty-state and saved-model handling.
3. On the Agents page, click an agent tile to open the read-only details view, then use the overflow menu to confirm `Edit`, `Duplicate`, `Export`, and `Delete` remain distinct actions.
4. Try importing an invalid file via both drag/drop and the picker to confirm the UI rejects it with a visible localized error, then import a valid `.json` file and confirm the success toast appears.
5. Open a file-backed agent and delete it, then switch agents in chat via both the picker and `@mention`; confirm the active chip updates without extra `Switched to ...` status pills in the timeline or composer.

### Screenshots/Demos

<img width="1502" height="959" alt="Screenshot 2026-04-21 at 3 05 43 PM" src="https://github.com/user-attachments/assets/5285b5f0-7ca4-49f7-904e-96632bf247f6" />

