### PR TITLE
fix(cli): emit cumulative token usage in stream-json/json complete event

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -1281,15 +1281,9 @@ impl CliSession {
                 .await
             {
                 Ok(session) => JsonMetadata {
-                    total_tokens: session
-                        .accumulated_total_tokens
-                        .or(session.total_tokens),
-                    input_tokens: session
-                        .accumulated_input_tokens
-                        .or(session.input_tokens),
-                    output_tokens: session
-                        .accumulated_output_tokens
-                        .or(session.output_tokens),
+                    total_tokens: session.accumulated_total_tokens.or(session.total_tokens),
+                    input_tokens: session.accumulated_input_tokens.or(session.input_tokens),
+                    output_tokens: session.accumulated_output_tokens.or(session.output_tokens),
                     status: "completed".to_string(),
                 },
                 Err(_) => JsonMetadata {

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -64,11 +64,6 @@ struct JsonOutput {
 
 #[derive(Serialize, Deserialize, Debug)]
 struct JsonMetadata {
-    /// Cumulative tokens across the whole session (sum of every LLM round-trip).
-    /// Mirrors `Session::accumulated_total_tokens`, **not** `Session::total_tokens`
-    /// (which is the last-turn context size and gets overwritten / reset on
-    /// compaction — see `update_session_metrics` in
-    /// `goose/src/agents/reply_parts.rs`).
     total_tokens: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     input_tokens: Option<i32>,
@@ -91,9 +86,6 @@ enum StreamEvent {
     Error {
         error: String,
     },
-    /// Emitted once at end of a `goose run` in `--output-format stream-json`.
-    /// `total_tokens` is the **cumulative** session usage
-    /// (`Session::accumulated_total_tokens`), not the last-turn context size.
     Complete {
         total_tokens: Option<i32>,
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -64,7 +64,16 @@ struct JsonOutput {
 
 #[derive(Serialize, Deserialize, Debug)]
 struct JsonMetadata {
+    /// Cumulative tokens across the whole session (sum of every LLM round-trip).
+    /// Mirrors `Session::accumulated_total_tokens`, **not** `Session::total_tokens`
+    /// (which is the last-turn context size and gets overwritten / reset on
+    /// compaction — see `update_session_metrics` in
+    /// `goose/src/agents/reply_parts.rs`).
     total_tokens: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    input_tokens: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output_tokens: Option<i32>,
     status: String,
 }
 
@@ -82,8 +91,15 @@ enum StreamEvent {
     Error {
         error: String,
     },
+    /// Emitted once at end of a `goose run` in `--output-format stream-json`.
+    /// `total_tokens` is the **cumulative** session usage
+    /// (`Session::accumulated_total_tokens`), not the last-turn context size.
     Complete {
         total_tokens: Option<i32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        input_tokens: Option<i32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        output_tokens: Option<i32>,
     },
 }
 
@@ -1265,11 +1281,21 @@ impl CliSession {
                 .await
             {
                 Ok(session) => JsonMetadata {
-                    total_tokens: session.total_tokens,
+                    total_tokens: session
+                        .accumulated_total_tokens
+                        .or(session.total_tokens),
+                    input_tokens: session
+                        .accumulated_input_tokens
+                        .or(session.input_tokens),
+                    output_tokens: session
+                        .accumulated_output_tokens
+                        .or(session.output_tokens),
                     status: "completed".to_string(),
                 },
                 Err(_) => JsonMetadata {
                     total_tokens: None,
+                    input_tokens: None,
+                    output_tokens: None,
                     status: "completed".to_string(),
                 },
             };
@@ -1279,15 +1305,26 @@ impl CliSession {
             };
             println!("{}", serde_json::to_string_pretty(&json_output)?);
         } else if is_stream_json_mode {
-            let total_tokens = self
+            let session = self
                 .agent
                 .config
                 .session_manager
                 .get_session(&self.session_id, false)
                 .await
-                .ok()
-                .and_then(|s| s.total_tokens);
-            emit_stream_event(&StreamEvent::Complete { total_tokens });
+                .ok();
+            let (total_tokens, input_tokens, output_tokens) = match session {
+                Some(s) => (
+                    s.accumulated_total_tokens.or(s.total_tokens),
+                    s.accumulated_input_tokens.or(s.input_tokens),
+                    s.accumulated_output_tokens.or(s.output_tokens),
+                ),
+                None => (None, None, None),
+            };
+            emit_stream_event(&StreamEvent::Complete {
+                total_tokens,
+                input_tokens,
+                output_tokens,
+            });
         } else {
             println!();
         }


### PR DESCRIPTION
## Summary
The `complete` event in `goose run --output-format stream-json` (and `metadata.total_tokens` in `--output-format json`) reports `Session::total_tokens`, which is the **last turn's** context size, it gets overwritten every LLM round-trip and reset to the summary output count after compaction (see `update_session_metrics` in `crates/goose/src/agents/reply_parts.rs`).

Downstream tools (eval harnesses, billing dashboards) interpret `total_tokens` as the cumulative session cost, so they under-report by an order of magnitude on multi-turn runs. We hit this in our eval harness where a session that streamed thousands of chunks reported `total_tokens=17099`, actually just the final-turn context.

**Fix:** read `Session::accumulated_total_tokens` (the true running sum), with `total_tokens` as a fallback for legacy/empty sessions. Also surface `input_tokens` / `output_tokens` so consumers can split prompt vs. completion cost without re-deriving them.

**Backwards compatible:** `total_tokens` keeps its name and position; existing consumers see a *correct* number where they previously saw an under-count. The two new fields are `Option<i32>` with `skip_serializing_if = "Option::is_none"` — omitted when unset, so no parser breakage.

**Files touched:** `crates/goose-cli/src/session/mod.rs` (`JsonMetadata`, `StreamEvent::Complete`, both emit sites).

### Testing
- [x] `cargo check -p goose-cli` : clean (verified locally, ~3 min build)
- [ ] `cargo test -p goose-cli` : please run in CI
- [x] Manual: re-ran a multi-turn `goose run --output-format stream-json` against our eval harness and confirmed the emitted `total_tokens` now matches the cumulative provider-reported usage rather than the last-turn context size

### Related Issues
N/A : surfaced internally while debugging token under-reporting in an external eval harness consuming `--output-format stream-json`. Happy to file a tracking issue if preferred.

### Screenshots/Demos (for UX changes)
N/A : backend change, no UX surface.
