### PR TITLE
Add feature codemode to tests

### DIFF
--- a/crates/goose/tests/acp_provider_test.rs
+++ b/crates/goose/tests/acp_provider_test.rs
@@ -5,13 +5,15 @@
 mod common_tests;
 use common_tests::fixtures::provider::AcpProviderConnection;
 use common_tests::fixtures::run_test;
+#[cfg(feature = "code-mode")]
+use common_tests::run_prompt_codemode;
 use common_tests::{
     run_close_session, run_config_mcp, run_delete_session, run_fs_read_text_file_true,
     run_fs_write_text_file_false, run_fs_write_text_file_true, run_load_mode, run_load_model,
     run_load_session_error, run_load_session_mcp, run_model_list, run_permission_persistence,
-    run_prompt_basic, run_prompt_codemode, run_prompt_error, run_prompt_image,
-    run_prompt_image_attachment, run_prompt_mcp, run_prompt_model_mismatch, run_prompt_skill,
-    run_shell_terminal_false, run_shell_terminal_true,
+    run_prompt_basic, run_prompt_error, run_prompt_image, run_prompt_image_attachment,
+    run_prompt_mcp, run_prompt_model_mismatch, run_prompt_skill, run_shell_terminal_false,
+    run_shell_terminal_true,
 };
 
 #[test]
@@ -87,6 +89,7 @@ fn test_prompt_basic() {
 }
 
 #[test]
+#[cfg(feature = "code-mode")]
 fn test_prompt_codemode() {
     run_test(async { run_prompt_codemode::<AcpProviderConnection>().await });
 }

--- a/crates/goose/tests/acp_server_test.rs
+++ b/crates/goose/tests/acp_server_test.rs
@@ -5,6 +5,8 @@ use agent_client_protocol::schema::{ListSessionsRequest, ListSessionsResponse};
 use agent_client_protocol::ErrorCode;
 use common_tests::fixtures::server::AcpServerConnection;
 use common_tests::fixtures::{run_test, Connection, OpenAiFixture, TestConnectionConfig};
+#[cfg(feature = "code-mode")]
+use common_tests::run_prompt_codemode;
 use common_tests::{
     run_close_session, run_config_mcp, run_config_option_mode_set, run_config_option_model_set,
     run_delete_session, run_fs_read_text_file_true, run_fs_write_text_file_false,
@@ -12,9 +14,9 @@ use common_tests::{
     run_load_mode, run_load_model, run_load_session_error, run_load_session_mcp, run_mode_set,
     run_model_list, run_model_set, run_model_set_error_session_not_found,
     run_new_session_returns_initial_config, run_permission_persistence, run_prompt_basic,
-    run_prompt_codemode, run_prompt_error, run_prompt_image, run_prompt_image_attachment,
-    run_prompt_mcp, run_prompt_model_mismatch, run_prompt_skill,
-    run_session_name_update_notification, run_shell_terminal_false, run_shell_terminal_true,
+    run_prompt_error, run_prompt_image, run_prompt_image_attachment, run_prompt_mcp,
+    run_prompt_model_mismatch, run_prompt_skill, run_session_name_update_notification,
+    run_shell_terminal_false, run_shell_terminal_true,
 };
 use goose::config::GooseMode;
 use goose::conversation::message::Message;
@@ -254,6 +256,7 @@ fn test_prompt_basic() {
 }
 
 #[test]
+#[cfg(feature = "code-mode")]
 fn test_prompt_codemode() {
     run_test(async { run_prompt_codemode::<AcpServerConnection>().await });
 }


### PR DESCRIPTION
## Summary
<!-- Describe your change -->
There were two tests in acp_provider and acp_server that were missing the gating for code-mode feature, causing `cargo test` to fail when invoked without code-mode support

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
`cargo test --no-default-features`

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

