### PR TITLE
docs: fix internal documentation anchors

### DIFF
--- a/documentation/docs/guides/cli-providers.md
+++ b/documentation/docs/guides/cli-providers.md
@@ -25,7 +25,7 @@ CLI providers are useful if you:
 - need session persistence to save, resume, and export conversation history
 - want to use goose recipes and scheduled tasks to create repeatable workflows
 - prefer unified commands across different AI providers
-- want to [use multiple models together](#combining-with-other-models) in your tasks 
+- want to [use multiple models together](#combining-with-planner-models) in your tasks
 
 ### Benefits
 

--- a/documentation/docs/guides/config-files.md
+++ b/documentation/docs/guides/config-files.md
@@ -149,7 +149,7 @@ These paths are prepended to the system PATH when running extension commands, en
 
 ## Observability Configuration
 
-Configure goose to export telemetry to [OpenTelemetry](https://opentelemetry.io/docs/) compatible platforms. Environment variables override these settings and support additional options like per-signal configuration. See the [environment variables guide](/docs/guides/environment-variables#opentelemetry-protocol-otlp) for details.
+Configure goose to export telemetry to [OpenTelemetry](https://opentelemetry.io/docs/) compatible platforms. Environment variables override these settings and support additional options like per-signal configuration. See the [environment variables guide](/docs/guides/environment-variables#observability-configuration) for details.
 
 | Setting | Purpose | Values | Default |
 |---------|---------|--------|---------|


### PR DESCRIPTION
## Summary
- Fix the CLI providers guide link to the current planner models heading.
- Fix the config files guide link to the current observability configuration heading in the environment variables guide.

## Verification
- `git diff --check`
- Checked 172 documentation Markdown/MDX files for internal `/docs/...` and same-page anchors; 0 broken anchors found.