### PR TITLE
fix: build Linux binaries in Ubuntu 22.04 container for glibc 2.35 compat

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -66,7 +66,7 @@ jobs:
             ubuntu:22.04 bash -c '
               set -euo pipefail
 
-              # Install build dependencies
+              # Install build dependencies as root
               apt-get update
               DEBIAN_FRONTEND=noninteractive apt-get install -y \
                 build-essential \
@@ -78,7 +78,8 @@ jobs:
                 curl \
                 ca-certificates \
                 wget \
-                gnupg
+                gnupg \
+                sudo
 
               # Install glslc from LunarG Vulkan SDK repo (not available in Ubuntu 22.04 base repos)
               wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add -
@@ -87,17 +88,29 @@ jobs:
               apt-get update
               DEBIAN_FRONTEND=noninteractive apt-get install -y shaderc
 
-              # Install Rust toolchain
-              curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | \
-                sh -s -- -y --default-toolchain 1.92.0
-              . "$HOME/.cargo/env"
+              # Create a non-root user matching the host runner UID/GID so that
+              # build artifacts are owned by the runner and subsequent host steps
+              # (Package CLI, Upload) can read/write them without permission errors.
+              HOST_UID=$(stat -c "%u" /workspace)
+              HOST_GID=$(stat -c "%g" /workspace)
+              groupadd -g "${HOST_GID}" builder 2>/dev/null || true
+              useradd -m -u "${HOST_UID}" -g "${HOST_GID}" -s /bin/bash builder
+              echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-              export TARGET="${{ matrix.target }}"
-              rustup target add "${TARGET}"
-              echo "Building for target: ${TARGET}"
-              rustup show
+              # Install Rust and build as the non-root builder user
+              su builder -c '\''
+                set -euo pipefail
+                curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | \
+                  sh -s -- -y --default-toolchain 1.92.0
+                . "$HOME/.cargo/env"
 
-              cargo build --release --target ${TARGET} -p goose-cli --features vulkan
+                export TARGET="${{ matrix.target }}"
+                rustup target add "${TARGET}"
+                echo "Building for target: ${TARGET}"
+                rustup show
+
+                cargo build --release --target ${TARGET} -p goose-cli --features vulkan
+              '\''
             '
 
       - name: Package CLI

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -56,10 +56,27 @@ jobs:
           sed -i.bak 's/^version = ".*"/version = "'${{ inputs.version }}'"/' Cargo.toml
           rm -f Cargo.toml.bak
 
+      - name: Install glslc on host
+        run: |
+          # glslc is a build-time shader compiler needed by llama.cpp's Vulkan backend.
+          # We install it on the host runner and bind-mount it into the container
+          # because the LunarG Vulkan SDK repo (used for Ubuntu 22.04 x86_64) only
+          # provides amd64/i386 packages — no arm64.
+          if command -v glslc &>/dev/null; then
+            echo "glslc already available: $(which glslc)"
+          else
+            sudo apt-get update
+            sudo apt-get install -y glslc || sudo apt-get install -y shaderc
+          fi
+          GLSLC_PATH=$(which glslc)
+          echo "GLSLC_PATH=${GLSLC_PATH}" >> $GITHUB_ENV
+          echo "Using glslc at: ${GLSLC_PATH}"
+
       - name: Build CLI in Ubuntu 22.04 container
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \
+            -v "${GLSLC_PATH}:/usr/local/bin/glslc:ro" \
             -w /workspace \
             -e RUST_LOG=debug \
             -e RUST_BACKTRACE=1 \
@@ -79,16 +96,7 @@ jobs:
                 cmake \
                 curl \
                 ca-certificates \
-                wget \
-                gnupg \
                 sudo
-
-              # Install glslc from LunarG Vulkan SDK repo (not available in Ubuntu 22.04 base repos)
-              wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add -
-              wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list \
-                https://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
-              apt-get update
-              DEBIAN_FRONTEND=noninteractive apt-get install -y shaderc
 
               # Create a non-root user matching the host runner UID/GID so that
               # build artifacts are owned by the runner and subsequent host steps
@@ -98,6 +106,8 @@ jobs:
               groupadd -g "${HOST_GID}" builder 2>/dev/null || true
               useradd -m -u "${HOST_UID}" -g "${HOST_GID}" -s /bin/bash builder
               echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+              echo "glslc version: $(glslc --version)"
 
               # Install Rust and build as the non-root builder user
               su builder -c '\''

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -4,7 +4,9 @@
 #  - canary.yml
 #
 # Platform Build Strategy:
-#  - Linux: Uses native Ubuntu runners, including arm64 hosted runners
+#  - Linux: Uses native Ubuntu runners with Docker container for glibc 2.35
+#    compatibility (builds inside ubuntu:22.04 to support older distros).
+#    Includes arm64 hosted runners.
 #  - macOS: Uses native macOS runners for each architecture
 #  - Windows: Uses Windows runner with native MSVC build
 on:
@@ -22,6 +24,104 @@ on:
 name: "Reusable workflow to build CLI"
 
 jobs:
+  # ------------------------------------
+  # Linux builds: run inside an ubuntu:22.04 container for glibc 2.35 compat.
+  # This ensures the resulting binary works on Ubuntu 22.04+, Debian 12+,
+  # RHEL 9+, Amazon Linux 2023+, and other LTS distros.
+  # ------------------------------------
+  build-cli-linux:
+    name: Build CLI (Linux ${{ matrix.architecture }})
+    runs-on: ${{ matrix.build-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - architecture: x86_64
+            target: x86_64-unknown-linux-gnu
+            build-on: ubuntu-24.04
+          - architecture: aarch64
+            target: aarch64-unknown-linux-gnu
+            build-on: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Update version in Cargo.toml
+        if: ${{ inputs.version != '' }}
+        shell: bash
+        run: |
+          sed -i.bak 's/^version = ".*"/version = "'${{ inputs.version }}'"/' Cargo.toml
+          rm -f Cargo.toml.bak
+
+      - name: Build CLI in Ubuntu 22.04 container
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            -e RUST_LOG=debug \
+            -e RUST_BACKTRACE=1 \
+            ubuntu:22.04 bash -c '
+              set -euo pipefail
+
+              # Install build dependencies
+              apt-get update
+              DEBIAN_FRONTEND=noninteractive apt-get install -y \
+                build-essential \
+                pkg-config \
+                libssl-dev \
+                libdbus-1-dev \
+                libxcb1-dev \
+                libvulkan-dev \
+                curl \
+                ca-certificates \
+                wget \
+                gnupg
+
+              # Install glslc from LunarG Vulkan SDK repo (not available in Ubuntu 22.04 base repos)
+              wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add -
+              wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list \
+                https://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
+              apt-get update
+              DEBIAN_FRONTEND=noninteractive apt-get install -y shaderc
+
+              # Install Rust toolchain
+              curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | \
+                sh -s -- -y --default-toolchain 1.92.0
+              . "$HOME/.cargo/env"
+
+              export TARGET="${{ matrix.target }}"
+              rustup target add "${TARGET}"
+              echo "Building for target: ${TARGET}"
+              rustup show
+
+              cargo build --release --target ${TARGET} -p goose-cli --features vulkan
+            '
+
+      - name: Package CLI
+        run: |
+          export TARGET="${{ matrix.target }}"
+          mkdir -p "target/${TARGET}/release/goose-package"
+          cp "target/${TARGET}/release/goose" "target/${TARGET}/release/goose-package/"
+          cd "target/${TARGET}/release"
+          tar -cjf "goose-${TARGET}.tar.bz2" -C goose-package .
+          tar -czf "goose-${TARGET}.tar.gz" -C goose-package .
+          echo "ARTIFACT_BZ2=target/${TARGET}/release/goose-${TARGET}.tar.bz2" >> $GITHUB_ENV
+          echo "ARTIFACT_GZ=target/${TARGET}/release/goose-${TARGET}.tar.gz" >> $GITHUB_ENV
+
+      - name: Upload CLI artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        with:
+          name: goose-${{ matrix.architecture }}-unknown-linux-gnu
+          path: |
+            ${{ env.ARTIFACT_BZ2 }}
+            ${{ env.ARTIFACT_GZ }}
+
+  # ------------------------------------
+  # macOS and Windows builds: unchanged, run natively on host runners.
+  # ------------------------------------
   build-cli:
     name: Build CLI
     runs-on: ${{ matrix.build-on }}
@@ -31,16 +131,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: linux
-            architecture: x86_64
-            target-suffix: unknown-linux-gnu
-            build-on: ubuntu-24.04
-            variant: standard
-          - platform: linux
-            architecture: aarch64
-            target-suffix: unknown-linux-gnu
-            build-on: ubuntu-24.04-arm
-            variant: standard
           - platform: macos
             architecture: x86_64
             target-suffix: apple-darwin
@@ -75,22 +165,8 @@ jobs:
           sed -i.bak 's/^version = ".*"/version = "'${{ inputs.version }}'"/' Cargo.toml
           rm -f Cargo.toml.bak
 
-      - name: Install Linux build dependencies
-        if: matrix.platform == 'linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            pkg-config \
-            libssl-dev \
-            libdbus-1-dev \
-            libxcb1-dev \
-            libvulkan-dev \
-            libvulkan1 \
-            glslc
-
-      - name: Cache Cargo artifacts (Linux/macOS)
-        if: matrix.platform != 'windows'
+      - name: Cache Cargo artifacts (macOS)
+        if: matrix.platform == 'macos'
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           key: ${{ matrix.architecture }}-${{ matrix.target-suffix }}-native-macos-deployment-target-12
@@ -101,8 +177,8 @@ jobs:
         with:
           key: windows-msvc-cli-${{ matrix.variant }}
 
-      - name: Build CLI (Linux/macOS)
-        if: matrix.platform != 'windows'
+      - name: Build CLI (macOS)
+        if: matrix.platform == 'macos'
         env:
           RUST_LOG: debug
           RUST_BACKTRACE: 1
@@ -114,11 +190,7 @@ jobs:
           echo "Rust toolchain info:"
           rustup show
 
-          FEATURE_ARGS=()
-          if [[ "${TARGET}" == *-unknown-linux-gnu ]]; then
-            FEATURE_ARGS=(--features vulkan)
-          fi
-          cargo build --release --target ${TARGET} -p goose-cli "${FEATURE_ARGS[@]}"
+          cargo build --release --target ${TARGET} -p goose-cli
 
       - name: Setup Rust (Windows)
         if: matrix.platform == 'windows'
@@ -175,8 +247,8 @@ jobs:
           Write-Output "Windows CLI binary found."
           Get-Item ./target/x86_64-pc-windows-msvc/release/goose.exe
 
-      - name: Package CLI (Linux/macOS)
-        if: matrix.platform != 'windows'
+      - name: Package CLI (macOS)
+        if: matrix.platform == 'macos'
         run: |
           source ./bin/activate-hermit
           export TARGET="${{ matrix.architecture }}-${{ matrix.target-suffix }}"

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -56,26 +56,23 @@ jobs:
           sed -i.bak 's/^version = ".*"/version = "'${{ inputs.version }}'"/' Cargo.toml
           rm -f Cargo.toml.bak
 
-      - name: Install glslc on host
+      - name: Install Vulkan SDK on host
         run: |
-          # glslc is a build-time shader compiler needed by llama.cpp's Vulkan backend.
-          # We install it on the host runner and bind-mount it into the container
-          # because the LunarG Vulkan SDK repo (used for Ubuntu 22.04 x86_64) only
-          # provides amd64/i386 packages — no arm64.
-          if command -v glslc &>/dev/null; then
-            echo "glslc already available: $(which glslc)"
-          else
-            sudo apt-get update
-            sudo apt-get install -y glslc || sudo apt-get install -y shaderc
-          fi
-          GLSLC_PATH=$(which glslc)
-          echo "GLSLC_PATH=${GLSLC_PATH}" >> $GITHUB_ENV
-          echo "Using glslc at: ${GLSLC_PATH}"
+          # Install Vulkan dev packages on the host (ubuntu-24.04) so we can
+          # bind-mount the newer headers and glslc into the ubuntu:22.04 container.
+          # Ubuntu 22.04's Vulkan headers (1.3.204) are too old for llama-cpp-sys-2
+          # which requires types from ~1.3.275+. The host's ubuntu-24.04 headers
+          # are new enough, and since headers are architecture-independent this
+          # works for both x86_64 and arm64 runners.
+          sudo apt-get update
+          sudo apt-get install -y libvulkan-dev glslc
+          echo "GLSLC_PATH=$(which glslc)" >> $GITHUB_ENV
 
       - name: Build CLI in Ubuntu 22.04 container
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \
+            -v "/usr/include/vulkan:/usr/include/vulkan-host:ro" \
             -v "${GLSLC_PATH}:/usr/local/bin/glslc:ro" \
             -w /workspace \
             -e RUST_LOG=debug \
@@ -97,6 +94,12 @@ jobs:
                 curl \
                 ca-certificates \
                 sudo
+
+              # Overlay newer Vulkan headers from the host (ubuntu-24.04) over the
+              # container'\''s older ones (ubuntu-22.04, SDK 1.3.204). The container'\''s
+              # libvulkan.so is kept for glibc-compatible linking; only the headers
+              # are updated for compilation compatibility with llama-cpp-sys-2.
+              cp -r /usr/include/vulkan-host/* /usr/include/vulkan/
 
               # Create a non-root user matching the host runner UID/GID so that
               # build artifacts are owned by the runner and subsequent host steps

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -75,6 +75,8 @@ jobs:
                 libdbus-1-dev \
                 libxcb1-dev \
                 libvulkan-dev \
+                libclang-dev \
+                cmake \
                 curl \
                 ca-certificates \
                 wget \

--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -85,6 +85,20 @@ jobs:
         run: |
           flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 
+      - name: Install glslc on host
+        run: |
+          # glslc is a build-time shader compiler needed by llama.cpp's Vulkan backend.
+          # Install on host and bind-mount into container for cross-architecture compat.
+          if command -v glslc &>/dev/null; then
+            echo "glslc already available: $(which glslc)"
+          else
+            sudo apt-get update
+            sudo apt-get install -y glslc || sudo apt-get install -y shaderc
+          fi
+          GLSLC_PATH=$(which glslc)
+          echo "GLSLC_PATH=${GLSLC_PATH}" >> $GITHUB_ENV
+          echo "Using glslc at: ${GLSLC_PATH}"
+
       # Build goosed inside an Ubuntu 22.04 container to produce a binary
       # compatible with glibc 2.35+ (Ubuntu 22.04, Debian 12, RHEL 9, etc.)
       - name: Build goosed binary (Ubuntu 22.04 container)
@@ -94,6 +108,7 @@ jobs:
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \
+            -v "${GLSLC_PATH}:/usr/local/bin/glslc:ro" \
             -w /workspace \
             -e RUST_LOG=debug \
             -e RUST_BACKTRACE=1 \
@@ -113,16 +128,7 @@ jobs:
                 cmake \
                 curl \
                 ca-certificates \
-                wget \
-                gnupg \
                 sudo
-
-              # Install glslc from LunarG Vulkan SDK repo (not available in Ubuntu 22.04 base repos)
-              wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add -
-              wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list \
-                https://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
-              apt-get update
-              DEBIAN_FRONTEND=noninteractive apt-get install -y shaderc
 
               # Create a non-root user matching the host runner UID/GID so that
               # build artifacts are owned by the runner and subsequent host steps
@@ -131,6 +137,8 @@ jobs:
               HOST_GID=$(stat -c "%g" /workspace)
               groupadd -g "${HOST_GID}" builder 2>/dev/null || true
               useradd -m -u "${HOST_UID}" -g "${HOST_GID}" -s /bin/bash builder
+
+              echo "glslc version: $(glslc --version)"
 
               # Install Rust and build as the non-root builder user
               su builder -c '\''

--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -109,6 +109,8 @@ jobs:
                 libdbus-1-dev \
                 libxcb1-dev \
                 libvulkan-dev \
+                libclang-dev \
+                cmake \
                 curl \
                 ca-certificates \
                 wget \

--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -79,35 +79,57 @@ jobs:
             protobuf-compiler \
             flatpak \
             flatpak-builder \
-            elfutils \
-            libvulkan-dev \
-            libvulkan1 \
-            glslc
+            elfutils
 
       - name: Setup Flatpak Runtimes
         run: |
           flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 
-      - name: Activate hermit and set CARGO_HOME
-        run: |
-          source bin/activate-hermit
-          echo "CARGO_HOME=$CARGO_HOME" >> $GITHUB_ENV
-          echo "RUSTUP_HOME=$RUSTUP_HOME" >> $GITHUB_ENV
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
-        with:
-          key: linux
-
-      - name: Build goosed binary
+      # Build goosed inside an Ubuntu 22.04 container to produce a binary
+      # compatible with glibc 2.35+ (Ubuntu 22.04, Debian 12, RHEL 9, etc.)
+      - name: Build goosed binary (Ubuntu 22.04 container)
         env:
           RUST_LOG: debug
           RUST_BACKTRACE: 1
         run: |
-          source ./bin/activate-hermit
-          export TARGET="x86_64-unknown-linux-gnu"
-          rustup target add "${TARGET}"
-          cargo build --release --target ${TARGET} -p goose-server --features vulkan
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            -e RUST_LOG=debug \
+            -e RUST_BACKTRACE=1 \
+            ubuntu:22.04 bash -c '
+              set -euo pipefail
+
+              # Install build dependencies
+              apt-get update
+              DEBIAN_FRONTEND=noninteractive apt-get install -y \
+                build-essential \
+                pkg-config \
+                libssl-dev \
+                libdbus-1-dev \
+                libxcb1-dev \
+                libvulkan-dev \
+                curl \
+                ca-certificates \
+                wget \
+                gnupg
+
+              # Install glslc from LunarG Vulkan SDK repo (not available in Ubuntu 22.04 base repos)
+              wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add -
+              wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list \
+                https://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
+              apt-get update
+              DEBIAN_FRONTEND=noninteractive apt-get install -y shaderc
+
+              # Install Rust toolchain
+              curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | \
+                sh -s -- -y --default-toolchain 1.92.0
+              . "$HOME/.cargo/env"
+
+              export TARGET="x86_64-unknown-linux-gnu"
+              rustup target add "${TARGET}"
+              cargo build --release --target ${TARGET} -p goose-server --features vulkan
+            '
 
       - name: Copy binaries into Electron folder
         run: |

--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -100,7 +100,7 @@ jobs:
             ubuntu:22.04 bash -c '
               set -euo pipefail
 
-              # Install build dependencies
+              # Install build dependencies as root
               apt-get update
               DEBIAN_FRONTEND=noninteractive apt-get install -y \
                 build-essential \
@@ -112,7 +112,8 @@ jobs:
                 curl \
                 ca-certificates \
                 wget \
-                gnupg
+                gnupg \
+                sudo
 
               # Install glslc from LunarG Vulkan SDK repo (not available in Ubuntu 22.04 base repos)
               wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add -
@@ -121,14 +122,25 @@ jobs:
               apt-get update
               DEBIAN_FRONTEND=noninteractive apt-get install -y shaderc
 
-              # Install Rust toolchain
-              curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | \
-                sh -s -- -y --default-toolchain 1.92.0
-              . "$HOME/.cargo/env"
+              # Create a non-root user matching the host runner UID/GID so that
+              # build artifacts are owned by the runner and subsequent host steps
+              # (Copy binaries, Electron packaging) can read them without permission errors.
+              HOST_UID=$(stat -c "%u" /workspace)
+              HOST_GID=$(stat -c "%g" /workspace)
+              groupadd -g "${HOST_GID}" builder 2>/dev/null || true
+              useradd -m -u "${HOST_UID}" -g "${HOST_GID}" -s /bin/bash builder
 
-              export TARGET="x86_64-unknown-linux-gnu"
-              rustup target add "${TARGET}"
-              cargo build --release --target ${TARGET} -p goose-server --features vulkan
+              # Install Rust and build as the non-root builder user
+              su builder -c '\''
+                set -euo pipefail
+                curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | \
+                  sh -s -- -y --default-toolchain 1.92.0
+                . "$HOME/.cargo/env"
+
+                export TARGET="x86_64-unknown-linux-gnu"
+                rustup target add "${TARGET}"
+                cargo build --release --target ${TARGET} -p goose-server --features vulkan
+              '\''
             '
 
       - name: Copy binaries into Electron folder

--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -79,35 +79,27 @@ jobs:
             protobuf-compiler \
             flatpak \
             flatpak-builder \
-            elfutils
+            elfutils \
+            libvulkan-dev \
+            glslc
 
       - name: Setup Flatpak Runtimes
         run: |
           flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 
-      - name: Install glslc on host
-        run: |
-          # glslc is a build-time shader compiler needed by llama.cpp's Vulkan backend.
-          # Install on host and bind-mount into container for cross-architecture compat.
-          if command -v glslc &>/dev/null; then
-            echo "glslc already available: $(which glslc)"
-          else
-            sudo apt-get update
-            sudo apt-get install -y glslc || sudo apt-get install -y shaderc
-          fi
-          GLSLC_PATH=$(which glslc)
-          echo "GLSLC_PATH=${GLSLC_PATH}" >> $GITHUB_ENV
-          echo "Using glslc at: ${GLSLC_PATH}"
-
       # Build goosed inside an Ubuntu 22.04 container to produce a binary
       # compatible with glibc 2.35+ (Ubuntu 22.04, Debian 12, RHEL 9, etc.)
+      # We bind-mount the host's newer Vulkan headers and glslc into the container
+      # because Ubuntu 22.04's Vulkan SDK (1.3.204) is too old for llama-cpp-sys-2.
       - name: Build goosed binary (Ubuntu 22.04 container)
         env:
           RUST_LOG: debug
           RUST_BACKTRACE: 1
         run: |
+          GLSLC_PATH=$(which glslc)
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \
+            -v "/usr/include/vulkan:/usr/include/vulkan-host:ro" \
             -v "${GLSLC_PATH}:/usr/local/bin/glslc:ro" \
             -w /workspace \
             -e RUST_LOG=debug \
@@ -129,6 +121,10 @@ jobs:
                 curl \
                 ca-certificates \
                 sudo
+
+              # Overlay newer Vulkan headers from the host over the container'\''s
+              # older ones. The container'\''s libvulkan.so is kept for linking.
+              cp -r /usr/include/vulkan-host/* /usr/include/vulkan/
 
               # Create a non-root user matching the host runner UID/GID so that
               # build artifacts are owned by the runner and subsequent host steps


### PR DESCRIPTION
## Summary

PR #9075 switched Linux builds from cross-compiled (with older glibc) to native `ubuntu-24.04` runners, producing binaries that require glibc >= 2.38. This broke compatibility with Ubuntu 22.04 and potentially some other distros that are still supported.

Users on these distros see:
```
./goose: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by ./goose)
./goose: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by ./goose)
```

## Fix

Build the Linux Rust binaries inside an `ubuntu:22.04` Docker container on the existing `ubuntu-24.04` runners. This preserves the native arm64 runner support added in #9075 (no `ubuntu-22.04-arm` hosted runners exist) while producing binaries compatible with glibc 2.35+.

Fixes #9203.

### Changes

- **`build-cli.yml`**: Split Linux builds into a separate `build-cli-linux` job that builds inside an `ubuntu:22.04` container. macOS/Windows jobs are unchanged. Artifact names are preserved so downstream workflows (`release.yml`, `canary.yml`, `pr-comment-build-cli.yml`) work without modification.
- **`bundle-desktop-linux.yml`**: Build the `goosed` binary inside an `ubuntu:22.04` container, then package with Electron on the host `ubuntu-24.04` runner as before. The Electron binary itself is built on Ubuntu 22.04 by the Electron project and is already compatible.
- `glslc` (needed for Vulkan shader compilation) is installed via the LunarG Vulkan SDK repo since it is not in Ubuntu 22.04 base repos.

### Not in scope

`bundle-goose2.yml` has the same `ubuntu-24.04` issue for its Linux job, but that is a separate v2 pipeline — left as a follow-up.