### PR TITLE
fix(goose): backfill session project_id from working_dir on upgrade

### DIFF
--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -1088,11 +1088,11 @@ impl SessionStorage {
                 }
             }
             13 => {
-                // Only backfill on first-time v13 users: if any session already
-                // has a non-NULL project_id, the user has used the feature in
-                // v12, which means existing NULL rows could include intentional
-                // unlinks. Preserving user intent (Codex P1 on #9171) > catching
-                // a few legacy rows; users can manually link later if they want.
+                // Only backfill when no session has a non-NULL project_id yet.
+                // Once the user has used the feature in v12, an existing NULL
+                // may represent an intentional unlink rather than a never-set
+                // row, and a working-dir-keyed backfill would silently relink
+                // it. Users can manually link any unbackfilled session later.
                 let has_any_project_id: i64 = sqlx::query_scalar(
                     "SELECT COUNT(*) FROM sessions WHERE project_id IS NOT NULL",
                 )
@@ -1789,11 +1789,11 @@ impl SessionStorage {
     }
 }
 
-/// Skips rows that already have a `project_id` so reruns are no-ops. Callers
-/// (currently only the v13 migration) must additionally gate on whether NULL
-/// rows could be intentional unlinks — this helper writes blindly to every
-/// matching `project_id IS NULL` row. Trailing slashes on either side are
-/// ignored.
+/// Sets `project_id` on every row whose `working_dir` matches one of the
+/// given `(working_dir, slug)` pairs and currently has `project_id IS NULL`.
+/// Callers must gate on whether NULL rows could represent intentional
+/// unlinks — this helper does not distinguish never-set from unlinked.
+/// Trailing slashes on either side are ignored.
 async fn backfill_session_project_ids(
     tx: &mut sqlx::Transaction<'_, Sqlite>,
     pairs: &[(String, String)],

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -1793,22 +1793,25 @@ impl SessionStorage {
 /// given `(working_dir, slug)` pairs and currently has `project_id IS NULL`.
 /// Callers must gate on whether NULL rows could represent intentional
 /// unlinks — this helper does not distinguish never-set from unlinked.
-/// Trailing slashes on either side are ignored.
+/// Backslashes are normalized to forward slashes and trailing separators
+/// on either side are ignored, so Windows paths like `C:\repo\` match
+/// project workingDirs entered as `C:/repo`.
 async fn backfill_session_project_ids(
     tx: &mut sqlx::Transaction<'_, Sqlite>,
     pairs: &[(String, String)],
 ) -> Result<u64> {
     let mut total = 0u64;
     for (working_dir, slug) in pairs {
-        let normalized = working_dir.trim_end_matches('/');
+        let normalized = working_dir.replace('\\', "/");
+        let normalized = normalized.trim_end_matches('/');
         if normalized.is_empty() {
             continue;
         }
         let result = sqlx::query(
-            "UPDATE sessions
-             SET project_id = ?
-             WHERE project_id IS NULL
-               AND rtrim(working_dir, '/') = ?",
+            r"UPDATE sessions
+              SET project_id = ?
+              WHERE project_id IS NULL
+                AND rtrim(replace(working_dir, '\', '/'), '/') = ?",
         )
         .bind(slug)
         .bind(normalized)
@@ -2350,6 +2353,7 @@ mod tests {
         let in_repo_a = make_test_session(&sm, "/Users/me/Projects/repo-a").await;
         let in_repo_a_with_slash = make_test_session(&sm, "/Users/me/Projects/repo-a/").await;
         let in_repo_b = make_test_session(&sm, "/Users/me/Projects/repo-b").await;
+        let win_session = make_test_session(&sm, r"C:\Users\me\Projects\repo-c\").await;
         let unmatched = make_test_session(&sm, "/tmp/scratch").await;
 
         // Pre-tag one session: backfill must not overwrite an explicit assignment.
@@ -2370,12 +2374,18 @@ mod tests {
                 "/Users/me/Projects/repo-b/".to_string(),
                 "repo-b".to_string(),
             ),
+            // Windows-style project path with backslash separators; the
+            // session was inserted with `C:\...\repo-c\` and must still match.
+            (
+                r"C:\Users\me\Projects\repo-c".to_string(),
+                "repo-c".to_string(),
+            ),
         ];
 
         let mut tx = pool.begin().await.unwrap();
         let updated = backfill_session_project_ids(&mut tx, &pairs).await.unwrap();
         tx.commit().await.unwrap();
-        assert_eq!(updated, 2, "two NULL rows should be backfilled");
+        assert_eq!(updated, 3, "three NULL rows should be backfilled");
 
         let pre_tagged = sm.get_session(&in_repo_a.id, false).await.unwrap();
         assert_eq!(pre_tagged.project_id.as_deref(), Some("manual-slug"));
@@ -2386,6 +2396,8 @@ mod tests {
         assert_eq!(slashed.project_id.as_deref(), Some("repo-a"));
         let b = sm.get_session(&in_repo_b.id, false).await.unwrap();
         assert_eq!(b.project_id.as_deref(), Some("repo-b"));
+        let win = sm.get_session(&win_session.id, false).await.unwrap();
+        assert_eq!(win.project_id.as_deref(), Some("repo-c"));
         let outside = sm.get_session(&unmatched.id, false).await.unwrap();
         assert_eq!(outside.project_id, None);
 

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -1,12 +1,12 @@
-use crate::config::GooseMode;
 use crate::config::paths::Paths;
-use crate::conversation::Conversation;
+use crate::config::GooseMode;
 use crate::conversation::message::Message;
+use crate::conversation::Conversation;
 use crate::model::ModelConfig;
-use crate::providers::base::{MSG_COUNT_FOR_SESSION_NAME_GENERATION, Provider};
+use crate::providers::base::{Provider, MSG_COUNT_FOR_SESSION_NAME_GENERATION};
 use crate::recipe::Recipe;
 use crate::session::extension_data::ExtensionData;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use rmcp::model::Role;
 use serde::{Deserialize, Serialize};
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use utoipa::ToSchema;
 
 pub const CURRENT_SCHEMA_VERSION: i32 = 13;
@@ -1088,10 +1088,29 @@ impl SessionStorage {
                 }
             }
             13 => {
-                let pairs = crate::sources::project_working_dir_pairs();
-                let updated = backfill_session_project_ids(tx, &pairs).await?;
-                if updated > 0 {
-                    info!("Backfilled project_id on {updated} legacy session(s)");
+                // Only backfill on first-time v13 users: if any session already
+                // has a non-NULL project_id, the user has used the feature in
+                // v12, which means existing NULL rows could include intentional
+                // unlinks. Preserving user intent (Codex P1 on #9171) > catching
+                // a few legacy rows; users can manually link later if they want.
+                let has_any_project_id: i64 = sqlx::query_scalar(
+                    "SELECT COUNT(*) FROM sessions WHERE project_id IS NOT NULL",
+                )
+                .fetch_one(&mut **tx)
+                .await?;
+                if has_any_project_id == 0 {
+                    let pairs = crate::sources::project_working_dir_pairs()
+                        .context("read project directory for v13 backfill")?;
+                    let updated = backfill_session_project_ids(tx, &pairs).await?;
+                    if updated > 0 {
+                        info!("Backfilled project_id on {updated} legacy session(s)");
+                    }
+                } else {
+                    debug!(
+                        "Skipping v13 project_id backfill: \
+                         sessions already have project_id assignments, \
+                         NULL rows may represent explicit unlinks"
+                    );
                 }
             }
             _ => {
@@ -1770,9 +1789,11 @@ impl SessionStorage {
     }
 }
 
-/// Skips rows that already have a `project_id` so explicit UI unlinks aren't
-/// silently re-tagged and reruns are no-ops. Trailing slashes on either side
-/// are ignored.
+/// Skips rows that already have a `project_id` so reruns are no-ops. Callers
+/// (currently only the v13 migration) must additionally gate on whether NULL
+/// rows could be intentional unlinks — this helper writes blindly to every
+/// matching `project_id IS NULL` row. Trailing slashes on either side are
+/// ignored.
 async fn backfill_session_project_ids(
     tx: &mut sqlx::Transaction<'_, Sqlite>,
     pairs: &[(String, String)],

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -1,9 +1,9 @@
-use crate::config::paths::Paths;
 use crate::config::GooseMode;
-use crate::conversation::message::Message;
+use crate::config::paths::Paths;
 use crate::conversation::Conversation;
+use crate::conversation::message::Message;
 use crate::model::ModelConfig;
-use crate::providers::base::{Provider, MSG_COUNT_FOR_SESSION_NAME_GENERATION};
+use crate::providers::base::{MSG_COUNT_FOR_SESSION_NAME_GENERATION, Provider};
 use crate::recipe::Recipe;
 use crate::session::extension_data::ExtensionData;
 use anyhow::Result;
@@ -19,7 +19,7 @@ use std::sync::{Arc, LazyLock};
 use tracing::{info, warn};
 use utoipa::ToSchema;
 
-pub const CURRENT_SCHEMA_VERSION: i32 = 12;
+pub const CURRENT_SCHEMA_VERSION: i32 = 13;
 pub const SESSIONS_FOLDER: &str = "sessions";
 pub const DB_NAME: &str = "sessions.db";
 
@@ -1087,6 +1087,13 @@ impl SessionStorage {
                         .await?;
                 }
             }
+            13 => {
+                let pairs = crate::sources::project_working_dir_pairs();
+                let updated = backfill_session_project_ids(tx, &pairs).await?;
+                if updated > 0 {
+                    info!("Backfilled project_id on {updated} legacy session(s)");
+                }
+            }
             _ => {
                 anyhow::bail!("Unknown migration version: {}", version);
             }
@@ -1763,6 +1770,34 @@ impl SessionStorage {
     }
 }
 
+/// Skips rows that already have a `project_id` so explicit UI unlinks aren't
+/// silently re-tagged and reruns are no-ops. Trailing slashes on either side
+/// are ignored.
+async fn backfill_session_project_ids(
+    tx: &mut sqlx::Transaction<'_, Sqlite>,
+    pairs: &[(String, String)],
+) -> Result<u64> {
+    let mut total = 0u64;
+    for (working_dir, slug) in pairs {
+        let normalized = working_dir.trim_end_matches('/');
+        if normalized.is_empty() {
+            continue;
+        }
+        let result = sqlx::query(
+            "UPDATE sessions
+             SET project_id = ?
+             WHERE project_id IS NULL
+               AND rtrim(working_dir, '/') = ?",
+        )
+        .bind(slug)
+        .bind(normalized)
+        .execute(&mut **tx)
+        .await?;
+        total += result.rows_affected();
+    }
+    Ok(total)
+}
+
 /// Merge a JSON object `patch` into an existing optional object value,
 /// preserving keys not present in the patch.
 fn merge_tool_meta(
@@ -2273,5 +2308,69 @@ mod tests {
 
         let acp_session = sm.storage().get_session("acp_id", false).await.unwrap();
         assert_eq!(acp_session.session_type, SessionType::Acp);
+    }
+
+    async fn make_test_session(sm: &SessionManager, dir: &str) -> Session {
+        sm.create_session(
+            PathBuf::from(dir),
+            "test".to_string(),
+            SessionType::Acp,
+            GooseMode::default(),
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_backfill_session_project_ids() {
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+
+        let in_repo_a = make_test_session(&sm, "/Users/me/Projects/repo-a").await;
+        let in_repo_a_with_slash = make_test_session(&sm, "/Users/me/Projects/repo-a/").await;
+        let in_repo_b = make_test_session(&sm, "/Users/me/Projects/repo-b").await;
+        let unmatched = make_test_session(&sm, "/tmp/scratch").await;
+
+        // Pre-tag one session: backfill must not overwrite an explicit assignment.
+        sm.update(&in_repo_a.id)
+            .project_id(Some("manual-slug".to_string()))
+            .apply()
+            .await
+            .unwrap();
+
+        let pool = sm.storage().pool().await.unwrap().clone();
+        let pairs = vec![
+            (
+                "/Users/me/Projects/repo-a".to_string(),
+                "repo-a".to_string(),
+            ),
+            // Trailing slash on the project side too, just to exercise both.
+            (
+                "/Users/me/Projects/repo-b/".to_string(),
+                "repo-b".to_string(),
+            ),
+        ];
+
+        let mut tx = pool.begin().await.unwrap();
+        let updated = backfill_session_project_ids(&mut tx, &pairs).await.unwrap();
+        tx.commit().await.unwrap();
+        assert_eq!(updated, 2, "two NULL rows should be backfilled");
+
+        let pre_tagged = sm.get_session(&in_repo_a.id, false).await.unwrap();
+        assert_eq!(pre_tagged.project_id.as_deref(), Some("manual-slug"));
+        let slashed = sm
+            .get_session(&in_repo_a_with_slash.id, false)
+            .await
+            .unwrap();
+        assert_eq!(slashed.project_id.as_deref(), Some("repo-a"));
+        let b = sm.get_session(&in_repo_b.id, false).await.unwrap();
+        assert_eq!(b.project_id.as_deref(), Some("repo-b"));
+        let outside = sm.get_session(&unmatched.id, false).await.unwrap();
+        assert_eq!(outside.project_id, None);
+
+        let mut tx = pool.begin().await.unwrap();
+        let updated = backfill_session_project_ids(&mut tx, &pairs).await.unwrap();
+        tx.commit().await.unwrap();
+        assert_eq!(updated, 0);
     }
 }

--- a/crates/goose/src/sources.rs
+++ b/crates/goose/src/sources.rs
@@ -238,18 +238,37 @@ pub fn read_project(slug: &str) -> Result<SourceEntry, Error> {
         .ok_or_else(|| Error::internal_error().data("Failed to read project file"))
 }
 
-/// Get the working directories configured for a project, if any.
-/// Returns an empty Vec when the project doesn't exist or has none configured.
-pub fn project_working_dirs(slug: &str) -> Vec<String> {
-    let entry = match read_project(slug) {
-        Ok(e) => e,
-        Err(_) => return Vec::new(),
-    };
+/// Read the `workingDirs` property bag off a project entry.
+fn working_dirs_of(entry: &SourceEntry) -> Vec<String> {
     entry
         .properties
         .get("workingDirs")
         .and_then(|v| serde_json::from_value::<Vec<String>>(v.clone()).ok())
         .unwrap_or_default()
+}
+
+/// Get the working directories configured for a project, if any.
+pub fn project_working_dirs(slug: &str) -> Vec<String> {
+    read_project(slug)
+        .map(|entry| working_dirs_of(&entry))
+        .unwrap_or_default()
+}
+
+/// Flat list of `(workingDir, projectSlug)` pairs across all projects, used by
+/// storage migrations that map session paths to a project.
+pub fn project_working_dir_pairs() -> Vec<(String, String)> {
+    let projects = match read_project_dir() {
+        Ok(p) => p,
+        Err(_) => return Vec::new(),
+    };
+    projects
+        .into_iter()
+        .flat_map(|proj| {
+            working_dirs_of(&proj)
+                .into_iter()
+                .map(move |dir| (dir, proj.name.clone()))
+        })
+        .collect()
 }
 
 /// Validate that the given path is a project file we manage and the file
@@ -886,11 +905,7 @@ pub fn list_sources_with_roots(
                     let projects = read_project_dir()?;
                     let already_scanned = working_dir.as_deref();
                     for proj in &projects {
-                        let dirs = proj
-                            .properties
-                            .get("workingDirs")
-                            .and_then(|v| serde_json::from_value::<Vec<String>>(v.clone()).ok())
-                            .unwrap_or_default();
+                        let dirs = working_dirs_of(proj);
                         let project_name = proj
                             .properties
                             .get("title")
@@ -1523,9 +1538,11 @@ mod tests {
     #[test]
     fn list_skill_excludes_builtin_skills() {
         let listed = list_sources(Some(SourceType::Skill), None, false).unwrap();
-        assert!(!listed
-            .iter()
-            .any(|source| source.source_type == SourceType::BuiltinSkill));
+        assert!(
+            !listed
+                .iter()
+                .any(|source| source.source_type == SourceType::BuiltinSkill)
+        );
     }
 
     #[test]
@@ -1554,9 +1571,11 @@ mod tests {
             false,
         )
         .unwrap();
-        assert!(!builtins
-            .iter()
-            .any(|source| source.name == "goose-doc-guide"));
+        assert!(
+            !builtins
+                .iter()
+                .any(|source| source.name == "goose-doc-guide")
+        );
 
         let skills = list_sources(
             Some(SourceType::Skill),
@@ -1624,9 +1643,11 @@ mod tests {
         assert!(format!("{:?}", err).contains("not supported"));
 
         let listed = list_sources(Some(SourceType::BuiltinSkill), Some(project), false).unwrap();
-        assert!(listed
-            .iter()
-            .any(|source| source.source_type == SourceType::BuiltinSkill));
+        assert!(
+            listed
+                .iter()
+                .any(|source| source.source_type == SourceType::BuiltinSkill)
+        );
 
         let err = list_sources(Some(SourceType::Recipe), Some(project), false).unwrap_err();
         assert!(format!("{:?}", err).contains("not supported"));

--- a/crates/goose/src/sources.rs
+++ b/crates/goose/src/sources.rs
@@ -256,19 +256,21 @@ pub fn project_working_dirs(slug: &str) -> Vec<String> {
 
 /// Flat list of `(workingDir, projectSlug)` pairs across all projects, used by
 /// storage migrations that map session paths to a project.
-pub fn project_working_dir_pairs() -> Vec<(String, String)> {
-    let projects = match read_project_dir() {
-        Ok(p) => p,
-        Err(_) => return Vec::new(),
-    };
-    projects
+///
+/// Returns the error from `read_project_dir` so the migration caller can choose
+/// to fail (transient FS/permissions issues shouldn't be silently treated as
+/// "no projects exist" — that would advance schema version without backfilling,
+/// and the migration won't re-run).
+pub fn project_working_dir_pairs() -> Result<Vec<(String, String)>, Error> {
+    let projects = read_project_dir()?;
+    Ok(projects
         .into_iter()
         .flat_map(|proj| {
             working_dirs_of(&proj)
                 .into_iter()
                 .map(move |dir| (dir, proj.name.clone()))
         })
-        .collect()
+        .collect())
 }
 
 /// Validate that the given path is a project file we manage and the file
@@ -1538,11 +1540,9 @@ mod tests {
     #[test]
     fn list_skill_excludes_builtin_skills() {
         let listed = list_sources(Some(SourceType::Skill), None, false).unwrap();
-        assert!(
-            !listed
-                .iter()
-                .any(|source| source.source_type == SourceType::BuiltinSkill)
-        );
+        assert!(!listed
+            .iter()
+            .any(|source| source.source_type == SourceType::BuiltinSkill));
     }
 
     #[test]
@@ -1571,11 +1571,9 @@ mod tests {
             false,
         )
         .unwrap();
-        assert!(
-            !builtins
-                .iter()
-                .any(|source| source.name == "goose-doc-guide")
-        );
+        assert!(!builtins
+            .iter()
+            .any(|source| source.name == "goose-doc-guide"));
 
         let skills = list_sources(
             Some(SourceType::Skill),
@@ -1643,11 +1641,9 @@ mod tests {
         assert!(format!("{:?}", err).contains("not supported"));
 
         let listed = list_sources(Some(SourceType::BuiltinSkill), Some(project), false).unwrap();
-        assert!(
-            listed
-                .iter()
-                .any(|source| source.source_type == SourceType::BuiltinSkill)
-        );
+        assert!(listed
+            .iter()
+            .any(|source| source.source_type == SourceType::BuiltinSkill));
 
         let err = list_sources(Some(SourceType::Recipe), Some(project), false).unwrap_err();
         assert!(format!("{:?}", err).contains("not supported"));


### PR DESCRIPTION
## Summary

Sessions created before the project-id column existed had `project_id = NULL`, so after upgrading, those sessions lost their project association even though `working_dir` was still set. Adds schema v13 migration that backfills `project_id` from `working_dir` (using the same sources-lookup helper the runtime uses) so the project sidebar groups historical sessions correctly.

### Notes
- Schema bumps from v12 to v13.
- Idempotent on subsequent launches — only rewrites rows where `project_id IS NULL` and a project source matches `working_dir`.

### Testing
- New migration test in `crates/goose/src/session/session_manager.rs` covers the backfill path.
- Manual: roll back to a v12 db, restart on this branch, confirm pre-existing sessions get re-grouped under their projects.

### Related Issues
None — change driven by code review and observed behavior.
