### PR TITLE
fix: convert quoted numeric config values to numbers if needed

### DIFF
--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -732,10 +732,20 @@ impl Config {
         }
 
         let values = self.load()?;
-        values
+        let value = values
             .get(key)
-            .ok_or_else(|| ConfigError::NotFound(key.to_string()))
-            .and_then(|v| Ok(serde_yaml::from_value(v.clone())?))
+            .ok_or_else(|| ConfigError::NotFound(key.to_string()))?;
+
+        match serde_yaml::from_value(value.clone()) {
+            Ok(value) => Ok(value),
+            Err(yaml_err) => {
+                let Some(string_value) = value.as_str() else {
+                    return Err(yaml_err.into());
+                };
+                let parsed = Self::parse_env_value(string_value)?;
+                serde_json::from_value(parsed).map_err(|_| yaml_err.into())
+            }
+        }
     }
 
     fn load_defaults(&self) -> Option<Mapping> {
@@ -1162,6 +1172,54 @@ mod tests {
 
         let result: Result<String, ConfigError> = config.get_param("nonexistent_key");
         assert!(matches!(result, Err(ConfigError::NotFound(_))));
+    }
+
+    #[test]
+    fn test_get_param_reads_numeric_yaml_as_u64() -> Result<(), ConfigError> {
+        let _guard = env_lock::lock_env([("XXX_TIMEOUT", None::<&str>)]);
+        let config = new_test_config();
+
+        config.set_param("XXX_TIMEOUT", 300_u64)?;
+
+        let value: u64 = config.get_param("XXX_TIMEOUT")?;
+        assert_eq!(value, 300);
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_param_reads_quoted_numeric_yaml_as_u64() -> Result<(), ConfigError> {
+        let _guard = env_lock::lock_env([("XXX_TIMEOUT", None::<&str>)]);
+        let config = new_test_config();
+
+        config.set_param("XXX_TIMEOUT", "300")?;
+
+        let value: u64 = config.get_param("XXX_TIMEOUT")?;
+        assert_eq!(value, 300);
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_param_reads_quoted_numeric_yaml_as_string() -> Result<(), ConfigError> {
+        let _guard = env_lock::lock_env([("XXX_TIMEOUT", None::<&str>)]);
+        let config = new_test_config();
+
+        config.set_param("XXX_TIMEOUT", "300")?;
+
+        let value: String = config.get_param("XXX_TIMEOUT")?;
+        assert_eq!(value, "300");
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_param_rejects_invalid_string_as_u64() -> Result<(), ConfigError> {
+        let _guard = env_lock::lock_env([("XXX_TIMEOUT", None::<&str>)]);
+        let config = new_test_config();
+
+        config.set_param("XXX_TIMEOUT", "invalid")?;
+
+        let result: Result<u64, ConfigError> = config.get_param("XXX_TIMEOUT");
+        assert!(matches!(result, Err(ConfigError::DeserializeError(_))));
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Summary

  Fix typed config reads so provider timeout values stored as strings can be used as numbers.

  Provider config values are currently stored in `config.yaml` as strings, which means entries like:

  ```yaml
  OLLAMA_TIMEOUT: '1200'
  ```
  failed to convert to u64 when provider code read them as numeric values. This now works for provider timeout configs such as OPENAI_TIMEOUT, OLLAMA_TIMEOUT, and
  LITELLM_TIMEOUT.

  ## Context

  A follow-up in #8437 reported that timeout values written with quotes in config.yaml were ignored unless the quotes were removed manually:
  https://github.com/aaif-goose/goose/issues/8437#issuecomment-4291079539

Problem exist in version 1.32.0

  ## Changes

  - Keep normal YAML deserialization as the first path.
  - If typed YAML deserialization fails for a string scalar, parse it with the same scalar parsing used for environment variables.
  - Preserve string behavior when callers request String.
  - Add tests for numeric YAML values, quoted numeric YAML values, and invalid quoted numeric values.

  ## Testing
  - cargo test -p goose providers::
  - cargo test -p goose config::base::tests

Ollama provider specific test. Set timeout to 6000 via goose desktop app. 
OLLAMA_TIMEOUT: '6000' is written to the config .yaml. It has quotes around it, causing it to be ignored before this fix. With this fix the timeout value is respected.

### Related Issues
Relates to #8437
[problem report](https://github.com/aaif-goose/goose/issues/8437#issuecomment-4318175576)


