### PR TITLE
Local inference provider improvements

### DIFF
--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -632,7 +632,7 @@ mod tests {
         assert_eq!(config.name, "llama_swap");
         assert_eq!(config.display_name, "Llama Swap");
         assert!(matches!(config.engine, ProviderEngine::OpenAI));
-        assert_eq!(config.api_key_env, "");
+        assert_eq!(config.api_key_env, "LLAMA_SWAP_API_KEY");
         assert!(!config.requires_auth);
         assert!(config.skip_canonical_filtering);
         assert_eq!(config.dynamic_models, Some(true));

--- a/crates/goose/src/providers/declarative/llama_swap.json
+++ b/crates/goose/src/providers/declarative/llama_swap.json
@@ -3,7 +3,7 @@
   "engine": "openai",
   "display_name": "Llama Swap",
   "description": "Local proxy that hot-swaps llama.cpp (and other) inference backends on demand via an OpenAI-compatible API.",
-  "api_key_env": "",
+  "api_key_env": "LLAMA_SWAP_API_KEY",
   "base_url": "${LLAMA_SWAP_HOST}/v1/chat/completions",
   "env_vars": [
     {

--- a/crates/goose/src/providers/declarative/lmstudio.json
+++ b/crates/goose/src/providers/declarative/lmstudio.json
@@ -3,7 +3,7 @@
   "engine": "openai",
   "display_name": "LM Studio",
   "description": "Run local models with LM Studio",
-  "api_key_env": "",
+  "api_key_env": "LMSTUDIO_API_KEY",
   "base_url": "${LMSTUDIO_HOST}/v1/chat/completions",
   "env_vars": [
     {

--- a/crates/goose/src/providers/declarative/omlx.json
+++ b/crates/goose/src/providers/declarative/omlx.json
@@ -1,0 +1,23 @@
+{
+  "name": "omlx",
+  "engine": "openai",
+  "display_name": "oMLX",
+  "description": "Run local models with oMLX",
+  "api_key_env": "OMLX_API_KEY",
+  "base_url": "${OMLX_HOST}/v1/chat/completions",
+  "env_vars": [
+    {
+      "name": "OMLX_HOST",
+      "required": false,
+      "secret": false,
+      "primary": true,
+      "default": "http://localhost:8000",
+      "description": "Base URL of the oMLX server (default: http://localhost:8000)"
+    }
+  ],
+  "dynamic_models": true,
+  "models": [],
+  "supports_streaming": true,
+  "requires_auth": false,
+  "skip_canonical_filtering": true
+}

--- a/crates/goose/src/providers/inventory/mod.rs
+++ b/crates/goose/src/providers/inventory/mod.rs
@@ -810,7 +810,7 @@ pub fn declarative_inventory_identity(
             .public_inputs
             .insert("headers".to_string(), serialize_string_map(headers)?);
     }
-    if config.requires_auth && !config.api_key_env.is_empty() {
+    if !config.api_key_env.is_empty() {
         if let Some(value) = config_secret_value(global, &config.api_key_env) {
             identity
                 .secret_inputs

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -305,20 +305,27 @@ impl OpenAiProvider {
                 Err(e) => {
                     use crate::config::ConfigError;
                     match e {
-                        ConfigError::NotFound(_) if config.requires_auth => anyhow::bail!(
-                            "Required API key {} is not set. Configure it via `goose configure` or set the {} environment variable.",
-                            config.api_key_env,
-                            config.api_key_env
-                        ),
-                        other if !config.requires_auth => {
-                            tracing::warn!(
-                                "Failed to read optional API key {} from secret storage: {}. Proceeding without authentication.",
-                                config.api_key_env,
-                                other
-                            );
+                        ConfigError::NotFound(_) => {
+                            if config.requires_auth {
+                                anyhow::bail!(
+                                    "Required API key {} is not set. Configure it via `goose configure` or set the {} environment variable.",
+                                    config.api_key_env,
+                                    config.api_key_env
+                                );
+                            }
                             None
                         }
-                        other => anyhow::bail!("Failed to read {}: {}", config.api_key_env, other),
+                        other => {
+                            if !config.requires_auth {
+                                tracing::warn!(
+                                    "Failed to read optional API key {}: {}. Proceeding without authentication.",
+                                    config.api_key_env,
+                                    other
+                                );
+                                return None;
+                            }
+                            anyhow::bail!("Failed to read {}: {}", config.api_key_env, other);
+                        }
                     }
                 }
             }

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -305,12 +305,19 @@ impl OpenAiProvider {
                 Err(e) => {
                     use crate::config::ConfigError;
                     match e {
-                        ConfigError::NotFound(_) if !config.requires_auth => None,
-                        ConfigError::NotFound(_) => anyhow::bail!(
+                        ConfigError::NotFound(_) if config.requires_auth => anyhow::bail!(
                             "Required API key {} is not set. Configure it via `goose configure` or set the {} environment variable.",
                             config.api_key_env,
                             config.api_key_env
                         ),
+                        other if !config.requires_auth => {
+                            tracing::warn!(
+                                "Failed to read optional API key {} from secret storage: {}. Proceeding without authentication.",
+                                config.api_key_env,
+                                other
+                            );
+                            None
+                        }
                         other => anyhow::bail!("Failed to read {}: {}", config.api_key_env, other),
                     }
                 }

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -299,18 +299,25 @@ impl OpenAiProvider {
     ) -> Result<Self> {
         let global_config = crate::config::Config::global();
 
-        let api_key: Option<String> = if config.requires_auth && !config.api_key_env.is_empty() {
-            Some(global_config.get_secret::<String>(&config.api_key_env).map_err(|e| {
-                use crate::config::ConfigError;
-                match e {
-                    ConfigError::NotFound(_) => anyhow::anyhow!(
-                        "Required API key {} is not set. Configure it via `goose configure` or set the {} environment variable.",
-                        config.api_key_env,
-                        config.api_key_env
-                    ),
-                    other => anyhow::anyhow!("Failed to read {}: {}", config.api_key_env, other),
+        let api_key: Option<String> = if !config.api_key_env.is_empty() {
+            match global_config.get_secret::<String>(&config.api_key_env) {
+                Ok(key) => Some(key),
+                Err(e) => {
+                    use crate::config::ConfigError;
+                    if config.requires_auth {
+                        return Err(match e {
+                            ConfigError::NotFound(_) => anyhow::anyhow!(
+                                "Required API key {} is not set. Configure it via `goose configure` or set the {} environment variable.",
+                                config.api_key_env,
+                                config.api_key_env
+                            ),
+                            other => anyhow::anyhow!("Failed to read {}: {}", config.api_key_env, other),
+                        });
+                    }
+                    // Optional auth — key not configured, proceed without it
+                    None
                 }
-            })?)
+            }
         } else {
             None
         };

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -304,18 +304,15 @@ impl OpenAiProvider {
                 Ok(key) => Some(key),
                 Err(e) => {
                     use crate::config::ConfigError;
-                    if config.requires_auth {
-                        return Err(match e {
-                            ConfigError::NotFound(_) => anyhow::anyhow!(
-                                "Required API key {} is not set. Configure it via `goose configure` or set the {} environment variable.",
-                                config.api_key_env,
-                                config.api_key_env
-                            ),
-                            other => anyhow::anyhow!("Failed to read {}: {}", config.api_key_env, other),
-                        });
+                    match e {
+                        ConfigError::NotFound(_) if !config.requires_auth => None,
+                        ConfigError::NotFound(_) => anyhow::bail!(
+                            "Required API key {} is not set. Configure it via `goose configure` or set the {} environment variable.",
+                            config.api_key_env,
+                            config.api_key_env
+                        ),
+                        other => anyhow::bail!("Failed to read {}: {}", config.api_key_env, other),
                     }
-                    // Optional auth — key not configured, proceed without it
-                    None
                 }
             }
         } else {

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -166,8 +166,8 @@ impl ProviderRegistry {
             .collect();
 
         let mut config_keys = if provider_type == ProviderType::Declarative {
-            if config.requires_auth && !config.api_key_env.is_empty() {
-                vec![ConfigKey::new(&config.api_key_env, true, true, None, true)]
+            if !config.api_key_env.is_empty() {
+                vec![ConfigKey::new(&config.api_key_env, config.requires_auth, true, None, true)]
             } else {
                 Vec::new()
             }


### PR DESCRIPTION
## Summary
- Add a new declarative provider for [oMLX](https://omlx.ai).
- Add api_key_env setting to the llama_swap and lmstudio providers.
- Fix an issue in provider_registry.rs that didn't allow an api key to be configured in the UI unless requires_auth was also set.
- Fix an issue in openai.rs where a configured api key would not be sent unless requires_auth was also set.

The oMLX endpoint behaves very similarly to LM Studio, but with a different default port number.
All three of these local providers support using an API Key for authentication, and the changes to their json files and provider_registry.rs allow this to be configured per-provider from the UI.

### Testing
Manual testing. 

### Related Issues


### Screenshots/Demos (for UX changes)
Before:  
<img width="599" height="508" alt="before" src="https://github.com/user-attachments/assets/185f4ed4-34e8-4ff7-84fd-520270c22b10" />

After:   
<img width="598" height="583" alt="after" src="https://github.com/user-attachments/assets/0189abba-d143-4194-b64c-29055fe888de" />

