### PR TITLE
feat(agent): auto-nudge model when it produces text without tool calls

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -69,10 +69,13 @@ const COMPACTION_THINKING_TEXT: &str = "goose is compacting the conversation..."
 const MAX_TEXT_ONLY_NUDGES: u32 = 3;
 const TEXT_ONLY_NUDGE_MESSAGE: &str =
     "Please continue by using the available tools to accomplish the task.";
-/// Models that emit pre-task planning text before their first tool call and
-/// need nudging to start using tools. For these we drop the
-/// `any_tools_ever_called` guard so the very first text-only turn is nudged.
-const PRE_TASK_NUDGE_MODELS: &[&str] = &["tencent/hy3-preview"];
+/// Substrings of model names that emit pre-task planning text before their
+/// first tool call and need nudging to start using tools. Matched with
+/// `contains`, so a short fragment like "hy3" covers the whole family
+/// (hy3-preview, hy3-large, future variants, etc.). For these models we drop
+/// the `any_tools_ever_called` guard so the very first text-only turn is
+/// nudged.
+const PRE_TASK_NUDGE_MODELS: &[&str] = &["hy3"];
 
 /// Context needed for the reply function
 pub struct ReplyContext {

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1281,6 +1281,7 @@ impl Agent {
             let mut compaction_attempts = 0;
             let mut last_assistant_text = String::new();
             let mut consecutive_text_only_turns: u32 = 0;
+            let mut any_tools_ever_called = false;
 
             loop {
                 if is_token_cancelled(&cancel_token) {
@@ -1754,6 +1755,7 @@ impl Agent {
 
                 if !no_tools_called {
                     consecutive_text_only_turns = 0;
+                    any_tools_ever_called = true;
                 }
 
                 if no_tools_called {
@@ -1781,7 +1783,7 @@ impl Agent {
                             // continue from last user message after recovery compact
                         }
                         None => {
-                            if !messages_to_add.is_empty() && consecutive_text_only_turns < MAX_TEXT_ONLY_NUDGES {
+                            if !any_tools_ever_called && !messages_to_add.is_empty() && consecutive_text_only_turns < MAX_TEXT_ONLY_NUDGES {
                                 consecutive_text_only_turns += 1;
                                 info!(
                                     "Model produced text without tool calls ({}/{}), nudging to continue",
@@ -1797,6 +1799,7 @@ impl Agent {
                                         if should_retry {
                                             info!("Retry logic triggered, restarting agent loop");
                                             messages_to_add = Conversation::default();
+                                            any_tools_ever_called = false;
                                             session_manager.replace_conversation(&session_config.id, &conversation).await?;
                                             yield AgentEvent::HistoryReplaced(conversation.clone());
                                         } else {

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1783,7 +1783,7 @@ impl Agent {
                             // continue from last user message after recovery compact
                         }
                         None => {
-                            if !any_tools_ever_called && !messages_to_add.is_empty() && consecutive_text_only_turns < MAX_TEXT_ONLY_NUDGES {
+                            if any_tools_ever_called && !messages_to_add.is_empty() && consecutive_text_only_turns < MAX_TEXT_ONLY_NUDGES {
                                 consecutive_text_only_turns += 1;
                                 info!(
                                     "Model produced text without tool calls ({}/{}), nudging to continue",

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -69,6 +69,10 @@ const COMPACTION_THINKING_TEXT: &str = "goose is compacting the conversation..."
 const MAX_TEXT_ONLY_NUDGES: u32 = 3;
 const TEXT_ONLY_NUDGE_MESSAGE: &str =
     "Please continue by using the available tools to accomplish the task.";
+/// Models that emit pre-task planning text before their first tool call and
+/// need nudging to start using tools. For these we drop the
+/// `any_tools_ever_called` guard so the very first text-only turn is nudged.
+const PRE_TASK_NUDGE_MODELS: &[&str] = &["tencent/hy3-preview"];
 
 /// Context needed for the reply function
 pub struct ReplyContext {
@@ -1246,6 +1250,10 @@ impl Agent {
         self.reset_retry_attempts().await;
 
         let provider = self.provider().await?;
+        let nudge_pre_task = {
+            let model_name = &provider.get_model_config().model_name;
+            PRE_TASK_NUDGE_MODELS.iter().any(|m| model_name.contains(m))
+        };
         let session_manager = self.config.session_manager.clone();
         let session_id = session_config.id.clone();
         if !self.config.disable_session_naming {
@@ -1783,7 +1791,7 @@ impl Agent {
                             // continue from last user message after recovery compact
                         }
                         None => {
-                            if any_tools_ever_called && !messages_to_add.is_empty() && consecutive_text_only_turns < MAX_TEXT_ONLY_NUDGES {
+                            if (any_tools_ever_called || nudge_pre_task) && !messages_to_add.is_empty() && consecutive_text_only_turns < MAX_TEXT_ONLY_NUDGES {
                                 consecutive_text_only_turns += 1;
                                 info!(
                                     "Model produced text without tool calls ({}/{}), nudging to continue",

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -66,6 +66,9 @@ use tracing::{debug, error, info, instrument, warn};
 
 const DEFAULT_MAX_TURNS: u32 = 1000;
 const COMPACTION_THINKING_TEXT: &str = "goose is compacting the conversation...";
+const MAX_TEXT_ONLY_NUDGES: u32 = 3;
+const TEXT_ONLY_NUDGE_MESSAGE: &str =
+    "Please continue by using the available tools to accomplish the task.";
 
 /// Context needed for the reply function
 pub struct ReplyContext {
@@ -1277,6 +1280,7 @@ impl Agent {
             });
             let mut compaction_attempts = 0;
             let mut last_assistant_text = String::new();
+            let mut consecutive_text_only_turns: u32 = 0;
 
             loop {
                 if is_token_cancelled(&cancel_token) {
@@ -1748,6 +1752,10 @@ impl Agent {
                     }
                 }
 
+                if !no_tools_called {
+                    consecutive_text_only_turns = 0;
+                }
+
                 if no_tools_called {
                     // Lock, extract state, drop guard before branching — handle_retry_logic
                     // also locks final_output_tool and tokio::sync::Mutex is not reentrant.
@@ -1773,25 +1781,37 @@ impl Agent {
                             // continue from last user message after recovery compact
                         }
                         None => {
-                            match self.handle_retry_logic(&mut conversation, &session_config, &initial_messages).await {
-                                Ok(should_retry) => {
-                                    if should_retry {
-                                        info!("Retry logic triggered, restarting agent loop");
-                                        messages_to_add = Conversation::default();
-                                        session_manager.replace_conversation(&session_config.id, &conversation).await?;
-                                        yield AgentEvent::HistoryReplaced(conversation.clone());
-                                    } else {
+                            if !messages_to_add.is_empty() && consecutive_text_only_turns < MAX_TEXT_ONLY_NUDGES {
+                                consecutive_text_only_turns += 1;
+                                info!(
+                                    "Model produced text without tool calls ({}/{}), nudging to continue",
+                                    consecutive_text_only_turns, MAX_TEXT_ONLY_NUDGES
+                                );
+                                let nudge = Message::user().with_text(TEXT_ONLY_NUDGE_MESSAGE);
+                                messages_to_add.push(nudge.clone());
+                                yield AgentEvent::Message(nudge);
+                            } else {
+                                consecutive_text_only_turns = 0;
+                                match self.handle_retry_logic(&mut conversation, &session_config, &initial_messages).await {
+                                    Ok(should_retry) => {
+                                        if should_retry {
+                                            info!("Retry logic triggered, restarting agent loop");
+                                            messages_to_add = Conversation::default();
+                                            session_manager.replace_conversation(&session_config.id, &conversation).await?;
+                                            yield AgentEvent::HistoryReplaced(conversation.clone());
+                                        } else {
+                                            exit_chat = true;
+                                        }
+                                    }
+                                    Err(e) => {
+                                        error!("Retry logic failed: {}", e);
+                                        yield AgentEvent::Message(
+                                            Message::assistant().with_text(
+                                                format!("Retry logic encountered an error: {}", e)
+                                            )
+                                        );
                                         exit_chat = true;
                                     }
-                                }
-                                Err(e) => {
-                                    error!("Retry logic failed: {}", e);
-                                    yield AgentEvent::Message(
-                                        Message::assistant().with_text(
-                                            format!("Retry logic encountered an error: {}", e)
-                                        )
-                                    );
-                                    exit_chat = true;
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary

- When a model returns a text-only response mid-task (no tool calls), the agent loop now injects a user message prompting it to use tools rather than exiting immediately
- Up to `MAX_TEXT_ONLY_NUDGES` (3) consecutive nudges are allowed before falling through to the existing retry/exit logic
- Counter resets whenever the model successfully makes tool calls, so nudges only fire on consecutive text-only turns

## Motivation

Models like `tencent/hy3-preview:free` (via OpenRouter) frequently emit planning-style responses ("Let me examine the code...") without making tool calls. This caused the agent to stop and required the user to manually click "continue" — sometimes 4–5 times per session. This pattern was confirmed across multiple sessions in the session DB.

The nudge approach matches industry practice (LangGraph, CrewAI, Pydantic AI all use bounded message injection for this case). A stronger fix using `tool_choice: "required"` at the API level is tracked in #9001.

## Changes

Single file: `crates/goose/src/agents/agent.rs`
- Add `MAX_TEXT_ONLY_NUDGES` and `TEXT_ONLY_NUDGE_MESSAGE` constants
- Add `consecutive_text_only_turns` counter in the reply stream
- Reset counter when tools are called successfully
- In the `no_tools_called → None` branch: nudge up to 3 times before exiting

## Test plan

- [ ] Build passes: `cargo build -p goose`
- [ ] Run a session with a model that produces planning text without tool calls — confirm agent auto-continues instead of stopping
- [ ] Confirm that after 3 consecutive text-only turns the agent still exits cleanly (no infinite loop)
- [ ] Confirm a session with normal tool-calling behavior is unaffected