### PR TITLE
fix(openai): accept null tool_call arguments in streaming chunks

### DIFF
--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -32,10 +32,17 @@ type ToolCallData = HashMap<
     ),
 >;
 
+fn deserialize_null_default_string<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<String>::deserialize(deserializer)?.unwrap_or_default())
+}
+
 #[derive(Serialize, Deserialize, Debug, Default)]
 struct DeltaToolCallFunction {
     name: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_default_string")]
     arguments: String,
 }
 
@@ -2434,5 +2441,20 @@ data: [DONE]"#;
             "expected thinking content from merged reasoning fields"
         );
         Ok(())
+    }
+
+    #[test]
+    fn test_delta_tool_call_function_accepts_null_arguments() {
+        let raw = r#"{"arguments":null}"#;
+        let parsed: DeltaToolCallFunction = serde_json::from_str(raw).expect("null arguments must deserialize");
+        assert_eq!(parsed.arguments, "");
+
+        let raw = r#"{}"#;
+        let parsed: DeltaToolCallFunction = serde_json::from_str(raw).expect("missing arguments must deserialize");
+        assert_eq!(parsed.arguments, "");
+
+        let raw = r#"{"arguments":"{\"k\":1}"}"#;
+        let parsed: DeltaToolCallFunction = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed.arguments, "{\"k\":1}");
     }
 }

--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -2446,11 +2446,13 @@ data: [DONE]"#;
     #[test]
     fn test_delta_tool_call_function_accepts_null_arguments() {
         let raw = r#"{"arguments":null}"#;
-        let parsed: DeltaToolCallFunction = serde_json::from_str(raw).expect("null arguments must deserialize");
+        let parsed: DeltaToolCallFunction =
+            serde_json::from_str(raw).expect("null arguments must deserialize");
         assert_eq!(parsed.arguments, "");
 
         let raw = r#"{}"#;
-        let parsed: DeltaToolCallFunction = serde_json::from_str(raw).expect("missing arguments must deserialize");
+        let parsed: DeltaToolCallFunction =
+            serde_json::from_str(raw).expect("missing arguments must deserialize");
         assert_eq!(parsed.arguments, "");
 
         let raw = r#"{"arguments":"{\"k\":1}"}"#;


### PR DESCRIPTION
## Summary

`DeltaToolCallFunction.arguments` is a `String` with `#[serde(default)]`. `serde(default)` only fires when the field is missing, so a streaming chunk that sends `"arguments": null` (deepseek-v4-pro in #8991) blows up the whole chunk parse with `invalid type: null, expected a string` and the tool call gets dropped.

Add a `deserialize_null_default_string` helper that maps both missing and explicit `null` to `""`, and use it on `arguments`. The field stays a `String`, so the `push_str` / clone sites that concatenate streaming deltas don't change.

Kept it as `String` rather than switching to `Option<String>` so the change is local to this one field and doesn't ripple through the streaming accumulator.

### Testing

- Added `test_delta_tool_call_function_accepts_null_arguments` covering the `null`, missing, and populated cases.
- `cargo test -p goose --lib providers::formats::openai`

### Related Issues

Fixes #8991