### PR TITLE
[RFC] feat(ui): group chat sessions by project

### DIFF
--- a/ui/desktop/src/App.test.tsx
+++ b/ui/desktop/src/App.test.tsx
@@ -4,10 +4,12 @@
  * @vitest-environment jsdom
  */
 import React from 'react';
-import { screen, render, waitFor } from '@testing-library/react';
+import { act, screen, render, waitFor } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { AppInner, resolveSessionInitialMessage } from './App';
+import { AppInner, getNewChatSourceSessionId, resolveSessionInitialMessage } from './App';
 import { IntlTestWrapper } from './i18n/test-utils';
+import { getSession } from './api';
+import { AppEvents } from './constants/events';
 
 // Set up globals for jsdom
 Object.defineProperty(window, 'location', {
@@ -52,6 +54,7 @@ vi.mock('./api', () => {
     validateConfig: vi.fn().mockResolvedValue(undefined),
     startAgent: vi.fn().mockResolvedValue(test_chat),
     resumeAgent: vi.fn().mockResolvedValue(test_chat),
+    getSession: vi.fn(),
   };
 });
 
@@ -162,6 +165,13 @@ const mockElectron = {
   setSetting: vi.fn().mockResolvedValue(undefined),
 };
 
+const getLatestElectronHandler = (channel: string) => {
+  const calls = mockElectron.on.mock.calls.filter(
+    ([registeredChannel]) => registeredChannel === channel
+  );
+  return calls[calls.length - 1]?.[1];
+};
+
 // Mock appConfig
 const mockAppConfig = {
   get: vi.fn((key: string): string | null => {
@@ -194,6 +204,12 @@ describe('App Component - Brand New State', () => {
     vi.clearAllMocks();
     mockNavigate.mockClear();
     mockSetSearchParams.mockClear();
+    vi.mocked(getSession).mockResolvedValue({
+      data: {
+        id: 'active-session',
+        working_dir: '/active/project',
+      },
+    } as any);
     mockAppConfig.get.mockImplementation((key: string): string | null => {
       if (key === 'GOOSE_WORKING_DIR') return '/test/dir';
       return null;
@@ -291,7 +307,56 @@ describe('App Component - Brand New State', () => {
 
     newChatHandler?.({} as any);
 
-    expect(mockNavigate).toHaveBeenCalledWith('/');
+    expect(mockNavigate).toHaveBeenCalledWith('/', { state: { workingDir: '/test/dir' } });
+  });
+
+  it('should use the active session working directory when set-view opens a new chat', async () => {
+    mockElectron.getConfig.mockReturnValue({
+      GOOSE_DEFAULT_PROVIDER: 'openai',
+      GOOSE_DEFAULT_MODEL: 'gpt-4',
+      GOOSE_ALLOWLIST_WARNING: false,
+    });
+
+    render(<AppInner />, { wrapper: IntlTestWrapper });
+
+    await waitFor(() => {
+      expect(mockElectron.reactReady).toHaveBeenCalled();
+    });
+
+    const initialSetViewHandlers = mockElectron.on.mock.calls.filter(
+      ([channel]) => channel === 'set-view'
+    ).length;
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(AppEvents.ADD_ACTIVE_SESSION, {
+          detail: { sessionId: 'active-session' },
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockElectron.on.mock.calls.filter(([channel]) => channel === 'set-view')).toHaveLength(
+        initialSetViewHandlers + 1
+      );
+    });
+
+    const setViewHandler = getLatestElectronHandler('set-view');
+    expect(setViewHandler).toBeDefined();
+
+    act(() => {
+      setViewHandler?.({} as any, '');
+    });
+
+    await waitFor(() => {
+      expect(getSession).toHaveBeenCalledWith({
+        path: { session_id: 'active-session' },
+        throwOnError: false,
+      });
+      expect(mockNavigate).toHaveBeenCalledWith('/', {
+        state: { workingDir: '/active/project' },
+      });
+    });
   });
 
   it('should seed recipe sessions with the recipe prompt when no initial message is provided', () => {
@@ -308,5 +373,29 @@ describe('App Component - Brand New State', () => {
       msg: 'Write a release note for the latest change',
       images: [],
     });
+  });
+
+  it('should prefer the visible session when choosing a New Chat source session', () => {
+    expect(
+      getNewChatSourceSessionId(
+        'visible',
+        [{ sessionId: 'background' }, { sessionId: 'stale-active' }],
+        'chat'
+      )
+    ).toBe('visible');
+  });
+
+  it('should fall back to the last active session before the shared chat session', () => {
+    expect(
+      getNewChatSourceSessionId(
+        undefined,
+        [{ sessionId: 'background' }, { sessionId: 'active' }],
+        'chat'
+      )
+    ).toBe('active');
+  });
+
+  it('should fall back to the shared chat session when there is no routed or active session', () => {
+    expect(getNewChatSourceSessionId(undefined, [], 'chat')).toBe('chat');
   });
 });

--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'react';
+import { useCallback, useEffect, useState, useRef } from 'react';
 import { IpcRendererEvent } from 'electron';
 import {
   HashRouter,
@@ -10,6 +10,8 @@ import {
 } from 'react-router-dom';
 import { openSharedSessionFromDeepLink, importNostrSessionFromDeepLink } from './sessionLinks';
 import { type SharedSessionDetails } from './sharedSessions';
+import { getSession } from './api';
+import type { Session } from './api';
 import { ErrorUI } from './components/ErrorBoundary';
 import { ExtensionInstallModal } from './components/ExtensionInstallModal';
 import { toast, ToastContainer } from 'react-toastify';
@@ -75,6 +77,19 @@ export function resolveSessionInitialMessage(
   return (
     initialMessage ??
     (session.recipe?.prompt ? { msg: session.recipe.prompt, images: [] } : undefined)
+  );
+}
+
+export function getNewChatSourceSessionId(
+  visibleSessionId: string | undefined,
+  activeSessions: Array<{ sessionId: string }>,
+  chatSessionId?: string
+): string | undefined {
+  return (
+    visibleSessionId ||
+    activeSessions[activeSessions.length - 1]?.sessionId ||
+    chatSessionId ||
+    undefined
   );
 }
 
@@ -347,6 +362,9 @@ export function AppInner() {
 
   const navigate = useNavigate();
   const setView = useNavigation();
+  const [searchParams] = useSearchParams();
+  const routedSessionId = searchParams.get('resumeSessionId') ?? undefined;
+  const lastRoutedSessionIdRef = useRef<string | undefined>(undefined);
 
   const [chat, setChat] = useState<ChatType>({
     sessionId: '',
@@ -360,6 +378,34 @@ export function AppInner() {
   const [activeSessions, setActiveSessions] = useState<
     Array<{ sessionId: string; initialMessage?: UserInput }>
   >([]);
+
+  useEffect(() => {
+    if (routedSessionId) {
+      lastRoutedSessionIdRef.current = routedSessionId;
+    }
+  }, [routedSessionId]);
+
+  const navigateToNewChat = useCallback(() => {
+    const activeSessionId = getNewChatSourceSessionId(
+      routedSessionId || lastRoutedSessionIdRef.current,
+      activeSessions,
+      chat.sessionId
+    );
+
+    if (!activeSessionId) {
+      navigate('/', { state: { workingDir: getInitialWorkingDir() } });
+      return;
+    }
+
+    void getSession({ path: { session_id: activeSessionId }, throwOnError: false })
+      .then((response) => {
+        const workingDir = (response.data as Session | undefined)?.working_dir?.trim();
+        navigate('/', { state: { workingDir: workingDir || getInitialWorkingDir() } });
+      })
+      .catch(() => {
+        navigate('/', { state: { workingDir: getInitialWorkingDir() } });
+      });
+  }, [activeSessions, chat.sessionId, navigate, routedSessionId]);
 
   useEffect(() => {
     const handleAddActiveSession = (event: Event) => {
@@ -569,6 +615,8 @@ export function AppInner() {
 
       if (section && newView === 'settings') {
         navigate(`/settings?section=${section}`);
+      } else if (!newView) {
+        navigateToNewChat();
       } else {
         navigate(`/${newView}`);
       }
@@ -576,16 +624,16 @@ export function AppInner() {
 
     window.electron.on('set-view', handleSetView);
     return () => window.electron.off('set-view', handleSetView);
-  }, [navigate]);
+  }, [navigate, navigateToNewChat]);
 
   useEffect(() => {
     const handleNewChat = (_event: IpcRendererEvent, ..._args: unknown[]) => {
-      navigate('/');
+      navigateToNewChat();
     };
 
     window.electron.on('new-chat', handleNewChat);
     return () => window.electron.off('new-chat', handleNewChat);
-  }, [navigate]);
+  }, [navigateToNewChat]);
 
   useEffect(() => {
     const handleFocusInput = (_event: IpcRendererEvent, ..._args: unknown[]) => {

--- a/ui/desktop/src/__tests__/projectSessions.test.ts
+++ b/ui/desktop/src/__tests__/projectSessions.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getProjectLabel,
+  groupSessionsByProject,
+  resolveNewChatWorkingDir,
+} from '../utils/projectSessions';
+import type { SessionListItem } from '../acp/sessions';
+
+function makeSession(overrides: Partial<SessionListItem> = {}): SessionListItem {
+  return {
+    id: 'session-1',
+    name: 'Session',
+    messageCount: 1,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    workingDir: '/tmp/goose',
+    ...overrides,
+  };
+}
+
+describe('groupSessionsByProject', () => {
+  it('groups sessions with the same working directory', () => {
+    const groups = groupSessionsByProject([
+      makeSession({ id: 'a', workingDir: '/tmp/goose' }),
+      makeSession({ id: 'b', workingDir: '/tmp/goose' }),
+      makeSession({ id: 'c', workingDir: '/tmp/other' }),
+    ]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups.find((group) => group.path === '/tmp/goose')?.sessions).toHaveLength(2);
+    expect(groups.find((group) => group.path === '/tmp/other')?.sessions).toHaveLength(1);
+  });
+
+  it('sorts project groups by most recent session', () => {
+    const groups = groupSessionsByProject([
+      makeSession({ id: 'old', workingDir: '/tmp/old', updatedAt: '2026-01-01T00:00:00.000Z' }),
+      makeSession({ id: 'new', workingDir: '/tmp/new', updatedAt: '2026-01-03T00:00:00.000Z' }),
+      makeSession({
+        id: 'middle',
+        workingDir: '/tmp/middle',
+        updatedAt: '2026-01-02T00:00:00.000Z',
+      }),
+    ]);
+
+    expect(groups.map((group) => group.path)).toEqual(['/tmp/new', '/tmp/middle', '/tmp/old']);
+  });
+
+  it('sorts sessions within each project newest first', () => {
+    const groups = groupSessionsByProject([
+      makeSession({ id: 'old', updatedAt: '2026-01-01T00:00:00.000Z' }),
+      makeSession({ id: 'new', updatedAt: '2026-01-03T00:00:00.000Z' }),
+      makeSession({ id: 'middle', updatedAt: '2026-01-02T00:00:00.000Z' }),
+    ]);
+
+    expect(groups[0].sessions.map((session) => session.id)).toEqual(['new', 'middle', 'old']);
+  });
+
+  it('normalizes empty working directories into one group', () => {
+    const groups = groupSessionsByProject([
+      makeSession({ id: 'a', workingDir: '' }),
+      makeSession({ id: 'b', workingDir: '   ' }),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].path).toBe('');
+    expect(groups[0].label).toBe('Unknown');
+    expect(groups[0].sessions).toHaveLength(2);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(groupSessionsByProject([])).toEqual([]);
+  });
+
+  it('disambiguates projects with the same basename', () => {
+    const groups = groupSessionsByProject([
+      makeSession({ id: 'a', workingDir: '/Users/me/work/goose' }),
+      makeSession({ id: 'b', workingDir: '/Users/me/forks/goose' }),
+    ]);
+
+    expect(groups.map((group) => group.label).sort()).toEqual(['forks/goose', 'work/goose']);
+  });
+});
+
+describe('getProjectLabel', () => {
+  it('extracts the basename from an absolute path', () => {
+    expect(getProjectLabel('/Users/me/work/goose')).toBe('goose');
+  });
+
+  it('handles the root path', () => {
+    expect(getProjectLabel('/')).toBe('/');
+  });
+
+  it('handles an empty path', () => {
+    expect(getProjectLabel('')).toBe('Unknown');
+  });
+
+  it('handles Windows-style paths', () => {
+    expect(getProjectLabel('C:\\Users\\me\\goose')).toBe('goose');
+  });
+});
+
+describe('resolveNewChatWorkingDir', () => {
+  const sessions = [
+    makeSession({ id: 'active', workingDir: '/tmp/active' }),
+    makeSession({ id: 'other', workingDir: '/tmp/other' }),
+  ];
+
+  it('returns the active session working directory when found', () => {
+    expect(resolveNewChatWorkingDir('active', sessions, '/tmp/fallback')).toBe('/tmp/active');
+  });
+
+  it('returns fallback when there is no active session id', () => {
+    expect(resolveNewChatWorkingDir(undefined, sessions, '/tmp/fallback')).toBe('/tmp/fallback');
+  });
+
+  it('returns fallback when the active session is not found', () => {
+    expect(resolveNewChatWorkingDir('missing', sessions, '/tmp/fallback')).toBe('/tmp/fallback');
+  });
+});

--- a/ui/desktop/src/__tests__/projectSessions.test.ts
+++ b/ui/desktop/src/__tests__/projectSessions.test.ts
@@ -55,6 +55,18 @@ describe('groupSessionsByProject', () => {
     expect(groups[0].sessions.map((session) => session.id)).toEqual(['new', 'middle', 'old']);
   });
 
+  it('canonicalizes trailing separators when grouping projects', () => {
+    const groups = groupSessionsByProject([
+      makeSession({ id: 'a', workingDir: '/tmp/goose' }),
+      makeSession({ id: 'b', workingDir: '/tmp/goose/' }),
+      makeSession({ id: 'c', workingDir: '  /tmp/goose//  ' }),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].path).toBe('/tmp/goose');
+    expect(groups[0].sessions.map((session) => session.id)).toEqual(['a', 'b', 'c']);
+  });
+
   it('normalizes empty working directories into one group', () => {
     const groups = groupSessionsByProject([
       makeSession({ id: 'a', workingDir: '' }),
@@ -115,5 +127,23 @@ describe('resolveNewChatWorkingDir', () => {
 
   it('returns fallback when the active session is not found', () => {
     expect(resolveNewChatWorkingDir('missing', sessions, '/tmp/fallback')).toBe('/tmp/fallback');
+  });
+
+  it('returns fallback when the active session working directory is blank', () => {
+    const sessionsWithBlankActive = [makeSession({ id: 'active', workingDir: '   ' })];
+
+    expect(resolveNewChatWorkingDir('active', sessionsWithBlankActive, '/tmp/fallback')).toBe(
+      '/tmp/fallback'
+    );
+  });
+
+  it('trims the active session working directory', () => {
+    const sessionsWithPaddedActive = [
+      makeSession({ id: 'active', workingDir: '  /tmp/active  ' }),
+    ];
+
+    expect(resolveNewChatWorkingDir('active', sessionsWithPaddedActive, '/tmp/fallback')).toBe(
+      '/tmp/active'
+    );
   });
 });

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -197,6 +197,7 @@ interface ChatInputProps {
   append?: (message: Message) => void;
   onWorkingDirChange?: (newDir: string) => void;
   inputRef?: React.RefObject<HTMLTextAreaElement | null>;
+  sessionWorkingDir?: string | null;
   sessionModel?: string | null;
   sessionProvider?: string | null;
   sessionLoaded?: boolean;
@@ -228,6 +229,7 @@ export default function ChatInput({
   append: _append,
   onWorkingDirChange,
   inputRef,
+  sessionWorkingDir: initialSessionWorkingDir,
   sessionModel,
   sessionProvider,
   sessionLoaded,
@@ -303,7 +305,15 @@ export default function ChatInput({
   const [tokenLimit, setTokenLimit] = useState<number>(TOKEN_LIMIT_DEFAULT);
   const [isTokenLimitLoaded, setIsTokenLimitLoaded] = useState(false);
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
-  const [sessionWorkingDir, setSessionWorkingDir] = useState<string | null>(null);
+  const [sessionWorkingDir, setSessionWorkingDir] = useState<string | null>(
+    initialSessionWorkingDir ?? null
+  );
+
+  useEffect(() => {
+    if (initialSessionWorkingDir !== undefined) {
+      setSessionWorkingDir(initialSessionWorkingDir);
+    }
+  }, [initialSessionWorkingDir]);
 
   // Hide non-essential bottom-bar controls when the chat input is narrow.
   // Only the model selector, mic, and send button remain visible.

--- a/ui/desktop/src/components/Hub.tsx
+++ b/ui/desktop/src/components/Hub.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { defineMessages, useIntl } from '../i18n';
 import { AppEvents } from '../constants/events';
 import ChatInput from './ChatInput';
@@ -31,6 +32,10 @@ const i18n = defineMessages({
   goodEvening: { id: 'hub.goodEvening', defaultMessage: 'Good evening' },
 });
 
+interface HubRouteState {
+  workingDir?: string;
+}
+
 function useClock(): { time: string; meridiem: string; hour: number } {
   const [now, setNow] = useState(() => new Date());
   useEffect(() => {
@@ -52,8 +57,10 @@ export default function Hub({
   setView: (view: View, viewOptions?: ViewOptions) => void;
 }) {
   const intl = useIntl();
+  const location = useLocation();
   const { extensionsList } = useConfig();
-  const [workingDir, setWorkingDir] = useState(getInitialWorkingDir());
+  const routeWorkingDir = (location.state as HubRouteState | null)?.workingDir?.trim();
+  const [workingDir, setWorkingDir] = useState(() => routeWorkingDir || getInitialWorkingDir());
   const [isCreatingSession, setIsCreatingSession] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const { time, meridiem, hour } = useClock();
@@ -71,6 +78,12 @@ export default function Hub({
     });
     return () => cancelAnimationFrame(frameId);
   }, []);
+
+  useEffect(() => {
+    if (routeWorkingDir) {
+      setWorkingDir(routeWorkingDir);
+    }
+  }, [routeWorkingDir]);
 
   const handleSubmit = async (input: UserInput) => {
     const { msg: userMessage, images } = input;
@@ -133,6 +146,7 @@ export default function Hub({
             toolCount={0}
             onWorkingDirChange={setWorkingDir}
             inputRef={inputRef}
+            sessionWorkingDir={workingDir}
           />
         </ChatInputCard>
       </div>

--- a/ui/desktop/src/components/Layout/NavigationPanel.tsx
+++ b/ui/desktop/src/components/Layout/NavigationPanel.tsx
@@ -145,6 +145,7 @@ export const Navigation: React.FC<{ className?: string }> = ({ className }) => {
 
   const {
     recentSessions,
+    recentSessionsByProject,
     activeSessionId,
     fetchSessions,
     handleNavClick,
@@ -194,6 +195,21 @@ export const Navigation: React.FC<{ className?: string }> = ({ className }) => {
   }, [isNavExpanded, fetchSessions]);
 
   const [isChatsExpanded, setIsChatsExpanded] = useState(true);
+  const groupedSessions = recentSessionsByProject.length > 1 ? recentSessionsByProject : null;
+
+  const renderSessionRow = (session: SessionListItem) => (
+    <SessionRow
+      key={session.id}
+      session={session}
+      active={session.id === activeSessionId}
+      status={sessionStatuses.get(session.id)}
+      onClick={() => {
+        clearUnread(session.id);
+        handleSessionClick(session.id);
+      }}
+      onRenamed={fetchSessions}
+    />
+  );
 
   if (!isNavExpanded) return null;
 
@@ -253,20 +269,20 @@ export const Navigation: React.FC<{ className?: string }> = ({ className }) => {
               <div className="px-3 py-2 text-xs text-text-secondary">
                 {intl.formatMessage(i18n.noChats)}
               </div>
-            ) : (
-              recentSessions.map((session) => (
-                <SessionRow
-                  key={session.id}
-                  session={session}
-                  active={session.id === activeSessionId}
-                  status={sessionStatuses.get(session.id)}
-                  onClick={() => {
-                    clearUnread(session.id);
-                    handleSessionClick(session.id);
-                  }}
-                  onRenamed={fetchSessions}
-                />
+            ) : groupedSessions ? (
+              groupedSessions.map((group) => (
+                <React.Fragment key={group.path}>
+                  <div
+                    className="px-3 pb-1 pt-2 text-[10px] uppercase tracking-wider text-text-tertiary truncate"
+                    title={group.path}
+                  >
+                    {group.label}
+                  </div>
+                  {group.sessions.map(renderSessionRow)}
+                </React.Fragment>
               ))
+            ) : (
+              recentSessions.map(renderSessionRow)
             )}
           </div>
         )}

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -47,7 +47,7 @@ import {
 } from '../../acp/sessions';
 import { getSearchShortcutText } from '../../utils/keyboardShortcuts';
 import { clearSessionCache } from '../../hooks/useChatStream';
-import { groupSessionsByProject } from '../../utils/projectSessions';
+import { groupSessionsByProject, normalizeProjectPath } from '../../utils/projectSessions';
 
 const i18n = defineMessages({
   editSessionTitle: { id: 'sessions.edit.title', defaultMessage: 'Edit Session Description' },
@@ -289,7 +289,7 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
     const projectGroups = useMemo(() => groupSessionsByProject(sessions), [sessions]);
     const projectFilteredSessions = useMemo(() => {
       if (selectedProject === null) return sessions;
-      return sessions.filter((session) => session.workingDir.trim() === selectedProject);
+      return sessions.filter((session) => normalizeProjectPath(session.workingDir) === selectedProject);
     }, [selectedProject, sessions]);
 
     useEffect(() => {

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -47,6 +47,7 @@ import {
 } from '../../acp/sessions';
 import { getSearchShortcutText } from '../../utils/keyboardShortcuts';
 import { clearSessionCache } from '../../hooks/useChatStream';
+import { groupSessionsByProject } from '../../utils/projectSessions';
 
 const i18n = defineMessages({
   editSessionTitle: { id: 'sessions.edit.title', defaultMessage: 'Edit Session Description' },
@@ -93,6 +94,8 @@ const i18n = defineMessages({
   shareNostrTitle: { id: 'sessions.shareNostr.title', defaultMessage: 'Encrypted Nostr Share Link' },
   shareNostrDesc: { id: 'sessions.shareNostr.description', defaultMessage: 'Anyone with this link can fetch and decrypt the session. Treat it like a secret.' },
   close: { id: 'sessions.close', defaultMessage: 'Close' },
+  allProjects: { id: 'sessions.projects.all', defaultMessage: 'All' },
+  projects: { id: 'sessions.projects.label', defaultMessage: 'Projects' },
 });
 
 interface EditSessionModalProps {
@@ -236,6 +239,7 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
   ({ onSelectSession, selectedSessionId }) => {
     const intl = useIntl();
     const [sessions, setSessions] = useState<SessionListItem[]>([]);
+    const [selectedProject, setSelectedProject] = useState<string | null>(null);
     const [isPrefetchingSessions, setIsPrefetchingSessions] = useState(false);
     const [dateGroups, setDateGroups] = useState<DateGroup[]>([]);
     const [isLoading, setIsLoading] = useState(true);
@@ -282,6 +286,18 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
     };
 
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const projectGroups = useMemo(() => groupSessionsByProject(sessions), [sessions]);
+    const projectFilteredSessions = useMemo(() => {
+      if (selectedProject === null) return sessions;
+      return sessions.filter((session) => session.workingDir.trim() === selectedProject);
+    }, [selectedProject, sessions]);
+
+    useEffect(() => {
+      if (selectedProject === null) return;
+      if (!projectGroups.some((group) => group.path === selectedProject)) {
+        setSelectedProject(null);
+      }
+    }, [projectGroups, selectedProject]);
 
     const visibleDateGroups = useMemo(() => {
       return dateGroups.slice(0, visibleGroupsCount);
@@ -419,11 +435,11 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
 
     // Memoize date groups calculation to prevent unnecessary recalculations
     const memoizedDateGroups = useMemo(() => {
-      if (sessions.length > 0) {
-        return groupSessionsByDate(sessions);
+      if (projectFilteredSessions.length > 0) {
+        return groupSessionsByDate(projectFilteredSessions);
       }
       return [];
-    }, [sessions]);
+    }, [projectFilteredSessions]);
 
     // Update date groups when filtered sessions change
     useEffect(() => {
@@ -459,7 +475,7 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
       // Update state immediately for optimistic UI
       setSessions((prevSessions) =>
         prevSessions.map((s) =>
-          s.id === sessionId ? { ...s, name: newDescription, user_set_name: true } : s
+          s.id === sessionId ? { ...s, name: newDescription, userSetName: true } : s
         )
       );
       window.dispatchEvent(
@@ -851,8 +867,6 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
       }
 
       if (sessions.length === 0) {
-        // `sessions` holds the keyword-filtered set, so an empty result while searching
-        // means "no matches" rather than "no sessions at all".
         if (debouncedSearchTerm) {
           return (
             <div className="flex flex-col items-center justify-center h-full text-text-secondary mt-4">
@@ -867,6 +881,16 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
             <MessageSquareText className="h-12 w-12 mb-4" />
             <p className="text-lg mb-2">{intl.formatMessage(i18n.noSessions)}</p>
             <p className="text-sm">{intl.formatMessage(i18n.noSessionsDesc)}</p>
+          </div>
+        );
+      }
+
+      if (dateGroups.length === 0 && selectedProject !== null) {
+        return (
+          <div className="flex flex-col items-center justify-center h-full text-text-secondary mt-4">
+            <MessageSquareText className="h-12 w-12 mb-4" />
+            <p className="text-lg mb-2">{intl.formatMessage(i18n.noMatching)}</p>
+            <p className="text-sm">{intl.formatMessage(i18n.noMatchingDesc)}</p>
           </div>
         );
       }
@@ -942,6 +966,39 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
                 <p className="text-sm text-text-secondary mb-4">
                   {intl.formatMessage(i18n.chatHistoryDesc, { shortcut: getSearchShortcutText() })}
                 </p>
+                {projectGroups.length > 1 && (
+                  <div
+                    className="flex gap-2 overflow-x-auto pb-1"
+                    aria-label={intl.formatMessage(i18n.projects)}
+                  >
+                    <button
+                      type="button"
+                      onClick={() => setSelectedProject(null)}
+                      className={`px-3 py-1.5 rounded-full text-xs whitespace-nowrap transition-colors ${
+                        selectedProject === null
+                          ? 'bg-background-inverse text-text-inverse'
+                          : 'bg-background-secondary text-text-secondary hover:bg-background-tertiary'
+                      }`}
+                    >
+                      {intl.formatMessage(i18n.allProjects)} ({sessions.length})
+                    </button>
+                    {projectGroups.map((project) => (
+                      <button
+                        key={project.path}
+                        type="button"
+                        title={project.path}
+                        onClick={() => setSelectedProject(project.path)}
+                        className={`px-3 py-1.5 rounded-full text-xs whitespace-nowrap transition-colors ${
+                          selectedProject === project.path
+                            ? 'bg-background-inverse text-text-inverse'
+                            : 'bg-background-secondary text-text-secondary hover:bg-background-tertiary'
+                        }`}
+                      >
+                        {project.label} ({project.sessions.length})
+                      </button>
+                    ))}
+                  </div>
+                )}
               </div>
             </div>
 

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -239,6 +239,7 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
   ({ onSelectSession, selectedSessionId }) => {
     const intl = useIntl();
     const [sessions, setSessions] = useState<SessionListItem[]>([]);
+    const [projectSessions, setProjectSessions] = useState<SessionListItem[]>([]);
     const [selectedProject, setSelectedProject] = useState<string | null>(null);
     const [isPrefetchingSessions, setIsPrefetchingSessions] = useState(false);
     const [dateGroups, setDateGroups] = useState<DateGroup[]>([]);
@@ -286,10 +287,12 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
     };
 
     const fileInputRef = useRef<HTMLInputElement>(null);
-    const projectGroups = useMemo(() => groupSessionsByProject(sessions), [sessions]);
+    const projectGroups = useMemo(() => groupSessionsByProject(projectSessions), [projectSessions]);
     const projectFilteredSessions = useMemo(() => {
       if (selectedProject === null) return sessions;
-      return sessions.filter((session) => normalizeProjectPath(session.workingDir) === selectedProject);
+      return sessions.filter(
+        (session) => normalizeProjectPath(session.workingDir) === selectedProject
+      );
     }, [selectedProject, sessions]);
 
     useEffect(() => {
@@ -317,7 +320,12 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
     }, [debouncedSearchTerm, dateGroups.length]);
 
     const loadRemainingSessionPages = useCallback(
-      async (initialCursor: string, loadId: number, keyword?: string) => {
+      async (
+        initialCursor: string,
+        loadId: number,
+        keyword?: string,
+        updateProjectSessions = false
+      ) => {
         let cursor: string | null = initialCursor;
         setIsPrefetchingSessions(true);
 
@@ -332,6 +340,12 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
                 const seen = new Set(prev.map((s) => s.id));
                 return [...prev, ...resp.sessions.filter((s) => !seen.has(s.id))];
               });
+              if (updateProjectSessions) {
+                setProjectSessions((prev) => {
+                  const seen = new Set(prev.map((s) => s.id));
+                  return [...prev, ...resp.sessions.filter((s) => !seen.has(s.id))];
+                });
+              }
             });
           }
         } catch (err) {
@@ -349,6 +363,7 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
       async (keyword: string = debouncedSearchTermRef.current) => {
         const loadId = loadGenerationRef.current + 1;
         loadGenerationRef.current = loadId;
+        const isProjectIndexLoad = keyword.trim().length === 0;
         // Only show the skeleton on the first load; subsequent loads (e.g. typing a
         // search keyword) update the list in place without flashing the skeleton.
         const isFirstLoad = !hasLoadedRef.current;
@@ -366,10 +381,13 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
 
           startTransition(() => {
             setSessions(resp.sessions);
+            if (isProjectIndexLoad) {
+              setProjectSessions(resp.sessions);
+            }
           });
 
           if (resp.nextCursor) {
-            void loadRemainingSessionPages(resp.nextCursor, loadId, keyword);
+            void loadRemainingSessionPages(resp.nextCursor, loadId, keyword, isProjectIndexLoad);
           }
         } catch (err) {
           if (loadGenerationRef.current !== loadId) return;
@@ -377,6 +395,9 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
           console.error('Failed to load sessions:', err);
           setError('Failed to load sessions. Please try again later.');
           setSessions([]);
+          if (isProjectIndexLoad) {
+            setProjectSessions([]);
+          }
         } finally {
           if (loadGenerationRef.current === loadId && isFirstLoad) {
             setIsLoading(false);
@@ -478,6 +499,11 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
           s.id === sessionId ? { ...s, name: newDescription, userSetName: true } : s
         )
       );
+      setProjectSessions((prevSessions) =>
+        prevSessions.map((s) =>
+          s.id === sessionId ? { ...s, name: newDescription, userSetName: true } : s
+        )
+      );
       window.dispatchEvent(
         new CustomEvent(AppEvents.SESSION_RENAMED, {
           detail: { sessionId, newName: newDescription, userInitiated: true },
@@ -525,6 +551,12 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
           new CustomEvent(AppEvents.SESSION_DELETED, { detail: { sessionId: sessionToDeleteId } })
         );
         clearSessionCache(sessionToDeleteId);
+        setSessions((prevSessions) =>
+          prevSessions.filter((session) => session.id !== sessionToDeleteId)
+        );
+        setProjectSessions((prevSessions) =>
+          prevSessions.filter((session) => session.id !== sessionToDeleteId)
+        );
       } catch (error) {
         console.error('Error deleting session:', error);
         toast.error(intl.formatMessage(i18n.deleteFailed, { name: sessionName, error: errorMessage(error, 'Unknown error') }));
@@ -980,7 +1012,7 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
                           : 'bg-background-secondary text-text-secondary hover:bg-background-tertiary'
                       }`}
                     >
-                      {intl.formatMessage(i18n.allProjects)} ({sessions.length})
+                      {intl.formatMessage(i18n.allProjects)} ({projectSessions.length})
                     </button>
                     {projectGroups.map((project) => (
                       <button

--- a/ui/desktop/src/hooks/useNavigationSessions.ts
+++ b/ui/desktop/src/hooks/useNavigationSessions.ts
@@ -7,6 +7,7 @@ import { AppEvents } from '../constants/events';
 import type { Session } from '../api';
 import { acpListRecentSessions, type SessionListItem } from '../acp/sessions';
 import { groupSessionsByProject } from '../utils/projectSessions';
+import { getInitialWorkingDir } from '../utils/workingDir';
 
 const MAX_RECENT_SESSIONS = 25;
 
@@ -175,6 +176,26 @@ export function useNavigationSessions() {
 
   const handleNavClick = useCallback(
     (path: string) => {
+      if (path === '/') {
+        const sessionId =
+          currentSessionId || lastSessionIdRef.current || chatContext?.chat?.sessionId;
+
+        if (!sessionId) {
+          navigate('/', { state: { workingDir: getInitialWorkingDir() } });
+          return;
+        }
+
+        void getSession({ path: { session_id: sessionId }, throwOnError: false })
+          .then((response) => {
+            const workingDir = (response.data as Session | undefined)?.working_dir?.trim();
+            navigate('/', { state: { workingDir: workingDir || getInitialWorkingDir() } });
+          })
+          .catch(() => {
+            navigate('/', { state: { workingDir: getInitialWorkingDir() } });
+          });
+        return;
+      }
+
       if (path === '/pair') {
         const sessionId =
           currentSessionId || lastSessionIdRef.current || chatContext?.chat?.sessionId;

--- a/ui/desktop/src/hooks/useNavigationSessions.ts
+++ b/ui/desktop/src/hooks/useNavigationSessions.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useNavigate, useLocation, useSearchParams } from 'react-router-dom';
 import { getSession } from '../api';
 import { useChatContext } from '../contexts/ChatContext';
@@ -6,6 +6,7 @@ import { shouldShowNewChatTitle } from '../sessions';
 import { AppEvents } from '../constants/events';
 import type { Session } from '../api';
 import { acpListRecentSessions, type SessionListItem } from '../acp/sessions';
+import { groupSessionsByProject } from '../utils/projectSessions';
 
 const MAX_RECENT_SESSIONS = 25;
 
@@ -48,6 +49,10 @@ export function useNavigationSessions() {
   const chatContext = useChatContext();
 
   const [recentSessions, setRecentSessions] = useState<SessionListItem[]>([]);
+  const recentSessionsByProject = useMemo(
+    () => groupSessionsByProject(recentSessions),
+    [recentSessions]
+  );
   const lastSessionIdRef = useRef<string | null>(null);
 
   const activeSessionId = searchParams.get('resumeSessionId') ?? undefined;
@@ -153,7 +158,7 @@ export function useNavigationSessions() {
       setRecentSessions((prev) =>
         prev.map((session) =>
           session.id === sessionId
-            ? { ...session, name: newName, ...(userInitiated && { user_set_name: true }) }
+            ? { ...session, name: newName, ...(userInitiated && { userSetName: true }) }
             : session
         )
       );
@@ -194,6 +199,7 @@ export function useNavigationSessions() {
 
   return {
     recentSessions,
+    recentSessionsByProject,
     activeSessionId,
     fetchSessions,
     handleNavClick,

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -3950,6 +3950,12 @@
   "sessions.loadingMore": {
     "defaultMessage": "Loading more sessions..."
   },
+  "sessions.projects.all": {
+    "defaultMessage": "All"
+  },
+  "sessions.projects.label": {
+    "defaultMessage": "Projects"
+  },
   "sessions.save": {
     "defaultMessage": "Save"
   },

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -3950,6 +3950,12 @@
   "sessions.loadingMore": {
     "defaultMessage": "अधिक सत्र लोड हो रहे हैं..."
   },
+  "sessions.projects.all": {
+    "defaultMessage": "सभी"
+  },
+  "sessions.projects.label": {
+    "defaultMessage": "प्रोजेक्ट"
+  },
   "sessions.save": {
     "defaultMessage": "सहेजें"
   },

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -3950,6 +3950,12 @@
   "sessions.loadingMore": {
     "defaultMessage": "さらにセッションを読み込み中..."
   },
+  "sessions.projects.all": {
+    "defaultMessage": "すべて"
+  },
+  "sessions.projects.label": {
+    "defaultMessage": "プロジェクト"
+  },
   "sessions.save": {
     "defaultMessage": "保存"
   },

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -3950,6 +3950,12 @@
   "sessions.loadingMore": {
     "defaultMessage": "Загрузка дополнительных сеансов..."
   },
+  "sessions.projects.all": {
+    "defaultMessage": "Все"
+  },
+  "sessions.projects.label": {
+    "defaultMessage": "Проекты"
+  },
   "sessions.save": {
     "defaultMessage": "Сохранить"
   },

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -3950,6 +3950,12 @@
   "sessions.loadingMore": {
     "defaultMessage": "Daha fazla oturum yükleniyor..."
   },
+  "sessions.projects.all": {
+    "defaultMessage": "Tümü"
+  },
+  "sessions.projects.label": {
+    "defaultMessage": "Projeler"
+  },
   "sessions.save": {
     "defaultMessage": "Kaydet"
   },

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -3950,6 +3950,12 @@
   "sessions.loadingMore": {
     "defaultMessage": "正在加载更多会话…"
   },
+  "sessions.projects.all": {
+    "defaultMessage": "全部"
+  },
+  "sessions.projects.label": {
+    "defaultMessage": "项目"
+  },
   "sessions.save": {
     "defaultMessage": "保存"
   },

--- a/ui/desktop/src/utils/projectSessions.ts
+++ b/ui/desktop/src/utils/projectSessions.ts
@@ -9,7 +9,7 @@ export interface ProjectGroup {
 
 const UNKNOWN_PROJECT_LABEL = 'Unknown';
 
-function normalizeProjectPath(workingDir: string): string {
+export function normalizeProjectPath(workingDir: string): string {
   const normalized = workingDir.trim();
   if (!normalized) {
     return '';

--- a/ui/desktop/src/utils/projectSessions.ts
+++ b/ui/desktop/src/utils/projectSessions.ts
@@ -1,0 +1,94 @@
+import type { SessionListItem } from '../acp/sessions';
+
+export interface ProjectGroup {
+  path: string;
+  label: string;
+  sessions: SessionListItem[];
+  updatedAt: Date;
+}
+
+const UNKNOWN_PROJECT_LABEL = 'Unknown';
+
+export function getProjectLabel(workingDir: string): string {
+  const normalized = workingDir.trim();
+  if (!normalized) {
+    return UNKNOWN_PROJECT_LABEL;
+  }
+
+  const withoutTrailingSeparators = normalized.replace(/[\\/]+$/, '');
+  if (!withoutTrailingSeparators) {
+    return normalized;
+  }
+
+  const parts = withoutTrailingSeparators.split(/[\\/]+/);
+  return parts[parts.length - 1] || normalized;
+}
+
+export function groupSessionsByProject(sessions: SessionListItem[]): ProjectGroup[] {
+  const groups = new Map<string, SessionListItem[]>();
+
+  for (const session of sessions) {
+    const path = session.workingDir.trim();
+    const existing = groups.get(path);
+    if (existing) {
+      existing.push(session);
+    } else {
+      groups.set(path, [session]);
+    }
+  }
+
+  const baseGroups = Array.from(groups.entries()).map(([path, projectSessions]) => {
+    const sortedSessions = [...projectSessions].sort(
+      (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    );
+    return {
+      path,
+      label: getProjectLabel(path),
+      sessions: sortedSessions,
+      updatedAt: new Date(sortedSessions[0]?.updatedAt ?? 0),
+    };
+  });
+
+  const labelCounts = baseGroups.reduce((counts, group) => {
+    counts.set(group.label, (counts.get(group.label) ?? 0) + 1);
+    return counts;
+  }, new Map<string, number>());
+
+  return baseGroups
+    .map((group) => ({
+      ...group,
+      label:
+        (labelCounts.get(group.label) ?? 0) > 1
+          ? getDisambiguatedProjectLabel(group.path)
+          : group.label,
+    }))
+    .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+}
+
+function getDisambiguatedProjectLabel(workingDir: string): string {
+  const normalized = workingDir.trim();
+  if (!normalized) {
+    return UNKNOWN_PROJECT_LABEL;
+  }
+
+  const withoutTrailingSeparators = normalized.replace(/[\\/]+$/, '');
+  const parts = withoutTrailingSeparators.split(/[\\/]+/).filter(Boolean);
+  if (parts.length >= 2) {
+    return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`;
+  }
+
+  return getProjectLabel(workingDir);
+}
+
+export function resolveNewChatWorkingDir(
+  activeSessionId: string | undefined,
+  sessions: SessionListItem[],
+  fallback: string
+): string {
+  if (!activeSessionId) {
+    return fallback;
+  }
+
+  const activeSession = sessions.find((session) => session.id === activeSessionId);
+  return activeSession?.workingDir || fallback;
+}

--- a/ui/desktop/src/utils/projectSessions.ts
+++ b/ui/desktop/src/utils/projectSessions.ts
@@ -9,13 +9,23 @@ export interface ProjectGroup {
 
 const UNKNOWN_PROJECT_LABEL = 'Unknown';
 
+function normalizeProjectPath(workingDir: string): string {
+  const normalized = workingDir.trim();
+  if (!normalized) {
+    return '';
+  }
+
+  const withoutTrailingSeparators = normalized.replace(/[\\/]+$/, '');
+  return withoutTrailingSeparators || normalized;
+}
+
 export function getProjectLabel(workingDir: string): string {
   const normalized = workingDir.trim();
   if (!normalized) {
     return UNKNOWN_PROJECT_LABEL;
   }
 
-  const withoutTrailingSeparators = normalized.replace(/[\\/]+$/, '');
+  const withoutTrailingSeparators = normalizeProjectPath(workingDir);
   if (!withoutTrailingSeparators) {
     return normalized;
   }
@@ -28,7 +38,7 @@ export function groupSessionsByProject(sessions: SessionListItem[]): ProjectGrou
   const groups = new Map<string, SessionListItem[]>();
 
   for (const session of sessions) {
-    const path = session.workingDir.trim();
+    const path = normalizeProjectPath(session.workingDir);
     const existing = groups.get(path);
     if (existing) {
       existing.push(session);
@@ -66,12 +76,10 @@ export function groupSessionsByProject(sessions: SessionListItem[]): ProjectGrou
 }
 
 function getDisambiguatedProjectLabel(workingDir: string): string {
-  const normalized = workingDir.trim();
-  if (!normalized) {
+  const withoutTrailingSeparators = normalizeProjectPath(workingDir);
+  if (!withoutTrailingSeparators) {
     return UNKNOWN_PROJECT_LABEL;
   }
-
-  const withoutTrailingSeparators = normalized.replace(/[\\/]+$/, '');
   const parts = withoutTrailingSeparators.split(/[\\/]+/).filter(Boolean);
   if (parts.length >= 2) {
     return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`;
@@ -90,5 +98,6 @@ export function resolveNewChatWorkingDir(
   }
 
   const activeSession = sessions.find((session) => session.id === activeSessionId);
-  return activeSession?.workingDir || fallback;
+  const workingDir = activeSession?.workingDir.trim();
+  return workingDir || fallback;
 }


### PR DESCRIPTION
## Summary
- Group sessions in the navigation panel and full history view by their `working_dir` (project)
- Project labels use the directory basename, with `parent/basename` disambiguation when two projects share the same basename
- Navigation list + dropdown only render project headers when 2+ projects are present, so single-project setups look unchanged
- Session history view gains a project filter chip row above the search bar (All + per-project with counts), with an empty state when a filter returns nothing
- New Chat now inherits the active session's `working_dir` instead of always falling back to the initial cwd, so creating a new chat stays within the current project
- The active filter auto-resets if the selected project disappears (last session deleted)
- No server changes — `working_dir` is already on `Session`

## Review Notes
- RFC because this changes New Chat behavior (inherits active working_dir). Happy to hide that piece behind a setting if you'd rather keep the old always-cwd default. Let me know your thoughts.
- IDK but I think rendering project headers only at 2+ projects is the right ergonomic default — otherwise every single-project user gets a useless label. Flexible on this if the team disagrees.
- Production-safety review passed (2 clean rounds). Added one small fix during review: the 'no matching' empty state now also shows when a project filter produces no results.
- i18n keys added (`sessions.projects.all`, `sessions.projects.label`) and `en.json` regenerated via `pnpm i18n:extract`.

## Test plan
- [x] `pnpm run lint:check` (typecheck + eslint + i18n:check) clean
- [x] `pnpm test:run` — 356/356 pass, including 13 new tests in `projectSessions.test.ts`
- [ ] Manual: open desktop app with sessions across 2+ working_dirs and confirm filter chips, grouped navigation headers, and inherited working_dir on New Chat
- [ ] Manual: single-project user still sees no project chrome

## What I would do if I were writing the commits from 0
1. `projectSessions` utility + tests
2. Navigation / history wiring
3. New Chat working_dir inheritance