### PR TITLE
fix(config): check file fallback when keyring has no entry

### DIFF
--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -594,7 +594,7 @@ impl Config {
                             if msg.contains("No entry found")
                                 || msg.contains("No matching entry found") =>
                         {
-                            HashMap::new()
+                            self.fallback_to_file_storage()?
                         }
                         Err(e) => return Err(e),
                     }


### PR DESCRIPTION
## Summary
Fixes #8902

When keyring is unavailable and secrets were written to the file fallback, reading secrets back returned empty because the "No entry found" handler skipped the file entirely. Now tries `fallback_to_file_storage()` before concluding no secrets exist.

