### PR TITLE
fix: only call cleanup when the pr is from same repo

### DIFF
--- a/.github/workflows/pr-website-preview.yml
+++ b/.github/workflows/pr-website-preview.yml
@@ -51,7 +51,7 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     needs: deploy
-    if: github.event.action == 'closed'
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == 'aaif-goose/goose'
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary
Restrict Documentation Site Preview cleanup to closed same-repo PRs only.

Preview deploys already run only for aaif-goose/goose branches. This keeps cleanup aligned with deploy behavior and avoids the fork-PR cleanup failures where the job tried to push to gh-pages and hit 403 Permission denied to github-actions[bot]. (Example failure: https://github.com/aaif-goose/goose/actions/runs/24809400623)

### Testing
will check the github action


