### PR TITLE
Add Repology badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ _your native open source AI agent — desktop app, CLI, and API — for code, wo
   <a href="https://github.com/aaif-goose/goose/actions/workflows/ci.yml"
      ><img src="https://img.shields.io/github/actions/workflow/status/aaif-goose/goose/ci.yml?branch=main" alt="CI"></a>
   <a href="https://insights.linuxfoundation.org/project/goose"><img src="https://insights.linuxfoundation.org/api/badge/health-score?project=goose"></a>
+  <a href="https://repology.org/project/goose-cli/versions"><img src="https://repology.org/badge/tiny-repos/goose-cli.svg" alt="Packaging status"></a>
 </p>
 </div>
 


### PR DESCRIPTION
Adds a Repology packaging status badge to the README badge row, linking to the [goose-cli versions page](https://repology.org/project/goose-cli/versions). This shows at a glance which distros/package managers carry goose-cli and whether they're up to date.

Uses the `tiny-repos` badge style to match the inline badge row.

Fixes #7588