### PR TITLE
fix(goose): exclude preprompt from session title generation

### DIFF
--- a/crates/goose/src/providers/base.rs
+++ b/crates/goose/src/providers/base.rs
@@ -731,14 +731,42 @@ pub trait Provider: Send + Sync {
         ))
     }
 
-    /// Returns the first 3 user messages as strings for session naming
+    /// Returns the first 3 user messages as strings for session naming,
+    /// filtering out assistant-only content (e.g. preprompt blocks).
     fn get_initial_user_messages(&self, messages: &Conversation) -> Vec<String> {
         messages
             .iter()
             .filter(|m| m.role == rmcp::model::Role::User)
             .take(MSG_COUNT_FOR_SESSION_NAME_GENERATION)
-            .map(|m| m.as_concat_text())
+            .map(|m| {
+                m.content
+                    .iter()
+                    .filter_map(|c| c.filter_for_audience(rmcp::model::Role::User))
+                    .filter_map(|c| c.as_text().map(|s| s.to_string()))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            })
             .collect()
+    }
+
+    /// Extracts preprompt context (assistant-audience blocks) from the first user message.
+    /// These are content blocks visible to the assistant but not the user.
+    fn get_preprompt_context(&self, messages: &Conversation) -> String {
+        messages
+            .iter()
+            .filter(|m| m.role == rmcp::model::Role::User)
+            .take(1)
+            .flat_map(|m| m.content.iter())
+            .filter_map(|c| {
+                // If this block is NOT visible to the user, it's preprompt/assistant-only content
+                if c.filter_for_audience(rmcp::model::Role::User).is_none() {
+                    c.as_text().map(|s| s.to_string())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     /// Generate a session name/description based on the conversation history
@@ -749,6 +777,7 @@ pub trait Provider: Send + Sync {
         messages: &Conversation,
     ) -> Result<String, ProviderError> {
         let context = self.get_initial_user_messages(messages);
+        let preprompt_context = self.get_preprompt_context(messages);
         let system = crate::prompt_template::render_template(
             "session_name.md",
             &std::collections::HashMap::<String, String>::new(),
@@ -758,8 +787,19 @@ pub trait Provider: Send + Sync {
         use super::cli_common::{
             SESSION_NAME_BEGIN_MARKER, SESSION_NAME_END_MARKER, SESSION_NAME_SUFFIX,
         };
+
+        let preprompt_section = if preprompt_context.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "---BEGIN BACKGROUND CONTEXT (for understanding only, do NOT base the title on this)---\n{}\n---END BACKGROUND CONTEXT---\n\n",
+                preprompt_context
+            )
+        };
+
         let user_text = format!(
-            "{}\n{}\n{}\n\n{}",
+            "{}{}\n{}\n{}\n\n{}",
+            preprompt_section,
             SESSION_NAME_BEGIN_MARKER,
             context.join("\n"),
             SESSION_NAME_END_MARKER,

--- a/crates/goose/src/providers/cli_common.rs
+++ b/crates/goose/src/providers/cli_common.rs
@@ -57,7 +57,7 @@ pub(crate) fn generate_simple_session_description(
         .map(|text| {
             // Strip the wrapper added by generate_session_name so we get
             // the actual user content. First strip the optional background context section.
-            let text = if let Some(idx) = text.find(SESSION_NAME_BEGIN_MARKER) {
+            let text = if let Some(idx) = text.rfind(SESSION_NAME_BEGIN_MARKER) {
                 &text[idx..]
             } else {
                 text

--- a/crates/goose/src/providers/cli_common.rs
+++ b/crates/goose/src/providers/cli_common.rs
@@ -57,11 +57,10 @@ pub(crate) fn generate_simple_session_description(
         .map(|text| {
             // Strip the wrapper added by generate_session_name so we get
             // the actual user content. First strip the optional background context section.
-            let text = if let Some(idx) = text.rfind(SESSION_NAME_BEGIN_MARKER) {
-                &text[idx..]
-            } else {
-                text
-            };
+            let text = text
+                .rfind(SESSION_NAME_BEGIN_MARKER)
+                .and_then(|idx| text.get(idx..))
+                .unwrap_or(text);
             let stripped = text
                 .strip_prefix(SESSION_NAME_BEGIN_MARKER)
                 .unwrap_or(text)

--- a/crates/goose/src/providers/cli_common.rs
+++ b/crates/goose/src/providers/cli_common.rs
@@ -56,7 +56,12 @@ pub(crate) fn generate_simple_session_description(
         })
         .map(|text| {
             // Strip the wrapper added by generate_session_name so we get
-            // the actual user content.
+            // the actual user content. First strip the optional background context section.
+            let text = if let Some(idx) = text.find(SESSION_NAME_BEGIN_MARKER) {
+                &text[idx..]
+            } else {
+                text
+            };
             let stripped = text
                 .strip_prefix(SESSION_NAME_BEGIN_MARKER)
                 .unwrap_or(text)


### PR DESCRIPTION
## Issue
When creating a session in a project, the additional preprompt text we provide to the agent to generate a session name meant often the session names were about the preprompt, not the actual user's message:
<img width="206" height="212" alt="Screenshot 2026-04-24 at 1 49 27 pm" src="https://github.com/user-attachments/assets/7f9c63c5-7902-4430-975a-9234999418e7" />

## Summary
- Filters out assistant-audience (preprompt) content blocks from user messages when generating session titles, so titles reflect what the user actually said
- Extracts preprompt context separately and includes it as background context in the title generation prompt, explicitly instructing the model not to base the title on it
- Updates the simple session description fallback to strip the new background context section

## Test plan
- [x] Verify session titles no longer incorporate preprompt/system instructions
- [x] Verify preprompt context is still available to the model for understanding but not title generation
- [x] Verify fallback simple session description still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)