### PR TITLE
fix(recipe): use mkdir -p for self-test workspace initialization

### DIFF
--- a/goose-self-test.yaml
+++ b/goose-self-test.yaml
@@ -120,7 +120,7 @@ prompt: |
   Test phases: {{ test_phases }}, Depth: {{ test_depth }}, Parallel: {{ parallel_tests }}
 
   ## 🚀 INITIALIZATION
-  Create test workspace: {{ workspace_dir }}/ for all test artifacts and reports.
+  Create test workspace using `mkdir -p {{ workspace_dir }}/archive` for all test artifacts and reports.
 
   Track your progress using the todo extension. Start with:
   - [ ] Initialize test workspace


### PR DESCRIPTION
The self-test recipe's initialization step was ambiguous about directory creation order. The LLM would sometimes attempt to create the archive subdirectory before the parent workspace directory existed, causing a noisy failure on the first step.

Explicitly instruct `mkdir -p` with the deepest path so the parent and archive directories are created in one shot.

Fixes #8486