### PR TITLE
chore(deps): bump strum 0.27→0.28, tokenizers 0.21→0.23, mockall 0.13→0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2479,6 +2479,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "daachorse"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f55d7153ba3b507595872a3874803f07a8a81d1e888abed8e5db7da0597d6e2"
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4449,14 +4455,14 @@ dependencies = [
  "shell-words",
  "shellexpand",
  "sqlx",
- "strum 0.27.2",
+ "strum 0.28.0",
  "symphonia",
  "sys-info",
  "tempfile",
  "test-case",
  "thiserror 1.0.69",
  "tiktoken-rs",
- "tokenizers 0.21.4",
+ "tokenizers 0.23.1",
  "tokio",
  "tokio-cron-scheduler",
  "tokio-stream",
@@ -4533,7 +4539,7 @@ dependencies = [
  "sha2",
  "shlex",
  "sigstore-verify",
- "strum 0.27.2",
+ "strum 0.28.0",
  "tar",
  "tempfile",
  "test-case",
@@ -6114,9 +6120,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+checksum = "f58d964098a5f9c6b63d0798e5372fd04708193510a7af313c22e9f29b7b620b"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -6128,9 +6134,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+checksum = "ca41ce716dda6a9be188b385aa78ee5260fc25cd3802cb2a8afdc6afbe6b6dbf"
 dependencies = [
  "cfg-if",
  "proc-macro2",
@@ -10598,9 +10604,9 @@ dependencies = [
 
 [[package]]
 name = "tokenizers"
-version = "0.21.4"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a620b996116a59e184c2fa2dfd8251ea34a36d0a514758c6f966386bd2e03476"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -10631,13 +10637,13 @@ dependencies = [
 
 [[package]]
 name = "tokenizers"
-version = "0.22.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+checksum = "44e5bea67576e04b6ff8564c5d9e09c2ef0cf476502245f2f120e497769d3112"
 dependencies = [
  "ahash",
- "aho-corasick",
  "compact_str 0.9.0",
+ "daachorse",
  "dary_heap",
  "derive_builder",
  "esaxx-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 shellexpand = "3.1"
-strum = { version = "0.27", features = ["derive"] }
+strum = { version = "0.28", features = ["derive"] }
 tempfile = "3"
 thiserror = "1.0"
 tokio = { version = "1.49", features = ["full"] }
@@ -99,7 +99,9 @@ tree-sitter-typescript = "0.23"
 [patch.crates-io]
 v8 = { path = "vendor/v8" }
 cudaforge = { git = "https://github.com/jbg/cudaforge", rev = "e7c1967340e40673db98dc9e17da0f04834a456f" }
-# TODO: switch to released version in opentelemetry 0.32.0
+# TODO: switch to released version in opentelemetry 0.32.0 — requires also
+# bumping tracing-opentelemetry and migrating away from
+# `with_span_attribute_allowlist` (removed in the 0.32 tracing bridge).
 # https://github.com/open-telemetry/opentelemetry-rust/issues/3408
 opentelemetry = { git = "https://github.com/open-telemetry/opentelemetry-rust", rev = "345cd74a" }
 opentelemetry_sdk = { git = "https://github.com/open-telemetry/opentelemetry-rust", rev = "345cd74a" }

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -155,7 +155,7 @@ candle-core = { version = "0.10.2", default-features = false, optional = true }
 candle-nn = { version = "0.10.2", default-features = false, optional = true }
 candle-transformers = { version = "0.10.2", default-features = false, optional = true }
 byteorder = { version = "1.5.0", optional = true }
-tokenizers = { version = "0.21.0", default-features = false, features = ["onig"], optional = true }
+tokenizers = { version = "0.23", default-features = false, features = ["onig"], optional = true }
 symphonia = { version = "0.5", features = ["all"], optional = true }
 rubato = { version = "0.16", optional = true }
 zip = { workspace = true }
@@ -213,7 +213,7 @@ libc = "0.2.186"
 
 [dev-dependencies]
 serial_test = { workspace = true }
-mockall = "0.13.1"
+mockall = "0.14"
 wiremock = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true, features = ["compat"] }


### PR DESCRIPTION
## Summary

Routine dependency bumps to pull in upstream fixes:

- `strum` 0.27 → 0.28
- `tokenizers` 0.21 → 0.23
- `mockall` 0.13 → 0.14

### Testing
- `cargo build` and `cargo test` pass with the bumped versions.
- No API breakage observed; existing usages compile unchanged.

### Related Issues
None — change driven by code review and observed behavior.
