### PR TITLE
feat(analyze): add Elixir support and clarify tool description

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -151,7 +151,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3165,7 +3165,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3480,7 +3480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4436,6 +4436,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "tree-sitter",
+ "tree-sitter-elixir",
  "tree-sitter-go",
  "tree-sitter-java",
  "tree-sitter-javascript",
@@ -5469,7 +5470,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6283,7 +6284,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8239,7 +8240,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8298,7 +8299,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9103,7 +9104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10248,7 +10249,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11078,6 +11079,16 @@ dependencies = [
  "regex-syntax",
  "serde_json",
  "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-elixir"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66dd064a762ed95bfc29857fa3cb7403bb1e5cb88112de0f6341b7e47284ba40"
+dependencies = [
+ "cc",
  "tree-sitter-language",
 ]
 
@@ -11916,7 +11927,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12418,7 +12429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ tracing-opentelemetry = "0.32"
 
 rayon = "1.12"
 tree-sitter = "0.26"
+tree-sitter-elixir = "0.3.5"
 tree-sitter-go = "0.25"
 tree-sitter-java = "0.23"
 tree-sitter-javascript = "0.25"

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -170,6 +170,7 @@ indexmap = "2.14.0"
 ignore = { workspace = true }
 rayon = { workspace = true }
 tree-sitter = { workspace = true }
+tree-sitter-elixir = { workspace = true }
 tree-sitter-go = { workspace = true }
 tree-sitter-java = { workspace = true }
 tree-sitter-javascript = { workspace = true }

--- a/crates/goose/src/agents/platform_extensions/analyze/languages.rs
+++ b/crates/goose/src/agents/platform_extensions/analyze/languages.rs
@@ -353,7 +353,8 @@ static LANGUAGES: &[LangInfo] = &[
             imports: r#"
                 (call
                   target: (identifier) @_method
-                  (#any-of? @_method "import" "alias" "require" "use")) @path
+                  (arguments . (_) @path)
+                  (#any-of? @_method "import" "alias" "require" "use"))
             "#,
             calls: r#"
                 (call target: (identifier) @name

--- a/crates/goose/src/agents/platform_extensions/analyze/languages.rs
+++ b/crates/goose/src/agents/platform_extensions/analyze/languages.rs
@@ -342,7 +342,7 @@ static LANGUAGES: &[LangInfo] = &[
                         left: (call target: (identifier) @name)
                         operator: "when")
                     ])
-                  (#any-of? @_ignore "def" "defp" "defmacro" "defmacrop" "defn" "defnp"))
+                  (#any-of? @_ignore "def" "defp" "defdelegate" "defguard" "defguardp" "defmacro" "defmacrop" "defn" "defnp"))
             "#,
             classes: r#"
                 (call
@@ -358,9 +358,12 @@ static LANGUAGES: &[LangInfo] = &[
             calls: r#"
                 (call target: (identifier) @name
                      (#not-any-of? @name
-                          "def" "defp" "defmacro" "defmacrop" "defn" "defnp"
-                          "defmodule" "defprotocol"
-                          "import" "alias" "require" "use"))
+                          "def" "defdelegate" "defexception" "defguard" "defguardp"
+                          "defimpl" "defmacro" "defmacrop" "defmodule" "defn" "defnp"
+                          "defoverridable" "defp" "defprotocol" "defstruct"
+                          "alias" "case" "cond" "else" "for" "if" "import" "quote"
+                          "raise" "receive" "require" "reraise" "super" "throw"
+                          "try" "unless" "unquote" "unquote_splicing" "use" "with"))
                 (call target: (dot right: (identifier) @name))
                 (binary_operator operator: "|>" right: (identifier) @name)
             "#,

--- a/crates/goose/src/agents/platform_extensions/analyze/languages.rs
+++ b/crates/goose/src/agents/platform_extensions/analyze/languages.rs
@@ -319,6 +319,49 @@ static LANGUAGES: &[LangInfo] = &[
             "#,
         },
     },
+    LangInfo {
+        name: "elixir",
+        extensions: &["ex", "exs"],
+        language: || tree_sitter_elixir::LANGUAGE.into(),
+        // Elixir's tree-sitter grammar represents `def`/`defmodule` as `call` nodes,
+        // the same type as regular function calls. Empty fn_kinds/class_kinds disables
+        // enclosing-context attribution in call graphs; semantic mode (function/module/import
+        // listing) works fully via the queries below.
+        fn_kinds: &[],
+        fn_name_kinds: &[],
+        class_kinds: &[],
+        queries: LangQueries {
+            functions: r#"
+                (call
+                  target: (identifier) @_ignore
+                  (arguments
+                    [
+                      (identifier) @name
+                      (call target: (identifier) @name)
+                      (binary_operator
+                        left: (call target: (identifier) @name)
+                        operator: "when")
+                    ])
+                  (#any-of? @_ignore "def" "defp" "defmacro" "defmacrop" "defn" "defnp"))
+            "#,
+            classes: r#"
+                (call
+                  target: (identifier) @_ignore
+                  (arguments (alias) @name)
+                  (#any-of? @_ignore "defmodule" "defprotocol"))
+            "#,
+            imports: r#"
+                (call
+                  target: (identifier) @_method
+                  (#any-of? @_method "import" "alias" "require" "use")) @path
+            "#,
+            calls: r#"
+                (call target: (identifier) @name)
+                (call target: (dot right: (identifier) @name))
+                (binary_operator operator: "|>" right: (identifier) @name)
+            "#,
+        },
+    },
 ];
 
 pub fn lang_for_ext(ext: &str) -> Option<&'static LangInfo> {

--- a/crates/goose/src/agents/platform_extensions/analyze/languages.rs
+++ b/crates/goose/src/agents/platform_extensions/analyze/languages.rs
@@ -356,7 +356,11 @@ static LANGUAGES: &[LangInfo] = &[
                   (#any-of? @_method "import" "alias" "require" "use")) @path
             "#,
             calls: r#"
-                (call target: (identifier) @name)
+                (call target: (identifier) @name
+                     (#not-any-of? @name
+                          "def" "defp" "defmacro" "defmacrop" "defn" "defnp"
+                          "defmodule" "defprotocol"
+                          "import" "alias" "require" "use"))
                 (call target: (dot right: (identifier) @name))
                 (binary_operator operator: "|>" right: (identifier) @name)
             "#,

--- a/crates/goose/src/agents/platform_extensions/analyze/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/analyze/mod.rs
@@ -60,7 +60,7 @@ impl AnalyzeClient {
             .with_instructions(indoc! {"
             Analyze code structure using tree-sitter AST parsing. Three auto-selected modes:
             - Directory path → structure overview (file tree with function/class counts)
-            - File path → semantic details (functions, classes, imports, call counts)
+            - File path → AST symbol details (functions, classes, imports — not for raw file reading; use shell cat for that)
             - Any path + focus parameter → symbol call graph (incoming/outgoing chains)
 
             For large codebases, delegate analysis to a subagent and retain only the summary.
@@ -215,7 +215,7 @@ impl McpClientTrait for AnalyzeClient {
     ) -> Result<ListToolsResult, Error> {
         let tool = Tool::new(
             "analyze".to_string(),
-            "Analyze code structure in 3 modes: 1) Directory overview - file tree with LOC/function/class counts to max_depth. 2) File details - functions, classes, imports. 3) Symbol focus - call graphs across directory to max_depth (requires file or directory path, case-sensitive). Typical flow: directory → files → symbols. Functions called >3x show •N.".to_string(),
+            "Analyze code structure via AST parsing (not a file reader — use shell cat for raw contents). 3 modes: 1) Directory overview - file tree with LOC/function/class counts to max_depth. 2) File symbols (AST-parsed) - functions, classes, imports. 3) Symbol focus - call graphs across directory to max_depth (requires file or directory path, case-sensitive). Typical flow: directory → files → symbols. Functions called >3x show •N.".to_string(),
             Self::schema::<AnalyzeParams>(),
         )
         .annotate(ToolAnnotations::from_raw(

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
@@ -41,7 +41,7 @@ Use list_resources and read_resource to work with extension data and resources.
 ### Instructions
 Analyze code structure using tree-sitter AST parsing. Three auto-selected modes:
 - Directory path → structure overview (file tree with function/class counts)
-- File path → semantic details (functions, classes, imports, call counts)
+- File path → AST symbol details (functions, classes, imports — not for raw file reading; use shell cat for that)
 - Any path + focus parameter → symbol call graph (incoming/outgoing chains)
 
 For large codebases, delegate analysis to a subagent and retain only the summary.


### PR DESCRIPTION
## Summary

- Add `tree-sitter-elixir 0.3.5` to extract functions, modules, and imports from `.ex`/`.exs` files
- Elixir uses macro-based definitions (`def`/`defmodule` are `call` nodes in the AST), so `fn_kinds`/`class_kinds` are left empty — semantic and structure modes work fully, call graph caller attribution is a known limitation for a follow-up
- Clarify `analyze` tool description in both the MCP tool definition and the extension instructions to distinguish AST symbol analysis from raw file reading, directing users to `shell cat` for the latter

## Test plan

- [ ] `cargo check -p goose` compiles cleanly with the new tree-sitter-elixir dependency
- [ ] `cargo clippy -p goose` passes with no new warnings
- [ ] `cargo test -p goose --test repetition_inspector_tests` — all existing tests pass
- [ ] Manual: `analyze` on a `.ex` file returns module name, function list, and imports correctly