### PR TITLE
fix small window chat and settings layout

### DIFF
--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -477,13 +477,18 @@ export function AppInner() {
   // Show a toast if mesh is the configured provider but isn't running.
   useEffect(() => {
     const handler = () => {
-      toast.warn('Inference Mesh is set as your provider but isn\'t running. Open Settings → Mesh to start it. Keep goose running to stay connected.', {
-        autoClose: false,
-        toastId: 'mesh-not-running',
-      });
+      toast.warn(
+        "Inference Mesh is set as your provider but isn't running. Open Settings → Mesh to start it. Keep goose running to stay connected.",
+        {
+          autoClose: false,
+          toastId: 'mesh-not-running',
+        }
+      );
     };
     window.electron.on('mesh-not-running', handler);
-    return () => { window.electron.off('mesh-not-running', handler); };
+    return () => {
+      window.electron.off('mesh-not-running', handler);
+    };
   }, []);
 
   // Prevent default drag and drop behavior globally to avoid opening files in new windows
@@ -626,7 +631,7 @@ export function AppInner() {
                text-text-inverse bg-background-inverse
               `
         }
-        style={{ width: '450px' }}
+        style={{ width: 'min(450px, calc(100vw - 24px))' }}
         className="mt-6"
         position="top-right"
         autoClose={3000}

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -1287,7 +1287,7 @@ export default function ChatInput({
 
   return (
     <div
-      className={`flex flex-col relative h-auto p-4 transition-colors ${
+      className={`flex flex-col relative h-auto p-3 sm:p-4 transition-colors ${
         disableAnimation ? '' : 'page-transition'
       } ${
         isFocused
@@ -1343,7 +1343,9 @@ export default function ChatInput({
               minHeight: `${minTextareaHeight}px`,
               maxHeight: `${maxHeight}px`,
               overflowY: 'auto',
-              paddingRight: dictationProvider ? '180px' : '120px',
+              paddingRight: dictationProvider
+                ? 'clamp(120px, 34vw, 180px)'
+                : 'clamp(76px, 24vw, 120px)',
             }}
             className="w-full outline-none border-none focus:ring-0 bg-transparent px-3 pt-3 pb-1.5 text-sm resize-none text-text-primary placeholder:text-text-secondary"
           />
@@ -1364,7 +1366,7 @@ export default function ChatInput({
                           variant="outline"
                           onClick={() => {}}
                           disabled={true}
-                          className="bg-slate-600 text-white cursor-not-allowed opacity-50 border-slate-600 rounded-full px-6 py-2"
+                          className="bg-slate-600 text-white cursor-not-allowed opacity-50 border-slate-600 rounded-full px-4 py-2 sm:px-6"
                         >
                           <Microphone />
                         </Button>
@@ -1409,7 +1411,7 @@ export default function ChatInput({
                           }
                         }}
                         disabled={isTranscribing}
-                        className={`rounded-full px-6 py-2 ${
+                        className={`rounded-full px-4 py-2 sm:px-6 ${
                           isRecording
                             ? 'bg-red-500 text-white hover:bg-red-600 border-red-500'
                             : isTranscribing
@@ -1439,7 +1441,7 @@ export default function ChatInput({
                 size="sm"
                 shape="round"
                 variant="outline"
-                className="bg-slate-600 text-white hover:bg-slate-700 border-slate-600 rounded-full px-6 py-2"
+                className="bg-slate-600 text-white hover:bg-slate-700 border-slate-600 rounded-full px-4 py-2 sm:px-6"
               >
                 <Stop />
               </Button>
@@ -1453,14 +1455,14 @@ export default function ChatInput({
                       shape="round"
                       variant="outline"
                       disabled={isSubmitButtonDisabled}
-                      className={`rounded-full px-10 py-2 flex items-center gap-2 ${
+                      className={`rounded-full px-4 py-2 flex items-center gap-2 sm:px-10 ${
                         isSubmitButtonDisabled
                           ? 'bg-slate-600 text-white cursor-not-allowed opacity-50 border-slate-600'
                           : 'bg-slate-600 text-white hover:bg-slate-700 border-slate-600 hover:cursor-pointer'
                       }`}
                     >
                       <Send className="w-4 h-4" />
-                      <span className="text-sm">Send</span>
+                      <span className="hidden text-sm sm:inline">Send</span>
                     </Button>
                   </span>
                 </TooltipTrigger>

--- a/ui/desktop/src/components/Layout/AppLayout.tsx
+++ b/ui/desktop/src/components/Layout/AppLayout.tsx
@@ -171,8 +171,8 @@ const AppLayoutContent: React.FC<AppLayoutContentProps> = ({ activeSessions }) =
 
   // Main content area
   const mainContent = (
-    <div className="flex-1 overflow-hidden min-h-0">
-      <div className="h-full w-full bg-background-primary rounded-lg overflow-hidden">
+    <div className="flex-1 overflow-hidden min-h-0 min-w-0">
+      <div className="h-full w-full min-w-0 bg-background-primary rounded-lg overflow-hidden">
         <Outlet />
         {/* Always render ChatSessionsContainer to keep SSE connections alive.
             When navigating away from /pair, hide it with CSS */}
@@ -212,7 +212,11 @@ const AppLayoutContent: React.FC<AppLayoutContentProps> = ({ activeSessions }) =
           className="no-drag hover:!bg-background-tertiary"
           variant="ghost"
           size="xs"
-          title={isNavExpanded ? intl.formatMessage(i18n.closeNavigation) : intl.formatMessage(i18n.openNavigation)}
+          title={
+            isNavExpanded
+              ? intl.formatMessage(i18n.closeNavigation)
+              : intl.formatMessage(i18n.openNavigation)
+          }
         >
           <Menu className="w-5 h-5" />
         </Button>

--- a/ui/desktop/src/components/settings/SettingsView.tsx
+++ b/ui/desktop/src/components/settings/SettingsView.tsx
@@ -170,15 +170,17 @@ export default function SettingsView({
     <>
       <MainPanelLayout>
         <div className="flex-1 flex flex-col min-h-0">
-          <div className="bg-background-primary px-8 pb-8 pt-16">
+          <div className="bg-background-primary px-4 pb-5 pt-12 sm:px-6 sm:pb-6 sm:pt-14 lg:px-8 lg:pb-8 lg:pt-16">
             <div className="flex flex-col page-transition">
               <div className="flex justify-between items-center mb-1">
-                <h1 className="text-4xl font-light">{intl.formatMessage(i18n.title)}</h1>
+                <h1 className="text-3xl font-light sm:text-4xl">
+                  {intl.formatMessage(i18n.title)}
+                </h1>
               </div>
             </div>
           </div>
 
-          <div className="flex-1 min-h-0 relative px-6">
+          <div className="flex-1 min-h-0 relative px-3 sm:px-6">
             <Tabs
               value={activeTab}
               onValueChange={handleTabChange}
@@ -188,7 +190,7 @@ export default function SettingsView({
                 <TabsList className="w-full mb-2 justify-start overflow-x-auto flex-nowrap">
                   <TabsTrigger
                     value="models"
-                    className="flex gap-2"
+                    className="flex shrink-0 gap-2"
                     data-testid="settings-models-tab"
                   >
                     <Bot className="h-4 w-4" />
@@ -197,7 +199,7 @@ export default function SettingsView({
                   {localInference && (
                     <TabsTrigger
                       value="local-inference"
-                      className="flex gap-2"
+                      className="flex shrink-0 gap-2"
                       data-testid="settings-local-inference-tab"
                     >
                       <HardDrive className="h-4 w-4" />
@@ -207,20 +209,24 @@ export default function SettingsView({
                   {!tunnelDisabled && (
                     <TabsTrigger
                       value="mesh"
-                      className="flex gap-2"
+                      className="flex shrink-0 gap-2"
                       data-testid="settings-mesh-tab"
                     >
                       <Network className="h-4 w-4" />
                       Mesh
                     </TabsTrigger>
                   )}
-                  <TabsTrigger value="chat" className="flex gap-2" data-testid="settings-chat-tab">
+                  <TabsTrigger
+                    value="chat"
+                    className="flex shrink-0 gap-2"
+                    data-testid="settings-chat-tab"
+                  >
                     <MessageSquare className="h-4 w-4" />
                     {intl.formatMessage(i18n.tabChat)}
                   </TabsTrigger>
                   <TabsTrigger
                     value="sharing"
-                    className="flex gap-2"
+                    className="flex shrink-0 gap-2"
                     data-testid="settings-sharing-tab"
                   >
                     <Share2 className="h-4 w-4" />
@@ -228,7 +234,7 @@ export default function SettingsView({
                   </TabsTrigger>
                   <TabsTrigger
                     value="prompts"
-                    className="flex gap-2"
+                    className="flex shrink-0 gap-2"
                     data-testid="settings-prompts-tab"
                   >
                     <FileText className="h-4 w-4" />
@@ -236,13 +242,17 @@ export default function SettingsView({
                   </TabsTrigger>
                   <TabsTrigger
                     value="keyboard"
-                    className="flex gap-2"
+                    className="flex shrink-0 gap-2"
                     data-testid="settings-keyboard-tab"
                   >
                     <Keyboard className="h-4 w-4" />
                     {intl.formatMessage(i18n.tabKeyboard)}
                   </TabsTrigger>
-                  <TabsTrigger value="app" className="flex gap-2" data-testid="settings-app-tab">
+                  <TabsTrigger
+                    value="app"
+                    className="flex shrink-0 gap-2"
+                    data-testid="settings-app-tab"
+                  >
                     <Monitor className="h-4 w-4" />
                     {intl.formatMessage(i18n.tabApp)}
                   </TabsTrigger>


### PR DESCRIPTION
**Category:** fix
**User Impact:** Chat, settings, and notifications stay usable when the Goose window is narrow.
**Problem:** Narrow desktop windows could squeeze the main app shell, settings tabs, and chat composer until controls felt cramped or risked overflowing. Toasts also kept a fixed width that could exceed the available viewport.
**Solution:** Add the missing flex shrink constraints, make settings spacing responsive, let settings tabs scroll without compressing labels, and compact the chat composer actions at small widths while preserving the existing desktop treatment.

<details>
<summary>File changes</summary>

**ui/desktop/src/App.tsx**
Constrains toast width to the visible viewport so notifications do not overflow in compact windows.

**ui/desktop/src/components/ChatInput.tsx**
Reduces composer padding and button width at small sizes, hides the send label below the small breakpoint, and uses responsive textarea padding so the input text does not run under action buttons.

**ui/desktop/src/components/Layout/AppLayout.tsx**
Adds `min-w-0` to the main content flex area so chat and settings can shrink inside the app shell instead of forcing overflow beside the navigation.

**ui/desktop/src/components/settings/SettingsView.tsx**
Makes settings header and content padding responsive, reduces the heading scale on smaller widths, and prevents tab labels from compressing so the tab row can scroll cleanly.

</details>

### Reproduction Steps

1. Open Goose in a narrow desktop window with the left navigation visible.
2. Visit chat and confirm the composer remains usable without action controls crowding the input text.
3. Visit Settings and confirm the heading, tab row, and content remain usable at the same narrow width.
4. Trigger a toast and confirm it fits within the visible window.

### Screenshots/Demos

Not captured in this environment. The changes were verified with TypeScript checks and the repo pre-commit UI checks.
