### PR TITLE
fix(ui): preserve pending env vars in Add Extension form

### DIFF
--- a/ui/desktop/src/components/settings/extensions/modal/EnvVarsSection.tsx
+++ b/ui/desktop/src/components/settings/extensions/modal/EnvVarsSection.tsx
@@ -42,7 +42,7 @@ interface EnvVarsSectionProps {
   onRemove: (index: number) => void;
   onChange: (index: number, field: 'key' | 'value', value: string) => void;
   submitAttempted: boolean;
-  onPendingInputChange?: (
+  onPendingInputChange: (
     hasPendingInput: boolean,
     pendingEnvVar: { key: string; value: string } | null
   ) => void;
@@ -70,7 +70,7 @@ export default function EnvVarsSection({
     const hasPendingInput = newKey.trim() !== '' || newValue.trim() !== '';
     const pendingEnvVar =
       newKey.trim() && newValue.trim() ? { key: newKey, value: newValue } : null;
-    onPendingInputChange?.(hasPendingInput, pendingEnvVar);
+    onPendingInputChange(hasPendingInput, pendingEnvVar);
   }, [newKey, newValue, onPendingInputChange]);
 
   const handleAdd = () => {

--- a/ui/desktop/src/components/settings/extensions/modal/EnvVarsSection.tsx
+++ b/ui/desktop/src/components/settings/extensions/modal/EnvVarsSection.tsx
@@ -42,7 +42,10 @@ interface EnvVarsSectionProps {
   onRemove: (index: number) => void;
   onChange: (index: number, field: 'key' | 'value', value: string) => void;
   submitAttempted: boolean;
-  onPendingInputChange?: (hasPendingInput: boolean) => void;
+  onPendingInputChange?: (
+    hasPendingInput: boolean,
+    pendingEnvVar: { key: string; value: string } | null
+  ) => void;
 }
 
 export default function EnvVarsSection({
@@ -65,7 +68,9 @@ export default function EnvVarsSection({
   // Notify parent when pending input changes
   React.useEffect(() => {
     const hasPendingInput = newKey.trim() !== '' || newValue.trim() !== '';
-    onPendingInputChange?.(hasPendingInput);
+    const pendingEnvVar =
+      newKey.trim() && newValue.trim() ? { key: newKey, value: newValue } : null;
+    onPendingInputChange?.(hasPendingInput, pendingEnvVar);
   }, [newKey, newValue, onPendingInputChange]);
 
   const handleAdd = () => {

--- a/ui/desktop/src/components/settings/extensions/modal/ExtensionModal.test.tsx
+++ b/ui/desktop/src/components/settings/extensions/modal/ExtensionModal.test.tsx
@@ -10,7 +10,7 @@ vi.mock('../../../../api', async () => {
   const actual = await vi.importActual<typeof import('../../../../api')>('../../../../api');
   return {
     ...actual,
-    upsertConfig: vi.fn().mockResolvedValue({ data: {} }),
+    upsertConfig: vi.fn().mockResolvedValue({ data: 'ok' }),
   };
 });
 
@@ -261,7 +261,12 @@ describe('ExtensionModal', () => {
   describe('pending env var capture (fix for #8969)', () => {
     beforeEach(() => {
       mockedUpsertConfig.mockClear();
-      mockedUpsertConfig.mockResolvedValue({ data: {} });
+      mockedUpsertConfig.mockResolvedValue({
+        data: 'ok',
+        error: undefined,
+        request: new globalThis.Request('http://localhost/test'),
+        response: new globalThis.Response(),
+      });
     });
 
     const emptyInitialData: ExtensionFormData = {

--- a/ui/desktop/src/components/settings/extensions/modal/ExtensionModal.test.tsx
+++ b/ui/desktop/src/components/settings/extensions/modal/ExtensionModal.test.tsx
@@ -1,9 +1,20 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, type RenderOptions, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ExtensionModal from './ExtensionModal';
 import { ExtensionFormData } from '../utils';
 import { IntlTestWrapper } from '../../../../i18n/test-utils';
+import { upsertConfig } from '../../../../api';
+
+vi.mock('../../../../api', async () => {
+  const actual = await vi.importActual<typeof import('../../../../api')>('../../../../api');
+  return {
+    ...actual,
+    upsertConfig: vi.fn().mockResolvedValue({ data: {} }),
+  };
+});
+
+const mockedUpsertConfig = vi.mocked(upsertConfig);
 
 const renderWithIntl = (ui: React.ReactElement, options?: RenderOptions) =>
   render(ui, { wrapper: IntlTestWrapper, ...options });
@@ -245,5 +256,136 @@ describe('ExtensionModal', () => {
     expect(submittedData.headers).toEqual([
       { key: 'Authorization', value: 'Bearer abc123', isEdited: true },
     ]);
+  });
+
+  describe('pending env var capture (fix for #8969)', () => {
+    beforeEach(() => {
+      mockedUpsertConfig.mockClear();
+      mockedUpsertConfig.mockResolvedValue({ data: {} });
+    });
+
+    const emptyInitialData: ExtensionFormData = {
+      name: '',
+      description: '',
+      type: 'stdio',
+      cmd: '',
+      endpoint: '',
+      enabled: true,
+      timeout: 300,
+      envVars: [],
+      headers: [],
+    };
+
+    // Returns the env-var key+value inputs (scoped to the "Environment Variables" section,
+    // disambiguated from the header inputs which share the "Value" placeholder).
+    function getEnvVarInputs() {
+      const envVarKeyInput = screen.getByPlaceholderText('Variable name');
+      const envVarValueInput = screen
+        .getAllByPlaceholderText('Value')
+        .find((input) =>
+          input.parentElement?.parentElement?.parentElement?.textContent?.includes(
+            'Environment Variables'
+          )
+        );
+      return { envVarKeyInput, envVarValueInput };
+    }
+
+    it('captures a pending env var typed but not "+ Added" when Submit is clicked', async () => {
+      const user = userEvent.setup();
+      const mockOnSubmit = vi.fn();
+      const mockOnClose = vi.fn();
+
+      renderWithIntl(
+        <ExtensionModal
+          title="Add custom extension"
+          initialData={emptyInitialData}
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+          submitLabel="Add Extension"
+          modalType="add"
+        />
+      );
+
+      await user.type(screen.getByPlaceholderText('Enter extension name...'), 'WooMCP');
+      await user.type(
+        screen.getByPlaceholderText(/^e\.g\. npx/),
+        'npx -y @automattic/mcp-wordpress-remote@latest'
+      );
+
+      const { envVarKeyInput, envVarValueInput } = getEnvVarInputs();
+      await user.type(envVarKeyInput, 'JWT_TOKEN');
+      if (envVarValueInput) {
+        await user.type(envVarValueInput, 'my_very_long_token');
+      }
+
+      // Note: intentionally NOT clicking the "+ Add" button — this is the #8969 repro.
+      await user.click(screen.getByTestId('extension-submit-btn'));
+
+      await waitFor(() => {
+        expect(mockOnSubmit).toHaveBeenCalled();
+      });
+
+      expect(mockedUpsertConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            is_secret: true,
+            key: 'JWT_TOKEN',
+            value: 'my_very_long_token',
+          }),
+        })
+      );
+
+      const submittedData = mockOnSubmit.mock.calls[0][0];
+      expect(submittedData.envVars).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            key: 'JWT_TOKEN',
+            value: 'my_very_long_token',
+            isEdited: true,
+          }),
+        ])
+      );
+    });
+
+    it('does not capture a pending env var when only the key is filled', async () => {
+      const user = userEvent.setup();
+      const mockOnSubmit = vi.fn();
+      const mockOnClose = vi.fn();
+
+      renderWithIntl(
+        <ExtensionModal
+          title="Add custom extension"
+          initialData={emptyInitialData}
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+          submitLabel="Add Extension"
+          modalType="add"
+        />
+      );
+
+      await user.type(screen.getByPlaceholderText('Enter extension name...'), 'WooMCP');
+      await user.type(screen.getByPlaceholderText(/^e\.g\. npx/), 'npx -y something');
+
+      const { envVarKeyInput } = getEnvVarInputs();
+      await user.type(envVarKeyInput, 'LONELY_KEY');
+      // Intentionally leaving the value field empty.
+
+      await user.click(screen.getByTestId('extension-submit-btn'));
+
+      await waitFor(() => {
+        expect(mockOnSubmit).toHaveBeenCalled();
+      });
+
+      expect(mockedUpsertConfig).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({ key: 'LONELY_KEY' }),
+        })
+      );
+
+      const submittedData = mockOnSubmit.mock.calls[0][0];
+      expect(submittedData.envVars).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ key: 'LONELY_KEY' })])
+      );
+    });
   });
 });

--- a/ui/desktop/src/components/settings/extensions/modal/ExtensionModal.tsx
+++ b/ui/desktop/src/components/settings/extensions/modal/ExtensionModal.tsx
@@ -83,6 +83,7 @@ export default function ExtensionModal({
   const [submitAttempted, setSubmitAttempted] = useState(false);
   const [showCloseConfirmation, setShowCloseConfirmation] = useState(false);
   const [hasPendingEnvVars, setHasPendingEnvVars] = useState(false);
+  const [pendingEnvVar, setPendingEnvVar] = useState<{ key: string; value: string } | null>(null);
   const [hasPendingHeaders, setHasPendingHeaders] = useState(false);
   const [pendingHeader, setPendingHeader] = useState<{ key: string; value: string } | null>(null);
 
@@ -232,6 +233,14 @@ export default function ExtensionModal({
     []
   );
 
+  const handlePendingEnvVarChange = useCallback(
+    (hasPending: boolean, envVar: { key: string; value: string } | null) => {
+      setHasPendingEnvVars(hasPending);
+      setPendingEnvVar(envVar);
+    },
+    []
+  );
+
   // Function to store a secret value
   const storeSecret = async (key: string, value: string) => {
     try {
@@ -289,6 +298,14 @@ export default function ExtensionModal({
     return finalHeaders;
   };
 
+  const getFinalEnvVars = () => {
+    const finalEnvVars = [...formData.envVars];
+    if (pendingEnvVar && pendingEnvVar.key.trim() !== '' && pendingEnvVar.value.trim() !== '') {
+      finalEnvVars.push({ ...pendingEnvVar, isEdited: true });
+    }
+    return finalEnvVars;
+  };
+
   const isHeadersValid = () => {
     return getFinalHeaders().every(
       ({ key, value }) => (key === '' && value === '') || (key !== '' && value !== '')
@@ -323,6 +340,7 @@ export default function ExtensionModal({
     if (isFormValid()) {
       const finalFormData = {
         ...formData,
+        envVars: getFinalEnvVars(),
         headers: getFinalHeaders(),
       };
 
@@ -437,7 +455,7 @@ export default function ExtensionModal({
                       onRemove={handleRemoveEnvVar}
                       onChange={handleEnvVarChange}
                       submitAttempted={submitAttempted}
-                      onPendingInputChange={setHasPendingEnvVars}
+                      onPendingInputChange={handlePendingEnvVarChange}
                     />
                   </div>
                 </>

--- a/ui/desktop/src/components/settings/extensions/modal/ExtensionModal.tsx
+++ b/ui/desktop/src/components/settings/extensions/modal/ExtensionModal.tsx
@@ -300,7 +300,12 @@ export default function ExtensionModal({
 
   const getFinalEnvVars = () => {
     const finalEnvVars = [...formData.envVars];
-    if (pendingEnvVar && pendingEnvVar.key.trim() !== '' && pendingEnvVar.value.trim() !== '') {
+    if (
+      pendingEnvVar &&
+      pendingEnvVar.key.trim() !== '' &&
+      pendingEnvVar.value.trim() !== '' &&
+      !pendingEnvVar.key.includes(' ')
+    ) {
       finalEnvVars.push({ ...pendingEnvVar, isEdited: true });
     }
     return finalEnvVars;


### PR DESCRIPTION
## Summary

When adding an MCP extension via the desktop UI, env vars typed into the empty input row at the bottom of the **Environment Variables** section are silently dropped if the user clicks Save without first clicking "+ Add". MCPs that need secrets (most of them — API tokens, JWTs, etc.) then fail at activation with:

> `Failed to add extension: invalid config: Failed to fetch secret 'KEY_NAME' from config: Configuration value not found: KEY_NAME`

This is an inconsistency with the sibling `HeadersSection`, which already handles this case correctly via `pendingHeader` + `getFinalHeaders()`. This PR mirrors the same pattern for env vars.

## Change

`EnvVarsSection.tsx` now passes the pending `{ key, value }` object alongside the boolean, the same way `HeadersSection.tsx` already does:

```diff
 React.useEffect(() => {
   const hasPendingInput = newKey.trim() !== '' || newValue.trim() !== '';
+  const pendingEnvVar =
+    newKey.trim() && newValue.trim() ? { key: newKey, value: newValue } : null;
-  onPendingInputChange?.(hasPendingInput);
+  onPendingInputChange?.(hasPendingInput, pendingEnvVar);
 }, [newKey, newValue, onPendingInputChange]);
```

`ExtensionModal.tsx` gets a matching `pendingEnvVar` state, a `handlePendingEnvVarChange` callback, and a `getFinalEnvVars()` helper (modeled on the existing `getFinalHeaders()`). `handleSubmit` now uses `getFinalEnvVars()` so the pending entry is included in both the `storeSecret` calls and the data passed to `onSubmit`.

Fixes #8969

## Test plan

- [x] Added regression test in `ExtensionModal.test.tsx`: typing `JWT_TOKEN` + `my_very_long_token` into the env-var row and clicking Submit **without "+ Add"** — verifies `upsertConfig({ is_secret: true, key, value })` is called and `onSubmit` receives the entry with `isEdited: true`. **This test fails on `main` and passes with this change.**
- [x] Added negative test: typing only a key (no value) does not trigger any `upsertConfig` call and does not appear in submitted data.
- [ ] Manual verification (recommended for reviewer):
  1. Run `just run-ui`
  2. Settings → Extensions → Add Extension
  3. Type a name, command, and a `JWT_TOKEN` + value in the env vars row — **do NOT click "+ Add"**
  4. Click Save
  5. **Expected (after fix):** extension activates successfully without "Configuration value not found"

## Follow-up (separate PR)

While investigating I noticed `EnvVarsSection.tsx:handleEdit` (lines 112-125) builds a local `newEnvVars` array but never sends it back to the parent — so clicking the edit (pencil) icon on an existing `••••••••` secret silently fails to mark it as edited. That's a related but distinct bug; I'll file a follow-up PR for it after this one lands.