### PR TITLE
make collapsed sidebar search actionable

### DIFF
--- a/ui/goose2/src/features/sidebar/ui/Sidebar.tsx
+++ b/ui/goose2/src/features/sidebar/ui/Sidebar.tsx
@@ -87,6 +87,7 @@ export function Sidebar({
   const [expanded, setExpanded] = useState(!collapsed);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const prevCollapsed = useRef(collapsed);
+  const [focusSearchOnExpand, setFocusSearchOnExpand] = useState(false);
   const [expandedProjects, setExpandedProjects] = useState<
     Record<string, boolean>
   >(() => {
@@ -122,6 +123,15 @@ export function Sidebar({
     }
     prevCollapsed.current = collapsed;
   }, [collapsed]);
+
+  useEffect(() => {
+    if (collapsed || !focusSearchOnExpand) return;
+    const frame = window.requestAnimationFrame(() => {
+      searchInputRef.current?.focus();
+      setFocusSearchOnExpand(false);
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [collapsed, focusSearchOnExpand]);
 
   const labelTransition = "transition-[opacity,width] duration-300 ease-out";
   const labelVisible = expanded && !collapsed;
@@ -264,6 +274,11 @@ export function Sidebar({
   const toggleProject = (projectId: string) =>
     setExpandedProjects((prev) => ({ ...prev, [projectId]: !prev[projectId] }));
 
+  const activateCollapsedSearch = () => {
+    setFocusSearchOnExpand(true);
+    onCollapse();
+  };
+
   return (
     <div
       className={cn(
@@ -324,16 +339,21 @@ export function Sidebar({
                 </button>
               )}
 
-              <div
-                className={cn(
-                  "mb-3 flex items-center w-full rounded-md transition-all duration-300 ease-out",
-                  collapsed
-                    ? "justify-center p-3 text-foreground"
-                    : "gap-2 border border-border px-2.5 py-1.5 text-xs text-foreground hover:text-foreground hover:bg-transparent",
-                )}
-              >
-                <IconSearch className="size-3.5 flex-shrink-0 text-placeholder" />
-                {!collapsed && (
+              {collapsed ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={activateCollapsedSearch}
+                  aria-label={t("actions.search")}
+                  title={t("actions.search")}
+                  className="mb-3 h-10 w-full rounded-md bg-transparent text-placeholder hover:bg-background-alt hover:text-foreground active:bg-background-alt"
+                >
+                  <IconSearch className="size-3.5 flex-shrink-0" />
+                </Button>
+              ) : (
+                <div className="mb-3 flex items-center w-full rounded-md gap-2 border border-border px-2.5 py-1.5 text-xs text-foreground transition-all duration-300 ease-out hover:text-foreground hover:bg-transparent">
+                  <IconSearch className="size-3.5 flex-shrink-0 text-placeholder" />
                   <input
                     ref={searchInputRef}
                     type="text"
@@ -356,8 +376,8 @@ export function Sidebar({
                     )}
                     onClick={(e) => e.stopPropagation()}
                   />
-                )}
-              </div>
+                </div>
+              )}
 
               <SidebarNavItem
                 testId="nav-home"

--- a/ui/goose2/src/features/sidebar/ui/__tests__/Sidebar.test.tsx
+++ b/ui/goose2/src/features/sidebar/ui/__tests__/Sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { Sidebar } from "../Sidebar";
@@ -130,5 +130,35 @@ describe("Sidebar", () => {
     );
 
     expect(screen.getByRole("button", { name: /home/i })).toBeInTheDocument();
+  });
+
+  it("expands and focuses search from the collapsed sidebar", async () => {
+    const user = userEvent.setup();
+    const onCollapse = vi.fn();
+    const { rerender } = render(
+      <Sidebar
+        collapsed
+        onCollapse={onCollapse}
+        onNavigate={vi.fn()}
+        projects={[]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Search chats" }));
+
+    expect(onCollapse).toHaveBeenCalledOnce();
+
+    rerender(
+      <Sidebar
+        collapsed={false}
+        onCollapse={onCollapse}
+        onNavigate={vi.fn()}
+        projects={[]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Search chats...")).toHaveFocus();
+    });
   });
 });

--- a/ui/goose2/src/shared/i18n/locales/en/sidebar.json
+++ b/ui/goose2/src/shared/i18n/locales/en/sidebar.json
@@ -5,7 +5,8 @@
     "newChat": "New chat",
     "newChatInProject": "New chat in project",
     "newProject": "New project",
-    "renameHint": "Double-click to rename"
+    "renameHint": "Double-click to rename",
+    "search": "Search chats"
   },
   "menu": {
     "optionsFor": "Options for {{label}}"

--- a/ui/goose2/src/shared/i18n/locales/es/sidebar.json
+++ b/ui/goose2/src/shared/i18n/locales/es/sidebar.json
@@ -5,7 +5,8 @@
     "newChat": "Nuevo chat",
     "newChatInProject": "Nuevo chat en el proyecto",
     "newProject": "Nuevo proyecto",
-    "renameHint": "Haz doble clic para renombrar"
+    "renameHint": "Haz doble clic para renombrar",
+    "search": "Buscar chats"
   },
   "menu": {
     "optionsFor": "Opciones para {{label}}"


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Users can now click the collapsed sidebar search icon to open and focus chat search.
**Problem:** In the collapsed sidebar, the search icon looked interactive but did not do anything. That made the collapsed navigation feel broken and left search available only after manually expanding the sidebar.
**Solution:** Convert the collapsed search affordance into a real button that expands the sidebar and focuses the existing search input. This keeps one search experience while making the collapsed state behave like a clear shortcut.

<details>
<summary>File changes</summary>

**ui/goose2/src/features/sidebar/ui/Sidebar.tsx**
Adds a focus-on-expand path for collapsed search and renders the collapsed search icon as a shared Button with a dedicated accessible label.

**ui/goose2/src/features/sidebar/ui/__tests__/Sidebar.test.tsx**
Adds a regression test that clicks collapsed search, verifies expansion is requested, and confirms focus lands in the expanded search input.

**ui/goose2/src/shared/i18n/locales/en/sidebar.json**
Adds the English action label for collapsed search.

**ui/goose2/src/shared/i18n/locales/es/sidebar.json**
Adds the Spanish action label so the sidebar locale files stay complete.

</details>

1. Collapse the goose2 sidebar.
2. Click the search icon in the collapsed nav.
3. Confirm the sidebar expands.
4. Confirm the chat search input is focused and ready for typing.
5. Use expanded sidebar search and confirm the existing search behavior is unchanged.

**Focused verification**

- `pnpm --dir ui/goose2 exec vitest run src/features/sidebar/ui/__tests__/Sidebar.test.tsx`
- `pnpm --dir ui/goose2 exec biome check src/features/sidebar/ui/Sidebar.tsx src/features/sidebar/ui/__tests__/Sidebar.test.tsx src/shared/i18n/locales/en/sidebar.json src/shared/i18n/locales/es/sidebar.json`
- `git diff --check`

Full goose2 pre-push/typecheck remains blocked by existing unrelated SDK definition mismatches on `main` such as missing `GoosePreferencesRead`, `GooseDefaultsRead`, and `ProviderConfigChangeResponse` exports.

**Screenshots/Demos**

Not captured in this pass.
