### PR TITLE
fix(flake): #8514 - added output hashes to flake.nix ...

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
             outputHashes = {
               "cudaforge-0.1.6" = "sha256-w0e/mfx08BkphDEFEWxuyxyZu/gHiG0m6RHx+3BLzDY=";
               "opentelemetry-0.31.0" = "sha256-WmrsJUT+hhY9A0YrDMPCB+U23ZPNyX6eZlZ4VYlLk5Y=";
+            };
           };
           
           LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";

--- a/flake.nix
+++ b/flake.nix
@@ -42,8 +42,14 @@
           version = workspaceToml.workspace.package.version;
           src = self;
 
-          cargoLock.lockFile = ./Cargo.lock;
-
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            outputHashes = {
+              "cudaforge-0.1.6" = "sha256-w0e/mfx08BkphDEFEWxuyxyZu/gHiG0m6RHx+3BLzDY=";
+              "opentelemetry-0.31.0" = "sha256-3uayFFBnM9LHnWpDdbKv+qjMvaqowrODAcZuK20/cdA=";
+            };
+          };
+          
           LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
 
           # Pre-fetch rusty_v8 binary to avoid network access during build

--- a/flake.nix
+++ b/flake.nix
@@ -46,8 +46,7 @@
             lockFile = ./Cargo.lock;
             outputHashes = {
               "cudaforge-0.1.6" = "sha256-w0e/mfx08BkphDEFEWxuyxyZu/gHiG0m6RHx+3BLzDY=";
-              "opentelemetry-0.31.0" = "sha256-3uayFFBnM9LHnWpDdbKv+qjMvaqowrODAcZuK20/cdA=";
-            };
+              "opentelemetry-0.31.0" = "sha256-WmrsJUT+hhY9A0YrDMPCB+U23ZPNyX6eZlZ4VYlLk5Y=";
           };
           
           LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";


### PR DESCRIPTION
… so that git dependencies resolve for nix based builds. Temporary until wq#9129 fixes it better

## Summary
Expanded the cargoLock by the neccessary hashes for flake based builds to, well, build.
As per suggestion of @DOsinga 

### Testing
Manually built it locally on nixos.

### Related Issues
Relates to #8514
Discussion: https://github.com/aaif-goose/goose/issues/8514#issuecomment-4460616181


PS: First ever pull, critique very welcome!


