### PR TITLE
Fix Gemini OAuth onboarding failure

### DIFF
--- a/crates/goose/src/providers/gemini_oauth.rs
+++ b/crates/goose/src/providers/gemini_oauth.rs
@@ -303,11 +303,15 @@ struct LoadCodeAssistResponse {
     cloudaicompanion_project: Option<String>,
     current_tier: Option<TierInfo>,
     onboard_tiers: Option<Vec<TierInfo>>,
+    allowed_tiers: Option<Vec<TierInfo>>,
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct TierInfo {
     id: Option<String>,
+    #[serde(default)]
+    is_default: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -424,7 +428,15 @@ async fn setup_code_assist(access_token: &str) -> Result<String> {
         .as_ref()
         .and_then(|tiers| tiers.first())
         .and_then(|t| t.id.clone())
-        .unwrap_or_else(|| "FREE".to_string());
+        .or_else(|| {
+            load_resp
+                .allowed_tiers
+                .as_ref()
+                .and_then(|tiers| tiers.iter().find(|t| t.is_default.unwrap_or(false)))
+                .or_else(|| load_resp.allowed_tiers.as_ref().and_then(|t| t.first()))
+                .and_then(|t| t.id.clone())
+        })
+        .unwrap_or_else(|| "free-tier".to_string());
 
     tracing::info!("Onboarding user with tier: {}", tier_id);
 

--- a/ui/desktop/src/components/settings/providers/modal/ProviderConfigurationModal.tsx
+++ b/ui/desktop/src/components/settings/providers/modal/ProviderConfigurationModal.tsx
@@ -213,9 +213,16 @@ export default function ProviderConfigurationModal({
           }
         }
       }
-      await configureProviderOauth({
+      const oauthResult = await configureProviderOauth({
         path: { name: provider.name },
       });
+      if (oauthResult.error) {
+        const err = oauthResult.error as Record<string, unknown>;
+        const errDetail = typeof oauthResult.error === 'string'
+          ? oauthResult.error
+          : (err?.message as string) ?? (err?.detail as string) ?? JSON.stringify(oauthResult.error);
+        throw new Error(errDetail);
+      }
       if (onConfigured) {
         onConfigured(provider);
       } else {


### PR DESCRIPTION
When choosing Gemini as a new Provider, the oauth seems to succeed in the browser, but then when returning to goose, it's not configured or available in the drop down.

## Root Cause
The Code Assist `loadCodeAssist` API returns `allowedTiers` (not `onboardTiers`) for new users. We were falling back to a hardcoded `"FREE"` tier ID that the `onboardUser` API rejects as an invalid argument.

**Fixes:**
- Parse `allowedTiers` from `loadCodeAssist` response, preferring the tier marked `isDefault`
- Default fallback changed from `"FREE"` to `"free-tier"`
- UI now surfaces OAuth errors instead of silently proceeding to model picker

## Before
<img width="1138" height="538" alt="image" src="https://github.com/user-attachments/assets/4c46118a-6b85-43eb-bf13-6859821eee7a" /><br>

<img width="998" height="610" alt="image" src="https://github.com/user-attachments/assets/10c845e8-e8d6-478c-94f1-d02f0f2b36bf" /><br>

<img width="990" height="794" alt="image" src="https://github.com/user-attachments/assets/fd7372d1-b826-43f2-9025-03b9ce7a2ac7" /><br>

<img width="1106" height="350" alt="image" src="https://github.com/user-attachments/assets/07b3cf51-8822-420f-8f9c-fa3a513b391b" />

## After

<img width="501" height="396" alt="image" src="https://github.com/user-attachments/assets/b2347125-6671-4011-a6be-a55b7d2c6326" />

