### PR TITLE
fix: add codex and gemini-cli to ALLOWED_FAILURES

### DIFF
--- a/scripts/test_providers_lib.sh
+++ b/scripts/test_providers_lib.sh
@@ -31,6 +31,8 @@ ALLOWED_FAILURES=(
   "openrouter:nvidia/nemotron-3-nano-30b-a3b"
   "openrouter:qwen/qwen3-coder:exacto"
   "openai:gpt-3.5-turbo"
+  "codex:gpt-5.2-codex"
+  "gemini-cli:gemini-2.5-pro"
 )
 
 AGENTIC_PROVIDERS=("claude-code" "codex" "gemini-cli" "cursor-agent")


### PR DESCRIPTION
## Summary

- Adds `codex:gpt-5.2-codex` and `gemini-cli:gemini-2.5-pro` to `ALLOWED_FAILURES` in `scripts/test_providers_lib.sh`
- Unblocks CI on `main` and PRs while upstream issues persist

## Context

**codex** is failing due to an upstream bug in the `@openai/codex` CLI — it sends `text.verbosity: "low"` to OpenAI's API, but `gpt-5.2-codex` only supports `"medium"`:

> ```
> "code": "unsupported_value",
> "message": "Unsupported value: 'low' is not supported with the 'gpt-5.2-codex' model. Supported values are: 'medium'.",
> "param": "text.verbosity"
> ```

**gemini-cli** has been intermittently failing due to a trusted-directory infrastructure issue.

Neither failure is caused by any Goose code change.

## Failing CI builds

- [Live Provider Tests (main, Apr 24)](https://github.com/aaif-goose/goose/actions/runs/24864833271) — codex fails with the verbosity error above

## Test plan

- [x] CI passes on this PR with codex/gemini-cli failures no longer blocking
- [ ] Remove these entries when upstream issues are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)