### PR TITLE
Prompt injection mitigation: update pattern-based detection

### DIFF
--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -55,7 +55,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "rm_rf_home_or_root",
-        pattern: r"rm(\s+(--[a-zA-Z][a-zA-Z\-]*|--|-[a-zA-Z]+))+\s+['\x22]?(~|\$HOME|\$\{HOME\}|/home|/root)/?(\*)?['\x22]?(\s|[;&|]|$)",
+        pattern: r"rm\s+((--[a-zA-Z][a-zA-Z\-]*|--|-[a-zA-Z]+)\s+)*(-[a-zA-Z]*[rR][a-zA-Z]*|--recursive|--dir|-d)(\s+(--[a-zA-Z][a-zA-Z\-]*|--|-[a-zA-Z]+))*\s+['\x22]?(~|\$HOME|\$\{HOME\}|/home|/root)/?(\*)?['\x22]?(\s|[;&|]|$)",
         description: "Recursive deletion of home or root directory",
         risk_level: RiskLevel::Critical,
         category: ThreatCategory::FileSystemDestruction,
@@ -454,6 +454,14 @@ mod tests {
         // Wildcards inside subdirs should not match
         assert!(!matches(pat, "rm -rf /home/user/*"));
         assert!(!matches(pat, "rm -rf ~/Documents/*"));
+        // Flags that cannot recursively remove directories should not fire
+        assert!(!matches(pat, "rm -i /root"));
+        assert!(!matches(pat, "rm -f ~"));
+        assert!(!matches(pat, "rm --force ~"));
+        assert!(!matches(pat, "rm --help ~"));
+        assert!(!matches(pat, "rm -v ~"));
+        assert!(!matches(pat, "rm -- ~"));
+        assert!(!matches(pat, "rm ~"));
     }
 
     #[test]

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -486,5 +486,4 @@ mod tests {
         assert!(!matches(pat, "rm -rf /var/log-backup"));
         assert!(!matches(pat, "rm -rf /var/logs"));
     }
-
 }

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -265,8 +265,6 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "log_manipulation",
-        // Removed `> /dev/null` — stderr suppression (2>/dev/null) is standard shell
-        // and generated many false positives. Kept actual log tampering patterns.
         pattern: r"(truncate.*log|rm\s+(-[rRfF]+\s+)*/var/log/|echo\s*>\s*/var/log)",
         description: "Log file manipulation or deletion",
         risk_level: RiskLevel::Medium,

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -55,7 +55,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "rm_rf_home_or_root",
-        pattern: r"rm\s+(-[rRfF]+\s+)*(-[rRfF]+|--recursive|--force|--no-preserve-root)(\s+(-[rRfF]+|--recursive|--force|--no-preserve-root))*\s+['\x22]?(~|\$HOME|\$\{HOME\}|/home|/root)/?['\x22]?(\s|[;&|]|$)",
+        pattern: r"rm(\s+(--[a-zA-Z][a-zA-Z\-]*|--|-[a-zA-Z]+))+\s+['\x22]?(~|\$HOME|\$\{HOME\}|/home|/root)/?(\*)?['\x22]?(\s|[;&|]|$)",
         description: "Recursive deletion of home or root directory",
         risk_level: RiskLevel::Critical,
         category: ThreatCategory::FileSystemDestruction,
@@ -272,7 +272,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "log_manipulation",
-        pattern: r"(truncate.*log|rm\s+((-[rRfF]+|--recursive|--force|--no-preserve-root)\s+)*/var/log(/|\s|[;&|]|$)|echo\s*>\s*/var/log)",
+        pattern: r"(truncate.*log|rm\s+((--[a-zA-Z][a-zA-Z\-]*|--|-[a-zA-Z]+)\s+)*/var/log(/|\s|[;&|]|$)|echo\s*>\s*/var/log)",
         description: "Log file manipulation or deletion",
         risk_level: RiskLevel::Medium,
         category: ThreatCategory::SystemModification,
@@ -426,6 +426,16 @@ mod tests {
         assert!(matches(pat, "rm --recursive --force ~"));
         assert!(matches(pat, r#"rm -rf "$HOME""#));
         assert!(matches(pat, "rm -rf ~; echo done"));
+        // Wildcard wipes of contents
+        assert!(matches(pat, "rm -rf /home/*"));
+        assert!(matches(pat, "rm -rf /root/*"));
+        assert!(matches(pat, "rm -rf ~/*"));
+        assert!(matches(pat, "rm -rf ${HOME}/*"));
+        assert!(matches(pat, r#"rm -rf "/home/*""#));
+        // Extra flags and option separator
+        assert!(matches(pat, "rm -rfv ~"));
+        assert!(matches(pat, "rm -rf -- ~"));
+        assert!(matches(pat, "rm --recursive --force -- /home/*"));
     }
 
     #[test]
@@ -441,6 +451,9 @@ mod tests {
         assert!(!matches(pat, "rm -rf /root/tmp"));
         assert!(!matches(pat, "rm -rf ./home"));
         assert!(!matches(pat, "rm -rf $HOMEDIR"));
+        // Wildcards inside subdirs should not match
+        assert!(!matches(pat, "rm -rf /home/user/*"));
+        assert!(!matches(pat, "rm -rf ~/Documents/*"));
     }
 
     #[test]
@@ -477,6 +490,8 @@ mod tests {
         assert!(matches(pat, "rm -rf /var/log"));
         assert!(matches(pat, "rm --recursive --force /var/log/auth.log"));
         assert!(matches(pat, "rm --recursive /var/log"));
+        assert!(matches(pat, "rm -rf -- /var/log/auth.log"));
+        assert!(matches(pat, "rm -rfv /var/log/auth.log"));
         // Similar-looking paths outside /var/log should NOT match
         assert!(!matches(pat, "rm -rf /var/log-backup"));
         assert!(!matches(pat, "rm -rf /var/logs"));

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -54,13 +54,6 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
         category: ThreatCategory::FileSystemDestruction,
     },
     ThreatPattern {
-        name: "rm_rf_system",
-        pattern: r"rm\s+(-[rf]*[rf][rf]*|--recursive|--force)\s+[^\s;|&]*/?(bin|etc|usr|var|sys|proc|dev|boot|lib|opt|srv)(?:/|\s|[;&|]|$)",
-        description: "Recursive deletion of system directories",
-        risk_level: RiskLevel::Critical,
-        category: ThreatCategory::FileSystemDestruction,
-    },
-    ThreatPattern {
         name: "dd_destruction",
         pattern: r"dd\s+.*if=/dev/(zero|random|urandom).*of=/dev/[sh]d[a-z]",
         description: "Disk destruction using dd command",
@@ -243,14 +236,6 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
         category: ThreatCategory::CommandInjection,
     },
     ThreatPattern {
-        name: "alternative_shell_invocation",
-        pattern: r"(/bin/|/usr/bin/|\./)?(bash|sh|zsh|fish|csh|tcsh|dash)\s+-c\s+.*[;&|]",
-        description: "Alternative shell invocation patterns",
-        risk_level: RiskLevel::Medium,
-        category: ThreatCategory::CommandInjection,
-    },
-    // Additional dangerous commands that might be missing
-    ThreatPattern {
         name: "docker_privileged_exec",
         pattern: r"docker\s+(run|exec).*--privileged",
         description: "Docker privileged container execution",
@@ -280,7 +265,9 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "log_manipulation",
-        pattern: r"(>\s*/dev/null|truncate.*log|rm.*\.log|echo\s*>\s*/var/log)",
+        // Removed `> /dev/null` — stderr suppression (2>/dev/null) is standard shell
+        // and generated many false positives. Kept actual log tampering patterns.
+        pattern: r"(truncate.*log|rm\s+(-[rRfF]+\s+)*/var/log/|echo\s*>\s*/var/log)",
         description: "Log file manipulation or deletion",
         risk_level: RiskLevel::Medium,
         category: ThreatCategory::SystemModification,
@@ -418,18 +405,55 @@ mod tests {
     }
 
     #[test]
-    fn rm_rf_system_matches_absolute_and_relative() {
-        let pat = "rm_rf_system";
-        assert!(matches(pat, "rm -rf /etc"));
-        assert!(matches(pat, "rm -rf /usr/bin"));
-        assert!(matches(pat, "rm -rf etc"));
-        assert!(matches(pat, "rm -rf var"));
+    fn rm_rf_system_pattern_removed() {
+        let matcher = PatternMatcher::new();
+        let commands = [
+            "rm -rf /etc",
+            "rm -rf build",
+            "rm -f /tmp/file.json",
+            "rm -rf /opt/homebrew/Library/Taps/square/homebrew-formula",
+        ];
+        for cmd in &commands {
+            let has_rm_rf_system = matcher
+                .scan_for_patterns(cmd)
+                .iter()
+                .any(|m| m.threat.name == "rm_rf_system");
+            assert!(!has_rm_rf_system, "rm_rf_system should not exist: {cmd}");
+        }
     }
 
     #[test]
-    fn rm_rf_system_no_false_positives() {
-        let pat = "rm_rf_system";
-        assert!(!matches(pat, "rm -rf ./etc-backup"));
-        assert!(!matches(pat, "rm -rf /home/user/project"));
+    fn log_manipulation_no_dev_null_false_positives() {
+        let pat = "log_manipulation";
+        // Standard stderr suppression should NOT match
+        assert!(!matches(pat, "ls 2>/dev/null"));
+        assert!(!matches(pat, "rm -f /tmp/file 2>/dev/null"));
+        assert!(!matches(pat, "command > /dev/null 2>&1"));
+        // Actual log tampering should still match
+        assert!(matches(pat, "truncate -s 0 /var/log/auth.log"));
+        assert!(matches(pat, "echo > /var/log/syslog"));
+        assert!(matches(pat, "rm -f /var/log/auth.log"));
+        assert!(matches(pat, "rm -rf /var/log/syslog"));
+        assert!(matches(pat, "rm -fr /var/log/auth.log"));
+    }
+
+    #[test]
+    fn alternative_shell_invocation_removed() {
+        // alternative_shell_invocation was removed — ML classifier handles this.
+        let matcher = PatternMatcher::new();
+        let commands = [
+            r#"bash -c "echo hello && echo world""#,
+            r#"sh -c "ls | grep test""#,
+        ];
+        for cmd in &commands {
+            let has_alt_shell = matcher
+                .scan_for_patterns(cmd)
+                .iter()
+                .any(|m| m.threat.name == "alternative_shell_invocation");
+            assert!(
+                !has_alt_shell,
+                "alternative_shell_invocation should not exist: {cmd}"
+            );
+        }
     }
 }

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -465,24 +465,6 @@ mod tests {
     }
 
     #[test]
-    fn rm_rf_system_pattern_removed() {
-        let matcher = PatternMatcher::new();
-        let commands = [
-            "rm -rf /etc",
-            "rm -rf build",
-            "rm -f /tmp/file.json",
-            "rm -rf /opt/homebrew/Library/Taps/square/homebrew-formula",
-        ];
-        for cmd in &commands {
-            let has_rm_rf_system = matcher
-                .scan_for_patterns(cmd)
-                .iter()
-                .any(|m| m.threat.name == "rm_rf_system");
-            assert!(!has_rm_rf_system, "rm_rf_system should not exist: {cmd}");
-        }
-    }
-
-    #[test]
     fn log_manipulation_no_dev_null_false_positives() {
         let pat = "log_manipulation";
         // Standard stderr suppression should NOT match
@@ -505,23 +487,4 @@ mod tests {
         assert!(!matches(pat, "rm -rf /var/logs"));
     }
 
-    #[test]
-    fn alternative_shell_invocation_removed() {
-        // alternative_shell_invocation was removed — ML classifier handles this.
-        let matcher = PatternMatcher::new();
-        let commands = [
-            r#"bash -c "echo hello && echo world""#,
-            r#"sh -c "ls | grep test""#,
-        ];
-        for cmd in &commands {
-            let has_alt_shell = matcher
-                .scan_for_patterns(cmd)
-                .iter()
-                .any(|m| m.threat.name == "alternative_shell_invocation");
-            assert!(
-                !has_alt_shell,
-                "alternative_shell_invocation should not exist: {cmd}"
-            );
-        }
-    }
 }

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -272,7 +272,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "log_manipulation",
-        pattern: r"(truncate.*log|rm\s+(-[rRfF]+\s+)*/var/log/|echo\s*>\s*/var/log)",
+        pattern: r"(truncate.*log|rm\s+((-[rRfF]+|--recursive|--force|--no-preserve-root)\s+)*/var/log(/|\s|[;&|]|$)|echo\s*>\s*/var/log)",
         description: "Log file manipulation or deletion",
         risk_level: RiskLevel::Medium,
         category: ThreatCategory::SystemModification,
@@ -470,6 +470,12 @@ mod tests {
         assert!(matches(pat, "rm -f /var/log/auth.log"));
         assert!(matches(pat, "rm -rf /var/log/syslog"));
         assert!(matches(pat, "rm -fr /var/log/auth.log"));
+        assert!(matches(pat, "rm -rf /var/log"));
+        assert!(matches(pat, "rm --recursive --force /var/log/auth.log"));
+        assert!(matches(pat, "rm --recursive /var/log"));
+        // Similar-looking paths outside /var/log should NOT match
+        assert!(!matches(pat, "rm -rf /var/log-backup"));
+        assert!(!matches(pat, "rm -rf /var/logs"));
     }
 
     #[test]

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -54,6 +54,13 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
         category: ThreatCategory::FileSystemDestruction,
     },
     ThreatPattern {
+        name: "rm_rf_home_or_root",
+        pattern: r"rm\s+(-[rRfF]+\s+)*(-[rRfF]+|--recursive|--force|--no-preserve-root)(\s+(-[rRfF]+|--recursive|--force|--no-preserve-root))*\s+['\x22]?(~|\$HOME|/home|/root)/?['\x22]?(\s|[;&|]|$)",
+        description: "Recursive deletion of home or root directory",
+        risk_level: RiskLevel::Critical,
+        category: ThreatCategory::FileSystemDestruction,
+    },
+    ThreatPattern {
         name: "dd_destruction",
         pattern: r"dd\s+.*if=/dev/(zero|random|urandom).*of=/dev/[sh]d[a-z]",
         description: "Disk destruction using dd command",
@@ -400,6 +407,36 @@ mod tests {
         let pat = "rm_rf_root_bare";
         assert!(!matches(pat, "rm -rf ./build"));
         assert!(!matches(pat, "rm -rf /tmp/cache"));
+    }
+
+    #[test]
+    fn rm_rf_home_or_root_matches_bare_targets() {
+        let pat = "rm_rf_home_or_root";
+        assert!(matches(pat, "rm -rf ~"));
+        assert!(matches(pat, "rm -rf ~/"));
+        assert!(matches(pat, "rm -rf $HOME"));
+        assert!(matches(pat, "rm -rf $HOME/"));
+        assert!(matches(pat, "rm -rf /home"));
+        assert!(matches(pat, "rm -rf /home/"));
+        assert!(matches(pat, "rm -rf /root"));
+        assert!(matches(pat, "rm -rf /root/"));
+        assert!(matches(pat, "rm -fr ~"));
+        assert!(matches(pat, "rm --recursive --force ~"));
+        assert!(matches(pat, r#"rm -rf "$HOME""#));
+        assert!(matches(pat, "rm -rf ~; echo done"));
+    }
+
+    #[test]
+    fn rm_rf_home_or_root_no_false_positives_on_subdirs() {
+        let pat = "rm_rf_home_or_root";
+        assert!(!matches(pat, "rm -rf ~/Documents/my-gh-repo"));
+        assert!(!matches(pat, "rm -rf ~/.cache"));
+        assert!(!matches(pat, "rm -rf $HOME/build"));
+        assert!(!matches(pat, "rm -rf /home/user"));
+        assert!(!matches(pat, "rm -rf /home/user/project"));
+        assert!(!matches(pat, "rm -rf /root/tmp"));
+        assert!(!matches(pat, "rm -rf ./home"));
+        assert!(!matches(pat, "rm -rf $HOMEDIR"));
     }
 
     #[test]

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -55,7 +55,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "rm_rf_home_or_root",
-        pattern: r"rm\s+(-[rRfF]+\s+)*(-[rRfF]+|--recursive|--force|--no-preserve-root)(\s+(-[rRfF]+|--recursive|--force|--no-preserve-root))*\s+['\x22]?(~|\$HOME|/home|/root)/?['\x22]?(\s|[;&|]|$)",
+        pattern: r"rm\s+(-[rRfF]+\s+)*(-[rRfF]+|--recursive|--force|--no-preserve-root)(\s+(-[rRfF]+|--recursive|--force|--no-preserve-root))*\s+['\x22]?(~|\$HOME|\$\{HOME\}|/home|/root)/?['\x22]?(\s|[;&|]|$)",
         description: "Recursive deletion of home or root directory",
         risk_level: RiskLevel::Critical,
         category: ThreatCategory::FileSystemDestruction,
@@ -416,6 +416,8 @@ mod tests {
         assert!(matches(pat, "rm -rf ~/"));
         assert!(matches(pat, "rm -rf $HOME"));
         assert!(matches(pat, "rm -rf $HOME/"));
+        assert!(matches(pat, "rm -rf ${HOME}"));
+        assert!(matches(pat, r#"rm -rf "${HOME}""#));
         assert!(matches(pat, "rm -rf /home"));
         assert!(matches(pat, "rm -rf /home/"));
         assert!(matches(pat, "rm -rf /root"));
@@ -432,6 +434,8 @@ mod tests {
         assert!(!matches(pat, "rm -rf ~/Documents/my-gh-repo"));
         assert!(!matches(pat, "rm -rf ~/.cache"));
         assert!(!matches(pat, "rm -rf $HOME/build"));
+        assert!(!matches(pat, "rm -rf ${HOME}/build"));
+        assert!(!matches(pat, "rm -rf ${HOMEDIR}"));
         assert!(!matches(pat, "rm -rf /home/user"));
         assert!(!matches(pat, "rm -rf /home/user/project"));
         assert!(!matches(pat, "rm -rf /root/tmp"));


### PR DESCRIPTION
## Summary
This PR aims to decrease false positives in pattern-based detection, especially in `rm -rf` commands. Whenever the command injection classifier is not available (i.e. not enabled in settings or WARP disabled), there is an automatic fallback to pattern-based detection. The command injection classifier has reasonably high accuracy, but the pattern-based detection is harder to get right. 

### Changes
* Removed rm_rf_system: Matched any rm -rf targeting system directory names (bin, etc, usr, var, tmp, opt, etc.). In practice this fired on build cleanup (rm -rf build), temp file deletion (rm -f /tmp/file.json), and Homebrew management (rm -rf /opt/homebrew/...). The rm_rf_root_bare pattern still catches the truly catastrophic rm -rf / and rm -rf /*.
* Removed alternative_shell_invocation: Matched any bash -c or sh -c containing ;, |, or &. This is normal shell usage (build scripts, CI commands, conditional checks). The ML classifier distinguishes actual injection from legitimate shell invocations.
* Simplified log_manipulation: Removed > /dev/null from the pattern. Stderr suppression (2>/dev/null) is standard in virtually every shell command. Kept the actual log tampering patterns: truncate.*log, rm /var/log/, echo > /var/log. Also fixed the rm flag regex from (-[rf]\s+)* to (-[rRfF]+\s+)* to correctly match rm -rf /var/log/... (aligned with rm_rf_root_bare).

### Estimated impact
Eliminates ~257 of ~310 weekly pattern-based flags (~83%) while all true positives remain covered by:
* The ML classifier (primary path)
* rm_rf_root_bare for rm -rf /
* curl_bash_execution for curl | bash
All other 20+ patterns unchanged (reverse shells, SUID, credential access, data exfil, etc.) 

### Testing
Unit tests. 


