### PR TITLE
feat: make tool output size limit configurable via GOOSE_MAX_TOOL_RESPONSE_SIZE

### DIFF
--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -21,7 +21,7 @@ use crate::providers::inventory::{
     InventoryIdentity, ProviderInventoryEntry, ProviderInventoryService, RefreshJobPlan,
     RefreshPlan, RefreshSkipReason,
 };
-use crate::session::session_manager::SessionType;
+use crate::session::session_manager::{SessionListCursor, SessionType};
 use crate::session::{EnabledExtensionsState, Session, SessionManager};
 use crate::source_roots::SourceRoot;
 use crate::utils::sanitize_unicode_tags;
@@ -51,6 +51,7 @@ use agent_client_protocol::{
     Responder,
 };
 use anyhow::Result;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use fs_err as fs;
 use futures::future::{BoxFuture, Either};
 use futures::stream::{self, StreamExt};
@@ -58,7 +59,7 @@ use futures::FutureExt;
 use rmcp::model::{
     AnnotateAble, CallToolResult, RawContent, RawTextContent, ResourceContents, Role,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
@@ -90,6 +91,8 @@ pub type AcpProviderFactory = Arc<
         + Send
         + Sync,
 >;
+
+const SESSION_LIST_PAGE_SIZE: usize = 50;
 
 /// Convenience conversions from any `Display` error into an `agent_client_protocol::Error`.
 ///
@@ -251,6 +254,65 @@ pub struct GooseAcpAgent {
 /// can be extracted with `grep 'perf:' <log> | grep 'sid=abc12345'`.
 fn sid_short(id: &str) -> String {
     id.chars().take(8).collect()
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct SessionListCursorToken {
+    updated_at: chrono::DateTime<chrono::Utc>,
+    // Goose stores updated_at with second precision in common write paths, so the
+    // cursor needs the full (updated_at, id) sort key to avoid skipping tied rows.
+    session_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    cwd: Option<std::path::PathBuf>,
+}
+
+fn invalid_session_list_cursor(message: &'static str) -> agent_client_protocol::Error {
+    agent_client_protocol::Error::invalid_params().data(message)
+}
+
+fn decode_session_list_cursor(
+    cursor: Option<&str>,
+    cwd: Option<&std::path::Path>,
+) -> Result<Option<SessionListCursor>, agent_client_protocol::Error> {
+    let Some(cursor) = cursor else {
+        return Ok(None);
+    };
+
+    let bytes = URL_SAFE_NO_PAD
+        .decode(cursor)
+        .map_err(|_| invalid_session_list_cursor("malformed session list cursor"))?;
+    let token: SessionListCursorToken = serde_json::from_slice(&bytes)
+        .map_err(|_| invalid_session_list_cursor("malformed session list cursor"))?;
+
+    if token.session_id.is_empty() {
+        return Err(invalid_session_list_cursor("malformed session list cursor"));
+    }
+
+    let requested_cwd = cwd.map(std::path::Path::to_path_buf);
+    if token.cwd != requested_cwd {
+        return Err(invalid_session_list_cursor(
+            "session list cursor does not match cwd",
+        ));
+    }
+
+    Ok(Some(SessionListCursor {
+        updated_at: token.updated_at,
+        session_id: token.session_id,
+    }))
+}
+
+fn encode_session_list_cursor(
+    cursor: &SessionListCursor,
+    cwd: Option<&std::path::Path>,
+) -> Result<String, agent_client_protocol::Error> {
+    let token = SessionListCursorToken {
+        updated_at: cursor.updated_at,
+        session_id: cursor.session_id.clone(),
+        cwd: cwd.map(std::path::Path::to_path_buf),
+    };
+    let bytes =
+        serde_json::to_vec(&token).internal_err_ctx("Failed to encode session list cursor")?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
 }
 
 fn session_meta(session: &Session) -> serde_json::Map<String, serde_json::Value> {
@@ -3306,16 +3368,34 @@ impl GooseAcpAgent {
         Ok(())
     }
 
-    async fn on_list_sessions(&self) -> Result<ListSessionsResponse, agent_client_protocol::Error> {
+    async fn on_list_sessions(
+        &self,
+        req: ListSessionsRequest,
+    ) -> Result<ListSessionsResponse, agent_client_protocol::Error> {
+        if let Some(cwd) = req.cwd.as_deref() {
+            if !cwd.is_absolute() {
+                return Err(agent_client_protocol::Error::invalid_params()
+                    .data("cwd must be an absolute path"));
+            }
+        }
+
+        let cwd = req.cwd.as_deref();
+        let cursor = decode_session_list_cursor(req.cursor.as_deref(), cwd)?;
+
         // ACP clients see their own (Acp) sessions plus legacy User/Scheduled ones.
-        let sessions = self
+        let page = self
             .session_manager
-            .list_sessions_by_types(&[SessionType::User, SessionType::Scheduled, SessionType::Acp])
+            .list_nonempty_sessions_by_types_paged(
+                &[SessionType::User, SessionType::Scheduled, SessionType::Acp],
+                cwd,
+                cursor.as_ref(),
+                SESSION_LIST_PAGE_SIZE,
+            )
             .await
             .internal_err()?;
-        let session_infos: Vec<SessionInfo> = sessions
+        let session_infos: Vec<SessionInfo> = page
+            .sessions
             .into_iter()
-            .filter(|s| s.message_count > 0)
             .map(|s| {
                 let meta = session_meta(&s);
                 SessionInfo::new(SessionId::new(s.id), s.working_dir)
@@ -3324,7 +3404,12 @@ impl GooseAcpAgent {
                     .meta(meta)
             })
             .collect();
-        Ok(ListSessionsResponse::new(session_infos))
+        let next_cursor = page
+            .next_cursor
+            .as_ref()
+            .map(|cursor| encode_session_list_cursor(cursor, cwd))
+            .transpose()?;
+        Ok(ListSessionsResponse::new(session_infos).next_cursor(next_cursor))
     }
 
     async fn on_fork_session(

--- a/crates/goose/src/acp/server/dispatch.rs
+++ b/crates/goose/src/acp/server/dispatch.rs
@@ -330,9 +330,12 @@ impl HandleDispatchFrom<Client> for GooseAcpHandler {
                 .if_request({
                     let agent = agent.clone();
                     let cx = cx.clone();
-                    |_req: ListSessionsRequest, responder: Responder<ListSessionsResponse>| async move {
+                    |req: ListSessionsRequest, responder: Responder<ListSessionsResponse>| async move {
                         cx.spawn(async move {
-                            responder.respond(agent.on_list_sessions().await?)?;
+                            match agent.on_list_sessions(req).await {
+                                Ok(response) => responder.respond(response)?,
+                                Err(e) => responder.respond_with_error(e)?,
+                            }
                             Ok(())
                         })?;
                         Ok(())

--- a/crates/goose/src/agents/large_response_handler.rs
+++ b/crates/goose/src/agents/large_response_handler.rs
@@ -1,14 +1,21 @@
+use crate::config::Config;
 use chrono::Utc;
 use rmcp::model::{CallToolResult, Content, ErrorData};
 use std::fs::File;
 use std::io::Write;
 
-const LARGE_TEXT_THRESHOLD: usize = 200_000;
+pub const DEFAULT_LARGE_TEXT_THRESHOLD: usize = 200_000;
 
-/// Process tool response and handle large text content
+fn large_text_threshold() -> usize {
+    Config::global()
+        .get_param::<usize>("GOOSE_MAX_TOOL_RESPONSE_SIZE")
+        .unwrap_or(DEFAULT_LARGE_TEXT_THRESHOLD)
+}
+
 pub fn process_tool_response(
     response: Result<CallToolResult, ErrorData>,
 ) -> Result<CallToolResult, ErrorData> {
+    let threshold = large_text_threshold();
     match response {
         Ok(mut result) => {
             let mut processed_contents = Vec::new();
@@ -16,12 +23,9 @@ pub fn process_tool_response(
             for content in result.content {
                 match content.as_text() {
                     Some(text_content) => {
-                        // Check if text exceeds threshold
-                        if text_content.text.chars().count() > LARGE_TEXT_THRESHOLD {
-                            // Write to temp file
+                        if text_content.text.chars().count() > threshold {
                             match write_large_text_to_file(&text_content.text) {
                                 Ok(file_path) => {
-                                    // Create a new text content with reference to the file
                                     let message = format!(
                                         "The response returned from the tool call was larger ({} characters) and is stored in the file which you can use other tools to examine or search in: {}",
                                         text_content.text.chars().count(),
@@ -30,7 +34,6 @@ pub fn process_tool_response(
                                     processed_contents.push(Content::text(message));
                                 }
                                 Err(e) => {
-                                    // If file writing fails, include original content with warning
                                     let warning = format!(
                                         "Warning: Failed to write large response to file: {}. Showing full content instead.\n\n{}",
                                         e,
@@ -40,12 +43,10 @@ pub fn process_tool_response(
                                 }
                             }
                         } else {
-                            // Keep original content for smaller texts
                             processed_contents.push(content);
                         }
                     }
                     None => {
-                        // Pass through other content types unchanged
                         processed_contents.push(content);
                     }
                 }
@@ -58,18 +59,13 @@ pub fn process_tool_response(
     }
 }
 
-/// Write large text content to a temporary file
 fn write_large_text_to_file(content: &str) -> Result<String, std::io::Error> {
-    // Create temp directory if it doesn't exist
     let temp_dir = std::env::temp_dir().join("goose_mcp_responses");
     std::fs::create_dir_all(&temp_dir)?;
 
-    // Generate a unique filename with timestamp
     let timestamp = Utc::now().format("%Y%m%d_%H%M%S%.6f");
-    let filename = format!("mcp_response_{}.txt", timestamp);
-    let file_path = temp_dir.join(&filename);
+    let file_path = temp_dir.join(format!("mcp_response_{}.txt", timestamp));
 
-    // Write content to file
     let mut file = File::create(&file_path)?;
     file.write_all(content.as_bytes())?;
 
@@ -86,16 +82,13 @@ mod tests {
 
     #[test]
     fn test_small_text_response_passes_through() {
-        // Create a small text response
         let small_text = "This is a small text response";
         let content = Content::text(small_text.to_string());
 
         let response = Ok(CallToolResult::success(vec![content]));
 
-        // Process the response
         let processed = process_tool_response(response).unwrap();
 
-        // Verify the response is unchanged
         assert_eq!(processed.content.len(), 1);
         if let Some(text_content) = processed.content[0].as_text() {
             assert_eq!(text_content.text, small_text);
@@ -106,16 +99,13 @@ mod tests {
 
     #[test]
     fn test_large_text_response_redirected_to_file() {
-        // Create a text larger than the threshold
-        let large_text = "a".repeat(LARGE_TEXT_THRESHOLD + 1000);
+        let large_text = "a".repeat(DEFAULT_LARGE_TEXT_THRESHOLD + 1000);
         let content = Content::text(large_text.clone());
 
         let response = Ok(CallToolResult::success(vec![content]));
 
-        // Process the response
         let processed = process_tool_response(response).unwrap();
 
-        // Verify the response contains a message about the file
         assert_eq!(processed.content.len(), 1);
         if let Some(text_content) = processed.content[0].as_text() {
             assert!(text_content
@@ -123,17 +113,13 @@ mod tests {
                 .contains("The response returned from the tool call was larger"));
             assert!(text_content.text.contains("characters"));
 
-            // Extract the file path from the message
             if let Some(file_path) = text_content.text.split("stored in the file: ").nth(1) {
-                // Verify the file exists and contains the original text
                 let path = Path::new(file_path.trim());
                 if path.exists() {
-                    // Only check content if file exists (may not exist in CI environments)
                     if let Ok(file_content) = fs::read_to_string(path) {
                         assert_eq!(file_content, large_text);
                     }
 
-                    // Clean up the file
                     let _ = fs::remove_file(path); // Ignore errors on cleanup
                 }
             }
@@ -144,15 +130,12 @@ mod tests {
 
     #[test]
     fn test_image_content_passes_through() {
-        // Create an image content
         let image_content = Content::image("base64data".to_string(), "image/png".to_string());
 
         let response = Ok(CallToolResult::success(vec![image_content]));
 
-        // Process the response
         let processed = process_tool_response(response).unwrap();
 
-        // Verify the response is unchanged
         assert_eq!(processed.content.len(), 1);
         if let Some(img) = processed.content[0].as_image() {
             assert_eq!(img.data, "base64data");
@@ -164,33 +147,27 @@ mod tests {
 
     #[test]
     fn test_mixed_content_handled_correctly() {
-        // Create a response with mixed content types
         let small_text = Content::text("Small text");
-        let large_text = Content::text("a".repeat(LARGE_TEXT_THRESHOLD + 1000));
+        let large_text = Content::text("a".repeat(DEFAULT_LARGE_TEXT_THRESHOLD + 1000));
         let image = Content::image("image_data".to_string(), "image/jpeg".to_string());
 
         let response = Ok(CallToolResult::success(vec![small_text, large_text, image]));
 
-        // Process the response
         let processed = process_tool_response(response).unwrap();
 
-        // Verify each item is handled correctly
         assert_eq!(processed.content.len(), 3);
 
-        // First item should be unchanged small text
         if let Some(text_content) = processed.content[0].as_text() {
             assert_eq!(text_content.text, "Small text");
         } else {
             panic!("Expected text content");
         }
 
-        // Second item should be a message about the file
         if let Some(text_content) = processed.content[1].as_text() {
             assert!(text_content
                 .text
                 .contains("The response returned from the tool call was larger"));
 
-            // Extract the file path and clean up
             if let Some(file_path) = text_content.text.split("stored in the file: ").nth(1) {
                 let path = Path::new(file_path.trim());
                 if path.exists() {
@@ -201,7 +178,6 @@ mod tests {
             panic!("Expected text content");
         }
 
-        // Third item should be unchanged image
         if let Some(img) = processed.content[2].as_image() {
             assert_eq!(img.data, "image_data");
             assert_eq!(img.mime_type, "image/jpeg");
@@ -212,7 +188,6 @@ mod tests {
 
     #[test]
     fn test_error_response_passes_through() {
-        // Create an error response
         let error = ErrorData {
             code: ErrorCode::INTERNAL_ERROR,
             message: Cow::from("Test error"),
@@ -220,10 +195,8 @@ mod tests {
         };
         let response: Result<CallToolResult, ErrorData> = Err(error);
 
-        // Process the response
         let processed = process_tool_response(response);
 
-        // Verify the error is passed through unchanged
         assert!(processed.is_err());
         match processed {
             Err(err) => {

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -266,6 +266,18 @@ pub struct SessionManager {
     storage: Arc<SessionStorage>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionListCursor {
+    pub(crate) updated_at: DateTime<Utc>,
+    pub(crate) session_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SessionListPage {
+    pub(crate) sessions: Vec<Session>,
+    pub(crate) next_cursor: Option<SessionListCursor>,
+}
+
 #[derive(Debug, Clone)]
 pub struct SessionNameUpdate {
     pub session_id: String,
@@ -330,6 +342,18 @@ impl SessionManager {
 
     pub async fn list_sessions_by_types(&self, types: &[SessionType]) -> Result<Vec<Session>> {
         self.storage.list_sessions_by_types(Some(types)).await
+    }
+
+    pub(crate) async fn list_nonempty_sessions_by_types_paged(
+        &self,
+        types: &[SessionType],
+        working_dir: Option<&Path>,
+        cursor: Option<&SessionListCursor>,
+        page_size: usize,
+    ) -> Result<SessionListPage> {
+        self.storage
+            .list_nonempty_sessions_by_types_paged(types, working_dir, cursor, page_size)
+            .await
     }
 
     pub async fn list_all_sessions(&self) -> Result<Vec<Session>> {
@@ -1467,6 +1491,91 @@ impl SessionStorage {
         q.fetch_all(pool).await.map_err(Into::into)
     }
 
+    async fn list_nonempty_sessions_by_types_paged(
+        &self,
+        types: &[SessionType],
+        working_dir: Option<&Path>,
+        cursor: Option<&SessionListCursor>,
+        page_size: usize,
+    ) -> Result<SessionListPage> {
+        if types.is_empty() || page_size == 0 {
+            return Ok(SessionListPage {
+                sessions: Vec::new(),
+                next_cursor: None,
+            });
+        }
+
+        let type_placeholders = types.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+        let mut where_clause = format!("s.session_type IN ({})", type_placeholders);
+        if working_dir.is_some() {
+            where_clause.push_str(" AND s.working_dir = ?");
+        }
+        if cursor.is_some() {
+            where_clause.push_str(
+                " AND (datetime(s.updated_at) < datetime(?) \
+                 OR (datetime(s.updated_at) = datetime(?) AND s.id < ?))",
+            );
+        }
+
+        let query = format!(
+            r#"
+            SELECT s.id, s.working_dir, s.name, s.description, s.user_set_name, s.session_type, s.created_at, s.updated_at, s.extension_data,
+                   s.total_tokens, s.input_tokens, s.output_tokens,
+                   s.accumulated_total_tokens, s.accumulated_input_tokens, s.accumulated_output_tokens,
+                   s.schedule_id, s.recipe_json, s.user_recipe_values_json,
+                   s.provider_name, s.model_config_json, s.goose_mode,
+                   s.archived_at, s.project_id,
+                   COUNT(m.id) as message_count
+            FROM sessions s
+            JOIN messages m ON s.id = m.session_id
+            WHERE {}
+            GROUP BY s.id
+            ORDER BY datetime(s.updated_at) DESC, s.id DESC
+            LIMIT ?
+            "#,
+            where_clause
+        );
+
+        let mut q = sqlx::query_as::<_, Session>(&query);
+        for session_type in types {
+            q = q.bind(session_type.to_string());
+        }
+
+        if let Some(working_dir) = working_dir {
+            q = q.bind(working_dir.to_string_lossy().to_string());
+        }
+
+        if let Some(cursor) = cursor {
+            let updated_at = cursor.updated_at.to_rfc3339();
+            // Normalize mixed SQLite CURRENT_TIMESTAMP and RFC3339 stored values.
+            q = q.bind(updated_at.clone());
+            q = q.bind(updated_at);
+            q = q.bind(&cursor.session_id);
+        }
+        q = q.bind((page_size + 1) as i64);
+
+        let pool = self.pool().await?;
+        let mut sessions = q.fetch_all(pool).await?;
+        let has_next_page = sessions.len() > page_size;
+        let next_cursor = if has_next_page {
+            let anchor = &sessions[page_size - 1];
+            Some(SessionListCursor {
+                updated_at: anchor.updated_at,
+                session_id: anchor.id.clone(),
+            })
+        } else {
+            None
+        };
+        if has_next_page {
+            sessions.truncate(page_size);
+        }
+
+        Ok(SessionListPage {
+            sessions,
+            next_cursor,
+        })
+    }
+
     async fn list_sessions(&self) -> Result<Vec<Session>> {
         self.list_sessions_by_types(Some(&[SessionType::User, SessionType::Scheduled]))
             .await
@@ -1790,6 +1899,74 @@ mod tests {
 
     const NUM_CONCURRENT_SESSIONS: i32 = 10;
 
+    async fn insert_session_for_list(
+        sm: &SessionManager,
+        id: &str,
+        working_dir: &str,
+        updated_at: &str,
+        message_count: usize,
+    ) {
+        let pool = sm.storage().pool().await.unwrap();
+        let updated_at = chrono::DateTime::parse_from_rfc3339(updated_at).unwrap();
+        let timestamp = updated_at.format("%Y-%m-%d %H:%M:%S").to_string();
+
+        sqlx::query(
+            "INSERT INTO sessions (
+                id, name, user_set_name, session_type, working_dir, created_at, updated_at, extension_data, goose_mode
+             ) VALUES (?, ?, FALSE, ?, ?, ?, ?, '{}', ?)",
+        )
+        .bind(id)
+        .bind(format!("Session {id}"))
+        .bind(SessionType::User.to_string())
+        .bind(working_dir)
+        .bind(&timestamp)
+        .bind(&timestamp)
+        .bind(GooseMode::default().to_string())
+        .execute(pool)
+        .await
+        .unwrap();
+
+        for index in 0..message_count {
+            sqlx::query(
+                "INSERT INTO messages (message_id, session_id, role, content_json, created_timestamp, metadata_json)
+                 VALUES (?, ?, 'user', '[]', ?, '{}')",
+            )
+            .bind(format!("{id}_{index}"))
+            .bind(id)
+            .bind(index as i64)
+            .execute(pool)
+            .await
+            .unwrap();
+        }
+    }
+
+    async fn assert_session_list_page(
+        sm: &SessionManager,
+        cursor: Option<&SessionListCursor>,
+        working_dir: Option<&str>,
+        page_size: usize,
+        expected_ids: &[&str],
+        expected_next_cursor: bool,
+    ) -> Option<SessionListCursor> {
+        let page = sm
+            .list_nonempty_sessions_by_types_paged(
+                &[SessionType::User],
+                working_dir.map(Path::new),
+                cursor,
+                page_size,
+            )
+            .await
+            .unwrap();
+        let ids: Vec<_> = page
+            .sessions
+            .iter()
+            .map(|session| session.id.as_str())
+            .collect();
+        assert_eq!(ids, expected_ids);
+        assert_eq!(page.next_cursor.is_some(), expected_next_cursor);
+        page.next_cursor
+    }
+
     async fn run_lock_upgrade_attempt(
         pool: Pool<Sqlite>,
         session_id: String,
@@ -1880,6 +2057,66 @@ mod tests {
                 .filter_map(|r| r.as_ref().err().map(ToString::to_string))
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[tokio::test]
+    async fn test_session_list_paged_first_second_and_final_page() {
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+        for index in 1..=5 {
+            insert_session_for_list(
+                &sm,
+                &format!("s{index:03}"),
+                "/tmp/session-list",
+                &format!("2024-01-01T00:00:0{index}Z"),
+                1,
+            )
+            .await;
+        }
+
+        let cursor = assert_session_list_page(&sm, None, None, 2, &["s005", "s004"], true).await;
+        let cursor =
+            assert_session_list_page(&sm, cursor.as_ref(), None, 2, &["s003", "s002"], true).await;
+        assert_session_list_page(&sm, cursor.as_ref(), None, 2, &["s001"], false).await;
+    }
+
+    #[tokio::test]
+    async fn test_session_list_paged_uses_id_tiebreaker_for_duplicate_updated_at() {
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+        for id in ["s001", "s002", "s003"] {
+            insert_session_for_list(&sm, id, "/tmp/session-list", "2024-01-01T00:00:00Z", 1).await;
+        }
+
+        let cursor = assert_session_list_page(&sm, None, None, 2, &["s003", "s002"], true).await;
+        assert_session_list_page(&sm, cursor.as_ref(), None, 2, &["s001"], false).await;
+    }
+
+    #[tokio::test]
+    async fn test_session_list_paged_filters_empty_and_cwd_before_pagination() {
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+        for (id, dir, updated_at, messages) in [
+            ("s004", "/tmp/session-list/a", "2024-01-01T00:00:04Z", 1),
+            ("s003", "/tmp/session-list/a", "2024-01-01T00:00:03Z", 0),
+            ("s002", "/tmp/session-list/b", "2024-01-01T00:00:02Z", 1),
+            ("s001", "/tmp/session-list/a", "2024-01-01T00:00:01Z", 1),
+        ] {
+            insert_session_for_list(&sm, id, dir, updated_at, messages).await;
+        }
+
+        let cursor =
+            assert_session_list_page(&sm, None, Some("/tmp/session-list/a"), 1, &["s004"], true)
+                .await;
+        assert_session_list_page(
+            &sm,
+            cursor.as_ref(),
+            Some("/tmp/session-list/a"),
+            1,
+            &["s001"],
+            false,
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/crates/goose/tests/acp_server_test.rs
+++ b/crates/goose/tests/acp_server_test.rs
@@ -1,8 +1,10 @@
 #[allow(dead_code)]
 #[path = "acp_common_tests/mod.rs"]
 mod common_tests;
-use common_tests::fixtures::run_test;
+use agent_client_protocol::schema::{ListSessionsRequest, ListSessionsResponse};
+use agent_client_protocol::ErrorCode;
 use common_tests::fixtures::server::AcpServerConnection;
+use common_tests::fixtures::{run_test, Connection, OpenAiFixture, TestConnectionConfig};
 use common_tests::{
     run_close_session, run_config_mcp, run_config_option_mode_set, run_config_option_model_set,
     run_delete_session, run_fs_read_text_file_true, run_fs_write_text_file_false,
@@ -14,9 +16,64 @@ use common_tests::{
     run_prompt_mcp, run_prompt_model_mismatch, run_prompt_skill,
     run_session_name_update_notification, run_shell_terminal_false, run_shell_terminal_true,
 };
+use goose::config::GooseMode;
+use goose::conversation::message::Message;
+use goose::session::{SessionManager, SessionType};
+use std::path::Path;
 
 tests_config_option_set_error!(AcpServerConnection);
 tests_mode_set_error!(AcpServerConnection);
+
+async fn seed_list_sessions(data_root: &Path, working_dir: &Path, count: usize) {
+    let session_manager = SessionManager::new(data_root.to_path_buf());
+    for index in 0..count {
+        let session = session_manager
+            .create_session(
+                working_dir.to_path_buf(),
+                format!("Seed session {index}"),
+                SessionType::Acp,
+                GooseMode::default(),
+            )
+            .await
+            .unwrap();
+        session_manager
+            .add_message(&session.id, &Message::user().with_text("hello"))
+            .await
+            .unwrap();
+    }
+}
+
+async fn new_connection(data_root: &Path) -> AcpServerConnection {
+    let openai = OpenAiFixture::new(
+        vec![],
+        <AcpServerConnection as Connection>::expected_session_id(),
+    )
+    .await;
+    <AcpServerConnection as Connection>::new(
+        TestConnectionConfig {
+            data_root: data_root.to_path_buf(),
+            ..Default::default()
+        },
+        openai,
+    )
+    .await
+}
+
+async fn list_sessions_request(
+    conn: &AcpServerConnection,
+    request: ListSessionsRequest,
+) -> anyhow::Result<ListSessionsResponse> {
+    conn.cx()
+        .send_request(request)
+        .block_task()
+        .await
+        .map_err(Into::into)
+}
+
+fn assert_invalid_params(error: anyhow::Error) {
+    let acp_error = error.downcast::<agent_client_protocol::Error>().unwrap();
+    assert_eq!(acp_error.code, ErrorCode::InvalidParams);
+}
 
 #[test]
 fn test_config_mcp() {
@@ -31,6 +88,74 @@ fn test_config_option_mode_set() {
 #[test]
 fn test_list_sessions() {
     run_test(async { run_list_sessions::<AcpServerConnection>().await });
+}
+
+#[test]
+fn test_list_sessions_pagination() {
+    run_test(async {
+        let data_root = tempfile::tempdir().unwrap();
+        seed_list_sessions(data_root.path(), Path::new("/tmp/acp-session-list"), 51).await;
+        let conn = new_connection(data_root.path()).await;
+
+        let first = list_sessions_request(&conn, ListSessionsRequest::new())
+            .await
+            .unwrap();
+        assert_eq!(first.sessions.len(), 50);
+
+        let second = list_sessions_request(
+            &conn,
+            ListSessionsRequest::new().cursor(first.next_cursor.clone().unwrap()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(second.sessions.len(), 1);
+        assert!(second.next_cursor.is_none());
+
+        let second_id = &second.sessions[0].session_id;
+        assert!(first
+            .sessions
+            .iter()
+            .all(|session| session.session_id != *second_id));
+    });
+}
+
+#[test]
+fn test_list_sessions_invalid_params() {
+    run_test(async {
+        let data_root = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        let other_cwd = tempfile::tempdir().unwrap();
+        seed_list_sessions(data_root.path(), cwd.path(), 51).await;
+        let conn = new_connection(data_root.path()).await;
+
+        let error =
+            list_sessions_request(&conn, ListSessionsRequest::new().cursor("*".to_string()))
+                .await
+                .unwrap_err();
+        assert_invalid_params(error);
+
+        let error = list_sessions_request(
+            &conn,
+            ListSessionsRequest::new().cwd(std::path::PathBuf::from("relative/path")),
+        )
+        .await
+        .unwrap_err();
+        assert_invalid_params(error);
+
+        let first = list_sessions_request(&conn, ListSessionsRequest::new().cwd(cwd.path()))
+            .await
+            .unwrap();
+
+        let error = list_sessions_request(
+            &conn,
+            ListSessionsRequest::new()
+                .cwd(other_cwd.path())
+                .cursor(first.next_cursor.unwrap()),
+        )
+        .await
+        .unwrap_err();
+        assert_invalid_params(error);
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The large tool response threshold (200K characters) was hardcoded. This makes it configurable via `GOOSE_MAX_TOOL_RESPONSE_SIZE`, using the same `Config::global().get_param` pattern already used for `GOOSE_TOOL_CALL_CUTOFF`.

Users with smaller-context models can lower this value to avoid performance degradation from large tool outputs being sent to the model.

Default behavior is unchanged (200,000 characters).

## Example

```bash
# In goose config or environment
GOOSE_MAX_TOOL_RESPONSE_SIZE=50000
```

Fixes #7027