### PR TITLE
feat(developer): add web_fetch tool for narrow URL fetching

### DIFF
--- a/crates/goose/src/agents/platform_extensions/developer/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/mod.rs
@@ -1,6 +1,7 @@
 pub mod edit;
 pub mod shell;
 pub mod tree;
+pub mod web;
 
 use crate::agents::extension::PlatformExtensionContext;
 use crate::agents::mcp_client::{Error, McpClientTrait};
@@ -19,6 +20,7 @@ use shell::{shell_display_name, ShellOutput, ShellParams, ShellTool};
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 use tree::{TreeParams, TreeTool};
+use web::{WebFetchParams, WebFetchTool};
 
 pub static EXTENSION_NAME: &str = "developer";
 
@@ -27,6 +29,7 @@ pub struct DeveloperClient {
     shell_tool: Arc<ShellTool>,
     edit_tools: Arc<EditTools>,
     tree_tool: Arc<TreeTool>,
+    web_fetch_tool: Arc<WebFetchTool>,
 }
 
 fn developer_instructions() -> &'static str {
@@ -72,6 +75,7 @@ impl DeveloperClient {
             shell_tool: Arc::new(ShellTool::new()?),
             edit_tools: Arc::new(EditTools::new()),
             tree_tool: Arc::new(TreeTool::new()),
+            web_fetch_tool: Arc::new(WebFetchTool::new()),
         })
     }
 
@@ -150,6 +154,21 @@ impl DeveloperClient {
                 Some(true),
                 Some(false),
             )),
+            Tool::new(
+                "web_fetch".to_string(),
+                "Fetch the body of an http(s) URL. Returns the response inline for small text or \
+                 JSON bodies, or a path to a temp file for large or binary bodies. Use `save_as` \
+                 to pick text (default), json (validates parse), or binary."
+                    .to_string(),
+                Self::schema::<WebFetchParams>(),
+            )
+            .annotate(ToolAnnotations::from_raw(
+                Some("WebFetch".to_string()),
+                Some(true),
+                Some(false),
+                Some(true),
+                Some(true),
+            )),
         ]
     }
 }
@@ -203,6 +222,13 @@ impl McpClientTrait for DeveloperClient {
                 ))
                 .with_priority(0.0)])),
             },
+            "web_fetch" => match Self::parse_args::<WebFetchParams>(arguments) {
+                Ok(params) => Ok(self.web_fetch_tool.fetch(params).await),
+                Err(error) => Ok(CallToolResult::error(vec![Content::text(format!(
+                    "Error: {error}"
+                ))
+                .with_priority(0.0)])),
+            },
             _ => Ok(CallToolResult::error(vec![Content::text(format!(
                 "Error: Unknown tool: {name}"
             ))
@@ -230,7 +256,7 @@ mod tests {
             .map(|t| t.name.to_string())
             .collect();
 
-        assert_eq!(names, vec!["write", "edit", "shell", "tree"]);
+        assert_eq!(names, vec!["write", "edit", "shell", "tree", "web_fetch"]);
     }
 
     fn test_context(data_dir: std::path::PathBuf) -> PlatformExtensionContext {

--- a/crates/goose/src/agents/platform_extensions/developer/web.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/web.rs
@@ -1,0 +1,331 @@
+use std::io::Write;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use rmcp::model::{CallToolResult, Content};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct WebFetchParams {
+    /// Absolute http:// or https:// URL to fetch.
+    pub url: String,
+    /// How to handle the response body. Defaults to `text`.
+    #[serde(default)]
+    pub save_as: SaveAsFormat,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SaveAsFormat {
+    /// Decode body as UTF-8 text.
+    #[default]
+    Text,
+    /// Decode body as UTF-8 text and validate it parses as JSON.
+    Json,
+    /// Treat body as raw bytes; always saved to a temp file.
+    Binary,
+}
+
+/// Bodies up to this size are returned inline in the tool result.
+/// Larger bodies (and all binary responses) are written to a temp file
+/// and the path is returned instead.
+const INLINE_BYTE_LIMIT: usize = 64 * 1024;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub struct WebFetchTool {
+    http_client: reqwest::Client,
+}
+
+impl WebFetchTool {
+    pub fn new() -> Self {
+        let user_agent = format!("goose/{}", env!("CARGO_PKG_VERSION"));
+        let http_client = reqwest::Client::builder()
+            .user_agent(user_agent)
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+        Self { http_client }
+    }
+
+    pub async fn fetch(&self, params: WebFetchParams) -> CallToolResult {
+        let url = params.url.trim();
+        if url.is_empty() {
+            return error_result("URL cannot be empty.");
+        }
+        if !url.starts_with("http://") && !url.starts_with("https://") {
+            return error_result(&format!(
+                "URL must start with http:// or https://, got: {url}"
+            ));
+        }
+
+        let response = match self
+            .http_client
+            .get(url)
+            .header("Accept", "text/markdown, text/html, application/json, */*")
+            .header("Accept-Language", "en-US,en;q=0.9")
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => return error_result(&format!("Failed to fetch URL: {e}")),
+        };
+
+        let status = response.status();
+        if !status.is_success() {
+            return error_result(&format!("HTTP request failed with status: {status}"));
+        }
+
+        match params.save_as {
+            SaveAsFormat::Text => match response.text().await {
+                Ok(text) => deliver_text(text, "txt"),
+                Err(e) => error_result(&format!("Failed to read body as text: {e}")),
+            },
+            SaveAsFormat::Json => match response.text().await {
+                Ok(text) => {
+                    if let Err(e) = serde_json::from_str::<Value>(&text) {
+                        return error_result(&format!("Invalid JSON response: {e}"));
+                    }
+                    deliver_text(text, "json")
+                }
+                Err(e) => error_result(&format!("Failed to read body as text: {e}")),
+            },
+            SaveAsFormat::Binary => match response.bytes().await {
+                Ok(bytes) => deliver_bytes(&bytes, "bin"),
+                Err(e) => error_result(&format!("Failed to read body bytes: {e}")),
+            },
+        }
+    }
+}
+
+impl Default for WebFetchTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn deliver_text(text: String, extension: &str) -> CallToolResult {
+    if text.len() <= INLINE_BYTE_LIMIT {
+        return CallToolResult::success(vec![Content::text(text).with_priority(0.0)]);
+    }
+    match write_to_temp(text.as_bytes(), extension) {
+        Ok(path) => CallToolResult::success(vec![Content::text(format!(
+            "Content saved to: {} ({} bytes)",
+            path.display(),
+            text.len()
+        ))
+        .with_priority(0.0)]),
+        Err(e) => error_result(&format!("Failed to write temp file: {e}")),
+    }
+}
+
+fn deliver_bytes(bytes: &[u8], extension: &str) -> CallToolResult {
+    match write_to_temp(bytes, extension) {
+        Ok(path) => CallToolResult::success(vec![Content::text(format!(
+            "Content saved to: {} ({} bytes)",
+            path.display(),
+            bytes.len()
+        ))
+        .with_priority(0.0)]),
+        Err(e) => error_result(&format!("Failed to write temp file: {e}")),
+    }
+}
+
+fn write_to_temp(bytes: &[u8], extension: &str) -> std::io::Result<PathBuf> {
+    let mut file = tempfile::Builder::new()
+        .prefix("goose-web-")
+        .suffix(&format!(".{extension}"))
+        .tempfile()?;
+    file.write_all(bytes)?;
+    file.flush()?;
+    let (_, path) = file.keep().map_err(|e| e.error)?;
+    Ok(path)
+}
+
+fn error_result(message: &str) -> CallToolResult {
+    CallToolResult::error(vec![Content::text(message.to_string()).with_priority(0.0)])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::model::RawContent;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn first_text(result: &CallToolResult) -> String {
+        match &result.content[0].raw {
+            RawContent::Text(t) => t.text.clone(),
+            _ => panic!("expected text content"),
+        }
+    }
+
+    fn extract_temp_path(message: &str) -> &str {
+        message
+            .strip_prefix("Content saved to: ")
+            .and_then(|s| s.rsplit_once(" ("))
+            .map(|(p, _)| p)
+            .expect("message should contain a saved path")
+    }
+
+    #[tokio::test]
+    async fn fetch_text_returns_inline_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/page"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("hello world"))
+            .mount(&server)
+            .await;
+
+        let tool = WebFetchTool::new();
+        let result = tool
+            .fetch(WebFetchParams {
+                url: format!("{}/page", server.uri()),
+                save_as: SaveAsFormat::Text,
+            })
+            .await;
+
+        assert_eq!(result.is_error, Some(false));
+        assert_eq!(first_text(&result), "hello world");
+    }
+
+    #[tokio::test]
+    async fn fetch_non_2xx_returns_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/missing"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let tool = WebFetchTool::new();
+        let result = tool
+            .fetch(WebFetchParams {
+                url: format!("{}/missing", server.uri()),
+                save_as: SaveAsFormat::Text,
+            })
+            .await;
+
+        assert_eq!(result.is_error, Some(true));
+        assert!(first_text(&result).contains("404"));
+    }
+
+    #[tokio::test]
+    async fn fetch_json_validates_payload() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/json-good"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"ok":true}"#))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/json-bad"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+            .mount(&server)
+            .await;
+
+        let tool = WebFetchTool::new();
+
+        let ok = tool
+            .fetch(WebFetchParams {
+                url: format!("{}/json-good", server.uri()),
+                save_as: SaveAsFormat::Json,
+            })
+            .await;
+        assert_eq!(ok.is_error, Some(false));
+        assert_eq!(first_text(&ok), r#"{"ok":true}"#);
+
+        let bad = tool
+            .fetch(WebFetchParams {
+                url: format!("{}/json-bad", server.uri()),
+                save_as: SaveAsFormat::Json,
+            })
+            .await;
+        assert_eq!(bad.is_error, Some(true));
+        assert!(first_text(&bad).to_lowercase().contains("invalid json"));
+    }
+
+    #[tokio::test]
+    async fn fetch_binary_writes_to_temp_file() {
+        let server = MockServer::start().await;
+        let payload: Vec<u8> = (0u8..32).collect();
+        Mock::given(method("GET"))
+            .and(path("/bin"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(payload.clone())
+                    .insert_header("content-type", "application/octet-stream"),
+            )
+            .mount(&server)
+            .await;
+
+        let tool = WebFetchTool::new();
+        let result = tool
+            .fetch(WebFetchParams {
+                url: format!("{}/bin", server.uri()),
+                save_as: SaveAsFormat::Binary,
+            })
+            .await;
+
+        assert_eq!(result.is_error, Some(false));
+        let msg = first_text(&result);
+        let path_str = extract_temp_path(&msg);
+        let bytes = std::fs::read(path_str).expect("temp file should be readable");
+        assert_eq!(bytes, payload);
+        std::fs::remove_file(path_str).ok();
+    }
+
+    #[tokio::test]
+    async fn fetch_text_over_limit_spills_to_temp_file() {
+        let server = MockServer::start().await;
+        let big = "x".repeat(INLINE_BYTE_LIMIT + 1);
+        Mock::given(method("GET"))
+            .and(path("/big"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(big.clone()))
+            .mount(&server)
+            .await;
+
+        let tool = WebFetchTool::new();
+        let result = tool
+            .fetch(WebFetchParams {
+                url: format!("{}/big", server.uri()),
+                save_as: SaveAsFormat::Text,
+            })
+            .await;
+
+        assert_eq!(result.is_error, Some(false));
+        let msg = first_text(&result);
+        let path_str = extract_temp_path(&msg);
+        let bytes = std::fs::read(path_str).expect("temp file should be readable");
+        assert_eq!(bytes.len(), big.len());
+        std::fs::remove_file(path_str).ok();
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_empty_url() {
+        let tool = WebFetchTool::new();
+        let result = tool
+            .fetch(WebFetchParams {
+                url: String::new(),
+                save_as: SaveAsFormat::Text,
+            })
+            .await;
+        assert_eq!(result.is_error, Some(true));
+        assert!(first_text(&result).to_lowercase().contains("empty"));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_non_http_scheme() {
+        let tool = WebFetchTool::new();
+        let result = tool
+            .fetch(WebFetchParams {
+                url: "file:///etc/passwd".to_string(),
+                save_as: SaveAsFormat::Text,
+            })
+            .await;
+        assert_eq!(result.is_error, Some(true));
+        assert!(first_text(&result).contains("http"));
+    }
+}

--- a/documentation/docs/mcp/developer-mcp.md
+++ b/documentation/docs/mcp/developer-mcp.md
@@ -188,6 +188,7 @@ The Developer extension provides these tools:
 | `analyze` | Analyze code structure | Understanding codebase, finding dependencies | ✅ Low<br />Read-only code analysis |
 | `screen_capture` | Take screenshots | Debugging UI issues, documenting state | ✅ Low<br />Visual information only |
 | `image_processor` | Process and resize images | Optimizing assets, format conversion | ✅ Low<br />Image manipulation only |
+| `web_fetch` | Fetch the body of an http(s) URL as text, JSON, or binary | Reading docs pages, calling JSON APIs, downloading small files | ⚠️ Medium<br />Performs outbound network requests; same network reach as `shell` + `curl` |
 
 ### Access Control Features
 

--- a/documentation/docs/mcp/fetch-mcp.md
+++ b/documentation/docs/mcp/fetch-mcp.md
@@ -17,6 +17,10 @@ The Fetch extension [does not work](https://github.com/aaif-goose/goose/issues/1
 
 This tutorial covers how to add the [Fetch MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch) as a goose extension to retrieve and process content from the web.
 
+:::tip Built-in alternative
+If you only need basic URL retrieval, the built-in `developer` extension exposes a `web_fetch` tool that returns text, JSON, or binary bodies without an extra install. Use the Fetch MCP Server below when you need HTML→markdown conversion or robots.txt enforcement.
+:::
+
 :::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Headless ACP integrations and CLI users can fetch URLs through the built-in `developer` extension without enabling `computercontroller` and its screen-control / arbitrary-script tools.

**Problem:** The only built-in path to web fetching today is `computercontroller`'s `web_scrape`. `computercontroller` also bundles screen automation (`computer_control`), arbitrary script execution (`automation_script`), and document parsers — all granted to the agent in one go. Headless ACP integrations that just need URL retrieval end up granting screen-control capability as a side effect, which has caused real user-reported incidents (agent typing into the active window unprompted). Block's own `fetch-mcp.md` recommends installing a separate MCP just to get URL fetching, which implies the bundled built-in path is unsafe.

**Solution:** This PR adds `web_fetch` to the `developer` extension. `developer` already exposes `shell` (which can run `curl`), so the change is additive within an extension that already has unrestricted network egress — strictly less capable than `shell + curl`, with structured output and content-negotiation defaults. The change does not modify `computercontroller`; `web_scrape` keeps working for backward compat.

`web_fetch` accepts:
- `save_as: text` (default) — UTF-8 body, returned inline if ≤64KB else spilled to a temp file.
- `save_as: json` — validates the body parses as JSON, then returns inline / spills.
- `save_as: binary` — raw bytes, always written to a temp file; path is returned.
- `Accept: text/markdown, text/html, application/json, */*` — LLM-friendly content negotiation.
- `User-Agent: goose/<version>`, 30s request timeout, http(s) only, empty-URL guard.

<details>
<summary>File changes</summary>

**crates/goose/src/agents/platform_extensions/developer/web.rs** (new)
`WebFetchTool`, `WebFetchParams`, `SaveAsFormat` enum (`text` / `json` / `binary`), 64KB inline-vs-temp-file threshold, and 7 wiremock-backed unit tests covering inline text, large-body spill, JSON validation (good + bad), binary spill, non-2xx, empty URL, and non-http schemes.

**crates/goose/src/agents/platform_extensions/developer/mod.rs**
Registers `web_fetch` in `get_tools` with `WebFetch` annotations (read-only, idempotent, open-world for network access), wires the tool into `call_tool` dispatch, and updates `developer_tools_are_flat` to expect the new tool.

**documentation/docs/mcp/developer-mcp.md**
Adds `web_fetch` row to the developer extension tools table.

**documentation/docs/mcp/fetch-mcp.md**
Adds a tip pointing at the built-in `web_fetch` for basic URL retrieval, while still recommending `mcp-server-fetch` for HTML→markdown conversion.

</details>

## Benchmarks

n=10 runs per binary, model `claude-sonnet-4-5`, default profile (`developer` + `code_execution` enabled, `computercontroller` disabled). Compared a build of `origin/main` (vanilla) against this branch (ours) on three real URLs:

| URL | Vanilla mean tokens | Ours mean tokens | Δ tokens | Vanilla tools | Ours tools | Vanilla wall | Ours wall |
|---|---|---|---|---|---|---|---|
| `docs.aws.amazon.com` (29KB static HTML) | 24,895 | **15,558** | **−37.5%** | 3.30 | 1.10 | 14.2s | 6.1s |
| `docs.diversion.dev` (333KB SPA / 10KB MD via Accept) | 415,327 | **17,134** | **−95.9%** | 8.10 | 1.00 | 39.7s | 6.7s |
| `en.wikipedia.org/wiki/Web_scraping` (166KB static HTML) | 23,195 | 24,946 | **+7.5%** | 2.90 | 3.00 | 13.9s | 13.0s |

- Mintlify and other llms-aware docs honor `Accept: text/markdown` and serve a ~33× smaller markdown payload. Vanilla `curl` defaults to `Accept: */*` and gets the full SPA bundle. This is the headline performance win.
- For static HTML that fits inline (AWS), single-call structured return saves ~37% tokens and ~3s wall over `curl` + follow-up parse.
- For static HTML over the 64KB inline threshold (Wikipedia), spill-to-temp loses ~7% tokens to `curl | grep` because reading the temp file costs an extra `shell` call. Tradeoff worth flagging.
- Model picks `web_fetch` 10/10 on ours, falls back to `shell+curl` 10/10 on vanilla. Tool substitution is clean.

### Testing

- `cargo test -p goose --lib agents::platform_extensions::developer` — 41 passed (7 new in `developer::web`).
- `cargo clippy -p goose --lib --tests -- -D warnings` — clean.
- Real-URL E2E benches above (n=10 each on 3 URLs).

### Reproduction Steps

1. `cd crates/goose && cargo test --lib agents::platform_extensions::developer::web`.
2. `cargo build --release --bin goose`.
3. `goose run --text "fetch https://example.com and report the page <title>"` — expect `developer__web_fetch` tool call, content returned inline.
4. Same with a binary URL (e.g. PNG) — expect `Content saved to: <temp path>`.

## Related

- PR #7824 (computercontroller headless workaround) — same underlying bundling problem.
- PR #7746 (closed) — rejected attempt to remove `peekaboo` from `computercontroller`. This PR is additive, not a capability removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)