### PR TITLE
align extensions page styling

### DIFF
--- a/ui/goose2/src/features/extensions/ui/ExtensionsSettings.tsx
+++ b/ui/goose2/src/features/extensions/ui/ExtensionsSettings.tsx
@@ -3,8 +3,7 @@ import { useTranslation } from "react-i18next";
 import { IconChevronDown, IconPlus } from "@tabler/icons-react";
 import { Button } from "@/shared/ui/button";
 import { SearchBar } from "@/shared/ui/SearchBar";
-import { FilterRow } from "@/shared/ui/page-shell";
-import { SettingsPage } from "@/shared/ui/SettingsPage";
+import { FilterRow, PageHeader } from "@/shared/ui/page-shell";
 import { useExtensionsSettings } from "../hooks/useExtensionsSettings";
 import {
   EXTENSION_CATEGORIES,
@@ -113,50 +112,51 @@ export function ExtensionsSettings() {
   };
 
   return (
-    <SettingsPage
-      title={t("extensions.title")}
-      actions={
-        <Button
-          type="button"
-          variant="outline-flat"
-          size="xs"
-          onClick={handleAdd}
-        >
-          <IconPlus className="size-3.5" />
-          {t("extensions.addExtension")}
-        </Button>
-      }
-      controls={
-        <div className="space-y-3">
-          <SearchBar
-            value={searchTerm}
-            onChange={setSearchTerm}
-            placeholder={t("extensions.search")}
-            aria-label={t("extensions.search")}
-            size="compact"
-          />
-          <FilterRow>
-            <FilterButton
-              active={activeFilter === "all"}
-              onClick={() => setActiveFilter("all")}
-            >
-              {t("extensions.filters.all")}
-            </FilterButton>
-            {EXTENSION_CATEGORIES.map((category) =>
-              categoryCounts[category] > 0 ? (
-                <FilterButton
-                  key={category}
-                  active={activeFilter === category}
-                  onClick={() => setActiveFilter(category)}
-                >
-                  {t(`extensions.categories.${category}`)}
-                </FilterButton>
-              ) : null,
-            )}
-          </FilterRow>
-        </div>
-      }
-    >
+    <>
+      <PageHeader
+        title={t("extensions.title")}
+        titleClassName="font-normal text-foreground"
+        actions={
+          <Button
+            type="button"
+            variant="outline-flat"
+            size="xs"
+            onClick={handleAdd}
+          >
+            <IconPlus className="size-3.5" />
+            {t("extensions.addExtension")}
+          </Button>
+        }
+      />
+
+      <div className="space-y-3">
+        <SearchBar
+          value={searchTerm}
+          onChange={setSearchTerm}
+          placeholder={t("extensions.search")}
+          aria-label={t("extensions.search")}
+        />
+        <FilterRow>
+          <FilterButton
+            active={activeFilter === "all"}
+            onClick={() => setActiveFilter("all")}
+          >
+            {t("extensions.filters.all")}
+          </FilterButton>
+          {EXTENSION_CATEGORIES.map((category) =>
+            categoryCounts[category] > 0 ? (
+              <FilterButton
+                key={category}
+                active={activeFilter === category}
+                onClick={() => setActiveFilter(category)}
+              >
+                {t(`extensions.categories.${category}`)}
+              </FilterButton>
+            ) : null,
+          )}
+        </FilterRow>
+      </div>
+
       {isLoading ? (
         <div className="grid gap-x-12 sm:grid-cols-2">
           {[1, 2, 3, 4, 5, 6].map((i) => (
@@ -225,6 +225,6 @@ export function ExtensionsSettings() {
           onClose={handleModalClose}
         />
       )}
-    </SettingsPage>
+    </>
   );
 }

--- a/ui/goose2/src/features/extensions/ui/ExtensionsSettings.tsx
+++ b/ui/goose2/src/features/extensions/ui/ExtensionsSettings.tsx
@@ -115,6 +115,7 @@ export function ExtensionsSettings() {
     <>
       <PageHeader
         title={t("extensions.title")}
+        description={t("extensions.description")}
         titleClassName="font-normal text-foreground"
         actions={
           <Button

--- a/ui/goose2/src/shared/i18n/locales/en/settings.json
+++ b/ui/goose2/src/shared/i18n/locales/en/settings.json
@@ -82,6 +82,7 @@
   },
   "extensions": {
     "title": "Extensions",
+    "description": "Connect Goose to apps, services, and built-in capabilities.",
     "search": "Search extensions...",
     "empty": "No extensions configured.",
     "noResults": "No extensions match your search.",

--- a/ui/goose2/src/shared/i18n/locales/es/settings.json
+++ b/ui/goose2/src/shared/i18n/locales/es/settings.json
@@ -82,6 +82,7 @@
   },
   "extensions": {
     "title": "Extensiones",
+    "description": "Conecta Goose con apps, servicios y capacidades integradas.",
     "search": "Buscar extensiones...",
     "empty": "No hay extensiones configuradas.",
     "noResults": "Ninguna extensión coincide con tu búsqueda.",


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Users see the Extensions page presented with the same page structure and search styling as the Agents and Skills pages.

**Problem:** The Extensions page still used the settings-page wrapper, which made its header and search treatment feel different from the newer Agents and Skills surfaces. That mismatch made the extension catalog feel like a separate settings panel instead of part of the same management experience.

**Solution:** Replace the settings wrapper with the shared page header pattern and use the default shared search bar treatment while preserving the existing extension filtering, grouping, list rows, and modal behavior.

<details>
<summary>File changes</summary>

**ui/goose2/src/features/extensions/ui/ExtensionsSettings.tsx**
Swaps `SettingsPage` for the shared `PageHeader` used by related management pages, and moves the search/filter controls into the page body. Keeps the extension list, category behavior, loading state, and add/edit modals unchanged.

</details>

### Reproduction Steps

1. Open the goose2 app and navigate to Extensions.
2. Compare the top of the page with Agents and Skills.
3. Confirm the Extensions title, add button, search field, and filter chips now use the same page-level styling.
4. Search and filter extensions to confirm existing results behavior still works.
5. Open Add extension and Configure extension to confirm modal behavior is unchanged.

### Screenshots/Demos

Not included. I could not run the local app in this worktree because `ui/goose2` dependencies are not installed, so `biome`, `tsc`, and `vitest` package scripts are unavailable.
<img width="1624" height="1061" alt="Screenshot 2026-05-04 at 3 39 05 PM" src="https://github.com/user-attachments/assets/b90947b8-a70c-4c2e-8479-777d0a29f555" />

