### PR TITLE
perf(goose-mcp): xlsx workbook cache + Arc<Spreadsheet> + INTERNAL_ERROR mapping

### DIFF
--- a/crates/goose-mcp/src/computercontroller/mod.rs
+++ b/crates/goose-mcp/src/computercontroller/mod.rs
@@ -1232,21 +1232,25 @@ impl ComputerControllerServer {
 
         match operation {
             XlsxOperation::ListWorksheets => {
-                let xlsx = xlsx_tool::XlsxTool::new(path).map_err(crate::io_error)?;
-                let worksheets = xlsx.list_worksheets().map_err(crate::io_error)?;
+                let xlsx = xlsx_tool::XlsxTool::new(path).map_err(crate::internal_error)?;
+                let worksheets = xlsx.list_worksheets().map_err(crate::internal_error)?;
                 Ok(CallToolResult::success(vec![Content::text(format!(
                     "{:#?}",
                     worksheets
                 ))]))
             }
             XlsxOperation::GetColumns => {
-                let xlsx = xlsx_tool::XlsxTool::new(path).map_err(crate::io_error)?;
+                let xlsx = xlsx_tool::XlsxTool::new(path).map_err(crate::internal_error)?;
                 let worksheet = if let Some(name) = &params.worksheet {
-                    xlsx.get_worksheet_by_name(name).map_err(crate::io_error)?
+                    xlsx.get_worksheet_by_name(name)
+                        .map_err(crate::internal_error)?
                 } else {
-                    xlsx.get_worksheet_by_index(0).map_err(crate::io_error)?
+                    xlsx.get_worksheet_by_index(0)
+                        .map_err(crate::internal_error)?
                 };
-                let columns = xlsx.get_column_names(worksheet).map_err(crate::io_error)?;
+                let columns = xlsx
+                    .get_column_names(worksheet)
+                    .map_err(crate::internal_error)?;
                 Ok(CallToolResult::success(vec![Content::text(format!(
                     "{:#?}",
                     columns
@@ -1261,13 +1265,17 @@ impl ComputerControllerServer {
                     )
                 })?;
 
-                let xlsx = xlsx_tool::XlsxTool::new(path).map_err(crate::io_error)?;
+                let xlsx = xlsx_tool::XlsxTool::new(path).map_err(crate::internal_error)?;
                 let worksheet = if let Some(name) = &params.worksheet {
-                    xlsx.get_worksheet_by_name(name).map_err(crate::io_error)?
+                    xlsx.get_worksheet_by_name(name)
+                        .map_err(crate::internal_error)?
                 } else {
-                    xlsx.get_worksheet_by_index(0).map_err(crate::io_error)?
+                    xlsx.get_worksheet_by_index(0)
+                        .map_err(crate::internal_error)?
                 };
-                let range_data = xlsx.get_range(worksheet, range).map_err(crate::io_error)?;
+                let range_data = xlsx
+                    .get_range(worksheet, range)
+                    .map_err(crate::internal_error)?;
                 Ok(CallToolResult::success(vec![Content::text(format!(
                     "{:#?}",
                     range_data
@@ -1284,15 +1292,17 @@ impl ComputerControllerServer {
 
                 let case_sensitive = params.case_sensitive;
 
-                let xlsx = xlsx_tool::XlsxTool::new(path).map_err(crate::io_error)?;
+                let xlsx = xlsx_tool::XlsxTool::new(path).map_err(crate::internal_error)?;
                 let worksheet = if let Some(name) = &params.worksheet {
-                    xlsx.get_worksheet_by_name(name).map_err(crate::io_error)?
+                    xlsx.get_worksheet_by_name(name)
+                        .map_err(crate::internal_error)?
                 } else {
-                    xlsx.get_worksheet_by_index(0).map_err(crate::io_error)?
+                    xlsx.get_worksheet_by_index(0)
+                        .map_err(crate::internal_error)?
                 };
                 let matches = xlsx
                     .find_in_worksheet(worksheet, search_text, case_sensitive)
-                    .map_err(crate::io_error)?;
+                    .map_err(crate::internal_error)?;
                 Ok(CallToolResult::success(vec![Content::text(format!(
                     "Found matches at: {:#?}",
                     matches
@@ -1323,18 +1333,18 @@ impl ComputerControllerServer {
 
                 let worksheet_name = params.worksheet.as_deref().unwrap_or("Sheet1");
 
-                let mut xlsx = xlsx_tool::XlsxTool::new(path).map_err(crate::io_error)?;
+                let mut xlsx = xlsx_tool::XlsxTool::new(path).map_err(crate::internal_error)?;
                 xlsx.update_cell(worksheet_name, row as u32, col as u32, value)
-                    .map_err(crate::io_error)?;
-                xlsx.save(path).map_err(crate::io_error)?;
+                    .map_err(crate::internal_error)?;
+                xlsx.save(path).map_err(crate::internal_error)?;
                 Ok(CallToolResult::success(vec![Content::text(format!(
                     "Updated cell ({}, {}) to '{}' in worksheet '{}'",
                     row, col, value, worksheet_name
                 ))]))
             }
             XlsxOperation::Save => {
-                let xlsx = xlsx_tool::XlsxTool::new(path).map_err(crate::io_error)?;
-                xlsx.save(path).map_err(crate::io_error)?;
+                let xlsx = xlsx_tool::XlsxTool::new(path).map_err(crate::internal_error)?;
+                xlsx.save(path).map_err(crate::internal_error)?;
                 Ok(CallToolResult::success(vec![Content::text(
                     "File saved successfully.",
                 )]))
@@ -1356,15 +1366,17 @@ impl ComputerControllerServer {
                     )
                 })?;
 
-                let xlsx = xlsx_tool::XlsxTool::new(path).map_err(crate::io_error)?;
+                let xlsx = xlsx_tool::XlsxTool::new(path).map_err(crate::internal_error)?;
                 let worksheet = if let Some(name) = &params.worksheet {
-                    xlsx.get_worksheet_by_name(name).map_err(crate::io_error)?
+                    xlsx.get_worksheet_by_name(name)
+                        .map_err(crate::internal_error)?
                 } else {
-                    xlsx.get_worksheet_by_index(0).map_err(crate::io_error)?
+                    xlsx.get_worksheet_by_index(0)
+                        .map_err(crate::internal_error)?
                 };
                 let cell_value = xlsx
                     .get_cell_value(worksheet, row as u32, col as u32)
-                    .map_err(crate::io_error)?;
+                    .map_err(crate::internal_error)?;
                 Ok(CallToolResult::success(vec![Content::text(format!(
                     "{:#?}",
                     cell_value

--- a/crates/goose-mcp/src/computercontroller/mod.rs
+++ b/crates/goose-mcp/src/computercontroller/mod.rs
@@ -1232,31 +1232,21 @@ impl ComputerControllerServer {
 
         match operation {
             XlsxOperation::ListWorksheets => {
-                let xlsx = xlsx_tool::XlsxTool::new(path)
-                    .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
-                let worksheets = xlsx
-                    .list_worksheets()
-                    .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+                let xlsx = xlsx_tool::XlsxTool::new(path).map_err(crate::io_error)?;
+                let worksheets = xlsx.list_worksheets().map_err(crate::io_error)?;
                 Ok(CallToolResult::success(vec![Content::text(format!(
                     "{:#?}",
                     worksheets
                 ))]))
             }
             XlsxOperation::GetColumns => {
-                let xlsx = xlsx_tool::XlsxTool::new(path)
-                    .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+                let xlsx = xlsx_tool::XlsxTool::new(path).map_err(crate::io_error)?;
                 let worksheet = if let Some(name) = &params.worksheet {
-                    xlsx.get_worksheet_by_name(name).map_err(|e| {
-                        ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None)
-                    })?
+                    xlsx.get_worksheet_by_name(name).map_err(crate::io_error)?
                 } else {
-                    xlsx.get_worksheet_by_index(0).map_err(|e| {
-                        ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None)
-                    })?
+                    xlsx.get_worksheet_by_index(0).map_err(crate::io_error)?
                 };
-                let columns = xlsx
-                    .get_column_names(worksheet)
-                    .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+                let columns = xlsx.get_column_names(worksheet).map_err(crate::io_error)?;
                 Ok(CallToolResult::success(vec![Content::text(format!(
                     "{:#?}",
                     columns
@@ -1271,20 +1261,13 @@ impl ComputerControllerServer {
                     )
                 })?;
 
-                let xlsx = xlsx_tool::XlsxTool::new(path)
-                    .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+                let xlsx = xlsx_tool::XlsxTool::new(path).map_err(crate::io_error)?;
                 let worksheet = if let Some(name) = &params.worksheet {
-                    xlsx.get_worksheet_by_name(name).map_err(|e| {
-                        ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None)
-                    })?
+                    xlsx.get_worksheet_by_name(name).map_err(crate::io_error)?
                 } else {
-                    xlsx.get_worksheet_by_index(0).map_err(|e| {
-                        ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None)
-                    })?
+                    xlsx.get_worksheet_by_index(0).map_err(crate::io_error)?
                 };
-                let range_data = xlsx
-                    .get_range(worksheet, range)
-                    .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+                let range_data = xlsx.get_range(worksheet, range).map_err(crate::io_error)?;
                 Ok(CallToolResult::success(vec![Content::text(format!(
                     "{:#?}",
                     range_data
@@ -1301,20 +1284,15 @@ impl ComputerControllerServer {
 
                 let case_sensitive = params.case_sensitive;
 
-                let xlsx = xlsx_tool::XlsxTool::new(path)
-                    .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+                let xlsx = xlsx_tool::XlsxTool::new(path).map_err(crate::io_error)?;
                 let worksheet = if let Some(name) = &params.worksheet {
-                    xlsx.get_worksheet_by_name(name).map_err(|e| {
-                        ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None)
-                    })?
+                    xlsx.get_worksheet_by_name(name).map_err(crate::io_error)?
                 } else {
-                    xlsx.get_worksheet_by_index(0).map_err(|e| {
-                        ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None)
-                    })?
+                    xlsx.get_worksheet_by_index(0).map_err(crate::io_error)?
                 };
                 let matches = xlsx
                     .find_in_worksheet(worksheet, search_text, case_sensitive)
-                    .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+                    .map_err(crate::io_error)?;
                 Ok(CallToolResult::success(vec![Content::text(format!(
                     "Found matches at: {:#?}",
                     matches
@@ -1345,22 +1323,18 @@ impl ComputerControllerServer {
 
                 let worksheet_name = params.worksheet.as_deref().unwrap_or("Sheet1");
 
-                let mut xlsx = xlsx_tool::XlsxTool::new(path)
-                    .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+                let mut xlsx = xlsx_tool::XlsxTool::new(path).map_err(crate::io_error)?;
                 xlsx.update_cell(worksheet_name, row as u32, col as u32, value)
-                    .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
-                xlsx.save(path)
-                    .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+                    .map_err(crate::io_error)?;
+                xlsx.save(path).map_err(crate::io_error)?;
                 Ok(CallToolResult::success(vec![Content::text(format!(
                     "Updated cell ({}, {}) to '{}' in worksheet '{}'",
                     row, col, value, worksheet_name
                 ))]))
             }
             XlsxOperation::Save => {
-                let xlsx = xlsx_tool::XlsxTool::new(path)
-                    .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
-                xlsx.save(path)
-                    .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+                let xlsx = xlsx_tool::XlsxTool::new(path).map_err(crate::io_error)?;
+                xlsx.save(path).map_err(crate::io_error)?;
                 Ok(CallToolResult::success(vec![Content::text(
                     "File saved successfully.",
                 )]))
@@ -1382,20 +1356,15 @@ impl ComputerControllerServer {
                     )
                 })?;
 
-                let xlsx = xlsx_tool::XlsxTool::new(path)
-                    .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+                let xlsx = xlsx_tool::XlsxTool::new(path).map_err(crate::io_error)?;
                 let worksheet = if let Some(name) = &params.worksheet {
-                    xlsx.get_worksheet_by_name(name).map_err(|e| {
-                        ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None)
-                    })?
+                    xlsx.get_worksheet_by_name(name).map_err(crate::io_error)?
                 } else {
-                    xlsx.get_worksheet_by_index(0).map_err(|e| {
-                        ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None)
-                    })?
+                    xlsx.get_worksheet_by_index(0).map_err(crate::io_error)?
                 };
                 let cell_value = xlsx
                     .get_cell_value(worksheet, row as u32, col as u32)
-                    .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+                    .map_err(crate::io_error)?;
                 Ok(CallToolResult::success(vec![Content::text(format!(
                     "{:#?}",
                     cell_value

--- a/crates/goose-mcp/src/computercontroller/xlsx_tool.rs
+++ b/crates/goose-mcp/src/computercontroller/xlsx_tool.rs
@@ -1,7 +1,50 @@
 use anyhow::{Context, Result};
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::SystemTime;
 use umya_spreadsheet::{Spreadsheet, Worksheet};
+
+// Single-entry cache for the most recently parsed workbook. Sequential
+// xlsx ops in one MCP turn (list → get_columns → get_range) all parse
+// the same file; this skips the re-parse on cache hit. Mtime-keyed so
+// any external write busts the cache. Cap of 1 entry keeps memory
+// bounded with no eviction logic; concurrent access to different files
+// just thrashes harmlessly.
+struct CachedWorkbook {
+    canonical: PathBuf,
+    mtime: SystemTime,
+    spreadsheet: Spreadsheet,
+}
+
+static WORKBOOK_CACHE: Lazy<Mutex<Option<CachedWorkbook>>> = Lazy::new(|| Mutex::new(None));
+
+#[cfg(test)]
+static CACHE_PARSE_COUNT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+#[cfg(test)]
+pub fn _test_reset_cache() {
+    if let Ok(mut g) = WORKBOOK_CACHE.lock() {
+        *g = None;
+    }
+    CACHE_PARSE_COUNT.store(0, std::sync::atomic::Ordering::SeqCst);
+}
+
+#[cfg(test)]
+pub fn _test_parse_count() -> usize {
+    CACHE_PARSE_COUNT.load(std::sync::atomic::Ordering::SeqCst)
+}
+
+fn invalidate_cache(canonical: &Path) {
+    if let Ok(mut g) = WORKBOOK_CACHE.lock() {
+        if let Some(c) = g.as_ref() {
+            if c.canonical == canonical {
+                *g = None;
+            }
+        }
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct WorksheetInfo {
@@ -33,8 +76,36 @@ pub struct XlsxTool {
 
 impl XlsxTool {
     pub fn new<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let path_ref = path.as_ref();
+        let canonical = path_ref
+            .canonicalize()
+            .unwrap_or_else(|_| path_ref.to_path_buf());
+        let mtime = std::fs::metadata(&canonical)
+            .and_then(|m| m.modified())
+            .context("Failed to read xlsx mtime")?;
+
+        if let Ok(guard) = WORKBOOK_CACHE.lock() {
+            if let Some(cached) = guard.as_ref() {
+                if cached.canonical == canonical && cached.mtime == mtime {
+                    return Ok(Self {
+                        workbook: cached.spreadsheet.clone(),
+                    });
+                }
+            }
+        }
+
         let workbook =
-            umya_spreadsheet::reader::xlsx::read(path).context("Failed to read Excel file")?;
+            umya_spreadsheet::reader::xlsx::read(path_ref).context("Failed to read Excel file")?;
+        #[cfg(test)]
+        CACHE_PARSE_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+        if let Ok(mut guard) = WORKBOOK_CACHE.lock() {
+            *guard = Some(CachedWorkbook {
+                canonical: canonical.clone(),
+                mtime,
+                spreadsheet: workbook.clone(),
+            });
+        }
         Ok(Self { workbook })
     }
 
@@ -152,8 +223,14 @@ impl XlsxTool {
     }
 
     pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<()> {
-        umya_spreadsheet::writer::xlsx::write(&self.workbook, path)
+        let path_ref = path.as_ref();
+        umya_spreadsheet::writer::xlsx::write(&self.workbook, path_ref)
             .context("Failed to save Excel file")?;
+        // Bust the cached parse so the next read sees the new bytes/mtime.
+        let canonical = path_ref
+            .canonicalize()
+            .unwrap_or_else(|_| path_ref.to_path_buf());
+        invalidate_cache(&canonical);
         Ok(())
     }
 
@@ -410,6 +487,48 @@ mod tests {
             "A2 should be 'Government'"
         );
         assert_eq!(range.values[1][1].value, "Canada", "B2 should be 'Canada'");
+
+        Ok(())
+    }
+
+    #[test]
+    fn cache_skips_reparse_for_same_path_and_mtime() -> Result<()> {
+        // Other tests in this module run concurrently and share the parse
+        // counter, so use deltas instead of absolute values.
+        _test_reset_cache();
+        let baseline = _test_parse_count();
+
+        let path = get_test_file();
+        let _ = XlsxTool::new(&path)?;
+        let _ = XlsxTool::new(&path)?;
+        let _ = XlsxTool::new(&path)?;
+
+        // Three opens, but only the first should have parsed. Concurrent
+        // tests opening *other* files may bump the counter further; we
+        // assert at least one parse occurred for our path.
+        let delta = _test_parse_count().saturating_sub(baseline);
+        assert!(delta >= 1, "first open should parse (delta {} >= 1)", delta);
+        // The cache holds at most one entry, and concurrent tests opening
+        // different paths will evict ours. So we can't reliably assert the
+        // delta is exactly 1 across the whole module run. Instead, run two
+        // back-to-back opens and ensure the second one is a cache hit by
+        // counting parses inside a tight loop:
+        _test_reset_cache();
+        let before = _test_parse_count();
+        let _ = XlsxTool::new(&path)?;
+        let after_first = _test_parse_count();
+        let _ = XlsxTool::new(&path)?;
+        let after_second = _test_parse_count();
+        assert_eq!(
+            after_second - after_first,
+            0,
+            "second back-to-back open should hit the cache"
+        );
+        assert_eq!(
+            after_first - before,
+            1,
+            "first open after reset should parse exactly once"
+        );
 
         Ok(())
     }

--- a/crates/goose-mcp/src/computercontroller/xlsx_tool.rs
+++ b/crates/goose-mcp/src/computercontroller/xlsx_tool.rs
@@ -8,12 +8,14 @@ use umya_spreadsheet::{Spreadsheet, Worksheet};
 
 // Single-entry cache for the most recently parsed workbook. Sequential
 // xlsx ops in one MCP turn (list → get_columns → get_range) all parse
-// the same file; this skips the re-parse on cache hit. Mtime-keyed so
-// any external write busts the cache. The Arc keeps cache hits to a
-// refcount bump instead of a deep Spreadsheet clone.
+// the same file; this skips the re-parse on cache hit. Keyed on (mtime,
+// len) so external writes bust the cache even on coarse-timestamp
+// filesystems where two writes can share an mtime. The Arc keeps cache
+// hits to a refcount bump instead of a deep Spreadsheet clone.
 struct CachedWorkbook {
     canonical: PathBuf,
     mtime: SystemTime,
+    len: u64,
     spreadsheet: Arc<Spreadsheet>,
 }
 
@@ -71,13 +73,13 @@ impl XlsxTool {
         let canonical = path_ref
             .canonicalize()
             .unwrap_or_else(|_| path_ref.to_path_buf());
-        let mtime = std::fs::metadata(&canonical)
-            .and_then(|m| m.modified())
-            .context("Failed to read xlsx mtime")?;
+        let meta = std::fs::metadata(&canonical).context("Failed to read xlsx metadata")?;
+        let mtime = meta.modified().context("Failed to read xlsx mtime")?;
+        let len = meta.len();
 
         if let Ok(guard) = WORKBOOK_CACHE.lock() {
             if let Some(cached) = guard.as_ref() {
-                if cached.canonical == canonical && cached.mtime == mtime {
+                if cached.canonical == canonical && cached.mtime == mtime && cached.len == len {
                     return Ok(Self {
                         workbook: Arc::clone(&cached.spreadsheet),
                         canonical,
@@ -94,6 +96,7 @@ impl XlsxTool {
             *guard = Some(CachedWorkbook {
                 canonical: canonical.clone(),
                 mtime,
+                len,
                 spreadsheet: Arc::clone(&workbook),
             });
         }

--- a/crates/goose-mcp/src/computercontroller/xlsx_tool.rs
+++ b/crates/goose-mcp/src/computercontroller/xlsx_tool.rs
@@ -19,7 +19,8 @@ struct CachedWorkbook {
 
 static WORKBOOK_CACHE: Lazy<Mutex<Option<CachedWorkbook>>> = Lazy::new(|| Mutex::new(None));
 
-fn _test_reset_cache() {
+#[cfg(test)]
+fn reset_cache_for_test() {
     if let Ok(mut g) = WORKBOOK_CACHE.lock() {
         *g = None;
     }
@@ -205,9 +206,11 @@ impl XlsxTool {
         value: &str,
     ) -> Result<()> {
         // Drop the cache's reference before mutating so `Arc::make_mut`
-        // doesn't deep-clone a multi-MB Spreadsheet on every cell write.
-        // `save()` would invalidate after the write anyway, so the cache
-        // bust is harmless either way.
+        // usually finds strong_count == 1 and avoids a deep clone of the
+        // multi-MB Spreadsheet. Best-effort: if another reader cloned the
+        // Arc before this invalidate ran, `make_mut` falls back to a deep
+        // clone, which is still correct. `save()` would invalidate after
+        // the write anyway, so the cache bust is harmless either way.
         invalidate_cache(&self.canonical);
         let worksheet = Arc::make_mut(&mut self.workbook)
             .get_sheet_by_name_mut(worksheet_name)
@@ -507,7 +510,7 @@ mod tests {
     #[test]
     fn cache_hit_shares_workbook_arc() -> Result<()> {
         let _g = lock();
-        _test_reset_cache();
+        reset_cache_for_test();
         let path = get_test_file();
         let first = XlsxTool::new(&path)?;
         let second = XlsxTool::new(&path)?;

--- a/crates/goose-mcp/src/computercontroller/xlsx_tool.rs
+++ b/crates/goose-mcp/src/computercontroller/xlsx_tool.rs
@@ -2,38 +2,27 @@ use anyhow::{Context, Result};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 use umya_spreadsheet::{Spreadsheet, Worksheet};
 
 // Single-entry cache for the most recently parsed workbook. Sequential
 // xlsx ops in one MCP turn (list → get_columns → get_range) all parse
 // the same file; this skips the re-parse on cache hit. Mtime-keyed so
-// any external write busts the cache. Cap of 1 entry keeps memory
-// bounded with no eviction logic; concurrent access to different files
-// just thrashes harmlessly.
+// any external write busts the cache. The Arc keeps cache hits to a
+// refcount bump instead of a deep Spreadsheet clone.
 struct CachedWorkbook {
     canonical: PathBuf,
     mtime: SystemTime,
-    spreadsheet: Spreadsheet,
+    spreadsheet: Arc<Spreadsheet>,
 }
 
 static WORKBOOK_CACHE: Lazy<Mutex<Option<CachedWorkbook>>> = Lazy::new(|| Mutex::new(None));
 
-#[cfg(test)]
-static CACHE_PARSE_COUNT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
-
-#[cfg(test)]
-pub fn _test_reset_cache() {
+fn _test_reset_cache() {
     if let Ok(mut g) = WORKBOOK_CACHE.lock() {
         *g = None;
     }
-    CACHE_PARSE_COUNT.store(0, std::sync::atomic::Ordering::SeqCst);
-}
-
-#[cfg(test)]
-pub fn _test_parse_count() -> usize {
-    CACHE_PARSE_COUNT.load(std::sync::atomic::Ordering::SeqCst)
 }
 
 fn invalidate_cache(canonical: &Path) {
@@ -71,7 +60,8 @@ pub struct RangeData {
 }
 
 pub struct XlsxTool {
-    workbook: Spreadsheet,
+    workbook: Arc<Spreadsheet>,
+    canonical: PathBuf,
 }
 
 impl XlsxTool {
@@ -88,25 +78,28 @@ impl XlsxTool {
             if let Some(cached) = guard.as_ref() {
                 if cached.canonical == canonical && cached.mtime == mtime {
                     return Ok(Self {
-                        workbook: cached.spreadsheet.clone(),
+                        workbook: Arc::clone(&cached.spreadsheet),
+                        canonical,
                     });
                 }
             }
         }
 
-        let workbook =
-            umya_spreadsheet::reader::xlsx::read(path_ref).context("Failed to read Excel file")?;
-        #[cfg(test)]
-        CACHE_PARSE_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let workbook = Arc::new(
+            umya_spreadsheet::reader::xlsx::read(path_ref).context("Failed to read Excel file")?,
+        );
 
         if let Ok(mut guard) = WORKBOOK_CACHE.lock() {
             *guard = Some(CachedWorkbook {
                 canonical: canonical.clone(),
                 mtime,
-                spreadsheet: workbook.clone(),
+                spreadsheet: Arc::clone(&workbook),
             });
         }
-        Ok(Self { workbook })
+        Ok(Self {
+            workbook,
+            canonical,
+        })
     }
 
     pub fn list_worksheets(&self) -> Result<Vec<WorksheetInfo>> {
@@ -211,8 +204,12 @@ impl XlsxTool {
         col: u32,
         value: &str,
     ) -> Result<()> {
-        let worksheet = self
-            .workbook
+        // Drop the cache's reference before mutating so `Arc::make_mut`
+        // doesn't deep-clone a multi-MB Spreadsheet on every cell write.
+        // `save()` would invalidate after the write anyway, so the cache
+        // bust is harmless either way.
+        invalidate_cache(&self.canonical);
+        let worksheet = Arc::make_mut(&mut self.workbook)
             .get_sheet_by_name_mut(worksheet_name)
             .context("Worksheet not found")?;
 
@@ -337,6 +334,18 @@ fn column_letter_to_number(column: &str) -> Result<u32> {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use std::sync::{Mutex, MutexGuard};
+
+    // The workbook cache is a process-global static, so concurrent tests
+    // can clobber each other's cache state mid-run (e.g. one peer's parse
+    // completes between another peer's two `new()` calls and overwrites the
+    // cached Arc). All tests in this module hold this lock for the duration
+    // of their work to make assertions reproducible.
+    static CACHE_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn lock() -> MutexGuard<'static, ()> {
+        CACHE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
 
     fn get_test_file() -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -349,6 +358,7 @@ mod tests {
 
     #[test]
     fn test_open_xlsx() -> Result<()> {
+        let _g = lock();
         let xlsx = XlsxTool::new(get_test_file())?;
         let worksheets = xlsx.list_worksheets()?;
         assert!(!worksheets.is_empty());
@@ -357,36 +367,37 @@ mod tests {
 
     #[test]
     fn test_get_column_names() -> Result<()> {
+        let _g = lock();
         let xlsx = XlsxTool::new(get_test_file())?;
         let worksheet = xlsx.get_worksheet_by_index(0)?;
         let columns = xlsx.get_column_names(worksheet)?;
         assert!(!columns.is_empty());
-        println!("Columns: {:?}", columns);
         Ok(())
     }
 
     #[test]
     fn test_get_range() -> Result<()> {
+        let _g = lock();
         let xlsx = XlsxTool::new(get_test_file())?;
         let worksheet = xlsx.get_worksheet_by_index(0)?;
         let range = xlsx.get_range(worksheet, "A1:C5")?;
         assert_eq!(range.values.len(), 5);
-        println!("Range data: {:?}", range);
         Ok(())
     }
 
     #[test]
     fn test_find_in_worksheet() -> Result<()> {
+        let _g = lock();
         let xlsx = XlsxTool::new(get_test_file())?;
         let worksheet = xlsx.get_worksheet_by_index(0)?;
         let matches = xlsx.find_in_worksheet(worksheet, "Government", false)?;
         assert!(!matches.is_empty());
-        println!("Found matches at: {:?}", matches);
         Ok(())
     }
 
     #[test]
     fn test_get_cell_value() -> Result<()> {
+        let _g = lock();
         let xlsx = XlsxTool::new(get_test_file())?;
         let worksheet = xlsx.get_worksheet_by_index(0)?;
 
@@ -420,6 +431,7 @@ mod tests {
 
     #[test]
     fn test_coordinate_mapping() -> Result<()> {
+        let _g = lock();
         let xlsx = XlsxTool::new(get_test_file())?;
         let worksheet = xlsx.get_worksheet_by_index(0)?;
 
@@ -457,6 +469,7 @@ mod tests {
 
     #[test]
     fn test_issue_4550_row_column_transposition() -> Result<()> {
+        let _g = lock();
         // This test specifically addresses issue #4550 where A2 was returning B1's value
         let xlsx = XlsxTool::new(get_test_file())?;
         let worksheet = xlsx.get_worksheet_by_index(0)?;
@@ -492,44 +505,16 @@ mod tests {
     }
 
     #[test]
-    fn cache_skips_reparse_for_same_path_and_mtime() -> Result<()> {
-        // Other tests in this module run concurrently and share the parse
-        // counter, so use deltas instead of absolute values.
+    fn cache_hit_shares_workbook_arc() -> Result<()> {
+        let _g = lock();
         _test_reset_cache();
-        let baseline = _test_parse_count();
-
         let path = get_test_file();
-        let _ = XlsxTool::new(&path)?;
-        let _ = XlsxTool::new(&path)?;
-        let _ = XlsxTool::new(&path)?;
-
-        // Three opens, but only the first should have parsed. Concurrent
-        // tests opening *other* files may bump the counter further; we
-        // assert at least one parse occurred for our path.
-        let delta = _test_parse_count().saturating_sub(baseline);
-        assert!(delta >= 1, "first open should parse (delta {} >= 1)", delta);
-        // The cache holds at most one entry, and concurrent tests opening
-        // different paths will evict ours. So we can't reliably assert the
-        // delta is exactly 1 across the whole module run. Instead, run two
-        // back-to-back opens and ensure the second one is a cache hit by
-        // counting parses inside a tight loop:
-        _test_reset_cache();
-        let before = _test_parse_count();
-        let _ = XlsxTool::new(&path)?;
-        let after_first = _test_parse_count();
-        let _ = XlsxTool::new(&path)?;
-        let after_second = _test_parse_count();
-        assert_eq!(
-            after_second - after_first,
-            0,
-            "second back-to-back open should hit the cache"
+        let first = XlsxTool::new(&path)?;
+        let second = XlsxTool::new(&path)?;
+        assert!(
+            Arc::ptr_eq(&first.workbook, &second.workbook),
+            "cache hit must reuse the Arc, not deep-clone the Spreadsheet"
         );
-        assert_eq!(
-            after_first - before,
-            1,
-            "first open after reset should parse exactly once"
-        );
-
         Ok(())
     }
 }

--- a/crates/goose-mcp/src/lib.rs
+++ b/crates/goose-mcp/src/lib.rs
@@ -1,7 +1,16 @@
 use etcetera::AppStrategyArgs;
 use once_cell::sync::Lazy;
+use rmcp::model::{ErrorCode, ErrorData};
 use rmcp::{ServerHandler, ServiceExt};
 use std::collections::HashMap;
+
+/// Wrap an error as an MCP `INTERNAL_ERROR` response. Threaded through
+/// `.map_err(io_error)` across the MCP servers so handlers don't repeat
+/// the `ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None)`
+/// boilerplate.
+pub fn io_error(e: impl ToString) -> ErrorData {
+    ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None)
+}
 
 // NOTE: "Block" is kept here for backwards compatibility with existing
 // user config/data directories. Changing this would orphan existing installations.

--- a/crates/goose-mcp/src/lib.rs
+++ b/crates/goose-mcp/src/lib.rs
@@ -5,10 +5,10 @@ use rmcp::{ServerHandler, ServiceExt};
 use std::collections::HashMap;
 
 /// Wrap an error as an MCP `INTERNAL_ERROR` response. Threaded through
-/// `.map_err(io_error)` across the MCP servers so handlers don't repeat
-/// the `ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None)`
-/// boilerplate.
-pub fn io_error(e: impl ToString) -> ErrorData {
+/// `.map_err(internal_error)` across the MCP servers so handlers don't
+/// repeat the `ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(),
+/// None)` boilerplate.
+pub fn internal_error(e: impl ToString) -> ErrorData {
     ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None)
 }
 

--- a/crates/goose-mcp/src/memory/mod.rs
+++ b/crates/goose-mcp/src/memory/mod.rs
@@ -361,7 +361,7 @@ impl MemoryServer {
             params.is_global,
             working_dir.as_ref(),
         )
-        .map_err(crate::io_error)?;
+        .map_err(crate::internal_error)?;
 
         Ok(CallToolResult::success(vec![Content::text(format!(
             "Stored memory in category: {}",
@@ -387,7 +387,7 @@ impl MemoryServer {
         } else {
             self.retrieve(&params.category, params.is_global, working_dir.as_ref())
         }
-        .map_err(crate::io_error)?;
+        .map_err(crate::internal_error)?;
 
         Ok(CallToolResult::success(vec![Content::text(format!(
             "Retrieved memories: {:?}",
@@ -410,14 +410,14 @@ impl MemoryServer {
 
         let message = if params.category == "*" {
             self.clear_all_global_or_local_memories(params.is_global, working_dir.as_ref())
-                .map_err(crate::io_error)?;
+                .map_err(crate::internal_error)?;
             format!(
                 "Cleared all memory {} categories",
                 if params.is_global { "global" } else { "local" }
             )
         } else {
             self.clear_memory(&params.category, params.is_global, working_dir.as_ref())
-                .map_err(crate::io_error)?;
+                .map_err(crate::internal_error)?;
             format!("Cleared memories in category: {}", params.category)
         };
 
@@ -443,7 +443,7 @@ impl MemoryServer {
             params.is_global,
             working_dir.as_ref(),
         )
-        .map_err(crate::io_error)?;
+        .map_err(crate::internal_error)?;
 
         Ok(CallToolResult::success(vec![Content::text(format!(
             "Removed specific memory from category: {}",

--- a/crates/goose-mcp/src/memory/mod.rs
+++ b/crates/goose-mcp/src/memory/mod.rs
@@ -361,7 +361,7 @@ impl MemoryServer {
             params.is_global,
             working_dir.as_ref(),
         )
-        .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+        .map_err(crate::io_error)?;
 
         Ok(CallToolResult::success(vec![Content::text(format!(
             "Stored memory in category: {}",
@@ -387,7 +387,7 @@ impl MemoryServer {
         } else {
             self.retrieve(&params.category, params.is_global, working_dir.as_ref())
         }
-        .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+        .map_err(crate::io_error)?;
 
         Ok(CallToolResult::success(vec![Content::text(format!(
             "Retrieved memories: {:?}",
@@ -410,14 +410,14 @@ impl MemoryServer {
 
         let message = if params.category == "*" {
             self.clear_all_global_or_local_memories(params.is_global, working_dir.as_ref())
-                .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+                .map_err(crate::io_error)?;
             format!(
                 "Cleared all memory {} categories",
                 if params.is_global { "global" } else { "local" }
             )
         } else {
             self.clear_memory(&params.category, params.is_global, working_dir.as_ref())
-                .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+                .map_err(crate::io_error)?;
             format!("Cleared memories in category: {}", params.category)
         };
 
@@ -443,7 +443,7 @@ impl MemoryServer {
             params.is_global,
             working_dir.as_ref(),
         )
-        .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+        .map_err(crate::io_error)?;
 
         Ok(CallToolResult::success(vec![Content::text(format!(
             "Removed specific memory from category: {}",


### PR DESCRIPTION
## Summary

Two stacked perf/refactor commits for `goose-mcp`'s computercontroller:

- `perf,refactor(goose-mcp): xlsx workbook cache + unified INTERNAL_ERROR mapping` — single-entry mtime-keyed workbook cache so sequential xlsx ops in one MCP turn (list → get_columns → get_range) skip re-parses; consolidates all `ErrorData::new(INTERNAL_ERROR, …)` patterns into a single `internal_error` helper.
- `perf(goose-mcp): Arc<Spreadsheet> for xlsx cache; rename io_error → internal_error` — cache hits become an `Arc` refcount bump instead of a deep `Spreadsheet` clone (negated most of the I/O savings without this). `update_cell` invalidates first so `Arc::make_mut` doesn't deep-clone either.

### Notes
Resolved one conflict at cherry-pick: dropped the `CACHE_PARSE_COUNT` test instrumentation (the second commit removed it intentionally) and kept `_test_reset_cache` private.

### Testing
- `cargo test -p goose-mcp computercontroller::xlsx_tool`.
- Manual: run xlsx list/get_columns/get_range on a multi-MB workbook in one MCP turn; second/third calls should be near-instant.

### Related Issues
None — change driven by code review and observed behavior.
