### PR TITLE
feat: added quarterly option for scheduler

### DIFF
--- a/ui/desktop/src/components/schedule/CronPicker.tsx
+++ b/ui/desktop/src/components/schedule/CronPicker.tsx
@@ -1,8 +1,16 @@
 import React, { useState, useEffect } from 'react';
-import cronstrue from 'cronstrue';
 import { ScheduledJob } from '../../schedule';
 import { errorMessage } from '../../utils/conversionUtils';
 import { defineMessages, useIntl } from '../../i18n';
+import {
+  buildCronForPeriod,
+  describeCron,
+  getQuarterStartMonth,
+  getValidDayOfMonth,
+  parseCron,
+  quarterDayLimitByStartMonth,
+  type Period,
+} from '../../utils/cronSchedule';
 
 const i18n = defineMessages({
   every: { id: 'cronPicker.every', defaultMessage: 'Every' },
@@ -52,149 +60,11 @@ const i18n = defineMessages({
   atSecond: { id: 'cronPicker.atSecond', defaultMessage: 'at second' },
 });
 
-type Period = 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year' | 'custom';
-
-const quarterMonthsByStartMonth: Record<string, string> = {
-  '1': '1,4,7,10',
-  '2': '2,5,8,11',
-  '3': '3,6,9,12',
-};
-
-const quarterDayLimitByStartMonth: Record<string, number> = {
-  '1': 30,
-  '2': 28,
-  '3': 30,
-};
-
-const getQuarterStartMonth = (month: string): string | null => {
-  const entry = Object.entries(quarterMonthsByStartMonth).find(
-    ([, quarterMonths]) => quarterMonths === month
-  );
-  return entry?.[0] ?? null;
-};
-
-type ParsedCron = {
-  period: Period;
-  second: string;
-  minute: string;
-  hour: string;
-  dayOfMonth: string;
-  month: string;
-  dayOfWeek: string;
-};
-
-const defaultParsedCron: ParsedCron = {
-  period: 'day',
-  second: '0',
-  minute: '0',
-  hour: '14',
-  dayOfMonth: '*',
-  month: '*',
-  dayOfWeek: '*',
-};
-
-const normalizeCronParts = (cron: string): string[] | null => {
-  const parts = cron.trim().split(/\s+/);
-  if (parts.length === 5) {
-    return ['0', ...parts];
-  }
-  if (parts.length === 6) {
-    return parts;
-  }
-  return null;
-};
-
-const isSingleNumericValue = (value: string): boolean => /^\d+$/.test(value);
-
-const getValidDayOfMonth = (value: string, max: number): string | null => {
-  if (!isSingleNumericValue(value)) {
-    return null;
-  }
-  const parsedDay = parseInt(value, 10);
-  if (parsedDay < 1 || parsedDay > max) {
-    return null;
-  }
-  return parsedDay.toString();
-};
-
-const asCustomCron = (parts: string[]): ParsedCron => {
-  const [second, minute, hour, dayOfMonth, month, dayOfWeek] = parts;
-  return { period: 'custom', second, minute, hour, dayOfMonth, month, dayOfWeek };
-};
-
-const describeCron = (cron: string): string => {
-  const parts = cron.trim().split(/\s+/);
-  if (parts.length === 5 || parts.length === 6) {
-    return cronstrue.toString(parts.join(' '));
-  }
-  throw new Error('Expected 5 or 6 fields');
-};
-
 interface CronPickerProps {
   schedule: ScheduledJob | null;
   onChange: (cron: string) => void;
   isValid: (valid: boolean) => void;
 }
-
-const parseCron = (cron: string): ParsedCron => {
-  if (!cron.trim()) {
-    return defaultParsedCron;
-  }
-
-  const parts = normalizeCronParts(cron);
-  if (!parts) {
-    return { ...defaultParsedCron, period: 'custom' };
-  }
-
-  const [second, minute, hour, dayOfMonth, month, dayOfWeek] = parts;
-
-  if (!isSingleNumericValue(second)) {
-    return asCustomCron(parts);
-  }
-
-  if (dayOfMonth !== '*') {
-    const quarterStartMonth = getQuarterStartMonth(month);
-    const dayOfMonthNumber = parseInt(dayOfMonth, 10);
-    if (
-      quarterStartMonth &&
-      isSingleNumericValue(dayOfMonth) &&
-      dayOfMonthNumber <= quarterDayLimitByStartMonth[quarterStartMonth]
-    ) {
-      return { period: 'quarter', second, minute, hour, dayOfMonth, month, dayOfWeek };
-    }
-  }
-  if (month !== '*' && dayOfMonth !== '*') {
-    if (!isSingleNumericValue(month) || !isSingleNumericValue(dayOfMonth)) {
-      return asCustomCron(parts);
-    }
-    return { period: 'year', second, minute, hour, dayOfMonth, month, dayOfWeek };
-  }
-  if (dayOfMonth !== '*') {
-    if (!isSingleNumericValue(dayOfMonth)) {
-      return asCustomCron(parts);
-    }
-    return { period: 'month', second, minute, hour, dayOfMonth, month, dayOfWeek };
-  }
-  if (dayOfWeek !== '*') {
-    if (!isSingleNumericValue(dayOfWeek)) {
-      return asCustomCron(parts);
-    }
-    return { period: 'week', second, minute, hour, dayOfMonth, month, dayOfWeek };
-  }
-  if (hour !== '*') {
-    if (!isSingleNumericValue(hour)) {
-      return asCustomCron(parts);
-    }
-    return { period: 'day', second, minute, hour, dayOfMonth, month, dayOfWeek };
-  }
-  if (minute !== '*') {
-    if (!isSingleNumericValue(minute)) {
-      return asCustomCron(parts);
-    }
-    return { period: 'hour', second, minute, hour, dayOfMonth, month, dayOfWeek };
-  }
-  return { period: 'minute', second, minute, hour, dayOfMonth, month, dayOfWeek };
-};
 
 const to24Hour = (hour12: number, isPM: boolean): number => {
   if (hour12 === 12) {
@@ -231,6 +101,19 @@ export const CronPicker: React.FC<CronPickerProps> = ({ schedule, onChange, isVa
   const [readableCron, setReadableCron] = useState('');
   const [hasCronError, setHasCronError] = useState(false);
 
+  const getCurrentCron = (selectedPeriod: Period, validDayOfMonth: string | null): string =>
+    buildCronForPeriod({
+      period: selectedPeriod,
+      second,
+      minute,
+      hour24: to24Hour(hour12, isPM),
+      dayOfWeek,
+      dayOfMonth: validDayOfMonth,
+      month,
+      quarterStartMonth,
+      customCron,
+    });
+
   useEffect(() => {
     const sourceCron = schedule?.cron || '';
     const parsed = parseCron(sourceCron);
@@ -258,53 +141,20 @@ export const CronPicker: React.FC<CronPickerProps> = ({ schedule, onChange, isVa
   }, [dayOfMonth, maxDayOfMonth]);
 
   useEffect(() => {
-    const hour24 = to24Hour(hour12, isPM);
     const validDayOfMonth = getValidDayOfMonth(dayOfMonth, maxDayOfMonth);
-    let cron: string;
 
     if (
       (period === 'month' || period === 'quarter' || period === 'year') &&
       validDayOfMonth === null
     ) {
-      const invalidDayCron =
-        period === 'quarter'
-          ? `${second} ${minute} ${hour24} 0 ${quarterMonthsByStartMonth[quarterStartMonth]} *`
-          : `${second} ${minute} ${hour24} 0 ${period === 'year' ? month : '*'} *`;
-      onChange(invalidDayCron);
+      onChange(getCurrentCron(period, null));
       isValid(false);
       setHasCronError(true);
       setReadableCron(intl.formatMessage(i18n.invalidDayOfMonth, { max: maxDayOfMonth }));
       return;
     }
 
-    switch (period) {
-      case 'custom':
-        cron = customCron;
-        break;
-      case 'minute':
-        cron = `${second} * * * * *`;
-        break;
-      case 'hour':
-        cron = `${second} ${minute} * * * *`;
-        break;
-      case 'day':
-        cron = `${second} ${minute} ${hour24} * * *`;
-        break;
-      case 'week':
-        cron = `${second} ${minute} ${hour24} * * ${dayOfWeek}`;
-        break;
-      case 'month':
-        cron = `${second} ${minute} ${hour24} ${validDayOfMonth} * *`;
-        break;
-      case 'quarter':
-        cron = `${second} ${minute} ${hour24} ${validDayOfMonth} ${quarterMonthsByStartMonth[quarterStartMonth]} *`;
-        break;
-      case 'year':
-        cron = `${second} ${minute} ${hour24} ${validDayOfMonth} ${month} *`;
-        break;
-      default:
-        cron = '0 0 0 * * *';
-    }
+    const cron = getCurrentCron(period, validDayOfMonth);
     onChange(cron);
     if (!cron.trim()) {
       isValid(false);
@@ -346,7 +196,13 @@ export const CronPicker: React.FC<CronPickerProps> = ({ schedule, onChange, isVa
         </span>
         <select
           value={period}
-          onChange={(e) => setPeriod(e.target.value as Period)}
+          onChange={(e) => {
+            const nextPeriod = e.target.value as Period;
+            if (nextPeriod === 'custom' && period !== 'custom') {
+              setCustomCron(getCurrentCron(period, getValidDayOfMonth(dayOfMonth, maxDayOfMonth)));
+            }
+            setPeriod(nextPeriod);
+          }}
           className={selectClassName}
         >
           <option value="minute">{intl.formatMessage(i18n.minute)}</option>

--- a/ui/desktop/src/components/schedule/CronPicker.tsx
+++ b/ui/desktop/src/components/schedule/CronPicker.tsx
@@ -6,6 +6,7 @@ import { defineMessages, useIntl } from '../../i18n';
 
 const i18n = defineMessages({
   every: { id: 'cronPicker.every', defaultMessage: 'Every' },
+  mode: { id: 'cronPicker.mode', defaultMessage: 'Mode' },
   minute: { id: 'cronPicker.minute', defaultMessage: 'Minute' },
   hour: { id: 'cronPicker.hour', defaultMessage: 'Hour' },
   day: { id: 'cronPicker.day', defaultMessage: 'Day' },
@@ -13,6 +14,16 @@ const i18n = defineMessages({
   month: { id: 'cronPicker.month', defaultMessage: 'Month' },
   quarter: { id: 'cronPicker.quarter', defaultMessage: 'Quarter' },
   year: { id: 'cronPicker.year', defaultMessage: 'Year' },
+  custom: { id: 'cronPicker.custom', defaultMessage: 'Custom cron' },
+  cronExpression: { id: 'cronPicker.cronExpression', defaultMessage: 'Cron expression' },
+  emptyCronError: {
+    id: 'cronPicker.emptyCronError',
+    defaultMessage: 'Cron expression cannot be empty',
+  },
+  invalidDayOfMonth: {
+    id: 'cronPicker.invalidDayOfMonth',
+    defaultMessage: 'Day must be between 1 and {max}',
+  },
   inMonth: { id: 'cronPicker.inMonth', defaultMessage: 'in' },
   startingMonth: { id: 'cronPicker.startingMonth', defaultMessage: 'starting month' },
   january: { id: 'cronPicker.january', defaultMessage: 'January' },
@@ -41,7 +52,7 @@ const i18n = defineMessages({
   atSecond: { id: 'cronPicker.atSecond', defaultMessage: 'at second' },
 });
 
-type Period = 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year';
+type Period = 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year' | 'custom';
 
 const quarterMonthsByStartMonth: Record<string, string> = {
   '1': '1,4,7,10',
@@ -72,6 +83,53 @@ type ParsedCron = {
   dayOfWeek: string;
 };
 
+const defaultParsedCron: ParsedCron = {
+  period: 'day',
+  second: '0',
+  minute: '0',
+  hour: '14',
+  dayOfMonth: '*',
+  month: '*',
+  dayOfWeek: '*',
+};
+
+const normalizeCronParts = (cron: string): string[] | null => {
+  const parts = cron.trim().split(/\s+/);
+  if (parts.length === 5) {
+    return ['0', ...parts];
+  }
+  if (parts.length === 6) {
+    return parts;
+  }
+  return null;
+};
+
+const isSingleNumericValue = (value: string): boolean => /^\d+$/.test(value);
+
+const getValidDayOfMonth = (value: string, max: number): string | null => {
+  if (!isSingleNumericValue(value)) {
+    return null;
+  }
+  const parsedDay = parseInt(value, 10);
+  if (parsedDay < 1 || parsedDay > max) {
+    return null;
+  }
+  return parsedDay.toString();
+};
+
+const asCustomCron = (parts: string[]): ParsedCron => {
+  const [second, minute, hour, dayOfMonth, month, dayOfWeek] = parts;
+  return { period: 'custom', second, minute, hour, dayOfMonth, month, dayOfWeek };
+};
+
+const describeCron = (cron: string): string => {
+  const parts = cron.trim().split(/\s+/);
+  if (parts.length === 5 || parts.length === 6) {
+    return cronstrue.toString(parts.join(' '));
+  }
+  throw new Error('Expected 5 or 6 fields');
+};
+
 interface CronPickerProps {
   schedule: ScheduledJob | null;
   onChange: (cron: string) => void;
@@ -79,43 +137,60 @@ interface CronPickerProps {
 }
 
 const parseCron = (cron: string): ParsedCron => {
-  const parts = cron.split(' ');
-  if (parts.length === 5) {
-    parts.unshift('0');
+  if (!cron.trim()) {
+    return defaultParsedCron;
   }
-  if (parts.length !== 6) {
-    return {
-      period: 'day',
-      second: '0',
-      minute: '0',
-      hour: '14',
-      dayOfMonth: '*',
-      month: '*',
-      dayOfWeek: '*',
-    };
+
+  const parts = normalizeCronParts(cron);
+  if (!parts) {
+    return { ...defaultParsedCron, period: 'custom' };
   }
 
   const [second, minute, hour, dayOfMonth, month, dayOfWeek] = parts;
 
+  if (!isSingleNumericValue(second)) {
+    return asCustomCron(parts);
+  }
+
   if (dayOfMonth !== '*') {
     const quarterStartMonth = getQuarterStartMonth(month);
-    if (quarterStartMonth) {
+    const dayOfMonthNumber = parseInt(dayOfMonth, 10);
+    if (
+      quarterStartMonth &&
+      isSingleNumericValue(dayOfMonth) &&
+      dayOfMonthNumber <= quarterDayLimitByStartMonth[quarterStartMonth]
+    ) {
       return { period: 'quarter', second, minute, hour, dayOfMonth, month, dayOfWeek };
     }
   }
   if (month !== '*' && dayOfMonth !== '*') {
+    if (!isSingleNumericValue(month) || !isSingleNumericValue(dayOfMonth)) {
+      return asCustomCron(parts);
+    }
     return { period: 'year', second, minute, hour, dayOfMonth, month, dayOfWeek };
   }
   if (dayOfMonth !== '*') {
+    if (!isSingleNumericValue(dayOfMonth)) {
+      return asCustomCron(parts);
+    }
     return { period: 'month', second, minute, hour, dayOfMonth, month, dayOfWeek };
   }
   if (dayOfWeek !== '*') {
+    if (!isSingleNumericValue(dayOfWeek)) {
+      return asCustomCron(parts);
+    }
     return { period: 'week', second, minute, hour, dayOfMonth, month, dayOfWeek };
   }
   if (hour !== '*') {
+    if (!isSingleNumericValue(hour)) {
+      return asCustomCron(parts);
+    }
     return { period: 'day', second, minute, hour, dayOfMonth, month, dayOfWeek };
   }
   if (minute !== '*') {
+    if (!isSingleNumericValue(minute)) {
+      return asCustomCron(parts);
+    }
     return { period: 'hour', second, minute, hour, dayOfMonth, month, dayOfWeek };
   }
   return { period: 'minute', second, minute, hour, dayOfMonth, month, dayOfWeek };
@@ -152,10 +227,13 @@ export const CronPicker: React.FC<CronPickerProps> = ({ schedule, onChange, isVa
   const [dayOfMonth, setDayOfMonth] = useState('1');
   const [month, setMonth] = useState('1');
   const [quarterStartMonth, setQuarterStartMonth] = useState('1');
+  const [customCron, setCustomCron] = useState('0 0 14 * * *');
   const [readableCron, setReadableCron] = useState('');
+  const [hasCronError, setHasCronError] = useState(false);
 
   useEffect(() => {
-    const parsed = parseCron(schedule?.cron || '');
+    const sourceCron = schedule?.cron || '';
+    const parsed = parseCron(sourceCron);
     setPeriod(parsed.period);
     setSecond(parsed.second === '*' ? '0' : parsed.second);
     setMinute(parsed.minute === '*' ? '0' : parsed.minute);
@@ -167,6 +245,7 @@ export const CronPicker: React.FC<CronPickerProps> = ({ schedule, onChange, isVa
     setDayOfMonth(parsed.dayOfMonth === '*' ? '1' : parsed.dayOfMonth);
     setMonth(parsed.month === '*' ? '1' : parsed.month);
     setQuarterStartMonth(getQuarterStartMonth(parsed.month) ?? '1');
+    setCustomCron(sourceCron || '0 0 14 * * *');
   }, [schedule]);
 
   const maxDayOfMonth = period === 'quarter' ? quarterDayLimitByStartMonth[quarterStartMonth] : 31;
@@ -180,13 +259,28 @@ export const CronPicker: React.FC<CronPickerProps> = ({ schedule, onChange, isVa
 
   useEffect(() => {
     const hour24 = to24Hour(hour12, isPM);
-    const clampedDayOfMonth = Math.min(
-      Math.max(parseInt(dayOfMonth, 10) || 1, 1),
-      maxDayOfMonth
-    ).toString();
+    const validDayOfMonth = getValidDayOfMonth(dayOfMonth, maxDayOfMonth);
     let cron: string;
 
+    if (
+      (period === 'month' || period === 'quarter' || period === 'year') &&
+      validDayOfMonth === null
+    ) {
+      const invalidDayCron =
+        period === 'quarter'
+          ? `${second} ${minute} ${hour24} 0 ${quarterMonthsByStartMonth[quarterStartMonth]} *`
+          : `${second} ${minute} ${hour24} 0 ${period === 'year' ? month : '*'} *`;
+      onChange(invalidDayCron);
+      isValid(false);
+      setHasCronError(true);
+      setReadableCron(intl.formatMessage(i18n.invalidDayOfMonth, { max: maxDayOfMonth }));
+      return;
+    }
+
     switch (period) {
+      case 'custom':
+        cron = customCron;
+        break;
       case 'minute':
         cron = `${second} * * * * *`;
         break;
@@ -200,27 +294,32 @@ export const CronPicker: React.FC<CronPickerProps> = ({ schedule, onChange, isVa
         cron = `${second} ${minute} ${hour24} * * ${dayOfWeek}`;
         break;
       case 'month':
-        cron = `${second} ${minute} ${hour24} ${dayOfMonth} * *`;
+        cron = `${second} ${minute} ${hour24} ${validDayOfMonth} * *`;
         break;
       case 'quarter':
-        cron = `${second} ${minute} ${hour24} ${clampedDayOfMonth} ${quarterMonthsByStartMonth[quarterStartMonth]} *`;
+        cron = `${second} ${minute} ${hour24} ${validDayOfMonth} ${quarterMonthsByStartMonth[quarterStartMonth]} *`;
         break;
       case 'year':
-        cron = `${second} ${minute} ${hour24} ${dayOfMonth} ${month} *`;
+        cron = `${second} ${minute} ${hour24} ${validDayOfMonth} ${month} *`;
         break;
       default:
         cron = '0 0 0 * * *';
     }
     onChange(cron);
-    if (cron) {
-      const cronWithoutSeconds = cron.split(' ').slice(1).join(' ');
-      try {
-        setReadableCron(cronstrue.toString(cronWithoutSeconds));
-        isValid(true);
-      } catch (e) {
-        isValid(false);
-        setReadableCron('error: ' + errorMessage(e));
-      }
+    if (!cron.trim()) {
+      isValid(false);
+      setHasCronError(true);
+      setReadableCron(intl.formatMessage(i18n.emptyCronError));
+      return;
+    }
+    try {
+      setReadableCron(describeCron(cron));
+      setHasCronError(false);
+      isValid(true);
+    } catch (e) {
+      isValid(false);
+      setHasCronError(true);
+      setReadableCron(errorMessage(e).replace(/^Error:\s*/, ''));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
@@ -234,6 +333,7 @@ export const CronPicker: React.FC<CronPickerProps> = ({ schedule, onChange, isVa
     month,
     quarterStartMonth,
     maxDayOfMonth,
+    customCron,
   ]);
 
   const selectClassName = 'px-2 py-1 border rounded bg-white dark:bg-gray-800 dark:border-gray-600';
@@ -241,7 +341,9 @@ export const CronPicker: React.FC<CronPickerProps> = ({ schedule, onChange, isVa
   return (
     <div className="space-y-4">
       <div className="flex items-center gap-2">
-        <span className="text-sm font-medium">{intl.formatMessage(i18n.every)}</span>
+        <span className="text-sm font-medium">
+          {intl.formatMessage(period === 'custom' ? i18n.mode : i18n.every)}
+        </span>
         <select
           value={period}
           onChange={(e) => setPeriod(e.target.value as Period)}
@@ -254,10 +356,26 @@ export const CronPicker: React.FC<CronPickerProps> = ({ schedule, onChange, isVa
           <option value="month">{intl.formatMessage(i18n.month)}</option>
           <option value="quarter">{intl.formatMessage(i18n.quarter)}</option>
           <option value="year">{intl.formatMessage(i18n.year)}</option>
+          <option value="custom">{intl.formatMessage(i18n.custom)}</option>
         </select>
       </div>
 
       <div className="space-y-3">
+        {period === 'custom' && (
+          <div className="space-y-1">
+            <label htmlFor="custom-cron-expression" className="text-sm">
+              {intl.formatMessage(i18n.cronExpression)}
+            </label>
+            <input
+              id="custom-cron-expression"
+              type="text"
+              value={customCron}
+              onChange={(e) => setCustomCron(e.target.value)}
+              className="w-full px-2 py-1 border rounded"
+            />
+          </div>
+        )}
+
         {period === 'quarter' && (
           <div className="flex flex-wrap items-center gap-2">
             <div className="flex items-center gap-2">
@@ -407,7 +525,9 @@ export const CronPicker: React.FC<CronPickerProps> = ({ schedule, onChange, isVa
         )}
       </div>
 
-      <div className="text-xs text-gray-500 mt-2">{readableCron}</div>
+      <div className={`text-xs mt-2 ${hasCronError ? 'text-text-danger' : 'text-gray-500'}`}>
+        {readableCron}
+      </div>
     </div>
   );
 };

--- a/ui/desktop/src/components/schedule/CronPicker.tsx
+++ b/ui/desktop/src/components/schedule/CronPicker.tsx
@@ -11,8 +11,10 @@ const i18n = defineMessages({
   day: { id: 'cronPicker.day', defaultMessage: 'Day' },
   week: { id: 'cronPicker.week', defaultMessage: 'Week' },
   month: { id: 'cronPicker.month', defaultMessage: 'Month' },
+  quarter: { id: 'cronPicker.quarter', defaultMessage: 'Quarter' },
   year: { id: 'cronPicker.year', defaultMessage: 'Year' },
   inMonth: { id: 'cronPicker.inMonth', defaultMessage: 'in' },
+  startingMonth: { id: 'cronPicker.startingMonth', defaultMessage: 'starting month' },
   january: { id: 'cronPicker.january', defaultMessage: 'January' },
   february: { id: 'cronPicker.february', defaultMessage: 'February' },
   march: { id: 'cronPicker.march', defaultMessage: 'March' },
@@ -39,7 +41,26 @@ const i18n = defineMessages({
   atSecond: { id: 'cronPicker.atSecond', defaultMessage: 'at second' },
 });
 
-type Period = 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year';
+type Period = 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year';
+
+const quarterMonthsByStartMonth: Record<string, string> = {
+  '1': '1,4,7,10',
+  '2': '2,5,8,11',
+  '3': '3,6,9,12',
+};
+
+const quarterDayLimitByStartMonth: Record<string, number> = {
+  '1': 30,
+  '2': 28,
+  '3': 30,
+};
+
+const getQuarterStartMonth = (month: string): string | null => {
+  const entry = Object.entries(quarterMonthsByStartMonth).find(
+    ([, quarterMonths]) => quarterMonths === month
+  );
+  return entry?.[0] ?? null;
+};
 
 type ParsedCron = {
   period: Period;
@@ -76,6 +97,12 @@ const parseCron = (cron: string): ParsedCron => {
 
   const [second, minute, hour, dayOfMonth, month, dayOfWeek] = parts;
 
+  if (dayOfMonth !== '*') {
+    const quarterStartMonth = getQuarterStartMonth(month);
+    if (quarterStartMonth) {
+      return { period: 'quarter', second, minute, hour, dayOfMonth, month, dayOfWeek };
+    }
+  }
   if (month !== '*' && dayOfMonth !== '*') {
     return { period: 'year', second, minute, hour, dayOfMonth, month, dayOfWeek };
   }
@@ -124,6 +151,7 @@ export const CronPicker: React.FC<CronPickerProps> = ({ schedule, onChange, isVa
   const [dayOfWeek, setDayOfWeek] = useState('1');
   const [dayOfMonth, setDayOfMonth] = useState('1');
   const [month, setMonth] = useState('1');
+  const [quarterStartMonth, setQuarterStartMonth] = useState('1');
   const [readableCron, setReadableCron] = useState('');
 
   useEffect(() => {
@@ -138,10 +166,24 @@ export const CronPicker: React.FC<CronPickerProps> = ({ schedule, onChange, isVa
     setDayOfWeek(parsed.dayOfWeek === '*' ? '1' : parsed.dayOfWeek);
     setDayOfMonth(parsed.dayOfMonth === '*' ? '1' : parsed.dayOfMonth);
     setMonth(parsed.month === '*' ? '1' : parsed.month);
+    setQuarterStartMonth(getQuarterStartMonth(parsed.month) ?? '1');
   }, [schedule]);
+
+  const maxDayOfMonth = period === 'quarter' ? quarterDayLimitByStartMonth[quarterStartMonth] : 31;
+
+  useEffect(() => {
+    const parsedDay = parseInt(dayOfMonth, 10);
+    if (!Number.isNaN(parsedDay) && parsedDay > maxDayOfMonth) {
+      setDayOfMonth(maxDayOfMonth.toString());
+    }
+  }, [dayOfMonth, maxDayOfMonth]);
 
   useEffect(() => {
     const hour24 = to24Hour(hour12, isPM);
+    const clampedDayOfMonth = Math.min(
+      Math.max(parseInt(dayOfMonth, 10) || 1, 1),
+      maxDayOfMonth
+    ).toString();
     let cron: string;
 
     switch (period) {
@@ -159,6 +201,9 @@ export const CronPicker: React.FC<CronPickerProps> = ({ schedule, onChange, isVa
         break;
       case 'month':
         cron = `${second} ${minute} ${hour24} ${dayOfMonth} * *`;
+        break;
+      case 'quarter':
+        cron = `${second} ${minute} ${hour24} ${clampedDayOfMonth} ${quarterMonthsByStartMonth[quarterStartMonth]} *`;
         break;
       case 'year':
         cron = `${second} ${minute} ${hour24} ${dayOfMonth} ${month} *`;
@@ -178,7 +223,18 @@ export const CronPicker: React.FC<CronPickerProps> = ({ schedule, onChange, isVa
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [period, second, minute, hour12, isPM, dayOfWeek, dayOfMonth, month]);
+  }, [
+    period,
+    second,
+    minute,
+    hour12,
+    isPM,
+    dayOfWeek,
+    dayOfMonth,
+    month,
+    quarterStartMonth,
+    maxDayOfMonth,
+  ]);
 
   const selectClassName = 'px-2 py-1 border rounded bg-white dark:bg-gray-800 dark:border-gray-600';
 
@@ -196,11 +252,40 @@ export const CronPicker: React.FC<CronPickerProps> = ({ schedule, onChange, isVa
           <option value="day">{intl.formatMessage(i18n.day)}</option>
           <option value="week">{intl.formatMessage(i18n.week)}</option>
           <option value="month">{intl.formatMessage(i18n.month)}</option>
+          <option value="quarter">{intl.formatMessage(i18n.quarter)}</option>
           <option value="year">{intl.formatMessage(i18n.year)}</option>
         </select>
       </div>
 
       <div className="space-y-3">
+        {period === 'quarter' && (
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="flex items-center gap-2">
+              <span className="text-sm">{intl.formatMessage(i18n.startingMonth)}</span>
+              <select
+                value={quarterStartMonth}
+                onChange={(e) => setQuarterStartMonth(e.target.value)}
+                className={selectClassName}
+              >
+                <option value="1">{intl.formatMessage(i18n.january)}</option>
+                <option value="2">{intl.formatMessage(i18n.february)}</option>
+                <option value="3">{intl.formatMessage(i18n.march)}</option>
+              </select>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-sm">{intl.formatMessage(i18n.onDay)}</span>
+              <input
+                type="number"
+                min="1"
+                max={maxDayOfMonth}
+                value={dayOfMonth}
+                onChange={(e) => setDayOfMonth(e.target.value)}
+                className="w-16 px-2 py-1 border rounded"
+              />
+            </div>
+          </div>
+        )}
+
         {period === 'year' && (
           <div className="flex items-center gap-2">
             <span className="text-sm">{intl.formatMessage(i18n.inMonth)}</span>
@@ -231,7 +316,7 @@ export const CronPicker: React.FC<CronPickerProps> = ({ schedule, onChange, isVa
             <input
               type="number"
               min="1"
-              max="31"
+              max={maxDayOfMonth}
               value={dayOfMonth}
               onChange={(e) => setDayOfMonth(e.target.value)}
               className="w-16 px-2 py-1 border rounded"
@@ -258,7 +343,11 @@ export const CronPicker: React.FC<CronPickerProps> = ({ schedule, onChange, isVa
           </div>
         )}
 
-        {(period === 'day' || period === 'week' || period === 'month' || period === 'year') && (
+        {(period === 'day' ||
+          period === 'week' ||
+          period === 'month' ||
+          period === 'quarter' ||
+          period === 'year') && (
           <div className="flex items-center gap-2">
             <span className="text-sm">{intl.formatMessage(i18n.at)}</span>
             <input

--- a/ui/desktop/src/components/schedule/__tests__/CronPicker.test.tsx
+++ b/ui/desktop/src/components/schedule/__tests__/CronPicker.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { IntlTestWrapper } from '../../../i18n/test-utils';
 import { CronPicker } from '../CronPicker';
+import type { ScheduledJob } from '../../../schedule';
 
 const renderWithIntl = (ui: React.ReactElement, options?: RenderOptions) =>
   render(ui, { wrapper: IntlTestWrapper, ...options });
@@ -11,6 +12,12 @@ const getLastCron = (onChange: ReturnType<typeof vi.fn>) => {
   const calls = onChange.mock.calls;
   return calls[calls.length - 1]?.[0];
 };
+
+const scheduledJob = (cron: string): ScheduledJob => ({
+  id: 'quarterly-report',
+  source: 'dummy.yaml',
+  cron,
+});
 
 describe('CronPicker', () => {
   it('generates quarterly cron expressions from the quarter preset', async () => {
@@ -33,6 +40,93 @@ describe('CronPicker', () => {
     await waitFor(() => {
       expect(dayInput).toHaveValue(28);
       expect(getLastCron(onChange)).toBe('0 0 14 28 2,5,8,11 *');
+    });
+  });
+
+  it('marks invalid quarter day input as invalid instead of silently clamping to day one', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const isValid = vi.fn();
+
+    renderWithIntl(<CronPicker schedule={null} onChange={onChange} isValid={isValid} />);
+
+    await user.selectOptions(screen.getAllByRole('combobox')[0], 'quarter');
+    const dayInput = screen.getAllByRole('spinbutton')[0];
+    await user.clear(dayInput);
+    await user.type(dayInput, '0');
+
+    await waitFor(() => {
+      expect(dayInput).toHaveValue(0);
+      expect(isValid).toHaveBeenLastCalledWith(false);
+      expect(getLastCron(onChange)).toBe('0 0 14 0 1,4,7,10 *');
+    });
+  });
+
+  it('uses custom cron for cron expressions that presets cannot represent', async () => {
+    const onChange = vi.fn();
+
+    renderWithIntl(
+      <CronPicker
+        schedule={scheduledJob('0 0 14 31 1,4,7,10 *')}
+        onChange={onChange}
+        isValid={vi.fn()}
+      />
+    );
+
+    const [periodSelect] = screen.getAllByRole('combobox');
+
+    await waitFor(() => {
+      expect(periodSelect).toHaveValue('custom');
+      expect(screen.getByLabelText('Cron expression')).toHaveValue('0 0 14 31 1,4,7,10 *');
+      expect(getLastCron(onChange)).toBe('0 0 14 31 1,4,7,10 *');
+    });
+  });
+
+  it('uses custom cron when seconds cannot be represented by presets', async () => {
+    const onChange = vi.fn();
+
+    renderWithIntl(
+      <CronPicker schedule={scheduledJob('* 0 14 * * *')} onChange={onChange} isValid={vi.fn()} />
+    );
+
+    const [periodSelect] = screen.getAllByRole('combobox');
+
+    await waitFor(() => {
+      expect(periodSelect).toHaveValue('custom');
+      expect(screen.getByLabelText('Cron expression')).toHaveValue('* 0 14 * * *');
+      expect(getLastCron(onChange)).toBe('* 0 14 * * *');
+    });
+  });
+
+  it('generates cron from custom cron input', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    renderWithIntl(<CronPicker schedule={null} onChange={onChange} isValid={vi.fn()} />);
+
+    await user.selectOptions(screen.getAllByRole('combobox')[0], 'custom');
+    const customCronInput = screen.getByLabelText('Cron expression');
+    await user.clear(customCronInput);
+    await user.type(customCronInput, '0 9 31 1,4,7,10 *');
+
+    await waitFor(() => {
+      expect(getLastCron(onChange)).toBe('0 9 31 1,4,7,10 *');
+    });
+  });
+
+  it('marks invalid custom cron input as invalid', async () => {
+    const user = userEvent.setup();
+    const isValid = vi.fn();
+
+    renderWithIntl(<CronPicker schedule={null} onChange={vi.fn()} isValid={isValid} />);
+
+    await user.selectOptions(screen.getAllByRole('combobox')[0], 'custom');
+    const customCronInput = screen.getByLabelText('Cron expression');
+    await user.clear(customCronInput);
+    await user.type(customCronInput, '99 0 14 * * *');
+
+    await waitFor(() => {
+      expect(isValid).toHaveBeenLastCalledWith(false);
     });
   });
 });

--- a/ui/desktop/src/components/schedule/__tests__/CronPicker.test.tsx
+++ b/ui/desktop/src/components/schedule/__tests__/CronPicker.test.tsx
@@ -114,6 +114,27 @@ describe('CronPicker', () => {
     });
   });
 
+  it('uses the current preset cron when switching to custom cron', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    renderWithIntl(<CronPicker schedule={null} onChange={onChange} isValid={vi.fn()} />);
+
+    const [periodSelect] = screen.getAllByRole('combobox');
+    await user.selectOptions(periodSelect, 'quarter');
+    await user.selectOptions(screen.getAllByRole('combobox')[1], '2');
+
+    const dayInput = screen.getAllByRole('spinbutton')[0];
+    await user.clear(dayInput);
+    await user.type(dayInput, '15');
+    await user.selectOptions(periodSelect, 'custom');
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Cron expression')).toHaveValue('0 0 14 15 2,5,8,11 *');
+      expect(getLastCron(onChange)).toBe('0 0 14 15 2,5,8,11 *');
+    });
+  });
+
   it('marks invalid custom cron input as invalid', async () => {
     const user = userEvent.setup();
     const isValid = vi.fn();

--- a/ui/desktop/src/components/schedule/__tests__/CronPicker.test.tsx
+++ b/ui/desktop/src/components/schedule/__tests__/CronPicker.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, type RenderOptions, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { IntlTestWrapper } from '../../../i18n/test-utils';
+import { CronPicker } from '../CronPicker';
+
+const renderWithIntl = (ui: React.ReactElement, options?: RenderOptions) =>
+  render(ui, { wrapper: IntlTestWrapper, ...options });
+
+const getLastCron = (onChange: ReturnType<typeof vi.fn>) => {
+  const calls = onChange.mock.calls;
+  return calls[calls.length - 1]?.[0];
+};
+
+describe('CronPicker', () => {
+  it('generates quarterly cron expressions from the quarter preset', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    renderWithIntl(<CronPicker schedule={null} onChange={onChange} isValid={vi.fn()} />);
+
+    await user.selectOptions(screen.getAllByRole('combobox')[0], 'quarter');
+
+    await waitFor(() => {
+      expect(getLastCron(onChange)).toBe('0 0 14 1 1,4,7,10 *');
+    });
+
+    const dayInput = screen.getAllByRole('spinbutton')[0];
+    await user.clear(dayInput);
+    await user.type(dayInput, '31');
+    await user.selectOptions(screen.getAllByRole('combobox')[1], '2');
+
+    await waitFor(() => {
+      expect(dayInput).toHaveValue(28);
+      expect(getLastCron(onChange)).toBe('0 0 14 28 2,5,8,11 *');
+    });
+  });
+});

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -575,11 +575,17 @@
   "cronPicker.onDay": {
     "defaultMessage": "on day"
   },
+  "cronPicker.quarter": {
+    "defaultMessage": "Quarter"
+  },
   "cronPicker.saturday": {
     "defaultMessage": "Saturday"
   },
   "cronPicker.september": {
     "defaultMessage": "September"
+  },
+  "cronPicker.startingMonth": {
+    "defaultMessage": "starting month"
   },
   "cronPicker.sunday": {
     "defaultMessage": "Sunday"

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -518,11 +518,20 @@
   "cronPicker.august": {
     "defaultMessage": "August"
   },
+  "cronPicker.cronExpression": {
+    "defaultMessage": "Cron expression"
+  },
+  "cronPicker.custom": {
+    "defaultMessage": "Custom cron"
+  },
   "cronPicker.day": {
     "defaultMessage": "Day"
   },
   "cronPicker.december": {
     "defaultMessage": "December"
+  },
+  "cronPicker.emptyCronError": {
+    "defaultMessage": "Cron expression cannot be empty"
   },
   "cronPicker.every": {
     "defaultMessage": "Every"
@@ -538,6 +547,9 @@
   },
   "cronPicker.inMonth": {
     "defaultMessage": "in"
+  },
+  "cronPicker.invalidDayOfMonth": {
+    "defaultMessage": "Day must be between 1 and {max}"
   },
   "cronPicker.january": {
     "defaultMessage": "January"
@@ -556,6 +568,9 @@
   },
   "cronPicker.minute": {
     "defaultMessage": "Minute"
+  },
+  "cronPicker.mode": {
+    "defaultMessage": "Mode"
   },
   "cronPicker.monday": {
     "defaultMessage": "Monday"

--- a/ui/desktop/src/utils/cronSchedule.ts
+++ b/ui/desktop/src/utils/cronSchedule.ts
@@ -1,0 +1,184 @@
+import cronstrue from 'cronstrue';
+
+export type Period = 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year' | 'custom';
+
+export const quarterMonthsByStartMonth: Record<string, string> = {
+  '1': '1,4,7,10',
+  '2': '2,5,8,11',
+  '3': '3,6,9,12',
+};
+
+export const quarterDayLimitByStartMonth: Record<string, number> = {
+  '1': 30,
+  '2': 28,
+  '3': 30,
+};
+
+export type ParsedCron = {
+  period: Period;
+  second: string;
+  minute: string;
+  hour: string;
+  dayOfMonth: string;
+  month: string;
+  dayOfWeek: string;
+};
+
+export type CronParts = {
+  period: Period;
+  second: string;
+  minute: string;
+  hour24: number;
+  dayOfWeek: string;
+  dayOfMonth: string | null;
+  month: string;
+  quarterStartMonth: string;
+  customCron: string;
+};
+
+export const defaultParsedCron: ParsedCron = {
+  period: 'day',
+  second: '0',
+  minute: '0',
+  hour: '14',
+  dayOfMonth: '*',
+  month: '*',
+  dayOfWeek: '*',
+};
+
+export const getQuarterStartMonth = (month: string): string | null => {
+  const entry = Object.entries(quarterMonthsByStartMonth).find(
+    ([, quarterMonths]) => quarterMonths === month
+  );
+  return entry?.[0] ?? null;
+};
+
+const normalizeCronParts = (cron: string): string[] | null => {
+  const parts = cron.trim().split(/\s+/);
+  if (parts.length === 5) {
+    return ['0', ...parts];
+  }
+  if (parts.length === 6) {
+    return parts;
+  }
+  return null;
+};
+
+export const isSingleNumericValue = (value: string): boolean => /^\d+$/.test(value);
+
+export const getValidDayOfMonth = (value: string, max: number): string | null => {
+  if (!isSingleNumericValue(value)) {
+    return null;
+  }
+  const parsedDay = parseInt(value, 10);
+  if (parsedDay < 1 || parsedDay > max) {
+    return null;
+  }
+  return parsedDay.toString();
+};
+
+const asCustomCron = (parts: string[]): ParsedCron => {
+  const [second, minute, hour, dayOfMonth, month, dayOfWeek] = parts;
+  return { period: 'custom', second, minute, hour, dayOfMonth, month, dayOfWeek };
+};
+
+export const describeCron = (cron: string): string => {
+  const parts = cron.trim().split(/\s+/);
+  if (parts.length === 5 || parts.length === 6) {
+    return cronstrue.toString(parts.join(' '));
+  }
+  throw new Error('Expected 5 or 6 fields');
+};
+
+export const parseCron = (cron: string): ParsedCron => {
+  if (!cron.trim()) {
+    return defaultParsedCron;
+  }
+
+  const parts = normalizeCronParts(cron);
+  if (!parts) {
+    return { ...defaultParsedCron, period: 'custom' };
+  }
+
+  const [second, minute, hour, dayOfMonth, month, dayOfWeek] = parts;
+
+  if (!isSingleNumericValue(second)) {
+    return asCustomCron(parts);
+  }
+
+  if (dayOfMonth !== '*') {
+    const quarterStartMonth = getQuarterStartMonth(month);
+    const dayOfMonthNumber = parseInt(dayOfMonth, 10);
+    if (
+      quarterStartMonth &&
+      isSingleNumericValue(dayOfMonth) &&
+      dayOfMonthNumber <= quarterDayLimitByStartMonth[quarterStartMonth]
+    ) {
+      return { period: 'quarter', second, minute, hour, dayOfMonth, month, dayOfWeek };
+    }
+  }
+  if (month !== '*' && dayOfMonth !== '*') {
+    if (!isSingleNumericValue(month) || !isSingleNumericValue(dayOfMonth)) {
+      return asCustomCron(parts);
+    }
+    return { period: 'year', second, minute, hour, dayOfMonth, month, dayOfWeek };
+  }
+  if (dayOfMonth !== '*') {
+    if (!isSingleNumericValue(dayOfMonth)) {
+      return asCustomCron(parts);
+    }
+    return { period: 'month', second, minute, hour, dayOfMonth, month, dayOfWeek };
+  }
+  if (dayOfWeek !== '*') {
+    if (!isSingleNumericValue(dayOfWeek)) {
+      return asCustomCron(parts);
+    }
+    return { period: 'week', second, minute, hour, dayOfMonth, month, dayOfWeek };
+  }
+  if (hour !== '*') {
+    if (!isSingleNumericValue(hour)) {
+      return asCustomCron(parts);
+    }
+    return { period: 'day', second, minute, hour, dayOfMonth, month, dayOfWeek };
+  }
+  if (minute !== '*') {
+    if (!isSingleNumericValue(minute)) {
+      return asCustomCron(parts);
+    }
+    return { period: 'hour', second, minute, hour, dayOfMonth, month, dayOfWeek };
+  }
+  return { period: 'minute', second, minute, hour, dayOfMonth, month, dayOfWeek };
+};
+
+export const buildCronForPeriod = ({
+  period,
+  second,
+  minute,
+  hour24,
+  dayOfWeek,
+  dayOfMonth,
+  month,
+  quarterStartMonth,
+  customCron,
+}: CronParts): string => {
+  switch (period) {
+    case 'custom':
+      return customCron;
+    case 'minute':
+      return `${second} * * * * *`;
+    case 'hour':
+      return `${second} ${minute} * * * *`;
+    case 'day':
+      return `${second} ${minute} ${hour24} * * *`;
+    case 'week':
+      return `${second} ${minute} ${hour24} * * ${dayOfWeek}`;
+    case 'month':
+      return `${second} ${minute} ${hour24} ${dayOfMonth ?? '0'} * *`;
+    case 'quarter':
+      return `${second} ${minute} ${hour24} ${dayOfMonth ?? '0'} ${quarterMonthsByStartMonth[quarterStartMonth]} *`;
+    case 'year':
+      return `${second} ${minute} ${hour24} ${dayOfMonth ?? '0'} ${month} *`;
+    default:
+      return '0 0 0 * * *';
+  }
+};


### PR DESCRIPTION
## Summary
Close https://github.com/aaif-goose/goose/issues/8975

Added quarterly and custom cron options

### Testing
Unit and manual

### Screenshots/Demos (for UX changes)
After:  
<img width="556" height="652" alt="Screenshot 2026-05-07 at 6 28 45 pm" src="https://github.com/user-attachments/assets/33330181-9501-482e-8ae2-bab0ff398da0" />


<img width="706" height="719" alt="Screenshot 2026-05-07 at 8 16 41 pm" src="https://github.com/user-attachments/assets/5a11a4ed-df8b-4db8-b731-c14a4ab49483" />



