### PR TITLE
fix: return 400 instead of panicking on invalid CSP header value

### DIFF
--- a/crates/goose-server/src/routes/mcp_app_proxy.rs
+++ b/crates/goose-server/src/routes/mcp_app_proxy.rs
@@ -255,10 +255,21 @@ async fn serve_guest_html(
             // no-referrer would cause 401s from SDK servers.
             headers.insert(
                 header::HeaderName::from_static("referrer-policy"),
-                "strict-origin".parse().unwrap(),
+                header::HeaderValue::from_static("strict-origin"),
             );
             if !csp.is_empty() {
-                headers.insert(header::CONTENT_SECURITY_POLICY, csp.parse().unwrap());
+                match csp.parse::<header::HeaderValue>() {
+                    Ok(csp_value) => {
+                        headers.insert(header::CONTENT_SECURITY_POLICY, csp_value);
+                    }
+                    Err(_) => {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            "Invalid characters in Content-Security-Policy value",
+                        )
+                            .into_response();
+                    }
+                }
             }
             response
         }


### PR DESCRIPTION
## Summary

- User-controlled CSP strings from the request body (`body.csp`) could contain invalid HTTP header characters, causing `csp.parse().unwrap()` to panic the `serve_guest_html` request handler
- Replace the unwrap with a `match` that returns `400 Bad Request` with a descriptive message on invalid input
- Also replace the static `"strict-origin".parse().unwrap()` with `HeaderValue::from_static` which is validated at compile time and has zero runtime cost

## Changes

`crates/goose-server/src/routes/mcp_app_proxy.rs`
- `"strict-origin".parse().unwrap()` → `header::HeaderValue::from_static("strict-origin")`
- `csp.parse().unwrap()` → `match csp.parse::<header::HeaderValue>()` returning `400 Bad Request` on error