### PR TITLE
feat: update provider row after saving credentials

### DIFF
--- a/ui/goose2/src/features/settings/ui/ModelProviderRow.tsx
+++ b/ui/goose2/src/features/settings/ui/ModelProviderRow.tsx
@@ -78,7 +78,6 @@ export function ModelProviderRow({
   const [setupOutput, setSetupOutput] = useState<SetupOutputLine[]>([]);
   const [setupError, setSetupError] = useState("");
   const [showSavedState, setShowSavedState] = useState(false);
-  const [preserveSetupLayout, setPreserveSetupLayout] = useState(false);
   const setupLineCounter = useRef(0);
   const hasLoadedConfig = useRef(false);
   const shouldRestorePanelFocus = useRef(false);
@@ -170,7 +169,6 @@ export function ModelProviderRow({
     setEditingKey(null);
     setError("");
     setShowSavedState(false);
-    setPreserveSetupLayout(false);
 
     const unlisten = await onModelSetupOutput(provider.id, appendSetupOutput);
 
@@ -195,7 +193,6 @@ export function ModelProviderRow({
     setExpanded((current) => {
       if (current) {
         setShowSavedState(false);
-        setPreserveSetupLayout(false);
       }
       return !current;
     });
@@ -295,8 +292,7 @@ export function ModelProviderRow({
         })),
       );
       await loadConfig();
-      setShowSavedState(true);
-      setPreserveSetupLayout(true);
+      setShowSavedState(false);
     } catch (nextError) {
       setError(
         nextError instanceof Error ? nextError.message : "Failed to save",
@@ -312,7 +308,6 @@ export function ModelProviderRow({
       setEditingKey(null);
       setError("");
       setShowSavedState(false);
-      setPreserveSetupLayout(false);
     } catch (nextError) {
       setError(
         nextError instanceof Error ? nextError.message : "Failed to remove",
@@ -403,7 +398,7 @@ export function ModelProviderRow({
       );
     }
 
-    if (hasFields && isConnected && !preserveSetupLayout) {
+    if (hasFields && isConnected) {
       return (
         <ConnectedFieldsPanel
           panelRef={panelRef}

--- a/ui/goose2/src/features/settings/ui/__tests__/ModelProviderRow.test.tsx
+++ b/ui/goose2/src/features/settings/ui/__tests__/ModelProviderRow.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { ComponentType } from "react";
+import { useState, type ComponentType } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getModelProviders } from "@/features/providers/providerCatalog";
 import { ModelProviderRow } from "../ModelProviderRow";
@@ -109,5 +109,60 @@ describe("ModelProviderRow", () => {
     await user.click(screen.getByRole("button", { name: /anthropic/i }));
 
     expect(screen.getByText(/model refresh failed/i)).toBeInTheDocument();
+  });
+
+  it("switches from setup save to connected controls after first configuration", async () => {
+    const user = userEvent.setup();
+    let saved = false;
+
+    function SetupSaveRow() {
+      const [status, setStatus] = useState<"connected" | "not_configured">(
+        "not_configured",
+      );
+
+      return (
+        <ModelProviderRow
+          provider={modelProvider("google", status)}
+          onGetConfig={async () =>
+            saved
+              ? [
+                  {
+                    key: "GOOGLE_API_KEY",
+                    value: null,
+                    isSet: true,
+                    isSecret: true,
+                    required: true,
+                  },
+                ]
+              : []
+          }
+          onSaveFields={async () => {
+            saved = true;
+            setStatus("connected");
+          }}
+          onRemoveConfig={onRemoveConfig}
+          onCompleteNativeSetup={onCompleteNativeSetup}
+        />
+      );
+    }
+
+    render(<SetupSaveRow />);
+
+    await user.click(screen.getByRole("button", { name: /google gemini/i }));
+    await user.type(
+      await screen.findByPlaceholderText(/paste your api key/i),
+      "google-token",
+    );
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /disconnect/i }),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /saved/i }),
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
**Category:** fix
**User Impact:** Provider settings now show edit and disconnect controls immediately after users save credentials.
**Problem:** After entering an API key for a model provider, the expanded row stayed in a disabled saved state until the user collapsed and reopened it. That made the successful setup feel incomplete and hid the next available actions.
**Solution:** The provider row now follows the connected provider status immediately after setup save, so the expanded view switches directly to edit and disconnect. A regression test covers the Google Gemini API key setup flow.

<details>
<summary>File changes</summary>

**ui/goose2/src/features/settings/ui/ModelProviderRow.tsx**
Removes the local setup-layout preservation state that kept newly configured providers in the saved setup panel. Connected providers with fields now always render the connected field controls once their status updates.

**ui/goose2/src/features/settings/ui/__tests__/ModelProviderRow.test.tsx**
Adds a first-time Google Gemini setup test that saves an API key, updates the row to connected, and verifies edit and disconnect appear without reopening the provider row.

</details>

1. Open goose2 provider settings.
2. Expand Google Gemini while it is not configured.
3. Enter an API key and save.
4. Confirm the expanded row immediately shows Edit and Disconnect instead of a disabled Saved button.

### Screenshots/Demos

Before: saving a new API key left the row showing a disabled Saved button until the provider accordion was collapsed and reopened.

After: saving a new API key switches the open row directly to the connected state with Edit and Disconnect visible.

Verification: `./bin/pnpm --dir ui/goose2 test src/features/settings/ui/__tests__/ModelProviderRow.test.tsx`