### PR TITLE
fix(desktop): ScheduleModal error message styling

### DIFF
--- a/ui/desktop/src/components/schedule/ScheduleModal.tsx
+++ b/ui/desktop/src/components/schedule/ScheduleModal.tsx
@@ -212,12 +212,12 @@ export const ScheduleModal: React.FC<ScheduleModalProps> = ({
           className="px-8 py-4 space-y-4 flex-grow overflow-y-auto"
         >
           {apiErrorExternally && (
-            <p className="text-text-danger text-sm mb-3 p-2 bg-background-danger border border-border-danger rounded-md">
+            <p className="text-text-danger text-sm mb-3 p-2 border border-border-danger rounded-md">
               {apiErrorExternally}
             </p>
           )}
           {internalValidationError && (
-            <p className="text-text-danger text-sm mb-3 p-2 bg-background-danger border border-border-danger rounded-md">
+            <p className="text-text-danger text-sm mb-3 p-2 border border-border-danger rounded-md">
               {internalValidationError}
             </p>
           )}
@@ -226,7 +226,7 @@ export const ScheduleModal: React.FC<ScheduleModalProps> = ({
             <>
               <div>
                 <label htmlFor="scheduleId-modal" className={modalLabelClassName}>
-                  {intl.formatMessage(i18n.nameLabel)}
+                  {intl.formatMessage(i18n.nameLabel)} <span className="text-red-500">*</span>
                 </label>
                 <Input
                   type="text"
@@ -239,7 +239,9 @@ export const ScheduleModal: React.FC<ScheduleModalProps> = ({
               </div>
 
               <div>
-                <label className={modalLabelClassName}>{intl.formatMessage(i18n.sourceLabel)}</label>
+                <label className={modalLabelClassName}>
+                    {intl.formatMessage(i18n.sourceLabel)} <span className="text-red-500">*</span>
+                </label>
                 <div className="space-y-2">
                   <div className="flex bg-gray-100 dark:bg-gray-700 rounded-full p-1">
                     <button


### PR DESCRIPTION
## Summary
The ScheduleModal had the error messages styled with danger border, background and text. This meant that the messages were not able to be seen due to the red-on-red.

This has been addressed by removing the danger background style so that only the text is styled.

Additionally, the schedule name and source fields have been marked up in a similar way to the CreateRecipe modal. Required fields have an explicit asterix `*` to give a visual indicator that they are required.

### Testing
This has been manually tested.

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

**No visual indicator**
<img width="451" height="574" alt="image" src="https://github.com/user-attachments/assets/249082c7-8b21-400a-b13c-47c3f300c5b3" />

**Unreadable error text**
<img width="451" height="574" alt="image" src="https://github.com/user-attachments/assets/cfcd3ca7-1f6f-42a0-9444-7e86f56238c0" />


After:   

**Visual indicator added to labels**
<img width="451" height="574" alt="image" src="https://github.com/user-attachments/assets/9619f0e5-c2d6-45a6-a948-7c6f52be8db1" />

**Error message styling fixed**
<img width="451" height="574" alt="image" src="https://github.com/user-attachments/assets/5a4f2f57-7586-4008-81ff-e5449aed9ccd" />

