### PR TITLE
fix: deduplicate tool_result blocks to prevent LLM API 400 errors

### DIFF
--- a/crates/goose/src/conversation/mod.rs
+++ b/crates/goose/src/conversation/mod.rs
@@ -208,6 +208,7 @@ fn fix_messages(messages: Vec<Message>) -> (Vec<Message>, Vec<String>) {
         fix_empty_tool_results,
         fix_tool_calling,
         merge_consecutive_messages,
+        deduplicate_tool_responses,
         fix_lead_trail,
         populate_if_empty,
     ]
@@ -461,6 +462,55 @@ pub fn merge_consecutive_messages(messages: Vec<Message>) -> (Vec<Message>, Vec<
     }
 
     (merged_messages, issues)
+}
+
+/// Deduplicate tool responses that share the same tool_use ID within a single message.
+///
+/// This can happen when `merge_consecutive_messages` combines two user/tool messages
+/// that both contain a ToolResponse for the same ID, or after session compaction /
+/// restore from storage. LLM APIs (Anthropic, Databricks) reject conversations that
+/// contain multiple `tool_result` blocks for the same `tool_use` ID.
+///
+/// When duplicates are found, the **last** response for each ID is kept (matching the
+/// deduplication strategy used by kgoose).
+fn deduplicate_tool_responses(messages: Vec<Message>) -> (Vec<Message>, Vec<String>) {
+    let mut issues = Vec::new();
+
+    let fixed_messages = messages
+        .into_iter()
+        .map(|mut message| {
+            // Only user-role messages carry tool responses
+            if message.role != Role::User {
+                return message;
+            }
+
+            let mut seen_response_ids = HashSet::new();
+            let mut indices_to_remove = Vec::new();
+
+            // Walk in reverse so the *last* response for each ID survives
+            for (idx, content) in message.content.iter().enumerate().rev() {
+                if let MessageContent::ToolResponse(resp) = content {
+                    if !seen_response_ids.insert(resp.id.clone()) {
+                        indices_to_remove.push(idx);
+                        issues.push(format!(
+                            "Removed duplicate tool response '{}'",
+                            resp.id
+                        ));
+                    }
+                }
+            }
+
+            // Remove from highest index first to preserve lower indices
+            indices_to_remove.sort_unstable();
+            for &idx in indices_to_remove.iter().rev() {
+                message.content.remove(idx);
+            }
+
+            message
+        })
+        .collect();
+
+    (fixed_messages, issues)
 }
 
 fn has_tool_response(message: &Message) -> bool {
@@ -1253,5 +1303,198 @@ mod tests {
 
         assert_eq!(fixed_messages[5].as_concat_text(), "Non-vis C");
         assert!(!fixed_messages[5].metadata.agent_visible);
+    }
+
+    #[test]
+    fn test_duplicate_tool_responses_are_deduplicated() {
+        use rmcp::model::Content;
+
+        // Simulate what happens when merge_consecutive_messages combines two
+        // user/tool messages that both carry a ToolResponse for the same ID.
+        let messages = vec![
+            Message::user().with_text("Help me search"),
+            Message::assistant().with_tool_request(
+                "tool_1",
+                Ok(CallToolRequestParams::new("web_search")
+                    .with_arguments(object!({"query": "rust"}))),
+            ),
+            // A single user message with TWO tool responses for the same ID
+            // (as would result from merge_consecutive_messages)
+            Message::user()
+                .with_tool_response(
+                    "tool_1",
+                    Ok(rmcp::model::CallToolResult::success(vec![Content::text(
+                        "First result",
+                    )])),
+                )
+                .with_tool_response(
+                    "tool_1",
+                    Ok(rmcp::model::CallToolResult::success(vec![Content::text(
+                        "Second result",
+                    )])),
+                ),
+        ];
+
+        let (fixed, issues) = run_verify(messages);
+
+        // Should have removed the duplicate
+        assert!(
+            issues.iter().any(|i| i.contains("duplicate tool response")),
+            "Expected a 'duplicate tool response' issue, got: {:?}",
+            issues
+        );
+
+        // The user message should have exactly one ToolResponse for tool_1
+        let tool_msg = fixed.last().unwrap();
+        let response_count = tool_msg
+            .content
+            .iter()
+            .filter(|c| matches!(c, MessageContent::ToolResponse(r) if r.id == "tool_1"))
+            .count();
+        assert_eq!(
+            response_count, 1,
+            "Expected exactly 1 tool response for tool_1, found {}",
+            response_count
+        );
+
+        // The kept response should be the LAST one ("Second result")
+        let kept_response = tool_msg
+            .content
+            .iter()
+            .find_map(|c| {
+                if let MessageContent::ToolResponse(r) = c {
+                    if r.id == "tool_1" {
+                        return Some(r);
+                    }
+                }
+                None
+            })
+            .expect("Should have a tool response");
+        let text = kept_response
+            .tool_result
+            .as_ref()
+            .unwrap()
+            .content
+            .iter()
+            .filter_map(|c| c.as_text().map(|t| t.text.clone()))
+            .collect::<Vec<_>>()
+            .join("");
+        assert_eq!(text, "Second result", "Should keep the last response");
+    }
+
+    #[test]
+    fn test_duplicate_tool_responses_across_merged_messages() {
+        use rmcp::model::Content;
+
+        // Simulate two consecutive user messages with tool responses for the
+        // same ID — merge_consecutive_messages will combine them, then
+        // deduplicate_tool_responses should clean up.
+        let messages = vec![
+            Message::user().with_text("Help me search"),
+            Message::assistant().with_tool_request(
+                "tool_1",
+                Ok(CallToolRequestParams::new("web_search")
+                    .with_arguments(object!({"query": "rust"}))),
+            ),
+            Message::user().with_tool_response(
+                "tool_1",
+                Ok(rmcp::model::CallToolResult::success(vec![Content::text(
+                    "First result",
+                )])),
+            ),
+            // A second consecutive user message with the same tool response ID
+            Message::user().with_tool_response(
+                "tool_1",
+                Ok(rmcp::model::CallToolResult::success(vec![Content::text(
+                    "Duplicate result",
+                )])),
+            ),
+        ];
+
+        let (fixed, issues) = run_verify(messages);
+
+        // Should have merged the consecutive messages AND deduplicated
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.contains("duplicate tool response")),
+            "Expected a 'duplicate tool response' issue, got: {:?}",
+            issues
+        );
+
+        // Verify only one tool response remains
+        let tool_msg = fixed.last().unwrap();
+        let response_count = tool_msg
+            .content
+            .iter()
+            .filter(|c| matches!(c, MessageContent::ToolResponse(r) if r.id == "tool_1"))
+            .count();
+        assert_eq!(
+            response_count, 1,
+            "Expected exactly 1 tool response for tool_1 after dedup, found {}",
+            response_count
+        );
+    }
+
+    #[test]
+    fn test_no_false_positive_dedup_for_different_tool_ids() {
+        use rmcp::model::Content;
+
+        // Two different tool responses with different IDs should NOT be deduplicated
+        let messages = vec![
+            Message::user().with_text("Help me search"),
+            Message::assistant()
+                .with_tool_request(
+                    "tool_1",
+                    Ok(CallToolRequestParams::new("web_search")
+                        .with_arguments(object!({"query": "rust"}))),
+                )
+                .with_tool_request(
+                    "tool_2",
+                    Ok(CallToolRequestParams::new("file_read")
+                        .with_arguments(object!({"path": "/tmp/test"}))),
+                ),
+            Message::user()
+                .with_tool_response(
+                    "tool_1",
+                    Ok(rmcp::model::CallToolResult::success(vec![Content::text(
+                        "Search result",
+                    )])),
+                )
+                .with_tool_response(
+                    "tool_2",
+                    Ok(rmcp::model::CallToolResult::success(vec![Content::text(
+                        "File content",
+                    )])),
+                ),
+        ];
+
+        let (fixed, issues) = run_verify(messages);
+
+        // Should have no dedup issues
+        assert!(
+            !issues
+                .iter()
+                .any(|i| i.contains("duplicate tool response")),
+            "Should not deduplicate different tool IDs, but got: {:?}",
+            issues
+        );
+
+        // Both responses should be present
+        let tool_msg = fixed.last().unwrap();
+        let response_ids: Vec<&str> = tool_msg
+            .content
+            .iter()
+            .filter_map(|c| {
+                if let MessageContent::ToolResponse(r) = c {
+                    Some(r.id.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(response_ids.len(), 2);
+        assert!(response_ids.contains(&"tool_1"));
+        assert!(response_ids.contains(&"tool_2"));
     }
 }

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -110,6 +110,10 @@ const EVENT_CONTENT_BLOCK_STOP: &str = "content_block_stop";
 /// Convert internal Message format to Anthropic's API message specification
 pub fn format_messages(messages: &[Message]) -> Vec<Value> {
     let mut anthropic_messages = Vec::new();
+    // Track emitted tool response IDs to prevent duplicate tool_result blocks.
+    // The Anthropic API rejects conversations with multiple tool_result blocks
+    // for the same tool_use ID.
+    let mut emitted_tool_response_ids = std::collections::HashSet::new();
 
     for message in messages {
         let role = match message.role {
@@ -144,41 +148,45 @@ pub fn format_messages(messages: &[Message]) -> Vec<Value> {
                         }
                     }
                 }
-                MessageContent::ToolResponse(tool_response) => match &tool_response.tool_result {
-                    Ok(result) => {
-                        let text = result
-                            .content
-                            .iter()
-                            .filter_map(|c| {
-                                if let Some(t) = c.as_text() {
-                                    return Some(t.text.clone());
-                                }
-                                if let Some(r) = c.as_resource() {
-                                    let text = extract_text_from_resource(&r.resource);
-                                    if !text.is_empty() {
-                                        return Some(text);
-                                    }
-                                }
-                                None
-                            })
-                            .collect::<Vec<_>>()
-                            .join("\n");
+                MessageContent::ToolResponse(tool_response) => {
+                    if emitted_tool_response_ids.insert(tool_response.id.clone()) {
+                        match &tool_response.tool_result {
+                            Ok(result) => {
+                                let text = result
+                                    .content
+                                    .iter()
+                                    .filter_map(|c| {
+                                        if let Some(t) = c.as_text() {
+                                            return Some(t.text.clone());
+                                        }
+                                        if let Some(r) = c.as_resource() {
+                                            let text = extract_text_from_resource(&r.resource);
+                                            if !text.is_empty() {
+                                                return Some(text);
+                                            }
+                                        }
+                                        None
+                                    })
+                                    .collect::<Vec<_>>()
+                                    .join("\n");
 
-                        content.push(json!({
-                            TYPE_FIELD: TOOL_RESULT_TYPE,
-                            TOOL_USE_ID_FIELD: tool_response.id,
-                            CONTENT_FIELD: text
-                        }));
+                                content.push(json!({
+                                    TYPE_FIELD: TOOL_RESULT_TYPE,
+                                    TOOL_USE_ID_FIELD: tool_response.id,
+                                    CONTENT_FIELD: text
+                                }));
+                            }
+                            Err(tool_error) => {
+                                content.push(json!({
+                                    TYPE_FIELD: TOOL_RESULT_TYPE,
+                                    TOOL_USE_ID_FIELD: tool_response.id,
+                                    CONTENT_FIELD: format!("Error: {}", tool_error),
+                                    IS_ERROR_FIELD: true
+                                }));
+                            }
+                        }
                     }
-                    Err(tool_error) => {
-                        content.push(json!({
-                            TYPE_FIELD: TOOL_RESULT_TYPE,
-                            TOOL_USE_ID_FIELD: tool_response.id,
-                            CONTENT_FIELD: format!("Error: {}", tool_error),
-                            IS_ERROR_FIELD: true
-                        }));
-                    }
-                },
+                }
                 MessageContent::ToolConfirmationRequest(_tool_confirmation_request) => {
                     // Skip tool confirmation requests
                 }

--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -108,6 +108,10 @@ fn format_tool_response(
 ///   even though the message structure is otherwise following openai, the enum switches this
 fn format_messages(messages: &[Message], image_format: &ImageFormat) -> Vec<DatabricksMessage> {
     let mut result = Vec::new();
+    // Track emitted tool response IDs to prevent duplicate tool_result blocks.
+    // The Anthropic API (via Databricks) rejects conversations with multiple
+    // tool_result blocks for the same tool_use ID.
+    let mut emitted_tool_response_ids = std::collections::HashSet::new();
     for message in messages {
         let mut converted = DatabricksMessage {
             content: Value::Null,
@@ -188,7 +192,9 @@ fn format_messages(messages: &[Message], image_format: &ImageFormat) -> Vec<Data
                     }
                 }
                 MessageContent::ToolResponse(response) => {
-                    result.extend(format_tool_response(response, image_format));
+                    if emitted_tool_response_ids.insert(response.id.clone()) {
+                        result.extend(format_tool_response(response, image_format));
+                    }
                 }
                 MessageContent::Image(image) => {
                     content_array.push(convert_image(image, image_format));


### PR DESCRIPTION
## Problem

When using Goose with the Databricks provider (or direct Anthropic), long sessions with many tool calls can fail with:

```
HTTP 400: each tool_use must have a single result. Found multiple tool_result blocks with id: <id>
```

The Anthropic API requires **exactly one `tool_result` per `tool_use`**, but Goose can produce duplicate `tool_result` blocks for the same `tool_use` ID.

## Root Cause

Duplicates enter the conversation history through several paths:

1. **`merge_consecutive_messages()`** — combines two consecutive user/tool messages that both contain a `ToolResponse` for the same ID into a single message with duplicate responses
2. **Session compaction** — can reconstruct the conversation with duplicates during context window management
3. **Session restore from SQLite** — can produce duplicate entries, especially after interrupted tool calls

The existing `fix_tool_calling()` processor handles **orphaned** tool responses (no matching request) but does not deduplicate responses that share the same `tool_use` ID.

Neither the Databricks nor Anthropic message formatters (`format_messages()`) check for duplicates — they blindly emit a `tool`/`tool_result` block for every `ToolResponse` in the message content.

Note: Other Goose frontends (kgoose backend, goosed-slackbot, sales-bridge) already have their own dedup logic for this exact issue. The goosed core was the missing piece.

## Fix

### 1. New `deduplicate_tool_responses()` processor (primary fix)

Added to the `fix_messages` pipeline, running **after** `merge_consecutive_messages` (which is the main source of duplicates). For each user message, it:
- Walks content items in reverse order
- Tracks seen tool response IDs in a `HashSet`
- Removes earlier duplicates, keeping the **last** response for each ID (matching kgoose's dedup strategy)

### 2. Defense-in-depth in formatters

Added `HashSet`-based dedup in both `databricks.rs` and `anthropic.rs` `format_messages()` functions, so even if a duplicate somehow survives the conversation pipeline, it won't be sent to the API.

## Tests

Three new tests in `conversation/mod.rs`:

| Test | Scenario |
|------|----------|
| `test_duplicate_tool_responses_are_deduplicated` | Two `ToolResponse` items with the same ID in a single message — verifies the last one is kept |
| `test_duplicate_tool_responses_across_merged_messages` | Two consecutive user messages with the same tool response ID — verifies merge + dedup work together |
| `test_no_false_positive_dedup_for_different_tool_ids` | Two different tool IDs in the same message — verifies they are NOT deduplicated |

## Files Changed

- `crates/goose/src/conversation/mod.rs` — new `deduplicate_tool_responses()` processor + 3 tests
- `crates/goose/src/providers/formats/databricks.rs` — defense-in-depth dedup in `format_messages()`
- `crates/goose/src/providers/formats/anthropic.rs` — defense-in-depth dedup in `format_messages()`