### PR TITLE
fix(acp): synchronously reap ACP child to avoid SIGCHLD race

### DIFF
--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -24,6 +24,7 @@ use std::sync::{
     Arc, Mutex,
 };
 use std::thread::JoinHandle;
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::{mpsc, oneshot, Mutex as TokioMutex};
 use tokio_util::compat::{TokioAsyncReadCompatExt as _, TokioAsyncWriteCompatExt as _};
@@ -647,8 +648,14 @@ impl AcpClientLoop {
     ) -> Result<()> {
         let stdin = child.stdin.take().context("no stdin")?;
         let stdout = child.stdout.take().context("no stdout")?;
+        if let Some(stderr) = child.stderr.take() {
+            tokio::spawn(forward_child_stderr(stderr));
+        }
         let transport = sacp::ByteStreams::new(stdin.compat_write(), stdout.compat());
-        self.run(transport, rx, init_tx).await
+        let result = self.run(transport, rx, init_tx).await;
+        let _ = child.kill().await;
+        let _ = child.wait().await;
+        result
     }
 
     async fn run(
@@ -872,12 +879,26 @@ impl AcpClientLoop {
     }
 }
 
+async fn forward_child_stderr(stderr: tokio::process::ChildStderr) {
+    let mut lines = BufReader::new(stderr).lines();
+    loop {
+        match lines.next_line().await {
+            Ok(Some(line)) => tracing::info!(target: "acp::child::stderr", "{line}"),
+            Ok(None) => break,
+            Err(e) => {
+                tracing::debug!(target: "acp::child::stderr", error = %e, "stderr read error");
+                break;
+            }
+        }
+    }
+}
+
 async fn spawn_acp_process(config: &AcpProviderConfig) -> Result<Child> {
     let mut cmd = Command::new(&config.command);
     cmd.args(&config.args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
+        .stderr(Stdio::piped())
         .kill_on_drop(true);
 
     for key in &config.env_remove {

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -24,10 +24,9 @@ use std::sync::{
     Arc, Mutex,
 };
 use std::thread::JoinHandle;
-use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::io::AsyncReadExt;
 use tokio::process::{Child, Command};
 use tokio::sync::{mpsc, oneshot, Mutex as TokioMutex};
-use tokio_stream::{wrappers::SplitStream, StreamExt};
 use tokio_util::compat::{TokioAsyncReadCompatExt as _, TokioAsyncWriteCompatExt as _};
 
 use crate::acp::{map_permission_response, PermissionDecision};
@@ -880,13 +879,31 @@ impl AcpClientLoop {
     }
 }
 
-async fn forward_child_stderr(stderr: tokio::process::ChildStderr) {
-    let mut lines = SplitStream::new(BufReader::new(stderr).split(b'\n'));
-    while let Some(result) = lines.next().await {
-        match result {
-            Ok(line) => {
-                let line = line.strip_suffix(b"\r").unwrap_or(&line);
-                tracing::info!(target: "acp::child::stderr", "{}", String::from_utf8_lossy(line));
+/// Forwards an ACP child's stderr to tracing line by line.
+///
+/// Lines longer than `MAX_LINE_LEN` are flushed in chunks so a child that
+/// emits unbounded output without newlines (e.g. carriage-return progress
+/// bars or binary data) cannot cause unbounded memory growth.
+async fn forward_child_stderr(mut stderr: tokio::process::ChildStderr) {
+    const MAX_LINE_LEN: usize = 8192;
+    const READ_CHUNK: usize = 1024;
+
+    let mut line: Vec<u8> = Vec::with_capacity(256);
+    let mut chunk = [0u8; READ_CHUNK];
+    loop {
+        match stderr.read(&mut chunk).await {
+            Ok(0) => break,
+            Ok(n) => {
+                for &b in &chunk[..n] {
+                    if b == b'\n' {
+                        emit_stderr_line(&mut line);
+                    } else {
+                        line.push(b);
+                        if line.len() >= MAX_LINE_LEN {
+                            emit_stderr_line(&mut line);
+                        }
+                    }
+                }
             }
             Err(e) => {
                 tracing::debug!(target: "acp::child::stderr", error = %e, "stderr read error");
@@ -894,6 +911,16 @@ async fn forward_child_stderr(stderr: tokio::process::ChildStderr) {
             }
         }
     }
+    emit_stderr_line(&mut line);
+}
+
+fn emit_stderr_line(line: &mut Vec<u8>) {
+    if line.is_empty() {
+        return;
+    }
+    let trimmed = line.strip_suffix(b"\r").unwrap_or(line);
+    tracing::info!(target: "acp::child::stderr", "{}", String::from_utf8_lossy(trimmed));
+    line.clear();
 }
 
 async fn spawn_acp_process(config: &AcpProviderConfig) -> Result<Child> {

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -27,6 +27,7 @@ use std::thread::JoinHandle;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::{mpsc, oneshot, Mutex as TokioMutex};
+use tokio_stream::{wrappers::SplitStream, StreamExt};
 use tokio_util::compat::{TokioAsyncReadCompatExt as _, TokioAsyncWriteCompatExt as _};
 
 use crate::acp::{map_permission_response, PermissionDecision};
@@ -880,11 +881,13 @@ impl AcpClientLoop {
 }
 
 async fn forward_child_stderr(stderr: tokio::process::ChildStderr) {
-    let mut lines = BufReader::new(stderr).lines();
-    loop {
-        match lines.next_line().await {
-            Ok(Some(line)) => tracing::info!(target: "acp::child::stderr", "{line}"),
-            Ok(None) => break,
+    let mut lines = SplitStream::new(BufReader::new(stderr).split(b'\n'));
+    while let Some(result) = lines.next().await {
+        match result {
+            Ok(line) => {
+                let line = line.strip_suffix(b"\r").unwrap_or(&line);
+                tracing::info!(target: "acp::child::stderr", "{}", String::from_utf8_lossy(line));
+            }
             Err(e) => {
                 tracing::debug!(target: "acp::child::stderr", error = %e, "stderr read error");
                 break;


### PR DESCRIPTION
Fixes #8373.
Supersedes #8790.

The `console` crate has a bug in its use of select(): any interruption is treated as a fatal error and propagated. We were killing the ACP child and then immediately proceeding, which set up a race; if the child was reaped after select() started, the SIGCHLD interrupting select() caused the program to exit.

Wait for the child to be reaped before proceeding to eliminate the race.

Also, use `Stdio::inherit()` for child stderr to prevent ACP children which output anything on stderr from messing up the CLI.

Upstream PR fixing the bug in the `console` crate: https://github.com/console-rs/console/pull/286