### PR TITLE
fix(a11y): improve inline code contrast in light theme

### DIFF
--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -183,6 +183,8 @@
   --text-inverse: var(--color-white);
   --text-danger: var(--color-red-200);
 
+  --color-inline-code: #c2410c;
+
   /* Search highlighting */
   --highlight-color: rgba(255, 213, 0, 0.5);
   --highlight-current: rgba(252, 213, 3, 0.6);
@@ -207,6 +209,8 @@
   /* Legacy aliases */
   --text-inverse: var(--color-black);
   --text-danger: var(--color-red-100);
+
+  --color-inline-code: #ff7235;
 
   /* Search highlighting */
   --highlight-color: rgba(255, 213, 0, 0.5);
@@ -551,12 +555,18 @@ body {
 
 .bg-inline-code {
   border-radius: 4px;
-  color: var(--color-neutral-200);
+  color: var(--color-inline-code);
+  background-color: var(--color-neutral-50);
   font-family: monospace;
   font-size: 12px;
   font-style: normal;
   font-weight: 400;
   line-height: normal;
+  padding: 2px 4px;
+}
+
+.dark .bg-inline-code {
+  background-color: var(--color-neutral-900);
 }
 
 .bg-inline-code:before {
@@ -565,12 +575,6 @@ body {
 
 pre:has(> code.bg-inline-code) {
   padding: 1em;
-}
-
-li > code.bg-inline-code,
-p > code.bg-inline-code {
-  color: var(--color-block-orange);
-  padding: 2px 4px;
 }
 
 .bg-inline-code:after {


### PR DESCRIPTION
## Summary

Inline code text rendered as nearly invisible light grey (#cbd1d6) on white background in the light theme. Contrast ratio was 1.54:1 — far below the WCAG 2.1 AA minimum of 4.5:1.

Root cause:
1. The base .bg-inline-code class used --color-neutral-200 (#cbd1d6), a color designed for dark backgrounds, with no light/dark theme differentiation.
2. The accent color override used parent-specific selectors (p > code, li > code) which failed in many common contexts:
   - Inline code inside `<strong>` (bold text)
   - Inline code inside `<em>` (italic text)
   - Inline code inside `<td>/<th>` (table cells)
   - Inline code inside `<a>` (links)
   - Any other nesting beyond direct child of `<p>` or `<li>`

Fix:
- Apply the accessible accent color directly on the base .bg-inline-code class so it works in ALL contexts (tables, headings, bold, italic, links, etc.)
- Light theme: #c2410c (4.78:1 contrast ✅ AA) with subtle #f4f6f7 background.
- Dark theme: #ff7235 (4.51:1 contrast ✅ AA) with #32353b background.
- Removed the parent-specific selectors entirely — no longer needed since the base class now carries the correct color everywhere.


### Testing

I've been manually testing this on macOS arm64.

### Related Issues
Relates to #9005 
Discussion: N/A


### Screenshots/Demos (for UX changes)
Before:  

<img width="1008" height="525" alt="Image" src="https://github.com/user-attachments/assets/5ec73a7b-4ea2-46ce-9d69-9bc68fdbf9e2" />

After:   

<img width="977" height="489" alt="Image" src="https://github.com/user-attachments/assets/4099af50-0b6d-4fda-aee5-9c8188b3b19d" />