### PR TITLE
fix: goose suspends at launch on macOS

### DIFF
--- a/crates/goose-mcp/src/subprocess.rs
+++ b/crates/goose-mcp/src/subprocess.rs
@@ -56,26 +56,44 @@ fn resolve_login_shell_path() -> Option<String> {
             }
         });
 
-    std::process::Command::new(&shell)
-        .args(["-l", "-i", "-c", "echo $PATH"])
+    // `-l -i` sources both the login profile (~/.bash_profile, ~/.zprofile)
+    // AND ~/.bashrc / ~/.zshrc, where many users put their PATH exports
+    // (homebrew-on-Apple-Silicon installers, asdf/rbenv/pyenv init, etc).
+    //
+    // Interactive shells call tcsetpgrp() on startup to claim the tty's
+    // foreground process group — and while that bash holds the tty, goose's
+    // next TUI write hits SIGTTOU and gets suspended. setsid() in pre_exec
+    // puts the probe child in a new session with NO controlling terminal,
+    // so it can't grab the foreground pgroup no matter what it does.
+    let mut cmd = std::process::Command::new(&shell);
+    cmd.args(["-l", "-i", "-c", "echo $PATH"])
         .stdin(Stdio::null())
-        .stderr(Stdio::null())
-        .output()
-        .ok()
-        .and_then(|output| {
-            if output.status.success() {
-                // Take the last non-empty line — interactive shells may emit
-                // extra output from profile scripts before our echo.
-                String::from_utf8_lossy(&output.stdout)
-                    .lines()
-                    .rev()
-                    .find(|line| !line.trim().is_empty())
-                    .map(|line| line.trim().to_string())
-                    .filter(|path| !path.is_empty())
-            } else {
-                None
-            }
-        })
+        .stderr(Stdio::null());
+    #[cfg(unix)]
+    unsafe {
+        use std::os::unix::process::CommandExt;
+        extern "C" {
+            fn setsid() -> i32;
+        }
+        cmd.pre_exec(|| {
+            let _ = setsid();
+            Ok(())
+        });
+    }
+    cmd.output().ok().and_then(|output| {
+        if output.status.success() {
+            // Take the last non-empty line — interactive shells may emit
+            // extra output from profile scripts before our echo.
+            String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .rev()
+                .find(|line| !line.trim().is_empty())
+                .map(|line| line.trim().to_string())
+                .filter(|path| !path.is_empty())
+        } else {
+            None
+        }
+    })
 }
 
 /// Returns the user's full login shell PATH, resolved once and cached.

--- a/crates/goose/src/agents/platform_extensions/developer/shell.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/shell.rs
@@ -168,6 +168,15 @@ pub struct ShellOutput {
 fn resolve_login_shell_path() -> Option<String> {
     let shell = unix_shell();
 
+    // `-l -i` sources both the login profile (~/.bash_profile, ~/.zprofile)
+    // AND ~/.bashrc / ~/.zshrc, where many users put their PATH exports
+    // (homebrew-on-Apple-Silicon installers, asdf/rbenv/pyenv init, etc).
+    //
+    // Interactive shells call tcsetpgrp() on startup to claim the tty's
+    // foreground process group — and while that bash holds the tty, goose's
+    // next TUI write hits SIGTTOU and gets suspended. setsid() in pre_exec
+    // puts the probe child in a new session with NO controlling terminal,
+    // so it can't grab the foreground pgroup no matter what it does.
     let mut child = if is_flatpak() {
         flatpak_spawn_process()
             .args([&shell, "-l", "-i", "-c", "echo $PATH"])
@@ -177,13 +186,23 @@ fn resolve_login_shell_path() -> Option<String> {
             .spawn()
             .ok()?
     } else {
-        std::process::Command::new(&shell)
-            .args(["-l", "-i", "-c", "echo $PATH"])
+        let mut cmd = std::process::Command::new(&shell);
+        cmd.args(["-l", "-i", "-c", "echo $PATH"])
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .spawn()
-            .ok()?
+            .stderr(Stdio::null());
+        #[cfg(unix)]
+        unsafe {
+            use std::os::unix::process::CommandExt;
+            extern "C" {
+                fn setsid() -> i32;
+            }
+            cmd.pre_exec(|| {
+                let _ = setsid();
+                Ok(())
+            });
+        }
+        cmd.spawn().ok()?
     };
 
     let mut stdout = child.stdout.take()?;


### PR DESCRIPTION
**Env:** macOS 26.4, M5 Pro

**Problem:** Goose suspends itself the second it launches:
<img width="669" height="95" alt="CleanShot 2026-04-23 at 23 42 03" src="https://github.com/user-attachments/assets/0936e9eb-032e-443f-a160-4c6fda298845" />

## Why
Goose runs `bash -l -i -c 'echo $PATH'` once at startup to pick up your full PATH. The `-i` makes bash interactive. Interactive shells grab the terminal the moment they start. While that bash is sourcing your `.bashrc` / `.zshrc` (a couple hundred ms), goose is no longer the foreground process, and the next thing goose tries to print to the screen gets `SIGTTOU` from the kernel — same signal as `Ctrl+Z`. Goose stops.

Caught with `ps`:

```
12345  goose                          T     <- stopped
15300  bash -l -i -c echo $PATH       TN    <- holding the terminal
```

## Fix
Keep `-i`. Don't drop it — a lot of people put their PATH in `~/.bashrc` / `~/.zshrc` (homebrew on Apple Silicon literally tells you to), and dropping it would silently break PATH for them.

Instead, call `setsid()` before exec on the probe. The child gets its own session with no terminal at all, so it can't grab goose's terminal no matter what bash does inside.

```diff
-    std::process::Command::new(&shell)
-        .args(["-l", "-i", "-c", "echo $PATH"])
+    let mut cmd = std::process::Command::new(&shell);
+    cmd.args(["-l", "-i", "-c", "echo $PATH"])
         .stdin(Stdio::null())
-        .stderr(Stdio::null())
-        .output()
+        .stderr(Stdio::null());
+    #[cfg(unix)]
+    unsafe {
+        use std::os::unix::process::CommandExt;
+        extern "C" { fn setsid() -> i32; }
+        cmd.pre_exec(|| {
+            let _ = setsid();
+            Ok(())
+        });
+    }
+    cmd.output()
```

Same change in both probe sites: `crates/goose-mcp/src/subprocess.rs` and `crates/goose/src/agents/platform_extensions/developer/shell.rs`. Flatpak branch left alone — `flatpak-spawn` runs outside the host terminal anyway.

## Tested
- `cargo build -p goose-cli --bin goose --release`
- Launches cleanly, no suspend.
- `echo $PATH` inside a session still shows `/opt/homebrew/bin` (proves `-i` is still sourcing my zshrc). 
<img width="652" height="99" alt="CleanShot 2026-04-23 at 23 48 28" src="https://github.com/user-attachments/assets/a00a5dc7-eb0a-498c-9fe1-dc62f096cd47" />

