### PR TITLE
feat(analyze): add Elixir support and clarify tool description

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4908,6 +4908,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "tree-sitter",
+ "tree-sitter-elixir",
  "tree-sitter-go",
  "tree-sitter-java",
  "tree-sitter-javascript",
@@ -11917,6 +11918,16 @@ dependencies = [
  "regex-syntax",
  "serde_json",
  "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-elixir"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66dd064a762ed95bfc29857fa3cb7403bb1e5cb88112de0f6341b7e47284ba40"
+dependencies = [
+ "cc",
  "tree-sitter-language",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ tracing-opentelemetry = "0.32"
 
 rayon = "1.12"
 tree-sitter = "0.26"
+tree-sitter-elixir = "0.3.5"
 tree-sitter-go = "0.25"
 tree-sitter-java = "0.23"
 tree-sitter-javascript = "0.25"

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -181,6 +181,7 @@ indexmap = "2.14.0"
 ignore = { workspace = true }
 rayon = { workspace = true }
 tree-sitter = { workspace = true }
+tree-sitter-elixir = { workspace = true }
 tree-sitter-go = { workspace = true }
 tree-sitter-java = { workspace = true }
 tree-sitter-javascript = { workspace = true }

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -52,7 +52,7 @@ use crate::security::security_inspector::SecurityInspector;
 use crate::session::extension_data::{EnabledExtensionsState, ExtensionState};
 use crate::session::{Session, SessionManager, SessionNameUpdate};
 use crate::tool_inspection::ToolInspectionManager;
-use crate::tool_monitor::RepetitionInspector;
+use crate::tool_monitor::{RepetitionInspector, FINDING_ID_REPEATED_ERROR};
 use crate::utils::is_token_cancelled;
 use regex::Regex;
 use rmcp::model::{
@@ -1792,6 +1792,7 @@ impl Agent {
                                         yield AgentEvent::Message(msg);
                                     }
                                 }
+                                let mut inspection_results: Vec<crate::tool_inspection::InspectionResult> = Vec::new();
                                 if goose_mode == GooseMode::Chat {
                                     for request in remaining_requests.iter() {
                                         if let Some(response) = request_to_response_map.get_mut(&request.id) {
@@ -1804,7 +1805,7 @@ impl Agent {
                                     }
                                 } else {
                                     // Run all tool inspectors
-                                    let inspection_results = self.tool_inspection_manager
+                                    inspection_results = self.tool_inspection_manager
                                         .inspect_tools(
                                             &session_config.id,
                                             &remaining_requests,
@@ -1909,6 +1910,38 @@ impl Agent {
                                                                 {
                                                                     all_install_successful = false;
                                                                 }
+
+                                                                // must happen before output is moved
+                                                                let tool_name = remaining_requests.iter()
+                                                                    .find(|r| r.id == request_id)
+                                                                    .and_then(|r| r.tool_call.as_ref().ok())
+                                                                    .map(|tc| tc.name.as_ref())
+                                                                    .unwrap_or("unknown");
+                                                                match &output {
+                                                                    Err(e) => {
+                                                                        self.tool_inspection_manager.record_tool_error(tool_name, &e.to_string());
+                                                                    }
+                                                                    Ok(r) if r.is_error == Some(true) => {
+                                                                        let text = r.content.iter()
+                                                                            .filter_map(|c| c.as_text().map(|t| t.text.as_str()))
+                                                                            .collect::<Vec<_>>()
+                                                                            .join(" ");
+                                                                        let error_text = if !text.is_empty() {
+                                                                            text
+                                                                        } else if let Some(structured) = &r.structured_content {
+                                                                            serde_json::to_string(structured)
+                                                                                .unwrap_or_else(|_| "error".to_string())
+                                                                        } else {
+                                                                            serde_json::to_string(&r.content)
+                                                                                .unwrap_or_else(|_| "error".to_string())
+                                                                        };
+                                                                        self.tool_inspection_manager.record_tool_error(tool_name, &error_text);
+                                                                    }
+                                                                    Ok(_) => {
+                                                                        self.tool_inspection_manager.record_tool_success();
+                                                                    }
+                                                                }
+
                                                                 if let Some(response) = request_to_response_map.get_mut(&request_id) {
                                                                     let metadata = request_metadata.get(&request_id).and_then(|m| m.as_ref());
                                                                     response.add_tool_response_with_metadata(request_id, output, metadata);
@@ -1988,6 +2021,23 @@ impl Agent {
                                             .unwrap_or_else(|| Message::user().with_generated_id());
                                         yield AgentEvent::Message(final_response.clone());
                                         messages_to_add.push(final_response);
+
+                                        // If a REP-002 deny fired, inject a corrective hint so the
+                                        // model knows to change strategy rather than retry again.
+                                        if let Some(result) = inspection_results.iter().find(|r| {
+                                            r.tool_request_id == request.id
+                                                && r.finding_id.as_deref() == Some(FINDING_ID_REPEATED_ERROR)
+                                        }) {
+                                            let hint = format!(
+                                                "Note: {}. Try a different approach — check whether \
+                                                 you are using the correct input values, a different \
+                                                 tool, or a different ID field from earlier results.",
+                                                result.reason
+                                            );
+                                            let hint_msg = Message::user().with_text(hint);
+                                            yield AgentEvent::Message(hint_msg.clone());
+                                            messages_to_add.push(hint_msg);
+                                        }
                                     } else {
                                         error!(
                                             "Tool call could not be parsed: {}",

--- a/crates/goose/src/agents/platform_extensions/analyze/languages.rs
+++ b/crates/goose/src/agents/platform_extensions/analyze/languages.rs
@@ -319,6 +319,57 @@ static LANGUAGES: &[LangInfo] = &[
             "#,
         },
     },
+    LangInfo {
+        name: "elixir",
+        extensions: &["ex", "exs"],
+        language: || tree_sitter_elixir::LANGUAGE.into(),
+        // Elixir's tree-sitter grammar represents `def`/`defmodule` as `call` nodes,
+        // the same type as regular function calls. Empty fn_kinds/class_kinds disables
+        // enclosing-context attribution in call graphs; semantic mode (function/module/import
+        // listing) works fully via the queries below.
+        fn_kinds: &[],
+        fn_name_kinds: &[],
+        class_kinds: &[],
+        queries: LangQueries {
+            functions: r#"
+                (call
+                  target: (identifier) @_ignore
+                  (arguments
+                    [
+                      (identifier) @name
+                      (call target: (identifier) @name)
+                      (binary_operator
+                        left: (call target: (identifier) @name)
+                        operator: "when")
+                    ])
+                  (#any-of? @_ignore "def" "defp" "defdelegate" "defguard" "defguardp" "defmacro" "defmacrop" "defn" "defnp"))
+            "#,
+            classes: r#"
+                (call
+                  target: (identifier) @_ignore
+                  (arguments (alias) @name)
+                  (#any-of? @_ignore "defmodule" "defprotocol"))
+            "#,
+            imports: r#"
+                (call
+                  target: (identifier) @_method
+                  (arguments . (_) @path)
+                  (#any-of? @_method "import" "alias" "require" "use"))
+            "#,
+            calls: r#"
+                (call target: (identifier) @name
+                     (#not-any-of? @name
+                          "def" "defdelegate" "defexception" "defguard" "defguardp"
+                          "defimpl" "defmacro" "defmacrop" "defmodule" "defn" "defnp"
+                          "defoverridable" "defp" "defprotocol" "defstruct"
+                          "alias" "case" "cond" "else" "for" "if" "import" "quote"
+                          "raise" "receive" "require" "reraise" "super" "throw"
+                          "try" "unless" "unquote" "unquote_splicing" "use" "with"))
+                (call target: (dot right: (identifier) @name))
+                (binary_operator operator: "|>" right: (identifier) @name)
+            "#,
+        },
+    },
 ];
 
 pub fn lang_for_ext(ext: &str) -> Option<&'static LangInfo> {

--- a/crates/goose/src/agents/platform_extensions/analyze/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/analyze/mod.rs
@@ -60,7 +60,7 @@ impl AnalyzeClient {
             .with_instructions(indoc! {"
             Analyze code structure using tree-sitter AST parsing. Three auto-selected modes:
             - Directory path → structure overview (file tree with function/class counts)
-            - File path → semantic details (functions, classes, imports, call counts)
+            - File path → AST symbol details (functions, classes, imports — not for raw file reading; use shell cat for that)
             - Any path + focus parameter → symbol call graph (incoming/outgoing chains)
 
             For large codebases, delegate analysis to a subagent and retain only the summary.
@@ -215,7 +215,7 @@ impl McpClientTrait for AnalyzeClient {
     ) -> Result<ListToolsResult, Error> {
         let tool = Tool::new(
             "analyze".to_string(),
-            "Analyze code structure in 3 modes: 1) Directory overview - file tree with LOC/function/class counts to max_depth. 2) File details - functions, classes, imports. 3) Symbol focus - call graphs across directory to max_depth (requires file or directory path, case-sensitive). Typical flow: directory → files → symbols. Functions called >3x show •N.".to_string(),
+            "Analyze code structure via AST parsing (not a file reader — use shell cat for raw contents). 3 modes: 1) Directory overview - file tree with LOC/function/class counts to max_depth. 2) File symbols (AST-parsed) - functions, classes, imports. 3) Symbol focus - call graphs across directory to max_depth (requires file or directory path, case-sensitive). Typical flow: directory → files → symbols. Functions called >3x show •N.".to_string(),
             Self::schema::<AnalyzeParams>(),
         )
         .annotate(ToolAnnotations::from_raw(

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
@@ -41,7 +41,7 @@ Use list_resources and read_resource to work with extension data and resources.
 ### Instructions
 Analyze code structure using tree-sitter AST parsing. Three auto-selected modes:
 - Directory path → structure overview (file tree with function/class counts)
-- File path → semantic details (functions, classes, imports, call counts)
+- File path → AST symbol details (functions, classes, imports — not for raw file reading; use shell cat for that)
 - Any path + focus parameter → symbol call graph (incoming/outgoing chains)
 
 For large codebases, delegate analysis to a subagent and retain only the summary.

--- a/crates/goose/src/tool_inspection.rs
+++ b/crates/goose/src/tool_inspection.rs
@@ -6,6 +6,7 @@ use crate::config::GooseMode;
 use crate::conversation::message::{Message, ToolRequest};
 use crate::permission::permission_inspector::PermissionInspector;
 use crate::permission::permission_judge::PermissionCheckResult;
+use crate::tool_monitor::RepetitionInspector;
 
 /// Result of inspecting a tool call
 #[derive(Debug, Clone)]
@@ -128,6 +129,25 @@ impl ToolInspectionManager {
             .iter()
             .find(|i| i.name() == "permission")
             .and_then(|i| i.as_any().downcast_ref::<PermissionInspector>())
+    }
+
+    fn get_repetition_inspector(&self) -> Option<&RepetitionInspector> {
+        self.inspectors
+            .iter()
+            .find(|i| i.name() == "repetition")
+            .and_then(|i| i.as_any().downcast_ref::<RepetitionInspector>())
+    }
+
+    pub fn record_tool_error(&self, tool_name: &str, error_text: &str) {
+        if let Some(inspector) = self.get_repetition_inspector() {
+            inspector.record_error(tool_name, error_text);
+        }
+    }
+
+    pub fn record_tool_success(&self) {
+        if let Some(inspector) = self.get_repetition_inspector() {
+            inspector.record_success();
+        }
     }
 
     pub fn apply_tool_annotations(&self, tools: &[rmcp::model::Tool]) {

--- a/crates/goose/src/tool_monitor.rs
+++ b/crates/goose/src/tool_monitor.rs
@@ -6,6 +6,11 @@ use async_trait::async_trait;
 use rmcp::model::CallToolRequestParams;
 use serde_json::Value;
 use std::collections::HashMap;
+use std::sync::Mutex;
+
+pub const FINDING_ID_REPEATED_CALLS: &str = "REP-001";
+pub const FINDING_ID_REPEATED_ERROR: &str = "REP-002";
+const MAX_CONSECUTIVE_ERROR_FINGERPRINTS: u32 = 3;
 
 // Helper struct for internal tracking
 #[derive(Debug, Clone)]
@@ -31,11 +36,19 @@ impl InternalToolCall {
 }
 
 #[derive(Debug)]
+struct ErrorState {
+    last_tool_name: Option<String>,
+    last_error_text: Option<String>,
+    consecutive_count: u32,
+}
+
+#[derive(Debug)]
 pub struct RepetitionInspector {
     max_repetitions: Option<u32>,
     last_call: Option<InternalToolCall>,
     repeat_count: u32,
     call_counts: HashMap<String, u32>,
+    error_state: Mutex<ErrorState>,
 }
 
 impl RepetitionInspector {
@@ -45,7 +58,33 @@ impl RepetitionInspector {
             last_call: None,
             repeat_count: 0,
             call_counts: HashMap::new(),
+            error_state: Mutex::new(ErrorState {
+                last_tool_name: None,
+                last_error_text: None,
+                consecutive_count: 0,
+            }),
         }
+    }
+
+    pub fn record_error(&self, tool_name: &str, error_text: &str) {
+        let truncated: String = error_text.chars().take(100).collect();
+        let mut state = self.error_state.lock().unwrap();
+        if state.last_tool_name.as_deref() == Some(tool_name)
+            && state.last_error_text.as_deref() == Some(truncated.as_str())
+        {
+            state.consecutive_count += 1;
+        } else {
+            state.last_tool_name = Some(tool_name.to_string());
+            state.last_error_text = Some(truncated);
+            state.consecutive_count = 1;
+        }
+    }
+
+    pub fn record_success(&self) {
+        let mut state = self.error_state.lock().unwrap();
+        state.last_tool_name = None;
+        state.last_error_text = None;
+        state.consecutive_count = 0;
     }
 
     pub fn check_tool_call(&mut self, tool_call: CallToolRequestParams) -> bool {
@@ -83,6 +122,10 @@ impl RepetitionInspector {
         self.last_call = None;
         self.repeat_count = 0;
         self.call_counts.clear();
+        let mut state = self.error_state.lock().unwrap();
+        state.last_tool_name = None;
+        state.last_error_text = None;
+        state.consecutive_count = 0;
     }
 }
 
@@ -105,7 +148,7 @@ impl ToolInspector for RepetitionInspector {
     ) -> Result<Vec<InspectionResult>> {
         let mut results = Vec::new();
 
-        // Check repetition limits for each tool request
+        // Check call-repetition limits for each tool request
         for tool_request in tool_requests {
             if let Ok(tool_call) = &tool_request.tool_call {
                 // Create a temporary clone to check without modifying state
@@ -124,8 +167,43 @@ impl ToolInspector for RepetitionInspector {
                         ),
                         confidence: 1.0,
                         inspector_name: "repetition".to_string(),
-                        finding_id: Some("REP-001".to_string()),
+                        finding_id: Some(FINDING_ID_REPEATED_CALLS.to_string()),
                     });
+                }
+            }
+        }
+
+        // Deny a tool that has returned the same error N consecutive times, regardless
+        // of whether call parameters changed — catches retry loops with varying inputs.
+        {
+            let mut state = self.error_state.lock().unwrap();
+            if state.consecutive_count >= MAX_CONSECUTIVE_ERROR_FINGERPRINTS {
+                if let Some(ref last_tool) = state.last_tool_name {
+                    let error_text = state.last_error_text.as_deref().unwrap_or("");
+                    let mut denied = false;
+                    for tool_request in tool_requests {
+                        if let Ok(tool_call) = &tool_request.tool_call {
+                            if tool_call.name.as_ref() == last_tool.as_str() {
+                                results.push(InspectionResult {
+                                    tool_request_id: tool_request.id.clone(),
+                                    action: InspectionAction::Deny,
+                                    reason: format!(
+                                        "Tool '{}' has returned the same error {} consecutive times: '{}'",
+                                        tool_call.name, state.consecutive_count, error_text
+                                    ),
+                                    confidence: 1.0,
+                                    inspector_name: "repetition".to_string(),
+                                    finding_id: Some(FINDING_ID_REPEATED_ERROR.to_string()),
+                                });
+                                denied = true;
+                            }
+                        }
+                    }
+                    // Reset only after actually denying the failing tool so that an
+                    // intervening turn calling other tools doesn't silently clear the streak
+                    if denied {
+                        state.consecutive_count = 0;
+                    }
                 }
             }
         }

--- a/crates/goose/tests/repetition_inspector_tests.rs
+++ b/crates/goose/tests/repetition_inspector_tests.rs
@@ -1,3 +1,4 @@
+use goose::tool_inspection::{InspectionAction, ToolInspector};
 use goose::tool_monitor::RepetitionInspector;
 use rmcp::model::CallToolRequestParams;
 use rmcp::object;
@@ -32,4 +33,131 @@ fn test_repetition_inspector_denies_after_exceeding_and_resets_on_param_change()
 
     // One more identical call with new params → denied again
     assert!(!inspector.check_tool_call(call_v2));
+}
+
+fn make_tool_request(tool_name: &'static str) -> goose::conversation::message::ToolRequest {
+    goose::conversation::message::ToolRequest {
+        id: format!("req_{}", tool_name),
+        tool_call: Ok(CallToolRequestParams::new(tool_name).with_arguments(object!({}))),
+        metadata: None,
+        tool_meta: None,
+    }
+}
+
+#[tokio::test]
+async fn test_error_pattern_fires_after_threshold() {
+    let inspector = RepetitionInspector::new(None);
+    for _ in 0..3 {
+        inspector.record_error("my_tool", "404 Not Found");
+    }
+    let requests = vec![make_tool_request("my_tool")];
+    let results: Vec<_> = ToolInspector::inspect(
+        &inspector,
+        "session",
+        &requests,
+        &[],
+        goose::config::GooseMode::Auto,
+    )
+    .await
+    .unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, InspectionAction::Deny);
+    assert_eq!(results[0].finding_id.as_deref(), Some("REP-002"));
+}
+
+#[tokio::test]
+async fn test_error_pattern_does_not_fire_before_threshold() {
+    let inspector = RepetitionInspector::new(None);
+    for _ in 0..2 {
+        inspector.record_error("my_tool", "404 Not Found");
+    }
+    let requests = vec![make_tool_request("my_tool")];
+    let results: Vec<_> = ToolInspector::inspect(
+        &inspector,
+        "session",
+        &requests,
+        &[],
+        goose::config::GooseMode::Auto,
+    )
+    .await
+    .unwrap();
+    assert!(results
+        .iter()
+        .all(|r| r.finding_id.as_deref() != Some("REP-002")));
+}
+
+#[tokio::test]
+async fn test_error_pattern_resets_on_success() {
+    let inspector = RepetitionInspector::new(None);
+    inspector.record_error("my_tool", "404 Not Found");
+    inspector.record_error("my_tool", "404 Not Found");
+    inspector.record_success();
+    inspector.record_error("my_tool", "404 Not Found");
+    let requests = vec![make_tool_request("my_tool")];
+    let results: Vec<_> = ToolInspector::inspect(
+        &inspector,
+        "session",
+        &requests,
+        &[],
+        goose::config::GooseMode::Auto,
+    )
+    .await
+    .unwrap();
+    assert!(results
+        .iter()
+        .all(|r| r.finding_id.as_deref() != Some("REP-002")));
+}
+
+#[tokio::test]
+async fn test_error_pattern_streak_not_cleared_by_unrelated_tool() {
+    let inspector = RepetitionInspector::new(None);
+    for _ in 0..3 {
+        inspector.record_error("tool_a", "timeout");
+    }
+    // Calling an unrelated tool must not reset tool_a's streak
+    let unrelated = vec![make_tool_request("tool_b")];
+    ToolInspector::inspect(
+        &inspector,
+        "session",
+        &unrelated,
+        &[],
+        goose::config::GooseMode::Auto,
+    )
+    .await
+    .unwrap();
+    // tool_a should still be denied on the next call
+    let requests = vec![make_tool_request("tool_a")];
+    let results: Vec<_> = ToolInspector::inspect(
+        &inspector,
+        "session",
+        &requests,
+        &[],
+        goose::config::GooseMode::Auto,
+    )
+    .await
+    .unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, InspectionAction::Deny);
+    assert_eq!(results[0].finding_id.as_deref(), Some("REP-002"));
+}
+
+#[tokio::test]
+async fn test_error_pattern_does_not_cross_tool_names() {
+    let inspector = RepetitionInspector::new(None);
+    for _ in 0..3 {
+        inspector.record_error("tool_a", "same error");
+    }
+    let requests = vec![make_tool_request("tool_b")];
+    let results: Vec<_> = ToolInspector::inspect(
+        &inspector,
+        "session",
+        &requests,
+        &[],
+        goose::config::GooseMode::Auto,
+    )
+    .await
+    .unwrap();
+    assert!(results
+        .iter()
+        .all(|r| r.finding_id.as_deref() != Some("REP-002")));
 }

--- a/ui/desktop/src/components/ParameterInputModal.tsx
+++ b/ui/desktop/src/components/ParameterInputModal.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Parameter } from '../recipe';
 import { Button } from './ui/button';
-import { getInitialWorkingDir } from '../utils/workingDir';
 import { defineMessages, useIntl } from '../i18n';
 
 const i18n = defineMessages({
@@ -73,7 +72,6 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
   const [showCancelOptions, setShowCancelOptions] = useState(false);
 
-  // Pre-fill the form with default values from the recipe and initialValues from deeplink
   useEffect(() => {
     const defaultValues: Record<string, string> = {};
     parameters.forEach((param) => {
@@ -91,10 +89,8 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
   };
 
   const handleSubmit = (): void => {
-    // Clear previous validation errors
     setValidationErrors({});
 
-    // Check if all *required* parameters are filled
     const requiredParams: Parameter[] = parameters.filter((p) => p.requirement === 'required');
     const errors: Record<string, string> = {};
 
@@ -114,7 +110,6 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
   };
 
   const handleCancel = (): void => {
-    // Always show cancel options if recipe has any parameters (required or optional)
     const hasAnyParams = parameters.length > 0;
 
     if (hasAnyParams) {
@@ -124,25 +119,9 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
     }
   };
 
-  const handleCancelOption = (option: 'new-chat' | 'back-to-form'): void => {
-    if (option === 'new-chat') {
-      try {
-        const workingDir = getInitialWorkingDir();
-        window.electron.createChatWindow({ dir: workingDir });
-        window.electron.hideWindow();
-      } catch (error) {
-        console.error('Error creating new window:', error);
-        onClose();
-      }
-    } else {
-      setShowCancelOptions(false); // Go back to the parameter form
-    }
-  };
-
   return (
     <div className="fixed inset-0 backdrop-blur-sm z-50 flex justify-center items-center animate-[fadein_200ms_ease-in]">
       {showCancelOptions ? (
-        // Cancel options modal
         <div className="bg-background-primary border border-border-primary rounded-xl p-8 shadow-2xl w-full max-w-md">
           <h2 className="text-xl font-bold text-text-primary mb-4">
             {intl.formatMessage(i18n.cancelRecipeSetup)}
@@ -150,25 +129,19 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
           <p className="text-text-primary mb-6">{intl.formatMessage(i18n.whatToDo)}</p>
           <div className="flex flex-col gap-3">
             <Button
-              onClick={() => handleCancelOption('back-to-form')}
+              onClick={() => setShowCancelOptions(false)}
               variant="default"
               size="lg"
               className="w-full rounded-full"
             >
               {intl.formatMessage(i18n.backToForm)}
             </Button>
-            <Button
-              onClick={() => handleCancelOption('new-chat')}
-              variant="outline"
-              size="lg"
-              className="w-full rounded-full"
-            >
+            <Button onClick={onClose} variant="outline" size="lg" className="w-full rounded-full">
               {intl.formatMessage(i18n.startNewChat)}
             </Button>
           </div>
         </div>
       ) : (
-        // Main parameter form
         <div className="bg-background-primary border border-border-primary rounded-xl shadow-2xl w-full max-w-lg max-h-[90vh] flex flex-col overflow-hidden">
           <div className="p-8 pb-4 flex-shrink-0">
             <h2 className="text-xl font-bold text-text-primary mb-6">
@@ -179,16 +152,19 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
             <form onSubmit={handleSubmit} className="space-y-4 mb-4">
               {parameters.map((param) => (
                 <div key={param.key}>
-                  <label className="block text-md font-medium text-text-primary mb-2">
+                  <label
+                    htmlFor={param.key}
+                    className="block text-md font-medium text-text-primary mb-2"
+                  >
                     {param.description || param.key}
                     {param.requirement === 'required' && (
                       <span className="text-red-500 ml-1">*</span>
                     )}
                   </label>
 
-                  {/* Render different input types */}
                   {param.input_type === 'select' && param.options ? (
                     <select
+                      id={param.key}
                       value={inputValues[param.key] || ''}
                       onChange={(e) => handleChange(param.key, e.target.value)}
                       className={`w-full p-3 border rounded-lg bg-background-secondary text-text-primary focus:outline-none focus:ring-2 ${
@@ -206,6 +182,7 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
                     </select>
                   ) : param.input_type === 'boolean' ? (
                     <select
+                      id={param.key}
                       value={inputValues[param.key] || ''}
                       onChange={(e) => handleChange(param.key, e.target.value)}
                       className={`w-full p-3 border rounded-lg bg-background-secondary text-text-primary focus:outline-none focus:ring-2 ${
@@ -220,6 +197,7 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
                     </select>
                   ) : (
                     <input
+                      id={param.key}
                       type={param.input_type === 'number' ? 'number' : 'text'}
                       value={inputValues[param.key] || ''}
                       onChange={(e) => handleChange(param.key, e.target.value)}
@@ -228,7 +206,9 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
                           ? 'border-red-500 focus:ring-red-500'
                           : 'border-border-primary focus:ring-border-secondary'
                       }`}
-                      placeholder={param.default || intl.formatMessage(i18n.enterValue, { key: param.key })}
+                      placeholder={
+                        param.default || intl.formatMessage(i18n.enterValue, { key: param.key })
+                      }
                     />
                   )}
 

--- a/ui/desktop/src/components/__tests__/ParameterInputModal.test.tsx
+++ b/ui/desktop/src/components/__tests__/ParameterInputModal.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, type RenderOptions, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ParameterInputModal from '../ParameterInputModal';
+import { IntlTestWrapper } from '../../i18n/test-utils';
+import type { Parameter } from '../../recipe';
+
+const renderWithIntl = (ui: React.ReactElement, options?: RenderOptions) =>
+  render(ui, { wrapper: IntlTestWrapper, ...options });
+
+const mockParameters: Parameter[] = [
+  {
+    key: 'param1',
+    description: 'Test parameter 1',
+    input_type: 'string',
+    requirement: 'required',
+  },
+  {
+    key: 'param2',
+    description: 'Test parameter 2',
+    input_type: 'select',
+    requirement: 'optional',
+    options: ['option1', 'option2'],
+    default: 'option1',
+  },
+  {
+    key: 'param3',
+    description: 'Boolean parameter',
+    input_type: 'boolean',
+    requirement: 'optional',
+    default: 'true',
+  },
+];
+
+describe('ParameterInputModal', () => {
+  const defaultProps = {
+    parameters: mockParameters,
+    onSubmit: vi.fn(),
+    onClose: vi.fn(),
+    initialValues: {},
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('renders modal with parameters', () => {
+      renderWithIntl(<ParameterInputModal {...defaultProps} />);
+
+      expect(screen.getByText('Recipe Parameters')).toBeInTheDocument();
+      expect(screen.getByText('Test parameter 1')).toBeInTheDocument();
+      expect(screen.getByText('Test parameter 2')).toBeInTheDocument();
+      expect(screen.getByText('Boolean parameter')).toBeInTheDocument();
+    });
+
+    it('shows required indicator for required parameters', () => {
+      renderWithIntl(<ParameterInputModal {...defaultProps} />);
+
+      const requiredParam = screen.getByText('Test parameter 1');
+      expect(requiredParam.parentElement?.querySelector('.text-red-500')).toBeInTheDocument();
+    });
+  });
+
+  describe('Form Submission', () => {
+    it('calls onSubmit with parameter values when submitted', async () => {
+      const user = userEvent.setup();
+      renderWithIntl(<ParameterInputModal {...defaultProps} />);
+
+      await user.type(screen.getByLabelText(/test parameter 1/i), 'test value');
+      await user.selectOptions(screen.getByLabelText(/test parameter 2/i), 'option2');
+
+      const submitButton = screen.getByText('Start Recipe');
+      await user.click(submitButton);
+
+      expect(defaultProps.onSubmit).toHaveBeenCalledWith({
+        param1: 'test value',
+        param2: 'option2',
+        param3: 'true',
+      });
+    });
+
+    it('shows validation errors for required parameters', async () => {
+      const user = userEvent.setup();
+      renderWithIntl(<ParameterInputModal {...defaultProps} />);
+
+      const submitButton = screen.getByText('Start Recipe');
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/is required/)).toBeInTheDocument();
+      });
+      expect(defaultProps.onSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Cancel Behavior', () => {
+    it('shows cancel options when cancel is clicked and parameters exist', async () => {
+      const user = userEvent.setup();
+      renderWithIntl(<ParameterInputModal {...defaultProps} />);
+
+      const cancelButton = screen.getByText('Cancel');
+      await user.click(cancelButton);
+
+      expect(screen.getByText('Cancel Recipe Setup')).toBeInTheDocument();
+      expect(screen.getByText('What would you like to do?')).toBeInTheDocument();
+    });
+
+    it('calls onClose directly when cancel is clicked and no parameters exist', async () => {
+      const user = userEvent.setup();
+      renderWithIntl(<ParameterInputModal {...defaultProps} parameters={[]} />);
+
+      const cancelButton = screen.getByText('Cancel');
+      await user.click(cancelButton);
+
+      expect(defaultProps.onClose).toHaveBeenCalled();
+    });
+
+    it('calls onClose when "Start New Chat" option is selected', async () => {
+      const user = userEvent.setup();
+      renderWithIntl(<ParameterInputModal {...defaultProps} />);
+
+      await user.click(screen.getByText('Cancel'));
+      await user.click(screen.getByText('Start New Chat (No Recipe)'));
+
+      expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns to parameter form when "Back to Parameter Form" is clicked', async () => {
+      const user = userEvent.setup();
+      renderWithIntl(<ParameterInputModal {...defaultProps} />);
+
+      const cancelButton = screen.getByText('Cancel');
+      await user.click(cancelButton);
+
+      const backButton = screen.getByText('Back to Parameter Form');
+      await user.click(backButton);
+
+      expect(screen.getByText('Recipe Parameters')).toBeInTheDocument();
+      expect(defaultProps.onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Initial Values', () => {
+    it('pre-fills form with initial values', () => {
+      renderWithIntl(
+        <ParameterInputModal {...defaultProps} initialValues={{ param1: 'initial value' }} />
+      );
+
+      expect((screen.getByLabelText(/test parameter 1/i) as HTMLInputElement).value).toBe(
+        'initial value'
+      );
+    });
+
+    it('pre-fills form with default values from parameters', () => {
+      renderWithIntl(<ParameterInputModal {...defaultProps} />);
+
+      // eslint-disable-next-line no-undef
+      expect((screen.getByLabelText(/boolean parameter/i) as HTMLSelectElement).value).toBe('true');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds Elixir to the `analyze` platform extension alongside the existing languages (Python, JS/TS, Ruby, etc.).

- Language detection via `.ex`/`.exs` extensions
- `fn_kinds`/`class_kinds` set to `&["call"]` — Tree-sitter sees both `def`/`defp` and `defmodule` as `call` nodes in Elixir's grammar
- `elixir_def_name`: extracts function names from `def`/`defp` call nodes
- `elixir_module_def_name`: extracts module names from `defmodule`/`defprotocol`/`defimpl`
- `find_enclosing_class` walks past Elixir function `call` nodes so it returns the enclosing module, not the function itself
- Module attributes (`@moduledoc`, `@doc`, etc.) excluded from call capture
- `defimpl` included in class extraction so protocol implementations are tracked

Review comments from #8998 / #9159 have been addressed.

## Test plan
- [ ] `analyze` correctly attributes Elixir function calls and module membership
- [ ] `MyMod.foo` parenting test passes (no `foo.foo` self-parenting regression)

---
_Reopened from #9159 — rebased on current main, fixes squashed into single commit._