### PR TITLE
fix: preprompt would show after loading session

### DIFF
--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1095,16 +1095,57 @@ impl GooseAcpAgent {
         self.sessions.lock().await.contains_key(session_id)
     }
 
-    fn convert_acp_prompt_to_message(&self, prompt: Vec<ContentBlock>) -> Message {
-        let mut user_message = Message::user();
+    /// Try to split a text block containing persona-instructions and user-message XML
+    /// into (context_text, user_text). Returns None if the pattern doesn't match.
+    fn split_persona_user_text(text: &str) -> Option<(String, String)> {
+        let trimmed = text.trim();
+        if !trimmed.starts_with("<persona-instructions>") {
+            return None;
+        }
+        // Find the user-message boundaries
+        let user_start_tag = "<user-message>";
+        let user_end_tag = "</user-message>";
+        let start_idx = trimmed.find(user_start_tag)?;
+        let end_idx = trimmed.rfind(user_end_tag)?;
+        if start_idx >= end_idx {
+            return None;
+        }
+        let user_text = trimmed[start_idx + user_start_tag.len()..end_idx]
+            .trim()
+            .to_string();
+        // Context is everything outside the user-message tags
+        let context_text = format!(
+            "{}{}",
+            &trimmed[..start_idx],
+            &trimmed[end_idx + user_end_tag.len()..]
+        )
+        .trim()
+        .to_string();
+        Some((context_text, user_text))
+    }
 
-        for block in prompt {
+    /// Convert ACP prompt content blocks into messages. When the prompt contains
+    /// persona-instructions wrapping a user-message, splits into a hidden context
+    /// message and a visible user message. Returns (messages_to_persist, message_for_agent).
+    fn convert_acp_prompt_to_messages(
+        &self,
+        prompt: Vec<ContentBlock>,
+    ) -> (Vec<Message>, Message) {
+        // Build the combined message preserving original block order
+        let mut combined_message = Message::user();
+        let mut combined_text = String::new();
+        let mut has_images = false;
+
+        for block in &prompt {
             match block {
                 ContentBlock::Text(text) => {
-                    user_message = user_message.with_text(&text.text);
+                    combined_message = combined_message.with_text(&text.text);
+                    combined_text.push_str(&text.text);
                 }
                 ContentBlock::Image(image) => {
-                    user_message = user_message.with_image(&image.data, &image.mime_type);
+                    combined_message =
+                        combined_message.with_image(&image.data, &image.mime_type);
+                    has_images = true;
                 }
                 ContentBlock::Resource(resource) => {
                     if let EmbeddedResourceResource::TextResourceContents(text_resource) =
@@ -1112,19 +1153,39 @@ impl GooseAcpAgent {
                     {
                         let header = format!("--- Resource: {} ---\n", text_resource.uri);
                         let content = format!("{}{}\n---\n", header, text_resource.text);
-                        user_message = user_message.with_text(&content);
+                        combined_message = combined_message.with_text(&content);
+                        combined_text.push_str(&content);
                     }
                 }
                 ContentBlock::ResourceLink(link) => {
-                    if let Some(text) = read_resource_link(link) {
-                        user_message = user_message.with_text(text)
+                    if let Some(text) = read_resource_link(link.clone()) {
+                        combined_message = combined_message.with_text(text.clone());
+                        combined_text.push_str(&text);
                     }
                 }
                 ContentBlock::Audio(..) | _ => (),
             }
         }
 
-        user_message
+        // Try to split persona context from user message
+        if let Some((context_text, user_text)) = Self::split_persona_user_text(&combined_text) {
+            let context_msg = Message::user().with_text(&context_text).agent_only();
+
+            let mut visible_msg = Message::user().with_text(&user_text);
+            // Non-text content (images, resources) goes on the visible message
+            if has_images {
+                for block in &prompt {
+                    if let ContentBlock::Image(image) = block {
+                        visible_msg =
+                            visible_msg.with_image(&image.data, &image.mime_type);
+                    }
+                }
+            }
+
+            (vec![context_msg, visible_msg], combined_message)
+        } else {
+            (vec![combined_message.clone()], combined_message)
+        }
     }
 
     async fn handle_message_content(
@@ -2041,15 +2102,19 @@ impl GooseAcpAgent {
             .await?;
         debug!(target: "perf", sid = %sid, ms = t_agent.elapsed().as_millis() as u64, "perf: prompt get_session_agent (waits for agent setup)");
 
-        let user_message = self.convert_acp_prompt_to_message(args.prompt);
+        let (messages_to_persist, agent_message) =
+            self.convert_acp_prompt_to_messages(args.prompt);
 
         let t_persist = std::time::Instant::now();
-        self.thread_manager
-            .append_message(&thread_id, Some(&internal_session_id), &user_message)
-            .await
-            .map_err(|e| {
-                sacp::Error::internal_error().data(format!("Failed to persist message: {}", e))
-            })?;
+        for msg in &messages_to_persist {
+            self.thread_manager
+                .append_message(&thread_id, Some(&internal_session_id), msg)
+                .await
+                .map_err(|e| {
+                    sacp::Error::internal_error()
+                        .data(format!("Failed to persist message: {}", e))
+                })?;
+        }
         debug!(target: "perf", sid = %sid, ms = t_persist.elapsed().as_millis() as u64, "perf: prompt append_user_message");
 
         let session_config = SessionConfig {
@@ -2061,7 +2126,7 @@ impl GooseAcpAgent {
 
         let t_reply = std::time::Instant::now();
         let mut stream = agent
-            .reply(user_message, session_config, Some(cancel_token.clone()))
+            .reply(agent_message, session_config, Some(cancel_token.clone()))
             .await
             .map_err(|e| {
                 sacp::Error::internal_error().data(format!("Error getting agent reply: {}", e))

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1,7 +1,7 @@
 use crate::acp::custom_requests::*;
 use crate::acp::fs::AcpTools;
 use crate::acp::tools::AcpAwareToolMeta;
-use crate::acp::{PermissionDecision, ACP_CURRENT_MODEL};
+use crate::acp::{ACP_CURRENT_MODEL, PermissionDecision};
 use crate::agents::extension::{Envs, PLATFORM_EXTENSIONS};
 use crate::agents::mcp_client::McpClientTrait;
 use crate::agents::platform_extensions::developer::DeveloperClient;
@@ -15,7 +15,7 @@ use crate::conversation::message::{ActionRequiredData, Message, MessageContent};
 #[cfg(feature = "local-inference")]
 use crate::dictation::providers::transcribe_local;
 use crate::dictation::providers::{
-    all_providers, is_configured, transcribe_with_provider, DictationProvider,
+    DictationProvider, all_providers, is_configured, transcribe_with_provider,
 };
 #[cfg(feature = "local-inference")]
 use crate::dictation::whisper;
@@ -28,28 +28,31 @@ use crate::providers::inventory::{
 };
 use crate::session::session_manager::SessionType;
 use crate::session::{EnabledExtensionsState, Session, SessionManager};
+use crate::utils::sanitize_unicode_tags;
 use anyhow::Result;
 use fs_err as fs;
 use futures::future::BoxFuture;
 use goose_acp_macros::custom_methods;
-use rmcp::model::{AnnotateAble, CallToolResult, RawContent, RawTextContent, ResourceContents, Role};
+use rmcp::model::{
+    AnnotateAble, CallToolResult, RawContent, RawTextContent, ResourceContents, Role,
+};
 use sacp::schema::{
-    AgentCapabilities, Annotations, AuthMethod, AuthMethodAgent, AuthenticateRequest, AuthenticateResponse,
-    BlobResourceContents, CancelNotification, CloseSessionRequest, CloseSessionResponse,
-    ConfigOptionUpdate, Content, ContentBlock, ContentChunk, CurrentModeUpdate, EmbeddedResource,
-    EmbeddedResourceResource, FileSystemCapabilities, ForkSessionRequest, ForkSessionResponse,
-    ImageContent, InitializeRequest, InitializeResponse, ListSessionsRequest, ListSessionsResponse,
-    LoadSessionRequest, LoadSessionResponse, McpCapabilities, McpServer, Meta, ModelId, ModelInfo,
-    NewSessionRequest, NewSessionResponse, PermissionOption, PermissionOptionKind,
-    PromptCapabilities, PromptRequest, PromptResponse, RequestPermissionOutcome,
-    RequestPermissionRequest, ResourceLink, SessionCapabilities, SessionCloseCapabilities,
-    SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOption, SessionId,
-    SessionInfo, SessionListCapabilities, SessionMode, SessionModeId, SessionModeState,
-    SessionModelState, SessionNotification, SessionUpdate, SetSessionConfigOptionRequest,
-    SetSessionConfigOptionResponse, SetSessionModeRequest, SetSessionModeResponse,
-    SetSessionModelRequest, SetSessionModelResponse, StopReason, TextContent, TextResourceContents,
-    ToolCall, ToolCallContent, ToolCallId, ToolCallLocation, ToolCallStatus, ToolCallUpdate,
-    ToolCallUpdateFields, ToolKind, Usage, UsageUpdate,
+    AgentCapabilities, Annotations, AuthMethod, AuthMethodAgent, AuthenticateRequest,
+    AuthenticateResponse, BlobResourceContents, CancelNotification, CloseSessionRequest,
+    CloseSessionResponse, ConfigOptionUpdate, Content, ContentBlock, ContentChunk,
+    CurrentModeUpdate, EmbeddedResource, EmbeddedResourceResource, FileSystemCapabilities,
+    ForkSessionRequest, ForkSessionResponse, ImageContent, InitializeRequest, InitializeResponse,
+    ListSessionsRequest, ListSessionsResponse, LoadSessionRequest, LoadSessionResponse,
+    McpCapabilities, McpServer, Meta, ModelId, ModelInfo, NewSessionRequest, NewSessionResponse,
+    PermissionOption, PermissionOptionKind, PromptCapabilities, PromptRequest, PromptResponse,
+    RequestPermissionOutcome, RequestPermissionRequest, ResourceLink, SessionCapabilities,
+    SessionCloseCapabilities, SessionConfigOption, SessionConfigOptionCategory,
+    SessionConfigSelectOption, SessionId, SessionInfo, SessionListCapabilities, SessionMode,
+    SessionModeId, SessionModeState, SessionModelState, SessionNotification, SessionUpdate,
+    SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, SetSessionModeRequest,
+    SetSessionModeResponse, SetSessionModelRequest, SetSessionModelResponse, StopReason,
+    TextContent, TextResourceContents, ToolCall, ToolCallContent, ToolCallId, ToolCallLocation,
+    ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind, Usage, UsageUpdate,
 };
 use sacp::util::MatchDispatchFrom;
 use sacp::{
@@ -1101,10 +1104,6 @@ impl GooseAcpAgent {
         for block in prompt {
             match block {
                 ContentBlock::Text(text) => {
-                    let raw = RawTextContent {
-                        text: text.text.clone(),
-                        meta: None,
-                    };
                     let annotated = if let Some(ref ann) = text.annotations {
                         let audience: Vec<Role> = ann
                             .audience
@@ -1120,9 +1119,24 @@ impl GooseAcpAgent {
                                     .collect()
                             })
                             .unwrap_or_default();
-                        raw.no_annotation().with_audience(audience)
+                        let raw = RawTextContent {
+                            text: text.text.clone(),
+                            meta: None,
+                        };
+                        if audience.is_empty() {
+                            raw.no_annotation()
+                        } else {
+                            raw.no_annotation().with_audience(audience)
+                        }
                     } else {
-                        raw.no_annotation()
+                        // No annotations — regular user text; sanitize against
+                        // invisible Unicode tag prompt-injection.
+                        let sanitized = sanitize_unicode_tags(&text.text);
+                        RawTextContent {
+                            text: sanitized,
+                            meta: None,
+                        }
+                        .no_annotation()
                     };
                     message = message.with_content(MessageContent::Text(annotated));
                 }
@@ -1857,15 +1871,17 @@ impl GooseAcpAgent {
                     MessageContent::Text(text) => {
                         let mut tc = TextContent::new(text.text.clone());
                         if let Some(audience) = text.audience() {
-                            tc = tc.annotations(Annotations::new().audience(
-                                audience
-                                    .iter()
-                                    .map(|r| match r {
-                                        Role::Assistant => sacp::schema::Role::Assistant,
-                                        Role::User => sacp::schema::Role::User,
-                                    })
-                                    .collect::<Vec<_>>(),
-                            ));
+                            tc = tc.annotations(
+                                Annotations::new().audience(
+                                    audience
+                                        .iter()
+                                        .map(|r| match r {
+                                            Role::Assistant => sacp::schema::Role::Assistant,
+                                            Role::User => sacp::schema::Role::User,
+                                        })
+                                        .collect::<Vec<_>>(),
+                                ),
+                            );
                         }
                         let chunk = ContentChunk::new(ContentBlock::Text(tc));
                         let update = match message.role {
@@ -2081,8 +2097,7 @@ impl GooseAcpAgent {
             .append_message(&thread_id, Some(&internal_session_id), &user_message)
             .await
             .map_err(|e| {
-                sacp::Error::internal_error()
-                    .data(format!("Failed to persist message: {}", e))
+                sacp::Error::internal_error().data(format!("Failed to persist message: {}", e))
             })?;
         debug!(target: "perf", sid = %sid, ms = t_persist.elapsed().as_millis() as u64, "perf: prompt append_user_message");
 
@@ -3190,7 +3205,7 @@ impl GooseAcpAgent {
         &self,
         req: DictationTranscribeRequest,
     ) -> Result<DictationTranscribeResponse, sacp::Error> {
-        use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+        use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
         let config = crate::config::Config::global();
 
         #[cfg(not(feature = "local-inference"))]
@@ -3223,7 +3238,7 @@ impl GooseAcpAgent {
             other => {
                 return Err(
                     sacp::Error::invalid_params().data(format!("Unsupported format: {other}"))
-                )
+                );
             }
         };
 
@@ -3329,7 +3344,7 @@ impl GooseAcpAgent {
     ) -> Result<DictationModelsListResponse, sacp::Error> {
         #[cfg(feature = "local-inference")]
         {
-            use crate::download_manager::{get_download_manager, DownloadStatus};
+            use crate::download_manager::{DownloadStatus, get_download_manager};
 
             let manager = get_download_manager();
             let models = whisper::available_models()

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1095,57 +1095,16 @@ impl GooseAcpAgent {
         self.sessions.lock().await.contains_key(session_id)
     }
 
-    /// Try to split a text block containing persona-instructions and user-message XML
-    /// into (context_text, user_text). Returns None if the pattern doesn't match.
-    fn split_persona_user_text(text: &str) -> Option<(String, String)> {
-        let trimmed = text.trim();
-        if !trimmed.starts_with("<persona-instructions>") {
-            return None;
-        }
-        // Find the user-message boundaries
-        let user_start_tag = "<user-message>";
-        let user_end_tag = "</user-message>";
-        let start_idx = trimmed.find(user_start_tag)?;
-        let end_idx = trimmed.rfind(user_end_tag)?;
-        if start_idx >= end_idx {
-            return None;
-        }
-        let user_text = trimmed[start_idx + user_start_tag.len()..end_idx]
-            .trim()
-            .to_string();
-        // Context is everything outside the user-message tags
-        let context_text = format!(
-            "{}{}",
-            &trimmed[..start_idx],
-            &trimmed[end_idx + user_end_tag.len()..]
-        )
-        .trim()
-        .to_string();
-        Some((context_text, user_text))
-    }
-
-    /// Convert ACP prompt content blocks into messages. When the prompt contains
-    /// persona-instructions wrapping a user-message, splits into a hidden context
-    /// message and a visible user message. Returns (messages_to_persist, message_for_agent).
-    fn convert_acp_prompt_to_messages(
-        &self,
-        prompt: Vec<ContentBlock>,
-    ) -> (Vec<Message>, Message) {
-        // Build the combined message preserving original block order
-        let mut combined_message = Message::user();
-        let mut combined_text = String::new();
-        let mut has_images = false;
-
-        for block in &prompt {
+    /// Convert ACP prompt content blocks into a user message.
+    fn convert_acp_prompt_to_message(prompt: &[ContentBlock]) -> Message {
+        let mut message = Message::user();
+        for block in prompt {
             match block {
                 ContentBlock::Text(text) => {
-                    combined_message = combined_message.with_text(&text.text);
-                    combined_text.push_str(&text.text);
+                    message = message.with_text(&text.text);
                 }
                 ContentBlock::Image(image) => {
-                    combined_message =
-                        combined_message.with_image(&image.data, &image.mime_type);
-                    has_images = true;
+                    message = message.with_image(&image.data, &image.mime_type);
                 }
                 ContentBlock::Resource(resource) => {
                     if let EmbeddedResourceResource::TextResourceContents(text_resource) =
@@ -1153,39 +1112,18 @@ impl GooseAcpAgent {
                     {
                         let header = format!("--- Resource: {} ---\n", text_resource.uri);
                         let content = format!("{}{}\n---\n", header, text_resource.text);
-                        combined_message = combined_message.with_text(&content);
-                        combined_text.push_str(&content);
+                        message = message.with_text(&content);
                     }
                 }
                 ContentBlock::ResourceLink(link) => {
                     if let Some(text) = read_resource_link(link.clone()) {
-                        combined_message = combined_message.with_text(text.clone());
-                        combined_text.push_str(&text);
+                        message = message.with_text(text);
                     }
                 }
                 ContentBlock::Audio(..) | _ => (),
             }
         }
-
-        // Try to split persona context from user message
-        if let Some((context_text, user_text)) = Self::split_persona_user_text(&combined_text) {
-            let context_msg = Message::user().with_text(&context_text).agent_only();
-
-            let mut visible_msg = Message::user().with_text(&user_text);
-            // Non-text content (images, resources) goes on the visible message
-            if has_images {
-                for block in &prompt {
-                    if let ContentBlock::Image(image) = block {
-                        visible_msg =
-                            visible_msg.with_image(&image.data, &image.mime_type);
-                    }
-                }
-            }
-
-            (vec![context_msg, visible_msg], combined_message)
-        } else {
-            (vec![combined_message.clone()], combined_message)
-        }
+        message
     }
 
     async fn handle_message_content(
@@ -2102,19 +2040,47 @@ impl GooseAcpAgent {
             .await?;
         debug!(target: "perf", sid = %sid, ms = t_agent.elapsed().as_millis() as u64, "perf: prompt get_session_agent (waits for agent setup)");
 
-        let (messages_to_persist, agent_message) =
-            self.convert_acp_prompt_to_messages(args.prompt);
+        // Extract system prompt from _meta if provided, persist as hidden message
+        let system_prompt = args
+            .meta
+            .as_ref()
+            .and_then(|m| m.get("systemPrompt"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let user_message = Self::convert_acp_prompt_to_message(&args.prompt);
+
+        // Build the agent message: system prompt + user content combined
+        let agent_message = if let Some(ref sp) = system_prompt {
+            let mut msg = Message::user().with_text(sp);
+            for content in user_message.content.iter() {
+                msg.content.push(content.clone());
+            }
+            msg
+        } else {
+            user_message.clone()
+        };
 
         let t_persist = std::time::Instant::now();
-        for msg in &messages_to_persist {
+        // Persist hidden system prompt message if present
+        if let Some(ref sp) = system_prompt {
+            let context_msg = Message::user().with_text(sp).agent_only();
             self.thread_manager
-                .append_message(&thread_id, Some(&internal_session_id), msg)
+                .append_message(&thread_id, Some(&internal_session_id), &context_msg)
                 .await
                 .map_err(|e| {
                     sacp::Error::internal_error()
                         .data(format!("Failed to persist message: {}", e))
                 })?;
         }
+        // Persist visible user message
+        self.thread_manager
+            .append_message(&thread_id, Some(&internal_session_id), &user_message)
+            .await
+            .map_err(|e| {
+                sacp::Error::internal_error()
+                    .data(format!("Failed to persist message: {}", e))
+            })?;
         debug!(target: "perf", sid = %sid, ms = t_persist.elapsed().as_millis() as u64, "perf: prompt append_user_message");
 
         let session_config = SessionConfig {

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -32,9 +32,9 @@ use anyhow::Result;
 use fs_err as fs;
 use futures::future::BoxFuture;
 use goose_acp_macros::custom_methods;
-use rmcp::model::{CallToolResult, RawContent, ResourceContents, Role};
+use rmcp::model::{AnnotateAble, CallToolResult, RawContent, RawTextContent, ResourceContents, Role};
 use sacp::schema::{
-    AgentCapabilities, AuthMethod, AuthMethodAgent, AuthenticateRequest, AuthenticateResponse,
+    AgentCapabilities, Annotations, AuthMethod, AuthMethodAgent, AuthenticateRequest, AuthenticateResponse,
     BlobResourceContents, CancelNotification, CloseSessionRequest, CloseSessionResponse,
     ConfigOptionUpdate, Content, ContentBlock, ContentChunk, CurrentModeUpdate, EmbeddedResource,
     EmbeddedResourceResource, FileSystemCapabilities, ForkSessionRequest, ForkSessionResponse,
@@ -1101,7 +1101,30 @@ impl GooseAcpAgent {
         for block in prompt {
             match block {
                 ContentBlock::Text(text) => {
-                    message = message.with_text(&text.text);
+                    let raw = RawTextContent {
+                        text: text.text.clone(),
+                        meta: None,
+                    };
+                    let annotated = if let Some(ref ann) = text.annotations {
+                        let audience: Vec<Role> = ann
+                            .audience
+                            .as_ref()
+                            .map(|roles| {
+                                roles
+                                    .iter()
+                                    .filter_map(|r| match r {
+                                        sacp::schema::Role::Assistant => Some(Role::Assistant),
+                                        sacp::schema::Role::User => Some(Role::User),
+                                        _ => None,
+                                    })
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        raw.no_annotation().with_audience(audience)
+                    } else {
+                        raw.no_annotation()
+                    };
+                    message = message.with_content(MessageContent::Text(annotated));
                 }
                 ContentBlock::Image(image) => {
                     message = message.with_image(&image.data, &image.mime_type);
@@ -1832,9 +1855,19 @@ impl GooseAcpAgent {
             for content_item in &message.content {
                 match content_item {
                     MessageContent::Text(text) => {
-                        let chunk = ContentChunk::new(ContentBlock::Text(TextContent::new(
-                            text.text.clone(),
-                        )));
+                        let mut tc = TextContent::new(text.text.clone());
+                        if let Some(audience) = text.audience() {
+                            tc = tc.annotations(Annotations::new().audience(
+                                audience
+                                    .iter()
+                                    .map(|r| match r {
+                                        Role::Assistant => sacp::schema::Role::Assistant,
+                                        Role::User => sacp::schema::Role::User,
+                                    })
+                                    .collect::<Vec<_>>(),
+                            ));
+                        }
+                        let chunk = ContentChunk::new(ContentBlock::Text(tc));
                         let update = match message.role {
                             Role::User => SessionUpdate::UserMessageChunk(chunk),
                             Role::Assistant => SessionUpdate::AgentMessageChunk(chunk),
@@ -2040,40 +2073,10 @@ impl GooseAcpAgent {
             .await?;
         debug!(target: "perf", sid = %sid, ms = t_agent.elapsed().as_millis() as u64, "perf: prompt get_session_agent (waits for agent setup)");
 
-        // Extract system prompt from _meta if provided, persist as hidden message
-        let system_prompt = args
-            .meta
-            .as_ref()
-            .and_then(|m| m.get("systemPrompt"))
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
-
         let user_message = Self::convert_acp_prompt_to_message(&args.prompt);
 
-        // Build the agent message: system prompt + user content combined
-        let agent_message = if let Some(ref sp) = system_prompt {
-            let mut msg = Message::user().with_text(sp);
-            for content in user_message.content.iter() {
-                msg.content.push(content.clone());
-            }
-            msg
-        } else {
-            user_message.clone()
-        };
-
         let t_persist = std::time::Instant::now();
-        // Persist hidden system prompt message if present
-        if let Some(ref sp) = system_prompt {
-            let context_msg = Message::user().with_text(sp).agent_only();
-            self.thread_manager
-                .append_message(&thread_id, Some(&internal_session_id), &context_msg)
-                .await
-                .map_err(|e| {
-                    sacp::Error::internal_error()
-                        .data(format!("Failed to persist message: {}", e))
-                })?;
-        }
-        // Persist visible user message
+        // Persist user message (may contain assistant-only annotated blocks)
         self.thread_manager
             .append_message(&thread_id, Some(&internal_session_id), &user_message)
             .await
@@ -2092,7 +2095,7 @@ impl GooseAcpAgent {
 
         let t_reply = std::time::Instant::now();
         let mut stream = agent
-            .reply(agent_message, session_config, Some(cancel_token.clone()))
+            .reply(user_message, session_config, Some(cancel_token.clone()))
             .await
             .map_err(|e| {
                 sacp::Error::internal_error().data(format!("Error getting agent reply: {}", e))

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1,7 +1,7 @@
 use crate::acp::custom_requests::*;
 use crate::acp::fs::AcpTools;
 use crate::acp::tools::AcpAwareToolMeta;
-use crate::acp::{ACP_CURRENT_MODEL, PermissionDecision};
+use crate::acp::{PermissionDecision, ACP_CURRENT_MODEL};
 use crate::agents::extension::{Envs, PLATFORM_EXTENSIONS};
 use crate::agents::mcp_client::McpClientTrait;
 use crate::agents::platform_extensions::developer::DeveloperClient;
@@ -15,7 +15,7 @@ use crate::conversation::message::{ActionRequiredData, Message, MessageContent};
 #[cfg(feature = "local-inference")]
 use crate::dictation::providers::transcribe_local;
 use crate::dictation::providers::{
-    DictationProvider, all_providers, is_configured, transcribe_with_provider,
+    all_providers, is_configured, transcribe_with_provider, DictationProvider,
 };
 #[cfg(feature = "local-inference")]
 use crate::dictation::whisper;
@@ -3204,7 +3204,7 @@ impl GooseAcpAgent {
         &self,
         req: DictationTranscribeRequest,
     ) -> Result<DictationTranscribeResponse, sacp::Error> {
-        use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+        use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
         let config = crate::config::Config::global();
 
         #[cfg(not(feature = "local-inference"))]
@@ -3343,7 +3343,7 @@ impl GooseAcpAgent {
     ) -> Result<DictationModelsListResponse, sacp::Error> {
         #[cfg(feature = "local-inference")]
         {
-            use crate::download_manager::{DownloadStatus, get_download_manager};
+            use crate::download_manager::{get_download_manager, DownloadStatus};
 
             let manager = get_download_manager();
             let models = whisper::available_models()

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1120,7 +1120,7 @@ impl GooseAcpAgent {
                             })
                             .unwrap_or_default();
                         let raw = RawTextContent {
-                            text: text.text.clone(),
+                            text: sanitize_unicode_tags(&text.text),
                             meta: None,
                         };
                         if audience.is_empty() {
@@ -1129,8 +1129,7 @@ impl GooseAcpAgent {
                             raw.no_annotation().with_audience(audience)
                         }
                     } else {
-                        // No annotations — regular user text; sanitize against
-                        // invisible Unicode tag prompt-injection.
+                        // No annotations — regular user text.
                         let sanitized = sanitize_unicode_tags(&text.text);
                         RawTextContent {
                             text: sanitized,

--- a/ui/goose2/src/features/chat/ui/MessageBubble.tsx
+++ b/ui/goose2/src/features/chat/ui/MessageBubble.tsx
@@ -101,7 +101,7 @@ interface ContentSection {
 function filterUserVisibleContent(content: MessageContent[]): MessageContent[] {
   return content.filter((b) => {
     const aud = b.annotations?.audience;
-    return !aud || aud.includes("user");
+    return !aud || aud.length === 0 || aud.includes("user");
   });
 }
 

--- a/ui/goose2/src/features/chat/ui/MessageBubble.tsx
+++ b/ui/goose2/src/features/chat/ui/MessageBubble.tsx
@@ -100,7 +100,10 @@ interface ContentSection {
 /** Keep only content blocks whose audience includes "user" (or has no audience). */
 function filterUserVisibleContent(content: MessageContent[]): MessageContent[] {
   return content.filter((b) => {
-    const aud = b.type === "text" ? b.annotations?.audience : undefined;
+    const aud =
+      "annotations" in b
+        ? (b.annotations as { audience?: string[] })?.audience
+        : undefined;
     return !aud || aud.includes("user");
   });
 }

--- a/ui/goose2/src/features/chat/ui/MessageBubble.tsx
+++ b/ui/goose2/src/features/chat/ui/MessageBubble.tsx
@@ -37,7 +37,6 @@ import type {
   Message,
   MessageAttachment,
   MessageContent,
-  ContentAnnotations,
   TextContent,
   ImageContent,
   ToolResponseContent,
@@ -101,9 +100,7 @@ interface ContentSection {
 /** Keep only content blocks whose audience includes "user" (or has no audience). */
 function filterUserVisibleContent(content: MessageContent[]): MessageContent[] {
   return content.filter((b) => {
-    if (!("annotations" in b)) return true;
-    const aud = (b as { annotations?: ContentAnnotations }).annotations
-      ?.audience;
+    const aud = b.annotations?.audience;
     return !aud || aud.includes("user");
   });
 }
@@ -337,6 +334,7 @@ export const MessageBubble = memo(function MessageBubble({
     .filter((c): c is TextContent => c.type === "text")
     .map((c) => c.text)
     .join("\n");
+
   if (role === "system") {
     return (
       <div className="flex justify-center px-4 py-2">

--- a/ui/goose2/src/features/chat/ui/MessageBubble.tsx
+++ b/ui/goose2/src/features/chat/ui/MessageBubble.tsx
@@ -97,6 +97,14 @@ interface ContentSection {
   items: MessageContent[] | ToolChainItem[];
 }
 
+/** Keep only content blocks whose audience includes "user" (or has no audience). */
+function filterUserVisibleContent(content: MessageContent[]): MessageContent[] {
+  return content.filter((b) => {
+    const aud = b.type === "text" ? b.annotations?.audience : undefined;
+    return !aud || aud.includes("user");
+  });
+}
+
 function findMatchingToolChainIndex(
   items: ToolChainItem[],
   response: ToolResponseContent,
@@ -224,29 +232,17 @@ function renderContentBlock(
     case "toolResponse":
       // Handled by groupContentSections toolChain rendering
       return null;
-    case "thinking": {
-      const th = content as ThinkingContent;
-      return (
-        <Reasoning
-          key={`thinking-${index}`}
-          isStreaming={isStreamingMsg}
-          defaultOpen={false}
-        >
-          <ReasoningTrigger />
-          <ReasoningContent>{th.text}</ReasoningContent>
-        </Reasoning>
-      );
-    }
+    case "thinking":
     case "reasoning": {
-      const r = content as ReasoningContentType;
+      const text = (content as ThinkingContent | ReasoningContentType).text;
       return (
         <Reasoning
-          key={`reasoning-${index}`}
+          key={`${content.type}-${index}`}
           isStreaming={isStreamingMsg}
           defaultOpen={false}
         >
           <ReasoningTrigger />
-          <ReasoningContent>{r.text}</ReasoningContent>
+          <ReasoningContent>{text}</ReasoningContent>
         </Reasoning>
       );
     }
@@ -319,11 +315,9 @@ export const MessageBubble = memo(function MessageBubble({
   const { t } = useTranslation(["chat", "common"]);
   const { formatDate } = useLocaleFormatting();
   const { role, content: rawContent, created } = message;
-  // Filter out assistant-only blocks (e.g. system prompt context)
-  const content = rawContent.filter((b) => {
-    const aud = b.type === "text" ? b.annotations?.audience : undefined;
-    return !aud || aud.includes("user");
-  });
+  // Only user messages carry annotated blocks; skip the filter for others.
+  const content =
+    role === "user" ? filterUserVisibleContent(rawContent) : rawContent;
   const { handleContentClick, pathNotice } = useArtifactLinkHandler();
   const persona = useAgentStore((state) =>
     message.metadata?.personaId

--- a/ui/goose2/src/features/chat/ui/MessageBubble.tsx
+++ b/ui/goose2/src/features/chat/ui/MessageBubble.tsx
@@ -37,6 +37,7 @@ import type {
   Message,
   MessageAttachment,
   MessageContent,
+  ContentAnnotations,
   TextContent,
   ImageContent,
   ToolResponseContent,
@@ -100,10 +101,9 @@ interface ContentSection {
 /** Keep only content blocks whose audience includes "user" (or has no audience). */
 function filterUserVisibleContent(content: MessageContent[]): MessageContent[] {
   return content.filter((b) => {
-    const aud =
-      "annotations" in b
-        ? (b.annotations as { audience?: string[] })?.audience
-        : undefined;
+    if (!("annotations" in b)) return true;
+    const aud = (b as { annotations?: ContentAnnotations }).annotations
+      ?.audience;
     return !aud || aud.includes("user");
   });
 }
@@ -330,11 +330,13 @@ export const MessageBubble = memo(function MessageBubble({
   const { isCopied: isCopyConfirmed, copyToClipboard } = useCopyToClipboard();
   const personaAvatarUrl = useAvatarSrc(persona?.avatar);
 
+  // Skip empty user bubbles (all blocks filtered as assistant-only).
+  if (role === "user" && content.length === 0) return null;
+
   const textContent = content
     .filter((c): c is TextContent => c.type === "text")
     .map((c) => c.text)
     .join("\n");
-
   if (role === "system") {
     return (
       <div className="flex justify-center px-4 py-2">
@@ -349,7 +351,6 @@ export const MessageBubble = memo(function MessageBubble({
       </div>
     );
   }
-
   const isUser = role === "user";
   const assistantProviderId = message.metadata?.providerId;
   const assistantProviderName = assistantProviderId

--- a/ui/goose2/src/features/chat/ui/MessageBubble.tsx
+++ b/ui/goose2/src/features/chat/ui/MessageBubble.tsx
@@ -318,7 +318,12 @@ export const MessageBubble = memo(function MessageBubble({
 }: MessageBubbleProps) {
   const { t } = useTranslation(["chat", "common"]);
   const { formatDate } = useLocaleFormatting();
-  const { role, content, created } = message;
+  const { role, content: rawContent, created } = message;
+  // Filter out assistant-only blocks (e.g. system prompt context)
+  const content = rawContent.filter((b) => {
+    const aud = b.type === "text" ? b.annotations?.audience : undefined;
+    return !aud || aud.includes("user");
+  });
   const { handleContentClick, pathNotice } = useArtifactLinkHandler();
   const persona = useAgentStore((state) =>
     message.metadata?.personaId

--- a/ui/goose2/src/shared/api/acp.ts
+++ b/ui/goose2/src/shared/api/acp.ts
@@ -71,17 +71,15 @@ export async function acpSendMessage(
     throw new Error("Session not prepared. Call acpPrepareSession first.");
   }
 
-  const hasSystem = systemPrompt && systemPrompt.trim().length > 0;
-  const effectivePrompt = hasSystem
-    ? `<persona-instructions>\n${systemPrompt}\n</persona-instructions>\n\n<user-message>\n${prompt}\n</user-message>`
-    : prompt;
-
-  const content: ContentBlock[] = [{ type: "text", text: effectivePrompt }];
+  const content: ContentBlock[] = [{ type: "text", text: prompt }];
   if (images) {
     for (const [data, mimeType] of images) {
       content.push({ type: "image", data, mimeType } as ContentBlock);
     }
   }
+
+  const hasSystem = systemPrompt && systemPrompt.trim().length > 0;
+  const meta = hasSystem ? { systemPrompt } : undefined;
 
   const messageId = crypto.randomUUID();
   setActiveMessageId(gooseSessionId, messageId);
@@ -90,7 +88,7 @@ export async function acpSendMessage(
     `[perf:send] ${sid} acpSendMessage → prompt(len=${prompt.length}, imgs=${images?.length ?? 0})`,
   );
   const tPrompt = performance.now();
-  await directAcp.prompt(gooseSessionId, content);
+  await directAcp.prompt(gooseSessionId, content, meta);
   const tDone = performance.now();
   perfLog(
     `[perf:send] ${sid} prompt() resolved in ${(tDone - tPrompt).toFixed(1)}ms (total acpSendMessage ${(tDone - tStart).toFixed(1)}ms)`,

--- a/ui/goose2/src/shared/api/acp.ts
+++ b/ui/goose2/src/shared/api/acp.ts
@@ -71,15 +71,20 @@ export async function acpSendMessage(
     throw new Error("Session not prepared. Call acpPrepareSession first.");
   }
 
-  const content: ContentBlock[] = [{ type: "text", text: prompt }];
+  const content: ContentBlock[] = [];
+  if (systemPrompt?.trim()) {
+    content.push({
+      type: "text",
+      text: systemPrompt,
+      annotations: { audience: ["assistant"] },
+    } as ContentBlock);
+  }
+  content.push({ type: "text", text: prompt });
   if (images) {
     for (const [data, mimeType] of images) {
       content.push({ type: "image", data, mimeType } as ContentBlock);
     }
   }
-
-  const hasSystem = systemPrompt && systemPrompt.trim().length > 0;
-  const meta = hasSystem ? { systemPrompt } : undefined;
 
   const messageId = crypto.randomUUID();
   setActiveMessageId(gooseSessionId, messageId);
@@ -88,7 +93,7 @@ export async function acpSendMessage(
     `[perf:send] ${sid} acpSendMessage → prompt(len=${prompt.length}, imgs=${images?.length ?? 0})`,
   );
   const tPrompt = performance.now();
-  await directAcp.prompt(gooseSessionId, content, meta);
+  await directAcp.prompt(gooseSessionId, content);
   const tDone = performance.now();
   perfLog(
     `[perf:send] ${sid} prompt() resolved in ${(tDone - tPrompt).toFixed(1)}ms (total acpSendMessage ${(tDone - tStart).toFixed(1)}ms)`,

--- a/ui/goose2/src/shared/api/acp.ts
+++ b/ui/goose2/src/shared/api/acp.ts
@@ -77,7 +77,7 @@ export async function acpSendMessage(
       type: "text",
       text: systemPrompt,
       annotations: { audience: ["assistant"] },
-    } as ContentBlock);
+    });
   }
   content.push({ type: "text", text: prompt });
   if (images) {

--- a/ui/goose2/src/shared/api/acpApi.ts
+++ b/ui/goose2/src/shared/api/acpApi.ts
@@ -187,7 +187,8 @@ export async function loadSession(
 export async function prompt(
   sessionId: string,
   content: ContentBlock[],
+  meta?: Record<string, unknown>,
 ): Promise<PromptResponse> {
   const client = await getClient();
-  return client.prompt({ sessionId, prompt: content });
+  return client.prompt({ sessionId, prompt: content, _meta: meta });
 }

--- a/ui/goose2/src/shared/api/acpApi.ts
+++ b/ui/goose2/src/shared/api/acpApi.ts
@@ -187,8 +187,7 @@ export async function loadSession(
 export async function prompt(
   sessionId: string,
   content: ContentBlock[],
-  meta?: Record<string, unknown>,
 ): Promise<PromptResponse> {
   const client = await getClient();
-  return client.prompt({ sessionId, prompt: content, _meta: meta });
+  return client.prompt({ sessionId, prompt: content });
 }

--- a/ui/goose2/src/shared/api/acpNotificationHandler.ts
+++ b/ui/goose2/src/shared/api/acpNotificationHandler.ts
@@ -217,12 +217,7 @@ function handleReplay(sessionId: string, update: SessionUpdate): void {
           metadata: { userVisible: true, agentVisible: true },
         });
       } else {
-        const last = existing.content[existing.content.length - 1];
-        if (last?.type === "text" && !ann) {
-          (last as { type: "text"; text: string }).text += update.content.text;
-        } else {
-          existing.content.push(textBlock);
-        }
+        existing.content.push(textBlock);
       }
       break;
     }

--- a/ui/goose2/src/shared/api/acpNotificationHandler.ts
+++ b/ui/goose2/src/shared/api/acpNotificationHandler.ts
@@ -207,6 +207,10 @@ function handleReplay(sessionId: string, update: SessionUpdate): void {
       const rawAnn = (update.content as any).annotations;
       const ann: TextContent["annotations"] | undefined =
         typeof rawAnn === "object" && rawAnn !== null ? rawAnn : undefined;
+      // Drop blocks whose audience does not include "user" so that
+      // assistant-only system prompt blocks never enter chat state
+      // (other consumers like getTextContent read raw message.content).
+      if (ann?.audience && !ann.audience.includes("user")) break;
       const textBlock = makeTextBlock(update.content.text, ann);
       if (!existing) {
         buffer.push({

--- a/ui/goose2/src/shared/api/acpNotificationHandler.ts
+++ b/ui/goose2/src/shared/api/acpNotificationHandler.ts
@@ -205,7 +205,7 @@ function handleReplay(sessionId: string, update: SessionUpdate): void {
       // but the wire format includes it. Guard with a runtime typeof check.
       // biome-ignore lint/suspicious/noExplicitAny: ACP SDK type narrowing
       const rawAnn = (update.content as any).annotations;
-      const ann: { audience?: ("user" | "assistant")[] } | undefined =
+      const ann: TextContent["annotations"] | undefined =
         typeof rawAnn === "object" && rawAnn !== null ? rawAnn : undefined;
       const textBlock = makeTextBlock(update.content.text, ann);
       if (!existing) {

--- a/ui/goose2/src/shared/api/acpNotificationHandler.ts
+++ b/ui/goose2/src/shared/api/acpNotificationHandler.ts
@@ -10,6 +10,7 @@ import {
   findLatestUnpairedToolRequest,
 } from "@/features/chat/hooks/replayBuffer";
 import type {
+  TextContent,
   ToolRequestContent,
   ToolResponseContent,
 } from "@/shared/types/messages";
@@ -196,31 +197,29 @@ function handleReplay(sessionId: string, update: SessionUpdate): void {
     }
 
     case "user_message_chunk": {
+      if (update.content.type !== "text" || !("text" in update.content)) break;
       const messageId = update.messageId ?? crypto.randomUUID();
       const buffer = ensureReplayBuffer(sessionId);
       const existing = getBufferedMessage(sessionId, messageId);
-      if (
-        !existing &&
-        update.content.type === "text" &&
-        "text" in update.content
-      ) {
+      // biome-ignore lint/suspicious/noExplicitAny: ACP SDK type narrowing
+      const ann = (update.content as any).annotations as
+        | { audience?: ("user" | "assistant")[] }
+        | undefined;
+      const textBlock = makeTextBlock(update.content.text, ann);
+      if (!existing) {
         buffer.push({
           id: messageId,
           role: "user",
           created: Date.now(),
-          content: [{ type: "text", text: update.content.text }],
+          content: [textBlock],
           metadata: { userVisible: true, agentVisible: true },
         });
-      } else if (
-        existing &&
-        update.content.type === "text" &&
-        "text" in update.content
-      ) {
+      } else {
         const last = existing.content[existing.content.length - 1];
-        if (last?.type === "text") {
+        if (last?.type === "text" && !ann) {
           (last as { type: "text"; text: string }).text += update.content.text;
         } else {
-          existing.content.push({ type: "text", text: update.content.text });
+          existing.content.push(textBlock);
         }
       }
       break;
@@ -484,6 +483,13 @@ function handleShared(sessionId: string, update: SessionUpdate): void {
 function findStreamingMessageId(sessionId: string): string | null {
   return useChatStore.getState().getSessionRuntime(sessionId)
     .streamingMessageId;
+}
+
+function makeTextBlock(
+  text: string,
+  ann?: TextContent["annotations"],
+): TextContent {
+  return { type: "text", text, ...(ann ? { annotations: ann } : {}) };
 }
 
 function findMessageInBuffer(

--- a/ui/goose2/src/shared/api/acpNotificationHandler.ts
+++ b/ui/goose2/src/shared/api/acpNotificationHandler.ts
@@ -201,16 +201,17 @@ function handleReplay(sessionId: string, update: SessionUpdate): void {
       const messageId = update.messageId ?? crypto.randomUUID();
       const buffer = ensureReplayBuffer(sessionId);
       const existing = getBufferedMessage(sessionId, messageId);
-      // ACP SDK's ContentBlock union doesn't expose annotations on the text branch,
-      // but the wire format includes it. Guard with a runtime typeof check.
-      // biome-ignore lint/suspicious/noExplicitAny: ACP SDK type narrowing
+      // biome-ignore lint/suspicious/noExplicitAny: wire format has annotations but SDK types don't
       const rawAnn = (update.content as any).annotations;
       const ann: TextContent["annotations"] | undefined =
         typeof rawAnn === "object" && rawAnn !== null ? rawAnn : undefined;
-      // Drop blocks whose audience does not include "user" so that
-      // assistant-only system prompt blocks never enter chat state
-      // (other consumers like getTextContent read raw message.content).
-      if (ann?.audience && !ann.audience.includes("user")) break;
+      // Drop assistant-only blocks so they never enter chat state.
+      if (
+        ann?.audience &&
+        ann.audience.length > 0 &&
+        !ann.audience.includes("user")
+      )
+        break;
       const textBlock = makeTextBlock(update.content.text, ann);
       if (!existing) {
         buffer.push({

--- a/ui/goose2/src/shared/api/acpNotificationHandler.ts
+++ b/ui/goose2/src/shared/api/acpNotificationHandler.ts
@@ -201,10 +201,12 @@ function handleReplay(sessionId: string, update: SessionUpdate): void {
       const messageId = update.messageId ?? crypto.randomUUID();
       const buffer = ensureReplayBuffer(sessionId);
       const existing = getBufferedMessage(sessionId, messageId);
+      // ACP SDK's ContentBlock union doesn't expose annotations on the text branch,
+      // but the wire format includes it. Guard with a runtime typeof check.
       // biome-ignore lint/suspicious/noExplicitAny: ACP SDK type narrowing
-      const ann = (update.content as any).annotations as
-        | { audience?: ("user" | "assistant")[] }
-        | undefined;
+      const rawAnn = (update.content as any).annotations;
+      const ann: { audience?: ("user" | "assistant")[] } | undefined =
+        typeof rawAnn === "object" && rawAnn !== null ? rawAnn : undefined;
       const textBlock = makeTextBlock(update.content.text, ann);
       if (!existing) {
         buffer.push({

--- a/ui/goose2/src/shared/types/messages.ts
+++ b/ui/goose2/src/shared/types/messages.ts
@@ -53,6 +53,7 @@ export interface ImageContent {
   source:
     | { type: "base64"; mediaType: string; data: string }
     | { type: "url"; url: string };
+  annotations?: ContentAnnotations;
 }
 
 export type ToolCallStatus =
@@ -76,6 +77,7 @@ export interface ToolRequestContent {
   status: ToolCallStatus;
   /** Epoch ms when the tool call started executing (set on event receipt). */
   startedAt?: number;
+  annotations?: ContentAnnotations;
 }
 
 export interface ToolResponseContent {
@@ -84,20 +86,24 @@ export interface ToolResponseContent {
   name: string;
   result: string;
   isError: boolean;
+  annotations?: ContentAnnotations;
 }
 
 export interface ThinkingContent {
   type: "thinking";
   text: string;
+  annotations?: ContentAnnotations;
 }
 
 export interface RedactedThinkingContent {
   type: "redactedThinking";
+  annotations?: ContentAnnotations;
 }
 
 export interface ReasoningContent {
   type: "reasoning";
   text: string;
+  annotations?: ContentAnnotations;
 }
 
 export interface ActionRequiredContent {
@@ -108,12 +114,14 @@ export interface ActionRequiredContent {
   toolName?: string;
   arguments?: Record<string, unknown>;
   schema?: Record<string, unknown>;
+  annotations?: ContentAnnotations;
 }
 
 export interface SystemNotificationContent {
   type: "systemNotification";
   notificationType: "compaction" | "info" | "warning" | "error";
   text: string;
+  annotations?: ContentAnnotations;
 }
 
 export type MessageContent =

--- a/ui/goose2/src/shared/types/messages.ts
+++ b/ui/goose2/src/shared/types/messages.ts
@@ -36,11 +36,16 @@ export type MessageRole = "user" | "assistant" | "system";
 /** ACP audience restriction — which roles may see a content block. */
 export type Audience = ("user" | "assistant")[];
 
+/** ACP content-block annotations (mirrors the SDK's Annotations shape). */
+export interface ContentAnnotations {
+  audience?: Audience;
+}
+
 // Content block types
 export interface TextContent {
   type: "text";
   text: string;
-  annotations?: { audience?: Audience };
+  annotations?: ContentAnnotations;
 }
 
 export interface ImageContent {

--- a/ui/goose2/src/shared/types/messages.ts
+++ b/ui/goose2/src/shared/types/messages.ts
@@ -37,6 +37,7 @@ export type MessageRole = "user" | "assistant" | "system";
 export interface TextContent {
   type: "text";
   text: string;
+  annotations?: { audience?: ("user" | "assistant")[] };
 }
 
 export interface ImageContent {

--- a/ui/goose2/src/shared/types/messages.ts
+++ b/ui/goose2/src/shared/types/messages.ts
@@ -33,11 +33,14 @@ export type ChatAttachmentDraft =
 // Message roles
 export type MessageRole = "user" | "assistant" | "system";
 
+/** ACP audience restriction — which roles may see a content block. */
+export type Audience = ("user" | "assistant")[];
+
 // Content block types
 export interface TextContent {
   type: "text";
   text: string;
-  annotations?: { audience?: ("user" | "assistant")[] };
+  annotations?: { audience?: Audience };
 }
 
 export interface ImageContent {


### PR DESCRIPTION
Previously after loading a session:
<img width="707" height="545" alt="Screenshot 2026-04-22 at 4 05 35 pm" src="https://github.com/user-attachments/assets/477a90f9-2232-4b05-a6f9-f400cee55d4c" />

When loading sessions we would show the preprompt text we added before starting the session.
We now separate the two into two text content blocks. The preprompt now has audience=[assistant], which can then filter out from the UI.

## Summary
- Replace XML wrapping of system prompts with ACP content block annotations (`audience: ["assistant"]`) to properly hide persona/project instructions from the user-visible message stream
- Add audience annotation roundtripping: Rust server preserves annotations when converting between ACP and internal message formats, and propagates them back on replay
- Filter annotated blocks in the UI so assistant-only content (system prompts) is not shown in `MessageBubble`
- Deduplicate `thinking`/`reasoning` rendering branches in `MessageBubble`

## Test plan
- [x] Existing tests pass (vitest, cargo clippy, biome check)
- [x] Verify persona instructions are sent as annotated blocks and hidden from the chat UI
- [x] Verify session replay correctly restores annotated user message blocks
- [x] Verify non-annotated user messages render normally