### PR TITLE
feat: make ollama host configurable in goose2

### DIFF
--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -122,6 +122,10 @@ fn apply_ollama_options(payload: &mut Value, model_config: &ModelConfig) {
     }
 }
 
+fn ollama_host_configured(config: &crate::config::Config) -> bool {
+    std::env::var("OLLAMA_HOST").is_ok() || config.get("OLLAMA_HOST", false).is_ok()
+}
+
 impl OllamaProvider {
     pub async fn from_env(model: ModelConfig) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -260,6 +264,10 @@ impl ProviderDef for OllamaProvider {
 
     fn supports_inventory_refresh() -> bool {
         true
+    }
+
+    fn inventory_configured() -> bool {
+        ollama_host_configured(crate::config::Config::global())
     }
 
     fn inventory_identity() -> Result<InventoryIdentityInput> {
@@ -464,6 +472,51 @@ fn stream_ollama(response: Response, mut log: RequestLog) -> Result<MessageStrea
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_ollama_host_default_does_not_mark_inventory_configured() {
+        let _guard = env_lock::lock_env([("OLLAMA_HOST", None::<&str>)]);
+        let config_file = tempfile::NamedTempFile::new().unwrap();
+        let secrets_file = tempfile::NamedTempFile::new().unwrap();
+        let config = crate::config::Config::new_with_config_paths(
+            vec![config_file.path().to_path_buf()],
+            secrets_file.path(),
+        )
+        .unwrap();
+
+        assert!(!ollama_host_configured(&config));
+    }
+
+    #[test]
+    fn test_ollama_host_env_marks_inventory_configured() {
+        let _guard = env_lock::lock_env([("OLLAMA_HOST", Some("http://127.0.0.1:11435"))]);
+        let config_file = tempfile::NamedTempFile::new().unwrap();
+        let secrets_file = tempfile::NamedTempFile::new().unwrap();
+        let config = crate::config::Config::new_with_config_paths(
+            vec![config_file.path().to_path_buf()],
+            secrets_file.path(),
+        )
+        .unwrap();
+
+        assert!(ollama_host_configured(&config));
+    }
+
+    #[test]
+    fn test_ollama_host_config_marks_inventory_configured() {
+        let _guard = env_lock::lock_env([("OLLAMA_HOST", None::<&str>)]);
+        let config_file = tempfile::NamedTempFile::new().unwrap();
+        let secrets_file = tempfile::NamedTempFile::new().unwrap();
+        let config = crate::config::Config::new_with_config_paths(
+            vec![config_file.path().to_path_buf()],
+            secrets_file.path(),
+        )
+        .unwrap();
+        config
+            .set_param("OLLAMA_HOST", "http://127.0.0.1:11435")
+            .unwrap();
+
+        assert!(ollama_host_configured(&config));
+    }
 
     #[test]
     fn test_apply_ollama_options_uses_input_limit() {

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -123,7 +123,7 @@ fn apply_ollama_options(payload: &mut Value, model_config: &ModelConfig) {
 }
 
 fn ollama_host_configured(config: &crate::config::Config) -> bool {
-    std::env::var("OLLAMA_HOST").is_ok() || config.get("OLLAMA_HOST", false).is_ok()
+    config.get_param::<String>("OLLAMA_HOST").is_ok()
 }
 
 impl OllamaProvider {

--- a/ui/goose2/src/features/providers/providerCatalog.test.ts
+++ b/ui/goose2/src/features/providers/providerCatalog.test.ts
@@ -1,5 +1,26 @@
 import { describe, expect, it } from "vitest";
-import { resolveAgentProviderCatalogId } from "./providerCatalog";
+import {
+  getCatalogEntry,
+  resolveAgentProviderCatalogId,
+} from "./providerCatalog";
+
+describe("provider catalog", () => {
+  it("exposes Ollama host configuration", () => {
+    const ollama = getCatalogEntry("ollama");
+
+    expect(ollama?.setupMethod).toBe("config_fields");
+    expect(ollama?.fields).toEqual([
+      {
+        key: "OLLAMA_HOST",
+        label: "Host",
+        secret: false,
+        required: true,
+        placeholder: "localhost or http://localhost:11434",
+        defaultValue: "http://localhost:11434",
+      },
+    ]);
+  });
+});
 
 describe("resolveAgentProviderCatalogId", () => {
   it("matches direct catalog ids", () => {

--- a/ui/goose2/src/features/providers/providerCatalog.ts
+++ b/ui/goose2/src/features/providers/providerCatalog.ts
@@ -6,7 +6,6 @@ import {
 } from "./providerCatalogAliases";
 
 export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
-  // ── Agent providers ──────────────────────────────────────────────
   {
     id: "goose",
     displayName: "Goose",
@@ -92,7 +91,6 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     showOnlyWhenInstalled: true,
   },
 
-  // ── Model providers (power Goose) ────────────────────────────────
   {
     id: "anthropic",
     displayName: "Anthropic",
@@ -164,8 +162,18 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     id: "ollama",
     displayName: "Ollama",
     category: "model",
-    description: "Run models locally",
-    setupMethod: "local",
+    description: "Run local or self-hosted models",
+    setupMethod: "config_fields",
+    fields: [
+      {
+        key: "OLLAMA_HOST",
+        label: "Host",
+        secret: false,
+        required: true,
+        placeholder: "localhost or http://localhost:11434",
+        defaultValue: "http://localhost:11434",
+      },
+    ],
     docsUrl: "https://ollama.com",
     tier: "promoted",
   },

--- a/ui/goose2/src/features/settings/ui/__tests__/ModelProviderRow.test.tsx
+++ b/ui/goose2/src/features/settings/ui/__tests__/ModelProviderRow.test.tsx
@@ -73,6 +73,37 @@ describe("ModelProviderRow", () => {
     ]);
   });
 
+  it("pre-fills and saves provider field defaults", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ModelProviderRow
+        provider={modelProvider("ollama", "not_configured")}
+        onGetConfig={onGetConfig}
+        onSaveFields={onSaveFields}
+        onRemoveConfig={onRemoveConfig}
+        onCompleteNativeSetup={onCompleteNativeSetup}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /ollama/i }));
+
+    expect(
+      await screen.findByDisplayValue("http://localhost:11434"),
+    ).toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => expect(onSaveFields).toHaveBeenCalledTimes(1));
+    expect(onSaveFields).toHaveBeenCalledWith([
+      {
+        key: "OLLAMA_HOST",
+        value: "http://localhost:11434",
+        isSecret: false,
+      },
+    ]);
+  });
+
   it("shows the connected row while model inventory is still loading", async () => {
     const user = userEvent.setup();
 

--- a/ui/goose2/src/features/settings/ui/modelProviderHelpers.tsx
+++ b/ui/goose2/src/features/settings/ui/modelProviderHelpers.tsx
@@ -49,7 +49,7 @@ export function createDraftValues(
       if (field.secret) {
         return [field.key, ""];
       }
-      return [field.key, currentValue?.value ?? ""];
+      return [field.key, currentValue?.value ?? field.defaultValue ?? ""];
     }),
   );
 }

--- a/ui/goose2/src/shared/types/providers.ts
+++ b/ui/goose2/src/shared/types/providers.ts
@@ -19,6 +19,7 @@ export interface ProviderField {
   secret: boolean;
   required: boolean;
   placeholder?: string;
+  defaultValue?: string;
 }
 
 export interface ProviderFieldValue {


### PR DESCRIPTION
**Category:** fix
**User Impact:** Users can configure Ollama with a custom host or port from goose2 instead of having it appear connected by default.
**Problem:** goose2 treated Ollama as connected because the backend default host counted as configured, even when users had not saved any Ollama settings. That made it unclear how to use a non-default Ollama host or port.
**Solution:** Ollama now reports configured status only when `OLLAMA_HOST` is explicitly set, and goose2 exposes a host field pre-filled with the effective local default so users can save or edit it.

<details>
<summary>File changes</summary>

**crates/goose/src/providers/ollama.rs**
Overrides Ollama inventory configuration status so the runtime fallback host does not make the provider appear configured. Adds focused tests for unset, environment, and saved-config host states.

**ui/goose2/src/features/providers/providerCatalog.ts**
Changes Ollama from a local zero-config entry to a configurable provider with an `OLLAMA_HOST` field and default host value.

**ui/goose2/src/features/providers/providerCatalog.test.ts**
Covers the Ollama catalog entry so the host field and default remain present.

**ui/goose2/src/features/settings/ui/ModelProviderRow.test.tsx**
Adds coverage that provider field defaults are pre-filled and saved from the setup form.

**ui/goose2/src/features/settings/ui/modelProviderHelpers.tsx**
Uses provider field defaults when initializing setup drafts and no saved config value exists.

**ui/goose2/src/shared/types/providers.ts**
Adds an optional `defaultValue` property to provider field metadata.

</details>

### Reproduction Steps

1. Open goose2 settings and go to model providers.
2. Expand Ollama before setting `OLLAMA_HOST`.
3. Confirm it is not shown as already connected and that the Host field is pre-filled with `http://localhost:11434`.
4. Change the Host field to a custom Ollama endpoint or keep the default, then save.
5. Confirm Ollama is marked connected and model inventory refresh starts for the saved host.

### Screenshots/Demos

Not included. The UI change is a settings form field and can be verified with the reproduction steps above.

### Verification

- `cargo fmt`
- `pnpm exec biome format --write ...`
- `git diff --check`
- `git push -u origin HEAD` pre-push checks passed, including goose2 `pnpm test`, `pnpm check`, `pnpm build`, Tauri `cargo fmt --check`, `cargo check`, and `cargo clippy -- -D warnings`.

## before:
<img width="810" height="623" alt="image" src="https://github.com/user-attachments/assets/04bd48d5-b768-423b-8483-d6d92aff1679" />

## after:
<img width="790" height="611" alt="image" src="https://github.com/user-attachments/assets/753020dc-b72a-4e4e-bf32-c0c9baf1c817" />
