### PR TITLE
chore(hooks): restrict goose2 biome pre-commit to web file types

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -17,11 +17,12 @@ if git diff --cached --no-renames --name-only | grep -q '^ui/goose2/'; then
     echo "Running goose2 pre-commit checks..."
 
     # Auto-format only staged files that biome can process, then re-stage them.
-    # Exclude justfile and .swift files — biome doesn't understand these formats
-    # and would fail with "no files were processed" when only such files are staged.
+    # Biome handles JS/TS/JSX/TSX/JSON/CSS/HTML — restrict to those extensions
+    # so staged Rust, Swift, TOML, justfile, etc. don't trigger "no files were
+    # processed" failures when no biome-supported file is staged.
     STAGED_FILES=$(git diff --cached --no-renames --diff-filter=ACMR --name-only \
       | grep '^ui/goose2/' \
-      | grep -v -E '(^ui/goose2/justfile$|\.swift$)' \
+      | grep -E '\.(js|jsx|ts|tsx|mjs|cjs|json|jsonc|css|html)$' \
       | sed 's|^ui/goose2/||' || true)
     if [ -n "$STAGED_FILES" ]; then
       cd ui/goose2

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -17,12 +17,12 @@ if git diff --cached --no-renames --name-only | grep -q '^ui/goose2/'; then
     echo "Running goose2 pre-commit checks..."
 
     # Auto-format only staged files that biome can process, then re-stage them.
-    # Biome handles JS/TS/JSX/TSX/JSON/CSS/HTML — restrict to those extensions
-    # so staged Rust, Swift, TOML, justfile, etc. don't trigger "no files were
-    # processed" failures when no biome-supported file is staged.
+    # Biome handles JS/TS/JSX/TSX/JSON/CSS/HTML/GraphQL — restrict to those
+    # extensions so staged Rust, Swift, TOML, justfile, etc. don't trigger "no
+    # files were processed" failures when no biome-supported file is staged.
     STAGED_FILES=$(git diff --cached --no-renames --diff-filter=ACMR --name-only \
       | grep '^ui/goose2/' \
-      | grep -E '\.(js|jsx|ts|tsx|mjs|cjs|json|jsonc|css|html)$' \
+      | grep -E '\.(js|jsx|ts|tsx|mjs|cjs|json|jsonc|css|html|graphql|gql)$' \
       | sed 's|^ui/goose2/||' || true)
     if [ -n "$STAGED_FILES" ]; then
       cd ui/goose2


### PR DESCRIPTION
## Summary

The husky pre-commit hook was running biome over every staged file under `ui/goose2/`, including images, lockfiles, and other binary/non-source assets — biome would silently no-op on those but it added noise and ran needlessly. This filters the staged file list to web source types (`.ts`, `.tsx`, `.js`, `.jsx`, `.json`, `.css`) before invoking biome.

### Testing
- Stage a `.png` under `ui/goose2/`; commit; confirm biome doesn't run on it.
- Stage a `.tsx` with a known biome issue; commit; confirm the hook flags it.

### Related Issues
None — change driven by code review and observed behavior.
