### PR TITLE
Flush OTLP traces reliably on exit with configurable timeout

### DIFF
--- a/crates/goose-cli/src/main.rs
+++ b/crates/goose-cli/src/main.rs
@@ -10,7 +10,6 @@ async fn run() -> Result<()> {
 
     #[cfg(feature = "otel")]
     if goose::otel::otlp::is_otlp_initialized() {
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
         goose::otel::otlp::shutdown_otlp();
     }
 

--- a/crates/goose-server/src/commands/agent.rs
+++ b/crates/goose-server/src/commands/agent.rs
@@ -137,7 +137,6 @@ pub async fn run() -> Result<()> {
 
     #[cfg(feature = "otel")]
     if goose::otel::otlp::is_otlp_initialized() {
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
         goose::otel::otlp::shutdown_otlp();
     }
 

--- a/crates/goose/src/otel/otlp.rs
+++ b/crates/goose/src/otel/otlp.rs
@@ -359,28 +359,39 @@ fn create_otlp_logs_filter() -> FilterFn<impl Fn(&Metadata<'_>) -> bool> {
     })
 }
 
-/// Shutdown OTLP providers gracefully
 pub fn shutdown_otlp() {
+    let timeout = std::time::Duration::from_millis(
+        crate::config::Config::global()
+            .get_param::<u64>("otel_shutdown_timeout_ms")
+            .unwrap_or(5000),
+    );
+
     if let Some(provider) = TRACER_PROVIDER
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .take()
     {
-        let _ = provider.shutdown();
+        if let Err(e) = provider.shutdown_with_timeout(timeout) {
+            tracing::warn!("OTLP tracer provider shutdown error: {e}");
+        }
     }
     if let Some(provider) = METER_PROVIDER
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .take()
     {
-        let _ = provider.shutdown();
+        if let Err(e) = provider.shutdown_with_timeout(timeout) {
+            tracing::warn!("OTLP meter provider shutdown error: {e}");
+        }
     }
     if let Some(provider) = LOGGER_PROVIDER
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .take()
     {
-        let _ = provider.shutdown();
+        if let Err(e) = provider.shutdown_with_timeout(timeout) {
+            tracing::warn!("OTLP logger provider shutdown error: {e}");
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #7844

- Use `shutdown_with_timeout` instead of `shutdown`, reading timeout from config key `otel_shutdown_timeout_ms` (env `OTEL_SHUTDOWN_TIMEOUT_MS`), defaulting to 5000ms
- Log shutdown errors instead of silently discarding them
- Remove the arbitrary 100ms pre-sleep that wasn't doing the actual flush