### PR TITLE
More improvements to local inference providers

### DIFF
--- a/.plan/per_model_context_limit_ui.md
+++ b/.plan/per_model_context_limit_ui.md
@@ -1,0 +1,159 @@
+# Per-Model Context Limit UI in Context Popover
+
+## Goal
+
+Let users override the context limit for dynamic models directly from the context usage popover (near the "Compact now" button). The override applies to the current session and persists across future sessions for that provider+model combination.
+
+## Background
+
+- Declarative providers (lmstudio, llama_swap, omlx) now have a `context_limit` field in their JSON config as a provider-level default (e.g., 1024K).
+- Users may need per-model overrides that differ from the provider default.
+- The local inference provider already has a `ModelSettingsPanel` with a `context_size` field — the declarative provider UI should offer a lighter-weight equivalent in the popover.
+
+---
+
+## Backend (Rust)
+
+### 1. ACP custom methods
+
+**File:** `crates/goose-sdk/src/custom_requests.rs`
+
+Add three new request/response structs:
+
+```
+_get goose/model/context_limit/set    — Store a per-model context limit override
+_get goose/model/context_limit/get    — Read the stored override for a provider+model
+_get goose/model/context_limit/reset  — Remove the override (revert to provider/default)
+```
+
+Request struct for set/get:
+```rust
+pub struct ModelContextLimitRequest {
+    pub provider: String,
+    pub model: String,
+}
+```
+
+Request struct for set:
+```rust
+pub struct ModelContextLimitSetRequest {
+    pub provider: String,
+    pub model: String,
+    pub context_limit: Option<usize>,  // None to reset
+}
+```
+
+Response:
+```rust
+pub struct ModelContextLimitResponse {
+    pub provider: String,
+    pub model: String,
+    pub context_limit: Option<usize>,
+}
+```
+
+### 2. Handler implementation
+
+**File:** `crates/goose/src/acp/server.rs`
+
+Implement handlers for the three methods. Persist overrides using the existing preferences system:
+- Key format: `model_context_limit:{provider}:{model}`
+- Value: the usize limit as a string
+
+### 3. Apply override during model resolution
+
+**File:** `crates/goose/src/acp/server.rs` (`set_model_and_extensions`)
+
+After resolving the provider default context limit, check for a stored override:
+1. Build the preference key from current provider + model
+2. Read via `config.get_param::<String>(&key)`
+3. If found and valid, use it as the `context_limit`
+
+---
+
+## Frontend (goose2)
+
+### 4. Regenerate SDK
+
+Run the SDK generation step so the new ACP methods appear as typed `GooseClient` methods.
+
+### 5. Feature API module
+
+**File:** `ui/goose2/src/features/chat/api/contextLimit.ts` (new)
+
+Thin wrappers around the new ACP methods:
+- `getModelContextLimit(provider: string, model: string): Promise<number | null>`
+- `setModelContextLimit(provider: string, model: string, limit: number | null): Promise<void>`
+- `resetModelContextLimit(provider: string, model: string): Promise<void>`
+
+### 6. Context limit editor in popover
+
+**File:** `ui/goose2/src/features/chat/ui/ChatInputToolbar.tsx`
+
+Add a new section below the "Compact now" / settings row in the context popover:
+
+```
++------------------------------------------+
+|  Context Window                          |
+|  [====================>] 78%            |
+|  78K / 1024K tokens                      |
+|  [Compact now] [Settings]                |
+|                                          |
+|  Context limit:  [1024K v]               |  ← new
+|  Default: 1024K  [Reset]                 |
++------------------------------------------+
+```
+
+**Components:**
+- **Preset selector**: Dropdown with "Default", "256K", "512K", "1024K", "2048K"
+- **Custom input**: When user types a value not in presets, show "Custom" badge
+- **Reset button**: Reverts to provider default, calls the reset ACP method
+- **Default label**: Shows the provider's built-in default for reference
+- Only visible for providers that support dynamic models (declarative providers)
+
+**State flow:**
+1. On popover open: fetch current override via `getModelContextLimit`
+2. On change: call `setModelContextLimit` → update `chatStore.tokenState.contextLimit`
+3. On reset: call `resetModelContextLimit` → revert to provider default
+
+### 7. Wire into chatStore
+
+**File:** `ui/goose2/src/features/chat/stores/chatStore.ts`
+
+Add an action to update context limit for a session:
+```ts
+setSessionContextLimit: (sessionId, contextLimit) =>
+  set((state) => ({
+    sessionStateById: {
+      ...state.sessionStateById,
+      [sessionId]: {
+        ...state.sessionStateById[sessionId],
+        tokenState: {
+          ...state.sessionStateById[sessionId]?.tokenState,
+          contextLimit,
+        },
+      },
+    },
+  })),
+```
+
+---
+
+## Files to modify
+
+| File | Action |
+|------|--------|
+| `crates/goose-sdk/src/custom_requests.rs` | Add 3 new ACP methods |
+| `crates/goose/src/acp/server.rs` | Implement handlers + apply override in model resolution |
+| `ui/goose2/src/features/chat/api/contextLimit.ts` | **New** — API wrappers |
+| `ui/goose2/src/features/chat/ui/ChatInputToolbar.tsx` | Add context limit editor to popover |
+| `ui/goose2/src/features/chat/stores/chatStore.ts` | Add `setSessionContextLimit` action |
+| `ui/sdk/src/generated/` | Regenerate from SDK defs |
+
+## Design notes
+
+- Control is unobtrusive — inline input, no modal
+- "Custom" badge shown when override differs from provider default
+- Only shown for declarative providers with dynamic models (check provider type)
+- For local inference models, existing `ModelSettingsPanel` already handles `context_size` — no duplicate UI needed
+- Quick presets cover common ranges; custom input accepts any value

--- a/crates/goose-sdk/src/custom_requests.rs
+++ b/crates/goose-sdk/src/custom_requests.rs
@@ -1280,3 +1280,40 @@ pub struct DictationModelSelectRequest {
     pub provider: String,
     pub model_id: String,
 }
+
+/// Set a per-model context limit override.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema, JsonRpcRequest)]
+#[request(method = "_goose/model/context_limit/set", response = EmptyResponse)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelContextLimitSetRequest {
+    pub provider: String,
+    pub model: String,
+    /// The context limit in tokens. Pass 0 to reset to provider default.
+    pub context_limit: u64,
+}
+
+/// Read the stored per-model context limit override.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema, JsonRpcRequest)]
+#[request(method = "_goose/model/context_limit/get", response = ModelContextLimitGetResponse)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelContextLimitGetRequest {
+    pub provider: String,
+    pub model: String,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema, JsonRpcResponse)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelContextLimitGetResponse {
+    /// The stored context limit in tokens, or null if no override is set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_limit: Option<usize>,
+}
+
+/// Remove a per-model context limit override.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema, JsonRpcRequest)]
+#[request(method = "_goose/model/context_limit/reset", response = EmptyResponse)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelContextLimitResetRequest {
+    pub provider: String,
+    pub model: String,
+}

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1043,6 +1043,41 @@ fn build_usage_update(session: &Session, context_limit: usize) -> UsageUpdate {
     UsageUpdate::new(used, context_limit as u64)
 }
 
+/// Resolve the effective context limit for a provider+model, checking:
+/// 1. The ModelConfig's context_limit
+/// 2. Known models in the provider registry
+/// 3. Declarative provider's provider-level context_limit (from registry metadata)
+/// 4. Fall back to DEFAULT_CONTEXT_LIMIT
+async fn resolve_effective_context_limit(
+    provider_name: &str,
+    model_name: &str,
+    model_config_context_limit: Option<usize>,
+) -> usize {
+    // Use the model config's context_limit if set
+    if let Some(limit) = model_config_context_limit {
+        return limit;
+    }
+
+    // Check known models in the provider registry
+    if let Ok(entry) = crate::providers::get_from_registry(provider_name).await {
+        if let Some(known_model) = entry
+            .metadata()
+            .known_models
+            .iter()
+            .find(|m| m.name == model_name && m.context_limit > 0)
+        {
+            return known_model.context_limit;
+        }
+        // Check provider-level context_limit from registry metadata
+        if let Some(limit) = entry.metadata().provider_context_limit {
+            return limit;
+        }
+    }
+
+    // Fall back to default
+    crate::model::DEFAULT_CONTEXT_LIMIT
+}
+
 impl GooseAcpAgent {
     pub fn permission_manager(&self) -> Arc<PermissionManager> {
         Arc::clone(&self.permission_manager)
@@ -2387,10 +2422,17 @@ impl GooseAcpAgent {
         let mode_state = build_mode_state(self.goose_mode)?;
 
         let resolved = resolve_provider_and_model(&self.config_dir, &goose_session).await;
-        let initial_usage_update = resolved
-            .as_ref()
-            .ok()
-            .map(|(_, mc)| build_usage_update(&goose_session, mc.context_limit()));
+        let initial_usage_update = if let Ok((provider_name, mc)) = resolved.as_ref() {
+            let context_limit = resolve_effective_context_limit(
+                provider_name,
+                &mc.model_name,
+                mc.context_limit,
+            )
+            .await;
+            Some(build_usage_update(&goose_session, context_limit))
+        } else {
+            None
+        };
         let acp_session_id = SessionId::new(session_id_str);
         let (model_state, config_options, prebuilt_provider) = self
             .prepare_session_init_config(&resolved, &mode_state, &goose_session)
@@ -2746,16 +2788,17 @@ impl GooseAcpAgent {
         let mode_state = build_mode_state(loaded_mode)?;
 
         let resolved = resolve_provider_and_model(&self.config_dir, &goose_session).await;
-        let initial_usage_update = resolved
-            .as_ref()
-            .ok()
-            .map(|(_, mc)| build_usage_update(&goose_session, mc.context_limit()))
-            .or_else(|| {
-                goose_session
-                    .model_config
-                    .as_ref()
-                    .map(|mc| build_usage_update(&goose_session, mc.context_limit()))
-            });
+        let initial_usage_update = if let Ok((provider_name, mc)) = resolved.as_ref() {
+            let context_limit = resolve_effective_context_limit(
+                provider_name,
+                &mc.model_name,
+                mc.context_limit,
+            )
+            .await;
+            Some(build_usage_update(&goose_session, context_limit))
+        } else {
+            None
+        };
         let (model_state, config_options, prebuilt_provider) = self
             .prepare_session_init_config(&resolved, &mode_state, &goose_session)
             .await;

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -2788,16 +2788,23 @@ impl GooseAcpAgent {
         let mode_state = build_mode_state(loaded_mode)?;
 
         let resolved = resolve_provider_and_model(&self.config_dir, &goose_session).await;
-        let initial_usage_update = if let Ok((provider_name, mc)) = resolved.as_ref() {
-            let context_limit = resolve_effective_context_limit(
-                provider_name,
-                &mc.model_name,
-                mc.context_limit,
-            )
-            .await;
+        let initial_usage_update = {
+            let context_limit = match resolved.as_ref().ok() {
+                Some((provider_name, mc)) => {
+                    resolve_effective_context_limit(
+                        provider_name,
+                        &mc.model_name,
+                        mc.context_limit,
+                    )
+                    .await
+                }
+                None => goose_session
+                    .model_config
+                    .as_ref()
+                    .map(|mc| mc.context_limit())
+                    .unwrap_or(crate::model::DEFAULT_CONTEXT_LIMIT),
+            };
             Some(build_usage_update(&goose_session, context_limit))
-        } else {
-            None
         };
         let (model_state, config_options, prebuilt_provider) = self
             .prepare_session_init_config(&resolved, &mode_state, &goose_session)

--- a/crates/goose/src/acp/server/config.rs
+++ b/crates/goose/src/acp/server/config.rs
@@ -256,3 +256,106 @@ fn optional_config_string(
         Err(e) => Err(agent_client_protocol::Error::internal_error().data(e.to_string())),
     }
 }
+
+impl GooseAcpAgent {
+    pub(super) async fn on_model_context_limit_set(
+        &self,
+        req: ModelContextLimitSetRequest,
+    ) -> Result<EmptyResponse, agent_client_protocol::Error> {
+        if req.provider.is_empty() || req.model.is_empty() {
+            return Err(
+                agent_client_protocol::Error::invalid_params()
+                    .data("provider and model must be non-empty"),
+            );
+        }
+        if req.context_limit == 0 {
+            return self
+                .on_model_context_limit_reset(ModelContextLimitResetRequest {
+                    provider: req.provider,
+                    model: req.model,
+                })
+                .await;
+        }
+        let config = self.config()?;
+        let key = format!("model_context_limit:{}", req.provider);
+        // Store as a JSON object: { "model": context_limit }
+        let existing = config
+            .get_param::<serde_json::Value>(&key)
+            .unwrap_or_else(|_| serde_json::Value::Object(serde_json::Map::new()));
+        let mut map = match existing.as_object().cloned() {
+            Some(m) => m,
+            None => serde_json::Map::new(),
+        };
+        map.insert(
+            req.model,
+            serde_json::Value::Number(serde_json::Number::from(req.context_limit)),
+        );
+        config
+            .set_param(&key, &serde_json::Value::Object(map))
+            .internal_err_ctx("Failed to save context limit")?;
+        Ok(EmptyResponse {})
+    }
+
+    pub(super) async fn on_model_context_limit_get(
+        &self,
+        req: ModelContextLimitGetRequest,
+    ) -> Result<ModelContextLimitGetResponse, agent_client_protocol::Error> {
+        if req.provider.is_empty() || req.model.is_empty() {
+            return Err(
+                agent_client_protocol::Error::invalid_params()
+                    .data("provider and model must be non-empty"),
+            );
+        }
+        let config = self.config()?;
+        let key = format!("model_context_limit:{}", req.provider);
+        match config.get_param::<serde_json::Value>(&key) {
+            Ok(serde_json::Value::Object(map)) => Ok(ModelContextLimitGetResponse {
+                context_limit: map
+                    .get(&req.model)
+                    .and_then(|v| v.as_u64())
+                    .and_then(|v| usize::try_from(v).ok()),
+            }),
+            Ok(_) => Ok(ModelContextLimitGetResponse {
+                context_limit: None,
+            }),
+            Err(crate::config::ConfigError::NotFound(_)) => Ok(ModelContextLimitGetResponse {
+                context_limit: None,
+            }),
+            Err(e) => Err(agent_client_protocol::Error::internal_error().data(e.to_string())),
+        }
+    }
+
+    pub(super) async fn on_model_context_limit_reset(
+        &self,
+        req: ModelContextLimitResetRequest,
+    ) -> Result<EmptyResponse, agent_client_protocol::Error> {
+        if req.provider.is_empty() || req.model.is_empty() {
+            return Err(
+                agent_client_protocol::Error::invalid_params()
+                    .data("provider and model must be non-empty"),
+            );
+        }
+        let config = self.config()?;
+        let key = format!("model_context_limit:{}", req.provider);
+        match config.get_param::<serde_json::Value>(&key) {
+            Ok(serde_json::Value::Object(mut map)) => {
+                map.remove(&req.model);
+                if map.is_empty() {
+                    config
+                        .delete(&key)
+                        .internal_err_ctx("Failed to clear context limit storage")?;
+                } else {
+                    config
+                        .set_param(&key, &serde_json::Value::Object(map))
+                        .internal_err_ctx("Failed to update context limit storage")?;
+                }
+            }
+            Ok(_) => {}
+            Err(crate::config::ConfigError::NotFound(_)) => {}
+            Err(e) => {
+                return Err(agent_client_protocol::Error::internal_error().data(e.to_string()))
+            }
+        }
+        Ok(EmptyResponse {})
+    }
+}

--- a/crates/goose/src/acp/server/custom_dispatch.rs
+++ b/crates/goose/src/acp/server/custom_dispatch.rs
@@ -449,4 +449,28 @@ impl GooseAcpAgent {
     ) -> Result<EmptyResponse, agent_client_protocol::Error> {
         self.on_dictation_model_select(req).await
     }
+
+    #[custom_method(ModelContextLimitSetRequest)]
+    async fn dispatch_model_context_limit_set(
+        &self,
+        req: ModelContextLimitSetRequest,
+    ) -> Result<EmptyResponse, agent_client_protocol::Error> {
+        self.on_model_context_limit_set(req).await
+    }
+
+    #[custom_method(ModelContextLimitGetRequest)]
+    async fn dispatch_model_context_limit_get(
+        &self,
+        req: ModelContextLimitGetRequest,
+    ) -> Result<ModelContextLimitGetResponse, agent_client_protocol::Error> {
+        self.on_model_context_limit_get(req).await
+    }
+
+    #[custom_method(ModelContextLimitResetRequest)]
+    async fn dispatch_model_context_limit_reset(
+        &self,
+        req: ModelContextLimitResetRequest,
+    ) -> Result<EmptyResponse, agent_client_protocol::Error> {
+        self.on_model_context_limit_reset(req).await
+    }
 }

--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -632,7 +632,7 @@ mod tests {
         assert_eq!(config.name, "llama_swap");
         assert_eq!(config.display_name, "Llama Swap");
         assert!(matches!(config.engine, ProviderEngine::OpenAI));
-        assert_eq!(config.api_key_env, "");
+        assert_eq!(config.api_key_env, "LLAMA_SWAP_API_KEY");
         assert!(!config.requires_auth);
         assert!(config.skip_canonical_filtering);
         assert_eq!(config.dynamic_models, Some(true));

--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -96,6 +96,12 @@ pub struct DeclarativeProviderConfig {
     pub setup_steps: Vec<String>,
     #[serde(default, deserialize_with = "deserialize_non_empty_string")]
     pub fast_model: Option<String>,
+    /// Default context limit for dynamic models when not explicitly set per-model.
+    #[serde(default)]
+    pub context_limit: Option<usize>,
+    /// Default max output tokens for dynamic models when not explicitly set per-model.
+    #[serde(default)]
+    pub max_output_tokens: Option<i32>,
 }
 
 fn default_requires_auth() -> bool {
@@ -301,6 +307,8 @@ pub fn create_custom_provider(
         model_doc_link: None,
         setup_steps: vec![],
         fast_model: None,
+        context_limit: None,
+        max_output_tokens: None,
     };
 
     let custom_providers_dir = custom_providers_dir();
@@ -371,6 +379,8 @@ pub fn update_custom_provider(params: UpdateCustomProviderParams) -> Result<()> 
             model_doc_link: existing_config.model_doc_link,
             setup_steps: existing_config.setup_steps,
             fast_model: existing_config.fast_model.clone(),
+            context_limit: existing_config.context_limit,
+            max_output_tokens: existing_config.max_output_tokens,
         };
 
         let file_path = custom_provider_file_path(&updated_config.name)?;

--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -130,6 +130,16 @@ impl AnthropicProvider {
             None
         };
 
+        let model = if config.context_limit.is_some() && model.context_limit.is_none() {
+            model.with_context_limit(config.context_limit)
+        } else {
+            model
+        };
+        let model = if config.max_output_tokens.is_some() && model.max_tokens.is_none() {
+            model.with_max_tokens(config.max_output_tokens)
+        } else {
+            model
+        };
         let model = if let Some(ref fast_model_name) = config.fast_model {
             model.with_fast(fast_model_name, &config.name)?
         } else {

--- a/crates/goose/src/providers/base.rs
+++ b/crates/goose/src/providers/base.rs
@@ -188,6 +188,12 @@ pub struct ProviderMetadata {
     /// Hint shown in the model picker when this provider manages its own model selection.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_selection_hint: Option<String>,
+    /// Default context limit for dynamic models when not explicitly set per-model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_context_limit: Option<usize>,
+    /// Default max output tokens for dynamic models when not explicitly set per-model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_max_output_tokens: Option<i32>,
 }
 
 impl ProviderMetadata {
@@ -222,6 +228,8 @@ impl ProviderMetadata {
             config_keys,
             setup_steps: vec![],
             model_selection_hint: None,
+            provider_context_limit: None,
+            provider_max_output_tokens: None,
         }
     }
 
@@ -244,6 +252,8 @@ impl ProviderMetadata {
             config_keys,
             setup_steps: vec![],
             model_selection_hint: None,
+            provider_context_limit: None,
+            provider_max_output_tokens: None,
         }
     }
 
@@ -258,6 +268,8 @@ impl ProviderMetadata {
             config_keys: vec![],
             setup_steps: vec![],
             model_selection_hint: None,
+            provider_context_limit: None,
+            provider_max_output_tokens: None,
         }
     }
 

--- a/crates/goose/src/providers/declarative/llama_swap.json
+++ b/crates/goose/src/providers/declarative/llama_swap.json
@@ -3,7 +3,7 @@
   "engine": "openai",
   "display_name": "Llama Swap",
   "description": "Local proxy that hot-swaps llama.cpp (and other) inference backends on demand via an OpenAI-compatible API.",
-  "api_key_env": "",
+  "api_key_env": "LLAMA_SWAP_API_KEY",
   "base_url": "${LLAMA_SWAP_HOST}/v1/chat/completions",
   "env_vars": [
     {

--- a/crates/goose/src/providers/declarative/llama_swap.json
+++ b/crates/goose/src/providers/declarative/llama_swap.json
@@ -17,6 +17,8 @@
   ],
   "dynamic_models": true,
   "models": [],
+  "context_limit": 1048576,
+  "max_output_tokens": 1048576,
   "supports_streaming": true,
   "requires_auth": false,
   "skip_canonical_filtering": true

--- a/crates/goose/src/providers/declarative/lmstudio.json
+++ b/crates/goose/src/providers/declarative/lmstudio.json
@@ -3,7 +3,7 @@
   "engine": "openai",
   "display_name": "LM Studio",
   "description": "Run local models with LM Studio",
-  "api_key_env": "",
+  "api_key_env": "LMSTUDIO_API_KEY",
   "base_url": "${LMSTUDIO_HOST}/v1/chat/completions",
   "env_vars": [
     {

--- a/crates/goose/src/providers/declarative/lmstudio.json
+++ b/crates/goose/src/providers/declarative/lmstudio.json
@@ -17,6 +17,8 @@
   ],
   "dynamic_models": true,
   "models": [],
+  "context_limit": 1048576,
+  "max_output_tokens": 1048576,
   "supports_streaming": true,
   "requires_auth": false,
   "skip_canonical_filtering": true

--- a/crates/goose/src/providers/declarative/omlx.json
+++ b/crates/goose/src/providers/declarative/omlx.json
@@ -1,0 +1,23 @@
+{
+  "name": "omlx",
+  "engine": "openai",
+  "display_name": "oMLX",
+  "description": "Run local models with oMLX",
+  "api_key_env": "OMLX_API_KEY",
+  "base_url": "${OMLX_HOST}/v1/chat/completions",
+  "env_vars": [
+    {
+      "name": "OMLX_HOST",
+      "required": false,
+      "secret": false,
+      "primary": true,
+      "default": "http://localhost:8000",
+      "description": "Base URL of the oMLX server (default: http://localhost:8000)"
+    }
+  ],
+  "dynamic_models": true,
+  "models": [],
+  "supports_streaming": true,
+  "requires_auth": false,
+  "skip_canonical_filtering": true
+}

--- a/crates/goose/src/providers/declarative/omlx.json
+++ b/crates/goose/src/providers/declarative/omlx.json
@@ -17,6 +17,8 @@
   ],
   "dynamic_models": true,
   "models": [],
+  "context_limit": 1048576,
+  "max_output_tokens": 1048576,
   "supports_streaming": true,
   "requires_auth": false,
   "skip_canonical_filtering": true

--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -381,4 +381,45 @@ mod tests {
 
         std::env::remove_var("GOOSE_PATH_ROOT");
     }
+
+    #[tokio::test]
+    async fn test_provider_context_limit_applied_to_dynamic_models() {
+        let _guard = env_lock::lock_env([("GOOSE_PATH_ROOT", None::<&str>)]);
+        let temp_dir = tempfile::tempdir().expect("tempdir should be created");
+        std::env::set_var("GOOSE_PATH_ROOT", temp_dir.path());
+
+        let custom_dir = Paths::config_dir().join("custom_providers");
+        fs::create_dir_all(&custom_dir).expect("custom providers dir should be created");
+
+        let custom_dynamic = r#"{
+  "name": "custom_dynamic",
+  "engine": "openai",
+  "display_name": "Custom Dynamic",
+  "description": "test provider with dynamic models",
+  "api_key_env": "",
+  "base_url": "https://example.invalid/v1/chat/completions",
+  "models": [],
+  "dynamic_models": true,
+  "context_limit": 1048576,
+  "requires_auth": false
+}"#;
+        fs::write(custom_dir.join("custom_dynamic.json"), custom_dynamic)
+            .expect("custom_dynamic.json should be written");
+
+        refresh_custom_providers()
+            .await
+            .expect("custom providers should refresh");
+
+        // When a dynamic model is selected, the provider's context_limit should be applied
+        let provider = create_with_named_model("custom_dynamic", "some-dynamic-model", Vec::new())
+            .await
+            .expect("custom_dynamic provider should be creatable");
+        assert_eq!(
+            provider.get_model_config().context_limit,
+            Some(1_048_576),
+            "provider context_limit should be applied to dynamic models"
+        );
+
+        std::env::remove_var("GOOSE_PATH_ROOT");
+    }
 }

--- a/crates/goose/src/providers/inventory/mod.rs
+++ b/crates/goose/src/providers/inventory/mod.rs
@@ -810,7 +810,7 @@ pub fn declarative_inventory_identity(
             .public_inputs
             .insert("headers".to_string(), serialize_string_map(headers)?);
     }
-    if config.requires_auth && !config.api_key_env.is_empty() {
+    if !config.api_key_env.is_empty() {
         if let Some(value) = config_secret_value(global, &config.api_key_env) {
             identity
                 .secret_inputs

--- a/crates/goose/src/providers/inventory/mod.rs
+++ b/crates/goose/src/providers/inventory/mod.rs
@@ -69,12 +69,14 @@ pub struct InventoryIdentity {
     pub provider_id: String,
     pub provider_family: String,
     pub inventory_key: String,
+    pub context_limit: Option<usize>,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct InventoryIdentityInput {
     pub provider_id: String,
     pub provider_family: String,
+    pub context_limit: Option<usize>,
     pub public_inputs: BTreeMap<String, String>,
     pub secret_inputs: BTreeMap<String, String>,
 }
@@ -87,6 +89,7 @@ impl InventoryIdentityInput {
         InventoryIdentityInput {
             provider_id: provider_id.into(),
             provider_family: provider_family.into(),
+            context_limit: None,
             public_inputs: BTreeMap::new(),
             secret_inputs: BTreeMap::new(),
         }
@@ -114,6 +117,7 @@ impl InventoryIdentityInput {
         let InventoryIdentityInput {
             provider_id,
             provider_family,
+            context_limit,
             public_inputs,
             secret_inputs,
         } = self;
@@ -126,6 +130,7 @@ impl InventoryIdentityInput {
         Ok(InventoryIdentity {
             provider_id,
             provider_family,
+            context_limit,
             inventory_key: format!("{digest:x}"),
         })
     }
@@ -421,7 +426,7 @@ impl ProviderInventoryService {
         identity: &InventoryIdentity,
         model_ids: &[String],
     ) -> Result<()> {
-        let models = enrich_model_ids_with_canonical(&identity.provider_family, model_ids);
+        let models = enrich_model_ids_with_canonical(&identity.provider_family, model_ids, identity.context_limit);
         let now = Utc::now();
         let pool = self.storage.pool().await?;
         let mut tx = pool.begin().await?;
@@ -757,9 +762,9 @@ pub fn declarative_inventory_identity(
     config: &DeclarativeProviderConfig,
 ) -> Result<InventoryIdentityInput> {
     let global = Config::global();
-    let mut identity = InventoryIdentityInput::new(
-        config.name.clone(),
-        config
+    let mut identity = InventoryIdentityInput {
+        provider_id: config.name.clone(),
+        provider_family: config
             .catalog_provider_id
             .clone()
             .unwrap_or_else(|| match config.engine {
@@ -767,7 +772,10 @@ pub fn declarative_inventory_identity(
                 ProviderEngine::Anthropic => "anthropic".to_string(),
                 ProviderEngine::Ollama => "ollama".to_string(),
             }),
-    );
+        context_limit: config.context_limit,
+        public_inputs: BTreeMap::new(),
+        secret_inputs: BTreeMap::new(),
+    };
 
     identity
         .public_inputs
@@ -869,12 +877,13 @@ fn fallback_inventory_identity(provider_id: &str) -> InventoryIdentityInput {
 fn enrich_model_ids_with_canonical(
     provider_family: &str,
     model_ids: &[String],
+    context_limit: Option<usize>,
 ) -> Vec<InventoryModel> {
     let mut models: Vec<InventoryModel> = Vec::new();
     let mut seen_names: HashSet<String> = HashSet::new();
 
     for id in model_ids {
-        let model = enriched_model(provider_family, id, None);
+        let model = enriched_model(provider_family, id, context_limit);
         if !seen_names.insert(model.name.clone()) {
             continue;
         }
@@ -1083,6 +1092,7 @@ mod tests {
         InventoryIdentity {
             provider_id: provider_id.to_string(),
             provider_family: provider_id.to_string(),
+            context_limit: None,
             inventory_key: inventory_key.to_string(),
         }
     }

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -218,6 +218,16 @@ impl OllamaProvider {
             ));
         }
 
+        let model = if config.context_limit.is_some() && model.context_limit.is_none() {
+            model.with_context_limit(config.context_limit)
+        } else {
+            model
+        };
+        let model = if config.max_output_tokens.is_some() && model.max_tokens.is_none() {
+            model.with_max_tokens(config.max_output_tokens)
+        } else {
+            model
+        };
         let model = if let Some(ref fast_model_name) = config.fast_model {
             model.with_fast(fast_model_name, &config.name)?
         } else {

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -385,6 +385,16 @@ impl OpenAiProvider {
             None
         };
 
+        let model = if config.context_limit.is_some() && model.context_limit.is_none() {
+            model.with_context_limit(config.context_limit)
+        } else {
+            model
+        };
+        let model = if config.max_output_tokens.is_some() && model.max_tokens.is_none() {
+            model.with_max_tokens(config.max_output_tokens)
+        } else {
+            model
+        };
         let model = if let Some(ref fast_model_name) = config.fast_model {
             model.with_fast(fast_model_name, &config.name)?
         } else {

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -303,18 +303,37 @@ impl OpenAiProvider {
     ) -> Result<Self> {
         let global_config = crate::config::Config::global();
 
-        let api_key: Option<String> = if config.requires_auth && !config.api_key_env.is_empty() {
-            Some(global_config.get_secret::<String>(&config.api_key_env).map_err(|e| {
-                use crate::config::ConfigError;
-                match e {
-                    ConfigError::NotFound(_) => anyhow::anyhow!(
-                        "Required API key {} is not set. Configure it via `goose configure` or set the {} environment variable.",
-                        config.api_key_env,
-                        config.api_key_env
-                    ),
-                    other => anyhow::anyhow!("Failed to read {}: {}", config.api_key_env, other),
+        let api_key: Option<String> = if !config.api_key_env.is_empty() {
+            match global_config.get_secret::<String>(&config.api_key_env) {
+                Ok(key) => Some(key),
+                Err(e) => {
+                    use crate::config::ConfigError;
+                    match e {
+                        ConfigError::NotFound(_) => {
+                            if config.requires_auth {
+                                anyhow::bail!(
+                                    "Required API key {} is not set. Configure it via `goose configure` or set the {} environment variable.",
+                                    config.api_key_env,
+                                    config.api_key_env
+                                );
+                            }
+                            None
+                        }
+                        other => {
+                            if config.requires_auth {
+                                anyhow::bail!("Failed to read {}: {}", config.api_key_env, other);
+                            } else {
+                                tracing::warn!(
+                                    "Failed to read optional API key {}: {}. Proceeding without authentication.",
+                                    config.api_key_env,
+                                    other
+                                );
+                                None
+                            }
+                        }
+                    }
                 }
-            })?)
+            }
         } else {
             None
         };

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -219,6 +219,8 @@ impl ProviderRegistry {
             config_keys,
             setup_steps: config.setup_steps.clone(),
             model_selection_hint: None,
+            provider_context_limit: config.context_limit,
+            provider_max_output_tokens: config.max_output_tokens,
         };
         let inventory_config_keys = custom_metadata.config_keys.clone();
 

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -166,8 +166,14 @@ impl ProviderRegistry {
             .collect();
 
         let mut config_keys = if provider_type == ProviderType::Declarative {
-            if config.requires_auth && !config.api_key_env.is_empty() {
-                vec![ConfigKey::new(&config.api_key_env, true, true, None, true)]
+            if !config.api_key_env.is_empty() {
+                vec![ConfigKey::new(
+                    &config.api_key_env,
+                    config.requires_auth,
+                    true,
+                    None,
+                    true,
+                )]
             } else {
                 Vec::new()
             }

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -375,6 +375,8 @@ mod tests {
                     config_keys: vec![],
                     setup_steps: vec![],
                     model_selection_hint: None,
+                    provider_context_limit: None,
+                    provider_max_output_tokens: None,
                 }
             }
 
@@ -544,6 +546,8 @@ mod tests {
                     config_keys: vec![],
                     setup_steps: vec![],
                     model_selection_hint: None,
+                    provider_context_limit: None,
+                    provider_max_output_tokens: None,
                 }
             }
 
@@ -897,6 +901,8 @@ mod tests {
                     config_keys: vec![],
                     setup_steps: vec![],
                     model_selection_hint: None,
+                    provider_context_limit: None,
+                    provider_max_output_tokens: None,
                 }
             }
 

--- a/crates/goose/tests/compaction.rs
+++ b/crates/goose/tests/compaction.rs
@@ -193,6 +193,8 @@ impl ProviderDef for MockCompactionProvider {
             config_keys: vec![],
             setup_steps: vec![],
             model_selection_hint: None,
+            provider_context_limit: None,
+            provider_max_output_tokens: None,
         }
     }
 

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -4542,6 +4542,12 @@
             "type": "string",
             "nullable": true
           },
+          "context_limit": {
+            "type": "integer",
+            "description": "Default context limit for dynamic models when not explicitly set per-model.",
+            "nullable": true,
+            "minimum": 0
+          },
           "description": {
             "type": "string",
             "nullable": true
@@ -4572,6 +4578,12 @@
             "additionalProperties": {
               "type": "string"
             },
+            "nullable": true
+          },
+          "max_output_tokens": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Default max output tokens for dynamic models when not explicitly set per-model.",
             "nullable": true
           },
           "model_doc_link": {
@@ -6814,6 +6826,18 @@
           "name": {
             "type": "string",
             "description": "The unique identifier for this provider"
+          },
+          "provider_context_limit": {
+            "type": "integer",
+            "description": "Default context limit for dynamic models when not explicitly set per-model.",
+            "nullable": true,
+            "minimum": 0
+          },
+          "provider_max_output_tokens": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Default max output tokens for dynamic models when not explicitly set per-model.",
+            "nullable": true
           },
           "setup_steps": {
             "type": "array",

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -211,6 +211,10 @@ export type DeclarativeProviderConfig = {
     base_path?: string | null;
     base_url: string;
     catalog_provider_id?: string | null;
+    /**
+     * Default context limit for dynamic models when not explicitly set per-model.
+     */
+    context_limit?: number | null;
     description?: string | null;
     display_name: string;
     dynamic_models?: boolean | null;
@@ -220,6 +224,10 @@ export type DeclarativeProviderConfig = {
     headers?: {
         [key: string]: string;
     } | null;
+    /**
+     * Default max output tokens for dynamic models when not explicitly set per-model.
+     */
+    max_output_tokens?: number | null;
     model_doc_link?: string | null;
     models: Array<ModelInfo>;
     name: string;
@@ -980,6 +988,14 @@ export type ProviderMetadata = {
      * The unique identifier for this provider
      */
     name: string;
+    /**
+     * Default context limit for dynamic models when not explicitly set per-model.
+     */
+    provider_context_limit?: number | null;
+    /**
+     * Default max output tokens for dynamic models when not explicitly set per-model.
+     */
+    provider_max_output_tokens?: number | null;
     /**
      * step-by-step instructions for set up providers eg: api key
      */

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -585,6 +585,13 @@ export default function ChatInput({
         }
       }
 
+      // Priority 3.5: Fall back to provider-level default context limit
+      if (currentProvider?.metadata?.provider_context_limit) {
+        setTokenLimit(currentProvider.metadata.provider_context_limit);
+        setIsTokenLimitLoaded(true);
+        return;
+      }
+
       // Priority 4: Use default if nothing else found
       setTokenLimit(TOKEN_LIMIT_DEFAULT);
       setIsTokenLimitLoaded(true);


### PR DESCRIPTION
## Summary
Add nonempty api_key_env configuration to lmstudio and llama_swap declarative providers.
Add a new declarative provider for [oMLX](https://omlx.ai), similar to the above.

These providers all set requires_auth=false since auth is optional for local inference, but due to logic elsewhere in the code, openai-engine based providers' api keys could not be configured through the UI and would not be sent to the endpoint unless requires_auth was set to true.

To fix this, also correct the logic in several places so that declarative providers based on the openai engine which define a nonempty api_key_env and have requires_auth=false allow the key to be set through the UI and will send the key to the endpoint.

Changes:
- omlx.json: New provider with api_key_env set to OMLX_API_KEY
- lmstudio.json: Set api_key_env to LMSTUDIO_API_KEY
- llama_swap.json: Set api_key_env to LLAMA_SWAP_API_KEY
- declarative_providers.rs: Update llama_swap api_key_env test assertion
- provider_registry.rs: Expose api_key_env config in UI regardless of requires_auth setting
- openai.rs: Read API key when configured, regardless of requires_auth. For the requires_auth=false case:
    - handle NotFound as not an error (the user didn't provide the optional api key)
    - warn on keyring errors instead of failing (the api key isn't needed, so this isn't fatal)
- inventory/mod.rs: Include api_key_env in identity hash regardless of the value of requires_auth so model cache invalidates when the optional key changes.

### Testing
I've tested this manually against the oMLX provider with it set to require an api key for authentication.

### Related Issues
N/A

### Screenshots/Demos (for UX changes)
Before:  
<img width="599" height="508" alt="587483722-185f4ed4-34e8-4ff7-84fd-520270c22b10" src="https://github.com/user-attachments/assets/cfe5346c-6f45-4905-853c-76a90d975e3f" />

After:   
<img width="598" height="583" alt="587478770-0189abba-d143-4194-b64c-29055fe888de" src="https://github.com/user-attachments/assets/1e0c9832-b943-4798-a239-a40bd1cfd475" />

