### PR TITLE
fix: allow adaptive thinking and xhigh effort with Claude Opus 4.7

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -776,6 +776,7 @@ pub async fn configure_provider_dialog() -> anyhow::Result<bool> {
                 .item("low", "Low - Better latency, lighter reasoning", "")
                 .item("medium", "Medium - Moderate thinking", "")
                 .item("high", "High - Deep reasoning", "")
+                .item("xhigh", "XHigh - Extended coding and agentic work", "")
                 .item("max", "Max - No constraints on thinking depth", "")
                 .initial_value("high")
                 .interact()?;

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -777,7 +777,7 @@ pub async fn configure_provider_dialog() -> anyhow::Result<bool> {
                 .item("medium", "Medium - Moderate thinking", "")
                 .item("high", "High - Deep reasoning", "")
                 .item("max", "Max - No constraints on thinking depth", "")
-                .initial_value("off")
+                .initial_value("high")
                 .interact()?;
             config.set_goose_thinking_effort(effort)?;
         }

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -1100,7 +1100,7 @@ config_value!(CURSOR_AGENT_COMMAND, String, "cursor-agent");
 config_value!(CODEX_COMMAND, String, "codex");
 config_value!(CODEX_ENABLE_SKILLS, String, "true");
 config_value!(CODEX_SKIP_GIT_CHECK, String, "false");
-config_value!(CHATGPT_CODEX_REASONING_EFFORT, String, "medium");
+config_value!(CHATGPT_CODEX_REASONING_EFFORT, String);
 
 config_value!(GOOSE_SEARCH_PATHS, Vec<String>);
 config_value!(GOOSE_MODE, GooseMode);

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -17,6 +17,7 @@ pub enum ThinkingEffort {
     Low,
     Medium,
     High,
+    XHigh,
     Max,
 }
 
@@ -28,7 +29,8 @@ impl FromStr for ThinkingEffort {
             "low" => Ok(Self::Low),
             "medium" | "med" => Ok(Self::Medium),
             "high" => Ok(Self::High),
-            "max" | "xhigh" => Ok(Self::Max),
+            "xhigh" => Ok(Self::XHigh),
+            "max" => Ok(Self::Max),
             other => Err(format!("unknown thinking effort: '{other}'")),
         }
     }
@@ -41,6 +43,7 @@ impl fmt::Display for ThinkingEffort {
             Self::Low => write!(f, "low"),
             Self::Medium => write!(f, "medium"),
             Self::High => write!(f, "high"),
+            Self::XHigh => write!(f, "xhigh"),
             Self::Max => write!(f, "max"),
         }
     }
@@ -445,7 +448,7 @@ impl ModelConfig {
             "low" => ThinkingEffort::Low,
             "medium" => ThinkingEffort::Medium,
             "high" => ThinkingEffort::High,
-            "xhigh" => ThinkingEffort::Max,
+            "xhigh" => ThinkingEffort::XHigh,
             _ => return,
         };
         self.model_name = parts[..parts.len() - 1].join("-");
@@ -794,7 +797,7 @@ mod tests {
             ]);
             let config = ModelConfig::new("gpt-5.4-xhigh").unwrap();
             assert_eq!(config.model_name, "gpt-5.4");
-            assert_eq!(config.thinking_effort(), Some(ThinkingEffort::Max));
+            assert_eq!(config.thinking_effort(), Some(ThinkingEffort::XHigh));
         }
 
         #[test]
@@ -857,7 +860,7 @@ mod tests {
             );
             assert_eq!("med".parse::<ThinkingEffort>(), Ok(ThinkingEffort::Medium));
             assert_eq!("max".parse::<ThinkingEffort>(), Ok(ThinkingEffort::Max));
-            assert_eq!("xhigh".parse::<ThinkingEffort>(), Ok(ThinkingEffort::Max));
+            assert_eq!("xhigh".parse::<ThinkingEffort>(), Ok(ThinkingEffort::XHigh));
             assert!("invalid".parse::<ThinkingEffort>().is_err());
         }
     }

--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -30,6 +30,8 @@ const ANTHROPIC_PROVIDER_NAME: &str = "anthropic";
 pub const ANTHROPIC_DEFAULT_MODEL: &str = "claude-sonnet-4-5";
 const ANTHROPIC_DEFAULT_FAST_MODEL: &str = "claude-haiku-4-5";
 const ANTHROPIC_KNOWN_MODELS: &[&str] = &[
+    // Claude 4.7 models
+    "claude-opus-4-7",
     // Claude 4.6 models
     "claude-opus-4-6",
     "claude-sonnet-4-6",

--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -210,7 +210,7 @@ fn build_input_items(messages: &[Message]) -> Result<Vec<Value>> {
 }
 
 fn configured_reasoning_effort(model_name: &str, config: &crate::config::Config) -> Option<String> {
-    let effort = String::from(config.get_chatgpt_codex_reasoning_effort().ok()?);
+    let effort = config.get_chatgpt_codex_reasoning_effort().ok()?;
     let valid_levels = reasoning_levels_for_model(model_name);
 
     if valid_levels.contains(&effort.as_str()) {

--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -209,32 +209,34 @@ fn build_input_items(messages: &[Message]) -> Result<Vec<Value>> {
     Ok(items)
 }
 
-fn get_reasoning_effort(model_name: &str) -> String {
-    let config = crate::config::Config::global();
-    let effort = config
-        .get_chatgpt_codex_reasoning_effort()
-        .map(String::from)
-        .unwrap_or_else(|_| "medium".to_string());
-
+fn configured_reasoning_effort(model_name: &str, config: &crate::config::Config) -> Option<String> {
+    let effort = String::from(config.get_chatgpt_codex_reasoning_effort().ok()?);
     let valid_levels = reasoning_levels_for_model(model_name);
+
     if valid_levels.contains(&effort.as_str()) {
-        effort
+        Some(effort)
     } else {
         tracing::warn!(
-            "Invalid CHATGPT_CODEX_REASONING_EFFORT '{}' for model '{}', using 'medium'",
+            "Invalid CHATGPT_CODEX_REASONING_EFFORT '{}' for model '{}', omitting reasoning effort",
             effort,
             model_name
         );
-        "medium".to_string()
+        None
     }
 }
 
 fn reasoning_effort_for_config(model_config: &ModelConfig) -> Option<String> {
+    reasoning_effort_for_config_with_config(model_config, crate::config::Config::global())
+}
+
+fn reasoning_effort_for_config_with_config(
+    model_config: &ModelConfig,
+    config: &crate::config::Config,
+) -> Option<String> {
     use crate::model::ThinkingEffort;
 
-    model_config
-        .thinking_effort()
-        .map(|effort| {
+    match model_config.thinking_effort() {
+        Some(effort) => {
             let valid_levels = reasoning_levels_for_model(&model_config.model_name);
             let preferred_levels: &[&str] = match effort {
                 ThinkingEffort::Off => return None,
@@ -248,8 +250,9 @@ fn reasoning_effort_for_config(model_config: &ModelConfig) -> Option<String> {
                 .iter()
                 .find(|level| valid_levels.contains(level))
                 .map(|level| (*level).to_string())
-        })
-        .unwrap_or_else(|| Some(get_reasoning_effort(&model_config.model_name)))
+        }
+        None => configured_reasoning_effort(&model_config.model_name, config),
+    }
 }
 
 fn create_codex_request(
@@ -1240,6 +1243,21 @@ mod tests {
         let payload = create_codex_request(&config, "sys", &[], &[]).unwrap();
         assert!(payload.get("reasoning").is_none());
         assert!(payload.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn test_create_codex_request_omits_reasoning_when_effort_unset() {
+        let _guard = env_lock::lock_env([
+            ("GOOSE_THINKING_EFFORT", None::<&str>),
+            ("CHATGPT_CODEX_REASONING_EFFORT", None::<&str>),
+        ]);
+        let config_file = tempfile::NamedTempFile::new().unwrap();
+        let secrets_file = tempfile::NamedTempFile::new().unwrap();
+        let empty_config =
+            crate::config::Config::new_with_file_secrets(config_file.path(), secrets_file.path())
+                .unwrap();
+
+        assert!(configured_reasoning_effort("gpt-5.2-codex", &empty_config).is_none());
     }
 
     #[test_case(

--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -243,6 +243,7 @@ fn reasoning_effort_for_config_with_config(
                 ThinkingEffort::Low => &["low", "medium", "high", "xhigh"],
                 ThinkingEffort::Medium => &["medium", "high", "low", "xhigh"],
                 ThinkingEffort::High => &["high", "medium", "xhigh", "low"],
+                ThinkingEffort::XHigh => &["xhigh", "high", "medium", "low"],
                 ThinkingEffort::Max => &["xhigh", "high", "medium", "low"],
             };
 

--- a/crates/goose/src/providers/codex.rs
+++ b/crates/goose/src/providers/codex.rs
@@ -79,10 +79,7 @@ impl CodexProvider {
         effort: Option<crate::model::ThinkingEffort>,
     ) -> Option<String> {
         use crate::model::ThinkingEffort;
-        match effort
-            .or_else(Self::legacy_reasoning_effort)
-            .unwrap_or(ThinkingEffort::High)
-        {
+        match effort.or_else(Self::legacy_reasoning_effort)? {
             ThinkingEffort::Off => Some("none".to_string()),
             ThinkingEffort::Low => Some("low".to_string()),
             ThinkingEffort::Medium => Some("medium".to_string()),
@@ -1259,7 +1256,7 @@ mod tests {
         );
         assert_eq!(
             CodexProvider::map_thinking_effort("gpt-5.2-codex", None),
-            Some("high".to_string())
+            None
         );
     }
 

--- a/crates/goose/src/providers/codex.rs
+++ b/crates/goose/src/providers/codex.rs
@@ -69,7 +69,7 @@ impl CodexProvider {
                 "low" => Some(crate::model::ThinkingEffort::Low),
                 "medium" => Some(crate::model::ThinkingEffort::Medium),
                 "high" => Some(crate::model::ThinkingEffort::High),
-                "xhigh" => Some(crate::model::ThinkingEffort::Max),
+                "xhigh" => Some(crate::model::ThinkingEffort::XHigh),
                 _ => None,
             })
     }
@@ -84,6 +84,7 @@ impl CodexProvider {
             ThinkingEffort::Low => Some("low".to_string()),
             ThinkingEffort::Medium => Some("medium".to_string()),
             ThinkingEffort::High => Some("high".to_string()),
+            ThinkingEffort::XHigh => Some("xhigh".to_string()),
             ThinkingEffort::Max => Some("xhigh".to_string()),
         }
     }

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -583,15 +583,24 @@ fn apply_thinking_config(
 
     if options.preserve_thinking_context {
         if !obj.contains_key("thinking") {
-            let budget_tokens = thinking_budget_tokens(model_config);
-            obj.insert("max_tokens".to_string(), json!(max_tokens + budget_tokens));
-            obj.insert(
-                "thinking".to_string(),
-                json!({
-                    "type": "enabled",
-                    "budget_tokens": budget_tokens
-                }),
-            );
+            if supports_adaptive_thinking(&model_config.model_name) {
+                obj.insert(
+                    "thinking".to_string(),
+                    json!({"type": "adaptive", "display": "summarized"}),
+                );
+                let effort = adaptive_effort_value(model_config);
+                obj.insert("output_config".to_string(), json!({"effort": effort}));
+            } else {
+                let budget_tokens = thinking_budget_tokens(model_config);
+                obj.insert("max_tokens".to_string(), json!(max_tokens + budget_tokens));
+                obj.insert(
+                    "thinking".to_string(),
+                    json!({
+                        "type": "enabled",
+                        "budget_tokens": budget_tokens
+                    }),
+                );
+            }
         }
 
         if let Some(thinking) = obj.get_mut("thinking").and_then(|t| t.as_object_mut()) {
@@ -1356,6 +1365,47 @@ mod tests {
         assert_eq!(payload["thinking"]["clear_thinking"], false);
         assert_eq!(payload["messages"][0]["content"][0]["type"], "thinking");
         assert_eq!(payload["messages"][0]["content"][0]["thinking"], "internal");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_request_preserves_thinking_context_with_opus_47_adaptive() -> Result<()> {
+        let _guard = env_lock::lock_env([
+            ("GOOSE_THINKING_EFFORT", None::<&str>),
+            ("CLAUDE_THINKING_TYPE", None::<&str>),
+            ("CLAUDE_THINKING_ENABLED", None::<&str>),
+            ("ANTHROPIC_THINKING_BUDGET", None::<&str>),
+            ("CLAUDE_THINKING_BUDGET", None::<&str>),
+            ("ANTHROPIC_PRESERVE_THINKING_CONTEXT", None::<&str>),
+            ("ANTHROPIC_PRESERVE_UNSIGNED_THINKING", None::<&str>),
+        ]);
+
+        let mut config = cfg_with_effort("claude-opus-4-7", "max");
+        config.max_tokens = Some(4096);
+        let messages = vec![
+            Message::assistant().with_content(MessageContent::thinking("internal", "")),
+            Message::user().with_text("Continue"),
+        ];
+
+        let payload = create_request_with_options(
+            &config,
+            "system",
+            &messages,
+            &[],
+            AnthropicFormatOptions {
+                preserve_unsigned_thinking: true,
+                preserve_thinking_context: true,
+            },
+        )?;
+
+        assert_eq!(payload["thinking"]["type"], "adaptive");
+        assert_eq!(payload["thinking"]["display"], "summarized");
+        assert_eq!(payload["thinking"]["clear_thinking"], false);
+        assert_eq!(payload["output_config"]["effort"], "xhigh");
+        assert!(payload["thinking"].get("budget_tokens").is_none());
+        assert_eq!(payload["max_tokens"], 4096);
+        assert_eq!(payload["messages"][0]["content"][0]["type"], "thinking");
 
         Ok(())
     }

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -504,13 +504,12 @@ pub fn thinking_effort(model_config: &ModelConfig) -> ThinkingEffort {
 }
 
 fn adaptive_effort_value(model_config: &ModelConfig) -> &'static str {
-    match thinking_effort(model_config) {
-        ThinkingEffort::Off => "high",
-        ThinkingEffort::Low => "low",
-        ThinkingEffort::Medium => "medium",
-        ThinkingEffort::High => "high",
-        ThinkingEffort::Max if is_claude_opus_47(&model_config.model_name) => "xhigh",
-        ThinkingEffort::Max => "max",
+    match model_config.thinking_effort() {
+        Some(ThinkingEffort::Low) => "low",
+        Some(ThinkingEffort::Medium) => "medium",
+        Some(ThinkingEffort::Max) if is_claude_opus_47(&model_config.model_name) => "xhigh",
+        Some(ThinkingEffort::Max) => "max",
+        Some(ThinkingEffort::Off | ThinkingEffort::High) | None => "high",
     }
 }
 
@@ -1240,6 +1239,43 @@ mod tests {
         assert_eq!(payload["thinking"]["type"], "adaptive");
         assert_eq!(payload["thinking"]["display"], "summarized");
         assert_eq!(payload["output_config"]["effort"], "xhigh");
+        assert_eq!(payload["max_tokens"], 4096);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_request_preserved_opus_47_context_defaults_to_high_effort() -> Result<()> {
+        let _guard = env_lock::lock_env([
+            ("GOOSE_THINKING_EFFORT", None::<&str>),
+            ("CLAUDE_THINKING_TYPE", None::<&str>),
+            ("CLAUDE_THINKING_ENABLED", None::<&str>),
+            ("ANTHROPIC_THINKING_BUDGET", None::<&str>),
+            ("CLAUDE_THINKING_BUDGET", None::<&str>),
+            ("ANTHROPIC_PRESERVE_THINKING_CONTEXT", None::<&str>),
+            ("ANTHROPIC_PRESERVE_UNSIGNED_THINKING", None::<&str>),
+        ]);
+
+        let mut config = cfg("claude-opus-4-7");
+        config.max_tokens = Some(4096);
+        let messages = vec![
+            Message::assistant().with_content(MessageContent::thinking("internal", "")),
+            Message::user().with_text("Continue"),
+        ];
+
+        let payload = create_request_with_options(
+            &config,
+            "system",
+            &messages,
+            &[],
+            AnthropicFormatOptions {
+                preserve_unsigned_thinking: true,
+                preserve_thinking_context: true,
+            },
+        )?;
+
+        assert_eq!(payload["thinking"]["type"], "adaptive");
+        assert_eq!(payload["output_config"]["effort"], "high");
         assert_eq!(payload["max_tokens"], 4096);
 
         Ok(())

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -503,13 +503,21 @@ pub fn thinking_effort(model_config: &ModelConfig) -> ThinkingEffort {
         .unwrap_or(ThinkingEffort::High)
 }
 
-fn adaptive_effort_value(model_config: &ModelConfig) -> &'static str {
-    match model_config.thinking_effort() {
-        Some(ThinkingEffort::Low) => "low",
-        Some(ThinkingEffort::Medium) => "medium",
-        Some(ThinkingEffort::Max) if is_claude_opus_47(&model_config.model_name) => "xhigh",
-        Some(ThinkingEffort::Max) => "max",
-        Some(ThinkingEffort::Off | ThinkingEffort::High) | None => "high",
+pub fn adaptive_effort_value(model_config: &ModelConfig) -> Option<&'static str> {
+    adaptive_effort_value_for_model(&model_config.model_name, model_config.thinking_effort())
+}
+
+fn adaptive_effort_value_for_model(
+    model_name: &str,
+    effort: Option<ThinkingEffort>,
+) -> Option<&'static str> {
+    match effort? {
+        ThinkingEffort::Off => None,
+        ThinkingEffort::Low => Some("low"),
+        ThinkingEffort::Medium => Some("medium"),
+        ThinkingEffort::High => Some("high"),
+        ThinkingEffort::Max if is_claude_opus_47(model_name) => Some("xhigh"),
+        ThinkingEffort::Max => Some("max"),
     }
 }
 
@@ -562,8 +570,9 @@ fn apply_thinking_config(
                 "thinking".to_string(),
                 json!({"type": "adaptive", "display": "summarized"}),
             );
-            let effort = adaptive_effort_value(model_config);
-            obj.insert("output_config".to_string(), json!({"effort": effort}));
+            if let Some(effort) = adaptive_effort_value(model_config) {
+                obj.insert("output_config".to_string(), json!({"effort": effort}));
+            }
         }
         ThinkingType::Enabled => {
             let budget_tokens = thinking_budget_tokens(model_config);
@@ -587,8 +596,9 @@ fn apply_thinking_config(
                     "thinking".to_string(),
                     json!({"type": "adaptive", "display": "summarized"}),
                 );
-                let effort = adaptive_effort_value(model_config);
-                obj.insert("output_config".to_string(), json!({"effort": effort}));
+                if let Some(effort) = adaptive_effort_value(model_config) {
+                    obj.insert("output_config".to_string(), json!({"effort": effort}));
+                }
             } else {
                 let budget_tokens = thinking_budget_tokens(model_config);
                 obj.insert("max_tokens".to_string(), json!(max_tokens + budget_tokens));
@@ -1245,40 +1255,11 @@ mod tests {
     }
 
     #[test]
-    fn test_create_request_preserved_opus_47_context_defaults_to_high_effort() -> Result<()> {
-        let _guard = env_lock::lock_env([
-            ("GOOSE_THINKING_EFFORT", None::<&str>),
-            ("CLAUDE_THINKING_TYPE", None::<&str>),
-            ("CLAUDE_THINKING_ENABLED", None::<&str>),
-            ("ANTHROPIC_THINKING_BUDGET", None::<&str>),
-            ("CLAUDE_THINKING_BUDGET", None::<&str>),
-            ("ANTHROPIC_PRESERVE_THINKING_CONTEXT", None::<&str>),
-            ("ANTHROPIC_PRESERVE_UNSIGNED_THINKING", None::<&str>),
-        ]);
-
-        let mut config = cfg("claude-opus-4-7");
-        config.max_tokens = Some(4096);
-        let messages = vec![
-            Message::assistant().with_content(MessageContent::thinking("internal", "")),
-            Message::user().with_text("Continue"),
-        ];
-
-        let payload = create_request_with_options(
-            &config,
-            "system",
-            &messages,
-            &[],
-            AnthropicFormatOptions {
-                preserve_unsigned_thinking: true,
-                preserve_thinking_context: true,
-            },
-        )?;
-
-        assert_eq!(payload["thinking"]["type"], "adaptive");
-        assert_eq!(payload["output_config"]["effort"], "high");
-        assert_eq!(payload["max_tokens"], 4096);
-
-        Ok(())
+    fn test_adaptive_effort_omits_unset_default() {
+        assert_eq!(
+            adaptive_effort_value_for_model("claude-opus-4-7", None),
+            None
+        );
     }
 
     #[test]

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -118,6 +118,7 @@ const IS_ERROR_FIELD: &str = "is_error";
 const SIGNATURE_FIELD: &str = "signature";
 const DATA_FIELD: &str = "data";
 const EVENT_MESSAGE_START: &str = "message_start";
+const DEFAULT_PRESERVED_THINKING_BUDGET_TOKENS: i32 = 16000;
 const EVENT_MESSAGE_DELTA: &str = "message_delta";
 const EVENT_MESSAGE_STOP: &str = "message_stop";
 const EVENT_CONTENT_BLOCK_START: &str = "content_block_start";
@@ -523,6 +524,20 @@ pub fn thinking_budget_tokens(model_config: &ModelConfig) -> Option<i32> {
     thinking_budget_tokens_for_effort(model_config, model_config.thinking_effort())
 }
 
+fn preserved_thinking_budget_tokens(model_config: &ModelConfig) -> i32 {
+    let request_budget = model_config
+        .request_params
+        .as_ref()
+        .and_then(|params| params.get("budget_tokens"))
+        .and_then(|v| serde_json::from_value::<i32>(v.clone()).ok());
+
+    preserved_thinking_budget_tokens_for_values(
+        request_budget,
+        legacy_thinking_budget_tokens(),
+        model_config.thinking_effort(),
+    )
+}
+
 fn thinking_budget_tokens_for_effort(
     model_config: &ModelConfig,
     effort: Option<ThinkingEffort>,
@@ -556,6 +571,15 @@ fn thinking_budget_tokens_for_values(
         ThinkingEffort::High => 16000,
         ThinkingEffort::Max => 32000,
     })
+}
+
+fn preserved_thinking_budget_tokens_for_values(
+    request_budget: Option<i32>,
+    legacy_budget: Option<i32>,
+    effort: Option<ThinkingEffort>,
+) -> i32 {
+    thinking_budget_tokens_for_values(request_budget, legacy_budget, effort)
+        .unwrap_or(DEFAULT_PRESERVED_THINKING_BUDGET_TOKENS)
 }
 
 fn legacy_thinking_budget_tokens() -> Option<i32> {
@@ -611,16 +635,15 @@ fn apply_thinking_config(
                     obj.insert("output_config".to_string(), json!({"effort": effort}));
                 }
             } else {
-                if let Some(budget_tokens) = thinking_budget_tokens(model_config) {
-                    obj.insert("max_tokens".to_string(), json!(max_tokens + budget_tokens));
-                    obj.insert(
-                        "thinking".to_string(),
-                        json!({
-                            "type": "enabled",
-                            "budget_tokens": budget_tokens
-                        }),
-                    );
-                }
+                let budget_tokens = preserved_thinking_budget_tokens(model_config);
+                obj.insert("max_tokens".to_string(), json!(max_tokens + budget_tokens));
+                obj.insert(
+                    "thinking".to_string(),
+                    json!({
+                        "type": "enabled",
+                        "budget_tokens": budget_tokens
+                    }),
+                );
             }
         }
 
@@ -1327,7 +1350,8 @@ mod tests {
     }
 
     #[test]
-    fn test_create_request_preserves_thinking_context_for_compatible_models() -> Result<()> {
+    fn test_create_request_preserves_thinking_context_without_effort_for_compatible_models(
+    ) -> Result<()> {
         let _guard = env_lock::lock_env([
             ("GOOSE_THINKING_EFFORT", None::<&str>),
             ("CLAUDE_THINKING_TYPE", None::<&str>),
@@ -1338,7 +1362,7 @@ mod tests {
             ("ANTHROPIC_PRESERVE_UNSIGNED_THINKING", None::<&str>),
         ]);
 
-        let mut config = cfg_with_effort("glm-4.7", "high");
+        let mut config = cfg("glm-4.7");
         config.max_tokens = Some(4096);
         let messages = vec![
             Message::assistant().with_content(MessageContent::thinking("internal", "")),
@@ -1372,6 +1396,14 @@ mod tests {
     #[test]
     fn test_thinking_budget_omits_unset_default() {
         assert_eq!(thinking_budget_tokens_for_values(None, None, None), None);
+    }
+
+    #[test]
+    fn test_preserved_thinking_context_uses_budget_when_effort_unset() {
+        assert_eq!(
+            preserved_thinking_budget_tokens_for_values(None, None, None),
+            DEFAULT_PRESERVED_THINKING_BUDGET_TOKENS
+        );
     }
 
     #[test]

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -507,7 +507,7 @@ pub fn adaptive_effort_value(model_config: &ModelConfig) -> Option<&'static str>
 }
 
 fn adaptive_effort_value_for_model(
-    model_name: &str,
+    _model_name: &str,
     effort: Option<ThinkingEffort>,
 ) -> Option<&'static str> {
     match effort? {
@@ -515,7 +515,7 @@ fn adaptive_effort_value_for_model(
         ThinkingEffort::Low => Some("low"),
         ThinkingEffort::Medium => Some("medium"),
         ThinkingEffort::High => Some("high"),
-        ThinkingEffort::Max if is_claude_opus_47(model_name) => Some("xhigh"),
+        ThinkingEffort::XHigh => Some("xhigh"),
         ThinkingEffort::Max => Some("max"),
     }
 }
@@ -569,6 +569,7 @@ fn thinking_budget_tokens_for_values(
         ThinkingEffort::Low => 4000,
         ThinkingEffort::Medium => 10000,
         ThinkingEffort::High => 16000,
+        ThinkingEffort::XHigh => 24000,
         ThinkingEffort::Max => 32000,
     })
 }
@@ -1283,6 +1284,23 @@ mod tests {
 
         assert_eq!(payload["thinking"]["type"], "adaptive");
         assert_eq!(payload["thinking"]["display"], "summarized");
+        assert_eq!(payload["output_config"]["effort"], "max");
+        assert_eq!(payload["max_tokens"], 4096);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_request_adaptive_thinking_for_opus_47_xhigh_effort() -> Result<()> {
+        let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
+
+        let mut config = cfg_with_effort("claude-opus-4-7", "xhigh");
+        config.max_tokens = Some(4096);
+        let messages = vec![Message::user().with_text("Hello")];
+        let payload = create_request(&config, "system", &messages, &[])?;
+
+        assert_eq!(payload["thinking"]["type"], "adaptive");
+        assert_eq!(payload["thinking"]["display"], "summarized");
         assert_eq!(payload["output_config"]["effort"], "xhigh");
         assert_eq!(payload["max_tokens"], 4096);
 
@@ -1470,7 +1488,7 @@ mod tests {
         assert_eq!(payload["thinking"]["type"], "adaptive");
         assert_eq!(payload["thinking"]["display"], "summarized");
         assert_eq!(payload["thinking"]["clear_thinking"], false);
-        assert_eq!(payload["output_config"]["effort"], "xhigh");
+        assert_eq!(payload["output_config"]["effort"], "max");
         assert!(payload["thinking"].get("budget_tokens").is_none());
         assert_eq!(payload["max_tokens"], 4096);
         assert_eq!(payload["messages"][0]["content"][0]["type"], "thinking");

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -69,7 +69,13 @@ impl AnthropicFormatOptions {
 
 pub fn supports_adaptive_thinking(model_name: &str) -> bool {
     let lower = model_name.to_lowercase();
-    lower.contains("claude-opus-4-6") || lower.contains("claude-sonnet-4-6")
+    lower.contains("claude-opus-4-7")
+        || lower.contains("claude-opus-4-6")
+        || lower.contains("claude-sonnet-4-6")
+}
+
+fn is_claude_opus_47(model_name: &str) -> bool {
+    model_name.to_lowercase().contains("claude-opus-4-7")
 }
 
 pub fn thinking_type(model_config: &ModelConfig) -> ThinkingType {
@@ -497,6 +503,17 @@ pub fn thinking_effort(model_config: &ModelConfig) -> ThinkingEffort {
         .unwrap_or(ThinkingEffort::High)
 }
 
+fn adaptive_effort_value(model_config: &ModelConfig) -> &'static str {
+    match thinking_effort(model_config) {
+        ThinkingEffort::Off => "high",
+        ThinkingEffort::Low => "low",
+        ThinkingEffort::Medium => "medium",
+        ThinkingEffort::High => "high",
+        ThinkingEffort::Max if is_claude_opus_47(&model_config.model_name) => "xhigh",
+        ThinkingEffort::Max => "max",
+    }
+}
+
 pub fn thinking_budget_tokens(model_config: &ModelConfig) -> i32 {
     if let Some(request_param) = model_config
         .request_params
@@ -542,8 +559,11 @@ fn apply_thinking_config(
     let obj = payload.as_object_mut().unwrap();
     match thinking_type(model_config) {
         ThinkingType::Adaptive => {
-            obj.insert("thinking".to_string(), json!({"type": "adaptive"}));
-            let effort = thinking_effort(model_config).to_string();
+            obj.insert(
+                "thinking".to_string(),
+                json!({"type": "adaptive", "display": "summarized"}),
+            );
+            let effort = adaptive_effort_value(model_config);
             obj.insert("output_config".to_string(), json!({"effort": effort}));
         }
         ThinkingType::Enabled => {
@@ -634,10 +654,17 @@ pub fn create_request_with_options(
     }
 
     if let Some(temp) = model_config.temperature {
-        payload
-            .as_object_mut()
-            .unwrap()
-            .insert("temperature".to_string(), json!(temp));
+        if is_claude_opus_47(&model_config.model_name) {
+            tracing::warn!(
+                "Temperature is not supported for {}, omitting configured temperature",
+                model_config.model_name
+            );
+        } else {
+            payload
+                .as_object_mut()
+                .unwrap()
+                .insert("temperature".to_string(), json!(temp));
+        }
     }
 
     apply_thinking_config(&mut payload, model_config, max_tokens, options);
@@ -1185,8 +1212,40 @@ mod tests {
         let payload = create_request(&config, "system", &messages, &[])?;
 
         assert_eq!(payload["thinking"]["type"], "adaptive");
+        assert_eq!(payload["thinking"]["display"], "summarized");
         assert_eq!(payload["output_config"]["effort"], "high");
         assert!(payload.get("budget_tokens").is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_request_adaptive_thinking_for_opus_47_max_effort() -> Result<()> {
+        let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
+
+        let mut config = cfg_with_effort("claude-opus-4-7", "max");
+        config.max_tokens = Some(4096);
+        let messages = vec![Message::user().with_text("Hello")];
+        let payload = create_request(&config, "system", &messages, &[])?;
+
+        assert_eq!(payload["thinking"]["type"], "adaptive");
+        assert_eq!(payload["thinking"]["display"], "summarized");
+        assert_eq!(payload["output_config"]["effort"], "xhigh");
+        assert_eq!(payload["max_tokens"], 4096);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_request_omits_temperature_for_opus_47() -> Result<()> {
+        let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
+
+        let mut config = cfg("claude-opus-4-7");
+        config.temperature = Some(0.2);
+        let messages = vec![Message::user().with_text("Hello")];
+        let payload = create_request(&config, "system", &messages, &[])?;
+
+        assert!(payload.get("temperature").is_none());
 
         Ok(())
     }
@@ -1449,6 +1508,10 @@ mod tests {
         // Adaptive model with effort → adaptive
         assert_eq!(
             thinking_type(&cfg_with_effort("claude-opus-4-6", "high")),
+            ThinkingType::Adaptive
+        );
+        assert_eq!(
+            thinking_type(&cfg_with_effort("claude-opus-4-7", "max")),
             ThinkingType::Adaptive
         );
         // Adaptive model with off → disabled

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -507,7 +507,7 @@ pub fn adaptive_effort_value(model_config: &ModelConfig) -> Option<&'static str>
 }
 
 fn adaptive_effort_value_for_model(
-    _model_name: &str,
+    model_name: &str,
     effort: Option<ThinkingEffort>,
 ) -> Option<&'static str> {
     match effort? {
@@ -515,7 +515,8 @@ fn adaptive_effort_value_for_model(
         ThinkingEffort::Low => Some("low"),
         ThinkingEffort::Medium => Some("medium"),
         ThinkingEffort::High => Some("high"),
-        ThinkingEffort::XHigh => Some("xhigh"),
+        ThinkingEffort::XHigh if is_claude_opus_47(model_name) => Some("xhigh"),
+        ThinkingEffort::XHigh => Some("high"),
         ThinkingEffort::Max => Some("max"),
     }
 }
@@ -1302,6 +1303,23 @@ mod tests {
         assert_eq!(payload["thinking"]["type"], "adaptive");
         assert_eq!(payload["thinking"]["display"], "summarized");
         assert_eq!(payload["output_config"]["effort"], "xhigh");
+        assert_eq!(payload["max_tokens"], 4096);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_request_adaptive_thinking_for_46_xhigh_effort_downgrades() -> Result<()> {
+        let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
+
+        let mut config = cfg_with_effort("claude-sonnet-4-6", "xhigh");
+        config.max_tokens = Some(4096);
+        let messages = vec![Message::user().with_text("Hello")];
+        let payload = create_request(&config, "system", &messages, &[])?;
+
+        assert_eq!(payload["thinking"]["type"], "adaptive");
+        assert_eq!(payload["thinking"]["display"], "summarized");
+        assert_eq!(payload["output_config"]["effort"], "high");
         assert_eq!(payload["max_tokens"], 4096);
 
         Ok(())

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -497,10 +497,8 @@ pub fn get_usage(data: &Value) -> Result<Usage> {
     }
 }
 
-pub fn thinking_effort(model_config: &ModelConfig) -> ThinkingEffort {
-    model_config
-        .thinking_effort()
-        .unwrap_or(ThinkingEffort::High)
+pub fn thinking_effort(model_config: &ModelConfig) -> Option<ThinkingEffort> {
+    model_config.thinking_effort()
 }
 
 pub fn adaptive_effort_value(model_config: &ModelConfig) -> Option<&'static str> {
@@ -521,30 +519,43 @@ fn adaptive_effort_value_for_model(
     }
 }
 
-pub fn thinking_budget_tokens(model_config: &ModelConfig) -> i32 {
-    if let Some(request_param) = model_config
+pub fn thinking_budget_tokens(model_config: &ModelConfig) -> Option<i32> {
+    thinking_budget_tokens_for_effort(model_config, model_config.thinking_effort())
+}
+
+fn thinking_budget_tokens_for_effort(
+    model_config: &ModelConfig,
+    effort: Option<ThinkingEffort>,
+) -> Option<i32> {
+    let request_budget = model_config
         .request_params
         .as_ref()
         .and_then(|params| params.get("budget_tokens"))
-        .and_then(|v| serde_json::from_value::<i32>(v.clone()).ok())
-    {
-        return request_param.max(1024);
+        .and_then(|v| serde_json::from_value::<i32>(v.clone()).ok());
+
+    thinking_budget_tokens_for_values(request_budget, legacy_thinking_budget_tokens(), effort)
+}
+
+fn thinking_budget_tokens_for_values(
+    request_budget: Option<i32>,
+    legacy_budget: Option<i32>,
+    effort: Option<ThinkingEffort>,
+) -> Option<i32> {
+    if let Some(request_budget) = request_budget {
+        return Some(request_budget.max(1024));
     }
 
-    if let Some(budget) = legacy_thinking_budget_tokens() {
-        return budget;
+    if let Some(legacy_budget) = legacy_budget {
+        return Some(legacy_budget);
     }
 
-    let effort = model_config
-        .thinking_effort()
-        .unwrap_or(ThinkingEffort::High);
-    match effort {
+    Some(match effort? {
         ThinkingEffort::Off => 1024,
         ThinkingEffort::Low => 4000,
         ThinkingEffort::Medium => 10000,
         ThinkingEffort::High => 16000,
         ThinkingEffort::Max => 32000,
-    }
+    })
 }
 
 fn legacy_thinking_budget_tokens() -> Option<i32> {
@@ -575,16 +586,16 @@ fn apply_thinking_config(
             }
         }
         ThinkingType::Enabled => {
-            let budget_tokens = thinking_budget_tokens(model_config);
-
-            obj.insert("max_tokens".to_string(), json!(max_tokens + budget_tokens));
-            obj.insert(
-                "thinking".to_string(),
-                json!({
-                    "type": "enabled",
-                    "budget_tokens": budget_tokens
-                }),
-            );
+            if let Some(budget_tokens) = thinking_budget_tokens(model_config) {
+                obj.insert("max_tokens".to_string(), json!(max_tokens + budget_tokens));
+                obj.insert(
+                    "thinking".to_string(),
+                    json!({
+                        "type": "enabled",
+                        "budget_tokens": budget_tokens
+                    }),
+                );
+            }
         }
         ThinkingType::Disabled => {}
     }
@@ -600,15 +611,16 @@ fn apply_thinking_config(
                     obj.insert("output_config".to_string(), json!({"effort": effort}));
                 }
             } else {
-                let budget_tokens = thinking_budget_tokens(model_config);
-                obj.insert("max_tokens".to_string(), json!(max_tokens + budget_tokens));
-                obj.insert(
-                    "thinking".to_string(),
-                    json!({
-                        "type": "enabled",
-                        "budget_tokens": budget_tokens
-                    }),
-                );
+                if let Some(budget_tokens) = thinking_budget_tokens(model_config) {
+                    obj.insert("max_tokens".to_string(), json!(max_tokens + budget_tokens));
+                    obj.insert(
+                        "thinking".to_string(),
+                        json!({
+                            "type": "enabled",
+                            "budget_tokens": budget_tokens
+                        }),
+                    );
+                }
             }
         }
 
@@ -1317,6 +1329,7 @@ mod tests {
     #[test]
     fn test_create_request_preserves_thinking_context_for_compatible_models() -> Result<()> {
         let _guard = env_lock::lock_env([
+            ("GOOSE_THINKING_EFFORT", None::<&str>),
             ("CLAUDE_THINKING_TYPE", None::<&str>),
             ("CLAUDE_THINKING_ENABLED", None::<&str>),
             ("ANTHROPIC_THINKING_BUDGET", None::<&str>),
@@ -1325,7 +1338,7 @@ mod tests {
             ("ANTHROPIC_PRESERVE_UNSIGNED_THINKING", None::<&str>),
         ]);
 
-        let mut config = cfg("glm-4.7");
+        let mut config = cfg_with_effort("glm-4.7", "high");
         config.max_tokens = Some(4096);
         let messages = vec![
             Message::assistant().with_content(MessageContent::thinking("internal", "")),
@@ -1357,6 +1370,11 @@ mod tests {
     }
 
     #[test]
+    fn test_thinking_budget_omits_unset_default() {
+        assert_eq!(thinking_budget_tokens_for_values(None, None, None), None);
+    }
+
+    #[test]
     fn test_create_request_model_params_enable_preserved_thinking_context() -> Result<()> {
         let _guard = env_lock::lock_env([
             ("CLAUDE_THINKING_TYPE", None::<&str>),
@@ -1369,6 +1387,7 @@ mod tests {
 
         let mut params = std::collections::HashMap::new();
         params.insert("preserve_thinking_context".to_string(), json!(true));
+        params.insert("thinking_effort".to_string(), json!("high"));
 
         let mut config = cfg("glm-4.7");
         config.request_params = Some(params);
@@ -1606,7 +1625,7 @@ mod tests {
             ("CLAUDE_THINKING_BUDGET", None::<&str>),
         ]);
         let config = cfg_with_effort("claude-3-7-sonnet-20250219", "high");
-        assert_eq!(thinking_budget_tokens(&config), 8192);
+        assert_eq!(thinking_budget_tokens(&config), Some(8192));
     }
 
     #[test]

--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -1,7 +1,7 @@
 use crate::conversation::message::{Message, MessageContent};
 use crate::model::ModelConfig;
 use crate::providers::formats::anthropic::{
-    thinking_budget_tokens, thinking_effort, thinking_type, ThinkingType,
+    adaptive_effort_value, thinking_budget_tokens, thinking_type, ThinkingType,
 };
 use crate::providers::utils::{
     convert_image, detect_image_path, extract_reasoning_effort, is_openai_responses_model,
@@ -237,10 +237,9 @@ fn apply_claude_thinking_config(payload: &mut Value, model_config: &ModelConfig)
     match thinking_type(model_config) {
         ThinkingType::Adaptive => {
             obj.insert("thinking".to_string(), json!({ "type": "adaptive" }));
-            obj.insert(
-                "output_config".to_string(),
-                json!({ "effort": thinking_effort(model_config).to_string() }),
-            );
+            if let Some(effort) = adaptive_effort_value(model_config) {
+                obj.insert("output_config".to_string(), json!({ "effort": effort }));
+            }
             obj.insert(
                 "max_completion_tokens".to_string(),
                 json!(model_config.max_output_tokens()),

--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -1114,19 +1114,12 @@ mod tests {
 
     #[test]
     fn test_create_request_reasoning_effort_xhigh() -> anyhow::Result<()> {
-        let model_config = ModelConfig {
-            model_name: "o3-xhigh".to_string(),
-            context_limit: Some(4096),
-            temperature: None,
-            max_tokens: Some(1024),
-            toolshim: false,
-            toolshim_model: None,
-            fast_model_config: None,
-            request_params: None,
-            reasoning: None,
-        };
+        let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
+
+        let mut model_config = ModelConfig::new_or_fail("gpt-5.4-xhigh");
+        model_config.max_tokens = Some(1024);
         let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
-        assert_eq!(request["model"], "o3");
+        assert_eq!(request["model"], "gpt-5.4");
         assert_eq!(request["reasoning_effort"], "xhigh");
         Ok(())
     }
@@ -1209,10 +1202,17 @@ mod tests {
 
     #[test]
     fn test_create_request_enabled_thinking_budget_tracks_effort() -> anyhow::Result<()> {
+        let _guard = env_lock::lock_env([
+            ("GOOSE_THINKING_EFFORT", None::<&str>),
+            ("ANTHROPIC_THINKING_BUDGET", None::<&str>),
+            ("CLAUDE_THINKING_BUDGET", None::<&str>),
+        ]);
+
         for (effort, expected_budget) in [
             ("low", 4000),
             ("medium", 10000),
             ("high", 16000),
+            ("xhigh", 24000),
             ("max", 32000),
         ] {
             let mut model_config = ModelConfig::new_or_fail("databricks-claude-3-7-sonnet");

--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -246,17 +246,18 @@ fn apply_claude_thinking_config(payload: &mut Value, model_config: &ModelConfig)
             );
         }
         ThinkingType::Enabled => {
-            let budget_tokens = thinking_budget_tokens(model_config);
-            let max_tokens = model_config.max_output_tokens() + budget_tokens;
-            obj.insert("max_tokens".to_string(), json!(max_tokens));
-            obj.insert(
-                "thinking".to_string(),
-                json!({
-                    "type": "enabled",
-                    "budget_tokens": budget_tokens
-                }),
-            );
-            obj.insert("temperature".to_string(), json!(2));
+            if let Some(budget_tokens) = thinking_budget_tokens(model_config) {
+                let max_tokens = model_config.max_output_tokens() + budget_tokens;
+                obj.insert("max_tokens".to_string(), json!(max_tokens));
+                obj.insert(
+                    "thinking".to_string(),
+                    json!({
+                        "type": "enabled",
+                        "budget_tokens": budget_tokens
+                    }),
+                );
+                obj.insert("temperature".to_string(), json!(2));
+            }
         }
         ThinkingType::Disabled => {
             if let Some(temp) = model_config.temperature {

--- a/crates/goose/src/providers/formats/google.rs
+++ b/crates/goose/src/providers/formats/google.rs
@@ -553,7 +553,9 @@ fn get_thinking_config(model_config: &ModelConfig) -> Option<ThinkingConfig> {
             ThinkingEffort::Off | ThinkingEffort::Low | ThinkingEffort::Medium => {
                 ThinkingLevel::Low
             }
-            ThinkingEffort::High | ThinkingEffort::Max => ThinkingLevel::High,
+            ThinkingEffort::High | ThinkingEffort::XHigh | ThinkingEffort::Max => {
+                ThinkingLevel::High
+            }
         };
 
         Some(ThinkingConfig {

--- a/crates/goose/src/providers/formats/openrouter.rs
+++ b/crates/goose/src/providers/formats/openrouter.rs
@@ -94,6 +94,7 @@ fn reasoning_effort_for_openrouter(effort: ThinkingEffort) -> &'static str {
         ThinkingEffort::Low => "low",
         ThinkingEffort::Medium => "medium",
         ThinkingEffort::High => "high",
+        ThinkingEffort::XHigh => "xhigh",
         ThinkingEffort::Max => "xhigh",
     }
 }

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -251,6 +251,7 @@ pub fn openai_reasoning_effort_for_thinking(
         ThinkingEffort::Low => &["low", "medium", "high", "xhigh"],
         ThinkingEffort::Medium => &["medium", "high", "low", "xhigh"],
         ThinkingEffort::High => &["high", "medium", "xhigh", "low"],
+        ThinkingEffort::XHigh => &["xhigh", "high", "medium", "low"],
         ThinkingEffort::Max => &["xhigh", "high", "medium", "low"],
     };
 

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -8676,6 +8676,7 @@
           "low",
           "medium",
           "high",
+          "xhigh",
           "max"
         ]
       },

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -1502,7 +1502,7 @@ export type ThinkingContent = {
     thinking: string;
 };
 
-export type ThinkingEffort = 'off' | 'low' | 'medium' | 'high' | 'max';
+export type ThinkingEffort = 'off' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 
 export type TokenState = {
     accumulatedCost?: number | null;

--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
@@ -413,12 +413,16 @@ export const SwitchModelModal = ({
       };
 
       if (showThinkingControl) {
-        const effort = thinkingEffort ?? modelObj.request_params?.thinking_effort ?? 'off';
-        modelObj = {
-          ...modelObj,
-          request_params: { ...modelObj.request_params, thinking_effort: effort },
-        };
-        upsert('GOOSE_THINKING_EFFORT', effort, false).catch(console.warn);
+        const effort = (thinkingEffort ?? modelObj.request_params?.thinking_effort) as
+          | ThinkingEffort
+          | undefined;
+        if (effort) {
+          modelObj = {
+            ...modelObj,
+            request_params: { ...modelObj.request_params, thinking_effort: effort },
+          };
+          upsert('GOOSE_THINKING_EFFORT', effort, false).catch(console.warn);
+        }
       }
 
       const success = await changeModel(sessionId, modelObj);
@@ -704,6 +708,9 @@ export const SwitchModelModal = ({
     }
   };
 
+  const selectedThinkingEffort =
+    thinkingEffort ?? (selectedPredefinedModel?.request_params?.thinking_effort as ThinkingEffort);
+
   const thinkingEffortControl = showThinkingControl && (
     <div className="mt-2">
       <label className="text-sm text-textSubtle mb-1 block">
@@ -711,10 +718,10 @@ export const SwitchModelModal = ({
       </label>
       <Select
         options={THINKING_EFFORT_OPTIONS}
-        value={THINKING_EFFORT_OPTIONS.find((o) => o.value === (thinkingEffort ?? 'off'))}
+        value={THINKING_EFFORT_OPTIONS.find((o) => o.value === selectedThinkingEffort) ?? null}
         onChange={(newValue: unknown) => {
           const option = newValue as { value: ThinkingEffort; label: string } | null;
-          setThinkingEffort(option?.value || 'off');
+          setThinkingEffort(option?.value ?? null);
         }}
         placeholder={intl.formatMessage(i18n.selectEffortLevel)}
       />

--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
@@ -53,6 +53,10 @@ const i18n = defineMessages({
     id: 'switchModelModal.claudeEffortHigh',
     defaultMessage: 'High - Deep reasoning (default)',
   },
+  claudeEffortXHigh: {
+    id: 'switchModelModal.claudeEffortXHigh',
+    defaultMessage: 'XHigh - Extended coding and agentic work',
+  },
   claudeEffortMax: {
     id: 'switchModelModal.claudeEffortMax',
     defaultMessage: 'Max - No constraints on thinking depth',
@@ -262,6 +266,7 @@ export const SwitchModelModal = ({
     { value: 'low', label: intl.formatMessage(i18n.claudeEffortLow) },
     { value: 'medium', label: intl.formatMessage(i18n.claudeEffortMedium) },
     { value: 'high', label: intl.formatMessage(i18n.claudeEffortHigh) },
+    { value: 'xhigh', label: intl.formatMessage(i18n.claudeEffortXHigh) },
     { value: 'max', label: intl.formatMessage(i18n.claudeEffortMax) },
   ];
 

--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
@@ -26,6 +26,8 @@ import { getPredefinedModelsFromEnv, shouldShowPredefinedModels } from '../prede
 import type { ProviderType, ThinkingEffort } from '../../../../api';
 import { trackModelChanged } from '../../../../utils/analytics';
 
+const DEFAULT_THINKING_EFFORT: ThinkingEffort = 'high';
+
 const i18n = defineMessages({
   thinkingEffortOff: {
     id: 'switchModelModal.thinkingEffortOff',
@@ -413,9 +415,9 @@ export const SwitchModelModal = ({
       };
 
       if (showThinkingControl) {
-        const effort = (thinkingEffort ?? modelObj.request_params?.thinking_effort) as
-          | ThinkingEffort
-          | undefined;
+        const effort = (thinkingEffort ??
+          modelObj.request_params?.thinking_effort ??
+          DEFAULT_THINKING_EFFORT) as ThinkingEffort;
         if (effort) {
           modelObj = {
             ...modelObj,
@@ -709,7 +711,9 @@ export const SwitchModelModal = ({
   };
 
   const selectedThinkingEffort =
-    thinkingEffort ?? (selectedPredefinedModel?.request_params?.thinking_effort as ThinkingEffort);
+    thinkingEffort ??
+    (selectedPredefinedModel?.request_params?.thinking_effort as ThinkingEffort | undefined) ??
+    DEFAULT_THINKING_EFFORT;
 
   const thinkingEffortControl = showThinkingControl && (
     <div className="mt-2">

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -4409,6 +4409,9 @@
   "switchModelModal.claudeEffortMedium": {
     "defaultMessage": "Medium - Moderate thinking"
   },
+  "switchModelModal.claudeEffortXHigh": {
+    "defaultMessage": "XHigh - Extended coding and agentic work"
+  },
   "switchModelModal.claudeEnabled": {
     "defaultMessage": "Enabled - Fixed token budget for thinking"
   },

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -4307,6 +4307,9 @@
   "switchModelModal.claudeEffortHigh": {
     "defaultMessage": "高 - 深度推理（默认）"
   },
+  "switchModelModal.claudeEffortXHigh": {
+    "defaultMessage": "超高 - 长程编码和代理任务"
+  },
   "switchModelModal.claudeEffortLow": {
     "defaultMessage": "低 - 最少思考，响应最快"
   },


### PR DESCRIPTION
## Summary
<!-- Describe your change -->

Claude Opus 4.7 has a few breaking changes with the Claude API: https://platform.claude.com/docs/en/about-claude/models/migration-guide

Currently, for Opus 4.7 with the Anthropic provider:
- the displayed extended thinking modes are "Enabled" (with a fixed token budget) or "Disabled" (no extended thinking); adaptive thinking is not displayed as an option
- if "Enabled" is selected, any messages fail with a 400 error, because Opus 4.7 doesn't support extended thinking
- xhigh is not an option for effort; this is an thinking effort level that only exists on Opus 4.7
- we don't emit `thinking.display = "summarized"`, which means we use default behavior which in Opus 4.7 was changed to be to not emit reasoning at all
- we pass temperature to the API call, which fails if it's set to any non-default value for Opus 4.7

This PR fixes this by:
- adding Opus 4.7 as a "known model" in the Anthropic provider
- adding `xhigh` as an effort level only for Opus 4.7, and making this the default for Opus 4.7 (this is the recommended default in the [Claude docs](https://platform.claude.com/docs/en/build-with-claude/effort#recommended-effort-levels-for-claude-opus-4-7))
- disabling "extended thinking" for Opus 4.7 in favor of adaptive thinking
- emitting `thinking.display = "summarized"` for all models with adaptive thinking (not technically needed for Sonnet 4.6 and Opus 4.6, but would rather be explicit there too)
- omitting temperature for Opus 4.7

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

There are some unit tests, but also tested this manually.

CLI ("adaptive" instead of "enabled" mode displayed, xhigh effort available):

https://github.com/user-attachments/assets/056a6d78-18d3-464d-a81f-40ab3cbd4fef

Desktop app:

https://github.com/user-attachments/assets/adb8dcc7-794a-4049-aa79-09c7bfad6f88

Summarized thinking being displayed with Opus 4.7:

<img width="2994" height="1090" alt="image" src="https://github.com/user-attachments/assets/b206608a-9718-484a-a269-19cd43c2cdf6" />

### Related Issues

N/A


### Screenshots/Demos (for UX changes)
Before: 

After:   