### PR TITLE
fix: use _meta instead of meta in newSession request

### DIFF
--- a/ui/goose2/src/shared/api/acpApi.ts
+++ b/ui/goose2/src/shared/api/acpApi.ts
@@ -187,9 +187,7 @@ export async function newSession(
 ): Promise<NewSessionResponse> {
   const tClient = performance.now();
   const client = await getClient();
-  const request: Parameters<typeof client.newSession>[0] & {
-    meta?: Record<string, string>;
-  } = {
+  const request: Parameters<typeof client.newSession>[0] = {
     cwd: workingDir,
     mcpServers: [],
   };
@@ -198,7 +196,7 @@ export async function newSession(
   if (providerId) meta.provider = providerId;
   if (projectId) meta.projectId = projectId;
   if (personaId) meta.personaId = personaId;
-  if (Object.keys(meta).length > 0) request.meta = meta;
+  if (Object.keys(meta).length > 0) request._meta = meta;
 
   const tCall = performance.now();
   const response = await client.newSession(request);


### PR DESCRIPTION
## Summary
- Fixes the metadata field name in the `newSession` API request from `meta` to `_meta`, aligning with the backend's expected field name
- Removes unnecessary type extension that was widening the request type to include the incorrect `meta` field
- This fixes sessions not being associated with projects due to metadata being sent under the wrong key

## Test plan
- [x] Verify that new sessions are correctly associated with projects when a `projectId` is provided
- [x] Verify that provider and persona metadata is correctly passed through to the backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)