### PR TITLE
fix: correct WSL2 OS detection by removing PWD-based Windows override

### DIFF
--- a/download_cli.sh
+++ b/download_cli.sh
@@ -59,14 +59,8 @@ OUT_FILE="goose"
 if [[ "${WINDIR:-}" ]] || [[ "${windir:-}" ]] || [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
     # Native Windows environments - use Windows user profile path
     DEFAULT_BIN_DIR="$USERPROFILE/goose"
-elif [[ -f "/proc/version" ]] && grep -q "Microsoft\|WSL" /proc/version 2>/dev/null; then
-    # WSL - use Linux-style path but make sure it exists
-    DEFAULT_BIN_DIR="$HOME/.local/bin"
-elif [[ "$PWD" =~ ^/mnt/[a-zA-Z]/ ]]; then
-    # WSL mount point detection
-    DEFAULT_BIN_DIR="$HOME/.local/bin"
 else
-    # Default for Linux/macOS
+    # Linux, macOS, and WSL all use the same bin directory
     DEFAULT_BIN_DIR="$HOME/.local/bin"
 fi
 
@@ -101,32 +95,11 @@ else
   if [[ "${WINDIR:-}" ]] || [[ "${windir:-}" ]] || [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
     OS="windows"
   elif [[ -f "/proc/version" ]] && grep -q "Microsoft\|WSL" /proc/version 2>/dev/null; then
-    # WSL detected. Prefer Linux unless there are clear signs we should install the Windows build:
-    # - running on a Windows-mounted path like /mnt/c/...   OR
-    # - Windows executables are available AND we're on a Windows mount
-    if [[ "$PWD" =~ ^/mnt/[a-zA-Z]/ ]]; then
-      OS="windows"
-    else
-      # If powershell/cmd exist, only treat as Windows when in a Windows mount
-      if command -v powershell.exe >/dev/null 2>&1 || command -v cmd.exe >/dev/null 2>&1; then
-        if [[ "$PWD" =~ ^/mnt/[a-zA-Z]/ ]] || [[ -d "/c" || -d "/d" || -d "/e" ]]; then
-          OS="windows"
-        else
-          OS="linux"
-        fi
-      else
-        # No strong Windows interop present — install Linux build inside WSL by default
-        OS="linux"
-      fi
-    fi
-  elif [[ "$PWD" =~ ^/mnt/[a-zA-Z]/ ]]; then
-    # WSL mount point detection (like /mnt/c/) outside of /proc/version check
-    OS="windows"
+    # WSL is a Linux environment regardless of the current working directory.
+    # The PWD (e.g. /mnt/c/) does not change the kernel — always install Linux.
+    OS="linux"
   elif [[ "$OSTYPE" == "darwin"* ]]; then
     OS="darwin"
-  elif command -v powershell.exe >/dev/null 2>&1 || command -v cmd.exe >/dev/null 2>&1; then
-    # Presence of Windows executables (likely a Windows environment)
-    OS="windows"
   elif [[ "$PWD" =~ ^/[a-zA-Z]/ ]] && [[ -d "/c" || -d "/d" || -d "/e" ]]; then
     # Check for Windows-style mount points (like in Git Bash)
     OS="windows"


### PR DESCRIPTION
## Summary
Fixes a bug in download_cli.sh where WSL2 was incorrectly detected as Windows when executed from a Windows-mounted directory (e.g., /mnt/c/...).
The script previously used $PWD to decide whether to install the Windows or Linux build of goose. In WSL2, uname -s correctly reports "Linux", but the script was overriding this based on the current working directory path. This caused:

- Download of goose-x86_64-pc-windows-msvc.zip instead of the Linux binary
- Installation of a .exe file into a Linux binary path ($HOME/.local/bin/)
- Attempts to use Windows-specific configuration paths (AppData\Roaming)

### Testing
- Verified bash -n download_cli.sh passes syntax check
- Manual review of all OS detection branches:
  - Native Windows (WINDIR, msys, cygwin): still detects as windows
  - WSL (from /mnt/c/... or Linux paths): now correctly detects as linux

### Related Issues
Relates to #8672 


### Screenshots/Demos (for UX changes)
After:   
<img width="897" height="407" alt="image" src="https://github.com/user-attachments/assets/ef9c95cb-8e4c-440d-8a1a-69ea3d3f8c46" />

<img width="844" height="119" alt="image" src="https://github.com/user-attachments/assets/8c16d178-01e9-4a7e-98b0-781466604042" />

