### PR TITLE
hide disabled Add Skills button

### DIFF
--- a/ui/desktop/src/components/skills/SkillsView.tsx
+++ b/ui/desktop/src/components/skills/SkillsView.tsx
@@ -216,7 +216,7 @@ export default function SkillsView() {
                 variant="outline"
                 size="sm"
                 className="flex items-center gap-2"
-                disabled
+                hidden
                 title={intl.formatMessage(i18n.comingSoon)}
               >
                 <Plus className="w-4 h-4" />


### PR DESCRIPTION
## Summary
There's a disabled "Add Skills" button on the Skills page that is never enabled. It has a title of "coming soon" but that's not displayed on hover. So, it just looks like a disabled button that doesn't work.

I changed `disabled` to `hidden`. Whenever the functionality for the button is implemented, we can make this button visible



### Screenshots/Demos (for UX changes)

Before:  

<img width="732" height="164" alt="image" src="https://github.com/user-attachments/assets/8a2f6e2e-5acb-4a90-ac87-c464794e0fde" />

After:   

<img width="712" height="182" alt="image" src="https://github.com/user-attachments/assets/6e6ebc47-3e06-4a79-bc6b-7f02292204d5" />
