### PR TITLE
chore: disable spellcheck in model search

### DIFF
--- a/ui/goose2/src/features/chat/ui/AgentModelPicker.tsx
+++ b/ui/goose2/src/features/chat/ui/AgentModelPicker.tsx
@@ -12,6 +12,7 @@ import { useProviderInventoryStore } from "@/features/providers/stores/providerI
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
+import { SearchBar } from "@/shared/ui/SearchBar";
 import { ScrollArea } from "@/shared/ui/scroll-area";
 import { Spinner } from "@/shared/ui/spinner";
 import {
@@ -244,17 +245,14 @@ function AllModelsList({
         >
           <IconChevronLeft className="size-4" />
         </button>
-        <div className="relative min-w-0 flex-1">
-          <IconSearch className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
-          <input
-            ref={inputRef}
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder={t("toolbar.searchModels")}
-            className="h-7 w-full rounded-sm border bg-transparent pl-7 pr-2 text-sm outline-none placeholder:text-muted-foreground focus:ring-1 focus:ring-ring"
-          />
-        </div>
+        <SearchBar
+          inputRef={inputRef}
+          size="small"
+          value={query}
+          onChange={setQuery}
+          placeholder={t("toolbar.searchModels")}
+          className="min-w-0 flex-1"
+        />
       </div>
       {filtered.length > 0 ? (
         <ScrollArea className="min-h-0 min-w-0 flex-1">

--- a/ui/goose2/src/features/chat/ui/__tests__/AgentModelPicker.test.tsx
+++ b/ui/goose2/src/features/chat/ui/__tests__/AgentModelPicker.test.tsx
@@ -129,6 +129,34 @@ describe("AgentModelPicker", () => {
     expect(longModelButton).toHaveClass("overflow-hidden");
   });
 
+  it("disables spellcheck in the all-models search field", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <AgentModelPicker
+        agents={AGENTS}
+        selectedAgentId="goose"
+        onAgentChange={vi.fn()}
+        currentModelId="claude-sonnet-4"
+        currentModelName="Claude Sonnet 4"
+        availableModels={[
+          { id: "claude-sonnet-4", name: "Claude Sonnet 4", recommended: true },
+          { id: "gpt-4o-mini-2024-07-18", name: "GPT-4o mini" },
+        ]}
+        onModelChange={vi.fn()}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /choose agent and model/i }),
+    );
+    await user.click(screen.getByRole("button", { name: "Browse all models" }));
+
+    const search = screen.getByPlaceholderText("Search models...");
+
+    expect(search).toHaveAttribute("spellcheck", "false");
+  });
+
   it("shows only agent name when no model info is available", () => {
     render(
       <AgentModelPicker


### PR DESCRIPTION
**Category:** fix
**User Impact:** Users no longer see spelling suggestions while searching model IDs in the desktop app.
**Problem:** The all-models search field could trigger browser spellcheck even though users are often typing provider-specific model IDs. That made technical search terms look incorrect and added visual noise in the model picker.
**Solution:** The picker now uses the shared search component, which carries the intended search-input behavior consistently across the UI, and the behavior is covered by a focused test.

<details>
<summary>File changes</summary>

**ui/goose2/src/features/chat/ui/AgentModelPicker.tsx**
Replaced the custom all-models search input with the shared `SearchBar` component so the model picker inherits the app's standard search behavior, including disabled spellcheck.

**ui/goose2/src/features/chat/ui/__tests__/AgentModelPicker.test.tsx**
Added coverage that opens the all-models view and verifies the search field disables spellcheck.

</details>

### Reproduction Steps
1. Open the agent and model picker in the desktop UI.
2. Select "Browse all models" to open the full model list.
3. Focus the "Search models..." field and type a model-like identifier such as `gpt-4o-mini-2024-07-18`.
4. Confirm the search input does not show spelling suggestions or correction UI.


## before:
<img width="536" height="488" alt="image" src="https://github.com/user-attachments/assets/07d39220-a1d6-4508-af53-407a446bf77a" />


## after:
<img width="420" height="186" alt="image" src="https://github.com/user-attachments/assets/8d447afe-1f03-4963-aeaa-cb0fed55686d" />
