### PR TITLE
fix: TUI proper binary resolution

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -10,9 +10,15 @@ on:
   workflow_dispatch:
     inputs:
       release-tag:
-        description: 'Release tag to fetch binaries from (e.g. v1.0.0)'
-        required: true
+        description: 'Release tag to fetch binaries from (e.g. v1.0.0). Ignored when canary=true.'
+        required: false
+        default: 'canary'
         type: string
+      canary:
+        description: 'Publish a canary off the branch selected above (npm dist-tag "canary", auto-bumped version)'
+        required: false
+        default: false
+        type: boolean
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -41,6 +47,22 @@ jobs:
         uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4
         with:
           version: 10.30.3
+
+      - name: Bump package versions for canary
+        if: inputs.canary
+        run: |
+          set -euo pipefail
+          base=$(npm view @aaif/goose dist-tags.latest)
+          # pick the next free N for ${base}-canary.N
+          n=$(npm view @aaif/goose versions --json \
+            | jq -r --arg b "${base}-canary." '
+                map(select(startswith($b)) | ltrimstr($b) | tonumber) | (max // -1) + 1')
+          version="${base}-canary.${n}"
+          echo "Canary version: ${version}"
+          for pkg in ui/sdk ui/text ui/goose-binary/*/; do
+            jq --arg v "$version" '.version = $v' "$pkg/package.json" > "$pkg/package.json.tmp"
+            mv "$pkg/package.json.tmp" "$pkg/package.json"
+          done
 
       - name: Download goose binaries from release
         env:
@@ -160,6 +182,8 @@ jobs:
           version: 10.30.3
 
       - name: Publish to npm
+        env:
+          NPM_TAG: ${{ inputs.canary && 'canary' || 'latest' }}
         run: |
           cd ui
           # Publish each package individually so one failure doesn't abort the rest.
@@ -169,8 +193,8 @@ jobs:
             if [ -f "$pkg/package.json" ]; then
               name=$(jq -r '.name' "$pkg/package.json")
               version=$(jq -r '.version' "$pkg/package.json")
-              echo "Publishing $name@$version..."
-              if (cd "$pkg" && pnpm publish --access public --no-git-checks --provenance); then
+              echo "Publishing $name@$version (tag: $NPM_TAG)..."
+              if (cd "$pkg" && pnpm publish --access public --no-git-checks --provenance --tag "$NPM_TAG"); then
                 echo "  ✅ $name@$version published"
               else
                 # Check if it failed because the version already exists

--- a/ui/goose-binary/goose-binary-darwin-arm64/package.json
+++ b/ui/goose-binary/goose-binary-darwin-arm64/package.json
@@ -13,6 +13,9 @@
     "agent",
     "binary"
   ],
+  "scripts": {
+    "postinstall": "node -e \"require('fs').chmodSync(require('path').join(__dirname,'bin','goose'), 0o755)\""
+  },
   "os": [
     "darwin"
   ],

--- a/ui/goose-binary/goose-binary-darwin-arm64/package.json
+++ b/ui/goose-binary/goose-binary-darwin-arm64/package.json
@@ -7,9 +7,6 @@
     "type": "git",
     "url": "git+https://github.com/aaif-goose/goose.git"
   },
-  "bin": {
-    "goose": "bin/goose"
-  },
   "keywords": [
     "goose",
     "ai",

--- a/ui/goose-binary/goose-binary-darwin-x64/package.json
+++ b/ui/goose-binary/goose-binary-darwin-x64/package.json
@@ -13,6 +13,9 @@
     "agent",
     "binary"
   ],
+  "scripts": {
+    "postinstall": "node -e \"require('fs').chmodSync(require('path').join(__dirname,'bin','goose'), 0o755)\""
+  },
   "os": [
     "darwin"
   ],

--- a/ui/goose-binary/goose-binary-darwin-x64/package.json
+++ b/ui/goose-binary/goose-binary-darwin-x64/package.json
@@ -7,9 +7,6 @@
     "type": "git",
     "url": "git+https://github.com/aaif-goose/goose.git"
   },
-  "bin": {
-    "goose": "bin/goose"
-  },
   "keywords": [
     "goose",
     "ai",

--- a/ui/goose-binary/goose-binary-linux-arm64/package.json
+++ b/ui/goose-binary/goose-binary-linux-arm64/package.json
@@ -13,6 +13,9 @@
     "agent",
     "binary"
   ],
+  "scripts": {
+    "postinstall": "node -e \"require('fs').chmodSync(require('path').join(__dirname,'bin','goose'), 0o755)\""
+  },
   "os": [
     "linux"
   ],

--- a/ui/goose-binary/goose-binary-linux-arm64/package.json
+++ b/ui/goose-binary/goose-binary-linux-arm64/package.json
@@ -7,9 +7,6 @@
     "type": "git",
     "url": "git+https://github.com/aaif-goose/goose.git"
   },
-  "bin": {
-    "goose": "bin/goose"
-  },
   "keywords": [
     "goose",
     "ai",

--- a/ui/goose-binary/goose-binary-linux-x64/package.json
+++ b/ui/goose-binary/goose-binary-linux-x64/package.json
@@ -13,6 +13,9 @@
     "agent",
     "binary"
   ],
+  "scripts": {
+    "postinstall": "node -e \"require('fs').chmodSync(require('path').join(__dirname,'bin','goose'), 0o755)\""
+  },
   "os": [
     "linux"
   ],

--- a/ui/goose-binary/goose-binary-linux-x64/package.json
+++ b/ui/goose-binary/goose-binary-linux-x64/package.json
@@ -7,9 +7,6 @@
     "type": "git",
     "url": "git+https://github.com/aaif-goose/goose.git"
   },
-  "bin": {
-    "goose": "bin/goose"
-  },
   "keywords": [
     "goose",
     "ai",

--- a/ui/goose-binary/goose-binary-win32-x64/package.json
+++ b/ui/goose-binary/goose-binary-win32-x64/package.json
@@ -7,9 +7,6 @@
     "type": "git",
     "url": "git+https://github.com/aaif-goose/goose.git"
   },
-  "bin": {
-    "goose": "bin/goose.exe"
-  },
   "keywords": [
     "goose",
     "ai",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -744,6 +744,22 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+    optionalDependencies:
+      '@aaif/goose-binary-darwin-arm64':
+        specifier: workspace:*
+        version: link:../goose-binary/goose-binary-darwin-arm64
+      '@aaif/goose-binary-darwin-x64':
+        specifier: workspace:*
+        version: link:../goose-binary/goose-binary-darwin-x64
+      '@aaif/goose-binary-linux-arm64':
+        specifier: workspace:*
+        version: link:../goose-binary/goose-binary-linux-arm64
+      '@aaif/goose-binary-linux-x64':
+        specifier: workspace:*
+        version: link:../goose-binary/goose-binary-linux-x64
+      '@aaif/goose-binary-win32-x64':
+        specifier: workspace:*
+        version: link:../goose-binary/goose-binary-win32-x64
 
 packages:
 
@@ -10354,7 +10370,7 @@ snapshots:
   '@mcp-ui/client@7.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@modelcontextprotocol/ext-apps': 1.2.2(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
-      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       zod: 3.25.76
@@ -10417,28 +10433,6 @@ snapshots:
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
       zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
-    dependencies:
-      '@hono/node-server': 1.19.11(hono@4.12.8)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.6
-      express: 5.2.1
-      express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.12.8
-      jose: 6.2.2
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 4.3.6
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color

--- a/ui/sdk/src/resolve-binary.ts
+++ b/ui/sdk/src/resolve-binary.ts
@@ -16,7 +16,11 @@ const PLATFORMS: Record<string, string> = {
  *   1. `GOOSE_BINARY` environment variable (explicit override)
  *   2. Platform-specific `@aaif/goose-binary-*` optional dependency
  *
- * @throws if no binary can be found
+ * Always returns an absolute path. Callers must spawn this directly
+ * without going through a shell so PATH lookups can't accidentally
+ * resolve a different `goose` binary.
+ *
+ * @throws if the current platform isn't supported
  */
 export function resolveGooseBinary(): string {
   const envBinary = process.env.GOOSE_BINARY;
@@ -30,14 +34,8 @@ export function resolveGooseBinary(): string {
     );
   }
 
-  try {
-    const require = createRequire(import.meta.url);
-    const pkgDir = dirname(require.resolve(`${pkg}/package.json`));
-    const binName = process.platform === "win32" ? "goose.exe" : "goose";
-    return join(pkgDir, "bin", binName);
-  } catch {
-    throw new Error(
-      `goose binary package ${pkg} is not installed. Set GOOSE_BINARY or install the native package.`,
-    );
-  }
+  const require = createRequire(import.meta.url);
+  const pkgDir = dirname(require.resolve(`${pkg}/package.json`));
+  const binName = process.platform === "win32" ? "goose.exe" : "goose";
+  return join(pkgDir, "bin", binName);
 }

--- a/ui/text/package.json
+++ b/ui/text/package.json
@@ -47,5 +47,12 @@
     "esbuild": "^0.25.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0"
+  },
+  "optionalDependencies": {
+    "@aaif/goose-binary-darwin-arm64": "workspace:*",
+    "@aaif/goose-binary-darwin-x64": "workspace:*",
+    "@aaif/goose-binary-linux-arm64": "workspace:*",
+    "@aaif/goose-binary-linux-x64": "workspace:*",
+    "@aaif/goose-binary-win32-x64": "workspace:*"
   }
 }


### PR DESCRIPTION
## Summary

Fixes two problems

1. When someone doesn't have goose at all, the TUI doesn't find the appropriate binary package in its `node_module` tree and it is unable to run `goose acp`. This is fixed by adding the `ui/goose-binary` packages as optional deps at the level of `ui/text` as well as `ui/sdk`.
2. Removes `bin` definitions in the `ui/goose-binary` npm `package.json` files which can activate if the CWD is in a location where an executable at that relative path exists. In this scenario you currently see the goose-cli experience when running `npx @aaif/goose`

### Testing
Will test published package

### Related Issues
N/A

### Screenshots/Demos (for UX changes)
N/A
