### PR TITLE
feat(goose): honor GOOSE_FAST_MODEL env var in ModelConfig::with_fast

### DIFF
--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -292,8 +292,16 @@ impl ModelConfig {
         fast_model_name: &str,
         provider_name: &str,
     ) -> Result<Self, ConfigError> {
-        // Create a full ModelConfig for the fast model with proper canonical lookup
-        let fast_config = ModelConfig::new(fast_model_name)?.with_canonical_limits(provider_name);
+        // Allow a global override via GOOSE_FAST_MODEL. When set and non-empty
+        // it replaces the provider-supplied default — mirrors the GOOSE_MODEL
+        // pattern for the primary model and lets users pin auxiliary traffic
+        // (tool-selection, classification, session titles) to a chosen model.
+        let resolved = std::env::var("GOOSE_FAST_MODEL")
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| fast_model_name.to_string());
+        let fast_config = ModelConfig::new(&resolved)?.with_canonical_limits(provider_name);
         self.fast_model_config = Some(Box::new(fast_config));
         Ok(self)
     }
@@ -415,6 +423,39 @@ mod tests {
         ]);
         let config = ModelConfig::new("test-model").unwrap();
         assert_eq!(config.max_tokens, None);
+    }
+
+    #[test]
+    fn test_with_fast_uses_default_when_env_unset() {
+        let _guard = env_lock::lock_env([("GOOSE_FAST_MODEL", None::<&str>)]);
+        let cfg = ModelConfig::new("anthropic/claude-sonnet-4")
+            .unwrap()
+            .with_fast("google/gemini-2.5-flash", "openrouter")
+            .unwrap();
+        let fast = cfg.use_fast_model();
+        assert_eq!(fast.model_name, "google/gemini-2.5-flash");
+    }
+
+    #[test]
+    fn test_with_fast_honors_env_override() {
+        let _guard = env_lock::lock_env([("GOOSE_FAST_MODEL", Some("deepseek/deepseek-v4-flash"))]);
+        let cfg = ModelConfig::new("anthropic/claude-sonnet-4")
+            .unwrap()
+            .with_fast("google/gemini-2.5-flash", "openrouter")
+            .unwrap();
+        let fast = cfg.use_fast_model();
+        assert_eq!(fast.model_name, "deepseek/deepseek-v4-flash");
+    }
+
+    #[test]
+    fn test_with_fast_ignores_empty_env() {
+        let _guard = env_lock::lock_env([("GOOSE_FAST_MODEL", Some("   "))]);
+        let cfg = ModelConfig::new("anthropic/claude-sonnet-4")
+            .unwrap()
+            .with_fast("google/gemini-2.5-flash", "openrouter")
+            .unwrap();
+        let fast = cfg.use_fast_model();
+        assert_eq!(fast.model_name, "google/gemini-2.5-flash");
     }
 
     #[test]

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -292,16 +292,11 @@ impl ModelConfig {
         fast_model_name: &str,
         provider_name: &str,
     ) -> Result<Self, ConfigError> {
-        // Allow a global override via GOOSE_FAST_MODEL. When set and non-empty
-        // it replaces the provider-supplied default — mirrors the GOOSE_MODEL
-        // pattern for the primary model and lets users pin auxiliary traffic
-        // (tool-selection, classification, session titles) to a chosen model.
-        let resolved = std::env::var("GOOSE_FAST_MODEL")
+        let name = std::env::var("GOOSE_FAST_MODEL")
             .ok()
-            .map(|v| v.trim().to_string())
-            .filter(|v| !v.is_empty())
+            .filter(|v| !v.trim().is_empty())
             .unwrap_or_else(|| fast_model_name.to_string());
-        let fast_config = ModelConfig::new(&resolved)?.with_canonical_limits(provider_name);
+        let fast_config = ModelConfig::new(&name)?.with_canonical_limits(provider_name);
         self.fast_model_config = Some(Box::new(fast_config));
         Ok(self)
     }
@@ -423,39 +418,6 @@ mod tests {
         ]);
         let config = ModelConfig::new("test-model").unwrap();
         assert_eq!(config.max_tokens, None);
-    }
-
-    #[test]
-    fn test_with_fast_uses_default_when_env_unset() {
-        let _guard = env_lock::lock_env([("GOOSE_FAST_MODEL", None::<&str>)]);
-        let cfg = ModelConfig::new("anthropic/claude-sonnet-4")
-            .unwrap()
-            .with_fast("google/gemini-2.5-flash", "openrouter")
-            .unwrap();
-        let fast = cfg.use_fast_model();
-        assert_eq!(fast.model_name, "google/gemini-2.5-flash");
-    }
-
-    #[test]
-    fn test_with_fast_honors_env_override() {
-        let _guard = env_lock::lock_env([("GOOSE_FAST_MODEL", Some("deepseek/deepseek-v4-flash"))]);
-        let cfg = ModelConfig::new("anthropic/claude-sonnet-4")
-            .unwrap()
-            .with_fast("google/gemini-2.5-flash", "openrouter")
-            .unwrap();
-        let fast = cfg.use_fast_model();
-        assert_eq!(fast.model_name, "deepseek/deepseek-v4-flash");
-    }
-
-    #[test]
-    fn test_with_fast_ignores_empty_env() {
-        let _guard = env_lock::lock_env([("GOOSE_FAST_MODEL", Some("   "))]);
-        let cfg = ModelConfig::new("anthropic/claude-sonnet-4")
-            .unwrap()
-            .with_fast("google/gemini-2.5-flash", "openrouter")
-            .unwrap();
-        let fast = cfg.use_fast_model();
-        assert_eq!(fast.model_name, "google/gemini-2.5-flash");
     }
 
     #[test]

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -294,7 +294,8 @@ impl ModelConfig {
     ) -> Result<Self, ConfigError> {
         let name = std::env::var("GOOSE_FAST_MODEL")
             .ok()
-            .filter(|v| !v.trim().is_empty())
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
             .unwrap_or_else(|| fast_model_name.to_string());
         let fast_config = ModelConfig::new(&name)?.with_canonical_limits(provider_name);
         self.fast_model_config = Some(Box::new(fast_config));

--- a/documentation/docs/guides/environment-variables.md
+++ b/documentation/docs/guides/environment-variables.md
@@ -18,6 +18,7 @@ These are the minimum required variables to get started with goose.
 |----------|---------|---------|---------|
 | `GOOSE_PROVIDER` | Specifies the LLM provider to use | [See available providers](/docs/getting-started/providers#available-providers) | None (must be [configured](/docs/getting-started/providers#configure-provider-and-model)) |
 | `GOOSE_MODEL` | Specifies which model to use from the provider | Model name (e.g., "gpt-4", "claude-sonnet-4-20250514") | None (must be [configured](/docs/getting-started/providers#configure-provider-and-model)) |
+| `GOOSE_FAST_MODEL` | Overrides the provider's default fast model used for auxiliary calls (tool-selection, classification, session titles) | Model name (e.g., "gpt-4o-mini", "google/gemini-2.5-flash") | Provider-specific default |
 | `GOOSE_TEMPERATURE` | Sets the [temperature](https://medium.com/@kelseyywang/a-comprehensive-guide-to-llm-temperature-%EF%B8%8F-363a40bbc91f) for model responses | Float between 0.0 and 1.0 | Model-specific default |
 | `GOOSE_MAX_TOKENS` | Sets the maximum number of tokens for each model response (truncates longer responses) | Positive integer (e.g., 4096, 8192) | Model-specific default |
 
@@ -28,6 +29,9 @@ These are the minimum required variables to get started with goose.
 export GOOSE_PROVIDER="anthropic"
 export GOOSE_MODEL="claude-sonnet-4-5-20250929"
 export GOOSE_TEMPERATURE=0.7
+
+# Override the fast model used for auxiliary calls (tool-selection, classification, etc.)
+export GOOSE_FAST_MODEL="gpt-4o-mini"
 
 # Set a lower limit for shorter interactions
 export GOOSE_MAX_TOKENS=4096


### PR DESCRIPTION
Closes #9295.

## Summary

Adds `GOOSE_FAST_MODEL` env var, honored at the single call site inside `ModelConfig::with_fast` in `crates/goose/src/model.rs`. When set and non-empty it replaces the provider-supplied fast-model default; when unset/empty (or whitespace-only) behavior is unchanged.

Mirrors the existing `GOOSE_MODEL` env-var pattern for the primary model.

## Motivation

Each provider's `from_env()` calls `with_fast(...)` with a hardcoded constant (e.g. `OPENROUTER_DEFAULT_FAST_MODEL = "google/gemini-2.5-flash"`, `OPEN_AI_DEFAULT_FAST_MODEL = "gpt-4o-mini"`). `use_fast_model()` is invoked by Goose internals for auxiliary calls (tool-selection, classification, session-title generation) independent of `GOOSE_MODEL` — so today users have no way to redirect that traffic.

Concrete impact: cost-controlled deployments that intentionally pin a single model on OpenRouter still bleed spend on Gemini 2.5 Flash because the auxiliary path is unreachable from config. Privacy/compliance setups have the same gap. Closely related to the closed #4350 / #4318, which addressed canonical lookups but left the override gap in place.

## Design

Single point of override at the existing `with_fast` call site means all 8 providers (`openrouter`, `openai`, `anthropic`, `google`, `gemini_oauth`, `ollama`, `databricks`, `kimicode`) pick it up via existing call sites without per-provider edits.

```rust
let resolved = std::env::var("GOOSE_FAST_MODEL")
    .ok()
    .map(|v| v.trim().to_string())
    .filter(|v| !v.is_empty())
    .unwrap_or_else(|| fast_model_name.to_string());
let fast_config = ModelConfig::new(&resolved)?.with_canonical_limits(provider_name);
```

The trim+filter handles both unset and accidentally-empty/whitespace values so a stray `GOOSE_FAST_MODEL=` in `.env` doesn't break the auxiliary path.

## Tests

Three unit tests in the existing `model::tests` module using the same `env_lock` pattern that covers `GOOSE_MAX_TOKENS` / `GOOSE_TEMPERATURE`:

- `test_with_fast_uses_default_when_env_unset` — preserves existing behavior
- `test_with_fast_honors_env_override` — env var wins over provider default
- `test_with_fast_ignores_empty_env` — whitespace-only value is treated as unset

```
$ cargo test -p goose --lib model::tests::test_with_fast
running 3 tests
test model::tests::test_with_fast_honors_env_override ... ok
test model::tests::test_with_fast_ignores_empty_env ... ok
test model::tests::test_with_fast_uses_default_when_env_unset ... ok
test result: ok. 3 passed; 0 failed
```

`cargo fmt -p goose --check` and `cargo clippy -p goose --lib --no-deps -- -D warnings` both clean.

## Backwards compatibility

No behavior change when `GOOSE_FAST_MODEL` is unset or empty. No new dependencies. No public API change beyond a new env var honored by an existing method.

## Out of scope (follow-ups, happy to address separately)

- Config-file field on `ModelConfig` for non-env-var users — chose env-var-only for this PR per CONTRIBUTING.md "start small" guidance.
- Per-provider override (`OPENROUTER_FAST_MODEL`, etc.) — 8x the surface area for the same outcome when users typically run one provider per session.
- A `GOOSE_DISABLE_FAST_MODEL=1` flag to skip the fast-model optimization entirely.

## Checklist

- [x] Code compiles with `cargo build`
- [x] Tests pass with `cargo test`
- [x] Clippy clean with `-D warnings`
- [x] `cargo fmt --check` clean
- [x] Linked to issue (#9295)
