### PR TITLE
fix: add missing underscore prefix in updateWorkingDir method name

### DIFF
--- a/ui/goose2/src/shared/api/acpApi.ts
+++ b/ui/goose2/src/shared/api/acpApi.ts
@@ -131,7 +131,10 @@ export async function updateWorkingDir(
   workingDir: string,
 ): Promise<void> {
   const client = await getClient();
-  await client.extMethod("goose/working_dir/update", { sessionId, workingDir });
+  await client.extMethod("_goose/working_dir/update", {
+    sessionId,
+    workingDir,
+  });
 }
 
 export async function cancelSession(sessionId: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Fix the `updateWorkingDir` API call to use the correct `_goose/working_dir/update` extension method name (prefixed with underscore) instead of `goose/working_dir/update`

## Test plan
- [x] Existing tests pass
- [x] Verify working directory updates function correctly in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)