### PR TITLE
fix: improve Telegram gateway error reporting and connection reliability

### DIFF
--- a/crates/goose/src/gateway/telegram.rs
+++ b/crates/goose/src/gateway/telegram.rs
@@ -101,10 +101,12 @@ impl TelegramGateway {
             .ok_or_else(|| anyhow::anyhow!("missing bot_token in platform_config"))?
             .to_string();
 
-        Ok(Self {
-            bot_token,
-            client: Client::new(),
-        })
+        let client = Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .http1_only()
+            .build()?;
+
+        Ok(Self { bot_token, client })
     }
 
     fn api_url(&self, method: &str) -> String {
@@ -438,7 +440,7 @@ impl Gateway for TelegramGateway {
                             }
                         }
                         Err(e) => {
-                            tracing::error!(error = %e, "Telegram poll error");
+                            tracing::error!(error = ?e, "Telegram poll error");
                             tokio::time::sleep(RETRY_DELAY).await;
                         }
                     }


### PR DESCRIPTION
## Summary

Fixes #7826 — Telegram gateway fails with the unhelpful error `error sending request for url` after successfully validating the bot token.

Two root causes addressed:

1. **HTTP/2 long-polling issues**: `reqwest`'s default HTTP/2 support has known problems with long-lived connections (especially Telegram's 30s long-poll). Switching to `http1_only()` avoids these.

2. **Vague error logging**: The poll error was logged with Display format (`%e`) which only shows the top-level reqwest error. Switching to Debug format (`?e`) prints the full error source chain (TLS failures, connection resets, DNS issues, etc.), making future reports actionable.

Also adds an explicit `connect_timeout(10s)` separate from the overall request timeout so stuck TCP connections fail fast instead of hanging for 40s.

## Changes

- `crates/goose/src/gateway/telegram.rs`: Use `Client::builder()` with `http1_only()` and `connect_timeout(10s)`; log poll errors with `?e` instead of `%e`