### PR TITLE
fix: Allow starting a new session in a project after creating one

### DIFF
--- a/ui/goose2/src/features/chat/lib/newChat.test.ts
+++ b/ui/goose2/src/features/chat/lib/newChat.test.ts
@@ -76,4 +76,49 @@ describe("findExistingDraft", () => {
       }),
     ).toBeUndefined();
   });
+
+  it("does not reuse the active empty draft without content", () => {
+    const draft = makeSession("alpha-draft", {
+      projectId: "alpha",
+      providerId: "goose",
+    });
+
+    expect(
+      findExistingDraft({
+        sessions: [draft],
+        activeSessionId: "alpha-draft",
+        draftsBySession: {},
+        messagesBySession: {},
+        request: {
+          title: "New Chat",
+          projectId: "alpha",
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not reuse a session with local messages even if messageCount is 0", () => {
+    const session = makeSession("alpha-session", {
+      projectId: "alpha",
+      providerId: "goose",
+      messageCount: 0,
+    });
+
+    expect(
+      findExistingDraft({
+        sessions: [session],
+        activeSessionId: "alpha-session",
+        draftsBySession: {},
+        messagesBySession: {
+          "alpha-session": [
+            { id: "msg-1", role: "user", content: "hello" } as any,
+          ],
+        },
+        request: {
+          title: "New Chat",
+          projectId: "alpha",
+        },
+      }),
+    ).toBeUndefined();
+  });
 });

--- a/ui/goose2/src/features/chat/lib/newChat.ts
+++ b/ui/goose2/src/features/chat/lib/newChat.ts
@@ -24,9 +24,13 @@ function isMatchingContext(
 
 function isReusableDraft(
   session: ChatSession,
-  _localMessages: Message[] | undefined,
+  localMessages: Message[] | undefined,
 ): boolean {
-  return !session.archivedAt && session.messageCount === 0;
+  return (
+    !session.archivedAt &&
+    session.messageCount === 0 &&
+    (localMessages?.length ?? 0) === 0
+  );
 }
 
 export function findExistingDraft({
@@ -60,5 +64,5 @@ export function findExistingDraft({
     );
   }
 
-  return candidates.find((session) => session.id === activeSessionId);
+  return undefined;
 }


### PR DESCRIPTION
## Repro steps
- Click on the plus button next to a project to get the new session UI
- Send a message to start a session
- Click on the plus button again... nothing happens


## Summary
- Fix bug where creating a new session after already having one open would reuse the existing session instead of creating a fresh one
- `isReusableDraft` now checks that `localMessages` is empty before considering a session reusable, preventing sessions with in-progress content from being recycled
- `findExistingDraft` no longer falls back to returning the active session as a candidate, ensuring a new session is always created when appropriate

## Test plan
- [x] Added test: does not reuse active empty draft without content
- [x] Added test: does not reuse session with local messages even if messageCount is 0
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)