### PR TITLE
Add "Trimmed trailing whitespace" message to moim whitelist

### DIFF
--- a/crates/goose/src/agents/moim.rs
+++ b/crates/goose/src/agents/moim.rs
@@ -36,6 +36,7 @@ pub async fn inject_moim(
             !issue.contains("Merged consecutive user messages")
                 && !issue.contains("Merged consecutive assistant messages")
                 && !issue.contains("Added placeholder to empty tool result")
+                && !issue.contains("Trimmed trailing whitespace from assistant message")
         });
 
         if has_unexpected_issues {


### PR DESCRIPTION
## Summary

Some language models produce trailing whitespace/newlines in its assistant messages. `fix_conversation` catches this as "Trimmed trailing whitespace from assistant message".

However, MOIM's allowed-issues guard (moim.rs:35) only whitelisted "Merged consecutive …" and "Added placeholder to empty tool result". The trailing-whitespace issue was therefore classified as unexpected, causing MOIM to return conversation — the original, unfixed conversation — rather than fixed.

Added "Trimmed trailing whitespace from assistant message" to the whitelist. MOIM now returns the fully fixed conversation, including the "(empty result)" placeholder, so model receives a well-formed message history and
continues calling tools.

### Testing

Tested with goose-cli with various models that caused the issue, QWEN3.5-35B, QWEN3.5-27B... Warning is gone.