### PR TITLE
fix: widen MOIM allowlist to suppress expected fix_conversation warnings

### DIFF
--- a/crates/goose/src/agents/moim.rs
+++ b/crates/goose/src/agents/moim.rs
@@ -37,6 +37,8 @@ pub async fn inject_moim(
                 && !issue.contains("Merged consecutive assistant messages")
                 && !issue.contains("Added placeholder to empty tool result")
                 && !issue.contains("Trimmed trailing whitespace from assistant message")
+                && !issue.contains("Removed trailing assistant message")
+                && !issue.contains("Merged text content")
         });
 
         if has_unexpected_issues {


### PR DESCRIPTION
## Summary

Add `Removed trailing assistant message` and `Merged text content` to the allowlist in `inject_moim`. Both are expected side effects of inserting a user message before the last assistant message and are automatically corrected by `fix_conversation`.

This eliminates the 142+ WARN-level log messages per session reported in the issue.

Fixes #8274