### PR TITLE
Dynamically refresh skill instructions each turn

### DIFF
--- a/crates/goose-cli/src/scenario_tests/mock_client.rs
+++ b/crates/goose-cli/src/scenario_tests/mock_client.rs
@@ -56,7 +56,7 @@ impl McpClientTrait for MockClient {
     }
 
     fn get_info(&self) -> std::option::Option<&rmcp::model::InitializeResult> {
-        todo!()
+        None
     }
 
     async fn read_resource(

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -106,9 +106,7 @@ impl Extension {
     }
 
     fn get_instructions(&self) -> Option<String> {
-        self.server_info
-            .as_ref()
-            .and_then(|info| info.instructions.clone())
+        self.client.get_instructions()
     }
 
     fn get_client(&self) -> McpClientBox {

--- a/crates/goose/src/agents/mcp_client.rs
+++ b/crates/goose/src/agents/mcp_client.rs
@@ -84,6 +84,13 @@ pub trait McpClientTrait: Send + Sync {
 
     fn get_info(&self) -> Option<&InitializeResult>;
 
+    /// Return the extension's current instructions. The default reads from
+    /// `get_info()`, but platform extensions can override this to provide
+    /// dynamically computed instructions (e.g. freshly discovered skills).
+    fn get_instructions(&self) -> Option<String> {
+        self.get_info().and_then(|info| info.instructions.clone())
+    }
+
     async fn list_resources(
         &self,
         _session_id: &str,

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -441,11 +441,9 @@ mod tests {
             .values()
             .map(|def| {
                 let client = (def.client_factory)(context.clone());
-                let info = client.get_info();
-                let instructions = info
-                    .and_then(|i| i.instructions.clone())
-                    .unwrap_or_default();
-                let has_resources = info
+                let instructions = client.get_instructions().unwrap_or_default();
+                let has_resources = client
+                    .get_info()
                     .and_then(|i| i.capabilities.resources.as_ref())
                     .is_some();
                 ExtensionInfo::new(def.name, &instructions, has_resources)

--- a/crates/goose/src/skills/client.rs
+++ b/crates/goose/src/skills/client.rs
@@ -19,6 +19,26 @@ pub struct SkillsClient {
     working_dir: PathBuf,
 }
 
+fn build_skill_instructions(working_dir: &Path) -> String {
+    let sources = discover_skills(Some(working_dir));
+    let mut skills: Vec<&SourceEntry> = sources
+        .iter()
+        .filter(|s| s.source_type == SourceType::Skill || s.source_type == SourceType::BuiltinSkill)
+        .collect();
+    skills.sort_by(|a, b| (&a.name, &a.path).cmp(&(&b.name, &b.path)));
+
+    let mut instructions = String::new();
+    if !skills.is_empty() {
+        instructions.push_str(
+            "\n\nYou have these skills at your disposal, when it is clear they can help you solve a problem or you are asked to use them:",
+        );
+        for skill in &skills {
+            instructions.push_str(&format!("\n• {} - {}", skill.name, skill.description));
+        }
+    }
+    instructions
+}
+
 impl SkillsClient {
     pub fn new(context: PlatformExtensionContext) -> anyhow::Result<Self> {
         let working_dir = context
@@ -27,30 +47,8 @@ impl SkillsClient {
             .map(|s| s.working_dir.clone())
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
 
-        let mut instructions = String::new();
-        if context.session.is_some() {
-            let sources = discover_skills(Some(&working_dir));
-            let mut skills: Vec<&SourceEntry> = sources
-                .iter()
-                .filter(|s| {
-                    s.source_type == SourceType::Skill || s.source_type == SourceType::BuiltinSkill
-                })
-                .collect();
-            skills.sort_by(|a, b| (&a.name, &a.path).cmp(&(&b.name, &b.path)));
-
-            if !skills.is_empty() {
-                instructions.push_str(
-                    "\n\nYou have these skills at your disposal, when it is clear they can help you solve a problem or you are asked to use them:",
-                );
-                for skill in &skills {
-                    instructions.push_str(&format!("\n• {} - {}", skill.name, skill.description));
-                }
-            }
-        }
-
         let info = InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
-            .with_server_info(Implementation::new(EXTENSION_NAME, "1.0.0").with_title("Skills"))
-            .with_instructions(instructions);
+            .with_server_info(Implementation::new(EXTENSION_NAME, "1.0.0").with_title("Skills"));
 
         Ok(Self { info, working_dir })
     }
@@ -250,6 +248,15 @@ impl McpClientTrait for SkillsClient {
 
     fn get_info(&self) -> Option<&InitializeResult> {
         Some(&self.info)
+    }
+
+    fn get_instructions(&self) -> Option<String> {
+        let instructions = build_skill_instructions(&self.working_dir);
+        if instructions.is_empty() {
+            None
+        } else {
+            Some(instructions)
+        }
     }
 
     async fn subscribe(&self) -> mpsc::Receiver<ServerNotification> {

--- a/crates/goose/src/skills/client.rs
+++ b/crates/goose/src/skills/client.rs
@@ -19,26 +19,6 @@ pub struct SkillsClient {
     working_dir: PathBuf,
 }
 
-fn build_skill_instructions(working_dir: &Path) -> String {
-    let sources = discover_skills(Some(working_dir));
-    let mut skills: Vec<&SourceEntry> = sources
-        .iter()
-        .filter(|s| s.source_type == SourceType::Skill || s.source_type == SourceType::BuiltinSkill)
-        .collect();
-    skills.sort_by(|a, b| (&a.name, &a.path).cmp(&(&b.name, &b.path)));
-
-    let mut instructions = String::new();
-    if !skills.is_empty() {
-        instructions.push_str(
-            "\n\nYou have these skills at your disposal, when it is clear they can help you solve a problem or you are asked to use them:",
-        );
-        for skill in &skills {
-            instructions.push_str(&format!("\n• {} - {}", skill.name, skill.description));
-        }
-    }
-    instructions
-}
-
 impl SkillsClient {
     pub fn new(context: PlatformExtensionContext) -> anyhow::Result<Self> {
         let working_dir = context
@@ -251,12 +231,26 @@ impl McpClientTrait for SkillsClient {
     }
 
     fn get_instructions(&self) -> Option<String> {
-        let instructions = build_skill_instructions(&self.working_dir);
-        if instructions.is_empty() {
-            None
-        } else {
-            Some(instructions)
+        let sources = discover_skills(Some(&self.working_dir));
+        let mut skills: Vec<&SourceEntry> = sources
+            .iter()
+            .filter(|s| {
+                s.source_type == SourceType::Skill || s.source_type == SourceType::BuiltinSkill
+            })
+            .collect();
+        skills.sort_by(|a, b| (&a.name, &a.path).cmp(&(&b.name, &b.path)));
+
+        if skills.is_empty() {
+            return None;
         }
+
+        let mut instructions = String::from(
+            "\n\nYou have these skills at your disposal, when it is clear they can help you solve a problem or you are asked to use them:",
+        );
+        for skill in &skills {
+            instructions.push_str(&format!("\n• {} - {}", skill.name, skill.description));
+        }
+        Some(instructions)
     }
 
     async fn subscribe(&self) -> mpsc::Receiver<ServerNotification> {


### PR DESCRIPTION
## Summary

Skills listed in the system prompt were computed once at session start and cached in `server_info`. Adding or modifying `SKILL.md` files mid-session had no effect on the system prompt until restart.

## Changes

- **`McpClientTrait`**: Add `get_instructions()` with a default implementation that reads from `get_info()`. This is a non-breaking addition — all existing implementors get the default.
- **`SkillsClient`**: Override `get_instructions()` to re-discover skills from disk on every call. The constructor no longer bakes instructions into `InitializeResult`.
- **`Extension::get_instructions()`**: Delegate to `self.client.get_instructions()` instead of reading from the cached `server_info` snapshot.

The system prompt is rebuilt each turn, and `get_extensions_info()` calls `Extension::get_instructions()` each time — so newly added, modified, or removed skills are now reflected immediately without session restart.

This is safe for non-skill platform extensions and external MCP servers: they use the default `get_instructions()` which reads from their static `get_info()`, preserving existing behavior.

Closes #6382