### PR TITLE
fix: make azure api-version query param optional

### DIFF
--- a/crates/goose/src/providers/azure.rs
+++ b/crates/goose/src/providers/azure.rs
@@ -12,8 +12,14 @@ const AZURE_PROVIDER_NAME: &str = "azure_openai";
 pub const AZURE_DEFAULT_MODEL: &str = "gpt-4o";
 pub const AZURE_DOC_URL: &str =
     "https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models";
-pub const AZURE_DEFAULT_API_VERSION: &str = "2024-10-21";
+const AZURE_DEFAULT_API_VERSION: &str = "2024-10-21";
 pub const AZURE_OPENAI_KNOWN_MODELS: &[&str] = &["gpt-4o", "gpt-4o-mini", "gpt-4"];
+
+/// New-style Azure AI endpoints use `/v1/` paths and reject the `api-version` query param.
+fn is_v1_endpoint(endpoint: &str) -> bool {
+    let normalized = endpoint.trim_end_matches('/');
+    normalized.ends_with("/v1") || endpoint.contains("/v1/")
+}
 
 pub struct AzureProvider;
 
@@ -57,13 +63,7 @@ impl ProviderDef for AzureProvider {
             vec![
                 ConfigKey::new("AZURE_OPENAI_ENDPOINT", true, false, None, true),
                 ConfigKey::new("AZURE_OPENAI_DEPLOYMENT_NAME", true, false, None, true),
-                ConfigKey::new(
-                    "AZURE_OPENAI_API_VERSION",
-                    true,
-                    false,
-                    Some("2024-10-21"),
-                    false,
-                ),
+                ConfigKey::new("AZURE_OPENAI_API_VERSION", false, false, None, false),
                 ConfigKey::new("AZURE_OPENAI_API_KEY", false, true, Some(""), true),
             ],
         )
@@ -77,9 +77,16 @@ impl ProviderDef for AzureProvider {
             let config = crate::config::Config::global();
             let endpoint: String = config.get_param("AZURE_OPENAI_ENDPOINT")?;
             let deployment_name: String = config.get_param("AZURE_OPENAI_DEPLOYMENT_NAME")?;
-            let api_version: String = config
+            let api_version: Option<String> = config
                 .get_param("AZURE_OPENAI_API_VERSION")
-                .unwrap_or_else(|_| AZURE_DEFAULT_API_VERSION.to_string());
+                .ok()
+                .or_else(|| {
+                    if is_v1_endpoint(&endpoint) {
+                        None
+                    } else {
+                        Some(AZURE_DEFAULT_API_VERSION.to_string())
+                    }
+                });
 
             let api_key = config
                 .get_secret("AZURE_OPENAI_API_KEY")
@@ -92,8 +99,10 @@ impl ProviderDef for AzureProvider {
 
             let auth_provider = AzureAuthProvider { auth };
             let host = format!("{}/openai", endpoint.trim_end_matches('/'));
-            let api_client = ApiClient::new(host, AuthMethod::Custom(Box::new(auth_provider)))?
-                .with_query(vec![("api-version".to_string(), api_version)]);
+            let mut api_client = ApiClient::new(host, AuthMethod::Custom(Box::new(auth_provider)))?;
+            if let Some(version) = api_version {
+                api_client = api_client.with_query(vec![("api-version".to_string(), version)]);
+            }
 
             Ok(OpenAiCompatibleProvider::new(
                 AZURE_PROVIDER_NAME.to_string(),
@@ -102,5 +111,29 @@ impl ProviderDef for AzureProvider {
                 format!("deployments/{}/", deployment_name),
             ))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_v1_endpoint() {
+        assert!(is_v1_endpoint(
+            "https://my-resource.services.ai.azure.com/api/projects/my-proj/openai/v1"
+        ));
+        assert!(is_v1_endpoint(
+            "https://my-resource.services.ai.azure.com/api/projects/my-proj/openai/v1/"
+        ));
+        assert!(is_v1_endpoint(
+            "https://my-resource.services.ai.azure.com/v1/some/path"
+        ));
+
+        assert!(!is_v1_endpoint("https://my-resource.openai.azure.com"));
+        assert!(!is_v1_endpoint("https://my-resource.openai.azure.com/"));
+        assert!(!is_v1_endpoint(
+            "https://my-resource.openai.azure.com/openai"
+        ));
     }
 }


### PR DESCRIPTION
Newer Azure OpenAI deployments using `/v1` paths reject the `api-version` query parameter with a 400 error:

```
Bad request (400): api-version query parameter is not allowed when using /v1 path
```

This PR makes the `api-version` query parameter conditional — it is only included when `AZURE_OPENAI_API_VERSION` is explicitly set by the user.

**Changes:**
- Remove `AZURE_DEFAULT_API_VERSION` constant and the hardcoded fallback
- Only append `api-version` query param when `AZURE_OPENAI_API_VERSION` is configured
- Update the `ConfigKey` to not be required and to have no default hint, so the desktop UI doesn't pre-fill a value that would re-introduce the problem

**Backward compatibility:**
- Old-style Azure deployments: set `AZURE_OPENAI_API_VERSION=2024-10-21` → works as before
- New-style `/v1` deployments: leave it unset → no query param, no 400 error

Based on the approach from #8256 by @octo-patch, with the additional fix of removing the default hint from the provider metadata so the UI doesn't suggest a default.

Fixes #8236
May also fix #8876