### PR TITLE
feat(openrouter): live inventory refresh, configurable fast model, XML tool-call fallback

### DIFF
--- a/crates/goose/src/providers/formats/ollama.rs
+++ b/crates/goose/src/providers/formats/ollama.rs
@@ -192,7 +192,11 @@ where
                 }
 
                 yield (Some(message), usage);
-            } else {
+            } else if !xml_detected {
+                // Usage-only chunks. Defer when xml is detected so the
+                // final synthesized message is the single emission that
+                // carries `last_usage`; otherwise consumers that sum
+                // usage across the stream would count it twice.
                 yield (None, usage);
             }
         }
@@ -373,6 +377,43 @@ hello
             panic!("Expected ToolRequest content from XML parsing");
         }
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn streaming_xml_fallback_yields_usage_once() -> anyhow::Result<()> {
+        use futures::StreamExt;
+
+        let response_lines = r#"data: {"model":"hermes","choices":[{"delta":{"role":"assistant","content":"<function=developer__shell>"},"index":0,"finish_reason":null}],"object":"chat.completion.chunk","id":"x","created":1}
+data: {"model":"hermes","choices":[{"delta":{"role":"assistant","content":"<parameter=command>ls</parameter></function>"},"index":0,"finish_reason":null}],"object":"chat.completion.chunk","id":"x","created":1}
+data: {"model":"hermes","choices":[{"delta":{"role":"assistant","content":""},"index":0,"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15},"object":"chat.completion.chunk","id":"x","created":1}
+data: [DONE]
+"#;
+        let lines: Vec<String> = response_lines.lines().map(|s| s.to_string()).collect();
+        let response_stream = tokio_stream::iter(lines.into_iter().map(Ok));
+        let mut messages = std::pin::pin!(response_to_streaming_message_ollama(response_stream));
+
+        let mut usage_count = 0;
+        let mut tool_calls = 0;
+        while let Some(item) = messages.next().await {
+            let (msg, usage) = item?;
+            if usage.is_some() {
+                usage_count += 1;
+            }
+            if let Some(m) = msg {
+                for c in &m.content {
+                    if matches!(c, MessageContent::ToolRequest(_)) {
+                        tool_calls += 1;
+                    }
+                }
+            }
+        }
+
+        assert_eq!(
+            usage_count, 1,
+            "usage should be yielded exactly once when XML fallback synthesizes the final message"
+        );
+        assert_eq!(tool_calls, 1, "XML fallback should produce one tool call");
         Ok(())
     }
 

--- a/crates/goose/src/providers/openai_compatible.rs
+++ b/crates/goose/src/providers/openai_compatible.rs
@@ -17,6 +17,7 @@ use super::retry::ProviderRetry;
 use super::utils::{ImageFormat, RequestLog};
 use crate::conversation::message::Message;
 use crate::model::ModelConfig;
+use crate::providers::formats::ollama::response_to_streaming_message_ollama;
 use crate::providers::formats::openai::{create_request, response_to_streaming_message};
 use rmcp::model::Tool;
 
@@ -149,6 +150,37 @@ pub fn stream_openai_compat(
             .map_err(Error::from);
 
         let message_stream = response_to_streaming_message(framed);
+        pin!(message_stream);
+        while let Some(message) = message_stream.next().await {
+            let (message, usage) = message.map_err(|e|
+                e.downcast::<ProviderError>()
+                    .unwrap_or_else(|e| ProviderError::RequestFailed(format!("Stream decode error: {e}")))
+            )?;
+            log.write(&message, usage.as_ref().map(|f| f.usage).as_ref())?;
+            yield (message, usage);
+        }
+    }))
+}
+
+/// Like `stream_openai_compat`, but routes through the XML tool-call fallback
+/// parser. Use for providers (e.g. OpenRouter free tier) that route to models
+/// emitting Hermes/Qwen-style `<function=name><parameter=...>...</function>`
+/// tool calls instead of OpenAI's structured `tool_calls` array.
+///
+/// The wrapper is a no-op for responses that contain real structured tool calls
+/// or no `<function=` markers — text streams normally in those cases.
+pub fn stream_openai_compat_with_xml_fallback(
+    response: Response,
+    mut log: RequestLog,
+) -> Result<MessageStream, ProviderError> {
+    let stream = response.bytes_stream().map_err(std::io::Error::other);
+
+    Ok(Box::pin(try_stream! {
+        let stream_reader = StreamReader::new(stream);
+        let framed = FramedRead::new(stream_reader, LinesCodec::new())
+            .map_err(Error::from);
+
+        let message_stream = response_to_streaming_message_ollama(framed);
         pin!(message_stream);
         while let Some(message) = message_stream.next().await {
             let (message, usage) = message.map_err(|e|

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -6,7 +6,7 @@ use serde_json::{json, Value};
 use super::api_client::{ApiClient, AuthMethod};
 use super::base::{ConfigKey, MessageStream, Provider, ProviderDef, ProviderMetadata};
 use super::errors::ProviderError;
-use super::openai_compatible::{handle_status, stream_openai_compat};
+use super::openai_compatible::{handle_status, stream_openai_compat_with_xml_fallback};
 use super::retry::ProviderRetry;
 use super::utils::{ImageFormat, RequestLog};
 use crate::conversation::message::Message;
@@ -315,6 +315,6 @@ impl Provider for OpenRouterProvider {
                 let _ = log.error(e);
             })?;
 
-        stream_openai_compat(response, log)
+        stream_openai_compat_with_xml_fallback(response, log)
     }
 }

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -212,6 +212,65 @@ impl Provider for OpenRouterProvider {
         self.model.clone()
     }
 
+    /// Override the default canonical-filtered inventory so `openrouter/auto`
+    /// survives refresh. The default filter drops any model that does not map
+    /// to a canonical id, and the auto-routing alias intentionally has no
+    /// single canonical mapping (it resolves to whatever backend OpenRouter
+    /// picks at request time). Without this override, clicking "Refresh
+    /// inventory" silently removes the auto-routing option until a user
+    /// resets their inventory data. Logic mirrors the trait's default
+    /// implementation with a carve-out for the auto alias.
+    async fn fetch_recommended_models(&self) -> Result<Vec<String>, ProviderError> {
+        use crate::providers::canonical::{
+            map_to_canonical_model, CanonicalModelRegistry, Modality,
+        };
+        const AUTO_ROUTE_MODEL: &str = "openrouter/auto";
+
+        let all_models = self.fetch_supported_models().await?;
+
+        let registry = CanonicalModelRegistry::bundled().map_err(|e| {
+            ProviderError::ExecutionError(format!("Failed to load canonical registry: {}", e))
+        })?;
+
+        let provider_name = self.get_name();
+        let mut models_with_dates: Vec<(String, Option<String>)> = all_models
+            .iter()
+            .filter_map(|model| {
+                if model == AUTO_ROUTE_MODEL {
+                    return Some((model.clone(), None));
+                }
+                let canonical_id = map_to_canonical_model(provider_name, model, registry)?;
+                let (provider, model_name) = canonical_id.split_once('/')?;
+                let canonical_model = registry.get(provider, model_name)?;
+                if !canonical_model.modalities.input.contains(&Modality::Text) {
+                    return None;
+                }
+                if !canonical_model.tool_call && !self.get_model_config().toolshim {
+                    return None;
+                }
+                Some((model.clone(), canonical_model.release_date.clone()))
+            })
+            .collect();
+
+        models_with_dates.sort_by(|a, b| match (&a.1, &b.1) {
+            (Some(date_a), Some(date_b)) => date_b.cmp(date_a),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => a.0.cmp(&b.0),
+        });
+
+        let inventory_models: Vec<String> = models_with_dates
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+
+        if inventory_models.is_empty() {
+            Ok(all_models)
+        } else {
+            Ok(inventory_models)
+        }
+    }
+
     /// Fetch supported models from OpenRouter API
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         let response = self

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -330,17 +330,21 @@ impl Provider for OpenRouterProvider {
     }
 }
 
-/// Returns true for OpenRouter model ids whose upstream stream emits
-/// Hermes/Qwen-style `<function=...>` XML tool-call blocks. These families
-/// don't produce OpenAI-style structured `tool_calls`, so we need the Ollama
-/// fallback parser to extract calls from text. All other models route through
-/// the plain OpenAI-compatible parser.
+/// Model-family substrings whose upstream stream emits Hermes/Qwen-style
+/// `<function=...>` XML tool-call blocks instead of OpenAI-style structured
+/// `tool_calls`. OpenRouter ids embed the family in either segment, so we
+/// match on the lowercased full id (e.g. `nousresearch/hermes-…`,
+/// `…/qwen-2.5-…`).
+const XML_TOOL_CALL_FAMILIES: &[&str] = &["hermes", "qwen"];
+
+/// Returns true when the model belongs to a family that needs the Ollama
+/// fallback parser to extract tool calls from text. All other models route
+/// through the plain OpenAI-compatible parser.
 fn model_emits_xml_tool_calls(model_name: &str) -> bool {
     let m = model_name.to_ascii_lowercase();
-    // Match by family substrings — OpenRouter model ids embed the family in
-    // either the provider segment (`nousresearch/hermes-…`) or the model
-    // segment (`…/qwen-2.5-…`).
-    m.contains("hermes") || m.contains("qwen")
+    XML_TOOL_CALL_FAMILIES
+        .iter()
+        .any(|family| m.contains(family))
 }
 
 #[cfg(test)]

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -48,13 +48,18 @@ pub struct OpenRouterProvider {
 
 impl OpenRouterProvider {
     pub async fn from_env(model: ModelConfig) -> Result<Self> {
-        let model = model.with_fast(OPENROUTER_DEFAULT_FAST_MODEL, OPENROUTER_PROVIDER_NAME)?;
-
         let config = crate::config::Config::global();
         let api_key: String = config.get_secret("OPENROUTER_API_KEY")?;
         let host: String = config
             .get_param("OPENROUTER_HOST")
             .unwrap_or_else(|_| "https://openrouter.ai".to_string());
+        let fast_model: String = config
+            .get_param("OPENROUTER_FAST_MODEL")
+            .ok()
+            .filter(|s: &String| !s.trim().is_empty())
+            .unwrap_or_else(|| OPENROUTER_DEFAULT_FAST_MODEL.to_string());
+
+        let model = model.with_fast(&fast_model, OPENROUTER_PROVIDER_NAME)?;
 
         let auth = AuthMethod::BearerToken(api_key);
         let api_client = ApiClient::new(host, auth)?
@@ -165,6 +170,13 @@ impl ProviderDef for OpenRouterProvider {
                     false,
                     false,
                     Some("https://openrouter.ai"),
+                    false,
+                ),
+                ConfigKey::new(
+                    "OPENROUTER_FAST_MODEL",
+                    false,
+                    false,
+                    Some(OPENROUTER_DEFAULT_FAST_MODEL),
                     false,
                 ),
             ],

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -334,8 +334,12 @@ impl Provider for OpenRouterProvider {
 /// `<function=...>` XML tool-call blocks instead of OpenAI-style structured
 /// `tool_calls`. OpenRouter ids embed the family in either segment, so we
 /// match on the lowercased full id (e.g. `nousresearch/hermes-…`,
-/// `…/qwen-2.5-…`).
-const XML_TOOL_CALL_FAMILIES: &[&str] = &["hermes", "qwen"];
+/// `…/qwen-2.5-…`). `openrouter/auto` is included because OpenRouter's
+/// auto-routing can resolve to any backend — including Hermes/Qwen — and
+/// the upstream model id we receive stays `openrouter/auto`. The XML
+/// fallback is a no-op on responses that emit proper structured
+/// `tool_calls`, so applying it speculatively here is safe.
+const XML_TOOL_CALL_FAMILIES: &[&str] = &["hermes", "qwen", "openrouter/auto"];
 
 /// Returns true when the model belongs to a family that needs the Ollama
 /// fallback parser to extract tool calls from text. All other models route
@@ -358,6 +362,15 @@ mod tests {
         ));
         assert!(model_emits_xml_tool_calls("qwen/qwen-2.5-72b-instruct"));
         assert!(model_emits_xml_tool_calls("Hermes-3-LLaMA"));
+    }
+
+    #[test]
+    fn xml_tool_call_models_include_openrouter_auto() {
+        // openrouter/auto can route to a Hermes/Qwen backend without that
+        // being visible in the upstream model id; route it through the
+        // fallback parser so XML tool calls survive auto-routed turns.
+        assert!(model_emits_xml_tool_calls("openrouter/auto"));
+        assert!(model_emits_xml_tool_calls("OpenRouter/Auto"));
     }
 
     #[test]

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -32,6 +32,7 @@ pub const OPENROUTER_KNOWN_MODELS: &[&str] = &[
     "deepseek/deepseek-r1-0528",
     "qwen/qwen3-coder",
     "moonshotai/kimi-k2",
+    "openrouter/auto",
 ];
 pub const OPENROUTER_DOC_URL: &str = "https://openrouter.ai/models";
 
@@ -181,6 +182,10 @@ impl ProviderDef for OpenRouterProvider {
     ) -> BoxFuture<'static, Result<Self::Provider>> {
         Box::pin(Self::from_env(model))
     }
+
+    fn supports_inventory_refresh() -> bool {
+        true
+    }
 }
 
 #[async_trait]
@@ -193,7 +198,7 @@ impl Provider for OpenRouterProvider {
         self.model.clone()
     }
 
-    /// Fetch supported models from OpenRouter API (only models with tool support)
+    /// Fetch supported models from OpenRouter API
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         let response = self
             .api_client

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -6,7 +6,9 @@ use serde_json::{json, Value};
 use super::api_client::{ApiClient, AuthMethod};
 use super::base::{ConfigKey, MessageStream, Provider, ProviderDef, ProviderMetadata};
 use super::errors::ProviderError;
-use super::openai_compatible::{handle_status, stream_openai_compat_with_xml_fallback};
+use super::openai_compatible::{
+    handle_status, stream_openai_compat, stream_openai_compat_with_xml_fallback,
+};
 use super::retry::ProviderRetry;
 use super::utils::{ImageFormat, RequestLog};
 use crate::conversation::message::Message;
@@ -315,6 +317,50 @@ impl Provider for OpenRouterProvider {
                 let _ = log.error(e);
             })?;
 
-        stream_openai_compat_with_xml_fallback(response, log)
+        // The XML-fallback parser buffers text chunks once it sees `<function=`,
+        // which can double-emit content when models stream explanatory prose
+        // *before* the XML block. Restrict it to model families that are known
+        // to emit Hermes/Qwen-style XML tool calls instead of OpenAI's
+        // structured `tool_calls` array. Anything else streams normally.
+        if model_emits_xml_tool_calls(&model_config.model_name) {
+            stream_openai_compat_with_xml_fallback(response, log)
+        } else {
+            stream_openai_compat(response, log)
+        }
+    }
+}
+
+/// Returns true for OpenRouter model ids whose upstream stream emits
+/// Hermes/Qwen-style `<function=...>` XML tool-call blocks. These families
+/// don't produce OpenAI-style structured `tool_calls`, so we need the Ollama
+/// fallback parser to extract calls from text. All other models route through
+/// the plain OpenAI-compatible parser.
+fn model_emits_xml_tool_calls(model_name: &str) -> bool {
+    let m = model_name.to_ascii_lowercase();
+    // Match by family substrings — OpenRouter model ids embed the family in
+    // either the provider segment (`nousresearch/hermes-…`) or the model
+    // segment (`…/qwen-2.5-…`).
+    m.contains("hermes") || m.contains("qwen")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::model_emits_xml_tool_calls;
+
+    #[test]
+    fn xml_tool_call_models_match_hermes_and_qwen_families() {
+        assert!(model_emits_xml_tool_calls(
+            "nousresearch/hermes-3-llama-3.1-405b"
+        ));
+        assert!(model_emits_xml_tool_calls("qwen/qwen-2.5-72b-instruct"));
+        assert!(model_emits_xml_tool_calls("Hermes-3-LLaMA"));
+    }
+
+    #[test]
+    fn xml_tool_call_models_excludes_openai_style_families() {
+        assert!(!model_emits_xml_tool_calls("openai/gpt-4o"));
+        assert!(!model_emits_xml_tool_calls("anthropic/claude-3.5-sonnet"));
+        assert!(!model_emits_xml_tool_calls("meta-llama/llama-3.1-70b"));
+        assert!(!model_emits_xml_tool_calls("google/gemini-1.5-pro"));
     }
 }


### PR DESCRIPTION
## Summary

Three small, independent OpenRouter improvements that share the same provider file:

- `feat(openrouter): enable inventory refresh to fetch live model list` — refresh actually hits the OpenRouter API instead of returning the bundled list.
- `feat(openrouter): make fast model configurable via OPENROUTER_FAST_MODEL` — env override for the fast-tier model.
- `fix(openrouter): parse Hermes/Qwen-style XML tool calls via Ollama fallback` — routes OpenRouter through the openai-compat XML tool-call wrapper so Hermes/Qwen-style `<tool_call>` blocks parse correctly.

### Testing
- Manual: refresh the OpenRouter inventory in the UI; confirm new models appear.
- Set `OPENROUTER_FAST_MODEL=…` and confirm the fast-tier picker reflects it.
- Run a Hermes/Qwen model through OpenRouter and confirm tool calls land instead of being dropped as text.

### Related Issues
None — change driven by code review and observed behavior.
