### PR TITLE
fix: return error instead of panicking on llama backend init failure

### DIFF
--- a/crates/goose-server/src/state.rs
+++ b/crates/goose-server/src/state.rs
@@ -48,7 +48,7 @@ impl AppState {
             gateway_manager,
             extension_loading_tasks: Arc::new(Mutex::new(HashMap::new())),
             #[cfg(feature = "local-inference")]
-            inference_runtime: InferenceRuntime::get_or_init(),
+            inference_runtime: InferenceRuntime::get_or_init()?,
             session_buses: Arc::new(Mutex::new(HashMap::new())),
         }))
     }

--- a/crates/goose/src/providers/local_inference.rs
+++ b/crates/goose/src/providers/local_inference.rs
@@ -62,10 +62,10 @@ pub struct InferenceRuntime {
 static RUNTIME: StdMutex<Weak<InferenceRuntime>> = StdMutex::new(Weak::new());
 
 impl InferenceRuntime {
-    pub fn get_or_init() -> Arc<Self> {
+    pub fn get_or_init() -> Result<Arc<Self>> {
         let mut guard = RUNTIME.lock().expect("runtime lock poisoned");
         if let Some(runtime) = guard.upgrade() {
-            return runtime;
+            return Ok(runtime);
         }
         // Safety invariant: the Weak::upgrade() check and LlamaBackend::init()
         // both execute inside this same mutex guard, so there is no window where
@@ -80,7 +80,7 @@ impl InferenceRuntime {
                      the mutex guard prevents concurrent re-init"
                 )
             }
-            Err(e) => panic!("Failed to init llama backend: {}", e),
+            Err(e) => return Err(anyhow::anyhow!("Failed to initialize llama backend: {}", e)),
         };
         llama_cpp_2::send_logs_to_tracing(LogOptions::default());
         let runtime = Arc::new(Self {
@@ -88,7 +88,7 @@ impl InferenceRuntime {
             backend,
         });
         *guard = Arc::downgrade(&runtime);
-        runtime
+        Ok(runtime)
     }
 
     pub fn backend(&self) -> &LlamaBackend {
@@ -357,7 +357,7 @@ pub struct LocalInferenceProvider {
 
 impl LocalInferenceProvider {
     pub async fn from_env(model: ModelConfig, _extensions: Vec<ExtensionConfig>) -> Result<Self> {
-        let runtime = InferenceRuntime::get_or_init();
+        let runtime = InferenceRuntime::get_or_init()?;
         let model_slot = runtime.get_or_create_model_slot(&model.model_name);
         Ok(Self {
             runtime,


### PR DESCRIPTION
## Summary

- `InferenceRuntime::get_or_init()` would `panic!` if `LlamaBackend::init()` failed (e.g. missing GPU, unsupported hardware, bad native library), giving callers no recovery path and crashing the entire process
- Change the return type from `Arc<Self>` to `Result<Arc<Self>>` so the failure propagates naturally up the call stack
- Both callers already return `Result`, so the fix is a minimal `?` propagation at each call site

## Changes

`crates/goose/src/providers/local_inference.rs`
- `get_or_init()` return type changed to `Result<Arc<Self>>`
- `panic!` on backend init failure replaced with `Err(anyhow::anyhow!(...))`
- All `return runtime` / `runtime` paths wrapped in `Ok(...)`
- `from_env()` caller updated with `?`

`crates/goose-server/src/state.rs`
- `AppState::new()` caller updated with `?` (already returns `anyhow::Result`)