### PR TITLE
fix(goose2): include mise shims in agent binary detection PATH

### DIFF
--- a/ui/goose2/src-tauri/src/commands/agent_setup.rs
+++ b/ui/goose2/src-tauri/src/commands/agent_setup.rs
@@ -129,6 +129,10 @@ fn build_extended_path() -> String {
                 }
             }
         }
+
+        // mise (formerly rtx) puts shims for every globally installed binary
+        // under one directory, regardless of which language runtime owns them.
+        paths.push(home.join(".local/share/mise/shims"));
     }
 
     let mut seen = std::collections::HashSet::new();


### PR DESCRIPTION
## Summary

When the Tauri shell looks for `goose` / `goosed` binaries to spawn, its PATH didn't include `~/.local/share/mise/shims`, so users managing the binary via mise hit "agent not found" on first launch. Adds the mise shim dirs to the detection PATH.

### Testing
- Manual: install goose via mise on a fresh machine; launch the app; agent detection succeeds without manual PATH fiddling.

### Related Issues
None — change driven by code review and observed behavior.
