### PR TITLE
feat: add Cursor ACP provider

### DIFF
--- a/crates/goose/src/providers/cursor_acp.rs
+++ b/crates/goose/src/providers/cursor_acp.rs
@@ -1,0 +1,89 @@
+use anyhow::Result;
+use futures::future::BoxFuture;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use crate::acp::{
+    extension_configs_to_mcp_servers, AcpProvider, AcpProviderConfig, ACP_CURRENT_MODEL,
+};
+use crate::config::search_path::SearchPaths;
+use crate::config::{Config, GooseMode};
+use crate::model::ModelConfig;
+use crate::providers::acp_tooling::{acp_adapter_installed, acp_inventory_identity};
+use crate::providers::base::{ProviderDef, ProviderMetadata};
+use crate::providers::inventory::InventoryIdentityInput;
+
+const CURSOR_ACP_PROVIDER_NAME: &str = "cursor-acp";
+const CURSOR_ACP_DOC_URL: &str = "https://cursor.com/docs/cli/acp";
+const CURSOR_ACP_BINARY: &str = "cursor-agent";
+
+pub struct CursorAcpProvider;
+
+impl ProviderDef for CursorAcpProvider {
+    type Provider = AcpProvider;
+
+    fn metadata() -> ProviderMetadata {
+        ProviderMetadata::new(
+            CURSOR_ACP_PROVIDER_NAME,
+            "Cursor (ACP)",
+            "Use goose with your Cursor subscription via the cursor-agent ACP adapter.",
+            ACP_CURRENT_MODEL,
+            vec![],
+            CURSOR_ACP_DOC_URL,
+            vec![],
+        )
+        .with_setup_steps(vec![
+            "Install the Cursor agent CLI (download from https://cursor.com)",
+            "Ensure your Cursor CLI is authenticated (run `cursor-agent login` to verify)",
+            "Set in your goose config file (`~/.config/goose/config.yaml` on macOS/Linux):\n  GOOSE_PROVIDER: cursor-acp\n  GOOSE_MODEL: current",
+            "Restart goose for changes to take effect",
+        ])
+    }
+
+    fn from_env(
+        model: ModelConfig,
+        extensions: Vec<crate::config::ExtensionConfig>,
+    ) -> BoxFuture<'static, Result<AcpProvider>> {
+        Box::pin(async move {
+            let config = Config::global();
+            let resolved_command = SearchPaths::builder()
+                .with_npm()
+                .resolve(CURSOR_ACP_BINARY)?;
+            let goose_mode = config.get_goose_mode().unwrap_or(GooseMode::Auto);
+
+            let mode_mapping = HashMap::from([
+                (GooseMode::Auto, "full-auto".to_string()),
+                (GooseMode::Approve, "default".to_string()),
+                (GooseMode::SmartApprove, "auto-accept-edits".to_string()),
+                (GooseMode::Chat, "plan".to_string()),
+            ]);
+
+            let provider_config = AcpProviderConfig {
+                command: resolved_command,
+                args: vec!["acp".to_string()],
+                env: vec![],
+                env_remove: vec![],
+                work_dir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+                mcp_servers: extension_configs_to_mcp_servers(&extensions),
+                session_mode_id: Some(mode_mapping[&goose_mode].clone()),
+                mode_mapping,
+                notification_callback: None,
+            };
+
+            let metadata = Self::metadata();
+            AcpProvider::connect(metadata.name, model, goose_mode, provider_config).await
+        })
+    }
+
+    fn supports_inventory_refresh() -> bool {
+        true
+    }
+
+    fn inventory_identity() -> Result<InventoryIdentityInput> {
+        acp_inventory_identity(CURSOR_ACP_PROVIDER_NAME, CURSOR_ACP_BINARY)
+    }
+
+    fn inventory_configured() -> bool {
+        acp_adapter_installed(CURSOR_ACP_BINARY)
+    }
+}

--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -18,6 +18,7 @@ use super::{
     codex::CodexProvider,
     codex_acp::CodexAcpProvider,
     copilot_acp::CopilotAcpProvider,
+    cursor_acp::CursorAcpProvider,
     cursor_agent::CursorAgentProvider,
     databricks::DatabricksProvider,
     gcpvertexai::GcpVertexAIProvider,
@@ -66,6 +67,7 @@ async fn init_registry() -> RwLock<ProviderRegistry> {
         registry.register::<CodexAcpProvider>(false);
         registry.register::<CopilotAcpProvider>(false);
         registry.register::<CodexProvider>(true);
+        registry.register::<CursorAcpProvider>(false);
         registry.register::<CursorAgentProvider>(false);
         registry.register::<DatabricksProvider>(true);
         registry.register::<GcpVertexAIProvider>(false);

--- a/crates/goose/src/providers/mod.rs
+++ b/crates/goose/src/providers/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod cli_common;
 pub mod codex;
 pub mod codex_acp;
 pub mod copilot_acp;
+pub mod cursor_acp;
 pub mod cursor_agent;
 pub mod databricks;
 pub mod embedding;

--- a/crates/goose/tests/providers.rs
+++ b/crates/goose/tests/providers.rs
@@ -905,6 +905,14 @@ async fn test_codex_acp_provider() -> Result<()> {
         .await
 }
 
+// Requires: cursor-agent CLI installed and authenticated
+#[tokio::test]
+async fn test_cursor_acp_provider() -> Result<()> {
+    ProviderTestConfig::with_agentic_provider("cursor-acp", ACP_CURRENT_MODEL, "cursor-agent")
+        .run()
+        .await
+}
+
 // Requires: npm install -g @github/copilot
 #[tokio::test]
 async fn test_copilot_acp_provider() -> Result<()> {


### PR DESCRIPTION
Add `cursor-acp` provider that wraps the `cursor-agent` CLI with the `acp` subcommand, following the same pattern as `claude-acp`, `copilot-acp`, and other ACP providers.

- Binary resolved via `cursor-agent` (matches the [ACP registry entry](https://github.com/agentclientprotocol/registry/blob/main/cursor/agent.json))
- Supports goose mode mapping: Auto → full-auto, Approve → default, SmartApprove → auto-accept-edits, Chat → plan
- Includes inventory support for auto-detection (`supports_inventory_refresh`, `inventory_identity`, `inventory_configured`)
- Registered in the provider registry alongside the existing CLI-based `cursor-agent` provider

Fixes #8391

## Test plan

- `cargo build -p goose --lib` passes
- `cargo clippy -p goose --lib -- -D warnings` passes (zero warnings)
- `cargo test -p goose --lib -- providers::init` passes (registry wiring tests)
- Manual: set `GOOSE_PROVIDER: cursor-acp` and `GOOSE_MODEL: current` in config, verify goose connects via `cursor-agent acp`