### PR TITLE
Add Location column to CLI skills table

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -907,6 +907,7 @@ impl CliSession {
 
     async fn handle_list_skills(&mut self) -> Result<()> {
         use comfy_table::{presets, Cell, ContentArrangement, Table};
+        use goose::custom_requests::SourceType;
         use goose::skills::list_installed_skills;
         let cwd = std::env::current_dir().unwrap_or_default();
         let skills = list_installed_skills(Some(&cwd));
@@ -919,13 +920,24 @@ impl CliSession {
         let mut table = Table::new();
         table.set_content_arrangement(ContentArrangement::Dynamic);
         table.load_preset(presets::ASCII_FULL);
-        table.set_header(vec!["Skill", "Description"]);
+        table.set_header(vec!["Skill", "Location", "Description"]);
 
         let mut sorted_skills = skills;
         sorted_skills.sort_by(|a, b| a.name.cmp(&b.name));
 
         for skill in &sorted_skills {
-            table.add_row(vec![Cell::new(&skill.name), Cell::new(&skill.description)]);
+            let location = if skill.source_type == SourceType::BuiltinSkill {
+                "built-in"
+            } else if skill.global {
+                "global"
+            } else {
+                "project"
+            };
+            table.add_row(vec![
+                Cell::new(&skill.name),
+                Cell::new(location),
+                Cell::new(&skill.description),
+            ]);
         }
 
         println!("{table}");


### PR DESCRIPTION
## Summary

There are three types of skills:

* Project -> Skills under the current working directory (e.g. .agents/skills/, .goose/skills/).

* Global -> Skills loaded from outside the working directory (e.g. ~/.agents/skills/, ~/.config/agents/skills/).

* Builtin -> Skills that ship with goose (BuiltinSkill kind).

This helps users distinguish project-specific skills (shared with the team via version control) from globally installed ones (personal to their machine) and built-in ones (shipped with goose, not editable), making it clear which skills are portable, which are personal, and which are part of goose itself.

### Screenshots/Demos (for UX changes)
```
🪿 /skills
+---------------------+----------+------------------------------------------------------------------------------------------------------------------------------------------+
| Skill               | Location | Description                                                                                                                              |
+===========================================================================================================================================================================+
| code-review         | project  | Senior engineer code review focused on catching issues before they become PR comments. Reviews only changed lines, categorizes issues by |
|                     |          | priority, and fixes them one by one. Use when the user says "code review", "review my code", "review this branch", or wants pre-PR       |
|                     |          | feedback.                                                                                                                                |
|---------------------+----------+------------------------------------------------------------------------------------------------------------------------------------------|
| coding              | global   | Strict coding guidelines biasing toward caution, precision, and minimalism. Use for all coding tasks to ensure clean, surgical changes.  |
|---------------------+----------+------------------------------------------------------------------------------------------------------------------------------------------|
| create-app-e2e-test | project  | Create app e2e tests for the Goose desktop app using the Tauri app test driver. Use when the user wants to generate, write, or verify UI |
|                     |          | tests that run against the live app.                                                                                                     |
|---------------------+----------+------------------------------------------------------------------------------------------------------------------------------------------|
| create-pr           | project  | Create a GitHub PR from the current branch: handle uncommitted changes, generate a summary, and submit via gh CLI. Use when the user     |
|                     |          | says "create PR", "open PR", "submit PR", "push PR", or wants to create a pull request.                                                  |
|---------------------+----------+------------------------------------------------------------------------------------------------------------------------------------------|
| edge-case-finder    | project  | Analyzes branch changes to find edge cases, error states, and untested user flow paths in UI code. Use when the user says "find edge     |
|                     |          | cases", "what am I missing", "edge cases", "test my flows", "what could go wrong", or wants to harden a feature before shipping.         |
|---------------------+----------+------------------------------------------------------------------------------------------------------------------------------------------|
| goose-doc-guide     | built-in | Reference goose documentation to create, configure, or explain goose-specific features like recipes, extensions, sessions, and           |
|                     |          | providers. You MUST fetch relevant goose docs before answering. You MUST NOT rely on training data or assumptions for any goose-specific |
|                     |          | fields, values, names, syntax, or commands.                                                                                              |
|---------------------+----------+------------------------------------------------------------------------------------------------------------------------------------------|
| insight             | global   | Direct, casual, and focused on mental models and analogies.                                                                              |
|---------------------+----------+------------------------------------------------------------------------------------------------------------------------------------------|
| peer-review         | global   | Conducts rigorous technical audits from a Senior Engineer perspective to identify logic flaws, security vulnerabilities, and             |
|                     |          | architectural debt.                                                                                                                      |
|---------------------+----------+------------------------------------------------------------------------------------------------------------------------------------------|
| repo-scan           | global   | Guidelines for analyzing an unfamiliar codebase. Prioritizes high-level architecture, structural clarity, and providing entry points for |
|                     |          | deep-dives.                                                                                                                              |
|---------------------+----------+------------------------------------------------------------------------------------------------------------------------------------------|
| sys-design          | global   | Architect-level skill for generating a Technical Design Doc (TDD) intended as the primary input for coding agents and human review.      |
+---------------------+----------+------------------------------------------------------------------------------------------------------------------------------------------+
```