### PR TITLE
perf: deduplicate _goose/providers/list RPC call at startup

### DIFF
--- a/ui/goose2/src/app/hooks/useAppStartup.ts
+++ b/ui/goose2/src/app/hooks/useAppStartup.ts
@@ -47,46 +47,44 @@ export function useAppStartup() {
         }
       };
 
-      const loadProviders = async () => {
+      const loadProvidersAndInventory = async () => {
         const t0 = performance.now();
         store.setProvidersLoading(true);
-        try {
-          const { discoverAcpProviders } = await import("@/shared/api/acp");
-          const providers = await discoverAcpProviders();
-          store.setProviders(providers);
-          perfLog(
-            `[perf:startup] loadProviders done in ${(performance.now() - t0).toFixed(1)}ms (n=${providers.length})`,
-          );
-        } catch (err) {
-          console.error("Failed to load ACP providers on startup:", err);
-        } finally {
-          store.setProvidersLoading(false);
-        }
-      };
-
-      const loadProviderInventory = async () => {
-        const t0 = performance.now();
         inventoryStore.setLoading(true);
         try {
           const { getProviderInventory } = await import(
             "@/features/providers/api/inventory"
           );
           const entries = await getProviderInventory();
+
+          // Populate inventory store
           inventoryStore.setEntries(entries);
+
+          // Derive ACP providers from the same response
+          const { discoverAcpProvidersFromEntries } = await import(
+            "@/shared/api/acp"
+          );
+          const providers = discoverAcpProvidersFromEntries(entries);
+          store.setProviders(providers);
+
           perfLog(
-            `[perf:startup] loadProviderInventory done in ${(performance.now() - t0).toFixed(1)}ms (n=${entries.length})`,
+            `[perf:startup] loadProvidersAndInventory done in ${(performance.now() - t0).toFixed(1)}ms (entries=${entries.length}, providers=${providers.length})`,
           );
           return entries;
         } catch (err) {
-          console.error("Failed to load provider inventory on startup:", err);
+          console.error(
+            "Failed to load providers and inventory on startup:",
+            err,
+          );
           return [];
         } finally {
+          store.setProvidersLoading(false);
           inventoryStore.setLoading(false);
         }
       };
 
       const refreshConfiguredProviderInventory = async (
-        initialEntries?: Awaited<ReturnType<typeof loadProviderInventory>>,
+        initialEntries?: Awaited<ReturnType<typeof loadProvidersAndInventory>>,
       ) => {
         try {
           const entries =
@@ -146,15 +144,14 @@ export function useAppStartup() {
         setActiveSession(null);
       };
 
-      const inventoryLoad = loadProviderInventory();
+      const providersAndInventoryLoad = loadProvidersAndInventory();
 
       await Promise.allSettled([
         loadPersonas(),
-        loadProviders(),
-        inventoryLoad,
+        providersAndInventoryLoad,
         loadSessionState(),
       ]);
-      void inventoryLoad.then((entries) =>
+      void providersAndInventoryLoad.then((entries) =>
         refreshConfiguredProviderInventory(entries),
       );
       perfLog(

--- a/ui/goose2/src/app/hooks/useAppStartup.ts
+++ b/ui/goose2/src/app/hooks/useAppStartup.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useAgentStore } from "@/features/agents/stores/agentStore";
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
 import { useProviderInventoryStore } from "@/features/providers/stores/providerInventoryStore";
+import { discoverAcpProvidersFromEntries } from "@/shared/api/acp";
 import { setNotificationHandler, getClient } from "@/shared/api/acpConnection";
 import notificationHandler from "@/shared/api/acpNotificationHandler";
 import { perfLog } from "@/shared/lib/perfLog";
@@ -61,9 +62,6 @@ export function useAppStartup() {
           inventoryStore.setEntries(entries);
 
           // Derive ACP providers from the same response
-          const { discoverAcpProvidersFromEntries } = await import(
-            "@/shared/api/acp"
-          );
           const providers = discoverAcpProvidersFromEntries(entries);
           store.setProviders(providers);
 

--- a/ui/goose2/src/shared/api/acp.ts
+++ b/ui/goose2/src/shared/api/acp.ts
@@ -1,6 +1,6 @@
 import type { ContentBlock } from "@agentclientprotocol/sdk";
 import * as directAcp from "./acpApi";
-import { buildProviderListFromEntries, type AcpSessionInfo } from "./acpApi";
+import type { AcpSessionInfo } from "./acpApi";
 import * as sessionTracker from "./acpSessionTracker";
 import {
   getCatalogEntry,
@@ -48,7 +48,9 @@ export async function discoverAcpProviders(): Promise<AcpProvider[]> {
 export function discoverAcpProvidersFromEntries(
   entries: Array<{ providerId: string; providerName: string }>,
 ): AcpProvider[] {
-  return resolveProvidersCatalog(buildProviderListFromEntries(entries));
+  return resolveProvidersCatalog(
+    directAcp.buildProviderListFromEntries(entries),
+  );
 }
 
 function resolveProvidersCatalog(providers: AcpProvider[]): AcpProvider[] {

--- a/ui/goose2/src/shared/api/acp.ts
+++ b/ui/goose2/src/shared/api/acp.ts
@@ -38,6 +38,31 @@ export interface AcpCreateSessionOptions extends AcpPrepareSessionOptions {
 /** Discover ACP providers installed on the system. */
 export async function discoverAcpProviders(): Promise<AcpProvider[]> {
   const providers = await directAcp.listProviders();
+  return resolveProvidersCatalog(providers);
+}
+
+/**
+ * Derive ACP providers from already-fetched inventory entries,
+ * avoiding a duplicate `_goose/providers/list` RPC.
+ */
+export function discoverAcpProvidersFromEntries(
+  entries: Array<{ providerId: string; providerName: string }>,
+): AcpProvider[] {
+  const DEPRECATED_PROVIDER_IDS = new Set([
+    "claude-code",
+    "codex",
+    "gemini-cli",
+  ]);
+  const providers: AcpProvider[] = [
+    { id: "goose", label: "Goose (Default)" },
+    ...entries
+      .filter((entry) => !DEPRECATED_PROVIDER_IDS.has(entry.providerId))
+      .map((entry) => ({ id: entry.providerId, label: entry.providerName })),
+  ];
+  return resolveProvidersCatalog(providers);
+}
+
+function resolveProvidersCatalog(providers: AcpProvider[]): AcpProvider[] {
   const seen = new Set<string>();
 
   return providers

--- a/ui/goose2/src/shared/api/acp.ts
+++ b/ui/goose2/src/shared/api/acp.ts
@@ -1,6 +1,10 @@
 import type { ContentBlock } from "@agentclientprotocol/sdk";
 import * as directAcp from "./acpApi";
-import type { AcpSessionInfo } from "./acpApi";
+import {
+  DEPRECATED_PROVIDER_IDS,
+  DEFAULT_PROVIDER,
+  type AcpSessionInfo,
+} from "./acpApi";
 import * as sessionTracker from "./acpSessionTracker";
 import {
   getCatalogEntry,
@@ -48,13 +52,8 @@ export async function discoverAcpProviders(): Promise<AcpProvider[]> {
 export function discoverAcpProvidersFromEntries(
   entries: Array<{ providerId: string; providerName: string }>,
 ): AcpProvider[] {
-  const DEPRECATED_PROVIDER_IDS = new Set([
-    "claude-code",
-    "codex",
-    "gemini-cli",
-  ]);
   const providers: AcpProvider[] = [
-    { id: "goose", label: "Goose (Default)" },
+    DEFAULT_PROVIDER,
     ...entries
       .filter((entry) => !DEPRECATED_PROVIDER_IDS.has(entry.providerId))
       .map((entry) => ({ id: entry.providerId, label: entry.providerName })),

--- a/ui/goose2/src/shared/api/acp.ts
+++ b/ui/goose2/src/shared/api/acp.ts
@@ -1,10 +1,6 @@
 import type { ContentBlock } from "@agentclientprotocol/sdk";
 import * as directAcp from "./acpApi";
-import {
-  DEPRECATED_PROVIDER_IDS,
-  DEFAULT_PROVIDER,
-  type AcpSessionInfo,
-} from "./acpApi";
+import { buildProviderListFromEntries, type AcpSessionInfo } from "./acpApi";
 import * as sessionTracker from "./acpSessionTracker";
 import {
   getCatalogEntry,
@@ -52,13 +48,7 @@ export async function discoverAcpProviders(): Promise<AcpProvider[]> {
 export function discoverAcpProvidersFromEntries(
   entries: Array<{ providerId: string; providerName: string }>,
 ): AcpProvider[] {
-  const providers: AcpProvider[] = [
-    DEFAULT_PROVIDER,
-    ...entries
-      .filter((entry) => !DEPRECATED_PROVIDER_IDS.has(entry.providerId))
-      .map((entry) => ({ id: entry.providerId, label: entry.providerName })),
-  ];
-  return resolveProvidersCatalog(providers);
+  return resolveProvidersCatalog(buildProviderListFromEntries(entries));
 }
 
 function resolveProvidersCatalog(providers: AcpProvider[]): AcpProvider[] {

--- a/ui/goose2/src/shared/api/acpApi.ts
+++ b/ui/goose2/src/shared/api/acpApi.ts
@@ -27,8 +27,12 @@ export interface AcpSessionInfo {
   personaId: string | null;
 }
 
-const DEPRECATED_PROVIDER_IDS = new Set(["claude-code", "codex", "gemini-cli"]);
-const DEFAULT_PROVIDER: AcpProvider = {
+export const DEPRECATED_PROVIDER_IDS = new Set([
+  "claude-code",
+  "codex",
+  "gemini-cli",
+]);
+export const DEFAULT_PROVIDER: AcpProvider = {
   id: "goose",
   label: "Goose (Default)",
 };

--- a/ui/goose2/src/shared/api/acpApi.ts
+++ b/ui/goose2/src/shared/api/acpApi.ts
@@ -37,20 +37,30 @@ export const DEFAULT_PROVIDER: AcpProvider = {
   label: "Goose (Default)",
 };
 
+/**
+ * Build the ACP provider list from raw inventory entries.
+ *
+ * Shared by both `listProviders` (which fetches entries via RPC) and
+ * `discoverAcpProvidersFromEntries` in acp.ts (which reuses
+ * already-fetched entries at startup).
+ */
+export function buildProviderListFromEntries(
+  entries: Array<{ providerId: string; providerName: string }>,
+): AcpProvider[] {
+  return [
+    DEFAULT_PROVIDER,
+    ...entries
+      .filter((entry) => !DEPRECATED_PROVIDER_IDS.has(entry.providerId))
+      .map((entry) => ({ id: entry.providerId, label: entry.providerName })),
+  ];
+}
+
 export async function listProviders(): Promise<AcpProvider[]> {
   const client = await getClient();
   const result = await client.goose.GooseProvidersList({
     providerIds: [],
   });
-
-  const providers = result.entries
-    .filter((entry) => !DEPRECATED_PROVIDER_IDS.has(entry.providerId))
-    .map((entry) => ({
-      id: entry.providerId,
-      label: entry.providerName,
-    }));
-
-  return [DEFAULT_PROVIDER, ...providers];
+  return buildProviderListFromEntries(result.entries);
 }
 
 export async function listSessions(): Promise<AcpSessionInfo[]> {


### PR DESCRIPTION
## Summary
- Merged the separate `loadProviders` and `loadProviderInventory` startup calls into a single `loadProvidersAndInventory` function, eliminating a duplicate `_goose/providers/list` RPC
- Extracted a shared `buildProviderListFromEntries` helper in `acpApi.ts` so both the startup path and `listProviders` reuse the same logic
- Added `discoverAcpProvidersFromEntries` in `acp.ts` to derive ACP providers from already-fetched inventory entries without an extra network call

## Test plan
- [x] Existing tests pass (`pnpm test`)
- [x] Biome check and build pass
- [x] Verify startup loads providers and inventory correctly with a single RPC call
- [x] Confirm provider list in UI matches previous behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)