### PR TITLE
feat: support google model inventory refresh

### DIFF
--- a/crates/goose/src/providers/google.rs
+++ b/crates/goose/src/providers/google.rs
@@ -1,7 +1,7 @@
 use super::api_client::{ApiClient, AuthMethod};
 use super::base::MessageStream;
 use super::errors::ProviderError;
-use super::openai_compatible::handle_status;
+use super::openai_compatible::{handle_status, map_http_error_to_provider_error};
 use super::retry::ProviderRetry;
 use super::utils::RequestLog;
 use crate::conversation::message::Message;
@@ -9,6 +9,7 @@ use crate::conversation::message::Message;
 use crate::model::ModelConfig;
 use crate::providers::base::{ConfigKey, Provider, ProviderDef, ProviderMetadata};
 use crate::providers::formats::google::{create_request, response_to_streaming_message};
+use crate::providers::inventory::{config_secret_value, InventoryIdentityInput};
 use anyhow::Result;
 use async_stream::try_stream;
 use async_trait::async_trait;
@@ -135,6 +136,27 @@ impl ProviderDef for GoogleProvider {
     ) -> BoxFuture<'static, Result<Self::Provider>> {
         Box::pin(Self::from_env(model))
     }
+
+    fn supports_inventory_refresh() -> bool {
+        true
+    }
+
+    fn inventory_identity() -> Result<InventoryIdentityInput> {
+        let config = crate::config::Config::global();
+        let mut identity = InventoryIdentityInput::new(GOOGLE_PROVIDER_NAME, GOOGLE_PROVIDER_NAME)
+            .with_public(
+                "host",
+                config
+                    .get_param::<String>("GOOGLE_HOST")
+                    .unwrap_or_else(|_| GOOGLE_API_HOST.to_string()),
+            );
+
+        if let Some(api_key) = config_secret_value(config, "GOOGLE_API_KEY") {
+            identity = identity.with_secret("api_key", api_key);
+        }
+
+        Ok(identity)
+    }
 }
 
 #[async_trait]
@@ -153,6 +175,13 @@ impl Provider for GoogleProvider {
             .request(None, "v1beta/models")
             .response_get()
             .await?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            let payload = serde_json::from_str::<serde_json::Value>(&body).ok();
+            return Err(map_http_error_to_provider_error(status, payload));
+        }
+
         let json: serde_json::Value = response.json().await?;
         let arr = json
             .get("models")


### PR DESCRIPTION
**Category:** fix
**User Impact:** Users setting up Google Gemini in goose2 now see model refresh and API key errors handled consistently with other providers.
**Problem:** Google Gemini credentials could be saved in goose2 without triggering the provider inventory refresh used by other model providers. Invalid Google API keys also produced a misleading missing models array error because the models response was parsed before checking the HTTP status.
**Solution:** Enable inventory refresh for the Google provider and include the relevant host/API key in its inventory identity. The Google model listing path now maps non-success responses before parsing the model list, so invalid keys surface the provider's actual error.

<details>
<summary>File changes</summary>

**crates/goose/src/providers/google.rs**
Adds Google provider support for ACP inventory refresh and identifies inventory entries by `GOOGLE_HOST` and `GOOGLE_API_KEY`. Updates model listing to handle non-success responses before parsing the `models` array, matching the behavior users expect from other providers.

</details>

### Reproduction Steps

1. Open goose2 provider settings and set up Google Gemini with an invalid API key.
2. Save the credentials and wait for the model refresh result.
3. Confirm the refresh warning shows the Google API key error instead of a missing `models` array message.
4. Set up Google Gemini with a valid API key and confirm model inventory refresh completes and Gemini models are listed.
