### PR TITLE
chore(goose2): full width assistant message

### DIFF
--- a/ui/goose2/src/features/chat/ui/MessageBubble.tsx
+++ b/ui/goose2/src/features/chat/ui/MessageBubble.tsx
@@ -422,7 +422,7 @@ export const MessageBubble = memo(function MessageBubble({
         {/* biome-ignore lint/a11y/noStaticElementInteractions: delegated link handler */}
         <div
           className={cn(
-            "w-full min-w-0 text-[13px] leading-relaxed",
+            "w-full min-w-0 text-sm leading-relaxed",
             isUser && "rounded-2xl bg-muted p-3",
           )}
           onClick={handleContentClick}

--- a/ui/goose2/src/features/chat/ui/MessageBubble.tsx
+++ b/ui/goose2/src/features/chat/ui/MessageBubble.tsx
@@ -390,7 +390,7 @@ export const MessageBubble = memo(function MessageBubble({
       <div
         className={cn(
           "group relative min-w-0 flex flex-col gap-1 pb-8",
-          isUser ? "max-w-[640px] items-end" : "max-w-[85%] items-start",
+          isUser ? "max-w-[640px] items-end" : "w-full items-start",
         )}
       >
         {showAssistantIdentity ? (


### PR DESCRIPTION
**Category:** fix
**User Impact:** Assistant messages in goose2 now use the full chat width and a standard small text size, so the conversation view feels more balanced and easier to read.
**Problem:** Incoming assistant messages looked visually off in goose2 because the content column stopped at 85% width and used a custom 13px font size. In wider layouts, that made responses feel narrower and slightly out of step with the rest of the chat surface.
**Solution:** Remove the assistant-only width cap and replace the one-off text size with Tailwind's `text-sm` utility. This keeps assistant messages aligned with the full conversation column while moving message typography back onto the shared type scale.

<details>
<summary>File changes</summary>

**ui/goose2/src/features/chat/ui/MessageBubble.tsx**
Remove the assistant message `max-w-[85%]` constraint and switch the message container from `text-[13px]` to `text-sm` so the chat layout and typography feel more consistent.

</details>

### Reproduction Steps
1. Run goose2 and open a conversation with a multi-line assistant response.
2. Compare the assistant message width against the full chat column.
3. Confirm the response now spans the available width instead of stopping early.
4. Check the message typography and confirm it uses the standard `text-sm` scale instead of the custom 13px size.

### Screenshots/Demos
<img width="1652" height="1036" alt="Screenshot 2026-04-22 at 3 22 56 PM" src="https://github.com/user-attachments/assets/f526c806-89c7-4363-9b66-828a14c928cb" />
