### PR TITLE
feat(agent): detect repeated tool errors and inject recovery hint

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1540,10 +1540,16 @@ impl Agent {
                                                                         self.tool_inspection_manager.record_tool_error(tool_name, &e.to_string());
                                                                     }
                                                                     Ok(r) if r.is_error == Some(true) => {
-                                                                        let error_text = r.content.iter()
+                                                                        let text = r.content.iter()
                                                                             .filter_map(|c| c.as_text().map(|t| t.text.as_str()))
                                                                             .collect::<Vec<_>>()
                                                                             .join(" ");
+                                                                        let error_text = if text.is_empty() {
+                                                                            serde_json::to_string(&r.content)
+                                                                                .unwrap_or_else(|_| "error".to_string())
+                                                                        } else {
+                                                                            text
+                                                                        };
                                                                         self.tool_inspection_manager.record_tool_error(tool_name, &error_text);
                                                                     }
                                                                     Ok(_) => {

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -52,7 +52,7 @@ use crate::security::security_inspector::SecurityInspector;
 use crate::session::extension_data::{EnabledExtensionsState, ExtensionState};
 use crate::session::{Session, SessionManager};
 use crate::tool_inspection::ToolInspectionManager;
-use crate::tool_monitor::RepetitionInspector;
+use crate::tool_monitor::{RepetitionInspector, FINDING_ID_REPEATED_ERROR};
 use crate::utils::is_token_cancelled;
 use regex::Regex;
 use rmcp::model::{
@@ -1410,6 +1410,7 @@ impl Agent {
                                         yield AgentEvent::Message(msg);
                                     }
                                 }
+                                let mut inspection_results: Vec<crate::tool_inspection::InspectionResult> = Vec::new();
                                 if goose_mode == GooseMode::Chat {
                                     for request in remaining_requests.iter() {
                                         if let Some(response) = request_to_response_map.get_mut(&request.id) {
@@ -1422,7 +1423,7 @@ impl Agent {
                                     }
                                 } else {
                                     // Run all tool inspectors
-                                    let inspection_results = self.tool_inspection_manager
+                                    inspection_results = self.tool_inspection_manager
                                         .inspect_tools(
                                             &session_config.id,
                                             &remaining_requests,
@@ -1527,6 +1528,29 @@ impl Agent {
                                                                 {
                                                                     all_install_successful = false;
                                                                 }
+
+                                                                // must happen before output is moved
+                                                                let tool_name = remaining_requests.iter()
+                                                                    .find(|r| r.id == request_id)
+                                                                    .and_then(|r| r.tool_call.as_ref().ok())
+                                                                    .map(|tc| tc.name.as_ref())
+                                                                    .unwrap_or("unknown");
+                                                                match &output {
+                                                                    Err(e) => {
+                                                                        self.tool_inspection_manager.record_tool_error(tool_name, &e.to_string());
+                                                                    }
+                                                                    Ok(r) if r.is_error == Some(true) => {
+                                                                        let error_text = r.content.iter()
+                                                                            .filter_map(|c| c.as_text().map(|t| t.text.as_str()))
+                                                                            .collect::<Vec<_>>()
+                                                                            .join(" ");
+                                                                        self.tool_inspection_manager.record_tool_error(tool_name, &error_text);
+                                                                    }
+                                                                    Ok(_) => {
+                                                                        self.tool_inspection_manager.record_tool_success();
+                                                                    }
+                                                                }
+
                                                                 if let Some(response) = request_to_response_map.get_mut(&request_id) {
                                                                     let metadata = request_metadata.get(&request_id).and_then(|m| m.as_ref());
                                                                     response.add_tool_response_with_metadata(request_id, output, metadata);
@@ -1606,6 +1630,23 @@ impl Agent {
                                             .unwrap_or_else(|| Message::user().with_generated_id());
                                         yield AgentEvent::Message(final_response.clone());
                                         messages_to_add.push(final_response);
+
+                                        // If a REP-002 deny fired, inject a corrective hint so the
+                                        // model knows to change strategy rather than retry again.
+                                        if let Some(result) = inspection_results.iter().find(|r| {
+                                            r.tool_request_id == request.id
+                                                && r.finding_id.as_deref() == Some(FINDING_ID_REPEATED_ERROR)
+                                        }) {
+                                            let hint = format!(
+                                                "Note: {}. Try a different approach — check whether \
+                                                 you are using the correct input values, a different \
+                                                 tool, or a different ID field from earlier results.",
+                                                result.reason
+                                            );
+                                            let hint_msg = Message::user().with_text(hint);
+                                            yield AgentEvent::Message(hint_msg.clone());
+                                            messages_to_add.push(hint_msg);
+                                        }
                                     } else {
                                         error!(
                                             "Tool call could not be parsed: {}",

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1544,11 +1544,14 @@ impl Agent {
                                                                             .filter_map(|c| c.as_text().map(|t| t.text.as_str()))
                                                                             .collect::<Vec<_>>()
                                                                             .join(" ");
-                                                                        let error_text = if text.is_empty() {
-                                                                            serde_json::to_string(&r.content)
+                                                                        let error_text = if !text.is_empty() {
+                                                                            text
+                                                                        } else if let Some(structured) = &r.structured_content {
+                                                                            serde_json::to_string(structured)
                                                                                 .unwrap_or_else(|_| "error".to_string())
                                                                         } else {
-                                                                            text
+                                                                            serde_json::to_string(&r.content)
+                                                                                .unwrap_or_else(|_| "error".to_string())
                                                                         };
                                                                         self.tool_inspection_manager.record_tool_error(tool_name, &error_text);
                                                                     }

--- a/crates/goose/src/tool_inspection.rs
+++ b/crates/goose/src/tool_inspection.rs
@@ -6,6 +6,7 @@ use crate::config::GooseMode;
 use crate::conversation::message::{Message, ToolRequest};
 use crate::permission::permission_inspector::PermissionInspector;
 use crate::permission::permission_judge::PermissionCheckResult;
+use crate::tool_monitor::RepetitionInspector;
 
 /// Result of inspecting a tool call
 #[derive(Debug, Clone)]
@@ -128,6 +129,25 @@ impl ToolInspectionManager {
             .iter()
             .find(|i| i.name() == "permission")
             .and_then(|i| i.as_any().downcast_ref::<PermissionInspector>())
+    }
+
+    fn get_repetition_inspector(&self) -> Option<&RepetitionInspector> {
+        self.inspectors
+            .iter()
+            .find(|i| i.name() == "repetition")
+            .and_then(|i| i.as_any().downcast_ref::<RepetitionInspector>())
+    }
+
+    pub fn record_tool_error(&self, tool_name: &str, error_text: &str) {
+        if let Some(inspector) = self.get_repetition_inspector() {
+            inspector.record_error(tool_name, error_text);
+        }
+    }
+
+    pub fn record_tool_success(&self) {
+        if let Some(inspector) = self.get_repetition_inspector() {
+            inspector.record_success();
+        }
     }
 
     pub fn apply_tool_annotations(&self, tools: &[rmcp::model::Tool]) {

--- a/crates/goose/src/tool_monitor.rs
+++ b/crates/goose/src/tool_monitor.rs
@@ -180,6 +180,7 @@ impl ToolInspector for RepetitionInspector {
             if state.consecutive_count >= MAX_CONSECUTIVE_ERROR_FINGERPRINTS {
                 if let Some(ref last_tool) = state.last_tool_name {
                     let error_text = state.last_error_text.as_deref().unwrap_or("");
+                    let mut denied = false;
                     for tool_request in tool_requests {
                         if let Ok(tool_call) = &tool_request.tool_call {
                             if tool_call.name.as_ref() == last_tool.as_str() {
@@ -194,12 +195,16 @@ impl ToolInspector for RepetitionInspector {
                                     inspector_name: "repetition".to_string(),
                                     finding_id: Some(FINDING_ID_REPEATED_ERROR.to_string()),
                                 });
+                                denied = true;
                             }
                         }
                     }
+                    // Reset only after actually denying the failing tool so that an
+                    // intervening turn calling other tools doesn't silently clear the streak
+                    if denied {
+                        state.consecutive_count = 0;
+                    }
                 }
-                // Reset so the model can retry after adapting strategy
-                state.consecutive_count = 0;
             }
         }
 

--- a/crates/goose/src/tool_monitor.rs
+++ b/crates/goose/src/tool_monitor.rs
@@ -6,6 +6,11 @@ use async_trait::async_trait;
 use rmcp::model::CallToolRequestParams;
 use serde_json::Value;
 use std::collections::HashMap;
+use std::sync::Mutex;
+
+pub const FINDING_ID_REPEATED_CALLS: &str = "REP-001";
+pub const FINDING_ID_REPEATED_ERROR: &str = "REP-002";
+const MAX_CONSECUTIVE_ERROR_FINGERPRINTS: u32 = 3;
 
 // Helper struct for internal tracking
 #[derive(Debug, Clone)]
@@ -31,11 +36,19 @@ impl InternalToolCall {
 }
 
 #[derive(Debug)]
+struct ErrorState {
+    last_tool_name: Option<String>,
+    last_error_text: Option<String>,
+    consecutive_count: u32,
+}
+
+#[derive(Debug)]
 pub struct RepetitionInspector {
     max_repetitions: Option<u32>,
     last_call: Option<InternalToolCall>,
     repeat_count: u32,
     call_counts: HashMap<String, u32>,
+    error_state: Mutex<ErrorState>,
 }
 
 impl RepetitionInspector {
@@ -45,7 +58,33 @@ impl RepetitionInspector {
             last_call: None,
             repeat_count: 0,
             call_counts: HashMap::new(),
+            error_state: Mutex::new(ErrorState {
+                last_tool_name: None,
+                last_error_text: None,
+                consecutive_count: 0,
+            }),
         }
+    }
+
+    pub fn record_error(&self, tool_name: &str, error_text: &str) {
+        let truncated = &error_text[..error_text.len().min(100)];
+        let mut state = self.error_state.lock().unwrap();
+        if state.last_tool_name.as_deref() == Some(tool_name)
+            && state.last_error_text.as_deref() == Some(truncated)
+        {
+            state.consecutive_count += 1;
+        } else {
+            state.last_tool_name = Some(tool_name.to_string());
+            state.last_error_text = Some(truncated.to_string());
+            state.consecutive_count = 1;
+        }
+    }
+
+    pub fn record_success(&self) {
+        let mut state = self.error_state.lock().unwrap();
+        state.last_tool_name = None;
+        state.last_error_text = None;
+        state.consecutive_count = 0;
     }
 
     pub fn check_tool_call(&mut self, tool_call: CallToolRequestParams) -> bool {
@@ -83,6 +122,10 @@ impl RepetitionInspector {
         self.last_call = None;
         self.repeat_count = 0;
         self.call_counts.clear();
+        let mut state = self.error_state.lock().unwrap();
+        state.last_tool_name = None;
+        state.last_error_text = None;
+        state.consecutive_count = 0;
     }
 }
 
@@ -105,7 +148,7 @@ impl ToolInspector for RepetitionInspector {
     ) -> Result<Vec<InspectionResult>> {
         let mut results = Vec::new();
 
-        // Check repetition limits for each tool request
+        // Check call-repetition limits for each tool request
         for tool_request in tool_requests {
             if let Ok(tool_call) = &tool_request.tool_call {
                 // Create a temporary clone to check without modifying state
@@ -124,8 +167,36 @@ impl ToolInspector for RepetitionInspector {
                         ),
                         confidence: 1.0,
                         inspector_name: "repetition".to_string(),
-                        finding_id: Some("REP-001".to_string()),
+                        finding_id: Some(FINDING_ID_REPEATED_CALLS.to_string()),
                     });
+                }
+            }
+        }
+
+        // Deny a tool that has returned the same error N consecutive times, regardless
+        // of whether call parameters changed — catches retry loops with varying inputs.
+        {
+            let state = self.error_state.lock().unwrap();
+            if state.consecutive_count >= MAX_CONSECUTIVE_ERROR_FINGERPRINTS {
+                if let Some(ref last_tool) = state.last_tool_name {
+                    let error_text = state.last_error_text.as_deref().unwrap_or("");
+                    for tool_request in tool_requests {
+                        if let Ok(tool_call) = &tool_request.tool_call {
+                            if tool_call.name.as_ref() == last_tool.as_str() {
+                                results.push(InspectionResult {
+                                    tool_request_id: tool_request.id.clone(),
+                                    action: InspectionAction::Deny,
+                                    reason: format!(
+                                        "Tool '{}' has returned the same error {} consecutive times: '{}'",
+                                        tool_call.name, state.consecutive_count, error_text
+                                    ),
+                                    confidence: 1.0,
+                                    inspector_name: "repetition".to_string(),
+                                    finding_id: Some(FINDING_ID_REPEATED_ERROR.to_string()),
+                                });
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/crates/goose/src/tool_monitor.rs
+++ b/crates/goose/src/tool_monitor.rs
@@ -67,7 +67,10 @@ impl RepetitionInspector {
     }
 
     pub fn record_error(&self, tool_name: &str, error_text: &str) {
-        let truncated = &error_text[..error_text.len().min(100)];
+        let truncated = error_text
+            .char_indices()
+            .nth(100)
+            .map_or(error_text, |(i, _)| &error_text[..i]);
         let mut state = self.error_state.lock().unwrap();
         if state.last_tool_name.as_deref() == Some(tool_name)
             && state.last_error_text.as_deref() == Some(truncated)

--- a/crates/goose/src/tool_monitor.rs
+++ b/crates/goose/src/tool_monitor.rs
@@ -67,18 +67,15 @@ impl RepetitionInspector {
     }
 
     pub fn record_error(&self, tool_name: &str, error_text: &str) {
-        let truncated = error_text
-            .char_indices()
-            .nth(100)
-            .map_or(error_text, |(i, _)| &error_text[..i]);
+        let truncated: String = error_text.chars().take(100).collect();
         let mut state = self.error_state.lock().unwrap();
         if state.last_tool_name.as_deref() == Some(tool_name)
-            && state.last_error_text.as_deref() == Some(truncated)
+            && state.last_error_text.as_deref() == Some(truncated.as_str())
         {
             state.consecutive_count += 1;
         } else {
             state.last_tool_name = Some(tool_name.to_string());
-            state.last_error_text = Some(truncated.to_string());
+            state.last_error_text = Some(truncated);
             state.consecutive_count = 1;
         }
     }
@@ -179,7 +176,7 @@ impl ToolInspector for RepetitionInspector {
         // Deny a tool that has returned the same error N consecutive times, regardless
         // of whether call parameters changed — catches retry loops with varying inputs.
         {
-            let state = self.error_state.lock().unwrap();
+            let mut state = self.error_state.lock().unwrap();
             if state.consecutive_count >= MAX_CONSECUTIVE_ERROR_FINGERPRINTS {
                 if let Some(ref last_tool) = state.last_tool_name {
                     let error_text = state.last_error_text.as_deref().unwrap_or("");
@@ -201,6 +198,8 @@ impl ToolInspector for RepetitionInspector {
                         }
                     }
                 }
+                // Reset so the model can retry after adapting strategy
+                state.consecutive_count = 0;
             }
         }
 

--- a/crates/goose/tests/repetition_inspector_tests.rs
+++ b/crates/goose/tests/repetition_inspector_tests.rs
@@ -51,9 +51,15 @@ async fn test_error_pattern_fires_after_threshold() {
         inspector.record_error("my_tool", "404 Not Found");
     }
     let requests = vec![make_tool_request("my_tool")];
-    let results: Vec<_> = ToolInspector::inspect(&inspector, "session", &requests, &[], goose::config::GooseMode::Auto)
-        .await
-        .unwrap();
+    let results: Vec<_> = ToolInspector::inspect(
+        &inspector,
+        "session",
+        &requests,
+        &[],
+        goose::config::GooseMode::Auto,
+    )
+    .await
+    .unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].action, InspectionAction::Deny);
     assert_eq!(results[0].finding_id.as_deref(), Some("REP-002"));
@@ -66,10 +72,18 @@ async fn test_error_pattern_does_not_fire_before_threshold() {
         inspector.record_error("my_tool", "404 Not Found");
     }
     let requests = vec![make_tool_request("my_tool")];
-    let results: Vec<_> = ToolInspector::inspect(&inspector, "session", &requests, &[], goose::config::GooseMode::Auto)
-        .await
-        .unwrap();
-    assert!(results.iter().all(|r| r.finding_id.as_deref() != Some("REP-002")));
+    let results: Vec<_> = ToolInspector::inspect(
+        &inspector,
+        "session",
+        &requests,
+        &[],
+        goose::config::GooseMode::Auto,
+    )
+    .await
+    .unwrap();
+    assert!(results
+        .iter()
+        .all(|r| r.finding_id.as_deref() != Some("REP-002")));
 }
 
 #[tokio::test]
@@ -80,10 +94,18 @@ async fn test_error_pattern_resets_on_success() {
     inspector.record_success();
     inspector.record_error("my_tool", "404 Not Found");
     let requests = vec![make_tool_request("my_tool")];
-    let results: Vec<_> = ToolInspector::inspect(&inspector, "session", &requests, &[], goose::config::GooseMode::Auto)
-        .await
-        .unwrap();
-    assert!(results.iter().all(|r| r.finding_id.as_deref() != Some("REP-002")));
+    let results: Vec<_> = ToolInspector::inspect(
+        &inspector,
+        "session",
+        &requests,
+        &[],
+        goose::config::GooseMode::Auto,
+    )
+    .await
+    .unwrap();
+    assert!(results
+        .iter()
+        .all(|r| r.finding_id.as_deref() != Some("REP-002")));
 }
 
 #[tokio::test]
@@ -93,8 +115,16 @@ async fn test_error_pattern_does_not_cross_tool_names() {
         inspector.record_error("tool_a", "same error");
     }
     let requests = vec![make_tool_request("tool_b")];
-    let results: Vec<_> = ToolInspector::inspect(&inspector, "session", &requests, &[], goose::config::GooseMode::Auto)
-        .await
-        .unwrap();
-    assert!(results.iter().all(|r| r.finding_id.as_deref() != Some("REP-002")));
+    let results: Vec<_> = ToolInspector::inspect(
+        &inspector,
+        "session",
+        &requests,
+        &[],
+        goose::config::GooseMode::Auto,
+    )
+    .await
+    .unwrap();
+    assert!(results
+        .iter()
+        .all(|r| r.finding_id.as_deref() != Some("REP-002")));
 }

--- a/crates/goose/tests/repetition_inspector_tests.rs
+++ b/crates/goose/tests/repetition_inspector_tests.rs
@@ -109,6 +109,39 @@ async fn test_error_pattern_resets_on_success() {
 }
 
 #[tokio::test]
+async fn test_error_pattern_streak_not_cleared_by_unrelated_tool() {
+    let inspector = RepetitionInspector::new(None);
+    for _ in 0..3 {
+        inspector.record_error("tool_a", "timeout");
+    }
+    // Calling an unrelated tool must not reset tool_a's streak
+    let unrelated = vec![make_tool_request("tool_b")];
+    ToolInspector::inspect(
+        &inspector,
+        "session",
+        &unrelated,
+        &[],
+        goose::config::GooseMode::Auto,
+    )
+    .await
+    .unwrap();
+    // tool_a should still be denied on the next call
+    let requests = vec![make_tool_request("tool_a")];
+    let results: Vec<_> = ToolInspector::inspect(
+        &inspector,
+        "session",
+        &requests,
+        &[],
+        goose::config::GooseMode::Auto,
+    )
+    .await
+    .unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, InspectionAction::Deny);
+    assert_eq!(results[0].finding_id.as_deref(), Some("REP-002"));
+}
+
+#[tokio::test]
 async fn test_error_pattern_does_not_cross_tool_names() {
     let inspector = RepetitionInspector::new(None);
     for _ in 0..3 {

--- a/crates/goose/tests/repetition_inspector_tests.rs
+++ b/crates/goose/tests/repetition_inspector_tests.rs
@@ -1,3 +1,4 @@
+use goose::tool_inspection::{InspectionAction, ToolInspector};
 use goose::tool_monitor::RepetitionInspector;
 use rmcp::model::CallToolRequestParams;
 use rmcp::object;
@@ -32,4 +33,68 @@ fn test_repetition_inspector_denies_after_exceeding_and_resets_on_param_change()
 
     // One more identical call with new params → denied again
     assert!(!inspector.check_tool_call(call_v2));
+}
+
+fn make_tool_request(tool_name: &'static str) -> goose::conversation::message::ToolRequest {
+    goose::conversation::message::ToolRequest {
+        id: format!("req_{}", tool_name),
+        tool_call: Ok(CallToolRequestParams::new(tool_name).with_arguments(object!({}))),
+        metadata: None,
+        tool_meta: None,
+    }
+}
+
+#[tokio::test]
+async fn test_error_pattern_fires_after_threshold() {
+    let inspector = RepetitionInspector::new(None);
+    for _ in 0..3 {
+        inspector.record_error("my_tool", "404 Not Found");
+    }
+    let requests = vec![make_tool_request("my_tool")];
+    let results: Vec<_> = ToolInspector::inspect(&inspector, "session", &requests, &[], goose::config::GooseMode::Auto)
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, InspectionAction::Deny);
+    assert_eq!(results[0].finding_id.as_deref(), Some("REP-002"));
+}
+
+#[tokio::test]
+async fn test_error_pattern_does_not_fire_before_threshold() {
+    let inspector = RepetitionInspector::new(None);
+    for _ in 0..2 {
+        inspector.record_error("my_tool", "404 Not Found");
+    }
+    let requests = vec![make_tool_request("my_tool")];
+    let results: Vec<_> = ToolInspector::inspect(&inspector, "session", &requests, &[], goose::config::GooseMode::Auto)
+        .await
+        .unwrap();
+    assert!(results.iter().all(|r| r.finding_id.as_deref() != Some("REP-002")));
+}
+
+#[tokio::test]
+async fn test_error_pattern_resets_on_success() {
+    let inspector = RepetitionInspector::new(None);
+    inspector.record_error("my_tool", "404 Not Found");
+    inspector.record_error("my_tool", "404 Not Found");
+    inspector.record_success();
+    inspector.record_error("my_tool", "404 Not Found");
+    let requests = vec![make_tool_request("my_tool")];
+    let results: Vec<_> = ToolInspector::inspect(&inspector, "session", &requests, &[], goose::config::GooseMode::Auto)
+        .await
+        .unwrap();
+    assert!(results.iter().all(|r| r.finding_id.as_deref() != Some("REP-002")));
+}
+
+#[tokio::test]
+async fn test_error_pattern_does_not_cross_tool_names() {
+    let inspector = RepetitionInspector::new(None);
+    for _ in 0..3 {
+        inspector.record_error("tool_a", "same error");
+    }
+    let requests = vec![make_tool_request("tool_b")];
+    let results: Vec<_> = ToolInspector::inspect(&inspector, "session", &requests, &[], goose::config::GooseMode::Auto)
+        .await
+        .unwrap();
+    assert!(results.iter().all(|r| r.finding_id.as_deref() != Some("REP-002")));
 }


### PR DESCRIPTION
## Problem

When a tool returns the same error repeatedly with varying parameters, the agent loops indefinitely without changing approach. The existing `RepetitionInspector` only blocks identical *calls* (same name + same arguments) — it does nothing when the arguments change but the error is the same.

Observed in practice: a session calling `pup error-tracking issues get <id>` returned a 404 error 3+ consecutive times (with different IDs each time). The agent never recovered because there was no signal it was stuck in an error loop.

## Solution

Extend `RepetitionInspector` with error-pattern tracking. After a tool returns the same error N consecutive times (default: 3), the next call to that tool is denied and a corrective hint is injected into the conversation context telling the model to try a different approach.

## Changes

**`crates/goose/src/tool_monitor.rs`**
- `RepetitionInspector` now tracks `last_tool_name`, `last_error_text`, and `consecutive_count` via interior `Mutex` (required by the `&self` trait bound on `inspect()`)
- `record_error(tool_name, error_text)` — updates state; only allocates new strings when the error fingerprint changes
- `record_success()` — resets state on any successful tool result
- `inspect()` emits a `Deny` result with `finding_id: "REP-002"` when the consecutive threshold is reached
- Added `FINDING_ID_REPEATED_ERROR` and `FINDING_ID_REPEATED_CALLS` constants to avoid stringly-typed cross-module matching

**`crates/goose/src/tool_inspection.rs`**
- `ToolInspectionManager::record_tool_error()` and `record_tool_success()` delegate to `RepetitionInspector` when present

**`crates/goose/src/agents/agent.rs`**
- After each `ToolStreamItem::Result`, calls `record_tool_error` or `record_tool_success` before the result is moved into `add_tool_response_with_metadata`
- After a tool response is committed, checks `inspection_results` for a `REP-002` deny on that request and injects a `Message::user` hint into `messages_to_add`

**`crates/goose/tests/repetition_inspector_tests.rs`**
- 4 new unit tests: threshold fires at N, does not fire before N, resets on success, does not cross tool names

## Test plan

- [ ] `cargo test -p goose --test repetition_inspector_tests` — all 5 tests pass
- [ ] `cargo check -p goose` — compiles cleanly
- [ ] Manual: run a session where a tool consistently returns an error; confirm the hint message appears after the 3rd failure and the agent changes strategy