### PR TITLE
fix: omit max_tokens for OpenAI-compatible requests when unset

### DIFF
--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -1029,15 +1029,22 @@ pub fn create_request(
         }
     }
 
-    let key = if is_reasoning_model {
-        "max_completion_tokens"
-    } else {
-        "max_tokens"
-    };
-    payload
-        .as_object_mut()
-        .unwrap()
-        .insert(key.to_string(), json!(model_config.max_output_tokens()));
+    // Only emit max_tokens / max_completion_tokens when the user (via
+    // GOOSE_MAX_TOKENS) or a canonical model record has supplied a value.
+    // For unknown models on OpenAI-compatible endpoints (e.g. llama_swap,
+    // lmstudio) sending the historic 4096 default truncates non-trivial
+    // responses; omitting the field lets the server use its own max.
+    if let Some(max_tokens) = model_config.max_tokens {
+        let key = if is_reasoning_model {
+            "max_completion_tokens"
+        } else {
+            "max_tokens"
+        };
+        payload
+            .as_object_mut()
+            .unwrap()
+            .insert(key.to_string(), json!(max_tokens));
+    }
 
     if for_streaming {
         payload["stream"] = json!(true);
@@ -1722,6 +1729,43 @@ mod tests {
             assert_eq!(obj.get(key).unwrap(), value);
         }
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_request_omits_max_tokens_when_unset() -> anyhow::Result<()> {
+        // Unknown models on OpenAI-compatible local providers (llama_swap,
+        // lmstudio) have no canonical record and no GOOSE_MAX_TOKENS, so the
+        // request must not pin the legacy 4096 default — the server should
+        // pick its own ceiling. See issue #9007.
+        let model_config = ModelConfig {
+            model_name: "some-unknown-local-model".to_string(),
+            context_limit: None,
+            temperature: None,
+            max_tokens: None,
+            toolshim: false,
+            toolshim_model: None,
+            fast_model_config: None,
+            request_params: None,
+            reasoning: None,
+        };
+        let request = create_request(
+            &model_config,
+            "system",
+            &[],
+            &[],
+            &ImageFormat::OpenAi,
+            false,
+        )?;
+        let obj = request.as_object().unwrap();
+        assert!(
+            !obj.contains_key("max_tokens"),
+            "max_tokens should be omitted when model_config.max_tokens is None"
+        );
+        assert!(
+            !obj.contains_key("max_completion_tokens"),
+            "max_completion_tokens should be omitted when model_config.max_tokens is None"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

For local OpenAI-compatible providers (`llama_swap`, `lmstudio`) the OpenAI request builder always sets `max_tokens` / `max_completion_tokens` to whatever `ModelConfig::max_output_tokens()` returns. When the user-supplied model has no canonical record and `GOOSE_MAX_TOKENS` is unset, that value is the legacy 4096 fallback, and local servers honor it and truncate non-trivial responses mid-tool-use. The user has no way to find this without discovering `GOOSE_MAX_TOKENS`.

This change skips emitting the field in `providers/formats/openai.rs::create_request` when `model_config.max_tokens` is `None`, letting the server pick its own ceiling. Behavior is unchanged when `GOOSE_MAX_TOKENS` is set or the model has a canonical record (which populates `max_tokens` via `with_canonical_limits`).

Only the shared OpenAI request builder is changed. The Ollama provider also routes through this `create_request` (re-exported at `formats/ollama.rs:24-26`); for unknown models with `GOOSE_MAX_TOKENS` unset, `apply_ollama_options` will simply leave `options.num_predict` unset, letting the Ollama server pick its own default — same fix, applied for free. Other format builders (anthropic, databricks, snowflake, openai_responses) still call `max_output_tokens()` and so still send the 4096 fallback; those APIs require `max_tokens`, so they're intentionally untouched.

### Testing

New unit test `test_create_request_omits_max_tokens_when_unset` asserts that an unknown model with `max_tokens: None` produces a payload containing neither `max_tokens` nor `max_completion_tokens`. Existing tests still pass.

```
cargo test -p goose --lib --no-default-features --features rustls-tls \
  providers::formats::openai providers::ollama
```

### Related Issues

Fixes #9007