### PR TITLE
test(goose): make model::tests hermetic against ~/.config/goose/config.yaml

### DIFF
--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -385,6 +385,18 @@ mod tests {
     use super::*;
     use tempfile::NamedTempFile;
 
+    /// Full set of env keys that `ModelConfig::new` reads through
+    /// `config.get_param(...)`. Tests that exercise `ModelConfig::new_or_fail`
+    /// or `new_or_fail_with_config` should lock these alongside the hermetic
+    /// config so neither side of the read can leak a developer's local value.
+    const ENV_LOCK_KEYS: [(&str, Option<&str>); 5] = [
+        ("GOOSE_MAX_TOKENS", None),
+        ("GOOSE_TEMPERATURE", None),
+        ("GOOSE_CONTEXT_LIMIT", None),
+        ("GOOSE_TOOLSHIM", None),
+        ("GOOSE_TOOLSHIM_OLLAMA_MODEL", None),
+    ];
+
     /// Hermetic Config pointed at empty temp files. Use this instead of
     /// `Config::global()` so a stray `GOOSE_MAX_TOKENS: …` in the developer's
     /// `~/.config/goose/config.yaml` doesn't bleed into the test.
@@ -392,6 +404,13 @@ mod tests {
         let cfg = NamedTempFile::new().unwrap();
         let secrets = NamedTempFile::new().unwrap();
         crate::config::Config::new_with_file_secrets(cfg.path(), secrets.path()).unwrap()
+    }
+
+    /// `ModelConfig::new_or_fail` against a hermetic config — the test-only
+    /// constructor that bypasses `Config::global()`. Pair with
+    /// `env_lock::lock_env(ENV_LOCK_KEYS)` to fully isolate from local state.
+    fn hermetic_model(model_name: &str) -> ModelConfig {
+        ModelConfig::new_or_fail_with_config(model_name, &hermetic_config())
     }
 
     #[test]
@@ -503,8 +522,7 @@ mod tests {
                 ("GOOSE_MAX_TOKENS", None::<&str>),
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
-            let config = ModelConfig::new_or_fail_with_config("gpt-4o", &hermetic_config())
-                .with_canonical_limits("openai");
+            let config = hermetic_model("gpt-4o").with_canonical_limits("openai");
 
             assert_eq!(config.context_limit, Some(128_000));
             assert_eq!(config.max_tokens, Some(16_384));
@@ -517,7 +535,7 @@ mod tests {
                 ("GOOSE_MAX_TOKENS", None::<&str>),
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
-            let mut config = ModelConfig::new_or_fail_with_config("gpt-4o", &hermetic_config());
+            let mut config = hermetic_model("gpt-4o");
             config.context_limit = Some(64_000);
             let config = config.with_canonical_limits("openai");
 
@@ -530,7 +548,7 @@ mod tests {
                 ("GOOSE_MAX_TOKENS", None::<&str>),
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
-            let mut config = ModelConfig::new_or_fail_with_config("gpt-4o", &hermetic_config());
+            let mut config = hermetic_model("gpt-4o");
             config.max_tokens = Some(1_000);
             let config = config.with_canonical_limits("openai");
 
@@ -543,9 +561,7 @@ mod tests {
                 ("GOOSE_MAX_TOKENS", None::<&str>),
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
-            let config =
-                ModelConfig::new_or_fail_with_config("moonshotai/kimi-k2.5", &hermetic_config())
-                    .with_canonical_limits("nvidia");
+            let config = hermetic_model("moonshotai/kimi-k2.5").with_canonical_limits("nvidia");
 
             assert_eq!(config.context_limit, Some(262_144));
             assert_eq!(config.max_tokens, None);
@@ -558,9 +574,7 @@ mod tests {
                 ("GOOSE_MAX_TOKENS", None::<&str>),
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
-            let config =
-                ModelConfig::new_or_fail_with_config("totally-unknown-model", &hermetic_config())
-                    .with_canonical_limits("openai");
+            let config = hermetic_model("totally-unknown-model").with_canonical_limits("openai");
 
             assert_eq!(config.context_limit, None);
             assert_eq!(config.max_tokens, None);
@@ -576,19 +590,15 @@ mod tests {
 
             // "databricks-gpt-5.4-high" should resolve via "databricks-gpt-5.4"
             let config =
-                ModelConfig::new_or_fail_with_config("databricks-gpt-5.4-high", &hermetic_config())
-                    .with_canonical_limits("databricks");
+                hermetic_model("databricks-gpt-5.4-high").with_canonical_limits("databricks");
             assert_eq!(config.context_limit, Some(1_050_000));
 
             // "gpt-5.4-xhigh" should resolve via "gpt-5.4"
-            let config = ModelConfig::new_or_fail_with_config("gpt-5.4-xhigh", &hermetic_config())
-                .with_canonical_limits("openai");
+            let config = hermetic_model("gpt-5.4-xhigh").with_canonical_limits("openai");
             assert_eq!(config.context_limit, Some(1_050_000));
 
             // "gpt-5.4-nano-low" should resolve via "gpt-5.4-nano"
-            let config =
-                ModelConfig::new_or_fail_with_config("gpt-5.4-nano-low", &hermetic_config())
-                    .with_canonical_limits("openai");
+            let config = hermetic_model("gpt-5.4-nano-low").with_canonical_limits("openai");
             assert_eq!(config.context_limit, Some(400_000));
         }
     }
@@ -596,52 +606,42 @@ mod tests {
     mod is_openai_reasoning_model {
         use super::*;
 
-        const ENV_LOCK_KEYS: [(&str, Option<&str>); 5] = [
-            ("GOOSE_MAX_TOKENS", None),
-            ("GOOSE_TEMPERATURE", None),
-            ("GOOSE_CONTEXT_LIMIT", None),
-            ("GOOSE_TOOLSHIM", None),
-            ("GOOSE_TOOLSHIM_OLLAMA_MODEL", None),
-        ];
-
         #[test]
         fn bare_reasoning_models() {
             let _guard = env_lock::lock_env(ENV_LOCK_KEYS);
-            assert!(ModelConfig::new_or_fail("o1").is_openai_reasoning_model());
-            assert!(ModelConfig::new_or_fail("o1-preview").is_openai_reasoning_model());
-            assert!(ModelConfig::new_or_fail("o3").is_openai_reasoning_model());
-            assert!(ModelConfig::new_or_fail("o3-mini").is_openai_reasoning_model());
-            assert!(ModelConfig::new_or_fail("o4-mini").is_openai_reasoning_model());
-            assert!(ModelConfig::new_or_fail("gpt-5").is_openai_reasoning_model());
-            assert!(ModelConfig::new_or_fail("gpt-5-3-codex").is_openai_reasoning_model());
+            assert!(hermetic_model("o1").is_openai_reasoning_model());
+            assert!(hermetic_model("o1-preview").is_openai_reasoning_model());
+            assert!(hermetic_model("o3").is_openai_reasoning_model());
+            assert!(hermetic_model("o3-mini").is_openai_reasoning_model());
+            assert!(hermetic_model("o4-mini").is_openai_reasoning_model());
+            assert!(hermetic_model("gpt-5").is_openai_reasoning_model());
+            assert!(hermetic_model("gpt-5-3-codex").is_openai_reasoning_model());
         }
 
         #[test]
         fn goose_prefixed_reasoning_models() {
             let _guard = env_lock::lock_env(ENV_LOCK_KEYS);
-            assert!(ModelConfig::new_or_fail("goose-o3-mini").is_openai_reasoning_model());
-            assert!(ModelConfig::new_or_fail("goose-o4-mini").is_openai_reasoning_model());
-            assert!(ModelConfig::new_or_fail("goose-gpt-5").is_openai_reasoning_model());
+            assert!(hermetic_model("goose-o3-mini").is_openai_reasoning_model());
+            assert!(hermetic_model("goose-o4-mini").is_openai_reasoning_model());
+            assert!(hermetic_model("goose-gpt-5").is_openai_reasoning_model());
         }
 
         #[test]
         fn databricks_prefixed_reasoning_models() {
             let _guard = env_lock::lock_env(ENV_LOCK_KEYS);
-            assert!(ModelConfig::new_or_fail("databricks-o3-mini").is_openai_reasoning_model());
-            assert!(ModelConfig::new_or_fail("databricks-o4-mini").is_openai_reasoning_model());
-            assert!(ModelConfig::new_or_fail("databricks-gpt-5").is_openai_reasoning_model());
+            assert!(hermetic_model("databricks-o3-mini").is_openai_reasoning_model());
+            assert!(hermetic_model("databricks-o4-mini").is_openai_reasoning_model());
+            assert!(hermetic_model("databricks-gpt-5").is_openai_reasoning_model());
         }
 
         #[test]
         fn non_reasoning_models() {
             let _guard = env_lock::lock_env(ENV_LOCK_KEYS);
-            assert!(!ModelConfig::new_or_fail("claude-sonnet-4").is_openai_reasoning_model());
-            assert!(!ModelConfig::new_or_fail("gpt-4o").is_openai_reasoning_model());
-            assert!(
-                !ModelConfig::new_or_fail("databricks-claude-sonnet-4").is_openai_reasoning_model()
-            );
-            assert!(!ModelConfig::new_or_fail("goose-claude-sonnet-4").is_openai_reasoning_model());
-            assert!(!ModelConfig::new_or_fail("llama-3-70b").is_openai_reasoning_model());
+            assert!(!hermetic_model("claude-sonnet-4").is_openai_reasoning_model());
+            assert!(!hermetic_model("gpt-4o").is_openai_reasoning_model());
+            assert!(!hermetic_model("databricks-claude-sonnet-4").is_openai_reasoning_model());
+            assert!(!hermetic_model("goose-claude-sonnet-4").is_openai_reasoning_model());
+            assert!(!hermetic_model("llama-3-70b").is_openai_reasoning_model());
         }
     }
 }

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -63,7 +63,18 @@ pub struct ModelConfig {
 
 impl ModelConfig {
     pub fn new(model_name: &str) -> Result<Self, ConfigError> {
-        Self::new_base(model_name.to_string(), None)
+        Self::new_base(model_name.to_string(), None, crate::config::Config::global())
+    }
+
+    /// Like [`ModelConfig::new`] but reads `GOOSE_CONTEXT_LIMIT` and
+    /// `GOOSE_MAX_TOKENS` from the supplied `Config` instead of the
+    /// process-wide singleton. Lets tests stub the underlying config file
+    /// without process-wide leakage from `~/.config/goose/config.yaml`.
+    pub fn new_with_config(
+        model_name: &str,
+        config: &crate::config::Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_base(model_name.to_string(), None, config)
     }
 
     pub fn new_with_context_env(
@@ -71,14 +82,18 @@ impl ModelConfig {
         provider_name: &str,
         context_env_var: Option<&str>,
     ) -> Result<Self, ConfigError> {
-        let config = Self::new_base(model_name, context_env_var)?;
+        let config = Self::new_base(model_name, context_env_var, crate::config::Config::global())?;
         Ok(config.with_canonical_limits(provider_name))
     }
 
-    fn new_base(model_name: String, context_env_var: Option<&str>) -> Result<Self, ConfigError> {
+    fn new_base(
+        model_name: String,
+        context_env_var: Option<&str>,
+        config: &crate::config::Config,
+    ) -> Result<Self, ConfigError> {
         // Check a provider-specific env var first (e.g. DATABRICKS_CONTEXT_LIMIT),
-        // then fall back to GOOSE_CONTEXT_LIMIT.  Using Config::global().get_param()
-        // reads from both environment variables and config.yaml, so users can set
+        // then fall back to GOOSE_CONTEXT_LIMIT.  config.get_param() reads from
+        // both environment variables and config.yaml, so users can set
         // `GOOSE_CONTEXT_LIMIT: 1000000` in config.yaml instead of exporting an
         // env var.  See #7839.
         let context_limit = if let Some(env_var) = context_env_var {
@@ -88,7 +103,7 @@ impl ModelConfig {
                 None
             }
         } else {
-            match crate::config::Config::global().get_param::<usize>("GOOSE_CONTEXT_LIMIT") {
+            match config.get_param::<usize>("GOOSE_CONTEXT_LIMIT") {
                 Ok(limit) => {
                     if limit == 0 {
                         return Err(ConfigError::InvalidRange(
@@ -109,7 +124,7 @@ impl ModelConfig {
             }
         };
 
-        let max_tokens = Self::parse_max_tokens()?;
+        let max_tokens = Self::parse_max_tokens(config)?;
         let temperature = Self::parse_temperature()?;
         let toolshim = Self::parse_toolshim()?;
         let toolshim_model = Self::parse_toolshim_model()?;
@@ -212,8 +227,8 @@ impl ModelConfig {
         }
     }
 
-    fn parse_max_tokens() -> Result<Option<i32>, ConfigError> {
-        match crate::config::Config::global().get_param::<i32>("GOOSE_MAX_TOKENS") {
+    fn parse_max_tokens(config: &crate::config::Config) -> Result<Option<i32>, ConfigError> {
+        match config.get_param::<i32>("GOOSE_MAX_TOKENS") {
             Ok(tokens) => {
                 if tokens <= 0 {
                     return Err(ConfigError::InvalidRange(
@@ -347,30 +362,52 @@ impl ModelConfig {
         ModelConfig::new(model_name)
             .unwrap_or_else(|_| panic!("Failed to create model config for {}", model_name))
     }
+
+    /// Tests should prefer this over [`Self::new_or_fail`] when they need
+    /// hermetic config: it reads from `config` instead of `Config::global()`,
+    /// so a stray `GOOSE_MAX_TOKENS: …` in the developer's local
+    /// `~/.config/goose/config.yaml` doesn't leak into the test.
+    pub fn new_or_fail_with_config(
+        model_name: &str,
+        config: &crate::config::Config,
+    ) -> ModelConfig {
+        ModelConfig::new_with_config(model_name, config)
+            .unwrap_or_else(|_| panic!("Failed to create model config for {}", model_name))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::NamedTempFile;
+
+    /// Hermetic Config pointed at empty temp files. Use this instead of
+    /// `Config::global()` so a stray `GOOSE_MAX_TOKENS: …` in the developer's
+    /// `~/.config/goose/config.yaml` doesn't bleed into the test.
+    fn hermetic_config() -> crate::config::Config {
+        let cfg = NamedTempFile::new().unwrap();
+        let secrets = NamedTempFile::new().unwrap();
+        crate::config::Config::new_with_file_secrets(cfg.path(), secrets.path()).unwrap()
+    }
 
     #[test]
     fn test_parse_max_tokens_valid() {
         let _guard = env_lock::lock_env([("GOOSE_MAX_TOKENS", Some("4096"))]);
-        let result = ModelConfig::parse_max_tokens().unwrap();
+        let result = ModelConfig::parse_max_tokens(&hermetic_config()).unwrap();
         assert_eq!(result, Some(4096));
     }
 
     #[test]
     fn test_parse_max_tokens_not_set() {
         let _guard = env_lock::lock_env([("GOOSE_MAX_TOKENS", None::<&str>)]);
-        let result = ModelConfig::parse_max_tokens().unwrap();
+        let result = ModelConfig::parse_max_tokens(&hermetic_config()).unwrap();
         assert_eq!(result, None);
     }
 
     #[test]
     fn test_parse_max_tokens_invalid_string() {
         let _guard = env_lock::lock_env([("GOOSE_MAX_TOKENS", Some("not_a_number"))]);
-        let result = ModelConfig::parse_max_tokens();
+        let result = ModelConfig::parse_max_tokens(&hermetic_config());
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), ConfigError::InvalidValue(..)));
     }
@@ -378,7 +415,7 @@ mod tests {
     #[test]
     fn test_parse_max_tokens_zero() {
         let _guard = env_lock::lock_env([("GOOSE_MAX_TOKENS", Some("0"))]);
-        let result = ModelConfig::parse_max_tokens();
+        let result = ModelConfig::parse_max_tokens(&hermetic_config());
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), ConfigError::InvalidRange(..)));
     }
@@ -386,7 +423,7 @@ mod tests {
     #[test]
     fn test_parse_max_tokens_negative() {
         let _guard = env_lock::lock_env([("GOOSE_MAX_TOKENS", Some("-100"))]);
-        let result = ModelConfig::parse_max_tokens();
+        let result = ModelConfig::parse_max_tokens(&hermetic_config());
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), ConfigError::InvalidRange(..)));
     }
@@ -400,7 +437,7 @@ mod tests {
             ("GOOSE_TOOLSHIM", None::<&str>),
             ("GOOSE_TOOLSHIM_OLLAMA_MODEL", None::<&str>),
         ]);
-        let config = ModelConfig::new("test-model").unwrap();
+        let config = ModelConfig::new_with_config("test-model", &hermetic_config()).unwrap();
         assert_eq!(config.max_tokens, Some(8192));
     }
 
@@ -413,7 +450,7 @@ mod tests {
             ("GOOSE_TOOLSHIM", None::<&str>),
             ("GOOSE_TOOLSHIM_OLLAMA_MODEL", None::<&str>),
         ]);
-        let config = ModelConfig::new("test-model").unwrap();
+        let config = ModelConfig::new_with_config("test-model", &hermetic_config()).unwrap();
         assert_eq!(config.max_tokens, None);
     }
 
@@ -462,7 +499,8 @@ mod tests {
                 ("GOOSE_MAX_TOKENS", None::<&str>),
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
-            let config = ModelConfig::new_or_fail("gpt-4o").with_canonical_limits("openai");
+            let config = ModelConfig::new_or_fail_with_config("gpt-4o", &hermetic_config())
+                .with_canonical_limits("openai");
 
             assert_eq!(config.context_limit, Some(128_000));
             assert_eq!(config.max_tokens, Some(16_384));
@@ -475,7 +513,7 @@ mod tests {
                 ("GOOSE_MAX_TOKENS", None::<&str>),
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
-            let mut config = ModelConfig::new_or_fail("gpt-4o");
+            let mut config = ModelConfig::new_or_fail_with_config("gpt-4o", &hermetic_config());
             config.context_limit = Some(64_000);
             let config = config.with_canonical_limits("openai");
 
@@ -488,7 +526,7 @@ mod tests {
                 ("GOOSE_MAX_TOKENS", None::<&str>),
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
-            let mut config = ModelConfig::new_or_fail("gpt-4o");
+            let mut config = ModelConfig::new_or_fail_with_config("gpt-4o", &hermetic_config());
             config.max_tokens = Some(1_000);
             let config = config.with_canonical_limits("openai");
 
@@ -501,8 +539,11 @@ mod tests {
                 ("GOOSE_MAX_TOKENS", None::<&str>),
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
-            let config =
-                ModelConfig::new_or_fail("moonshotai/kimi-k2.5").with_canonical_limits("nvidia");
+            let config = ModelConfig::new_or_fail_with_config(
+                "moonshotai/kimi-k2.5",
+                &hermetic_config(),
+            )
+            .with_canonical_limits("nvidia");
 
             assert_eq!(config.context_limit, Some(262_144));
             assert_eq!(config.max_tokens, None);
@@ -515,8 +556,11 @@ mod tests {
                 ("GOOSE_MAX_TOKENS", None::<&str>),
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
-            let config =
-                ModelConfig::new_or_fail("totally-unknown-model").with_canonical_limits("openai");
+            let config = ModelConfig::new_or_fail_with_config(
+                "totally-unknown-model",
+                &hermetic_config(),
+            )
+            .with_canonical_limits("openai");
 
             assert_eq!(config.context_limit, None);
             assert_eq!(config.max_tokens, None);
@@ -531,8 +575,11 @@ mod tests {
             ]);
 
             // "databricks-gpt-5.4-high" should resolve via "databricks-gpt-5.4"
-            let config = ModelConfig::new_or_fail("databricks-gpt-5.4-high")
-                .with_canonical_limits("databricks");
+            let config = ModelConfig::new_or_fail_with_config(
+                "databricks-gpt-5.4-high",
+                &hermetic_config(),
+            )
+            .with_canonical_limits("databricks");
             assert_eq!(config.context_limit, Some(1_050_000));
 
             // "gpt-5.4-xhigh" should resolve via "gpt-5.4"

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -63,7 +63,11 @@ pub struct ModelConfig {
 
 impl ModelConfig {
     pub fn new(model_name: &str) -> Result<Self, ConfigError> {
-        Self::new_base(model_name.to_string(), None, crate::config::Config::global())
+        Self::new_base(
+            model_name.to_string(),
+            None,
+            crate::config::Config::global(),
+        )
     }
 
     /// Like [`ModelConfig::new`] but reads `GOOSE_CONTEXT_LIMIT` and
@@ -539,11 +543,9 @@ mod tests {
                 ("GOOSE_MAX_TOKENS", None::<&str>),
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
-            let config = ModelConfig::new_or_fail_with_config(
-                "moonshotai/kimi-k2.5",
-                &hermetic_config(),
-            )
-            .with_canonical_limits("nvidia");
+            let config =
+                ModelConfig::new_or_fail_with_config("moonshotai/kimi-k2.5", &hermetic_config())
+                    .with_canonical_limits("nvidia");
 
             assert_eq!(config.context_limit, Some(262_144));
             assert_eq!(config.max_tokens, None);
@@ -556,11 +558,9 @@ mod tests {
                 ("GOOSE_MAX_TOKENS", None::<&str>),
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
-            let config = ModelConfig::new_or_fail_with_config(
-                "totally-unknown-model",
-                &hermetic_config(),
-            )
-            .with_canonical_limits("openai");
+            let config =
+                ModelConfig::new_or_fail_with_config("totally-unknown-model", &hermetic_config())
+                    .with_canonical_limits("openai");
 
             assert_eq!(config.context_limit, None);
             assert_eq!(config.max_tokens, None);
@@ -575,20 +575,20 @@ mod tests {
             ]);
 
             // "databricks-gpt-5.4-high" should resolve via "databricks-gpt-5.4"
-            let config = ModelConfig::new_or_fail_with_config(
-                "databricks-gpt-5.4-high",
-                &hermetic_config(),
-            )
-            .with_canonical_limits("databricks");
+            let config =
+                ModelConfig::new_or_fail_with_config("databricks-gpt-5.4-high", &hermetic_config())
+                    .with_canonical_limits("databricks");
             assert_eq!(config.context_limit, Some(1_050_000));
 
             // "gpt-5.4-xhigh" should resolve via "gpt-5.4"
-            let config = ModelConfig::new_or_fail("gpt-5.4-xhigh").with_canonical_limits("openai");
+            let config = ModelConfig::new_or_fail_with_config("gpt-5.4-xhigh", &hermetic_config())
+                .with_canonical_limits("openai");
             assert_eq!(config.context_limit, Some(1_050_000));
 
             // "gpt-5.4-nano-low" should resolve via "gpt-5.4-nano"
             let config =
-                ModelConfig::new_or_fail("gpt-5.4-nano-low").with_canonical_limits("openai");
+                ModelConfig::new_or_fail_with_config("gpt-5.4-nano-low", &hermetic_config())
+                    .with_canonical_limits("openai");
             assert_eq!(config.context_limit, Some(400_000));
         }
     }


### PR DESCRIPTION
## Summary

`crates/goose/src/model.rs` tests previously read the user's `~/.config/goose/config.yaml`, so the suite passed on a clean CI box and failed on a dev machine with a custom config. This isolates each test against a tempdir config so it runs the same anywhere.

### Testing
- `cargo test -p goose model::tests` passes both with an empty config and with a populated one.

### Related Issues
None — change driven by code review and observed behavior.
