### PR TITLE
feat: add Atomic Chat as declarative OpenAI-compatible provider

### DIFF
--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -880,6 +880,37 @@ mod tests {
     }
 
     #[test]
+    fn test_atomic_chat_json_deserializes() {
+        let json = include_str!("../providers/declarative/atomic_chat.json");
+        let config: DeclarativeProviderConfig =
+            serde_json::from_str(json).expect("atomic_chat.json should parse");
+        assert_eq!(config.name, "atomic_chat");
+        assert_eq!(config.display_name, "Atomic Chat");
+        assert!(matches!(config.engine, ProviderEngine::OpenAI));
+        assert_eq!(config.api_key_env, "");
+        assert!(!config.requires_auth);
+        assert!(config.skip_canonical_filtering);
+        assert_eq!(config.dynamic_models, Some(true));
+        assert_eq!(config.supports_streaming, Some(true));
+        assert_eq!(
+            config.base_url,
+            "${ATOMIC_CHAT_HOST}/v1/chat/completions"
+        );
+        assert!(config.models.is_empty());
+
+        let env_vars = config.env_vars.as_ref().expect("env_vars should be set");
+        assert_eq!(env_vars.len(), 1);
+        assert_eq!(env_vars[0].name, "ATOMIC_CHAT_HOST");
+        assert!(!env_vars[0].required);
+        assert!(!env_vars[0].secret);
+        assert_eq!(env_vars[0].primary, Some(true));
+        assert_eq!(
+            env_vars[0].default,
+            Some("http://localhost:1337".to_string())
+        );
+    }
+
+    #[test]
     fn test_routstr_json_deserializes() {
         let json = include_str!("../providers/declarative/routstr.json");
         let config: DeclarativeProviderConfig =

--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -892,10 +892,7 @@ mod tests {
         assert!(config.skip_canonical_filtering);
         assert_eq!(config.dynamic_models, Some(true));
         assert_eq!(config.supports_streaming, Some(true));
-        assert_eq!(
-            config.base_url,
-            "${ATOMIC_CHAT_HOST}/v1/chat/completions"
-        );
+        assert_eq!(config.base_url, "${ATOMIC_CHAT_HOST}/v1/chat/completions");
         assert!(config.models.is_empty());
 
         let env_vars = config.env_vars.as_ref().expect("env_vars should be set");

--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -886,6 +886,10 @@ mod tests {
             serde_json::from_str(json).expect("atomic_chat.json should parse");
         assert_eq!(config.name, "atomic_chat");
         assert_eq!(config.display_name, "Atomic Chat");
+        assert_eq!(
+            config.description.as_deref(),
+            Some("Local models through Atomic Chat\u{2019}s OpenAI-compatible server")
+        );
         assert!(matches!(config.engine, ProviderEngine::OpenAI));
         assert_eq!(config.api_key_env, "");
         assert!(!config.requires_auth);
@@ -894,6 +898,8 @@ mod tests {
         assert_eq!(config.supports_streaming, Some(true));
         assert_eq!(config.base_url, "${ATOMIC_CHAT_HOST}/v1/chat/completions");
         assert!(config.models.is_empty());
+        assert!(config.model_doc_link.is_none());
+        assert!(config.setup_steps.is_empty());
 
         let env_vars = config.env_vars.as_ref().expect("env_vars should be set");
         assert_eq!(env_vars.len(), 1);
@@ -904,6 +910,10 @@ mod tests {
         assert_eq!(
             env_vars[0].default,
             Some("http://localhost:1337".to_string())
+        );
+        assert_eq!(
+            env_vars[0].description.as_deref(),
+            Some("Base URL of the Atomic Chat server (default: http://localhost:1337)")
         );
     }
 

--- a/crates/goose/src/providers/catalog.rs
+++ b/crates/goose/src/providers/catalog.rs
@@ -704,6 +704,28 @@ const SETUP_METADATA: &[CuratedSetupMetadata] = &[
         }],
     },
     CuratedSetupMetadata {
+        provider_id: "atomic_chat",
+        category: ProviderSetupCategory::Model,
+        setup_method: ProviderSetupMethod::ConfigFields,
+        group: ProviderSetupGroup::Additional,
+        display_name: None,
+        description: None,
+        docs_url: Some("https://github.com/AtomicBot-ai/Atomic-Chat?tab=readme-ov-file#readme"),
+        aliases: &[],
+        native_connect_query: None,
+        binary_name: None,
+        setup_capabilities: setup_capabilities(false, false, false),
+        show_only_when_installed: false,
+        synthetic: false,
+        secret_field_default: None,
+        field_overrides: &[CuratedFieldMetadata {
+            key: "ATOMIC_CHAT_HOST",
+            label: "Host URL",
+            placeholder: Some("http://localhost:1337"),
+            default_value: Some("http://localhost:1337"),
+        }],
+    },
+    CuratedSetupMetadata {
         provider_id: "nvidia",
         category: ProviderSetupCategory::Model,
         setup_method: ProviderSetupMethod::SingleApiKey,
@@ -1093,6 +1115,22 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["DATABRICKS_HOST", "DATABRICKS_TOKEN"]
         );
+
+        let atomic_chat = entries
+            .iter()
+            .find(|entry| entry.provider_id == "atomic_chat")
+            .expect("setup catalog should include atomic_chat declarative provider");
+        assert_eq!(atomic_chat.setup_method, ProviderSetupMethod::ConfigFields);
+        let host_field = atomic_chat
+            .fields
+            .iter()
+            .find(|field| field.key == "ATOMIC_CHAT_HOST")
+            .expect("atomic_chat should expose ATOMIC_CHAT_HOST");
+        assert_eq!(host_field.label, "Host URL");
+        assert_eq!(
+            host_field.default_value.as_deref(),
+            Some("http://localhost:1337")
+        );
     }
 
     #[tokio::test]
@@ -1105,6 +1143,7 @@ mod tests {
 
         assert!(provider_ids.contains("claude-acp"));
         assert!(provider_ids.contains("codex-acp"));
+        assert!(provider_ids.contains("atomic_chat"));
         assert!(!provider_ids.contains("claude_code"));
         assert!(!provider_ids.contains("codex"));
         assert!(!provider_ids.contains("gemini_cli"));

--- a/crates/goose/src/providers/declarative/atomic_chat.json
+++ b/crates/goose/src/providers/declarative/atomic_chat.json
@@ -2,7 +2,7 @@
   "name": "atomic_chat",
   "engine": "openai",
   "display_name": "Atomic Chat",
-  "description": "Open-source Atomic Chat desktop app (Tauri) for local and cloud models. It exposes an OpenAI-compatible HTTP API (default `http://localhost:1337/v1`) so other tools can call your local MLX / llama.cpp stack through a single endpoint. Project: https://github.com/AtomicBot-ai/Atomic-Chat",
+  "description": "Local models through Atomic Chat's OpenAI-compatible server",
   "api_key_env": "",
   "base_url": "${ATOMIC_CHAT_HOST}/v1/chat/completions",
   "env_vars": [

--- a/crates/goose/src/providers/declarative/atomic_chat.json
+++ b/crates/goose/src/providers/declarative/atomic_chat.json
@@ -1,0 +1,29 @@
+{
+  "name": "atomic_chat",
+  "engine": "openai",
+  "display_name": "Atomic Chat",
+  "description": "Open-source Atomic Chat desktop app (Tauri) for local and cloud models. It exposes an OpenAI-compatible HTTP API (default `http://localhost:1337/v1`) so other tools can call your local MLX / llama.cpp stack through a single endpoint. Project: https://github.com/AtomicBot-ai/Atomic-Chat",
+  "api_key_env": "",
+  "base_url": "${ATOMIC_CHAT_HOST}/v1/chat/completions",
+  "env_vars": [
+    {
+      "name": "ATOMIC_CHAT_HOST",
+      "required": false,
+      "secret": false,
+      "primary": true,
+      "default": "http://localhost:1337",
+      "description": "Origin of Atomic Chat's OpenAI-compatible API (default: http://localhost:1337)"
+    }
+  ],
+  "dynamic_models": true,
+  "models": [],
+  "supports_streaming": true,
+  "requires_auth": false,
+  "skip_canonical_filtering": true,
+  "model_doc_link": "https://github.com/AtomicBot-ai/Atomic-Chat?tab=readme-ov-file#readme",
+  "setup_steps": [
+    "Install and launch Atomic Chat (see https://github.com/AtomicBot-ai/Atomic-Chat or https://atomic.chat/) so its local OpenAI-compatible server is running.",
+    "In Atomic Chat, download or select a model so `/v1/models` and chat completions are available at your configured host (default port 1337).",
+    "Override `ATOMIC_CHAT_HOST` only if the app listens on a different origin than `http://localhost:1337`."
+  ]
+}

--- a/crates/goose/src/providers/declarative/atomic_chat.json
+++ b/crates/goose/src/providers/declarative/atomic_chat.json
@@ -2,7 +2,7 @@
   "name": "atomic_chat",
   "engine": "openai",
   "display_name": "Atomic Chat",
-  "description": "Local models through Atomic Chat's OpenAI-compatible server",
+  "description": "Local models through Atomic Chat\u2019s OpenAI-compatible server",
   "api_key_env": "",
   "base_url": "${ATOMIC_CHAT_HOST}/v1/chat/completions",
   "env_vars": [
@@ -12,18 +12,12 @@
       "secret": false,
       "primary": true,
       "default": "http://localhost:1337",
-      "description": "Origin of Atomic Chat's OpenAI-compatible API (default: http://localhost:1337)"
+      "description": "Base URL of the Atomic Chat server (default: http://localhost:1337)"
     }
   ],
   "dynamic_models": true,
   "models": [],
   "supports_streaming": true,
   "requires_auth": false,
-  "skip_canonical_filtering": true,
-  "model_doc_link": "https://github.com/AtomicBot-ai/Atomic-Chat?tab=readme-ov-file#readme",
-  "setup_steps": [
-    "Install and launch Atomic Chat (see https://github.com/AtomicBot-ai/Atomic-Chat or https://atomic.chat/) so its local OpenAI-compatible server is running.",
-    "In Atomic Chat, download or select a model so `/v1/models` and chat completions are available at your configured host (default port 1337).",
-    "Override `ATOMIC_CHAT_HOST` only if the app listens on a different origin than `http://localhost:1337`."
-  ]
+  "skip_canonical_filtering": true
 }

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -25,6 +25,7 @@ goose is compatible with a wide range of LLM providers, allowing you to choose a
 | [Amazon Bedrock](https://aws.amazon.com/bedrock/)                           | Offers a variety of foundation models, including Claude, Jurassic-2, and others. **AWS environment variables must be set in advance, not configured through `goose configure`**                                           | Credential auth: `AWS_PROFILE`, or `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`<br /><br />Bearer token auth: `AWS_BEARER_TOKEN_BEDROCK` and `AWS_REGION`, `AWS_DEFAULT_REGION`, or `AWS_PROFILE` |
 | [Amazon SageMaker TGI](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints.html) | Run Text Generation Inference models through Amazon SageMaker endpoints. **AWS credentials must be configured in advance.** | `SAGEMAKER_ENDPOINT_NAME`, `AWS_REGION` (optional), `AWS_PROFILE` (optional)  |
 | [Anthropic](https://www.anthropic.com/)                                     | Offers Claude, an advanced AI model for natural language tasks.                                                                                                                                                           | `ANTHROPIC_API_KEY`, `ANTHROPIC_HOST` (optional)                                                                                                                                                                 |
+| [Atomic Chat](https://github.com/AtomicBot-ai/Atomic-Chat)                | Open-source desktop client with a local OpenAI-compatible API (default `http://localhost:1337/v1`) for local MLX / llama.cpp models and optional cloud providers. **Start Atomic Chat and ensure a model is available** (see project README). | None required in goose for the default local API. `ATOMIC_CHAT_HOST` (optional, default `http://localhost:1337`). If your endpoint requires auth, use a [custom OpenAI-compatible provider](#configure-custom-provider). |
 | [Avian](https://avian.io/)                                                   | Cost-effective inference API with DeepSeek, Kimi, GLM, and MiniMax models. OpenAI-compatible with streaming and function calling support.                                                                                  | `AVIAN_API_KEY`, `AVIAN_HOST` (optional)                                                                                                                                            |
 | [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/) | Access Azure-hosted OpenAI models, including GPT-4 and GPT-3.5. Supports both API key and Azure credential chain authentication.                                                                                          | `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_DEPLOYMENT_NAME`, `AZURE_OPENAI_API_KEY` (optional)                                                                                           |
 | [ChatGPT Codex](https://chatgpt.com/codex) | Access GPT-5 Codex models optimized for code generation and understanding. **Requires a ChatGPT Plus/Pro subscription.** | No manual key. Uses browser-based OAuth authentication for both CLI and Desktop. |
@@ -771,6 +772,40 @@ To set up Novita AI with goose, follow these steps:
     3. Follow the prompts to choose `Novita AI` as the provider.
     4. Enter your API key when prompted.
     5. Select the Novita AI model of your choice.
+  </TabItem>
+</Tabs>
+
+### Atomic Chat
+[Atomic Chat](https://github.com/AtomicBot-ai/Atomic-Chat) is an open-source ChatGPT-style desktop app (Tauri) for local LLMs and optional cloud models. While the app is running it serves an **OpenAI-compatible HTTP API** at `http://localhost:1337/v1` by default, so goose can use `POST /v1/chat/completions` against the same local models you use in the UI.
+
+`/v1/models` is queried at configure time when dynamic models are enabled. For the shipped declarative defaults, see [atomic_chat.json](https://github.com/aaif-goose/goose/blob/main/crates/goose/src/providers/declarative/atomic_chat.json).
+
+This built-in provider assumes the default **unauthenticated** local API. If you point goose at an endpoint that requires a bearer token or other auth, configure a [custom OpenAI-compatible provider](#configure-custom-provider) instead.
+
+To set up Atomic Chat with goose, follow these steps:
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  **To update your LLM provider:**
+
+    1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar.
+    2. Click the `Settings` button on the sidebar.
+    3. Click the `Models` tab.
+    4. Click `Configure Providers`
+    5. Choose `Atomic Chat` as provider from the list.
+    6. Click `Configure`, set `ATOMIC_CHAT_HOST` if Atomic Chat's API is not at the default `http://localhost:1337`, and click `Submit`.
+    7. Select a model from the list returned by Atomic Chat's `/v1/models` endpoint.
+
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    1. Run:
+    ```sh
+    goose configure
+    ```
+    2. Select `Configure Providers` from the menu.
+    3. Follow the prompts to choose `Atomic Chat` as the provider.
+    4. Adjust `ATOMIC_CHAT_HOST` if needed (default `http://localhost:1337`).
+    5. Select a model from Atomic Chat's API.
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -25,7 +25,7 @@ goose is compatible with a wide range of LLM providers, allowing you to choose a
 | [Amazon Bedrock](https://aws.amazon.com/bedrock/)                           | Offers a variety of foundation models, including Claude, Jurassic-2, and others. **AWS environment variables must be set in advance, not configured through `goose configure`**                                           | Credential auth: `AWS_PROFILE`, or `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`<br /><br />Bearer token auth: `AWS_BEARER_TOKEN_BEDROCK` and `AWS_REGION`, `AWS_DEFAULT_REGION`, or `AWS_PROFILE` |
 | [Amazon SageMaker TGI](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints.html) | Run Text Generation Inference models through Amazon SageMaker endpoints. **AWS credentials must be configured in advance.** | `SAGEMAKER_ENDPOINT_NAME`, `AWS_REGION` (optional), `AWS_PROFILE` (optional)  |
 | [Anthropic](https://www.anthropic.com/)                                     | Offers Claude, an advanced AI model for natural language tasks.                                                                                                                                                           | `ANTHROPIC_API_KEY`, `ANTHROPIC_HOST` (optional)                                                                                                                                                                 |
-| [Atomic Chat](https://github.com/AtomicBot-ai/Atomic-Chat)                | Open-source desktop client with a local OpenAI-compatible API (default `http://localhost:1337/v1`) for local MLX / llama.cpp models and optional cloud providers. **Start Atomic Chat and ensure a model is available** (see project README). | None required in goose for the default local API. `ATOMIC_CHAT_HOST` (optional, default `http://localhost:1337`). If your endpoint requires auth, use a [custom OpenAI-compatible provider](#configure-custom-provider). |
+| [Atomic Chat](https://github.com/AtomicBot-ai/Atomic-Chat)                | Run local models with Atomic Chat's OpenAI-compatible server. **Because this provider runs locally, you must first [download a model](#local-llms).** | None required. Connects to local server at `localhost:1337` by default. |
 | [Avian](https://avian.io/)                                                   | Cost-effective inference API with DeepSeek, Kimi, GLM, and MiniMax models. OpenAI-compatible with streaming and function calling support.                                                                                  | `AVIAN_API_KEY`, `AVIAN_HOST` (optional)                                                                                                                                            |
 | [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/) | Access Azure-hosted OpenAI models, including GPT-4 and GPT-3.5. Supports both API key and Azure credential chain authentication.                                                                                          | `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_DEPLOYMENT_NAME`, `AZURE_OPENAI_API_KEY` (optional)                                                                                           |
 | [ChatGPT Codex](https://chatgpt.com/codex) | Access GPT-5 Codex models optimized for code generation and understanding. **Requires a ChatGPT Plus/Pro subscription.** | No manual key. Uses browser-based OAuth authentication for both CLI and Desktop. |
@@ -775,40 +775,6 @@ To set up Novita AI with goose, follow these steps:
   </TabItem>
 </Tabs>
 
-### Atomic Chat
-[Atomic Chat](https://github.com/AtomicBot-ai/Atomic-Chat) is an open-source ChatGPT-style desktop app (Tauri) for local LLMs and optional cloud models. While the app is running it serves an **OpenAI-compatible HTTP API** at `http://localhost:1337/v1` by default, so goose can use `POST /v1/chat/completions` against the same local models you use in the UI.
-
-`/v1/models` is queried at configure time when dynamic models are enabled. For the shipped declarative defaults, see [atomic_chat.json](https://github.com/aaif-goose/goose/blob/main/crates/goose/src/providers/declarative/atomic_chat.json).
-
-This built-in provider assumes the default **unauthenticated** local API. If you point goose at an endpoint that requires a bearer token or other auth, configure a [custom OpenAI-compatible provider](#configure-custom-provider) instead.
-
-To set up Atomic Chat with goose, follow these steps:
-
-<Tabs groupId="interface">
-  <TabItem value="ui" label="goose Desktop" default>
-  **To update your LLM provider:**
-
-    1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar.
-    2. Click the `Settings` button on the sidebar.
-    3. Click the `Models` tab.
-    4. Click `Configure Providers`
-    5. Choose `Atomic Chat` as provider from the list.
-    6. Click `Configure`, set `ATOMIC_CHAT_HOST` if Atomic Chat's API is not at the default `http://localhost:1337`, and click `Submit`.
-    7. Select a model from the list returned by Atomic Chat's `/v1/models` endpoint.
-
-  </TabItem>
-  <TabItem value="cli" label="goose CLI">
-    1. Run:
-    ```sh
-    goose configure
-    ```
-    2. Select `Configure Providers` from the menu.
-    3. Follow the prompts to choose `Atomic Chat` as the provider.
-    4. Adjust `ATOMIC_CHAT_HOST` if needed (default `http://localhost:1337`).
-    5. Select a model from Atomic Chat's API.
-  </TabItem>
-</Tabs>
-
 ### Routstr
 [Routstr](https://routstr.com/) is an OpenAI-compatible aggregator that fronts dozens of upstream providers behind a single API. Payment is handled by the Routstr instance itself, so all goose needs is the `sk-...` bearer that instance issues you. To use Routstr with goose, pick an instance (the default is `https://api.routstr.com`) and obtain an API key from its payment flow.
 
@@ -1243,6 +1209,55 @@ Here are some local providers we support:
 
     :::tip Model Name
     Make sure the model name you enter in goose matches the model identifier shown in LM Studio's server panel.
+    :::
+  </TabItem>
+  <TabItem value="atomic-chat" label="Atomic Chat">
+    [Atomic Chat](https://github.com/AtomicBot-ai/Atomic-Chat) runs local (and optional cloud) models behind a single OpenAI-compatible API while the app is open.
+
+    1. Download and install Atomic Chat from [atomic.chat](https://atomic.chat/) or [GitHub Releases](https://github.com/AtomicBot-ai/Atomic-Chat/releases).
+    2. Open Atomic Chat and download or select a model that supports tool calling (see the in-app catalog; Qwen, Llama, and Gemma families are common choices).
+    3. Keep Atomic Chat running so the local server stays up. It serves `http://localhost:1337/v1` by default.
+
+    4. Configure goose to use Atomic Chat:
+
+    <Tabs groupId="interface">
+      <TabItem value="ui" label="goose Desktop" default>
+        1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar.
+        2. Click the `Settings` button on the sidebar.
+        3. Click the `Models` tab.
+        4. Click `Configure providers`.
+        5. Choose `Atomic Chat` from the provider list and click `Configure`.
+        6. Set `ATOMIC_CHAT_HOST` if your server is not at `http://localhost:1337`, then click `Submit` (no API key is needed for the default local server).
+        7. Select the model exposed by Atomic Chat's `/v1/models` endpoint.
+      </TabItem>
+      <TabItem value="cli" label="goose CLI">
+        1. Run:
+        ```sh
+        goose configure
+        ```
+        2. Select `Configure Providers` from the menu.
+        3. Choose `Atomic Chat` as the provider.
+        4. Enter the model id that matches a model listed by Atomic Chat.
+
+        ```
+        ┌   goose-configure
+        │
+        ◇  What would you like to configure?
+        │  Configure Providers
+        │
+        ◇  Which model provider should we use?
+        │  Atomic Chat
+        │
+        ◇  Enter a model from that provider:
+        │  your-model-id
+        │
+        └  Configuration saved successfully
+        ```
+      </TabItem>
+    </Tabs>
+
+    :::tip Model name
+    Use the same model identifier Atomic Chat reports from `/v1/models`; if you changed the API origin in Atomic Chat, set `ATOMIC_CHAT_HOST` in goose to match (scheme, host, and port only).
     :::
   </TabItem>
   <TabItem value="docker" label="Docker Model Runner" default>

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -1212,11 +1212,11 @@ Here are some local providers we support:
     :::
   </TabItem>
   <TabItem value="atomic-chat" label="Atomic Chat">
-    [Atomic Chat](https://github.com/AtomicBot-ai/Atomic-Chat) runs local (and optional cloud) models behind a single OpenAI-compatible API while the app is open.
+    [Atomic Chat](https://github.com/AtomicBot-ai/Atomic-Chat) lets you run open-source models locally with an OpenAI-compatible API server.
 
     1. Download and install Atomic Chat from [atomic.chat](https://atomic.chat/) or [GitHub Releases](https://github.com/AtomicBot-ai/Atomic-Chat/releases).
-    2. Open Atomic Chat and download or select a model that supports tool calling (see the in-app catalog; Qwen, Llama, and Gemma families are common choices).
-    3. Keep Atomic Chat running so the local server stays up. It serves `http://localhost:1337/v1` by default.
+    2. Open Atomic Chat and download a model that supports tool calling (e.g., Qwen, Llama, or Mistral variants).
+    3. Start the local server in Atomic Chat. The server runs on `http://localhost:1337` by default
 
     4. Configure goose to use Atomic Chat:
 
@@ -1227,8 +1227,8 @@ Here are some local providers we support:
         3. Click the `Models` tab.
         4. Click `Configure providers`.
         5. Choose `Atomic Chat` from the provider list and click `Configure`.
-        6. Set `ATOMIC_CHAT_HOST` if your server is not at `http://localhost:1337`, then click `Submit` (no API key is needed for the default local server).
-        7. Select the model exposed by Atomic Chat's `/v1/models` endpoint.
+        6. Click `Submit` (no API key is needed).
+        7. Select the model you have loaded in Atomic Chat.
       </TabItem>
       <TabItem value="cli" label="goose CLI">
         1. Run:
@@ -1237,7 +1237,7 @@ Here are some local providers we support:
         ```
         2. Select `Configure Providers` from the menu.
         3. Choose `Atomic Chat` as the provider.
-        4. Enter the model id that matches a model listed by Atomic Chat.
+        4. Enter the model name that matches the model loaded in Atomic Chat.
 
         ```
         ┌   goose-configure
@@ -1249,15 +1249,15 @@ Here are some local providers we support:
         │  Atomic Chat
         │
         ◇  Enter a model from that provider:
-        │  your-model-id
+        │  qwen2.5-7b-instruct
         │
         └  Configuration saved successfully
         ```
       </TabItem>
     </Tabs>
 
-    :::tip Model name
-    Use the same model identifier Atomic Chat reports from `/v1/models`; if you changed the API origin in Atomic Chat, set `ATOMIC_CHAT_HOST` in goose to match (scheme, host, and port only).
+    :::tip Model Name
+    Make sure the model name you enter in goose matches the model identifier shown for your server in Atomic Chat. If the API listens on a different origin than `http://localhost:1337`, set `ATOMIC_CHAT_HOST` in goose to match (scheme, host, and port only).
     :::
   </TabItem>
   <TabItem value="docker" label="Docker Model Runner" default>


### PR DESCRIPTION

## Summary

Adds Atomic Chat as a declarative OpenAI-compatible provider: point Goose at the app’s local API ([Atomic-Chat](https://github.com/AtomicBot-ai/Atomic-Chat), default http://localhost:1337/v1) so chat uses the same MLX / llama.cpp models as the desktop client.

## Included changes

- `crates/goose/src/providers/declarative/atomic_chat.json` — provider config (`atomic_chat`), configurable `ATOMIC_CHAT_HOST`, dynamic models from `/v1/models`.
- `documentation/docs/getting-started/providers.md` — table entry and setup (Desktop + CLI).
- `crates/goose/src/config/declarative_providers.rs` — `test_atomic_chat_json_deserializes`.

## Configuration
| Goose / env | Role |
|-------------|------|
| `ATOMIC_CHAT_HOST` | Origin of the Atomic Chat API (default `http://localhost:1337`). |
| Declarative `base_url` | Resolves to `{host}/v1/chat/completions` — same shape as other OpenAI-compatible local providers. |

No API key is wired in this declarative profile; if the local API requires auth, use a **custom OpenAI-compatible provider** and store credentials there.

## Testing
- `cargo test -p goose test_atomic_chat_json_deserializes`
- Manual: start Atomic Chat, load a model, run `goose configure` → **Atomic Chat** → pick a model from `/v1/models`.


