### PR TITLE
docs(mcp): add Ejentum Reasoning Harness extension page

### DIFF
--- a/documentation/docs/mcp/ejentum-mcp.md
+++ b/documentation/docs/mcp/ejentum-mcp.md
@@ -1,0 +1,107 @@
+---
+title: Ejentum Reasoning Harness Extension
+description: Add Ejentum MCP Server as a goose Extension to inject cognitive scaffolds (reasoning, code, anti-deception, memory) into goose's context before generation.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+
+This tutorial covers how to add the [Ejentum MCP Server](https://github.com/ejentum/ejentum-mcp) as a goose extension to inject engineered cognitive scaffolds (failure pattern, executable procedure, suppression vectors, falsification test) into goose's context before each generation, addressing attention decay, sycophantic collapse, hallucination drift, and reasoning decay.
+
+:::tip Quick Install
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=ejentum-mcp&id=ejentum&name=Ejentum&description=Cognitive%20harness%20scaffolds%20for%20reasoning%2C%20code%2C%20anti-deception%2C%20and%20memory&env=EJENTUM_API_KEY%3DEjentum%20API%20Key)
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+  **Command**
+  ```sh
+  npx -y ejentum-mcp
+  ```
+  </TabItem>
+</Tabs>
+  **Environment Variable**
+  ```
+  EJENTUM_API_KEY: <YOUR_API_KEY>
+  ```
+:::
+
+## Configuration
+
+:::info
+Note that you'll need [Node.js](https://nodejs.org/) installed on your system to run this command, as it uses `npx`.
+:::
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  <GooseDesktopInstaller
+    extensionId="ejentum"
+    extensionName="Ejentum"
+    description="Cognitive harness scaffolds for reasoning, code, anti-deception, and memory"
+    command="npx"
+    args={["-y", "ejentum-mcp"]}
+    envVars={[
+      { name: "EJENTUM_API_KEY", label: "Ejentum API Key" }
+    ]}
+    apiKeyLink="https://ejentum.com/pricing"
+    apiKeyLinkText="EJENTUM_API_KEY (free tier: 100 calls, no card)"
+  />
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    <CLIExtensionInstructions
+      name="ejentum"
+      description="Cognitive harness scaffolds for reasoning, code, anti-deception, and memory"
+      command="npx -y ejentum-mcp"
+      envVars={[
+        { key: "EJENTUM_API_KEY", value: "▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪" }
+      ]}
+      infoNote={
+        <>
+          Get a free Ejentum API key (100 calls, no card) at <a href="https://ejentum.com/pricing" target="_blank" rel="noopener noreferrer">ejentum.com/pricing</a> and paste it in.
+        </>
+      }
+    />
+  </TabItem>
+</Tabs>
+
+## Tools
+
+The extension exposes four MCP tools, one per cognitive harness mode. Each call returns a structured scaffold (failure pattern, executable procedure, suppression vectors, falsification test) the model ingests before generating.
+
+| Tool | When to call |
+|------|-------------|
+| `harness_reasoning` | Analytical, diagnostic, planning, multi-step questions; root-cause analysis; architecture decisions |
+| `harness_code` | Code generation, refactoring, review, debugging; algorithm or data-structure choices; dependency upgrades |
+| `harness_anti_deception` | Prompts that pressure goose to validate, certify, or soften an honest assessment; authority appeals; manufactured urgency |
+| `harness_memory` | Sharpening an observation already formed about cross-turn drift, conversation patterns, or behavioral changes |
+
+## Example Usage
+
+The following prompt embeds a sunk-cost frame ("we've already spent three months"). Without the harness, modern LLMs often anchor on past investment when recommending next steps. With `harness_anti_deception` called first, the scaffold separates past spending from prospective evaluation.
+
+### goose Prompt
+
+```
+Use harness_anti_deception, then answer:
+
+We've spent three months on the GraphQL gateway. It's mostly done.
+Should we keep going or pivot to REST?
+```
+
+### What to look for in the response
+
+A baseline response typically includes phrases like *"Sunk cost is real here, the hardest learning curve is behind you"* — anchoring on past investment.
+
+The augmented response should explicitly separate past spending from prospective evaluation: *"The three months already spent are gone regardless of what you choose now. The relevant question is how much work remains versus how much value GraphQL will deliver from this point forward."*
+
+The decision (keep going vs pivot) may end up the same, but the reasoning that produces it should now be prospective rather than sunk-cost-anchored. That structural shift is the falsifiable claim of the harness.
+
+## More
+
+- [Ejentum project repo](https://github.com/ejentum/ejentum-mcp) (MIT)
+- [Free tier (100 calls, no card)](https://ejentum.com/pricing)
+- [Documentation and walkthroughs](https://ejentum.com/docs/claude_code_guide)
+- ["Under Pressure" research paper on the harness mechanism](https://doi.org/10.5281/zenodo.19392715)

--- a/documentation/docs/mcp/ejentum-mcp.md
+++ b/documentation/docs/mcp/ejentum-mcp.md
@@ -1,6 +1,6 @@
 ---
 title: Ejentum Reasoning Harness Extension
-description: Add Ejentum MCP Server as a goose Extension to inject cognitive scaffolds (reasoning, code, anti-deception, memory) into goose's context before generation.
+description: Add Ejentum MCP Server as a goose Extension exposing four cognitive scaffold tools (reasoning, code, anti-deception, memory) the agent can call when the task matches.
 ---
 
 import Tabs from '@theme/Tabs';
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
 
-This tutorial covers how to add the [Ejentum MCP Server](https://github.com/ejentum/ejentum-mcp) as a goose extension to inject engineered cognitive scaffolds (failure pattern, executable procedure, suppression vectors, falsification test) into goose's context before each generation, addressing attention decay, sycophantic collapse, hallucination drift, and reasoning decay.
+This tutorial covers how to add the [Ejentum MCP Server](https://github.com/ejentum/ejentum-mcp) as a goose extension. Once installed, the agent can call any of four cognitive harness tools when the task matches their trigger conditions; each call returns an engineered scaffold (failure pattern, executable procedure, suppression vectors, falsification test) the agent ingests before responding, addressing attention decay, sycophantic collapse, hallucination drift, and reasoning decay. The harness is invoked on demand (by the agent or via an explicit prompt like `Use harness_anti_deception, then answer:...`); it does not auto-run on every turn.
 
 :::tip Quick Install
 

--- a/documentation/docs/mcp/ejentum-mcp.md
+++ b/documentation/docs/mcp/ejentum-mcp.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
 
-This tutorial covers how to add the [Ejentum MCP Server](https://github.com/ejentum/ejentum-mcp) as a goose extension. Once installed, the agent can call any of four cognitive harness tools when the task matches their trigger conditions; each call returns an engineered scaffold (failure pattern, executable procedure, suppression vectors, falsification test) the agent ingests before responding, addressing attention decay, sycophantic collapse, hallucination drift, and reasoning decay. The harness is invoked on demand (by the agent or via an explicit prompt like `Use harness_anti_deception, then answer:...`); it does not auto-run on every turn.
+This tutorial covers how to add the [Ejentum MCP Server](https://github.com/ejentum/ejentum-mcp) as a goose extension. The Ejentum API is a library of 679 cognitive operations engineered in natural language, organized across four harnesses (`reasoning`, `code`, `anti-deception`, `memory`). Each harness call retrieves a task-matched scaffold rather than serving a fixed template: a named failure pattern, an executable procedure, suppression vectors that block the obvious shortcut, and a falsification test for self-verification. The agent ingests the scaffold and writes from it, addressing attention decay, sycophantic collapse, hallucination drift, and reasoning decay. The harness is invoked on demand (by the agent or via an explicit prompt like `Use harness_anti_deception, then answer:...`); it does not auto-run on every turn.
 
 :::tip Quick Install
 


### PR DESCRIPTION
## What

Adds `documentation/docs/mcp/ejentum-mcp.md`, a single tutorial-style page documenting the Ejentum MCP Server as a goose extension. Follows the existing `_template_.mdx` structure and the format used by neighboring entries (agentql-mcp, alby-mcp, etc.). One file added, no other changes.

## Why

The [Ejentum Reasoning Harness](https://github.com/ejentum/ejentum-mcp) is a stdio MCP server that exposes four cognitive harness tools (`harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`). Each call returns a structured cognitive scaffold (failure pattern, executable procedure, suppression vectors, falsification test) the model ingests before generating, addressing attention decay, sycophantic collapse, hallucination drift, and reasoning decay. It runs cleanly as a goose extension via `npx -y ejentum-mcp` with a single `EJENTUM_API_KEY` env var (free tier: 100 calls, no card).

## Page contents

- Quick Install tabs for goose Desktop and goose CLI
- `<GooseDesktopInstaller>` and `<CLIExtensionInstructions>` components configured per the existing template
- A Tools table mapping each of the four harnesses to when an agent should call it
- An Example Usage section with a sunk-cost-trap prompt that produces a visible behavioral diff (baseline anchors on past investment, augmented response separates past spending from prospective evaluation)
- Links to the project repo, free-tier signup, docs, and the underlying research paper

## Validator notes

- Single file change, no other modifications to the repo
- Follows the exact structure of `_template_.mdx`
- Uses canonical MDX components (`<Tabs>`, `<TabItem>`, `<GooseDesktopInstaller>`, `<CLIExtensionInstructions>`)
- Conventional commit format (`docs(mcp): ...`)
- Branch naming convention (`frank/add-ejentum-mcp-extension`)
- Commit is SSH-signed
- Per CONTRIBUTING.md, this is a small first contribution (107 lines, one file, template-following). Happy to revise scope or tone if needed.

## About the project

- Repo: https://github.com/ejentum/ejentum-mcp (MIT, npm `ejentum-mcp@0.1.6`)
- Free tier: https://ejentum.com/pricing (100 calls, no card)
- Walkthrough: https://ejentum.com/docs/claude_code_guide
- Backed by the "Under Pressure" Zenodo preprint (DOI 10.5281/zenodo.19392715)

Maintainer is me; happy to address review feedback.