### PR TITLE
fix(autovisualiser): use appInfo instead of clientInfo in MCP Apps init handshake

### DIFF
--- a/crates/goose-mcp/src/autovisualiser/templates/assets/mcp-app-bridge.js
+++ b/crates/goose-mcp/src/autovisualiser/templates/assets/mcp-app-bridge.js
@@ -192,7 +192,7 @@ var McpAppBridge = (function () {
     };
     sendRequest("ui/initialize", {
       protocolVersion: "2026-01-26",
-      clientInfo: appIdentity,
+      appInfo: appIdentity,
       appCapabilities: {
         availableDisplayModes: ["inline", "fullscreen"],
       },


### PR DESCRIPTION
The custom `mcp-app-bridge.js` embedded in all autovisualiser HTML templates was sending `clientInfo` in the `ui/initialize` request, but the host-side `@mcp-ui/client` SDK validates against the MCP Apps schema which requires `appInfo`. The Zod validation failure meant the guest never became "initialized", so tool results were never delivered to the iframe — leaving all charts permanently stuck on "Waiting for data…".

One-line fix: rename `clientInfo` to `appInfo` on line 195 of `mcp-app-bridge.js`.

Fixes #8506