### PR TITLE
Build non-vulkan linux variants using ubuntu 22.04

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -4,7 +4,7 @@
 #  - canary.yml
 #
 # Platform Build Strategy:
-#  - Linux: Uses native Ubuntu runners, including arm64 hosted runners
+#  - Linux: Uses native Ubuntu 22.04 runners to keep glibc compatibility with Ubuntu 22.04 LTS
 #  - macOS: Uses native macOS runners for each architecture
 #  - Windows: Uses Windows runner with native MSVC build
 on:
@@ -34,12 +34,12 @@ jobs:
           - platform: linux
             architecture: x86_64
             target-suffix: unknown-linux-gnu
-            build-on: ubuntu-24.04
+            build-on: ubuntu-22.04
             variant: standard
           - platform: linux
             architecture: aarch64
             target-suffix: unknown-linux-gnu
-            build-on: ubuntu-24.04-arm
+            build-on: ubuntu-22.04-arm
             variant: standard
           - platform: macos
             architecture: x86_64
@@ -93,7 +93,7 @@ jobs:
         if: matrix.platform != 'windows'
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
-          key: ${{ matrix.architecture }}-${{ matrix.target-suffix }}-native-macos-deployment-target-12
+          key: ${{ matrix.architecture }}-${{ matrix.target-suffix }}-${{ matrix.build-on }}-native-macos-deployment-target-12
 
       - name: Cache Cargo artifacts (Windows)
         if: matrix.platform == 'windows'

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -4,7 +4,8 @@
 #  - canary.yml
 #
 # Platform Build Strategy:
-#  - Linux: Uses native Ubuntu 22.04 runners to keep glibc compatibility with Ubuntu 22.04 LTS
+#  - Linux standard: Uses native Ubuntu 22.04 runners to keep glibc compatibility with Ubuntu 22.04 LTS
+#  - Linux Vulkan: Uses native Ubuntu 24.04 runners for newer Vulkan headers/tooling
 #  - macOS: Uses native macOS runners for each architecture
 #  - Windows: Uses Windows runner with native MSVC build
 on:
@@ -41,6 +42,16 @@ jobs:
             target-suffix: unknown-linux-gnu
             build-on: ubuntu-22.04-arm
             variant: standard
+          - platform: linux
+            architecture: x86_64
+            target-suffix: unknown-linux-gnu
+            build-on: ubuntu-24.04
+            variant: vulkan
+          - platform: linux
+            architecture: aarch64
+            target-suffix: unknown-linux-gnu
+            build-on: ubuntu-24.04-arm
+            variant: vulkan
           - platform: macos
             architecture: x86_64
             target-suffix: apple-darwin
@@ -84,10 +95,14 @@ jobs:
             pkg-config \
             libssl-dev \
             libdbus-1-dev \
-            libxcb1-dev \
-            libvulkan-dev \
-            libvulkan1 \
-            glslc
+            libxcb1-dev
+
+          if [ "${{ matrix.variant }}" = "vulkan" ]; then
+            sudo apt-get install -y \
+              libvulkan-dev \
+              libvulkan1 \
+              glslc
+          fi
 
       - name: Cache Cargo artifacts (Linux/macOS)
         if: matrix.platform != 'windows'
@@ -115,7 +130,7 @@ jobs:
           rustup show
 
           FEATURE_ARGS=()
-          if [[ "${TARGET}" == *-unknown-linux-gnu ]]; then
+          if [ "${{ matrix.variant }}" = "vulkan" ]; then
             FEATURE_ARGS=(--features vulkan)
           fi
           cargo build --release --target ${TARGET} -p goose-cli "${FEATURE_ARGS[@]}"
@@ -180,6 +195,10 @@ jobs:
         run: |
           source ./bin/activate-hermit
           export TARGET="${{ matrix.architecture }}-${{ matrix.target-suffix }}"
+          export VARIANT_SUFFIX=""
+          if [ "${{ matrix.variant }}" = "vulkan" ]; then
+            VARIANT_SUFFIX="-vulkan"
+          fi
 
           # Create a directory for the package contents
           mkdir -p "target/${TARGET}/release/goose-package"
@@ -188,10 +207,10 @@ jobs:
           cp "target/${TARGET}/release/goose" "target/${TARGET}/release/goose-package/"
 
           cd "target/${TARGET}/release"
-          tar -cjf "goose-${TARGET}.tar.bz2" -C goose-package .
-          tar -czf "goose-${TARGET}.tar.gz" -C goose-package .
-          echo "ARTIFACT_BZ2=target/${TARGET}/release/goose-${TARGET}.tar.bz2" >> $GITHUB_ENV
-          echo "ARTIFACT_GZ=target/${TARGET}/release/goose-${TARGET}.tar.gz" >> $GITHUB_ENV
+          tar -cjf "goose-${TARGET}${VARIANT_SUFFIX}.tar.bz2" -C goose-package .
+          tar -czf "goose-${TARGET}${VARIANT_SUFFIX}.tar.gz" -C goose-package .
+          echo "ARTIFACT_BZ2=target/${TARGET}/release/goose-${TARGET}${VARIANT_SUFFIX}.tar.bz2" >> $GITHUB_ENV
+          echo "ARTIFACT_GZ=target/${TARGET}/release/goose-${TARGET}${VARIANT_SUFFIX}.tar.gz" >> $GITHUB_ENV
 
       - name: Package CLI (Windows)
         if: matrix.platform == 'windows'
@@ -214,7 +233,7 @@ jobs:
       - name: Upload CLI artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
-          name: goose-${{ matrix.architecture }}-${{ matrix.target-suffix }}${{ matrix.variant == 'cuda' && '-cuda' || '' }}
+          name: goose-${{ matrix.architecture }}-${{ matrix.target-suffix }}${{ matrix.variant != 'standard' && format('-{0}', matrix.variant) || '' }}
           path: |
             ${{ env.ARTIFACT_BZ2 }}
             ${{ env.ARTIFACT_GZ }}

--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -79,10 +79,7 @@ jobs:
             protobuf-compiler \
             flatpak \
             flatpak-builder \
-            elfutils \
-            libvulkan-dev \
-            libvulkan1 \
-            glslc
+            elfutils
 
       - name: Setup Flatpak Runtimes
         run: |
@@ -107,7 +104,7 @@ jobs:
           source ./bin/activate-hermit
           export TARGET="x86_64-unknown-linux-gnu"
           rustup target add "${TARGET}"
-          cargo build --release --target ${TARGET} -p goose-server --features vulkan
+          cargo build --release --target ${TARGET} -p goose-server
 
       - name: Copy binaries into Electron folder
         run: |

--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -21,7 +21,7 @@ name: "Bundle Desktop (Linux)"
 jobs:
   build-desktop-linux:
     name: Build Desktop (Linux)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository
@@ -72,7 +72,7 @@ jobs:
             libxrandr2 \
             libgbm1 \
             libxss1 \
-            libasound2t64 \
+            libasound2 \
             rpm \
             fakeroot \
             dpkg-dev \

--- a/.github/workflows/pr-comment-build-cli.yml
+++ b/.github/workflows/pr-comment-build-cli.yml
@@ -81,7 +81,7 @@ jobs:
             }
 
       - name: Run command action
-        if: steps.security_check.outputs.authorized == 'true'
+        if: steps.security_check.outputs.authorized == 'true' && github.event_name == 'issue_comment'
         uses: github/command@v2.0.3
         id: command
         with:
@@ -104,7 +104,7 @@ jobs:
           echo "head_sha=$HEAD_SHA"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ steps.command.outputs.issue_number }}
+          ISSUE_NUMBER: ${{ steps.command.outputs.issue_number || github.event.inputs.pr_number }}
 
   build-cli:
     needs: [trigger-on-command]

--- a/.github/workflows/pr-comment-build-cli.yml
+++ b/.github/workflows/pr-comment-build-cli.yml
@@ -136,8 +136,10 @@ jobs:
             ### CLI Builds
 
             Download CLI builds for different platforms:
-            - [📦 Linux (x86_64)](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/goose-x86_64-unknown-linux-gnu.zip)
-            - [📦 Linux (aarch64)](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/goose-aarch64-unknown-linux-gnu.zip)
+            - [📦 Linux (x86_64, Ubuntu 22.04-compatible)](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/goose-x86_64-unknown-linux-gnu.zip)
+            - [📦 Linux (aarch64, Ubuntu 22.04-compatible)](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/goose-aarch64-unknown-linux-gnu.zip)
+            - [📦 Linux Vulkan (x86_64, Ubuntu 24.04+)](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/goose-x86_64-unknown-linux-gnu-vulkan.zip)
+            - [📦 Linux Vulkan (aarch64, Ubuntu 24.04+)](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/goose-aarch64-unknown-linux-gnu-vulkan.zip)
             - [📦 macOS (x86_64)](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/goose-x86_64-apple-darwin.zip)
             - [📦 macOS (aarch64)](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/goose-aarch64-apple-darwin.zip)
             - [📦 Windows (x86_64)](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/goose-x86_64-pc-windows-msvc.zip)

--- a/download_cli.sh
+++ b/download_cli.sh
@@ -18,6 +18,7 @@ set -eu
 #   GOOSE_VERSION  - Optional: specific version to install (e.g., "v1.0.25"). Overrides CANARY. Can be in the format vX.Y.Z, vX.Y.Z-suffix, or X.Y.Z
 #   GOOSE_PROVIDER - Optional: provider for goose
 #   GOOSE_MODEL    - Optional: model for goose
+#   GOOSE_LINUX_VARIANT - Optional: Linux package variant to install (`standard` or `vulkan`)
 #   GOOSE_WINDOWS_VARIANT - Optional: Windows package variant to install (`standard` or `cuda`)
 #   CANARY         - Optional: if set to "true", downloads from canary release instead of stable
 #   CONFIGURE      - Optional: if set to "false", disables running goose configure interactively
@@ -68,6 +69,7 @@ fi
 GOOSE_BIN_DIR="${GOOSE_BIN_DIR:-$DEFAULT_BIN_DIR}"
 RELEASE="${CANARY:-false}"
 CONFIGURE="${CONFIGURE:-true}"
+GOOSE_LINUX_VARIANT="${GOOSE_LINUX_VARIANT:-standard}"
 GOOSE_WINDOWS_VARIANT="${GOOSE_WINDOWS_VARIANT:-standard}"
 if [ -n "${GOOSE_VERSION:-}" ]; then
   # Validate the version format
@@ -173,7 +175,17 @@ elif [ "$OS" = "windows" ]; then
   EXTRACT_CMD="unzip"
   OUT_FILE="goose.exe"
 else
+  case "$GOOSE_LINUX_VARIANT" in
+    standard|vulkan) ;;
+    *)
+      echo "Error: Unsupported GOOSE_LINUX_VARIANT '$GOOSE_LINUX_VARIANT'. Expected 'standard' or 'vulkan'."
+      exit 1
+      ;;
+  esac
   FILE="goose-$ARCH-unknown-linux-gnu.tar.bz2"
+  if [ "$GOOSE_LINUX_VARIANT" = "vulkan" ]; then
+    FILE="goose-$ARCH-unknown-linux-gnu-vulkan.tar.bz2"
+  fi
   EXTRACT_CMD="tar"
 fi
 

--- a/ui/desktop/forge.config.ts
+++ b/ui/desktop/forge.config.ts
@@ -92,7 +92,6 @@ module.exports = {
         categories: ['Development'],
         desktopTemplate: './forge.deb.desktop',
         options: {
-          depends: ['libvulkan1'],
           icon: 'src/images/icon.png',
           prefix: '/opt',
         },
@@ -108,7 +107,6 @@ module.exports = {
         categories: ['Development'],
         desktopTemplate: './forge.rpm.desktop',
         options: {
-          requires: ['vulkan-loader'],
           icon: 'src/images/icon.png',
           prefix: '/opt',
           fpm: ['--rpm-rpmbuild-define', '_build_id_links none'],


### PR DESCRIPTION
Fixes #9203
Fixes #9205 

Adds non-vulkan linux builds using ubuntu 22.04. This might not put us exactly where we want to be, but should get things working again for users who need this.