### PR TITLE
fix: drop -i flag from login shell PATH resolution to prevent SIGTTOU

### DIFF
--- a/crates/goose-mcp/src/subprocess.rs
+++ b/crates/goose-mcp/src/subprocess.rs
@@ -56,8 +56,13 @@ fn resolve_login_shell_path() -> Option<String> {
             }
         });
 
+    // NOTE: We intentionally do NOT pass `-i` (interactive) here. An interactive
+    // shell can call tcsetpgrp() to claim the foreground process group of the
+    // controlling terminal, which steals it from the parent goose process and
+    // causes SIGTTOU when goose later tries to enter raw mode.
+    // `-l` (login) is sufficient to source profile files where PATH is set.
     std::process::Command::new(&shell)
-        .args(["-l", "-i", "-c", "echo $PATH"])
+        .args(["-l", "-c", "echo $PATH"])
         .stdin(Stdio::null())
         .stderr(Stdio::null())
         .output()

--- a/crates/goose/src/agents/platform_extensions/developer/shell.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/shell.rs
@@ -168,9 +168,15 @@ pub struct ShellOutput {
 fn resolve_login_shell_path() -> Option<String> {
     let shell = unix_shell();
 
+    // NOTE: We intentionally do NOT pass `-i` (interactive) here. An interactive
+    // shell can call tcsetpgrp() to claim the foreground process group of the
+    // controlling terminal, which steals it from the parent goose process. When
+    // goose later tries to enter raw mode (via rustyline), it is now in a
+    // background process group and receives SIGTTOU, causing it to suspend.
+    // `-l` (login) is sufficient to source profile files where PATH is set.
     let mut child = if is_flatpak() {
         flatpak_spawn_process()
-            .args([&shell, "-l", "-i", "-c", "echo $PATH"])
+            .args([&shell, "-l", "-c", "echo $PATH"])
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
@@ -178,7 +184,7 @@ fn resolve_login_shell_path() -> Option<String> {
             .ok()?
     } else {
         std::process::Command::new(&shell)
-            .args(["-l", "-i", "-c", "echo $PATH"])
+            .args(["-l", "-c", "echo $PATH"])
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())


### PR DESCRIPTION
**Category:** fix
**User Impact:** The CLI no longer randomly suspends with "suspended (tty output)" when starting a session.

**Problem:** Since #8631 ("warm shell PATH lookup during session init"), goose eagerly spawns `zsh -l -i -c "echo $PATH"` during startup to resolve the user's PATH. The `-i` (interactive) flag causes zsh to call `tcsetpgrp()`, stealing the foreground process group from goose. When rustyline then calls `tcsetattr` to enter raw mode for the input prompt, goose is in a background process group and the kernel sends SIGTTOU, immediately suspending the CLI.

**Solution:** Drop the `-i` flag from both call sites. The `-l` (login) flag alone is sufficient to source `.zprofile`/`.bash_profile` where PATH is configured. Interactive mode is unnecessary and actively harmful when the spawned shell shares a controlling terminal with the parent process.

<details>
<summary>File changes</summary>

**crates/goose/src/agents/platform_extensions/developer/shell.rs**
Removed `-i` from the shell args in `resolve_login_shell_path()` for both the flatpak and normal code paths. Added a comment explaining why interactive mode must not be used.

**crates/goose-mcp/src/subprocess.rs**
Same fix for the equivalent `resolve_login_shell_path()` used by MCP extension subprocesses.

</details>

## Reproduction Steps

1. Build: `cargo build --release -p goose-cli`
2. Open a fresh terminal tab
3. Run `./target/release/goose`
4. Before this fix: the CLI prints the banner then immediately suspends with `suspended (tty output)`
5. After this fix: the CLI prints the banner and shows the input prompt normally
