### PR TITLE
fix(ci): mark openai/gpt-5 smoke test as flaky

### DIFF
--- a/ui/desktop/tests/integration/test_providers_lib.ts
+++ b/ui/desktop/tests/integration/test_providers_lib.ts
@@ -69,7 +69,12 @@ function getProviders(): ProviderConfig[] {
     },
     {
       provider: 'openai',
-      models: ['gpt-4o', 'gpt-4o-mini', { name: 'gpt-3.5-turbo', flaky: true }, 'gpt-5'],
+      models: [
+        'gpt-4o',
+        'gpt-4o-mini',
+        { name: 'gpt-3.5-turbo', flaky: true },
+        { name: 'gpt-5', flaky: true },
+      ],
       available: () => hasEnv('OPENAI_API_KEY'),
     },
     {


### PR DESCRIPTION
## Summary

The `Smoke Tests (Code Execution)` job has been failing repeatedly on `main` (and on PR branches once they merge in `main`) on the `invokes code_execution tool — 'openai' / 'gpt-5'` test case. The model spends its turn calling `list_functions` and `get_function_details` for `Memory` and `Todo`, never reaching `code_execution` before the 55s `runGoose` timeout fires.

This change marks `openai / gpt-5` as `flaky: true`, mirroring the established pattern from #8837 (`fix(ci): prevent flaky smoke test timeouts from failing the build`) already used for `gpt-3.5-turbo`, `qwen/qwen3-coder:exacto`, `gemini-2.5-flash`, `gemini-3-pro-preview`, and `nvidia/nemotron-3-nano-30b-a3b:free`.

For flaky entries:
- vitest test timeout is bumped to 90s so the internal 55s `runGoose` rejection fires first
- the rejection is caught and logged as ``console.warn(`Flaky test ... failed (allowed): ${err}`)`` instead of failing the build

The faster non-code-exec smoke test (which gpt-5 passes in ~5s) is unaffected — only how timeouts are treated changes.

### Evidence

- Latest failing run on `main`: https://github.com/aaif-goose/goose/actions/runs/25366266244 (gpt-5 timed out at 55007ms in code-exec)
- Several other recent failing runs on `main`: 25329705071, 25325931805, 25319479744, 25297284836, 25296973706
- All other 14 non-flaky models pass code-exec consistently

## Test plan

- [ ] `Smoke Tests` job (regular) still passes — gpt-5 succeeds there in ~5s
- [ ] `Smoke Tests (Code Execution)` job no longer fails the build when gpt-5 times out; check the run for a `Flaky test openai/gpt-5 failed (allowed)` warning if it does time out