### PR TITLE
fix(extension_manager): apply configured timeout to StreamableHttp reqwest client

### DIFF
--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -60,7 +60,7 @@ static RE_ENV_BRACES: Lazy<regex::Regex> =
 static RE_ENV_SIMPLE: Lazy<regex::Regex> =
     Lazy::new(|| regex::Regex::new(r"\$([A-Za-z_][A-Za-z0-9_]*)").expect("valid regex"));
 
-pub(crate) fn resolve_timeout(timeout: Option<u64>) -> u64 {
+fn resolve_timeout(timeout: Option<u64>) -> u64 {
     timeout.unwrap_or_else(|| {
         Config::global()
             .get_goose_default_extension_timeout()
@@ -2617,5 +2617,16 @@ mod tests {
             ),
         );
         assert!(should_attempt_oauth_fallback(&Err(err)));
+    }
+
+    #[test]
+    fn resolve_timeout_uses_per_extension_value() {
+        assert_eq!(resolve_timeout(Some(120)), 120);
+    }
+
+    #[test]
+    fn resolve_timeout_uses_default_when_none() {
+        use crate::config::extensions::DEFAULT_EXTENSION_TIMEOUT;
+        assert_eq!(resolve_timeout(None), DEFAULT_EXTENSION_TIMEOUT);
     }
 }

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -60,7 +60,7 @@ static RE_ENV_BRACES: Lazy<regex::Regex> =
 static RE_ENV_SIMPLE: Lazy<regex::Regex> =
     Lazy::new(|| regex::Regex::new(r"\$([A-Za-z_][A-Za-z0-9_]*)").expect("valid regex"));
 
-fn resolve_timeout(timeout: Option<u64>) -> u64 {
+pub(crate) fn resolve_timeout(timeout: Option<u64>) -> u64 {
     timeout.unwrap_or_else(|| {
         Config::global()
             .get_goose_default_extension_timeout()
@@ -555,8 +555,11 @@ async fn create_streamable_http_client(
         );
     }
 
+    let timeout_duration = Duration::from_secs(resolve_timeout(timeout));
+
     let http_client = reqwest::Client::builder()
         .default_headers(default_headers)
+        .timeout(timeout_duration)
         .build()
         .map_err(|_| ExtensionError::ConfigError("could not construct http client".to_string()))?;
 
@@ -564,8 +567,6 @@ async fn create_streamable_http_client(
         http_client,
         StreamableHttpClientTransportConfig::with_uri(uri),
     );
-
-    let timeout_duration = Duration::from_secs(resolve_timeout(timeout));
 
     let client_res = McpClient::connect(
         transport,
@@ -584,6 +585,7 @@ async fn create_streamable_http_client(
                 auth_headers.insert(reqwest::header::USER_AGENT, GOOSE_USER_AGENT);
                 let auth_http_client = reqwest::Client::builder()
                     .default_headers(auth_headers)
+                    .timeout(timeout_duration)
                     .build()
                     .map_err(|_| {
                         ExtensionError::ConfigError("could not construct http client".to_string())

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -559,7 +559,7 @@ async fn create_streamable_http_client(
 
     let http_client = reqwest::Client::builder()
         .default_headers(default_headers)
-        .timeout(timeout_duration)
+        .connect_timeout(timeout_duration)
         .build()
         .map_err(|_| ExtensionError::ConfigError("could not construct http client".to_string()))?;
 
@@ -585,7 +585,7 @@ async fn create_streamable_http_client(
                 auth_headers.insert(reqwest::header::USER_AGENT, GOOSE_USER_AGENT);
                 let auth_http_client = reqwest::Client::builder()
                     .default_headers(auth_headers)
-                    .timeout(timeout_duration)
+                    .connect_timeout(timeout_duration)
                     .build()
                     .map_err(|_| {
                         ExtensionError::ConfigError("could not construct http client".to_string())

--- a/crates/goose/tests/extension_timeout_test.rs
+++ b/crates/goose/tests/extension_timeout_test.rs
@@ -1,22 +1,5 @@
 use goose::agents::extension::ExtensionConfig;
-use goose::agents::extension_manager::resolve_timeout;
-use goose::config::DEFAULT_EXTENSION_TIMEOUT;
-use serde_json;
 use std::collections::HashMap;
-
-#[test]
-fn resolve_timeout_uses_per_extension_value() {
-    let timeout = Some(120);
-    let resolved = resolve_timeout(timeout);
-    assert_eq!(resolved, 120);
-}
-
-#[test]
-fn resolve_timeout_uses_default_when_none() {
-    let timeout = None;
-    let resolved = resolve_timeout(timeout);
-    assert_eq!(resolved, DEFAULT_EXTENSION_TIMEOUT);
-}
 
 #[test]
 fn streamable_http_config_timeout_roundtrips() {

--- a/crates/goose/tests/extension_timeout_test.rs
+++ b/crates/goose/tests/extension_timeout_test.rs
@@ -1,0 +1,45 @@
+use goose::agents::extension::ExtensionConfig;
+use goose::agents::extension_manager::resolve_timeout;
+use goose::config::DEFAULT_EXTENSION_TIMEOUT;
+use serde_json;
+use std::collections::HashMap;
+
+#[test]
+fn resolve_timeout_uses_per_extension_value() {
+    let timeout = Some(120);
+    let resolved = resolve_timeout(timeout);
+    assert_eq!(resolved, 120);
+}
+
+#[test]
+fn resolve_timeout_uses_default_when_none() {
+    let timeout = None;
+    let resolved = resolve_timeout(timeout);
+    assert_eq!(resolved, DEFAULT_EXTENSION_TIMEOUT);
+}
+
+#[test]
+fn streamable_http_config_timeout_roundtrips() {
+    let config = ExtensionConfig::StreamableHttp {
+        name: "test-extension".to_string(),
+        description: "Test extension".to_string(),
+        uri: "http://localhost:8080".to_string(),
+        envs: Default::default(),
+        env_keys: Vec::new(),
+        headers: HashMap::new(),
+        timeout: Some(42),
+        socket: None,
+        bundled: None,
+        available_tools: Vec::new(),
+    };
+
+    let json = serde_json::to_string(&config).expect("Failed to serialize");
+    let deserialized: ExtensionConfig = serde_json::from_str(&json).expect("Failed to deserialize");
+
+    match deserialized {
+        ExtensionConfig::StreamableHttp { timeout, .. } => {
+            assert_eq!(timeout, Some(42));
+        }
+        _ => panic!("Expected StreamableHttp variant"),
+    }
+}


### PR DESCRIPTION
## Summary

`create_streamable_http_client` built its `reqwest::Client` without a connection timeout, so the extension timeout from `config.yaml` was correctly resolved by `resolve_timeout()` but silently discarded at the HTTP transport layer. The OS TCP default (~30s on Linux) fired instead, regardless of the configured value.

This is the root cause of #9022 (streamable HTTP calls reset after ~30s on Linux). The session persistence path (`EnabledExtensionsState`) is correct; the bug was exclusively in HTTP client construction.

## Changes

- `crates/goose/src/agents/extension_manager.rs`: compute `timeout_duration` via `resolve_timeout()` once before both `reqwest::Client::builder()` calls; add `.connect_timeout(timeout_duration)` to the primary client and the OAuth fallback client. `.connect_timeout()` bounds TCP connection establishment without capping long-lived SSE streams (using `.timeout()` would disconnect SSE streams every 300s).
- `crates/goose/tests/extension_timeout_test.rs` (new): serde roundtrip test for `ExtensionConfig::StreamableHttp` timeout field (public API only).
- `crates/goose/src/agents/extension_manager.rs` `#[cfg(test)]` module: two unit tests for `resolve_timeout` with a per-extension value and with `None` (default fallback). Placed here since `resolve_timeout` is private.

The fix follows the existing pattern used in `download_manager.rs` (which also uses `.connect_timeout()`). Note: `.tcp_user_timeout()` suggested in #9022 is not available in reqwest 0.13.

## Test plan

- [ ] Tests pass (`cargo test -p goose`)
- [ ] Linter clean (`cargo clippy --all-targets -- -D warnings`)
- [ ] Security scan clean (no findings from `aptu scan_security`)

Fixes #9022
