### PR TITLE
fix(oidc-proxy): validate exp independently of MAX_TOKEN_AGE_SECONDS (#8832)

### DIFF
--- a/oidc-proxy/src/index.js
+++ b/oidc-proxy/src/index.js
@@ -195,7 +195,9 @@ async function verifyOidcToken(token, env) {
       if (age > parseInt(env.MAX_TOKEN_AGE_SECONDS, 10)) {
         return { valid: false, reason: "Token too old" };
       }
-    } else if (!payload.exp || payload.exp < Date.now() / 1000) {
+    }
+
+    if (!payload.exp || payload.exp < Date.now() / 1000) {
       return { valid: false, reason: "Token expired" };
     }
 

--- a/oidc-proxy/test/index.test.js
+++ b/oidc-proxy/test/index.test.js
@@ -229,7 +229,7 @@ describe("proxies valid requests", () => {
     expect((await response.json()).id).toBe("msg_123");
   });
 
-  it("accepts recently-expired token within MAX_TOKEN_AGE_SECONDS", async () => {
+  it("rejects expired token even when within MAX_TOKEN_AGE_SECONDS", async () => {
     const now = Math.floor(Date.now() / 1000);
     const token = await createSignedJwt(
       validPayload({ iat: now - 600, exp: now - 300 }),
@@ -245,7 +245,8 @@ describe("proxies valid requests", () => {
     const response = await worker.fetch(request, testEnv(), ctx);
     await waitOnExecutionContext(ctx);
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(401);
+    expect((await response.json()).error).toBe("Token expired");
   });
 });
 


### PR DESCRIPTION
## Problem

When `MAX_TOKEN_AGE_SECONDS` is configured, the `exp` validation in `oidc-proxy/src/index.js` lives inside an `else if` branch that is only reached when `MAX_TOKEN_AGE_SECONDS` is **not** set. As a result, a validly-signed but expired token is accepted as long as it is within the max-age window.

## Fix

Split the two checks into independent `if` statements so both must pass:
- Token must not exceed `MAX_TOKEN_AGE_SECONDS` (when configured)
- Token must not be past its `exp` claim

## Test

Updated the existing test that inadvertently documented the bypass behavior. The test now correctly asserts that an expired token is rejected (401 "Token expired") even when it falls within `MAX_TOKEN_AGE_SECONDS`.

All 8 unit tests pass:

```
npm test
 ✓ test/index.test.js (8 tests) 70ms
```

## Checklist

- [x] Fix implemented
- [x] Unit test updated to cover the bypass case
- [x] DCO sign-off on commit

Fixes #8832
