### PR TITLE
fix: enable SQLite foreign key enforcement in session pool

### DIFF
--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -584,6 +584,7 @@ impl SessionStorage {
         let options = SqliteConnectOptions::new()
             .filename(path)
             .create_if_missing(true)
+            .foreign_keys(true)
             .busy_timeout(std::time::Duration::from_secs(30))
             .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal);
 


### PR DESCRIPTION
## Summary

SQLite does not enforce foreign key constraints by default — `PRAGMA foreign_keys = ON` must be set per connection. Without it, `ON DELETE CASCADE` on `provider_inventory_models.inventory_key` is silently inert: deleting a `provider_inventory_entries` row leaves orphaned `provider_inventory_models` rows even though the schema declares a cascade.

This PR adds `.foreign_keys(true)` to `SqliteConnectOptions` in `create_pool()` — one line, no schema changes needed.

### Testing

Existing tests pass. FK enforcement is now active for all connections in the pool; the declared `ON DELETE CASCADE` on `provider_inventory_models` will be enforced at runtime.

### Related Issues

Fixes #9120

> **Note:** The cascade gap on `thread_messages` mentioned in the issue is no longer relevant — `thread_messages` and `threads` were removed in #9078 (v12). The FK pragma fix still stands as the underlying enforcement was missing across all tables.