### PR TITLE
chore: bump package.json versions from 0.19.1 to 0.20.0

### DIFF
--- a/ui/goose-binary/goose-binary-darwin-arm64/package.json
+++ b/ui/goose-binary/goose-binary-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaif/goose-binary-darwin-arm64",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Goose binary for macOS ARM64",
   "license": "Apache-2.0",
   "repository": {

--- a/ui/goose-binary/goose-binary-darwin-x64/package.json
+++ b/ui/goose-binary/goose-binary-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaif/goose-binary-darwin-x64",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Goose binary for macOS x64",
   "license": "Apache-2.0",
   "repository": {

--- a/ui/goose-binary/goose-binary-linux-arm64/package.json
+++ b/ui/goose-binary/goose-binary-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaif/goose-binary-linux-arm64",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Goose binary for Linux ARM64",
   "license": "Apache-2.0",
   "repository": {

--- a/ui/goose-binary/goose-binary-linux-x64/package.json
+++ b/ui/goose-binary/goose-binary-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaif/goose-binary-linux-x64",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Goose binary for Linux x64",
   "license": "Apache-2.0",
   "repository": {

--- a/ui/goose-binary/goose-binary-win32-x64/package.json
+++ b/ui/goose-binary/goose-binary-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaif/goose-binary-win32-x64",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Goose binary for Windows x64",
   "license": "Apache-2.0",
   "repository": {

--- a/ui/goose2/package.json
+++ b/ui/goose2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "goose2",
   "private": true,
-  "version": "0.19.1",
+  "version": "0.20.0",
   "type": "module",
   "packageManager": "pnpm@10.33.0",
   "scripts": {

--- a/ui/sdk/package.json
+++ b/ui/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaif/goose-sdk",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Agent Client Protocol (ACP) SDK for Goose AI agent",
   "license": "Apache-2.0",
   "repository": {

--- a/ui/text/package.json
+++ b/ui/text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaif/goose",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Goose - an open-source AI agent",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Bumps version from 0.19.1 to 0.20.0 across all ui/ package.json files.