### PR TITLE
feat(desktop): add goose://new-session deep link to open fresh chat

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -410,6 +410,16 @@ if (process.platform !== 'darwin') {
           return; // Skip the rest of the handler
         }
 
+        // Handle new-session URL by creating a fresh chat window
+        if (parsedUrl.hostname === 'new-session') {
+          app.whenReady().then(async () => {
+            const recentDirs = loadRecentDirs();
+            const openDir = recentDirs.length > 0 ? recentDirs[0] : null;
+            await createChat(app, { dir: openDir || undefined });
+          });
+          return;
+        }
+
         // For non-bot URLs, continue with normal handling
         handleProtocolUrl(protocolUrl);
       }
@@ -448,7 +458,11 @@ async function handleProtocolUrl(url: string) {
   const recentDirs = loadRecentDirs();
   const openDir = recentDirs.length > 0 ? recentDirs[0] : null;
 
-  if (parsedUrl.hostname === 'bot' || parsedUrl.hostname === 'recipe') {
+  if (parsedUrl.hostname === 'new-session') {
+    await createChat(app, { dir: openDir || undefined });
+    pendingDeepLink = null;
+    return;
+  } else if (parsedUrl.hostname === 'bot' || parsedUrl.hostname === 'recipe') {
     // For bot/recipe URLs, get existing window or create new one
     const existingWindows = BrowserWindow.getAllWindows();
     const targetWindow =
@@ -517,6 +531,14 @@ app.on('open-url', async (_event, url) => {
 
     const recentDirs = loadRecentDirs();
     const openDir = recentDirs.length > 0 ? recentDirs[0] : null;
+
+    // Handle new-session URL by creating a fresh chat window
+    if (parsedUrl.hostname === 'new-session') {
+      log.info('[Main] Detected new-session URL, creating new chat window');
+      openUrlHandledLaunch = true;
+      await createChat(app, { dir: openDir || undefined });
+      return;
+    }
 
     // Handle bot/recipe URLs by directly creating a new window
     if (parsedUrl.hostname === 'bot' || parsedUrl.hostname === 'recipe') {


### PR DESCRIPTION
## Summary

Add support for the `goose://new-session` deep link URL scheme so that opening this URL always creates a fresh chat window in the desktop app, rather than focusing the most recent session.

This enables desktop widgets, keyboard shortcuts (Alfred/Raycast), Apple Shortcuts, and other automation tools to launch new Goose sessions without going through a terminal.

## Changes

Single file change in `ui/desktop/src/main.ts` — adds `new-session` hostname handling in the three existing protocol URL dispatch points:

1. **`second-instance` handler** (Windows/Linux) — creates a new chat window and returns early
2. **`handleProtocolUrl`** (shared handler) — creates a new chat window, clears pending deep link, returns
3. **`open-url` event** (macOS) — creates a new chat window and returns early

Each follows the same pattern already used for `bot`/`recipe` deep links.

## Testing

- `pnpm lint` ✅
- `tsc --noEmit` ✅
- Manual: `open goose://new-session` on macOS should open a fresh chat window

Closes #6509