### PR TITLE
Add FuturMix provider

### DIFF
--- a/crates/goose/src/providers/declarative/futurmix.json
+++ b/crates/goose/src/providers/declarative/futurmix.json
@@ -1,0 +1,36 @@
+{
+  "name": "futurmix",
+  "engine": "openai",
+  "display_name": "FuturMix",
+  "description": "Unified AI gateway with OpenAI-compatible API supporting models from Anthropic, Google, and OpenAI",
+  "api_key_env": "FUTURMIX_API_KEY",
+  "base_url": "https://futurmix.ai/v1/chat/completions",
+  "models": [
+    {
+      "name": "claude-sonnet-4-20250514",
+      "context_limit": 200000,
+      "max_tokens": 16384
+    },
+    {
+      "name": "gpt-4o",
+      "context_limit": 128000,
+      "max_tokens": 16384
+    },
+    {
+      "name": "gemini-2.5-pro",
+      "context_limit": 1048576,
+      "max_tokens": 65536
+    },
+    {
+      "name": "deepseek-chat",
+      "context_limit": 131072,
+      "max_tokens": 8192
+    },
+    {
+      "name": "claude-haiku-4-20250514",
+      "context_limit": 200000,
+      "max_tokens": 16384
+    }
+  ],
+  "supports_streaming": true
+}

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -30,6 +30,7 @@ goose is compatible with a wide range of LLM providers, allowing you to choose a
 | [ChatGPT Codex](https://chatgpt.com/codex) | Access GPT-5 Codex models optimized for code generation and understanding. **Requires a ChatGPT Plus/Pro subscription.** | No manual key. Uses browser-based OAuth authentication for both CLI and Desktop. |
 | [Databricks](https://www.databricks.com/)                                   | Unified data analytics and AI platform for building and deploying models.                                                                                                                                                 | `DATABRICKS_HOST`, `DATABRICKS_TOKEN` |
 | [Docker Model Runner](https://docs.docker.com/ai/model-runner/)                             | Local models running in Docker Desktop or Docker CE with OpenAI-compatible API endpoints. **Because this provider runs locally, you must first [download a model](#local-llms).**                     | `OPENAI_HOST`, `OPENAI_BASE_PATH`   |
+| [FuturMix](https://futurmix.ai/)                                            | Unified AI gateway providing access to models from Anthropic, Google, OpenAI, and DeepSeek through an OpenAI-compatible API.                                                                          | `FUTURMIX_API_KEY`                                                                                                                                                                  |
 | [Gemini](https://ai.google.dev/gemini-api/docs)                             | Advanced LLMs by Google with multimodal capabilities (text, images). Gemini 3 models support configurable [thinking levels](#gemini-3-thinking-levels).                                                                                                | `GOOGLE_API_KEY`, `GEMINI3_THINKING_LEVEL` (optional)                                                                                                                              |
 | [GCP Vertex AI](https://cloud.google.com/vertex-ai)                         | Google Cloud's Vertex AI platform, supporting Gemini and Claude models. **Credentials must be [configured in advance](https://cloud.google.com/vertex-ai/docs/authentication).** Filters for allowed models by organization policy (if configured). | `GCP_PROJECT_ID`, `GCP_LOCATION` and optionally `GCP_MAX_RATE_LIMIT_RETRIES` (5), `GCP_MAX_OVERLOADED_RETRIES` (5), `GCP_INITIAL_RETRY_INTERVAL_MS` (5000), `GCP_BACKOFF_MULTIPLIER` (2.0), `GCP_MAX_RETRY_INTERVAL_MS` (320_000). |
 | [GitHub Copilot](https://docs.github.com/en/copilot/using-github-copilot/ai-models) | Access to AI models from OpenAI, Anthropic, Google, and other providers through GitHub's Copilot infrastructure. **GitHub account with Copilot access required.** | No manual key. Uses [device flow authentication](#github-copilot-authentication) for both CLI and Desktop. |
@@ -691,6 +692,45 @@ To set up Groq with goose, follow these steps:
     3. Follow the prompts to choose `Groq` as the provider.
     4. Enter your API key when prompted.
     5. Select the Groq model of your choice.
+  </TabItem>
+</Tabs>
+
+### FuturMix
+[FuturMix](https://futurmix.ai/) is a unified AI gateway providing access to models from Anthropic, Google, OpenAI, and DeepSeek through an OpenAI-compatible API. To use FuturMix with goose, you need an API key from [FuturMix](https://futurmix.ai/).
+
+FuturMix offers models that support tool calling, including:
+- **claude-sonnet-4-20250514** - Anthropic Claude Sonnet 4 with 200K context
+- **gpt-4o** - OpenAI GPT-4o with 128K context
+- **gemini-2.5-pro** - Google Gemini 2.5 Pro with 1M context
+- **deepseek-chat** - DeepSeek V3 with 131K context
+- **claude-haiku-4-20250514** - Anthropic Claude Haiku 4 with 200K context
+
+For the complete list of supported FuturMix models, see [futurmix.json](https://github.com/aaif-goose/goose/blob/main/crates/goose/src/providers/declarative/futurmix.json).
+
+To set up FuturMix with goose, follow these steps:
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  **To update your LLM provider and API key:** 
+
+    1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar.
+    2. Click the `Settings` button on the sidebar.
+    3. Click the `Models` tab.
+    4. Click `Configure Providers`
+    5. Choose `FuturMix` as provider from the list.
+    6. Click `Configure`, enter your API key, and click `Submit`.
+    7. Select the FuturMix model of your choice.
+
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    1. Run: 
+    ```sh
+    goose configure
+    ```
+    2. Select `Configure Providers` from the menu.
+    3. Follow the prompts to choose `FuturMix` as the provider.
+    4. Enter your API key when prompted.
+    5. Select the FuturMix model of your choice.
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
## Summary

Adds [FuturMix](https://futurmix.ai/) as a declarative provider for goose.

FuturMix is an enterprise AI agent platform with an OpenAI-compatible API that provides access to models from Anthropic, Google, OpenAI, and DeepSeek.

### Changes

- **`crates/goose/src/providers/declarative/futurmix.json`** — Declarative provider config following the existing pattern (groq.json, novita.json). Includes 5 models: Claude Sonnet 4, GPT-4o, Gemini 2.5 Pro, DeepSeek Chat, and Claude Haiku 4.
- **`documentation/docs/getting-started/providers.md`** — Added FuturMix to the provider table and a setup section with Desktop/CLI instructions.

### Configuration

| Parameter | Value |
|-----------|-------|
| Engine | `openai` |
| API Key Env | `FUTURMIX_API_KEY` |
| Base URL | (see [futurmix.ai](https://futurmix.ai))chat/completions` |
| Streaming | Supported |

### Test plan

- [ ] Verify `futurmix.json` is auto-discovered by the declarative provider registry
- [ ] Confirm `goose configure` lists FuturMix as a provider option
- [ ] Test streaming chat completion with a FuturMix API key
- [ ] Verify documentation renders correctly