### PR TITLE
add empty sidebar state

### DIFF
--- a/ui/goose2/src/features/sidebar/ui/Sidebar.tsx
+++ b/ui/goose2/src/features/sidebar/ui/Sidebar.tsx
@@ -434,6 +434,7 @@ export function Sidebar({
                 <SidebarProjectsSection
                   projects={projects}
                   projectSessions={projectSessions}
+                  hasVisibleChats={activeSessions.length > 0}
                   expandedProjects={expandedProjects}
                   toggleProject={toggleProject}
                   collapsed={collapsed}

--- a/ui/goose2/src/features/sidebar/ui/SidebarProjectsSection.tsx
+++ b/ui/goose2/src/features/sidebar/ui/SidebarProjectsSection.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import { IconEdit, IconFolderPlus } from "@tabler/icons-react";
 import type { AppView } from "@/app/AppShell";
 import type { ProjectInfo } from "@/features/projects/api/projects";
 import { cn } from "@/shared/lib/cn";
@@ -19,6 +20,7 @@ interface SidebarProjectsSectionProps {
     byProject: Record<string, TabInfo[]>;
     standalone: TabInfo[];
   };
+  hasVisibleChats: boolean;
   expandedProjects: Record<string, boolean>;
   toggleProject: (projectId: string) => void;
   collapsed: boolean;
@@ -41,6 +43,7 @@ interface SidebarProjectsSectionProps {
 export function SidebarProjectsSection({
   projects,
   projectSessions,
+  hasVisibleChats,
   expandedProjects,
   toggleProject,
   collapsed,
@@ -60,6 +63,7 @@ export function SidebarProjectsSection({
   onReorderProject,
 }: SidebarProjectsSectionProps) {
   const { t } = useTranslation(["sidebar", "common"]);
+  const showEmptyState = projects.length === 0 && !hasVisibleChats;
 
   return (
     <div
@@ -90,7 +94,7 @@ export function SidebarProjectsSection({
         >
           {t("sections.projects")}
         </span>
-        {!collapsed && (
+        {!collapsed && !showEmptyState && (
           <Button
             type="button"
             variant="ghost"
@@ -125,18 +129,50 @@ export function SidebarProjectsSection({
         onReorderProject={onReorderProject}
       />
 
-      <SidebarRecentsSection
-        sessions={projectSessions.standalone}
-        collapsed={collapsed}
-        labelTransition={labelTransition}
-        labelVisible={labelVisible}
-        activeSessionId={activeSessionId}
-        onNewChat={onNewChat}
-        onSelectSession={onSelectSession}
-        onArchiveChat={onArchiveChat}
-        onRenameChat={onRenameChat}
-        onMoveToProject={onMoveToProject}
-      />
+      {showEmptyState ? (
+        <div className="px-2.5 py-4">
+          <div className="rounded-lg border border-border-soft bg-background-alt/45 px-3 py-3">
+            <p className="text-[12px] font-medium leading-5 text-foreground">
+              {t("empty.noProjectsOrChats")}
+            </p>
+            <div className="mt-2 flex flex-col gap-1">
+              <Button
+                type="button"
+                variant="inline-subtle"
+                size="xs"
+                onClick={onCreateProject}
+                className="h-7 justify-start px-2 text-[12px] text-muted-foreground"
+                leftIcon={<IconFolderPlus className="size-3.5" />}
+              >
+                {t("actions.newProject")}
+              </Button>
+              <Button
+                type="button"
+                variant="inline-subtle"
+                size="xs"
+                onClick={onNewChat}
+                className="h-7 justify-start px-2 text-[12px] text-muted-foreground"
+                leftIcon={<IconEdit className="size-3.5" />}
+              >
+                {t("actions.newChat")}
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <SidebarRecentsSection
+          sessions={projectSessions.standalone}
+          collapsed={collapsed}
+          labelTransition={labelTransition}
+          labelVisible={labelVisible}
+          activeSessionId={activeSessionId}
+          onNewChat={onNewChat}
+          onSelectSession={onSelectSession}
+          onArchiveChat={onArchiveChat}
+          onRenameChat={onRenameChat}
+          onMoveToProject={onMoveToProject}
+        />
+      )}
     </div>
   );
 }

--- a/ui/goose2/src/features/sidebar/ui/SidebarProjectsSection.tsx
+++ b/ui/goose2/src/features/sidebar/ui/SidebarProjectsSection.tsx
@@ -64,6 +64,8 @@ export function SidebarProjectsSection({
 }: SidebarProjectsSectionProps) {
   const { t } = useTranslation(["sidebar", "common"]);
   const showEmptyState = projects.length === 0 && !hasVisibleChats;
+  const emptyActionClasses =
+    "h-8 w-full justify-start px-3 text-[13px] text-muted-foreground";
 
   return (
     <div
@@ -129,36 +131,76 @@ export function SidebarProjectsSection({
         onReorderProject={onReorderProject}
       />
 
-      {showEmptyState ? (
-        <div className="px-2.5 py-4">
-          <div className="rounded-lg border border-border-soft bg-background-alt/45 px-3 py-3">
-            <p className="text-[12px] font-medium leading-5 text-foreground">
-              {t("empty.noProjectsOrChats")}
-            </p>
-            <div className="mt-2 flex flex-col gap-1">
-              <Button
-                type="button"
-                variant="inline-subtle"
-                size="xs"
-                onClick={onCreateProject}
-                className="h-7 justify-start px-2 text-[12px] text-muted-foreground"
-                leftIcon={<IconFolderPlus className="size-3.5" />}
-              >
-                {t("actions.newProject")}
-              </Button>
-              <Button
-                type="button"
-                variant="inline-subtle"
-                size="xs"
-                onClick={onNewChat}
-                className="h-7 justify-start px-2 text-[12px] text-muted-foreground"
-                leftIcon={<IconEdit className="size-3.5" />}
-              >
-                {t("actions.newChat")}
-              </Button>
-            </div>
-          </div>
+      {showEmptyState && collapsed ? (
+        <div className="flex flex-col items-center gap-1">
+          <Button
+            type="button"
+            variant="quiet"
+            size="icon-xs"
+            onClick={onCreateProject}
+            aria-label={t("empty.createProject")}
+            title={t("empty.createProject")}
+            className="rounded-lg"
+          >
+            <IconFolderPlus className="size-4" />
+          </Button>
+          <Button
+            type="button"
+            variant="quiet"
+            size="icon-xs"
+            onClick={onNewChat}
+            aria-label={t("empty.startChat")}
+            title={t("empty.startChat")}
+            className="rounded-lg"
+          >
+            <IconEdit className="size-4" />
+          </Button>
         </div>
+      ) : showEmptyState ? (
+        <>
+          <div className="space-y-0.5">
+            <Button
+              type="button"
+              variant="quiet"
+              size="xs"
+              onClick={onCreateProject}
+              className={emptyActionClasses}
+              leftIcon={<IconFolderPlus className="size-3.5" />}
+            >
+              {t("empty.createProject")}
+            </Button>
+          </div>
+          <div
+            className={cn(
+              "relative flex items-center transition-all duration-300",
+              collapsed ? "px-0 pt-0 pb-1 justify-center" : "pt-5 pb-1.5",
+            )}
+          >
+            <span
+              className={cn(
+                "text-[12px] font-normal text-muted-foreground/80 flex-1 pl-3",
+                labelTransition,
+                labelVisible
+                  ? "opacity-100 w-auto"
+                  : "opacity-0 w-0 overflow-hidden",
+              )}
+            >
+              {t("sections.recents")}
+            </span>
+          </div>
+          <div className="space-y-0.5">
+            <Button
+              type="button"
+              variant="quiet"
+              size="xs"
+              onClick={onNewChat}
+              className={emptyActionClasses}
+              leftIcon={<IconEdit className="size-3.5" />}
+            >
+              {t("empty.startChat")}
+            </Button>
+          </div>
+        </>
       ) : (
         <SidebarRecentsSection
           sessions={projectSessions.standalone}

--- a/ui/goose2/src/features/sidebar/ui/__tests__/Sidebar.test.tsx
+++ b/ui/goose2/src/features/sidebar/ui/__tests__/Sidebar.test.tsx
@@ -43,6 +43,35 @@ vi.mock("@/features/projects/stores/projectStore", () => ({
 }));
 
 describe("Sidebar", () => {
+  it("shows an empty state when there are no projects or chats", async () => {
+    const user = userEvent.setup();
+    const onCreateProject = vi.fn();
+    const onNewChat = vi.fn();
+
+    mockSessions.splice(0, mockSessions.length);
+
+    render(
+      <Sidebar
+        collapsed={false}
+        onCollapse={vi.fn()}
+        onNavigate={vi.fn()}
+        onCreateProject={onCreateProject}
+        onNewChat={onNewChat}
+        projects={[]}
+      />,
+    );
+
+    expect(
+      screen.getByText("Create a Project and Start a New Chat"),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "New project" }));
+    await user.click(screen.getByRole("button", { name: "New chat" }));
+
+    expect(onCreateProject).toHaveBeenCalledOnce();
+    expect(onNewChat).toHaveBeenCalledOnce();
+  });
+
   it("shows sessions in recents when their project is not loaded", () => {
     mockSessions.splice(0, mockSessions.length, {
       id: "session-1",

--- a/ui/goose2/src/features/sidebar/ui/__tests__/Sidebar.test.tsx
+++ b/ui/goose2/src/features/sidebar/ui/__tests__/Sidebar.test.tsx
@@ -61,12 +61,11 @@ describe("Sidebar", () => {
       />,
     );
 
-    expect(
-      screen.getByText("Create a Project and Start a New Chat"),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Projects")).toBeInTheDocument();
+    expect(screen.getByText("Chats")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "New project" }));
-    await user.click(screen.getByRole("button", { name: "New chat" }));
+    await user.click(screen.getByRole("button", { name: "Create a project" }));
+    await user.click(screen.getByRole("button", { name: "Start a chat" }));
 
     expect(onCreateProject).toHaveBeenCalledOnce();
     expect(onNewChat).toHaveBeenCalledOnce();

--- a/ui/goose2/src/shared/i18n/locales/en/sidebar.json
+++ b/ui/goose2/src/shared/i18n/locales/en/sidebar.json
@@ -10,6 +10,9 @@
   "menu": {
     "optionsFor": "Options for {{label}}"
   },
+  "empty": {
+    "noProjectsOrChats": "Create a Project and Start a New Chat"
+  },
   "navigation": {
     "agents": "Agents",
     "extensions": "Extensions",

--- a/ui/goose2/src/shared/i18n/locales/en/sidebar.json
+++ b/ui/goose2/src/shared/i18n/locales/en/sidebar.json
@@ -11,7 +11,8 @@
     "optionsFor": "Options for {{label}}"
   },
   "empty": {
-    "noProjectsOrChats": "Create a Project and Start a New Chat"
+    "createProject": "Create a project",
+    "startChat": "Start a chat"
   },
   "navigation": {
     "agents": "Agents",

--- a/ui/goose2/src/shared/i18n/locales/es/sidebar.json
+++ b/ui/goose2/src/shared/i18n/locales/es/sidebar.json
@@ -11,7 +11,8 @@
     "optionsFor": "Opciones para {{label}}"
   },
   "empty": {
-    "noProjectsOrChats": "Crea un proyecto e inicia un chat nuevo"
+    "createProject": "Crear un proyecto",
+    "startChat": "Iniciar un chat"
   },
   "navigation": {
     "agents": "Agentes",

--- a/ui/goose2/src/shared/i18n/locales/es/sidebar.json
+++ b/ui/goose2/src/shared/i18n/locales/es/sidebar.json
@@ -10,6 +10,9 @@
   "menu": {
     "optionsFor": "Opciones para {{label}}"
   },
+  "empty": {
+    "noProjectsOrChats": "Crea un proyecto e inicia un chat nuevo"
+  },
   "navigation": {
     "agents": "Agentes",
     "extensions": "Extensiones",

--- a/ui/goose2/src/shared/ui/button.tsx
+++ b/ui/goose2/src/shared/ui/button.tsx
@@ -27,6 +27,8 @@ const buttonVariants = cva(
           "font-normal hover:bg-accent hover:text-accent-foreground",
         "inline-subtle":
           "rounded-md bg-transparent font-normal text-muted-foreground shadow-none hover:bg-muted/70 hover:text-foreground",
+        quiet:
+          "bg-transparent font-normal text-muted-foreground shadow-none hover:bg-transparent hover:text-foreground active:bg-transparent active:text-foreground data-[state=open]:bg-transparent data-[state=open]:text-foreground aria-expanded:bg-transparent aria-expanded:text-foreground",
         toolbar:
           "justify-start bg-transparent font-normal text-foreground shadow-none hover:bg-accent hover:text-accent-foreground active:bg-accent active:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground aria-expanded:bg-accent aria-expanded:text-accent-foreground",
         back: "justify-start text-muted-foreground hover:text-foreground",


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Users with no projects or chats now see a clear starting point in the goose2 sidebar.
**Problem:** When the sidebar had neither projects nor chats, the Projects and Chats sections could feel like empty chrome with no obvious first action. That made a fresh workspace feel unfinished instead of ready to use.
**Solution:** Add a compact empty state in the Projects area with the requested line, plus direct actions for creating a project or starting a chat. The empty state only appears when both projects and visible chats are absent, so existing project and chat lists keep their current behavior.

<details>
<summary>File changes</summary>

**ui/goose2/src/features/sidebar/ui/Sidebar.tsx**
Passes whether there are any visible active chats into the projects section so the empty state is based on the same filtered chat list the sidebar already renders.

**ui/goose2/src/features/sidebar/ui/SidebarProjectsSection.tsx**
Renders a restrained empty state when there are no projects or visible chats, with explicit project and chat actions using the shared button primitive.

**ui/goose2/src/features/sidebar/ui/__tests__/Sidebar.test.tsx**
Adds coverage for the empty sidebar state and verifies both actions call through to their handlers.

**ui/goose2/src/shared/i18n/locales/en/sidebar.json**
Adds the English empty-state copy.

**ui/goose2/src/shared/i18n/locales/es/sidebar.json**
Adds the Spanish empty-state copy so the sidebar locale files stay complete.

</details>

1. Open goose2 with no saved projects and no visible chat sessions.
2. Look at the expanded sidebar.
3. Confirm the sidebar shows “Create a Project and Start a New Chat.”
4. Click “New project” and confirm the create-project flow opens.
5. Click “New chat” and confirm a new chat starts.
6. Add a project or a visible chat and confirm the normal project/chat sections return.

**Focused verification**

- `pnpm --dir ui/goose2 exec vitest run src/features/sidebar/ui/__tests__/Sidebar.test.tsx`
- `pnpm --dir ui/goose2 exec biome check src/features/sidebar/ui/Sidebar.tsx src/features/sidebar/ui/SidebarProjectsSection.tsx src/features/sidebar/ui/__tests__/Sidebar.test.tsx src/shared/i18n/locales/en/sidebar.json src/shared/i18n/locales/es/sidebar.json`
- `git diff --check`

Full goose2 pre-push/typecheck remains blocked by existing unrelated SDK definition mismatches on `main` such as missing `GoosePreferencesRead`, `GooseDefaultsRead`, and `ProviderConfigChangeResponse` exports.

**Screenshots/Demos**

Not captured in this pass.
