### PR TITLE
docs: document summon extension requirement for delegate and load tools

### DIFF
--- a/documentation/docs/guides/recipes/recipe-reference.md
+++ b/documentation/docs/guides/recipes/recipe-reference.md
@@ -176,6 +176,18 @@ The `extensions` field allows you to specify which Model Context Protocol (MCP) 
 - **`frontend`**: Frontend-provided tools called through the frontend
 - **`inline_python`**: Inline Python code executed using uvx. Requires `code` field; optional `dependencies` for packages.
 
+:::note Summon Extension and Subagents
+The `delegate` and `load` tools are provided by the `summon` platform extension. When a recipe specifies an explicit `extensions` block, only the listed extensions are available — default platform extensions like `summon` are not automatically included. If your recipe needs subagent delegation, add `summon` to your extensions list:
+
+```yaml
+extensions:
+  - type: platform
+    name: summon
+```
+
+Recipes that define [`sub_recipes`](/docs/guides/recipes/subrecipes) have `summon` auto-injected and do not need to list it explicitly.
+:::
+
 #### Example Extensions Configuration
 
 <Tabs groupId="format">

--- a/documentation/docs/guides/recipes/subrecipes.md
+++ b/documentation/docs/guides/recipes/subrecipes.md
@@ -28,6 +28,10 @@ When the main recipe is run, goose generates a tool for each subrecipe that:
 
 Sub-recipe sessions run in isolation - they don't share conversation history, memory, or state with the main recipe or other subrecipes. Additionally, subrecipes cannot define their own subrecipes (no nesting allowed).
 
+:::note
+Recipes that define `sub_recipes` automatically get the `summon` platform extension injected, so the `delegate` tool is available without needing to list it in `extensions`.
+:::
+
 ### Parameter Handling
 
 Parameters received by subrecipes can be used in prompts and instructions using `{{ parameter_name }}` syntax. Subrecipes receive parameters in two ways:

--- a/documentation/docs/guides/subagents.mdx
+++ b/documentation/docs/guides/subagents.mdx
@@ -299,6 +299,19 @@ You can override any default by including the setting in your natural language r
 
 Control which tools and capabilities subagents can access. By default, subagents inherit all extensions from your main session, but you can restrict access for security, focus or performance.
 
+:::note Summon Extension
+The `delegate` and `load` tools are provided by the `summon` platform extension, which is enabled by default. If you are using a [recipe](/docs/guides/recipes/) with an explicit `extensions` block, you must include `summon` in that list or the `delegate` tool will not be available:
+
+```yaml
+extensions:
+  - type: platform
+    name: summon
+  # ... your other extensions
+```
+
+Recipes that define [`sub_recipes`](/docs/guides/recipes/subrecipes) have `summon` auto-injected.
+:::
+
 **Examples:**
 ```
 "Create a subagent to write a summary, but don't give it file access"


### PR DESCRIPTION
When a recipe specifies an explicit `extensions` block, default platform extensions like `summon` are not included. This means the `delegate` and `load` tools silently disappear.

This adds notes to three docs pages:

- **Subagents guide** (`subagents.mdx`) — note under Extension Control explaining that recipes with explicit `extensions` must include `summon`
- **Recipe reference** (`recipe-reference.md`) — note after Extension Types explaining the behavior and showing the required YAML
- **Subrecipes guide** (`subrecipes.md`) — note that `sub_recipes` auto-injects `summon`

The subagents tutorial was not updated since it uses natural language delegation in regular sessions where `summon` is enabled by default.

Fixes #7570