### PR TITLE
fix(otel): emit trace_output as span attribute instead of event

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1505,7 +1505,7 @@ impl Agent {
             .count();
 
         let working_dir = session.working_dir.clone();
-        let reply_stream_span = tracing::info_span!(target: "goose::agents::agent", "reply_stream", session.id = %session_config.id);
+        let reply_stream_span = tracing::info_span!(target: "goose::agents::agent", "reply_stream", trace_output = tracing::field::Empty, session.id = %session_config.id);
         let inner = Box::pin(async_stream::try_stream! {
             let mut turns_taken = 0u32;
             let max_turns = session_config.max_turns.unwrap_or_else(|| {
@@ -2090,7 +2090,7 @@ impl Agent {
             }
 
             if !last_assistant_text.is_empty() {
-                tracing::info!(target: "goose::agents::agent", trace_output = last_assistant_text.as_str());
+                tracing::Span::current().record("trace_output", last_assistant_text.as_str());
             }
         }.instrument(reply_stream_span));
         Ok(inner)


### PR DESCRIPTION
## Summary

`trace_output` was emitted via `tracing::info!()` which becomes an OTEL **event** (a log line attached to the span), not a **span attribute**. Observability backends like MLflow and Langfuse (via OTEL ingestion) look for span attributes to populate input/output fields, so the assistant output was invisible to them.

## Changes

- Declare `trace_output` as a field on `reply_stream_span` so it can accept a recorded value
- Replace `tracing::info!(trace_output = ...)` with `tracing::Span::current().record("trace_output", ...)` to set it as a proper span attribute

The Langfuse custom layer's `on_record` and `on_event` both call `handle_record` with the same metadata, so this change is transparent to the Langfuse-specific path.

Fixes #8586