### PR TITLE
feat(analyze): add Elixir support and clarify tool description

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4467,6 +4467,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "tree-sitter",
+ "tree-sitter-elixir",
  "tree-sitter-go",
  "tree-sitter-java",
  "tree-sitter-javascript",
@@ -11096,6 +11097,16 @@ dependencies = [
  "regex-syntax",
  "serde_json",
  "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-elixir"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66dd064a762ed95bfc29857fa3cb7403bb1e5cb88112de0f6341b7e47284ba40"
+dependencies = [
+ "cc",
  "tree-sitter-language",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ tracing-opentelemetry = "0.32"
 
 rayon = "1.12"
 tree-sitter = "0.26"
+tree-sitter-elixir = "0.3.5"
 tree-sitter-go = "0.25"
 tree-sitter-java = "0.23"
 tree-sitter-javascript = "0.25"

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -170,6 +170,7 @@ indexmap = "2.14.0"
 ignore = { workspace = true }
 rayon = { workspace = true }
 tree-sitter = { workspace = true }
+tree-sitter-elixir = { workspace = true }
 tree-sitter-go = { workspace = true }
 tree-sitter-java = { workspace = true }
 tree-sitter-javascript = { workspace = true }

--- a/crates/goose/src/agents/platform_extensions/analyze/languages.rs
+++ b/crates/goose/src/agents/platform_extensions/analyze/languages.rs
@@ -319,6 +319,57 @@ static LANGUAGES: &[LangInfo] = &[
             "#,
         },
     },
+    LangInfo {
+        name: "elixir",
+        extensions: &["ex", "exs"],
+        language: || tree_sitter_elixir::LANGUAGE.into(),
+        // Elixir's tree-sitter grammar represents `def`/`defmodule` as `call` nodes,
+        // the same type as regular function calls. Empty fn_kinds/class_kinds disables
+        // enclosing-context attribution in call graphs; semantic mode (function/module/import
+        // listing) works fully via the queries below.
+        fn_kinds: &[],
+        fn_name_kinds: &[],
+        class_kinds: &[],
+        queries: LangQueries {
+            functions: r#"
+                (call
+                  target: (identifier) @_ignore
+                  (arguments
+                    [
+                      (identifier) @name
+                      (call target: (identifier) @name)
+                      (binary_operator
+                        left: (call target: (identifier) @name)
+                        operator: "when")
+                    ])
+                  (#any-of? @_ignore "def" "defp" "defdelegate" "defguard" "defguardp" "defmacro" "defmacrop" "defn" "defnp"))
+            "#,
+            classes: r#"
+                (call
+                  target: (identifier) @_ignore
+                  (arguments (alias) @name)
+                  (#any-of? @_ignore "defmodule" "defprotocol"))
+            "#,
+            imports: r#"
+                (call
+                  target: (identifier) @_method
+                  (arguments . (_) @path)
+                  (#any-of? @_method "import" "alias" "require" "use"))
+            "#,
+            calls: r#"
+                (call target: (identifier) @name
+                     (#not-any-of? @name
+                          "def" "defdelegate" "defexception" "defguard" "defguardp"
+                          "defimpl" "defmacro" "defmacrop" "defmodule" "defn" "defnp"
+                          "defoverridable" "defp" "defprotocol" "defstruct"
+                          "alias" "case" "cond" "else" "for" "if" "import" "quote"
+                          "raise" "receive" "require" "reraise" "super" "throw"
+                          "try" "unless" "unquote" "unquote_splicing" "use" "with"))
+                (call target: (dot right: (identifier) @name))
+                (binary_operator operator: "|>" right: (identifier) @name)
+            "#,
+        },
+    },
 ];
 
 pub fn lang_for_ext(ext: &str) -> Option<&'static LangInfo> {

--- a/crates/goose/src/agents/platform_extensions/analyze/languages.rs
+++ b/crates/goose/src/agents/platform_extensions/analyze/languages.rs
@@ -350,7 +350,7 @@ static LANGUAGES: &[LangInfo] = &[
                 (call
                   target: (identifier) @_ignore
                   (arguments (alias) @name)
-                  (#any-of? @_ignore "defmodule" "defprotocol"))
+                  (#any-of? @_ignore "defmodule" "defprotocol" "defimpl"))
             "#,
             imports: r#"
                 (call

--- a/crates/goose/src/agents/platform_extensions/analyze/languages.rs
+++ b/crates/goose/src/agents/platform_extensions/analyze/languages.rs
@@ -323,13 +323,15 @@ static LANGUAGES: &[LangInfo] = &[
         name: "elixir",
         extensions: &["ex", "exs"],
         language: || tree_sitter_elixir::LANGUAGE.into(),
-        // Elixir's tree-sitter grammar represents `def`/`defmodule` as `call` nodes,
-        // the same type as regular function calls. Empty fn_kinds/class_kinds disables
-        // enclosing-context attribution in call graphs; semantic mode (function/module/import
-        // listing) works fully via the queries below.
-        fn_kinds: &[],
+        // Elixir's tree-sitter grammar represents `def`/`defmodule` as `call` nodes
+        // (target: (identifier "def" | "defp" | ...)), the same kind as regular
+        // function calls. `find_enclosing_fn` therefore special-cases "call" for
+        // Elixir below: it walks up to a `call`, confirms the target identifier
+        // is a def-style macro, and pulls the function name out of the arguments
+        // shape (identifier / call target / binary_operator "when").
+        fn_kinds: &["call"],
         fn_name_kinds: &[],
-        class_kinds: &[],
+        class_kinds: &["call"],
         queries: LangQueries {
             functions: r#"
                 (call

--- a/crates/goose/src/agents/platform_extensions/analyze/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/analyze/mod.rs
@@ -439,6 +439,41 @@ fn helper() { validate(0); }
         assert!(format::check_size(&big, true).is_ok());
     }
 
+    #[test]
+    fn elixir_module_attributes_not_captured_as_calls() {
+        let tmp = tempdir().unwrap();
+        let file = tmp.path().join("attrs.ex");
+        fs::write(
+            &file,
+            r#"defmodule Attrs do
+  @moduledoc "module doc"
+  @doc "fn doc"
+  @spec foo() :: :ok
+  def foo do
+    bar()
+  end
+
+  def bar, do: :ok
+end
+"#,
+        )
+        .unwrap();
+
+        let analysis =
+            AnalyzeClient::analyze_file(&file).expect("analyze_file should return an analysis");
+        let callees: Vec<String> = analysis.calls.iter().map(|c| c.callee.clone()).collect();
+        for attr in ["moduledoc", "doc", "spec"] {
+            assert!(
+                !callees.iter().any(|c| c == attr),
+                "module attribute @{attr} leaked into calls (callees: {callees:?})"
+            );
+        }
+        assert!(
+            callees.iter().any(|c| c == "bar"),
+            "expected `bar` call from inside `foo` (callees: {callees:?})"
+        );
+    }
+
     #[tokio::test]
     async fn elixir_function_parent_is_module() {
         let tmp = tempdir().unwrap();

--- a/crates/goose/src/agents/platform_extensions/analyze/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/analyze/mod.rs
@@ -60,7 +60,7 @@ impl AnalyzeClient {
             .with_instructions(indoc! {"
             Analyze code structure using tree-sitter AST parsing. Three auto-selected modes:
             - Directory path → structure overview (file tree with function/class counts)
-            - File path → semantic details (functions, classes, imports, call counts)
+            - File path → AST symbol details (functions, classes, imports — not for raw file reading; use shell cat for that)
             - Any path + focus parameter → symbol call graph (incoming/outgoing chains)
 
             For large codebases, delegate analysis to a subagent and retain only the summary.
@@ -215,7 +215,7 @@ impl McpClientTrait for AnalyzeClient {
     ) -> Result<ListToolsResult, Error> {
         let tool = Tool::new(
             "analyze".to_string(),
-            "Analyze code structure in 3 modes: 1) Directory overview - file tree with LOC/function/class counts to max_depth. 2) File details - functions, classes, imports. 3) Symbol focus - call graphs across directory to max_depth (requires file or directory path, case-sensitive). Typical flow: directory → files → symbols. Functions called >3x show •N.".to_string(),
+            "Analyze code structure via AST parsing (not a file reader — use shell cat for raw contents). 3 modes: 1) Directory overview - file tree with LOC/function/class counts to max_depth. 2) File symbols (AST-parsed) - functions, classes, imports. 3) Symbol focus - call graphs across directory to max_depth (requires file or directory path, case-sensitive). Typical flow: directory → files → symbols. Functions called >3x show •N.".to_string(),
             Self::schema::<AnalyzeParams>(),
         )
         .annotate(ToolAnnotations::from_raw(

--- a/crates/goose/src/agents/platform_extensions/analyze/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/analyze/mod.rs
@@ -438,4 +438,41 @@ fn helper() { validate(0); }
         assert!(format::check_size(&big, false).is_err());
         assert!(format::check_size(&big, true).is_ok());
     }
+
+    #[tokio::test]
+    async fn elixir_function_parent_is_module() {
+        let tmp = tempdir().unwrap();
+        let file = tmp.path().join("demo.ex");
+        fs::write(
+            &file,
+            r#"defmodule MyMod do
+  def foo do
+    bar()
+  end
+
+  def bar, do: 1
+end
+"#,
+        )
+        .unwrap();
+
+        let client = AnalyzeClient::new(ctx()).unwrap();
+        let result = client.analyze(
+            AnalyzeParams {
+                path: file.to_str().unwrap().into(),
+                focus: None,
+                max_depth: 3,
+                follow_depth: 2,
+                force: false,
+            },
+            file.clone(),
+        );
+        let out = text(&result);
+
+        // Functions must be parented to their enclosing module, not themselves.
+        assert!(out.contains("MyMod.foo"), "missing MyMod.foo in {out}");
+        assert!(out.contains("MyMod.bar"), "missing MyMod.bar in {out}");
+        assert!(!out.contains("foo.foo"), "self-parented foo.foo in {out}");
+        assert!(!out.contains("bar.bar"), "self-parented bar.bar in {out}");
+    }
 }

--- a/crates/goose/src/agents/platform_extensions/analyze/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/analyze/mod.rs
@@ -474,6 +474,36 @@ end
         );
     }
 
+    #[test]
+    fn elixir_defimpl_listed_as_class() {
+        let tmp = tempdir().unwrap();
+        let file = tmp.path().join("impl.ex");
+        fs::write(
+            &file,
+            r#"defmodule MyProto do
+  defprotocol Greeter do
+    def hello(thing)
+  end
+end
+
+defimpl MyProto.Greeter, for: BitString do
+  def hello(s), do: "hi " <> s
+end
+"#,
+        )
+        .unwrap();
+
+        let analysis =
+            AnalyzeClient::analyze_file(&file).expect("analyze_file should return an analysis");
+        let class_names: Vec<&str> = analysis.classes.iter().map(|c| c.name.as_str()).collect();
+        for expected in ["MyProto", "Greeter", "MyProto.Greeter"] {
+            assert!(
+                class_names.contains(&expected),
+                "expected `{expected}` in classes; got {class_names:?}"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn elixir_function_parent_is_module() {
         let tmp = tempdir().unwrap();

--- a/crates/goose/src/agents/platform_extensions/analyze/parser.rs
+++ b/crates/goose/src/agents/platform_extensions/analyze/parser.rs
@@ -698,6 +698,9 @@ fn extract_calls(
             if query.capture_names()[cap.index as usize] != "name" {
                 continue;
             }
+            if info.name == "elixir" && is_inside_elixir_module_attribute(cap.node) {
+                continue;
+            }
             let callee = node_text(source, &cap.node).to_string();
             let line = cap.node.start_position().row + 1;
             let caller =
@@ -710,6 +713,28 @@ fn extract_calls(
         }
     }
     calls
+}
+
+/// True when `node` lives inside a `@foo ...` module attribute. Tree-sitter
+/// elixir parses module attributes as `(unary_operator operator: "@" operand:
+/// (call ...))`, and the call-extraction query otherwise captures both the
+/// attribute target (`doc`, `moduledoc`, `spec`, ...) and any sub-calls in the
+/// attribute's body (`foo()` in `@spec foo() :: :ok`) as if they were ordinary
+/// calls. Caller-graph attribution for the surrounding module degrades when
+/// those entries are mixed into the real call list.
+fn is_inside_elixir_module_attribute(node: tree_sitter::Node) -> bool {
+    let mut cur = node;
+    while let Some(parent) = cur.parent() {
+        if parent.kind() == "unary_operator" {
+            if let Some(op) = parent.child(0) {
+                if op.kind() == "@" {
+                    return true;
+                }
+            }
+        }
+        cur = parent;
+    }
+    false
 }
 
 fn find_enclosing_fn(node: tree_sitter::Node, source: &str, info: &LangInfo) -> Option<String> {

--- a/crates/goose/src/agents/platform_extensions/analyze/parser.rs
+++ b/crates/goose/src/agents/platform_extensions/analyze/parser.rs
@@ -378,11 +378,13 @@ fn find_enclosing_class(node: tree_sitter::Node, source: &str, info: &LangInfo) 
     let mut cur = node;
     while let Some(parent) = cur.parent() {
         if info.class_kinds.contains(&parent.kind()) {
-            // Elixir: defmodule/defprotocol/defimpl are also `call` nodes. Reuse
-            // the same matcher used by find_enclosing_fn; defmodule's first
-            // argument is an `alias` node containing the module name.
+            // Elixir: defmodule/defprotocol/defimpl are also `call` nodes, but so
+            // are `def`/`defp`/... — both share the `call` kind. Only treat
+            // module-defining calls as the enclosing class; walk past function
+            // defs (otherwise a captured `foo` inside `def foo` would self-parent
+            // to `foo.foo` instead of its surrounding module).
             if info.name == "elixir" && parent.kind() == "call" {
-                if let Some(name) = elixir_def_name(&parent, source) {
+                if let Some(name) = elixir_module_def_name(&parent, source) {
                     return Some(name);
                 }
                 cur = parent;
@@ -804,6 +806,19 @@ fn elixir_def_name(call: &tree_sitter::Node, source: &str) -> Option<String> {
         }
     }
     None
+}
+
+/// Like `elixir_def_name`, but only for module-defining macros
+/// (`defmodule`/`defprotocol`/`defimpl`). Function defs (`def`/`defp`/...)
+/// return `None` so `find_enclosing_class` walks past them to the surrounding
+/// module instead of attributing a function to itself.
+fn elixir_module_def_name(call: &tree_sitter::Node, source: &str) -> Option<String> {
+    let target = find_child_by_kind(call, "identifier")?;
+    let target_text = node_text(source, &target);
+    if !matches!(target_text, "defmodule" | "defprotocol" | "defimpl") {
+        return None;
+    }
+    elixir_def_name(call, source)
 }
 
 fn find_child_text(node: &tree_sitter::Node, kinds: &[&str], source: &str) -> Option<String> {

--- a/crates/goose/src/agents/platform_extensions/analyze/parser.rs
+++ b/crates/goose/src/agents/platform_extensions/analyze/parser.rs
@@ -751,9 +751,11 @@ fn find_enclosing_fn(node: tree_sitter::Node, source: &str, info: &LangInfo) -> 
     None
 }
 
-/// If the given `call` node represents an Elixir `def`/`defp`/`defmacro`/etc.
-/// (or `defmodule`/`defprotocol`/`defimpl` when called from the class-resolution
-/// path), return the function/module name. Returns `None` for non-def calls.
+/// If the given `call` node represents an Elixir def-style macro
+/// (`def`/`defp`/`defmacro`/`defmodule`/`defprotocol`/`defimpl`/...), return
+/// the function or module name. Used by both `find_enclosing_fn` and
+/// `find_enclosing_class` — Elixir's grammar gives them the same `call` shape.
+/// Returns `None` for non-def calls.
 fn elixir_def_name(call: &tree_sitter::Node, source: &str) -> Option<String> {
     let target = find_child_by_kind(call, "identifier")?;
     let target_text = node_text(source, &target);

--- a/crates/goose/src/agents/platform_extensions/analyze/parser.rs
+++ b/crates/goose/src/agents/platform_extensions/analyze/parser.rs
@@ -378,6 +378,16 @@ fn find_enclosing_class(node: tree_sitter::Node, source: &str, info: &LangInfo) 
     let mut cur = node;
     while let Some(parent) = cur.parent() {
         if info.class_kinds.contains(&parent.kind()) {
+            // Elixir: defmodule/defprotocol/defimpl are also `call` nodes. Reuse
+            // the same matcher used by find_enclosing_fn; defmodule's first
+            // argument is an `alias` node containing the module name.
+            if info.name == "elixir" && parent.kind() == "call" {
+                if let Some(name) = elixir_def_name(&parent, source) {
+                    return Some(name);
+                }
+                cur = parent;
+                continue;
+            }
             if parent.kind() == "impl_item" {
                 // For trait impls (impl Trait for Type), get the type after "for"
                 let mut found_for = false;
@@ -720,6 +730,16 @@ fn find_enclosing_fn(node: tree_sitter::Node, source: &str, info: &LangInfo) -> 
                     continue; // skip — not a function declarator
                 }
             }
+            // Elixir special case: def/defp are call nodes, not a dedicated grammar
+            // kind, so distinguish them from regular `call` nodes by inspecting the
+            // target identifier and pulling the name out of the arguments shape.
+            if info.name == "elixir" && parent.kind() == "call" {
+                if let Some(name) = elixir_def_name(&parent, source) {
+                    return Some(name);
+                }
+                cur = parent;
+                continue; // call node, but not a def — skip
+            }
             // If this is an anonymous function-like node (closure, async block, arrow
             // function with no name), keep walking up to find the enclosing named function.
             if let Some(name) = find_child_text(&parent, info.fn_name_kinds, source) {
@@ -727,6 +747,59 @@ fn find_enclosing_fn(node: tree_sitter::Node, source: &str, info: &LangInfo) -> 
             }
         }
         cur = parent;
+    }
+    None
+}
+
+/// If the given `call` node represents an Elixir `def`/`defp`/`defmacro`/etc.
+/// (or `defmodule`/`defprotocol`/`defimpl` when called from the class-resolution
+/// path), return the function/module name. Returns `None` for non-def calls.
+fn elixir_def_name(call: &tree_sitter::Node, source: &str) -> Option<String> {
+    let target = find_child_by_kind(call, "identifier")?;
+    let target_text = node_text(source, &target);
+    let is_def = matches!(
+        target_text,
+        "def"
+            | "defp"
+            | "defdelegate"
+            | "defguard"
+            | "defguardp"
+            | "defmacro"
+            | "defmacrop"
+            | "defn"
+            | "defnp"
+            | "defmodule"
+            | "defprotocol"
+            | "defimpl"
+    );
+    if !is_def {
+        return None;
+    }
+    let arguments = find_child_by_kind(call, "arguments")?;
+    // The first argument is either:
+    //   - (identifier name)                              — `def foo do ... end`
+    //   - (alias name)                                   — `defmodule Foo do ... end`
+    //   - (call target: (identifier name))               — `def foo(args) do ... end`
+    //   - (binary_operator left: (call target: (identifier name)) operator: "when")
+    //                                                    — `def foo(args) when guard do ... end`
+    for i in 0..arguments.child_count() as u32 {
+        let child = arguments.child(i)?;
+        match child.kind() {
+            "identifier" | "alias" => return Some(node_text(source, &child).to_string()),
+            "call" => {
+                if let Some(inner) = find_child_by_kind(&child, "identifier") {
+                    return Some(node_text(source, &inner).to_string());
+                }
+            }
+            "binary_operator" => {
+                if let Some(left) = find_child_by_kind(&child, "call") {
+                    if let Some(inner) = find_child_by_kind(&left, "identifier") {
+                        return Some(node_text(source, &inner).to_string());
+                    }
+                }
+            }
+            _ => {}
+        }
     }
     None
 }

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
@@ -41,7 +41,7 @@ Use list_resources and read_resource to work with extension data and resources.
 ### Instructions
 Analyze code structure using tree-sitter AST parsing. Three auto-selected modes:
 - Directory path → structure overview (file tree with function/class counts)
-- File path → semantic details (functions, classes, imports, call counts)
+- File path → AST symbol details (functions, classes, imports — not for raw file reading; use shell cat for that)
 - Any path + focus parameter → symbol call graph (incoming/outgoing chains)
 
 For large codebases, delegate analysis to a subagent and retain only the summary.


### PR DESCRIPTION
## Summary

- Adds Elixir to the analyze tool's supported-language list (parser, fixtures, focus heuristics).
- Clarifies the tool description so the LLM picks `analyze` over ad-hoc grep/find for symbol/structure queries.

### Testing
- `cargo test -p goose analyze` exercises the Elixir parser fixtures.
- Manual: run `analyze` on an Elixir file and confirm symbols/refs come back.

### Related Issues
None — change driven by code review and observed behavior.
