### PR TITLE
removed the specific code owner for documentation change

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,0 @@
-# CODEOWNERS file for aaif-goose/goose repository
-# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-
-# Documentation owned by DevRel
-/documentation/ @blackgirlbytes @angiejones @DOsinga
-


### PR DESCRIPTION
Removed the limited code owner for documentation change.  We can treat the doc change as the other change for pr approval by contributor with `write` access
