### PR TITLE
fix(extension_manager): set TCP_USER_TIMEOUT on streamable HTTP clients

### DIFF
--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -517,8 +517,13 @@ async fn connect_with_auth(
 ) -> ExtensionResult<Box<dyn McpClientTrait>> {
     let mut auth_headers = HeaderMap::new();
     auth_headers.insert(reqwest::header::USER_AGENT, GOOSE_USER_AGENT);
-    let auth_http_client = reqwest::Client::builder()
-        .default_headers(auth_headers)
+    #[allow(unused_mut)]
+    let mut auth_client_builder = reqwest::Client::builder().default_headers(auth_headers);
+    #[cfg(target_os = "linux")]
+    {
+        auth_client_builder = auth_client_builder.tcp_user_timeout(Some(timeout));
+    }
+    let auth_http_client = auth_client_builder
         .build()
         .map_err(|_| ExtensionError::ConfigError("could not construct http client".to_string()))?;
     let auth_client = AuthClient::new(auth_http_client, auth_manager);
@@ -587,8 +592,15 @@ async fn create_streamable_http_client(
         );
     }
 
-    let http_client = reqwest::Client::builder()
-        .default_headers(default_headers)
+    let timeout_duration = Duration::from_secs(resolve_timeout(timeout));
+
+    #[allow(unused_mut)]
+    let mut http_client_builder = reqwest::Client::builder().default_headers(default_headers);
+    #[cfg(target_os = "linux")]
+    {
+        http_client_builder = http_client_builder.tcp_user_timeout(Some(timeout_duration));
+    }
+    let http_client = http_client_builder
         .build()
         .map_err(|_| ExtensionError::ConfigError("could not construct http client".to_string()))?;
 
@@ -596,8 +608,6 @@ async fn create_streamable_http_client(
         http_client,
         StreamableHttpClientTransportConfig::with_uri(uri),
     );
-
-    let timeout_duration = Duration::from_secs(resolve_timeout(timeout));
 
     // If we have stored OAuth credentials, try refreshing and connecting directly.
     // This avoids the unnecessary 401 → browser re-auth cycle on every new session.


### PR DESCRIPTION
## Summary

`TCP_USER_TIMEOUT` is a Linux-only kernel socket option. reqwest 0.13.2 defaults it to 30s on Linux, killing established Streamable HTTP MCP connections after ~30s regardless of the configured extension timeout.

PR #9101 used `.connect_timeout()`, which only bounds the TCP handshake and has no effect on established connections. The correct fix is `.tcp_user_timeout()`.

## Changes

Add `.tcp_user_timeout(Some(timeout_duration))` to both `reqwest::Client` builders in `create_streamable_http_client()` (primary and OAuth fallback), gated on `#[cfg(target_os = "linux")]`. macOS and Windows do not have this socket option and are unaffected by the bug.

`timeout_duration` is moved before the first builder so both can use it. A `mut` builder with a cfg-gated reassignment avoids duplicating the chain; `#[allow(unused_mut)]` suppresses the clippy false positive on non-Linux targets.

`.timeout()` is omitted -- it caps total request duration and breaks SSE streams.

## Test plan

- [ ] `cargo build -p goose` passes
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo fmt` applied

Closes #9022
