### PR TITLE
fix: activate custom provider after adding via configure

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -2005,6 +2005,7 @@ fn collect_custom_headers() -> anyhow::Result<Option<std::collections::HashMap<S
 }
 
 fn add_provider() -> anyhow::Result<()> {
+    let config = Config::global();
     let provider_type = cliclack::select("What type of API is this?")
         .item(
             "openai_compatible",
@@ -2089,7 +2090,7 @@ fn add_provider() -> anyhow::Result<()> {
 
     let headers = collect_custom_headers()?;
 
-    create_custom_provider(CreateCustomProviderParams {
+    let provider_config = create_custom_provider(CreateCustomProviderParams {
         engine: provider_type.to_string(),
         display_name: display_name.clone(),
         api_url,
@@ -2101,6 +2102,21 @@ fn add_provider() -> anyhow::Result<()> {
         catalog_provider_id: None,
         base_path,
     })?;
+
+    if !provider_config.models.is_empty() {
+        let model_items: Vec<_> = provider_config
+            .models
+            .iter()
+            .map(|m| (m.name.as_str(), m.name.as_str(), ""))
+            .collect();
+        if let Ok(model) = cliclack::select("Which model should be the default?")
+            .items(&model_items)
+            .interact()
+        {
+            config.set_goose_provider(&provider_config.name)?;
+            config.set_goose_model(model)?;
+        }
+    }
 
     cliclack::outro(format!("Custom provider added: {}", display_name))?;
     Ok(())


### PR DESCRIPTION
After adding a custom provider through `goose configure → Custom Providers → Add`, the provider was saved to disk but not set as the active provider in config.yaml. Users had to separately navigate to "Configure Providers" to select it.

Now prompts the user to set the new provider as active immediately after creation, and if confirmed, writes `GOOSE_PROVIDER` and `GOOSE_MODEL` to config.yaml. If only one model was entered, it's auto-selected; if multiple, the user picks the default.

Closes #6692