### PR TITLE
perf(goose,goose2): read-tool guidance + tool-aware response handling

### DIFF
--- a/crates/goose/src/acp/fs.rs
+++ b/crates/goose/src/acp/fs.rs
@@ -83,7 +83,12 @@ fn read_tool() -> Tool {
         .as_object()
         .expect("schema should serialize to an object")
         .clone();
-    Tool::new("read", "Read a text file from disk.", schema).annotate(
+    Tool::new(
+        "read",
+        "Read a text file from disk. Pass `line` and `limit` to read a specific range; avoid reading whole large files when you only need a portion.",
+        schema,
+    )
+    .annotate(
         ToolAnnotations::with_title("Read")
             .read_only(true)
             .destructive(false)

--- a/crates/goose/src/acp/fs.rs
+++ b/crates/goose/src/acp/fs.rs
@@ -427,8 +427,17 @@ impl McpClientTrait for AcpTools {
                 .await
                 .map(|r| r.with_acp_aware_meta()),
             _ => {
+                // Forward a ctx that carries the ACP read-tool capability so
+                // downstream tools (e.g. shell) can tailor model-facing hints
+                // about how to inspect saved output.
+                let inner_ctx = crate::agents::ToolCallContext::new(
+                    ctx.session_id.clone(),
+                    ctx.working_dir.clone(),
+                    ctx.tool_call_request_id.clone(),
+                )
+                .with_read_tool_available(self.fs_read);
                 self.inner
-                    .call_tool(ctx, name, arguments, cancellation_token)
+                    .call_tool(&inner_ctx, name, arguments, cancellation_token)
                     .await
             }
         }

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -311,8 +311,8 @@ impl Agent {
         session: &Session,
     ) -> ToolCallResult {
         // Default-install case: no PostToolUse/PostToolUseFailure hooks are
-        // registered, so skip cloning session id, working_dir, tool name, and
-        // (potentially multi-KB) tool args for every tool call.
+        // registered, so skip cloning session id, working_dir, and (potentially
+        // multi-KB) tool args for every tool call.
         let has_success_hook = self
             .hook_manager
             .has_hooks(crate::hooks::HookEvent::PostToolUse);

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -310,6 +310,30 @@ impl Agent {
         tool_call: &CallToolRequestParams,
         session: &Session,
     ) -> ToolCallResult {
+        // Default-install case: no PostToolUse/PostToolUseFailure hooks are
+        // registered, so skip cloning session id, working_dir, tool name, and
+        // (potentially multi-KB) tool args for every tool call.
+        let has_success_hook = self
+            .hook_manager
+            .has_hooks(crate::hooks::HookEvent::PostToolUse);
+        let has_failure_hook = self
+            .hook_manager
+            .has_hooks(crate::hooks::HookEvent::PostToolUseFailure);
+        if !has_success_hook && !has_failure_hook {
+            let tool_name = tool_call.name.to_string();
+            let fut = async move {
+                super::large_response_handler::process_tool_response(
+                    result.result.await,
+                    &tool_name,
+                )
+            };
+            return ToolCallResult {
+                notification_stream: result.notification_stream,
+                result: Box::new(fut.boxed()),
+            };
+        }
+
+
         let hook_manager = self.hook_manager.clone();
         let session_id = session.id.clone();
         let working_dir = session.working_dir.to_string_lossy().to_string();
@@ -320,8 +344,10 @@ impl Agent {
             .map(|a| serde_json::Value::Object(a.clone()));
 
         let fut = async move {
-            let processed_result =
-                super::large_response_handler::process_tool_response(result.result.await);
+            let processed_result = super::large_response_handler::process_tool_response(
+                result.result.await,
+                &tool_name,
+            );
             let event = match &processed_result {
                 Ok(call_result) if call_result.is_error != Some(true) => {
                     crate::hooks::HookEvent::PostToolUse

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -333,7 +333,6 @@ impl Agent {
             };
         }
 
-
         let hook_manager = self.hook_manager.clone();
         let session_id = session.id.clone();
         let working_dir = session.working_dir.to_string_lossy().to_string();

--- a/crates/goose/src/agents/large_response_handler.rs
+++ b/crates/goose/src/agents/large_response_handler.rs
@@ -4,25 +4,35 @@ use std::fs::File;
 use std::io::Write;
 
 const DEFAULT_LARGE_TEXT_THRESHOLD: usize = 200_000;
-const RANGE_AWARE_TOOL_THRESHOLD: usize = 50_000;
+const SHELL_TOOL_THRESHOLD: usize = 50_000;
 
 fn threshold_for_tool(tool_name: &str) -> usize {
     // Tool names vary by provider (`shell`, `developer__shell`, `platform__developer__shell`,
-    // `read`, `developer__read`, ...), so suffix-match. Tools that already self-truncate
-    // or accept range parameters get a tighter safety net; opaque extension outputs keep
-    // the default.
-    if tool_name.ends_with("shell") || tool_name.ends_with("read") {
-        RANGE_AWARE_TOOL_THRESHOLD
+    // ...), so suffix-match. Shell output is easy to re-slice with `sed`/`head`/`tail`, so
+    // it gets a tighter safety net. The `read` tool is intentionally kept on the default
+    // threshold: a single-line file between the two thresholds would be uninspectable
+    // because `line`/`limit` cannot slice within a line.
+    if tool_name.ends_with("shell") {
+        SHELL_TOOL_THRESHOLD
     } else {
         DEFAULT_LARGE_TEXT_THRESHOLD
     }
 }
 
+fn shell_slice_example(path: &str) -> String {
+    if cfg!(target_os = "windows") {
+        format!("Get-Content {path} -TotalCount B | Select-Object -Skip A")
+    } else {
+        format!("sed -n 'A,Bp' {path}")
+    }
+}
+
 fn redirect_message(char_count: usize, path: &str) -> String {
+    let shell_example = shell_slice_example(path);
     format!(
         "Tool output was {char_count} characters and is saved to {path}. To view portions, \
          use the `read` tool with `path: {path}` (and `line`/`limit` for ranges) if available, \
-         or `sed -n 'A,Bp' {path}` via shell. Do NOT re-run the tool to see different slices."
+         or `{shell_example}` via shell. Do NOT re-run the tool to see different slices."
     )
 }
 
@@ -206,11 +216,11 @@ mod tests {
     }
 
     #[test]
-    fn threshold_lower_for_shell_and_read_tools() {
-        // 60K-char output: above shell/read threshold (50K) but below default (200K).
-        let text = "a".repeat(RANGE_AWARE_TOOL_THRESHOLD + 10_000);
-        let response = Ok(CallToolResult::success(vec![Content::text(text.clone())]));
+    fn threshold_lower_for_shell_but_not_read() {
+        // 60K-char output: above shell threshold (50K) but below default (200K).
+        let text = "a".repeat(SHELL_TOOL_THRESHOLD + 10_000);
 
+        let response = Ok(CallToolResult::success(vec![Content::text(text.clone())]));
         let processed_shell = process_tool_response(response, "developer__shell").unwrap();
         let shell_msg = &processed_shell.content[0]
             .as_text()
@@ -222,6 +232,19 @@ mod tests {
         );
         let _ = fs::remove_file(extract_saved_path(shell_msg));
 
+        // `read` stays on the default threshold so single-line files between 50K and
+        // 200K aren't bounced through a redirect that can't be unstuck with `line`/`limit`.
+        let response = Ok(CallToolResult::success(vec![Content::text(text.clone())]));
+        let processed_read = process_tool_response(response, "read").unwrap();
+        assert!(
+            !processed_read.content[0]
+                .as_text()
+                .expect("expected text")
+                .text
+                .contains("Tool output was"),
+            "read stays under default threshold for outputs below 200K"
+        );
+
         let response = Ok(CallToolResult::success(vec![Content::text(text)]));
         let processed_other = process_tool_response(response, "some_extension__tool").unwrap();
         assert!(
@@ -230,7 +253,7 @@ mod tests {
                 .expect("expected text")
                 .text
                 .contains("Tool output was"),
-            "non-range-aware tool stays under default threshold"
+            "non-shell tool stays under default threshold"
         );
     }
 
@@ -243,7 +266,15 @@ mod tests {
 
         assert!(msg.contains("`read` tool"), "mentions read tool");
         assert!(msg.contains("`line`/`limit`"), "mentions range params");
-        assert!(msg.contains("sed -n"), "mentions shell fallback");
+        let expected_shell_hint = if cfg!(target_os = "windows") {
+            "Get-Content"
+        } else {
+            "sed -n"
+        };
+        assert!(
+            msg.contains(expected_shell_hint),
+            "mentions OS-appropriate shell fallback ({expected_shell_hint})"
+        );
         assert!(
             msg.contains("Do NOT re-run"),
             "anti-loop language is present"

--- a/crates/goose/src/agents/large_response_handler.rs
+++ b/crates/goose/src/agents/large_response_handler.rs
@@ -3,12 +3,35 @@ use rmcp::model::{CallToolResult, Content, ErrorData};
 use std::fs::File;
 use std::io::Write;
 
-const LARGE_TEXT_THRESHOLD: usize = 200_000;
+const DEFAULT_LARGE_TEXT_THRESHOLD: usize = 200_000;
+const RANGE_AWARE_TOOL_THRESHOLD: usize = 50_000;
+
+fn threshold_for_tool(tool_name: &str) -> usize {
+    // Tool names vary by provider (`shell`, `developer__shell`, `platform__developer__shell`,
+    // `read`, `developer__read`, ...), so suffix-match. Tools that already self-truncate
+    // or accept range parameters get a tighter safety net; opaque extension outputs keep
+    // the default.
+    if tool_name.ends_with("shell") || tool_name.ends_with("read") {
+        RANGE_AWARE_TOOL_THRESHOLD
+    } else {
+        DEFAULT_LARGE_TEXT_THRESHOLD
+    }
+}
+
+fn redirect_message(char_count: usize, path: &str) -> String {
+    format!(
+        "Tool output was {char_count} characters and is saved to {path}. To view portions, \
+         use the `read` tool with `path: {path}` (and `line`/`limit` for ranges) if available, \
+         or `sed -n 'A,Bp' {path}` via shell. Do NOT re-run the tool to see different slices."
+    )
+}
 
 /// Process tool response and handle large text content
 pub fn process_tool_response(
     response: Result<CallToolResult, ErrorData>,
+    tool_name: &str,
 ) -> Result<CallToolResult, ErrorData> {
+    let threshold = threshold_for_tool(tool_name);
     match response {
         Ok(mut result) => {
             let mut processed_contents = Vec::new();
@@ -16,36 +39,27 @@ pub fn process_tool_response(
             for content in result.content {
                 match content.as_text() {
                     Some(text_content) => {
-                        // Check if text exceeds threshold
-                        if text_content.text.chars().count() > LARGE_TEXT_THRESHOLD {
-                            // Write to temp file
+                        let char_count = text_content.text.chars().count();
+                        if char_count > threshold {
                             match write_large_text_to_file(&text_content.text) {
                                 Ok(file_path) => {
-                                    // Create a new text content with reference to the file
-                                    let message = format!(
-                                        "The response returned from the tool call was larger ({} characters) and is stored in the file which you can use other tools to examine or search in: {}",
-                                        text_content.text.chars().count(),
-                                        file_path
-                                    );
-                                    processed_contents.push(Content::text(message));
+                                    processed_contents.push(Content::text(redirect_message(
+                                        char_count, &file_path,
+                                    )));
                                 }
                                 Err(e) => {
-                                    // If file writing fails, include original content with warning
                                     let warning = format!(
                                         "Warning: Failed to write large response to file: {}. Showing full content instead.\n\n{}",
-                                        e,
-                                        text_content.text
+                                        e, text_content.text
                                     );
                                     processed_contents.push(Content::text(warning));
                                 }
                             }
                         } else {
-                            // Keep original content for smaller texts
                             processed_contents.push(content);
                         }
                     }
                     None => {
-                        // Pass through other content types unchanged
                         processed_contents.push(content);
                     }
                 }
@@ -84,153 +98,157 @@ mod tests {
     use std::fs;
     use std::path::Path;
 
+    fn extract_saved_path(message: &str) -> &str {
+        // Redirect message shape: "... saved to {path}. To view portions, ..."
+        // Saved filenames contain dots (microseconds + ".txt"), so split on the
+        // sentinel that follows the path, not on the first '.'.
+        let after = message
+            .split("saved to ")
+            .nth(1)
+            .expect("redirect message contains saved path");
+        after
+            .split(". To view")
+            .next()
+            .expect("path is followed by '. To view'")
+            .trim()
+    }
+
     #[test]
     fn test_small_text_response_passes_through() {
-        // Create a small text response
         let small_text = "This is a small text response";
         let content = Content::text(small_text.to_string());
 
         let response = Ok(CallToolResult::success(vec![content]));
+        let processed = process_tool_response(response, "some_extension__tool").unwrap();
 
-        // Process the response
-        let processed = process_tool_response(response).unwrap();
-
-        // Verify the response is unchanged
         assert_eq!(processed.content.len(), 1);
-        if let Some(text_content) = processed.content[0].as_text() {
-            assert_eq!(text_content.text, small_text);
-        } else {
-            panic!("Expected text content");
-        }
+        let text_content = processed.content[0]
+            .as_text()
+            .expect("expected text content");
+        assert_eq!(text_content.text, small_text);
     }
 
     #[test]
     fn test_large_text_response_redirected_to_file() {
-        // Create a text larger than the threshold
-        let large_text = "a".repeat(LARGE_TEXT_THRESHOLD + 1000);
+        let large_text = "a".repeat(DEFAULT_LARGE_TEXT_THRESHOLD + 1000);
         let content = Content::text(large_text.clone());
 
         let response = Ok(CallToolResult::success(vec![content]));
+        let processed = process_tool_response(response, "some_extension__tool").unwrap();
 
-        // Process the response
-        let processed = process_tool_response(response).unwrap();
-
-        // Verify the response contains a message about the file
         assert_eq!(processed.content.len(), 1);
-        if let Some(text_content) = processed.content[0].as_text() {
-            assert!(text_content
-                .text
-                .contains("The response returned from the tool call was larger"));
-            assert!(text_content.text.contains("characters"));
+        let text_content = processed.content[0]
+            .as_text()
+            .expect("expected text content");
+        assert!(text_content.text.contains("Tool output was"));
+        assert!(text_content.text.contains("characters"));
 
-            // Extract the file path from the message
-            if let Some(file_path) = text_content.text.split("stored in the file: ").nth(1) {
-                // Verify the file exists and contains the original text
-                let path = Path::new(file_path.trim());
-                if path.exists() {
-                    // Only check content if file exists (may not exist in CI environments)
-                    if let Ok(file_content) = fs::read_to_string(path) {
-                        assert_eq!(file_content, large_text);
-                    }
-
-                    // Clean up the file
-                    let _ = fs::remove_file(path); // Ignore errors on cleanup
-                }
-            }
-        } else {
-            panic!("Expected text content");
-        }
+        let path = Path::new(extract_saved_path(&text_content.text));
+        assert!(path.exists(), "redirect message names a file that exists");
+        let file_content = fs::read_to_string(path).expect("file is readable");
+        assert_eq!(file_content, large_text);
+        let _ = fs::remove_file(path);
     }
 
     #[test]
     fn test_image_content_passes_through() {
-        // Create an image content
         let image_content = Content::image("base64data".to_string(), "image/png".to_string());
 
         let response = Ok(CallToolResult::success(vec![image_content]));
+        let processed = process_tool_response(response, "some_extension__tool").unwrap();
 
-        // Process the response
-        let processed = process_tool_response(response).unwrap();
-
-        // Verify the response is unchanged
         assert_eq!(processed.content.len(), 1);
-        if let Some(img) = processed.content[0].as_image() {
-            assert_eq!(img.data, "base64data");
-            assert_eq!(img.mime_type, "image/png");
-        } else {
-            panic!("Expected image content");
-        }
+        let img = processed.content[0].as_image().expect("expected image");
+        assert_eq!(img.data, "base64data");
+        assert_eq!(img.mime_type, "image/png");
     }
 
     #[test]
     fn test_mixed_content_handled_correctly() {
-        // Create a response with mixed content types
         let small_text = Content::text("Small text");
-        let large_text = Content::text("a".repeat(LARGE_TEXT_THRESHOLD + 1000));
+        let large_text = Content::text("a".repeat(DEFAULT_LARGE_TEXT_THRESHOLD + 1000));
         let image = Content::image("image_data".to_string(), "image/jpeg".to_string());
 
         let response = Ok(CallToolResult::success(vec![small_text, large_text, image]));
+        let processed = process_tool_response(response, "some_extension__tool").unwrap();
 
-        // Process the response
-        let processed = process_tool_response(response).unwrap();
-
-        // Verify each item is handled correctly
         assert_eq!(processed.content.len(), 3);
 
-        // First item should be unchanged small text
-        if let Some(text_content) = processed.content[0].as_text() {
-            assert_eq!(text_content.text, "Small text");
-        } else {
-            panic!("Expected text content");
-        }
+        assert_eq!(
+            processed.content[0].as_text().expect("expected text").text,
+            "Small text"
+        );
 
-        // Second item should be a message about the file
-        if let Some(text_content) = processed.content[1].as_text() {
-            assert!(text_content
-                .text
-                .contains("The response returned from the tool call was larger"));
+        let redirect = &processed.content[1].as_text().expect("expected text").text;
+        assert!(redirect.contains("Tool output was"));
+        let path = Path::new(extract_saved_path(redirect));
+        assert!(path.exists());
+        let _ = fs::remove_file(path);
 
-            // Extract the file path and clean up
-            if let Some(file_path) = text_content.text.split("stored in the file: ").nth(1) {
-                let path = Path::new(file_path.trim());
-                if path.exists() {
-                    let _ = fs::remove_file(path); // Ignore errors on cleanup
-                }
-            }
-        } else {
-            panic!("Expected text content");
-        }
-
-        // Third item should be unchanged image
-        if let Some(img) = processed.content[2].as_image() {
-            assert_eq!(img.data, "image_data");
-            assert_eq!(img.mime_type, "image/jpeg");
-        } else {
-            panic!("Expected image content");
-        }
+        let img = processed.content[2].as_image().expect("expected image");
+        assert_eq!(img.data, "image_data");
+        assert_eq!(img.mime_type, "image/jpeg");
     }
 
     #[test]
     fn test_error_response_passes_through() {
-        // Create an error response
         let error = ErrorData {
             code: ErrorCode::INTERNAL_ERROR,
             message: Cow::from("Test error"),
             data: None,
         };
         let response: Result<CallToolResult, ErrorData> = Err(error);
+        let processed = process_tool_response(response, "shell");
 
-        // Process the response
-        let processed = process_tool_response(response);
+        let err = processed.expect_err("expected error to pass through");
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert_eq!(err.message, "Test error");
+    }
 
-        // Verify the error is passed through unchanged
-        assert!(processed.is_err());
-        match processed {
-            Err(err) => {
-                assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
-                assert_eq!(err.message, "Test error");
-            }
-            _ => panic!("Expected execution error"),
-        }
+    #[test]
+    fn threshold_lower_for_shell_and_read_tools() {
+        // 60K-char output: above shell/read threshold (50K) but below default (200K).
+        let text = "a".repeat(RANGE_AWARE_TOOL_THRESHOLD + 10_000);
+        let response = Ok(CallToolResult::success(vec![Content::text(text.clone())]));
+
+        let processed_shell = process_tool_response(response, "developer__shell").unwrap();
+        let shell_msg = &processed_shell.content[0]
+            .as_text()
+            .expect("expected text")
+            .text;
+        assert!(
+            shell_msg.contains("Tool output was"),
+            "shell exceeds tight threshold and should redirect"
+        );
+        let _ = fs::remove_file(extract_saved_path(shell_msg));
+
+        let response = Ok(CallToolResult::success(vec![Content::text(text)]));
+        let processed_other = process_tool_response(response, "some_extension__tool").unwrap();
+        assert!(
+            !processed_other.content[0]
+                .as_text()
+                .expect("expected text")
+                .text
+                .contains("Tool output was"),
+            "non-range-aware tool stays under default threshold"
+        );
+    }
+
+    #[test]
+    fn redirect_message_mentions_read_tool_and_shell_fallback() {
+        let text = "a".repeat(DEFAULT_LARGE_TEXT_THRESHOLD + 1);
+        let response = Ok(CallToolResult::success(vec![Content::text(text)]));
+        let processed = process_tool_response(response, "some_extension__tool").unwrap();
+        let msg = &processed.content[0].as_text().expect("expected text").text;
+
+        assert!(msg.contains("`read` tool"), "mentions read tool");
+        assert!(msg.contains("`line`/`limit`"), "mentions range params");
+        assert!(msg.contains("sed -n"), "mentions shell fallback");
+        assert!(
+            msg.contains("Do NOT re-run"),
+            "anti-loop language is present"
+        );
+
+        let _ = fs::remove_file(extract_saved_path(msg));
     }
 }

--- a/crates/goose/src/agents/platform_extensions/developer/edit.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/edit.rs
@@ -11,10 +11,12 @@ const NO_MATCH_PREVIEW_LINES: usize = 20;
 pub struct FileReadParams {
     /// Absolute path to the file to read.
     pub path: String,
-    /// Line number to start reading from (1-based).
+    /// 1-based line number to start reading from. Use with `limit` to read a specific
+    /// range instead of the whole file.
     #[schemars(range(min = 1))]
     pub line: Option<u32>,
-    /// Maximum number of lines to read.
+    /// Maximum number of lines to read. Combine with `line` to fetch a specific range —
+    /// prefer this over reading whole large files.
     pub limit: Option<u32>,
 }
 

--- a/crates/goose/src/agents/platform_extensions/developer/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/mod.rs
@@ -43,6 +43,13 @@ fn developer_instructions() -> &'static str {
             and file sizes. When you need to search, prefer findstr or Select-String (via shell).
             Then use type or Get-Content to gather the context you need, always reading before
             editing. Use write and edit to efficiently make changes. Test and verify as appropriate.
+
+            When modifying existing files, prefer `edit` over `write` — `edit` sends only the
+            changed region, not the whole file. Reserve `write` for new files or full rewrites.
+
+            When reading large files, fetch only the range you need (the `read` tool's `line` and
+            `limit` parameters when available, otherwise `Get-Content -TotalCount` or
+            `Select-Object -Skip/-First`). Don't re-read the same file across turns.
         "}
     } else {
         indoc! {"
@@ -57,6 +64,13 @@ fn developer_instructions() -> &'static str {
             and file sizes. When you need to search, prefer rg which correctly respects gitignored
             content. Then use cat or sed to gather the context you need, always reading before editing.
             Use write and edit to efficiently make changes. Test and verify as appropriate.
+
+            When modifying existing files, prefer `edit` over `write` — `edit` sends only the
+            changed region, not the whole file. Reserve `write` for new files or full rewrites.
+
+            When reading large files, fetch only the range you need (the `read` tool's `line` and
+            `limit` parameters when available, otherwise `sed -n 'A,Bp'`). Don't re-read the same
+            file across turns.
 
             When running Python scripts or commands, always use `python3` instead of `python`.
         "}
@@ -98,7 +112,7 @@ impl DeveloperClient {
         vec![
             Tool::new(
                 "write".to_string(),
-                "Create a new file or overwrite an existing file. Creates parent directories if needed.".to_string(),
+                "Create a new file or overwrite an existing file. Creates parent directories if needed. Prefer `edit` for modifying existing files — it sends only the changed region.".to_string(),
                 Self::schema::<FileWriteParams>(),
             )
             .annotate(ToolAnnotations::from_raw(

--- a/crates/goose/src/agents/platform_extensions/developer/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/mod.rs
@@ -181,7 +181,10 @@ impl McpClientTrait for DeveloperClient {
         let working_dir = ctx.working_dir.as_deref();
         match name {
             "shell" => match Self::parse_args::<ShellParams>(arguments) {
-                Ok(params) => Ok(self.shell_tool.shell_with_cwd(params, working_dir).await),
+                Ok(params) => Ok(self
+                    .shell_tool
+                    .shell_with_cwd(params, working_dir, ctx.read_tool_available)
+                    .await),
                 Err(error) => Ok(ShellTool::error_result(&format!("Error: {error}"), None)),
             },
             "write" => match Self::parse_args::<FileWriteParams>(arguments) {

--- a/crates/goose/src/agents/platform_extensions/developer/shell.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/shell.rs
@@ -947,7 +947,10 @@ mod tests {
         // triggered truncation — head AND tail must both be visible.
         let preview = &result.text;
         assert!(preview.contains("line_000_"), "preview missing head line 0");
-        assert!(preview.contains("line_099_"), "preview missing tail line 99");
+        assert!(
+            preview.contains("line_099_"),
+            "preview missing tail line 99"
+        );
         let expected_elided = 100 - OUTPUT_PREVIEW_HEAD_LINES - OUTPUT_PREVIEW_TAIL_LINES;
         assert!(
             preview.contains(&format!("{expected_elided} lines elided")),

--- a/crates/goose/src/agents/platform_extensions/developer/shell.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/shell.rs
@@ -113,7 +113,8 @@ fn unix_shell() -> String {
 
 const OUTPUT_LIMIT_LINES: usize = 2000;
 pub const OUTPUT_LIMIT_BYTES: usize = 50_000;
-const OUTPUT_PREVIEW_LINES: usize = 50;
+const OUTPUT_PREVIEW_HEAD_LINES: usize = 25;
+const OUTPUT_PREVIEW_TAIL_LINES: usize = 25;
 
 const OUTPUT_SLOTS: usize = 8;
 
@@ -157,6 +158,16 @@ pub struct ShellOutput {
     /// Error reported by output collection after process exit.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output_collection_error: Option<String>,
+    /// Path where the full stdout was saved when truncated. Absent when stdout
+    /// fit within the preview budget.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stdout_saved_path: Option<String>,
+    /// Path where the full stderr was saved when truncated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stderr_saved_path: Option<String>,
+    /// Path where the full interleaved output was saved when truncated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub combined_saved_path: Option<String>,
 }
 
 /// Resolve the user's full PATH by running a login shell.
@@ -303,13 +314,14 @@ impl ShellTool {
     }
 
     pub async fn shell(&self, params: ShellParams) -> CallToolResult {
-        self.shell_with_cwd(params, None).await
+        self.shell_with_cwd(params, None, false).await
     }
 
     pub async fn shell_with_cwd(
         &self,
         params: ShellParams,
         working_dir: Option<&std::path::Path>,
+        read_tool_available: bool,
     ) -> CallToolResult {
         if params.command.trim().is_empty() {
             return Self::error_result("Command cannot be empty.", None);
@@ -362,6 +374,23 @@ impl ShellTool {
             }
         };
 
+        let render_result = match render_output(&interleaved, &format!("output-{slot}"), output_dir)
+        {
+            Ok(r) => r,
+            Err(error) => return Self::error_result(&error, None),
+        };
+        let stdout_saved_path = stdout_result
+            .truncation
+            .as_ref()
+            .map(|t| t.path.display().to_string());
+        let stderr_saved_path = stderr_result
+            .truncation
+            .as_ref()
+            .map(|t| t.path.display().to_string());
+        let combined_saved_path = render_result
+            .truncation
+            .as_ref()
+            .map(|t| t.path.display().to_string());
         let shell_output = ShellOutput {
             stdout: stdout_result.text,
             stderr: stderr_result.text,
@@ -369,13 +398,11 @@ impl ShellTool {
             timed_out: execution.timed_out,
             output_truncated: execution.output_truncated,
             output_collection_error: execution.output_collection_error.clone(),
+            stdout_saved_path,
+            stderr_saved_path,
+            combined_saved_path,
         };
         let structured_content = serde_json::to_value(&shell_output).ok();
-        let render_result = match render_output(&interleaved, &format!("output-{slot}"), output_dir)
-        {
-            Ok(r) => r,
-            Err(error) => return Self::error_result(&error, None),
-        };
         let mut rendered = render_result.text;
 
         // Collect truncation notices from stdout, stderr, and interleaved output.
@@ -387,7 +414,10 @@ impl ShellTool {
             &render_result.truncation,
         ]
         .iter()
-        .filter_map(|t| t.as_ref().map(truncation_notice))
+        .filter_map(|t| {
+            t.as_ref()
+                .map(|info| truncation_notice(info, read_tool_available))
+        })
         .collect();
 
         let is_error = if execution.timed_out {
@@ -447,6 +477,9 @@ impl ShellTool {
             timed_out: false,
             output_truncated: false,
             output_collection_error: None,
+            stdout_saved_path: None,
+            stderr_saved_path: None,
+            combined_saved_path: None,
         };
         let mut result = CallToolResult::error(vec![Content::text(message).with_priority(0.0)]);
         result.structured_content = serde_json::to_value(&shell_output).ok();
@@ -660,20 +693,28 @@ async fn collect_tagged_lines(
 }
 
 /// Build a human-readable truncation notice with platform-appropriate commands.
-fn truncation_notice(info: &TruncationInfo) -> String {
+fn truncation_notice(info: &TruncationInfo, read_tool_available: bool) -> String {
     let path = info.path.display();
-    let commands = if cfg!(windows) {
-        "PowerShell commands like `Get-Content -TotalCount 200`, `Select-String`, or \
-         `Get-Content | Select-Object -Skip 100 -First 100`"
+    let reason = &info.reason;
+    if read_tool_available {
+        format!(
+            "[{reason} Full output saved to {path}. \
+             Use the `read` tool on that path to view any range — \
+             do NOT re-run the command to see different slices.]"
+        )
     } else {
-        "shell commands like `head`, `tail`, or `sed -n '100,200p'`"
-    };
-    format!(
-        "[{reason} Full output saved to {path}. \
-         Read it with {commands} up to {limit} lines at a time.]",
-        reason = info.reason,
-        limit = OUTPUT_LIMIT_LINES,
-    )
+        let commands = if cfg!(windows) {
+            "PowerShell commands like `Get-Content -TotalCount 200`, `Select-String`, or \
+             `Get-Content | Select-Object -Skip 100 -First 100`"
+        } else {
+            "shell commands like `cat`, `head`, `tail`, or `sed -n '100,200p'`"
+        };
+        format!(
+            "[{reason} Full output saved to {path}. \
+             Use {commands} on that path to view ranges — \
+             do NOT re-run the command to see different slices.]"
+        )
+    }
 }
 
 fn render_output(
@@ -695,9 +736,16 @@ fn truncate_output(
     label: &str,
     output_dir: &std::path::Path,
 ) -> Result<TruncateResult, String> {
-    let lines: Vec<&str> = full_output.split('\n').collect();
-    let total_lines = lines.len();
     let total_bytes = full_output.len();
+    // split('\n') yields a trailing empty element when input ends with '\n';
+    // dropping it keeps the bookended preview from picking up a blank tail line.
+    let raw_lines: Vec<&str> = full_output.split('\n').collect();
+    let lines: &[&str] = if raw_lines.last() == Some(&"") {
+        &raw_lines[..raw_lines.len() - 1]
+    } else {
+        &raw_lines[..]
+    };
+    let total_lines = lines.len();
 
     let exceeded_lines = total_lines > OUTPUT_LIMIT_LINES;
     let exceeded_bytes = total_bytes > OUTPUT_LIMIT_BYTES;
@@ -711,16 +759,26 @@ fn truncate_output(
 
     let output_path = save_full_output(full_output, label, output_dir)?;
 
-    let preview_start = total_lines.saturating_sub(OUTPUT_PREVIEW_LINES);
-    let preview = lines[preview_start..].join("\n");
+    let preview_kept = OUTPUT_PREVIEW_HEAD_LINES + OUTPUT_PREVIEW_TAIL_LINES;
+    let preview = if total_lines <= preview_kept + 1 {
+        // No elision needed — only the byte limit was the trigger and the
+        // line count fits within head + tail.
+        lines.join("\n")
+    } else {
+        let head = lines[..OUTPUT_PREVIEW_HEAD_LINES].join("\n");
+        let tail_start = total_lines - OUTPUT_PREVIEW_TAIL_LINES;
+        let tail = lines[tail_start..].join("\n");
+        let elided = total_lines - preview_kept;
+        format!(
+            "{head}\n... [{elided} lines elided — see {path} for full output] ...\n{tail}",
+            path = output_path.display(),
+        )
+    };
 
     let reason = if exceeded_lines {
         format!("Output exceeded {OUTPUT_LIMIT_LINES} line limit ({total_lines} lines total).")
     } else {
-        format!(
-            "Output exceeded {} byte limit ({total_bytes} bytes total).",
-            OUTPUT_LIMIT_BYTES
-        )
+        format!("Output exceeded {OUTPUT_LIMIT_BYTES} byte limit ({total_bytes} bytes total).")
     };
 
     Ok(TruncateResult {
@@ -803,6 +861,7 @@ mod tests {
                     timeout_secs: None,
                 },
                 Some(dir.path()),
+                false,
             )
             .await;
 
@@ -834,7 +893,7 @@ mod tests {
     }
 
     #[test]
-    fn render_output_truncates_when_lines_exceeded() {
+    fn render_output_truncates_with_head_and_tail() {
         let dir = tempfile::tempdir().unwrap();
         let input = (0..2500)
             .map(|i| format!("line {}", i))
@@ -844,8 +903,17 @@ mod tests {
         let result = render_output(&input, "test_lines", dir.path()).unwrap();
         let preview = &result.text;
 
-        assert_eq!(preview.lines().count(), OUTPUT_PREVIEW_LINES);
-        assert!(preview.starts_with("line 2450"));
+        // Bookended preview: HEAD + 1 elision marker line + TAIL.
+        let expected_lines = OUTPUT_PREVIEW_HEAD_LINES + 1 + OUTPUT_PREVIEW_TAIL_LINES;
+        assert_eq!(preview.lines().count(), expected_lines);
+        assert!(preview.starts_with("line 0\n"));
+        assert!(preview.contains("line 24"));
+        let expected_elided = 2500 - OUTPUT_PREVIEW_HEAD_LINES - OUTPUT_PREVIEW_TAIL_LINES;
+        assert!(
+            preview.contains(&format!("{expected_elided} lines elided")),
+            "preview missing expected elision marker; got: {preview}"
+        );
+        assert!(preview.contains("line 2475"));
         assert!(preview.contains("line 2499"));
 
         let info = result
@@ -854,17 +922,14 @@ mod tests {
             .expect("expected truncation info");
         assert!(info.reason.contains("2000 line limit"));
         assert!(info.reason.contains("2500 lines total"));
-
-        let notice = truncation_notice(info);
-        assert!(notice.contains("Full output saved to"));
     }
 
     #[test]
-    fn render_output_truncates_when_bytes_exceeded() {
+    fn render_output_byte_limit_keeps_head_and_tail() {
         let dir = tempfile::tempdir().unwrap();
-        let long_line = "x".repeat(1000);
+        let filler = "x".repeat(990);
         let input = (0..100)
-            .map(|_| long_line.clone())
+            .map(|i| format!("line_{i:03}_{filler}"))
             .collect::<Vec<_>>()
             .join("\n");
         assert!(input.len() > OUTPUT_LIMIT_BYTES);
@@ -878,8 +943,61 @@ mod tests {
         assert!(info.reason.contains("byte limit"));
         assert!(info.reason.contains("bytes total"));
 
-        let notice = truncation_notice(info);
-        assert!(notice.contains("Full output saved to"));
+        // Preview should bookend the output even when only the byte limit
+        // triggered truncation — head AND tail must both be visible.
+        let preview = &result.text;
+        assert!(preview.contains("line_000_"), "preview missing head line 0");
+        assert!(preview.contains("line_099_"), "preview missing tail line 99");
+        let expected_elided = 100 - OUTPUT_PREVIEW_HEAD_LINES - OUTPUT_PREVIEW_TAIL_LINES;
+        assert!(
+            preview.contains(&format!("{expected_elided} lines elided")),
+            "preview missing elision marker"
+        );
+    }
+
+    #[test]
+    fn render_output_below_threshold_passes_through() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = "line 1\nline 2\nline 3\n";
+
+        let result = render_output(input, "test_small", dir.path()).unwrap();
+        assert_eq!(result.text, input);
+        assert!(result.truncation.is_none());
+    }
+
+    #[test]
+    fn truncation_notice_recommends_read_tool_when_available() {
+        let info = TruncationInfo {
+            path: PathBuf::from("/tmp/goose-out"),
+            reason: "Output exceeded 2000 line limit (2500 lines total).".to_string(),
+        };
+        let notice = truncation_notice(&info, true);
+        assert!(notice.contains("`read` tool"));
+        assert!(notice.contains("/tmp/goose-out"));
+        assert!(notice.contains("do NOT re-run"));
+        // Make sure we no longer steer the model at shell utilities when the
+        // ACP read tool is available — that pattern caused observed retry loops.
+        assert!(!notice.contains("`head`"));
+        assert!(!notice.contains("`tail`"));
+        assert!(!notice.contains("`sed`"));
+    }
+
+    #[test]
+    fn truncation_notice_falls_back_to_shell_when_read_unavailable() {
+        let info = TruncationInfo {
+            path: PathBuf::from("/tmp/goose-out"),
+            reason: "Output exceeded 50000 byte limit (60000 bytes total).".to_string(),
+        };
+        let notice = truncation_notice(&info, false);
+        assert!(notice.contains("do NOT re-run"));
+        if cfg!(windows) {
+            assert!(notice.contains("Get-Content"));
+        } else {
+            assert!(notice.contains("`cat`"));
+            assert!(notice.contains("`head`"));
+            assert!(notice.contains("`tail`"));
+        }
+        assert!(!notice.contains("`read` tool"));
     }
 
     #[test]

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/goose/src/agents/prompt_manager.rs
-assertion_line: 458
 expression: system_prompt
 ---
 You are a general-purpose AI agent called goose, created by AAIF (Agentic AI Foundation).
@@ -89,6 +88,13 @@ For editing software, prefer the flow of using tree to understand the codebase s
 and file sizes. When you need to search, prefer rg which correctly respects gitignored
 content. Then use cat or sed to gather the context you need, always reading before editing.
 Use write and edit to efficiently make changes. Test and verify as appropriate.
+
+When modifying existing files, prefer `edit` over `write` — `edit` sends only the
+changed region, not the whole file. Reserve `write` for new files or full rewrites.
+
+When reading large files, fetch only the range you need (the `read` tool's `line` and
+`limit` parameters when available, otherwise `sed -n 'A,Bp'`). Don't re-read the same
+file across turns.
 
 When running Python scripts or commands, always use `python3` instead of `python`.
 

--- a/crates/goose/src/agents/tool_execution.rs
+++ b/crates/goose/src/agents/tool_execution.rs
@@ -18,6 +18,11 @@ pub struct ToolCallContext {
     pub session_id: String,
     pub working_dir: Option<PathBuf>,
     pub tool_call_request_id: Option<String>,
+    /// Whether the ACP client advertised `fs.readTextFile`. Tools that emit
+    /// hints to the model (e.g. shell's "output truncated" notice) use this
+    /// to decide whether to recommend the `read` tool or fall back to shell
+    /// utilities like `head`/`tail`/`sed`.
+    pub read_tool_available: bool,
 }
 
 impl ToolCallContext {
@@ -30,7 +35,13 @@ impl ToolCallContext {
             session_id,
             working_dir,
             tool_call_request_id,
+            read_tool_available: false,
         }
+    }
+
+    pub fn with_read_tool_available(mut self, value: bool) -> Self {
+        self.read_tool_available = value;
+        self
     }
 
     pub fn working_dir_str(&self) -> Option<&str> {

--- a/ui/goose2/src-tauri/src/commands/acp_fs.rs
+++ b/ui/goose2/src-tauri/src/commands/acp_fs.rs
@@ -1,0 +1,97 @@
+use std::fs;
+use std::path::PathBuf;
+
+// TODO(security): no sandboxing today — the agent can read or write any path
+// the desktop user can. Mirrors the dev extension's prior behavior so this
+// PR is a pure bug fix. Once we want to scope agent fs access (project root,
+// prompt-on-write-outside, etc.), the check goes here.
+
+#[tauri::command]
+pub fn acp_read_text_file(
+    path: String,
+    line: Option<u32>,
+    limit: Option<u32>,
+) -> Result<String, String> {
+    let p = PathBuf::from(&path);
+    let content = fs::read_to_string(&p)
+        .map_err(|e| format!("Failed to read file '{}': {}", p.display(), e))?;
+    Ok(apply_line_limit(&content, line, limit))
+}
+
+#[tauri::command]
+pub fn acp_write_text_file(path: String, content: String) -> Result<(), String> {
+    let path = PathBuf::from(&path);
+    if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create directory '{}': {}", parent.display(), e))?;
+    }
+    fs::write(&path, content)
+        .map_err(|e| format!("Failed to write file '{}': {}", path.display(), e))
+}
+
+// Match the slicing semantics of the dev extension's `apply_line_limit` in
+// crates/goose/src/agents/platform_extensions/developer/edit.rs so the `read`
+// tool produces identical output whether routed through ACP or the legacy path.
+fn apply_line_limit(content: &str, line: Option<u32>, limit: Option<u32>) -> String {
+    if line.is_none() && limit.is_none() {
+        return content.to_string();
+    }
+    let lines: Vec<&str> = content.split_inclusive('\n').collect();
+    let start = line
+        .map(|l| (l as usize).saturating_sub(1))
+        .unwrap_or(0)
+        .min(lines.len());
+    let end = limit
+        .map(|l| start + l as usize)
+        .unwrap_or(lines.len())
+        .min(lines.len());
+    lines[start..end].concat()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::apply_line_limit;
+
+    const SAMPLE: &str = "a\nb\nc\nd\ne\n";
+
+    #[test]
+    fn no_line_no_limit_returns_full_content() {
+        assert_eq!(apply_line_limit(SAMPLE, None, None), SAMPLE);
+    }
+
+    #[test]
+    fn line_only_skips_to_offset() {
+        assert_eq!(apply_line_limit(SAMPLE, Some(3), None), "c\nd\ne\n");
+    }
+
+    #[test]
+    fn limit_only_truncates_from_start() {
+        assert_eq!(apply_line_limit(SAMPLE, None, Some(2)), "a\nb\n");
+    }
+
+    #[test]
+    fn line_and_limit_combine() {
+        assert_eq!(apply_line_limit(SAMPLE, Some(2), Some(2)), "b\nc\n");
+    }
+
+    #[test]
+    fn line_one_is_same_as_no_offset() {
+        assert_eq!(apply_line_limit(SAMPLE, Some(1), Some(3)), "a\nb\nc\n");
+    }
+
+    #[test]
+    fn line_past_end_returns_empty() {
+        assert_eq!(apply_line_limit(SAMPLE, Some(99), None), "");
+    }
+
+    #[test]
+    fn limit_past_end_clamps() {
+        assert_eq!(apply_line_limit(SAMPLE, Some(4), Some(100)), "d\ne\n");
+    }
+
+    #[test]
+    fn handles_missing_trailing_newline() {
+        let content = "a\nb\nc";
+        assert_eq!(apply_line_limit(content, Some(2), Some(2)), "b\nc");
+    }
+}

--- a/ui/goose2/src-tauri/src/commands/mod.rs
+++ b/ui/goose2/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod acp;
+pub mod acp_fs;
 pub mod agent_setup;
 pub mod agents;
 pub mod distro;

--- a/ui/goose2/src-tauri/src/lib.rs
+++ b/ui/goose2/src-tauri/src/lib.rs
@@ -38,6 +38,8 @@ pub fn run() {
             commands::agents::read_import_persona_file,
             commands::acp::get_goose_serve_url,
             commands::acp::get_goose_serve_host_info,
+            commands::acp_fs::acp_read_text_file,
+            commands::acp_fs::acp_write_text_file,
             commands::project_icons::scan_project_icons,
             commands::project_icons::read_project_icon,
             commands::doctor::run_doctor,

--- a/ui/goose2/src/shared/api/__tests__/acpFsCallbacks.test.ts
+++ b/ui/goose2/src/shared/api/__tests__/acpFsCallbacks.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+import { acpFsCallbacks } from "../acpFsCallbacks";
+
+const mockInvoke = vi.mocked(invoke);
+
+describe("acpFsCallbacks", () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+  });
+
+  describe("readTextFile", () => {
+    it("delegates to acp_read_text_file Tauri command", async () => {
+      mockInvoke.mockResolvedValueOnce("hello world\n");
+
+      const result = await acpFsCallbacks.readTextFile({
+        sessionId: "session-1",
+        path: "/tmp/example.txt",
+      });
+
+      expect(mockInvoke).toHaveBeenCalledWith("acp_read_text_file", {
+        path: "/tmp/example.txt",
+        line: null,
+        limit: null,
+      });
+      expect(result).toEqual({ content: "hello world\n" });
+    });
+
+    it("forwards line and limit when provided", async () => {
+      mockInvoke.mockResolvedValueOnce("b\nc\n");
+
+      const result = await acpFsCallbacks.readTextFile({
+        sessionId: "session-1",
+        path: "/tmp/example.txt",
+        line: 2,
+        limit: 2,
+      });
+
+      expect(mockInvoke).toHaveBeenCalledWith("acp_read_text_file", {
+        path: "/tmp/example.txt",
+        line: 2,
+        limit: 2,
+      });
+      expect(result).toEqual({ content: "b\nc\n" });
+    });
+
+    it("propagates errors from the Tauri command", async () => {
+      mockInvoke.mockRejectedValueOnce(new Error("No such file"));
+
+      await expect(
+        acpFsCallbacks.readTextFile({
+          sessionId: "session-1",
+          path: "/tmp/missing.txt",
+        }),
+      ).rejects.toThrow("No such file");
+    });
+  });
+
+  describe("writeTextFile", () => {
+    it("delegates to acp_write_text_file Tauri command", async () => {
+      mockInvoke.mockResolvedValueOnce(undefined);
+
+      const result = await acpFsCallbacks.writeTextFile({
+        sessionId: "session-1",
+        path: "/tmp/out.txt",
+        content: "payload",
+      });
+
+      expect(mockInvoke).toHaveBeenCalledWith("acp_write_text_file", {
+        path: "/tmp/out.txt",
+        content: "payload",
+      });
+      expect(result).toEqual({});
+    });
+
+    it("propagates errors from the Tauri command", async () => {
+      mockInvoke.mockRejectedValueOnce(new Error("Permission denied"));
+
+      await expect(
+        acpFsCallbacks.writeTextFile({
+          sessionId: "session-1",
+          path: "/forbidden",
+          content: "",
+        }),
+      ).rejects.toThrow("Permission denied");
+    });
+  });
+});

--- a/ui/goose2/src/shared/api/acpConnection.ts
+++ b/ui/goose2/src/shared/api/acpConnection.ts
@@ -12,6 +12,7 @@ import {
   type RequestPermissionResponse,
 } from "@agentclientprotocol/sdk";
 import packageJson from "../../../package.json";
+import { acpFsCallbacks } from "./acpFsCallbacks";
 import { createWebSocketStream } from "./createWebSocketStream";
 import { perfLog } from "@/shared/lib/perfLog";
 
@@ -47,6 +48,8 @@ function createClientCallbacks(): () => Client {
         await notificationHandler.handleSessionNotification(notification);
       }
     },
+
+    ...acpFsCallbacks,
   });
 }
 
@@ -87,6 +90,10 @@ async function initializeConnection(): Promise<GooseClient> {
   await client.initialize({
     protocolVersion: PROTOCOL_VERSION,
     clientCapabilities: {
+      fs: {
+        readTextFile: true,
+        writeTextFile: true,
+      },
       _meta: {
         goose: {
           mcpHostCapabilities: DEFAULT_GOOSE_MCP_HOST_CAPABILITIES,

--- a/ui/goose2/src/shared/api/acpFsCallbacks.ts
+++ b/ui/goose2/src/shared/api/acpFsCallbacks.ts
@@ -1,0 +1,33 @@
+import { invoke } from "@tauri-apps/api/core";
+import type {
+  ReadTextFileRequest,
+  ReadTextFileResponse,
+  WriteTextFileRequest,
+  WriteTextFileResponse,
+} from "@agentclientprotocol/sdk";
+
+const ACP_READ_TEXT_FILE = "acp_read_text_file";
+const ACP_WRITE_TEXT_FILE = "acp_write_text_file";
+
+export const acpFsCallbacks = {
+  readTextFile: async (
+    args: ReadTextFileRequest,
+  ): Promise<ReadTextFileResponse> => {
+    const content = await invoke<string>(ACP_READ_TEXT_FILE, {
+      path: args.path,
+      line: args.line ?? null,
+      limit: args.limit ?? null,
+    });
+    return { content };
+  },
+
+  writeTextFile: async (
+    args: WriteTextFileRequest,
+  ): Promise<WriteTextFileResponse> => {
+    await invoke(ACP_WRITE_TEXT_FILE, {
+      path: args.path,
+      content: args.content,
+    });
+    return {};
+  },
+};


### PR DESCRIPTION
## Summary

Token-efficiency stack centered on getting the LLM to use the dedicated read tool (instead of `cat`/`head`/`tail` via shell) and bookending large outputs so the model doesn't burn context on noise.

- `fix(goose2): honor ACP fs capabilities so the read tool reappears` — goose2's ACP initialize now declares fs capabilities and wires the `acp_read_text_file`/`acp_write_text_file` Tauri commands so the read tool actually shows up in the tool list.
- `fix(goose): bookend shell output preview + recommend read tool` — long shell outputs get head/tail preview bookends, and the system prompt recommends the read tool over `cat` for file inspection.
- `perf(goose): system-prompt guidance for edit-over-write + ranged reads` — adds explicit guidance preferring `edit` over `write` and ranged reads over full-file reads.
- `perf(goose): tool-aware large-response threshold + read-tool-aware redirect` — large-response handler now has per-tool thresholds; read-tool responses get a tool-aware redirect that points the model at the read tool for further inspection. Also adds a fast-path in `with_post_tool_hook` so default-install (no hooks) doesn't clone session/tool args per call.
- `chore(goose): /simplify findings on the token-efficiency roadmap` — comment-only cleanup of two over-narrated comments. (The `context_mgmt/mod.rs` half is deferred — it depends on `5de28654` summarization tuning that needs to rebase against upstream `#9087`.)

### Notes
Resolved 2 conflicts at cherry-pick:
- `agents/agent.rs`: kept the fast-path `has_hooks` short-circuit.
- `context_mgmt/mod.rs`: dropped the comment cleanup since it targets code from `5de28654` (ADAPT, deferred).

### Testing
- `cargo test -p goose agents large_response_handler shell tool_execution`.
- Manual: ask the agent to "show me what's in foo.rs"; confirm it uses the read tool instead of `cat`.
- Manual: run a `find` that produces a huge output; confirm head/tail bookends appear and the agent is redirected to the read tool.

### Related Issues
None — change driven by code review and observed behavior.
