### PR TITLE
feat: ACP tool-chain metadata

### DIFF
--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -2387,7 +2387,9 @@ impl GooseAcpAgent {
                             .cloned()
                             .unwrap_or(ReplayToolChainMeta {
                                 chain_id: tool_request.id.clone(),
-                                summary: summarize_tool_chain(&[fallback_title.clone()]),
+                                summary: summarize_tool_chain(std::slice::from_ref(
+                                    &fallback_title,
+                                )),
                             });
 
                         cx.send_notification(SessionNotification::new(

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -28,28 +28,34 @@ use crate::providers::inventory::{
 };
 use crate::session::session_manager::SessionType;
 use crate::session::{EnabledExtensionsState, Session, SessionManager};
+use crate::utils::sanitize_unicode_tags;
 use anyhow::Result;
+use chrono::{DateTime, Utc};
 use fs_err as fs;
 use futures::future::{BoxFuture, Either};
 use goose_acp_macros::custom_methods;
-use rmcp::model::{CallToolResult, RawContent, ResourceContents, Role};
+use rmcp::model::{
+    AnnotateAble, Annotations as RmcpAnnotations, CallToolResult, Meta as RmcpMeta, RawContent,
+    RawImageContent, RawTextContent, ResourceContents, Role,
+};
 use sacp::schema::{
-    AgentCapabilities, AuthMethod, AuthMethodAgent, AuthenticateRequest, AuthenticateResponse,
-    BlobResourceContents, CancelNotification, CloseSessionRequest, CloseSessionResponse,
-    ConfigOptionUpdate, Content, ContentBlock, ContentChunk, CurrentModeUpdate, EmbeddedResource,
-    EmbeddedResourceResource, FileSystemCapabilities, ForkSessionRequest, ForkSessionResponse,
-    ImageContent, InitializeRequest, InitializeResponse, ListSessionsRequest, ListSessionsResponse,
-    LoadSessionRequest, LoadSessionResponse, McpCapabilities, McpServer, Meta, ModelId, ModelInfo,
-    NewSessionRequest, NewSessionResponse, PermissionOption, PermissionOptionKind,
+    AgentCapabilities, Annotations as AcpAnnotations, AuthMethod, AuthMethodAgent,
+    AuthenticateRequest, AuthenticateResponse, BlobResourceContents, CancelNotification,
+    CloseSessionRequest, CloseSessionResponse, ConfigOptionUpdate, Content, ContentBlock,
+    ContentChunk, CurrentModeUpdate, EmbeddedResource, EmbeddedResourceResource,
+    FileSystemCapabilities, ForkSessionRequest, ForkSessionResponse, ImageContent,
+    InitializeRequest, InitializeResponse, ListSessionsRequest, ListSessionsResponse,
+    LoadSessionRequest, LoadSessionResponse, McpCapabilities, McpServer, Meta as AcpMeta, ModelId,
+    ModelInfo, NewSessionRequest, NewSessionResponse, PermissionOption, PermissionOptionKind,
     PromptCapabilities, PromptRequest, PromptResponse, RequestPermissionOutcome,
-    RequestPermissionRequest, ResourceLink, SessionCapabilities, SessionCloseCapabilities,
-    SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOption, SessionId,
-    SessionInfo, SessionListCapabilities, SessionMode, SessionModeId, SessionModeState,
-    SessionModelState, SessionNotification, SessionUpdate, SetSessionConfigOptionRequest,
-    SetSessionConfigOptionResponse, SetSessionModeRequest, SetSessionModeResponse,
-    SetSessionModelRequest, SetSessionModelResponse, StopReason, TextContent, TextResourceContents,
-    ToolCall, ToolCallContent, ToolCallId, ToolCallLocation, ToolCallStatus, ToolCallUpdate,
-    ToolCallUpdateFields, ToolKind, Usage, UsageUpdate,
+    RequestPermissionRequest, ResourceLink, Role as AcpRole, SessionCapabilities,
+    SessionCloseCapabilities, SessionConfigOption, SessionConfigOptionCategory,
+    SessionConfigSelectOption, SessionId, SessionInfo, SessionListCapabilities, SessionMode,
+    SessionModeId, SessionModeState, SessionModelState, SessionNotification, SessionUpdate,
+    SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, SetSessionModeRequest,
+    SetSessionModeResponse, SetSessionModelRequest, SetSessionModelResponse, StopReason,
+    TextContent, TextResourceContents, ToolCall, ToolCallContent, ToolCallId, ToolCallLocation,
+    ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind, Usage, UsageUpdate,
 };
 use sacp::util::MatchDispatchFrom;
 use sacp::{
@@ -218,14 +224,14 @@ fn thread_session_meta(
     meta
 }
 
-fn extract_timeout_from_meta(meta: &Option<Meta>) -> Option<u64> {
+fn extract_timeout_from_meta(meta: &Option<AcpMeta>) -> Option<u64> {
     meta.as_ref()
         .and_then(|m| m.get("timeout"))
         .and_then(|v| v.as_u64())
 }
 
-fn tool_chain_meta(chain_id: &str, chain_summary: &str) -> Meta {
-    let mut meta = Meta::new();
+fn tool_chain_meta(chain_id: &str, chain_summary: &str) -> AcpMeta {
+    let mut meta = AcpMeta::new();
     meta.insert(
         TOOL_CHAIN_META_KEY.to_string(),
         serde_json::Value::String(chain_id.to_string()),
@@ -235,6 +241,116 @@ fn tool_chain_meta(chain_id: &str, chain_summary: &str) -> Meta {
         serde_json::Value::String(chain_summary.to_string()),
     );
     meta
+}
+
+fn acp_meta_to_rmcp(meta: Option<AcpMeta>) -> Option<RmcpMeta> {
+    meta.map(RmcpMeta)
+}
+
+fn rmcp_meta_to_acp(meta: Option<RmcpMeta>) -> Option<AcpMeta> {
+    meta.map(|meta| meta.0)
+}
+
+fn acp_annotations_to_rmcp(annotations: Option<AcpAnnotations>) -> Option<RmcpAnnotations> {
+    annotations.map(|annotations| {
+        let mut rmcp_annotations = RmcpAnnotations::default();
+        rmcp_annotations.audience = annotations.audience.map(|audience| {
+            audience
+                .into_iter()
+                .map(|role| match role {
+                    AcpRole::Assistant => Role::Assistant,
+                    AcpRole::User => Role::User,
+                    _ => Role::User,
+                })
+                .collect()
+        });
+        rmcp_annotations.priority = annotations.priority.map(|priority| priority as f32);
+        rmcp_annotations.last_modified = annotations.last_modified.and_then(|last_modified| {
+            DateTime::parse_from_rfc3339(&last_modified)
+                .ok()
+                .map(|timestamp| timestamp.with_timezone(&Utc))
+        });
+        rmcp_annotations
+    })
+}
+
+fn rmcp_annotations_to_acp(annotations: Option<RmcpAnnotations>) -> Option<AcpAnnotations> {
+    annotations.map(|annotations| {
+        let audience = annotations.audience.map(|audience| {
+            audience
+                .into_iter()
+                .map(|role| match role {
+                    Role::Assistant => AcpRole::Assistant,
+                    Role::User => AcpRole::User,
+                })
+                .collect()
+        });
+
+        AcpAnnotations::new()
+            .audience(audience)
+            .last_modified(
+                annotations
+                    .last_modified
+                    .map(|last_modified| last_modified.to_rfc3339()),
+            )
+            .priority(annotations.priority.map(f64::from))
+    })
+}
+
+fn acp_text_to_message_content(
+    text: impl Into<String>,
+    annotations: Option<AcpAnnotations>,
+    meta: Option<AcpMeta>,
+) -> MessageContent {
+    MessageContent::Text(
+        RawTextContent {
+            text: sanitize_unicode_tags(&text.into()),
+            meta: acp_meta_to_rmcp(meta),
+        }
+        .optional_annotate(acp_annotations_to_rmcp(annotations)),
+    )
+}
+
+fn acp_prompt_block_to_message_content(block: ContentBlock) -> Option<MessageContent> {
+    match block {
+        ContentBlock::Text(text) => Some(acp_text_to_message_content(
+            text.text,
+            text.annotations,
+            text.meta,
+        )),
+        ContentBlock::Image(image) => Some(MessageContent::Image(
+            RawImageContent {
+                data: image.data,
+                mime_type: image.mime_type,
+                meta: acp_meta_to_rmcp(image.meta),
+            }
+            .optional_annotate(acp_annotations_to_rmcp(image.annotations)),
+        )),
+        ContentBlock::Resource(resource) => match resource.resource {
+            EmbeddedResourceResource::TextResourceContents(text_resource) => {
+                Some(acp_text_to_message_content(
+                    format!(
+                        "--- Resource: {} ---\n{}\n---\n",
+                        text_resource.uri, text_resource.text
+                    ),
+                    resource.annotations,
+                    resource.meta,
+                ))
+            }
+            EmbeddedResourceResource::BlobResourceContents(_) => None,
+            _ => None,
+        },
+        ContentBlock::ResourceLink(link) => read_resource_link(link.clone())
+            .map(|text| acp_text_to_message_content(text, link.annotations, link.meta)),
+        ContentBlock::Audio(..) => None,
+        _ => None,
+    }
+}
+
+fn rmcp_text_to_acp(text: &rmcp::model::TextContent) -> TextContent {
+    TextContent::new(text.text.clone())
+        .annotations(rmcp_annotations_to_acp(text.annotations.clone()))
+        .meta(rmcp_meta_to_acp(text.meta.clone()))
 }
 
 fn start_or_continue_tool_chain(
@@ -1642,28 +1758,8 @@ impl GooseAcpAgent {
         let mut user_message = Message::user();
 
         for block in prompt {
-            match block {
-                ContentBlock::Text(text) => {
-                    user_message = user_message.with_text(&text.text);
-                }
-                ContentBlock::Image(image) => {
-                    user_message = user_message.with_image(&image.data, &image.mime_type);
-                }
-                ContentBlock::Resource(resource) => {
-                    if let EmbeddedResourceResource::TextResourceContents(text_resource) =
-                        &resource.resource
-                    {
-                        let header = format!("--- Resource: {} ---\n", text_resource.uri);
-                        let content = format!("{}{}\n---\n", header, text_resource.text);
-                        user_message = user_message.with_text(&content);
-                    }
-                }
-                ContentBlock::ResourceLink(link) => {
-                    if let Some(text) = read_resource_link(link) {
-                        user_message = user_message.with_text(text)
-                    }
-                }
-                ContentBlock::Audio(..) | _ => (),
+            if let Some(content) = acp_prompt_block_to_message_content(block) {
+                user_message = user_message.with_content(content);
             }
         }
 
@@ -1684,7 +1780,7 @@ impl GooseAcpAgent {
                 cx.send_notification(SessionNotification::new(
                     session_id.clone(),
                     SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(
-                        TextContent::new(text.text.clone()),
+                        rmcp_text_to_acp(text),
                     ))),
                 ))?;
             }
@@ -2352,9 +2448,7 @@ impl GooseAcpAgent {
             for content_item in &message.content {
                 match content_item {
                     MessageContent::Text(text) => {
-                        let chunk = ContentChunk::new(ContentBlock::Text(TextContent::new(
-                            text.text.clone(),
-                        )));
+                        let chunk = ContentChunk::new(ContentBlock::Text(rmcp_text_to_acp(text)));
                         let update = match message.role {
                             Role::User => SessionUpdate::UserMessageChunk(chunk),
                             Role::Assistant => SessionUpdate::AgentMessageChunk(chunk),
@@ -4559,7 +4653,9 @@ pub async fn run(builtins: Vec<String>) -> Result<()> {
 mod tests {
     use super::*;
     use crate::conversation::message::{ToolRequest, ToolResponse};
-    use rmcp::model::{CallToolRequestParams, Content as RmcpContent};
+    use rmcp::model::{
+        AnnotateAble, CallToolRequestParams, Content as RmcpContent, RawTextContent,
+    };
     use sacp::schema::{
         EnvVariable, HttpHeader, McpServer, McpServerHttp, McpServerSse, McpServerStdio,
         PermissionOptionId, ResourceLink, SelectedPermissionOutcome, SessionConfigSelectOption,
@@ -5196,6 +5292,41 @@ print(\"hello, world\")
                 chain_id: "req_1".to_string(),
                 summary: "running commands".to_string(),
             })
+        );
+    }
+
+    #[test]
+    fn test_acp_prompt_block_to_message_content_preserves_text_audience() {
+        let content = acp_prompt_block_to_message_content(ContentBlock::Text(
+            TextContent::new("assistant-only prompt")
+                .annotations(AcpAnnotations::new().audience(vec![AcpRole::Assistant])),
+        ))
+        .expect("text blocks should convert");
+
+        let MessageContent::Text(text) = content else {
+            panic!("expected text content");
+        };
+
+        assert_eq!(text.text, "assistant-only prompt");
+        assert_eq!(text.audience(), Some(&vec![Role::Assistant]));
+    }
+
+    #[test]
+    fn test_rmcp_text_to_acp_preserves_text_audience() {
+        let text = RawTextContent {
+            text: "assistant-only replay".to_string(),
+            meta: None,
+        }
+        .with_audience(vec![Role::Assistant]);
+
+        let replay_text = rmcp_text_to_acp(&text);
+
+        assert_eq!(replay_text.text, "assistant-only replay");
+        assert_eq!(
+            replay_text
+                .annotations
+                .and_then(|annotations| annotations.audience),
+            Some(vec![AcpRole::Assistant]),
         );
     }
 

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -28,31 +28,28 @@ use crate::providers::inventory::{
 };
 use crate::session::session_manager::SessionType;
 use crate::session::{EnabledExtensionsState, Session, SessionManager};
-use crate::utils::sanitize_unicode_tags;
 use anyhow::Result;
 use fs_err as fs;
 use futures::future::{BoxFuture, Either};
 use goose_acp_macros::custom_methods;
-use rmcp::model::{
-    AnnotateAble, CallToolResult, RawContent, RawTextContent, ResourceContents, Role,
-};
+use rmcp::model::{CallToolResult, RawContent, ResourceContents, Role};
 use sacp::schema::{
-    AgentCapabilities, Annotations, AuthMethod, AuthMethodAgent, AuthenticateRequest,
-    AuthenticateResponse, BlobResourceContents, CancelNotification, CloseSessionRequest,
-    CloseSessionResponse, ConfigOptionUpdate, Content, ContentBlock, ContentChunk,
-    CurrentModeUpdate, EmbeddedResource, EmbeddedResourceResource, FileSystemCapabilities,
-    ForkSessionRequest, ForkSessionResponse, ImageContent, InitializeRequest, InitializeResponse,
-    ListSessionsRequest, ListSessionsResponse, LoadSessionRequest, LoadSessionResponse,
-    McpCapabilities, McpServer, Meta, ModelId, ModelInfo, NewSessionRequest, NewSessionResponse,
-    PermissionOption, PermissionOptionKind, PromptCapabilities, PromptRequest, PromptResponse,
-    RequestPermissionOutcome, RequestPermissionRequest, ResourceLink, SessionCapabilities,
-    SessionCloseCapabilities, SessionConfigOption, SessionConfigOptionCategory,
-    SessionConfigSelectOption, SessionId, SessionInfo, SessionListCapabilities, SessionMode,
-    SessionModeId, SessionModeState, SessionModelState, SessionNotification, SessionUpdate,
-    SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, SetSessionModeRequest,
-    SetSessionModeResponse, SetSessionModelRequest, SetSessionModelResponse, StopReason,
-    TextContent, TextResourceContents, ToolCall, ToolCallContent, ToolCallId, ToolCallLocation,
-    ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind, Usage, UsageUpdate,
+    AgentCapabilities, AuthMethod, AuthMethodAgent, AuthenticateRequest, AuthenticateResponse,
+    BlobResourceContents, CancelNotification, CloseSessionRequest, CloseSessionResponse,
+    ConfigOptionUpdate, Content, ContentBlock, ContentChunk, CurrentModeUpdate, EmbeddedResource,
+    EmbeddedResourceResource, FileSystemCapabilities, ForkSessionRequest, ForkSessionResponse,
+    ImageContent, InitializeRequest, InitializeResponse, ListSessionsRequest, ListSessionsResponse,
+    LoadSessionRequest, LoadSessionResponse, McpCapabilities, McpServer, Meta, ModelId, ModelInfo,
+    NewSessionRequest, NewSessionResponse, PermissionOption, PermissionOptionKind,
+    PromptCapabilities, PromptRequest, PromptResponse, RequestPermissionOutcome,
+    RequestPermissionRequest, ResourceLink, SessionCapabilities, SessionCloseCapabilities,
+    SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOption, SessionId,
+    SessionInfo, SessionListCapabilities, SessionMode, SessionModeId, SessionModeState,
+    SessionModelState, SessionNotification, SessionUpdate, SetSessionConfigOptionRequest,
+    SetSessionConfigOptionResponse, SetSessionModeRequest, SetSessionModeResponse,
+    SetSessionModelRequest, SetSessionModelResponse, StopReason, TextContent, TextResourceContents,
+    ToolCall, ToolCallContent, ToolCallId, ToolCallLocation, ToolCallStatus, ToolCallUpdate,
+    ToolCallUpdateFields, ToolKind, Usage, UsageUpdate,
 };
 use sacp::util::MatchDispatchFrom;
 use sacp::{
@@ -86,6 +83,9 @@ const ELEVENLABS_TRANSCRIPTION_MODEL_CONFIG_KEY: &str = "ELEVENLABS_TRANSCRIPTIO
 const OPENAI_TRANSCRIPTION_MODEL: &str = "whisper-1";
 const GROQ_TRANSCRIPTION_MODEL: &str = "whisper-large-v3-turbo";
 const ELEVENLABS_TRANSCRIPTION_MODEL: &str = "scribe_v1";
+const TOOL_CHAIN_META_KEY: &str = "_goose/tool-chain-id";
+const TOOL_CHAIN_SUMMARY_META_KEY: &str = "_goose/tool-chain-summary";
+const ACTIVE_TOOL_CHAIN_SUMMARY: &str = "working";
 
 /// In-memory state for an active ACP session.
 ///
@@ -109,6 +109,10 @@ struct GooseAcpSession {
     agent: AgentHandle,
     internal_session_id: String,
     tool_requests: HashMap<String, crate::conversation::message::ToolRequest>,
+    active_tool_chain_id: Option<String>,
+    active_tool_chain_request_ids: Vec<String>,
+    active_tool_chain_fallback_titles: Vec<String>,
+    tool_chain_ids_by_request: HashMap<String, String>,
     cancel_token: Option<CancellationToken>,
     /// Working directory set while the agent was still loading.
     /// Applied once the agent becomes ready.
@@ -129,6 +133,32 @@ enum AgentSetupProgress {
 
 type AgentSetupSignal = Option<Result<AgentSetupProgress, String>>;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ClosedToolChain {
+    chain_id: String,
+    request_ids: Vec<String>,
+    summary: String,
+}
+
+impl ClosedToolChain {
+    fn last_request_id(&self) -> Option<&str> {
+        self.request_ids.last().map(String::as_str)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ReplayToolChainMeta {
+    chain_id: String,
+    summary: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ToolChainStepKind {
+    ReviewingFiles,
+    RunningCommands,
+    CheckingResources,
+    UpdatingFiles,
+}
 /// The agent may still be initializing in the background (extension loading,
 /// provider setup).  Callers that need the live agent (e.g. `on_prompt`) await
 /// the handle; callers that only need the session metadata can proceed without it.
@@ -192,6 +222,227 @@ fn extract_timeout_from_meta(meta: &Option<Meta>) -> Option<u64> {
     meta.as_ref()
         .and_then(|m| m.get("timeout"))
         .and_then(|v| v.as_u64())
+}
+
+fn tool_chain_meta(chain_id: &str, chain_summary: &str) -> Meta {
+    let mut meta = Meta::new();
+    meta.insert(
+        TOOL_CHAIN_META_KEY.to_string(),
+        serde_json::Value::String(chain_id.to_string()),
+    );
+    meta.insert(
+        TOOL_CHAIN_SUMMARY_META_KEY.to_string(),
+        serde_json::Value::String(chain_summary.to_string()),
+    );
+    meta
+}
+
+fn start_or_continue_tool_chain(
+    active_tool_chain_id: &mut Option<String>,
+    active_tool_chain_request_ids: &mut Vec<String>,
+    active_tool_chain_fallback_titles: &mut Vec<String>,
+    tool_chain_ids_by_request: &mut HashMap<String, String>,
+    request_id: &str,
+    fallback_title: &str,
+) -> String {
+    let chain_id = active_tool_chain_id
+        .clone()
+        .unwrap_or_else(|| request_id.to_string());
+    *active_tool_chain_id = Some(chain_id.clone());
+    active_tool_chain_request_ids.push(request_id.to_string());
+    active_tool_chain_fallback_titles.push(fallback_title.to_string());
+    tool_chain_ids_by_request.insert(request_id.to_string(), chain_id.clone());
+    chain_id
+}
+
+fn resolve_tool_chain_for_response(
+    active_tool_chain_id: &mut Option<String>,
+    tool_chain_ids_by_request: &HashMap<String, String>,
+    response_id: &str,
+) -> String {
+    if let Some(chain_id) = tool_chain_ids_by_request.get(response_id) {
+        return chain_id.clone();
+    }
+
+    let chain_id = active_tool_chain_id
+        .clone()
+        .unwrap_or_else(|| response_id.to_string());
+    *active_tool_chain_id = Some(chain_id.clone());
+    chain_id
+}
+
+fn reset_tool_chain(
+    active_tool_chain_id: &mut Option<String>,
+    active_tool_chain_request_ids: &mut Vec<String>,
+    active_tool_chain_fallback_titles: &mut Vec<String>,
+    tool_chain_ids_by_request: &mut HashMap<String, String>,
+) {
+    *active_tool_chain_id = None;
+    active_tool_chain_request_ids.clear();
+    active_tool_chain_fallback_titles.clear();
+    tool_chain_ids_by_request.clear();
+}
+
+fn classify_tool_chain_step(step_label: &str) -> ToolChainStepKind {
+    let lower = step_label.to_ascii_lowercase();
+    let (prefix, detail) = lower.split_once(" · ").unwrap_or((lower.as_str(), ""));
+
+    if detail.starts_with("http://")
+        || detail.starts_with("https://")
+        || prefix.contains("fetch")
+        || prefix.contains("http")
+        || prefix.contains("url")
+        || prefix.contains("uri")
+        || prefix.contains("download")
+    {
+        return ToolChainStepKind::CheckingResources;
+    }
+
+    if prefix.contains("edit")
+        || prefix.contains("write")
+        || prefix.contains("create")
+        || prefix.contains("update")
+        || prefix.contains("replace")
+        || prefix.contains("rename")
+        || prefix.contains("move")
+        || prefix.contains("delete")
+    {
+        return ToolChainStepKind::UpdatingFiles;
+    }
+
+    if prefix.contains("shell")
+        || prefix.contains("command")
+        || prefix.contains("bash")
+        || prefix.contains("terminal")
+        || prefix.contains("execute")
+    {
+        return ToolChainStepKind::RunningCommands;
+    }
+
+    ToolChainStepKind::ReviewingFiles
+}
+
+fn summarize_tool_chain(step_labels: &[String]) -> String {
+    if step_labels.is_empty() {
+        return ACTIVE_TOOL_CHAIN_SUMMARY.to_string();
+    }
+
+    let mut reviewing_files = 0;
+    let mut running_commands = 0;
+    let mut checking_resources = 0;
+    let mut updating_files = 0;
+
+    for step_label in step_labels {
+        match classify_tool_chain_step(step_label) {
+            ToolChainStepKind::ReviewingFiles => reviewing_files += 1,
+            ToolChainStepKind::RunningCommands => running_commands += 1,
+            ToolChainStepKind::CheckingResources => checking_resources += 1,
+            ToolChainStepKind::UpdatingFiles => updating_files += 1,
+        }
+    }
+
+    if updating_files > reviewing_files
+        && updating_files >= running_commands
+        && updating_files >= checking_resources
+    {
+        return "updating files".to_string();
+    }
+
+    if checking_resources > reviewing_files && checking_resources >= running_commands {
+        return "checking resources".to_string();
+    }
+
+    if running_commands > reviewing_files {
+        return "running commands".to_string();
+    }
+
+    "reviewing files".to_string()
+}
+
+fn close_tool_chain(
+    active_tool_chain_id: &mut Option<String>,
+    active_tool_chain_request_ids: &mut Vec<String>,
+    active_tool_chain_fallback_titles: &mut Vec<String>,
+    tool_chain_ids_by_request: &mut HashMap<String, String>,
+) -> Option<ClosedToolChain> {
+    let chain_id = active_tool_chain_id.clone()?;
+    let request_ids = active_tool_chain_request_ids.clone();
+    let summary = summarize_tool_chain(active_tool_chain_fallback_titles.as_slice());
+
+    reset_tool_chain(
+        active_tool_chain_id,
+        active_tool_chain_request_ids,
+        active_tool_chain_fallback_titles,
+        tool_chain_ids_by_request,
+    );
+
+    if request_ids.is_empty() {
+        return None;
+    }
+
+    Some(ClosedToolChain {
+        chain_id,
+        request_ids,
+        summary,
+    })
+}
+
+fn emit_tool_chain_summary_update(
+    cx: &ConnectionTo<Client>,
+    session_id: &SessionId,
+    closed_tool_chain: &ClosedToolChain,
+) -> Result<(), sacp::Error> {
+    let Some(last_request_id) = closed_tool_chain.last_request_id() else {
+        return Ok(());
+    };
+
+    cx.send_notification(SessionNotification::new(
+        session_id.clone(),
+        SessionUpdate::ToolCallUpdate(
+            ToolCallUpdate::new(
+                ToolCallId::new(last_request_id.to_string()),
+                ToolCallUpdateFields::new(),
+            )
+            .meta(tool_chain_meta(
+                &closed_tool_chain.chain_id,
+                &closed_tool_chain.summary,
+            )),
+        ),
+    ))?;
+
+    Ok(())
+}
+
+fn flush_tool_chain_summary(
+    cx: &ConnectionTo<Client>,
+    session_id: &SessionId,
+    session: &mut GooseAcpSession,
+) -> Result<(), sacp::Error> {
+    if let Some(closed_tool_chain) = close_tool_chain(
+        &mut session.active_tool_chain_id,
+        &mut session.active_tool_chain_request_ids,
+        &mut session.active_tool_chain_fallback_titles,
+        &mut session.tool_chain_ids_by_request,
+    ) {
+        emit_tool_chain_summary_update(cx, session_id, &closed_tool_chain)?;
+    }
+
+    Ok(())
+}
+
+fn insert_replay_tool_chain_meta(
+    replay_tool_chain_meta_by_request: &mut HashMap<String, ReplayToolChainMeta>,
+    closed_tool_chain: ClosedToolChain,
+) {
+    for request_id in closed_tool_chain.request_ids {
+        replay_tool_chain_meta_by_request.insert(
+            request_id,
+            ReplayToolChainMeta {
+                chain_id: closed_tool_chain.chain_id.clone(),
+                summary: closed_tool_chain.summary.clone(),
+            },
+        );
+    }
 }
 
 fn mcp_server_to_extension_config(mcp_server: McpServer) -> Result<ExtensionConfig, String> {
@@ -400,38 +651,267 @@ fn format_tool_name(tool_name: &str) -> String {
     }
 }
 
-/// Build a short fallback title from the tool name and arguments by extracting
-/// the most useful value (file path, command, query, url, etc.).
-fn summarize_tool_call(tool_name: &str, arguments: Option<&serde_json::Value>) -> String {
-    let base = format_tool_name(tool_name);
+fn canonical_tool_name(tool_name: &str) -> &str {
+    let tool = tool_name
+        .rsplit_once("__")
+        .map_or(tool_name, |(_, suffix)| suffix);
+    tool.rsplit_once('/').map_or(tool, |(_, suffix)| suffix)
+}
 
-    let detail = arguments.and_then(|args| {
-        let obj = args.as_object()?;
-        let keys = [
-            "path", "file", "command", "query", "url", "uri", "name", "pattern", "source",
-        ];
-        for key in &keys {
-            if let Some(v) = obj.get(*key) {
-                let s = match v {
-                    serde_json::Value::String(s) => s.clone(),
-                    other => other.to_string(),
-                };
-                if !s.is_empty() {
-                    let first_line = s.lines().next().unwrap_or(&s);
-                    if first_line.len() > 60 {
-                        return Some(format!("{}…", crate::utils::safe_truncate(first_line, 57)));
-                    }
-                    return Some(first_line.to_string());
+fn title_case(text: &str) -> String {
+    text.split_whitespace()
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                Some(first) => {
+                    let mut capitalized = first.to_uppercase().collect::<String>();
+                    capitalized.push_str(chars.as_str());
+                    capitalized
                 }
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn first_argument_string(arguments: Option<&serde_json::Value>, keys: &[&str]) -> Option<String> {
+    let obj = arguments?.as_object()?;
+    for key in keys {
+        if let Some(value) = obj.get(*key) {
+            let text = match value {
+                serde_json::Value::String(text) => text.trim().to_string(),
+                other => other.to_string(),
+            };
+            if !text.is_empty() {
+                return Some(text);
             }
         }
-        None
-    });
-
-    match detail {
-        Some(d) => format!("{base} · {d}"),
-        None => base,
     }
+    None
+}
+
+fn shorten_label(text: &str, max_len: usize) -> String {
+    if text.chars().count() > max_len {
+        format!(
+            "{}…",
+            crate::utils::safe_truncate(text, max_len.saturating_sub(1))
+        )
+    } else {
+        text.to_string()
+    }
+}
+
+fn path_label(value: &str) -> Option<String> {
+    let trimmed = value
+        .trim()
+        .trim_matches(|c| c == '"' || c == '\'')
+        .trim_end_matches(['/', '\\']);
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let candidate = std::path::Path::new(trimmed)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or(trimmed);
+
+    Some(shorten_label(candidate, 40))
+}
+
+fn looks_like_file_target(value: &str) -> bool {
+    let trimmed = value.trim().trim_matches(|c| c == '"' || c == '\'');
+    let trimmed = trimmed.trim_end_matches(['/', '\\']);
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    let path = std::path::Path::new(trimmed);
+    path.extension().is_some()
+}
+
+fn action_title(action: &str, target: Option<String>, fallback: &str) -> String {
+    match target {
+        Some(target) => format!("{action} {target}"),
+        None => format!("{action} {fallback}"),
+    }
+}
+
+fn shell_command_title(arguments: Option<&serde_json::Value>) -> String {
+    let command = first_argument_string(arguments, &["command", "cmd", "script"]);
+    let first_line = command
+        .as_deref()
+        .and_then(|text| text.lines().next())
+        .map(str::trim)
+        .unwrap_or("");
+
+    if first_line.is_empty() {
+        return "Run command".to_string();
+    }
+
+    let lower = first_line.to_ascii_lowercase();
+    if lower.contains("pwd")
+        || (lower.starts_with("cd ") && (lower.contains("&&") || lower.contains(';')))
+    {
+        return "Check working directory".to_string();
+    }
+
+    let tokens = first_line.split_whitespace().collect::<Vec<_>>();
+    let Some(raw_command) = tokens.first().copied() else {
+        return "Run command".to_string();
+    };
+    let command_name = std::path::Path::new(raw_command)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(raw_command)
+        .to_ascii_lowercase();
+
+    match command_name.as_str() {
+        "cat" | "bat" | "head" | "tail" | "sed" => {
+            let target = tokens.last().and_then(|token| path_label(token));
+            action_title("Read", target, "file")
+        }
+        "tree" | "ls" | "dir" => "List project files".to_string(),
+        "rg" | "grep" | "find" | "findstr" | "fd" => "Search files".to_string(),
+        "curl" | "wget" => "Fetch resource".to_string(),
+        _ => "Run command".to_string(),
+    }
+}
+
+fn summarize_tool_call(tool_name: &str, arguments: Option<&serde_json::Value>) -> String {
+    let canonical = canonical_tool_name(tool_name);
+    let lower = canonical.to_ascii_lowercase();
+    let path_argument = first_argument_string(arguments, &["path", "file", "source", "name"]);
+    let target = path_argument.as_deref().and_then(path_label);
+
+    if matches!(lower.as_str(), "shell" | "bash" | "terminal")
+        || lower.contains("command")
+        || lower.contains("execute")
+    {
+        return shell_command_title(arguments);
+    }
+
+    if lower == "tree" || lower.contains("list") {
+        return "List project files".to_string();
+    }
+
+    if lower == "analyze" {
+        return if path_argument.as_deref().is_some_and(looks_like_file_target) {
+            action_title("Read", target, "file")
+        } else {
+            "Inspect project files".to_string()
+        };
+    }
+
+    if lower.contains("read") || lower == "view" {
+        return action_title("Read", target, "file");
+    }
+
+    if lower.contains("edit")
+        || lower.contains("write")
+        || lower.contains("replace")
+        || lower.contains("insert")
+        || lower.contains("update")
+    {
+        return action_title("Edit", target, "file");
+    }
+
+    if lower.contains("search") || lower.contains("find") || lower.contains("grep") {
+        return "Search files".to_string();
+    }
+
+    if lower.contains("fetch") || lower.contains("download") || lower.contains("request") {
+        return "Fetch resource".to_string();
+    }
+
+    match target {
+        Some(target) => format!("{} {}", title_case(&lower.replace('_', " ")), target),
+        None => title_case(&lower.replace('_', " ")),
+    }
+}
+
+fn build_initial_tool_call(
+    request_id: &str,
+    title: String,
+    raw_input: Option<serde_json::Value>,
+    chain_id: &str,
+    chain_summary: &str,
+) -> ToolCall {
+    let mut tool_call = ToolCall::new(ToolCallId::new(request_id.to_string()), title)
+        .status(ToolCallStatus::Pending);
+    if let Some(args) = raw_input {
+        tool_call = tool_call.raw_input(args);
+    }
+    tool_call.meta(tool_chain_meta(chain_id, chain_summary))
+}
+
+fn build_replay_tool_chain_meta(
+    thread_messages: &[Message],
+) -> HashMap<String, ReplayToolChainMeta> {
+    let mut replay_tool_chain_meta_by_request = HashMap::new();
+    let mut active_tool_chain_id = None;
+    let mut active_tool_chain_request_ids = Vec::<String>::new();
+    let mut active_tool_chain_fallback_titles = Vec::<String>::new();
+    let mut tool_chain_ids_by_request = HashMap::<String, String>::new();
+
+    for message in thread_messages {
+        if !message.metadata.user_visible {
+            continue;
+        }
+
+        for content_item in &message.content {
+            match content_item {
+                MessageContent::Text(_) => {
+                    if let Some(closed_tool_chain) = close_tool_chain(
+                        &mut active_tool_chain_id,
+                        &mut active_tool_chain_request_ids,
+                        &mut active_tool_chain_fallback_titles,
+                        &mut tool_chain_ids_by_request,
+                    ) {
+                        insert_replay_tool_chain_meta(
+                            &mut replay_tool_chain_meta_by_request,
+                            closed_tool_chain,
+                        );
+                    }
+                }
+                MessageContent::ToolRequest(tool_request) => {
+                    let tool_name = match &tool_request.tool_call {
+                        Ok(tool_call) => tool_call.name.to_string(),
+                        Err(_) => "error".to_string(),
+                    };
+                    let args_value = tool_request
+                        .tool_call
+                        .as_ref()
+                        .ok()
+                        .and_then(|tc| tc.arguments.as_ref())
+                        .map(|args| serde_json::Value::Object(args.clone()));
+                    let fallback_title = summarize_tool_call(&tool_name, args_value.as_ref());
+
+                    start_or_continue_tool_chain(
+                        &mut active_tool_chain_id,
+                        &mut active_tool_chain_request_ids,
+                        &mut active_tool_chain_fallback_titles,
+                        &mut tool_chain_ids_by_request,
+                        &tool_request.id,
+                        &fallback_title,
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+
+    if let Some(closed_tool_chain) = close_tool_chain(
+        &mut active_tool_chain_id,
+        &mut active_tool_chain_request_ids,
+        &mut active_tool_chain_fallback_titles,
+        &mut tool_chain_ids_by_request,
+    ) {
+        insert_replay_tool_chain_meta(&mut replay_tool_chain_meta_by_request, closed_tool_chain);
+    }
+
+    replay_tool_chain_meta_by_request
 }
 
 fn builtin_to_extension_config(name: &str) -> ExtensionConfig {
@@ -1158,49 +1638,16 @@ impl GooseAcpAgent {
         self.sessions.lock().await.contains_key(session_id)
     }
 
-    /// Convert ACP prompt content blocks into a user message.
-    fn convert_acp_prompt_to_message(prompt: &[ContentBlock]) -> Message {
-        let mut message = Message::user();
+    fn convert_acp_prompt_to_message(&self, prompt: Vec<ContentBlock>) -> Message {
+        let mut user_message = Message::user();
+
         for block in prompt {
             match block {
                 ContentBlock::Text(text) => {
-                    let annotated = if let Some(ref ann) = text.annotations {
-                        let audience: Vec<Role> = ann
-                            .audience
-                            .as_ref()
-                            .map(|roles| {
-                                roles
-                                    .iter()
-                                    .filter_map(|r| match r {
-                                        sacp::schema::Role::Assistant => Some(Role::Assistant),
-                                        sacp::schema::Role::User => Some(Role::User),
-                                        _ => None,
-                                    })
-                                    .collect()
-                            })
-                            .unwrap_or_default();
-                        let raw = RawTextContent {
-                            text: sanitize_unicode_tags(&text.text),
-                            meta: None,
-                        };
-                        if audience.is_empty() {
-                            raw.no_annotation()
-                        } else {
-                            raw.no_annotation().with_audience(audience)
-                        }
-                    } else {
-                        // No annotations — regular user text.
-                        let sanitized = sanitize_unicode_tags(&text.text);
-                        RawTextContent {
-                            text: sanitized,
-                            meta: None,
-                        }
-                        .no_annotation()
-                    };
-                    message = message.with_content(MessageContent::Text(annotated));
+                    user_message = user_message.with_text(&text.text);
                 }
                 ContentBlock::Image(image) => {
-                    message = message.with_image(&image.data, &image.mime_type);
+                    user_message = user_message.with_image(&image.data, &image.mime_type);
                 }
                 ContentBlock::Resource(resource) => {
                     if let EmbeddedResourceResource::TextResourceContents(text_resource) =
@@ -1208,18 +1655,19 @@ impl GooseAcpAgent {
                     {
                         let header = format!("--- Resource: {} ---\n", text_resource.uri);
                         let content = format!("{}{}\n---\n", header, text_resource.text);
-                        message = message.with_text(&content);
+                        user_message = user_message.with_text(&content);
                     }
                 }
                 ContentBlock::ResourceLink(link) => {
-                    if let Some(text) = read_resource_link(link.clone()) {
-                        message = message.with_text(text);
+                    if let Some(text) = read_resource_link(link) {
+                        user_message = user_message.with_text(text)
                     }
                 }
                 ContentBlock::Audio(..) | _ => (),
             }
         }
-        message
+
+        user_message
     }
 
     async fn handle_message_content(
@@ -1232,6 +1680,7 @@ impl GooseAcpAgent {
     ) -> Result<(), sacp::Error> {
         match content_item {
             MessageContent::Text(text) => {
+                flush_tool_chain_summary(cx, session_id, session)?;
                 cx.send_notification(SessionNotification::new(
                     session_id.clone(),
                     SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(
@@ -1302,110 +1751,25 @@ impl GooseAcpAgent {
             .and_then(|tc| tc.arguments.as_ref())
             .map(|a| serde_json::Value::Object(a.clone()));
         let fallback_title = summarize_tool_call(&tool_name, args_value.as_ref());
+        let chain_id = start_or_continue_tool_chain(
+            &mut session.active_tool_chain_id,
+            &mut session.active_tool_chain_request_ids,
+            &mut session.active_tool_chain_fallback_titles,
+            &mut session.tool_chain_ids_by_request,
+            &tool_request.id,
+            &fallback_title,
+        );
 
-        let mut initial_tool_call = ToolCall::new(
-            ToolCallId::new(tool_request.id.clone()),
-            fallback_title.clone(),
-        )
-        .status(ToolCallStatus::Pending);
-        if let Some(args) = args_value.clone() {
-            initial_tool_call = initial_tool_call.raw_input(args);
-        }
         cx.send_notification(SessionNotification::new(
             session_id.clone(),
-            SessionUpdate::ToolCall(initial_tool_call),
+            SessionUpdate::ToolCall(build_initial_tool_call(
+                &tool_request.id,
+                fallback_title.clone(),
+                args_value.clone(),
+                &chain_id,
+                ACTIVE_TOOL_CHAIN_SUMMARY,
+            )),
         ))?;
-
-        if let Ok(tool_call) = &tool_request.tool_call {
-            let agent = match &session.agent {
-                AgentHandle::Ready(a) => a.clone(),
-                AgentHandle::Loading(_) => return Ok(()),
-            };
-            let sid = session_id.clone();
-            let request_id = tool_request.id.clone();
-            let cx = cx.clone();
-            let name = tool_call.name.to_string();
-            let args_json = tool_call
-                .arguments
-                .as_ref()
-                .map(|a| {
-                    let s = serde_json::to_string(a).unwrap_or_default();
-                    if s.len() > 300 {
-                        format!("{}…", crate::utils::safe_truncate(&s, 300))
-                    } else {
-                        s
-                    }
-                })
-                .unwrap_or_default();
-
-            tokio::spawn(async move {
-                let provider: Arc<dyn Provider> = match agent.provider().await {
-                    Ok(p) => p,
-                    Err(e) => {
-                        warn!("tool call summary: failed to get provider: {e}");
-                        let fields = ToolCallUpdateFields::new().title(fallback_title);
-                        let _ = cx.send_notification(SessionNotification::new(
-                            sid,
-                            SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
-                                ToolCallId::new(request_id),
-                                fields,
-                            )),
-                        ));
-                        return;
-                    }
-                };
-
-                // in these case, the title summarization request would
-                // be added to the conversation which we don't want
-                if provider.manages_own_context() {
-                    return;
-                }
-
-                let system = "Summarize this tool call in a short lowercase phrase (3-8 words). \
-                              No punctuation. No quotes. Examples: reading project configuration, \
-                              checking network connectivity, listing files in src directory";
-                let user_text = format!("Tool: {name}\nArguments: {args_json}");
-                let message = Message::user().with_text(&user_text);
-                match provider
-                    .complete_fast(&sid.0, system, &[message], &[])
-                    .await
-                {
-                    Ok((response, _)) => {
-                        let summary: String = response
-                            .content
-                            .iter()
-                            .filter_map(|c: &MessageContent| c.as_text())
-                            .collect::<String>()
-                            .trim()
-                            .to_string();
-                        let title = if summary.is_empty() {
-                            fallback_title
-                        } else {
-                            summary
-                        };
-                        let fields = ToolCallUpdateFields::new().title(title);
-                        let _ = cx.send_notification(SessionNotification::new(
-                            sid,
-                            SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
-                                ToolCallId::new(request_id),
-                                fields,
-                            )),
-                        ));
-                    }
-                    Err(e) => {
-                        warn!("tool call summary: fast_complete failed: {e}");
-                        let fields = ToolCallUpdateFields::new().title(fallback_title);
-                        let _ = cx.send_notification(SessionNotification::new(
-                            sid,
-                            SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
-                                ToolCallId::new(request_id),
-                                fields,
-                            )),
-                        ));
-                    }
-                }
-            });
-        }
 
         Ok(())
     }
@@ -1422,6 +1786,11 @@ impl GooseAcpAgent {
             Ok(_) => ToolCallStatus::Completed,
             Err(_) => ToolCallStatus::Failed,
         };
+        let chain_id = resolve_tool_chain_for_response(
+            &mut session.active_tool_chain_id,
+            &session.tool_chain_ids_by_request,
+            &tool_response.id,
+        );
 
         let mut fields = ToolCallUpdateFields::new().status(status);
         if !tool_response
@@ -1446,10 +1815,10 @@ impl GooseAcpAgent {
 
         cx.send_notification(SessionNotification::new(
             session_id.clone(),
-            SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
-                ToolCallId::new(tool_response.id.clone()),
-                fields,
-            )),
+            SessionUpdate::ToolCallUpdate(
+                ToolCallUpdate::new(ToolCallId::new(tool_response.id.clone()), fields)
+                    .meta(tool_chain_meta(&chain_id, ACTIVE_TOOL_CHAIN_SUMMARY)),
+            ),
         ))?;
 
         Ok(())
@@ -1684,6 +2053,10 @@ impl GooseAcpAgent {
             agent: AgentHandle::Loading(agent_rx),
             internal_session_id: internal_session_id.clone(),
             tool_requests: HashMap::new(),
+            active_tool_chain_id: None,
+            active_tool_chain_request_ids: Vec::new(),
+            active_tool_chain_fallback_titles: Vec::new(),
+            tool_chain_ids_by_request: HashMap::new(),
             cancel_token: None,
             pending_working_dir: None,
         };
@@ -1967,6 +2340,7 @@ impl GooseAcpAgent {
         // matching request. No GooseAcpSession required.
         let mut replay_tool_requests =
             HashMap::<String, crate::conversation::message::ToolRequest>::new();
+        let replay_tool_chain_meta_by_request = build_replay_tool_chain_meta(&thread_messages);
 
         let t_replay = std::time::Instant::now();
         let mut replay_notifications: u32 = 0;
@@ -1978,21 +2352,9 @@ impl GooseAcpAgent {
             for content_item in &message.content {
                 match content_item {
                     MessageContent::Text(text) => {
-                        let mut tc = TextContent::new(text.text.clone());
-                        if let Some(audience) = text.audience() {
-                            tc = tc.annotations(
-                                Annotations::new().audience(
-                                    audience
-                                        .iter()
-                                        .map(|r| match r {
-                                            Role::Assistant => sacp::schema::Role::Assistant,
-                                            Role::User => sacp::schema::Role::User,
-                                        })
-                                        .collect::<Vec<_>>(),
-                                ),
-                            );
-                        }
-                        let chunk = ContentChunk::new(ContentBlock::Text(tc));
+                        let chunk = ContentChunk::new(ContentBlock::Text(TextContent::new(
+                            text.text.clone(),
+                        )));
                         let update = match message.role {
                             Role::User => SessionUpdate::UserMessageChunk(chunk),
                             Role::Assistant => SessionUpdate::AgentMessageChunk(chunk),
@@ -2013,16 +2375,30 @@ impl GooseAcpAgent {
                             Ok(tool_call) => tool_call.name.to_string(),
                             Err(_) => "error".to_string(),
                         };
+                        let args_value = tool_request
+                            .tool_call
+                            .as_ref()
+                            .ok()
+                            .and_then(|tc| tc.arguments.as_ref())
+                            .map(|args| serde_json::Value::Object(args.clone()));
+                        let fallback_title = summarize_tool_call(&tool_name, args_value.as_ref());
+                        let replay_tool_chain_meta = replay_tool_chain_meta_by_request
+                            .get(&tool_request.id)
+                            .cloned()
+                            .unwrap_or(ReplayToolChainMeta {
+                                chain_id: tool_request.id.clone(),
+                                summary: summarize_tool_chain(&[fallback_title.clone()]),
+                            });
 
                         cx.send_notification(SessionNotification::new(
                             args.session_id.clone(),
-                            SessionUpdate::ToolCall(
-                                ToolCall::new(
-                                    ToolCallId::new(tool_request.id.clone()),
-                                    format_tool_name(&tool_name),
-                                )
-                                .status(ToolCallStatus::Pending),
-                            ),
+                            SessionUpdate::ToolCall(build_initial_tool_call(
+                                &tool_request.id,
+                                fallback_title.clone(),
+                                args_value.clone(),
+                                &replay_tool_chain_meta.chain_id,
+                                &replay_tool_chain_meta.summary,
+                            )),
                         ))?;
                         replay_notifications += 1;
                     }
@@ -2035,6 +2411,36 @@ impl GooseAcpAgent {
                             Ok(_) => ToolCallStatus::Completed,
                             Err(_) => ToolCallStatus::Failed,
                         };
+                        let replay_tool_chain_meta = replay_tool_chain_meta_by_request
+                            .get(&tool_response.id)
+                            .cloned()
+                            .or_else(|| {
+                                replay_tool_requests
+                                    .get(&tool_response.id)
+                                    .map(|tool_request| {
+                                        let tool_name = match &tool_request.tool_call {
+                                            Ok(tool_call) => tool_call.name.to_string(),
+                                            Err(_) => "error".to_string(),
+                                        };
+                                        let args_value = tool_request
+                                            .tool_call
+                                            .as_ref()
+                                            .ok()
+                                            .and_then(|tc| tc.arguments.as_ref())
+                                            .map(|args| serde_json::Value::Object(args.clone()));
+                                        let fallback_title =
+                                            summarize_tool_call(&tool_name, args_value.as_ref());
+
+                                        ReplayToolChainMeta {
+                                            chain_id: tool_response.id.clone(),
+                                            summary: summarize_tool_chain(&[fallback_title]),
+                                        }
+                                    })
+                            })
+                            .unwrap_or(ReplayToolChainMeta {
+                                chain_id: tool_response.id.clone(),
+                                summary: "reviewing files".to_string(),
+                            });
 
                         let mut fields = ToolCallUpdateFields::new().status(status);
                         if !tool_response
@@ -2062,10 +2468,16 @@ impl GooseAcpAgent {
 
                         cx.send_notification(SessionNotification::new(
                             args.session_id.clone(),
-                            SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
-                                ToolCallId::new(tool_response.id.clone()),
-                                fields,
-                            )),
+                            SessionUpdate::ToolCallUpdate(
+                                ToolCallUpdate::new(
+                                    ToolCallId::new(tool_response.id.clone()),
+                                    fields,
+                                )
+                                .meta(tool_chain_meta(
+                                    &replay_tool_chain_meta.chain_id,
+                                    &replay_tool_chain_meta.summary,
+                                )),
+                            ),
                         ))?;
                         replay_notifications += 1;
                     }
@@ -2118,6 +2530,10 @@ impl GooseAcpAgent {
             agent: AgentHandle::Loading(agent_rx),
             internal_session_id: internal_session_id.clone(),
             tool_requests: replay_tool_requests,
+            active_tool_chain_id: None,
+            active_tool_chain_request_ids: Vec::new(),
+            active_tool_chain_fallback_titles: Vec::new(),
+            tool_chain_ids_by_request: HashMap::new(),
             cancel_token: None,
             pending_working_dir: None,
         };
@@ -2197,10 +2613,22 @@ impl GooseAcpAgent {
             .await?;
         debug!(target: "perf", sid = %sid, ms = t_agent.elapsed().as_millis() as u64, "perf: prompt get_session_agent (waits for agent setup)");
 
-        let user_message = Self::convert_acp_prompt_to_message(&args.prompt);
+        {
+            let mut sessions = self.sessions.lock().await;
+            let session = sessions.get_mut(&thread_id).ok_or_else(|| {
+                sacp::Error::invalid_params().data(format!("Session not found: {}", thread_id))
+            })?;
+            reset_tool_chain(
+                &mut session.active_tool_chain_id,
+                &mut session.active_tool_chain_request_ids,
+                &mut session.active_tool_chain_fallback_titles,
+                &mut session.tool_chain_ids_by_request,
+            );
+        }
+
+        let user_message = self.convert_acp_prompt_to_message(args.prompt);
 
         let t_persist = std::time::Instant::now();
-        // Persist user message (may contain assistant-only annotated blocks)
         self.thread_manager
             .append_message(&thread_id, Some(&internal_session_id), &user_message)
             .await
@@ -2286,6 +2714,7 @@ impl GooseAcpAgent {
             let mut sessions = self.sessions.lock().await;
             if let Some(session) = sessions.get_mut(&thread_id) {
                 session.cancel_token = None;
+                flush_tool_chain_summary(cx, &args.session_id, session)?;
             }
         }
 
@@ -2739,6 +3168,10 @@ impl GooseAcpAgent {
             agent: AgentHandle::Loading(agent_rx),
             internal_session_id: internal_session_id.clone(),
             tool_requests: HashMap::new(),
+            active_tool_chain_id: None,
+            active_tool_chain_request_ids: Vec::new(),
+            active_tool_chain_fallback_titles: Vec::new(),
+            tool_chain_ids_by_request: HashMap::new(),
             cancel_token: None,
             pending_working_dir: None,
         };
@@ -4243,10 +4676,7 @@ print(\"hello, world\")
 
     #[test]
     fn test_summarize_tool_call_no_args() {
-        assert_eq!(
-            summarize_tool_call("developer__shell", None),
-            "developer: shell"
-        );
+        assert_eq!(summarize_tool_call("developer__shell", None), "Run command");
     }
 
     #[test]
@@ -4254,7 +4684,7 @@ print(\"hello, world\")
         let args = serde_json::json!({"path": "/src/main.rs", "content": "fn main() {}"});
         assert_eq!(
             summarize_tool_call("developer__edit", Some(&args)),
-            "developer: edit · /src/main.rs"
+            "Edit main.rs"
         );
     }
 
@@ -4263,7 +4693,49 @@ print(\"hello, world\")
         let args = serde_json::json!({"command": "cargo build"});
         assert_eq!(
             summarize_tool_call("developer__shell", Some(&args)),
-            "developer: shell · cargo build"
+            "Run command"
+        );
+    }
+
+    #[test]
+    fn test_summarize_tool_call_with_cmd() {
+        let args = serde_json::json!({"cmd": "cargo test -p goose"});
+        assert_eq!(
+            summarize_tool_call("developer__shell", Some(&args)),
+            "Run command"
+        );
+    }
+
+    #[test]
+    fn test_summarize_tool_call_reads_files_from_shell_commands() {
+        let args = serde_json::json!({"command": "cat /tmp/package.json"});
+        assert_eq!(
+            summarize_tool_call("developer__shell", Some(&args)),
+            "Read package.json"
+        );
+    }
+
+    #[test]
+    fn test_summarize_tool_call_reads_files_from_analyze() {
+        let args = serde_json::json!({"path": "/src/main.js"});
+        assert_eq!(summarize_tool_call("analyze", Some(&args)), "Read main.js");
+    }
+
+    #[test]
+    fn test_summarize_tool_call_lists_project_files() {
+        let args = serde_json::json!({"path": "/tmp/project"});
+        assert_eq!(
+            summarize_tool_call("tree", Some(&args)),
+            "List project files"
+        );
+    }
+
+    #[test]
+    fn test_summarize_tool_call_checks_working_directory() {
+        let args = serde_json::json!({"command": "pwd && ls -la"});
+        assert_eq!(
+            summarize_tool_call("developer__shell", Some(&args)),
+            "Check working directory"
         );
     }
 
@@ -4273,7 +4745,23 @@ print(\"hello, world\")
         let args = serde_json::json!({"path": long_path});
         let result = summarize_tool_call("developer__read_file", Some(&args));
         assert!(result.ends_with('…'));
-        assert!(result.len() < 90);
+        assert!(result.starts_with("Read "));
+        assert!(result.len() < 50);
+    }
+
+    #[test]
+    fn test_build_initial_tool_call_preserves_raw_input() {
+        let raw_input = serde_json::json!({"command": "cargo test -p goose"});
+        let tool_call = build_initial_tool_call(
+            "req_1",
+            "Run command".to_string(),
+            Some(raw_input.clone()),
+            "chain_1",
+            "running commands",
+        );
+
+        assert_eq!(tool_call.raw_input, Some(raw_input));
+        assert_eq!(tool_call.title, "Run command");
     }
 
     #[test_case(
@@ -4498,6 +4986,215 @@ print(\"hello, world\")
     ) -> Option<Vec<(PathBuf, Option<u32>)>> {
         extract_locations_from_meta(&response)
             .map(|locs| locs.into_iter().map(|loc| (loc.path, loc.line)).collect())
+    }
+
+    #[test]
+    fn test_start_or_continue_tool_chain_reuses_first_request_id() {
+        let mut active_tool_chain_id = None;
+        let mut active_tool_chain_request_ids = Vec::new();
+        let mut active_tool_chain_fallback_titles = Vec::new();
+        let mut tool_chain_ids_by_request = HashMap::new();
+
+        let first_chain_id = start_or_continue_tool_chain(
+            &mut active_tool_chain_id,
+            &mut active_tool_chain_request_ids,
+            &mut active_tool_chain_fallback_titles,
+            &mut tool_chain_ids_by_request,
+            "req_1",
+            "Read main.rs",
+        );
+        let second_chain_id = start_or_continue_tool_chain(
+            &mut active_tool_chain_id,
+            &mut active_tool_chain_request_ids,
+            &mut active_tool_chain_fallback_titles,
+            &mut tool_chain_ids_by_request,
+            "req_2",
+            "Read Cargo.toml",
+        );
+
+        assert_eq!(first_chain_id, "req_1");
+        assert_eq!(second_chain_id, "req_1");
+        assert_eq!(active_tool_chain_id.as_deref(), Some("req_1"));
+        assert_eq!(active_tool_chain_request_ids, vec!["req_1", "req_2"]);
+        assert_eq!(
+            active_tool_chain_fallback_titles,
+            vec!["Read main.rs", "Read Cargo.toml"]
+        );
+        assert_eq!(
+            tool_chain_ids_by_request.get("req_2").map(String::as_str),
+            Some("req_1")
+        );
+    }
+
+    #[test]
+    fn test_summarize_tool_chain_defaults_to_reviewing_files_for_mixed_work() {
+        let summary = summarize_tool_chain(&[
+            "Read main.rs".to_string(),
+            "Run command".to_string(),
+            "Read Cargo.toml".to_string(),
+        ]);
+
+        assert_eq!(summary, "reviewing files");
+    }
+
+    #[test]
+    fn test_summarize_tool_chain_returns_running_commands_for_command_only_chain() {
+        let summary = summarize_tool_chain(&["Run command".to_string(), "Run command".to_string()]);
+
+        assert_eq!(summary, "running commands");
+    }
+
+    #[test]
+    fn test_summarize_tool_chain_returns_updating_files_for_edit_heavy_chain() {
+        let summary = summarize_tool_chain(&[
+            "Edit main.rs".to_string(),
+            "Edit lib.rs".to_string(),
+            "Read lib.rs".to_string(),
+        ]);
+
+        assert_eq!(summary, "updating files");
+    }
+
+    #[test]
+    fn test_resolve_tool_chain_for_response_prefers_request_mapping() {
+        let mut active_tool_chain_id = Some("req_1".to_string());
+        let tool_chain_ids_by_request = HashMap::from([("req_2".to_string(), "req_1".to_string())]);
+
+        let chain_id = resolve_tool_chain_for_response(
+            &mut active_tool_chain_id,
+            &tool_chain_ids_by_request,
+            "req_2",
+        );
+
+        assert_eq!(chain_id, "req_1");
+        assert_eq!(active_tool_chain_id.as_deref(), Some("req_1"));
+    }
+
+    #[test]
+    fn test_resolve_tool_chain_for_response_falls_back_to_active_chain() {
+        let mut active_tool_chain_id = Some("req_1".to_string());
+        let tool_chain_ids_by_request = HashMap::new();
+
+        let chain_id = resolve_tool_chain_for_response(
+            &mut active_tool_chain_id,
+            &tool_chain_ids_by_request,
+            "req_9",
+        );
+
+        assert_eq!(chain_id, "req_1");
+        assert_eq!(active_tool_chain_id.as_deref(), Some("req_1"));
+    }
+
+    #[test]
+    fn test_resolve_tool_chain_for_response_starts_new_chain_when_none_active() {
+        let mut active_tool_chain_id = None;
+        let tool_chain_ids_by_request = HashMap::new();
+
+        let chain_id = resolve_tool_chain_for_response(
+            &mut active_tool_chain_id,
+            &tool_chain_ids_by_request,
+            "req_9",
+        );
+
+        assert_eq!(chain_id, "req_9");
+        assert_eq!(active_tool_chain_id.as_deref(), Some("req_9"));
+    }
+
+    #[test]
+    fn test_reset_tool_chain_clears_state() {
+        let mut active_tool_chain_id = Some("req_1".to_string());
+        let mut active_tool_chain_request_ids = vec!["req_1".to_string()];
+        let mut active_tool_chain_fallback_titles = vec!["Read main.rs".to_string()];
+        let mut tool_chain_ids_by_request =
+            HashMap::from([("req_1".to_string(), "req_1".to_string())]);
+
+        reset_tool_chain(
+            &mut active_tool_chain_id,
+            &mut active_tool_chain_request_ids,
+            &mut active_tool_chain_fallback_titles,
+            &mut tool_chain_ids_by_request,
+        );
+
+        assert!(active_tool_chain_id.is_none());
+        assert!(active_tool_chain_request_ids.is_empty());
+        assert!(active_tool_chain_fallback_titles.is_empty());
+        assert!(tool_chain_ids_by_request.is_empty());
+    }
+
+    #[test]
+    fn test_close_tool_chain_returns_summary_and_clears_state() {
+        let mut active_tool_chain_id = None;
+        let mut active_tool_chain_request_ids = Vec::new();
+        let mut active_tool_chain_fallback_titles = Vec::new();
+        let mut tool_chain_ids_by_request = HashMap::new();
+
+        start_or_continue_tool_chain(
+            &mut active_tool_chain_id,
+            &mut active_tool_chain_request_ids,
+            &mut active_tool_chain_fallback_titles,
+            &mut tool_chain_ids_by_request,
+            "req_1",
+            "Read main.rs",
+        );
+        start_or_continue_tool_chain(
+            &mut active_tool_chain_id,
+            &mut active_tool_chain_request_ids,
+            &mut active_tool_chain_fallback_titles,
+            &mut tool_chain_ids_by_request,
+            "req_2",
+            "Run command",
+        );
+
+        let closed_tool_chain = close_tool_chain(
+            &mut active_tool_chain_id,
+            &mut active_tool_chain_request_ids,
+            &mut active_tool_chain_fallback_titles,
+            &mut tool_chain_ids_by_request,
+        )
+        .expect("tool chain should close");
+
+        assert_eq!(closed_tool_chain.chain_id, "req_1");
+        assert_eq!(closed_tool_chain.last_request_id(), Some("req_2"));
+        assert_eq!(closed_tool_chain.summary, "reviewing files");
+        assert!(active_tool_chain_id.is_none());
+        assert!(active_tool_chain_request_ids.is_empty());
+        assert!(active_tool_chain_fallback_titles.is_empty());
+        assert!(tool_chain_ids_by_request.is_empty());
+    }
+
+    #[test]
+    fn test_build_replay_tool_chain_meta_uses_final_summary_for_entire_chain() {
+        let shell_args_1 = serde_json::json!({"command": "cargo fmt"});
+        let shell_args_2 = serde_json::json!({"command": "cargo test"});
+        let message = Message::assistant()
+            .with_tool_request(
+                "req_1",
+                Ok(CallToolRequestParams::new("developer__shell")
+                    .with_arguments(shell_args_1.as_object().unwrap().clone())),
+            )
+            .with_tool_request(
+                "req_2",
+                Ok(CallToolRequestParams::new("developer__shell")
+                    .with_arguments(shell_args_2.as_object().unwrap().clone())),
+            )
+            .with_text("done");
+
+        let replay_tool_chain_meta = build_replay_tool_chain_meta(&[message]);
+
+        assert_eq!(
+            replay_tool_chain_meta.get("req_1"),
+            Some(&ReplayToolChainMeta {
+                chain_id: "req_1".to_string(),
+                summary: "running commands".to_string(),
+            })
+        );
+        assert_eq!(
+            replay_tool_chain_meta.get("req_2"),
+            Some(&ReplayToolChainMeta {
+                chain_id: "req_1".to_string(),
+                summary: "running commands".to_string(),
+            })
+        );
     }
 
     fn make_session_with_usage(

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -976,6 +976,20 @@ fn build_replay_tool_chain_meta(
             continue;
         }
 
+        if message.role != Role::Assistant {
+            if let Some(closed_tool_chain) = close_tool_chain(
+                &mut active_tool_chain_id,
+                &mut active_tool_chain_request_ids,
+                &mut active_tool_chain_fallback_titles,
+                &mut tool_chain_ids_by_request,
+            ) {
+                insert_replay_tool_chain_meta(
+                    &mut replay_tool_chain_meta_by_request,
+                    closed_tool_chain,
+                );
+            }
+        }
+
         for content_item in &message.content {
             match content_item {
                 MessageContent::Text(_) => {
@@ -5290,6 +5304,48 @@ print(\"hello, world\")
             replay_tool_chain_meta.get("req_2"),
             Some(&ReplayToolChainMeta {
                 chain_id: "req_1".to_string(),
+                summary: "running commands".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn test_build_replay_tool_chain_meta_resets_chain_on_non_text_user_turn() {
+        let shell_args_1 = serde_json::json!({"command": "cargo fmt"});
+        let shell_args_2 = serde_json::json!({"command": "cargo test"});
+        let first_assistant_message = Message::assistant().with_tool_request(
+            "req_1",
+            Ok(
+                CallToolRequestParams::new("developer__shell")
+                    .with_arguments(shell_args_1.as_object().unwrap().clone()),
+            ),
+        );
+        let user_message = Message::user().with_image("aGVsbG8=", "image/png");
+        let second_assistant_message = Message::assistant().with_tool_request(
+            "req_2",
+            Ok(
+                CallToolRequestParams::new("developer__shell")
+                    .with_arguments(shell_args_2.as_object().unwrap().clone()),
+            ),
+        );
+
+        let replay_tool_chain_meta = build_replay_tool_chain_meta(&[
+            first_assistant_message,
+            user_message,
+            second_assistant_message,
+        ]);
+
+        assert_eq!(
+            replay_tool_chain_meta.get("req_1"),
+            Some(&ReplayToolChainMeta {
+                chain_id: "req_1".to_string(),
+                summary: "running commands".to_string(),
+            })
+        );
+        assert_eq!(
+            replay_tool_chain_meta.get("req_2"),
+            Some(&ReplayToolChainMeta {
+                chain_id: "req_2".to_string(),
                 summary: "running commands".to_string(),
             })
         );

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -2814,6 +2814,11 @@ impl GooseAcpAgent {
                 }
                 Ok(_) => {}
                 Err(e) => {
+                    let mut sessions = self.sessions.lock().await;
+                    if let Some(session) = sessions.get_mut(&thread_id) {
+                        session.cancel_token = None;
+                        flush_tool_chain_summary(cx, &args.session_id, session)?;
+                    }
                     return Err(sacp::Error::internal_error()
                         .data(format!("Error in agent response stream: {}", e)));
                 }

--- a/crates/goose/src/providers/codex.rs
+++ b/crates/goose/src/providers/codex.rs
@@ -60,6 +60,10 @@ pub struct CodexProvider {
 }
 
 impl CodexProvider {
+    fn verbosity_override(model_name: &str) -> Option<&'static str> {
+        model_name.starts_with("gpt-5").then_some("medium")
+    }
+
     fn supports_reasoning_effort(model_name: &str, reasoning_effort: &str) -> bool {
         if !CODEX_REASONING_LEVELS.contains(&reasoning_effort) {
             return false;
@@ -147,6 +151,10 @@ impl CodexProvider {
             "model_reasoning_effort=\"{}\"",
             self.reasoning_effort
         ));
+        if let Some(verbosity) = Self::verbosity_override(&self.model.model_name) {
+            cmd.arg("-c")
+                .arg(format!("model_verbosity=\"{verbosity}\""));
+        }
 
         for override_config in &self.mcp_config_overrides {
             cmd.arg("-c").arg(override_config);
@@ -1013,6 +1021,19 @@ mod tests {
             "gpt-5.2-codex",
             "xhigh"
         ));
+    }
+
+    #[test]
+    fn test_verbosity_override_for_gpt5_models() {
+        assert_eq!(
+            CodexProvider::verbosity_override("gpt-5.2-codex"),
+            Some("medium")
+        );
+        assert_eq!(
+            CodexProvider::verbosity_override("gpt-5.1-codex-max"),
+            Some("medium")
+        );
+        assert_eq!(CodexProvider::verbosity_override("o4-mini"), None);
     }
 
     #[test]

--- a/ui/goose2/src/shared/api/acpNotificationHandler.test.ts
+++ b/ui/goose2/src/shared/api/acpNotificationHandler.test.ts
@@ -12,6 +12,8 @@ describe("acpNotificationHandler", () => {
   beforeEach(() => {
     clearReplayBuffer("draft-session-1");
     clearReplayBuffer("draft-session-2");
+    clearReplayBuffer("draft-session-3");
+    clearReplayBuffer("draft-session-4");
     useChatStore.setState({
       messagesBySession: {},
       sessionStateById: {},
@@ -73,5 +75,259 @@ describe("acpNotificationHandler", () => {
     expect(
       useChatStore.getState().messagesBySession["draft-session-2"],
     ).toBeUndefined();
+  });
+
+  it("stores live tool chain ids and falls back to the request chain on completion", async () => {
+    registerSession("draft-session-3", "goose-session-3", "goose", "/tmp");
+
+    await handleSessionNotification({
+      sessionId: "goose-session-3",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "message-1",
+        content: {
+          type: "text",
+          text: "Working on it",
+        },
+      },
+    } as SessionNotification);
+
+    await handleSessionNotification({
+      sessionId: "goose-session-3",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tool-1",
+        title: "readFile",
+        kind: "execute",
+        rawInput: {
+          command: "tree -L 2",
+        },
+        _meta: {
+          "_goose/tool-chain-id": "chain-1",
+          "_goose/tool-chain-summary": "working",
+        },
+      },
+    } as SessionNotification);
+
+    await handleSessionNotification({
+      sessionId: "goose-session-3",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tool-1",
+        status: "completed",
+        kind: "execute",
+        locations: [{ path: "/tmp/project", line: 1 }],
+        rawOutput: {
+          exitCode: 0,
+        },
+        _meta: {
+          "_goose/tool-chain-id": "chain-1",
+          "_goose/tool-chain-summary": "working",
+        },
+        content: [
+          {
+            type: "content",
+            content: {
+              type: "text",
+              text: "done",
+            },
+          },
+        ],
+      },
+    } as SessionNotification);
+
+    await handleSessionNotification({
+      sessionId: "goose-session-3",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tool-1",
+        _meta: {
+          "_goose/tool-chain-id": "chain-1",
+          "_goose/tool-chain-summary": "reviewing files",
+        },
+      },
+    } as SessionNotification);
+
+    await handleSessionNotification({
+      sessionId: "goose-session-3",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tool-1",
+        title: "read project files",
+        _meta: {
+          "_goose/tool-chain-id": "chain-1",
+          "_goose/tool-chain-summary": "working",
+        },
+      },
+    } as SessionNotification);
+
+    const message =
+      useChatStore.getState().messagesBySession["draft-session-3"]?.[0];
+    expect(message).toBeDefined();
+    expect(message?.content).toEqual([
+      {
+        type: "text",
+        text: "Working on it",
+      },
+      {
+        type: "toolRequest",
+        id: "tool-1",
+        chainId: "chain-1",
+        chainSummary: "reviewing files",
+        name: "read project files",
+        arguments: {
+          command: "tree -L 2",
+        },
+        kind: "execute",
+        locations: [{ path: "/tmp/project", line: 1 }],
+        content: [
+          {
+            type: "content",
+            content: {
+              type: "text",
+              text: "done",
+            },
+          },
+        ],
+        rawOutput: {
+          exitCode: 0,
+        },
+        status: "completed",
+        startedAt: expect.any(Number),
+      },
+      {
+        type: "toolResponse",
+        id: "tool-1",
+        chainId: "chain-1",
+        chainSummary: "reviewing files",
+        name: "read project files",
+        result: "done",
+        kind: "execute",
+        locations: [{ path: "/tmp/project", line: 1 }],
+        content: [
+          {
+            type: "content",
+            content: {
+              type: "text",
+              text: "done",
+            },
+          },
+        ],
+        rawOutput: {
+          exitCode: 0,
+        },
+        isError: false,
+      },
+    ]);
+  });
+
+  it("stores replay tool chain ids from ACP metadata", async () => {
+    registerSession("draft-session-4", "goose-session-4", "goose", "/tmp");
+    useChatStore.setState({
+      loadingSessionIds: new Set(["draft-session-4"]),
+    });
+
+    await handleSessionNotification({
+      sessionId: "goose-session-4",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "message-1",
+        content: {
+          type: "text",
+          text: "Working on it",
+        },
+      },
+    } as SessionNotification);
+
+    await handleSessionNotification({
+      sessionId: "goose-session-4",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tool-1",
+        title: "readFile",
+        kind: "read",
+        rawInput: {
+          path: "/tmp/project/main.js",
+        },
+        _meta: {
+          "_goose/tool-chain-id": "chain-1",
+          "_goose/tool-chain-summary": "reviewing files",
+        },
+      },
+    } as SessionNotification);
+
+    await handleSessionNotification({
+      sessionId: "goose-session-4",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tool-1",
+        status: "completed",
+        locations: [{ path: "/tmp/project/main.js", line: 12 }],
+        _meta: {
+          "_goose/tool-chain-id": "chain-1",
+          "_goose/tool-chain-summary": "reviewing files",
+        },
+        content: [
+          {
+            type: "content",
+            content: {
+              type: "text",
+              text: "done",
+            },
+          },
+        ],
+      },
+    } as SessionNotification);
+
+    const buffer = getAndDeleteReplayBuffer("draft-session-4");
+    expect(buffer?.[0]?.content).toEqual([
+      {
+        type: "text",
+        text: "Working on it",
+      },
+      {
+        type: "toolRequest",
+        id: "tool-1",
+        chainId: "chain-1",
+        chainSummary: "reviewing files",
+        name: "readFile",
+        arguments: {
+          path: "/tmp/project/main.js",
+        },
+        kind: "read",
+        locations: [{ path: "/tmp/project/main.js", line: 12 }],
+        content: [
+          {
+            type: "content",
+            content: {
+              type: "text",
+              text: "done",
+            },
+          },
+        ],
+        status: "completed",
+        startedAt: expect.any(Number),
+      },
+      {
+        type: "toolResponse",
+        id: "tool-1",
+        chainId: "chain-1",
+        chainSummary: "reviewing files",
+        name: "readFile",
+        result: "done",
+        kind: "read",
+        locations: [{ path: "/tmp/project/main.js", line: 12 }],
+        content: [
+          {
+            type: "content",
+            content: {
+              type: "text",
+              text: "done",
+            },
+          },
+        ],
+        isError: false,
+      },
+    ]);
   });
 });

--- a/ui/goose2/src/shared/api/acpNotificationHandler.test.ts
+++ b/ui/goose2/src/shared/api/acpNotificationHandler.test.ts
@@ -14,6 +14,8 @@ describe("acpNotificationHandler", () => {
     clearReplayBuffer("draft-session-2");
     clearReplayBuffer("draft-session-3");
     clearReplayBuffer("draft-session-4");
+    clearReplayBuffer("draft-session-5");
+    clearReplayBuffer("draft-session-6");
     useChatStore.setState({
       messagesBySession: {},
       sessionStateById: {},
@@ -327,6 +329,118 @@ describe("acpNotificationHandler", () => {
           },
         ],
         isError: false,
+      },
+    ]);
+  });
+
+  it("preserves live text annotations and splits chunks when audience changes", async () => {
+    registerSession("draft-session-5", "goose-session-5", "goose", "/tmp");
+
+    await handleSessionNotification({
+      sessionId: "goose-session-5",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "message-1",
+        content: {
+          type: "text",
+          text: "internal ",
+          annotations: {
+            audience: ["assistant"],
+          },
+        },
+      },
+    } as SessionNotification);
+
+    await handleSessionNotification({
+      sessionId: "goose-session-5",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "message-1",
+        content: {
+          type: "text",
+          text: "prompt",
+          annotations: {
+            audience: ["assistant"],
+          },
+        },
+      },
+    } as SessionNotification);
+
+    await handleSessionNotification({
+      sessionId: "goose-session-5",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "message-1",
+        content: {
+          type: "text",
+          text: "Visible reply",
+        },
+      },
+    } as SessionNotification);
+
+    expect(
+      useChatStore.getState().messagesBySession["draft-session-5"]?.[0]
+        ?.content,
+    ).toEqual([
+      {
+        type: "text",
+        text: "internal prompt",
+        annotations: {
+          audience: ["assistant"],
+        },
+      },
+      {
+        type: "text",
+        text: "Visible reply",
+      },
+    ]);
+  });
+
+  it("preserves replay text annotations on user message chunks", async () => {
+    registerSession("draft-session-6", "goose-session-6", "goose", "/tmp");
+    useChatStore.setState({
+      loadingSessionIds: new Set(["draft-session-6"]),
+    });
+
+    await handleSessionNotification({
+      sessionId: "goose-session-6",
+      update: {
+        sessionUpdate: "user_message_chunk",
+        messageId: "message-1",
+        content: {
+          type: "text",
+          text: "internal prompt",
+          annotations: {
+            audience: ["assistant"],
+          },
+        },
+      },
+    } as SessionNotification);
+
+    await handleSessionNotification({
+      sessionId: "goose-session-6",
+      update: {
+        sessionUpdate: "user_message_chunk",
+        messageId: "message-1",
+        content: {
+          type: "text",
+          text: "Visible prompt",
+        },
+      },
+    } as SessionNotification);
+
+    const buffer = getAndDeleteReplayBuffer("draft-session-6");
+    expect(buffer?.[0]?.content).toEqual([
+      {
+        type: "text",
+        text: "internal prompt",
+        annotations: {
+          audience: ["assistant"],
+        },
+      },
+      {
+        type: "text",
+        text: "Visible prompt",
       },
     ]);
   });

--- a/ui/goose2/src/shared/api/acpNotificationHandler.test.ts
+++ b/ui/goose2/src/shared/api/acpNotificationHandler.test.ts
@@ -333,7 +333,7 @@ describe("acpNotificationHandler", () => {
     ]);
   });
 
-  it("preserves live text annotations and splits chunks when audience changes", async () => {
+  it("drops assistant-only live text chunks while preserving visible annotations", async () => {
     registerSession("draft-session-5", "goose-session-5", "goose", "/tmp");
 
     await handleSessionNotification({
@@ -358,9 +358,9 @@ describe("acpNotificationHandler", () => {
         messageId: "message-1",
         content: {
           type: "text",
-          text: "prompt",
+          text: "Visible ",
           annotations: {
-            audience: ["assistant"],
+            audience: ["user"],
           },
         },
       },
@@ -373,7 +373,10 @@ describe("acpNotificationHandler", () => {
         messageId: "message-1",
         content: {
           type: "text",
-          text: "Visible reply",
+          text: "reply",
+          annotations: {
+            audience: ["user"],
+          },
         },
       },
     } as SessionNotification);
@@ -384,19 +387,15 @@ describe("acpNotificationHandler", () => {
     ).toEqual([
       {
         type: "text",
-        text: "internal prompt",
-        annotations: {
-          audience: ["assistant"],
-        },
-      },
-      {
-        type: "text",
         text: "Visible reply",
+        annotations: {
+          audience: ["user"],
+        },
       },
     ]);
   });
 
-  it("preserves replay text annotations on user message chunks", async () => {
+  it("drops assistant-only replay text chunks while preserving visible annotations", async () => {
     registerSession("draft-session-6", "goose-session-6", "goose", "/tmp");
     useChatStore.setState({
       loadingSessionIds: new Set(["draft-session-6"]),
@@ -424,7 +423,25 @@ describe("acpNotificationHandler", () => {
         messageId: "message-1",
         content: {
           type: "text",
-          text: "Visible prompt",
+          text: "Visible ",
+          annotations: {
+            audience: ["user"],
+          },
+        },
+      },
+    } as SessionNotification);
+
+    await handleSessionNotification({
+      sessionId: "goose-session-6",
+      update: {
+        sessionUpdate: "user_message_chunk",
+        messageId: "message-1",
+        content: {
+          type: "text",
+          text: "prompt",
+          annotations: {
+            audience: ["user"],
+          },
         },
       },
     } as SessionNotification);
@@ -433,14 +450,10 @@ describe("acpNotificationHandler", () => {
     expect(buffer?.[0]?.content).toEqual([
       {
         type: "text",
-        text: "internal prompt",
-        annotations: {
-          audience: ["assistant"],
-        },
-      },
-      {
-        type: "text",
         text: "Visible prompt",
+        annotations: {
+          audience: ["user"],
+        },
       },
     ]);
   });

--- a/ui/goose2/src/shared/api/acpNotificationHandler.ts
+++ b/ui/goose2/src/shared/api/acpNotificationHandler.ts
@@ -9,17 +9,24 @@ import {
   getBufferedMessage,
   findLatestUnpairedToolRequest,
 } from "@/features/chat/hooks/replayBuffer";
-import type {
-  TextContent,
-  ToolRequestContent,
-  ToolResponseContent,
-} from "@/shared/types/messages";
 import type { AcpNotificationHandler } from "./acpConnection";
 import {
   getLocalSessionId,
   subscribeToSessionRegistration,
 } from "./acpSessionTracker";
 import { perfLog } from "@/shared/lib/perfLog";
+import { findToolRequestById, updateToolCallBlocks } from "./toolCallChainMeta";
+import {
+  findMessageInBuffer,
+  findMessageWithToolCall,
+  normalizeToolCallPayload,
+} from "./acpNotificationMessageHelpers";
+import {
+  buildToolCallPatch,
+  buildToolRequestBlock,
+  buildToolResponseBlock,
+  hasToolCallPatch,
+} from "./toolCallBlockBuilders";
 
 // Pre-set message ID for the next live stream per goose session
 const presetMessageIds = new Map<string, string>();
@@ -197,32 +204,32 @@ function handleReplay(sessionId: string, update: SessionUpdate): void {
     }
 
     case "user_message_chunk": {
-      if (update.content.type !== "text" || !("text" in update.content)) break;
       const messageId = update.messageId ?? crypto.randomUUID();
       const buffer = ensureReplayBuffer(sessionId);
       const existing = getBufferedMessage(sessionId, messageId);
-      // biome-ignore lint/suspicious/noExplicitAny: wire format has annotations but SDK types don't
-      const rawAnn = (update.content as any).annotations;
-      const ann: TextContent["annotations"] | undefined =
-        typeof rawAnn === "object" && rawAnn !== null ? rawAnn : undefined;
-      // Drop assistant-only blocks so they never enter chat state.
       if (
-        ann?.audience &&
-        ann.audience.length > 0 &&
-        !ann.audience.includes("user")
-      )
-        break;
-      const textBlock = makeTextBlock(update.content.text, ann);
-      if (!existing) {
+        !existing &&
+        update.content.type === "text" &&
+        "text" in update.content
+      ) {
         buffer.push({
           id: messageId,
           role: "user",
           created: Date.now(),
-          content: [textBlock],
+          content: [{ type: "text", text: update.content.text }],
           metadata: { userVisible: true, agentVisible: true },
         });
-      } else {
-        existing.content.push(textBlock);
+      } else if (
+        existing &&
+        update.content.type === "text" &&
+        "text" in update.content
+      ) {
+        const last = existing.content[existing.content.length - 1];
+        if (last?.type === "text") {
+          (last as { type: "text"; text: string }).text += update.content.text;
+        } else {
+          existing.content.push({ type: "text", text: update.content.text });
+        }
       }
       break;
     }
@@ -230,14 +237,8 @@ function handleReplay(sessionId: string, update: SessionUpdate): void {
     case "tool_call": {
       const msg = findMessageInBuffer(sessionId, update.toolCallId);
       if (msg) {
-        msg.content.push({
-          type: "toolRequest",
-          id: update.toolCallId,
-          name: update.title,
-          arguments: {},
-          status: "executing",
-          startedAt: Date.now(),
-        });
+        const payload = normalizeToolCallPayload(update);
+        msg.content.push(buildToolRequestBlock(update, payload));
       }
       break;
     }
@@ -245,35 +246,29 @@ function handleReplay(sessionId: string, update: SessionUpdate): void {
     case "tool_call_update": {
       const msg = findMessageWithToolCall(sessionId, update.toolCallId);
       if (msg) {
-        if (update.title) {
-          const tc = msg.content.find(
-            (c) => c.type === "toolRequest" && c.id === update.toolCallId,
+        const payload = normalizeToolCallPayload(update);
+
+        if (hasToolCallPatch(update, payload)) {
+          msg.content = updateToolCallBlocks(
+            msg.content,
+            update.toolCallId,
+            buildToolCallPatch(update, payload),
           );
-          if (tc && tc.type === "toolRequest") {
-            (tc as ToolRequestContent).name = update.title;
-          }
         }
+
         if (update.status === "completed" || update.status === "failed") {
-          const tc = msg.content.find(
-            (c) => c.type === "toolRequest" && c.id === update.toolCallId,
+          msg.content = updateToolCallBlocks(
+            msg.content,
+            update.toolCallId,
+            buildToolCallPatch(update, payload, true),
           );
-          if (tc && tc.type === "toolRequest") {
-            const idx = msg.content.indexOf(tc);
-            if (idx >= 0) {
-              msg.content[idx] = {
-                ...tc,
-                status: "completed",
-              } as ToolRequestContent;
-            }
-          }
-          const resultText = extractToolResultText(update);
-          msg.content.push({
-            type: "toolResponse",
-            id: update.toolCallId,
-            name: (tc as ToolRequestContent)?.name ?? "",
-            result: resultText,
-            isError: update.status === "failed",
-          });
+          const completedToolRequest = findToolRequestById(
+            msg.content,
+            update.toolCallId,
+          );
+          msg.content.push(
+            buildToolResponseBlock(update, payload, completedToolRequest),
+          );
         }
       }
       break;
@@ -333,17 +328,12 @@ function handleLive(
     case "tool_call": {
       const messageId = findStreamingMessageId(sessionId);
       if (!messageId) break;
-
-      const toolRequest: ToolRequestContent = {
-        type: "toolRequest",
-        id: update.toolCallId,
-        name: update.title,
-        arguments: {},
-        status: "executing",
-        startedAt: Date.now(),
-      };
+      const payload = normalizeToolCallPayload(update);
       store.setStreamingMessageId(sessionId, messageId);
-      store.appendToStreamingMessage(sessionId, toolRequest);
+      store.appendToStreamingMessage(
+        sessionId,
+        buildToolRequestBlock(update, payload),
+      );
       break;
     }
 
@@ -351,13 +341,15 @@ function handleLive(
       const messageId = findStreamingMessageId(sessionId);
       if (!messageId) break;
 
-      if (update.title) {
+      const payload = normalizeToolCallPayload(update);
+
+      if (hasToolCallPatch(update, payload)) {
         store.updateMessage(sessionId, messageId, (msg) => ({
           ...msg,
-          content: msg.content.map((c) =>
-            c.type === "toolRequest" && c.id === update.toolCallId
-              ? { ...c, name: update.title ?? "" }
-              : c,
+          content: updateToolCallBlocks(
+            msg.content,
+            update.toolCallId,
+            buildToolCallPatch(update, payload),
           ),
         }));
       }
@@ -367,28 +359,24 @@ function handleLive(
           (m) => m.id === messageId,
         );
         const toolRequest = streamingMessage
-          ? findLatestUnpairedToolRequest(streamingMessage.content)
+          ? (findToolRequestById(streamingMessage.content, update.toolCallId) ??
+            findLatestUnpairedToolRequest(streamingMessage.content))
           : null;
 
         store.updateMessage(sessionId, messageId, (msg) => ({
           ...msg,
-          content: msg.content.map((block) =>
-            block.type === "toolRequest" && block.id === update.toolCallId
-              ? { ...block, status: "completed" }
-              : block,
+          content: updateToolCallBlocks(
+            msg.content,
+            update.toolCallId,
+            buildToolCallPatch(update, payload, true),
           ),
         }));
 
-        const resultText = extractToolResultText(update);
-        const toolResponse: ToolResponseContent = {
-          type: "toolResponse",
-          id: update.toolCallId,
-          name: toolRequest?.name ?? "",
-          result: resultText,
-          isError: update.status === "failed",
-        };
         store.setStreamingMessageId(sessionId, messageId);
-        store.appendToStreamingMessage(sessionId, toolResponse);
+        store.appendToStreamingMessage(
+          sessionId,
+          buildToolResponseBlock(update, payload, toolRequest),
+        );
       }
       break;
     }
@@ -480,62 +468,9 @@ function handleShared(sessionId: string, update: SessionUpdate): void {
   }
 }
 
-// Helpers
-
 function findStreamingMessageId(sessionId: string): string | null {
   return useChatStore.getState().getSessionRuntime(sessionId)
     .streamingMessageId;
-}
-
-function makeTextBlock(
-  text: string,
-  ann?: TextContent["annotations"],
-): TextContent {
-  return { type: "text", text, ...(ann ? { annotations: ann } : {}) };
-}
-
-function findMessageInBuffer(
-  sessionId: string,
-  _toolCallId: string,
-): ReturnType<typeof getBufferedMessage> {
-  const buffer = ensureReplayBuffer(sessionId);
-  return buffer[buffer.length - 1];
-}
-
-function findMessageWithToolCall(
-  sessionId: string,
-  toolCallId: string,
-): ReturnType<typeof getBufferedMessage> {
-  const buffer = ensureReplayBuffer(sessionId);
-  for (let i = buffer.length - 1; i >= 0; i--) {
-    const msg = buffer[i];
-    if (
-      msg.content.some((c) => c.type === "toolRequest" && c.id === toolCallId)
-    ) {
-      return msg;
-    }
-  }
-  return buffer[buffer.length - 1];
-}
-
-function extractToolResultText(update: {
-  // biome-ignore lint/suspicious/noExplicitAny: ACP SDK ToolCallContent type is complex
-  content?: Array<any> | null;
-  rawOutput?: unknown;
-}): string {
-  if (update.content && update.content.length > 0) {
-    for (const item of update.content) {
-      if (item.type === "content" && item.content?.type === "text") {
-        return item.content.text;
-      }
-    }
-  }
-  if (update.rawOutput !== undefined && update.rawOutput !== null) {
-    return typeof update.rawOutput === "string"
-      ? update.rawOutput
-      : JSON.stringify(update.rawOutput);
-  }
-  return "";
 }
 
 export function clearMessageTracking(): void {

--- a/ui/goose2/src/shared/api/acpNotificationHandler.ts
+++ b/ui/goose2/src/shared/api/acpNotificationHandler.ts
@@ -27,6 +27,10 @@ import {
   buildToolResponseBlock,
   hasToolCallPatch,
 } from "./toolCallBlockBuilders";
+import {
+  appendTextContent,
+  normalizeTextAnnotations,
+} from "./textContentBlocks";
 
 // Pre-set message ID for the next live stream per goose session
 const presetMessageIds = new Map<string, string>();
@@ -193,12 +197,11 @@ function handleReplay(sessionId: string, update: SessionUpdate): void {
       }
       const msg = getBufferedMessage(sessionId, messageId);
       if (msg && update.content.type === "text" && "text" in update.content) {
-        const last = msg.content[msg.content.length - 1];
-        if (last?.type === "text") {
-          (last as { type: "text"; text: string }).text += update.content.text;
-        } else {
-          msg.content.push({ type: "text", text: update.content.text });
-        }
+        msg.content = appendTextContent(
+          msg.content,
+          update.content.text,
+          normalizeTextAnnotations(update.content.annotations),
+        );
       }
       break;
     }
@@ -212,11 +215,14 @@ function handleReplay(sessionId: string, update: SessionUpdate): void {
         update.content.type === "text" &&
         "text" in update.content
       ) {
+        const annotations = normalizeTextAnnotations(
+          update.content.annotations,
+        );
         buffer.push({
           id: messageId,
           role: "user",
           created: Date.now(),
-          content: [{ type: "text", text: update.content.text }],
+          content: [{ type: "text", text: update.content.text, annotations }],
           metadata: { userVisible: true, agentVisible: true },
         });
       } else if (
@@ -224,12 +230,11 @@ function handleReplay(sessionId: string, update: SessionUpdate): void {
         update.content.type === "text" &&
         "text" in update.content
       ) {
-        const last = existing.content[existing.content.length - 1];
-        if (last?.type === "text") {
-          (last as { type: "text"; text: string }).text += update.content.text;
-        } else {
-          existing.content.push({ type: "text", text: update.content.text });
-        }
+        existing.content = appendTextContent(
+          existing.content,
+          update.content.text,
+          normalizeTextAnnotations(update.content.annotations),
+        );
       }
       break;
     }
@@ -319,8 +324,15 @@ function handleLive(
       }
 
       if (update.content.type === "text" && "text" in update.content) {
+        const text = update.content.text;
+        const annotations = normalizeTextAnnotations(
+          update.content.annotations,
+        );
         store.setStreamingMessageId(sessionId, messageId);
-        store.updateStreamingText(sessionId, update.content.text);
+        store.updateMessage(sessionId, messageId, (msg) => ({
+          ...msg,
+          content: appendTextContent(msg.content, text, annotations),
+        }));
       }
       break;
     }

--- a/ui/goose2/src/shared/api/acpNotificationHandler.ts
+++ b/ui/goose2/src/shared/api/acpNotificationHandler.ts
@@ -29,6 +29,7 @@ import {
 } from "./toolCallBlockBuilders";
 import {
   appendTextContent,
+  isUserVisibleTextAnnotations,
   normalizeTextAnnotations,
 } from "./textContentBlocks";
 
@@ -180,61 +181,69 @@ export function clearReplayPerf(sessionId: string): void {
 function handleReplay(sessionId: string, update: SessionUpdate): void {
   switch (update.sessionUpdate) {
     case "agent_message_chunk": {
-      const messageId = update.messageId ?? crypto.randomUUID();
-      const buffer = ensureReplayBuffer(sessionId);
-      if (!getBufferedMessage(sessionId, messageId)) {
-        buffer.push({
-          id: messageId,
-          role: "assistant",
-          created: Date.now(),
-          content: [],
-          metadata: {
-            userVisible: true,
-            agentVisible: true,
-            completionStatus: "inProgress",
-          },
-        });
-      }
-      const msg = getBufferedMessage(sessionId, messageId);
-      if (msg && update.content.type === "text" && "text" in update.content) {
+      if (update.content.type === "text" && "text" in update.content) {
+        const annotations = normalizeTextAnnotations(
+          update.content.annotations,
+        );
+        if (!isUserVisibleTextAnnotations(annotations)) {
+          break;
+        }
+
+        const messageId = update.messageId ?? crypto.randomUUID();
+        const buffer = ensureReplayBuffer(sessionId);
+        if (!getBufferedMessage(sessionId, messageId)) {
+          buffer.push({
+            id: messageId,
+            role: "assistant",
+            created: Date.now(),
+            content: [],
+            metadata: {
+              userVisible: true,
+              agentVisible: true,
+              completionStatus: "inProgress",
+            },
+          });
+        }
+        const msg = getBufferedMessage(sessionId, messageId);
+        if (!msg) {
+          break;
+        }
         msg.content = appendTextContent(
           msg.content,
           update.content.text,
-          normalizeTextAnnotations(update.content.annotations),
+          annotations,
         );
       }
       break;
     }
 
     case "user_message_chunk": {
-      const messageId = update.messageId ?? crypto.randomUUID();
-      const buffer = ensureReplayBuffer(sessionId);
-      const existing = getBufferedMessage(sessionId, messageId);
-      if (
-        !existing &&
-        update.content.type === "text" &&
-        "text" in update.content
-      ) {
+      if (update.content.type === "text" && "text" in update.content) {
         const annotations = normalizeTextAnnotations(
           update.content.annotations,
         );
-        buffer.push({
-          id: messageId,
-          role: "user",
-          created: Date.now(),
-          content: [{ type: "text", text: update.content.text, annotations }],
-          metadata: { userVisible: true, agentVisible: true },
-        });
-      } else if (
-        existing &&
-        update.content.type === "text" &&
-        "text" in update.content
-      ) {
-        existing.content = appendTextContent(
-          existing.content,
-          update.content.text,
-          normalizeTextAnnotations(update.content.annotations),
-        );
+        if (!isUserVisibleTextAnnotations(annotations)) {
+          break;
+        }
+
+        const messageId = update.messageId ?? crypto.randomUUID();
+        const buffer = ensureReplayBuffer(sessionId);
+        const existing = getBufferedMessage(sessionId, messageId);
+        if (!existing) {
+          buffer.push({
+            id: messageId,
+            role: "user",
+            created: Date.now(),
+            content: [{ type: "text", text: update.content.text, annotations }],
+            metadata: { userVisible: true, agentVisible: true },
+          });
+        } else {
+          existing.content = appendTextContent(
+            existing.content,
+            update.content.text,
+            annotations,
+          );
+        }
       }
       break;
     }
@@ -299,35 +308,39 @@ function handleLive(
 
   switch (update.sessionUpdate) {
     case "agent_message_chunk": {
-      const messageId =
-        update.messageId ??
-        presetMessageIds.get(gooseSessionId) ??
-        crypto.randomUUID();
-      const existing = store.messagesBySession[sessionId]?.find(
-        (m) => m.id === messageId,
-      );
-
-      if (!existing) {
-        store.addMessage(sessionId, {
-          id: messageId,
-          role: "assistant",
-          created: Date.now(),
-          content: [],
-          metadata: {
-            userVisible: true,
-            agentVisible: true,
-            completionStatus: "inProgress",
-          },
-        });
-        store.setPendingAssistantProvider(sessionId, null);
-        store.setStreamingMessageId(sessionId, messageId);
-      }
-
       if (update.content.type === "text" && "text" in update.content) {
-        const text = update.content.text;
         const annotations = normalizeTextAnnotations(
           update.content.annotations,
         );
+        if (!isUserVisibleTextAnnotations(annotations)) {
+          break;
+        }
+
+        const messageId =
+          update.messageId ??
+          presetMessageIds.get(gooseSessionId) ??
+          crypto.randomUUID();
+        const existing = store.messagesBySession[sessionId]?.find(
+          (m) => m.id === messageId,
+        );
+
+        if (!existing) {
+          store.addMessage(sessionId, {
+            id: messageId,
+            role: "assistant",
+            created: Date.now(),
+            content: [],
+            metadata: {
+              userVisible: true,
+              agentVisible: true,
+              completionStatus: "inProgress",
+            },
+          });
+          store.setPendingAssistantProvider(sessionId, null);
+          store.setStreamingMessageId(sessionId, messageId);
+        }
+
+        const text = update.content.text;
         store.setStreamingMessageId(sessionId, messageId);
         store.updateMessage(sessionId, messageId, (msg) => ({
           ...msg,

--- a/ui/goose2/src/shared/api/acpNotificationMessageHelpers.ts
+++ b/ui/goose2/src/shared/api/acpNotificationMessageHelpers.ts
@@ -1,0 +1,127 @@
+import type {
+  ToolCall,
+  ToolCallContent,
+  ToolCallLocation,
+  ToolCallUpdate,
+  ToolKind,
+} from "@agentclientprotocol/sdk";
+import { ensureReplayBuffer } from "@/features/chat/hooks/replayBuffer";
+import type { getBufferedMessage } from "@/features/chat/hooks/replayBuffer";
+
+type ToolCallPayloadCarrier = {
+  content?: ToolCall["content"] | ToolCallUpdate["content"];
+  kind?: ToolCall["kind"] | ToolCallUpdate["kind"];
+  locations?: ToolCall["locations"] | ToolCallUpdate["locations"];
+  rawInput?: unknown;
+  raw_input?: unknown;
+  rawOutput?: ToolCall["rawOutput"] | ToolCallUpdate["rawOutput"];
+  raw_output?: unknown;
+};
+
+export interface NormalizedToolCallPayload {
+  arguments?: Record<string, unknown>;
+  kind?: ToolKind;
+  locations?: ToolCallLocation[];
+  content?: ToolCallContent[];
+  rawOutput?: unknown;
+  resultText: string;
+}
+
+export function findMessageInBuffer(
+  sessionId: string,
+  _toolCallId: string,
+): ReturnType<typeof getBufferedMessage> {
+  const buffer = ensureReplayBuffer(sessionId);
+  return buffer[buffer.length - 1];
+}
+
+export function findMessageWithToolCall(
+  sessionId: string,
+  toolCallId: string,
+): ReturnType<typeof getBufferedMessage> {
+  const buffer = ensureReplayBuffer(sessionId);
+  for (let i = buffer.length - 1; i >= 0; i -= 1) {
+    const msg = buffer[i];
+    if (
+      msg.content.some((content) => {
+        return content.type === "toolRequest" && content.id === toolCallId;
+      })
+    ) {
+      return msg;
+    }
+  }
+  return buffer[buffer.length - 1];
+}
+
+export function getToolCallArguments(
+  update: ToolCallPayloadCarrier,
+): Record<string, unknown> | undefined {
+  const rawInput = update.rawInput ?? update.raw_input;
+
+  if (!rawInput || typeof rawInput !== "object" || Array.isArray(rawInput)) {
+    return undefined;
+  }
+
+  return rawInput as Record<string, unknown>;
+}
+
+function getToolCallContent(
+  update: ToolCallPayloadCarrier,
+): ToolCallContent[] | undefined {
+  return Array.isArray(update.content) ? update.content : undefined;
+}
+
+function getToolCallKind(update: ToolCallPayloadCarrier): ToolKind | undefined {
+  return typeof update.kind === "string" ? update.kind : undefined;
+}
+
+function getToolCallLocations(
+  update: ToolCallPayloadCarrier,
+): ToolCallLocation[] | undefined {
+  return Array.isArray(update.locations) ? update.locations : undefined;
+}
+
+function getToolCallRawOutput(update: ToolCallPayloadCarrier): unknown {
+  return update.rawOutput ?? update.raw_output;
+}
+
+export function extractToolResultText(update: ToolCallPayloadCarrier): string {
+  const textParts: string[] = [];
+
+  if (update.content && update.content.length > 0) {
+    for (const item of update.content) {
+      if (item.type === "content" && item.content?.type === "text") {
+        const text = item.content.text?.trim();
+        if (text) {
+          textParts.push(text);
+        }
+      }
+    }
+  }
+
+  if (textParts.length > 0) {
+    return textParts.join("\n\n");
+  }
+
+  const rawOutput = getToolCallRawOutput(update);
+  if (rawOutput !== undefined && rawOutput !== null) {
+    return typeof rawOutput === "string"
+      ? rawOutput
+      : JSON.stringify(rawOutput);
+  }
+
+  return "";
+}
+
+export function normalizeToolCallPayload(
+  update: ToolCallPayloadCarrier,
+): NormalizedToolCallPayload {
+  return {
+    arguments: getToolCallArguments(update),
+    kind: getToolCallKind(update),
+    locations: getToolCallLocations(update),
+    content: getToolCallContent(update),
+    rawOutput: getToolCallRawOutput(update),
+    resultText: extractToolResultText(update),
+  };
+}

--- a/ui/goose2/src/shared/api/textContentBlocks.ts
+++ b/ui/goose2/src/shared/api/textContentBlocks.ts
@@ -1,0 +1,62 @@
+import type {
+  ContentAnnotations,
+  MessageContent,
+  TextContent,
+} from "@/shared/types/messages";
+
+export function normalizeTextAnnotations(
+  annotations: unknown,
+): ContentAnnotations | undefined {
+  if (!annotations || typeof annotations !== "object") {
+    return undefined;
+  }
+
+  const audience = "audience" in annotations ? annotations.audience : undefined;
+  const normalizedAudience = Array.isArray(audience)
+    ? audience.filter(
+        (role): role is "user" | "assistant" =>
+          role === "user" || role === "assistant",
+      )
+    : undefined;
+
+  return normalizedAudience?.length
+    ? { audience: normalizedAudience }
+    : undefined;
+}
+
+function sameTextAnnotations(
+  left?: ContentAnnotations,
+  right?: ContentAnnotations,
+): boolean {
+  const leftAudience = left?.audience ?? [];
+  const rightAudience = right?.audience ?? [];
+
+  return (
+    leftAudience.length === rightAudience.length &&
+    leftAudience.every((role, index) => role === rightAudience[index])
+  );
+}
+
+export function appendTextContent(
+  content: MessageContent[],
+  text: string,
+  annotations?: ContentAnnotations,
+): MessageContent[] {
+  const nextBlock: TextContent = { type: "text", text, annotations };
+  const lastContent = content[content.length - 1];
+
+  if (
+    lastContent?.type === "text" &&
+    sameTextAnnotations(lastContent.annotations, annotations)
+  ) {
+    return [
+      ...content.slice(0, -1),
+      {
+        ...lastContent,
+        text: lastContent.text + text,
+      },
+    ];
+  }
+
+  return [...content, nextBlock];
+}

--- a/ui/goose2/src/shared/api/textContentBlocks.ts
+++ b/ui/goose2/src/shared/api/textContentBlocks.ts
@@ -24,6 +24,13 @@ export function normalizeTextAnnotations(
     : undefined;
 }
 
+export function isUserVisibleTextAnnotations(
+  annotations?: ContentAnnotations,
+): boolean {
+  const audience = annotations?.audience;
+  return !audience || audience.length === 0 || audience.includes("user");
+}
+
 function sameTextAnnotations(
   left?: ContentAnnotations,
   right?: ContentAnnotations,

--- a/ui/goose2/src/shared/api/toolCallBlockBuilders.ts
+++ b/ui/goose2/src/shared/api/toolCallBlockBuilders.ts
@@ -1,0 +1,97 @@
+import type { ToolCall, ToolCallUpdate } from "@agentclientprotocol/sdk";
+import type {
+  ToolRequestContent,
+  ToolResponseContent,
+} from "@/shared/types/messages";
+import {
+  getToolChainId,
+  getToolChainSummary,
+  type AcpMetaCarrier,
+} from "./toolCallChainMeta";
+import type { NormalizedToolCallPayload } from "./acpNotificationMessageHelpers";
+
+type ToolCallWithMeta = ToolCall & AcpMetaCarrier;
+type ToolCallUpdateWithMeta = ToolCallUpdate & AcpMetaCarrier;
+
+export interface ToolCallBlockPatch {
+  title?: string | null;
+  chainSummary?: string;
+  arguments?: Record<string, unknown>;
+  kind?: ToolRequestContent["kind"];
+  locations?: ToolRequestContent["locations"];
+  content?: ToolRequestContent["content"];
+  rawOutput?: ToolRequestContent["rawOutput"];
+  markCompleted?: boolean;
+}
+
+export function buildToolRequestBlock(
+  update: ToolCallWithMeta,
+  payload: NormalizedToolCallPayload,
+): ToolRequestContent {
+  return {
+    type: "toolRequest",
+    id: update.toolCallId,
+    chainId: getToolChainId(update),
+    chainSummary: getToolChainSummary(update),
+    name: update.title,
+    arguments: payload.arguments ?? {},
+    kind: payload.kind,
+    locations: payload.locations,
+    content: payload.content,
+    rawOutput: payload.rawOutput,
+    status: "executing",
+    startedAt: Date.now(),
+  };
+}
+
+export function hasToolCallPatch(
+  update: ToolCallUpdateWithMeta,
+  payload: NormalizedToolCallPayload,
+): boolean {
+  return Boolean(
+    update.title ||
+      getToolChainSummary(update) ||
+      payload.arguments ||
+      payload.kind ||
+      payload.locations ||
+      payload.content ||
+      payload.rawOutput !== undefined,
+  );
+}
+
+export function buildToolCallPatch(
+  update: ToolCallUpdateWithMeta,
+  payload: NormalizedToolCallPayload,
+  markCompleted = false,
+): ToolCallBlockPatch {
+  return {
+    title: update.title,
+    chainSummary: getToolChainSummary(update),
+    arguments: payload.arguments,
+    kind: payload.kind,
+    locations: payload.locations,
+    content: payload.content,
+    rawOutput: payload.rawOutput,
+    markCompleted,
+  };
+}
+
+export function buildToolResponseBlock(
+  update: ToolCallUpdateWithMeta,
+  payload: NormalizedToolCallPayload,
+  toolRequest: ToolRequestContent | null,
+): ToolResponseContent {
+  return {
+    type: "toolResponse",
+    id: update.toolCallId,
+    chainId: getToolChainId(update) ?? toolRequest?.chainId,
+    chainSummary: getToolChainSummary(update) ?? toolRequest?.chainSummary,
+    name: toolRequest?.name ?? "",
+    result: payload.resultText,
+    kind: payload.kind ?? toolRequest?.kind,
+    locations: payload.locations ?? toolRequest?.locations,
+    content: payload.content ?? toolRequest?.content,
+    rawOutput: payload.rawOutput ?? toolRequest?.rawOutput,
+    isError: update.status === "failed",
+  };
+}

--- a/ui/goose2/src/shared/api/toolCallChainMeta.ts
+++ b/ui/goose2/src/shared/api/toolCallChainMeta.ts
@@ -1,0 +1,124 @@
+import type {
+  MessageContent,
+  ToolRequestContent,
+} from "@/shared/types/messages";
+
+const TOOL_CHAIN_META_KEY = "_goose/tool-chain-id";
+const TOOL_CHAIN_SUMMARY_META_KEY = "_goose/tool-chain-summary";
+const ACTIVE_TOOL_CHAIN_SUMMARY = "working";
+
+export type AcpMetaCarrier = {
+  _meta?: Record<string, unknown> | null;
+};
+
+export function getToolChainId(update: AcpMetaCarrier): string | undefined {
+  const chainId = update._meta?.[TOOL_CHAIN_META_KEY];
+  return typeof chainId === "string" ? chainId : undefined;
+}
+
+export function getToolChainSummary(
+  update: AcpMetaCarrier,
+): string | undefined {
+  const chainSummary = update._meta?.[TOOL_CHAIN_SUMMARY_META_KEY];
+  return typeof chainSummary === "string" ? chainSummary : undefined;
+}
+
+function mergeToolChainSummary(
+  currentSummary: string | undefined,
+  nextSummary: string | undefined,
+): string | undefined {
+  if (!nextSummary) {
+    return currentSummary;
+  }
+
+  if (
+    currentSummary &&
+    currentSummary !== ACTIVE_TOOL_CHAIN_SUMMARY &&
+    nextSummary === ACTIVE_TOOL_CHAIN_SUMMARY
+  ) {
+    return currentSummary;
+  }
+
+  return nextSummary;
+}
+
+export function updateToolCallBlocks(
+  content: MessageContent[],
+  toolCallId: string,
+  options: {
+    title?: string | null;
+    chainSummary?: string;
+    arguments?: Record<string, unknown>;
+    kind?: ToolRequestContent["kind"];
+    locations?: ToolRequestContent["locations"];
+    content?: ToolRequestContent["content"];
+    rawOutput?: ToolRequestContent["rawOutput"];
+    markCompleted?: boolean;
+  },
+): MessageContent[] {
+  return content.map((block) => {
+    if (
+      (block.type !== "toolRequest" && block.type !== "toolResponse") ||
+      block.id !== toolCallId
+    ) {
+      return block;
+    }
+
+    const chainSummary = mergeToolChainSummary(
+      block.chainSummary,
+      options.chainSummary,
+    );
+
+    if (block.type === "toolRequest") {
+      return {
+        ...block,
+        ...(options.title !== undefined && options.title !== null
+          ? { name: options.title }
+          : {}),
+        ...(options.arguments !== undefined
+          ? { arguments: options.arguments }
+          : {}),
+        ...(options.kind !== undefined ? { kind: options.kind } : {}),
+        ...(options.locations !== undefined
+          ? { locations: options.locations }
+          : {}),
+        ...(options.content !== undefined ? { content: options.content } : {}),
+        ...(options.rawOutput !== undefined
+          ? { rawOutput: options.rawOutput }
+          : {}),
+        ...(options.markCompleted ? { status: "completed" as const } : {}),
+        ...(chainSummary !== undefined ? { chainSummary } : {}),
+      };
+    }
+
+    return {
+      ...block,
+      ...(options.title !== undefined && options.title !== null
+        ? { name: options.title }
+        : {}),
+      ...(options.kind !== undefined ? { kind: options.kind } : {}),
+      ...(options.locations !== undefined
+        ? { locations: options.locations }
+        : {}),
+      ...(options.content !== undefined ? { content: options.content } : {}),
+      ...(options.rawOutput !== undefined
+        ? { rawOutput: options.rawOutput }
+        : {}),
+      ...(chainSummary !== undefined ? { chainSummary } : {}),
+    };
+  });
+}
+
+export function findToolRequestById(
+  content: MessageContent[],
+  toolCallId: string,
+): ToolRequestContent | null {
+  for (let index = content.length - 1; index >= 0; index -= 1) {
+    const block = content[index];
+    if (block.type === "toolRequest" && block.id === toolCallId) {
+      return block;
+    }
+  }
+
+  return null;
+}

--- a/ui/goose2/src/shared/types/messages.ts
+++ b/ui/goose2/src/shared/types/messages.ts
@@ -1,3 +1,9 @@
+import type {
+  ToolCallContent as AcpToolCallContent,
+  ToolCallLocation as AcpToolCallLocation,
+  ToolKind as AcpToolKind,
+} from "@agentclientprotocol/sdk";
+
 export type ChatAttachmentKind = "image" | "file" | "directory";
 
 export interface ChatImageAttachmentDraft {
@@ -63,6 +69,10 @@ export type ToolCallStatus =
   | "error"
   | "stopped";
 
+export type ToolCallKind = AcpToolKind;
+export type ToolCallLocation = AcpToolCallLocation;
+export type ToolCallStructuredContent = AcpToolCallContent;
+
 export type MessageCompletionStatus =
   | "inProgress"
   | "completed"
@@ -72,8 +82,14 @@ export type MessageCompletionStatus =
 export interface ToolRequestContent {
   type: "toolRequest";
   id: string;
+  chainId?: string;
+  chainSummary?: string;
   name: string;
   arguments: Record<string, unknown>;
+  kind?: ToolCallKind;
+  locations?: ToolCallLocation[];
+  content?: ToolCallStructuredContent[];
+  rawOutput?: unknown;
   status: ToolCallStatus;
   /** Epoch ms when the tool call started executing (set on event receipt). */
   startedAt?: number;
@@ -83,8 +99,14 @@ export interface ToolRequestContent {
 export interface ToolResponseContent {
   type: "toolResponse";
   id: string;
+  chainId?: string;
+  chainSummary?: string;
   name: string;
   result: string;
+  kind?: ToolCallKind;
+  locations?: ToolCallLocation[];
+  content?: ToolCallStructuredContent[];
+  rawOutput?: unknown;
   isError: boolean;
   annotations?: ContentAnnotations;
 }


### PR DESCRIPTION
**Category:** infrastructure
**User Impact:** Tool activity now keeps consistent titles, inputs, and chain metadata across live streaming and replay.
**Problem:** Goose was inferring tool-call presentation differently in the live stream and in replay, which caused generic labels, dropped raw input, and implicit chain grouping that the UI could not reliably reconstruct. That made refreshed sessions look worse than the original run and made grouped tool UX hard to build on top of ACP.
**Solution:** Normalize tool-chain metadata and deterministic tool titles in the ACP server, then preserve the richer ACP payload in Goose2 so live and replay build the same tool-call state. This makes the UI contract explicit before any grouped-chain or tool-card redesign lands.

**Note:** This PR also includes a very small legacy `codex` provider compatibility shim in `crates/goose/src/providers/codex.rs`. The live provider smoke job still exercises `GOOSE_PROVIDER=codex` against the currently installed `@openai/codex` CLI, and that path now fails for `gpt-5.2-codex` unless `text.verbosity` is forced to `medium`. That fix is intentionally included here only to keep the stack reviewable and green while the broader ACP work lands; it is not part of the core ACP/tool-chain design.

<details>
<summary>File changes</summary>

**crates/goose/src/acp/server.rs**
Adds explicit `_goose/tool-chain-id` and `_goose/tool-chain-summary` metadata, deterministic tool-call titles, raw-input preservation, and replay/live parity for tool-call emission. This is the contract layer that makes chain grouping and stable tool labels reliable.

**ui/goose2/src/shared/types/messages.ts**
Extends tool request/response blocks to carry chain metadata plus richer ACP fields like kind, locations, content, and raw output. This keeps the normalized Goose2 message model aligned with the server payload.

**ui/goose2/src/shared/api/acpNotificationHandler.ts**
Switches the handler to a normalized tool-call pipeline so live and replay both build and patch the same message blocks. It also supports metadata-only summary updates without special-casing the UI.

**ui/goose2/src/shared/api/acpNotificationMessageHelpers.ts**
Introduces shared ACP payload normalization helpers so the handler can read richer tool-call fields consistently. This reduces duplication and keeps parsing behavior in one place.

**ui/goose2/src/shared/api/toolCallBlockBuilders.ts**
Adds builders for tool request blocks, tool response blocks, and tool-call patches. This makes the notification handler compose normalized tool state instead of hand-assembling message content inline.

**ui/goose2/src/shared/api/toolCallChainMeta.ts**
Adds chain metadata extraction and merge behavior, including protection against overwriting a finalized chain summary with the transient `working` placeholder. This gives Goose2 a stable source of truth for grouped tool titles.

**ui/goose2/src/shared/api/acpNotificationHandler.test.ts**
Adds coverage for chain metadata, metadata-only final summary updates, raw input preservation, and replay/live parity in the normalization path.

</details>

### Reproduction Steps
1. Start a session that triggers several shell and file tool calls in one assistant turn.
2. Watch the live run and note the friendly tool titles and grouped chain metadata-driven behavior.
3. Refresh or reopen the same session so Goose replays it from stored messages.
4. Verify the replayed tool calls keep the same titles, preserved inputs, and final chain summaries instead of falling back to raw tool names.
