### PR TITLE
fix goose2 window minimum sizing

### DIFF
--- a/ui/goose2/src-tauri/tauri.conf.json
+++ b/ui/goose2/src-tauri/tauri.conf.json
@@ -19,6 +19,8 @@
         "title": "Goose",
         "width": 800,
         "height": 600,
+        "minWidth": 800,
+        "minHeight": 600,
         "visible": false,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,

--- a/ui/goose2/src/features/settings/ui/SettingsModal.tsx
+++ b/ui/goose2/src/features/settings/ui/SettingsModal.tsx
@@ -154,7 +154,7 @@ export function SettingsModal({
       {/* biome-ignore lint/a11y/noStaticElementInteractions: click handler only prevents backdrop dismiss propagation */}
       <div
         className={cn(
-          "flex h-[600px] w-full max-w-3xl overflow-hidden rounded-xl border bg-background shadow-modal transition-opacity duration-300 ease-out",
+          "flex h-[min(600px,calc(100vh-4rem))] w-[calc(100vw-2rem)] max-w-3xl overflow-hidden rounded-xl border bg-background shadow-modal transition-opacity duration-300 ease-out",
           isLoaded ? "opacity-100" : "opacity-0",
         )}
         onClick={(e) => e.stopPropagation()}
@@ -162,7 +162,7 @@ export function SettingsModal({
         {/* Sidebar */}
         <div
           className={cn(
-            "flex w-44 flex-col border-r bg-muted/50 transition-all duration-700 ease-out",
+            "flex min-h-0 w-44 flex-shrink-0 flex-col border-r bg-muted/50 transition-all duration-700 ease-out",
             isLoaded ? "opacity-100 translate-x-0" : "opacity-0 -translate-x-2",
           )}
         >
@@ -176,31 +176,33 @@ export function SettingsModal({
           >
             <h2 className="text-sm font-semibold">{t("title")}</h2>
           </div>
-          <nav className="flex flex-col gap-1 px-2">
-            {navItems.map((item, index) => (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                key={item.id}
-                onClick={() => setActiveSection(item.id)}
-                className={cn(
-                  "w-full justify-start rounded-lg px-3 py-2 transition-all duration-600 ease-out",
-                  activeSection === item.id
-                    ? "bg-background text-foreground shadow-sm hover:bg-background"
-                    : "text-muted-foreground hover:bg-accent/50 hover:text-foreground duration-300",
-                  isLoaded
-                    ? "opacity-100 translate-x-0"
-                    : "opacity-0 translate-x-4",
-                )}
-                style={{
-                  transitionDelay: isLoaded ? "0ms" : `${index * 40 + 300}ms`,
-                }}
-              >
-                <item.icon className="size-4" />
-                {item.label}
-              </Button>
-            ))}
+          <nav className="min-h-0 flex-1 overflow-y-auto px-2 pb-3">
+            <div className="flex flex-col gap-1">
+              {navItems.map((item, index) => (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  key={item.id}
+                  onClick={() => setActiveSection(item.id)}
+                  className={cn(
+                    "w-full justify-start rounded-lg px-3 py-2 transition-all duration-600 ease-out",
+                    activeSection === item.id
+                      ? "bg-background text-foreground shadow-sm hover:bg-background"
+                      : "text-muted-foreground hover:bg-accent/50 hover:text-foreground duration-300",
+                    isLoaded
+                      ? "opacity-100 translate-x-0"
+                      : "opacity-0 translate-x-4",
+                  )}
+                  style={{
+                    transitionDelay: isLoaded ? "0ms" : `${index * 40 + 300}ms`,
+                  }}
+                >
+                  <item.icon className="size-4" />
+                  {item.label}
+                </Button>
+              ))}
+            </div>
           </nav>
         </div>
 


### PR DESCRIPTION
**Category:** fix
**User Impact:** Users can no longer resize the Goose2 desktop app into a state where the settings UI overlaps native window controls or clips essential content.
**Problem:** Goose2 allowed the desktop window to shrink below the space the app chrome and settings modal need, which made the settings screen overlap macOS traffic lights and crop content. The settings dialog also had a fixed 600px height, so small viewports could still produce broken layouts.
**Solution:** The Tauri window now enforces an 800x600 minimum, matching the app's launch size. The settings modal now fits within the viewport with margin and gives the settings navigation its own scroll area when space is constrained.

<details>
<summary>File changes</summary>

**ui/goose2/src-tauri/tauri.conf.json**
Adds minimum window dimensions so the desktop app cannot be resized below the size the shell is designed around.

**ui/goose2/src/features/settings/ui/SettingsModal.tsx**
Makes the settings modal responsive to viewport height and width, and makes the settings navigation scroll independently to avoid overflow at constrained sizes.

</details>

**Reproduction Steps**
1. Launch the Goose2 desktop app.
2. Open Settings from the sidebar.
3. Resize the app toward its smallest allowed size.
4. Confirm the window stops at 800x600 and the settings modal remains clear of native window controls.
5. Confirm settings navigation/content remains usable instead of clipping or overlapping.

**Screenshots/Demos**
Manual visual validation was performed locally; the reporter confirmed the updated behavior works well.

**Verification**
- `jq empty src-tauri/tauri.conf.json`
- `pnpm exec biome check src/features/settings/ui/SettingsModal.tsx`
- `pnpm build`
- `sq agents review --intent "Constrain Goose2 desktop window minimum size and make the settings modal fit within smaller viewports"`
- Pre-push gate: `pnpm exec biome format .`, `cargo fmt --check`, `cargo clippy -- -D warnings`, `pnpm test`, `pnpm check`, `pnpm build`, `cargo check`