### PR TITLE
New declarative oMLX provider

### DIFF
--- a/crates/goose/src/providers/declarative/omlx.json
+++ b/crates/goose/src/providers/declarative/omlx.json
@@ -1,0 +1,23 @@
+{
+  "name": "omlx",
+  "engine": "openai",
+  "display_name": "oMLX",
+  "description": "Run local models with oMLX",
+  "api_key_env": "",
+  "base_url": "${OMLX_HOST}/v1/chat/completions",
+  "env_vars": [
+    {
+      "name": "OMLX_HOST",
+      "required": false,
+      "secret": false,
+      "primary": true,
+      "default": "http://localhost:8000",
+      "description": "Base URL of the oMLX server (default: http://localhost:8000)"
+    }
+  ],
+  "dynamic_models": true,
+  "models": [],
+  "supports_streaming": true,
+  "requires_auth": false,
+  "skip_canonical_filtering": true
+}


### PR DESCRIPTION
## Summary
Add a new declarative provider for [oMLX](https://omlx.ai), similar to the existing llama_swap and lmstudio providers.

### Testing
Manual testing. I configured the provider through the desktop UI, selected a model from the dynamic list, and ran some test prompts.

### Related Issues
N/A


### Screenshots/Demos (for UX changes)
Before:  

After:   
<img width="600" height="505" alt="omlx" src="https://github.com/user-attachments/assets/b27590e0-7746-4c74-9e0e-8661a0c87641" />

