### PR TITLE
fix: close modal instead of spawning window when canceling recipe parameters

### DIFF
--- a/ui/desktop/src/components/ParameterInputModal.tsx
+++ b/ui/desktop/src/components/ParameterInputModal.tsx
@@ -123,14 +123,6 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
     }
   };
 
-  const handleCancelOption = (option: 'new-chat' | 'back-to-form'): void => {
-    if (option === 'new-chat') {
-      onClose();
-    } else {
-      setShowCancelOptions(false);
-    }
-  };
-
   return (
     <div className="fixed inset-0 backdrop-blur-sm z-50 flex justify-center items-center animate-[fadein_200ms_ease-in]">
       {showCancelOptions ? (
@@ -142,7 +134,7 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
           <p className="text-text-primary mb-6">{intl.formatMessage(i18n.whatToDo)}</p>
           <div className="flex flex-col gap-3">
             <Button
-              onClick={() => handleCancelOption('back-to-form')}
+              onClick={() => setShowCancelOptions(false)}
               variant="default"
               size="lg"
               className="w-full rounded-full"
@@ -150,7 +142,7 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
               {intl.formatMessage(i18n.backToForm)}
             </Button>
             <Button
-              onClick={() => handleCancelOption('new-chat')}
+              onClick={onClose}
               variant="outline"
               size="lg"
               className="w-full rounded-full"

--- a/ui/desktop/src/components/ParameterInputModal.tsx
+++ b/ui/desktop/src/components/ParameterInputModal.tsx
@@ -72,7 +72,6 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
   const [showCancelOptions, setShowCancelOptions] = useState(false);
 
-  // Pre-fill the form with default values from the recipe and initialValues from deeplink
   useEffect(() => {
     const defaultValues: Record<string, string> = {};
     parameters.forEach((param) => {
@@ -90,10 +89,8 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
   };
 
   const handleSubmit = (): void => {
-    // Clear previous validation errors
     setValidationErrors({});
 
-    // Check if all *required* parameters are filled
     const requiredParams: Parameter[] = parameters.filter((p) => p.requirement === 'required');
     const errors: Record<string, string> = {};
 
@@ -113,7 +110,6 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
   };
 
   const handleCancel = (): void => {
-    // Always show cancel options if recipe has any parameters (required or optional)
     const hasAnyParams = parameters.length > 0;
 
     if (hasAnyParams) {
@@ -126,7 +122,6 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
   return (
     <div className="fixed inset-0 backdrop-blur-sm z-50 flex justify-center items-center animate-[fadein_200ms_ease-in]">
       {showCancelOptions ? (
-        // Cancel options modal
         <div className="bg-background-primary border border-border-primary rounded-xl p-8 shadow-2xl w-full max-w-md">
           <h2 className="text-xl font-bold text-text-primary mb-4">
             {intl.formatMessage(i18n.cancelRecipeSetup)}
@@ -141,18 +136,12 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
             >
               {intl.formatMessage(i18n.backToForm)}
             </Button>
-            <Button
-              onClick={onClose}
-              variant="outline"
-              size="lg"
-              className="w-full rounded-full"
-            >
+            <Button onClick={onClose} variant="outline" size="lg" className="w-full rounded-full">
               {intl.formatMessage(i18n.startNewChat)}
             </Button>
           </div>
         </div>
       ) : (
-        // Main parameter form
         <div className="bg-background-primary border border-border-primary rounded-xl shadow-2xl w-full max-w-lg max-h-[90vh] flex flex-col overflow-hidden">
           <div className="p-8 pb-4 flex-shrink-0">
             <h2 className="text-xl font-bold text-text-primary mb-6">
@@ -163,7 +152,10 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
             <form onSubmit={handleSubmit} className="space-y-4 mb-4">
               {parameters.map((param) => (
                 <div key={param.key}>
-                  <label htmlFor={param.key} className="block text-md font-medium text-text-primary mb-2">
+                  <label
+                    htmlFor={param.key}
+                    className="block text-md font-medium text-text-primary mb-2"
+                  >
                     {param.description || param.key}
                     {param.requirement === 'required' && (
                       <span className="text-red-500 ml-1">*</span>
@@ -214,7 +206,9 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
                           ? 'border-red-500 focus:ring-red-500'
                           : 'border-border-primary focus:ring-border-secondary'
                       }`}
-                      placeholder={param.default || intl.formatMessage(i18n.enterValue, { key: param.key })}
+                      placeholder={
+                        param.default || intl.formatMessage(i18n.enterValue, { key: param.key })
+                      }
                     />
                   )}
 

--- a/ui/desktop/src/components/ParameterInputModal.tsx
+++ b/ui/desktop/src/components/ParameterInputModal.tsx
@@ -125,11 +125,9 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
 
   const handleCancelOption = (option: 'new-chat' | 'back-to-form'): void => {
     if (option === 'new-chat') {
-      // Just close the modal - don't create a new window
-      // The user can manually start a new chat if needed
       onClose();
     } else {
-      setShowCancelOptions(false); // Go back to the parameter form
+      setShowCancelOptions(false);
     }
   };
 
@@ -173,16 +171,16 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
             <form onSubmit={handleSubmit} className="space-y-4 mb-4">
               {parameters.map((param) => (
                 <div key={param.key}>
-                  <label className="block text-md font-medium text-text-primary mb-2">
+                  <label htmlFor={param.key} className="block text-md font-medium text-text-primary mb-2">
                     {param.description || param.key}
                     {param.requirement === 'required' && (
                       <span className="text-red-500 ml-1">*</span>
                     )}
                   </label>
 
-                  {/* Render different input types */}
                   {param.input_type === 'select' && param.options ? (
                     <select
+                      id={param.key}
                       value={inputValues[param.key] || ''}
                       onChange={(e) => handleChange(param.key, e.target.value)}
                       className={`w-full p-3 border rounded-lg bg-background-secondary text-text-primary focus:outline-none focus:ring-2 ${
@@ -200,6 +198,7 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
                     </select>
                   ) : param.input_type === 'boolean' ? (
                     <select
+                      id={param.key}
                       value={inputValues[param.key] || ''}
                       onChange={(e) => handleChange(param.key, e.target.value)}
                       className={`w-full p-3 border rounded-lg bg-background-secondary text-text-primary focus:outline-none focus:ring-2 ${
@@ -214,6 +213,7 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
                     </select>
                   ) : (
                     <input
+                      id={param.key}
                       type={param.input_type === 'number' ? 'number' : 'text'}
                       value={inputValues[param.key] || ''}
                       onChange={(e) => handleChange(param.key, e.target.value)}

--- a/ui/desktop/src/components/ParameterInputModal.tsx
+++ b/ui/desktop/src/components/ParameterInputModal.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Parameter } from '../recipe';
 import { Button } from './ui/button';
-import { getInitialWorkingDir } from '../utils/workingDir';
 import { defineMessages, useIntl } from '../i18n';
 
 const i18n = defineMessages({
@@ -126,14 +125,9 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
 
   const handleCancelOption = (option: 'new-chat' | 'back-to-form'): void => {
     if (option === 'new-chat') {
-      try {
-        const workingDir = getInitialWorkingDir();
-        window.electron.createChatWindow({ dir: workingDir });
-        window.electron.hideWindow();
-      } catch (error) {
-        console.error('Error creating new window:', error);
-        onClose();
-      }
+      // Just close the modal - don't create a new window
+      // The user can manually start a new chat if needed
+      onClose();
     } else {
       setShowCancelOptions(false); // Go back to the parameter form
     }

--- a/ui/desktop/src/components/__tests__/ParameterInputModal.test.tsx
+++ b/ui/desktop/src/components/__tests__/ParameterInputModal.test.tsx
@@ -67,14 +67,9 @@ describe('ParameterInputModal', () => {
     it('calls onSubmit with parameter values when submitted', async () => {
       const user = userEvent.setup();
       renderWithIntl(<ParameterInputModal {...defaultProps} />);
-      
-      // Fill in required parameter
-      const input = screen.getByPlaceholderText('Enter value for param1...');
-      await user.type(input, 'test value');
-      
-      // Select optional parameter
-      const select = screen.getByRole('combobox', { name: /test parameter 2/i });
-      await user.selectOptions(select, 'option2');
+
+      await user.type(screen.getByLabelText(/test parameter 1/i), 'test value');
+      await user.selectOptions(screen.getByLabelText(/test parameter 2/i), 'option2');
       
       // Submit form
       const submitButton = screen.getByText('Start Recipe');
@@ -166,9 +161,8 @@ describe('ParameterInputModal', () => {
           initialValues={{ param1: 'initial value' }}
         />
       );
-      
-      const input = screen.getByPlaceholderText('Enter value for param1...') as HTMLInputElement;
-      expect(input.value).toBe('initial value');
+
+      expect((screen.getByLabelText(/test parameter 1/i) as HTMLInputElement).value).toBe('initial value');
     });
 
     it('pre-fills form with default values from parameters', () => {

--- a/ui/desktop/src/components/__tests__/ParameterInputModal.test.tsx
+++ b/ui/desktop/src/components/__tests__/ParameterInputModal.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, type RenderOptions, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ParameterInputModal from '../ParameterInputModal';
+import { IntlTestWrapper } from '../../i18n/test-utils';
+import type { Parameter } from '../../recipe';
+
+const renderWithIntl = (ui: React.ReactElement, options?: RenderOptions) =>
+  render(ui, { wrapper: IntlTestWrapper, ...options });
+
+const mockParameters: Parameter[] = [
+  {
+    key: 'param1',
+    description: 'Test parameter 1',
+    input_type: 'string',
+    requirement: 'required',
+  },
+  {
+    key: 'param2',
+    description: 'Test parameter 2',
+    input_type: 'select',
+    requirement: 'optional',
+    options: ['option1', 'option2'],
+    default: 'option1',
+  },
+  {
+    key: 'param3',
+    description: 'Boolean parameter',
+    input_type: 'boolean',
+    requirement: 'optional',
+    default: true,
+  },
+];
+
+describe('ParameterInputModal', () => {
+  const defaultProps = {
+    parameters: mockParameters,
+    onSubmit: vi.fn(),
+    onClose: vi.fn(),
+    initialValues: {},
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('renders modal with parameters', () => {
+      renderWithIntl(<ParameterInputModal {...defaultProps} />);
+      
+      expect(screen.getByText('Recipe Parameters')).toBeInTheDocument();
+      expect(screen.getByText('Test parameter 1')).toBeInTheDocument();
+      expect(screen.getByText('Test parameter 2')).toBeInTheDocument();
+      expect(screen.getByText('Boolean parameter')).toBeInTheDocument();
+    });
+
+    it('shows required indicator for required parameters', () => {
+      renderWithIntl(<ParameterInputModal {...defaultProps} />);
+      
+      // param1 is required, should have red asterisk
+      const requiredParam = screen.getByText('Test parameter 1');
+      expect(requiredParam.parentElement?.querySelector('.text-red-500')).toBeInTheDocument();
+    });
+  });
+
+  describe('Form Submission', () => {
+    it('calls onSubmit with parameter values when submitted', async () => {
+      const user = userEvent.setup();
+      renderWithIntl(<ParameterInputModal {...defaultProps} />);
+      
+      // Fill in required parameter
+      const input = screen.getByPlaceholderText('Enter value for param1...');
+      await user.type(input, 'test value');
+      
+      // Select optional parameter
+      const select = screen.getByRole('combobox', { name: /test parameter 2/i });
+      await user.selectOptions(select, 'option2');
+      
+      // Submit form
+      const submitButton = screen.getByText('Start Recipe');
+      await user.click(submitButton);
+      
+      expect(defaultProps.onSubmit).toHaveBeenCalledWith({
+        param1: 'test value',
+        param2: 'option2',
+        param3: 'true', // boolean default
+      });
+    });
+
+    it('shows validation errors for required parameters', async () => {
+      const user = userEvent.setup();
+      renderWithIntl(<ParameterInputModal {...defaultProps} />);
+      
+      // Try to submit without filling required field
+      const submitButton = screen.getByText('Start Recipe');
+      await user.click(submitButton);
+      
+      await waitFor(() => {
+        expect(screen.getByText(/is required/)).toBeInTheDocument();
+      });
+      expect(defaultProps.onSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Cancel Behavior (Bug Fix #8864)', () => {
+    it('shows cancel options when cancel is clicked and parameters exist', async () => {
+      const user = userEvent.setup();
+      renderWithIntl(<ParameterInputModal {...defaultProps} />);
+      
+      const cancelButton = screen.getByText('Cancel');
+      await user.click(cancelButton);
+      
+      expect(screen.getByText('Cancel Recipe Setup')).toBeInTheDocument();
+      expect(screen.getByText('What would you like to do?')).toBeInTheDocument();
+    });
+
+    it('calls onClose directly when cancel is clicked and no parameters exist', async () => {
+      const user = userEvent.setup();
+      renderWithIntl(<ParameterInputModal {...defaultProps} parameters={[]} />);
+      
+      const cancelButton = screen.getByText('Cancel');
+      await user.click(cancelButton);
+      
+      expect(defaultProps.onClose).toHaveBeenCalled();
+    });
+
+    it('calls onClose (not createChatWindow) when "Start New Chat" is selected - Bug #8864 fix', async () => {
+      const user = userEvent.setup();
+      renderWithIntl(<ParameterInputModal {...defaultProps} />);
+      
+      // Click cancel to show options
+      const cancelButton = screen.getByText('Cancel');
+      await user.click(cancelButton);
+      
+      // Click "Start New Chat (No Recipe)"
+      const newChatButton = screen.getByText('Start New Chat (No Recipe)');
+      await user.click(newChatButton);
+      
+      // Should call onClose, NOT createChatWindow (this is the bug fix)
+      expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns to parameter form when "Back to Parameter Form" is clicked', async () => {
+      const user = userEvent.setup();
+      renderWithIntl(<ParameterInputModal {...defaultProps} />);
+      
+      // Click cancel to show options
+      const cancelButton = screen.getByText('Cancel');
+      await user.click(cancelButton);
+      
+      // Click "Back to Parameter Form"
+      const backButton = screen.getByText('Back to Parameter Form');
+      await user.click(backButton);
+      
+      // Should be back to parameter form
+      expect(screen.getByText('Recipe Parameters')).toBeInTheDocument();
+      expect(defaultProps.onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Initial Values', () => {
+    it('pre-fills form with initial values', () => {
+      renderWithIntl(
+        <ParameterInputModal
+          {...defaultProps}
+          initialValues={{ param1: 'initial value' }}
+        />
+      );
+      
+      const input = screen.getByPlaceholderText('Enter value for param1...') as HTMLInputElement;
+      expect(input.value).toBe('initial value');
+    });
+
+    it('pre-fills form with default values from parameters', () => {
+      renderWithIntl(<ParameterInputModal {...defaultProps} />);
+      
+      // param3 has default=true, should be pre-selected
+      const booleanSelect = screen.getAllByRole('combobox')[1] as HTMLSelectElement;
+      expect(booleanSelect.value).toBe('true');
+    });
+  });
+});

--- a/ui/desktop/src/components/__tests__/ParameterInputModal.test.tsx
+++ b/ui/desktop/src/components/__tests__/ParameterInputModal.test.tsx
@@ -97,7 +97,7 @@ describe('ParameterInputModal', () => {
     });
   });
 
-  describe('Cancel Behavior (Bug Fix #8864)', () => {
+  describe('Cancel Behavior', () => {
     it('shows cancel options when cancel is clicked and parameters exist', async () => {
       const user = userEvent.setup();
       renderWithIntl(<ParameterInputModal {...defaultProps} />);
@@ -119,19 +119,13 @@ describe('ParameterInputModal', () => {
       expect(defaultProps.onClose).toHaveBeenCalled();
     });
 
-    it('calls onClose (not createChatWindow) when "Start New Chat" is selected - Bug #8864 fix', async () => {
+    it('calls onClose when "Start New Chat" option is selected', async () => {
       const user = userEvent.setup();
       renderWithIntl(<ParameterInputModal {...defaultProps} />);
-      
-      // Click cancel to show options
-      const cancelButton = screen.getByText('Cancel');
-      await user.click(cancelButton);
-      
-      // Click "Start New Chat (No Recipe)"
-      const newChatButton = screen.getByText('Start New Chat (No Recipe)');
-      await user.click(newChatButton);
-      
-      // Should call onClose, NOT createChatWindow (this is the bug fix)
+
+      await user.click(screen.getByText('Cancel'));
+      await user.click(screen.getByText('Start New Chat (No Recipe)'));
+
       expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
     });
 
@@ -167,10 +161,8 @@ describe('ParameterInputModal', () => {
 
     it('pre-fills form with default values from parameters', () => {
       renderWithIntl(<ParameterInputModal {...defaultProps} />);
-      
-      // param3 has default=true, should be pre-selected
-      const booleanSelect = screen.getAllByRole('combobox')[1] as HTMLSelectElement;
-      expect(booleanSelect.value).toBe('true');
+
+      expect((screen.getByLabelText(/boolean parameter/i) as HTMLSelectElement).value).toBe('true');
     });
   });
 });

--- a/ui/desktop/src/components/__tests__/ParameterInputModal.test.tsx
+++ b/ui/desktop/src/components/__tests__/ParameterInputModal.test.tsx
@@ -28,7 +28,7 @@ const mockParameters: Parameter[] = [
     description: 'Boolean parameter',
     input_type: 'boolean',
     requirement: 'optional',
-    default: true,
+    default: 'true',
   },
 ];
 

--- a/ui/desktop/src/components/__tests__/ParameterInputModal.test.tsx
+++ b/ui/desktop/src/components/__tests__/ParameterInputModal.test.tsx
@@ -47,7 +47,7 @@ describe('ParameterInputModal', () => {
   describe('Rendering', () => {
     it('renders modal with parameters', () => {
       renderWithIntl(<ParameterInputModal {...defaultProps} />);
-      
+
       expect(screen.getByText('Recipe Parameters')).toBeInTheDocument();
       expect(screen.getByText('Test parameter 1')).toBeInTheDocument();
       expect(screen.getByText('Test parameter 2')).toBeInTheDocument();
@@ -56,8 +56,7 @@ describe('ParameterInputModal', () => {
 
     it('shows required indicator for required parameters', () => {
       renderWithIntl(<ParameterInputModal {...defaultProps} />);
-      
-      // param1 is required, should have red asterisk
+
       const requiredParam = screen.getByText('Test parameter 1');
       expect(requiredParam.parentElement?.querySelector('.text-red-500')).toBeInTheDocument();
     });
@@ -70,26 +69,24 @@ describe('ParameterInputModal', () => {
 
       await user.type(screen.getByLabelText(/test parameter 1/i), 'test value');
       await user.selectOptions(screen.getByLabelText(/test parameter 2/i), 'option2');
-      
-      // Submit form
+
       const submitButton = screen.getByText('Start Recipe');
       await user.click(submitButton);
-      
+
       expect(defaultProps.onSubmit).toHaveBeenCalledWith({
         param1: 'test value',
         param2: 'option2',
-        param3: 'true', // boolean default
+        param3: 'true',
       });
     });
 
     it('shows validation errors for required parameters', async () => {
       const user = userEvent.setup();
       renderWithIntl(<ParameterInputModal {...defaultProps} />);
-      
-      // Try to submit without filling required field
+
       const submitButton = screen.getByText('Start Recipe');
       await user.click(submitButton);
-      
+
       await waitFor(() => {
         expect(screen.getByText(/is required/)).toBeInTheDocument();
       });
@@ -101,10 +98,10 @@ describe('ParameterInputModal', () => {
     it('shows cancel options when cancel is clicked and parameters exist', async () => {
       const user = userEvent.setup();
       renderWithIntl(<ParameterInputModal {...defaultProps} />);
-      
+
       const cancelButton = screen.getByText('Cancel');
       await user.click(cancelButton);
-      
+
       expect(screen.getByText('Cancel Recipe Setup')).toBeInTheDocument();
       expect(screen.getByText('What would you like to do?')).toBeInTheDocument();
     });
@@ -112,10 +109,10 @@ describe('ParameterInputModal', () => {
     it('calls onClose directly when cancel is clicked and no parameters exist', async () => {
       const user = userEvent.setup();
       renderWithIntl(<ParameterInputModal {...defaultProps} parameters={[]} />);
-      
+
       const cancelButton = screen.getByText('Cancel');
       await user.click(cancelButton);
-      
+
       expect(defaultProps.onClose).toHaveBeenCalled();
     });
 
@@ -132,16 +129,13 @@ describe('ParameterInputModal', () => {
     it('returns to parameter form when "Back to Parameter Form" is clicked', async () => {
       const user = userEvent.setup();
       renderWithIntl(<ParameterInputModal {...defaultProps} />);
-      
-      // Click cancel to show options
+
       const cancelButton = screen.getByText('Cancel');
       await user.click(cancelButton);
-      
-      // Click "Back to Parameter Form"
+
       const backButton = screen.getByText('Back to Parameter Form');
       await user.click(backButton);
-      
-      // Should be back to parameter form
+
       expect(screen.getByText('Recipe Parameters')).toBeInTheDocument();
       expect(defaultProps.onClose).not.toHaveBeenCalled();
     });
@@ -150,18 +144,18 @@ describe('ParameterInputModal', () => {
   describe('Initial Values', () => {
     it('pre-fills form with initial values', () => {
       renderWithIntl(
-        <ParameterInputModal
-          {...defaultProps}
-          initialValues={{ param1: 'initial value' }}
-        />
+        <ParameterInputModal {...defaultProps} initialValues={{ param1: 'initial value' }} />
       );
 
-      expect((screen.getByLabelText(/test parameter 1/i) as HTMLInputElement).value).toBe('initial value');
+      expect((screen.getByLabelText(/test parameter 1/i) as HTMLInputElement).value).toBe(
+        'initial value'
+      );
     });
 
     it('pre-fills form with default values from parameters', () => {
       renderWithIntl(<ParameterInputModal {...defaultProps} />);
 
+      // eslint-disable-next-line no-undef
       expect((screen.getByLabelText(/boolean parameter/i) as HTMLSelectElement).value).toBe('true');
     });
   });


### PR DESCRIPTION
## Description
Fixes #8864 — Canceling the recipe parameter form spawned a new window instead of closing the modal overlay.

## Changes
**`ui/desktop/src/components/ParameterInputModal.tsx`**
- "Start New Chat (No Recipe)" now calls `onClose()` directly instead of spawning a new window via `window.electron.createChatWindow()`
- Removed the `handleCancelOption` indirection — both cancel buttons now use inline handlers (`onClose` / `setShowCancelOptions(false)`)
- Removed unused `getInitialWorkingDir` import
- Added `htmlFor`/`id` associations between labels and inputs for accessibility

**`ui/desktop/src/components/__tests__/ParameterInputModal.test.tsx`** (new)
- Test suite covering the cancel flow and parameter rendering

## Type of Change
- [x] Bug fix
- [x] New tests added

## Checklist
- [x] Commit signed off (DCO)
- [x] PR title follows Conventional Commits
- [x] Linked to issue #8864