### PR TITLE
chore: replace lazy_static with std::sync::LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4372,7 +4372,6 @@ dependencies = [
  "jsonschema",
  "jsonwebtoken",
  "keyring",
- "lazy_static",
  "libc",
  "llama-cpp-2",
  "lru",

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -98,7 +98,6 @@ base64 = { workspace = true }
 url = { workspace = true }
 axum = { workspace = true, features = ["ws"] }
 webbrowser = { workspace = true }
-lazy_static = "1.5.0"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-futures = { workspace = true }

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -1,6 +1,6 @@
-use lazy_static::lazy_static;
 use regex::Regex;
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
 /// Security threat patterns for command injection detection
 /// These patterns detect dangerous shell commands and injection attempts
@@ -352,17 +352,15 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
 ];
 
-lazy_static! {
-    static ref COMPILED_PATTERNS: HashMap<&'static str, Regex> = {
-        let mut patterns = HashMap::new();
-        for threat in THREAT_PATTERNS {
-            if let Ok(regex) = Regex::new(&format!("(?i){}", threat.pattern)) {
-                patterns.insert(threat.name, regex);
-            }
+static COMPILED_PATTERNS: LazyLock<HashMap<&'static str, Regex>> = LazyLock::new(|| {
+    let mut patterns = HashMap::new();
+    for threat in THREAT_PATTERNS {
+        if let Ok(regex) = Regex::new(&format!("(?i){}", threat.pattern)) {
+            patterns.insert(threat.name, regex);
         }
-        patterns
-    };
-}
+    }
+    patterns
+});
 
 /// Pattern matcher for detecting security threats
 pub struct PatternMatcher {

--- a/crates/goose/tests/providers.rs
+++ b/crates/goose/tests/providers.rs
@@ -90,10 +90,9 @@ impl TestReport {
     }
 }
 
-lazy_static::lazy_static! {
-    static ref TEST_REPORT: Arc<TestReport> = TestReport::new();
-    static ref ENV_LOCK: Mutex<()> = Mutex::new(());
-}
+static TEST_REPORT: std::sync::LazyLock<Arc<TestReport>> =
+    std::sync::LazyLock::new(TestReport::new);
+static ENV_LOCK: std::sync::LazyLock<Mutex<()>> = std::sync::LazyLock::new(|| Mutex::new(()));
 
 struct ProviderFixture {
     name: String,


### PR DESCRIPTION
## Summary

- The codebase had three lazy-initialization approaches in use simultaneously: `lazy_static`, `once_cell`, and `std::sync::LazyLock`
- `lazy_static` is legacy — its functionality was stabilized into `std::sync::LazyLock` in Rust 1.80, well below this project's MSRV
- Remove the `lazy_static` crate dependency entirely and migrate its two usages to `std::sync::LazyLock`

## Changes

- `crates/goose/Cargo.toml` — removed `lazy_static = "1.5.0"` dependency
- `crates/goose/src/security/patterns.rs` — `lazy_static! { static ref COMPILED_PATTERNS }` → `static COMPILED_PATTERNS: LazyLock<...>`
- `crates/goose/tests/providers.rs` — `lazy_static! { static ref TEST_REPORT; static ref ENV_LOCK }` → two `std::sync::LazyLock` statics
- `Cargo.lock` — `lazy_static` entry removed