### PR TITLE
fix: removed hardcoded dependency of goose-acp-macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8263,9 +8263,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -190,7 +190,7 @@ pem = { version = "3", optional = true }
 pkcs1 = { version = "0.7", default-features = false, features = ["pkcs8"], optional = true }
 pkcs8 = { version = "0.10", default-features = false, features = ["alloc"], optional = true }
 sec1 = { version = "0.7", default-features = false, features = ["der", "pkcs8"], optional = true }
-goose-acp-macros = { version = "1.31.0", path = "../goose-acp-macros" }
+goose-acp-macros = { path = "../goose-acp-macros" }
 tower-http = { workspace = true, features = ["cors"] }
 http-body-util = "0.1.3"
 


### PR DESCRIPTION
## Summary
Removed hardcoded dependency of `goose-acp-macro`

Why: https://github.com/aaif-goose/goose/actions/runs/24745252740/job/72395273643 Canary build failed

### Testing
Canary build

