### PR TITLE
Fix Windows dev loop: beforeDevCommand script + Vite IPv4 bind + test_acp_client.py stdin-flush

### DIFF
--- a/test_acp_client.py
+++ b/test_acp_client.py
@@ -8,24 +8,78 @@ Tests:
 2. session/new - Create a new session
 3. session/prompt - Send a prompt to the session
 4. session/load - Load an existing session (new feature)
+
+Usage:
+    # Uses `cargo run -p goose-cli -- acp` by default.
+    python3 test_acp_client.py
+
+    # Faster: point at a pre-built binary via env var.
+    GOOSE_BIN=target/debug/goose.exe python3 test_acp_client.py
 """
 
-import subprocess
 import json
 import os
+import shutil
+import subprocess
 import sys
 import time
+
+# Windows consoles default to cp1252, which can't encode the unicode glyphs
+# used in test progress output (✓, ✗, 📝). Force UTF-8 so the test runs
+# uniformly on Windows, Linux, and macOS.
+if sys.stdout.encoding and sys.stdout.encoding.lower() != "utf-8":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+        sys.stderr.reconfigure(encoding="utf-8")
+    except (AttributeError, OSError):
+        pass
+
+
+def _resolve_goose_cmd():
+    """Return the argv to launch the ACP server.
+
+    Preference order:
+      1. $GOOSE_BIN (explicit override — fastest path, no cargo startup).
+      2. target/debug/goose.exe or target/debug/goose if already built.
+      3. Fall back to `cargo run -p goose-cli -- acp` (recompiles on demand).
+    """
+    bin_env = os.environ.get("GOOSE_BIN")
+    if bin_env and os.path.isfile(bin_env):
+        return [bin_env, "acp"]
+
+    is_windows = sys.platform.startswith("win")
+    exe = "goose.exe" if is_windows else "goose"
+    prebuilt = os.path.join("target", "debug", exe)
+    if os.path.isfile(prebuilt):
+        return [prebuilt, "acp"]
+
+    if shutil.which("cargo"):
+        return ["cargo", "run", "-p", "goose-cli", "--", "acp"]
+
+    raise RuntimeError(
+        "Could not find the goose binary. Build it with "
+        "`cargo build -p goose-cli` or set GOOSE_BIN=<path-to-goose>"
+    )
 
 
 class AcpClient:
     def __init__(self):
+        # On Windows, if stderr is PIPE and nobody reads it, `cargo run`'s
+        # compile chatter fills the ~4 KB pipe buffer, blocks the child's
+        # stderr write, and deadlocks the stdio loop (classic subprocess
+        # pitfall). Route stderr to DEVNULL — this test cares only about
+        # the JSON-RPC framing on stdout.
+        #
+        # `bufsize=1` (line-buffered) matches text-mode semantics on both
+        # Windows and POSIX; the prior `bufsize=0` is only meaningful for
+        # binary streams and made stdout flushes unreliable on Windows.
         self.process = subprocess.Popen(
-            ['cargo', 'run', '-p', 'goose-cli', '--', 'acp'],
+            _resolve_goose_cmd(),
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
             text=True,
-            bufsize=0
+            bufsize=1,
         )
         self.request_id = 0
 

--- a/ui/goose2/justfile
+++ b/ui/goose2/justfile
@@ -99,7 +99,20 @@ dev: setup
     else
         unset GOOSE_BIN
     fi
-    EXTRA_CONFIG_ARGS=(--config "{\"build\":{\"devUrl\":\"http://localhost:${VITE_PORT}\",\"beforeDevCommand\":{\"script\":\"cd ${PROJECT_DIR} && exec pnpm exec vite --port ${VITE_PORT} --strictPort\",\"cwd\":\".\",\"wait\":false}}}")
+    # Windows compatibility — three adjustments to the beforeDevCommand script:
+    #   1. Dropped 'cd ${PROJECT_DIR} && ' prefix. The unescaped '&&' inside
+    #      the JSON value gets split by Windows' bash→npm→tauri argv
+    #      passthrough, truncating the --config JSON there.
+    #   2. Dropped the leading 'exec'. Tauri runs beforeDevCommand via
+    #      cmd.exe on Windows, which doesn't recognize the bash 'exec'
+    #      builtin. Harmless to drop on Unix too — pnpm handles its own
+    #      subprocess lifecycle.
+    #   3. Added '--host 127.0.0.1'. Vite 7 binds '::1' (IPv6) only on
+    #      Windows by default; WebView2 and browsers try IPv4 first and
+    #      fail with "no page found".
+    # Also: cwd must be '..' (goose2/) not '.' (src-tauri/) — Tauri resolves
+    # beforeDevCommand cwd relative to src-tauri, not to where `just` ran.
+    EXTRA_CONFIG_ARGS=(--config "{\"build\":{\"devUrl\":\"http://localhost:${VITE_PORT}\",\"beforeDevCommand\":{\"script\":\"pnpm exec vite --port ${VITE_PORT} --strictPort --host 127.0.0.1\",\"cwd\":\"..\",\"wait\":false}}}")
 
     if [[ -n "${GOOSE_BIN:-}" ]]; then
         echo "Using local goose binary: ${GOOSE_BIN}"
@@ -147,7 +160,10 @@ dev-debug: setup
     else
         unset GOOSE_BIN
     fi
-    EXTRA_CONFIG_ARGS=(--config "{\"build\":{\"devUrl\":\"http://localhost:${VITE_PORT}\",\"beforeDevCommand\":{\"script\":\"exec ./node_modules/.bin/vite --port ${VITE_PORT} --strictPort\",\"cwd\":\"..\",\"wait\":false}}}")
+    # Windows compatibility: drop the 'exec' bash builtin (cmd.exe doesn't
+    # know it) and add '--host 127.0.0.1' (Vite 7 binds IPv6 only on Windows
+    # by default; WebView2/browsers try IPv4 first). Matches the `dev` recipe.
+    EXTRA_CONFIG_ARGS=(--config "{\"build\":{\"devUrl\":\"http://localhost:${VITE_PORT}\",\"beforeDevCommand\":{\"script\":\"./node_modules/.bin/vite --port ${VITE_PORT} --strictPort --host 127.0.0.1\",\"cwd\":\"..\",\"wait\":false}}}")
 
     if [[ -n "${GOOSE_BIN:-}" ]]; then
         echo "Using local goose binary: ${GOOSE_BIN}"


### PR DESCRIPTION
## Summary

Two small, surgical fixes found while bringing goose2 up on Windows 11.
Both are no-ops on macOS/Linux — they only affect the Windows code
paths.

1. `ui/goose2/justfile` — `just dev` fails on Windows with a malformed
   Tauri `--config` argument. Three interacting causes in the
   `beforeDevCommand.script` string, fixed together because they share
   a code path:

   - `cd ${PROJECT_DIR} && ...` prefix — the unescaped `&&` inside a
     JSON value gets split by Windows' bash → npm → tauri argv
     passthrough, truncating the `--config` JSON. Dropped; `cwd` already
     sets the working directory.
   - Leading `exec` — a bash builtin. Tauri runs `beforeDevCommand` via
     cmd.exe on Windows, which reports `'exec' is not recognized as an
     internal or external command`. Harmless to drop on Unix.
   - Missing `--host 127.0.0.1` — Vite 7 binds `::1` (IPv6 loopback)
     only on Windows by default, and WebView2 resolves `localhost` to
     IPv4 first, so the page never loads. Forcing IPv4 bind works on
     every platform.

   Also corrected `cwd` in the `dev` recipe from `.` to `..`. Tauri
   resolves `beforeDevCommand.cwd` relative to `src-tauri/`, not to the
   just-invocation dir. `dev-debug` already had `..`.

2. `test_acp_client.py` — times out with `Failed to initialize: None`
   on Windows. Three layered causes:

   - `stderr=subprocess.PIPE` with nobody reading it. `cargo run -p
     goose-cli -- acp` writes several KB of compile progress to stderr;
     Windows' ~4 KB pipe buffer fills, the child blocks on stderr
     write, and the stdio loop deadlocks before `initialize` can
     resolve. Routed to `DEVNULL` — the test only cares about JSON-RPC
     framing on stdout.
   - `bufsize=0` combined with `text=True` — text mode always uses
     `io.TextIOWrapper` which needs at least line buffering. `bufsize=0`
     made stdout flushes unreliable on Windows. Changed to `bufsize=1`.
   - (surfaced only after the above was fixed) cp1252 consoles can't
     encode the unicode progress glyphs (`✓ ✗ 📝`). Forced
     `sys.stdout.reconfigure(encoding="utf-8")` so the suite runs
     uniformly on Windows, Linux, macOS.

   Opportunistic: added an optional `GOOSE_BIN` env override plus
   automatic fallback to `target/debug/goose[.exe]` so the test can skip
   the cargo-run path when a pre-built binary exists. Cuts wall time
   from minutes (recompile + cargo noise) to under a second.

## Test plan

- [x] Windows 11, Rust 1.92, Node 22, pnpm 10: `just dev` launches the
      native window, React UI renders, `goose serve` streams perf logs.
- [x] Windows 11: full 6-phase `test_acp_client.py` suite (initialize,
      session/new, session/prompt, re-initialize after restart,
      session/load, prompt-to-loaded-session) passes end-to-end
      against `target/debug/goose.exe`.
- [ ] macOS: no behaviour change expected (dropping `exec` is harmless,
      `--host 127.0.0.1` matches the default bind on Unix). Worth a
      reviewer confirmation.
- [ ] Linux: same as macOS — no behaviour change expected.

No new deps, no config surface changes, no doc changes needed. The
only semantic shift on non-Windows platforms is `test_acp_client.py`
preferring `target/debug/goose` over `cargo run` when the binary
exists, which is a speed improvement.
