### PR TITLE
fix: respect use_jinja setting in native tools inference

### DIFF
--- a/crates/goose/src/providers/local_inference/inference_native_tools.rs
+++ b/crates/goose/src/providers/local_inference/inference_native_tools.rs
@@ -47,7 +47,7 @@ pub(super) fn generate_with_native_tools(
                 },
                 chat_template_kwargs: None,
                 add_generation_prompt: true,
-                use_jinja: true,
+                use_jinja: ctx.settings.use_jinja,
                 parallel_tool_calls: false,
                 enable_thinking: ctx.settings.enable_thinking,
                 add_bos: false,


### PR DESCRIPTION
## Summary
Fixes a bug where the `use_jinja` parameter was hardcoded to `true`, ignoring the user's configuration in `ModelSettings.use_jinja`.

## Changes
- Modified `crates/goose/src/providers/local_inference/inference_native_tools.rs` to respect the `use_jinja` setting from `ctx.settings.use_jinja` instead of hardcoding it to `true`

## Motivation
This allows users to disable Jinja template parsing when needed for compatibility with models that don't have proper Jinja support in the bundled llama.cpp version.

## Testing
- [ ] Tested with models that have embedded chat templates
- [ ] Tested with `use_jinja: false` configuration

## Related Issues
This is related to Gemma-4 model compatibility issues with the current bundled llama-cpp-2 version (0.1.145), which doesn't support Gemma-4's chat template format. While this fix doesn't solve the Gemma-4 issue entirely, it allows users to work around it by disabling Jinja parsing.