### PR TITLE
show unread state for background chat responses

### DIFF
--- a/ui/goose2/src/app/AppShell.tsx
+++ b/ui/goose2/src/app/AppShell.tsx
@@ -145,8 +145,11 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
   const { activeSessionId } = sessionStore;
 
   useEffect(() => {
-    if (activeView === "chat" && activeSessionId) {
-      useChatStore.getState().markSessionRead(activeSessionId);
+    const viewedSessionId = activeView === "chat" ? activeSessionId : null;
+    const liveChatStore = useChatStore.getState();
+    liveChatStore.setViewedSession(viewedSessionId);
+    if (viewedSessionId) {
+      liveChatStore.markSessionRead(viewedSessionId);
     }
   }, [activeSessionId, activeView]);
 

--- a/ui/goose2/src/app/AppShell.tsx
+++ b/ui/goose2/src/app/AppShell.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { Sidebar } from "@/features/sidebar/ui/Sidebar";
 import { CreateProjectDialog } from "@/features/projects/ui/CreateProjectDialog";
 import { archiveProject } from "@/features/projects/api/projects";
@@ -59,6 +65,19 @@ const SETTINGS_SECTIONS = new Set<SectionId>([
   "doctor",
   "about",
 ]);
+
+function syncViewedSessionForView(
+  view: AppView,
+  sessionId: string | null,
+): void {
+  const viewedSessionId = view === "chat" ? sessionId : null;
+  const liveChatStore = useChatStore.getState();
+  liveChatStore.setViewedSession(viewedSessionId);
+  if (viewedSessionId) {
+    liveChatStore.markSessionRead(viewedSessionId);
+  }
+}
+
 export function AppShell({ children }: { children?: React.ReactNode }) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [sidebarWidth, setSidebarWidth] = useState(SIDEBAR_DEFAULT_WIDTH);
@@ -144,13 +163,16 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
 
   const { activeSessionId } = sessionStore;
 
-  useEffect(() => {
-    const viewedSessionId = activeView === "chat" ? activeSessionId : null;
-    const liveChatStore = useChatStore.getState();
-    liveChatStore.setViewedSession(viewedSessionId);
-    if (viewedSessionId) {
-      liveChatStore.markSessionRead(viewedSessionId);
-    }
+  const setActiveViewWithViewedSession = useCallback(
+    (view: AppView, sessionId: string | null = activeSessionId) => {
+      syncViewedSessionForView(view, sessionId);
+      setActiveView(view);
+    },
+    [activeSessionId],
+  );
+
+  useLayoutEffect(() => {
+    syncViewedSessionForView(activeView, activeSessionId);
   }, [activeSessionId, activeView]);
 
   const activeSession = activeSessionId
@@ -291,7 +313,7 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
 
       if (existingDraft) {
         sessionStore.setActiveSession(existingDraft.id);
-        setActiveView("chat");
+        setActiveViewWithViewedSession("chat", existingDraft.id);
         chatStore.setActiveSession(existingDraft.id);
         perfLog(
           `[perf:newtab] ${existingDraft.id.slice(0, 8)} reused draft in ${(performance.now() - tStart).toFixed(1)}ms`,
@@ -309,7 +331,7 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
         modelName: sessionModelPreference.modelName,
       });
       sessionStore.setActiveSession(session.id);
-      setActiveView("chat");
+      setActiveViewWithViewedSession("chat", session.id);
       chatStore.setActiveSession(session.id);
       perfLog(
         `[perf:newtab] ${session.id.slice(0, 8)} created session in ${(performance.now() - tStart).toFixed(1)}ms`,
@@ -320,6 +342,7 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
       agentStore.selectedProvider,
       chatStore,
       providerInventoryEntries,
+      setActiveViewWithViewedSession,
       sessionStore,
     ],
   );
@@ -376,9 +399,9 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
     (sessionId: string) => {
       chatStore.cleanupSession(sessionId);
       sessionStore.setActiveSession(null);
-      setActiveView("home");
+      setActiveViewWithViewedSession("home", null);
     },
-    [chatStore, sessionStore],
+    [chatStore, sessionStore, setActiveViewWithViewedSession],
   );
   const openSettings = useCallback((section: SectionId = "appearance") => {
     setSettingsInitialSection(section);
@@ -424,12 +447,12 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
         }
 
         sessionStore.setActiveSession(null);
-        setActiveView("home");
+        setActiveViewWithViewedSession("home", null);
       } catch {
         // best-effort
       }
     },
-    [chatStore, sessionStore],
+    [chatStore, sessionStore, setActiveViewWithViewedSession],
   );
 
   const handleEditProject = useCallback(
@@ -507,22 +530,25 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
         setHomeSessionId(null);
       }
       sessionStore.setActiveSession(sessionId);
-      setActiveView("chat");
+      setActiveViewWithViewedSession("chat", sessionId);
       chatStore.setActiveSession(sessionId);
-      useChatStore.getState().markSessionRead(sessionId);
     },
-    [chatStore, homeSessionId, sessionStore],
+    [chatStore, homeSessionId, sessionStore, setActiveViewWithViewedSession],
   );
 
   const handleSelectSession = useCallback(
     (id: string) => {
       sessionStore.setActiveSession(id);
-      setActiveView("chat");
+      setActiveViewWithViewedSession("chat", id);
       chatStore.setActiveSession(id);
-      useChatStore.getState().markSessionRead(id);
       loadSessionMessages(id);
     },
-    [sessionStore, chatStore, loadSessionMessages],
+    [
+      sessionStore,
+      chatStore,
+      loadSessionMessages,
+      setActiveViewWithViewedSession,
+    ],
   );
 
   const handleSelectSearchResult = useCallback(
@@ -539,12 +565,14 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
 
   const handleNavigate = useCallback(
     (view: AppView) => {
+      const nextSessionId =
+        view === "chat" ? useChatSessionStore.getState().activeSessionId : null;
       if (view !== "chat") {
         sessionStore.setActiveSession(null);
       }
-      setActiveView(view);
+      setActiveViewWithViewedSession(view, nextSessionId);
     },
-    [sessionStore],
+    [sessionStore, setActiveViewWithViewedSession],
   );
 
   const handleCreatePersona = useCreatePersonaNavigation(() =>
@@ -626,12 +654,12 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
       if (e.key === "n" && e.metaKey) {
         e.preventDefault();
         sessionStore.setActiveSession(null);
-        setActiveView("home");
+        setActiveViewWithViewedSession("home", null);
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [clearActiveSession, sessionStore]);
+  }, [clearActiveSession, sessionStore, setActiveViewWithViewedSession]);
 
   return (
     <div className="flex h-screen w-screen flex-col overflow-hidden bg-background text-foreground">
@@ -657,7 +685,7 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
             onNewChatInProject={handleNewChatInProject}
             onNewChat={() => {
               sessionStore.setActiveSession(null);
-              setActiveView("home");
+              setActiveViewWithViewedSession("home", null);
             }}
             onCreateProject={() => openCreateProjectDialog()}
             onEditProject={handleEditProject}

--- a/ui/goose2/src/features/chat/stores/__tests__/chatStore.test.ts
+++ b/ui/goose2/src/features/chat/stores/__tests__/chatStore.test.ts
@@ -27,6 +27,7 @@ describe("chatStore", () => {
       draftsBySession: {},
       skillDraftsBySession: {},
       activeSessionId: null,
+      viewedSessionId: null,
       isConnected: false,
     });
   });
@@ -108,17 +109,29 @@ describe("chatStore", () => {
     expect(getRuntime("s1").hasUnread).toBe(false);
   });
 
+  it("tracks which session is currently visible", () => {
+    const store = useChatStore.getState();
+
+    store.setViewedSession("s1");
+    expect(useChatStore.getState().viewedSessionId).toBe("s1");
+
+    store.setViewedSession(null);
+    expect(useChatStore.getState().viewedSessionId).toBeNull();
+  });
+
   it("clears messages and runtime state for a single session", () => {
     useChatStore.getState().addMessage("s1", makeMessage());
     useChatStore.getState().setChatState("s1", "streaming");
     useChatStore.getState().setStreamingMessageId("s1", "stream-1");
     useChatStore.getState().markSessionUnread("s1");
+    useChatStore.getState().setViewedSession("s1");
     useChatStore.getState().clearMessages("s1");
 
     expect(useChatStore.getState().messagesBySession.s1).toEqual([]);
     expect(getRuntime("s1").chatState).toBe("idle");
     expect(getRuntime("s1").streamingMessageId).toBeNull();
     expect(getRuntime("s1").hasUnread).toBe(false);
+    expect(useChatStore.getState().viewedSessionId).toBe("s1");
   });
 
   it("enqueues and dismisses messages per session", () => {
@@ -166,14 +179,17 @@ describe("chatStore", () => {
     store.setDraft("s1", "draft text");
     store.setSkillDrafts("s1", [{ id: "skill-1", name: "code-review" }]);
     store.setActiveSession("s1");
+    store.setViewedSession("s1");
     store.cleanupSession("s1");
 
-    expect(store.messagesBySession.s1).toBeUndefined();
-    expect(store.sessionStateById.s1).toBeUndefined();
-    expect(store.queuedMessageBySession.s1).toBeUndefined();
-    expect(store.draftsBySession.s1).toBeUndefined();
+    const state = useChatStore.getState();
+    expect(state.messagesBySession.s1).toBeUndefined();
+    expect(state.sessionStateById.s1).toBeUndefined();
+    expect(state.queuedMessageBySession.s1).toBeUndefined();
+    expect(state.draftsBySession.s1).toBeUndefined();
     expect(useChatStore.getState().skillDraftsBySession.s1).toBeUndefined();
-    expect(store.activeSessionId).toBeNull();
+    expect(state.activeSessionId).toBeNull();
+    expect(state.viewedSessionId).toBeNull();
   });
 
   it("stores and clears scroll targets per session", () => {
@@ -204,6 +220,7 @@ describe("chatStore draft localStorage persistence", () => {
       draftsBySession: {},
       skillDraftsBySession: {},
       activeSessionId: null,
+      viewedSessionId: null,
       isConnected: false,
     });
   });

--- a/ui/goose2/src/features/chat/stores/chatStore.ts
+++ b/ui/goose2/src/features/chat/stores/chatStore.ts
@@ -43,6 +43,7 @@ interface ChatStoreState {
   draftsBySession: Record<string, string>;
   skillDraftsBySession: Record<string, ChatSkillDraft[]>;
   activeSessionId: string | null;
+  viewedSessionId: string | null;
   isConnected: boolean;
   loadingSessionIds: Set<string>;
   scrollTargetMessageBySession: Record<string, ScrollTargetMessage | null>;
@@ -50,6 +51,7 @@ interface ChatStoreState {
 
 interface ChatStoreActions {
   setActiveSession: (sessionId: string) => void;
+  setViewedSession: (sessionId: string | null) => void;
   addMessage: (sessionId: string, message: Message) => void;
   updateMessage: (
     sessionId: string,
@@ -109,6 +111,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   draftsBySession: loadCachedDrafts(),
   skillDraftsBySession: {},
   activeSessionId: null,
+  viewedSessionId: null,
   isConnected: false,
   loadingSessionIds: new Set<string>(),
   scrollTargetMessageBySession: {},
@@ -124,6 +127,8 @@ export const useChatStore = create<ChatStore>((set, get) => ({
             [sessionId]: createInitialSessionRuntime(),
           },
     })),
+
+  setViewedSession: (sessionId) => set({ viewedSessionId: sessionId }),
 
   // Message management
   addMessage: (sessionId, message) =>
@@ -508,6 +513,8 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         scrollTargetMessageBySession: remainingTargets,
         activeSessionId:
           state.activeSessionId === sessionId ? null : state.activeSessionId,
+        viewedSessionId:
+          state.viewedSessionId === sessionId ? null : state.viewedSessionId,
       };
     });
     persistDrafts(get().draftsBySession);

--- a/ui/goose2/src/shared/api/__tests__/acpNotificationHandler.test.ts
+++ b/ui/goose2/src/shared/api/__tests__/acpNotificationHandler.test.ts
@@ -40,6 +40,7 @@ describe("acpNotificationHandler", () => {
       queuedMessageBySession: {},
       draftsBySession: {},
       activeSessionId: null,
+      viewedSessionId: null,
       isConnected: false,
       loadingSessionIds: new Set<string>(),
       scrollTargetMessageBySession: {},
@@ -141,6 +142,82 @@ describe("acpNotificationHandler", () => {
       useChatStore.getState().getSessionRuntime("acp-session")
         .streamingMessageId,
     ).toBe("assistant-1");
+  });
+
+  it("marks unviewed sessions unread when live agent output arrives", async () => {
+    await handleSessionNotification({
+      sessionId: "acp-session",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: {
+          type: "text",
+          text: "Background answer.",
+        },
+      },
+    } as never);
+
+    expect(
+      useChatStore.getState().getSessionRuntime("acp-session").hasUnread,
+    ).toBe(true);
+  });
+
+  it("keeps live output read when the session is being viewed", async () => {
+    useChatStore.getState().setViewedSession("acp-session");
+
+    await handleSessionNotification({
+      sessionId: "acp-session",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: {
+          type: "text",
+          text: "Visible answer.",
+        },
+      },
+    } as never);
+
+    expect(
+      useChatStore.getState().getSessionRuntime("acp-session").hasUnread,
+    ).toBe(false);
+  });
+
+  it("marks active sessions unread when they are not being viewed", async () => {
+    useChatStore.getState().setActiveSession("acp-session");
+
+    await handleSessionNotification({
+      sessionId: "acp-session",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: {
+          type: "text",
+          text: "Answer while another view is open.",
+        },
+      },
+    } as never);
+
+    expect(
+      useChatStore.getState().getSessionRuntime("acp-session").hasUnread,
+    ).toBe(true);
+  });
+
+  it("does not mark replayed agent output unread", async () => {
+    useChatStore.setState({
+      loadingSessionIds: new Set<string>(["acp-session"]),
+    });
+
+    await handleSessionNotification({
+      sessionId: "acp-session",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: {
+          type: "text",
+          text: "Historical answer.",
+        },
+      },
+    } as never);
+
+    expect(
+      useChatStore.getState().getSessionRuntime("acp-session").hasUnread,
+    ).toBe(false);
   });
 
   it("preserves ACP tool kind and locations on tool requests", async () => {

--- a/ui/goose2/src/shared/api/acpNotificationHandler.test.ts
+++ b/ui/goose2/src/shared/api/acpNotificationHandler.test.ts
@@ -18,6 +18,7 @@ describe("acpNotificationHandler", () => {
       queuedMessageBySession: {},
       draftsBySession: {},
       activeSessionId: null,
+      viewedSessionId: null,
       isConnected: false,
       loadingSessionIds: new Set<string>(),
       scrollTargetMessageBySession: {},

--- a/ui/goose2/src/shared/api/acpNotificationHandler.ts
+++ b/ui/goose2/src/shared/api/acpNotificationHandler.ts
@@ -332,6 +332,7 @@ function handleLive(sessionId: string, update: SessionUpdate): void {
         sessionId,
         getChunkMessageId(update) ?? undefined,
       );
+      markUnreadIfNotViewed(sessionId);
 
       if (update.content.type === "text" && "text" in update.content) {
         store.setStreamingMessageId(sessionId, messageId);
@@ -356,6 +357,7 @@ function handleLive(sessionId: string, update: SessionUpdate): void {
       };
       store.setStreamingMessageId(sessionId, messageId);
       store.appendToStreamingMessage(sessionId, toolRequest);
+      markUnreadIfNotViewed(sessionId);
       break;
     }
 
@@ -418,6 +420,7 @@ function handleLive(sessionId: string, update: SessionUpdate): void {
         };
         store.setStreamingMessageId(sessionId, messageId);
         store.appendToStreamingMessage(sessionId, toolResponse);
+        markUnreadIfNotViewed(sessionId);
         if (update.status === "completed") {
           attachMcpAppPayload(
             sessionId,
@@ -439,6 +442,13 @@ function handleLive(sessionId: string, update: SessionUpdate): void {
 
     default:
       break;
+  }
+}
+
+function markUnreadIfNotViewed(sessionId: string): void {
+  const store = useChatStore.getState();
+  if (store.viewedSessionId !== sessionId) {
+    store.markSessionUnread(sessionId);
   }
 }
 

--- a/ui/goose2/src/shared/ui/SessionActivityIndicator.test.tsx
+++ b/ui/goose2/src/shared/ui/SessionActivityIndicator.test.tsx
@@ -21,6 +21,20 @@ describe("SessionActivityIndicator", () => {
     expect(screen.getByLabelText(/chat active/i)).toBeInTheDocument();
   });
 
+  it("replaces the running spinner with unread state when activity ends", () => {
+    const { rerender } = render(
+      <SessionActivityIndicator isRunning hasUnread />,
+    );
+
+    expect(screen.getByLabelText(/chat active/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/unread messages/i)).not.toBeInTheDocument();
+
+    rerender(<SessionActivityIndicator hasUnread />);
+
+    expect(screen.queryByLabelText(/chat active/i)).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/unread messages/i)).toBeInTheDocument();
+  });
+
   it("renders nothing when the session is idle and read", () => {
     const { container } = render(<SessionActivityIndicator />);
 


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Users can now see when an agent has responded in a chat they are not currently viewing.
**Problem:** The sidebar could show a chat as busy while the agent was working, but once the response finished there was no reliable handoff to a response-ready indicator for chats outside the current view. That made it easy to miss completed background replies.
**Solution:** Track which chat is actually being viewed, mark live assistant output unread when it arrives for any other session, and keep replayed history quiet. The existing session activity indicator already prioritizes the loading spinner while work is running, then falls back to the unread dot after activity ends.

<details>
<summary>File changes</summary>

**ui/goose2/src/app/AppShell.tsx**
Updates the chat store with the session currently visible in the chat view and clears unread state when that session is viewed.

**ui/goose2/src/features/chat/stores/chatStore.ts**
Adds `viewedSessionId` state so response notifications can distinguish a selected session from a session the user is actually looking at.

**ui/goose2/src/features/chat/stores/__tests__/chatStore.test.ts**
Adds coverage for viewed-session state and cleanup behavior.

**ui/goose2/src/shared/api/acpNotificationHandler.ts**
Marks live agent text/tool output unread when it arrives for a session that is not currently viewed, while replay loading remains unaffected.

**ui/goose2/src/shared/api/__tests__/acpNotificationHandler.test.ts**
Covers unviewed output, viewed output, active-but-not-viewed output, and replayed output.

**ui/goose2/src/shared/api/acpNotificationHandler.test.ts**
Resets viewed-session state in the existing notification handler test setup.

**ui/goose2/src/shared/ui/SessionActivityIndicator.test.tsx**
Adds coverage that the running spinner takes priority while active and the unread indicator appears after activity ends.

</details>

1. Start a chat and send a message that causes the agent to respond.
2. Navigate away from that chat while the response is still running.
3. Confirm the sidebar shows the chat activity spinner while the agent is working.
4. After the response completes, confirm the chat row shows the unread indicator.
5. Select the chat and confirm the unread indicator clears.
6. Load an existing session from history and confirm replayed messages do not create unread indicators.

**Focused verification**

- `pnpm --dir ui/goose2 exec vitest run src/shared/api/__tests__/acpNotificationHandler.test.ts src/shared/api/acpNotificationHandler.test.ts src/shared/ui/SessionActivityIndicator.test.tsx src/features/chat/stores/__tests__/chatStore.test.ts`
- `pnpm --dir ui/goose2 exec biome check src/app/AppShell.tsx src/features/chat/stores/chatStore.ts src/features/chat/stores/__tests__/chatStore.test.ts src/shared/api/acpNotificationHandler.ts src/shared/api/__tests__/acpNotificationHandler.test.ts src/shared/api/acpNotificationHandler.test.ts src/shared/ui/SessionActivityIndicator.test.tsx`
- `git diff --check`

Full goose2 pre-push/typecheck remains blocked by existing unrelated SDK definition mismatches on `main` such as missing `GoosePreferencesRead`, `GooseDefaultsRead`, and `ProviderConfigChangeResponse` exports.

**Screenshots/Demos**

Not captured in this pass.
