### PR TITLE
fix: goose configure exits silently at the model picker

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -740,6 +740,11 @@ pub async fn configure_provider_dialog() -> anyhow::Result<bool> {
         .await
     };
     spin.stop(style("Model fetch complete").green());
+    // cliclack's spinner render thread outlives `stop()` and races the next
+    // prompt's raw-mode stdin read; drop and yield so the picker's
+    // `interact()` doesn't fail before any key is read. See #8373.
+    drop(spin);
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
     // Select a model: on fetch error show styled error and abort; if models available, show list; otherwise free-text input
     let model: String = match models_res {


### PR DESCRIPTION
Fixes #8373.

## Summary
On macOS 26.4 (M5 Pro, tested in kitty and Terminal.app), `goose configure` exits with code 2 right after `Model fetch complete` prints. The model picker draws one frame and disappears before any keypress is registered.

The cause is a race between cliclack's spinner and the next prompt. `spin.stop()` flips a flag and returns, but the spinner's render thread keeps writing to the terminal for a few more ms. The next line opens the model picker, which puts stdin in raw mode and reads. Both widgets fight over the terminal and the picker's first read returns `Err`, which propagates out as exit 2.

Fix: drop the spinner explicitly and yield 50ms so cliclack tears the render thread down before the picker starts reading. The user does not see the delay.

```diff
     spin.stop(style("Model fetch complete").green());
+    // cliclack's spinner render thread outlives `stop()` and races the next
+    // prompt's raw-mode stdin read; drop and yield so the picker's
+    // `interact()` doesn't fail before any key is read. See #8373.
+    drop(spin);
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
```

### Testing
- `cargo build -p goose-cli --bin goose`
- `goose configure` → Claude Code → picker stays open, arrow keys and enter work.

Before:
https://github.com/user-attachments/assets/27d1d5b6-2d94-4f0b-9f0d-33d20fd7a52a

After:
https://github.com/user-attachments/assets/116f6d7c-84e8-4c6e-9845-81049615cc4b