### PR TITLE
fix: prevent duplicate OAuth flows from agent creation race condition

### DIFF
--- a/crates/goose/src/execution/manager.rs
+++ b/crates/goose/src/execution/manager.rs
@@ -10,7 +10,7 @@ use lru::LruCache;
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
-use tokio::sync::{OnceCell, RwLock};
+use tokio::sync::{Mutex, OnceCell, RwLock};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
 
@@ -20,6 +20,7 @@ static AGENT_MANAGER: OnceCell<Arc<AgentManager>> = OnceCell::const_new();
 
 pub struct AgentManager {
     sessions: Arc<RwLock<LruCache<String, Arc<Agent>>>>,
+    creating: Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
     scheduler: Arc<dyn SchedulerTrait>,
     session_manager: Arc<SessionManager>,
     default_provider: Arc<RwLock<Option<Arc<dyn crate::providers::base::Provider>>>>,
@@ -41,6 +42,7 @@ impl AgentManager {
 
         let manager = Self {
             sessions: Arc::new(RwLock::new(LruCache::new(capacity))),
+            creating: Arc::new(Mutex::new(HashMap::new())),
             scheduler,
             session_manager,
             default_provider: Arc::new(RwLock::new(None)),
@@ -89,6 +91,26 @@ impl AgentManager {
     }
 
     pub async fn get_or_create_agent(&self, session_id: String) -> Result<Arc<Agent>> {
+        // Fast path: agent already exists.
+        {
+            let mut sessions = self.sessions.write().await;
+            if let Some(existing) = sessions.get(&session_id) {
+                return Ok(Arc::clone(existing));
+            }
+        }
+
+        // Acquire a per-session creation lock to prevent concurrent callers from
+        // each independently creating an agent (and triggering duplicate OAuth flows).
+        let session_lock = {
+            let mut creating = self.creating.lock().await;
+            creating
+                .entry(session_id.clone())
+                .or_insert_with(|| Arc::new(Mutex::new(())))
+                .clone()
+        };
+        let _guard = session_lock.lock().await;
+
+        // Re-check: another caller may have created the agent while we waited.
         {
             let mut sessions = self.sessions.write().await;
             if let Some(existing) = sessions.get(&session_id) {
@@ -146,12 +168,13 @@ impl AgentManager {
         }
 
         let mut sessions = self.sessions.write().await;
-        if let Some(existing) = sessions.get(&session_id) {
-            Ok(Arc::clone(existing))
-        } else {
-            sessions.put(session_id, agent.clone());
-            Ok(agent)
-        }
+        sessions.put(session_id.clone(), agent.clone());
+
+        // Clean up the creation lock now that the agent is cached.
+        let mut creating = self.creating.lock().await;
+        creating.remove(&session_id);
+
+        Ok(agent)
     }
 
     pub async fn remove_session(&self, session_id: &str) -> Result<()> {


### PR DESCRIPTION
## Summary

Race condition in `AgentManager::get_or_create_agent` causes multiple concurrent callers to each independently create an agent and trigger OAuth browser flows — opening 3 browser windows instead of 1.

## Root Cause

Classic TOCTOU (time-of-check-time-of-use) race:

1. Check if agent exists → not found, **release lock**
2. Create agent + load extensions (triggers OAuth) — **no lock held**
3. Re-acquire lock and insert — too late, OAuth already triggered N times

Multiple desktop UI routes (`resume_agent`, `sessionReply`, etc.) call `get_or_create_agent` concurrently on session load, so all three pass step 1 before any finishes step 2.

## Fix

Add a per-session creation mutex (`creating: HashMap<String, Arc<Mutex<()>>>`). When a session isn't in cache:

1. Fast path: return cached agent if it exists
2. Acquire per-session mutex (concurrent callers for the same session wait here)
3. Re-check cache (loser sees the agent the winner created)
4. Only the winner does the expensive creation work
5. Clean up the creation lock entry after caching

This is a focused, minimal change — one new field, same public API.

## Testing

All 12 existing manager tests pass, including `test_concurrent_access` (10 concurrent spawns) and `test_concurrent_session_creation_race_condition` (20 concurrent spawns).

Fixes #9181