### PR TITLE
fix: stop killing goosed when a window closes

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -810,7 +810,6 @@ const createChat = async (app: App, options: CreateChatOptions = {}) => {
   const {
     baseUrl,
     workingDir,
-    process: goosedProcess,
     errorLog,
     stopErrorLogCollection,
     startupDiagnosticsPath,
@@ -1153,9 +1152,6 @@ const createChat = async (app: App, options: CreateChatOptions = {}) => {
       windowPowerSaveBlockers.delete(windowId);
     }
 
-    if (goosedProcess && typeof goosedProcess === 'object' && 'kill' in goosedProcess) {
-      goosedProcess.kill();
-    }
   });
   return mainWindow;
 };


### PR DESCRIPTION
## Summary

Closing a `BrowserWindow` killed its dedicated `goosed` process via `goosedProcess.kill()` in the `mainWindow.on('closed')` handler. This severed sessions for users who close one window while others are still open, causing the "session error" failures described in the issue.

The `app.on('will-quit')` handler already calls `goosedResult.cleanup()` for every spawned goosed process (with graceful SIGTERM + 5s SIGKILL fallback), so the per-window kill was redundant and harmful.

## Changes

- Removed `goosedProcess.kill()` from the `mainWindow.on('closed')` handler in `ui/desktop/src/main.ts`
- Removed the now-unused `process: goosedProcess` destructuring from `goosedResult`

## Testing

- `pnpm lint` passes clean
- All 347 desktop tests pass

Fixes #8711