### PR TITLE
fix(shell): spawn login shell in separate process group on Unix

### DIFF
--- a/crates/goose/src/agents/platform_extensions/developer/shell.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/shell.rs
@@ -177,13 +177,19 @@ fn resolve_login_shell_path() -> Option<String> {
             .spawn()
             .ok()?
     } else {
-        std::process::Command::new(&shell)
-            .args(["-l", "-i", "-c", "echo $PATH"])
+        let mut cmd = std::process::Command::new(&shell);
+        cmd.args(["-l", "-i", "-c", "echo $PATH"])
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .spawn()
-            .ok()?
+            .stderr(Stdio::null());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            cmd.process_group(0);
+        }
+
+        cmd.spawn().ok()?
     };
 
     let mut stdout = child.stdout.take()?;


### PR DESCRIPTION
## Summary
Prevents the shell command from affecting the parent process group when resolving the login shell path. This fixes issues where the shell spawn could interfere with the parent terminal session.

Uses process_group(0) on Unix to create a new process group, ensuring the child shell is detached from the parent's terminal control.

 ### Testing                                                                                      
  - `cargo test` passes                                                                           
  - `cargo clippy` and `cargo fmt` run cleanly                                                    
  - Verified fix works on RHEL 9 (the original failure environment)  

### Related Issues
Relates to #8727  
Discussion: https://github.com/aaif-goose/goose/issues/8727