### PR TITLE
fix(cli): use plain '> ' prompt instead of goose emoji

### DIFF
--- a/crates/goose-cli/src/session/input.rs
+++ b/crates/goose-cli/src/session/input.rs
@@ -149,9 +149,7 @@ pub fn get_input(
         rustyline::EventHandler::Conditional(Box::new(CtrlCHandler::new(completion_cache))),
     );
 
-    let prompt = get_input_prompt_string();
-
-    let input = match editor.readline(&prompt) {
+    let input = match editor.readline("> ") {
         Ok(text) => text,
         Err(e) => match e {
             rustyline::error::ReadlineError::Interrupted => return Ok(InputResult::Exit),
@@ -385,24 +383,6 @@ fn parse_plan_command(input: String) -> Option<InputResult> {
     };
 
     Some(InputResult::Plan(options))
-}
-
-fn get_input_prompt_string() -> String {
-    if is_vte_with_broken_emoji_width() {
-        return "> ".to_string();
-    }
-    "🪿 ".to_string()
-}
-
-/// VTE < 0.70 renders 🪿 as 1 cell while unicode-width counts 2, causing cursor offset.
-fn is_vte_with_broken_emoji_width() -> bool {
-    let Ok(vte_version) = std::env::var("VTE_VERSION") else {
-        return false;
-    };
-    let Ok(version) = vte_version.parse::<u32>() else {
-        return true;
-    };
-    version < 7000
 }
 
 fn print_help() {


### PR DESCRIPTION
## Problem

The 🪿 (goose) emoji in the CLI prompt is rendered as 1 cell wide on many terminals while `unicode-width` counts it as 2. This causes cursor misalignment — characters appear spaced out and backspace behaves oddly.

PR #8385 worked around this for some VTE-based terminals, but the same bug affects plain Linux consoles, macOS Terminal.app, and many other terminals — and terminal sniffing is fragile.

## Fix

Drop the emoji entirely from the CLI prompt and always use `> `. Users who want a fancier UI can use the TUI.

Fixes #8841