### PR TITLE
docs workflows for better pr-preview handling

### DIFF
--- a/.github/workflows/cleanup-pr-previews.yml
+++ b/.github/workflows/cleanup-pr-previews.yml
@@ -1,0 +1,30 @@
+name: Cleanup Stale PR Previews
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  cleanup:
+    name: Remove previews for closed/merged PRs
+    runs-on: ubuntu-latest
+    if: github.repository == 'aaif-goose/goose'
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b  # v7.2.0
+
+      - name: Clean up stale PR previews
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/clean-gh-pages.sh
+
+      - name: Force push cleaned branch
+        run: |
+          updated_ref=$(git rev-parse origin/gh-pages)
+          git push origin "$updated_ref":gh-pages --force

--- a/.github/workflows/pr-website-preview.yml
+++ b/.github/workflows/pr-website-preview.yml
@@ -47,21 +47,3 @@ jobs:
         if: ${{ github.event.pull_request.head.repo.full_name == 'aaif-goose/goose' }}
         with:
           source-dir: documentation/build
-
-  cleanup:
-    runs-on: ubuntu-latest
-    needs: deploy
-    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == 'aaif-goose/goose'
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
-        with:
-          fetch-depth: 0
-
-      - uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b  # v7.2.0
-
-      - name: Clean up gh-pages branch
-        run: |
-          bash scripts/clean-gh-pages.sh
-          git push origin $(git rev-parse origin/gh-pages):gh-pages --force

--- a/scripts/clean-gh-pages.sh
+++ b/scripts/clean-gh-pages.sh
@@ -7,11 +7,6 @@ echo "Starting gh-pages branch cleanup..."
 REMOVE_PATHS_FILE="/tmp/remove-paths.txt"
 > "$REMOVE_PATHS_FILE"
 
-dirs_with_visible_files=$(git ls-tree -r origin/gh-pages:pr-preview --name-only 2>/dev/null | \
-    grep -v '/\.' | \
-    cut -d/ -f1 | \
-    sort -u || true)
-
 all_dirs=$(git ls-tree -d origin/gh-pages:pr-preview --name-only 2>/dev/null || true)
 
 if [ -z "$all_dirs" ]; then
@@ -20,20 +15,31 @@ if [ -z "$all_dirs" ]; then
     exit 0
 fi
 
+echo "Found PR preview directories: $(echo "$all_dirs" | wc -l | tr -d ' ')"
+
 while IFS= read -r dir; do
-    if [ -n "$dir" ]; then
-        if ! echo "$dirs_with_visible_files" | grep -q "^${dir}$"; then
-            dir_path="pr-preview/$dir"
-            echo "Found directory to remove: $dir_path"
-            echo "$dir_path" >> "$REMOVE_PATHS_FILE"
-        fi
+    if [ -z "$dir" ]; then continue; fi
+
+    pr_num="${dir#pr-}"
+
+    # Check if PR is still open via GitHub CLI
+    state=$(gh pr view "$pr_num" --json state -q '.state' 2>/dev/null || echo "UNKNOWN")
+
+    if [ "$state" = "OPEN" ]; then
+        echo "PR #$pr_num is OPEN — keeping pr-preview/$dir"
+    else
+        echo "PR #$pr_num is $state — marking pr-preview/$dir for removal"
+        echo "pr-preview/$dir" >> "$REMOVE_PATHS_FILE"
     fi
 done <<< "$all_dirs"
 
 if [ ! -s "$REMOVE_PATHS_FILE" ]; then
-    echo "No empty or hidden-file-only directories found. Nothing to clean up."
+    echo "All preview directories belong to open PRs. Nothing to clean."
     rm "$REMOVE_PATHS_FILE"
     exit 0
 fi
 
-uvx git-filter-repo@2.47.0 --paths-from-file "$REMOVE_PATHS_FILE" --invert-paths --refs origin/gh-pages
+count=$(wc -l < "$REMOVE_PATHS_FILE" | tr -d ' ')
+echo "Removing $count preview directories..."
+
+uvx git-filter-repo@2.47.0 --force --paths-from-file "$REMOVE_PATHS_FILE" --invert-paths --refs refs/remotes/origin/gh-pages


### PR DESCRIPTION
## Summary
This pull request refactors and improves the process for cleaning up stale PR website previews. The cleanup logic is moved to a dedicated workflow and the cleanup script is updated to more accurately remove only previews for closed or merged PRs. The main changes are summarized below:

