### PR TITLE
chore: update canonical model registry

### DIFF
--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -502,7 +502,7 @@ mod tests {
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
             let config =
-                ModelConfig::new_or_fail("moonshotai/kimi-k2.5").with_canonical_limits("nvidia");
+                ModelConfig::new_or_fail("moonshotai/kimi-k2.6").with_canonical_limits("nvidia");
 
             assert_eq!(config.context_limit, Some(262_144));
             assert_eq!(config.max_tokens, None);

--- a/crates/goose/src/providers/canonical/data/canonical_models.json
+++ b/crates/goose/src/providers/canonical/data/canonical_models.json
@@ -167,7 +167,7 @@
   },
   {
     "id": "302ai/claude-3.5-haiku",
-    "name": "claude-3-5-haiku-latest",
+    "name": "claude-3-5-haiku-20241022",
     "family": "claude-haiku",
     "attachment": true,
     "reasoning": false,
@@ -505,7 +505,7 @@
   },
   {
     "id": "302ai/claude-sonnet-4.5",
-    "name": "claude-sonnet-4-5",
+    "name": "claude-sonnet-4-5-20250929",
     "family": "claude-sonnet",
     "attachment": true,
     "reasoning": true,
@@ -4631,6 +4631,96 @@
     }
   },
   {
+    "id": "aihubmix/alicloud-deepseek-v4-flash",
+    "name": "DeepSeek V4 Flash (Alibaba Cloud)",
+    "family": "deepseek-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.028
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "aihubmix/alicloud-deepseek-v4-pro",
+    "name": "DeepSeek V4 Pro (Alibaba Cloud)",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.69,
+      "output": 3.38,
+      "cache_read": 0.13
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "aihubmix/alicloud-glm-5.1",
+    "name": "GLM-5.1 (Alibaba Cloud)",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-27",
+    "last_updated": "2026-03-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.84,
+      "output": 3.38,
+      "cache_read": 0.169,
+      "cache_write": 1.05625
+    },
+    "limit": {
+      "context": 200000,
+      "output": 128000
+    }
+  },
+  {
     "id": "aihubmix/claude-opus-4.6",
     "name": "Claude Opus 4.6",
     "family": "claude-opus",
@@ -4665,7 +4755,7 @@
   },
   {
     "id": "aihubmix/claude-opus-4.6-think",
-    "name": "Claude Opus 4.6",
+    "name": "Claude Opus 4.6 Thinking",
     "family": "claude-opus",
     "attachment": true,
     "reasoning": true,
@@ -4692,13 +4782,46 @@
       "cache_write": 6.25
     },
     "limit": {
-      "context": 200000,
-      "output": 32000
+      "context": 1000000,
+      "output": 128000
     }
   },
   {
     "id": "aihubmix/claude-opus-4.7",
     "name": "Claude Opus 4.7",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-04-16",
+    "last_updated": "2026-04-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "aihubmix/claude-opus-4.7-think",
+    "name": "Claude Opus 4.7 Thinking",
     "family": "claude-opus",
     "attachment": true,
     "reasoning": true,
@@ -4739,7 +4862,7 @@
     "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-17",
-    "last_updated": "2026-02-17",
+    "last_updated": "2026-03-13",
     "modalities": {
       "input": [
         "text",
@@ -4758,13 +4881,13 @@
       "cache_write": 3.75
     },
     "limit": {
-      "context": 200000,
+      "context": 1000000,
       "output": 64000
     }
   },
   {
     "id": "aihubmix/claude-sonnet-4.6-think",
-    "name": "Claude Sonnet 4.6 Think",
+    "name": "Claude Sonnet 4.6 Thinking",
     "family": "claude-sonnet",
     "attachment": true,
     "reasoning": true,
@@ -4772,7 +4895,7 @@
     "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-17",
-    "last_updated": "2026-02-17",
+    "last_updated": "2026-03-13",
     "modalities": {
       "input": [
         "text",
@@ -4791,41 +4914,13 @@
       "cache_write": 3.75
     },
     "limit": {
-      "context": 200000,
+      "context": 1000000,
       "output": 64000
     }
   },
   {
-    "id": "aihubmix/coding-glm-5-free",
-    "name": "Coding-GLM-5-Free",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-02-11",
-    "last_updated": "2026-02-11",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 204800,
-      "output": 131072
-    }
-  },
-  {
     "id": "aihubmix/coding-glm-5.1",
-    "name": "Coding-GLM-5.1",
+    "name": "Coding GLM 5.1",
     "family": "glm",
     "attachment": false,
     "reasoning": true,
@@ -4841,10 +4936,11 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.06,
-      "output": 0.22
+      "output": 0.22,
+      "cache_read": 0.013
     },
     "limit": {
       "context": 200000,
@@ -4852,9 +4948,65 @@
     }
   },
   {
-    "id": "aihubmix/coding-minimax-m2.7-free",
-    "name": "Coding-MiniMax-M2.7-Free",
+    "id": "aihubmix/coding-glm-5.1-free",
+    "name": "Coding GLM 5.1 (free)",
+    "family": "glm-free",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-11",
+    "last_updated": "2026-04-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 200000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "aihubmix/coding-minimax-m2.7",
+    "name": "Coding MiniMax M2.7",
     "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.2,
+      "output": 0.2
+    },
+    "limit": {
+      "context": 204800,
+      "output": 128100
+    }
+  },
+  {
+    "id": "aihubmix/coding-minimax-m2.7-free",
+    "name": "Coding MiniMax M2.7 (Free)",
+    "family": "minimax-free",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
@@ -4876,12 +5028,103 @@
     },
     "limit": {
       "context": 204800,
-      "output": 13100
+      "output": 128100
     }
   },
   {
-    "id": "aihubmix/deepseek-v4-flash",
-    "name": "DeepSeek V4 Flash",
+    "id": "aihubmix/coding-minimax-m2.7-highspeed",
+    "name": "Coding MiniMax M2.7 Highspeed",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.2,
+      "output": 0.2
+    },
+    "limit": {
+      "context": 204800,
+      "output": 128100
+    }
+  },
+  {
+    "id": "aihubmix/coding-xiaomi-mimo-v2.5",
+    "name": "Coding Xiaomi MiMo-V2.5",
+    "family": "mimo-v2.5",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-05-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.08,
+      "output": 0.4,
+      "cache_read": 0.016
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "aihubmix/coding-xiaomi-mimo-v2.5-pro",
+    "name": "Coding Xiaomi MiMo-V2.5-Pro",
+    "family": "mimo-v2.5-pro",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-05-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.2,
+      "output": 0.6,
+      "cache_read": 0.04
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "aihubmix/deep-deepseek-v4-flash",
+    "name": "DeepSeek V4 Flash (DeepSeek)",
     "family": "deepseek-flash",
     "attachment": false,
     "reasoning": true,
@@ -4910,38 +5153,8 @@
     }
   },
   {
-    "id": "aihubmix/deepseek-v4-flash-think",
-    "name": "DeepSeek V4 Flash Think",
-    "family": "deepseek",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-05",
-    "release_date": "2026-04-24",
-    "last_updated": "2026-04-24",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.154,
-      "output": 0.308,
-      "cache_read": 0.0308
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 384000
-    }
-  },
-  {
-    "id": "aihubmix/deepseek-v4-pro",
-    "name": "DeepSeek V4 Pro",
+    "id": "aihubmix/deep-deepseek-v4-pro",
+    "name": "DeepSeek V4 Pro (DeepSeek)",
     "family": "deepseek-thinking",
     "attachment": false,
     "reasoning": true,
@@ -4970,6 +5183,130 @@
     }
   },
   {
+    "id": "aihubmix/doubao-seed-2.0-code-preview",
+    "name": "Doubao Seed 2.0 Code Preview",
+    "family": "seed",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-14",
+    "last_updated": "2026-02-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.48,
+      "output": 2.41,
+      "cache_read": 0.09644
+    },
+    "limit": {
+      "context": 256000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "aihubmix/doubao-seed-2.0-lite-260428",
+    "name": "Doubao Seed 2.0 Lite 260428",
+    "family": "seed",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-28",
+    "last_updated": "2026-04-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.08,
+      "output": 0.51,
+      "cache_read": 0.01692
+    },
+    "limit": {
+      "context": 256000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "aihubmix/doubao-seed-2.0-mini-260428",
+    "name": "Doubao Seed 2.0 Mini 260428",
+    "family": "seed",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-28",
+    "last_updated": "2026-04-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.03,
+      "output": 0.28,
+      "cache_read": 0.00564
+    },
+    "limit": {
+      "context": 256000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "aihubmix/doubao-seed-2.0-pro",
+    "name": "Doubao Seed 2.0 Pro",
+    "family": "seed",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-14",
+    "last_updated": "2026-02-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.48,
+      "output": 2.41,
+      "cache_read": 0.09644
+    },
+    "limit": {
+      "context": 256000,
+      "output": 128000
+    }
+  },
+  {
     "id": "aihubmix/gemini-2.5-flash",
     "name": "Gemini 2.5 Flash",
     "family": "gemini-flash",
@@ -4995,7 +5332,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.3,
-      "output": 2.499,
+      "output": 2.5,
       "cache_read": 0.03
     },
     "limit": {
@@ -5072,16 +5409,16 @@
     }
   },
   {
-    "id": "aihubmix/gemini-3.1-flash-lite-preview",
-    "name": "Gemini 3.1 Flash Lite Preview",
+    "id": "aihubmix/gemini-3.1-flash-lite",
+    "name": "Gemini 3.1 Flash Lite",
     "family": "gemini-flash-lite",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-01",
-    "release_date": "2026-03-03",
-    "last_updated": "2026-03-03",
+    "release_date": "2026-05-07",
+    "last_updated": "2026-05-07",
     "modalities": {
       "input": [
         "text",
@@ -5098,7 +5435,8 @@
     "cost": {
       "input": 0.25,
       "output": 1.5,
-      "cache_read": 0.25
+      "cache_read": 0.025,
+      "cache_write": 1.0
     },
     "limit": {
       "context": 1048576,
@@ -5140,78 +5478,23 @@
     }
   },
   {
-    "id": "aihubmix/glm-5",
-    "name": "GLM-5",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-02-11",
-    "last_updated": "2026-02-11",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.88,
-      "output": 2.816,
-      "cache_read": 0.176
-    },
-    "limit": {
-      "context": 202752,
-      "output": 0
-    }
-  },
-  {
-    "id": "aihubmix/glm-5.1",
-    "name": "GLM-5.1",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-03-27",
-    "last_updated": "2026-03-27",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.845,
-      "output": 3.38,
-      "cache_read": 0.183112
-    },
-    "limit": {
-      "context": 200000,
-      "output": 128000
-    }
-  },
-  {
-    "id": "aihubmix/gpt-4.1",
-    "name": "GPT-4.1",
-    "family": "gpt",
+    "id": "aihubmix/gemini-3.1-pro-preview-customtools",
+    "name": "Gemini 3.1 Pro Preview Custom Tools",
+    "family": "gemini-pro",
     "attachment": true,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-04",
-    "release_date": "2025-04-14",
-    "last_updated": "2025-04-14",
+    "knowledge": "2025-01",
+    "release_date": "2026-02-19",
+    "last_updated": "2026-02-19",
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "audio",
+        "video",
+        "pdf"
       ],
       "output": [
         "text"
@@ -5220,29 +5503,29 @@
     "open_weights": false,
     "cost": {
       "input": 2.0,
-      "output": 8.0,
-      "cache_read": 0.5
+      "output": 12.0,
+      "cache_read": 0.2
     },
     "limit": {
-      "context": 1047576,
-      "output": 32768
+      "context": 1048576,
+      "output": 65536
     }
   },
   {
-    "id": "aihubmix/gpt-4.1-mini",
-    "name": "GPT-4.1 mini",
-    "family": "gpt-mini",
+    "id": "aihubmix/glm-5v-turbo",
+    "name": "GLM 5 Vision Turbo",
+    "family": "glmv",
     "attachment": true,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-04",
-    "release_date": "2025-04-14",
-    "last_updated": "2025-04-14",
+    "release_date": "2026-05-09",
+    "last_updated": "2026-05-09",
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "video"
       ],
       "output": [
         "text"
@@ -5250,13 +5533,13 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.4,
-      "output": 1.6,
-      "cache_read": 0.1
+      "input": 0.7042,
+      "output": 3.09848,
+      "cache_read": 0.169008
     },
     "limit": {
-      "context": 1047576,
-      "output": 32768
+      "context": 200000,
+      "output": 128000
     }
   },
   {
@@ -5266,10 +5549,10 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-11",
-    "release_date": "2025-11-15",
-    "last_updated": "2025-11-15",
+    "temperature": false,
+    "knowledge": "2024-09-30",
+    "release_date": "2025-11-13",
+    "last_updated": "2025-11-13",
     "modalities": {
       "input": [
         "text",
@@ -5283,7 +5566,7 @@
     "cost": {
       "input": 1.25,
       "output": 10.0,
-      "cache_read": 0.125
+      "cache_read": 0.13
     },
     "limit": {
       "context": 400000,
@@ -5385,18 +5668,20 @@
   },
   {
     "id": "aihubmix/gpt-5.2-codex",
-    "name": "GPT-5.2-Codex",
+    "name": "GPT-5.2 Codex",
     "family": "gpt-codex",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
+    "temperature": false,
     "knowledge": "2025-08-31",
-    "release_date": "2026-01-14",
-    "last_updated": "2026-01-14",
+    "release_date": "2025-12-11",
+    "last_updated": "2025-12-11",
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -5453,12 +5738,14 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
-    "release_date": "2026-03-11",
-    "last_updated": "2026-03-11",
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-05",
+    "last_updated": "2026-03-05",
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -5471,20 +5758,21 @@
       "cache_read": 0.25
     },
     "limit": {
-      "context": 400000,
+      "context": 1050000,
       "output": 128000
     }
   },
   {
     "id": "aihubmix/gpt-5.4-mini",
-    "name": "GPT-5.4-Mini",
+    "name": "GPT-5.4 mini",
     "family": "gpt-mini",
     "attachment": true,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": false,
-    "release_date": "2026-03-11",
-    "last_updated": "2026-03-11",
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
     "modalities": {
       "input": [
         "text",
@@ -5538,10 +5826,40 @@
     }
   },
   {
+    "id": "aihubmix/grok-4.3",
+    "name": "Grok 4.3",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-05-01",
+    "last_updated": "2026-05-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 1000000
+    }
+  },
+  {
     "id": "aihubmix/kimi-k2.5",
     "name": "Kimi K2.5",
     "family": "kimi-k2.5",
-    "attachment": false,
+    "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
@@ -5562,11 +5880,11 @@
     "cost": {
       "input": 0.6,
       "output": 3.0,
-      "cache_read": 0.105
+      "cache_read": 0.1
     },
     "limit": {
-      "context": 256000,
-      "output": 0
+      "context": 262144,
+      "output": 32768
     }
   },
   {
@@ -5576,7 +5894,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
     "knowledge": "2025-01",
     "release_date": "2026-04-21",
     "last_updated": "2026-04-21",
@@ -5593,45 +5911,17 @@
     "open_weights": true,
     "cost": {
       "input": 0.95,
-      "output": 3.9995,
-      "cache_read": 0.160835
+      "output": 4.0,
+      "cache_read": 0.16
     },
     "limit": {
       "context": 262144,
-      "output": 262144
-    }
-  },
-  {
-    "id": "aihubmix/minimax-m2.1",
-    "name": "MiniMax-M2.1",
-    "family": "minimax",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-12-23",
-    "last_updated": "2025-12-23",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.288,
-      "output": 1.152
-    },
-    "limit": {
-      "context": 204800,
-      "output": 192000
+      "output": 32768
     }
   },
   {
     "id": "aihubmix/minimax-m2.7",
-    "name": "MiniMax-M2.7",
+    "name": "MiniMax M2.7",
     "family": "minimax",
     "attachment": false,
     "reasoning": true,
@@ -5649,144 +5939,21 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.2958,
-      "output": 1.1832,
-      "cache_read": 0.05916
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.06,
+      "cache_write": 0.375
     },
     "limit": {
-      "context": 200000,
+      "context": 204800,
       "output": 128000
     }
   },
   {
-    "id": "aihubmix/o4-mini",
-    "name": "o4-mini",
-    "family": "o-mini",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2024-05",
-    "release_date": "2025-04-16",
-    "last_updated": "2025-04-16",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.1,
-      "output": 4.4,
-      "cache_read": 0.275
-    },
-    "limit": {
-      "context": 200000,
-      "output": 100000
-    }
-  },
-  {
-    "id": "aihubmix/qwen3-coder-next",
-    "name": "Qwen3 Coder Plus",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-04",
-    "release_date": "2025-07-23",
-    "last_updated": "2025-07-23",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.137,
-      "output": 0.548,
-      "cache_read": 0.137
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 64000
-    }
-  },
-  {
-    "id": "aihubmix/qwen3-max",
-    "name": "Qwen3 Max",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-04",
-    "release_date": "2025-09-23",
-    "last_updated": "2025-09-23",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.34246,
-      "output": 1.36984,
-      "cache_read": 0.34246
-    },
-    "limit": {
-      "context": 252000,
-      "output": 32000
-    }
-  },
-  {
-    "id": "aihubmix/qwen3.5-plus",
-    "name": "Qwen3.5 Plus",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-04",
-    "release_date": "2026-02-16",
-    "last_updated": "2026-02-16",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.1096,
-      "output": 0.6576,
-      "cache_read": 0.01096,
-      "cache_write": 0.137
-    },
-    "limit": {
-      "context": 991000,
-      "output": 64000
-    }
-  },
-  {
     "id": "aihubmix/qwen3.6-flash",
-    "name": "Qwen3.6 Plus",
-    "family": "qwen",
-    "attachment": false,
+    "name": "Qwen3.6 Flash",
+    "family": "qwen3.6",
+    "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -5805,14 +5972,233 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.169,
-      "output": 1.014,
+      "input": 0.17,
+      "output": 1.01,
       "cache_read": 0.0169,
       "cache_write": 0.21125
     },
     "limit": {
-      "context": 1000000,
-      "output": 65536
+      "context": 991000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "aihubmix/qwen3.6-max-preview",
+    "name": "Qwen3.6 Max Preview",
+    "family": "qwen3.6",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-05-09",
+    "last_updated": "2026-05-09",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.27,
+      "output": 7.61,
+      "cache_read": 0.1268,
+      "cache_write": 1.585
+    },
+    "limit": {
+      "context": 240000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "aihubmix/qwen3.6-plus",
+    "name": "Qwen3.6 Plus",
+    "family": "qwen3.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-05-09",
+    "last_updated": "2026-05-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.28,
+      "output": 1.69,
+      "cache_read": 0.0282,
+      "cache_write": 0.3525
+    },
+    "limit": {
+      "context": 991000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "aihubmix/xiaomi-mimo-v2.5",
+    "name": "Xiaomi MiMo-V2.5",
+    "family": "mimo-v2.5",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-05-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.44,
+      "output": 2.2,
+      "cache_read": 0.088
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "aihubmix/xiaomi-mimo-v2.5-free",
+    "name": "Xiaomi MiMo-V2.5 (free)",
+    "family": "mimo-v2.5",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-05-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "aihubmix/xiaomi-mimo-v2.5-pro",
+    "name": "Xiaomi MiMo-V2.5-Pro",
+    "family": "mimo-v2.5-pro",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-05-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.1,
+      "output": 3.3,
+      "cache_read": 0.22
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "aihubmix/xiaomi-mimo-v2.5-pro-free",
+    "name": "Xiaomi MiMo-V2.5-Pro (free)",
+    "family": "mimo-v2.5-pro",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-05-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "aihubmix/zai-glm-5.1",
+    "name": "GLM-5.1 (Z.ai)",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-27",
+    "last_updated": "2026-03-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.845,
+      "output": 3.38,
+      "cache_read": 0.183112
+    },
+    "limit": {
+      "context": 200000,
+      "output": 128000
     }
   },
   {
@@ -7926,10 +8312,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.276,
-      "output": 1.651,
-      "cache_read": 0.028,
-      "cache_write": 0.344
+      "input": 0.5,
+      "output": 3.0,
+      "cache_read": 0.05,
+      "cache_write": 0.625
     },
     "limit": {
       "context": 1000000,
@@ -10102,10 +10488,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.276,
-      "output": 1.651,
-      "cache_read": 0.028,
-      "cache_write": 0.344
+      "input": 0.5,
+      "output": 3.0,
+      "cache_read": 0.05,
+      "cache_write": 0.625
     },
     "limit": {
       "context": 1000000,
@@ -10234,37 +10620,6 @@
     }
   },
   {
-    "id": "amazon-bedrock/amazon.nova-premier-v1:0",
-    "name": "Nova Premier",
-    "family": "nova",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-10",
-    "release_date": "2024-12-03",
-    "last_updated": "2024-12-03",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 2.5,
-      "output": 12.5
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 16384
-    }
-  },
-  {
     "id": "amazon-bedrock/amazon.nova-pro-v1:0",
     "name": "Nova Pro",
     "family": "nova-pro",
@@ -10293,169 +10648,6 @@
     },
     "limit": {
       "context": 300000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "amazon-bedrock/anthropic.claude-3-haiku-20240307-v1:0",
-    "name": "Claude Haiku 3",
-    "family": "claude-haiku",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-02",
-    "release_date": "2024-03-13",
-    "last_updated": "2024-03-13",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.25,
-      "output": 1.25
-    },
-    "limit": {
-      "context": 200000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "amazon-bedrock/anthropic.claude-3.5-haiku-20241022-v1:0",
-    "name": "Claude Haiku 3.5",
-    "family": "claude-haiku",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-07-31",
-    "release_date": "2024-10-22",
-    "last_updated": "2024-10-22",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.8,
-      "output": 4.0,
-      "cache_read": 0.08,
-      "cache_write": 1.0
-    },
-    "limit": {
-      "context": 200000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "amazon-bedrock/anthropic.claude-3.5-sonnet-20240620-v1:0",
-    "name": "Claude Sonnet 3.5",
-    "family": "claude-sonnet",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-04-30",
-    "release_date": "2024-06-20",
-    "last_updated": "2024-06-20",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.3,
-      "cache_write": 3.75
-    },
-    "limit": {
-      "context": 200000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "amazon-bedrock/anthropic.claude-3.5-sonnet-20241022-v2:0",
-    "name": "Claude Sonnet 3.5 v2",
-    "family": "claude-sonnet",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-04",
-    "release_date": "2024-10-22",
-    "last_updated": "2024-10-22",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.3,
-      "cache_write": 3.75
-    },
-    "limit": {
-      "context": 200000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "amazon-bedrock/anthropic.claude-3.7-sonnet-20250219-v1:0",
-    "name": "Claude Sonnet 3.7",
-    "family": "claude-sonnet",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-04",
-    "release_date": "2025-02-19",
-    "last_updated": "2025-02-19",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.3,
-      "cache_write": 3.75
-    },
-    "limit": {
-      "context": 200000,
       "output": 8192
     }
   },
@@ -10490,39 +10682,6 @@
     "limit": {
       "context": 200000,
       "output": 64000
-    }
-  },
-  {
-    "id": "amazon-bedrock/anthropic.claude-opus-4-20250514-v1:0",
-    "name": "Claude Opus 4",
-    "family": "claude-opus",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-03-31",
-    "release_date": "2025-05-22",
-    "last_updated": "2025-05-22",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 15.0,
-      "output": 75.0,
-      "cache_read": 1.5,
-      "cache_write": 18.75
-    },
-    "limit": {
-      "context": 200000,
-      "output": 32000
     }
   },
   {
@@ -10658,39 +10817,6 @@
     }
   },
   {
-    "id": "amazon-bedrock/anthropic.claude-sonnet-4-20250514-v1:0",
-    "name": "Claude Sonnet 4",
-    "family": "claude-sonnet",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-03-31",
-    "release_date": "2025-05-22",
-    "last_updated": "2025-05-22",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.3,
-      "cache_write": 3.75
-    },
-    "limit": {
-      "context": 200000,
-      "output": 64000
-    }
-  },
-  {
     "id": "amazon-bedrock/anthropic.claude-sonnet-4.5-20250929-v1:0",
     "name": "Claude Sonnet 4.5",
     "family": "claude-sonnet",
@@ -10757,6 +10883,39 @@
     }
   },
   {
+    "id": "amazon-bedrock/au.anthropic.claude-haiku-4.5-20251001-v1:0",
+    "name": "Claude Haiku 4.5 (AU)",
+    "family": "claude-haiku",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-02-28",
+    "release_date": "2025-10-15",
+    "last_updated": "2025-10-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 5.0,
+      "cache_read": 0.1,
+      "cache_write": 1.25
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
     "id": "amazon-bedrock/au.anthropic.claude-opus-4.6-v1",
     "name": "AU Anthropic Claude Opus 4.6",
     "family": "claude-opus",
@@ -10787,6 +10946,39 @@
     "limit": {
       "context": 1000000,
       "output": 128000
+    }
+  },
+  {
+    "id": "amazon-bedrock/au.anthropic.claude-sonnet-4.5-20250929-v1:0",
+    "name": "Claude Sonnet 4.5 (AU)",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-07-31",
+    "release_date": "2025-09-29",
+    "last_updated": "2025-09-29",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
     }
   },
   {
@@ -11042,39 +11234,6 @@
     }
   },
   {
-    "id": "amazon-bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0",
-    "name": "Claude Sonnet 4 (EU)",
-    "family": "claude-sonnet",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-03-31",
-    "release_date": "2025-05-22",
-    "last_updated": "2025-05-22",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.3,
-      "cache_write": 3.75
-    },
-    "limit": {
-      "context": 200000,
-      "output": 64000
-    }
-  },
-  {
     "id": "amazon-bedrock/eu.anthropic.claude-sonnet-4.5-20250929-v1:0",
     "name": "Claude Sonnet 4.5 (EU)",
     "family": "claude-sonnet",
@@ -11273,39 +11432,6 @@
     }
   },
   {
-    "id": "amazon-bedrock/global.anthropic.claude-sonnet-4-20250514-v1:0",
-    "name": "Claude Sonnet 4 (Global)",
-    "family": "claude-sonnet",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-03-31",
-    "release_date": "2025-05-22",
-    "last_updated": "2025-05-22",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.3,
-      "cache_write": 3.75
-    },
-    "limit": {
-      "context": 200000,
-      "output": 64000
-    }
-  },
-  {
     "id": "amazon-bedrock/global.anthropic.claude-sonnet-4.5-20250929-v1:0",
     "name": "Claude Sonnet 4.5 (Global)",
     "family": "claude-sonnet",
@@ -11461,32 +11587,102 @@
     }
   },
   {
-    "id": "amazon-bedrock/meta.llama3-1-405b-instruct-v1:0",
-    "name": "Llama 3.1 405B Instruct",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
+    "id": "amazon-bedrock/jp.anthropic.claude-opus-4.7",
+    "name": "Claude Opus 4.7 (JP)",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
     "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-12",
-    "release_date": "2024-07-23",
-    "last_updated": "2024-07-23",
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-04-16",
+    "last_updated": "2026-04-16",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
-      "input": 2.4,
-      "output": 2.4
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
     },
     "limit": {
-      "context": 128000,
-      "output": 4096
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "amazon-bedrock/jp.anthropic.claude-sonnet-4.5-20250929-v1:0",
+    "name": "Claude Sonnet 4.5 (JP)",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-07-31",
+    "release_date": "2025-09-29",
+    "last_updated": "2025-09-29",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "amazon-bedrock/jp.anthropic.claude-sonnet-4.6",
+    "name": "Claude Sonnet 4.6 (JP)",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-02-17",
+    "last_updated": "2026-03-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 64000
     }
   },
   {
@@ -11541,124 +11737,6 @@
     "cost": {
       "input": 0.22,
       "output": 0.22
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "amazon-bedrock/meta.llama3-2-11b-instruct-v1:0",
-    "name": "Llama 3.2 11B Instruct",
-    "family": "llama",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-12",
-    "release_date": "2024-09-25",
-    "last_updated": "2024-09-25",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.16,
-      "output": 0.16
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "amazon-bedrock/meta.llama3-2-1b-instruct-v1:0",
-    "name": "Llama 3.2 1B Instruct",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-12",
-    "release_date": "2024-09-25",
-    "last_updated": "2024-09-25",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.1,
-      "output": 0.1
-    },
-    "limit": {
-      "context": 131000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "amazon-bedrock/meta.llama3-2-3b-instruct-v1:0",
-    "name": "Llama 3.2 3B Instruct",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-12",
-    "release_date": "2024-09-25",
-    "last_updated": "2024-09-25",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.15,
-      "output": 0.15
-    },
-    "limit": {
-      "context": 131000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "amazon-bedrock/meta.llama3-2-90b-instruct-v1:0",
-    "name": "Llama 3.2 90B Instruct",
-    "family": "llama",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-12",
-    "release_date": "2024-09-25",
-    "last_updated": "2024-09-25",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.72,
-      "output": 0.72
     },
     "limit": {
       "context": 128000,
@@ -12120,8 +12198,8 @@
       "output": 2.5
     },
     "limit": {
-      "context": 256000,
-      "output": 256000
+      "context": 262143,
+      "output": 16000
     }
   },
   {
@@ -12149,8 +12227,8 @@
       "output": 3.0
     },
     "limit": {
-      "context": 256000,
-      "output": 256000
+      "context": 262143,
+      "output": 16000
     }
   },
   {
@@ -12274,8 +12352,8 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2024-12-01",
-    "last_updated": "2024-12-01",
+    "release_date": "2025-08-05",
+    "last_updated": "2025-08-05",
     "modalities": {
       "input": [
         "text"
@@ -12291,7 +12369,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 4096
+      "output": 16384
     }
   },
   {
@@ -12302,8 +12380,8 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2024-12-01",
-    "last_updated": "2024-12-01",
+    "release_date": "2025-08-05",
+    "last_updated": "2025-08-05",
     "modalities": {
       "input": [
         "text"
@@ -12319,7 +12397,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 4096
+      "output": 16384
     }
   },
   {
@@ -12330,8 +12408,8 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2024-12-01",
-    "last_updated": "2024-12-01",
+    "release_date": "2025-10-29",
+    "last_updated": "2025-10-29",
     "modalities": {
       "input": [
         "text"
@@ -12347,7 +12425,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 4096
+      "output": 16384
     }
   },
   {
@@ -12358,8 +12436,8 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2024-12-01",
-    "last_updated": "2024-12-01",
+    "release_date": "2025-10-29",
+    "last_updated": "2025-10-29",
     "modalities": {
       "input": [
         "text"
@@ -12375,7 +12453,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 4096
+      "output": 16384
     }
   },
   {
@@ -12613,39 +12691,6 @@
     }
   },
   {
-    "id": "amazon-bedrock/us.anthropic.claude-opus-4-20250514-v1:0",
-    "name": "Claude Opus 4 (US)",
-    "family": "claude-opus",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-03-31",
-    "release_date": "2025-05-22",
-    "last_updated": "2025-05-22",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 15.0,
-      "output": 75.0,
-      "cache_read": 1.5,
-      "cache_write": 18.75
-    },
-    "limit": {
-      "context": 200000,
-      "output": 32000
-    }
-  },
-  {
     "id": "amazon-bedrock/us.anthropic.claude-opus-4.1-20250805-v1:0",
     "name": "Claude Opus 4.1 (US)",
     "family": "claude-opus",
@@ -12778,39 +12823,6 @@
     }
   },
   {
-    "id": "amazon-bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0",
-    "name": "Claude Sonnet 4 (US)",
-    "family": "claude-sonnet",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-03-31",
-    "release_date": "2025-05-22",
-    "last_updated": "2025-05-22",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.3,
-      "cache_write": 3.75
-    },
-    "limit": {
-      "context": 200000,
-      "output": 64000
-    }
-  },
-  {
     "id": "amazon-bedrock/us.anthropic.claude-sonnet-4.5-20250929-v1:0",
     "name": "Claude Sonnet 4.5 (US)",
     "family": "claude-sonnet",
@@ -12874,6 +12886,95 @@
     "limit": {
       "context": 1000000,
       "output": 64000
+    }
+  },
+  {
+    "id": "amazon-bedrock/us.deepseek.r1-v1:0",
+    "name": "DeepSeek-R1 (US)",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-07",
+    "release_date": "2025-01-20",
+    "last_updated": "2025-05-29",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.35,
+      "output": 5.4
+    },
+    "limit": {
+      "context": 128000,
+      "output": 32768
+    }
+  },
+  {
+    "id": "amazon-bedrock/us.meta.llama4-maverick-17b-instruct-v1:0",
+    "name": "Llama 4 Maverick 17B Instruct (US)",
+    "family": "llama",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-08",
+    "release_date": "2025-04-05",
+    "last_updated": "2025-04-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.24,
+      "output": 0.97
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 16384
+    }
+  },
+  {
+    "id": "amazon-bedrock/us.meta.llama4-scout-17b-instruct-v1:0",
+    "name": "Llama 4 Scout 17B Instruct (US)",
+    "family": "llama",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-08",
+    "release_date": "2025-04-05",
+    "last_updated": "2025-04-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.17,
+      "output": 0.66
+    },
+    "limit": {
+      "context": 3500000,
+      "output": 16384
     }
   },
   {
@@ -13019,6 +13120,68 @@
     }
   },
   {
+    "id": "ambient/moonshotai/kimi-k2.6",
+    "name": "Kimi K2.6",
+    "family": "kimi-k2.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.95,
+      "output": 4.0,
+      "cache_read": 0.2,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "ambient/zai-org/GLM-5.1-FP8",
+    "name": "GLM-5.1",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-27",
+    "last_updated": "2026-03-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.0,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 202752,
+      "output": 131072
+    }
+  },
+  {
     "id": "anthropic/claude-3-haiku",
     "name": "Claude Haiku 3",
     "family": "claude-haiku",
@@ -13119,7 +13282,7 @@
   },
   {
     "id": "anthropic/claude-3.5-haiku",
-    "name": "Claude Haiku 3.5 (latest)",
+    "name": "Claude Haiku 3.5",
     "family": "claude-haiku",
     "attachment": true,
     "reasoning": false,
@@ -13152,15 +13315,15 @@
   },
   {
     "id": "anthropic/claude-3.5-sonnet",
-    "name": "Claude Sonnet 3.5",
+    "name": "Claude Sonnet 3.5 v2",
     "family": "claude-sonnet",
     "attachment": true,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2024-04-30",
-    "release_date": "2024-06-20",
-    "last_updated": "2024-06-20",
+    "release_date": "2024-10-22",
+    "last_updated": "2024-10-22",
     "modalities": {
       "input": [
         "text",
@@ -13317,7 +13480,7 @@
   },
   {
     "id": "anthropic/claude-opus-4.1",
-    "name": "Claude Opus 4.1",
+    "name": "Claude Opus 4.1 (latest)",
     "family": "claude-opus",
     "attachment": true,
     "reasoning": true,
@@ -13515,7 +13678,7 @@
   },
   {
     "id": "anthropic/claude-sonnet-4.5",
-    "name": "Claude Sonnet 4.5 (latest)",
+    "name": "Claude Sonnet 4.5",
     "family": "claude-sonnet",
     "attachment": true,
     "reasoning": true,
@@ -13577,6 +13740,621 @@
     "limit": {
       "context": 1000000,
       "output": 64000
+    }
+  },
+  {
+    "id": "atomic-chat/Meta-Llama-3_1-8B-Instruct-GGUF",
+    "name": "Meta Llama 3.1 8B Instruct (GGUF)",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2024-07-23",
+    "last_updated": "2024-07-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 131072,
+      "output": 4096
+    }
+  },
+  {
+    "id": "atomic-chat/Qwen3_5-9B-MLX-4bit",
+    "name": "Qwen 3.5 9B (MLX 4-bit)",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-05",
+    "last_updated": "2026-04-04",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 32768,
+      "output": 8192
+    }
+  },
+  {
+    "id": "atomic-chat/Qwen3_5-9B-Q4_K_M",
+    "name": "Qwen 3.5 9B (Q4_K_M)",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-05",
+    "last_updated": "2026-04-04",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 32768,
+      "output": 8192
+    }
+  },
+  {
+    "id": "atomic-chat/gemma-4-E4B-it-IQ4_XS",
+    "name": "Gemma 4 E4B Instruct (IQ4_XS)",
+    "family": "gemma",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 32768,
+      "output": 8192
+    }
+  },
+  {
+    "id": "atomic-chat/gemma-4-E4B-it-MLX-4bit",
+    "name": "Gemma 4 E4B Instruct (MLX 4-bit)",
+    "family": "gemma",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 32768,
+      "output": 8192
+    }
+  },
+  {
+    "id": "auriko/claude-opus-4.6",
+    "name": "Claude Opus 4.6",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05-31",
+    "release_date": "2026-02-05",
+    "last_updated": "2026-03-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "auriko/claude-opus-4.7",
+    "name": "Claude Opus 4.7",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-04-16",
+    "last_updated": "2026-04-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "auriko/claude-sonnet-4.6",
+    "name": "Claude Sonnet 4.6",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-02-17",
+    "last_updated": "2026-03-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "auriko/deepseek-v4-flash",
+    "name": "DeepSeek V4 Flash",
+    "family": "deepseek-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.0028
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "auriko/deepseek-v4-pro",
+    "name": "DeepSeek V4 Pro",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.435,
+      "output": 0.87,
+      "cache_read": 0.003625
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "auriko/gemini-2.5-flash",
+    "name": "Gemini 2.5 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-03-20",
+    "last_updated": "2025-06-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 2.5,
+      "cache_read": 0.03
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "auriko/gemini-2.5-pro",
+    "name": "Gemini 2.5 Pro",
+    "family": "gemini-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-03-20",
+    "last_updated": "2025-06-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "auriko/gemini-3.1-pro-preview",
+    "name": "Gemini 3.1 Pro Preview",
+    "family": "gemini-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-02-19",
+    "last_updated": "2026-02-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 12.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "auriko/glm-5.1",
+    "name": "GLM-5.1",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-27",
+    "last_updated": "2026-03-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26
+    },
+    "limit": {
+      "context": 200000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "auriko/grok-4.3",
+    "name": "Grok 4.3",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-05-01",
+    "last_updated": "2026-05-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 30000
+    }
+  },
+  {
+    "id": "auriko/kimi-k2.5",
+    "name": "Kimi K2.5",
+    "family": "kimi-k2.5",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-01",
+    "release_date": "2026-01",
+    "last_updated": "2026-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.5,
+      "output": 2.8
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "auriko/kimi-k2.6",
+    "name": "Kimi K2.6",
+    "family": "kimi-k2.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.95,
+      "output": 4.0,
+      "cache_read": 0.16
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "auriko/minimax-m2-7",
+    "name": "MiniMax-M2.7",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_write": 0.375
+    },
+    "limit": {
+      "context": 204800,
+      "output": 131072
+    }
+  },
+  {
+    "id": "auriko/minimax-m2-7-highspeed",
+    "name": "MiniMax-M2.7-highspeed",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.6,
+      "output": 2.4,
+      "cache_write": 0.375
+    },
+    "limit": {
+      "context": 204800,
+      "output": 131072
+    }
+  },
+  {
+    "id": "auriko/qwen-3.6-plus",
+    "name": "Qwen3.6 Plus",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.5,
+      "output": 3.0,
+      "cache_read": 0.1
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
     }
   },
   {
@@ -14122,15 +14900,15 @@
   },
   {
     "id": "azure-cognitive-services/gpt-3.5-turbo",
-    "name": "GPT-3.5 Turbo 0125",
+    "name": "GPT-3.5 Turbo 0301",
     "family": "gpt",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
     "knowledge": "2021-08",
-    "release_date": "2024-01-25",
-    "last_updated": "2024-01-25",
+    "release_date": "2023-03-01",
+    "last_updated": "2023-03-01",
     "modalities": {
       "input": [
         "text"
@@ -14141,12 +14919,12 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.5,
-      "output": 1.5
+      "input": 1.5,
+      "output": 2.0
     },
     "limit": {
-      "context": 16384,
-      "output": 16384
+      "context": 4096,
+      "output": 4096
     }
   },
   {
@@ -15052,96 +15830,6 @@
     }
   },
   {
-    "id": "azure-cognitive-services/grok-3",
-    "name": "Grok 3",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-11",
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.75
-    },
-    "limit": {
-      "context": 131072,
-      "output": 8192
-    }
-  },
-  {
-    "id": "azure-cognitive-services/grok-3-mini",
-    "name": "Grok 3 Mini",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-11",
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.3,
-      "output": 0.5,
-      "cache_read": 0.075
-    },
-    "limit": {
-      "context": 131072,
-      "output": 8192
-    }
-  },
-  {
-    "id": "azure-cognitive-services/grok-4",
-    "name": "Grok 4",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
-    "release_date": "2025-07-09",
-    "last_updated": "2025-07-09",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.75
-    },
-    "limit": {
-      "context": 256000,
-      "output": 64000
-    }
-  },
-  {
     "id": "azure-cognitive-services/grok-4-fast",
     "name": "Grok 4 Fast (Reasoning)",
     "family": "grok",
@@ -15170,67 +15858,6 @@
     "limit": {
       "context": 2000000,
       "output": 30000
-    }
-  },
-  {
-    "id": "azure-cognitive-services/grok-4-fast-non",
-    "name": "Grok 4 Fast (Non-Reasoning)",
-    "family": "grok",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
-    "release_date": "2025-09-19",
-    "last_updated": "2025-09-19",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.5,
-      "cache_read": 0.05
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 30000
-    }
-  },
-  {
-    "id": "azure-cognitive-services/grok-code-fast-1",
-    "name": "Grok Code Fast 1",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-10",
-    "release_date": "2025-08-28",
-    "last_updated": "2025-08-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 1.5,
-      "cache_read": 0.02
-    },
-    "limit": {
-      "context": 256000,
-      "output": 10000
     }
   },
   {
@@ -16238,10 +16865,10 @@
   },
   {
     "id": "azure-cognitive-services/phi-4",
-    "name": "Phi-4-reasoning",
+    "name": "Phi-4",
     "family": "phi",
     "attachment": false,
-    "reasoning": true,
+    "reasoning": false,
     "tool_call": false,
     "temperature": true,
     "knowledge": "2023-10",
@@ -16261,16 +16888,16 @@
       "output": 0.5
     },
     "limit": {
-      "context": 32000,
+      "context": 128000,
       "output": 4096
     }
   },
   {
     "id": "azure-cognitive-services/phi-4-mini",
-    "name": "Phi-4-mini-reasoning",
+    "name": "Phi-4-mini",
     "family": "phi",
     "attachment": false,
-    "reasoning": true,
+    "reasoning": false,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2023-10",
@@ -18003,96 +18630,6 @@
     }
   },
   {
-    "id": "azure/grok-3",
-    "name": "Grok 3",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-11",
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.75
-    },
-    "limit": {
-      "context": 131072,
-      "output": 8192
-    }
-  },
-  {
-    "id": "azure/grok-3-mini",
-    "name": "Grok 3 Mini",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-11",
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.3,
-      "output": 0.5,
-      "cache_read": 0.075
-    },
-    "limit": {
-      "context": 131072,
-      "output": 8192
-    }
-  },
-  {
-    "id": "azure/grok-4",
-    "name": "Grok 4",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
-    "release_date": "2025-07-09",
-    "last_updated": "2025-07-09",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.75
-    },
-    "limit": {
-      "context": 256000,
-      "output": 64000
-    }
-  },
-  {
     "id": "azure/grok-4-20",
     "name": "Grok 4.20 (Reasoning)",
     "family": "grok",
@@ -18182,37 +18719,6 @@
     }
   },
   {
-    "id": "azure/grok-4-fast-non",
-    "name": "Grok 4 Fast (Non-Reasoning)",
-    "family": "grok",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
-    "release_date": "2025-09-19",
-    "last_updated": "2025-09-19",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.5,
-      "cache_read": 0.05
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 30000
-    }
-  },
-  {
     "id": "azure/grok-4.1-fast",
     "name": "Grok 4.1 Fast (Reasoning)",
     "family": "grok",
@@ -18270,36 +18776,6 @@
     "limit": {
       "context": 128000,
       "output": 8192
-    }
-  },
-  {
-    "id": "azure/grok-code-fast-1",
-    "name": "Grok Code Fast 1",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-10",
-    "release_date": "2025-08-28",
-    "last_updated": "2025-08-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 1.5,
-      "cache_read": 0.02
-    },
-    "limit": {
-      "context": 256000,
-      "output": 10000
     }
   },
   {
@@ -19307,10 +19783,10 @@
   },
   {
     "id": "azure/phi-4",
-    "name": "Phi-4",
+    "name": "Phi-4-reasoning",
     "family": "phi",
     "attachment": false,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": false,
     "temperature": true,
     "knowledge": "2023-10",
@@ -19330,16 +19806,16 @@
       "output": 0.5
     },
     "limit": {
-      "context": 128000,
+      "context": 32000,
       "output": 4096
     }
   },
   {
     "id": "azure/phi-4-mini",
-    "name": "Phi-4-mini",
+    "name": "Phi-4-mini-reasoning",
     "family": "phi",
     "attachment": false,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2023-10",
@@ -20092,6 +20568,38 @@
     }
   },
   {
+    "id": "berget/moonshotai/Kimi-K2.6",
+    "name": "Kimi K2.6",
+    "family": "kimi-k2.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-05-07",
+    "last_updated": "2026-05-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.83,
+      "output": 3.85,
+      "cache_read": 0.16
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
     "id": "berget/openai/gpt-oss-120b",
     "name": "GPT-OSS-120B",
     "family": "gpt-oss",
@@ -20265,34 +20773,6 @@
     }
   },
   {
-    "id": "chutes/MiniMaxAI/MiniMax-M2.1-TEE",
-    "name": "MiniMax M2.1 TEE",
-    "family": "minimax",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-27",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.27,
-      "output": 1.12
-    },
-    "limit": {
-      "context": 196608,
-      "output": 65536
-    }
-  },
-  {
     "id": "chutes/MiniMaxAI/MiniMax-M2.5-TEE",
     "name": "MiniMax M2.5 TEE",
     "family": "minimax",
@@ -20301,7 +20781,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-02-15",
-    "last_updated": "2026-02-15",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -20312,9 +20792,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.3,
-      "output": 1.1,
-      "cache_read": 0.15
+      "input": 0.15,
+      "output": 1.2,
+      "cache_read": 0.075
     },
     "limit": {
       "context": 196608,
@@ -20330,7 +20810,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -20341,8 +20821,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.02,
-      "output": 0.1
+      "input": 0.0245,
+      "output": 0.0978,
+      "cache_read": 0.01225
     },
     "limit": {
       "context": 32768,
@@ -20358,7 +20839,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -20369,125 +20850,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.01,
-      "output": 0.05
+      "input": 0.0136,
+      "output": 0.0543,
+      "cache_read": 0.0068
     },
     "limit": {
       "context": 40960,
       "output": 40960
-    }
-  },
-  {
-    "id": "chutes/NousResearch/Hermes-4-405B-FP8-TEE",
-    "name": "Hermes 4 405B FP8 TEE",
-    "family": "nousresearch",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.3,
-      "output": 1.2
-    },
-    "limit": {
-      "context": 131072,
-      "output": 65536
-    }
-  },
-  {
-    "id": "chutes/NousResearch/Hermes-4-70B",
-    "name": "Hermes 4 70B",
-    "family": "nousresearch",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.11,
-      "output": 0.38
-    },
-    "limit": {
-      "context": 131072,
-      "output": 131072
-    }
-  },
-  {
-    "id": "chutes/NousResearch/Hermes-4.3-36B",
-    "name": "Hermes 4.3 36B",
-    "family": "nousresearch",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.1,
-      "output": 0.39
-    },
-    "limit": {
-      "context": 32768,
-      "output": 8192
-    }
-  },
-  {
-    "id": "chutes/OpenGVLab/InternVL3-78B-TEE",
-    "name": "InternVL3 78B TEE",
-    "family": "opengvlab",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2025-01-06",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.1,
-      "output": 0.39
-    },
-    "limit": {
-      "context": 32768,
-      "output": 32768
     }
   },
   {
@@ -20499,7 +20868,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -20510,8 +20879,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.13,
-      "output": 0.52
+      "input": 0.2989,
+      "output": 1.1957,
+      "cache_read": 0.14945
     },
     "limit": {
       "context": 32768,
@@ -20527,7 +20897,7 @@
     "tool_call": false,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -20538,8 +20908,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.03,
-      "output": 0.11
+      "input": 0.0272,
+      "output": 0.1087,
+      "cache_read": 0.0136
     },
     "limit": {
       "context": 32768,
@@ -20550,12 +20921,12 @@
     "id": "chutes/Qwen/Qwen2.5-VL-32B-Instruct",
     "name": "Qwen2.5 VL 32B Instruct",
     "family": "qwen",
-    "attachment": false,
+    "attachment": true,
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text",
@@ -20567,97 +20938,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.05,
-      "output": 0.22
+      "input": 0.0543,
+      "output": 0.2174,
+      "cache_read": 0.02715
     },
     "limit": {
       "context": 16384,
       "output": 16384
-    }
-  },
-  {
-    "id": "chutes/Qwen/Qwen2.5-VL-72B-Instruct-TEE",
-    "name": "Qwen2.5 VL 72B Instruct TEE",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.15,
-      "output": 0.6
-    },
-    "limit": {
-      "context": 32768,
-      "output": 32768
-    }
-  },
-  {
-    "id": "chutes/Qwen/Qwen3-14B",
-    "name": "Qwen3 14B",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.05,
-      "output": 0.22
-    },
-    "limit": {
-      "context": 40960,
-      "output": 40960
-    }
-  },
-  {
-    "id": "chutes/Qwen/Qwen3-235B-A22B",
-    "name": "Qwen3 235B A22B",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.3,
-      "output": 1.2
-    },
-    "limit": {
-      "context": 40960,
-      "output": 40960
     }
   },
   {
@@ -20669,7 +20956,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -20680,9 +20967,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.08,
-      "output": 0.55,
-      "cache_read": 0.04
+      "input": 0.1,
+      "output": 0.6,
+      "cache_read": 0.05
     },
     "limit": {
       "context": 262144,
@@ -20698,7 +20985,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -20710,7 +20997,8 @@
     "open_weights": true,
     "cost": {
       "input": 0.11,
-      "output": 0.6
+      "output": 0.6,
+      "cache_read": 0.055
     },
     "limit": {
       "context": 262144,
@@ -20726,7 +21014,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -20738,7 +21026,8 @@
     "open_weights": true,
     "cost": {
       "input": 0.06,
-      "output": 0.22
+      "output": 0.22,
+      "cache_read": 0.03
     },
     "limit": {
       "context": 40960,
@@ -20746,43 +21035,15 @@
     }
   },
   {
-    "id": "chutes/Qwen/Qwen3-30B-A3B-Instruct",
-    "name": "Qwen3 30B A3B Instruct 2507",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.08,
-      "output": 0.33
-    },
-    "limit": {
-      "context": 262144,
-      "output": 262144
-    }
-  },
-  {
-    "id": "chutes/Qwen/Qwen3-32B",
-    "name": "Qwen3 32B",
+    "id": "chutes/Qwen/Qwen3-32B-TEE",
+    "name": "Qwen3 32B TEE",
     "family": "qwen",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "release_date": "2026-04-25",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -20803,15 +21064,15 @@
     }
   },
   {
-    "id": "chutes/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8-TEE",
-    "name": "Qwen3 Coder 480B A35B Instruct FP8 TEE",
+    "id": "chutes/Qwen/Qwen3-Coder-Next-TEE",
+    "name": "Qwen3 Coder Next TEE",
     "family": "qwen",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "release_date": "2026-04-25",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -20822,37 +21083,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.22,
-      "output": 0.95,
-      "cache_read": 0.11
-    },
-    "limit": {
-      "context": 262144,
-      "output": 262144
-    }
-  },
-  {
-    "id": "chutes/Qwen/Qwen3-Coder-Next",
-    "name": "Qwen3 Coder Next",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-02-05",
-    "last_updated": "2026-02-05",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.07,
-      "output": 0.3
+      "input": 0.12,
+      "output": 0.75,
+      "cache_read": 0.06
     },
     "limit": {
       "context": 262144,
@@ -20868,7 +21101,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -20880,36 +21113,8 @@
     "open_weights": true,
     "cost": {
       "input": 0.1,
-      "output": 0.8
-    },
-    "limit": {
-      "context": 262144,
-      "output": 262144
-    }
-  },
-  {
-    "id": "chutes/Qwen/Qwen3-VL-235B-A22B-Instruct",
-    "name": "Qwen3 VL 235B A22B Instruct",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.3,
-      "output": 1.2
+      "output": 0.8,
+      "cache_read": 0.05
     },
     "limit": {
       "context": 262144,
@@ -20925,7 +21130,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-02-18",
-    "last_updated": "2026-02-18",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text",
@@ -20947,6 +21152,36 @@
     }
   },
   {
+    "id": "chutes/Qwen/Qwen3.6-27B-TEE",
+    "name": "Qwen3.6 27B TEE",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-25",
+    "last_updated": "2026-04-25",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.195,
+      "output": 1.56,
+      "cache_read": 0.0975
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
     "id": "chutes/Qwen/Qwen3Guard-Gen-0.6B",
     "name": "Qwen3Guard Gen 0.6B",
     "family": "qwen",
@@ -20955,7 +21190,7 @@
     "tool_call": false,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -20967,7 +21202,7 @@
     "open_weights": true,
     "cost": {
       "input": 0.01,
-      "output": 0.01,
+      "output": 0.0109,
       "cache_read": 0.005
     },
     "limit": {
@@ -20976,15 +21211,15 @@
     }
   },
   {
-    "id": "chutes/XiaomiMiMo/MiMo-V2-Flash",
-    "name": "MiMo V2 Flash",
+    "id": "chutes/XiaomiMiMo/MiMo-V2-Flash-TEE",
+    "name": "MiMo V2 Flash TEE",
     "family": "mimo",
     "attachment": false,
-    "reasoning": true,
+    "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-27",
+    "release_date": "2026-04-25",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -20996,70 +21231,12 @@
     "open_weights": true,
     "cost": {
       "input": 0.09,
-      "output": 0.29
+      "output": 0.29,
+      "cache_read": 0.045
     },
     "limit": {
       "context": 262144,
-      "output": 32000
-    }
-  },
-  {
-    "id": "chutes/chutesai/Mistral-Small-3.1-24B-Instruct",
-    "name": "Mistral Small 3.1 24B Instruct 2503",
-    "family": "chutesai",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.03,
-      "output": 0.11,
-      "cache_read": 0.015
-    },
-    "limit": {
-      "context": 131072,
-      "output": 131072
-    }
-  },
-  {
-    "id": "chutes/chutesai/Mistral-Small-3.2-24B-Instruct",
-    "name": "Mistral Small 3.2 24B Instruct 2506",
-    "family": "chutesai",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.06,
-      "output": 0.18
-    },
-    "limit": {
-      "context": 131072,
-      "output": 131072
+      "output": 65536
     }
   },
   {
@@ -21071,7 +21248,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -21082,8 +21259,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.4,
-      "output": 1.75
+      "input": 0.45,
+      "output": 2.15,
+      "cache_read": 0.225
     },
     "limit": {
       "context": 163840,
@@ -21099,7 +21277,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -21110,68 +21288,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.03,
-      "output": 0.11
+      "input": 0.0272,
+      "output": 0.1087,
+      "cache_read": 0.0136
     },
     "limit": {
       "context": 131072,
       "output": 131072
-    }
-  },
-  {
-    "id": "chutes/deepseek-ai/DeepSeek-R1-TEE",
-    "name": "DeepSeek R1 TEE",
-    "family": "deepseek-thinking",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.3,
-      "output": 1.2
-    },
-    "limit": {
-      "context": 163840,
-      "output": 163840
-    }
-  },
-  {
-    "id": "chutes/deepseek-ai/DeepSeek-V3",
-    "name": "DeepSeek V3",
-    "family": "deepseek",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.3,
-      "output": 1.2
-    },
-    "limit": {
-      "context": 163840,
-      "output": 163840
     }
   },
   {
@@ -21183,7 +21306,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -21194,9 +21317,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.19,
-      "output": 0.87,
-      "cache_read": 0.095
+      "input": 0.25,
+      "output": 1.0,
+      "cache_read": 0.125
     },
     "limit": {
       "context": 163840,
@@ -21212,63 +21335,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.2,
-      "output": 0.8
-    },
-    "limit": {
-      "context": 163840,
-      "output": 65536
-    }
-  },
-  {
-    "id": "chutes/deepseek-ai/DeepSeek-V3.1-Terminus-TEE",
-    "name": "DeepSeek V3.1 Terminus TEE",
-    "family": "deepseek",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.23,
-      "output": 0.9
-    },
-    "limit": {
-      "context": 163840,
-      "output": 65536
-    }
-  },
-  {
-    "id": "chutes/deepseek-ai/DeepSeek-V3.2-Speciale-TEE",
-    "name": "DeepSeek V3.2 Speciale TEE",
-    "family": "deepseek",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -21280,7 +21347,8 @@
     "open_weights": true,
     "cost": {
       "input": 0.27,
-      "output": 0.41
+      "output": 1.0,
+      "cache_read": 0.135
     },
     "limit": {
       "context": 163840,
@@ -21296,7 +21364,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -21317,102 +21385,19 @@
     }
   },
   {
-    "id": "chutes/miromind-ai/MiroThinker-v1.5-235B",
-    "name": "MiroThinker V1.5 235B",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2026-01-10",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.3,
-      "output": 1.2,
-      "cache_read": 0.15
-    },
-    "limit": {
-      "context": 262144,
-      "output": 8192
-    }
-  },
-  {
-    "id": "chutes/mistralai/Devstral-2-123B-Instruct-2512-TEE",
-    "name": "Devstral 2 123B Instruct 2512 TEE",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-01-10",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.05,
-      "output": 0.22
-    },
-    "limit": {
-      "context": 262144,
-      "output": 65536
-    }
-  },
-  {
-    "id": "chutes/moonshotai/Kimi-K2-Instruct",
-    "name": "Kimi K2 Instruct 0905",
-    "family": "kimi",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.39,
-      "output": 1.9,
-      "cache_read": 0.195
-    },
-    "limit": {
-      "context": 262144,
-      "output": 262144
-    }
-  },
-  {
-    "id": "chutes/moonshotai/Kimi-K2-Thinking-TEE",
-    "name": "Kimi K2 Thinking TEE",
-    "family": "kimi-thinking",
-    "attachment": false,
+    "id": "chutes/google/gemma-4-31B-turbo-TEE",
+    "name": "gemma 4 31B turbo TEE",
+    "family": "gemma",
+    "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "release_date": "2026-04-25",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image"
       ],
       "output": [
         "text"
@@ -21420,25 +21405,26 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.4,
-      "output": 1.75
+      "input": 0.13,
+      "output": 0.38,
+      "cache_read": 0.065
     },
     "limit": {
-      "context": 262144,
-      "output": 65535
+      "context": 131072,
+      "output": 65536
     }
   },
   {
     "id": "chutes/moonshotai/Kimi-K2.5-TEE",
     "name": "Kimi K2.5 TEE",
     "family": "kimi",
-    "attachment": false,
+    "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2024-10",
     "release_date": "2026-01-27",
-    "last_updated": "2026-01-27",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text",
@@ -21451,8 +21437,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.6,
-      "output": 3.0
+      "input": 0.44,
+      "output": 2.0,
+      "cache_read": 0.22
     },
     "limit": {
       "context": 262144,
@@ -21469,7 +21456,7 @@
     "temperature": true,
     "knowledge": "2025-12",
     "release_date": "2026-04-20",
-    "last_updated": "2026-04-23",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text",
@@ -21482,40 +21469,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.44,
-      "output": 2.0
+      "input": 0.95,
+      "output": 4.0,
+      "cache_read": 0.475
     },
     "limit": {
       "context": 262144,
-      "output": 262144
-    }
-  },
-  {
-    "id": "chutes/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
-    "name": "NVIDIA Nemotron 3 Nano 30B A3B BF16",
-    "family": "nemotron",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.06,
-      "output": 0.24
-    },
-    "limit": {
-      "context": 262144,
-      "output": 262144
+      "output": 65535
     }
   },
   {
@@ -21527,7 +21487,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -21538,8 +21498,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.04,
-      "output": 0.18
+      "input": 0.09,
+      "output": 0.36,
+      "cache_read": 0.045
     },
     "limit": {
       "context": 131072,
@@ -21547,43 +21508,15 @@
     }
   },
   {
-    "id": "chutes/openai/gpt-oss-20b",
-    "name": "gpt oss 20b",
-    "family": "gpt-oss",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.02,
-      "output": 0.1
-    },
-    "limit": {
-      "context": 131072,
-      "output": 131072
-    }
-  },
-  {
     "id": "chutes/rednote-hilab/dots.ocr",
     "name": "dots.ocr",
     "family": "rednote",
-    "attachment": false,
+    "attachment": true,
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text",
@@ -21596,7 +21529,7 @@
     "open_weights": true,
     "cost": {
       "input": 0.01,
-      "output": 0.01,
+      "output": 0.0109,
       "cache_read": 0.005
     },
     "limit": {
@@ -21605,15 +21538,15 @@
     }
   },
   {
-    "id": "chutes/tngtech/DeepSeek-R1T-Chimera",
-    "name": "DeepSeek R1T Chimera",
-    "family": "tngtech",
+    "id": "chutes/tngtech/DeepSeek-TNG-R1T2-Chimera-TEE",
+    "name": "DeepSeek TNG R1T2 Chimera TEE",
+    "family": "deepseek",
     "attachment": false,
     "reasoning": true,
-    "tool_call": false,
+    "tool_call": true,
     "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "release_date": "2026-04-25",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -21625,105 +21558,24 @@
     "open_weights": true,
     "cost": {
       "input": 0.3,
-      "output": 1.2
+      "output": 1.1,
+      "cache_read": 0.15
     },
     "limit": {
       "context": 163840,
       "output": 163840
-    }
-  },
-  {
-    "id": "chutes/tngtech/DeepSeek-TNG-R1T2-Chimera",
-    "name": "DeepSeek TNG R1T2 Chimera",
-    "family": "tngtech",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.25,
-      "output": 0.85
-    },
-    "limit": {
-      "context": 163840,
-      "output": 163840
-    }
-  },
-  {
-    "id": "chutes/tngtech/TNG-R1T-Chimera-TEE",
-    "name": "TNG R1T Chimera TEE",
-    "family": "tngtech",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.25,
-      "output": 0.85
-    },
-    "limit": {
-      "context": 163840,
-      "output": 65536
-    }
-  },
-  {
-    "id": "chutes/tngtech/TNG-R1T-Chimera-Turbo",
-    "name": "TNG R1T Chimera Turbo",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-01-27",
-    "last_updated": "2026-01-27",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.22,
-      "output": 0.6
-    },
-    "limit": {
-      "context": 163840,
-      "output": 65536
     }
   },
   {
     "id": "chutes/unsloth/Llama-3.2-1B-Instruct",
     "name": "Llama 3.2 1B Instruct",
+    "family": "unsloth",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
     "release_date": "2026-01-27",
-    "last_updated": "2026-01-27",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -21735,11 +21587,11 @@
     "open_weights": true,
     "cost": {
       "input": 0.01,
-      "output": 0.01,
+      "output": 0.0109,
       "cache_read": 0.005
     },
     "limit": {
-      "context": 32768,
+      "context": 16384,
       "output": 8192
     }
   },
@@ -21752,7 +21604,7 @@
     "tool_call": false,
     "temperature": true,
     "release_date": "2025-02-12",
-    "last_updated": "2025-02-12",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -21764,7 +21616,7 @@
     "open_weights": true,
     "cost": {
       "input": 0.01,
-      "output": 0.01,
+      "output": 0.0136,
       "cache_read": 0.005
     },
     "limit": {
@@ -21781,7 +21633,7 @@
     "tool_call": false,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -21802,44 +21654,15 @@
     }
   },
   {
-    "id": "chutes/unsloth/Mistral-Small-24B-Instruct",
-    "name": "Mistral Small 24B Instruct 2501",
-    "family": "unsloth",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.03,
-      "output": 0.11
-    },
-    "limit": {
-      "context": 32768,
-      "output": 32768
-    }
-  },
-  {
     "id": "chutes/unsloth/gemma-3-12b-it",
     "name": "gemma 3 12b it",
     "family": "unsloth",
-    "attachment": false,
+    "attachment": true,
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text",
@@ -21852,7 +21675,8 @@
     "open_weights": true,
     "cost": {
       "input": 0.03,
-      "output": 0.1
+      "output": 0.1,
+      "cache_read": 0.015
     },
     "limit": {
       "context": 131072,
@@ -21863,12 +21687,12 @@
     "id": "chutes/unsloth/gemma-3-27b-it",
     "name": "gemma 3 27b it",
     "family": "unsloth",
-    "attachment": false,
+    "attachment": true,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text",
@@ -21880,9 +21704,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.04,
-      "output": 0.15,
-      "cache_read": 0.02
+      "input": 0.0272,
+      "output": 0.1087,
+      "cache_read": 0.0136
     },
     "limit": {
       "context": 128000,
@@ -21893,12 +21717,12 @@
     "id": "chutes/unsloth/gemma-3-4b-it",
     "name": "gemma 3 4b it",
     "family": "unsloth",
-    "attachment": false,
+    "attachment": true,
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text",
@@ -21911,7 +21735,8 @@
     "open_weights": true,
     "cost": {
       "input": 0.01,
-      "output": 0.03
+      "output": 0.0272,
+      "cache_read": 0.005
     },
     "limit": {
       "context": 96000,
@@ -21919,154 +21744,15 @@
     }
   },
   {
-    "id": "chutes/zai-org/GLM-4.5-Air",
-    "name": "GLM 4.5 Air",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.05,
-      "output": 0.22
-    },
-    "limit": {
-      "context": 131072,
-      "output": 131072
-    }
-  },
-  {
-    "id": "chutes/zai-org/GLM-4.5-FP8",
-    "name": "GLM 4.5 FP8",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-01-27",
-    "last_updated": "2026-01-27",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.3,
-      "output": 1.2
-    },
-    "limit": {
-      "context": 131072,
-      "output": 65536
-    }
-  },
-  {
-    "id": "chutes/zai-org/GLM-4.5-TEE",
-    "name": "GLM 4.5 TEE",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.35,
-      "output": 1.55
-    },
-    "limit": {
-      "context": 131072,
-      "output": 65536
-    }
-  },
-  {
-    "id": "chutes/zai-org/GLM-4.6-FP8",
-    "name": "GLM 4.6 FP8",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-01-27",
-    "last_updated": "2026-01-27",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.3,
-      "output": 1.2
-    },
-    "limit": {
-      "context": 202752,
-      "output": 65535
-    }
-  },
-  {
-    "id": "chutes/zai-org/GLM-4.6-TEE",
-    "name": "GLM 4.6 TEE",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.4,
-      "output": 1.7,
-      "cache_read": 0.2
-    },
-    "limit": {
-      "context": 202752,
-      "output": 65536
-    }
-  },
-  {
     "id": "chutes/zai-org/GLM-4.6V",
     "name": "GLM 4.6V",
     "family": "glm",
-    "attachment": false,
+    "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text",
@@ -22090,12 +21776,13 @@
   {
     "id": "chutes/zai-org/GLM-4.7-FP8",
     "name": "GLM 4.7 FP8",
+    "family": "glm",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-01-27",
-    "last_updated": "2026-01-27",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -22106,35 +21793,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.3,
-      "output": 1.2
-    },
-    "limit": {
-      "context": 202752,
-      "output": 65535
-    }
-  },
-  {
-    "id": "chutes/zai-org/GLM-4.7-Flash",
-    "name": "GLM 4.7 Flash",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-01-27",
-    "last_updated": "2026-01-27",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.06,
-      "output": 0.35
+      "input": 0.2989,
+      "output": 1.1957,
+      "cache_read": 0.14945
     },
     "limit": {
       "context": 202752,
@@ -22150,7 +21811,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-12-29",
-    "last_updated": "2026-01-10",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -22161,8 +21822,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.4,
-      "output": 1.5
+      "input": 0.39,
+      "output": 1.75,
+      "cache_read": 0.195
     },
     "limit": {
       "context": 202752,
@@ -22178,7 +21840,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-02-14",
-    "last_updated": "2026-02-14",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -22190,7 +21852,7 @@
     "open_weights": true,
     "cost": {
       "input": 0.95,
-      "output": 3.15,
+      "output": 2.55,
       "cache_read": 0.475
     },
     "limit": {
@@ -22207,7 +21869,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-03-11",
-    "last_updated": "2026-03-11",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -22218,9 +21880,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.49,
-      "output": 1.96,
-      "cache_read": 0.245
+      "input": 0.4891,
+      "output": 1.9565,
+      "cache_read": 0.24455
     },
     "limit": {
       "context": 202752,
@@ -22236,7 +21898,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-04-08",
-    "last_updated": "2026-04-08",
+    "last_updated": "2026-04-25",
     "modalities": {
       "input": [
         "text"
@@ -22247,9 +21909,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.95,
-      "output": 3.15,
-      "cache_read": 0.475
+      "input": 1.05,
+      "output": 3.5,
+      "cache_read": 0.525
     },
     "limit": {
       "context": 202752,
@@ -22603,6 +22265,35 @@
     }
   },
   {
+    "id": "claudinio/claudinio",
+    "name": "Claudinio",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "knowledge": "2026-05",
+    "release_date": "2026-05-12",
+    "last_updated": "2026-05-12",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.5,
+      "output": 2.0,
+      "cache_read": 0.05
+    },
+    "limit": {
+      "context": 256000,
+      "output": 64000
+    }
+  },
+  {
     "id": "cloudferro-sherlock/MiniMaxAI/MiniMax-M2.5",
     "name": "MiniMax-M2.5",
     "family": "minimax",
@@ -22628,7 +22319,7 @@
     },
     "limit": {
       "context": 196000,
-      "output": 196000
+      "output": 16000
     }
   },
   {
@@ -26940,6 +26631,811 @@
     }
   },
   {
+    "id": "databricks/databricks-claude-haiku-4.5",
+    "name": "Claude Haiku 4.5 (latest)",
+    "family": "claude-haiku",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-02-28",
+    "release_date": "2025-10-15",
+    "last_updated": "2025-10-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 5.0,
+      "cache_read": 0.1,
+      "cache_write": 1.25
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "databricks/databricks-claude-opus-4.1",
+    "name": "Claude Opus 4.1 (latest)",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-08-05",
+    "last_updated": "2025-08-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 15.0,
+      "output": 75.0,
+      "cache_read": 1.5,
+      "cache_write": 18.75
+    },
+    "limit": {
+      "context": 200000,
+      "output": 32000
+    }
+  },
+  {
+    "id": "databricks/databricks-claude-opus-4.5",
+    "name": "Claude Opus 4.5 (latest)",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-11-24",
+    "last_updated": "2025-11-24",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "databricks/databricks-claude-opus-4.6",
+    "name": "Claude Opus 4.6",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05-31",
+    "release_date": "2026-02-05",
+    "last_updated": "2026-03-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "databricks/databricks-claude-opus-4.7",
+    "name": "Claude Opus 4.7",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-04-16",
+    "last_updated": "2026-04-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "databricks/databricks-claude-sonnet-4",
+    "name": "Claude Sonnet 4.5",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-07-31",
+    "release_date": "2025-09-29",
+    "last_updated": "2025-09-29",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "databricks/databricks-claude-sonnet-4.5",
+    "name": "Claude Sonnet 4.5 (latest)",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-07-31",
+    "release_date": "2025-09-29",
+    "last_updated": "2025-09-29",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "databricks/databricks-claude-sonnet-4.6",
+    "name": "Claude Sonnet 4.6",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-02-17",
+    "last_updated": "2026-03-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "databricks/databricks-gemini-2.5-flash",
+    "name": "Gemini 2.5 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-03-20",
+    "last_updated": "2025-06-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 2.5,
+      "cache_read": 0.03
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "databricks/databricks-gemini-2.5-pro",
+    "name": "Gemini 2.5 Pro",
+    "family": "gemini-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-03-20",
+    "last_updated": "2025-06-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "databricks/databricks-gemini-3-flash",
+    "name": "Gemini 3 Flash Preview",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-12-17",
+    "last_updated": "2025-12-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.5,
+      "output": 3.0,
+      "cache_read": 0.05
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "databricks/databricks-gemini-3-pro",
+    "name": "Gemini 3 Pro Preview",
+    "family": "gemini-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-11-18",
+    "last_updated": "2025-11-18",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 12.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "databricks/databricks-gemini-3.1-flash-lite",
+    "name": "Gemini 3.1 Flash Lite Preview",
+    "family": "gemini-flash-lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-03-03",
+    "last_updated": "2026-03-03",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 1.5,
+      "cache_read": 0.025
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "databricks/databricks-gemini-3.1-pro",
+    "name": "Gemini 3.1 Pro Preview Custom Tools",
+    "family": "gemini-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-02-19",
+    "last_updated": "2026-02-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 12.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "databricks/databricks-gpt-5",
+    "name": "GPT-5",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-09-30",
+    "release_date": "2025-08-07",
+    "last_updated": "2025-08-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "databricks/databricks-gpt-5-mini",
+    "name": "GPT-5 Mini",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-05-30",
+    "release_date": "2025-08-07",
+    "last_updated": "2025-08-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 2.0,
+      "cache_read": 0.025
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "databricks/databricks-gpt-5-nano",
+    "name": "GPT-5 Nano",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-05-30",
+    "release_date": "2025-08-07",
+    "last_updated": "2025-08-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.05,
+      "output": 0.4,
+      "cache_read": 0.005
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "databricks/databricks-gpt-5.1",
+    "name": "GPT-5.1",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-09-30",
+    "release_date": "2025-11-13",
+    "last_updated": "2025-11-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.13
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "databricks/databricks-gpt-5.2",
+    "name": "GPT-5.2",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2025-12-11",
+    "last_updated": "2025-12-11",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.75,
+      "output": 14.0,
+      "cache_read": 0.175
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "databricks/databricks-gpt-5.4",
+    "name": "GPT-5.4",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-05",
+    "last_updated": "2026-03-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 15.0,
+      "cache_read": 0.25
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "databricks/databricks-gpt-5.4-mini",
+    "name": "GPT-5.4 mini",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 4.5,
+      "cache_read": 0.075
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "databricks/databricks-gpt-5.4-nano",
+    "name": "GPT-5.4 nano",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.2,
+      "output": 1.25,
+      "cache_read": 0.02
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "databricks/databricks-gpt-5.5",
+    "name": "GPT-5.5",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-12-01",
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "databricks/databricks-gpt-oss-120b",
+    "name": "GPT OSS 120B",
+    "family": "gpt-oss",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-08-05",
+    "last_updated": "2025-08-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.072,
+      "output": 0.28
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    }
+  },
+  {
+    "id": "databricks/databricks-gpt-oss-20b",
+    "name": "GPT OSS 20B",
+    "family": "gpt-oss",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-08-05",
+    "last_updated": "2025-08-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.05,
+      "output": 0.2
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    }
+  },
+  {
     "id": "deepinfra/MiniMaxAI/MiniMax-M2",
     "name": "MiniMax M2",
     "family": "minimax",
@@ -27294,6 +27790,36 @@
     "limit": {
       "context": 163840,
       "output": 64000
+    }
+  },
+  {
+    "id": "deepinfra/deepseek-ai/DeepSeek-V4-Flash",
+    "name": "DeepSeek V4 Flash",
+    "family": "deepseek-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.028
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
     }
   },
   {
@@ -27754,6 +28280,69 @@
     }
   },
   {
+    "id": "deepinfra/xiaomi/mimo-v2.5",
+    "name": "MiMo-V2.5",
+    "family": "mimo",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.4,
+      "output": 2.0,
+      "cache_read": 0.08
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "deepinfra/xiaomi/mimo-v2.5-pro",
+    "name": "MiMo-V2.5-Pro",
+    "family": "mimo",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.0,
+      "output": 3.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 16384
+    }
+  },
+  {
     "id": "deepinfra/zai-org/GLM-4.5",
     "name": "GLM-4.5",
     "family": "glm",
@@ -28138,6 +28727,133 @@
     }
   },
   {
+    "id": "digitalocean/anthropic-claude-3-opus",
+    "name": "Claude 3 Opus",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-08",
+    "release_date": "2024-02-29",
+    "last_updated": "2024-02-29",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 15.0,
+      "output": 75.0,
+      "cache_read": 1.5,
+      "cache_write": 18.75
+    },
+    "limit": {
+      "context": 200000,
+      "output": 4096
+    }
+  },
+  {
+    "id": "digitalocean/anthropic-claude-3.5-haiku",
+    "name": "Claude 3.5 Haiku",
+    "family": "claude-haiku",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-07",
+    "release_date": "2024-11-05",
+    "last_updated": "2024-11-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.8,
+      "output": 4.0,
+      "cache_read": 0.08,
+      "cache_write": 1.0
+    },
+    "limit": {
+      "context": 200000,
+      "output": 8192
+    }
+  },
+  {
+    "id": "digitalocean/anthropic-claude-3.5-sonnet",
+    "name": "Claude 3.5 Sonnet",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-04",
+    "release_date": "2024-06-20",
+    "last_updated": "2024-10-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 200000,
+      "output": 8192
+    }
+  },
+  {
+    "id": "digitalocean/anthropic-claude-3.7-sonnet",
+    "name": "Claude 3.7 Sonnet",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-11",
+    "release_date": "2025-02-24",
+    "last_updated": "2025-02-24",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
     "id": "digitalocean/anthropic-claude-4.1-opus",
     "name": "Claude Opus 4.1",
     "family": "claude-opus",
@@ -28168,6 +28884,38 @@
     "limit": {
       "context": 200000,
       "output": 32000
+    }
+  },
+  {
+    "id": "digitalocean/anthropic-claude-4.5-haiku",
+    "name": "Claude Haiku 4.5",
+    "family": "claude-haiku",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-02-28",
+    "release_date": "2025-10-15",
+    "last_updated": "2025-10-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 5.0,
+      "cache_read": 1.0,
+      "cache_write": 1.25
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
     }
   },
   {
@@ -28577,6 +29325,32 @@
     }
   },
   {
+    "id": "digitalocean/deepseek-v3",
+    "name": "DeepSeek V3",
+    "family": "deepseek",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-07",
+    "release_date": "2024-12-26",
+    "last_updated": "2025-03-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {},
+    "limit": {
+      "context": 163840,
+      "output": 131072
+    }
+  },
+  {
     "id": "digitalocean/deepseek-v4-pro",
     "name": "DeepSeek V4 Pro",
     "family": "deepseek-thinking",
@@ -28846,6 +29620,36 @@
     }
   },
   {
+    "id": "digitalocean/kimi-k2.6",
+    "name": "Kimi K2.6",
+    "family": "kimi",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-01",
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.95,
+      "output": 4.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
     "id": "digitalocean/llama-4-maverick",
     "name": "Llama 4 Maverick 17B 128E Instruct",
     "family": "llama",
@@ -28876,29 +29680,32 @@
     }
   },
   {
-    "id": "digitalocean/llama-guard-4-12b",
-    "name": "Llama Guard 4 12B",
+    "id": "digitalocean/llama3-8b-instruct",
+    "name": "Llama 3.1 Instruct (8B)",
     "family": "llama",
-    "attachment": true,
+    "attachment": false,
     "reasoning": false,
-    "tool_call": false,
+    "tool_call": true,
     "temperature": true,
-    "release_date": "2025-04-05",
-    "last_updated": "2026-04-30",
+    "knowledge": "2023-12",
+    "release_date": "2024-07-23",
+    "last_updated": "2024-07-23",
     "modalities": {
       "input": [
-        "text",
-        "image"
+        "text"
       ],
       "output": [
         "text"
       ]
     },
     "open_weights": true,
-    "cost": {},
+    "cost": {
+      "input": 0.198,
+      "output": 0.198
+    },
     "limit": {
-      "context": 128000,
-      "output": 16384
+      "context": 131072,
+      "output": 131072
     }
   },
   {
@@ -28960,6 +29767,32 @@
     }
   },
   {
+    "id": "digitalocean/ministral-3-8b-instruct",
+    "name": "Ministral 3 8B",
+    "family": "ministral",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-12-15",
+    "last_updated": "2025-12-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {},
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
     "id": "digitalocean/mistral-3-14B",
     "name": "Ministral 3 14B Instruct",
     "family": "ministral",
@@ -28988,6 +29821,59 @@
     }
   },
   {
+    "id": "digitalocean/mistral-7b-instruct-v0.3",
+    "name": "Mistral 7B Instruct v0.3",
+    "family": "mistral",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2024-05-22",
+    "last_updated": "2024-05-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {},
+    "limit": {
+      "context": 32768,
+      "output": 32768
+    }
+  },
+  {
+    "id": "digitalocean/mistral-nemo-instruct",
+    "name": "Mistral Nemo Instruct",
+    "family": "mistral",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2024-07-18",
+    "last_updated": "2024-07-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.3,
+      "output": 0.3
+    },
+    "limit": {
+      "context": 128000,
+      "output": 16384
+    }
+  },
+  {
     "id": "digitalocean/multi-qa-mpnet-base-dot-v1",
     "name": "Multi-QA-mpnet-base-dot-v1",
     "family": "text-embedding",
@@ -29013,6 +29899,31 @@
     "limit": {
       "context": 512,
       "output": 768
+    }
+  },
+  {
+    "id": "digitalocean/nemotron-3-nano-30b",
+    "name": "Nemotron 3 Nano 30B A3B",
+    "family": "nemotron",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-04-14",
+    "last_updated": "2025-04-14",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {},
+    "limit": {
+      "context": 262144,
+      "output": 262144
     }
   },
   {
@@ -29635,6 +30546,32 @@
     }
   },
   {
+    "id": "digitalocean/openai-gpt-image-2",
+    "name": "GPT Image 2",
+    "family": "gpt-image",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2025-04-24",
+    "last_updated": "2025-04-24",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
     "id": "digitalocean/openai-gpt-oss-120b",
     "name": "gpt-oss-120b",
     "family": "gpt-oss",
@@ -29784,6 +30721,32 @@
     "limit": {
       "context": 200000,
       "output": 100000
+    }
+  },
+  {
+    "id": "digitalocean/qwen-2.5-14b-instruct",
+    "name": "Qwen 2.5 14B Instruct",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-09",
+    "release_date": "2024-09-19",
+    "last_updated": "2024-09-19",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {},
+    "limit": {
+      "context": 131072,
+      "output": 131072
     }
   },
   {
@@ -30991,6 +31954,36 @@
     }
   },
   {
+    "id": "firepass/accounts/fireworks/routers/kimi-k2p6-turbo",
+    "name": "Kimi K2.6 Turbo",
+    "family": "kimi-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-17",
+    "last_updated": "2026-04-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0
+    },
+    "limit": {
+      "context": 262000,
+      "output": 262000
+    }
+  },
+  {
     "id": "fireworks-ai/accounts/fireworks/models/deepseek-v3p1",
     "name": "DeepSeek V3.1",
     "family": "deepseek",
@@ -31047,6 +32040,36 @@
     "limit": {
       "context": 160000,
       "output": 160000
+    }
+  },
+  {
+    "id": "fireworks-ai/accounts/fireworks/models/deepseek-v4-flash",
+    "name": "DeepSeek V4 Flash",
+    "family": "deepseek-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.03
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
     }
   },
   {
@@ -34226,7 +35249,7 @@
   },
   {
     "id": "github-models/microsoft/phi-4",
-    "name": "Phi-4",
+    "name": "Phi-4-Reasoning",
     "family": "phi",
     "attachment": false,
     "reasoning": true,
@@ -34249,7 +35272,7 @@
       "output": 0.0
     },
     "limit": {
-      "context": 16000,
+      "context": 128000,
       "output": 4096
     }
   },
@@ -35179,6 +36202,37 @@
     }
   },
   {
+    "id": "gitlab/duo-chat-gpt-5.5",
+    "name": "Agentic Chat (GPT-5.5)",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
     "id": "gitlab/duo-chat-haiku-4.5",
     "name": "Agentic Chat (Claude Haiku 4.5)",
     "family": "claude-haiku",
@@ -35374,6 +36428,244 @@
     "limit": {
       "context": 1000000,
       "output": 64000
+    }
+  },
+  {
+    "id": "gmicloud/anthropic/claude-opus-4.6",
+    "name": "Claude Opus 4.6",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05-31",
+    "release_date": "2026-02-05",
+    "last_updated": "2026-03-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 409600,
+      "output": 128000
+    }
+  },
+  {
+    "id": "gmicloud/anthropic/claude-opus-4.7",
+    "name": "Claude Opus 4.7",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-04-16",
+    "last_updated": "2026-04-16",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 4.5,
+      "output": 22.5,
+      "cache_read": 0.45
+    },
+    "limit": {
+      "context": 409600,
+      "output": 128000
+    }
+  },
+  {
+    "id": "gmicloud/anthropic/claude-sonnet-4.6",
+    "name": "Claude Sonnet 4.6",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-02-17",
+    "last_updated": "2026-03-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3
+    },
+    "limit": {
+      "context": 409600,
+      "output": 64000
+    }
+  },
+  {
+    "id": "gmicloud/deepseek-ai/DeepSeek-V4-Flash",
+    "name": "DeepSeek V4 Flash",
+    "family": "deepseek-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.112,
+      "output": 0.224,
+      "cache_read": 0.022
+    },
+    "limit": {
+      "context": 1048575,
+      "output": 384000
+    }
+  },
+  {
+    "id": "gmicloud/deepseek-ai/DeepSeek-V4-Pro",
+    "name": "DeepSeek V4 Pro",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.392,
+      "output": 2.784,
+      "cache_read": 0.116
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 384000
+    }
+  },
+  {
+    "id": "gmicloud/moonshotai/Kimi-K2.6",
+    "name": "Kimi K2.6",
+    "family": "kimi-k2.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.855,
+      "output": 3.6,
+      "cache_read": 0.144
+    },
+    "limit": {
+      "context": 65536,
+      "output": 65536
+    }
+  },
+  {
+    "id": "gmicloud/zai-org/GLM-5-FP8",
+    "name": "GLM-5",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-11",
+    "last_updated": "2026-02-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.6,
+      "output": 1.92,
+      "cache_read": 0.12
+    },
+    "limit": {
+      "context": 202752,
+      "output": 131072
+    }
+  },
+  {
+    "id": "gmicloud/zai-org/GLM-5.1-FP8",
+    "name": "GLM-5.1",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-27",
+    "last_updated": "2026-03-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.98,
+      "output": 3.08,
+      "cache_read": 0.182
+    },
+    "limit": {
+      "context": 202752,
+      "output": 131072
     }
   },
   {
@@ -35749,7 +37041,403 @@
     "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-17",
-    "last_updated": "2026-02-17",
+    "last_updated": "2026-03-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "google-vertex/claude-3.5-haiku",
+    "name": "Claude Haiku 3.5",
+    "family": "claude-haiku",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-07-31",
+    "release_date": "2024-10-22",
+    "last_updated": "2024-10-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.8,
+      "output": 4.0,
+      "cache_read": 0.08,
+      "cache_write": 1.0
+    },
+    "limit": {
+      "context": 200000,
+      "output": 8192
+    }
+  },
+  {
+    "id": "google-vertex/claude-3.5-sonnet",
+    "name": "Claude Sonnet 3.5 v2",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-04-30",
+    "release_date": "2024-10-22",
+    "last_updated": "2024-10-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 200000,
+      "output": 8192
+    }
+  },
+  {
+    "id": "google-vertex/claude-3.7-sonnet",
+    "name": "Claude Sonnet 3.7",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-10-31",
+    "release_date": "2025-02-19",
+    "last_updated": "2025-02-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "google-vertex/claude-haiku-4.5",
+    "name": "Claude Haiku 4.5",
+    "family": "claude-haiku",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-02-28",
+    "release_date": "2025-10-15",
+    "last_updated": "2025-10-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 5.0,
+      "cache_read": 0.1,
+      "cache_write": 1.25
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "google-vertex/claude-opus-4",
+    "name": "Claude Opus 4",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-05-22",
+    "last_updated": "2025-05-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 15.0,
+      "output": 75.0,
+      "cache_read": 1.5,
+      "cache_write": 18.75
+    },
+    "limit": {
+      "context": 200000,
+      "output": 32000
+    }
+  },
+  {
+    "id": "google-vertex/claude-opus-4.1",
+    "name": "Claude Opus 4.1",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-08-05",
+    "last_updated": "2025-08-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 15.0,
+      "output": 75.0,
+      "cache_read": 1.5,
+      "cache_write": 18.75
+    },
+    "limit": {
+      "context": 200000,
+      "output": 32000
+    }
+  },
+  {
+    "id": "google-vertex/claude-opus-4.5",
+    "name": "Claude Opus 4.5",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-11-01",
+    "last_updated": "2025-11-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "google-vertex/claude-opus-4.6@default",
+    "name": "Claude Opus 4.6",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05-31",
+    "release_date": "2026-02-05",
+    "last_updated": "2026-03-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "google-vertex/claude-opus-4.7@default",
+    "name": "Claude Opus 4.7",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-04-16",
+    "last_updated": "2026-04-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "google-vertex/claude-sonnet-4",
+    "name": "Claude Sonnet 4",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-05-22",
+    "last_updated": "2025-05-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "google-vertex/claude-sonnet-4.5",
+    "name": "Claude Sonnet 4.5",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-07-31",
+    "release_date": "2025-09-29",
+    "last_updated": "2025-09-29",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "google-vertex/claude-sonnet-4.6@default",
+    "name": "Claude Sonnet 4.6",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-02-17",
+    "last_updated": "2026-03-13",
     "modalities": {
       "input": [
         "text",
@@ -35960,7 +37648,7 @@
     "cost": {
       "input": 0.1,
       "output": 0.4,
-      "cache_read": 0.025
+      "cache_read": 0.01
     },
     "limit": {
       "context": 1048576,
@@ -36309,6 +37997,40 @@
     }
   },
   {
+    "id": "google-vertex/gemini-3.1-flash-lite",
+    "name": "Gemini 3.1 Flash Lite",
+    "family": "gemini-flash-lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-05-07",
+    "last_updated": "2026-05-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 1.5,
+      "cache_read": 0.025
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
     "id": "google-vertex/gemini-3.1-flash-lite-preview",
     "name": "Gemini 3.1 Flash Lite Preview",
     "family": "gemini-flash-lite",
@@ -36335,8 +38057,7 @@
     "cost": {
       "input": 0.25,
       "output": 1.5,
-      "cache_read": 0.025,
-      "cache_write": 1.0
+      "cache_read": 0.025
     },
     "limit": {
       "context": 1048576,
@@ -37031,7 +38752,7 @@
     "cost": {
       "input": 0.1,
       "output": 0.4,
-      "cache_read": 0.025
+      "cache_read": 0.01
     },
     "limit": {
       "context": 1048576,
@@ -37460,12 +39181,46 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.25,
+      "input": 0.5,
       "output": 60.0
     },
     "limit": {
       "context": 131072,
       "output": 32768
+    }
+  },
+  {
+    "id": "google/gemini-3.1-flash-lite",
+    "name": "Gemini 3.1 Flash Lite",
+    "family": "gemini-flash-lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-05-07",
+    "last_updated": "2026-05-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 1.5,
+      "cache_read": 0.025
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
     }
   },
   {
@@ -37495,8 +39250,7 @@
     "cost": {
       "input": 0.25,
       "output": 1.5,
-      "cache_read": 0.025,
-      "cache_write": 1.0
+      "cache_read": 0.025
     },
     "limit": {
       "context": 1048576,
@@ -37565,6 +39319,40 @@
       "input": 2.0,
       "output": 12.0,
       "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "google/gemini-3.5-flash",
+    "name": "Gemini 3.5 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-05-19",
+    "last_updated": "2026-05-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 9.0,
+      "cache_read": 0.15
     },
     "limit": {
       "context": 1048576,
@@ -38458,15 +40246,15 @@
   },
   {
     "id": "groq/moonshotai/kimi-k2-instruct",
-    "name": "Kimi K2 Instruct 0905",
+    "name": "Kimi K2 Instruct",
     "family": "kimi",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2024-10",
-    "release_date": "2025-09-05",
-    "last_updated": "2025-09-05",
+    "release_date": "2025-07-14",
+    "last_updated": "2025-07-14",
     "modalities": {
       "input": [
         "text"
@@ -38481,7 +40269,7 @@
       "output": 3.0
     },
     "limit": {
-      "context": 262144,
+      "context": 131072,
       "output": 16384
     }
   },
@@ -39007,7 +40795,7 @@
   },
   {
     "id": "helicone/claude-opus-4.1",
-    "name": "Anthropic: Claude Opus 4.1 (20250805)",
+    "name": "Anthropic: Claude Opus 4.1",
     "family": "claude-opus",
     "attachment": false,
     "reasoning": true,
@@ -40325,15 +42113,15 @@
   },
   {
     "id": "helicone/kimi-k2",
-    "name": "Kimi K2 (09/05)",
+    "name": "Kimi K2 (07/11)",
     "family": "kimi",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-09",
-    "release_date": "2025-09-05",
-    "last_updated": "2025-09-05",
+    "knowledge": "2025-01",
+    "release_date": "2025-01-01",
+    "last_updated": "2025-01-01",
     "modalities": {
       "input": [
         "text"
@@ -40344,12 +42132,11 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.5,
-      "output": 2.0,
-      "cache_read": 0.39999999999999997
+      "input": 0.5700000000000001,
+      "output": 2.3
     },
     "limit": {
-      "context": 262144,
+      "context": 131072,
       "output": 16384
     }
   },
@@ -41190,10 +42977,10 @@
   },
   {
     "id": "helicone/sonar",
-    "name": "Perplexity Sonar Reasoning",
-    "family": "sonar-reasoning",
+    "name": "Perplexity Sonar",
+    "family": "sonar",
     "attachment": false,
-    "reasoning": true,
+    "reasoning": false,
     "tool_call": false,
     "temperature": true,
     "knowledge": "2025-01",
@@ -41210,7 +42997,7 @@
     "open_weights": false,
     "cost": {
       "input": 1.0,
-      "output": 5.0
+      "output": 1.0
     },
     "limit": {
       "context": 127000,
@@ -45287,60 +47074,6 @@
     }
   },
   {
-    "id": "kilo/allenai/olmo-3.1-32b-instruct",
-    "name": "AllenAI: Olmo 3.1 32B Instruct",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-01-07",
-    "last_updated": "2026-03-15",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.2,
-      "output": 0.6
-    },
-    "limit": {
-      "context": 65536,
-      "output": 32768
-    }
-  },
-  {
-    "id": "kilo/alpindale/goliath-120b",
-    "name": "Goliath 120B",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2023-11-10",
-    "last_updated": "2026-03-15",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 3.75,
-      "output": 7.5
-    },
-    "limit": {
-      "context": 6144,
-      "output": 1024
-    }
-  },
-  {
     "id": "kilo/amazon/nova-2-lite-v1",
     "name": "Amazon: Nova 2 Lite",
     "attachment": true,
@@ -45569,68 +47302,6 @@
     }
   },
   {
-    "id": "kilo/anthropic/claude-3.7-sonnet",
-    "name": "Anthropic: Claude 3.7 Sonnet",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-02-19",
-    "last_updated": "2026-03-15",
-    "modalities": {
-      "input": [
-        "image",
-        "pdf",
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.3,
-      "cache_write": 3.75
-    },
-    "limit": {
-      "context": 200000,
-      "output": 64000
-    }
-  },
-  {
-    "id": "kilo/anthropic/claude-3.7-sonnet:thinking",
-    "name": "Anthropic: Claude 3.7 Sonnet (thinking)",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-02-19",
-    "last_updated": "2026-03-15",
-    "modalities": {
-      "input": [
-        "image",
-        "pdf",
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.3,
-      "cache_write": 3.75
-    },
-    "limit": {
-      "context": 200000,
-      "output": 64000
-    }
-  },
-  {
     "id": "kilo/anthropic/claude-haiku-4.5",
     "name": "Anthropic: Claude Haiku 4.5",
     "attachment": true,
@@ -45840,6 +47511,37 @@
       "output": 25.0,
       "cache_read": 0.5,
       "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "kilo/anthropic/claude-opus-4.7-fast",
+    "name": "Anthropic: Claude Opus 4.7 (Fast)",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-05-12",
+    "last_updated": "2026-05-16",
+    "modalities": {
+      "input": [
+        "image",
+        "pdf",
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 30.0,
+      "output": 150.0,
+      "cache_read": 3.0,
+      "cache_write": 37.5
     },
     "limit": {
       "context": 1000000,
@@ -46128,6 +47830,33 @@
     }
   },
   {
+    "id": "kilo/baidu/cobuddy:free",
+    "name": "Baidu: CoBuddy (free)",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-05-06",
+    "last_updated": "2026-05-07",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 131072,
+      "output": 65536
+    }
+  },
+  {
     "id": "kilo/baidu/ernie-4.5-21b-a3b",
     "name": "Baidu: ERNIE 4.5 21B A3B",
     "attachment": false,
@@ -46265,14 +47994,14 @@
     }
   },
   {
-    "id": "kilo/baidu/qianfan-ocr-fast:free",
-    "name": "Baidu: Qianfan-OCR-Fast (free)",
+    "id": "kilo/baidu/qianfan-ocr-fast",
+    "name": "Baidu: Qianfan-OCR-Fast",
     "attachment": true,
     "reasoning": true,
     "tool_call": false,
     "temperature": true,
     "release_date": "2026-04-20",
-    "last_updated": "2026-05-01",
+    "last_updated": "2026-05-16",
     "modalities": {
       "input": [
         "image",
@@ -46284,8 +48013,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.0,
-      "output": 0.0
+      "input": 0.68,
+      "output": 2.81
     },
     "limit": {
       "context": 65536,
@@ -46877,6 +48606,33 @@
     }
   },
   {
+    "id": "kilo/deepseek/deepseek-v4-flash:free",
+    "name": "DeepSeek: DeepSeek V4 Flash (free)",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-04-24",
+    "last_updated": "2026-05-16",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 384000
+    }
+  },
+  {
     "id": "kilo/deepseek/deepseek-v4-pro",
     "name": "DeepSeek: DeepSeek V4 Pro",
     "attachment": false,
@@ -47309,6 +49065,39 @@
     },
     "limit": {
       "context": 65536,
+      "output": 65536
+    }
+  },
+  {
+    "id": "kilo/google/gemini-3.1-flash-lite",
+    "name": "Google: Gemini 3.1 Flash Lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-05-07",
+    "last_updated": "2026-05-16",
+    "modalities": {
+      "input": [
+        "audio",
+        "image",
+        "pdf",
+        "text",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 1.5,
+      "cache_read": 0.025,
+      "cache_write": 0.08333
+    },
+    "limit": {
+      "context": 1048576,
       "output": 65536
     }
   },
@@ -47772,14 +49561,14 @@
     }
   },
   {
-    "id": "kilo/inclusionai/ling-2.6-1t:free",
-    "name": "inclusionAI: Ling-2.6-1T (free)",
+    "id": "kilo/inclusionai/ling-2.6-1t",
+    "name": "inclusionAI: Ling-2.6-1T",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-04-23",
-    "last_updated": "2026-05-01",
+    "last_updated": "2026-05-16",
     "modalities": {
       "input": [
         "text"
@@ -47790,8 +49579,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.0,
-      "output": 0.0
+      "input": 0.3,
+      "output": 2.5,
+      "cache_read": 0.06
     },
     "limit": {
       "context": 262144,
@@ -47824,6 +49614,34 @@
     "limit": {
       "context": 262144,
       "output": 32768
+    }
+  },
+  {
+    "id": "kilo/inclusionai/ring-2.6-1t",
+    "name": "inclusionAI: Ring-2.6-1T",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-05-08",
+    "last_updated": "2026-05-16",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.075,
+      "output": 0.625,
+      "cache_read": 0.015
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
     }
   },
   {
@@ -48428,6 +50246,34 @@
     }
   },
   {
+    "id": "kilo/microsoft/phi-4-mini-instruct",
+    "name": "Microsoft: Phi 4 Mini Instruct",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-10-17",
+    "last_updated": "2026-05-07",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.08,
+      "output": 0.35,
+      "cache_read": 0.08
+    },
+    "limit": {
+      "context": 128000,
+      "output": 128000
+    }
+  },
+  {
     "id": "kilo/microsoft/wizardlm-2-8x22b",
     "name": "WizardLM-2 8x22B",
     "attachment": false,
@@ -48953,6 +50799,34 @@
     }
   },
   {
+    "id": "kilo/mistralai/mistral-medium-3.5",
+    "name": "Mistral: Mistral Medium 3.5",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-05-07",
+    "modalities": {
+      "input": [
+        "image",
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 7.5
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
     "id": "kilo/mistralai/mistral-nemo",
     "name": "Mistral: Mistral Nemo",
     "attachment": false,
@@ -49148,33 +51022,6 @@
     }
   },
   {
-    "id": "kilo/mistralai/mixtral-8x7b-instruct",
-    "name": "Mistral: Mixtral 8x7B Instruct",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2023-12-10",
-    "last_updated": "2026-03-15",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.54,
-      "output": 0.54
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
     "id": "kilo/mistralai/pixtral-large",
     "name": "Mistral: Pixtral Large 2411",
     "attachment": true,
@@ -49321,7 +51168,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-04-20",
-    "last_updated": "2026-04-20",
+    "last_updated": "2026-05-12",
     "modalities": {
       "input": [
         "text",
@@ -49333,13 +51180,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.95,
-      "output": 4.0,
-      "cache_read": 0.16
+      "input": 0.75,
+      "output": 3.5,
+      "cache_read": 0.375
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 65535
     }
   },
   {
@@ -49560,33 +51407,6 @@
     }
   },
   {
-    "id": "kilo/nvidia/llama-3.1-nemotron-70b-instruct",
-    "name": "NVIDIA: Llama 3.1 Nemotron 70B Instruct",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2024-10-12",
-    "last_updated": "2024-10-12",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.2,
-      "output": 1.2
-    },
-    "limit": {
-      "context": 131072,
-      "output": 16384
-    }
-  },
-  {
     "id": "kilo/nvidia/llama-3.3-nemotron-super-49b-v1.5",
     "name": "NVIDIA: Llama 3.3 Nemotron Super 49B V1.5",
     "attachment": false,
@@ -49726,35 +51546,6 @@
     }
   },
   {
-    "id": "kilo/nvidia/nemotron-nano-12b-v2-vl",
-    "name": "NVIDIA: Nemotron Nano 12B 2 VL",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2025-10-28",
-    "last_updated": "2026-01-31",
-    "modalities": {
-      "input": [
-        "image",
-        "text",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.2,
-      "output": 0.6
-    },
-    "limit": {
-      "context": 131072,
-      "output": 26215
-    }
-  },
-  {
     "id": "kilo/nvidia/nemotron-nano-9b-v2",
     "name": "NVIDIA: Nemotron Nano 9B V2",
     "attachment": false,
@@ -49864,13 +51655,13 @@
   },
   {
     "id": "kilo/openai/gpt-4",
-    "name": "OpenAI: GPT-4 (older v0314)",
+    "name": "OpenAI: GPT-4",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2023-05-28",
-    "last_updated": "2026-03-15",
+    "release_date": "2023-03-14",
+    "last_updated": "2024-04-09",
     "modalities": {
       "input": [
         "text"
@@ -50063,12 +51854,12 @@
   },
   {
     "id": "kilo/openai/gpt-4o",
-    "name": "OpenAI: GPT-4o (2024-11-20)",
+    "name": "OpenAI: GPT-4o (2024-08-06)",
     "attachment": true,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2024-11-20",
+    "release_date": "2024-08-06",
     "last_updated": "2026-03-15",
     "modalities": {
       "input": [
@@ -51025,6 +52816,36 @@
     }
   },
   {
+    "id": "kilo/openai/gpt-chat",
+    "name": "OpenAI: GPT Chat Latest",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-05-05",
+    "last_updated": "2026-05-07",
+    "modalities": {
+      "input": [
+        "image",
+        "pdf",
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
     "id": "kilo/openai/gpt-oss-120b",
     "name": "OpenAI: gpt-oss-120b",
     "attachment": false,
@@ -51541,6 +53362,35 @@
     }
   },
   {
+    "id": "kilo/perceptron/perceptron-mk1",
+    "name": "Perceptron: Perceptron Mk1",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-05-12",
+    "last_updated": "2026-05-16",
+    "modalities": {
+      "input": [
+        "image",
+        "text",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 1.5
+    },
+    "limit": {
+      "context": 32768,
+      "output": 8192
+    }
+  },
+  {
     "id": "kilo/perplexity/sonar",
     "name": "Perplexity: Sonar",
     "attachment": true,
@@ -51843,14 +53693,14 @@
     }
   },
   {
-    "id": "kilo/qwen/qwen-max",
-    "name": "Qwen: Qwen-Max ",
+    "id": "kilo/qwen/qwen-plus",
+    "name": "Qwen: Qwen-Plus",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2024-04-03",
-    "last_updated": "2026-03-15",
+    "release_date": "2024-01-25",
+    "last_updated": "2025-09-11",
     "modalities": {
       "input": [
         "text"
@@ -51861,36 +53711,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 1.04,
-      "output": 4.16,
-      "cache_read": 0.32
-    },
-    "limit": {
-      "context": 32768,
-      "output": 8192
-    }
-  },
-  {
-    "id": "kilo/qwen/qwen-plus",
-    "name": "Qwen: Qwen Plus 0728",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-09-09",
-    "last_updated": "2026-03-15",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.26,
-      "output": 0.78
+      "input": 0.4,
+      "output": 1.2,
+      "cache_read": 0.08
     },
     "limit": {
       "context": 1000000,
@@ -51922,91 +53745,6 @@
     "limit": {
       "context": 1000000,
       "output": 32768
-    }
-  },
-  {
-    "id": "kilo/qwen/qwen-turbo",
-    "name": "Qwen: Qwen-Turbo",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2024-11-01",
-    "last_updated": "2026-03-15",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.0325,
-      "output": 0.13,
-      "cache_read": 0.01
-    },
-    "limit": {
-      "context": 131072,
-      "output": 8192
-    }
-  },
-  {
-    "id": "kilo/qwen/qwen-vl-max",
-    "name": "Qwen: Qwen VL Max",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2024-04-08",
-    "last_updated": "2025-08-13",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.8,
-      "output": 3.2
-    },
-    "limit": {
-      "context": 131072,
-      "output": 32768
-    }
-  },
-  {
-    "id": "kilo/qwen/qwen-vl-plus",
-    "name": "Qwen: Qwen VL Plus",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2024-01-25",
-    "last_updated": "2026-03-15",
-    "modalities": {
-      "input": [
-        "image",
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.1365,
-      "output": 0.4095,
-      "cache_read": 0.042
-    },
-    "limit": {
-      "context": 131072,
-      "output": 8192
     }
   },
   {
@@ -52068,13 +53806,13 @@
   },
   {
     "id": "kilo/qwen/qwen3-235b-a22b",
-    "name": "Qwen: Qwen3 235B A22B Instruct 2507",
+    "name": "Qwen: Qwen3 235B A22B",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-04",
-    "last_updated": "2026-01",
+    "release_date": "2024-12-01",
+    "last_updated": "2026-03-15",
     "modalities": {
       "input": [
         "text"
@@ -52085,12 +53823,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.071,
-      "output": 0.1
+      "input": 0.455,
+      "output": 1.82,
+      "cache_read": 0.15
     },
     "limit": {
-      "context": 262144,
-      "output": 52429
+      "context": 131072,
+      "output": 8192
     }
   },
   {
@@ -53437,14 +55176,14 @@
     }
   },
   {
-    "id": "kilo/tencent/hy3-preview:free",
-    "name": "Tencent: Hy3 Preview (free)",
+    "id": "kilo/tencent/hy3-preview",
+    "name": "Tencent: Hy3 Preview",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-04-22",
-    "last_updated": "2026-05-01",
+    "last_updated": "2026-05-16",
     "modalities": {
       "input": [
         "text"
@@ -53455,8 +55194,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.0,
-      "output": 0.0
+      "input": 0.066,
+      "output": 0.26,
+      "cache_read": 0.029
     },
     "limit": {
       "context": 262144,
@@ -53572,34 +55312,6 @@
     }
   },
   {
-    "id": "kilo/tngtech/deepseek-r1t2-chimera",
-    "name": "TNG: DeepSeek R1T2 Chimera",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-07-08",
-    "last_updated": "2025-07-08",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.25,
-      "output": 0.85,
-      "cache_read": 0.125
-    },
-    "limit": {
-      "context": 163840,
-      "output": 163840
-    }
-  },
-  {
     "id": "kilo/undi95/remm-slerp-l2-13b",
     "name": "ReMM SLERP 13B",
     "attachment": false,
@@ -53678,205 +55390,6 @@
     "limit": {
       "context": 1040000,
       "output": 8192
-    }
-  },
-  {
-    "id": "kilo/x-ai/grok-3",
-    "name": "xAI: Grok 3",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.75
-    },
-    "limit": {
-      "context": 131072,
-      "output": 26215
-    }
-  },
-  {
-    "id": "kilo/x-ai/grok-3-beta",
-    "name": "xAI: Grok 3 Beta",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.75
-    },
-    "limit": {
-      "context": 131072,
-      "output": 26215
-    }
-  },
-  {
-    "id": "kilo/x-ai/grok-3-mini",
-    "name": "xAI: Grok 3 Mini",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.3,
-      "output": 0.5,
-      "cache_read": 0.075
-    },
-    "limit": {
-      "context": 131072,
-      "output": 26215
-    }
-  },
-  {
-    "id": "kilo/x-ai/grok-3-mini-beta",
-    "name": "xAI: Grok 3 Mini Beta",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.3,
-      "output": 0.5,
-      "cache_read": 0.075
-    },
-    "limit": {
-      "context": 131072,
-      "output": 26215
-    }
-  },
-  {
-    "id": "kilo/x-ai/grok-4",
-    "name": "xAI: Grok 4",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-07-09",
-    "last_updated": "2025-07-09",
-    "modalities": {
-      "input": [
-        "image",
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.75
-    },
-    "limit": {
-      "context": 256000,
-      "output": 51200
-    }
-  },
-  {
-    "id": "kilo/x-ai/grok-4-fast",
-    "name": "xAI: Grok 4 Fast",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-08-19",
-    "last_updated": "2025-08-19",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.5,
-      "cache_read": 0.05
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 30000
-    }
-  },
-  {
-    "id": "kilo/x-ai/grok-4.1-fast",
-    "name": "xAI: Grok 4.1 Fast",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-11-19",
-    "last_updated": "2025-11-19",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.5,
-      "cache_read": 0.05
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 30000
     }
   },
   {
@@ -53970,34 +55483,6 @@
     }
   },
   {
-    "id": "kilo/x-ai/grok-code-fast-1",
-    "name": "xAI: Grok Code Fast 1",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-08-26",
-    "last_updated": "2025-08-26",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 1.5,
-      "cache_read": 0.02
-    },
-    "limit": {
-      "context": 256000,
-      "output": 10000
-    }
-  },
-  {
     "id": "kilo/x-ai/grok-code-fast-1:optimized:free",
     "name": "xAI: Grok Code Fast 1 Optimized (experimental, free)",
     "attachment": false,
@@ -54027,12 +55512,14 @@
   {
     "id": "kilo/xiaomi/mimo-v2-flash",
     "name": "Xiaomi: MiMo-V2-Flash",
+    "family": "mimo",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-12-14",
-    "last_updated": "2026-03-15",
+    "knowledge": "2024-12-01",
+    "release_date": "2025-12-16",
+    "last_updated": "2026-02-04",
     "modalities": {
       "input": [
         "text"
@@ -54055,24 +55542,27 @@
   {
     "id": "kilo/xiaomi/mimo-v2-omni",
     "name": "Xiaomi: MiMo-V2-Omni",
+    "family": "mimo",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2024-12",
     "release_date": "2026-03-18",
-    "last_updated": "2026-04-11",
+    "last_updated": "2026-03-18",
     "modalities": {
       "input": [
-        "audio",
-        "image",
         "text",
-        "video"
+        "image",
+        "audio",
+        "video",
+        "pdf"
       ],
       "output": [
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
       "input": 0.4,
       "output": 2.0,
@@ -54086,12 +55576,14 @@
   {
     "id": "kilo/xiaomi/mimo-v2-pro",
     "name": "Xiaomi: MiMo-V2-Pro",
+    "family": "mimo",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2024-12",
     "release_date": "2026-03-18",
-    "last_updated": "2026-04-11",
+    "last_updated": "2026-03-18",
     "modalities": {
       "input": [
         "text"
@@ -54100,7 +55592,7 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
       "input": 1.0,
       "output": 3.0,
@@ -54114,6 +55606,7 @@
   {
     "id": "kilo/xiaomi/mimo-v2.5",
     "name": "Xiaomi: MiMo-V2.5",
+    "family": "mimo",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
@@ -54123,13 +55616,16 @@
     "last_updated": "2026-04-22",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "audio",
+        "video"
       ],
       "output": [
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.4,
       "output": 2.0,
@@ -54143,7 +55639,8 @@
   {
     "id": "kilo/xiaomi/mimo-v2.5-pro",
     "name": "Xiaomi: MiMo V2.5 Pro",
-    "attachment": true,
+    "family": "mimo",
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -54166,7 +55663,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 128000
+      "output": 131072
     }
   },
   {
@@ -54883,6 +56380,128 @@
     }
   },
   {
+    "id": "lilac/google/gemma-4-31b-it",
+    "name": "Gemma 4 31B IT",
+    "family": "gemma",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.11,
+      "output": 0.35
+    },
+    "limit": {
+      "context": 262100,
+      "output": 262100
+    }
+  },
+  {
+    "id": "lilac/minimaxai/minimax-m2.7",
+    "name": "MiniMax M2.7",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.055
+    },
+    "limit": {
+      "context": 204800,
+      "output": 204800
+    }
+  },
+  {
+    "id": "lilac/moonshotai/kimi-k2.6",
+    "name": "Kimi K2.6",
+    "family": "kimi-k2.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.7,
+      "output": 3.5,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "lilac/zai-org/glm-5.1",
+    "name": "GLM 5.1",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-03-27",
+    "last_updated": "2026-03-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.9,
+      "output": 3.0,
+      "cache_read": 0.27
+    },
+    "limit": {
+      "context": 202800,
+      "output": 131072
+    }
+  },
+  {
     "id": "llmgateway/auto",
     "name": "Auto Route",
     "family": "auto",
@@ -55269,7 +56888,7 @@
   },
   {
     "id": "llmgateway/claude-sonnet-4.5",
-    "name": "Claude Sonnet 4.5 (latest)",
+    "name": "Claude Sonnet 4.5",
     "family": "claude-sonnet",
     "attachment": true,
     "reasoning": true,
@@ -55724,7 +57343,7 @@
     "cost": {
       "input": 0.1,
       "output": 0.4,
-      "cache_read": 0.025
+      "cache_read": 0.01
     },
     "limit": {
       "context": 1048576,
@@ -55834,6 +57453,40 @@
     }
   },
   {
+    "id": "llmgateway/gemini-3.1-flash-lite",
+    "name": "Gemini 3.1 Flash Lite",
+    "family": "gemini-flash-lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-05-07",
+    "last_updated": "2026-05-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 1.5,
+      "cache_read": 0.025
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
     "id": "llmgateway/gemini-3.1-flash-lite-preview",
     "name": "Gemini 3.1 Flash Lite Preview",
     "family": "gemini-flash-lite",
@@ -55860,8 +57513,7 @@
     "cost": {
       "input": 0.25,
       "output": 1.5,
-      "cache_read": 0.025,
-      "cache_write": 1.0
+      "cache_read": 0.025
     },
     "limit": {
       "context": 1048576,
@@ -57602,44 +59254,13 @@
     }
   },
   {
-    "id": "llmgateway/grok-3",
-    "name": "Grok 3",
+    "id": "llmgateway/grok-4",
+    "name": "Grok 4 (0709)",
     "family": "grok",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-11",
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.75
-    },
-    "limit": {
-      "context": 131072,
-      "output": 8192
-    }
-  },
-  {
-    "id": "llmgateway/grok-4",
-    "name": "Grok 4",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
     "release_date": "2025-07-09",
     "last_updated": "2025-07-09",
     "modalities": {
@@ -57653,12 +59274,11 @@
     "open_weights": false,
     "cost": {
       "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.75
+      "output": 15.0
     },
     "limit": {
       "context": 256000,
-      "output": 64000
+      "output": 256000
     }
   },
   {
@@ -57723,46 +59343,14 @@
   },
   {
     "id": "llmgateway/grok-4-fast",
-    "name": "Grok 4 Fast",
+    "name": "Grok 4 Fast Reasoning",
     "family": "grok",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-07",
-    "release_date": "2025-09-19",
-    "last_updated": "2025-09-19",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.5,
-      "cache_read": 0.05
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 30000
-    }
-  },
-  {
-    "id": "llmgateway/grok-4-fast-non",
-    "name": "Grok 4 Fast (Non-Reasoning)",
-    "family": "grok",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
-    "release_date": "2025-09-19",
-    "last_updated": "2025-09-19",
+    "release_date": "2025-07-09",
+    "last_updated": "2025-07-09",
     "modalities": {
       "input": [
         "text",
@@ -57785,13 +59373,12 @@
   },
   {
     "id": "llmgateway/grok-4.1-fast",
-    "name": "Grok 4.1 Fast",
+    "name": "Grok 4.1 Fast Reasoning",
     "family": "grok",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-07",
     "release_date": "2025-11-19",
     "last_updated": "2025-11-19",
     "modalities": {
@@ -57815,16 +59402,15 @@
     }
   },
   {
-    "id": "llmgateway/grok-4.1-fast-non",
-    "name": "Grok 4.1 Fast (Non-Reasoning)",
+    "id": "llmgateway/grok-4.3",
+    "name": "Grok 4.3",
     "family": "grok",
     "attachment": true,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-07",
-    "release_date": "2025-11-19",
-    "last_updated": "2025-11-19",
+    "release_date": "2026-05-01",
+    "last_updated": "2026-05-01",
     "modalities": {
       "input": [
         "text",
@@ -57836,43 +59422,13 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.2,
-      "output": 0.5,
-      "cache_read": 0.05
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2
     },
     "limit": {
-      "context": 2000000,
+      "context": 1000000,
       "output": 30000
-    }
-  },
-  {
-    "id": "llmgateway/grok-code-fast-1",
-    "name": "Grok Code Fast 1",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-10",
-    "release_date": "2025-08-28",
-    "last_updated": "2025-08-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 1.5,
-      "cache_read": 0.02
-    },
-    "limit": {
-      "context": 256000,
-      "output": 10000
     }
   },
   {
@@ -58393,8 +59949,135 @@
       "cache_read": 0.01
     },
     "limit": {
-      "context": 256000,
-      "output": 64000
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "llmgateway/mimo-v2-omni",
+    "name": "MiMo-V2-Omni",
+    "family": "mimo",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.4,
+      "output": 2.0,
+      "cache_read": 0.08
+    },
+    "limit": {
+      "context": 262144,
+      "output": 131072
+    }
+  },
+  {
+    "id": "llmgateway/mimo-v2-pro",
+    "name": "MiMo-V2-Pro",
+    "family": "mimo",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 3.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "llmgateway/mimo-v2.5",
+    "name": "MiMo-V2.5",
+    "family": "mimo",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.4,
+      "output": 2.0,
+      "cache_read": 0.08
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "llmgateway/mimo-v2.5-pro",
+    "name": "MiMo-V2.5-Pro",
+    "family": "mimo",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.0,
+      "output": 3.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
     }
   },
   {
@@ -59998,7 +61681,8 @@
     "cost": {
       "input": 1.3,
       "output": 7.8,
-      "cache_read": 0.13
+      "cache_read": 0.13,
+      "cache_write": 1.625
     },
     "limit": {
       "context": 262144,
@@ -60028,10 +61712,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.276,
-      "output": 1.651,
-      "cache_read": 0.028,
-      "cache_write": 0.344
+      "input": 0.5,
+      "output": 3.0,
+      "cache_read": 0.05,
+      "cache_write": 0.625
     },
     "limit": {
       "context": 1000000,
@@ -62285,15 +63969,15 @@
   },
   {
     "id": "mistralai/mistral-small",
-    "name": "Mistral Small 4",
+    "name": "Mistral Small 3.2",
     "family": "mistral-small",
-    "attachment": true,
-    "reasoning": true,
+    "attachment": false,
+    "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-06",
-    "release_date": "2026-03-16",
-    "last_updated": "2026-03-16",
+    "knowledge": "2025-03",
+    "release_date": "2025-06-20",
+    "last_updated": "2025-06-20",
     "modalities": {
       "input": [
         "text",
@@ -62305,12 +63989,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.15,
-      "output": 0.6
+      "input": 0.1,
+      "output": 0.3
     },
     "limit": {
-      "context": 256000,
-      "output": 256000
+      "context": 128000,
+      "output": 16384
     }
   },
   {
@@ -68366,17 +70050,16 @@
   },
   {
     "id": "nano-gpt/claude-3.5-sonnet",
-    "name": "Claude 3.5 Sonnet Old",
+    "name": "Claude 3.5 Sonnet",
     "attachment": true,
     "reasoning": false,
     "tool_call": true,
-    "release_date": "2024-06-20",
-    "last_updated": "2024-06-20",
+    "release_date": "2025-08-26",
+    "last_updated": "2025-08-26",
     "modalities": {
       "input": [
         "text",
-        "image",
-        "pdf"
+        "image"
       ],
       "output": [
         "text"
@@ -71591,12 +73274,12 @@
   },
   {
     "id": "nano-gpt/glm-4-air",
-    "name": "GLM-4 Air",
+    "name": "GLM 4 Air 0111",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "release_date": "2024-06-05",
-    "last_updated": "2024-06-05",
+    "release_date": "2025-01-11",
+    "last_updated": "2025-01-11",
     "modalities": {
       "input": [
         "text"
@@ -71607,8 +73290,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.2006,
-      "output": 0.2006
+      "input": 0.1394,
+      "output": 0.1394
     },
     "limit": {
       "context": 128000,
@@ -71695,12 +73378,12 @@
   },
   {
     "id": "nano-gpt/glm-4-plus",
-    "name": "GLM-4 Plus",
+    "name": "GLM 4 Plus 0111",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "release_date": "2024-08-01",
-    "last_updated": "2024-08-01",
+    "release_date": "2025-02-19",
+    "last_updated": "2025-02-19",
     "modalities": {
       "input": [
         "text"
@@ -71711,8 +73394,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 7.497,
-      "output": 7.497
+      "input": 9.996,
+      "output": 9.996
     },
     "limit": {
       "context": 128000,
@@ -74292,13 +75975,13 @@
   },
   {
     "id": "nano-gpt/openai/gpt-4o",
-    "name": "GPT-4o (2024-11-20)",
+    "name": "GPT-4o (2024-08-06)",
     "family": "gpt",
     "attachment": true,
     "reasoning": false,
     "tool_call": false,
-    "release_date": "2024-11-20",
-    "last_updated": "2024-11-20",
+    "release_date": "2024-08-06",
+    "last_updated": "2024-08-06",
     "modalities": {
       "input": [
         "text",
@@ -74310,8 +75993,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.5,
-      "output": 10.0
+      "input": 2.499,
+      "output": 9.996
     },
     "limit": {
       "context": 128000,
@@ -74571,16 +76254,18 @@
   },
   {
     "id": "nano-gpt/openai/gpt-5.1",
-    "name": "GPT-5.1 (2025-11-13)",
+    "name": "GPT 5.1",
     "family": "gpt",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -74592,8 +76277,8 @@
       "output": 10.0
     },
     "limit": {
-      "context": 1000000,
-      "output": 32768
+      "context": 400000,
+      "output": 128000
     }
   },
   {
@@ -76736,11 +78421,11 @@
   },
   {
     "id": "nano-gpt/x-ai/grok-4.1-fast",
-    "name": "Grok 4.1 Fast Reasoning",
+    "name": "Grok 4.1 Fast",
     "family": "grok",
     "attachment": true,
     "reasoning": true,
-    "tool_call": false,
+    "tool_call": true,
     "release_date": "2025-11-20",
     "last_updated": "2025-11-20",
     "modalities": {
@@ -77272,16 +78957,43 @@
     }
   },
   {
-    "id": "nebius/BAAI/bge-en-icl",
-    "name": "BGE-ICL",
+    "id": "nearai/Qwen/Qwen3-30B-A3B-Instruct",
+    "name": "Qwen3 30B-A3B Instruct 2507",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-07-29",
+    "last_updated": "2025-07-29",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.15,
+      "output": 0.55
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "nearai/Qwen/Qwen3-Embedding-0.6B",
+    "name": "Qwen3 Embedding 0.6B",
     "family": "text-embedding",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
     "temperature": false,
-    "knowledge": "2024-06",
-    "release_date": "2024-07-30",
-    "last_updated": "2026-02-04",
+    "release_date": "2025-06-03",
+    "last_updated": "2025-06-03",
     "modalities": {
       "input": [
         "text"
@@ -77296,21 +79008,20 @@
       "output": 0.0
     },
     "limit": {
-      "context": 32768,
-      "output": 0
+      "context": 40960,
+      "output": 1024
     }
   },
   {
-    "id": "nebius/BAAI/bge-multilingual-gemma2",
-    "name": "bge-multilingual-gemma2",
-    "family": "text-embedding",
+    "id": "nearai/Qwen/Qwen3-Reranker-0.6B",
+    "name": "Qwen3 Reranker 0.6B",
+    "family": "qwen",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
     "temperature": false,
-    "knowledge": "2024-06",
-    "release_date": "2024-07-30",
-    "last_updated": "2026-02-04",
+    "release_date": "2025-06-03",
+    "last_updated": "2025-06-03",
     "modalities": {
       "input": [
         "text"
@@ -77322,23 +79033,963 @@
     "open_weights": true,
     "cost": {
       "input": 0.01,
-      "output": 0.0
+      "output": 0.01
     },
     "limit": {
-      "context": 8192,
-      "output": 0
+      "context": 40960,
+      "output": 1024
     }
   },
   {
-    "id": "nebius/MiniMaxAI/MiniMax-M2.1",
-    "name": "MiniMax-M2.1",
+    "id": "nearai/Qwen/Qwen3-VL-30B-A3B-Instruct",
+    "name": "Qwen3-VL 30B-A3B Instruct",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-09-23",
+    "last_updated": "2025-09-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.15,
+      "output": 0.55
+    },
+    "limit": {
+      "context": 256000,
+      "output": 32768
+    }
+  },
+  {
+    "id": "nearai/Qwen/Qwen3.5-122B-A10B",
+    "name": "Qwen3.5 122B-A10B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-23",
+    "last_updated": "2026-02-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.4,
+      "output": 3.2
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    }
+  },
+  {
+    "id": "nearai/anthropic/claude-haiku-4.5",
+    "name": "Claude Haiku 4.5 (latest)",
+    "family": "claude-haiku",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-02-28",
+    "release_date": "2025-10-15",
+    "last_updated": "2025-10-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 5.0,
+      "cache_read": 0.1,
+      "cache_write": 1.25
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "nearai/anthropic/claude-opus-4.6",
+    "name": "Claude Opus 4.6",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05-31",
+    "release_date": "2026-02-05",
+    "last_updated": "2026-03-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 200000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nearai/anthropic/claude-opus-4.7",
+    "name": "Claude Opus 4.7",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-04-16",
+    "last_updated": "2026-04-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nearai/anthropic/claude-sonnet-4.5",
+    "name": "Claude Sonnet 4.5 (latest)",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-07-31",
+    "release_date": "2025-09-29",
+    "last_updated": "2025-09-29",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.5,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "nearai/anthropic/claude-sonnet-4.6",
+    "name": "Claude Sonnet 4.6",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-02-17",
+    "last_updated": "2026-03-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "nearai/black-forest-labs/FLUX.2-klein-4B",
+    "name": "FLUX.2 Klein 4B",
+    "family": "flux",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-01-14",
+    "last_updated": "2026-01-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.0,
+      "output": 1.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nearai/google/gemini-2.5-flash",
+    "name": "Gemini 2.5 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-03-20",
+    "last_updated": "2025-06-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 2.5,
+      "cache_read": 0.03
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nearai/google/gemini-2.5-flash-lite",
+    "name": "Gemini 2.5 Flash Lite",
+    "family": "gemini-flash-lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-06-17",
+    "last_updated": "2025-06-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.4,
+      "cache_read": 0.01
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nearai/google/gemini-2.5-pro",
+    "name": "Gemini 2.5 Pro",
+    "family": "gemini-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-03-20",
+    "last_updated": "2025-06-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nearai/google/gemini-3.1-flash-lite",
+    "name": "Gemini 3.1 Flash Lite",
+    "family": "gemini-flash-lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-05-07",
+    "last_updated": "2026-05-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 1.5,
+      "cache_read": 0.025
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nearai/openai/gpt-4.1",
+    "name": "GPT-4.1",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-04",
+    "release_date": "2025-04-14",
+    "last_updated": "2025-04-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 8.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 1047576,
+      "output": 32768
+    }
+  },
+  {
+    "id": "nearai/openai/gpt-4.1-mini",
+    "name": "GPT-4.1 mini",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-04",
+    "release_date": "2025-04-14",
+    "last_updated": "2025-04-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.4,
+      "output": 1.6,
+      "cache_read": 0.1
+    },
+    "limit": {
+      "context": 1047576,
+      "output": 32768
+    }
+  },
+  {
+    "id": "nearai/openai/gpt-4.1-nano",
+    "name": "GPT-4.1 nano",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-04",
+    "release_date": "2025-04-14",
+    "last_updated": "2025-04-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.4,
+      "cache_read": 0.03
+    },
+    "limit": {
+      "context": 1047576,
+      "output": 32768
+    }
+  },
+  {
+    "id": "nearai/openai/gpt-5",
+    "name": "GPT-5",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-09-30",
+    "release_date": "2025-08-07",
+    "last_updated": "2025-08-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nearai/openai/gpt-5-mini",
+    "name": "GPT-5 Mini",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-05-30",
+    "release_date": "2025-08-07",
+    "last_updated": "2025-08-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 2.0,
+      "cache_read": 0.025
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nearai/openai/gpt-5-nano",
+    "name": "GPT-5 Nano",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-05-30",
+    "release_date": "2025-08-07",
+    "last_updated": "2025-08-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.05,
+      "output": 0.4,
+      "cache_read": 0.005
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nearai/openai/gpt-5.1",
+    "name": "GPT-5.1",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-09-30",
+    "release_date": "2025-11-13",
+    "last_updated": "2025-11-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.13
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nearai/openai/gpt-5.2",
+    "name": "GPT-5.2",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2025-12-11",
+    "last_updated": "2025-12-11",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.8,
+      "output": 15.5,
+      "cache_read": 0.18
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nearai/openai/gpt-5.4",
+    "name": "GPT-5.4",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-05",
+    "last_updated": "2026-03-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 15.0,
+      "cache_read": 0.25
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nearai/openai/gpt-5.4-mini",
+    "name": "GPT-5.4 mini",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 4.5,
+      "cache_read": 0.075
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nearai/openai/gpt-5.4-nano",
+    "name": "GPT-5.4 nano",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.2,
+      "output": 1.25,
+      "cache_read": 0.02
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nearai/openai/gpt-5.5",
+    "name": "GPT-5.5",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-12-01",
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nearai/openai/gpt-oss-120b",
+    "name": "GPT-OSS 120B",
+    "family": "gpt-oss",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-10",
-    "release_date": "2026-02-01",
-    "last_updated": "2026-02-04",
+    "release_date": "2025-08-05",
+    "last_updated": "2025-08-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.15,
+      "output": 0.55
+    },
+    "limit": {
+      "context": 131000,
+      "output": 32768
+    }
+  },
+  {
+    "id": "nearai/openai/o3",
+    "name": "o3",
+    "family": "o",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-05",
+    "release_date": "2025-04-16",
+    "last_updated": "2025-04-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 8.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 200000,
+      "output": 100000
+    }
+  },
+  {
+    "id": "nearai/openai/o3-mini",
+    "name": "o3-mini",
+    "family": "o-mini",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-05",
+    "release_date": "2024-12-20",
+    "last_updated": "2025-01-29",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.1,
+      "output": 4.4,
+      "cache_read": 0.55
+    },
+    "limit": {
+      "context": 200000,
+      "output": 100000
+    }
+  },
+  {
+    "id": "nearai/openai/o4-mini",
+    "name": "o4-mini",
+    "family": "o-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-05",
+    "release_date": "2025-04-16",
+    "last_updated": "2025-04-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.1,
+      "output": 4.4,
+      "cache_read": 0.28
+    },
+    "limit": {
+      "context": 200000,
+      "output": 100000
+    }
+  },
+  {
+    "id": "nearai/openai/whisper-large-v3",
+    "name": "Whisper Large v3",
+    "family": "whisper",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2023-11-06",
+    "last_updated": "2023-11-06",
+    "modalities": {
+      "input": [
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.01,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 448,
+      "output": 448
+    }
+  },
+  {
+    "id": "nearai/zai-org/GLM-5.1-FP8",
+    "name": "GLM-5.1 FP8",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-27",
+    "last_updated": "2026-03-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.85,
+      "output": 3.3
+    },
+    "limit": {
+      "context": 202752,
+      "output": 131072
+    }
+  },
+  {
+    "id": "nebius/MiniMaxAI/MiniMax-M2.5",
+    "name": "MiniMax-M2.5",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-01-20",
+    "last_updated": "2026-05-07",
     "modalities": {
       "input": [
         "text"
@@ -77355,7 +80006,37 @@
       "cache_write": 0.375
     },
     "limit": {
-      "context": 128000,
+      "context": 196608,
+      "output": 8192
+    }
+  },
+  {
+    "id": "nebius/MiniMaxAI/MiniMax-M2.5-fast",
+    "name": "MiniMax-M2.5-fast",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-01-20",
+    "last_updated": "2026-05-07",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.03,
+      "cache_write": 0.375
+    },
+    "limit": {
+      "context": 8000,
       "output": 8192
     }
   },
@@ -77450,36 +80131,6 @@
     }
   },
   {
-    "id": "nebius/Qwen/Qwen2.5-Coder-7B-fast",
-    "name": "Qwen2.5-Coder-7B (Fast)",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-09",
-    "release_date": "2024-09-19",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.03,
-      "output": 0.09,
-      "cache_read": 0.003,
-      "cache_write": 0.03
-    },
-    "limit": {
-      "context": 128000,
-      "output": 8192
-    }
-  },
-  {
     "id": "nebius/Qwen/Qwen2.5-VL-72B-Instruct",
     "name": "Qwen2.5-VL-72B-Instruct",
     "attachment": true,
@@ -77540,16 +80191,15 @@
     }
   },
   {
-    "id": "nebius/Qwen/Qwen3-235B-A22B-Thinking",
-    "name": "Qwen3 235B A22B Thinking 2507",
-    "family": "qwen",
+    "id": "nebius/Qwen/Qwen3-235B-A22B-Thinking-2507-fast",
+    "name": "Qwen3-235B-A22B-Thinking-2507-fast",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-07",
     "release_date": "2025-07-25",
-    "last_updated": "2025-10-04",
+    "last_updated": "2026-05-07",
     "modalities": {
       "input": [
         "text"
@@ -77558,13 +80208,15 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
-      "input": 0.2,
-      "output": 0.8
+      "input": 0.5,
+      "output": 2.0,
+      "cache_read": 0.05,
+      "cache_write": 0.625
     },
     "limit": {
-      "context": 262144,
+      "context": 8000,
       "output": 8192
     }
   },
@@ -77599,36 +80251,6 @@
     }
   },
   {
-    "id": "nebius/Qwen/Qwen3-30B-A3B-Thinking",
-    "name": "Qwen3-30B-A3B-Thinking-2507",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-12",
-    "release_date": "2026-01-28",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.1,
-      "output": 0.3,
-      "cache_read": 0.01,
-      "cache_write": 0.125
-    },
-    "limit": {
-      "context": 128000,
-      "output": 16384
-    }
-  },
-  {
     "id": "nebius/Qwen/Qwen3-32B",
     "name": "Qwen3-32B",
     "attachment": false,
@@ -77656,95 +80278,6 @@
     "limit": {
       "context": 128000,
       "output": 8192
-    }
-  },
-  {
-    "id": "nebius/Qwen/Qwen3-32B-fast",
-    "name": "Qwen3-32B (Fast)",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-12",
-    "release_date": "2026-01-28",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.2,
-      "output": 0.6,
-      "cache_read": 0.02,
-      "cache_write": 0.25
-    },
-    "limit": {
-      "context": 128000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nebius/Qwen/Qwen3-Coder-30B-A3B-Instruct",
-    "name": "Qwen3-Coder-30B-A3B-Instruct",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-12",
-    "release_date": "2026-01-28",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.1,
-      "output": 0.3,
-      "cache_read": 0.01,
-      "cache_write": 0.125
-    },
-    "limit": {
-      "context": 128000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nebius/Qwen/Qwen3-Coder-480B-A35B-Instruct",
-    "name": "Qwen3 Coder 480B A35B Instruct",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-04",
-    "release_date": "2025-07-23",
-    "last_updated": "2025-10-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.4,
-      "output": 1.8
-    },
-    "limit": {
-      "context": 262144,
-      "output": 66536
     }
   },
   {
@@ -77807,71 +80340,15 @@
     }
   },
   {
-    "id": "nebius/black-forest-labs/flux-dev",
-    "name": "FLUX.1-dev",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": false,
-    "knowledge": "2024-07",
-    "release_date": "2024-08-01",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "image"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 77,
-      "output": 0
-    }
-  },
-  {
-    "id": "nebius/black-forest-labs/flux-schnell",
-    "name": "FLUX.1-schnell",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": false,
-    "knowledge": "2024-07",
-    "release_date": "2024-08-01",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "image"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 77,
-      "output": 0
-    }
-  },
-  {
-    "id": "nebius/deepseek-ai/DeepSeek-R1",
-    "name": "DeepSeek-R1-0528",
+    "id": "nebius/Qwen/Qwen3-Next-80B-A3B-Thinking-fast",
+    "name": "Qwen3-Next-80B-A3B-Thinking-fast",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-11",
-    "release_date": "2026-01-15",
-    "last_updated": "2026-02-04",
+    "knowledge": "2025-07",
+    "release_date": "2025-07-25",
+    "last_updated": "2026-05-07",
     "modalities": {
       "input": [
         "text"
@@ -77882,85 +80359,26 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.8,
-      "output": 2.4,
-      "cache_read": 0.08,
-      "cache_write": 1.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 32768
-    }
-  },
-  {
-    "id": "nebius/deepseek-ai/DeepSeek-R1-0528-fast",
-    "name": "DeepSeek R1 0528 Fast",
-    "family": "deepseek",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2025-01-01",
-    "last_updated": "2025-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 2.0,
-      "output": 6.0
-    },
-    "limit": {
-      "context": 131072,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nebius/deepseek-ai/DeepSeek-V3",
-    "name": "DeepSeek-V3-0324",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-12",
-    "release_date": "2025-03-24",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.5,
-      "output": 1.5,
-      "cache_read": 0.05,
+      "input": 0.15,
+      "output": 1.2,
+      "cache_read": 0.015,
       "cache_write": 0.1875
     },
     "limit": {
-      "context": 128000,
+      "context": 8000,
       "output": 8192
     }
   },
   {
-    "id": "nebius/deepseek-ai/DeepSeek-V3-0324-fast",
-    "name": "DeepSeek-V3-0324 (Fast)",
+    "id": "nebius/Qwen/Qwen3.5-397B-A17B",
+    "name": "Qwen3.5-397B-A17B",
     "attachment": false,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-12",
-    "release_date": "2025-03-24",
-    "last_updated": "2026-02-04",
+    "knowledge": "2025-07",
+    "release_date": "2025-07-15",
+    "last_updated": "2026-05-07",
     "modalities": {
       "input": [
         "text"
@@ -77971,13 +80389,43 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.75,
-      "output": 2.25,
-      "cache_read": 0.075,
-      "cache_write": 0.28125
+      "input": 0.6,
+      "output": 3.6,
+      "cache_read": 0.06,
+      "cache_write": 0.75
     },
     "limit": {
-      "context": 128000,
+      "context": 262144,
+      "output": 8192
+    }
+  },
+  {
+    "id": "nebius/Qwen/Qwen3.5-397B-A17B-fast",
+    "name": "Qwen3.5-397B-A17B-fast",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-07",
+    "release_date": "2025-07-15",
+    "last_updated": "2026-05-07",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.6,
+      "output": 3.6,
+      "cache_read": 0.06,
+      "cache_write": 0.75
+    },
+    "limit": {
+      "context": 8000,
       "output": 8192
     }
   },
@@ -78012,6 +80460,66 @@
     }
   },
   {
+    "id": "nebius/deepseek-ai/DeepSeek-V3.2-fast",
+    "name": "DeepSeek-V3.2-fast",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-01-27",
+    "last_updated": "2026-05-07",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.4,
+      "output": 2.0,
+      "cache_read": 0.04,
+      "cache_write": 0.5
+    },
+    "limit": {
+      "context": 8000,
+      "output": 8192
+    }
+  },
+  {
+    "id": "nebius/deepseek-ai/DeepSeek-V4-Pro",
+    "name": "DeepSeek V4 Pro",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.75,
+      "output": 3.5,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
     "id": "nebius/google/gemma-2-2b-it",
     "name": "Gemma-2-2b-it",
     "attachment": false,
@@ -78035,36 +80543,6 @@
       "output": 0.06,
       "cache_read": 0.002,
       "cache_write": 0.025
-    },
-    "limit": {
-      "context": 8192,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nebius/google/gemma-2-9b-it-fast",
-    "name": "Gemma-2-9b-it (Fast)",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2024-06",
-    "release_date": "2024-06-27",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.03,
-      "output": 0.09,
-      "cache_read": 0.003,
-      "cache_write": 0.0375
     },
     "limit": {
       "context": 8192,
@@ -78103,66 +80581,6 @@
     }
   },
   {
-    "id": "nebius/google/gemma-3-27b-it-fast",
-    "name": "Gemma-3-27b-it (Fast)",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-10",
-    "release_date": "2026-01-20",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.2,
-      "output": 0.6,
-      "cache_read": 0.02,
-      "cache_write": 0.25
-    },
-    "limit": {
-      "context": 110000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nebius/intfloat/e5-mistral-7b-instruct",
-    "name": "e5-mistral-7b-instruct",
-    "family": "text-embedding",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": false,
-    "knowledge": "2023-12",
-    "release_date": "2024-01-01",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.01,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 32768,
-      "output": 0
-    }
-  },
-  {
     "id": "nebius/meta-llama/Llama-3.3-70B-Instruct",
     "name": "Llama-3.3-70B-Instruct",
     "attachment": false,
@@ -78193,66 +80611,6 @@
     }
   },
   {
-    "id": "nebius/meta-llama/Llama-3.3-70B-Instruct-fast",
-    "name": "Llama-3.3-70B-Instruct (Fast)",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-08",
-    "release_date": "2025-12-05",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.25,
-      "output": 0.75,
-      "cache_read": 0.025,
-      "cache_write": 0.31
-    },
-    "limit": {
-      "context": 128000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nebius/meta-llama/Llama-Guard-3-8B",
-    "name": "Llama-Guard-3-8B",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": false,
-    "knowledge": "2024-04",
-    "release_date": "2024-04-18",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.02,
-      "output": 0.06,
-      "cache_read": 0.002,
-      "cache_write": 0.025
-    },
-    "limit": {
-      "context": 8192,
-      "output": 1024
-    }
-  },
-  {
     "id": "nebius/meta-llama/Meta-Llama-3.1-8B-Instruct",
     "name": "Meta-Llama-3.1-8B-Instruct",
     "attachment": false,
@@ -78280,97 +80638,6 @@
     "limit": {
       "context": 128000,
       "output": 4096
-    }
-  },
-  {
-    "id": "nebius/meta-llama/Meta-Llama-3.1-8B-Instruct-fast",
-    "name": "Meta-Llama-3.1-8B-Instruct (Fast)",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-12",
-    "release_date": "2024-07-23",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.03,
-      "output": 0.09,
-      "cache_read": 0.003,
-      "cache_write": 0.03
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nebius/moonshotai/Kimi-K2-Instruct",
-    "name": "Kimi-K2-Instruct",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-10",
-    "release_date": "2026-01-05",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.5,
-      "output": 2.4,
-      "cache_read": 0.05,
-      "cache_write": 0.625
-    },
-    "limit": {
-      "context": 200000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nebius/moonshotai/Kimi-K2-Thinking",
-    "name": "Kimi-K2-Thinking",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-10",
-    "release_date": "2026-01-05",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.6,
-      "output": 2.5,
-      "cache_read": 0.06,
-      "cache_write": 0.75
-    },
-    "limit": {
-      "context": 128000,
-      "output": 16384
     }
   },
   {
@@ -78498,15 +80765,15 @@
     }
   },
   {
-    "id": "nebius/nvidia/Nemotron-Nano-V2-12b",
-    "name": "Nemotron-Nano-V2-12b",
+    "id": "nebius/nvidia/Nemotron-3-Nano-Omni",
+    "name": "Nemotron-3-Nano-Omni",
     "attachment": false,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-01",
-    "release_date": "2025-03-15",
-    "last_updated": "2026-02-04",
+    "release_date": "2025-01-20",
+    "last_updated": "2026-05-07",
     "modalities": {
       "input": [
         "text"
@@ -78517,14 +80784,14 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.07,
-      "output": 0.2,
-      "cache_read": 0.007,
-      "cache_write": 0.08
+      "input": 0.06,
+      "output": 0.24,
+      "cache_read": 0.006,
+      "cache_write": 0.075
     },
     "limit": {
-      "context": 32000,
-      "output": 4096
+      "context": 65536,
+      "output": 8192
     }
   },
   {
@@ -78586,15 +80853,15 @@
     }
   },
   {
-    "id": "nebius/openai/gpt-oss-20b",
-    "name": "gpt-oss-20b",
+    "id": "nebius/openai/gpt-oss-120b-fast",
+    "name": "gpt-oss-120b-fast",
     "attachment": false,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-09",
-    "release_date": "2026-01-10",
-    "last_updated": "2026-02-04",
+    "knowledge": "2025-06",
+    "release_date": "2025-06-10",
+    "last_updated": "2026-05-07",
     "modalities": {
       "input": [
         "text"
@@ -78605,104 +80872,14 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.05,
-      "output": 0.2,
-      "cache_read": 0.005,
-      "cache_write": 0.06
+      "input": 0.1,
+      "output": 0.5,
+      "cache_read": 0.01,
+      "cache_write": 0.125
     },
     "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nebius/zai-org/GLM-4.5",
-    "name": "GLM-4.5",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-06",
-    "release_date": "2025-11-15",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.6,
-      "output": 2.2,
-      "cache_read": 0.06,
-      "cache_write": 0.75
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nebius/zai-org/GLM-4.5-Air",
-    "name": "GLM-4.5-Air",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-06",
-    "release_date": "2025-11-15",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 1.2,
-      "cache_read": 0.02,
-      "cache_write": 0.25
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nebius/zai-org/GLM-4.7-FP8",
-    "name": "GLM-4.7 (FP8)",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-12",
-    "release_date": "2026-01-15",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.4,
-      "output": 2.0,
-      "cache_read": 0.04,
-      "cache_write": 0.5
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
+      "context": 8000,
+      "output": 8192
     }
   },
   {
@@ -78759,8 +80936,8 @@
       "output": 1.38
     },
     "limit": {
-      "context": 196608,
-      "output": 196608
+      "context": 196592,
+      "output": 196592
     }
   },
   {
@@ -78787,8 +80964,8 @@
       "output": 4.14
     },
     "limit": {
-      "context": 262144,
-      "output": 262144
+      "context": 262128,
+      "output": 262128
     }
   },
   {
@@ -78816,8 +80993,8 @@
       "output": 0.1
     },
     "limit": {
-      "context": 131072,
-      "output": 131072
+      "context": 131056,
+      "output": 131056
     }
   },
   {
@@ -78844,8 +81021,8 @@
       "output": 3.6
     },
     "limit": {
-      "context": 200000,
-      "output": 200000
+      "context": 202736,
+      "output": 202736
     }
   },
   {
@@ -78872,8 +81049,8 @@
       "output": 3.6
     },
     "limit": {
-      "context": 200000,
-      "output": 200000
+      "context": 202736,
+      "output": 202736
     }
   },
   {
@@ -78901,8 +81078,8 @@
       "output": 2.59
     },
     "limit": {
-      "context": 262144,
-      "output": 262144
+      "context": 262128,
+      "output": 262128
     }
   },
   {
@@ -78930,8 +81107,8 @@
       "output": 3.22
     },
     "limit": {
-      "context": 262144,
-      "output": 262144
+      "context": 262128,
+      "output": 262128
     }
   },
   {
@@ -78959,8 +81136,8 @@
       "output": 0.35
     },
     "limit": {
-      "context": 262144,
-      "output": 262144
+      "context": 262128,
+      "output": 262128
     }
   },
   {
@@ -78988,8 +81165,8 @@
       "output": 2.59
     },
     "limit": {
-      "context": 262144,
-      "output": 262144
+      "context": 262128,
+      "output": 262128
     }
   },
   {
@@ -79017,8 +81194,8 @@
       "output": 3.22
     },
     "limit": {
-      "context": 262144,
-      "output": 262144
+      "context": 262128,
+      "output": 262128
     }
   },
   {
@@ -79045,8 +81222,8 @@
       "output": 0.16
     },
     "limit": {
-      "context": 16384,
-      "output": 16384
+      "context": 16368,
+      "output": 16368
     }
   },
   {
@@ -79073,8 +81250,8 @@
       "output": 4.14
     },
     "limit": {
-      "context": 262144,
-      "output": 262144
+      "context": 262128,
+      "output": 262128
     }
   },
   {
@@ -79102,8 +81279,8 @@
       "output": 0.1
     },
     "limit": {
-      "context": 131072,
-      "output": 131072
+      "context": 131056,
+      "output": 131056
     }
   },
   {
@@ -79130,8 +81307,8 @@
       "output": 3.6
     },
     "limit": {
-      "context": 200000,
-      "output": 200000
+      "context": 202736,
+      "output": 202736
     }
   },
   {
@@ -79567,7 +81744,7 @@
     "name": "DeepSeek R1 Distill Qwen 14B",
     "family": "deepseek-thinking",
     "attachment": false,
-    "reasoning": true,
+    "reasoning": false,
     "tool_call": false,
     "temperature": true,
     "release_date": "2025-01-20",
@@ -79595,7 +81772,7 @@
     "name": "DeepSeek R1 Distill Qwen 32B",
     "family": "deepseek-thinking",
     "attachment": false,
-    "reasoning": true,
+    "reasoning": false,
     "tool_call": false,
     "temperature": true,
     "release_date": "2025-01-20",
@@ -79867,9 +82044,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 1.74,
-      "output": 3.48,
-      "cache_read": 0.145
+      "input": 1.69,
+      "output": 3.38,
+      "cache_read": 0.13
     },
     "limit": {
       "context": 1048576,
@@ -79884,7 +82061,6 @@
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
-    "knowledge": "2024-10",
     "release_date": "2025-03-13",
     "last_updated": "2025-03-13",
     "modalities": {
@@ -80042,6 +82218,35 @@
     "cost": {
       "input": 0.0,
       "output": 0.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "novita-ai/inclusionai/ling-2.6-flash",
+    "name": "Ling-2.6-flash",
+    "family": "ling",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.1,
+      "output": 0.3,
+      "cache_read": 0.02
     },
     "limit": {
       "context": 262144,
@@ -80620,7 +82825,7 @@
   {
     "id": "novita-ai/moonshotai/kimi-k2.6",
     "name": "Kimi K2.6",
-    "family": "kimi",
+    "family": "kimi-k2.6",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
@@ -81562,39 +83767,9 @@
     }
   },
   {
-    "id": "novita-ai/qwen/qwen3.6-27b",
-    "name": "Qwen3.6-27B",
-    "family": "qwen3.6",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-04",
-    "release_date": "2026-04-02",
-    "last_updated": "2026-04-02",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.6,
-      "output": 3.6
-    },
-    "limit": {
-      "context": 262144,
-      "output": 65536
-    }
-  },
-  {
-    "id": "novita-ai/sao10k/L3-8B-Stheno-v3.2",
+    "id": "novita-ai/sao10K/L3-8B-stheno-v3.2",
     "name": "L3 8B Stheno V3.2",
+    "family": "llama",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
@@ -81620,7 +83795,7 @@
     }
   },
   {
-    "id": "novita-ai/sao10k/l3-70b-euryale-v2.1",
+    "id": "novita-ai/sao10K/l3-70b-euryale-v2.1",
     "name": "L3 70B Euryale V2.1\t",
     "attachment": false,
     "reasoning": false,
@@ -81647,7 +83822,7 @@
     }
   },
   {
-    "id": "novita-ai/sao10k/l3-8b-lunaris",
+    "id": "novita-ai/sao10K/l3-8b-lunaris",
     "name": "Sao10k L3 8B Lunaris\t",
     "attachment": false,
     "reasoning": false,
@@ -81674,7 +83849,7 @@
     }
   },
   {
-    "id": "novita-ai/sao10k/l31-70b-euryale-v2.2",
+    "id": "novita-ai/sao10K/l31-70b-euryale-v2.2",
     "name": "L31 70B Euryale V2.2",
     "attachment": false,
     "reasoning": false,
@@ -82027,6 +84202,61 @@
     }
   },
   {
+    "id": "nvidia/abacusai/dracarys-llama-3_1-70b-instruct",
+    "name": "dracarys-llama-3.1-70b-instruct",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2024-09-11",
+    "last_updated": "2025-05-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 8192
+    }
+  },
+  {
+    "id": "nvidia/baai/bge-m3",
+    "name": "BGE M3",
+    "family": "bge",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2024-01-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 8192,
+      "output": 1024
+    }
+  },
+  {
     "id": "nvidia/black-forest-labs/flux.1-dev",
     "name": "FLUX.1-dev",
     "family": "flux",
@@ -82056,70 +84286,101 @@
     }
   },
   {
-    "id": "nvidia/deepseek-ai/deepseek-coder-6.7b-instruct",
-    "name": "Deepseek Coder 6.7b Instruct",
+    "id": "nvidia/black-forest-labs/flux_1-kontext-dev",
+    "name": "FLUX.1-Kontext-dev",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2025-08-12",
+    "last_updated": "2025-08-12",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 40960,
+      "output": 40960
+    }
+  },
+  {
+    "id": "nvidia/black-forest-labs/flux_1-schnell",
+    "name": "FLUX.1-schnell",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "knowledge": "2024-07",
+    "release_date": "2024-08-01",
+    "last_updated": "2026-02-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 77,
+      "output": 0
+    }
+  },
+  {
+    "id": "nvidia/black-forest-labs/flux_2-klein-4b",
+    "name": "FLUX.2 Klein 4B",
+    "family": "flux",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-06",
+    "release_date": "2026-01-14",
+    "last_updated": "2026-01-31",
+    "modalities": {
+      "input": [
+        "image",
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 40960,
+      "output": 40960
+    }
+  },
+  {
+    "id": "nvidia/bytedance/seed-oss-36b-instruct",
+    "name": "ByteDance-Seed/Seed-OSS-36B-Instruct",
+    "family": "seed",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2023-10-29",
-    "last_updated": "2023-10-29",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nvidia/deepseek-ai/deepseek-r1",
-    "name": "Deepseek R1 0528",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-05-28",
-    "last_updated": "2025-05-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nvidia/deepseek-ai/deepseek-v3.1",
-    "name": "DeepSeek V3.1",
-    "family": "deepseek",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-07",
-    "release_date": "2025-08-20",
-    "last_updated": "2025-08-26",
+    "release_date": "2025-09-04",
+    "last_updated": "2025-11-25",
     "modalities": {
       "input": [
         "text"
@@ -82134,8 +84395,8 @@
       "output": 0.0
     },
     "limit": {
-      "context": 128000,
-      "output": 8192
+      "context": 262000,
+      "output": 262000
     }
   },
   {
@@ -82257,87 +84518,6 @@
     }
   },
   {
-    "id": "nvidia/google/codegemma-1.1-7b",
-    "name": "Codegemma 1.1 7b",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2024-04-30",
-    "last_updated": "2024-04-30",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nvidia/google/codegemma-7b",
-    "name": "Codegemma 7b",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2024-03-21",
-    "last_updated": "2024-03-21",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nvidia/google/gemma-2-27b-it",
-    "name": "Gemma 2 27b It",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2024-06-24",
-    "last_updated": "2024-06-24",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
     "id": "nvidia/google/gemma-2-2b-it",
     "name": "Gemma 2 2b It",
     "attachment": false,
@@ -82349,61 +84529,6 @@
     "modalities": {
       "input": [
         "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nvidia/google/gemma-3-12b-it",
-    "name": "Gemma 3 12b It",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-03-01",
-    "last_updated": "2025-03-01",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nvidia/google/gemma-3-1b-it",
-    "name": "Gemma 3 1b It",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-03-10",
-    "last_updated": "2025-03-10",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
       ],
       "output": [
         "text"
@@ -82539,14 +84664,42 @@
     }
   },
   {
-    "id": "nvidia/meta/codellama-70b",
-    "name": "Codellama 70b",
+    "id": "nvidia/google/google-paligemma",
+    "name": "paligemma",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2024-05-14",
+    "last_updated": "2024-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 8192
+    }
+  },
+  {
+    "id": "nvidia/meta/esm2-650m",
+    "name": "esm2-650m",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
-    "release_date": "2024-01-29",
-    "last_updated": "2024-01-29",
+    "release_date": "2024-08-29",
+    "last_updated": "2025-03-10",
     "modalities": {
       "input": [
         "text"
@@ -82562,18 +84715,18 @@
     },
     "limit": {
       "context": 128000,
-      "output": 4096
+      "output": 8192
     }
   },
   {
-    "id": "nvidia/meta/llama-3.1-405b-instruct",
-    "name": "Llama 3.1 405b Instruct",
+    "id": "nvidia/meta/esmfold",
+    "name": "esmfold",
     "attachment": false,
     "reasoning": false,
-    "tool_call": true,
+    "tool_call": false,
     "temperature": true,
-    "release_date": "2024-07-16",
-    "last_updated": "2024-07-16",
+    "release_date": "2024-03-15",
+    "last_updated": "2025-06-12",
     "modalities": {
       "input": [
         "text"
@@ -82589,7 +84742,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 4096
+      "output": 8192
     }
   },
   {
@@ -82616,6 +84769,35 @@
     },
     "limit": {
       "context": 128000,
+      "output": 4096
+    }
+  },
+  {
+    "id": "nvidia/meta/llama-3.1-8b-instruct",
+    "name": "Llama 3.1 8B Instruct",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-12",
+    "release_date": "2025-01-01",
+    "last_updated": "2025-01-01",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 16000,
       "output": 4096
     }
   },
@@ -82677,6 +84859,64 @@
     }
   },
   {
+    "id": "nvidia/meta/llama-3.2-3b-instruct",
+    "name": "Llama 3.2 3B Instruct",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2024-09-18",
+    "last_updated": "2024-09-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 32768,
+      "output": 32000
+    }
+  },
+  {
+    "id": "nvidia/meta/llama-3.2-90b-vision-instruct",
+    "name": "Llama-3.2-90B-Vision-Instruct",
+    "family": "llama",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-12",
+    "release_date": "2024-09-25",
+    "last_updated": "2024-09-25",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 8192
+    }
+  },
+  {
     "id": "nvidia/meta/llama-3.3-70b-instruct",
     "name": "Llama 3.3 70b Instruct",
     "attachment": false,
@@ -82733,15 +84973,15 @@
     }
   },
   {
-    "id": "nvidia/meta/llama-4-scout-17b-16e-instruct",
-    "name": "Llama 4 Scout 17b 16e Instruct",
+    "id": "nvidia/meta/llama-guard-4-12b",
+    "name": "Llama Guard 4 12B",
+    "family": "llama",
     "attachment": true,
     "reasoning": false,
-    "tool_call": true,
+    "tool_call": false,
     "temperature": true,
-    "knowledge": "2024-02",
-    "release_date": "2025-04-02",
-    "last_updated": "2025-04-02",
+    "release_date": "2025-04-05",
+    "last_updated": "2026-04-30",
     "modalities": {
       "input": [
         "text",
@@ -82758,260 +84998,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nvidia/meta/llama3-70b-instruct",
-    "name": "Llama3 70b Instruct",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2024-04-17",
-    "last_updated": "2024-04-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nvidia/meta/llama3-8b-instruct",
-    "name": "Llama3 8b Instruct",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2024-04-17",
-    "last_updated": "2024-04-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nvidia/microsoft/phi-3-medium-128k-instruct",
-    "name": "Phi 3 Medium 128k Instruct",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-10",
-    "release_date": "2024-05-07",
-    "last_updated": "2024-05-07",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nvidia/microsoft/phi-3-medium-4k-instruct",
-    "name": "Phi 3 Medium 4k Instruct",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-10",
-    "release_date": "2024-05-07",
-    "last_updated": "2024-05-07",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 4000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nvidia/microsoft/phi-3-small-128k-instruct",
-    "name": "Phi 3 Small 128k Instruct",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-10",
-    "release_date": "2024-05-07",
-    "last_updated": "2024-05-07",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nvidia/microsoft/phi-3-small-8k-instruct",
-    "name": "Phi 3 Small 8k Instruct",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-10",
-    "release_date": "2024-05-07",
-    "last_updated": "2024-05-07",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 8000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nvidia/microsoft/phi-3-vision-128k-instruct",
-    "name": "Phi 3 Vision 128k Instruct",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2024-05-19",
-    "last_updated": "2024-05-19",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nvidia/microsoft/phi-3.5-moe-instruct",
-    "name": "Phi 3.5 Moe Instruct",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2024-08-17",
-    "last_updated": "2024-08-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nvidia/microsoft/phi-3.5-vision-instruct",
-    "name": "Phi 3.5 Vision Instruct",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2024-08-16",
-    "last_updated": "2024-08-16",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
+      "output": 16384
     }
   },
   {
@@ -83046,15 +85033,13 @@
     }
   },
   {
-    "id": "nvidia/minimaxai/minimax-m2.1",
-    "name": "MiniMax-M2.1",
-    "family": "minimax",
+    "id": "nvidia/microsoft/phi-4-multimodal-instruct",
+    "name": "Phi 4 Multimodal",
     "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-12-23",
-    "last_updated": "2025-12-23",
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2025-07-26",
+    "last_updated": "2025-07-26",
     "modalities": {
       "input": [
         "text"
@@ -83063,14 +85048,14 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
       "input": 0.0,
       "output": 0.0
     },
     "limit": {
-      "context": 204800,
-      "output": 131072
+      "context": 128000,
+      "output": 16384
     }
   },
   {
@@ -83131,33 +85116,6 @@
     }
   },
   {
-    "id": "nvidia/mistralai/codestral-22b-instruct-v0.1",
-    "name": "Codestral 22b Instruct V0.1",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2024-05-29",
-    "last_updated": "2024-05-29",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
     "id": "nvidia/mistralai/devstral-2-123b-instruct",
     "name": "Devstral-2-123B-Instruct-2512",
     "family": "devstral",
@@ -83187,14 +85145,13 @@
     }
   },
   {
-    "id": "nvidia/mistralai/mamba-codestral-7b-v0.1",
-    "name": "Mamba Codestral 7b V0.1",
+    "id": "nvidia/mistralai/magistral-small",
+    "name": "Magistral Small 2506",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": true,
-    "release_date": "2024-07-16",
-    "last_updated": "2024-07-16",
+    "release_date": "2025-09-25",
+    "last_updated": "2025-09-25",
     "modalities": {
       "input": [
         "text"
@@ -83203,55 +85160,25 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
       "input": 0.0,
       "output": 0.0
     },
     "limit": {
-      "context": 128000,
-      "output": 4096
+      "context": 32768,
+      "output": 32768
     }
   },
   {
-    "id": "nvidia/mistralai/ministral-14b-instruct",
-    "name": "Ministral 3 14B Instruct 2512",
-    "family": "ministral",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-12",
-    "release_date": "2025-12-01",
-    "last_updated": "2025-12-08",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 262144,
-      "output": 262144
-    }
-  },
-  {
-    "id": "nvidia/mistralai/mistral-large-2-instruct",
-    "name": "Mistral Large 2 Instruct",
+    "id": "nvidia/mistralai/mistral-7b-instruct-v03",
+    "name": "Mistral-7B-Instruct-v0.3",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2024-07-24",
-    "last_updated": "2024-07-24",
+    "release_date": "2025-04-01",
+    "last_updated": "2025-04-01",
     "modalities": {
       "input": [
         "text"
@@ -83266,8 +85193,8 @@
       "output": 0.0
     },
     "limit": {
-      "context": 128000,
-      "output": 4096
+      "context": 65536,
+      "output": 65536
     }
   },
   {
@@ -83301,15 +85228,14 @@
     }
   },
   {
-    "id": "nvidia/mistralai/mistral-medium-3.5-128b",
-    "name": "Mistral Medium 3.5 128B",
+    "id": "nvidia/mistralai/mistral-medium-3-instruct",
+    "name": "Mistral Medium 3",
     "family": "mistral-medium",
     "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-04-29",
-    "last_updated": "2026-04-29",
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2025-09-25",
+    "last_updated": "2025-09-25",
     "modalities": {
       "input": [
         "text",
@@ -83319,25 +85245,25 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
       "input": 0.0,
       "output": 0.0
     },
     "limit": {
-      "context": 262144,
-      "output": 262144
+      "context": 131072,
+      "output": 32768
     }
   },
   {
-    "id": "nvidia/mistralai/mistral-small-3.1-24b-instruct",
-    "name": "Mistral Small 3.1 24b Instruct 2503",
+    "id": "nvidia/mistralai/mistral-nemotron",
+    "name": "mistral-nemotron",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-03-11",
-    "last_updated": "2025-03-11",
+    "release_date": "2025-06-11",
+    "last_updated": "2025-06-12",
     "modalities": {
       "input": [
         "text"
@@ -83353,20 +85279,18 @@
     },
     "limit": {
       "context": 128000,
-      "output": 4096
+      "output": 8192
     }
   },
   {
-    "id": "nvidia/moonshotai/kimi-k2-instruct",
-    "name": "Kimi K2 0905",
-    "family": "kimi",
+    "id": "nvidia/mistralai/mistral-small-4-119b",
+    "name": "mistral-small-4-119b-2603",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-10",
-    "release_date": "2025-09-05",
-    "last_updated": "2025-09-05",
+    "release_date": "2026-03-16",
+    "last_updated": "2026-03-16",
     "modalities": {
       "input": [
         "text"
@@ -83381,8 +85305,91 @@
       "output": 0.0
     },
     "limit": {
-      "context": 262144,
-      "output": 262144
+      "context": 128000,
+      "output": 8192
+    }
+  },
+  {
+    "id": "nvidia/mistralai/mixtral-8x22b-instruct",
+    "name": "Mistral: Mixtral 8x22B Instruct",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2024-04-17",
+    "last_updated": "2024-04-17",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 65536,
+      "output": 13108
+    }
+  },
+  {
+    "id": "nvidia/mistralai/mixtral-8x7b-instruct",
+    "name": "Mistral: Mixtral 8x7B Instruct",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2023-12-10",
+    "last_updated": "2026-03-15",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 32768,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nvidia/moonshotai/kimi-k2-instruct",
+    "name": "Kimi K2 Instruct",
+    "family": "kimi",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-01",
+    "release_date": "2025-01-01",
+    "last_updated": "2025-09-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 8192
     }
   },
   {
@@ -83410,37 +85417,6 @@
       "output": 0.0,
       "cache_read": 0.0,
       "cache_write": 0.0
-    },
-    "limit": {
-      "context": 262144,
-      "output": 262144
-    }
-  },
-  {
-    "id": "nvidia/moonshotai/kimi-k2.5",
-    "name": "Kimi K2.5",
-    "family": "kimi",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
-    "release_date": "2026-01-27",
-    "last_updated": "2026-01-27",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
     },
     "limit": {
       "context": 262144,
@@ -83479,16 +85455,68 @@
     }
   },
   {
-    "id": "nvidia/nvidia/cosmos-nemotron-34b",
-    "name": "Cosmos Nemotron 34B",
-    "family": "nemotron",
-    "attachment": false,
-    "reasoning": true,
+    "id": "nvidia/nvidia/active-speaker-detection",
+    "name": "Active Speaker Detection",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2026-04-16",
+    "last_updated": "2026-04-16",
+    "modalities": {
+      "input": [
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 0,
+      "output": 4096
+    }
+  },
+  {
+    "id": "nvidia/nvidia/bevformer",
+    "name": "bevformer",
+    "attachment": true,
+    "reasoning": false,
     "tool_call": false,
     "temperature": true,
-    "knowledge": "2024-01",
-    "release_date": "2024-01-01",
-    "last_updated": "2025-09-05",
+    "release_date": "2025-03-18",
+    "last_updated": "2025-07-20",
+    "modalities": {
+      "input": [
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 8192
+    }
+  },
+  {
+    "id": "nvidia/nvidia/cosmos-predict1-5b",
+    "name": "cosmos-predict1-5b",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2025-03-18",
+    "last_updated": "2025-03-18",
     "modalities": {
       "input": [
         "text",
@@ -83496,111 +85524,86 @@
         "video"
       ],
       "output": [
-        "text"
+        "video"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.0,
       "output": 0.0
     },
     "limit": {
-      "context": 131072,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nvidia/nvidia/llama-3.1-nemotron-51b-instruct",
-    "name": "Llama 3.1 Nemotron 51b Instruct",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2024-09-22",
-    "last_updated": "2024-09-22",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 128000,
+      "context": 0,
       "output": 4096
     }
   },
   {
-    "id": "nvidia/nvidia/llama-3.1-nemotron-70b-instruct",
-    "name": "Llama 3.1 Nemotron 70b Instruct",
-    "attachment": false,
+    "id": "nvidia/nvidia/cosmos-transfer1-7b",
+    "name": "cosmos-transfer1-7b",
+    "attachment": true,
     "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2024-10-12",
-    "last_updated": "2024-10-12",
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2025-06-13",
+    "last_updated": "2025-06-30",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "video"
       ],
       "output": [
-        "text"
+        "video"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.0,
       "output": 0.0
     },
     "limit": {
-      "context": 128000,
+      "context": 0,
       "output": 4096
     }
   },
   {
-    "id": "nvidia/nvidia/llama-3.1-nemotron-ultra-253b-v1",
-    "name": "Llama-3.1-Nemotron-Ultra-253B-v1",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-07",
-    "release_date": "2024-07-01",
-    "last_updated": "2025-09-05",
+    "id": "nvidia/nvidia/cosmos-transfer2_5-2b",
+    "name": "cosmos-transfer2.5-2b",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2026-02-26",
+    "last_updated": "2026-02-26",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "video"
       ],
       "output": [
-        "text"
+        "video"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.0,
       "output": 0.0
     },
     "limit": {
-      "context": 131072,
-      "output": 8192
+      "context": 0,
+      "output": 4096
     }
   },
   {
-    "id": "nvidia/nvidia/llama-3.3-nemotron-super-49b-v1",
-    "name": "Llama 3.3 Nemotron Super 49b V1",
+    "id": "nvidia/nvidia/gliner-pii",
+    "name": "gliner-pii",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
-    "release_date": "2025-03-16",
-    "last_updated": "2025-03-16",
+    "release_date": "2026-03-03",
+    "last_updated": "2026-03-03",
     "modalities": {
       "input": [
         "text"
@@ -83609,7 +85612,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.0,
       "output": 0.0
@@ -83620,43 +85623,14 @@
     }
   },
   {
-    "id": "nvidia/nvidia/llama-3.3-nemotron-super-49b-v1.5",
-    "name": "Llama 3.3 Nemotron Super 49b V1.5",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2025-03-16",
-    "last_updated": "2025-03-16",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nvidia/nvidia/llama-embed-nemotron-8b",
-    "name": "Llama Embed Nemotron 8B",
-    "family": "llama",
+    "id": "nvidia/nvidia/llama-3_1-nemotron-safety-guard-8b-v3",
+    "name": "llama-3.1-nemotron-safety-guard-8b-v3",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
     "temperature": false,
-    "knowledge": "2025-03",
-    "release_date": "2025-03-18",
-    "last_updated": "2025-03-18",
+    "release_date": "2025-10-28",
+    "last_updated": "2025-10-28",
     "modalities": {
       "input": [
         "text"
@@ -83665,7 +85639,34 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 4096
+    }
+  },
+  {
+    "id": "nvidia/nvidia/llama-3_2-nemoretriever-300m-embed-v1",
+    "name": "llama-3_2-nemoretriever-300m-embed-v1",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2025-07-24",
+    "last_updated": "2025-07-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
     "cost": {
       "input": 0.0,
       "output": 0.0
@@ -83676,14 +85677,16 @@
     }
   },
   {
-    "id": "nvidia/nvidia/llama3-chatqa-1.5-70b",
-    "name": "Llama3 Chatqa 1.5 70b",
+    "id": "nvidia/nvidia/llama-3_3-nemotron-super-49b-v1",
+    "name": "Llama 3.3 Nemotron Super 49B v1",
+    "family": "nemotron",
     "attachment": false,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2024-04-28",
-    "last_updated": "2024-04-28",
+    "knowledge": "2023-12",
+    "release_date": "2025-04-07",
+    "last_updated": "2025-04-07",
     "modalities": {
       "input": [
         "text"
@@ -83692,7 +85695,92 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 131072,
+      "output": 131072
+    }
+  },
+  {
+    "id": "nvidia/nvidia/llama-3_3-nemotron-super-49b-v1_5",
+    "name": "Llama 3.3 Nemotron Super 49B v1.5",
+    "family": "nemotron",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-12",
+    "release_date": "2025-07-25",
+    "last_updated": "2025-07-25",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 131072,
+      "output": 131072
+    }
+  },
+  {
+    "id": "nvidia/nvidia/llama-nemotron-embed-vl-1b-v2",
+    "name": "llama-nemotron-embed-vl-1b-v2",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2026-02-10",
+    "last_updated": "2026-02-10",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 32768,
+      "output": 2048
+    }
+  },
+  {
+    "id": "nvidia/nvidia/llama-nemotron-rerank-vl-1b-v2",
+    "name": "llama-nemotron-rerank-vl-1b-v2",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2026-03-31",
+    "last_updated": "2026-03-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
     "cost": {
       "input": 0.0,
       "output": 0.0
@@ -83703,31 +85791,57 @@
     }
   },
   {
-    "id": "nvidia/nvidia/nemoretriever-ocr-v1",
-    "name": "NeMo Retriever OCR v1",
-    "family": "nemoretriever",
-    "attachment": false,
+    "id": "nvidia/nvidia/magpie-tts-zeroshot",
+    "name": "magpie-tts-zeroshot",
+    "attachment": true,
     "reasoning": false,
     "tool_call": false,
     "temperature": false,
-    "knowledge": "2024-01",
-    "release_date": "2024-01-01",
-    "last_updated": "2025-09-05",
+    "release_date": "2025-05-22",
+    "last_updated": "2025-06-12",
     "modalities": {
       "input": [
-        "image"
+        "text",
+        "audio"
       ],
       "output": [
-        "text"
+        "audio"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.0,
       "output": 0.0
     },
     "limit": {
       "context": 0,
+      "output": 4096
+    }
+  },
+  {
+    "id": "nvidia/nvidia/nemotron-3-content-safety",
+    "name": "nemotron-3-content-safety",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2026-04-16",
+    "last_updated": "2026-04-16",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 128000,
       "output": 4096
     }
   },
@@ -83821,14 +85935,14 @@
     }
   },
   {
-    "id": "nvidia/nvidia/nemotron-4-340b-instruct",
-    "name": "Nemotron 4 340b Instruct",
+    "id": "nvidia/nvidia/nemotron-content-safety-reasoning-4b",
+    "name": "nemotron-content-safety-reasoning-4b",
     "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2024-06-13",
-    "last_updated": "2024-06-13",
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2026-01-22",
+    "last_updated": "2026-01-22",
     "modalities": {
       "input": [
         "text"
@@ -83837,7 +85951,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.0,
       "output": 0.0
@@ -83845,6 +85959,115 @@
     "limit": {
       "context": 128000,
       "output": 4096
+    }
+  },
+  {
+    "id": "nvidia/nvidia/nemotron-mini-4b-instruct",
+    "name": "nemotron-mini-4b-instruct",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2024-08-21",
+    "last_updated": "2024-08-26",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 8192
+    }
+  },
+  {
+    "id": "nvidia/nvidia/nemotron-voicechat",
+    "name": "nemotron-voicechat",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-16",
+    "last_updated": "2026-03-16",
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 8192
+    }
+  },
+  {
+    "id": "nvidia/nvidia/nv-embed-v1",
+    "name": "nv-embed-v1",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2024-06-07",
+    "last_updated": "2025-07-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 32768,
+      "output": 2048
+    }
+  },
+  {
+    "id": "nvidia/nvidia/nv-embedcode-7b-v1",
+    "name": "nv-embedcode-7b-v1",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2025-03-17",
+    "last_updated": "2025-05-29",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 32768,
+      "output": 2048
     }
   },
   {
@@ -83877,25 +86100,212 @@
     }
   },
   {
-    "id": "nvidia/nvidia/parakeet-tdt-0.6b-v2",
-    "name": "Parakeet TDT 0.6B v2",
-    "family": "parakeet",
+    "id": "nvidia/nvidia/rerank-qa-mistral-4b",
+    "name": "rerank-qa-mistral-4b",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
     "temperature": false,
-    "knowledge": "2024-01",
-    "release_date": "2024-01-01",
-    "last_updated": "2025-09-05",
+    "release_date": "2024-03-17",
+    "last_updated": "2025-01-17",
     "modalities": {
       "input": [
-        "audio"
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 4096
+    }
+  },
+  {
+    "id": "nvidia/nvidia/riva-translate-4b-instruct-v1_1",
+    "name": "riva-translate-4b-instruct-v1_1",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2025-12-12",
+    "last_updated": "2025-12-12",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 4096
+    }
+  },
+  {
+    "id": "nvidia/nvidia/sparsedrive",
+    "name": "sparsedrive",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-03-18",
+    "last_updated": "2025-07-20",
+    "modalities": {
+      "input": [
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 8192
+    }
+  },
+  {
+    "id": "nvidia/nvidia/streampetr",
+    "name": "streampetr",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-11-13",
+    "last_updated": "2025-11-13",
+    "modalities": {
+      "input": [
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 8192
+    }
+  },
+  {
+    "id": "nvidia/nvidia/studiovoice",
+    "name": "studiovoice",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2024-10-03",
+    "last_updated": "2025-06-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 8192
+    }
+  },
+  {
+    "id": "nvidia/nvidia/synthetic-video-detector",
+    "name": "synthetic-video-detector",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-04-16",
+    "last_updated": "2026-04-16",
+    "modalities": {
+      "input": [
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 0,
+      "output": 4096
+    }
+  },
+  {
+    "id": "nvidia/nvidia/usdcode",
+    "name": "usdcode",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-01-01",
+    "last_updated": "2026-01-01",
+    "modalities": {
+      "input": [
+        "text"
       ],
       "output": [
         "text"
       ]
     },
     "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 4096
+    }
+  },
+  {
+    "id": "nvidia/nvidia/usdvalidate",
+    "name": "usdvalidate",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2024-07-24",
+    "last_updated": "2025-01-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
     "cost": {
       "input": 0.0,
       "output": 0.0
@@ -83935,6 +86345,34 @@
     }
   },
   {
+    "id": "nvidia/openai/gpt-oss-20b",
+    "name": "GPT OSS 20B",
+    "family": "gpt-oss",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-08-05",
+    "last_updated": "2025-08-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    }
+  },
+  {
     "id": "nvidia/openai/whisper-large-v3",
     "name": "Whisper Large v3",
     "family": "whisper",
@@ -83964,6 +86402,64 @@
     }
   },
   {
+    "id": "nvidia/qwen/qwen-image",
+    "name": "Qwen Image",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-08-07",
+    "last_updated": "2025-08-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "nvidia/qwen/qwen-image-edit",
+    "name": "Qwen Image Edit",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-08-19",
+    "last_updated": "2025-08-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
     "id": "nvidia/qwen/qwen2.5-coder-32b-instruct",
     "name": "Qwen2.5 Coder 32b Instruct",
     "attachment": false,
@@ -83988,62 +86484,6 @@
     "limit": {
       "context": 128000,
       "output": 4096
-    }
-  },
-  {
-    "id": "nvidia/qwen/qwen2.5-coder-7b-instruct",
-    "name": "Qwen2.5 Coder 7b Instruct",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2024-09-17",
-    "last_updated": "2024-09-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nvidia/qwen/qwen3-235b-a22b",
-    "name": "Qwen3-235B-A22B",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-12",
-    "release_date": "2024-12-01",
-    "last_updated": "2025-09-05",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 131072,
-      "output": 8192
     }
   },
   {
@@ -84134,6 +86574,37 @@
     }
   },
   {
+    "id": "nvidia/qwen/qwen3.5-122b-a10b",
+    "name": "Qwen3.5 122B-A10B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-23",
+    "last_updated": "2026-02-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
     "id": "nvidia/qwen/qwen3.5-397b-a17b",
     "name": "Qwen3.5-397B-A17B",
     "family": "qwen",
@@ -84164,14 +86635,14 @@
     }
   },
   {
-    "id": "nvidia/qwen/qwq-32b",
-    "name": "Qwq 32b",
+    "id": "nvidia/sarvamai/sarvam-m",
+    "name": "sarvam-m",
     "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
+    "reasoning": false,
+    "tool_call": true,
     "temperature": true,
-    "release_date": "2025-03-05",
-    "last_updated": "2025-03-05",
+    "release_date": "2025-07-25",
+    "last_updated": "2025-07-25",
     "modalities": {
       "input": [
         "text"
@@ -84187,7 +86658,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 4096
+      "output": 8192
     }
   },
   {
@@ -84215,6 +86686,33 @@
     "limit": {
       "context": 256000,
       "output": 16384
+    }
+  },
+  {
+    "id": "nvidia/upstage/solar-10_7b-instruct",
+    "name": "solar-10.7b-instruct",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2024-06-05",
+    "last_updated": "2025-04-10",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 8192
     }
   },
   {
@@ -84272,34 +86770,6 @@
     "limit": {
       "context": 204800,
       "output": 131072
-    }
-  },
-  {
-    "id": "nvidia/z-ai/glm5",
-    "name": "GLM5",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-02-12",
-    "last_updated": "2026-02-12",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 202752,
-      "output": 131000
     }
   },
   {
@@ -84691,7 +87161,7 @@
     "cost": {},
     "limit": {
       "context": 202752,
-      "output": 202752
+      "output": 131072
     }
   },
   {
@@ -84793,8 +87263,8 @@
     }
   },
   {
-    "id": "ollama-cloud/kimi-k2.6:cloud",
-    "name": "kimi-k2.6:cloud",
+    "id": "ollama-cloud/kimi-k2.6",
+    "name": "kimi-k2.6",
     "family": "kimi",
     "attachment": true,
     "reasoning": true,
@@ -85231,7 +87701,7 @@
     "cost": {},
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 65536
     }
   },
   {
@@ -85471,15 +87941,15 @@
   },
   {
     "id": "openai/gpt-4o",
-    "name": "GPT-4o (2024-11-20)",
+    "name": "GPT-4o (2024-08-06)",
     "family": "gpt",
     "attachment": true,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2023-09",
-    "release_date": "2024-11-20",
-    "last_updated": "2024-11-20",
+    "release_date": "2024-08-06",
+    "last_updated": "2024-08-06",
     "modalities": {
       "input": [
         "text",
@@ -86905,7 +89375,7 @@
   },
   {
     "id": "opencode-go/kimi-k2.6",
-    "name": "Kimi K2.6 (3x limits)",
+    "name": "Kimi K2.6",
     "family": "kimi-k2.6",
     "attachment": true,
     "reasoning": true,
@@ -86926,9 +89396,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.32,
-      "output": 1.34,
-      "cache_read": 0.054
+      "input": 0.95,
+      "output": 4.0,
+      "cache_read": 0.16
     },
     "limit": {
       "context": 262144,
@@ -87014,7 +89484,7 @@
         "text",
         "image",
         "audio",
-        "pdf"
+        "video"
       ],
       "output": [
         "text"
@@ -87516,6 +89986,36 @@
     }
   },
   {
+    "id": "opencode/deepseek-v4-flash-free",
+    "name": "DeepSeek V4 Flash Free",
+    "family": "deepseek-flash-free",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0
+    },
+    "limit": {
+      "context": 200000,
+      "output": 128000
+    }
+  },
+  {
     "id": "opencode/gemini-3-flash",
     "name": "Gemini 3 Flash",
     "family": "gemini-flash",
@@ -87881,9 +90381,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.0,
-      "output": 0.0,
-      "cache_read": 0.0
+      "input": 0.05,
+      "output": 0.4,
+      "cache_read": 0.005
     },
     "limit": {
       "context": 400000,
@@ -88948,16 +91448,18 @@
     "id": "opencode/qwen3.6-plus-free",
     "name": "Qwen3.6 Plus Free",
     "family": "qwen-free",
-    "attachment": false,
+    "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-12",
-    "release_date": "2026-03-30",
-    "last_updated": "2026-03-30",
+    "knowledge": "2025-04",
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "video"
       ],
       "output": [
         "text"
@@ -88970,8 +91472,37 @@
       "cache_read": 0.0
     },
     "limit": {
-      "context": 1048576,
-      "output": 64000
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "opencode/ring-2.6-1t-free",
+    "name": "Ring 2.6 1T Free",
+    "family": "ring-1t-free",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-06",
+    "release_date": "2026-05-08",
+    "last_updated": "2026-05-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 262000,
+      "output": 66000
     }
   },
   {
@@ -89004,21 +91535,457 @@
     }
   },
   {
+    "id": "openrouter/ai21/jamba-large-1.7",
+    "name": "Jamba Large 1.7",
+    "family": "jamba",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-08-31",
+    "release_date": "2025-08-08",
+    "last_updated": "2025-08-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 2.0,
+      "output": 8.0
+    },
+    "limit": {
+      "context": 256000,
+      "output": 4096
+    }
+  },
+  {
+    "id": "openrouter/aion-labs/aion-1.0",
+    "name": "Aion-1.0",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-02-04",
+    "last_updated": "2025-02-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 4.0,
+      "output": 8.0
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/aion-labs/aion-1.0-mini",
+    "name": "Aion-1.0-Mini",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-02-04",
+    "last_updated": "2025-02-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.7,
+      "output": 1.4
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/aion-labs/aion-2.0",
+    "name": "Aion-2.0",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-02-23",
+    "last_updated": "2026-02-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.8,
+      "output": 1.6,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/aion-labs/aion-rp-llama-3.1-8b",
+    "name": "Aion-RP 1.0 (8B)",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2023-12-31",
+    "release_date": "2025-02-04",
+    "last_updated": "2025-02-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.8,
+      "output": 1.6
+    },
+    "limit": {
+      "context": 32768,
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/alfredpros/codellama-7b-instruct-solidity",
+    "name": "CodeLLaMa 7B Instruct Solidity",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2023-06-30",
+    "release_date": "2025-04-14",
+    "last_updated": "2025-04-14",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.8,
+      "output": 1.2
+    },
+    "limit": {
+      "context": 4096,
+      "output": 4096
+    }
+  },
+  {
+    "id": "openrouter/alibaba/tongyi-deepresearch-30b-a3b",
+    "name": "Tongyi DeepResearch 30B A3B",
+    "family": "yi",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-09-18",
+    "last_updated": "2025-09-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.09,
+      "output": 0.45,
+      "cache_read": 0.09
+    },
+    "limit": {
+      "context": 131072,
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/allenai/olmo-3-32b-think",
+    "name": "Olmo 3 32B Think",
+    "family": "allenai",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-11-21",
+    "last_updated": "2025-11-21",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.15,
+      "output": 0.5
+    },
+    "limit": {
+      "context": 65536,
+      "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/amazon/nova-2-lite-v1",
+    "name": "Nova 2 Lite",
+    "family": "nova",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-12-02",
+    "last_updated": "2025-12-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 2.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65535
+    }
+  },
+  {
+    "id": "openrouter/amazon/nova-lite-v1",
+    "name": "Nova Lite 1.0",
+    "family": "nova-lite",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-10-31",
+    "release_date": "2024-12-05",
+    "last_updated": "2024-12-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.06,
+      "output": 0.24
+    },
+    "limit": {
+      "context": 300000,
+      "output": 5120
+    }
+  },
+  {
+    "id": "openrouter/amazon/nova-micro-v1",
+    "name": "Nova Micro 1.0",
+    "family": "nova-micro",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-10-31",
+    "release_date": "2024-12-05",
+    "last_updated": "2024-12-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.035,
+      "output": 0.14
+    },
+    "limit": {
+      "context": 128000,
+      "output": 5120
+    }
+  },
+  {
+    "id": "openrouter/amazon/nova-premier-v1",
+    "name": "Nova Premier 1.0",
+    "family": "nova",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-10-31",
+    "last_updated": "2025-10-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 12.5,
+      "cache_read": 0.625
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 32000
+    }
+  },
+  {
+    "id": "openrouter/amazon/nova-pro-v1",
+    "name": "Nova Pro 1.0",
+    "family": "nova-pro",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-10-31",
+    "release_date": "2024-12-05",
+    "last_updated": "2024-12-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.8,
+      "output": 3.2
+    },
+    "limit": {
+      "context": 300000,
+      "output": 5120
+    }
+  },
+  {
+    "id": "openrouter/anthracite-org/magnum-v4-72b",
+    "name": "Magnum v4 72B",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2024-06-30",
+    "release_date": "2024-10-22",
+    "last_updated": "2024-10-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 3.0,
+      "output": 5.0
+    },
+    "limit": {
+      "context": 16384,
+      "output": 2048
+    }
+  },
+  {
+    "id": "openrouter/anthropic/claude-3-haiku",
+    "name": "Claude 3 Haiku",
+    "family": "claude",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-08-31",
+    "release_date": "2024-03-13",
+    "last_updated": "2024-03-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 1.25,
+      "cache_read": 0.03,
+      "cache_write": 0.3
+    },
+    "limit": {
+      "context": 200000,
+      "output": 4096
+    }
+  },
+  {
     "id": "openrouter/anthropic/claude-3.5-haiku",
-    "name": "Claude Haiku 3.5",
-    "family": "claude-haiku",
+    "name": "Claude 3.5 Haiku",
+    "family": "claude",
     "attachment": true,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2024-07-31",
-    "release_date": "2024-10-22",
-    "last_updated": "2024-10-22",
+    "release_date": "2024-11-04",
+    "last_updated": "2024-11-04",
     "modalities": {
       "input": [
         "text",
-        "image",
-        "pdf"
+        "image"
       ],
       "output": [
         "text"
@@ -89034,39 +92001,6 @@
     "limit": {
       "context": 200000,
       "output": 8192
-    }
-  },
-  {
-    "id": "openrouter/anthropic/claude-3.7-sonnet",
-    "name": "Claude Sonnet 3.7",
-    "family": "claude-sonnet",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-01",
-    "release_date": "2025-02-19",
-    "last_updated": "2025-02-19",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 15.0,
-      "output": 75.0,
-      "cache_read": 1.5,
-      "cache_write": 18.75
-    },
-    "limit": {
-      "context": 200000,
-      "output": 128000
     }
   },
   {
@@ -89110,13 +92044,13 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-03-31",
+    "knowledge": "2025-01-31",
     "release_date": "2025-05-22",
     "last_updated": "2025-05-22",
     "modalities": {
       "input": [
-        "text",
         "image",
+        "text",
         "pdf"
       ],
       "output": [
@@ -89143,13 +92077,13 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-03-31",
+    "knowledge": "2025-01-31",
     "release_date": "2025-08-05",
     "last_updated": "2025-08-05",
     "modalities": {
       "input": [
-        "text",
         "image",
+        "text",
         "pdf"
       ],
       "output": [
@@ -89181,9 +92115,9 @@
     "last_updated": "2025-11-24",
     "modalities": {
       "input": [
-        "text",
+        "pdf",
         "image",
-        "pdf"
+        "text"
       ],
       "output": [
         "text"
@@ -89198,7 +92132,7 @@
     },
     "limit": {
       "context": 200000,
-      "output": 32000
+      "output": 64000
     }
   },
   {
@@ -89210,8 +92144,8 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-05-31",
-    "release_date": "2026-02-05",
-    "last_updated": "2026-02-05",
+    "release_date": "2026-02-04",
+    "last_updated": "2026-02-04",
     "modalities": {
       "input": [
         "text",
@@ -89228,6 +92162,38 @@
       "output": 25.0,
       "cache_read": 0.5,
       "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/anthropic/claude-opus-4.6-fast",
+    "name": "Claude Opus 4.6 (Fast)",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-07",
+    "last_updated": "2026-04-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 30.0,
+      "output": 150.0,
+      "cache_read": 3.0,
+      "cache_write": 37.5
     },
     "limit": {
       "context": 1000000,
@@ -89268,6 +92234,38 @@
     }
   },
   {
+    "id": "openrouter/anthropic/claude-opus-4.7-fast",
+    "name": "Claude Opus 4.7 (Fast)",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-05-12",
+    "last_updated": "2026-05-12",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 30.0,
+      "output": 150.0,
+      "cache_read": 3.0,
+      "cache_write": 37.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "openrouter/anthropic/claude-sonnet-4",
     "name": "Claude Sonnet 4",
     "family": "claude-sonnet",
@@ -89275,13 +92273,13 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-03-31",
+    "knowledge": "2025-01-31",
     "release_date": "2025-05-22",
     "last_updated": "2025-05-22",
     "modalities": {
       "input": [
-        "text",
         "image",
+        "text",
         "pdf"
       ],
       "output": [
@@ -89296,7 +92294,7 @@
       "cache_write": 3.75
     },
     "limit": {
-      "context": 200000,
+      "context": 1000000,
       "output": 64000
     }
   },
@@ -89308,7 +92306,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-07-31",
+    "knowledge": "2025-01-31",
     "release_date": "2025-09-29",
     "last_updated": "2025-09-29",
     "modalities": {
@@ -89347,7 +92345,8 @@
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -89366,16 +92365,100 @@
     }
   },
   {
-    "id": "openrouter/arcee-ai/trinity-large-preview:free",
+    "id": "openrouter/arcee-ai/coder-large",
+    "name": "Coder Large",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-05-05",
+    "last_updated": "2025-05-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.5,
+      "output": 0.8
+    },
+    "limit": {
+      "context": 32768,
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/arcee-ai/maestro",
+    "name": "Maestro Reasoning",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-05-05",
+    "last_updated": "2025-05-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.9,
+      "output": 3.3
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32000
+    }
+  },
+  {
+    "id": "openrouter/arcee-ai/spotlight",
+    "name": "Spotlight",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-05-05",
+    "last_updated": "2025-05-05",
+    "modalities": {
+      "input": [
+        "image",
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.18,
+      "output": 0.18
+    },
+    "limit": {
+      "context": 131072,
+      "output": 65537
+    }
+  },
+  {
+    "id": "openrouter/arcee-ai/trinity-large-preview",
     "name": "Trinity Large Preview",
     "family": "trinity",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-06",
-    "release_date": "2026-01-28",
-    "last_updated": "2026-01-28",
+    "release_date": "2026-01-27",
+    "last_updated": "2026-01-27",
     "modalities": {
       "input": [
         "text"
@@ -89386,12 +92469,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.0,
-      "output": 0.0
+      "input": 0.15,
+      "output": 0.45
     },
     "limit": {
-      "context": 131072,
-      "output": 131072
+      "context": 131000,
+      "output": 131000
     }
   },
   {
@@ -89403,7 +92486,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-04-01",
-    "last_updated": "2026-04-03",
+    "last_updated": "2026-04-01",
     "modalities": {
       "input": [
         "text"
@@ -89415,7 +92498,36 @@
     "open_weights": true,
     "cost": {
       "input": 0.22,
-      "output": 0.85
+      "output": 0.85,
+      "cache_read": 0.06
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "openrouter/arcee-ai/trinity-large-thinking:free",
+    "name": "Trinity Large Thinking (free)",
+    "family": "trinity",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-01",
+    "last_updated": "2026-04-01",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
     },
     "limit": {
       "context": 262144,
@@ -89423,83 +92535,76 @@
     }
   },
   {
-    "id": "openrouter/black-forest-labs/flux.2-flex",
-    "name": "FLUX.2 Flex",
-    "family": "flux",
+    "id": "openrouter/arcee-ai/trinity-mini",
+    "name": "Trinity Mini",
+    "family": "trinity-mini",
     "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
+    "reasoning": true,
+    "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-06",
-    "release_date": "2025-11-25",
-    "last_updated": "2026-01-31",
+    "release_date": "2025-12-01",
+    "last_updated": "2025-12-01",
     "modalities": {
       "input": [
-        "image",
         "text"
       ],
       "output": [
-        "image"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 67344,
-      "output": 67344
-    }
-  },
-  {
-    "id": "openrouter/black-forest-labs/flux.2-klein-4b",
-    "name": "FLUX.2 Klein 4B",
-    "family": "flux",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2025-06",
-    "release_date": "2026-01-14",
-    "last_updated": "2026-01-31",
-    "modalities": {
-      "input": [
-        "image",
         "text"
-      ],
-      "output": [
-        "image"
       ]
     },
     "open_weights": true,
     "cost": {
-      "input": 0.0,
-      "output": 0.0
+      "input": 0.045,
+      "output": 0.15
     },
     "limit": {
-      "context": 40960,
-      "output": 40960
+      "context": 131072,
+      "output": 131072
     }
   },
   {
-    "id": "openrouter/black-forest-labs/flux.2-max",
-    "name": "FLUX.2 Max",
-    "family": "flux",
+    "id": "openrouter/arcee-ai/virtuoso-large",
+    "name": "Virtuoso Large",
     "attachment": false,
     "reasoning": false,
-    "tool_call": false,
+    "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-06",
-    "release_date": "2025-12-16",
-    "last_updated": "2026-01-31",
+    "knowledge": "2025-03-31",
+    "release_date": "2025-05-05",
+    "last_updated": "2025-05-05",
     "modalities": {
       "input": [
-        "image",
         "text"
       ],
       "output": [
-        "image"
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 1.2
+    },
+    "limit": {
+      "context": 131072,
+      "output": 64000
+    }
+  },
+  {
+    "id": "openrouter/baidu/cobuddy:free",
+    "name": "CoBuddy (free)",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-05-06",
+    "last_updated": "2026-05-06",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
       ]
     },
     "open_weights": false,
@@ -89508,68 +92613,333 @@
       "output": 0.0
     },
     "limit": {
-      "context": 46864,
-      "output": 46864
+      "context": 131072,
+      "output": 65536
     }
   },
   {
-    "id": "openrouter/black-forest-labs/flux.2-pro",
-    "name": "FLUX.2 Pro",
-    "family": "flux",
+    "id": "openrouter/baidu/ernie-4.5-21b-a3b",
+    "name": "ERNIE 4.5 21B A3B",
+    "family": "ernie",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-08-12",
+    "last_updated": "2025-08-12",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.07,
+      "output": 0.28
+    },
+    "limit": {
+      "context": 120000,
+      "output": 8000
+    }
+  },
+  {
+    "id": "openrouter/baidu/ernie-4.5-21b-a3b-thinking",
+    "name": "ERNIE 4.5 21B A3B Thinking",
+    "family": "ernie",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-10-09",
+    "last_updated": "2025-10-09",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.07,
+      "output": 0.28
+    },
+    "limit": {
+      "context": 131072,
+      "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/baidu/ernie-4.5-300b-a47b",
+    "name": "ERNIE 4.5 300B A47B ",
+    "family": "ernie",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
-    "knowledge": "2025-06",
-    "release_date": "2025-11-25",
-    "last_updated": "2026-01-31",
+    "knowledge": "2025-03-31",
+    "release_date": "2025-06-30",
+    "last_updated": "2025-06-30",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.28,
+      "output": 1.1
+    },
+    "limit": {
+      "context": 123000,
+      "output": 12000
+    }
+  },
+  {
+    "id": "openrouter/baidu/ernie-4.5-vl-28b-a3b",
+    "name": "ERNIE 4.5 VL 28B A3B",
+    "family": "ernie",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-08-12",
+    "last_updated": "2025-08-12",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.14,
+      "output": 0.56
+    },
+    "limit": {
+      "context": 30000,
+      "output": 8000
+    }
+  },
+  {
+    "id": "openrouter/baidu/ernie-4.5-vl-424b-a47b",
+    "name": "ERNIE 4.5 VL 424B A47B ",
+    "family": "ernie",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-06-30",
+    "last_updated": "2025-06-30",
     "modalities": {
       "input": [
         "image",
         "text"
       ],
       "output": [
-        "image"
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.42,
+      "output": 1.25
+    },
+    "limit": {
+      "context": 123000,
+      "output": 16000
+    }
+  },
+  {
+    "id": "openrouter/baidu/qianfan-ocr-fast",
+    "name": "Qianfan-OCR-Fast",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-04-20",
+    "last_updated": "2026-04-20",
+    "modalities": {
+      "input": [
+        "image",
+        "text"
+      ],
+      "output": [
+        "text"
       ]
     },
     "open_weights": false,
     "cost": {
-      "input": 0.0,
-      "output": 0.0
+      "input": 0.68,
+      "output": 2.81
     },
     "limit": {
-      "context": 46864,
-      "output": 46864
+      "context": 65536,
+      "output": 28672
     }
   },
   {
-    "id": "openrouter/bytedance-seed/seedream-4.5",
-    "name": "Seedream 4.5",
+    "id": "openrouter/bytedance-seed/seed-1.6",
+    "name": "Seed 1.6",
     "family": "seed",
-    "attachment": false,
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-12-23",
+    "last_updated": "2025-12-23",
+    "modalities": {
+      "input": [
+        "image",
+        "text",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 2.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/bytedance-seed/seed-1.6-flash",
+    "name": "Seed 1.6 Flash",
+    "family": "seed",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-12-23",
+    "last_updated": "2025-12-23",
+    "modalities": {
+      "input": [
+        "image",
+        "text",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.075,
+      "output": 0.3
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/bytedance-seed/seed-2.0-lite",
+    "name": "Seed-2.0-Lite",
+    "family": "seed",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-10",
+    "last_updated": "2026-03-10",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 2.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/bytedance-seed/seed-2.0-mini",
+    "name": "Seed-2.0-Mini",
+    "family": "seed",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-26",
+    "last_updated": "2026-02-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.4
+    },
+    "limit": {
+      "context": 262144,
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/bytedance/ui-tars-1.5-7b",
+    "name": "UI-TARS 7B ",
+    "attachment": true,
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
-    "knowledge": "2025-06",
-    "release_date": "2025-12-23",
-    "last_updated": "2026-01-31",
+    "knowledge": "2025-01-31",
+    "release_date": "2025-07-22",
+    "last_updated": "2025-07-22",
     "modalities": {
       "input": [
         "image",
         "text"
       ],
       "output": [
-        "image"
+        "text"
       ]
     },
     "open_weights": true,
     "cost": {
-      "input": 0.0,
-      "output": 0.0
+      "input": 0.1,
+      "output": 0.2,
+      "cache_read": 0.1
     },
     "limit": {
-      "context": 4096,
-      "output": 4096
+      "context": 128000,
+      "output": 2048
     }
   },
   {
@@ -89580,9 +92950,9 @@
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
-    "knowledge": "2025-06",
+    "knowledge": "2024-04-30",
     "release_date": "2025-07-09",
-    "last_updated": "2026-01-31",
+    "last_updated": "2025-07-09",
     "modalities": {
       "input": [
         "text"
@@ -89602,14 +92972,187 @@
     }
   },
   {
+    "id": "openrouter/cohere/command-a",
+    "name": "Command A",
+    "family": "command-a",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2024-08-31",
+    "release_date": "2025-03-13",
+    "last_updated": "2025-03-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 2.5,
+      "output": 10.0
+    },
+    "limit": {
+      "context": 256000,
+      "output": 8192
+    }
+  },
+  {
+    "id": "openrouter/cohere/command-r-08",
+    "name": "Command R (08-2024)",
+    "family": "command-r",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-03-31",
+    "release_date": "2024-08-30",
+    "last_updated": "2024-08-30",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.6
+    },
+    "limit": {
+      "context": 128000,
+      "output": 4000
+    }
+  },
+  {
+    "id": "openrouter/cohere/command-r-plus-08",
+    "name": "Command R+ (08-2024)",
+    "family": "command-r",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-03-31",
+    "release_date": "2024-08-30",
+    "last_updated": "2024-08-30",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 10.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 4000
+    }
+  },
+  {
+    "id": "openrouter/cohere/command-r7b-12",
+    "name": "Command R7B (12-2024)",
+    "family": "command-r",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2024-08-31",
+    "release_date": "2024-12-14",
+    "last_updated": "2024-12-14",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0375,
+      "output": 0.15
+    },
+    "limit": {
+      "context": 128000,
+      "output": 4000
+    }
+  },
+  {
+    "id": "openrouter/deepcogito/cogito-v2.1-671b",
+    "name": "Cogito v2.1 671B",
+    "family": "cogito",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-11-13",
+    "last_updated": "2025-11-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 1.25
+    },
+    "limit": {
+      "context": 128000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/deepseek/deepseek-chat",
+    "name": "DeepSeek V3",
+    "family": "deepseek",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-07-31",
+    "release_date": "2024-12-26",
+    "last_updated": "2024-12-26",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.32,
+      "output": 0.89
+    },
+    "limit": {
+      "context": 163840,
+      "output": 16384
+    }
+  },
+  {
     "id": "openrouter/deepseek/deepseek-chat-v3",
     "name": "DeepSeek V3 0324",
     "family": "deepseek",
     "attachment": false,
     "reasoning": false,
-    "tool_call": false,
+    "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-10",
+    "knowledge": "2024-07-31",
     "release_date": "2025-03-24",
     "last_updated": "2025-03-24",
     "modalities": {
@@ -89622,23 +93165,24 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.0,
-      "output": 0.0
+      "input": 0.2,
+      "output": 0.77,
+      "cache_read": 0.135
     },
     "limit": {
-      "context": 16384,
-      "output": 8192
+      "context": 163840,
+      "output": 16384
     }
   },
   {
     "id": "openrouter/deepseek/deepseek-chat-v3.1",
-    "name": "DeepSeek-V3.1",
+    "name": "DeepSeek V3.1",
     "family": "deepseek",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-07",
+    "knowledge": "2025-03-31",
     "release_date": "2025-08-21",
     "last_updated": "2025-08-21",
     "modalities": {
@@ -89651,25 +93195,26 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.2,
-      "output": 0.8
+      "input": 0.21,
+      "output": 0.79,
+      "cache_read": 0.13
     },
     "limit": {
       "context": 163840,
-      "output": 163840
+      "output": 32768
     }
   },
   {
     "id": "openrouter/deepseek/deepseek-r1",
-    "name": "DeepSeek: R1",
-    "family": "deepseek-thinking",
+    "name": "R1 0528",
+    "family": "deepseek",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-07",
-    "release_date": "2025-01-20",
-    "last_updated": "2025-01-20",
+    "knowledge": "2025-03-31",
+    "release_date": "2025-05-28",
+    "last_updated": "2025-05-28",
     "modalities": {
       "input": [
         "text"
@@ -89680,23 +93225,24 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.7,
-      "output": 2.5
+      "input": 0.5,
+      "output": 2.15,
+      "cache_read": 0.35
     },
     "limit": {
-      "context": 64000,
-      "output": 16000
+      "context": 163840,
+      "output": 32768
     }
   },
   {
     "id": "openrouter/deepseek/deepseek-r1-distill-llama-70b",
-    "name": "DeepSeek R1 Distill Llama 70B",
+    "name": "R1 Distill Llama 70B",
     "family": "deepseek-thinking",
     "attachment": false,
     "reasoning": true,
     "tool_call": false,
     "temperature": true,
-    "knowledge": "2024-10",
+    "knowledge": "2024-07-31",
     "release_date": "2025-01-23",
     "last_updated": "2025-01-23",
     "modalities": {
@@ -89709,12 +93255,41 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.0,
-      "output": 0.0
+      "input": 0.7,
+      "output": 0.8
     },
     "limit": {
-      "context": 8192,
-      "output": 8192
+      "context": 131072,
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/deepseek/deepseek-r1-distill-qwen-32b",
+    "name": "R1 Distill Qwen 32B",
+    "family": "deepseek",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2024-07-31",
+    "release_date": "2025-01-29",
+    "last_updated": "2025-01-29",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.29,
+      "output": 0.29
+    },
+    "limit": {
+      "context": 32768,
+      "output": 32768
     }
   },
   {
@@ -89725,7 +93300,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-07",
+    "knowledge": "2025-03-31",
     "release_date": "2025-09-22",
     "last_updated": "2025-09-22",
     "modalities": {
@@ -89739,40 +93314,12 @@
     "open_weights": true,
     "cost": {
       "input": 0.27,
-      "output": 1.0
+      "output": 0.95,
+      "cache_read": 0.13
     },
     "limit": {
-      "context": 131072,
-      "output": 65536
-    }
-  },
-  {
-    "id": "openrouter/deepseek/deepseek-v3.1-terminus:exacto",
-    "name": "DeepSeek V3.1 Terminus (exacto)",
-    "family": "deepseek",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
-    "release_date": "2025-09-22",
-    "last_updated": "2025-09-22",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.27,
-      "output": 1.0
-    },
-    "limit": {
-      "context": 131072,
-      "output": 65536
+      "context": 163840,
+      "output": 32768
     }
   },
   {
@@ -89796,25 +93343,26 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.28,
-      "output": 0.4
+      "input": 0.252,
+      "output": 0.378,
+      "cache_read": 0.0252
     },
     "limit": {
-      "context": 163840,
+      "context": 131072,
       "output": 65536
     }
   },
   {
-    "id": "openrouter/deepseek/deepseek-v3.2-speciale",
-    "name": "DeepSeek V3.2 Speciale",
+    "id": "openrouter/deepseek/deepseek-v3.2-exp",
+    "name": "DeepSeek V3.2 Exp",
     "family": "deepseek",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-07",
-    "release_date": "2025-12-01",
-    "last_updated": "2025-12-01",
+    "knowledge": "2025-07-31",
+    "release_date": "2025-09-29",
+    "last_updated": "2025-09-29",
     "modalities": {
       "input": [
         "text"
@@ -89834,14 +93382,43 @@
     }
   },
   {
+    "id": "openrouter/deepseek/deepseek-v3.2-speciale",
+    "name": "DeepSeek V3.2 Speciale",
+    "family": "deepseek",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2024-07",
+    "release_date": "2025-12-01",
+    "last_updated": "2025-12-01",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.287,
+      "output": 0.431,
+      "cache_read": 0.058
+    },
+    "limit": {
+      "context": 163840,
+      "output": 163840
+    }
+  },
+  {
     "id": "openrouter/deepseek/deepseek-v4-flash",
     "name": "DeepSeek V4 Flash",
-    "family": "deepseek-flash",
+    "family": "deepseek",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-05",
     "release_date": "2026-04-24",
     "last_updated": "2026-04-24",
     "modalities": {
@@ -89854,24 +93431,51 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.14,
-      "output": 0.28,
-      "cache_read": 0.028
+      "input": 0.112,
+      "output": 0.224,
+      "cache_read": 0.022
+    },
+    "limit": {
+      "context": 1048575,
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/deepseek/deepseek-v4-flash:free",
+    "name": "DeepSeek V4 Flash (free)",
+    "family": "deepseek",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
     },
     "limit": {
       "context": 1048576,
-      "output": 393216
+      "output": 384000
     }
   },
   {
     "id": "openrouter/deepseek/deepseek-v4-pro",
     "name": "DeepSeek V4 Pro",
-    "family": "deepseek-thinking",
+    "family": "deepseek",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-05",
     "release_date": "2026-04-24",
     "last_updated": "2026-04-24",
     "modalities": {
@@ -89884,13 +93488,41 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 1.74,
-      "output": 3.48,
-      "cache_read": 0.145
+      "input": 0.435,
+      "output": 0.87,
+      "cache_read": 0.003625
     },
     "limit": {
       "context": 1048576,
-      "output": 393216
+      "output": 384000
+    }
+  },
+  {
+    "id": "openrouter/essentialai/rnj-1-instruct",
+    "name": "Rnj 1 Instruct",
+    "family": "rnj",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-12-07",
+    "last_updated": "2025-12-07",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.15,
+      "output": 0.15
+    },
+    "limit": {
+      "context": 32768,
+      "output": 32768
     }
   },
   {
@@ -89901,16 +93533,16 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-06",
-    "release_date": "2024-12-11",
-    "last_updated": "2024-12-11",
+    "knowledge": "2024-08-31",
+    "release_date": "2025-02-05",
+    "last_updated": "2025-02-05",
     "modalities": {
       "input": [
         "text",
         "image",
+        "pdf",
         "audio",
-        "video",
-        "pdf"
+        "video"
       ],
       "output": [
         "text"
@@ -89920,7 +93552,41 @@
     "cost": {
       "input": 0.1,
       "output": 0.4,
-      "cache_read": 0.025
+      "cache_read": 0.025,
+      "cache_write": 0.083333
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 8192
+    }
+  },
+  {
+    "id": "openrouter/google/gemini-2.0-flash-lite-001",
+    "name": "Gemini 2.0 Flash Lite",
+    "family": "gemini",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-08-31",
+    "release_date": "2025-02-25",
+    "last_updated": "2025-02-25",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.075,
+      "output": 0.3
     },
     "limit": {
       "context": 1048576,
@@ -89935,16 +93601,16 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2025-07-17",
-    "last_updated": "2025-07-17",
+    "knowledge": "2025-01-31",
+    "release_date": "2025-06-17",
+    "last_updated": "2025-06-17",
     "modalities": {
       "input": [
-        "text",
+        "pdf",
         "image",
+        "text",
         "audio",
-        "video",
-        "pdf"
+        "video"
       ],
       "output": [
         "text"
@@ -89954,11 +93620,45 @@
     "cost": {
       "input": 0.3,
       "output": 2.5,
-      "cache_read": 0.0375
+      "cache_read": 0.03,
+      "cache_write": 0.083333
     },
     "limit": {
       "context": 1048576,
-      "output": 65536
+      "output": 65535
+    }
+  },
+  {
+    "id": "openrouter/google/gemini-2.5-flash-image",
+    "name": "Nano Banana (Gemini 2.5 Flash Image)",
+    "family": "gemini",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-01-31",
+    "release_date": "2025-10-07",
+    "last_updated": "2025-10-07",
+    "modalities": {
+      "input": [
+        "image",
+        "text"
+      ],
+      "output": [
+        "image",
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 2.5,
+      "cache_read": 0.03,
+      "cache_write": 0.083333
+    },
+    "limit": {
+      "context": 32768,
+      "output": 32768
     }
   },
   {
@@ -89969,118 +93669,86 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-01",
+    "knowledge": "2025-01-31",
+    "release_date": "2025-07-22",
+    "last_updated": "2025-07-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.4,
+      "cache_read": 0.01,
+      "cache_write": 0.083333
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65535
+    }
+  },
+  {
+    "id": "openrouter/google/gemini-2.5-flash-lite-preview-09",
+    "name": "Gemini 2.5 Flash Lite Preview 09-2025",
+    "family": "gemini-flash-lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01-31",
+    "release_date": "2025-09-25",
+    "last_updated": "2025-09-25",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.4,
+      "cache_read": 0.01,
+      "cache_write": 0.083333
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65535
+    }
+  },
+  {
+    "id": "openrouter/google/gemini-2.5-pro",
+    "name": "Gemini 2.5 Pro",
+    "family": "gemini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01-31",
     "release_date": "2025-06-17",
     "last_updated": "2025-06-17",
     "modalities": {
       "input": [
         "text",
         "image",
+        "pdf",
         "audio",
-        "video",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.1,
-      "output": 0.4,
-      "cache_read": 0.025
-    },
-    "limit": {
-      "context": 1048576,
-      "output": 65536
-    }
-  },
-  {
-    "id": "openrouter/google/gemini-2.5-flash-lite-preview-09",
-    "name": "Gemini 2.5 Flash Lite Preview 09-25",
-    "family": "gemini-flash-lite",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2025-09-25",
-    "last_updated": "2025-09-25",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.1,
-      "output": 0.4,
-      "cache_read": 0.025
-    },
-    "limit": {
-      "context": 1048576,
-      "output": 65536
-    }
-  },
-  {
-    "id": "openrouter/google/gemini-2.5-flash-preview-09",
-    "name": "Gemini 2.5 Flash Preview 09-25",
-    "family": "gemini-flash",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2025-09-25",
-    "last_updated": "2025-09-25",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.3,
-      "output": 2.5,
-      "cache_read": 0.031
-    },
-    "limit": {
-      "context": 1048576,
-      "output": 65536
-    }
-  },
-  {
-    "id": "openrouter/google/gemini-2.5-pro",
-    "name": "Gemini 2.5 Pro",
-    "family": "gemini-pro",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2025-03-20",
-    "last_updated": "2025-06-05",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video",
-        "pdf"
+        "video"
       ],
       "output": [
         "text"
@@ -90090,7 +93758,42 @@
     "cost": {
       "input": 1.25,
       "output": 10.0,
-      "cache_read": 0.125
+      "cache_read": 0.125,
+      "cache_write": 0.375
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/google/gemini-2.5-pro-preview",
+    "name": "Gemini 2.5 Pro Preview 06-05",
+    "family": "gemini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01-31",
+    "release_date": "2025-06-05",
+    "last_updated": "2025-06-05",
+    "modalities": {
+      "input": [
+        "pdf",
+        "image",
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125,
+      "cache_write": 0.375
     },
     "limit": {
       "context": 1048576,
@@ -90105,16 +93808,16 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2025-05-06",
-    "last_updated": "2025-05-06",
+    "knowledge": "2025-01-31",
+    "release_date": "2025-05-07",
+    "last_updated": "2025-05-07",
     "modalities": {
       "input": [
         "text",
         "image",
+        "pdf",
         "audio",
-        "video",
-        "pdf"
+        "video"
       ],
       "output": [
         "text"
@@ -90124,45 +93827,12 @@
     "cost": {
       "input": 1.25,
       "output": 10.0,
-      "cache_read": 0.31
+      "cache_read": 0.125,
+      "cache_write": 0.375
     },
     "limit": {
       "context": 1048576,
-      "output": 65536
-    }
-  },
-  {
-    "id": "openrouter/google/gemini-2.5-pro-preview-06-05",
-    "name": "Gemini 2.5 Pro Preview 06-05",
-    "family": "gemini-pro",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2025-06-05",
-    "last_updated": "2025-06-05",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.25,
-      "output": 10.0,
-      "cache_read": 0.31
-    },
-    "limit": {
-      "context": 1048576,
-      "output": 65536
+      "output": 65535
     }
   },
   {
@@ -90180,9 +93850,9 @@
       "input": [
         "text",
         "image",
+        "pdf",
         "audio",
-        "video",
-        "pdf"
+        "video"
       ],
       "output": [
         "text"
@@ -90192,7 +93862,8 @@
     "cost": {
       "input": 0.5,
       "output": 3.0,
-      "cache_read": 0.05
+      "cache_read": 0.05,
+      "cache_write": 0.083333
     },
     "limit": {
       "context": 1048576,
@@ -90200,41 +93871,40 @@
     }
   },
   {
-    "id": "openrouter/google/gemini-3-pro-preview",
-    "name": "Gemini 3 Pro Preview",
-    "family": "gemini-pro",
+    "id": "openrouter/google/gemini-3-pro-image-preview",
+    "name": "Nano Banana Pro (Gemini 3 Pro Image Preview)",
+    "family": "gemini",
     "attachment": true,
     "reasoning": true,
-    "tool_call": true,
+    "tool_call": false,
     "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2025-11-18",
-    "last_updated": "2025-11",
+    "release_date": "2025-11-20",
+    "last_updated": "2025-11-20",
     "modalities": {
       "input": [
-        "text",
         "image",
-        "audio",
-        "video",
-        "pdf"
+        "text"
       ],
       "output": [
+        "image",
         "text"
       ]
     },
     "open_weights": false,
     "cost": {
       "input": 2.0,
-      "output": 12.0
+      "output": 12.0,
+      "cache_read": 0.2,
+      "cache_write": 0.375
     },
     "limit": {
-      "context": 1050000,
-      "output": 66000
+      "context": 65536,
+      "output": 32768
     }
   },
   {
     "id": "openrouter/google/gemini-3.1-flash-image-preview",
-    "name": "Gemini 3.1 Flash Image Preview (Nano Banana 2)",
+    "name": "Nano Banana 2 (Gemini 3.1 Flash Image Preview)",
     "family": "gemini-flash",
     "attachment": true,
     "reasoning": true,
@@ -90245,12 +93915,12 @@
     "last_updated": "2026-02-26",
     "modalities": {
       "input": [
-        "text",
-        "image"
+        "image",
+        "text"
       ],
       "output": [
-        "text",
-        "image"
+        "image",
+        "text"
       ]
     },
     "open_weights": false,
@@ -90260,6 +93930,40 @@
     },
     "limit": {
       "context": 65536,
+      "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/google/gemini-3.1-flash-lite",
+    "name": "Gemini 3.1 Flash Lite",
+    "family": "gemini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-05-07",
+    "last_updated": "2026-05-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 1.5,
+      "cache_read": 0.025,
+      "cache_write": 0.083333
+    },
+    "limit": {
+      "context": 1048576,
       "output": 65536
     }
   },
@@ -90290,7 +93994,7 @@
       "input": 0.25,
       "output": 1.5,
       "cache_read": 0.025,
-      "cache_write": 0.083
+      "cache_write": 0.083333
     },
     "limit": {
       "context": 1048576,
@@ -90310,11 +94014,11 @@
     "last_updated": "2026-02-19",
     "modalities": {
       "input": [
-        "text",
-        "image",
         "audio",
-        "video",
-        "pdf"
+        "pdf",
+        "image",
+        "text",
+        "video"
       ],
       "output": [
         "text"
@@ -90323,7 +94027,9 @@
     "open_weights": false,
     "cost": {
       "input": 2.0,
-      "output": 12.0
+      "output": 12.0,
+      "cache_read": 0.2,
+      "cache_write": 0.375
     },
     "limit": {
       "context": 1048576,
@@ -90339,13 +94045,13 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-01",
-    "release_date": "2026-02-19",
-    "last_updated": "2026-02-19",
+    "release_date": "2026-02-25",
+    "last_updated": "2026-02-25",
     "modalities": {
       "input": [
         "text",
-        "image",
         "audio",
+        "image",
         "video",
         "pdf"
       ],
@@ -90356,7 +94062,9 @@
     "open_weights": false,
     "cost": {
       "input": 2.0,
-      "output": 12.0
+      "output": 12.0,
+      "cache_read": 0.2,
+      "cache_write": 0.375
     },
     "limit": {
       "context": 1048576,
@@ -90364,16 +94072,16 @@
     }
   },
   {
-    "id": "openrouter/google/gemma-2-9b-it",
-    "name": "Gemma 2 9B",
+    "id": "openrouter/google/gemma-2-27b-it",
+    "name": "Gemma 2 27B",
     "family": "gemma",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
-    "knowledge": "2024-06",
-    "release_date": "2024-06-28",
-    "last_updated": "2024-06-28",
+    "knowledge": "2024-06-30",
+    "release_date": "2024-07-13",
+    "last_updated": "2024-07-13",
     "modalities": {
       "input": [
         "text"
@@ -90384,12 +94092,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.03,
-      "output": 0.09
+      "input": 0.65,
+      "output": 0.65
     },
     "limit": {
       "context": 8192,
-      "output": 8192
+      "output": 2048
     }
   },
   {
@@ -90398,71 +94106,11 @@
     "family": "gemma",
     "attachment": true,
     "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2024-10",
-    "release_date": "2025-03-13",
-    "last_updated": "2025-03-13",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.03,
-      "output": 0.1
-    },
-    "limit": {
-      "context": 131072,
-      "output": 131072
-    }
-  },
-  {
-    "id": "openrouter/google/gemma-3-12b-it:free",
-    "name": "Gemma 3 12B (free)",
-    "family": "gemma",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2024-10",
-    "release_date": "2025-03-13",
-    "last_updated": "2025-03-13",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 32768,
-      "output": 8192
-    }
-  },
-  {
-    "id": "openrouter/google/gemma-3-27b-it",
-    "name": "Gemma 3 27B",
-    "family": "gemma",
-    "attachment": true,
-    "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-10",
-    "release_date": "2025-03-12",
-    "last_updated": "2025-03-12",
+    "knowledge": "2024-08-31",
+    "release_date": "2025-03-13",
+    "last_updated": "2025-03-13",
     "modalities": {
       "input": [
         "text",
@@ -90475,22 +94123,22 @@
     "open_weights": true,
     "cost": {
       "input": 0.04,
-      "output": 0.15
+      "output": 0.13
     },
     "limit": {
-      "context": 96000,
-      "output": 96000
+      "context": 131072,
+      "output": 16384
     }
   },
   {
-    "id": "openrouter/google/gemma-3-27b-it:free",
-    "name": "Gemma 3 27B (free)",
+    "id": "openrouter/google/gemma-3-27b-it",
+    "name": "Gemma 3 27B",
     "family": "gemma",
     "attachment": true,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-10",
+    "knowledge": "2024-08-31",
     "release_date": "2025-03-12",
     "last_updated": "2025-03-12",
     "modalities": {
@@ -90504,12 +94152,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.0,
-      "output": 0.0
+      "input": 0.08,
+      "output": 0.16
     },
     "limit": {
       "context": 131072,
-      "output": 8192
+      "output": 16384
     }
   },
   {
@@ -90520,7 +94168,7 @@
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
-    "knowledge": "2024-10",
+    "knowledge": "2024-08-31",
     "release_date": "2025-03-13",
     "last_updated": "2025-03-13",
     "modalities": {
@@ -90534,82 +94182,23 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.01703,
-      "output": 0.06815
+      "input": 0.04,
+      "output": 0.08
     },
     "limit": {
-      "context": 96000,
-      "output": 96000
-    }
-  },
-  {
-    "id": "openrouter/google/gemma-3-4b-it:free",
-    "name": "Gemma 3 4B (free)",
-    "family": "gemma",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2024-10",
-    "release_date": "2025-03-13",
-    "last_updated": "2025-03-13",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 32768,
-      "output": 8192
-    }
-  },
-  {
-    "id": "openrouter/google/gemma-3n-e2b-it:free",
-    "name": "Gemma 3n 2B (free)",
-    "family": "gemma",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2024-06",
-    "release_date": "2025-07-09",
-    "last_updated": "2025-07-09",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 8192,
-      "output": 2000
+      "context": 131072,
+      "output": 16384
     }
   },
   {
     "id": "openrouter/google/gemma-3n-e4b-it",
     "name": "Gemma 3n 4B",
     "family": "gemma",
-    "attachment": true,
+    "attachment": false,
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
-    "knowledge": "2024-06",
+    "knowledge": "2024-08-31",
     "release_date": "2025-05-20",
     "last_updated": "2025-05-20",
     "modalities": {
@@ -90622,8 +94211,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.02,
-      "output": 0.04
+      "input": 0.06,
+      "output": 0.12
     },
     "limit": {
       "context": 32768,
@@ -90631,37 +94220,8 @@
     }
   },
   {
-    "id": "openrouter/google/gemma-3n-e4b-it:free",
-    "name": "Gemma 3n 4B (free)",
-    "family": "gemma",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2024-06",
-    "release_date": "2025-05-20",
-    "last_updated": "2025-05-20",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 8192,
-      "output": 2000
-    }
-  },
-  {
     "id": "openrouter/google/gemma-4-26b-a4b-it",
-    "name": "Gemma 4 26B A4B",
+    "name": "Gemma 4 26B A4B ",
     "family": "gemma",
     "attachment": true,
     "reasoning": true,
@@ -90672,8 +94232,8 @@
     "last_updated": "2026-04-03",
     "modalities": {
       "input": [
-        "text",
         "image",
+        "text",
         "video"
       ],
       "output": [
@@ -90682,8 +94242,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.13,
-      "output": 0.4
+      "input": 0.06,
+      "output": 0.33
     },
     "limit": {
       "context": 262144,
@@ -90692,7 +94252,7 @@
   },
   {
     "id": "openrouter/google/gemma-4-26b-a4b-it:free",
-    "name": "Gemma 4 26B A4B (free)",
+    "name": "Gemma 4 26B A4B  (free)",
     "family": "gemma",
     "attachment": true,
     "reasoning": true,
@@ -90703,8 +94263,8 @@
     "last_updated": "2026-04-03",
     "modalities": {
       "input": [
-        "text",
         "image",
+        "text",
         "video"
       ],
       "output": [
@@ -90734,8 +94294,8 @@
     "last_updated": "2026-04-02",
     "modalities": {
       "input": [
-        "text",
         "image",
+        "text",
         "video"
       ],
       "output": [
@@ -90744,12 +94304,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.14,
-      "output": 0.4
+      "input": 0.12,
+      "output": 0.37
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 16384
     }
   },
   {
@@ -90765,8 +94325,8 @@
     "last_updated": "2026-04-02",
     "modalities": {
       "input": [
-        "text",
         "image",
+        "text",
         "video"
       ],
       "output": [
@@ -90781,6 +94341,151 @@
     "limit": {
       "context": 262144,
       "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/google/lyria-3-clip-preview",
+    "name": "Lyria 3 Clip Preview",
+    "family": "lyria",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-03-30",
+    "last_updated": "2026-03-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/google/lyria-3-pro-preview",
+    "name": "Lyria 3 Pro Preview",
+    "family": "lyria",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-03-30",
+    "last_updated": "2026-03-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/gryphe/mythomax-l2-13b",
+    "name": "MythoMax 13B",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2023-06-30",
+    "release_date": "2023-07-02",
+    "last_updated": "2023-07-02",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.06,
+      "output": 0.06
+    },
+    "limit": {
+      "context": 4096,
+      "output": 4096
+    }
+  },
+  {
+    "id": "openrouter/ibm-granite/granite-4.0-h-micro",
+    "name": "Granite 4.0 Micro",
+    "family": "granite",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-10-20",
+    "last_updated": "2025-10-20",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.017,
+      "output": 0.112
+    },
+    "limit": {
+      "context": 131000,
+      "output": 131000
+    }
+  },
+  {
+    "id": "openrouter/ibm-granite/granite-4.1-8b",
+    "name": "Granite 4.1 8B",
+    "family": "granite",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.05,
+      "output": 0.1,
+      "cache_read": 0.05
+    },
+    "limit": {
+      "context": 131072,
+      "output": 131072
     }
   },
   {
@@ -90813,14 +94518,15 @@
     }
   },
   {
-    "id": "openrouter/inception/mercury-edit-2",
-    "name": "Mercury Edit 2",
+    "id": "openrouter/inclusionai/ling-2.6-1t",
+    "name": "Ling-2.6-1T",
+    "family": "ling",
     "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
+    "reasoning": false,
+    "tool_call": true,
     "temperature": true,
-    "release_date": "2026-03-30",
-    "last_updated": "2026-03-30",
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
     "modalities": {
       "input": [
         "text"
@@ -90831,13 +94537,184 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.25,
-      "output": 0.75,
-      "cache_read": 0.025
+      "input": 0.3,
+      "output": 2.5,
+      "cache_read": 0.06
     },
     "limit": {
-      "context": 128000,
-      "output": 8192
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/inclusionai/ling-2.6-flash",
+    "name": "Ling-2.6-flash",
+    "family": "ling",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.01,
+      "output": 0.03,
+      "cache_read": 0.002
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/inclusionai/ring-2.6-1t",
+    "name": "Ring-2.6-1T",
+    "family": "ring",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-05-08",
+    "last_updated": "2026-05-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.075,
+      "output": 0.625,
+      "cache_read": 0.015
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/inflection/inflection-3-pi",
+    "name": "Inflection 3 Pi",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2024-10-31",
+    "release_date": "2024-10-11",
+    "last_updated": "2024-10-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 10.0
+    },
+    "limit": {
+      "context": 8000,
+      "output": 1024
+    }
+  },
+  {
+    "id": "openrouter/inflection/inflection-3-productivity",
+    "name": "Inflection 3 Productivity",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2024-10-31",
+    "release_date": "2024-10-11",
+    "last_updated": "2024-10-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 10.0
+    },
+    "limit": {
+      "context": 8000,
+      "output": 1024
+    }
+  },
+  {
+    "id": "openrouter/kwaipilot/kat-coder-pro-v2",
+    "name": "KAT-Coder-Pro V2",
+    "family": "kat-coder",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-27",
+    "last_updated": "2026-03-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.06
+    },
+    "limit": {
+      "context": 256000,
+      "output": 80000
+    }
+  },
+  {
+    "id": "openrouter/liquid/lfm-2-24b-a2b",
+    "name": "LFM2-24B-A2B",
+    "family": "liquid",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-02-25",
+    "last_updated": "2026-02-25",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.03,
+      "output": 0.12
+    },
+    "limit": {
+      "context": 32768,
+      "output": 32768
     }
   },
   {
@@ -90850,7 +94727,7 @@
     "temperature": true,
     "knowledge": "2025-06",
     "release_date": "2026-01-20",
-    "last_updated": "2026-01-28",
+    "last_updated": "2026-01-20",
     "modalities": {
       "input": [
         "text"
@@ -90865,7 +94742,7 @@
       "output": 0.0
     },
     "limit": {
-      "context": 131072,
+      "context": 32768,
       "output": 32768
     }
   },
@@ -90879,7 +94756,7 @@
     "temperature": true,
     "knowledge": "2025-06",
     "release_date": "2026-01-20",
-    "last_updated": "2026-01-28",
+    "last_updated": "2026-01-20",
     "modalities": {
       "input": [
         "text"
@@ -90894,8 +94771,153 @@
       "output": 0.0
     },
     "limit": {
-      "context": 131072,
+      "context": 32768,
       "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/mancer/weaver",
+    "name": "Weaver (alpha)",
+    "family": "alpha",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2023-06-30",
+    "release_date": "2023-08-02",
+    "last_updated": "2023-08-02",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 1.0
+    },
+    "limit": {
+      "context": 8000,
+      "output": 2000
+    }
+  },
+  {
+    "id": "openrouter/meta-llama/llama-3-70b-instruct",
+    "name": "Llama 3 70B Instruct",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2023-12-31",
+    "release_date": "2024-04-18",
+    "last_updated": "2024-04-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.51,
+      "output": 0.74
+    },
+    "limit": {
+      "context": 8192,
+      "output": 8000
+    }
+  },
+  {
+    "id": "openrouter/meta-llama/llama-3-8b-instruct",
+    "name": "Llama 3 8B Instruct",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2023-12-31",
+    "release_date": "2024-04-18",
+    "last_updated": "2024-04-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.04,
+      "output": 0.04
+    },
+    "limit": {
+      "context": 8192,
+      "output": 8192
+    }
+  },
+  {
+    "id": "openrouter/meta-llama/llama-3.1-70b-instruct",
+    "name": "Llama 3.1 70B Instruct",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-12-31",
+    "release_date": "2024-07-23",
+    "last_updated": "2024-07-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.4,
+      "output": 0.4
+    },
+    "limit": {
+      "context": 131072,
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/meta-llama/llama-3.1-8b-instruct",
+    "name": "Llama 3.1 8B Instruct",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-12-31",
+    "release_date": "2024-07-23",
+    "last_updated": "2024-07-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.02,
+      "output": 0.05
+    },
+    "limit": {
+      "context": 16384,
+      "output": 16384
     }
   },
   {
@@ -90906,7 +94928,7 @@
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
-    "knowledge": "2023-12",
+    "knowledge": "2023-12-31",
     "release_date": "2024-09-25",
     "last_updated": "2024-09-25",
     "modalities": {
@@ -90920,29 +94942,86 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.0,
-      "output": 0.0
+      "input": 0.245,
+      "output": 0.245
     },
     "limit": {
       "context": 131072,
-      "output": 8192
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/meta-llama/llama-3.2-1b-instruct",
+    "name": "Llama 3.2 1B Instruct",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2023-12-31",
+    "release_date": "2024-09-25",
+    "last_updated": "2024-09-25",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.027,
+      "output": 0.201
+    },
+    "limit": {
+      "context": 60000,
+      "output": 60000
+    }
+  },
+  {
+    "id": "openrouter/meta-llama/llama-3.2-3b-instruct",
+    "name": "Llama 3.2 3B Instruct",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2023-12-31",
+    "release_date": "2024-09-25",
+    "last_updated": "2024-09-25",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0509,
+      "output": 0.335
+    },
+    "limit": {
+      "context": 80000,
+      "output": 80000
     }
   },
   {
     "id": "openrouter/meta-llama/llama-3.2-3b-instruct:free",
     "name": "Llama 3.2 3B Instruct (free)",
     "family": "llama",
-    "attachment": true,
+    "attachment": false,
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
-    "knowledge": "2023-12",
+    "knowledge": "2023-12-31",
     "release_date": "2024-09-25",
     "last_updated": "2024-09-25",
     "modalities": {
       "input": [
-        "text",
-        "image"
+        "text"
       ],
       "output": [
         "text"
@@ -90959,6 +95038,35 @@
     }
   },
   {
+    "id": "openrouter/meta-llama/llama-3.3-70b-instruct",
+    "name": "Llama 3.3 70B Instruct",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-12-31",
+    "release_date": "2024-12-06",
+    "last_updated": "2024-12-06",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.1,
+      "output": 0.32
+    },
+    "limit": {
+      "context": 131072,
+      "output": 16384
+    }
+  },
+  {
     "id": "openrouter/meta-llama/llama-3.3-70b-instruct:free",
     "name": "Llama 3.3 70B Instruct (free)",
     "family": "llama",
@@ -90966,7 +95074,7 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-12",
+    "knowledge": "2023-12-31",
     "release_date": "2024-12-06",
     "last_updated": "2024-12-06",
     "modalities": {
@@ -90983,8 +95091,213 @@
       "output": 0.0
     },
     "limit": {
+      "context": 65536,
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/meta-llama/llama-4-maverick",
+    "name": "Llama 4 Maverick",
+    "family": "llama",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2024-08-31",
+    "release_date": "2025-04-05",
+    "last_updated": "2025-04-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.15,
+      "output": 0.6
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/meta-llama/llama-4-scout",
+    "name": "Llama 4 Scout",
+    "family": "llama",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-08-31",
+    "release_date": "2025-04-05",
+    "last_updated": "2025-04-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.08,
+      "output": 0.3
+    },
+    "limit": {
+      "context": 327680,
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/meta-llama/llama-guard-3-8b",
+    "name": "Llama Guard 3 8B",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2023-12-31",
+    "release_date": "2025-02-12",
+    "last_updated": "2025-02-12",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.484,
+      "output": 0.03
+    },
+    "limit": {
       "context": 131072,
       "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/meta-llama/llama-guard-4-12b",
+    "name": "Llama Guard 4 12B",
+    "family": "llama",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2024-08-31",
+    "release_date": "2025-04-30",
+    "last_updated": "2025-04-30",
+    "modalities": {
+      "input": [
+        "image",
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.18,
+      "output": 0.18
+    },
+    "limit": {
+      "context": 163840,
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/microsoft/phi-4",
+    "name": "Phi 4",
+    "family": "phi",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2024-06-30",
+    "release_date": "2025-01-10",
+    "last_updated": "2025-01-10",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.065,
+      "output": 0.14
+    },
+    "limit": {
+      "context": 16384,
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/microsoft/phi-4-mini-instruct",
+    "name": "Phi 4 Mini Instruct",
+    "family": "phi",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-10-17",
+    "last_updated": "2025-10-17",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.08,
+      "output": 0.35,
+      "cache_read": 0.08
+    },
+    "limit": {
+      "context": 128000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/microsoft/wizardlm-2-8x22b",
+    "name": "WizardLM-2 8x22B",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2024-04-30",
+    "release_date": "2024-04-16",
+    "last_updated": "2024-04-16",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.62,
+      "output": 0.62
+    },
+    "limit": {
+      "context": 65535,
+      "output": 8000
     }
   },
   {
@@ -90992,9 +95305,10 @@
     "name": "MiniMax-01",
     "family": "minimax",
     "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
+    "reasoning": false,
+    "tool_call": false,
     "temperature": true,
+    "knowledge": "2024-03-31",
     "release_date": "2025-01-15",
     "last_updated": "2025-01-15",
     "modalities": {
@@ -91012,8 +95326,8 @@
       "output": 1.1
     },
     "limit": {
-      "context": 1000000,
-      "output": 1000000
+      "context": 1000192,
+      "output": 1000192
     }
   },
   {
@@ -91024,6 +95338,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2024-06-30",
     "release_date": "2025-06-17",
     "last_updated": "2025-06-17",
     "modalities": {
@@ -91034,7 +95349,7 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
       "input": 0.4,
       "output": 2.2
@@ -91064,14 +95379,42 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.28,
-      "output": 1.15,
-      "cache_read": 0.28,
-      "cache_write": 1.15
+      "input": 0.255,
+      "output": 1.0,
+      "cache_read": 0.03
     },
     "limit": {
-      "context": 196600,
-      "output": 118000
+      "context": 196608,
+      "output": 196608
+    }
+  },
+  {
+    "id": "openrouter/minimax/minimax-m2-her",
+    "name": "MiniMax M2-her",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-01-23",
+    "last_updated": "2026-01-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.03
+    },
+    "limit": {
+      "context": 65536,
+      "output": 2048
     }
   },
   {
@@ -91094,12 +95437,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.3,
-      "output": 1.2
+      "input": 0.29,
+      "output": 0.95,
+      "cache_read": 0.03
     },
     "limit": {
-      "context": 204800,
-      "output": 131072
+      "context": 196608,
+      "output": 196608
     }
   },
   {
@@ -91122,13 +95466,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.3,
-      "output": 1.2,
-      "cache_read": 0.03
+      "input": 0.15,
+      "output": 1.15
     },
     "limit": {
-      "context": 204800,
-      "output": 131072
+      "context": 196608,
+      "output": 196608
     }
   },
   {
@@ -91155,8 +95498,8 @@
       "output": 0.0
     },
     "limit": {
-      "context": 204800,
-      "output": 131072
+      "context": 196608,
+      "output": 8192
     }
   },
   {
@@ -91179,13 +95522,11 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.3,
-      "output": 1.2,
-      "cache_read": 0.06,
-      "cache_write": 0.375
+      "input": 0.279,
+      "output": 1.2
     },
     "limit": {
-      "context": 204800,
+      "context": 196608,
       "output": 131072
     }
   },
@@ -91193,25 +95534,27 @@
     "id": "openrouter/mistralai/codestral",
     "name": "Codestral 2508",
     "family": "codestral",
-    "attachment": false,
+    "attachment": true,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-05",
+    "knowledge": "2025-03-31",
     "release_date": "2025-08-01",
     "last_updated": "2025-08-01",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "pdf"
       ],
       "output": [
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
       "input": 0.3,
-      "output": 0.9
+      "output": 0.9,
+      "cache_read": 0.03
     },
     "limit": {
       "context": 256000,
@@ -91222,16 +95565,17 @@
     "id": "openrouter/mistralai/devstral",
     "name": "Devstral 2 2512",
     "family": "devstral",
-    "attachment": false,
+    "attachment": true,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-12",
-    "release_date": "2025-09-12",
-    "last_updated": "2025-09-12",
+    "release_date": "2025-12-09",
+    "last_updated": "2025-12-09",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "pdf"
       ],
       "output": [
         "text"
@@ -91239,8 +95583,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.15,
-      "output": 0.6
+      "input": 0.4,
+      "output": 2.0,
+      "cache_read": 0.04
     },
     "limit": {
       "context": 262144,
@@ -91251,25 +95596,27 @@
     "id": "openrouter/mistralai/devstral-medium",
     "name": "Devstral Medium",
     "family": "devstral",
-    "attachment": false,
+    "attachment": true,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-05",
+    "knowledge": "2025-06-30",
     "release_date": "2025-07-10",
     "last_updated": "2025-07-10",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "pdf"
       ],
       "output": [
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
       "input": 0.4,
-      "output": 2.0
+      "output": 2.0,
+      "cache_read": 0.04
     },
     "limit": {
       "context": 131072,
@@ -91280,13 +95627,134 @@
     "id": "openrouter/mistralai/devstral-small",
     "name": "Devstral Small 1.1",
     "family": "devstral",
-    "attachment": false,
+    "attachment": true,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-05",
+    "knowledge": "2025-03-31",
     "release_date": "2025-07-10",
     "last_updated": "2025-07-10",
+    "modalities": {
+      "input": [
+        "text",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.1,
+      "output": 0.3,
+      "cache_read": 0.01
+    },
+    "limit": {
+      "context": 131072,
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/mistralai/ministral-14b",
+    "name": "Ministral 3 14B 2512",
+    "family": "ministral",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-12-02",
+    "last_updated": "2025-12-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.2,
+      "output": 0.2,
+      "cache_read": 0.02
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "openrouter/mistralai/ministral-3b",
+    "name": "Ministral 3 3B 2512",
+    "family": "ministral",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-12-02",
+    "last_updated": "2025-12-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.1,
+      "output": 0.1,
+      "cache_read": 0.01
+    },
+    "limit": {
+      "context": 131072,
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/mistralai/ministral-8b",
+    "name": "Ministral 3 8B 2512",
+    "family": "ministral",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-12-02",
+    "last_updated": "2025-12-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.15,
+      "output": 0.15,
+      "cache_read": 0.015
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "openrouter/mistralai/mistral-7b-instruct-v0.1",
+    "name": "Mistral 7B Instruct v0.1",
+    "family": "mistral",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2023-09-30",
+    "release_date": "2023-09-28",
+    "last_updated": "2023-09-28",
     "modalities": {
       "input": [
         "text"
@@ -91297,12 +95765,43 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.1,
-      "output": 0.3
+      "input": 0.11,
+      "output": 0.19
     },
     "limit": {
-      "context": 131072,
-      "output": 131072
+      "context": 2824,
+      "output": 2824
+    }
+  },
+  {
+    "id": "openrouter/mistralai/mistral-large",
+    "name": "Mistral Large",
+    "family": "mistral-large",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-11-30",
+    "release_date": "2024-02-26",
+    "last_updated": "2024-02-26",
+    "modalities": {
+      "input": [
+        "text",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 6.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 128000,
+      "output": 128000
     }
   },
   {
@@ -91313,13 +95812,14 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-05",
+    "knowledge": "2025-03-31",
     "release_date": "2025-05-07",
     "last_updated": "2025-05-07",
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -91328,7 +95828,8 @@
     "open_weights": false,
     "cost": {
       "input": 0.4,
-      "output": 2.0
+      "output": 2.0,
+      "cache_read": 0.04
     },
     "limit": {
       "context": 131072,
@@ -91343,13 +95844,14 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-05",
-    "release_date": "2025-08-12",
-    "last_updated": "2025-08-12",
+    "knowledge": "2025-06-30",
+    "release_date": "2025-08-13",
+    "last_updated": "2025-08-13",
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -91358,11 +95860,102 @@
     "open_weights": false,
     "cost": {
       "input": 0.4,
-      "output": 2.0
+      "output": 2.0,
+      "cache_read": 0.04
+    },
+    "limit": {
+      "context": 131072,
+      "output": 262144
+    }
+  },
+  {
+    "id": "openrouter/mistralai/mistral-medium-3.5",
+    "name": "Mistral Medium 3.5",
+    "family": "mistral-medium",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 7.5
     },
     "limit": {
       "context": 262144,
       "output": 262144
+    }
+  },
+  {
+    "id": "openrouter/mistralai/mistral-nemo",
+    "name": "Mistral Nemo",
+    "family": "mistral-nemo",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-04-30",
+    "release_date": "2024-07-19",
+    "last_updated": "2024-07-19",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.02,
+      "output": 0.03
+    },
+    "limit": {
+      "context": 131072,
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/mistralai/mistral-saba",
+    "name": "Saba",
+    "family": "mistral",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-09-30",
+    "release_date": "2025-02-17",
+    "last_updated": "2025-02-17",
+    "modalities": {
+      "input": [
+        "text",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.2,
+      "output": 0.6,
+      "cache_read": 0.02
+    },
+    "limit": {
+      "context": 32768,
+      "output": 32768
     }
   },
   {
@@ -91388,7 +95981,8 @@
     "open_weights": true,
     "cost": {
       "input": 0.15,
-      "output": 0.6
+      "output": 0.6,
+      "cache_read": 0.015
     },
     "limit": {
       "context": 262144,
@@ -91396,14 +95990,43 @@
     }
   },
   {
+    "id": "openrouter/mistralai/mistral-small-24b-instruct",
+    "name": "Mistral Small 3",
+    "family": "mistral-small",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2023-10-31",
+    "release_date": "2025-01-30",
+    "last_updated": "2025-01-30",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.05,
+      "output": 0.08
+    },
+    "limit": {
+      "context": 32768,
+      "output": 16384
+    }
+  },
+  {
     "id": "openrouter/mistralai/mistral-small-3.1-24b-instruct",
-    "name": "Mistral Small 3.1 24B Instruct",
+    "name": "Mistral Small 3.1 24B",
     "family": "mistral-small",
     "attachment": true,
     "reasoning": false,
-    "tool_call": true,
+    "tool_call": false,
     "temperature": true,
-    "knowledge": "2024-10",
+    "knowledge": "2023-10-31",
     "release_date": "2025-03-17",
     "last_updated": "2025-03-17",
     "modalities": {
@@ -91417,29 +96040,29 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.0,
-      "output": 0.0
+      "input": 0.351,
+      "output": 0.555
     },
     "limit": {
       "context": 128000,
-      "output": 8192
+      "output": 128000
     }
   },
   {
     "id": "openrouter/mistralai/mistral-small-3.2-24b-instruct",
-    "name": "Mistral Small 3.2 24B Instruct",
+    "name": "Mistral Small 3.2 24B",
     "family": "mistral-small",
     "attachment": true,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-10",
+    "knowledge": "2023-10-31",
     "release_date": "2025-06-20",
     "last_updated": "2025-06-20",
     "modalities": {
       "input": [
-        "text",
-        "image"
+        "image",
+        "text"
       ],
       "output": [
         "text"
@@ -91447,23 +96070,117 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.0,
-      "output": 0.0
+      "input": 0.075,
+      "output": 0.2
     },
     "limit": {
-      "context": 96000,
-      "output": 8192
+      "context": 128000,
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/mistralai/mixtral-8x22b-instruct",
+    "name": "Mixtral 8x22B Instruct",
+    "family": "mistral",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-01-31",
+    "release_date": "2024-04-17",
+    "last_updated": "2024-04-17",
+    "modalities": {
+      "input": [
+        "text",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 2.0,
+      "output": 6.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 65536,
+      "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/mistralai/pixtral-large",
+    "name": "Pixtral Large 2411",
+    "family": "mistral",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-07-31",
+    "release_date": "2024-11-19",
+    "last_updated": "2024-11-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 6.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 131072,
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/mistralai/voxtral-small-24b",
+    "name": "Voxtral Small 24B 2507",
+    "family": "mistral",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-10-30",
+    "last_updated": "2025-10-30",
+    "modalities": {
+      "input": [
+        "text",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.1,
+      "output": 0.3,
+      "cache_read": 0.01
+    },
+    "limit": {
+      "context": 32000,
+      "output": 32000
     }
   },
   {
     "id": "openrouter/moonshotai/kimi-k2",
-    "name": "Kimi K2",
+    "name": "Kimi K2 0711",
     "family": "kimi",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-10",
+    "knowledge": "2024-12-31",
     "release_date": "2025-07-11",
     "last_updated": "2025-07-11",
     "modalities": {
@@ -91476,41 +96193,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.55,
-      "output": 2.2
+      "input": 0.57,
+      "output": 2.3
     },
     "limit": {
       "context": 131072,
       "output": 32768
-    }
-  },
-  {
-    "id": "openrouter/moonshotai/kimi-k2-0905:exacto",
-    "name": "Kimi K2 Instruct 0905 (exacto)",
-    "family": "kimi",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-10",
-    "release_date": "2025-09-05",
-    "last_updated": "2025-09-05",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.6,
-      "output": 2.5
-    },
-    "limit": {
-      "context": 262144,
-      "output": 16384
     }
   },
   {
@@ -91535,8 +96223,7 @@
     "open_weights": true,
     "cost": {
       "input": 0.6,
-      "output": 2.5,
-      "cache_read": 0.15
+      "output": 2.5
     },
     "limit": {
       "context": 262144,
@@ -91557,8 +96244,7 @@
     "modalities": {
       "input": [
         "text",
-        "image",
-        "video"
+        "image"
       ],
       "output": [
         "text"
@@ -91566,9 +96252,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.6,
-      "output": 3.0,
-      "cache_read": 0.1
+      "input": 0.4,
+      "output": 1.9,
+      "cache_read": 0.09
     },
     "limit": {
       "context": 262144,
@@ -91596,13 +96282,155 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.95,
-      "output": 4.0,
-      "cache_read": 0.16
+      "input": 0.73,
+      "output": 3.49,
+      "cache_read": 0.25
+    },
+    "limit": {
+      "context": 262142,
+      "output": 262142
+    }
+  },
+  {
+    "id": "openrouter/morph/morph-v3-fast",
+    "name": "Morph V3 Fast",
+    "family": "morph",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-07-07",
+    "last_updated": "2025-07-07",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.8,
+      "output": 1.2
+    },
+    "limit": {
+      "context": 81920,
+      "output": 38000
+    }
+  },
+  {
+    "id": "openrouter/morph/morph-v3-large",
+    "name": "Morph V3 Large",
+    "family": "morph",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-07-07",
+    "last_updated": "2025-07-07",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.9,
+      "output": 1.9
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/nex-agi/deepseek-v3.1-nex-n1",
+    "name": "DeepSeek V3.1 Nex N1",
+    "family": "deepseek",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-12-08",
+    "last_updated": "2025-12-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.135,
+      "output": 0.5
+    },
+    "limit": {
+      "context": 131072,
+      "output": 163840
+    }
+  },
+  {
+    "id": "openrouter/nousresearch/hermes-2-pro-llama-3-8b",
+    "name": "Hermes 2 Pro - Llama-3 8B",
+    "family": "nousresearch",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2023-12-31",
+    "release_date": "2024-05-27",
+    "last_updated": "2024-05-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.14,
+      "output": 0.14
+    },
+    "limit": {
+      "context": 8192,
+      "output": 8192
+    }
+  },
+  {
+    "id": "openrouter/nousresearch/hermes-3-llama-3.1-405b",
+    "name": "Hermes 3 405B Instruct",
+    "family": "nousresearch",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2023-12-31",
+    "release_date": "2024-08-16",
+    "last_updated": "2024-08-16",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.0,
+      "output": 1.0
+    },
+    "limit": {
+      "context": 131072,
+      "output": 16384
     }
   },
   {
@@ -91610,10 +96438,10 @@
     "name": "Hermes 3 405B Instruct (free)",
     "family": "hermes",
     "attachment": false,
-    "reasoning": true,
+    "reasoning": false,
     "tool_call": false,
     "temperature": true,
-    "knowledge": "2023-12",
+    "knowledge": "2023-12-31",
     "release_date": "2024-08-16",
     "last_updated": "2024-08-16",
     "modalities": {
@@ -91635,16 +96463,45 @@
     }
   },
   {
+    "id": "openrouter/nousresearch/hermes-3-llama-3.1-70b",
+    "name": "Hermes 3 70B Instruct",
+    "family": "nousresearch",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2023-12-31",
+    "release_date": "2024-08-18",
+    "last_updated": "2024-08-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.3,
+      "output": 0.3
+    },
+    "limit": {
+      "context": 131072,
+      "output": 16384
+    }
+  },
+  {
     "id": "openrouter/nousresearch/hermes-4-405b",
     "name": "Hermes 4 405B",
     "family": "hermes",
     "attachment": false,
     "reasoning": true,
-    "tool_call": true,
+    "tool_call": false,
     "temperature": true,
-    "knowledge": "2023-12",
-    "release_date": "2025-08-25",
-    "last_updated": "2025-08-25",
+    "knowledge": "2024-08-31",
+    "release_date": "2025-08-26",
+    "last_updated": "2025-08-26",
     "modalities": {
       "input": [
         "text"
@@ -91669,11 +96526,11 @@
     "family": "hermes",
     "attachment": false,
     "reasoning": true,
-    "tool_call": true,
+    "tool_call": false,
     "temperature": true,
-    "knowledge": "2023-12",
-    "release_date": "2025-08-25",
-    "last_updated": "2025-08-25",
+    "knowledge": "2024-08-31",
+    "release_date": "2025-08-26",
+    "last_updated": "2025-08-26",
     "modalities": {
       "input": [
         "text"
@@ -91693,6 +96550,63 @@
     }
   },
   {
+    "id": "openrouter/nvidia/llama-3.3-nemotron-super-49b-v1.5",
+    "name": "Llama 3.3 Nemotron Super 49B V1.5",
+    "family": "nemotron",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-03-31",
+    "release_date": "2025-10-10",
+    "last_updated": "2025-10-10",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.1,
+      "output": 0.4
+    },
+    "limit": {
+      "context": 131072,
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/nvidia/nemotron-3-nano-30b-a3b",
+    "name": "Nemotron 3 Nano 30B A3B",
+    "family": "nemotron",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-12-14",
+    "last_updated": "2025-12-14",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.05,
+      "output": 0.2
+    },
+    "limit": {
+      "context": 262144,
+      "output": 228000
+    }
+  },
+  {
     "id": "openrouter/nvidia/nemotron-3-nano-30b-a3b:free",
     "name": "Nemotron 3 Nano 30B A3B (free)",
     "family": "nemotron",
@@ -91702,7 +96616,7 @@
     "temperature": true,
     "knowledge": "2025-11",
     "release_date": "2025-12-14",
-    "last_updated": "2026-01-31",
+    "last_updated": "2025-12-14",
     "modalities": {
       "input": [
         "text"
@@ -91734,15 +96648,15 @@
     "modalities": {
       "input": [
         "text",
+        "audio",
         "image",
-        "video",
-        "audio"
+        "video"
       ],
       "output": [
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
       "input": 0.0,
       "output": 0.0
@@ -91773,8 +96687,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.1,
-      "output": 0.5
+      "input": 0.09,
+      "output": 0.45
     },
     "limit": {
       "context": 262144,
@@ -91814,17 +96728,18 @@
     "id": "openrouter/nvidia/nemotron-nano-12b-v2-vl:free",
     "name": "Nemotron Nano 12B 2 VL (free)",
     "family": "nemotron",
-    "attachment": false,
+    "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-11",
     "release_date": "2025-10-28",
-    "last_updated": "2026-01-31",
+    "last_updated": "2025-10-28",
     "modalities": {
       "input": [
+        "image",
         "text",
-        "image"
+        "video"
       ],
       "output": [
         "text"
@@ -91842,15 +96757,15 @@
   },
   {
     "id": "openrouter/nvidia/nemotron-nano-9b-v2",
-    "name": "nvidia-nemotron-nano-9b-v2",
+    "name": "Nemotron Nano 9B V2",
     "family": "nemotron",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-09",
-    "release_date": "2025-08-18",
-    "last_updated": "2025-08-18",
+    "knowledge": "2025-03-31",
+    "release_date": "2025-09-05",
+    "last_updated": "2025-09-05",
     "modalities": {
       "input": [
         "text"
@@ -91866,7 +96781,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 16384
     }
   },
   {
@@ -91877,9 +96792,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-09",
+    "knowledge": "2025-03-31",
     "release_date": "2025-09-05",
-    "last_updated": "2025-08-18",
+    "last_updated": "2025-09-05",
     "modalities": {
       "input": [
         "text"
@@ -91899,6 +96814,210 @@
     }
   },
   {
+    "id": "openrouter/openai/gpt-3.5-turbo",
+    "name": "GPT-3.5 Turbo (older v0613)",
+    "family": "gpt",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2021-09-30",
+    "release_date": "2024-01-25",
+    "last_updated": "2024-01-25",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 2.0
+    },
+    "limit": {
+      "context": 4095,
+      "output": 4096
+    }
+  },
+  {
+    "id": "openrouter/openai/gpt-3.5-turbo-16k",
+    "name": "GPT-3.5 Turbo 16k",
+    "family": "gpt",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2021-09-30",
+    "release_date": "2023-08-28",
+    "last_updated": "2023-08-28",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 4.0
+    },
+    "limit": {
+      "context": 16385,
+      "output": 4096
+    }
+  },
+  {
+    "id": "openrouter/openai/gpt-3.5-turbo-instruct",
+    "name": "GPT-3.5 Turbo Instruct",
+    "family": "gpt",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2021-09-30",
+    "release_date": "2023-09-28",
+    "last_updated": "2023-09-28",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 2.0
+    },
+    "limit": {
+      "context": 4095,
+      "output": 4096
+    }
+  },
+  {
+    "id": "openrouter/openai/gpt-4",
+    "name": "GPT-4",
+    "family": "gpt",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2021-09-30",
+    "release_date": "2023-05-28",
+    "last_updated": "2023-05-28",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 30.0,
+      "output": 60.0
+    },
+    "limit": {
+      "context": 8191,
+      "output": 4096
+    }
+  },
+  {
+    "id": "openrouter/openai/gpt-4-1106-preview",
+    "name": "GPT-4 Turbo (older v1106)",
+    "family": "gpt",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-04-30",
+    "release_date": "2023-11-06",
+    "last_updated": "2023-11-06",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 30.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 4096
+    }
+  },
+  {
+    "id": "openrouter/openai/gpt-4-turbo",
+    "name": "GPT-4 Turbo",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-12-31",
+    "release_date": "2024-04-09",
+    "last_updated": "2024-04-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 30.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 4096
+    }
+  },
+  {
+    "id": "openrouter/openai/gpt-4-turbo-preview",
+    "name": "GPT-4 Turbo Preview",
+    "family": "gpt",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-12-31",
+    "release_date": "2024-01-25",
+    "last_updated": "2024-01-25",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 30.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 4096
+    }
+  },
+  {
     "id": "openrouter/openai/gpt-4.1",
     "name": "GPT-4.1",
     "family": "gpt",
@@ -91906,13 +97025,14 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-04",
+    "knowledge": "2024-06-30",
     "release_date": "2025-04-14",
     "last_updated": "2025-04-14",
     "modalities": {
       "input": [
+        "image",
         "text",
-        "image"
+        "pdf"
       ],
       "output": [
         "text"
@@ -91937,13 +97057,14 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-04",
+    "knowledge": "2024-06-30",
     "release_date": "2025-04-14",
     "last_updated": "2025-04-14",
     "modalities": {
       "input": [
+        "image",
         "text",
-        "image"
+        "pdf"
       ],
       "output": [
         "text"
@@ -91961,20 +97082,116 @@
     }
   },
   {
-    "id": "openrouter/openai/gpt-4o-mini",
-    "name": "GPT-4o-mini",
-    "family": "gpt-mini",
+    "id": "openrouter/openai/gpt-4.1-nano",
+    "name": "GPT-4.1 Nano",
+    "family": "gpt",
     "attachment": true,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-10",
+    "knowledge": "2024-06-30",
+    "release_date": "2025-04-14",
+    "last_updated": "2025-04-14",
+    "modalities": {
+      "input": [
+        "image",
+        "text",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.4,
+      "cache_read": 0.025
+    },
+    "limit": {
+      "context": 1047576,
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/openai/gpt-4o",
+    "name": "GPT-4o (2024-08-06)",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-10-31",
+    "release_date": "2024-08-06",
+    "last_updated": "2024-08-06",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 10.0,
+      "cache_read": 1.25
+    },
+    "limit": {
+      "context": 128000,
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/openai/gpt-4o-audio-preview",
+    "name": "GPT-4o Audio",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-10-31",
+    "release_date": "2025-08-15",
+    "last_updated": "2025-08-15",
+    "modalities": {
+      "input": [
+        "audio",
+        "text"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 10.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/openai/gpt-4o-mini",
+    "name": "GPT-4o-mini (2024-07-18)",
+    "family": "o-mini",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-10-31",
     "release_date": "2024-07-18",
     "last_updated": "2024-07-18",
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -91984,7 +97201,65 @@
     "cost": {
       "input": 0.15,
       "output": 0.6,
-      "cache_read": 0.08
+      "cache_read": 0.075
+    },
+    "limit": {
+      "context": 128000,
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/openai/gpt-4o-mini-search-preview",
+    "name": "GPT-4o-mini Search Preview",
+    "family": "o-mini",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "knowledge": "2023-10-31",
+    "release_date": "2025-03-12",
+    "last_updated": "2025-03-12",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.6
+    },
+    "limit": {
+      "context": 128000,
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/openai/gpt-4o-search-preview",
+    "name": "GPT-4o Search Preview",
+    "family": "gpt",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "knowledge": "2023-10-31",
+    "release_date": "2025-03-12",
+    "last_updated": "2025-03-12",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 10.0
     },
     "limit": {
       "context": 128000,
@@ -91998,14 +97273,15 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-10-01",
+    "temperature": false,
+    "knowledge": "2024-09-30",
     "release_date": "2025-08-07",
     "last_updated": "2025-08-07",
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -92014,7 +97290,8 @@
     "open_weights": false,
     "cost": {
       "input": 1.25,
-      "output": 10.0
+      "output": 10.0,
+      "cache_read": 0.125
     },
     "limit": {
       "context": 400000,
@@ -92023,19 +97300,20 @@
   },
   {
     "id": "openrouter/openai/gpt-5-chat",
-    "name": "GPT-5 Chat (latest)",
+    "name": "GPT-5 Chat",
     "family": "gpt-codex",
     "attachment": true,
-    "reasoning": true,
+    "reasoning": false,
     "tool_call": false,
-    "temperature": true,
+    "temperature": false,
     "knowledge": "2024-09-30",
     "release_date": "2025-08-07",
     "last_updated": "2025-08-07",
     "modalities": {
       "input": [
-        "text",
-        "image"
+        "pdf",
+        "image",
+        "text"
       ],
       "output": [
         "text"
@@ -92044,11 +97322,12 @@
     "open_weights": false,
     "cost": {
       "input": 1.25,
-      "output": 10.0
+      "output": 10.0,
+      "cache_read": 0.125
     },
     "limit": {
-      "context": 400000,
-      "output": 128000
+      "context": 128000,
+      "output": 16384
     }
   },
   {
@@ -92058,10 +97337,10 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-10-01",
-    "release_date": "2025-09-15",
-    "last_updated": "2025-09-15",
+    "temperature": false,
+    "knowledge": "2024-09-30",
+    "release_date": "2025-09-23",
+    "last_updated": "2025-09-23",
     "modalities": {
       "input": [
         "text",
@@ -92088,27 +97367,59 @@
     "family": "gpt",
     "attachment": true,
     "reasoning": true,
-    "tool_call": true,
+    "tool_call": false,
     "temperature": true,
     "knowledge": "2024-10-01",
     "release_date": "2025-10-14",
     "last_updated": "2025-10-14",
     "modalities": {
       "input": [
-        "text",
         "image",
+        "text",
         "pdf"
       ],
       "output": [
-        "text",
-        "image"
+        "image",
+        "text"
       ]
     },
     "open_weights": false,
     "cost": {
-      "input": 5.0,
+      "input": 10.0,
       "output": 10.0,
       "cache_read": 1.25
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/openai/gpt-5-image-mini",
+    "name": "GPT-5 Image Mini",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-10-16",
+    "last_updated": "2025-10-16",
+    "modalities": {
+      "input": [
+        "pdf",
+        "image",
+        "text"
+      ],
+      "output": [
+        "image",
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 2.0,
+      "cache_read": 0.25
     },
     "limit": {
       "context": 400000,
@@ -92122,14 +97433,15 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-10-01",
+    "temperature": false,
+    "knowledge": "2024-05-31",
     "release_date": "2025-08-07",
     "last_updated": "2025-08-07",
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -92138,7 +97450,8 @@
     "open_weights": false,
     "cost": {
       "input": 0.25,
-      "output": 2.0
+      "output": 2.0,
+      "cache_read": 0.025
     },
     "limit": {
       "context": 400000,
@@ -92152,14 +97465,15 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-10-01",
+    "temperature": false,
+    "knowledge": "2024-05-31",
     "release_date": "2025-08-07",
     "last_updated": "2025-08-07",
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -92168,7 +97482,8 @@
     "open_weights": false,
     "cost": {
       "input": 0.05,
-      "output": 0.4
+      "output": 0.4,
+      "cache_read": 0.01
     },
     "limit": {
       "context": 400000,
@@ -92188,8 +97503,9 @@
     "last_updated": "2025-10-06",
     "modalities": {
       "input": [
+        "image",
         "text",
-        "image"
+        "pdf"
       ],
       "output": [
         "text"
@@ -92202,7 +97518,7 @@
     },
     "limit": {
       "context": 400000,
-      "output": 272000
+      "output": 128000
     }
   },
   {
@@ -92212,14 +97528,15 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
     "modalities": {
       "input": [
+        "image",
         "text",
-        "image"
+        "pdf"
       ],
       "output": [
         "text"
@@ -92229,7 +97546,7 @@
     "cost": {
       "input": 1.25,
       "output": 10.0,
-      "cache_read": 0.125
+      "cache_read": 0.13
     },
     "limit": {
       "context": 400000,
@@ -92241,16 +97558,17 @@
     "name": "GPT-5.1 Chat",
     "family": "gpt-codex",
     "attachment": true,
-    "reasoning": true,
+    "reasoning": false,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
     "modalities": {
       "input": [
-        "text",
-        "image"
+        "pdf",
+        "image",
+        "text"
       ],
       "output": [
         "text"
@@ -92274,7 +97592,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
@@ -92305,10 +97623,10 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
     "knowledge": "2024-09-30",
-    "release_date": "2025-11-13",
-    "last_updated": "2025-11-13",
+    "release_date": "2025-12-04",
+    "last_updated": "2025-12-04",
     "modalities": {
       "input": [
         "text",
@@ -92320,9 +97638,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 1.1,
-      "output": 9.0,
-      "cache_read": 0.11
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125
     },
     "limit": {
       "context": 400000,
@@ -92336,14 +97654,14 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
     "modalities": {
       "input": [
-        "text",
-        "image"
+        "image",
+        "text"
       ],
       "output": [
         "text"
@@ -92353,11 +97671,11 @@
     "cost": {
       "input": 0.25,
       "output": 2.0,
-      "cache_read": 0.025
+      "cache_read": 0.03
     },
     "limit": {
       "context": 400000,
-      "output": 100000
+      "output": 128000
     }
   },
   {
@@ -92369,12 +97687,13 @@
     "tool_call": true,
     "temperature": false,
     "knowledge": "2025-08-31",
-    "release_date": "2025-12-11",
-    "last_updated": "2025-12-11",
+    "release_date": "2025-12-10",
+    "last_updated": "2025-12-10",
     "modalities": {
       "input": [
-        "text",
-        "image"
+        "pdf",
+        "image",
+        "text"
       ],
       "output": [
         "text"
@@ -92396,16 +97715,17 @@
     "name": "GPT-5.2 Chat",
     "family": "gpt-codex",
     "attachment": true,
-    "reasoning": true,
+    "reasoning": false,
     "tool_call": true,
     "temperature": false,
     "knowledge": "2025-08-31",
-    "release_date": "2025-12-11",
-    "last_updated": "2025-12-11",
+    "release_date": "2025-12-10",
+    "last_updated": "2025-12-10",
     "modalities": {
       "input": [
-        "text",
-        "image"
+        "pdf",
+        "image",
+        "text"
       ],
       "output": [
         "text"
@@ -92419,7 +97739,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 16384
+      "output": 32000
     }
   },
   {
@@ -92429,7 +97749,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
     "knowledge": "2025-08-31",
     "release_date": "2026-01-14",
     "last_updated": "2026-01-14",
@@ -92462,12 +97782,13 @@
     "tool_call": true,
     "temperature": false,
     "knowledge": "2025-08-31",
-    "release_date": "2025-12-11",
-    "last_updated": "2025-12-11",
+    "release_date": "2025-12-10",
+    "last_updated": "2025-12-10",
     "modalities": {
       "input": [
+        "image",
         "text",
-        "image"
+        "pdf"
       ],
       "output": [
         "text"
@@ -92481,6 +97802,37 @@
     "limit": {
       "context": 400000,
       "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/openai/gpt-5.3-chat",
+    "name": "GPT-5.3 Chat",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-03-03",
+    "last_updated": "2026-03-03",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.75,
+      "output": 14.0,
+      "cache_read": 0.175
+    },
+    "limit": {
+      "context": 128000,
+      "output": 16384
     }
   },
   {
@@ -92523,7 +97875,6 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
-    "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
     "modalities": {
@@ -92548,21 +97899,53 @@
     }
   },
   {
+    "id": "openrouter/openai/gpt-5.4-image-2",
+    "name": "GPT-5.4 Image 2",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "image",
+        "text",
+        "pdf"
+      ],
+      "output": [
+        "image",
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 8.0,
+      "output": 15.0,
+      "cache_read": 2.0
+    },
+    "limit": {
+      "context": 272000,
+      "output": 128000
+    }
+  },
+  {
     "id": "openrouter/openai/gpt-5.4-mini",
     "name": "GPT-5.4 Mini",
     "family": "gpt-mini",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
     "modalities": {
       "input": [
-        "text",
+        "pdf",
         "image",
-        "pdf"
+        "text"
       ],
       "output": [
         "text"
@@ -92584,17 +97967,17 @@
     "name": "GPT-5.4 Nano",
     "family": "gpt-nano",
     "attachment": true,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
     "modalities": {
       "input": [
-        "text",
+        "pdf",
         "image",
-        "pdf"
+        "text"
       ],
       "output": [
         "text"
@@ -92635,8 +98018,7 @@
     "open_weights": false,
     "cost": {
       "input": 30.0,
-      "output": 180.0,
-      "cache_read": 30.0
+      "output": 180.0
     },
     "limit": {
       "context": 1050000,
@@ -92652,13 +98034,13 @@
     "tool_call": true,
     "temperature": false,
     "knowledge": "2025-12-01",
-    "release_date": "2026-04-23",
-    "last_updated": "2026-04-23",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
     "modalities": {
       "input": [
-        "text",
+        "pdf",
         "image",
-        "pdf"
+        "text"
       ],
       "output": [
         "text"
@@ -92678,19 +98060,19 @@
   {
     "id": "openrouter/openai/gpt-5.5-pro",
     "name": "GPT-5.5 Pro",
-    "family": "gpt-pro",
+    "family": "gpt",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
     "knowledge": "2025-12-01",
-    "release_date": "2026-04-23",
-    "last_updated": "2026-04-23",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
     "modalities": {
       "input": [
-        "text",
+        "pdf",
         "image",
-        "pdf"
+        "text"
       ],
       "output": [
         "text"
@@ -92707,41 +98089,105 @@
     }
   },
   {
-    "id": "openrouter/openai/gpt-oss-120b",
-    "name": "GPT OSS 120B",
-    "family": "gpt-oss",
-    "attachment": false,
-    "reasoning": true,
+    "id": "openrouter/openai/gpt-audio",
+    "name": "GPT Audio",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-08-05",
-    "last_updated": "2025-08-05",
+    "release_date": "2026-01-19",
+    "last_updated": "2026-01-19",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "audio"
       ],
       "output": [
-        "text"
+        "text",
+        "audio"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
-      "input": 0.072,
-      "output": 0.28
+      "input": 2.5,
+      "output": 10.0
     },
     "limit": {
-      "context": 131072,
-      "output": 32768
+      "context": 128000,
+      "output": 16384
     }
   },
   {
-    "id": "openrouter/openai/gpt-oss-120b:exacto",
-    "name": "GPT OSS 120B (exacto)",
+    "id": "openrouter/openai/gpt-audio-mini",
+    "name": "GPT Audio Mini",
+    "family": "o-mini",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-01-19",
+    "last_updated": "2026-01-19",
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.6,
+      "output": 2.4
+    },
+    "limit": {
+      "context": 128000,
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/openai/gpt-chat",
+    "name": "GPT Chat Latest",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-05-05",
+    "last_updated": "2026-05-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/openai/gpt-oss-120b",
+    "name": "gpt-oss-120b",
     "family": "gpt-oss",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2024-06-30",
     "release_date": "2025-08-05",
     "last_updated": "2025-08-05",
     "modalities": {
@@ -92754,8 +98200,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.05,
-      "output": 0.24
+      "input": 0.039,
+      "output": 0.18
     },
     "limit": {
       "context": 131072,
@@ -92770,6 +98216,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2024-06-30",
     "release_date": "2025-08-05",
     "last_updated": "2025-08-05",
     "modalities": {
@@ -92787,17 +98234,18 @@
     },
     "limit": {
       "context": 131072,
-      "output": 32768
+      "output": 131072
     }
   },
   {
     "id": "openrouter/openai/gpt-oss-20b",
-    "name": "GPT OSS 20B",
+    "name": "gpt-oss-20b",
     "family": "gpt-oss",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2024-06-30",
     "release_date": "2025-08-05",
     "last_updated": "2025-08-05",
     "modalities": {
@@ -92810,12 +98258,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.05,
-      "output": 0.2
+      "input": 0.03,
+      "output": 0.14
     },
     "limit": {
       "context": 131072,
-      "output": 32768
+      "output": 131072
     }
   },
   {
@@ -92826,8 +98274,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2024-06-30",
     "release_date": "2025-08-05",
-    "last_updated": "2026-01-31",
+    "last_updated": "2025-08-05",
     "modalities": {
       "input": [
         "text"
@@ -92843,12 +98292,12 @@
     },
     "limit": {
       "context": 131072,
-      "output": 32768
+      "output": 8192
     }
   },
   {
     "id": "openrouter/openai/gpt-oss-safeguard-20b",
-    "name": "GPT OSS Safeguard 20B",
+    "name": "gpt-oss-safeguard-20b",
     "family": "gpt-oss",
     "attachment": false,
     "reasoning": true,
@@ -92864,10 +98313,11 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.075,
-      "output": 0.3
+      "output": 0.3,
+      "cache_read": 0.037
     },
     "limit": {
       "context": 131072,
@@ -92875,20 +98325,146 @@
     }
   },
   {
-    "id": "openrouter/openai/o4-mini",
-    "name": "o4 Mini",
-    "family": "o-mini",
+    "id": "openrouter/openai/o1",
+    "name": "o1",
+    "family": "o",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-06",
+    "temperature": false,
+    "knowledge": "2023-10-31",
+    "release_date": "2024-12-17",
+    "last_updated": "2024-12-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 15.0,
+      "output": 60.0,
+      "cache_read": 7.5
+    },
+    "limit": {
+      "context": 200000,
+      "output": 100000
+    }
+  },
+  {
+    "id": "openrouter/openai/o1-pro",
+    "name": "o1-pro",
+    "family": "o",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": false,
+    "knowledge": "2023-10-31",
+    "release_date": "2025-03-19",
+    "last_updated": "2025-03-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 150.0,
+      "output": 600.0
+    },
+    "limit": {
+      "context": 200000,
+      "output": 100000
+    }
+  },
+  {
+    "id": "openrouter/openai/o3",
+    "name": "o3",
+    "family": "o",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-06-30",
     "release_date": "2025-04-16",
     "last_updated": "2025-04-16",
     "modalities": {
       "input": [
+        "image",
         "text",
-        "image"
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 8.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 200000,
+      "output": 100000
+    }
+  },
+  {
+    "id": "openrouter/openai/o3-deep-research",
+    "name": "o3 Deep Research",
+    "family": "o",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-10-10",
+    "last_updated": "2025-10-10",
+    "modalities": {
+      "input": [
+        "image",
+        "text",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 40.0,
+      "cache_read": 2.5
+    },
+    "limit": {
+      "context": 200000,
+      "output": 100000
+    }
+  },
+  {
+    "id": "openrouter/openai/o3-mini",
+    "name": "o3 Mini",
+    "family": "o",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2023-10-31",
+    "release_date": "2025-01-31",
+    "last_updated": "2025-01-31",
+    "modalities": {
+      "input": [
+        "text",
+        "pdf"
       ],
       "output": [
         "text"
@@ -92898,7 +98474,7 @@
     "cost": {
       "input": 1.1,
       "output": 4.4,
-      "cache_read": 0.28
+      "cache_read": 0.55
     },
     "limit": {
       "context": 200000,
@@ -92906,15 +98482,201 @@
     }
   },
   {
-    "id": "openrouter/openrouter/elephant-alpha",
-    "name": "Elephant (free)",
-    "family": "elephant",
-    "attachment": false,
+    "id": "openrouter/openai/o3-mini-high",
+    "name": "o3 Mini High",
+    "family": "o",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2023-10-31",
+    "release_date": "2025-02-12",
+    "last_updated": "2025-02-12",
+    "modalities": {
+      "input": [
+        "text",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.1,
+      "output": 4.4,
+      "cache_read": 0.55
+    },
+    "limit": {
+      "context": 200000,
+      "output": 100000
+    }
+  },
+  {
+    "id": "openrouter/openai/o3-pro",
+    "name": "o3 Pro",
+    "family": "o",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-06-30",
+    "release_date": "2025-06-10",
+    "last_updated": "2025-06-10",
+    "modalities": {
+      "input": [
+        "text",
+        "pdf",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 20.0,
+      "output": 80.0
+    },
+    "limit": {
+      "context": 200000,
+      "output": 100000
+    }
+  },
+  {
+    "id": "openrouter/openai/o4-mini",
+    "name": "o4 Mini",
+    "family": "o-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-06-30",
+    "release_date": "2025-04-16",
+    "last_updated": "2025-04-16",
+    "modalities": {
+      "input": [
+        "image",
+        "text",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.1,
+      "output": 4.4,
+      "cache_read": 0.275
+    },
+    "limit": {
+      "context": 200000,
+      "output": 100000
+    }
+  },
+  {
+    "id": "openrouter/openai/o4-mini-deep-research",
+    "name": "o4 Mini Deep Research",
+    "family": "o",
+    "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-04-13",
-    "last_updated": "2026-04-13",
+    "release_date": "2025-10-10",
+    "last_updated": "2025-10-10",
+    "modalities": {
+      "input": [
+        "pdf",
+        "image",
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 8.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 200000,
+      "output": 100000
+    }
+  },
+  {
+    "id": "openrouter/openai/o4-mini-high",
+    "name": "o4 Mini High",
+    "family": "o",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-06-30",
+    "release_date": "2025-04-16",
+    "last_updated": "2025-04-16",
+    "modalities": {
+      "input": [
+        "image",
+        "text",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.1,
+      "output": 4.4,
+      "cache_read": 0.275
+    },
+    "limit": {
+      "context": 200000,
+      "output": 100000
+    }
+  },
+  {
+    "id": "openrouter/openrouter/auto",
+    "name": "Auto Router",
+    "family": "auto",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2023-11-08",
+    "last_updated": "2023-11-08",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "pdf",
+        "video"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 2000000,
+      "output": 2000000
+    }
+  },
+  {
+    "id": "openrouter/openrouter/bodybuilder",
+    "name": "Body Builder (beta)",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2025-12-05",
+    "last_updated": "2025-12-05",
     "modalities": {
       "input": [
         "text"
@@ -92924,13 +98686,10 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
-      "context": 262144,
-      "output": 32768
+      "context": 128000,
+      "output": 128000
     }
   },
   {
@@ -92964,12 +98723,13 @@
   {
     "id": "openrouter/openrouter/owl-alpha",
     "name": "Owl Alpha",
+    "family": "alpha",
     "attachment": false,
-    "reasoning": true,
+    "reasoning": false,
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-04-28",
-    "last_updated": "2026-04-30",
+    "last_updated": "2026-04-28",
     "modalities": {
       "input": [
         "text"
@@ -92991,10 +98751,10 @@
   {
     "id": "openrouter/openrouter/pareto-code",
     "name": "Pareto Code Router",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
     "release_date": "2026-04-21",
     "last_updated": "2026-04-21",
     "modalities": {
@@ -93008,13 +98768,186 @@
     "open_weights": false,
     "cost": {},
     "limit": {
-      "context": 200000,
+      "context": 2000000,
       "output": 200000
     }
   },
   {
+    "id": "openrouter/perceptron/perceptron-mk1",
+    "name": "Perceptron Mk1",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-05-12",
+    "last_updated": "2026-05-12",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 1.5
+    },
+    "limit": {
+      "context": 32768,
+      "output": 8192
+    }
+  },
+  {
+    "id": "openrouter/perplexity/sonar",
+    "name": "Sonar",
+    "family": "sonar",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-01-27",
+    "last_updated": "2025-01-27",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 1.0
+    },
+    "limit": {
+      "context": 127072,
+      "output": 127072
+    }
+  },
+  {
+    "id": "openrouter/perplexity/sonar-deep-research",
+    "name": "Sonar Deep Research",
+    "family": "sonar-deep-research",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-03-07",
+    "last_updated": "2025-03-07",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 8.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/perplexity/sonar-pro",
+    "name": "Sonar Pro",
+    "family": "sonar-pro",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-03-07",
+    "last_updated": "2025-03-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0
+    },
+    "limit": {
+      "context": 200000,
+      "output": 8000
+    }
+  },
+  {
+    "id": "openrouter/perplexity/sonar-pro-search",
+    "name": "Sonar Pro Search",
+    "family": "sonar-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-10-30",
+    "last_updated": "2025-10-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0
+    },
+    "limit": {
+      "context": 200000,
+      "output": 8000
+    }
+  },
+  {
+    "id": "openrouter/perplexity/sonar-reasoning-pro",
+    "name": "Sonar Reasoning Pro",
+    "family": "sonar-reasoning",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-03-07",
+    "last_updated": "2025-03-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 8.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 128000
+    }
+  },
+  {
     "id": "openrouter/poolside/laguna-m.1:free",
-    "name": "Laguna M.1",
+    "name": "Laguna M.1 (free)",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
@@ -93032,9 +98965,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.0,
-      "output": 0.0,
-      "cache_read": 0.0,
-      "cache_write": 0.0
+      "output": 0.0
     },
     "limit": {
       "context": 131072,
@@ -93043,7 +98974,7 @@
   },
   {
     "id": "openrouter/poolside/laguna-xs.2:free",
-    "name": "Laguna XS.2",
+    "name": "Laguna XS.2 (free)",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
@@ -93061,9 +98992,7 @@
     "open_weights": true,
     "cost": {
       "input": 0.0,
-      "output": 0.0,
-      "cache_read": 0.0,
-      "cache_write": 0.0
+      "output": 0.0
     },
     "limit": {
       "context": 131072,
@@ -93072,15 +99001,15 @@
   },
   {
     "id": "openrouter/prime-intellect/intellect-3",
-    "name": "Intellect 3",
+    "name": "INTELLECT-3",
     "family": "glm",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2024-10",
-    "release_date": "2025-01-15",
-    "last_updated": "2025-01-15",
+    "release_date": "2025-11-27",
+    "last_updated": "2025-11-27",
     "modalities": {
       "input": [
         "text"
@@ -93096,7 +99025,65 @@
     },
     "limit": {
       "context": 131072,
-      "output": 8192
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen-2.5-72b-instruct",
+    "name": "Qwen2.5 72B Instruct",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-06-30",
+    "release_date": "2024-09-19",
+    "last_updated": "2024-09-19",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.36,
+      "output": 0.4
+    },
+    "limit": {
+      "context": 32768,
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen-2.5-7b-instruct",
+    "name": "Qwen2.5 7B Instruct",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-06-30",
+    "release_date": "2024-10-16",
+    "last_updated": "2024-10-16",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.04,
+      "output": 0.1
+    },
+    "limit": {
+      "context": 32768,
+      "output": 32768
     }
   },
   {
@@ -93107,7 +99094,7 @@
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
-    "knowledge": "2024-10",
+    "knowledge": "2024-06-30",
     "release_date": "2024-11-11",
     "last_updated": "2024-11-11",
     "modalities": {
@@ -93120,12 +99107,73 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.0,
-      "output": 0.0
+      "input": 0.66,
+      "output": 1.0
     },
     "limit": {
       "context": 32768,
-      "output": 8192
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen-plus",
+    "name": "Qwen-Plus",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-02-01",
+    "last_updated": "2025-02-01",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.26,
+      "output": 0.78,
+      "cache_read": 0.052,
+      "cache_write": 0.325
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen-plus-2025-07-28:thinking",
+    "name": "Qwen Plus 0728 (thinking)",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-09-08",
+    "last_updated": "2025-09-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.26,
+      "output": 0.78,
+      "cache_write": 0.325
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 32768
     }
   },
   {
@@ -93136,7 +99184,7 @@
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
-    "knowledge": "2024-10",
+    "knowledge": "2024-06-30",
     "release_date": "2025-02-01",
     "last_updated": "2025-02-01",
     "modalities": {
@@ -93150,25 +99198,25 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.0,
-      "output": 0.0
+      "input": 0.25,
+      "output": 0.75
     },
     "limit": {
-      "context": 32768,
+      "context": 32000,
       "output": 8192
     }
   },
   {
-    "id": "openrouter/qwen/qwen3-235b-a22b-07-25",
-    "name": "Qwen3 235B A22B Instruct 2507",
+    "id": "openrouter/qwen/qwen3-14b",
+    "name": "Qwen3 14B",
     "family": "qwen",
     "attachment": false,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-04",
+    "knowledge": "2025-03-31",
     "release_date": "2025-04-28",
-    "last_updated": "2025-07-21",
+    "last_updated": "2025-04-28",
     "modalities": {
       "input": [
         "text"
@@ -93179,12 +99227,41 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.15,
-      "output": 0.85
+      "input": 0.1,
+      "output": 0.24
     },
     "limit": {
-      "context": 262144,
-      "output": 131072
+      "context": 40960,
+      "output": 40960
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3-235b-a22b",
+    "name": "Qwen3 235B A22B",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-04-28",
+    "last_updated": "2025-04-28",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.455,
+      "output": 1.82
+    },
+    "limit": {
+      "context": 131072,
+      "output": 8192
     }
   },
   {
@@ -93195,7 +99272,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-04",
+    "knowledge": "2025-06-30",
     "release_date": "2025-07-25",
     "last_updated": "2025-07-25",
     "modalities": {
@@ -93208,12 +99285,41 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.078,
-      "output": 0.312
+      "input": 0.1495,
+      "output": 1.495
     },
     "limit": {
-      "context": 262144,
+      "context": 131072,
       "output": 81920
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3-30b-a3b",
+    "name": "Qwen3 30B A3B",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-04-28",
+    "last_updated": "2025-04-28",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.09,
+      "output": 0.45
+    },
+    "limit": {
+      "context": 40960,
+      "output": 20000
     }
   },
   {
@@ -93224,7 +99330,7 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-04",
+    "knowledge": "2025-06-30",
     "release_date": "2025-07-29",
     "last_updated": "2025-07-29",
     "modalities": {
@@ -93237,12 +99343,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.2,
-      "output": 0.8
+      "input": 0.09,
+      "output": 0.3
     },
     "limit": {
-      "context": 262000,
-      "output": 262000
+      "context": 262144,
+      "output": 262144
     }
   },
   {
@@ -93253,9 +99359,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-04",
-    "release_date": "2025-07-29",
-    "last_updated": "2025-07-29",
+    "knowledge": "2025-06-30",
+    "release_date": "2025-08-28",
+    "last_updated": "2025-08-28",
     "modalities": {
       "input": [
         "text"
@@ -93266,23 +99372,83 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.2,
-      "output": 0.8
+      "input": 0.08,
+      "output": 0.4,
+      "cache_read": 0.08
     },
     "limit": {
-      "context": 262000,
-      "output": 262000
+      "context": 131072,
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3-32b",
+    "name": "Qwen3 32B",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-04-28",
+    "last_updated": "2025-04-28",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.08,
+      "output": 0.28
+    },
+    "limit": {
+      "context": 40960,
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3-8b",
+    "name": "Qwen3 8B",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-04-28",
+    "last_updated": "2025-04-28",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.05,
+      "output": 0.4,
+      "cache_read": 0.05
+    },
+    "limit": {
+      "context": 40960,
+      "output": 8192
     }
   },
   {
     "id": "openrouter/qwen/qwen3-coder",
-    "name": "Qwen3 Coder",
+    "name": "Qwen3 Coder 480B A35B",
     "family": "qwen",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-04",
+    "knowledge": "2025-06-30",
     "release_date": "2025-07-23",
     "last_updated": "2025-07-23",
     "modalities": {
@@ -93295,12 +99461,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.3,
-      "output": 1.2
+      "input": 0.22,
+      "output": 1.8
     },
     "limit": {
       "context": 262144,
-      "output": 66536
+      "output": 65536
     }
   },
   {
@@ -93311,7 +99477,7 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-04",
+    "knowledge": "2025-06-30",
     "release_date": "2025-07-31",
     "last_updated": "2025-07-31",
     "modalities": {
@@ -93329,7 +99495,7 @@
     },
     "limit": {
       "context": 160000,
-      "output": 65536
+      "output": 32768
     }
   },
   {
@@ -93340,9 +99506,9 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-04",
-    "release_date": "2025-07-23",
-    "last_updated": "2025-07-23",
+    "knowledge": "2025-06-30",
+    "release_date": "2025-09-17",
+    "last_updated": "2025-09-17",
     "modalities": {
       "input": [
         "text"
@@ -93353,23 +99519,85 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.3,
-      "output": 1.5
+      "input": 0.195,
+      "output": 0.975,
+      "cache_read": 0.039,
+      "cache_write": 0.24375
     },
     "limit": {
-      "context": 128000,
-      "output": 66536
+      "context": 1000000,
+      "output": 65536
     }
   },
   {
-    "id": "openrouter/qwen/qwen3-coder:exacto",
-    "name": "Qwen3 Coder (exacto)",
+    "id": "openrouter/qwen/qwen3-coder-next",
+    "name": "Qwen3 Coder Next",
     "family": "qwen",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-04",
+    "release_date": "2026-02-04",
+    "last_updated": "2026-02-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.11,
+      "output": 0.8,
+      "cache_read": 0.07
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3-coder-plus",
+    "name": "Qwen3 Coder Plus",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-06-30",
+    "release_date": "2025-09-23",
+    "last_updated": "2025-09-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.65,
+      "output": 3.25,
+      "cache_read": 0.13,
+      "cache_write": 0.8125
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3-coder:free",
+    "name": "Qwen3 Coder 480B A35B (free)",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-06-30",
     "release_date": "2025-07-23",
     "last_updated": "2025-07-23",
     "modalities": {
@@ -93382,12 +99610,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.38,
-      "output": 1.53
+      "input": 0.0,
+      "output": 0.0
     },
     "limit": {
-      "context": 131072,
-      "output": 32768
+      "context": 262000,
+      "output": 262000
     }
   },
   {
@@ -93395,11 +99623,12 @@
     "name": "Qwen3 Max",
     "family": "qwen",
     "attachment": false,
-    "reasoning": true,
+    "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-09-05",
-    "last_updated": "2025-09-05",
+    "knowledge": "2025-06-30",
+    "release_date": "2025-09-23",
+    "last_updated": "2025-09-23",
     "modalities": {
       "input": [
         "text"
@@ -93410,8 +99639,38 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 1.2,
-      "output": 6.0
+      "input": 0.78,
+      "output": 3.9,
+      "cache_read": 0.156,
+      "cache_write": 0.975
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3-max-thinking",
+    "name": "Qwen3 Max Thinking",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-09",
+    "last_updated": "2026-02-09",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.78,
+      "output": 3.9
     },
     "limit": {
       "context": 262144,
@@ -93426,7 +99685,7 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-04",
+    "knowledge": "2025-09-30",
     "release_date": "2025-09-11",
     "last_updated": "2025-09-11",
     "modalities": {
@@ -93439,8 +99698,37 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.14,
-      "output": 1.4
+      "input": 0.09,
+      "output": 1.1
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3-next-80b-a3b-instruct:free",
+    "name": "Qwen3 Next 80B A3B Instruct (free)",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-09-30",
+    "release_date": "2025-09-11",
+    "last_updated": "2025-09-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
     },
     "limit": {
       "context": 262144,
@@ -93455,7 +99743,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-04",
+    "knowledge": "2025-09-30",
     "release_date": "2025-09-11",
     "last_updated": "2025-09-11",
     "modalities": {
@@ -93468,12 +99756,311 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.14,
-      "output": 1.4
+      "input": 0.0975,
+      "output": 0.78
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3-vl-235b-a22b-instruct",
+    "name": "Qwen3 VL 235B A22B Instruct",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-09-23",
+    "last_updated": "2025-09-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.2,
+      "output": 0.88,
+      "cache_read": 0.11
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3-vl-235b-a22b-thinking",
+    "name": "Qwen3 VL 235B A22B Thinking",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-09-23",
+    "last_updated": "2025-09-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.26,
+      "output": 2.6
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3-vl-30b-a3b-instruct",
+    "name": "Qwen3 VL 30B A3B Instruct",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-10-06",
+    "last_updated": "2025-10-06",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.13,
+      "output": 0.52
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3-vl-30b-a3b-thinking",
+    "name": "Qwen3 VL 30B A3B Thinking",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-10-06",
+    "last_updated": "2025-10-06",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.13,
+      "output": 1.56
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3-vl-32b-instruct",
+    "name": "Qwen3 VL 32B Instruct",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-10-23",
+    "last_updated": "2025-10-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.104,
+      "output": 0.416
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3-vl-8b-instruct",
+    "name": "Qwen3 VL 8B Instruct",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-10-14",
+    "last_updated": "2025-10-14",
+    "modalities": {
+      "input": [
+        "image",
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.08,
+      "output": 0.5
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3-vl-8b-thinking",
+    "name": "Qwen3 VL 8B Thinking",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-10-14",
+    "last_updated": "2025-10-14",
+    "modalities": {
+      "input": [
+        "image",
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.117,
+      "output": 1.365
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3.5-122b-a10b",
+    "name": "Qwen3.5-122B-A10B",
+    "family": "qwen3.5",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-25",
+    "last_updated": "2026-02-25",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.26,
+      "output": 2.08
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3.5-27b",
+    "name": "Qwen3.5-27B",
+    "family": "qwen3.5",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-25",
+    "last_updated": "2026-02-25",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.195,
+      "output": 1.56
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3.5-35b-a3b",
+    "name": "Qwen3.5-35B-A3B",
+    "family": "qwen3.5",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-25",
+    "last_updated": "2026-02-25",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.14,
+      "output": 1.0,
+      "cache_read": 0.05
+    },
+    "limit": {
+      "context": 262144,
+      "output": 81920
     }
   },
   {
@@ -93499,8 +100086,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.6,
-      "output": 3.6
+      "input": 0.39,
+      "output": 2.34,
+      "cache_read": 0.195
     },
     "limit": {
       "context": 262144,
@@ -93508,8 +100096,38 @@
     }
   },
   {
+    "id": "openrouter/qwen/qwen3.5-9b",
+    "name": "Qwen3.5-9B",
+    "family": "qwen3.5",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-10",
+    "last_updated": "2026-03-10",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.04,
+      "output": 0.15
+    },
+    "limit": {
+      "context": 262144,
+      "output": 81920
+    }
+  },
+  {
     "id": "openrouter/qwen/qwen3.5-flash-02-23",
-    "name": "Qwen: Qwen3.5-Flash",
+    "name": "Qwen3.5-Flash",
     "family": "qwen",
     "attachment": true,
     "reasoning": true,
@@ -93530,7 +100148,38 @@
     "open_weights": false,
     "cost": {
       "input": 0.065,
-      "output": 0.26
+      "output": 0.26,
+      "cache_write": 0.08125
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3.5-plus",
+    "name": "Qwen3.5 Plus 2026-04-20",
+    "family": "qwen3.5",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-27",
+    "last_updated": "2026-04-27",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 1.8
     },
     "limit": {
       "context": 1000000,
@@ -93560,11 +100209,133 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.4,
-      "output": 2.4
+      "input": 0.26,
+      "output": 1.56,
+      "cache_write": 0.325
     },
     "limit": {
       "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3.6-27b",
+    "name": "Qwen3.6 27B",
+    "family": "qwen3.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-27",
+    "last_updated": "2026-04-27",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.32,
+      "output": 3.2
+    },
+    "limit": {
+      "context": 262144,
+      "output": 81920
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3.6-35b-a3b",
+    "name": "Qwen3.6 35B A3B",
+    "family": "qwen3.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-27",
+    "last_updated": "2026-04-27",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.15,
+      "output": 1.0,
+      "cache_read": 0.05
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3.6-flash",
+    "name": "Qwen3.6 Flash",
+    "family": "qwen3.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-27",
+    "last_updated": "2026-04-27",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1875,
+      "output": 1.125,
+      "cache_write": 0.234375
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3.6-max-preview",
+    "name": "Qwen3.6 Max Preview",
+    "family": "qwen3.6",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-27",
+    "last_updated": "2026-04-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.04,
+      "output": 6.24,
+      "cache_write": 1.3
+    },
+    "limit": {
+      "context": 262144,
       "output": 65536
     }
   },
@@ -93592,7 +100363,8 @@
     "open_weights": false,
     "cost": {
       "input": 0.325,
-      "output": 1.95
+      "output": 1.95,
+      "cache_write": 0.40625
     },
     "limit": {
       "context": 1000000,
@@ -93600,29 +100372,141 @@
     }
   },
   {
-    "id": "openrouter/sourceful/riverflow-v2-fast-preview",
-    "name": "Riverflow V2 Fast Preview",
-    "family": "sourceful",
-    "attachment": false,
+    "id": "openrouter/rekaai/reka-edge",
+    "name": "Reka Edge",
+    "family": "reka",
+    "attachment": true,
     "reasoning": false,
-    "tool_call": false,
+    "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-06",
-    "release_date": "2025-12-08",
-    "last_updated": "2026-01-28",
+    "release_date": "2026-03-20",
+    "last_updated": "2026-03-20",
     "modalities": {
       "input": [
+        "image",
         "text",
-        "image"
+        "video"
       ],
       "output": [
-        "image"
+        "text"
       ]
     },
     "open_weights": true,
     "cost": {
-      "input": 0.0,
-      "output": 0.0
+      "input": 0.1,
+      "output": 0.1
+    },
+    "limit": {
+      "context": 16384,
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/rekaai/reka-flash-3",
+    "name": "Reka Flash 3",
+    "family": "reka",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-01-31",
+    "release_date": "2025-03-12",
+    "last_updated": "2025-03-12",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.1,
+      "output": 0.2
+    },
+    "limit": {
+      "context": 65536,
+      "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/relace/relace-apply-3",
+    "name": "Relace Apply 3",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2025-09-26",
+    "last_updated": "2025-09-26",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.85,
+      "output": 1.25
+    },
+    "limit": {
+      "context": 256000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/relace/relace-search",
+    "name": "Relace Search",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-12-08",
+    "last_updated": "2025-12-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 3.0
+    },
+    "limit": {
+      "context": 256000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/sao10k/l3-euryale-70b",
+    "name": "Llama 3 Euryale 70B v2.1",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-12-31",
+    "release_date": "2024-06-18",
+    "last_updated": "2024-06-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.48,
+      "output": 1.48
     },
     "limit": {
       "context": 8192,
@@ -93630,63 +100514,119 @@
     }
   },
   {
-    "id": "openrouter/sourceful/riverflow-v2-max-preview",
-    "name": "Riverflow V2 Max Preview",
-    "family": "sourceful",
+    "id": "openrouter/sao10k/l3-lunaris-8b",
+    "name": "Llama 3 8B Lunaris",
+    "family": "llama",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
-    "knowledge": "2025-06",
-    "release_date": "2025-12-08",
-    "last_updated": "2026-01-28",
+    "knowledge": "2023-12-31",
+    "release_date": "2024-08-13",
+    "last_updated": "2024-08-13",
     "modalities": {
       "input": [
-        "text",
-        "image"
+        "text"
       ],
       "output": [
-        "image"
+        "text"
       ]
     },
     "open_weights": true,
     "cost": {
-      "input": 0.0,
-      "output": 0.0
+      "input": 0.04,
+      "output": 0.05
     },
     "limit": {
       "context": 8192,
-      "output": 8192
+      "output": 16384
     }
   },
   {
-    "id": "openrouter/sourceful/riverflow-v2-standard-preview",
-    "name": "Riverflow V2 Standard Preview",
-    "family": "sourceful",
+    "id": "openrouter/sao10k/l3.1-70b-hanami-x1",
+    "name": "Llama 3.1 70B Hanami x1",
+    "family": "llama",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
-    "knowledge": "2025-06",
-    "release_date": "2025-12-08",
-    "last_updated": "2026-01-28",
+    "knowledge": "2023-12-31",
+    "release_date": "2025-01-08",
+    "last_updated": "2025-01-08",
     "modalities": {
       "input": [
-        "text",
-        "image"
+        "text"
       ],
       "output": [
-        "image"
+        "text"
       ]
     },
     "open_weights": true,
     "cost": {
-      "input": 0.0,
-      "output": 0.0
+      "input": 3.0,
+      "output": 3.0
     },
     "limit": {
-      "context": 8192,
-      "output": 8192
+      "context": 16000,
+      "output": 16000
+    }
+  },
+  {
+    "id": "openrouter/sao10k/l3.1-euryale-70b",
+    "name": "Llama 3.1 Euryale 70B v2.2",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-12-31",
+    "release_date": "2024-08-28",
+    "last_updated": "2024-08-28",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.85,
+      "output": 0.85
+    },
+    "limit": {
+      "context": 131072,
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/sao10k/l3.3-euryale-70b",
+    "name": "Llama 3.3 Euryale 70B",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2023-12-31",
+    "release_date": "2024-12-18",
+    "last_updated": "2024-12-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.65,
+      "output": 0.75
+    },
+    "limit": {
+      "context": 131072,
+      "output": 16384
     }
   },
   {
@@ -93711,25 +100651,137 @@
     "open_weights": true,
     "cost": {
       "input": 0.1,
-      "output": 0.3,
-      "cache_read": 0.02
+      "output": 0.3
     },
     "limit": {
-      "context": 256000,
-      "output": 256000
+      "context": 262144,
+      "output": 65536
     }
   },
   {
-    "id": "openrouter/x-ai/grok-3",
-    "name": "Grok 3",
-    "family": "grok",
+    "id": "openrouter/switchpoint/router",
+    "name": "Switchpoint Router",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-07-11",
+    "last_updated": "2025-07-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.85,
+      "output": 3.4
+    },
+    "limit": {
+      "context": 131072,
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/tencent/hunyuan-a13b-instruct",
+    "name": "Hunyuan A13B Instruct",
+    "family": "hunyuan",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-07-08",
+    "last_updated": "2025-07-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.14,
+      "output": 0.57
+    },
+    "limit": {
+      "context": 131072,
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/tencent/hy3-preview",
+    "name": "Hy3 preview",
+    "family": "Hy",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.066,
+      "output": 0.26,
+      "cache_read": 0.029
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "openrouter/thedrummer/cydonia-24b-v4.1",
+    "name": "Cydonia 24B V4.1",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2024-04-30",
+    "release_date": "2025-09-27",
+    "last_updated": "2025-09-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.3,
+      "output": 0.5,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 131072,
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/thedrummer/rocinante-12b",
+    "name": "Rocinante 12B",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-11",
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
+    "knowledge": "2024-04-30",
+    "release_date": "2024-09-30",
+    "last_updated": "2024-09-30",
     "modalities": {
       "input": [
         "text"
@@ -93738,29 +100790,111 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.75,
-      "cache_write": 15.0
+      "input": 0.17,
+      "output": 0.43
     },
     "limit": {
-      "context": 131072,
-      "output": 8192
+      "context": 32768,
+      "output": 32768
     }
   },
   {
-    "id": "openrouter/x-ai/grok-3-beta",
-    "name": "Grok 3 Beta",
-    "family": "grok",
+    "id": "openrouter/thedrummer/skyfall-36b-v2",
+    "name": "Skyfall 36B V2",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2024-06-30",
+    "release_date": "2025-03-10",
+    "last_updated": "2025-03-10",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.55,
+      "output": 0.8,
+      "cache_read": 0.25
+    },
+    "limit": {
+      "context": 32768,
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/thedrummer/unslopnemo-12b",
+    "name": "UnslopNemo 12B",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-11",
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
+    "knowledge": "2024-04-30",
+    "release_date": "2024-11-08",
+    "last_updated": "2024-11-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.4,
+      "output": 0.4
+    },
+    "limit": {
+      "context": 32768,
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/undi95/remm-slerp-l2-13b",
+    "name": "ReMM SLERP 13B",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2023-06-30",
+    "release_date": "2023-07-22",
+    "last_updated": "2023-07-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.45,
+      "output": 0.65
+    },
+    "limit": {
+      "context": 6144,
+      "output": 4096
+    }
+  },
+  {
+    "id": "openrouter/upstage/solar-pro-3",
+    "name": "Solar Pro 3",
+    "family": "solar-pro",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-01-27",
+    "last_updated": "2026-01-27",
     "modalities": {
       "input": [
         "text"
@@ -93771,187 +100905,59 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.75,
-      "cache_write": 15.0
+      "input": 0.15,
+      "output": 0.6,
+      "cache_read": 0.015
     },
     "limit": {
-      "context": 131072,
+      "context": 128000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/writer/palmyra-x5",
+    "name": "Palmyra X5",
+    "family": "palmyra",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-01-21",
+    "last_updated": "2026-01-21",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.6,
+      "output": 6.0
+    },
+    "limit": {
+      "context": 1040000,
       "output": 8192
     }
   },
   {
-    "id": "openrouter/x-ai/grok-3-mini",
-    "name": "Grok 3 Mini",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-11",
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.3,
-      "output": 0.5,
-      "cache_read": 0.075,
-      "cache_write": 0.5
-    },
-    "limit": {
-      "context": 131072,
-      "output": 8192
-    }
-  },
-  {
-    "id": "openrouter/x-ai/grok-3-mini-beta",
-    "name": "Grok 3 Mini Beta",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-11",
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.3,
-      "output": 0.5,
-      "cache_read": 0.075,
-      "cache_write": 0.5
-    },
-    "limit": {
-      "context": 131072,
-      "output": 8192
-    }
-  },
-  {
-    "id": "openrouter/x-ai/grok-4",
-    "name": "Grok 4",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
-    "release_date": "2025-07-09",
-    "last_updated": "2025-07-09",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.75,
-      "cache_write": 15.0
-    },
-    "limit": {
-      "context": 256000,
-      "output": 64000
-    }
-  },
-  {
-    "id": "openrouter/x-ai/grok-4-fast",
-    "name": "Grok 4 Fast",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-11",
-    "release_date": "2025-08-19",
-    "last_updated": "2025-08-19",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.5,
-      "cache_read": 0.05,
-      "cache_write": 0.05
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 30000
-    }
-  },
-  {
-    "id": "openrouter/x-ai/grok-4.1-fast",
-    "name": "Grok 4.1 Fast",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-11",
-    "release_date": "2025-11-19",
-    "last_updated": "2025-11-19",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.5,
-      "cache_read": 0.05,
-      "cache_write": 0.05
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 30000
-    }
-  },
-  {
-    "id": "openrouter/x-ai/grok-4.20-beta",
-    "name": "Grok 4.20 Beta",
+    "id": "openrouter/x-ai/grok-4.20",
+    "name": "Grok 4.20",
     "family": "grok",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-03-12",
-    "last_updated": "2026-03-12",
+    "knowledge": "2025-09-01",
+    "release_date": "2026-03-31",
+    "last_updated": "2026-03-31",
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -93959,29 +100965,31 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.0,
-      "output": 6.0,
+      "input": 1.25,
+      "output": 2.5,
       "cache_read": 0.2
     },
     "limit": {
       "context": 2000000,
-      "output": 30000
+      "output": 2000000
     }
   },
   {
-    "id": "openrouter/x-ai/grok-4.20-multi-agent-beta",
-    "name": "Grok 4.20 Multi - Agent Beta",
+    "id": "openrouter/x-ai/grok-4.20-multi-agent",
+    "name": "Grok 4.20 Multi-Agent",
     "family": "grok",
     "attachment": true,
     "reasoning": true,
     "tool_call": false,
     "temperature": true,
-    "release_date": "2026-03-12",
-    "last_updated": "2026-03-12",
+    "knowledge": "2025-09-01",
+    "release_date": "2026-03-31",
+    "last_updated": "2026-03-31",
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -93995,11 +101003,1652 @@
     },
     "limit": {
       "context": 2000000,
-      "output": 30000
+      "output": 2000000
     }
   },
   {
     "id": "openrouter/x-ai/grok-4.3",
+    "name": "Grok 4.3",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 1000000
+    }
+  },
+  {
+    "id": "openrouter/xiaomi/mimo-v2-flash",
+    "name": "MiMo-V2-Flash",
+    "family": "mimo",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-12-14",
+    "last_updated": "2025-12-14",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.1,
+      "output": 0.3,
+      "cache_read": 0.01
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/xiaomi/mimo-v2-omni",
+    "name": "MiMo-V2-Omni",
+    "family": "mimo-v2-omni",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text",
+        "audio",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.4,
+      "output": 2.0,
+      "cache_read": 0.08
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/xiaomi/mimo-v2-pro",
+    "name": "MiMo-V2-Pro",
+    "family": "mimo-v2-pro",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 3.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/xiaomi/mimo-v2.5",
+    "name": "MiMo-V2.5",
+    "family": "mimo-v2.5",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text",
+        "audio",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.4,
+      "output": 2.0,
+      "cache_read": 0.08
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/xiaomi/mimo-v2.5-pro",
+    "name": "MiMo-V2.5-Pro",
+    "family": "mimo-v2.5-pro",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.0,
+      "output": 3.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/z-ai/glm-4-32b",
+    "name": "GLM 4 32B ",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-06-30",
+    "release_date": "2025-07-24",
+    "last_updated": "2025-07-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.1
+    },
+    "limit": {
+      "context": 128000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/z-ai/glm-4.5",
+    "name": "GLM 4.5",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12-31",
+    "release_date": "2025-07-25",
+    "last_updated": "2025-07-25",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.6,
+      "output": 2.2,
+      "cache_read": 0.11
+    },
+    "limit": {
+      "context": 131072,
+      "output": 98304
+    }
+  },
+  {
+    "id": "openrouter/z-ai/glm-4.5-air",
+    "name": "GLM 4.5 Air",
+    "family": "glm-air",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12-31",
+    "release_date": "2025-07-25",
+    "last_updated": "2025-07-25",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.13,
+      "output": 0.85,
+      "cache_read": 0.025
+    },
+    "limit": {
+      "context": 131072,
+      "output": 98304
+    }
+  },
+  {
+    "id": "openrouter/z-ai/glm-4.5-air:free",
+    "name": "GLM 4.5 Air (free)",
+    "family": "glm-air",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12-31",
+    "release_date": "2025-07-25",
+    "last_updated": "2025-07-25",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 131072,
+      "output": 96000
+    }
+  },
+  {
+    "id": "openrouter/z-ai/glm-4.5v",
+    "name": "GLM 4.5V",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12-31",
+    "release_date": "2025-08-11",
+    "last_updated": "2025-08-11",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.6,
+      "output": 1.8,
+      "cache_read": 0.11
+    },
+    "limit": {
+      "context": 65536,
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/z-ai/glm-4.6",
+    "name": "GLM 4.6",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-09-30",
+    "last_updated": "2025-09-30",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.43,
+      "output": 1.74,
+      "cache_read": 0.08
+    },
+    "limit": {
+      "context": 202752,
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/z-ai/glm-4.6v",
+    "name": "GLM 4.6V",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-12-08",
+    "last_updated": "2025-12-08",
+    "modalities": {
+      "input": [
+        "image",
+        "text",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.3,
+      "output": 0.9,
+      "cache_read": 0.05
+    },
+    "limit": {
+      "context": 131072,
+      "output": 24000
+    }
+  },
+  {
+    "id": "openrouter/z-ai/glm-4.7",
+    "name": "GLM 4.7",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2025-12-22",
+    "last_updated": "2025-12-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.4,
+      "output": 1.75,
+      "cache_read": 0.08
+    },
+    "limit": {
+      "context": 202752,
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/z-ai/glm-4.7-flash",
+    "name": "GLM 4.7 Flash",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-01-19",
+    "last_updated": "2026-01-19",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.06,
+      "output": 0.4,
+      "cache_read": 0.01
+    },
+    "limit": {
+      "context": 202752,
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/z-ai/glm-5",
+    "name": "GLM 5",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-11",
+    "last_updated": "2026-02-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.6,
+      "output": 1.92,
+      "cache_read": 0.12
+    },
+    "limit": {
+      "context": 202752,
+      "output": 131000
+    }
+  },
+  {
+    "id": "openrouter/z-ai/glm-5-turbo",
+    "name": "GLM 5 Turbo",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-15",
+    "last_updated": "2026-03-15",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.2,
+      "output": 4.0,
+      "cache_read": 0.24
+    },
+    "limit": {
+      "context": 202752,
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/z-ai/glm-5.1",
+    "name": "GLM 5.1",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-07",
+    "last_updated": "2026-04-07",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.98,
+      "output": 3.08,
+      "cache_read": 0.182
+    },
+    "limit": {
+      "context": 202752,
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/z-ai/glm-5v-turbo",
+    "name": "GLM 5V Turbo",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-01",
+    "last_updated": "2026-04-01",
+    "modalities": {
+      "input": [
+        "image",
+        "text",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.2,
+      "output": 4.0,
+      "cache_read": 0.24
+    },
+    "limit": {
+      "context": 202752,
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/~anthropic/claude-haiku",
+    "name": "Anthropic Claude Haiku Latest",
+    "family": "claude-haiku",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-27",
+    "last_updated": "2026-04-27",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 5.0,
+      "cache_read": 0.1,
+      "cache_write": 1.25
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "openrouter/~anthropic/claude-opus",
+    "name": "Claude Opus Latest",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/~anthropic/claude-sonnet",
+    "name": "Anthropic Claude Sonnet Latest",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-27",
+    "last_updated": "2026-04-27",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/~google/gemini-flash",
+    "name": "Google Gemini Flash Latest",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-27",
+    "last_updated": "2026-04-27",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.5,
+      "output": 3.0,
+      "cache_read": 0.05,
+      "cache_write": 0.083333
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/~google/gemini-pro",
+    "name": "Google Gemini Pro Latest",
+    "family": "gemini-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-27",
+    "last_updated": "2026-04-27",
+    "modalities": {
+      "input": [
+        "audio",
+        "pdf",
+        "image",
+        "text",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 12.0,
+      "cache_read": 0.2,
+      "cache_write": 0.375
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/~moonshotai/kimi",
+    "name": "MoonshotAI Kimi Latest",
+    "family": "kimi",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-27",
+    "last_updated": "2026-04-27",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.73,
+      "output": 3.49,
+      "cache_read": 0.25
+    },
+    "limit": {
+      "context": 262142,
+      "output": 262142
+    }
+  },
+  {
+    "id": "openrouter/~openai/gpt",
+    "name": "OpenAI GPT Latest",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-12-01",
+    "release_date": "2026-04-27",
+    "last_updated": "2026-04-27",
+    "modalities": {
+      "input": [
+        "pdf",
+        "image",
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/~openai/gpt-mini",
+    "name": "OpenAI GPT Mini Latest",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-04-27",
+    "last_updated": "2026-04-27",
+    "modalities": {
+      "input": [
+        "pdf",
+        "image",
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 4.5,
+      "cache_read": 0.075
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "orcarouter/anthropic/claude-haiku-4.5",
+    "name": "Claude Haiku 4.5 (latest)",
+    "family": "claude-haiku",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-02-28",
+    "release_date": "2025-10-15",
+    "last_updated": "2025-10-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 5.0,
+      "cache_read": 0.1,
+      "cache_write": 1.25
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "orcarouter/anthropic/claude-opus-4",
+    "name": "Claude Opus 4 (latest)",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-05-22",
+    "last_updated": "2025-05-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 15.0,
+      "output": 75.0,
+      "cache_read": 1.5,
+      "cache_write": 18.75
+    },
+    "limit": {
+      "context": 200000,
+      "output": 32000
+    }
+  },
+  {
+    "id": "orcarouter/anthropic/claude-opus-4.1",
+    "name": "Claude Opus 4.1 (latest)",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-08-05",
+    "last_updated": "2025-08-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 15.0,
+      "output": 75.0,
+      "cache_read": 1.5,
+      "cache_write": 18.75
+    },
+    "limit": {
+      "context": 200000,
+      "output": 32000
+    }
+  },
+  {
+    "id": "orcarouter/anthropic/claude-opus-4.5",
+    "name": "Claude Opus 4.5 (latest)",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-11-24",
+    "last_updated": "2025-11-24",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "orcarouter/anthropic/claude-opus-4.6",
+    "name": "Claude Opus 4.6",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05-31",
+    "release_date": "2026-02-05",
+    "last_updated": "2026-03-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "orcarouter/anthropic/claude-opus-4.7",
+    "name": "Claude Opus 4.7",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-04-16",
+    "last_updated": "2026-04-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "orcarouter/anthropic/claude-sonnet-4",
+    "name": "Claude Sonnet 4 (latest)",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-05-22",
+    "last_updated": "2025-05-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "orcarouter/anthropic/claude-sonnet-4.5",
+    "name": "Claude Sonnet 4.5 (latest)",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-07-31",
+    "release_date": "2025-09-29",
+    "last_updated": "2025-09-29",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "orcarouter/anthropic/claude-sonnet-4.6",
+    "name": "Claude Sonnet 4.6",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-02-17",
+    "last_updated": "2026-03-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "orcarouter/deepseek/deepseek-chat",
+    "name": "DeepSeek Chat",
+    "family": "deepseek",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-09",
+    "release_date": "2025-12-01",
+    "last_updated": "2026-02-28",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.028
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "orcarouter/deepseek/deepseek-reasoner",
+    "name": "DeepSeek Reasoner",
+    "family": "deepseek-thinking",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-09",
+    "release_date": "2025-12-01",
+    "last_updated": "2026-02-28",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.435,
+      "output": 0.87,
+      "cache_read": 0.028
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "orcarouter/deepseek/deepseek-v4-flash",
+    "name": "DeepSeek V4 Flash",
+    "family": "deepseek-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.19,
+      "output": 0.37,
+      "cache_read": 0.028
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "orcarouter/deepseek/deepseek-v4-pro",
+    "name": "DeepSeek V4 Pro",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.56,
+      "output": 1.12,
+      "cache_read": 0.145
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "orcarouter/google/gemini-2.5-flash",
+    "name": "Gemini 2.5 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-03-20",
+    "last_updated": "2025-06-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 2.5,
+      "cache_read": 0.03
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "orcarouter/google/gemini-2.5-flash-lite",
+    "name": "Gemini 2.5 Flash Lite",
+    "family": "gemini-flash-lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-06-17",
+    "last_updated": "2025-06-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.4,
+      "cache_read": 0.01
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "orcarouter/google/gemini-2.5-pro",
+    "name": "Gemini 2.5 Pro",
+    "family": "gemini-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-03-20",
+    "last_updated": "2025-06-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 15.0,
+      "cache_read": 0.125
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "orcarouter/google/gemini-3-flash-preview",
+    "name": "Gemini 3 Flash Preview",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-12-17",
+    "last_updated": "2025-12-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.5,
+      "output": 3.0,
+      "cache_read": 0.05
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "orcarouter/google/gemini-3-pro-preview",
+    "name": "Gemini 3 Pro Preview",
+    "family": "gemini-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-11-18",
+    "last_updated": "2025-11-18",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 4.0,
+      "output": 18.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "orcarouter/google/gemini-3.1-flash-lite-preview",
+    "name": "Gemini 3.1 Flash Lite Preview",
+    "family": "gemini-flash-lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-03-03",
+    "last_updated": "2026-03-03",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 1.5,
+      "cache_read": 0.025
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "orcarouter/google/gemini-3.1-pro-preview",
+    "name": "Gemini 3.1 Pro Preview",
+    "family": "gemini-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-02-19",
+    "last_updated": "2026-02-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 4.0,
+      "output": 18.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "orcarouter/google/gemini-3.1-pro-preview-customtools",
+    "name": "Gemini 3.1 Pro Preview Custom Tools",
+    "family": "gemini-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-02-19",
+    "last_updated": "2026-02-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 4.0,
+      "output": 18.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "orcarouter/google/gemini-flash",
+    "name": "Gemini Flash Latest",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-09-25",
+    "last_updated": "2025-09-25",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.5,
+      "output": 3.0,
+      "cache_read": 0.075
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "orcarouter/google/gemini-flash-lite",
+    "name": "Gemini Flash-Lite Latest",
+    "family": "gemini-flash-lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-09-25",
+    "last_updated": "2025-09-25",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 1.5,
+      "cache_read": 0.025
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "orcarouter/google/gemma-4-26b-a4b-it",
+    "name": "Gemma 4 26B",
+    "family": "gemma",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.06,
+      "output": 0.33
+    },
+    "limit": {
+      "context": 256000,
+      "output": 8192
+    }
+  },
+  {
+    "id": "orcarouter/google/gemma-4-31b-it",
+    "name": "Gemma 4 31B",
+    "family": "gemma",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.13,
+      "output": 0.38
+    },
+    "limit": {
+      "context": 256000,
+      "output": 8192
+    }
+  },
+  {
+    "id": "orcarouter/grok/grok-4.3",
     "name": "Grok 4.3",
     "family": "grok",
     "attachment": true,
@@ -94025,292 +102674,20 @@
     },
     "limit": {
       "context": 1000000,
-      "output": 1000000
+      "output": 30000
     }
   },
   {
-    "id": "openrouter/x-ai/grok-code-fast-1",
-    "name": "Grok Code Fast 1",
-    "family": "grok",
+    "id": "orcarouter/kimi/kimi-k2.5",
+    "name": "Kimi K2.5",
+    "family": "kimi-k2.5",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-08",
-    "release_date": "2025-08-26",
-    "last_updated": "2025-08-26",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 1.5,
-      "cache_read": 0.02
-    },
-    "limit": {
-      "context": 256000,
-      "output": 10000
-    }
-  },
-  {
-    "id": "openrouter/xiaomi/mimo-v2-flash",
-    "name": "MiMo-V2-Flash",
-    "family": "mimo",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-12",
-    "release_date": "2025-12-14",
-    "last_updated": "2025-12-14",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.1,
-      "output": 0.3,
-      "cache_read": 0.01
-    },
-    "limit": {
-      "context": 262144,
-      "output": 65536
-    }
-  },
-  {
-    "id": "openrouter/xiaomi/mimo-v2-omni",
-    "name": "MiMo-V2-Omni",
-    "family": "mimo",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-03-18",
-    "last_updated": "2026-03-18",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video",
-        "audio"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.4,
-      "output": 2.0,
-      "cache_read": 0.08
-    },
-    "limit": {
-      "context": 262144,
-      "output": 65536
-    }
-  },
-  {
-    "id": "openrouter/xiaomi/mimo-v2-pro",
-    "name": "MiMo-V2-Pro",
-    "family": "mimo",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-03-18",
-    "last_updated": "2026-03-18",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 1.0,
-      "output": 3.0,
-      "cache_read": 0.2
-    },
-    "limit": {
-      "context": 1048576,
-      "output": 65536
-    }
-  },
-  {
-    "id": "openrouter/xiaomi/mimo-v2.5",
-    "name": "MiMo-V2.5",
-    "family": "mimo",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-12",
-    "release_date": "2026-04-22",
-    "last_updated": "2026-04-22",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.4,
-      "output": 2.0,
-      "cache_read": 0.08
-    },
-    "limit": {
-      "context": 1048576,
-      "output": 131072
-    }
-  },
-  {
-    "id": "openrouter/xiaomi/mimo-v2.5-pro",
-    "name": "MiMo-V2.5-Pro",
-    "family": "mimo",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-12",
-    "release_date": "2026-04-22",
-    "last_updated": "2026-04-22",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.0,
-      "output": 3.0,
-      "cache_read": 0.2
-    },
-    "limit": {
-      "context": 1048576,
-      "output": 131072
-    }
-  },
-  {
-    "id": "openrouter/z-ai/glm-4.5",
-    "name": "GLM 4.5",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-04",
-    "release_date": "2025-07-28",
-    "last_updated": "2025-07-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.6,
-      "output": 2.2
-    },
-    "limit": {
-      "context": 128000,
-      "output": 96000
-    }
-  },
-  {
-    "id": "openrouter/z-ai/glm-4.5-air",
-    "name": "GLM 4.5 Air",
-    "family": "glm-air",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-04",
-    "release_date": "2025-07-28",
-    "last_updated": "2025-07-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.2,
-      "output": 1.1
-    },
-    "limit": {
-      "context": 128000,
-      "output": 96000
-    }
-  },
-  {
-    "id": "openrouter/z-ai/glm-4.5-air:free",
-    "name": "GLM 4.5 Air (free)",
-    "family": "glm-air",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2025-04",
-    "release_date": "2025-07-28",
-    "last_updated": "2025-07-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 96000
-    }
-  },
-  {
-    "id": "openrouter/z-ai/glm-4.5v",
-    "name": "GLM 4.5V",
-    "family": "glm",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-04",
-    "release_date": "2025-08-11",
-    "last_updated": "2025-08-11",
+    "temperature": false,
+    "knowledge": "2025-01",
+    "release_date": "2026-01",
+    "last_updated": "2026-01",
     "modalities": {
       "input": [
         "text",
@@ -94324,22 +102701,1474 @@
     "open_weights": true,
     "cost": {
       "input": 0.6,
-      "output": 1.8
+      "output": 3.0,
+      "cache_read": 0.1
     },
     "limit": {
-      "context": 64000,
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "orcarouter/kimi/kimi-k2.6",
+    "name": "Kimi K2.6",
+    "family": "kimi-k2.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.95,
+      "output": 4.0,
+      "cache_read": 0.16
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "orcarouter/minimax/minimax-m2.5",
+    "name": "MiniMax-M2.5",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-12",
+    "last_updated": "2026-02-12",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.03,
+      "cache_write": 0.375
+    },
+    "limit": {
+      "context": 204800,
+      "output": 131072
+    }
+  },
+  {
+    "id": "orcarouter/minimax/minimax-m2.5-highspeed",
+    "name": "MiniMax-M2.5-highspeed",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-13",
+    "last_updated": "2026-02-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.6,
+      "output": 2.4,
+      "cache_read": 0.06,
+      "cache_write": 0.375
+    },
+    "limit": {
+      "context": 204800,
+      "output": 131072
+    }
+  },
+  {
+    "id": "orcarouter/minimax/minimax-m2.7",
+    "name": "MiniMax-M2.7",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.06,
+      "cache_write": 0.375
+    },
+    "limit": {
+      "context": 204800,
+      "output": 131072
+    }
+  },
+  {
+    "id": "orcarouter/minimax/minimax-m2.7-highspeed",
+    "name": "MiniMax-M2.7-highspeed",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.6,
+      "output": 2.4,
+      "cache_read": 0.06,
+      "cache_write": 0.375
+    },
+    "limit": {
+      "context": 204800,
+      "output": 131072
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-3.5-turbo",
+    "name": "GPT-3.5-turbo",
+    "family": "gpt",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2021-09-01",
+    "release_date": "2023-03-01",
+    "last_updated": "2023-11-06",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.5,
+      "output": 1.5,
+      "cache_read": 1.25
+    },
+    "limit": {
+      "context": 16385,
+      "output": 4096
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-4",
+    "name": "GPT-4",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-11",
+    "release_date": "2023-11-06",
+    "last_updated": "2024-04-09",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 30.0,
+      "output": 60.0
+    },
+    "limit": {
+      "context": 8192,
+      "output": 8192
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-4-turbo",
+    "name": "GPT-4 Turbo",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-12",
+    "release_date": "2023-11-06",
+    "last_updated": "2024-04-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 30.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 4096
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-4.1",
+    "name": "GPT-4.1",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-04",
+    "release_date": "2025-04-14",
+    "last_updated": "2025-04-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 8.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 1047576,
+      "output": 32768
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-4.1-mini",
+    "name": "GPT-4.1 mini",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-04",
+    "release_date": "2025-04-14",
+    "last_updated": "2025-04-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.4,
+      "output": 1.6,
+      "cache_read": 0.1
+    },
+    "limit": {
+      "context": 1047576,
+      "output": 32768
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-4.1-nano",
+    "name": "GPT-4.1 nano",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-04",
+    "release_date": "2025-04-14",
+    "last_updated": "2025-04-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.4,
+      "cache_read": 0.03
+    },
+    "limit": {
+      "context": 1047576,
+      "output": 32768
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-4o",
+    "name": "GPT-4o (2024-08-06)",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-09",
+    "release_date": "2024-08-06",
+    "last_updated": "2024-08-06",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 10.0,
+      "cache_read": 1.25
+    },
+    "limit": {
+      "context": 128000,
       "output": 16384
     }
   },
   {
-    "id": "openrouter/z-ai/glm-4.6",
-    "name": "GLM 4.6",
+    "id": "orcarouter/openai/gpt-4o-mini",
+    "name": "GPT-4o mini",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-09",
+    "release_date": "2024-07-18",
+    "last_updated": "2024-07-18",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.6,
+      "cache_read": 0.08
+    },
+    "limit": {
+      "context": 128000,
+      "output": 16384
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5",
+    "name": "GPT-5",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-09-30",
+    "release_date": "2025-08-07",
+    "last_updated": "2025-08-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5-chat",
+    "name": "GPT-5 Chat (latest)",
+    "family": "gpt-codex",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2024-09-30",
+    "release_date": "2025-08-07",
+    "last_updated": "2025-08-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 10.0
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5-codex",
+    "name": "GPT-5-Codex",
+    "family": "gpt-codex",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-09-30",
+    "release_date": "2025-09-15",
+    "last_updated": "2025-09-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5-mini",
+    "name": "GPT-5 Mini",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-05-30",
+    "release_date": "2025-08-07",
+    "last_updated": "2025-08-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 2.0,
+      "cache_read": 0.025
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5-nano",
+    "name": "GPT-5 Nano",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-05-30",
+    "release_date": "2025-08-07",
+    "last_updated": "2025-08-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.05,
+      "output": 0.4,
+      "cache_read": 0.005
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5-pro",
+    "name": "GPT-5 Pro",
+    "family": "gpt-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-09-30",
+    "release_date": "2025-10-06",
+    "last_updated": "2025-10-06",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 15.0,
+      "output": 120.0
+    },
+    "limit": {
+      "context": 400000,
+      "output": 272000
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5.1",
+    "name": "GPT-5.1",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-09-30",
+    "release_date": "2025-11-13",
+    "last_updated": "2025-11-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.13
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5.1-chat",
+    "name": "GPT-5.1 Chat",
+    "family": "gpt-codex",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-09-30",
+    "release_date": "2025-11-13",
+    "last_updated": "2025-11-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125
+    },
+    "limit": {
+      "context": 128000,
+      "output": 16384
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5.1-codex",
+    "name": "GPT-5.1 Codex",
+    "family": "gpt-codex",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-09-30",
+    "release_date": "2025-11-13",
+    "last_updated": "2025-11-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5.1-codex-max",
+    "name": "GPT-5.1 Codex Max",
+    "family": "gpt-codex",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-09-30",
+    "release_date": "2025-11-13",
+    "last_updated": "2025-11-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5.1-codex-mini",
+    "name": "GPT-5.1 Codex mini",
+    "family": "gpt-codex",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-09-30",
+    "release_date": "2025-11-13",
+    "last_updated": "2025-11-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 2.0,
+      "cache_read": 0.025
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5.2",
+    "name": "GPT-5.2",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2025-12-11",
+    "last_updated": "2025-12-11",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.75,
+      "output": 14.0,
+      "cache_read": 0.175
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5.2-chat",
+    "name": "GPT-5.2 Chat",
+    "family": "gpt-codex",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2025-12-11",
+    "last_updated": "2025-12-11",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.75,
+      "output": 14.0,
+      "cache_read": 0.175
+    },
+    "limit": {
+      "context": 128000,
+      "output": 16384
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5.2-codex",
+    "name": "GPT-5.2 Codex",
+    "family": "gpt-codex",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2025-12-11",
+    "last_updated": "2025-12-11",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.75,
+      "output": 14.0,
+      "cache_read": 0.175
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5.2-pro",
+    "name": "GPT-5.2 Pro",
+    "family": "gpt-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2025-12-11",
+    "last_updated": "2025-12-11",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 21.0,
+      "output": 168.0
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5.3-chat",
+    "name": "GPT-5.3 Chat (latest)",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-03",
+    "last_updated": "2026-03-03",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.75,
+      "output": 14.0,
+      "cache_read": 0.175
+    },
+    "limit": {
+      "context": 128000,
+      "output": 16384
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5.3-codex",
+    "name": "GPT-5.3 Codex",
+    "family": "gpt-codex",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-02-05",
+    "last_updated": "2026-02-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.75,
+      "output": 14.0,
+      "cache_read": 0.175
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5.4",
+    "name": "GPT-5.4",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-05",
+    "last_updated": "2026-03-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 22.5,
+      "cache_read": 0.25
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5.4-mini",
+    "name": "GPT-5.4 mini",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 4.5,
+      "cache_read": 0.075
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5.4-nano",
+    "name": "GPT-5.4 nano",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.2,
+      "output": 1.25,
+      "cache_read": 0.02
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5.4-pro",
+    "name": "GPT-5.4 Pro",
+    "family": "gpt-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-05",
+    "last_updated": "2026-03-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 60.0,
+      "output": 270.0
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5.5",
+    "name": "GPT-5.5",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-12-01",
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "orcarouter/openai/gpt-5.5-pro",
+    "name": "GPT-5.5 Pro",
+    "family": "gpt-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-12-01",
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 30.0,
+      "output": 180.0
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "orcarouter/orcarouter/auto",
+    "name": "OrcaRouter Auto",
+    "family": "auto",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-01-01",
+    "last_updated": "2026-05-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 16384
+    }
+  },
+  {
+    "id": "orcarouter/qwen/qwen3-max",
+    "name": "Qwen3 Max",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2025-09-23",
+    "last_updated": "2025-09-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.359,
+      "output": 1.434
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "orcarouter/qwen/qwen3.5-122b-a10b",
+    "name": "Qwen3.5 122B-A10B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-23",
+    "last_updated": "2026-02-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.115,
+      "output": 0.917
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "orcarouter/qwen/qwen3.5-27b",
+    "name": "Qwen3.5 27B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-23",
+    "last_updated": "2026-02-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.086,
+      "output": 0.688
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "orcarouter/qwen/qwen3.5-35b-a3b",
+    "name": "Qwen3.5 35B-A3B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-23",
+    "last_updated": "2026-02-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.057,
+      "output": 0.459
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "orcarouter/qwen/qwen3.5-397b-a17b",
+    "name": "Qwen3.5 397B-A17B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-15",
+    "last_updated": "2026-02-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.172,
+      "output": 1.032
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "orcarouter/qwen/qwen3.5-plus",
+    "name": "Qwen3.5 Plus",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-02-16",
+    "last_updated": "2026-02-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.115,
+      "output": 0.688
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "orcarouter/qwen/qwen3.6-35b-a3b",
+    "name": "Qwen3.6 35B-A3B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-17",
+    "last_updated": "2026-04-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.248,
+      "output": 1.485
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "orcarouter/qwen/qwen3.6-plus",
+    "name": "Qwen3.6 Plus",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.5,
+      "output": 3.0,
+      "cache_read": 0.05,
+      "cache_write": 0.625
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "orcarouter/z-ai/glm-4.5",
+    "name": "GLM-4.5",
     "family": "glm",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-09",
+    "knowledge": "2025-04",
+    "release_date": "2025-07-28",
+    "last_updated": "2025-07-28",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.6,
+      "output": 2.2,
+      "cache_read": 0.11,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 131072,
+      "output": 98304
+    }
+  },
+  {
+    "id": "orcarouter/z-ai/glm-4.5-air",
+    "name": "GLM-4.5-Air",
+    "family": "glm-air",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2025-07-28",
+    "last_updated": "2025-07-28",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.2,
+      "output": 1.1,
+      "cache_read": 0.03,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 131072,
+      "output": 98304
+    }
+  },
+  {
+    "id": "orcarouter/z-ai/glm-4.6",
+    "name": "GLM-4.6",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
     "release_date": "2025-09-30",
     "last_updated": "2025-09-30",
     "modalities": {
@@ -94354,45 +104183,16 @@
     "cost": {
       "input": 0.6,
       "output": 2.2,
-      "cache_read": 0.11
+      "cache_read": 0.11,
+      "cache_write": 0.0
     },
     "limit": {
-      "context": 200000,
-      "output": 128000
+      "context": 204800,
+      "output": 131072
     }
   },
   {
-    "id": "openrouter/z-ai/glm-4.6:exacto",
-    "name": "GLM 4.6 (exacto)",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-09",
-    "release_date": "2025-09-30",
-    "last_updated": "2025-09-30",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.6,
-      "output": 1.9,
-      "cache_read": 0.11
-    },
-    "limit": {
-      "context": 200000,
-      "output": 128000
-    }
-  },
-  {
-    "id": "openrouter/z-ai/glm-4.7",
+    "id": "orcarouter/z-ai/glm-4.7",
     "name": "GLM-4.7",
     "family": "glm",
     "attachment": false,
@@ -94414,7 +104214,8 @@
     "cost": {
       "input": 0.6,
       "output": 2.2,
-      "cache_read": 0.11
+      "cache_read": 0.11,
+      "cache_write": 0.0
     },
     "limit": {
       "context": 204800,
@@ -94422,43 +104223,15 @@
     }
   },
   {
-    "id": "openrouter/z-ai/glm-4.7-flash",
-    "name": "GLM-4.7-Flash",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-01-19",
-    "last_updated": "2026-01-19",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.07,
-      "output": 0.4
-    },
-    "limit": {
-      "context": 200000,
-      "output": 65535
-    }
-  },
-  {
-    "id": "openrouter/z-ai/glm-5",
+    "id": "orcarouter/z-ai/glm-5",
     "name": "GLM-5",
     "family": "glm",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-02-12",
-    "last_updated": "2026-02-12",
+    "release_date": "2026-02-11",
+    "last_updated": "2026-02-11",
     "modalities": {
       "input": [
         "text"
@@ -94471,23 +104244,24 @@
     "cost": {
       "input": 1.0,
       "output": 3.2,
-      "cache_read": 0.2
+      "cache_read": 0.2,
+      "cache_write": 0.0
     },
     "limit": {
-      "context": 202752,
-      "output": 131000
+      "context": 204800,
+      "output": 131072
     }
   },
   {
-    "id": "openrouter/z-ai/glm-5-turbo",
-    "name": "GLM-5-Turbo",
+    "id": "orcarouter/z-ai/glm-5.1",
+    "name": "GLM-5.1",
     "family": "glm",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-03-16",
-    "last_updated": "2026-03-16",
+    "release_date": "2026-03-27",
+    "last_updated": "2026-03-27",
     "modalities": {
       "input": [
         "text"
@@ -94498,42 +104272,13 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.96,
-      "output": 3.2,
-      "cache_read": 0.192,
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26,
       "cache_write": 0.0
     },
     "limit": {
-      "context": 202752,
-      "output": 131072
-    }
-  },
-  {
-    "id": "openrouter/z-ai/glm-5.1",
-    "name": "GLM-5.1",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-04-07",
-    "last_updated": "2026-04-07",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 1.4,
-      "output": 4.4,
-      "cache_read": 0.26
-    },
-    "limit": {
-      "context": 202752,
+      "context": 200000,
       "output": 131072
     }
   },
@@ -96173,6 +105918,58 @@
     }
   },
   {
+    "id": "poe/empiriolabs/deepseek-v4-flash-el",
+    "name": "DeepSeek-V4-Flash-EL",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-04-24",
+    "last_updated": "2026-05-02",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.14,
+      "output": 0.28
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "poe/empiriolabs/deepseek-v4-pro-el",
+    "name": "DeepSeek-V4-Pro-EL",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-04-24",
+    "last_updated": "2026-05-02",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.67,
+      "output": 3.33
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
     "id": "poe/fireworks-ai/kimi-k2.5-fw",
     "name": "Kimi-K2.5-FW",
     "attachment": true,
@@ -97233,6 +107030,37 @@
     },
     "limit": {
       "context": 128000,
+      "output": 262144
+    }
+  },
+  {
+    "id": "poe/novita/kimi-k2.6",
+    "name": "Kimi-K2.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-04-20",
+    "last_updated": "2026-05-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.96,
+      "output": 4.04,
+      "cache_read": 0.16
+    },
+    "limit": {
+      "context": 262144,
       "output": 262144
     }
   },
@@ -100813,12 +110641,14 @@
   {
     "id": "qiniu-ai/mimo-v2-flash",
     "name": "Mimo-V2-Flash",
+    "family": "mimo",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-12-17",
-    "last_updated": "2025-12-17",
+    "knowledge": "2024-12-01",
+    "release_date": "2025-12-16",
+    "last_updated": "2026-02-04",
     "modalities": {
       "input": [
         "text"
@@ -100827,8 +110657,12 @@
         "text"
       ]
     },
-    "open_weights": false,
-    "cost": {},
+    "open_weights": true,
+    "cost": {
+      "input": 0.1,
+      "output": 0.3,
+      "cache_read": 0.01
+    },
     "limit": {
       "context": 256000,
       "output": 256000
@@ -101627,19 +111461,16 @@
   },
   {
     "id": "qiniu-ai/x-ai/grok-4.1-fast",
-    "name": "X-Ai/Grok 4.1 Fast Reasoning",
-    "attachment": true,
+    "name": "x-AI/Grok-4.1-Fast",
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-12-19",
-    "last_updated": "2025-12-19",
+    "release_date": "2025-11-20",
+    "last_updated": "2025-11-20",
     "modalities": {
       "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
+        "text"
       ],
       "output": [
         "text"
@@ -101648,7 +111479,7 @@
     "open_weights": false,
     "cost": {},
     "limit": {
-      "context": 20000000,
+      "context": 2000000,
       "output": 2000000
     }
   },
@@ -101706,12 +111537,14 @@
   {
     "id": "qiniu-ai/xiaomi/mimo-v2-flash",
     "name": "Xiaomi/Mimo-V2-Flash",
+    "family": "mimo",
     "attachment": false,
     "reasoning": true,
-    "tool_call": false,
+    "tool_call": true,
     "temperature": true,
-    "release_date": "2025-12-26",
-    "last_updated": "2025-12-26",
+    "knowledge": "2024-12-01",
+    "release_date": "2025-12-16",
+    "last_updated": "2026-02-04",
     "modalities": {
       "input": [
         "text"
@@ -101720,8 +111553,12 @@
         "text"
       ]
     },
-    "open_weights": false,
-    "cost": {},
+    "open_weights": true,
+    "cost": {
+      "input": 0.1,
+      "output": 0.3,
+      "cache_read": 0.01
+    },
     "limit": {
       "context": 256000,
       "output": 256000
@@ -103408,6 +113245,706 @@
     }
   },
   {
+    "id": "routing-run/route/deepseek-v3.2",
+    "name": "DeepSeek V3.2",
+    "family": "deepseek",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-07",
+    "release_date": "2025-12-01",
+    "last_updated": "2025-12-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.4928,
+      "output": 0.7392
+    },
+    "limit": {
+      "context": 163840,
+      "output": 163840
+    }
+  },
+  {
+    "id": "routing-run/route/deepseek-v4-flash",
+    "name": "DeepSeek V4 Flash",
+    "family": "deepseek-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.4928,
+      "output": 0.7392,
+      "cache_read": 0.028
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "routing-run/route/deepseek-v4-flash-6bit",
+    "name": "DeepSeek V4 Flash 6bit",
+    "family": "deepseek-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.4928,
+      "output": 0.7392,
+      "cache_read": 0.028
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "routing-run/route/deepseek-v4-pro",
+    "name": "DeepSeek V4 Pro",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.4928,
+      "output": 0.7392,
+      "cache_read": 0.145
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "routing-run/route/deepseek-v4-pro-6bit",
+    "name": "DeepSeek V4 Pro 6bit",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.4928,
+      "output": 0.7392,
+      "cache_read": 0.145
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "routing-run/route/gemma-4-31b-it",
+    "name": "Gemma 4 31B IT",
+    "family": "gemma",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.1,
+      "output": 0.3
+    },
+    "limit": {
+      "context": 131072,
+      "output": 65536
+    }
+  },
+  {
+    "id": "routing-run/route/glm-5.1",
+    "name": "GLM 5.1",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-27",
+    "last_updated": "2026-03-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 3.0,
+      "cache_read": 0.26,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 202752,
+      "output": 202752
+    }
+  },
+  {
+    "id": "routing-run/route/glm-5.1-6bit",
+    "name": "GLM 5.1 6bit",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-27",
+    "last_updated": "2026-03-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 3.0,
+      "cache_read": 0.26,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 202752,
+      "output": 202752
+    }
+  },
+  {
+    "id": "routing-run/route/kimi-k2.5",
+    "name": "Kimi K2.5",
+    "family": "kimi-k2.5",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-01",
+    "release_date": "2026-01",
+    "last_updated": "2026-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.462,
+      "output": 2.42,
+      "cache_read": 0.1
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    }
+  },
+  {
+    "id": "routing-run/route/kimi-k2.6",
+    "name": "Kimi K2.6",
+    "family": "kimi-k2.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.462,
+      "output": 2.42,
+      "cache_read": 0.16
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "routing-run/route/kimi-k2.6-6bit",
+    "name": "Kimi K2.6 6bit",
+    "family": "kimi-k2.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.462,
+      "output": 2.42,
+      "cache_read": 0.16
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "routing-run/route/mimo-v2.5-pro",
+    "name": "MiMo V2.5 Pro",
+    "family": "mimo",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.45,
+      "output": 1.35,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 262144
+    }
+  },
+  {
+    "id": "routing-run/route/mimo-v2.5-pro-6bit",
+    "name": "MiMo V2.5 Pro 6bit",
+    "family": "mimo",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.45,
+      "output": 1.35,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 262144
+    }
+  },
+  {
+    "id": "routing-run/route/minimax-m2.5",
+    "name": "MiniMax M2.5",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-12",
+    "last_updated": "2026-02-12",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.193,
+      "output": 1.238,
+      "cache_read": 0.03,
+      "cache_write": 0.375
+    },
+    "limit": {
+      "context": 100000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "routing-run/route/minimax-m2.5-highspeed",
+    "name": "MiniMax M2.5 Highspeed",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-13",
+    "last_updated": "2026-02-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.193,
+      "output": 1.238,
+      "cache_read": 0.06,
+      "cache_write": 0.375
+    },
+    "limit": {
+      "context": 100000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "routing-run/route/minimax-m2.7",
+    "name": "MiniMax M2.7",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.33,
+      "output": 1.32,
+      "cache_read": 0.06,
+      "cache_write": 0.375
+    },
+    "limit": {
+      "context": 100000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "routing-run/route/minimax-m2.7-highspeed",
+    "name": "MiniMax M2.7 Highspeed",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.33,
+      "output": 1.32,
+      "cache_read": 0.06,
+      "cache_write": 0.375
+    },
+    "limit": {
+      "context": 100000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "routing-run/route/mistral-large-3",
+    "name": "Mistral Large 3",
+    "family": "mistral-large",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-11",
+    "release_date": "2024-11-01",
+    "last_updated": "2025-12-02",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.5,
+      "output": 1.5
+    },
+    "limit": {
+      "context": 128000,
+      "output": 32768
+    }
+  },
+  {
+    "id": "routing-run/route/mistral-medium",
+    "name": "Mistral Medium 2505",
+    "family": "mistral-medium",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2025-05-07",
+    "last_updated": "2025-05-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.4,
+      "output": 2.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 32768
+    }
+  },
+  {
+    "id": "routing-run/route/mistral-small",
+    "name": "Mistral Small 2503",
+    "family": "mistral-small",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-06",
+    "release_date": "2026-03-16",
+    "last_updated": "2026-03-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.15,
+      "output": 0.6
+    },
+    "limit": {
+      "context": 128000,
+      "output": 32768
+    }
+  },
+  {
+    "id": "routing-run/route/qwen3.6-27b",
+    "name": "Qwen3.6 27B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.1,
+      "output": 3.3
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "routing-run/route/step-3.5-flash",
+    "name": "Step 3.5 Flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-01-29",
+    "last_updated": "2026-02-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.096,
+      "output": 0.288,
+      "cache_read": 0.019
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "routing-run/route/stepfun-3.5-flash",
+    "name": "StepFun 3.5 Flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-01-29",
+    "last_updated": "2026-02-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.096,
+      "output": 0.288,
+      "cache_read": 0.019
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
     "id": "sap-ai-core/anthropic--claude-3-haiku",
     "name": "anthropic--claude-3-haiku",
     "family": "claude-haiku",
@@ -103804,6 +114341,39 @@
     }
   },
   {
+    "id": "sap-ai-core/anthropic--claude-4.7-opus",
+    "name": "anthropic--claude-4.7-opus",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-04-16",
+    "last_updated": "2026-04-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "sap-ai-core/gemini-2.5-flash",
     "name": "gemini-2.5-flash",
     "family": "gemini-flash",
@@ -103812,7 +114382,7 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-01",
-    "release_date": "2025-03-25",
+    "release_date": "2025-04-17",
     "last_updated": "2025-06-05",
     "modalities": {
       "input": [
@@ -103864,7 +114434,7 @@
     "cost": {
       "input": 0.1,
       "output": 0.4,
-      "cache_read": 0.025
+      "cache_read": 0.01
     },
     "limit": {
       "context": 1048576,
@@ -103919,7 +114489,8 @@
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -103950,7 +114521,8 @@
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -104061,6 +114633,38 @@
     }
   },
   {
+    "id": "sap-ai-core/gpt-5.4",
+    "name": "gpt-5.4",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-04-27",
+    "last_updated": "2026-04-27",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 15.0,
+      "cache_read": 0.25
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
     "id": "sap-ai-core/sonar",
     "name": "sonar",
     "family": "sonar",
@@ -104146,6 +114750,56 @@
     "limit": {
       "context": 200000,
       "output": 8192
+    }
+  },
+  {
+    "id": "sarvam/sarvam-105b",
+    "name": "Sarvam-105B",
+    "family": "sarvam",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-18",
+    "last_updated": "2026-03-06",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {},
+    "limit": {
+      "context": 131072,
+      "output": 131072
+    }
+  },
+  {
+    "id": "sarvam/sarvam-30b",
+    "name": "Sarvam-30B",
+    "family": "sarvam",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-18",
+    "last_updated": "2026-03-06",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {},
+    "limit": {
+      "context": 65536,
+      "output": 65536
     }
   },
   {
@@ -108307,6 +118961,66 @@
     }
   },
   {
+    "id": "siliconflow/deepseek-ai/deepseek-v4-flash",
+    "name": "DeepSeek V4 Flash",
+    "family": "deepseek-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.028
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "siliconflow/deepseek-ai/deepseek-v4-pro",
+    "name": "DeepSeek V4 Pro",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.74,
+      "output": 3.48,
+      "cache_read": 0.145
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
     "id": "siliconflow/deepseek-ai/deepseek-vl2",
     "name": "deepseek-ai/deepseek-vl2",
     "family": "deepseek",
@@ -111327,6 +122041,162 @@
     }
   },
   {
+    "id": "umans-ai-coding-plan/umans-coder",
+    "name": "Umans Coder",
+    "family": "kimi-k2.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-01",
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "umans-ai-coding-plan/umans-flash",
+    "name": "Umans Flash",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-04-17",
+    "last_updated": "2026-04-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "umans-ai-coding-plan/umans-glm-5.1",
+    "name": "GLM 5.1",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-27",
+    "last_updated": "2026-03-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 204800,
+      "output": 131072
+    }
+  },
+  {
+    "id": "umans-ai-coding-plan/umans-kimi-k2.6",
+    "name": "Kimi K2.6",
+    "family": "kimi-k2.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-01",
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "umans-ai-coding-plan/umans-qwen3.6-35b-a3b",
+    "name": "Qwen3.6 35B A3B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-04-17",
+    "last_updated": "2026-04-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
     "id": "upstage/solar-mini",
     "name": "solar-mini",
     "family": "solar-mini",
@@ -111685,6 +122555,37 @@
     }
   },
   {
+    "id": "venice/claude-opus-4.7-fast",
+    "name": "Claude Opus 4.7 Fast",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-05-14",
+    "last_updated": "2026-05-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 36.0,
+      "output": 180.0,
+      "cache_read": 3.6,
+      "cache_write": 45.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "venice/claude-sonnet-4.5",
     "name": "Claude Sonnet 4.5",
     "family": "claude-sonnet",
@@ -112030,7 +122931,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-03-12",
-    "last_updated": "2026-04-19",
+    "last_updated": "2026-05-07",
     "modalities": {
       "input": [
         "text",
@@ -112042,8 +122943,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.27,
-      "output": 6.8,
+      "input": 1.42,
+      "output": 2.83,
       "cache_read": 0.23
     },
     "limit": {
@@ -112060,7 +122961,7 @@
     "tool_call": false,
     "temperature": true,
     "release_date": "2026-03-12",
-    "last_updated": "2026-04-19",
+    "last_updated": "2026-05-07",
     "modalities": {
       "input": [
         "text",
@@ -112072,8 +122973,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.27,
-      "output": 6.8,
+      "input": 1.42,
+      "output": 2.83,
       "cache_read": 0.23
     },
     "limit": {
@@ -112226,36 +123127,6 @@
       "input": 0.85,
       "output": 4.655,
       "cache_read": 0.22
-    },
-    "limit": {
-      "context": 256000,
-      "output": 65536
-    }
-  },
-  {
-    "id": "venice/kimi-k2-thinking",
-    "name": "Kimi K2 Thinking",
-    "family": "kimi-thinking",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-04",
-    "release_date": "2025-12-10",
-    "last_updated": "2026-03-12",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.75,
-      "output": 3.2,
-      "cache_read": 0.375
     },
     "limit": {
       "context": 256000,
@@ -112851,12 +123722,12 @@
     "name": "OpenAI GPT OSS 120B",
     "family": "gpt-oss",
     "attachment": false,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-07",
     "release_date": "2025-11-06",
-    "last_updated": "2026-03-12",
+    "last_updated": "2026-05-06",
     "modalities": {
       "input": [
         "text"
@@ -113086,35 +123957,6 @@
     }
   },
   {
-    "id": "venice/qwen3-coder-480b-a35b-instruct",
-    "name": "Qwen 3 Coder 480b",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
-    "release_date": "2025-04-29",
-    "last_updated": "2026-03-12",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.75,
-      "output": 3.0
-    },
-    "limit": {
-      "context": 256000,
-      "output": 65536
-    }
-  },
-  {
     "id": "venice/qwen3-coder-480b-a35b-instruct-turbo",
     "name": "Qwen 3 Coder 480B Turbo",
     "family": "qwen",
@@ -113199,35 +124041,6 @@
     "limit": {
       "context": 256000,
       "output": 16384
-    }
-  },
-  {
-    "id": "venice/venice-uncensored",
-    "name": "Venice Uncensored 1.1",
-    "family": "venice",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2023-10",
-    "release_date": "2025-03-18",
-    "last_updated": "2026-03-12",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.2,
-      "output": 0.9
-    },
-    "limit": {
-      "context": 32000,
-      "output": 8192
     }
   },
   {
@@ -115859,6 +126672,37 @@
     "limit": {
       "context": 131072,
       "output": 32768
+    }
+  },
+  {
+    "id": "vercel/google/gemini-3.1-flash-lite",
+    "name": "Gemini 3.1 Flash Lite",
+    "family": "gemini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-05-07",
+    "last_updated": "2026-05-08",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 1.5,
+      "cache_read": 0.03
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65000
     }
   },
   {
@@ -119134,18 +129978,19 @@
   },
   {
     "id": "vercel/perplexity/sonar",
-    "name": "Sonar Reasoning",
-    "family": "sonar-reasoning",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
+    "name": "Sonar",
+    "family": "sonar",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-09",
+    "knowledge": "2025-02",
     "release_date": "2025-02-19",
     "last_updated": "2025-02-19",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image"
       ],
       "output": [
         "text"
@@ -119154,7 +129999,7 @@
     "open_weights": false,
     "cost": {
       "input": 1.0,
-      "output": 5.0
+      "output": 1.0
     },
     "limit": {
       "context": 127000,
@@ -119660,156 +130505,6 @@
     }
   },
   {
-    "id": "vercel/xai/grok-3",
-    "name": "Grok 3",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-11",
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.75
-    },
-    "limit": {
-      "context": 131072,
-      "output": 8192
-    }
-  },
-  {
-    "id": "vercel/xai/grok-3-fast",
-    "name": "Grok 3 Fast",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-11",
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 5.0,
-      "output": 25.0,
-      "cache_read": 1.25
-    },
-    "limit": {
-      "context": 131072,
-      "output": 8192
-    }
-  },
-  {
-    "id": "vercel/xai/grok-3-mini",
-    "name": "Grok 3 Mini",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-11",
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.3,
-      "output": 0.5,
-      "cache_read": 0.075
-    },
-    "limit": {
-      "context": 131072,
-      "output": 8192
-    }
-  },
-  {
-    "id": "vercel/xai/grok-3-mini-fast",
-    "name": "Grok 3 Mini Fast",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-11",
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.6,
-      "output": 4.0,
-      "cache_read": 0.15
-    },
-    "limit": {
-      "context": 131072,
-      "output": 8192
-    }
-  },
-  {
-    "id": "vercel/xai/grok-4",
-    "name": "Grok 4",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
-    "release_date": "2025-07-09",
-    "last_updated": "2025-07-09",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.75
-    },
-    "limit": {
-      "context": 256000,
-      "output": 64000
-    }
-  },
-  {
     "id": "vercel/xai/grok-4-fast",
     "name": "Grok 4 Fast Reasoning",
     "family": "grok",
@@ -119837,37 +130532,6 @@
     "limit": {
       "context": 2000000,
       "output": 256000
-    }
-  },
-  {
-    "id": "vercel/xai/grok-4-fast-non",
-    "name": "Grok 4 Fast (Non-Reasoning)",
-    "family": "grok",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
-    "release_date": "2025-09-19",
-    "last_updated": "2025-09-19",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.5,
-      "cache_read": 0.05
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 30000
     }
   },
   {
@@ -120144,36 +130808,6 @@
     }
   },
   {
-    "id": "vercel/xai/grok-code-fast-1",
-    "name": "Grok Code Fast 1",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-10",
-    "release_date": "2025-08-28",
-    "last_updated": "2025-08-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 1.5,
-      "cache_read": 0.02
-    },
-    "limit": {
-      "context": 256000,
-      "output": 10000
-    }
-  },
-  {
     "id": "vercel/xai/grok-imagine-image",
     "name": "Grok Imagine Image",
     "family": "grok",
@@ -120297,7 +130931,8 @@
       "input": [
         "text",
         "image",
-        "pdf"
+        "audio",
+        "video"
       ],
       "output": [
         "text"
@@ -120326,9 +130961,7 @@
     "last_updated": "2026-05-01",
     "modalities": {
       "input": [
-        "text",
-        "image",
-        "pdf"
+        "text"
       ],
       "output": [
         "text"
@@ -121287,37 +131920,6 @@
     }
   },
   {
-    "id": "wafer.ai/DeepSeek-V4-Pro",
-    "name": "DeepSeek V4 Pro",
-    "family": "deepseek-thinking",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-05",
-    "release_date": "2026-04-24",
-    "last_updated": "2026-04-24",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0,
-      "cache_read": 0.0,
-      "cache_write": 0.0
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 384000
-    }
-  },
-  {
     "id": "wafer.ai/GLM-5.1",
     "name": "GLM-5.1",
     "family": "glm",
@@ -121928,7 +132530,7 @@
   },
   {
     "id": "x-ai/grok-2-vision",
-    "name": "Grok 2 Vision (1212)",
+    "name": "Grok 2 Vision",
     "family": "grok",
     "attachment": true,
     "reasoning": false,
@@ -121936,7 +132538,7 @@
     "temperature": true,
     "knowledge": "2024-08",
     "release_date": "2024-08-20",
-    "last_updated": "2024-12-12",
+    "last_updated": "2024-08-20",
     "modalities": {
       "input": [
         "text",
@@ -121955,280 +132557,6 @@
     "limit": {
       "context": 8192,
       "output": 4096
-    }
-  },
-  {
-    "id": "x-ai/grok-3",
-    "name": "Grok 3",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-11",
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.75
-    },
-    "limit": {
-      "context": 131072,
-      "output": 8192
-    }
-  },
-  {
-    "id": "x-ai/grok-3-fast",
-    "name": "Grok 3 Fast Latest",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-11",
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 5.0,
-      "output": 25.0,
-      "cache_read": 1.25
-    },
-    "limit": {
-      "context": 131072,
-      "output": 8192
-    }
-  },
-  {
-    "id": "x-ai/grok-3-mini",
-    "name": "Grok 3 Mini",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-11",
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.3,
-      "output": 0.5,
-      "cache_read": 0.075
-    },
-    "limit": {
-      "context": 131072,
-      "output": 8192
-    }
-  },
-  {
-    "id": "x-ai/grok-3-mini-fast",
-    "name": "Grok 3 Mini Fast Latest",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-11",
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.6,
-      "output": 4.0,
-      "cache_read": 0.15
-    },
-    "limit": {
-      "context": 131072,
-      "output": 8192
-    }
-  },
-  {
-    "id": "x-ai/grok-4",
-    "name": "Grok 4",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
-    "release_date": "2025-07-09",
-    "last_updated": "2025-07-09",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.75
-    },
-    "limit": {
-      "context": 256000,
-      "output": 64000
-    }
-  },
-  {
-    "id": "x-ai/grok-4-fast",
-    "name": "Grok 4 Fast",
-    "family": "grok",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
-    "release_date": "2025-09-19",
-    "last_updated": "2025-09-19",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.5,
-      "cache_read": 0.05
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 30000
-    }
-  },
-  {
-    "id": "x-ai/grok-4-fast-non",
-    "name": "Grok 4 Fast (Non-Reasoning)",
-    "family": "grok",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
-    "release_date": "2025-09-19",
-    "last_updated": "2025-09-19",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.5,
-      "cache_read": 0.05
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 30000
-    }
-  },
-  {
-    "id": "x-ai/grok-4.1-fast",
-    "name": "Grok 4.1 Fast",
-    "family": "grok",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
-    "release_date": "2025-11-19",
-    "last_updated": "2025-11-19",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.5,
-      "cache_read": 0.05
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 30000
-    }
-  },
-  {
-    "id": "x-ai/grok-4.1-fast-non",
-    "name": "Grok 4.1 Fast (Non-Reasoning)",
-    "family": "grok",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
-    "release_date": "2025-11-19",
-    "last_updated": "2025-11-19",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.5,
-      "cache_read": 0.05
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 30000
     }
   },
   {
@@ -122382,33 +132710,82 @@
     }
   },
   {
-    "id": "x-ai/grok-code-fast-1",
-    "name": "Grok Code Fast 1",
+    "id": "x-ai/grok-imagine-image",
+    "name": "Grok Imagine Image",
     "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-10",
-    "release_date": "2025-08-28",
-    "last_updated": "2025-08-28",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2026-03",
+    "last_updated": "2026-05-16",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image"
       ],
       "output": [
-        "text"
+        "image"
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 1.5,
-      "cache_read": 0.02
-    },
+    "cost": {},
     "limit": {
-      "context": 256000,
-      "output": 10000
+      "context": 1024,
+      "output": 0
+    }
+  },
+  {
+    "id": "x-ai/grok-imagine-image-quality",
+    "name": "Grok Imagine Image Quality",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2026-04",
+    "last_updated": "2026-05-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 1024,
+      "output": 0
+    }
+  },
+  {
+    "id": "x-ai/grok-imagine-video",
+    "name": "Grok Imagine Video",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2026-03",
+    "last_updated": "2026-05-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 1024,
+      "output": 0
     }
   },
   {
@@ -122443,6 +132820,36 @@
     }
   },
   {
+    "id": "xiaomi-token-plan-ams/mimo-v2-flash",
+    "name": "MiMo-V2-Flash",
+    "family": "mimo",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12-01",
+    "release_date": "2025-12-16",
+    "last_updated": "2026-02-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
     "id": "xiaomi-token-plan-ams/mimo-v2-omni",
     "name": "MiMo-V2-Omni",
     "family": "mimo",
@@ -122465,22 +132872,22 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
       "input": 0.0,
       "output": 0.0,
       "cache_read": 0.0
     },
     "limit": {
-      "context": 256000,
-      "output": 128000
+      "context": 262144,
+      "output": 131072
     }
   },
   {
     "id": "xiaomi-token-plan-ams/mimo-v2-pro",
     "name": "MiMo-V2-Pro",
     "family": "mimo",
-    "attachment": true,
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -122495,15 +132902,15 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
       "input": 0.0,
       "output": 0.0,
       "cache_read": 0.0
     },
     "limit": {
-      "context": 1000000,
-      "output": 128000
+      "context": 1048576,
+      "output": 131072
     }
   },
   {
@@ -122529,14 +132936,14 @@
       "output": 0.0
     },
     "limit": {
-      "context": 8000,
-      "output": 16000
+      "context": 8192,
+      "output": 16384
     }
   },
   {
     "id": "xiaomi-token-plan-ams/mimo-v2.5",
     "name": "MiMo-V2.5",
-    "family": "mimo-v2.5",
+    "family": "mimo",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
@@ -122549,8 +132956,7 @@
         "text",
         "image",
         "audio",
-        "video",
-        "pdf"
+        "video"
       ],
       "output": [
         "text"
@@ -122563,15 +132969,15 @@
       "cache_read": 0.0
     },
     "limit": {
-      "context": 1000000,
-      "output": 128000
+      "context": 1048576,
+      "output": 131072
     }
   },
   {
     "id": "xiaomi-token-plan-ams/mimo-v2.5-pro",
     "name": "MiMo-V2.5-Pro",
-    "family": "mimo-v2.5-pro",
-    "attachment": true,
+    "family": "mimo",
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -122593,8 +132999,38 @@
       "cache_read": 0.0
     },
     "limit": {
-      "context": 1000000,
-      "output": 128000
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "xiaomi-token-plan-cn/mimo-v2-flash",
+    "name": "MiMo-V2-Flash",
+    "family": "mimo",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12-01",
+    "release_date": "2025-12-16",
+    "last_updated": "2026-02-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
     }
   },
   {
@@ -122620,22 +133056,22 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
       "input": 0.0,
       "output": 0.0,
       "cache_read": 0.0
     },
     "limit": {
-      "context": 256000,
-      "output": 128000
+      "context": 262144,
+      "output": 131072
     }
   },
   {
     "id": "xiaomi-token-plan-cn/mimo-v2-pro",
     "name": "MiMo-V2-Pro",
     "family": "mimo",
-    "attachment": true,
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -122650,15 +133086,15 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
       "input": 0.0,
       "output": 0.0,
       "cache_read": 0.0
     },
     "limit": {
-      "context": 1000000,
-      "output": 128000
+      "context": 1048576,
+      "output": 131072
     }
   },
   {
@@ -122684,14 +133120,14 @@
       "output": 0.0
     },
     "limit": {
-      "context": 8000,
-      "output": 16000
+      "context": 8192,
+      "output": 16384
     }
   },
   {
     "id": "xiaomi-token-plan-cn/mimo-v2.5",
     "name": "MiMo-V2.5",
-    "family": "mimo-v2.5",
+    "family": "mimo",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
@@ -122704,8 +133140,7 @@
         "text",
         "image",
         "audio",
-        "video",
-        "pdf"
+        "video"
       ],
       "output": [
         "text"
@@ -122718,15 +133153,15 @@
       "cache_read": 0.0
     },
     "limit": {
-      "context": 1000000,
-      "output": 128000
+      "context": 1048576,
+      "output": 131072
     }
   },
   {
     "id": "xiaomi-token-plan-cn/mimo-v2.5-pro",
     "name": "MiMo-V2.5-Pro",
-    "family": "mimo-v2.5-pro",
-    "attachment": true,
+    "family": "mimo",
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -122748,8 +133183,38 @@
       "cache_read": 0.0
     },
     "limit": {
-      "context": 1000000,
-      "output": 128000
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "xiaomi-token-plan-sgp/mimo-v2-flash",
+    "name": "MiMo-V2-Flash",
+    "family": "mimo",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12-01",
+    "release_date": "2025-12-16",
+    "last_updated": "2026-02-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
     }
   },
   {
@@ -122775,22 +133240,22 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
       "input": 0.0,
       "output": 0.0,
       "cache_read": 0.0
     },
     "limit": {
-      "context": 256000,
-      "output": 128000
+      "context": 262144,
+      "output": 131072
     }
   },
   {
     "id": "xiaomi-token-plan-sgp/mimo-v2-pro",
     "name": "MiMo-V2-Pro",
     "family": "mimo",
-    "attachment": true,
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -122805,15 +133270,15 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
       "input": 0.0,
       "output": 0.0,
       "cache_read": 0.0
     },
     "limit": {
-      "context": 1000000,
-      "output": 128000
+      "context": 1048576,
+      "output": 131072
     }
   },
   {
@@ -122839,14 +133304,14 @@
       "output": 0.0
     },
     "limit": {
-      "context": 8000,
-      "output": 16000
+      "context": 8192,
+      "output": 16384
     }
   },
   {
     "id": "xiaomi-token-plan-sgp/mimo-v2.5",
     "name": "MiMo-V2.5",
-    "family": "mimo-v2.5",
+    "family": "mimo",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
@@ -122859,8 +133324,7 @@
         "text",
         "image",
         "audio",
-        "video",
-        "pdf"
+        "video"
       ],
       "output": [
         "text"
@@ -122873,15 +133337,15 @@
       "cache_read": 0.0
     },
     "limit": {
-      "context": 1000000,
-      "output": 128000
+      "context": 1048576,
+      "output": 131072
     }
   },
   {
     "id": "xiaomi-token-plan-sgp/mimo-v2.5-pro",
     "name": "MiMo-V2.5-Pro",
-    "family": "mimo-v2.5-pro",
-    "attachment": true,
+    "family": "mimo",
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -122903,8 +133367,8 @@
       "cache_read": 0.0
     },
     "limit": {
-      "context": 1000000,
-      "output": 128000
+      "context": 1048576,
+      "output": 131072
     }
   },
   {
@@ -122933,8 +133397,8 @@
       "cache_read": 0.01
     },
     "limit": {
-      "context": 256000,
-      "output": 64000
+      "context": 262144,
+      "output": 65536
     }
   },
   {
@@ -122960,22 +133424,22 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
       "input": 0.4,
       "output": 2.0,
       "cache_read": 0.08
     },
     "limit": {
-      "context": 256000,
-      "output": 128000
+      "context": 262144,
+      "output": 131072
     }
   },
   {
     "id": "xiaomi/mimo-v2-pro",
     "name": "MiMo-V2-Pro",
     "family": "mimo",
-    "attachment": true,
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -122990,15 +133454,15 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
       "input": 1.0,
       "output": 3.0,
       "cache_read": 0.2
     },
     "limit": {
-      "context": 1000000,
-      "output": 128000
+      "context": 1048576,
+      "output": 131072
     }
   },
   {
@@ -123014,13 +133478,16 @@
     "last_updated": "2026-04-22",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "audio",
+        "video"
       ],
       "output": [
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.4,
       "output": 2.0,
@@ -123035,7 +133502,7 @@
     "id": "xiaomi/mimo-v2.5-pro",
     "name": "MiMo-V2.5-Pro",
     "family": "mimo",
-    "attachment": true,
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -123044,17 +133511,13 @@
     "last_updated": "2026-04-22",
     "modalities": {
       "input": [
-        "text",
-        "image",
-        "audio",
-        "video",
-        "pdf"
+        "text"
       ],
       "output": [
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 1.0,
       "output": 3.0,
@@ -123063,6 +133526,35 @@
     "limit": {
       "context": 1048576,
       "output": 131072
+    }
+  },
+  {
+    "id": "xpersona/xpersona-frieren-coder",
+    "name": "Xpersona Frieren Coder",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-12-30",
+    "release_date": "2026-05-01",
+    "last_updated": "2026-05-15",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 6.0,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
     }
   },
   {
@@ -125974,13 +136466,14 @@
   {
     "id": "zenmux/xiaomi/mimo-v2-flash",
     "name": "MiMo-V2-Flash",
+    "family": "mimo",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-01-01",
-    "release_date": "2025-12-17",
-    "last_updated": "2025-12-17",
+    "knowledge": "2024-12-01",
+    "release_date": "2025-12-16",
+    "last_updated": "2026-02-04",
     "modalities": {
       "input": [
         "text"
@@ -125989,32 +136482,35 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.1,
       "output": 0.3,
       "cache_read": 0.01
     },
     "limit": {
-      "context": 262000,
-      "output": 64000
+      "context": 262144,
+      "output": 65536
     }
   },
   {
     "id": "zenmux/xiaomi/mimo-v2-omni",
     "name": "MiMo V2 Omni",
+    "family": "mimo",
     "attachment": true,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-01-01",
-    "release_date": "2026-03-20",
-    "last_updated": "2026-03-20",
+    "knowledge": "2024-12",
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
     "modalities": {
       "input": [
         "text",
         "image",
-        "video"
+        "audio",
+        "video",
+        "pdf"
       ],
       "output": [
         "text"
@@ -126023,7 +136519,8 @@
     "open_weights": false,
     "cost": {
       "input": 0.4,
-      "output": 2.0
+      "output": 2.0,
+      "cache_read": 0.08
     },
     "limit": {
       "context": 265000,
@@ -126033,18 +136530,17 @@
   {
     "id": "zenmux/xiaomi/mimo-v2-pro",
     "name": "MiMo V2 Pro",
-    "attachment": true,
+    "family": "mimo",
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-01-01",
-    "release_date": "2026-03-20",
-    "last_updated": "2026-03-20",
+    "knowledge": "2024-12",
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
     "modalities": {
       "input": [
-        "text",
-        "image",
-        "video"
+        "text"
       ],
       "output": [
         "text"
@@ -126052,8 +136548,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 1.5,
-      "output": 4.5
+      "input": 1.0,
+      "output": 3.0,
+      "cache_read": 0.2
     },
     "limit": {
       "context": 1000000,
@@ -126073,13 +136570,16 @@
     "last_updated": "2026-04-22",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "audio",
+        "video"
       ],
       "output": [
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.4,
       "output": 2.0,
@@ -126094,7 +136594,7 @@
     "id": "zenmux/xiaomi/mimo-v2.5-pro",
     "name": "MiMo-V2.5-Pro",
     "family": "mimo",
-    "attachment": true,
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -126103,17 +136603,13 @@
     "last_updated": "2026-04-22",
     "modalities": {
       "input": [
-        "text",
-        "image",
-        "audio",
-        "video",
-        "pdf"
+        "text"
       ],
       "output": [
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 1.0,
       "output": 3.0,

--- a/crates/goose/src/providers/canonical/data/provider_metadata.json
+++ b/crates/goose/src/providers/canonical/data/provider_metadata.json
@@ -1,36 +1,36 @@
 [
   {
-    "id": "302ai",
-    "display_name": "302.AI",
+    "id": "helicone",
+    "display_name": "Helicone",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.302.ai/v1",
-    "doc": "https://doc.302.ai",
+    "api": "https://ai-gateway.helicone.ai/v1",
+    "doc": "https://helicone.ai/models",
     "env": [
-      "302AI_API_KEY"
+      "HELICONE_API_KEY"
     ],
-    "model_count": 97
+    "model_count": 90
   },
   {
-    "id": "alibaba",
-    "display_name": "Alibaba",
+    "id": "auriko",
+    "display_name": "Auriko",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-    "doc": "https://www.alibabacloud.com/help/en/model-studio/models",
+    "api": "https://api.auriko.ai/v1",
+    "doc": "https://docs.auriko.ai",
     "env": [
-      "DASHSCOPE_API_KEY"
+      "AURIKO_API_KEY"
     ],
-    "model_count": 48
+    "model_count": 15
   },
   {
-    "id": "scaleway",
-    "display_name": "Scaleway",
+    "id": "firepass",
+    "display_name": "Fireworks (Firepass)",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.scaleway.ai/v1",
-    "doc": "https://www.scaleway.com/en/docs/generative-apis/",
+    "api": "https://api.fireworks.ai/inference/v1/",
+    "doc": "https://docs.fireworks.ai/firepass",
     "env": [
-      "SCALEWAY_API_KEY"
+      "FIREPASS_API_KEY"
     ],
-    "model_count": 16
+    "model_count": 1
   },
   {
     "id": "nano-gpt",
@@ -44,37 +44,26 @@
     "model_count": 525
   },
   {
-    "id": "abacus",
-    "display_name": "Abacus",
+    "id": "io-net",
+    "display_name": "IO.NET",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://routellm.abacus.ai/v1",
-    "doc": "https://abacus.ai/help/api",
+    "api": "https://api.intelligence.io.solutions/api/v1",
+    "doc": "https://io.net/docs/guides/intelligence/io-intelligence",
     "env": [
-      "ABACUS_API_KEY"
+      "IOINTELLIGENCE_API_KEY"
     ],
-    "model_count": 65
+    "model_count": 17
   },
   {
-    "id": "perplexity-agent",
-    "display_name": "Perplexity Agent",
-    "npm": "@ai-sdk/openai",
-    "api": "https://api.perplexity.ai/v1",
-    "doc": "https://docs.perplexity.ai/docs/agent-api/models",
-    "env": [
-      "PERPLEXITY_API_KEY"
-    ],
-    "model_count": 18
-  },
-  {
-    "id": "siliconflow-cn",
-    "display_name": "SiliconFlow (China)",
+    "id": "inception",
+    "display_name": "Inception",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.siliconflow.cn/v1",
-    "doc": "https://cloud.siliconflow.com/models",
+    "api": "https://api.inceptionlabs.ai/v1/",
+    "doc": "https://platform.inceptionlabs.ai/docs",
     "env": [
-      "SILICONFLOW_CN_API_KEY"
+      "INCEPTION_API_KEY"
     ],
-    "model_count": 81
+    "model_count": 2
   },
   {
     "id": "submodel",
@@ -88,59 +77,48 @@
     "model_count": 9
   },
   {
-    "id": "minimax-coding-plan",
-    "display_name": "MiniMax Coding Plan (minimax.io)",
-    "npm": "@ai-sdk/anthropic",
-    "api": "https://api.minimax.io/anthropic/v1",
-    "doc": "https://platform.minimax.io/docs/coding-plan/intro",
-    "env": [
-      "MINIMAX_API_KEY"
-    ],
-    "model_count": 6
-  },
-  {
-    "id": "deepseek",
-    "display_name": "DeepSeek",
+    "id": "requesty",
+    "display_name": "Requesty",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.deepseek.com",
-    "doc": "https://api-docs.deepseek.com/quick_start/pricing",
+    "api": "https://router.requesty.ai/v1",
+    "doc": "https://requesty.ai/solution/llm-routing/models",
     "env": [
-      "DEEPSEEK_API_KEY"
+      "REQUESTY_API_KEY"
     ],
-    "model_count": 4
+    "model_count": 38
   },
   {
-    "id": "meta-llama",
-    "display_name": "Llama",
+    "id": "zai",
+    "display_name": "Z.AI",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.llama.com/compat/v1/",
-    "doc": "https://llama.developer.meta.com/docs/models",
+    "api": "https://api.z.ai/api/paas/v4",
+    "doc": "https://docs.z.ai/guides/overview/pricing",
     "env": [
-      "LLAMA_API_KEY"
+      "ZHIPU_API_KEY"
     ],
-    "model_count": 7
+    "model_count": 13
   },
   {
-    "id": "fireworks-ai",
-    "display_name": "Fireworks AI",
+    "id": "zai-coding-plan",
+    "display_name": "Z.AI Coding Plan",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.fireworks.ai/inference/v1/",
-    "doc": "https://fireworks.ai/docs/",
+    "api": "https://api.z.ai/api/coding/paas/v4",
+    "doc": "https://docs.z.ai/devpack/overview",
     "env": [
-      "FIREWORKS_API_KEY"
+      "ZHIPU_API_KEY"
     ],
-    "model_count": 19
+    "model_count": 5
   },
   {
-    "id": "kimi-for-coding",
-    "display_name": "Kimi For Coding",
-    "npm": "@ai-sdk/anthropic",
-    "api": "https://api.kimi.com/coding/v1",
-    "doc": "https://www.kimi.com/coding/docs/en/third-party-agents.html",
+    "id": "clarifai",
+    "display_name": "Clarifai",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.clarifai.com/v2/ext/openai/v1",
+    "doc": "https://docs.clarifai.com/compute/inference/",
     "env": [
-      "KIMI_API_KEY"
+      "CLARIFAI_PAT"
     ],
-    "model_count": 3
+    "model_count": 12
   },
   {
     "id": "moark",
@@ -154,136 +132,15 @@
     "model_count": 2
   },
   {
-    "id": "opencode-go",
-    "display_name": "OpenCode Go",
+    "id": "frogbot",
+    "display_name": "FrogBot",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://opencode.ai/zen/go/v1",
-    "doc": "https://opencode.ai/docs/zen",
+    "api": "https://app.frogbot.ai/api/v1",
+    "doc": "https://docs.frogbot.ai",
     "env": [
-      "OPENCODE_API_KEY"
+      "FROGBOT_API_KEY"
     ],
-    "model_count": 14
-  },
-  {
-    "id": "io-net",
-    "display_name": "IO.NET",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.intelligence.io.solutions/api/v1",
-    "doc": "https://io.net/docs/guides/intelligence/io-intelligence",
-    "env": [
-      "IOINTELLIGENCE_API_KEY"
-    ],
-    "model_count": 17
-  },
-  {
-    "id": "alibaba-cn",
-    "display_name": "Alibaba (China)",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://dashscope.aliyuncs.com/compatible-mode/v1",
-    "doc": "https://www.alibabacloud.com/help/en/model-studio/models",
-    "env": [
-      "DASHSCOPE_API_KEY"
-    ],
-    "model_count": 80
-  },
-  {
-    "id": "minimax-cn-coding-plan",
-    "display_name": "MiniMax Coding Plan (minimaxi.com)",
-    "npm": "@ai-sdk/anthropic",
-    "api": "https://api.minimaxi.com/anthropic/v1",
-    "doc": "https://platform.minimaxi.com/docs/coding-plan/intro",
-    "env": [
-      "MINIMAX_API_KEY"
-    ],
-    "model_count": 6
-  },
-  {
-    "id": "jiekou",
-    "display_name": "Jiekou.AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.jiekou.ai/openai",
-    "doc": "https://docs.jiekou.ai/docs/support/quickstart?utm_source=github_models.dev",
-    "env": [
-      "JIEKOU_API_KEY"
-    ],
-    "model_count": 61
-  },
-  {
-    "id": "bailing",
-    "display_name": "Bailing",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.tbox.cn/api/llm/v1/chat/completions",
-    "doc": "https://alipaytbox.yuque.com/sxs0ba/ling/intro",
-    "env": [
-      "BAILING_API_TOKEN"
-    ],
-    "model_count": 2
-  },
-  {
-    "id": "iflowcn",
-    "display_name": "iFlow",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://apis.iflow.cn/v1",
-    "doc": "https://platform.iflow.cn/en/docs",
-    "env": [
-      "IFLOW_API_KEY"
-    ],
-    "model_count": 14
-  },
-  {
-    "id": "huggingface",
-    "display_name": "Hugging Face",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://router.huggingface.co/v1",
-    "doc": "https://huggingface.co/docs/inference-providers",
-    "env": [
-      "HF_TOKEN"
-    ],
-    "model_count": 24
-  },
-  {
-    "id": "zenmux",
-    "display_name": "ZenMux",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://zenmux.ai/api/v1",
-    "doc": "https://docs.zenmux.ai",
-    "env": [
-      "ZENMUX_API_KEY"
-    ],
-    "model_count": 96
-  },
-  {
-    "id": "upstage",
-    "display_name": "Upstage",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.upstage.ai/v1/solar",
-    "doc": "https://developers.upstage.ai/docs/apis/chat",
-    "env": [
-      "UPSTAGE_API_KEY"
-    ],
-    "model_count": 3
-  },
-  {
-    "id": "novita-ai",
-    "display_name": "NovitaAI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.novita.ai/openai",
-    "doc": "https://novita.ai/docs/guides/introduction",
-    "env": [
-      "NOVITA_API_KEY"
-    ],
-    "model_count": 99
-  },
-  {
-    "id": "xiaomi-token-plan-cn",
-    "display_name": "Xiaomi Token Plan (China)",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://token-plan-cn.xiaomimimo.com/v1",
-    "doc": "https://platform.xiaomimimo.com/#/docs",
-    "env": [
-      "XIAOMI_API_KEY"
-    ],
-    "model_count": 5
+    "model_count": 26
   },
   {
     "id": "wandb",
@@ -297,15 +154,259 @@
     "model_count": 18
   },
   {
-    "id": "chutes",
-    "display_name": "Chutes",
+    "id": "gmicloud",
+    "display_name": "GMI Cloud",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://llm.chutes.ai/v1",
-    "doc": "https://llm.chutes.ai/v1/models",
+    "api": "https://api.gmi-serving.com/v1",
+    "doc": "https://docs.gmicloud.ai/inference-engine/api-reference/llm-api-reference",
     "env": [
-      "CHUTES_API_KEY"
+      "GMICLOUD_API_KEY"
     ],
-    "model_count": 70
+    "model_count": 8
+  },
+  {
+    "id": "ambient",
+    "display_name": "Ambient",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.ambient.xyz/v1",
+    "doc": "https://ambient.xyz",
+    "env": [
+      "AMBIENT_API_KEY"
+    ],
+    "model_count": 2
+  },
+  {
+    "id": "routing-run",
+    "display_name": "routing.run",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.routing.run/v1",
+    "doc": "https://docs.routing.run/api-reference/models",
+    "env": [
+      "ROUTING_RUN_API_KEY"
+    ],
+    "model_count": 24
+  },
+  {
+    "id": "the-grid-ai",
+    "display_name": "The Grid AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.thegrid.ai/v1",
+    "doc": "https://thegrid.ai/docs",
+    "env": [
+      "THEGRIDAI_API_KEY"
+    ],
+    "model_count": 3
+  },
+  {
+    "id": "fastrouter",
+    "display_name": "FastRouter",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://go.fastrouter.ai/api/v1",
+    "doc": "https://fastrouter.ai/models",
+    "env": [
+      "FASTROUTER_API_KEY"
+    ],
+    "model_count": 15
+  },
+  {
+    "id": "tencent-coding-plan",
+    "display_name": "Tencent Coding Plan (China)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.lkeap.cloud.tencent.com/coding/v3",
+    "doc": "https://cloud.tencent.com/document/product/1772/128947",
+    "env": [
+      "TENCENT_CODING_PLAN_API_KEY"
+    ],
+    "model_count": 8
+  },
+  {
+    "id": "cortecs",
+    "display_name": "Cortecs",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.cortecs.ai/v1",
+    "doc": "https://api.cortecs.ai/v1/models",
+    "env": [
+      "CORTECS_API_KEY"
+    ],
+    "model_count": 49
+  },
+  {
+    "id": "baseten",
+    "display_name": "Baseten",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://inference.baseten.co/v1",
+    "doc": "https://docs.baseten.co/development/model-apis/overview",
+    "env": [
+      "BASETEN_API_KEY"
+    ],
+    "model_count": 14
+  },
+  {
+    "id": "meta-llama",
+    "display_name": "Llama",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.llama.com/compat/v1/",
+    "doc": "https://llama.developer.meta.com/docs/models",
+    "env": [
+      "LLAMA_API_KEY"
+    ],
+    "model_count": 7
+  },
+  {
+    "id": "novita-ai",
+    "display_name": "NovitaAI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.novita.ai/openai",
+    "doc": "https://novita.ai/docs/guides/introduction",
+    "env": [
+      "NOVITA_API_KEY"
+    ],
+    "model_count": 99
+  },
+  {
+    "id": "digitalocean",
+    "display_name": "DigitalOcean",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://inference.do-ai.run/v1",
+    "doc": "https://docs.digitalocean.com/products/gradient-ai-platform/details/models/",
+    "env": [
+      "DIGITALOCEAN_ACCESS_TOKEN"
+    ],
+    "model_count": 76
+  },
+  {
+    "id": "moonshotai",
+    "display_name": "Moonshot AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.moonshot.ai/v1",
+    "doc": "https://platform.moonshot.ai/docs/api/chat",
+    "env": [
+      "MOONSHOT_API_KEY"
+    ],
+    "model_count": 7
+  },
+  {
+    "id": "kilo",
+    "display_name": "Kilo Gateway",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.kilo.ai/api/gateway",
+    "doc": "https://kilo.ai",
+    "env": [
+      "KILO_API_KEY"
+    ],
+    "model_count": 344
+  },
+  {
+    "id": "cloudflare-workers-ai",
+    "display_name": "Cloudflare Workers AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1",
+    "doc": "https://developers.cloudflare.com/workers-ai/models/",
+    "env": [
+      "CLOUDFLARE_ACCOUNT_ID",
+      "CLOUDFLARE_API_KEY"
+    ],
+    "model_count": 8
+  },
+  {
+    "id": "lmstudio",
+    "display_name": "LMStudio",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "http://127.0.0.1:1234/v1",
+    "doc": "https://lmstudio.ai/models",
+    "env": [
+      "LMSTUDIO_API_KEY"
+    ],
+    "model_count": 3
+  },
+  {
+    "id": "xiaomi-token-plan-cn",
+    "display_name": "Xiaomi Token Plan (China)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://token-plan-cn.xiaomimimo.com/v1",
+    "doc": "https://platform.xiaomimimo.com/#/docs",
+    "env": [
+      "XIAOMI_API_KEY"
+    ],
+    "model_count": 6
+  },
+  {
+    "id": "morph",
+    "display_name": "Morph",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.morphllm.com/v1",
+    "doc": "https://docs.morphllm.com/api-reference/introduction",
+    "env": [
+      "MORPH_API_KEY"
+    ],
+    "model_count": 3
+  },
+  {
+    "id": "nearai",
+    "display_name": "NEAR AI Cloud",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://cloud-api.near.ai/v1",
+    "doc": "https://docs.near.ai/",
+    "env": [
+      "NEARAI_API_KEY"
+    ],
+    "model_count": 33
+  },
+  {
+    "id": "abacus",
+    "display_name": "Abacus",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://routellm.abacus.ai/v1",
+    "doc": "https://abacus.ai/help/api",
+    "env": [
+      "ABACUS_API_KEY"
+    ],
+    "model_count": 65
+  },
+  {
+    "id": "privatemode-ai",
+    "display_name": "Privatemode AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "http://localhost:8080/v1",
+    "doc": "https://docs.privatemode.ai/api/overview",
+    "env": [
+      "PRIVATEMODE_API_KEY",
+      "PRIVATEMODE_ENDPOINT"
+    ],
+    "model_count": 5
+  },
+  {
+    "id": "minimax-cn-coding-plan",
+    "display_name": "MiniMax Token Plan (minimaxi.com)",
+    "npm": "@ai-sdk/anthropic",
+    "api": "https://api.minimaxi.com/anthropic/v1",
+    "doc": "https://platform.minimaxi.com/docs/token-plan/intro",
+    "env": [
+      "MINIMAX_API_KEY"
+    ],
+    "model_count": 6
+  },
+  {
+    "id": "xiaomi-token-plan-ams",
+    "display_name": "Xiaomi Token Plan (Europe)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://token-plan-ams.xiaomimimo.com/v1",
+    "doc": "https://platform.xiaomimimo.com/#/docs",
+    "env": [
+      "XIAOMI_API_KEY"
+    ],
+    "model_count": 6
+  },
+  {
+    "id": "cloudferro-sherlock",
+    "display_name": "CloudFerro Sherlock",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api-sherlock.cloudferro.com/openai/v1/",
+    "doc": "https://docs.sherlock.cloudferro.com/",
+    "env": [
+      "CLOUDFERRO_SHERLOCK_API_KEY"
+    ],
+    "model_count": 5
   },
   {
     "id": "dinference",
@@ -330,277 +431,13 @@
     "model_count": 13
   },
   {
-    "id": "qiniu-ai",
-    "display_name": "Qiniu",
+    "id": "vultr",
+    "display_name": "Vultr",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.qnaigc.com/v1",
-    "doc": "https://developer.qiniu.com/aitokenapi",
+    "api": "https://api.vultrinference.com/v1",
+    "doc": "https://api.vultrinference.com/",
     "env": [
-      "QINIU_API_KEY"
-    ],
-    "model_count": 91
-  },
-  {
-    "id": "kilo",
-    "display_name": "Kilo Gateway",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.kilo.ai/api/gateway",
-    "doc": "https://kilo.ai",
-    "env": [
-      "KILO_API_KEY"
-    ],
-    "model_count": 355
-  },
-  {
-    "id": "morph",
-    "display_name": "Morph",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.morphllm.com/v1",
-    "doc": "https://docs.morphllm.com/api-reference/introduction",
-    "env": [
-      "MORPH_API_KEY"
-    ],
-    "model_count": 3
-  },
-  {
-    "id": "github-copilot",
-    "display_name": "GitHub Copilot",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.githubcopilot.com",
-    "doc": "https://docs.github.com/en/copilot",
-    "env": [
-      "GITHUB_TOKEN"
-    ],
-    "model_count": 27
-  },
-  {
-    "id": "mixlayer",
-    "display_name": "Mixlayer",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://models.mixlayer.ai/v1",
-    "doc": "https://docs.mixlayer.com",
-    "env": [
-      "MIXLAYER_API_KEY"
-    ],
-    "model_count": 5
-  },
-  {
-    "id": "xiaomi-token-plan-sgp",
-    "display_name": "Xiaomi Token Plan (Singapore)",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://token-plan-sgp.xiaomimimo.com/v1",
-    "doc": "https://platform.xiaomimimo.com/#/docs",
-    "env": [
-      "XIAOMI_API_KEY"
-    ],
-    "model_count": 5
-  },
-  {
-    "id": "zai",
-    "display_name": "Z.AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.z.ai/api/paas/v4",
-    "doc": "https://docs.z.ai/guides/overview/pricing",
-    "env": [
-      "ZHIPU_API_KEY"
-    ],
-    "model_count": 13
-  },
-  {
-    "id": "opencode",
-    "display_name": "OpenCode Zen",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://opencode.ai/zen/v1",
-    "doc": "https://opencode.ai/docs/zen",
-    "env": [
-      "OPENCODE_API_KEY"
-    ],
-    "model_count": 58
-  },
-  {
-    "id": "stepfun",
-    "display_name": "StepFun",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.stepfun.com/v1",
-    "doc": "https://platform.stepfun.com/docs/zh/overview/concept",
-    "env": [
-      "STEPFUN_API_KEY"
-    ],
-    "model_count": 4
-  },
-  {
-    "id": "nebius",
-    "display_name": "Nebius Token Factory",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.tokenfactory.nebius.com/v1",
-    "doc": "https://docs.tokenfactory.nebius.com/",
-    "env": [
-      "NEBIUS_API_KEY"
-    ],
-    "model_count": 49
-  },
-  {
-    "id": "poe",
-    "display_name": "Poe",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.poe.com/v1",
-    "doc": "https://creator.poe.com/docs/external-applications/openai-compatible-api",
-    "env": [
-      "POE_API_KEY"
-    ],
-    "model_count": 132
-  },
-  {
-    "id": "helicone",
-    "display_name": "Helicone",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://ai-gateway.helicone.ai/v1",
-    "doc": "https://helicone.ai/models",
-    "env": [
-      "HELICONE_API_KEY"
-    ],
-    "model_count": 90
-  },
-  {
-    "id": "ollama-cloud",
-    "display_name": "Ollama Cloud",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://ollama.com/v1",
-    "doc": "https://docs.ollama.com/cloud",
-    "env": [
-      "OLLAMA_API_KEY"
-    ],
-    "model_count": 39
-  },
-  {
-    "id": "zai-coding-plan",
-    "display_name": "Z.AI Coding Plan",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.z.ai/api/coding/paas/v4",
-    "doc": "https://docs.z.ai/devpack/overview",
-    "env": [
-      "ZHIPU_API_KEY"
-    ],
-    "model_count": 5
-  },
-  {
-    "id": "the-grid-ai",
-    "display_name": "The Grid AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.thegrid.ai/v1",
-    "doc": "https://thegrid.ai/docs",
-    "env": [
-      "THEGRIDAI_API_KEY"
-    ],
-    "model_count": 3
-  },
-  {
-    "id": "baseten",
-    "display_name": "Baseten",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://inference.baseten.co/v1",
-    "doc": "https://docs.baseten.co/development/model-apis/overview",
-    "env": [
-      "BASETEN_API_KEY"
-    ],
-    "model_count": 14
-  },
-  {
-    "id": "frogbot",
-    "display_name": "FrogBot",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://app.frogbot.ai/api/v1",
-    "doc": "https://docs.frogbot.ai",
-    "env": [
-      "FROGBOT_API_KEY"
-    ],
-    "model_count": 26
-  },
-  {
-    "id": "zhipuai-coding-plan",
-    "display_name": "Zhipu AI Coding Plan",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://open.bigmodel.cn/api/coding/paas/v4",
-    "doc": "https://docs.bigmodel.cn/cn/coding-plan/overview",
-    "env": [
-      "ZHIPU_API_KEY"
-    ],
-    "model_count": 5
-  },
-  {
-    "id": "alibaba-coding-plan",
-    "display_name": "Alibaba Coding Plan",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://coding-intl.dashscope.aliyuncs.com/v1",
-    "doc": "https://www.alibabacloud.com/help/en/model-studio/coding-plan",
-    "env": [
-      "ALIBABA_CODING_PLAN_API_KEY"
-    ],
-    "model_count": 9
-  },
-  {
-    "id": "lmstudio",
-    "display_name": "LMStudio",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "http://127.0.0.1:1234/v1",
-    "doc": "https://lmstudio.ai/models",
-    "env": [
-      "LMSTUDIO_API_KEY"
-    ],
-    "model_count": 3
-  },
-  {
-    "id": "lucidquery",
-    "display_name": "LucidQuery AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://lucidquery.com/api/v1",
-    "doc": "https://lucidquery.com/api/docs",
-    "env": [
-      "LUCIDQUERY_API_KEY"
-    ],
-    "model_count": 2
-  },
-  {
-    "id": "moonshotai-cn",
-    "display_name": "Moonshot AI (China)",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.moonshot.cn/v1",
-    "doc": "https://platform.moonshot.cn/docs/api/chat",
-    "env": [
-      "MOONSHOT_API_KEY"
-    ],
-    "model_count": 7
-  },
-  {
-    "id": "abliteration-ai",
-    "display_name": "abliteration.ai",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.abliteration.ai/v1",
-    "doc": "https://docs.abliteration.ai/models",
-    "env": [
-      "ABLIT_KEY"
-    ],
-    "model_count": 1
-  },
-  {
-    "id": "wafer.ai",
-    "display_name": "Wafer",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://pass.wafer.ai/v1",
-    "doc": "https://docs.wafer.ai/wafer-pass",
-    "env": [
-      "WAFER_API_KEY"
-    ],
-    "model_count": 3
-  },
-  {
-    "id": "cloudferro-sherlock",
-    "display_name": "CloudFerro Sherlock",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api-sherlock.cloudferro.com/openai/v1/",
-    "doc": "https://docs.sherlock.cloudferro.com/",
-    "env": [
-      "CLOUDFERRO_SHERLOCK_API_KEY"
+      "VULTR_API_KEY"
     ],
     "model_count": 5
   },
@@ -616,114 +453,59 @@
     "model_count": 1
   },
   {
-    "id": "meganova",
-    "display_name": "Meganova",
+    "id": "modelscope",
+    "display_name": "ModelScope",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.meganova.ai/v1",
-    "doc": "https://docs.meganova.ai",
+    "api": "https://api-inference.modelscope.cn/v1",
+    "doc": "https://modelscope.cn/docs/model-service/API-Inference/intro",
     "env": [
-      "MEGANOVA_API_KEY"
+      "MODELSCOPE_API_KEY"
     ],
-    "model_count": 19
+    "model_count": 7
   },
   {
-    "id": "evroc",
-    "display_name": "evroc",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://models.think.evroc.com/v1",
-    "doc": "https://docs.evroc.com/products/think/overview.html",
+    "id": "kimi-for-coding",
+    "display_name": "Kimi For Coding",
+    "npm": "@ai-sdk/anthropic",
+    "api": "https://api.kimi.com/coding/v1",
+    "doc": "https://www.kimi.com/coding/docs/en/third-party-agents.html",
     "env": [
-      "EVROC_API_KEY"
+      "KIMI_API_KEY"
     ],
-    "model_count": 13
+    "model_count": 3
   },
   {
-    "id": "synthetic",
-    "display_name": "Synthetic",
+    "id": "lucidquery",
+    "display_name": "LucidQuery AI",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.synthetic.new/openai/v1",
-    "doc": "https://synthetic.new/pricing",
+    "api": "https://lucidquery.com/api/v1",
+    "doc": "https://lucidquery.com/api/docs",
     "env": [
-      "SYNTHETIC_API_KEY"
-    ],
-    "model_count": 33
-  },
-  {
-    "id": "nvidia",
-    "display_name": "Nvidia",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://integrate.api.nvidia.com/v1",
-    "doc": "https://docs.api.nvidia.com/nim/",
-    "env": [
-      "NVIDIA_API_KEY"
-    ],
-    "model_count": 82
-  },
-  {
-    "id": "inference",
-    "display_name": "Inference",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://inference.net/v1",
-    "doc": "https://inference.net/models",
-    "env": [
-      "INFERENCE_API_KEY"
-    ],
-    "model_count": 9
-  },
-  {
-    "id": "inception",
-    "display_name": "Inception",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.inceptionlabs.ai/v1/",
-    "doc": "https://platform.inceptionlabs.ai/docs",
-    "env": [
-      "INCEPTION_API_KEY"
+      "LUCIDQUERY_API_KEY"
     ],
     "model_count": 2
   },
   {
-    "id": "requesty",
-    "display_name": "Requesty",
+    "id": "neuralwatt",
+    "display_name": "Neuralwatt",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://router.requesty.ai/v1",
-    "doc": "https://requesty.ai/solution/llm-routing/models",
+    "api": "https://api.neuralwatt.com/v1",
+    "doc": "https://portal.neuralwatt.com/docs",
     "env": [
-      "REQUESTY_API_KEY"
+      "NEURALWATT_API_KEY"
     ],
-    "model_count": 38
+    "model_count": 14
   },
   {
-    "id": "digitalocean",
-    "display_name": "DigitalOcean",
+    "id": "jiekou",
+    "display_name": "Jiekou.AI",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://inference.do-ai.run/v1",
-    "doc": "https://docs.digitalocean.com/products/gradient-ai-platform/details/models/",
+    "api": "https://api.jiekou.ai/openai",
+    "doc": "https://docs.jiekou.ai/docs/support/quickstart?utm_source=github_models.dev",
     "env": [
-      "DIGITALOCEAN_ACCESS_TOKEN"
+      "JIEKOU_API_KEY"
     ],
-    "model_count": 63
-  },
-  {
-    "id": "vultr",
-    "display_name": "Vultr",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.vultrinference.com/v1",
-    "doc": "https://api.vultrinference.com/",
-    "env": [
-      "VULTR_API_KEY"
-    ],
-    "model_count": 5
-  },
-  {
-    "id": "alibaba-coding-plan-cn",
-    "display_name": "Alibaba Coding Plan (China)",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://coding.dashscope.aliyuncs.com/v1",
-    "doc": "https://help.aliyun.com/zh/model-studio/coding-plan",
-    "env": [
-      "ALIBABA_CODING_PLAN_API_KEY"
-    ],
-    "model_count": 9
+    "model_count": 61
   },
   {
     "id": "ovhcloud",
@@ -748,26 +530,70 @@
     "model_count": 6
   },
   {
-    "id": "cortecs",
-    "display_name": "Cortecs",
+    "id": "regolo-ai",
+    "display_name": "Regolo AI",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.cortecs.ai/v1",
-    "doc": "https://api.cortecs.ai/v1/models",
+    "api": "https://api.regolo.ai/v1",
+    "doc": "https://docs.regolo.ai/",
     "env": [
-      "CORTECS_API_KEY"
+      "REGOLO_API_KEY"
     ],
-    "model_count": 49
+    "model_count": 13
   },
   {
-    "id": "siliconflow",
-    "display_name": "SiliconFlow",
+    "id": "claudinio",
+    "display_name": "Claudinio",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.siliconflow.com/v1",
-    "doc": "https://cloud.siliconflow.com/models",
+    "api": "https://api.claudin.io/v1",
+    "doc": "https://claudin.io",
     "env": [
-      "SILICONFLOW_API_KEY"
+      "CLAUDINIO_API_KEY"
     ],
-    "model_count": 74
+    "model_count": 1
+  },
+  {
+    "id": "orcarouter",
+    "display_name": "OrcaRouter",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.orcarouter.ai/v1",
+    "doc": "https://docs.orcarouter.ai",
+    "env": [
+      "ORCAROUTER_API_KEY"
+    ],
+    "model_count": 81
+  },
+  {
+    "id": "opencode-go",
+    "display_name": "OpenCode Go",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://opencode.ai/zen/go/v1",
+    "doc": "https://opencode.ai/docs/zen",
+    "env": [
+      "OPENCODE_API_KEY"
+    ],
+    "model_count": 14
+  },
+  {
+    "id": "llmgateway",
+    "display_name": "LLM Gateway",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.llmgateway.io/v1",
+    "doc": "https://llmgateway.io/docs",
+    "env": [
+      "LLMGATEWAY_API_KEY"
+    ],
+    "model_count": 189
+  },
+  {
+    "id": "poe",
+    "display_name": "Poe",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.poe.com/v1",
+    "doc": "https://creator.poe.com/docs/external-applications/openai-compatible-api",
+    "env": [
+      "POE_API_KEY"
+    ],
+    "model_count": 135
   },
   {
     "id": "minimax",
@@ -781,94 +607,49 @@
     "model_count": 6
   },
   {
-    "id": "llmgateway",
-    "display_name": "LLM Gateway",
+    "id": "xiaomi-token-plan-sgp",
+    "display_name": "Xiaomi Token Plan (Singapore)",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.llmgateway.io/v1",
-    "doc": "https://llmgateway.io/docs",
+    "api": "https://token-plan-sgp.xiaomimimo.com/v1",
+    "doc": "https://platform.xiaomimimo.com/#/docs",
     "env": [
-      "LLMGATEWAY_API_KEY"
+      "XIAOMI_API_KEY"
     ],
-    "model_count": 190
+    "model_count": 6
   },
   {
-    "id": "cloudflare-workers-ai",
-    "display_name": "Cloudflare Workers AI",
+    "id": "siliconflow",
+    "display_name": "SiliconFlow",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1",
-    "doc": "https://developers.cloudflare.com/workers-ai/models/",
+    "api": "https://api.siliconflow.com/v1",
+    "doc": "https://cloud.siliconflow.com/models",
     "env": [
-      "CLOUDFLARE_ACCOUNT_ID",
-      "CLOUDFLARE_API_KEY"
+      "SILICONFLOW_API_KEY"
     ],
-    "model_count": 8
+    "model_count": 76
   },
   {
-    "id": "fastrouter",
-    "display_name": "FastRouter",
+    "id": "ollama-cloud",
+    "display_name": "Ollama Cloud",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://go.fastrouter.ai/api/v1",
-    "doc": "https://fastrouter.ai/models",
+    "api": "https://ollama.com/v1",
+    "doc": "https://docs.ollama.com/cloud",
     "env": [
-      "FASTROUTER_API_KEY"
+      "OLLAMA_API_KEY"
     ],
-    "model_count": 15
+    "model_count": 39
   },
   {
-    "id": "stackit",
-    "display_name": "STACKIT",
+    "id": "databricks",
+    "display_name": "Databricks",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1",
-    "doc": "https://docs.stackit.cloud/products/data-and-ai/ai-model-serving/basics/available-shared-models",
+    "api": "https://${DATABRICKS_HOST}/ai-gateway/mlflow/v1",
+    "doc": "https://docs.databricks.com/aws/en/machine-learning/foundation-models/",
     "env": [
-      "STACKIT_API_KEY"
+      "DATABRICKS_HOST",
+      "DATABRICKS_TOKEN"
     ],
-    "model_count": 8
-  },
-  {
-    "id": "tencent-coding-plan",
-    "display_name": "Tencent Coding Plan (China)",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.lkeap.cloud.tencent.com/coding/v3",
-    "doc": "https://cloud.tencent.com/document/product/1772/128947",
-    "env": [
-      "TENCENT_CODING_PLAN_API_KEY"
-    ],
-    "model_count": 8
-  },
-  {
-    "id": "privatemode-ai",
-    "display_name": "Privatemode AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "http://localhost:8080/v1",
-    "doc": "https://docs.privatemode.ai/api/overview",
-    "env": [
-      "PRIVATEMODE_API_KEY",
-      "PRIVATEMODE_ENDPOINT"
-    ],
-    "model_count": 5
-  },
-  {
-    "id": "drun",
-    "display_name": "D.Run (China)",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://chat.d.run/v1",
-    "doc": "https://www.d.run",
-    "env": [
-      "DRUN_API_KEY"
-    ],
-    "model_count": 3
-  },
-  {
-    "id": "moonshotai",
-    "display_name": "Moonshot AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.moonshot.ai/v1",
-    "doc": "https://platform.moonshot.ai/docs/api/chat",
-    "env": [
-      "MOONSHOT_API_KEY"
-    ],
-    "model_count": 7
+    "model_count": 25
   },
   {
     "id": "berget",
@@ -879,7 +660,95 @@
     "env": [
       "BERGET_API_KEY"
     ],
+    "model_count": 7
+  },
+  {
+    "id": "moonshotai-cn",
+    "display_name": "Moonshot AI (China)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.moonshot.cn/v1",
+    "doc": "https://platform.moonshot.cn/docs/api/chat",
+    "env": [
+      "MOONSHOT_API_KEY"
+    ],
+    "model_count": 7
+  },
+  {
+    "id": "alibaba-coding-plan-cn",
+    "display_name": "Alibaba Coding Plan (China)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://coding.dashscope.aliyuncs.com/v1",
+    "doc": "https://help.aliyun.com/zh/model-studio/coding-plan",
+    "env": [
+      "ALIBABA_CODING_PLAN_API_KEY"
+    ],
+    "model_count": 9
+  },
+  {
+    "id": "minimax-cn",
+    "display_name": "MiniMax (minimaxi.com)",
+    "npm": "@ai-sdk/anthropic",
+    "api": "https://api.minimaxi.com/anthropic/v1",
+    "doc": "https://platform.minimaxi.com/docs/guides/quickstart",
+    "env": [
+      "MINIMAX_API_KEY"
+    ],
     "model_count": 6
+  },
+  {
+    "id": "chutes",
+    "display_name": "Chutes",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://llm.chutes.ai/v1",
+    "doc": "https://llm.chutes.ai/v1/models",
+    "env": [
+      "CHUTES_API_KEY"
+    ],
+    "model_count": 39
+  },
+  {
+    "id": "siliconflow-cn",
+    "display_name": "SiliconFlow (China)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.siliconflow.cn/v1",
+    "doc": "https://cloud.siliconflow.com/models",
+    "env": [
+      "SILICONFLOW_CN_API_KEY"
+    ],
+    "model_count": 81
+  },
+  {
+    "id": "nvidia",
+    "display_name": "Nvidia",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://integrate.api.nvidia.com/v1",
+    "doc": "https://docs.api.nvidia.com/nim/",
+    "env": [
+      "NVIDIA_API_KEY"
+    ],
+    "model_count": 92
+  },
+  {
+    "id": "zhipuai-coding-plan",
+    "display_name": "Zhipu AI Coding Plan",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://open.bigmodel.cn/api/coding/paas/v4",
+    "doc": "https://docs.bigmodel.cn/cn/coding-plan/overview",
+    "env": [
+      "ZHIPU_API_KEY"
+    ],
+    "model_count": 5
+  },
+  {
+    "id": "atomic-chat",
+    "display_name": "Atomic Chat",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "http://127.0.0.1:1337/v1",
+    "doc": "https://atomic.chat",
+    "env": [
+      "ATOMIC_CHAT_API_KEY"
+    ],
+    "model_count": 5
   },
   {
     "id": "github-models",
@@ -893,15 +762,290 @@
     "model_count": 55
   },
   {
-    "id": "neuralwatt",
-    "display_name": "Neuralwatt",
+    "id": "qiniu-ai",
+    "display_name": "Qiniu",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.neuralwatt.com/v1",
-    "doc": "https://portal.neuralwatt.com/docs",
+    "api": "https://api.qnaigc.com/v1",
+    "doc": "https://developer.qiniu.com/aitokenapi",
     "env": [
-      "NEURALWATT_API_KEY"
+      "QINIU_API_KEY"
+    ],
+    "model_count": 91
+  },
+  {
+    "id": "scaleway",
+    "display_name": "Scaleway",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.scaleway.ai/v1",
+    "doc": "https://www.scaleway.com/en/docs/generative-apis/",
+    "env": [
+      "SCALEWAY_API_KEY"
+    ],
+    "model_count": 16
+  },
+  {
+    "id": "opencode",
+    "display_name": "OpenCode Zen",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://opencode.ai/zen/v1",
+    "doc": "https://opencode.ai/docs/zen",
+    "env": [
+      "OPENCODE_API_KEY"
+    ],
+    "model_count": 60
+  },
+  {
+    "id": "mixlayer",
+    "display_name": "Mixlayer",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://models.mixlayer.ai/v1",
+    "doc": "https://docs.mixlayer.com",
+    "env": [
+      "MIXLAYER_API_KEY"
+    ],
+    "model_count": 5
+  },
+  {
+    "id": "zenmux",
+    "display_name": "ZenMux",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://zenmux.ai/api/v1",
+    "doc": "https://docs.zenmux.ai",
+    "env": [
+      "ZENMUX_API_KEY"
+    ],
+    "model_count": 96
+  },
+  {
+    "id": "perplexity-agent",
+    "display_name": "Perplexity Agent",
+    "npm": "@ai-sdk/openai",
+    "api": "https://api.perplexity.ai/v1",
+    "doc": "https://docs.perplexity.ai/docs/agent-api/models",
+    "env": [
+      "PERPLEXITY_API_KEY"
+    ],
+    "model_count": 18
+  },
+  {
+    "id": "alibaba-coding-plan",
+    "display_name": "Alibaba Coding Plan",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://coding-intl.dashscope.aliyuncs.com/v1",
+    "doc": "https://www.alibabacloud.com/help/en/model-studio/coding-plan",
+    "env": [
+      "ALIBABA_CODING_PLAN_API_KEY"
+    ],
+    "model_count": 9
+  },
+  {
+    "id": "meganova",
+    "display_name": "Meganova",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.meganova.ai/v1",
+    "doc": "https://docs.meganova.ai",
+    "env": [
+      "MEGANOVA_API_KEY"
+    ],
+    "model_count": 19
+  },
+  {
+    "id": "synthetic",
+    "display_name": "Synthetic",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.synthetic.new/openai/v1",
+    "doc": "https://synthetic.new/pricing",
+    "env": [
+      "SYNTHETIC_API_KEY"
+    ],
+    "model_count": 33
+  },
+  {
+    "id": "minimax-coding-plan",
+    "display_name": "MiniMax Token Plan (minimax.io)",
+    "npm": "@ai-sdk/anthropic",
+    "api": "https://api.minimax.io/anthropic/v1",
+    "doc": "https://platform.minimax.io/docs/token-plan/intro",
+    "env": [
+      "MINIMAX_API_KEY"
+    ],
+    "model_count": 6
+  },
+  {
+    "id": "upstage",
+    "display_name": "Upstage",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.upstage.ai/v1/solar",
+    "doc": "https://developers.upstage.ai/docs/apis/chat",
+    "env": [
+      "UPSTAGE_API_KEY"
+    ],
+    "model_count": 3
+  },
+  {
+    "id": "abliteration-ai",
+    "display_name": "abliteration.ai",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.abliteration.ai/v1",
+    "doc": "https://docs.abliteration.ai/models",
+    "env": [
+      "ABLIT_KEY"
+    ],
+    "model_count": 1
+  },
+  {
+    "id": "deepseek",
+    "display_name": "DeepSeek",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.deepseek.com",
+    "doc": "https://api-docs.deepseek.com/quick_start/pricing",
+    "env": [
+      "DEEPSEEK_API_KEY"
+    ],
+    "model_count": 4
+  },
+  {
+    "id": "iflowcn",
+    "display_name": "iFlow",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://apis.iflow.cn/v1",
+    "doc": "https://platform.iflow.cn/en/docs",
+    "env": [
+      "IFLOW_API_KEY"
     ],
     "model_count": 14
+  },
+  {
+    "id": "stackit",
+    "display_name": "STACKIT",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1",
+    "doc": "https://docs.stackit.cloud/products/data-and-ai/ai-model-serving/basics/available-shared-models",
+    "env": [
+      "STACKIT_API_KEY"
+    ],
+    "model_count": 8
+  },
+  {
+    "id": "wafer.ai",
+    "display_name": "Wafer",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://pass.wafer.ai/v1",
+    "doc": "https://docs.wafer.ai/wafer-pass",
+    "env": [
+      "WAFER_API_KEY"
+    ],
+    "model_count": 2
+  },
+  {
+    "id": "evroc",
+    "display_name": "evroc",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://models.think.evroc.com/v1",
+    "doc": "https://docs.evroc.com/products/think/overview.html",
+    "env": [
+      "EVROC_API_KEY"
+    ],
+    "model_count": 13
+  },
+  {
+    "id": "nova",
+    "display_name": "Nova",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.nova.amazon.com/v1",
+    "doc": "https://nova.amazon.com/dev/documentation",
+    "env": [
+      "NOVA_API_KEY"
+    ],
+    "model_count": 2
+  },
+  {
+    "id": "fireworks-ai",
+    "display_name": "Fireworks AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.fireworks.ai/inference/v1/",
+    "doc": "https://fireworks.ai/docs/",
+    "env": [
+      "FIREWORKS_API_KEY"
+    ],
+    "model_count": 20
+  },
+  {
+    "id": "alibaba",
+    "display_name": "Alibaba",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+    "doc": "https://www.alibabacloud.com/help/en/model-studio/models",
+    "env": [
+      "DASHSCOPE_API_KEY"
+    ],
+    "model_count": 48
+  },
+  {
+    "id": "302ai",
+    "display_name": "302.AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.302.ai/v1",
+    "doc": "https://doc.302.ai",
+    "env": [
+      "302AI_API_KEY"
+    ],
+    "model_count": 97
+  },
+  {
+    "id": "xpersona",
+    "display_name": "Xpersona",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://www.xpersona.co/v1",
+    "doc": "https://www.xpersona.co/docs",
+    "env": [
+      "XPERSONA_API_KEY"
+    ],
+    "model_count": 1
+  },
+  {
+    "id": "stepfun",
+    "display_name": "StepFun",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.stepfun.com/v1",
+    "doc": "https://platform.stepfun.com/docs/zh/overview/concept",
+    "env": [
+      "STEPFUN_API_KEY"
+    ],
+    "model_count": 4
+  },
+  {
+    "id": "sarvam",
+    "display_name": "Sarvam AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.sarvam.ai/v1",
+    "doc": "https://docs.sarvam.ai/api-reference-docs/getting-started/models",
+    "env": [
+      "SARVAM_API_KEY"
+    ],
+    "model_count": 2
+  },
+  {
+    "id": "zhipuai",
+    "display_name": "Zhipu AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://open.bigmodel.cn/api/paas/v4",
+    "doc": "https://docs.z.ai/guides/overview/pricing",
+    "env": [
+      "ZHIPU_API_KEY"
+    ],
+    "model_count": 12
+  },
+  {
+    "id": "bailing",
+    "display_name": "Bailing",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.tbox.cn/api/llm/v1/chat/completions",
+    "doc": "https://alipaytbox.yuque.com/sxs0ba/ling/intro",
+    "env": [
+      "BAILING_API_TOKEN"
+    ],
+    "model_count": 2
   },
   {
     "id": "qihang-ai",
@@ -915,6 +1059,61 @@
     "model_count": 9
   },
   {
+    "id": "lilac",
+    "display_name": "Lilac",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.getlilac.com/v1",
+    "doc": "https://docs.getlilac.com/inference/models",
+    "env": [
+      "LILAC_API_KEY"
+    ],
+    "model_count": 4
+  },
+  {
+    "id": "alibaba-cn",
+    "display_name": "Alibaba (China)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    "doc": "https://www.alibabacloud.com/help/en/model-studio/models",
+    "env": [
+      "DASHSCOPE_API_KEY"
+    ],
+    "model_count": 80
+  },
+  {
+    "id": "drun",
+    "display_name": "D.Run (China)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://chat.d.run/v1",
+    "doc": "https://www.d.run",
+    "env": [
+      "DRUN_API_KEY"
+    ],
+    "model_count": 3
+  },
+  {
+    "id": "huggingface",
+    "display_name": "Hugging Face",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://router.huggingface.co/v1",
+    "doc": "https://huggingface.co/docs/inference-providers",
+    "env": [
+      "HF_TOKEN"
+    ],
+    "model_count": 24
+  },
+  {
+    "id": "umans-ai-coding-plan",
+    "display_name": "Umans AI Coding Plan",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.code.umans.ai/v1",
+    "doc": "https://app.umans.ai/offers/code/docs",
+    "env": [
+      "UMANS_AI_CODING_PLAN_API_KEY"
+    ],
+    "model_count": 5
+  },
+  {
     "id": "tencent-tokenhub",
     "display_name": "Tencent TokenHub",
     "npm": "@ai-sdk/openai-compatible",
@@ -926,15 +1125,15 @@
     "model_count": 1
   },
   {
-    "id": "modelscope",
-    "display_name": "ModelScope",
+    "id": "nebius",
+    "display_name": "Nebius Token Factory",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api-inference.modelscope.cn/v1",
-    "doc": "https://modelscope.cn/docs/model-service/API-Inference/intro",
+    "api": "https://api.tokenfactory.nebius.com/v1",
+    "doc": "https://docs.tokenfactory.nebius.com/",
     "env": [
-      "MODELSCOPE_API_KEY"
+      "NEBIUS_API_KEY"
     ],
-    "model_count": 7
+    "model_count": 31
   },
   {
     "id": "hpc-ai",
@@ -959,69 +1158,25 @@
     "model_count": 5
   },
   {
-    "id": "clarifai",
-    "display_name": "Clarifai",
+    "id": "github-copilot",
+    "display_name": "GitHub Copilot",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.clarifai.com/v2/ext/openai/v1",
-    "doc": "https://docs.clarifai.com/compute/inference/",
+    "api": "https://api.githubcopilot.com",
+    "doc": "https://docs.github.com/en/copilot",
     "env": [
-      "CLARIFAI_PAT"
+      "GITHUB_TOKEN"
     ],
-    "model_count": 12
+    "model_count": 27
   },
   {
-    "id": "minimax-cn",
-    "display_name": "MiniMax (minimaxi.com)",
-    "npm": "@ai-sdk/anthropic",
-    "api": "https://api.minimaxi.com/anthropic/v1",
-    "doc": "https://platform.minimaxi.com/docs/guides/quickstart",
-    "env": [
-      "MINIMAX_API_KEY"
-    ],
-    "model_count": 6
-  },
-  {
-    "id": "regolo-ai",
-    "display_name": "Regolo AI",
+    "id": "inference",
+    "display_name": "Inference",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.regolo.ai/v1",
-    "doc": "https://docs.regolo.ai/",
+    "api": "https://inference.net/v1",
+    "doc": "https://inference.net/models",
     "env": [
-      "REGOLO_API_KEY"
+      "INFERENCE_API_KEY"
     ],
-    "model_count": 13
-  },
-  {
-    "id": "xiaomi-token-plan-ams",
-    "display_name": "Xiaomi Token Plan (Europe)",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://token-plan-ams.xiaomimimo.com/v1",
-    "doc": "https://platform.xiaomimimo.com/#/docs",
-    "env": [
-      "XIAOMI_API_KEY"
-    ],
-    "model_count": 5
-  },
-  {
-    "id": "zhipuai",
-    "display_name": "Zhipu AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://open.bigmodel.cn/api/paas/v4",
-    "doc": "https://docs.z.ai/guides/overview/pricing",
-    "env": [
-      "ZHIPU_API_KEY"
-    ],
-    "model_count": 12
-  },
-  {
-    "id": "nova",
-    "display_name": "Nova",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.nova.amazon.com/v1",
-    "doc": "https://nova.amazon.com/dev/documentation",
-    "env": [
-      "NOVA_API_KEY"
-    ],
-    "model_count": 2
+    "model_count": 9
   }
 ]

--- a/crates/goose/src/providers/canonical/name_builder.rs
+++ b/crates/goose/src/providers/canonical/name_builder.rs
@@ -448,16 +448,16 @@ mod tests {
 
         // === Grok (X.AI) ===
         assert_eq!(
-            map_to_canonical_model("databricks", "grok-3", r),
-            Some("x-ai/grok-3".to_string())
+            map_to_canonical_model("databricks", "grok-4.20", r),
+            Some("x-ai/grok-4.20".to_string())
         );
         assert_eq!(
-            map_to_canonical_model("databricks", "databricks-grok-4-fast", r),
-            Some("x-ai/grok-4-fast".to_string())
+            map_to_canonical_model("databricks", "databricks-grok-4.20", r),
+            Some("x-ai/grok-4.20".to_string())
         );
         assert_eq!(
-            map_to_canonical_model("databricks", "kgoose-grok-4-fast", r),
-            Some("x-ai/grok-4-fast".to_string())
+            map_to_canonical_model("databricks", "kgoose-grok-4.20", r),
+            Some("x-ai/grok-4.20".to_string())
         );
 
         // === Cohere Command ===
@@ -493,8 +493,8 @@ mod tests {
             Some("deepseek/deepseek-chat".to_string())
         );
         assert_eq!(
-            map_to_canonical_model("databricks", "x-ai-grok-3", r),
-            Some("x-ai/grok-3".to_string())
+            map_to_canonical_model("databricks", "x-ai-grok-4.20", r),
+            Some("x-ai/grok-4.20".to_string())
         );
 
         // === Zhipu AI ===
@@ -518,27 +518,27 @@ mod tests {
         );
         assert_eq!(
             map_to_canonical_model("gcp_vertex_ai", "claude-3-5-sonnet", r),
-            Some("anthropic/claude-3.5-sonnet".to_string())
+            Some("google-vertex/claude-3.5-sonnet".to_string())
         );
         assert_eq!(
             map_to_canonical_model("gcp_vertex_ai", "claude-sonnet-4@20250514", r),
-            Some("anthropic/claude-sonnet-4".to_string())
+            Some("google-vertex/claude-sonnet-4".to_string())
         );
         assert_eq!(
             map_to_canonical_model("gcp_vertex_ai", "claude-3-5-haiku@20241022", r),
-            Some("anthropic/claude-3.5-haiku".to_string())
+            Some("google-vertex/claude-3.5-haiku".to_string())
         );
         assert_eq!(
             map_to_canonical_model("gcp_vertex_ai", "claude-sonnet-4-5@20250929", r),
-            Some("anthropic/claude-sonnet-4.5".to_string())
+            Some("google-vertex/claude-sonnet-4.5".to_string())
         );
         assert_eq!(
             map_to_canonical_model("gcp_vertex_ai", "claude-opus-4-5@20251101", r),
-            Some("anthropic/claude-opus-4.5".to_string())
+            Some("google-vertex/claude-opus-4.5".to_string())
         );
         assert_eq!(
             map_to_canonical_model("gcp_vertex_ai", "claude-haiku-4-5@20251001", r),
-            Some("anthropic/claude-haiku-4.5".to_string())
+            Some("google-vertex/claude-haiku-4.5".to_string())
         );
     }
 }


### PR DESCRIPTION
## Summary
- Regenerate canonical model registry from models.dev
- Update provider metadata snapshot
- Includes newly available Gemini entries such as `google/gemini-3.5-flash`

## Validation
- `source bin/activate-hermit && just build-canonical-models`
- `cargo fmt`
- `jq empty crates/goose/src/providers/canonical/data/canonical_models.json`
- `jq empty crates/goose/src/providers/canonical/data/provider_metadata.json`