### PR TITLE
fix: resolve Azure CLI on Windows by using az.cmd

### DIFF
--- a/crates/goose/src/providers/azureauth.rs
+++ b/crates/goose/src/providers/azureauth.rs
@@ -127,8 +127,8 @@ impl AzureAuth {
             }
         }
 
-        // Get new token using Azure CLI credential
-        let output = tokio::process::Command::new("az")
+        let az = if cfg!(windows) { "az.cmd" } else { "az" };
+        let output = tokio::process::Command::new(az)
             .args([
                 "account",
                 "get-access-token",


### PR DESCRIPTION
On Windows, Azure CLI is installed as `az.cmd` rather than `az.exe`. Rust's `Command::new("az")` cannot resolve `.cmd` extensions, unlike cmd.exe and PowerShell which do this transparently.

Uses `cfg!(windows)` to select `az.cmd` on Windows and `az` elsewhere.

Fixes #6738