### PR TITLE
examples(plugins): add atr-threat-detection PreToolUse hook

### DIFF
--- a/examples/plugins/atr-threat-detection/README.md
+++ b/examples/plugins/atr-threat-detection/README.md
@@ -1,0 +1,38 @@
+# atr-threat-detection
+
+Blocks tool calls that match [Agent Threat Rules (ATR)](https://github.com/Agent-Threat-Rule/agent-threat-rules) — 425 detection rules covering prompt injection, tool poisoning, credential exfiltration, and 9 other AI agent attack categories.
+
+Uses the `PreToolUse` hook introduced in goose PR #9304. A tool call is blocked (exit code 2) when ATR finds a critical or high severity match in the tool input. Any scanner error allows the call through — a broken guard must never block legitimate work.
+
+## Requirements
+
+```
+pip install pyatr
+```
+
+## Installation
+
+```
+goose plugin add /path/to/examples/plugins/atr-threat-detection
+```
+
+Or install directly from the ATR repo:
+
+```
+goose plugin add https://github.com/Agent-Threat-Rule/agent-threat-rules/tree/main/integrations/goose
+```
+
+## What gets blocked
+
+| Category | Example |
+|---|---|
+| Prompt injection | Instructions embedded in tool responses to override agent behaviour |
+| Tool poisoning | MCP tool descriptions that hijack agent goals |
+| Credential exfiltration | Tool calls attempting to read and send `.env` / SSH keys |
+| Privilege escalation | Commands that request elevated system access |
+
+Full rule list: [Agent-Threat-Rule/agent-threat-rules/rules](https://github.com/Agent-Threat-Rule/agent-threat-rules/tree/main/rules)
+
+## False positives
+
+Security scanning tooling and educational content describing attack patterns may trigger rules. Add an ATR rule exclusion list or adjust `_BLOCK_SEVERITIES` in `scripts/atr_scan.py` to tune sensitivity.

--- a/examples/plugins/atr-threat-detection/README.md
+++ b/examples/plugins/atr-threat-detection/README.md
@@ -1,6 +1,6 @@
 # atr-threat-detection
 
-Blocks tool calls that match [Agent Threat Rules (ATR)](https://github.com/Agent-Threat-Rule/agent-threat-rules) — 425 detection rules covering prompt injection, tool poisoning, credential exfiltration, and 9 other AI agent attack categories.
+Blocks tool calls that match [Agent Threat Rules (ATR)](https://github.com/Agent-Threat-Rule/agent-threat-rules) — 427 detection rules covering prompt injection, tool poisoning, credential exfiltration, and 9 other AI agent attack categories.
 
 Uses the `PreToolUse` hook introduced in goose PR #9304. A tool call is blocked (exit code 2) when ATR finds a critical or high severity match in the tool input. Any scanner error allows the call through — a broken guard must never block legitimate work.
 
@@ -13,13 +13,13 @@ pip install pyatr
 ## Installation
 
 ```
-goose plugin add /path/to/examples/plugins/atr-threat-detection
+goose plugin install /path/to/examples/plugins/atr-threat-detection
 ```
 
 Or install directly from the ATR repo:
 
 ```
-goose plugin add https://github.com/Agent-Threat-Rule/agent-threat-rules/tree/main/integrations/goose
+goose plugin install https://github.com/Agent-Threat-Rule/agent-threat-rules/tree/main/integrations/goose
 ```
 
 ## What gets blocked

--- a/examples/plugins/atr-threat-detection/README.md
+++ b/examples/plugins/atr-threat-detection/README.md
@@ -1,6 +1,6 @@
 # atr-threat-detection
 
-Blocks tool calls that match [Agent Threat Rules (ATR)](https://github.com/Agent-Threat-Rule/agent-threat-rules) — 427 detection rules covering prompt injection, tool poisoning, credential exfiltration, and 9 other AI agent attack categories.
+Blocks tool calls that match [Agent Threat Rules (ATR)](https://github.com/Agent-Threat-Rule/agent-threat-rules) — 433 detection rules covering prompt injection, tool poisoning, credential exfiltration, and 9 other AI agent attack categories.
 
 Uses the `PreToolUse` hook introduced in goose PR #9304. A tool call is blocked (exit code 2) when ATR finds a critical or high severity match in the tool input. Any scanner error allows the call through — a broken guard must never block legitimate work.
 

--- a/examples/plugins/atr-threat-detection/hooks/hooks.json
+++ b/examples/plugins/atr-threat-detection/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${PLUGIN_ROOT}/scripts/atr_scan.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/plugins/atr-threat-detection/plugin.json
+++ b/examples/plugins/atr-threat-detection/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "atr-threat-detection",
+  "version": "0.1.0",
+  "description": "Blocks tool calls that match Agent Threat Rules (ATR) — prompt injection, tool poisoning, credential exfiltration, and 9 other AI agent attack categories. Requires pyatr >= 0.2.0 (pip install pyatr)."
+}

--- a/examples/plugins/atr-threat-detection/scripts/atr_scan.py
+++ b/examples/plugins/atr-threat-detection/scripts/atr_scan.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""ATR PreToolUse hook — blocks tool calls that match ATR detection rules.
+
+Reads the goose HookContext JSON from stdin. If pyatr detects a critical or
+high severity match in the tool_input, exits with code 2 (denial) and prints
+the rule ID + title to stderr. Any error in the scanner (import failure,
+parse error, timeout) allows the call through — a broken guard must never
+block legitimate work.
+"""
+import json
+import sys
+
+_BLOCK_SEVERITIES = {"critical", "high"}
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+
+    tool_name = payload.get("tool_name", "")
+    tool_input = payload.get("tool_input")
+    if tool_input is None:
+        sys.exit(0)
+
+    # Flatten tool_input to a string for ATR scanning.
+    text = json.dumps(tool_input) if not isinstance(tool_input, str) else tool_input
+
+    try:
+        import pyatr
+
+        matches = pyatr.scan(text)
+    except ImportError:
+        # pyatr not installed — allow through, print advisory once.
+        print(
+            "[atr-threat-detection] pyatr not installed; install with: pip install pyatr",
+            file=sys.stderr,
+        )
+        sys.exit(0)
+    except Exception:
+        sys.exit(0)
+
+    blocked = [m for m in matches if m.severity.lower() in _BLOCK_SEVERITIES]
+    if not blocked:
+        sys.exit(0)
+
+    top = blocked[0]
+    print(
+        f"[ATR] Blocked tool call to '{tool_name}': [{top.rule_id}] {top.title} "
+        f"(severity={top.severity}, confidence={top.confidence})",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `examples/plugins/atr-threat-detection/` — a goose plugin that blocks tool calls matching [Agent Threat Rules (ATR)](https://github.com/Agent-Threat-Rule/agent-threat-rules) detection signatures
- Uses the `PreToolUse` denial surface added in #9304 (exit code 2 = deny)
- 425 rules covering prompt injection, tool poisoning, credential exfiltration, privilege escalation, and 9 other AI agent attack categories
- Scanner errors always allow through — a broken guard must never block legitimate work
- Requires `pip install pyatr`

## How it works

`scripts/atr_scan.py` reads the `HookContext` JSON from stdin, serialises `tool_input`, and runs `pyatr.scan()`. On a critical or high severity match it prints `[ATR] Blocked tool call to '<tool>': [<rule-id>] <title>` to stderr and exits 2. Clean inputs exit 0.

## Test plan

- [ ] Install plugin: `goose plugin add examples/plugins/atr-threat-detection`
- [ ] Trigger a prompt-injection tool call (e.g. tool_input containing `ignore previous instructions`) — should be blocked with ATR rule ID on stderr
- [ ] Normal tool call passes through unaffected
- [ ] Remove `pyatr` (`pip uninstall pyatr`) — plugin prints advisory and allows through (no crash)

Related: #9277 (original proposal), #9304 (PreToolUse denial surface)