### PR TITLE
fix(build): reduce release link-phase memory on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,10 @@ tree-sitter-rust = "0.24"
 tree-sitter-swift = "0.7"
 tree-sitter-typescript = "0.23"
 
+[profile.release]
+strip = "debuginfo"
+split-debuginfo = "unpacked"
+
 [patch.crates-io]
 v8 = { path = "vendor/v8" }
 cudaforge = { git = "https://github.com/jbg/cudaforge", rev = "e7c1967340e40673db98dc9e17da0f04834a456f" }


### PR DESCRIPTION
## Summary
- Adds `[profile.release]` with `strip = "debuginfo"` and `split-debuginfo = "unpacked"` so the linker (and dsymutil on macOS) has less to process at the end of a release build.
- Targets the late-stage memory spike reported on Apple Silicon during `just run-ui` / `just release-binary`, with no impact on runtime behavior.

Closes #9258