### PR TITLE
fix(goose2): avoid transform-rasterized dialog text

### DIFF
--- a/ui/goose2/src/shared/ui/alert-dialog.tsx
+++ b/ui/goose2/src/shared/ui/alert-dialog.tsx
@@ -49,11 +49,14 @@ function AlertDialogContent({
   return (
     <AlertDialogPortal>
       <AlertDialogOverlay />
-      <div className="pointer-events-none fixed inset-0 z-[81] grid place-items-center p-4">
+      <div
+        data-slot="alert-dialog-positioner"
+        className="pointer-events-none fixed inset-0 z-[81] grid grid-rows-[minmax(1rem,1fr)_auto_minmax(1rem,1fr)] justify-items-center overflow-y-auto px-4"
+      >
         <AlertDialogPrimitive.Content
           data-slot="alert-dialog-content"
           className={cn(
-            "pointer-events-auto bg-background shadow-modal data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative grid w-full max-w-[calc(100vw-2rem)] gap-4 rounded-modal border p-6 duration-200 sm:max-w-lg",
+            "pointer-events-auto relative row-start-2 grid w-full max-w-lg gap-4 rounded-modal border bg-background p-6 shadow-modal data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
             className,
           )}
           {...props}

--- a/ui/goose2/src/shared/ui/alert-dialog.tsx
+++ b/ui/goose2/src/shared/ui/alert-dialog.tsx
@@ -51,12 +51,12 @@ function AlertDialogContent({
       <AlertDialogOverlay />
       <div
         data-slot="alert-dialog-positioner"
-        className="pointer-events-none fixed inset-0 z-[81] grid grid-rows-[minmax(1rem,1fr)_auto_minmax(1rem,1fr)] justify-items-center overflow-y-auto px-4"
+        className="pointer-events-none fixed inset-0 z-[81] grid place-items-center p-4"
       >
         <AlertDialogPrimitive.Content
           data-slot="alert-dialog-content"
           className={cn(
-            "pointer-events-auto relative row-start-2 grid w-full max-w-lg gap-4 rounded-modal border bg-background p-6 shadow-modal data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+            "pointer-events-auto relative grid max-h-[calc(100dvh-2rem)] w-full max-w-lg gap-4 overflow-y-auto rounded-modal border bg-background p-6 shadow-modal data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
             className,
           )}
           {...props}

--- a/ui/goose2/src/shared/ui/dialog.tsx
+++ b/ui/goose2/src/shared/ui/dialog.tsx
@@ -55,11 +55,14 @@ function DialogContent({
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
-      <div className="pointer-events-none fixed inset-0 z-[61] grid place-items-center p-4">
+      <div
+        data-slot="dialog-positioner"
+        className="pointer-events-none fixed inset-0 z-[61] grid grid-rows-[minmax(1rem,1fr)_auto_minmax(1rem,1fr)] justify-items-center overflow-y-auto px-4"
+      >
         <DialogPrimitive.Content
           data-slot="dialog-content"
           className={cn(
-            "pointer-events-auto bg-background shadow-modal data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative grid w-full max-w-[calc(100vw-2rem)] gap-4 rounded-modal border p-6 duration-200 sm:max-w-lg",
+            "pointer-events-auto relative row-start-2 grid w-full max-w-lg gap-4 rounded-modal border bg-background p-6 shadow-modal data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
             className,
           )}
           {...props}

--- a/ui/goose2/src/shared/ui/dialog.tsx
+++ b/ui/goose2/src/shared/ui/dialog.tsx
@@ -57,12 +57,12 @@ function DialogContent({
       <DialogOverlay />
       <div
         data-slot="dialog-positioner"
-        className="pointer-events-none fixed inset-0 z-[61] grid grid-rows-[minmax(1rem,1fr)_auto_minmax(1rem,1fr)] justify-items-center overflow-y-auto px-4"
+        className="pointer-events-none fixed inset-0 z-[61] grid place-items-center p-4"
       >
         <DialogPrimitive.Content
           data-slot="dialog-content"
           className={cn(
-            "pointer-events-auto relative row-start-2 grid w-full max-w-lg gap-4 rounded-modal border bg-background p-6 shadow-modal data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+            "pointer-events-auto relative grid max-h-[calc(100dvh-2rem)] w-full max-w-lg gap-4 overflow-y-auto rounded-modal border bg-background p-6 shadow-modal data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
             className,
           )}
           {...props}


### PR DESCRIPTION
**Category:** fix
**User Impact:** Dialog text in Goose 2 renders more sharply on external displays.
**Problem:** On macOS/Tauri WebView, transformed text can be rasterized on a composited layer. That is usually hard to see on a Retina laptop display, but on lower-DPI or scaled external monitors, fractional pixel placement can make dialog text look blurry.
**Solution:** Center dialog surfaces with an untransformed positioner instead of translating and scaling the dialog content layer, while preserving fade transitions and allowing tall dialogs to scroll naturally.

<details>
<summary>File changes</summary>

**ui/goose2/src/shared/ui/dialog.tsx**
Moves dialog centering into a full-screen positioner so the content layer is no longer translated or scaled. Adds scroll-aware vertical layout for tall dialogs and keeps existing per-dialog width overrides working through Tailwind class merging.

**ui/goose2/src/shared/ui/alert-dialog.tsx**
Applies the same untransformed centering and scroll-aware layout to alert dialogs so confirmation surfaces follow the shared dialog rendering behavior.

</details>

## Reproduction Steps

1. Open Goose 2 on an external monitor where dialog text previously appeared blurry.
2. Open the Agents panel and create or edit an agent.
3. Open the Skills editor.
4. Confirm dialog text appears sharp and that oversized dialog content can scroll instead of clipping.

## Screenshots/Demos

### branch on left, main on right
<img width="2773" height="907" alt="image" src="https://github.com/user-attachments/assets/8eaaee81-ddea-4c9f-add5-ec93011281ca" />
