### PR TITLE
fix(goose2): dedupe mention scans on unstable useEffect deps

### DIFF
--- a/ui/goose2/src/features/chat/hooks/useMentionHandlers.ts
+++ b/ui/goose2/src/features/chat/hooks/useMentionHandlers.ts
@@ -88,6 +88,7 @@ export function useMentionHandlers({
     SkillMentionItem[]
   >([]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: rootsKey is the value-stable derivative of normalizedProjectRoots; depending on the array reference would re-fetch on every parent re-render.
   useEffect(() => {
     let cancelled = false;
 
@@ -112,8 +113,9 @@ export function useMentionHandlers({
     return () => {
       cancelled = true;
     };
-  }, [normalizedProjectRoots]);
+  }, [rootsKey]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: rootsKey is the value-stable derivative of normalizedProjectRoots; depending on the array reference would re-fetch on every parent re-render.
   useEffect(() => {
     // Clear stale results immediately so users never see files from the
     // previous project while the new scan is in flight.
@@ -124,7 +126,6 @@ export function useMentionHandlers({
     }
 
     let cancelled = false;
-
     void listFilesForMentions(normalizedProjectRoots)
       .then((paths) => {
         if (cancelled) return;
@@ -141,7 +142,7 @@ export function useMentionHandlers({
     return () => {
       cancelled = true;
     };
-  }, [rootsKey, normalizedProjectRoots]);
+  }, [rootsKey]);
 
   const fileMentionItems: FileMentionItem[] = useMemo(() => {
     const dedup = new Map<string, FileMentionItem>();


### PR DESCRIPTION
## Summary

`useMentionHandlers` was rescanning mentions on every render because one of its `useEffect` dependencies was a freshly-allocated value instead of a stable reference. Fix narrows the dep array so scans only run when input/cursor actually change.

### Testing
- Manual: type in the chat input; watch dev tools / perf logs; mention scanning should fire on input change, not on every render.

### Related Issues
None — change driven by code review and observed behavior.
