### PR TITLE
fix: handle non-interactive terminal in goose configure on Windows

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -30,12 +30,20 @@ use goose::providers::{create, providers, retry_operation, RetryConfig};
 use goose::session::SessionType;
 use serde_json::Value;
 use std::collections::HashMap;
+use std::io::IsTerminal;
 
 // useful for light themes where there is no discernible colour contrast between
 // cursor-selected and cursor-unselected items.
 const MULTISELECT_VISIBILITY_HINT: &str = "<";
 
 pub async fn handle_configure() -> anyhow::Result<()> {
+    if !std::io::stdin().is_terminal() {
+        anyhow::bail!(
+            "goose configure requires an interactive terminal.\n\
+             If you installed via 'curl ... | bash', run 'goose configure' separately after installation."
+        );
+    }
+
     let config = Config::global();
 
     if !config.exists() {

--- a/download_cli.sh
+++ b/download_cli.sh
@@ -310,7 +310,15 @@ if [ "$CONFIGURE" = true ]; then
   echo ""
   echo "Configuring goose"
   echo ""
-  "$GOOSE_BIN_DIR/$OUT_FILE" configure
+  if [ -t 0 ]; then
+    "$GOOSE_BIN_DIR/$OUT_FILE" configure
+  elif [ -r /dev/tty ]; then
+    "$GOOSE_BIN_DIR/$OUT_FILE" configure < /dev/tty
+  else
+    echo "Non-interactive shell detected (e.g. 'curl ... | bash')."
+    echo "Skipping 'goose configure' — please run it manually after installation:"
+    echo "    $GOOSE_BIN_DIR/$OUT_FILE configure"
+  fi
 else
   echo "Skipping 'goose configure', you may need to run this manually later"
 fi


### PR DESCRIPTION
## Summary

Fixes #5910

When installing goose on Windows via `curl ... | bash` in Git Bash, stdin is a pipe rather than a TTY. The `cliclack` library (used by `goose configure` for interactive prompts) tries to set terminal raw mode on stdin, which fails with "Incorrect function (os error 1)" on a non-TTY file descriptor on Windows.

## Changes

**Install script (`download_cli.sh`):**
- Detect when stdin is not a TTY (`[ -t 0 ]`)
- If `/dev/tty` is available (typical in Git Bash/MSYS), redirect stdin from it
- Otherwise, skip `goose configure` with a message telling the user to run it manually

**Rust CLI (`crates/goose-cli/src/commands/configure.rs`):**
- Check `std::io::stdin().is_terminal()` at the top of `handle_configure()`
- Bail with a clear error message instead of letting cliclack crash with a cryptic OS error

## Testing

- Verified build and clippy pass cleanly
- The install script change handles all three cases: direct TTY, piped-with-tty-available (Git Bash `curl | bash`), and fully non-interactive (Docker/CI)