### PR TITLE
fix: avoid ghost sessions showing up in the desktop app

### DIFF
--- a/crates/goose-server/src/routes/session.rs
+++ b/crates/goose-server/src/routes/session.rs
@@ -111,7 +111,22 @@ async fn list_sessions(
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
+    let sessions = sessions
+        .into_iter()
+        .filter(|s| !is_ghost_session(s))
+        .collect();
+
     Ok(Json(SessionListResponse { sessions }))
+}
+
+/// Returns true for "ghost" sessions: empty user chats that were created by
+/// `POST /agent/start` but never received a message. These appear as blank
+/// "New Chat" entries in the session list and clutter the UI without
+fn is_ghost_session(session: &Session) -> bool {
+    session.session_type == SessionType::User
+        && session.message_count == 0
+        && !session.user_set_name
+        && session.recipe.is_none()
 }
 
 #[utoipa::path(
@@ -713,7 +728,7 @@ async fn search_sessions(
 
     let matching_sessions: Vec<Session> = all_sessions
         .into_iter()
-        .filter(|s| session_ids.contains(&s.id))
+        .filter(|s| session_ids.contains(&s.id) && !is_ghost_session(s))
         .collect();
 
     Ok(Json(matching_sessions))


### PR DESCRIPTION
## Summary
* Several users have reported sessions being created with no messages and showing up in session history
* This filters them out at serving time to the desktop app
* Having the system not create sessions with empty conversations in the first place seems cleaner, but goose seems to think it would be a large change, because some components of the system need a session id before the first message. (Findings at bottom of this description)

### Testing
Local

### Related Issues
N/A

### Screenshots/Demos (for UX changes)
N/A


From goose:

> **Why "create on first message" is not minimal in this codebase**
> 
> The renderer needs a real session.id before SSE subscription — useChatStream subscribes to /sessions/{id}/events on mount, gated by route's resumeSessionId. To defer creation, you'd either:
> 
> Generate the id client-side and accept that /sessions/{id}/events returns 404 until the first /reply arrives (renderer must handle "session doesn't exist yet" gracefully across SSE retry logic, conversation-load, name-refresh, etc.), or
> Block the Pair view from mounting until the user types and submits, then call create + reply together (re-shaping the route flow).
> start_agent does more than write a row — it resolves recipe, applies recipe settings (provider override, model override, extensions), kicks off background extension loading. Pushing this to /reply time means the renderer has to choose between (a) a slow first-reply latency or (b) speculative extension loading that races the user's typing — both regressions versus today.
> 
> The id is DB-allocated (MAX(id)+1 per day in a BEGIN IMMEDIATE tx). Lazy persistence needs a new id scheme or a counter-in-memory. Both are bigger than the ghost-filter fix.
> 
> Pending sessions tier touches 46 call sites of .session_manager() — every reader has to be aware of the dual-tier model, or we have to put a fake "pending" row in SQLite (which defeats the purpose).
> 
> There's no client-disconnect signal to garbage-collect with — SSE drops are normal during streaming and aren't a "user gave up" signal.
> 
