### PR TITLE
Fix OTLP trace flush on exit with configurable shutdown timeout

### DIFF
--- a/crates/goose-cli/src/main.rs
+++ b/crates/goose-cli/src/main.rs
@@ -10,7 +10,6 @@ async fn run() -> Result<()> {
 
     #[cfg(feature = "otel")]
     if goose::otel::otlp::is_otlp_initialized() {
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
         goose::otel::otlp::shutdown_otlp();
     }
 

--- a/crates/goose-server/src/commands/agent.rs
+++ b/crates/goose-server/src/commands/agent.rs
@@ -137,7 +137,6 @@ pub async fn run() -> Result<()> {
 
     #[cfg(feature = "otel")]
     if goose::otel::otlp::is_otlp_initialized() {
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
         goose::otel::otlp::shutdown_otlp();
     }
 

--- a/crates/goose/src/otel/otlp.rs
+++ b/crates/goose/src/otel/otlp.rs
@@ -359,28 +359,54 @@ fn create_otlp_logs_filter() -> FilterFn<impl Fn(&Metadata<'_>) -> bool> {
     })
 }
 
-/// Shutdown OTLP providers gracefully
+/// Default shutdown timeout for OTLP providers (milliseconds).
+const DEFAULT_OTEL_SHUTDOWN_TIMEOUT_MS: u64 = 5000;
+
+/// Read the configured OTLP shutdown timeout.
+///
+/// Checked via `Config::global()` key `otel_shutdown_timeout_ms` which
+/// resolves from env var `OTEL_SHUTDOWN_TIMEOUT_MS` first, then the
+/// goose config file, falling back to [`DEFAULT_OTEL_SHUTDOWN_TIMEOUT_MS`].
+fn shutdown_timeout() -> std::time::Duration {
+    let ms = crate::config::Config::global()
+        .get_param::<u64>("otel_shutdown_timeout_ms")
+        .unwrap_or(DEFAULT_OTEL_SHUTDOWN_TIMEOUT_MS);
+    std::time::Duration::from_millis(ms)
+}
+
+/// Shutdown OTLP providers gracefully, flushing all pending telemetry.
+///
+/// The timeout is read from the goose config key `otel_shutdown_timeout_ms`
+/// (env `OTEL_SHUTDOWN_TIMEOUT_MS`), defaulting to 5 000 ms.
 pub fn shutdown_otlp() {
+    let timeout = shutdown_timeout();
+
     if let Some(provider) = TRACER_PROVIDER
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .take()
     {
-        let _ = provider.shutdown();
+        if let Err(e) = provider.shutdown_with_timeout(timeout) {
+            tracing::warn!("OTLP tracer provider shutdown error: {e}");
+        }
     }
     if let Some(provider) = METER_PROVIDER
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .take()
     {
-        let _ = provider.shutdown();
+        if let Err(e) = provider.shutdown_with_timeout(timeout) {
+            tracing::warn!("OTLP meter provider shutdown error: {e}");
+        }
     }
     if let Some(provider) = LOGGER_PROVIDER
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .take()
     {
-        let _ = provider.shutdown();
+        if let Err(e) = provider.shutdown_with_timeout(timeout) {
+            tracing::warn!("OTLP logger provider shutdown error: {e}");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Previously, `shutdown_otlp()` used the default 5s timeout via `provider.shutdown()` and silently discarded errors. Fast `goose run` invocations could lose traces because the arbitrary 100ms pre-sleep was insufficient and errors were invisible.

## Changes

- Read shutdown timeout from config key `otel_shutdown_timeout_ms` (env `OTEL_SHUTDOWN_TIMEOUT_MS`), defaulting to 5000ms
- Use `shutdown_with_timeout()` so users can tune the flush window
- Log warnings on shutdown errors instead of discarding them
- Remove the arbitrary 100ms pre-sleep (shutdown itself handles flushing)

## Configuration

Set via goose config file:
```yaml
otel_shutdown_timeout_ms: 10000
```

Or environment variable:
```
OTEL_SHUTDOWN_TIMEOUT_MS=10000
```

Default is 5000ms (matching the OpenTelemetry SDK default).

Fixes #7844