### PR TITLE
fix(release): look for .dmg in the right place

### DIFF
--- a/.github/workflows/release-goose2.yml
+++ b/.github/workflows/release-goose2.yml
@@ -163,7 +163,7 @@ jobs:
             release/goose-*.tar.bz2
             release/goose-*.tar.gz
             release/goose-*.zip
-            release/*.dmg
+            release/**/*.dmg
             release/*.exe
             release/*.msi
             release/*.deb
@@ -181,7 +181,7 @@ jobs:
             release/goose-*.tar.bz2
             release/goose-*.tar.gz
             release/goose-*.zip
-            release/*.dmg
+            release/**/*.dmg
             release/*.exe
             release/*.msi
             release/*.deb


### PR DESCRIPTION
.dmgs are up/downloaded at `release/dmg`, so we need to look for them there when creating a release artifact.