### PR TITLE
Improvements to LM Studio declarative provider

### DIFF
--- a/crates/goose/src/providers/declarative/lmstudio.json
+++ b/crates/goose/src/providers/declarative/lmstudio.json
@@ -4,7 +4,18 @@
   "display_name": "LM Studio",
   "description": "Run local models with LM Studio",
   "api_key_env": "",
-  "base_url": "http://localhost:1234/v1/chat/completions",
+  "base_url": "${LMSTUDIO_HOST}/v1/chat/completions",
+  "env_vars": [
+    {
+      "name": "LMSTUDIO_HOST",
+      "required": false,
+      "secret": false,
+      "primary": true,
+      "default": "http://localhost:1234",
+      "description": "Base URL of the LMStudio server (default: http://localhost:1234)"
+    }
+  ],
+  "dynamic_models": true,
   "models": [],
   "supports_streaming": true,
   "requires_auth": false,


### PR DESCRIPTION
## Summary
This changes lmstudio.json to better align with the capabilities of the LM Studio server.
I used llama_swap.json as a template. The change to the lmstudio provider:
- gives the ability to set the host url via `LMSTUDIO_HOST`, with a default of `http://localhost:1234`
- sets `dynamic_models` to `true`, since the LM Studio provides an OpenAI-compliant `models` endpoint 

### Testing
I've manually tested this by pointing it at LM Studio instances running on both localhost and on a remote machine. 
It allows for dynamic querying of the installed models through both the GUI app and `goose configure` when the LM Studio provider is selected.

### Related Issues
Relates to #8180
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

