### PR TITLE
build: set LLAMA_STATIC_CRT for Windows CUDA

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -157,6 +157,7 @@ jobs:
         shell: pwsh
         env:
           CUDA_COMPUTE_CAP: ${{ matrix.variant == 'cuda' && '80' || '' }}
+          LLAMA_STATIC_CRT: ${{ matrix.variant == 'cuda' && '1' || '' }}
         run: |
           Write-Output "Building Windows CLI executable..."
           if ("${{ matrix.variant }}" -eq "cuda") {

--- a/.github/workflows/bundle-desktop-windows.yml
+++ b/.github/workflows/bundle-desktop-windows.yml
@@ -112,6 +112,7 @@ jobs:
         shell: pwsh
         env:
           CUDA_COMPUTE_CAP: ${{ inputs.windows_variant == 'cuda' && '80' || '' }}
+          LLAMA_STATIC_CRT: ${{ inputs.windows_variant == 'cuda' && '1' || '' }}
         run: |
           Write-Output "Building Windows executable..."
           if ("${{ inputs.windows_variant }}" -eq "cuda") {


### PR DESCRIPTION
fixes the CUDA build failure when cutting a release: https://github.com/aaif-goose/goose/actions/runs/25087875737/job/73507277991

