### PR TITLE
fix(desktop/ui): Set correct mcp-app host capabilities

### DIFF
--- a/ui/goose2/src/features/chat/ui/McpAppView.tsx
+++ b/ui/goose2/src/features/chat/ui/McpAppView.tsx
@@ -93,6 +93,22 @@ function getDeviceCapabilities(): NonNullable<
   };
 }
 
+// Derives https://github.com/modelcontextprotocol/ext-apps/blob/1d091e21321c0680564f19fea9c82a805a352a9c/src/spec.types.ts#L494
+// from the handlers passed to <AppRenderer>, keeping advertised capabilities in sync with what the host supports.
+function buildHostCapabilities(handlers: {
+  onCallTool?: unknown;
+  onOpenLink?: unknown;
+  onReadResource?: unknown;
+  onSendMessage?: unknown;
+}) {
+  return {
+    ...(handlers.onCallTool !== undefined && { serverTools: {} }),
+    ...(handlers.onOpenLink !== undefined && { openLinks: {} }),
+    ...(handlers.onReadResource !== undefined && { serverResources: {} }),
+    ...(handlers.onSendMessage !== undefined && { message: { text: {} } }),
+  };
+}
+
 function buildHostContextToolInfo(payload: McpAppPayload): HostContextToolInfo {
   const tool: HostContextTool = {
     name: payload.tool.name,
@@ -426,6 +442,12 @@ export function McpAppView({
             toolInput={currentToolInput}
             toolResult={currentToolResult}
             hostContext={hostContext}
+            hostCapabilities={buildHostCapabilities({
+              onCallTool: handleCallTool,
+              onOpenLink: handleOpenLink,
+              onReadResource: handleReadResource,
+              onSendMessage: onSendMessage,
+            })}
             onOpenLink={handleOpenLink}
             onMessage={handleMessage}
             onCallTool={handleCallTool}


### PR DESCRIPTION
## Summary

Both AppRenderer were missing the hostCapabilities prop. Without it, apps that check server tools (such as Datadog's) are unable to know what capabilities the Goose host actually has

## Changes

Add a helper to that takes the handler refs passed to <AppRenderer> and returns the matching McpUiHostCapabilities object, keeping advertised capabilities in sync with what the host supports.

**Scope note:** The fix is applied to goose2 only. The desktop (Electron) app uses `@mcp-ui/client@6.1.0`, which does not expose the `hostCapabilities` prop on `AppRenderer` until v7. 

Upgrading the goose1 to v7 would be a separate effort, as `UIResourceRenderer` and related exports used in `MCPUIResourceRenderer.tsx` were removed in v7 and would need to be migrated first.

### Testing

This is my first time contributing to Goose's UI instead of the SDK layer. My local pnpm / node versions aren't compatible with the versions used and I'm not able to update them locally, hopefully this change is simple enough that the diff is enough? Happy to contribute tests that may run in CI if needed.

### Design notes

Perhaps this mapping is something `AppRenderer` could compute someday (as a followup to https://github.com/MCP-UI-Org/mcp-ui/pull/179/ ) , but since it's not doing that yet, this is a workaround

### Related Issues

Perhaps this can help with MCP apps compliance:  https://github.com/aaif-goose/goose/issues/8017

### Screenshots/Demos (for UX changes)

Before this change, we can see that Goose reports serverTools as unavailable, which is not the case since those are implemented here: https://github.com/aaif-goose/goose/blob/ea5802c3806d23cf1eddacffd4f343f0edc7634a/crates/goose/src/agents/tool_execution.rs#L163

<img width="2087" height="622" alt="image" src="https://github.com/user-attachments/assets/d0592c53-05a8-4fea-adba-4162ff8a2e6d" />