### PR TITLE
soften goose2 text selection polish

### DIFF
--- a/ui/goose2/src/shared/styles/globals.css
+++ b/ui/goose2/src/shared/styles/globals.css
@@ -745,8 +745,21 @@ body,
   }
 
   ::selection {
-    background: color-mix(in oklab, var(--brand) 60%, transparent);
-    color: var(--brand-foreground);
+    background: color-mix(in oklab, var(--brand) 18%, transparent);
+    color: inherit;
+  }
+
+  button,
+  [role="button"],
+  [data-tauri-drag-region] {
+    user-select: none;
+  }
+
+  input,
+  textarea,
+  [contenteditable="true"],
+  [data-streamdown] {
+    user-select: text;
   }
 
   ::-webkit-scrollbar {

--- a/ui/goose2/src/shared/ui/input.tsx
+++ b/ui/goose2/src/shared/ui/input.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/shared/lib/cn";
 
 const variantStyles = {
   default: [
-    "file:text-foreground placeholder:text-placeholder selection:bg-primary selection:text-primary-foreground border-input hover:border-border-input-hover focus-visible:border-ring focus-visible:ring-0 focus-visible:ring-offset-0 flex h-9 w-full min-w-0 rounded-input border bg-transparent px-3 py-1 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+    "file:text-foreground placeholder:text-placeholder border-input hover:border-border-input-hover focus-visible:border-ring focus-visible:ring-0 focus-visible:ring-offset-0 flex h-9 w-full min-w-0 rounded-input border bg-transparent px-3 py-1 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
     "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   ],
   ghost: [


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Text selection in goose2 now feels calmer and less visually jarring while preserving copyable chat and input text.
**Problem:** The global selection treatment used a strong brand fill with inverse text, which made selected text feel loud and heavy. App chrome could also be selected in places where selection is not useful, making accidental drag or right-click interactions feel messy.
**Solution:** Switch global selection to a low-opacity neutral tint that keeps the original text color, remove the input override that forced inverse selection colors, and make button/drag-region chrome non-selectable. Inputs, textareas, contenteditable content, and Streamdown-rendered chat content remain selectable.

<details>
<summary>File changes</summary>

**ui/goose2/src/shared/styles/globals.css**
Softens `::selection` globally and scopes `user-select` so chrome is not selectable while text-entry and chat markdown surfaces remain selectable.

**ui/goose2/src/shared/ui/input.tsx**
Removes the input-specific primary/inverse selection classes so fields use the calmer global selection treatment.

</details>

1. Select text in a chat response and confirm the highlight is subtle and the text color does not invert to white.
2. Select text in an input and confirm it uses the same calmer treatment.
3. Drag or right-click around app chrome/buttons and confirm accidental chrome text selection is reduced.
4. Confirm intentional selection in chat content still works for copy workflows.

**Focused verification**

- `pnpm --dir ui/goose2 exec biome check src/shared/styles/globals.css src/shared/ui/input.tsx`
- `git diff --check`
- `rg -n "selection:bg-primary|selection:text-primary-foreground|::selection" ui/goose2/src ui/goose2 -g '*.css' -g '*.tsx' -g '*.ts'`

Full goose2 pre-push/typecheck remains blocked by existing unrelated SDK definition mismatches on `main` such as missing `GoosePreferencesRead`, `GooseDefaultsRead`, and `ProviderConfigChangeResponse` exports.

**Screenshots/Demos**

Not captured in this pass.
