### PR TITLE
fix(cli): enable VT processing on Windows Console Host

### DIFF
--- a/crates/goose-cli/src/main.rs
+++ b/crates/goose-cli/src/main.rs
@@ -1,6 +1,19 @@
 use anyhow::Result;
 use goose_cli::cli::cli;
 
+/// Enable ANSI/VT escape sequence processing on Windows Console Host.
+///
+/// Without this, spinners and progress bars from cliclack/indicatif render as
+/// repeated new lines instead of updating in place, because Windows Console Host
+/// does not process ANSI escapes by default.
+#[cfg(windows)]
+fn enable_windows_vt_processing() {
+    // colors_supported() has the side effect of calling SetConsoleMode with
+    // ENABLE_VIRTUAL_TERMINAL_PROCESSING on the underlying console handle.
+    let _ = console::Term::stdout().features().colors_supported();
+    let _ = console::Term::stderr().features().colors_supported();
+}
+
 async fn run() -> Result<()> {
     if let Err(e) = goose_cli::logging::setup_logging(None) {
         eprintln!("Warning: Failed to initialize logging: {}", e);
@@ -18,6 +31,9 @@ async fn run() -> Result<()> {
 }
 
 fn main() -> Result<()> {
+    #[cfg(windows)]
+    enable_windows_vt_processing();
+
     let handle = std::thread::Builder::new()
         .name("goose-cli-main".to_string())
         .stack_size(8 * 1024 * 1024)


### PR DESCRIPTION
## Summary

Windows Console Host (conhost.exe) does not process ANSI escape sequences by default. This causes spinners and progress bars from `cliclack` and `indicatif` to render as repeated new lines instead of updating in place.

## Fix

Call `console::Term::features().colors_supported()` on both stdout and stderr at startup on Windows. This triggers `SetConsoleMode` with `ENABLE_VIRTUAL_TERMINAL_PROCESSING` on the underlying console handles, enabling ANSI/VT escape processing for the remainder of the process.

The `console` crate is already a dependency — no new deps needed. The code is `#[cfg(windows)]` gated so it compiles to nothing on other platforms.

Fixes #8422