### PR TITLE
Add/auto slash commands

### DIFF
--- a/crates/goose-server/src/routes/config_management.rs
+++ b/crates/goose-server/src/routes/config_management.rs
@@ -415,7 +415,7 @@ pub struct SlashCommandsQuery {
 pub async fn get_slash_commands(
     axum::extract::Query(query): axum::extract::Query<SlashCommandsQuery>,
 ) -> Result<Json<SlashCommandsResponse>, ErrorResponse> {
-    let mut commands: Vec<_> = slash_commands::list_commands()
+    let mut commands: Vec<_> = slash_commands::list_slash_commands()
         .iter()
         .map(|command| SlashCommand {
             command: command.command.clone(),

--- a/crates/goose-server/src/routes/recipe.rs
+++ b/crates/goose-server/src/routes/recipe.rs
@@ -321,7 +321,7 @@ async fn list_recipes(
         .map(|j| (PathBuf::from(j.source), j.cron))
         .collect();
 
-    let all_commands = slash_commands::list_commands();
+    let all_commands = slash_commands::list_slash_commands();
     let slash_map: HashMap<_, _> = all_commands
         .into_iter()
         .map(|sc| (PathBuf::from(sc.recipe_path), sc.command))

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -2163,7 +2163,7 @@ impl GooseAcpAgent {
     async fn build_available_commands_from_slash_commands() -> Vec<AvailableCommand> {
         let mut commands = Vec::new();
 
-        for mapping in crate::slash_commands::list_commands() {
+        for mapping in crate::slash_commands::list_slash_commands() {
             if Self::is_builtin_agent_command(&mapping.command) {
                 continue;
             }

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -26,22 +26,23 @@ use crate::session::{EnabledExtensionsState, Session, SessionManager};
 use crate::utils::sanitize_unicode_tags;
 use agent_client_protocol::schema::{
     AgentCapabilities, Annotations, AuthMethod, AuthMethodAgent, AuthenticateRequest,
-    AuthenticateResponse, BlobResourceContents, CancelNotification, CloseSessionRequest,
-    CloseSessionResponse, ConfigOptionUpdate, Content, ContentBlock, ContentChunk,
-    CurrentModeUpdate, EmbeddedResource, EmbeddedResourceResource, FileSystemCapabilities,
-    ForkSessionRequest, ForkSessionResponse, ImageContent, InitializeRequest, InitializeResponse,
-    ListSessionsRequest, ListSessionsResponse, LoadSessionRequest, LoadSessionResponse,
-    McpCapabilities, McpServer, Meta, ModelId, ModelInfo, NewSessionRequest, NewSessionResponse,
-    PermissionOption, PermissionOptionKind, PromptCapabilities, PromptRequest, PromptResponse,
-    RequestPermissionOutcome, RequestPermissionRequest, ResourceLink, SessionCapabilities,
-    SessionCloseCapabilities, SessionConfigOption, SessionConfigOptionCategory,
-    SessionConfigSelectOption, SessionId, SessionInfo, SessionInfoUpdate, SessionListCapabilities,
-    SessionMode, SessionModeId, SessionModeState, SessionModelState, SessionNotification,
-    SessionUpdate, SetSessionConfigOptionRequest, SetSessionConfigOptionResponse,
-    SetSessionModeRequest, SetSessionModeResponse, SetSessionModelRequest, SetSessionModelResponse,
-    StopReason, TextContent, TextResourceContents, ToolCall, ToolCallContent, ToolCallId,
-    ToolCallLocation, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind, Usage,
-    UsageUpdate,
+    AuthenticateResponse, AvailableCommand, AvailableCommandInput, AvailableCommandsUpdate,
+    BlobResourceContents, CancelNotification, CloseSessionRequest, CloseSessionResponse,
+    ConfigOptionUpdate, Content, ContentBlock, ContentChunk, CurrentModeUpdate, EmbeddedResource,
+    EmbeddedResourceResource, FileSystemCapabilities, ForkSessionRequest, ForkSessionResponse,
+    ImageContent, InitializeRequest, InitializeResponse, ListSessionsRequest, ListSessionsResponse,
+    LoadSessionRequest, LoadSessionResponse, McpCapabilities, McpServer, Meta, ModelId, ModelInfo,
+    NewSessionRequest, NewSessionResponse, PermissionOption, PermissionOptionKind,
+    PromptCapabilities, PromptRequest, PromptResponse, RequestPermissionOutcome,
+    RequestPermissionRequest, ResourceLink, SessionCapabilities, SessionCloseCapabilities,
+    SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOption, SessionId,
+    SessionInfo, SessionInfoUpdate, SessionListCapabilities, SessionMode, SessionModeId,
+    SessionModeState, SessionModelState, SessionNotification, SessionUpdate,
+    SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, SetSessionModeRequest,
+    SetSessionModeResponse, SetSessionModelRequest, SetSessionModelResponse, StopReason,
+    TextContent, TextResourceContents, ToolCall, ToolCallContent, ToolCallId, ToolCallLocation,
+    ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind, UnstructuredCommandInput,
+    Usage, UsageUpdate,
 };
 use agent_client_protocol::util::MatchDispatchFrom;
 use agent_client_protocol::{
@@ -2145,6 +2146,106 @@ impl GooseAcpAgent {
 
         Ok(())
     }
+
+    fn command_input_hint_from_params(
+        params: Option<&Vec<crate::recipe::RecipeParameter>>,
+    ) -> Option<String> {
+        let params = params?;
+
+        params
+            .iter()
+            .find(|p| p.key == "args")
+            .or_else(|| params.iter().find(|p| p.default.is_none()))
+            .or_else(|| params.first())
+            .map(|p| p.description.clone())
+    }
+
+    async fn build_available_commands_from_slash_commands() -> Vec<AvailableCommand> {
+        let mut commands = Vec::new();
+
+        for mapping in crate::slash_commands::list_commands() {
+            if Self::is_builtin_agent_command(&mapping.command) {
+                continue;
+            }
+
+            let recipe_path = std::path::PathBuf::from(&mapping.recipe_path);
+
+            if !recipe_path.exists() {
+                continue;
+            }
+
+            let Ok(recipe_content) = tokio::fs::read_to_string(&recipe_path).await else {
+                continue;
+            };
+
+            let Some(recipe_dir) = recipe_path.parent() else {
+                continue;
+            };
+
+            let recipe_dir_str = recipe_dir.display().to_string();
+
+            let Ok(validation_result) =
+                crate::recipe::validate_recipe::validate_recipe_template_from_content(
+                    &recipe_content,
+                    Some(recipe_dir_str),
+                )
+            else {
+                continue;
+            };
+
+            let required_param_count = validation_result
+                .parameters
+                .as_ref()
+                .map(|params| params.iter().filter(|p| p.default.is_none()).count())
+                .unwrap_or(0);
+
+            if required_param_count > 1 {
+                continue;
+            }
+
+            let mut command =
+                AvailableCommand::new(mapping.command, validation_result.description.clone());
+
+            if let Some(hint) =
+                Self::command_input_hint_from_params(validation_result.parameters.as_ref())
+            {
+                command = command.input(AvailableCommandInput::Unstructured(
+                    UnstructuredCommandInput::new(hint),
+                ));
+            }
+
+            commands.push(command);
+        }
+
+        commands
+    }
+
+    async fn send_available_commands_update(
+        &self,
+        cx: &ConnectionTo<Client>,
+        session_id: &SessionId,
+    ) -> Result<(), agent_client_protocol::Error> {
+        let commands = Self::build_available_commands_from_slash_commands().await;
+
+        cx.send_notification(SessionNotification::new(
+            session_id.clone(),
+            SessionUpdate::AvailableCommandsUpdate(AvailableCommandsUpdate::new(commands)),
+        ))?;
+
+        Ok(())
+    }
+
+    fn is_builtin_agent_command(command: &str) -> bool {
+        let normalized = command.trim_start_matches('/');
+
+        crate::agents::execute_commands::list_commands()
+            .iter()
+            .any(|cmd| cmd.name == normalized)
+            || crate::agents::execute_commands::COMPACT_TRIGGERS
+                .iter()
+                .filter_map(|trigger| trigger.strip_prefix('/'))
+                .any(|trigger| trigger == normalized)
+    }
 }
 
 fn outcome_to_confirmation(outcome: &RequestPermissionOutcome) -> PermissionConfirmation {
@@ -2411,10 +2512,14 @@ impl GooseAcpAgent {
         }
         if let Some(usage_update) = initial_usage_update {
             cx.send_notification(SessionNotification::new(
-                acp_session_id,
+                acp_session_id.clone(),
                 SessionUpdate::UsageUpdate(usage_update),
             ))?;
         }
+
+        self.send_available_commands_update(cx, &acp_session_id)
+            .await?;
+
         debug!(
             target: "perf",
             sid = %sid,
@@ -2779,6 +2884,10 @@ impl GooseAcpAgent {
                 SessionUpdate::UsageUpdate(usage_update),
             ))?;
         }
+
+        self.send_available_commands_update(cx, &args.session_id)
+            .await?;
+
         debug!(
             target: "perf",
             sid = %sid,
@@ -2804,6 +2913,29 @@ impl GooseAcpAgent {
             .await?;
 
         let user_message = Self::convert_acp_prompt_to_message(&args.prompt);
+
+        let message_text = user_message.as_concat_text();
+        if let Some(parsed) = crate::agents::execute_commands::parse_slash_command(&message_text) {
+            let full_command = format!("/{}", parsed.command);
+
+            if !Self::is_builtin_agent_command(parsed.command) {
+                if let Some(recipe_path) =
+                    crate::slash_commands::get_recipe_for_command(&full_command)
+                {
+                    if recipe_path.exists() {
+                        cx.send_notification(SessionNotification::new(
+                            args.session_id.clone(),
+                            SessionUpdate::AgentMessageChunk(ContentChunk::new(
+                                ContentBlock::Text(TextContent::new(format!(
+                                    "Running recipe: {}",
+                                    full_command
+                                ))),
+                            )),
+                        ))?;
+                    }
+                }
+            }
+        }
 
         let session_config = SessionConfig {
             id: session_id.clone(),
@@ -3248,15 +3380,22 @@ impl GooseAcpAgent {
 
         let meta = session_meta(&new_session);
 
-        let mut response = ForkSessionResponse::new(SessionId::new(new_session_id))
+        let acp_session_id = SessionId::new(new_session_id);
+
+        let mut response = ForkSessionResponse::new(acp_session_id.clone())
             .modes(mode_state)
             .meta(meta);
+
         if let Some(ms) = model_state {
             response = response.models(ms);
         }
         if let Some(co) = config_options {
             response = response.config_options(co);
         }
+
+        self.send_available_commands_update(cx, &acp_session_id)
+            .await?;
+
         Ok(response)
     }
 

--- a/crates/goose/src/agents/execute_commands.rs
+++ b/crates/goose/src/agents/execute_commands.rs
@@ -43,6 +43,34 @@ static COMMANDS: &[CommandDef] = &[
     },
 ];
 
+pub struct ParsedSlashCommand<'a> {
+    pub command: &'a str,
+    pub params_str: &'a str,
+}
+
+pub fn parse_slash_command(message_text: &str) -> Option<ParsedSlashCommand<'_>> {
+    let mut trimmed = message_text.trim();
+
+    if COMPACT_TRIGGERS.contains(&trimmed) {
+        trimmed = COMPACT_TRIGGERS[0];
+    }
+
+    if !trimmed.starts_with('/') {
+        return None;
+    }
+
+    let command_str = trimmed.strip_prefix('/').unwrap_or(trimmed);
+    let (command, params_str) = command_str
+        .split_once(' ')
+        .map(|(cmd, p)| (cmd, p.trim()))
+        .unwrap_or((command_str, ""));
+
+    Some(ParsedSlashCommand {
+        command,
+        params_str,
+    })
+}
+
 pub fn list_commands() -> &'static [CommandDef] {
     COMMANDS
 }
@@ -53,21 +81,12 @@ impl Agent {
         message_text: &str,
         session_id: &str,
     ) -> Result<Option<Message>> {
-        let mut trimmed = message_text.trim().to_string();
-
-        if COMPACT_TRIGGERS.contains(&trimmed.as_str()) {
-            trimmed = COMPACT_TRIGGERS[0].to_string();
-        }
-
-        if !trimmed.starts_with('/') {
+        let Some(parsed) = parse_slash_command(message_text) else {
             return Ok(None);
-        }
+        };
 
-        let command_str = trimmed.strip_prefix('/').unwrap_or(&trimmed);
-        let (command, params_str) = command_str
-            .split_once(' ')
-            .map(|(cmd, p)| (cmd, p.trim()))
-            .unwrap_or((command_str, ""));
+        let command = parsed.command;
+        let params_str = parsed.params_str;
 
         let params: Vec<&str> = if params_str.is_empty() {
             vec![]
@@ -440,5 +459,29 @@ impl Agent {
             .join("\n\n");
 
         Ok(Some(Message::user().with_text(prompt)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_slash_command_splits_on_literal_space() {
+        let parsed = parse_slash_command("/speckit.plan hello world").unwrap();
+
+        assert_eq!(parsed.command, "speckit.plan");
+        assert_eq!(parsed.params_str, "hello world");
+    }
+
+    #[test]
+    fn parse_slash_command_does_not_split_on_tab_or_newline() {
+        let parsed = parse_slash_command("/speckit.plan\thello").unwrap();
+        assert_eq!(parsed.command, "speckit.plan\thello");
+        assert_eq!(parsed.params_str, "");
+
+        let parsed = parse_slash_command("/speckit.plan\nhello").unwrap();
+        assert_eq!(parsed.command, "speckit.plan\nhello");
+        assert_eq!(parsed.params_str, "");
     }
 }

--- a/crates/goose/src/slash_commands.rs
+++ b/crates/goose/src/slash_commands.rs
@@ -1,4 +1,6 @@
-use std::path::PathBuf;
+use std::collections::HashSet;
+use std::env;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -6,8 +8,11 @@ use tracing::warn;
 
 use crate::config::Config;
 use crate::recipe::Recipe;
+use crate::recipe::RECIPE_FILE_EXTENSIONS;
 
 const SLASH_COMMANDS_CONFIG_KEY: &str = "slash_commands";
+const AUTO_SLASH_COMMANDS_CONFIG_KEY: &str = "auto_slash_commands";
+const GOOSE_RECIPE_PATH_ENV_VAR: &str = "GOOSE_RECIPE_PATH";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SlashCommandMapping {
@@ -15,7 +20,19 @@ pub struct SlashCommandMapping {
     pub recipe_path: String,
 }
 
-pub fn list_commands() -> Vec<SlashCommandMapping> {
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AutoSlashCommandsConfig {
+    #[serde(default)]
+    pub from_goose_recipe_path: bool,
+}
+
+fn save_slash_commands(commands: Vec<SlashCommandMapping>) -> Result<()> {
+    Config::global()
+        .set_param(SLASH_COMMANDS_CONFIG_KEY, &commands)
+        .map_err(|e| anyhow::anyhow!("Failed to save slash commands: {}", e))
+}
+
+fn list_explicit_slash_commands() -> Vec<SlashCommandMapping> {
     Config::global()
         .get_param(SLASH_COMMANDS_CONFIG_KEY)
         .unwrap_or_else(|err| {
@@ -27,21 +44,61 @@ pub fn list_commands() -> Vec<SlashCommandMapping> {
         })
 }
 
-fn save_slash_commands(commands: Vec<SlashCommandMapping>) -> Result<()> {
-    Config::global()
-        .set_param(SLASH_COMMANDS_CONFIG_KEY, &commands)
-        .map_err(|e| anyhow::anyhow!("Failed to save slash commands: {}", e))
+fn is_reserved_command_name(command: &str) -> bool {
+    let normalized = command.trim_start_matches('/');
+
+    crate::agents::execute_commands::list_commands()
+        .iter()
+        .any(|cmd| cmd.name == normalized)
+        || crate::agents::execute_commands::COMPACT_TRIGGERS
+            .iter()
+            .filter_map(|trigger| trigger.strip_prefix('/'))
+            .any(|trigger| trigger == normalized)
+}
+
+pub fn list_slash_commands() -> Vec<SlashCommandMapping> {
+    let commands = list_explicit_slash_commands();
+
+    let auto_config: AutoSlashCommandsConfig = Config::global()
+        .get_param(AUTO_SLASH_COMMANDS_CONFIG_KEY)
+        .unwrap_or_default();
+
+    let recipe_dirs = goose_recipe_path_dirs();
+
+    build_slash_commands(commands, &auto_config, &recipe_dirs)
+}
+
+fn build_slash_commands(
+    mut commands: Vec<SlashCommandMapping>,
+    auto_config: &AutoSlashCommandsConfig,
+    recipe_dirs: &[PathBuf],
+) -> Vec<SlashCommandMapping> {
+    if auto_config.from_goose_recipe_path {
+        extend_from_recipe_dirs(&mut commands, recipe_dirs);
+    }
+
+    commands.retain(|mapping| !is_reserved_command_name(&mapping.command));
+    commands
 }
 
 pub fn set_recipe_slash_command(recipe_path: PathBuf, command: Option<String>) -> Result<()> {
+    // Does not allow registering reserved command names as slash commands.
     let recipe_path_str = recipe_path.to_string_lossy().to_string();
 
-    let mut commands = list_commands();
+    let mut commands = list_explicit_slash_commands();
     commands.retain(|mapping| mapping.recipe_path != recipe_path_str);
 
     if let Some(cmd) = command {
-        let normalized_cmd = cmd.trim_start_matches('/').to_lowercase();
+        let normalized_cmd = normalize_command(&cmd);
+
         if !normalized_cmd.is_empty() {
+            if is_reserved_command_name(&normalized_cmd) {
+                anyhow::bail!(
+                    "Slash command '{}' conflicts with a built-in command",
+                    normalized_cmd
+                );
+            }
+
             commands.push(SlashCommandMapping {
                 command: normalized_cmd,
                 recipe_path: recipe_path_str,
@@ -52,9 +109,116 @@ pub fn set_recipe_slash_command(recipe_path: PathBuf, command: Option<String>) -
     save_slash_commands(commands)
 }
 
+fn extend_from_recipe_dirs(commands: &mut Vec<SlashCommandMapping>, dirs: &[PathBuf]) {
+    let mut seen: HashSet<String> = commands
+        .iter()
+        .map(|mapping| normalize_command(&mapping.command))
+        .collect();
+
+    for dir in dirs {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            continue;
+        };
+
+        let mut paths = entries
+            .flatten()
+            .map(|entry| entry.path())
+            .collect::<Vec<_>>();
+
+        paths.sort();
+
+        for path in paths {
+            if !is_supported_slash_command_recipe(&path) {
+                continue;
+            }
+
+            let Some(command) = command_from_recipe_path(&path) else {
+                continue;
+            };
+
+            let normalized = normalize_command(&command);
+
+            if !seen.insert(normalized.clone()) {
+                continue;
+            }
+
+            commands.push(SlashCommandMapping {
+                command: normalized,
+                recipe_path: path.to_string_lossy().to_string(),
+            });
+        }
+    }
+}
+
+fn goose_recipe_path_dirs() -> Vec<PathBuf> {
+    let Ok(recipe_path_env) = env::var(GOOSE_RECIPE_PATH_ENV_VAR) else {
+        return Vec::new();
+    };
+
+    let path_separator = if cfg!(windows) { ';' } else { ':' };
+
+    recipe_path_env
+        .split(path_separator)
+        .filter(|path| !path.trim().is_empty())
+        .map(PathBuf::from)
+        .collect()
+}
+
+fn is_supported_slash_command_recipe(path: &Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+
+    let Some(extension) = path.extension().and_then(|ext| ext.to_str()) else {
+        return false;
+    };
+
+    if !RECIPE_FILE_EXTENSIONS.contains(&extension) {
+        return false;
+    }
+
+    let Ok(recipe_content) = std::fs::read_to_string(path) else {
+        return false;
+    };
+
+    let Some(recipe_dir) = path.parent() else {
+        return false;
+    };
+
+    let recipe_dir_str = recipe_dir.display().to_string();
+
+    let Ok(validation_result) =
+        crate::recipe::validate_recipe::validate_recipe_template_from_content(
+            &recipe_content,
+            Some(recipe_dir_str),
+        )
+    else {
+        return false;
+    };
+
+    let required_param_count = validation_result
+        .parameters
+        .as_ref()
+        .map(|params| params.iter().filter(|p| p.default.is_none()).count())
+        .unwrap_or(0);
+
+    required_param_count <= 1
+}
+
+fn command_from_recipe_path(path: &Path) -> Option<String> {
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .map(normalize_command)
+}
+
+fn normalize_command(command: &str) -> String {
+    command.trim_start_matches('/').to_lowercase()
+}
+
 pub fn get_recipe_for_command(command: &str) -> Option<PathBuf> {
-    let normalized = command.trim_start_matches('/').to_lowercase();
-    let commands = list_commands();
+    let normalized = normalize_command(command);
+    let commands = list_slash_commands();
+
     commands
         .into_iter()
         .find(|mapping| mapping.command == normalized)
@@ -71,4 +235,212 @@ pub fn resolve_slash_command(command: &str) -> Option<Recipe> {
     let recipe = Recipe::from_content(&recipe_content).ok()?;
 
     Some(recipe)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn mapping(command: &str, recipe_path: &str) -> SlashCommandMapping {
+        SlashCommandMapping {
+            command: command.to_string(),
+            recipe_path: recipe_path.to_string(),
+        }
+    }
+
+    fn valid_recipe(title: &str) -> String {
+        format!(
+            r#"
+version: "1.0.0"
+title: "{title}"
+description: "Test recipe"
+parameters:
+  - key: args
+    input_type: string
+    requirement: optional
+    description: "User input"
+    default: ""
+prompt: "Run test recipe with {{{{ args }}}}"
+"#
+        )
+    }
+
+    fn recipe_with_two_required_params() -> String {
+        r#"
+version: "1.0.0"
+title: "Unsupported"
+description: "Unsupported recipe"
+prompt: "Run unsupported recipe"
+parameters:
+  - key: first
+    input_type: string
+    requirement: required
+    description: "First input"
+  - key: second
+    input_type: string
+    requirement: required
+    description: "Second input"
+"#
+        .to_string()
+    }
+
+    #[test]
+    fn auto_slash_commands_disabled_does_not_discover_recipes() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("speckit.plan.yaml"), valid_recipe("Plan")).unwrap();
+
+        let commands = build_slash_commands(
+            Vec::new(),
+            &AutoSlashCommandsConfig {
+                from_goose_recipe_path: false,
+            },
+            &[dir.path().to_path_buf()],
+        );
+
+        assert!(commands.is_empty());
+    }
+
+    #[test]
+    fn auto_slash_commands_discovers_supported_recipe_files() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("speckit.plan.yaml"), valid_recipe("Plan")).unwrap();
+        fs::write(
+            dir.path().join("daily-report.json"),
+            valid_recipe("Daily Report"),
+        )
+        .unwrap();
+        fs::write(dir.path().join("notes.txt"), "not a recipe").unwrap();
+
+        let commands = build_slash_commands(
+            Vec::new(),
+            &AutoSlashCommandsConfig {
+                from_goose_recipe_path: true,
+            },
+            &[dir.path().to_path_buf()],
+        );
+
+        let names = commands
+            .iter()
+            .map(|m| m.command.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(names.contains(&"speckit.plan"));
+        assert!(names.contains(&"daily-report"));
+        assert!(!names.contains(&"notes"));
+    }
+
+    #[test]
+    fn auto_slash_commands_excludes_recipes_with_multiple_required_parameters() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("unsupported.yaml"),
+            recipe_with_two_required_params(),
+        )
+        .unwrap();
+
+        let commands = build_slash_commands(
+            Vec::new(),
+            &AutoSlashCommandsConfig {
+                from_goose_recipe_path: true,
+            },
+            &[dir.path().to_path_buf()],
+        );
+
+        assert!(commands.is_empty());
+    }
+
+    #[test]
+    fn explicit_slash_commands_take_precedence_over_auto_discovered_commands() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("speckit.plan.yaml"),
+            valid_recipe("Auto Plan"),
+        )
+        .unwrap();
+
+        let explicit_path = "/explicit/speckit.plan.yaml";
+        let commands = build_slash_commands(
+            vec![mapping("speckit.plan", explicit_path)],
+            &AutoSlashCommandsConfig {
+                from_goose_recipe_path: true,
+            },
+            &[dir.path().to_path_buf()],
+        );
+
+        let matches = commands
+            .iter()
+            .filter(|m| m.command == "speckit.plan")
+            .collect::<Vec<_>>();
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].recipe_path, explicit_path);
+    }
+
+    #[test]
+    fn auto_slash_commands_normalizes_file_stems_to_lowercase() {
+        let dir = tempdir().unwrap();
+
+        // ###########################################################
+        let path = dir.path().join("speckit.plan.yaml");
+        fs::write(&path, valid_recipe("Plan")).unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        let result = crate::recipe::validate_recipe::validate_recipe_template_from_content(
+            &content,
+            Some(dir.path().display().to_string()),
+        );
+
+        assert!(result.is_ok(), "{result:?}");
+        // ###########################################################
+        fs::write(dir.path().join("Speckit.Plan.yaml"), valid_recipe("Plan")).unwrap();
+
+        let commands = build_slash_commands(
+            Vec::new(),
+            &AutoSlashCommandsConfig {
+                from_goose_recipe_path: true,
+            },
+            &[dir.path().to_path_buf()],
+        );
+
+        assert_eq!(commands[0].command, "speckit.plan");
+    }
+
+    #[test]
+    fn auto_slash_commands_uses_deterministic_order_before_deduping() {
+        let dir = tempdir().unwrap();
+        let json_path = dir.path().join("build.json");
+        let yaml_path = dir.path().join("build.yaml");
+
+        fs::write(&yaml_path, valid_recipe("Build YAML")).unwrap();
+        fs::write(&json_path, valid_recipe("Build JSON")).unwrap();
+
+        let commands = build_slash_commands(
+            Vec::new(),
+            &AutoSlashCommandsConfig {
+                from_goose_recipe_path: true,
+            },
+            &[dir.path().to_path_buf()],
+        );
+
+        let build = commands.iter().find(|m| m.command == "build").unwrap();
+
+        // Paths are sorted before first-seen-wins dedupe, so build.json wins
+        // lexicographically over build.yaml.
+        assert_eq!(PathBuf::from(&build.recipe_path), json_path);
+    }
+
+    #[test]
+    fn reserved_command_names_are_filtered_from_effective_slash_commands() {
+        let commands = build_slash_commands(
+            vec![mapping("compact", "/explicit/compact.yaml")],
+            &AutoSlashCommandsConfig {
+                from_goose_recipe_path: false,
+            },
+            &[],
+        );
+
+        assert!(commands.is_empty());
+    }
 }

--- a/documentation/docs/guides/context-engineering/slash-commands.md
+++ b/documentation/docs/guides/context-engineering/slash-commands.md
@@ -46,6 +46,37 @@ slash_commands:
    </TabItem>
 </Tabs>
 
+## Automatically Load Commands from `GOOSE_RECIPE_PATH`
+
+You can automatically expose recipes in `GOOSE_RECIPE_PATH` as slash commands:
+
+```yaml
+auto_slash_commands:
+  from_goose_recipe_path: true
+```
+
+Each recipe file in `GOOSE_RECIPE_PATH` becomes a slash command using the recipe filename (without the extension):
+
+```text
+recipes/
+├── run-tests.yaml
+├── daily-report.yaml
+└── translate.json
+```
+
+Becomes:
+
+```text
+/run-tests
+/daily-report
+/translate
+```
+
+This is especially useful for editor integrations and project-local recipe collections that dynamically set `GOOSE_RECIPE_PATH`.
+
+Explicit `slash_commands` entries take precedence over automatically discovered commands.
+
+
 ## Use Slash Commands
 
 In any chat session, type your custom command with a leading slash at the start of your message:


### PR DESCRIPTION
# Auto-discover slash commands from `GOOSE_RECIPE_PATH`

## Summary

Adds an optional `auto_slash_commands.from_goose_recipe_path` config setting that automatically exposes recipes in `GOOSE_RECIPE_PATH` as slash commands using their filename stem.

Example:

```yaml
auto_slash_commands:
  from_goose_recipe_path: true
```

With:

```text
GOOSE_RECIPE_PATH=/project/.goose/recipes
```

and:

```text
recipes/
├── speckit.plan.yaml
├── speckit.tasks.yaml
└── daily-report.json
```

the following commands become available automatically:

```text
/speckit.plan
/speckit.tasks
/daily-report
```

## Motivation

This improves project-local recipe workflows and ACP/editor integrations that dynamically configure `GOOSE_RECIPE_PATH`.

Without autodiscovery, every project recipe must also be manually duplicated in `slash_commands`, which can become repetitive and difficult to maintain for repositories with larger recipe collections.

## Behavior

* Auto-discovery is opt-in
* Recipe command names are derived from the filename stem
* Only files matching `RECIPE_FILE_EXTENSIONS` are considered
* Explicit `slash_commands` entries take precedence over auto-discovered commands
* Reserved built-in command names are filtered from the effective slash command list
* Reserved names are rejected by `set_recipe_slash_command`

## Internal changes

* Split persisted explicit mappings from effective runtime mappings:

  * `list_explicit_slash_commands()`
  * `list_slash_commands()`
* Added runtime expansion of commands from `GOOSE_RECIPE_PATH`
* Added reserved command filtering
* Added unit tests covering:

  * autodiscovery enable/disable behavior
  * extension filtering
  * precedence rules
  * normalization
  * reserved command filtering

## Documentation

Updated the slash commands documentation with:

* `auto_slash_commands.from_goose_recipe_path`
* examples of automatic command generation from recipe filenames
