### PR TITLE
Add Linux desktop Vulkan packages

### DIFF
--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -4,6 +4,12 @@
 #  - canary.yml (when added)
 #  - pr-comment-bundle-desktop.yml (when added)
 on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch name to bundle app from'
+        required: true
+        type: string
   workflow_call:
     inputs:
       version:
@@ -35,7 +41,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref || inputs.branch }}
 
       - name: Update versions
         if: ${{ inputs.version != '' }}

--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -165,7 +165,7 @@ jobs:
           pnpm run make --platform=linux --arch=x64
 
           if [ "${{ matrix.variant }}" = "vulkan" ]; then
-            for package in out/make/deb/x64/*.deb out/make/flatpak/x86_64/*.flatpak; do
+            for package in out/make/deb/x64/*.deb out/make/rpm/x64/*.rpm out/make/flatpak/x86_64/*.flatpak; do
               [ -e "$package" ] || continue
               extension="${package##*.}"
               base="${package%.*}"
@@ -210,6 +210,14 @@ jobs:
         with:
           name: Goose-linux-x64-rpm
           path: ui/desktop/out/make/rpm/x64/*.rpm
+          if-no-files-found: error
+
+      - name: Upload .rpm package (Vulkan)
+        if: matrix.variant == 'vulkan'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        with:
+          name: Goose-linux-x64-vulkan-rpm
+          path: ui/desktop/out/make/rpm/x64/*-vulkan.rpm
           if-no-files-found: error
 
       - name: Upload .flatpak package

--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -162,6 +162,8 @@ jobs:
           ls -la node_modules/.bin/ | head -5
 
       - name: Build Linux packages
+        env:
+          GOOSE_DESKTOP_LINUX_VARIANT: ${{ matrix.variant }}
         run: |
           source ./bin/activate-hermit
           cd ui/desktop

--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -20,8 +20,16 @@ name: "Bundle Desktop (Linux)"
 
 jobs:
   build-desktop-linux:
-    name: Build Desktop (Linux)
-    runs-on: ubuntu-22.04
+    name: Build Desktop (Linux, ${{ matrix.variant }})
+    runs-on: ${{ matrix.build-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: standard
+            build-on: ubuntu-22.04
+          - variant: vulkan
+            build-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository
@@ -72,7 +80,6 @@ jobs:
             libxrandr2 \
             libgbm1 \
             libxss1 \
-            libasound2 \
             rpm \
             fakeroot \
             dpkg-dev \
@@ -80,6 +87,16 @@ jobs:
             flatpak \
             flatpak-builder \
             elfutils
+
+          if [ "${{ matrix.variant }}" = "vulkan" ]; then
+            sudo apt-get install -y \
+              libasound2t64 \
+              libvulkan-dev \
+              libvulkan1 \
+              glslc
+          else
+            sudo apt-get install -y libasound2
+          fi
 
       - name: Setup Flatpak Runtimes
         run: |
@@ -94,7 +111,7 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
-          key: linux
+          key: linux-${{ matrix.build-on }}-${{ matrix.variant }}
 
       - name: Build goosed binary
         env:
@@ -104,7 +121,12 @@ jobs:
           source ./bin/activate-hermit
           export TARGET="x86_64-unknown-linux-gnu"
           rustup target add "${TARGET}"
-          cargo build --release --target ${TARGET} -p goose-server
+          FEATURE_ARGS=()
+          if [ "${{ matrix.variant }}" = "vulkan" ]; then
+            FEATURE_ARGS=(--features vulkan)
+          fi
+
+          cargo build --release --target ${TARGET} -p goose-server "${FEATURE_ARGS[@]}"
 
       - name: Copy binaries into Electron folder
         run: |
@@ -137,10 +159,19 @@ jobs:
         run: |
           source ./bin/activate-hermit
           cd ui/desktop
-          echo "Building Linux packages (.deb, .rpm, and .flatpak)..."
+          echo "Building Linux packages (.deb, .rpm, and .flatpak) for ${{ matrix.variant }}..."
 
           # Build all configured packages
           pnpm run make --platform=linux --arch=x64
+
+          if [ "${{ matrix.variant }}" = "vulkan" ]; then
+            for package in out/make/deb/x64/*.deb out/make/flatpak/x86_64/*.flatpak; do
+              [ -e "$package" ] || continue
+              extension="${package##*.}"
+              base="${package%.*}"
+              mv "$package" "${base}-vulkan.${extension}"
+            done
+          fi
 
           echo "Build completed. Checking output..."
           ls -la out/
@@ -158,13 +189,23 @@ jobs:
           find ui/desktop/out/ -name "*.deb" -o -name "*.rpm" -o -name "*.flatpak" -exec ls -lh {} \;
 
       - name: Upload .deb package
+        if: matrix.variant == 'standard'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: Goose-linux-x64-deb
           path: ui/desktop/out/make/deb/x64/*.deb
           if-no-files-found: error
 
+      - name: Upload .deb package (Vulkan)
+        if: matrix.variant == 'vulkan'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        with:
+          name: Goose-linux-x64-vulkan-deb
+          path: ui/desktop/out/make/deb/x64/*-vulkan.deb
+          if-no-files-found: error
+
       - name: Upload .rpm package
+        if: matrix.variant == 'standard'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: Goose-linux-x64-rpm
@@ -172,8 +213,17 @@ jobs:
           if-no-files-found: error
 
       - name: Upload .flatpak package
+        if: matrix.variant == 'standard'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: Goose-linux-x64-flatpak
           path: ui/desktop/out/make/flatpak/x86_64/*.flatpak
+          if-no-files-found: error
+
+      - name: Upload .flatpak package (Vulkan)
+        if: matrix.variant == 'vulkan'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        with:
+          name: Goose-linux-x64-vulkan-flatpak
+          path: ui/desktop/out/make/flatpak/x86_64/*-vulkan.flatpak
           if-no-files-found: error

--- a/documentation/src/components/LinuxDesktopInstallButtons.js
+++ b/documentation/src/components/LinuxDesktopInstallButtons.js
@@ -4,6 +4,8 @@ import { useState, useEffect } from "react";
 
 const FALLBACK_URL = "https://github.com/aaif-goose/goose/releases/latest";
 
+const isStandardLinuxAsset = (asset) => !asset.name.includes('-vulkan');
+
 const LinuxDesktopInstallButtons = () => {
   const [downloadUrls, setDownloadUrls] = useState({
     deb: FALLBACK_URL,
@@ -33,9 +35,15 @@ const LinuxDesktopInstallButtons = () => {
         const assets = release.assets || [];
 
         // Find DEB, RPM, and Flatpak files
-        const debAsset = assets.find(asset => asset.name.includes('.deb') && asset.name.includes('amd64'));
-        const rpmAsset = assets.find(asset => asset.name.includes('.rpm') && asset.name.includes('x86_64'));
-        const flatpakAsset = assets.find(asset => asset.name.endsWith('.flatpak'));
+        const debAsset = assets.find(asset =>
+          isStandardLinuxAsset(asset) && asset.name.includes('.deb') && asset.name.includes('amd64')
+        );
+        const rpmAsset = assets.find(asset =>
+          isStandardLinuxAsset(asset) && asset.name.includes('.rpm') && asset.name.includes('x86_64')
+        );
+        const flatpakAsset = assets.find(asset =>
+          isStandardLinuxAsset(asset) && asset.name.endsWith('.flatpak')
+        );
 
         const newUrls = {
           deb: debAsset?.browser_download_url || FALLBACK_URL,

--- a/ui/desktop/forge.config.ts
+++ b/ui/desktop/forge.config.ts
@@ -2,6 +2,8 @@ const { FusesPlugin } = require('@electron-forge/plugin-fuses');
 const { FuseV1Options, FuseVersion } = require('@electron/fuses');
 const { resolve } = require('path');
 
+const isLinuxVulkanBuild = process.env.GOOSE_DESKTOP_LINUX_VARIANT === 'vulkan';
+
 let cfg = {
   asar: true,
   extraResource: ['src/bin', 'src/images'],
@@ -94,6 +96,7 @@ module.exports = {
         options: {
           icon: 'src/images/icon.png',
           prefix: '/opt',
+          ...(isLinuxVulkanBuild ? { depends: ['libvulkan1'] } : {}),
         },
       },
     },
@@ -109,6 +112,7 @@ module.exports = {
         options: {
           icon: 'src/images/icon.png',
           prefix: '/opt',
+          ...(isLinuxVulkanBuild ? { requires: ['vulkan-loader'] } : {}),
           fpm: ['--rpm-rpmbuild-define', '_build_id_links none'],
         },
       },


### PR DESCRIPTION
Build the Linux desktop workflow as standard and Vulkan variants. Keep standard packages on Ubuntu 22.04 for glibc compatibility while building Vulkan packages on Ubuntu 24.04 with the required Vulkan tooling and distinct artifact names.

Fixes #9286 