### PR TITLE
fix(providers): detect image paths with spaces

### DIFF
--- a/crates/goose-providers/src/images.rs
+++ b/crates/goose-providers/src/images.rs
@@ -37,6 +37,7 @@ pub fn detect_image_path(text: &str) -> Option<&str> {
     const EXTENSIONS: [&str; 3] = [".png", ".jpg", ".jpeg"];
     const MAX_PATH_LEN: usize = 4096;
 
+    let mut best: Option<&str> = None;
     let mut from = 0;
     while from < text.len() {
         let Some(end) = EXTENSIONS
@@ -71,14 +72,20 @@ pub fn detect_image_path(text: &str) -> Option<&str> {
                     };
                     let path = Path::new(candidate);
                     if path.is_absolute() && path.is_file() && is_image_file(path) {
-                        return Some(candidate);
+                        // A whitespace-terminated extension is ambiguous: the
+                        // filename may continue to a later extension, so keep
+                        // the longest existing match rather than the first.
+                        if best.is_none_or(|b| candidate.len() > b.len()) {
+                            best = Some(candidate);
+                        }
+                        break;
                     }
                 }
             }
         }
         from = end;
     }
-    None
+    best
 }
 
 /// Case-insensitive ASCII substring search returning a byte index into
@@ -232,6 +239,16 @@ mod tests {
         // unquoted path.
         let text = format!("here {}\" trailing", png_path_str);
         assert_eq!(detect_image_path(&text), Some(png_path_str));
+
+        // When a spaced filename contains an earlier image extension, prefer
+        // the longer existing candidate over the embedded prefix.
+        let edited = temp_dir.path().join("Screen Shot.png edited.jpg");
+        std::fs::write(&edited, png_data).unwrap();
+        let edited_str = edited.to_str().unwrap();
+        let prefix = temp_dir.path().join("Screen Shot.png");
+        std::fs::write(&prefix, png_data).unwrap();
+        let text = format!("look at {}", edited_str);
+        assert_eq!(detect_image_path(&text), Some(edited_str));
     }
 
     #[test]

--- a/crates/goose-providers/src/images.rs
+++ b/crates/goose-providers/src/images.rs
@@ -37,7 +37,7 @@ pub fn detect_image_path(text: &str) -> Option<&str> {
     const EXTENSIONS: [&str; 3] = [".png", ".jpg", ".jpeg"];
     const MAX_PATH_LEN: usize = 4096;
 
-    let mut best: Option<&str> = None;
+    let mut best: Option<(usize, &str)> = None;
     let mut from = 0;
     while from < text.len() {
         let Some(end) = EXTENSIONS
@@ -72,11 +72,16 @@ pub fn detect_image_path(text: &str) -> Option<&str> {
                     };
                     let path = Path::new(candidate);
                     if path.is_absolute() && path.is_file() && is_image_file(path) {
-                        // A whitespace-terminated extension is ambiguous: the
-                        // filename may continue to a later extension, so keep
-                        // the longest existing match rather than the first.
-                        if best.is_none_or(|b| candidate.len() > b.len()) {
-                            best = Some(candidate);
+                        // Keep the first referenced path, but allow a longer
+                        // match anchored at the same start to extend it (a
+                        // whitespace-terminated extension may be a prefix of a
+                        // spaced filename ending in a later extension).
+                        match best {
+                            Some((best_start, _)) if start == best_start => {
+                                best = Some((start, candidate));
+                            }
+                            None => best = Some((start, candidate)),
+                            Some(_) => {}
                         }
                         break;
                     }
@@ -85,7 +90,7 @@ pub fn detect_image_path(text: &str) -> Option<&str> {
         }
         from = end;
     }
-    best
+    best.map(|(_, candidate)| candidate)
 }
 
 /// Case-insensitive ASCII substring search returning a byte index into
@@ -249,6 +254,19 @@ mod tests {
         std::fs::write(&prefix, png_data).unwrap();
         let text = format!("look at {}", edited_str);
         assert_eq!(detect_image_path(&text), Some(edited_str));
+
+        // With multiple distinct images, the first referenced one wins even if
+        // a later one has a longer path.
+        let a = temp_dir.path().join("a.png");
+        std::fs::write(&a, png_data).unwrap();
+        let longer = temp_dir.path().join("much-longer.png");
+        std::fs::write(&longer, png_data).unwrap();
+        let text = format!(
+            "compare {} with {}",
+            a.to_str().unwrap(),
+            longer.to_str().unwrap()
+        );
+        assert_eq!(detect_image_path(&text), Some(a.to_str().unwrap()));
     }
 
     #[test]

--- a/crates/goose-providers/src/images.rs
+++ b/crates/goose-providers/src/images.rs
@@ -44,7 +44,8 @@ pub fn convert_image(image: &ImageContent, image_format: &ImageFormat) -> Value 
 /// The extension must terminate the candidate (so `/tmp/foo.png.backup` is not
 /// truncated to `/tmp/foo.png`) and the leading `/` must follow a whitespace or
 /// quote boundary (so a `://` in a URL like `https://host/x.png` is not mistaken
-/// for an absolute path).
+/// for an absolute path). A path may be wrapped in matching quotes
+/// (`"/tmp/Screen Shot.png"`), in which case the closing quote terminates it.
 pub fn detect_image_path(text: &str) -> Option<&str> {
     const EXTENSIONS: [&str; 3] = [".png", ".jpg", ".jpeg"];
     const MAX_PATH_LEN: usize = 4096;
@@ -59,10 +60,9 @@ pub fn detect_image_path(text: &str) -> Option<&str> {
             break;
         };
 
-        let terminated = text
-            .get(end..)
-            .and_then(|rest| rest.chars().next())
-            .is_none_or(|c| c == '/' || c.is_whitespace());
+        let terminator = text.get(end..).and_then(|rest| rest.chars().next());
+        let terminated =
+            terminator.is_none_or(|c| c == '/' || c.is_whitespace() || c == '"' || c == '\'');
 
         if terminated {
             let mut floor = end.saturating_sub(MAX_PATH_LEN);
@@ -234,6 +234,17 @@ mod tests {
         let upper_str = upper.to_str().unwrap();
         let text = format!("see {}", upper_str);
         assert_eq!(detect_image_path(&text), Some(upper_str));
+
+        // Quoted path with spaces: the closing quote terminates the candidate.
+        let text = format!("describe \"{}\" please", png_path_str);
+        assert_eq!(detect_image_path(&text), Some(png_path_str));
+        let text = format!("describe '{}'", png_path_str);
+        assert_eq!(detect_image_path(&text), Some(png_path_str));
+
+        // A stray closing quote in prose must not act as a terminator for an
+        // unquoted path.
+        let text = format!("here {}\" trailing", png_path_str);
+        assert_eq!(detect_image_path(&text), Some(png_path_str));
     }
 
     #[test]

--- a/crates/goose-providers/src/images.rs
+++ b/crates/goose-providers/src/images.rs
@@ -33,28 +33,56 @@ pub fn convert_image(image: &ImageContent, image_format: &ImageFormat) -> Value 
     }
 }
 
-/// Detect if a string contains a path to an image file
+/// Detect if a string contains a path to an image file.
+///
+/// Absolute paths can contain spaces (e.g. macOS screenshots like
+/// `/…/Screen Shot 2026.png`), so rather than splitting on whitespace we anchor
+/// on each image-extension occurrence and walk back over `/`-rooted starts,
+/// returning the longest candidate that is an existing image file. The backward
+/// scan is bounded so extension-heavy text can't cause quadratic work.
 pub fn detect_image_path(text: &str) -> Option<&str> {
-    // Basic image file extension check
-    let extensions = [".png", ".jpg", ".jpeg"];
+    const EXTENSIONS: [&str; 3] = [".png", ".jpg", ".jpeg"];
+    const MAX_PATH_LEN: usize = 4096;
 
-    // Find any word that ends with an image extension
-    for word in text.split_whitespace() {
-        if extensions
+    let mut from = 0;
+    while from < text.len() {
+        let Some(end) = EXTENSIONS
             .iter()
-            .any(|ext| word.to_lowercase().ends_with(ext))
-        {
-            let path = Path::new(word);
-            // Check if it's an absolute path and file exists
-            if path.is_absolute() && path.is_file() {
-                // Verify it's actually an image file
-                if is_image_file(path) {
-                    return Some(word);
+            .filter_map(|ext| find_ascii_ci(text, ext, from).map(|i| i + ext.len()))
+            .min()
+        else {
+            break;
+        };
+
+        let mut floor = end.saturating_sub(MAX_PATH_LEN);
+        while floor < end && !text.is_char_boundary(floor) {
+            floor += 1;
+        }
+        if let Some(window) = text.get(floor..end) {
+            for (rel, _) in window.match_indices('/') {
+                let Some(candidate) = text.get(floor + rel..end) else {
+                    continue;
+                };
+                let path = Path::new(candidate);
+                if path.is_absolute() && path.is_file() && is_image_file(path) {
+                    return Some(candidate);
                 }
             }
         }
+        from = end;
     }
     None
+}
+
+/// Case-insensitive ASCII substring search returning a byte index into
+/// `haystack` (no allocation, so the index stays valid for slicing).
+fn find_ascii_ci(haystack: &str, needle: &str, from: usize) -> Option<usize> {
+    let (hb, nb) = (haystack.as_bytes(), needle.as_bytes());
+    if nb.is_empty() || hb.len() < nb.len() || from > hb.len() - nb.len() {
+        return None;
+    }
+    (from..=hb.len() - nb.len())
+        .find(|&i| hb[i..i + nb.len()].iter().zip(nb).all(|(a, b)| a.eq_ignore_ascii_case(b)))
 }
 
 /// Check if a file is actually an image by examining its magic bytes
@@ -162,6 +190,34 @@ mod tests {
         // Test with relative path (should not match)
         let text = "Here is a relative/path/image.png";
         assert_eq!(detect_image_path(text), None);
+    }
+
+    #[test]
+    fn test_detect_image_path_with_spaces() {
+        // Absolute path containing spaces (macOS screenshot style).
+        let temp_dir = tempfile::tempdir().unwrap();
+        let png_path = temp_dir.path().join("Screen Shot 2026.png");
+        let png_data = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        std::fs::write(&png_path, png_data).unwrap();
+        let png_path_str = png_path.to_str().unwrap();
+
+        let text = format!("please describe {} for me", png_path_str);
+        assert_eq!(detect_image_path(&text), Some(png_path_str));
+
+        // Case-insensitive extension also matches.
+        let upper = temp_dir.path().join("Another Shot.PNG");
+        std::fs::write(&upper, png_data).unwrap();
+        let upper_str = upper.to_str().unwrap();
+        let text = format!("see {}", upper_str);
+        assert_eq!(detect_image_path(&text), Some(upper_str));
+    }
+
+    #[test]
+    fn test_detect_image_path_ignores_extension_flood() {
+        // Many extension-like tokens but no real absolute path: must scan
+        // cheaply (bounded) and find nothing.
+        let text = "see foo.png and bar.jpg and baz.jpeg ".repeat(500);
+        assert_eq!(detect_image_path(&text), None);
     }
 
     #[test]

--- a/crates/goose-providers/src/images.rs
+++ b/crates/goose-providers/src/images.rs
@@ -33,19 +33,11 @@ pub fn convert_image(image: &ImageContent, image_format: &ImageFormat) -> Value 
     }
 }
 
-/// Detect if a string contains a path to an image file.
+/// Detect an absolute path to an existing image file within `text`.
 ///
-/// Absolute paths can contain spaces (e.g. macOS screenshots like
-/// `/…/Screen Shot 2026.png`), so rather than splitting on whitespace we anchor
-/// on each image-extension occurrence and walk back over `/`-rooted starts,
-/// returning the longest candidate that is an existing image file. The backward
-/// scan is bounded so extension-heavy text can't cause quadratic work.
-///
-/// The extension must terminate the candidate (so `/tmp/foo.png.backup` is not
-/// truncated to `/tmp/foo.png`) and the leading `/` must follow a whitespace or
-/// quote boundary (so a `://` in a URL like `https://host/x.png` is not mistaken
-/// for an absolute path). A path may be wrapped in matching quotes
-/// (`"/tmp/Screen Shot.png"`), in which case the closing quote terminates it.
+/// Anchors on each image extension and walks back to a `/`-rooted, boundary-
+/// delimited start so paths containing spaces (e.g. macOS screenshots) are
+/// detected without being confused by URLs or longer extensions.
 pub fn detect_image_path(text: &str) -> Option<&str> {
     const EXTENSIONS: [&str; 3] = [".png", ".jpg", ".jpeg"];
     const MAX_PATH_LEN: usize = 4096;

--- a/crates/goose-providers/src/images.rs
+++ b/crates/goose-providers/src/images.rs
@@ -33,11 +33,6 @@ pub fn convert_image(image: &ImageContent, image_format: &ImageFormat) -> Value 
     }
 }
 
-/// Detect an absolute path to an existing image file within `text`.
-///
-/// Anchors on each image extension and walks back to a `/`-rooted, boundary-
-/// delimited start so paths containing spaces (e.g. macOS screenshots) are
-/// detected without being confused by URLs or longer extensions.
 pub fn detect_image_path(text: &str) -> Option<&str> {
     const EXTENSIONS: [&str; 3] = [".png", ".jpg", ".jpeg"];
     const MAX_PATH_LEN: usize = 4096;

--- a/crates/goose-providers/src/images.rs
+++ b/crates/goose-providers/src/images.rs
@@ -40,6 +40,11 @@ pub fn convert_image(image: &ImageContent, image_format: &ImageFormat) -> Value 
 /// on each image-extension occurrence and walk back over `/`-rooted starts,
 /// returning the longest candidate that is an existing image file. The backward
 /// scan is bounded so extension-heavy text can't cause quadratic work.
+///
+/// The extension must terminate the candidate (so `/tmp/foo.png.backup` is not
+/// truncated to `/tmp/foo.png`) and the leading `/` must follow a whitespace or
+/// quote boundary (so a `://` in a URL like `https://host/x.png` is not mistaken
+/// for an absolute path).
 pub fn detect_image_path(text: &str) -> Option<&str> {
     const EXTENSIONS: [&str; 3] = [".png", ".jpg", ".jpeg"];
     const MAX_PATH_LEN: usize = 4096;
@@ -54,18 +59,33 @@ pub fn detect_image_path(text: &str) -> Option<&str> {
             break;
         };
 
-        let mut floor = end.saturating_sub(MAX_PATH_LEN);
-        while floor < end && !text.is_char_boundary(floor) {
-            floor += 1;
-        }
-        if let Some(window) = text.get(floor..end) {
-            for (rel, _) in window.match_indices('/') {
-                let Some(candidate) = text.get(floor + rel..end) else {
-                    continue;
-                };
-                let path = Path::new(candidate);
-                if path.is_absolute() && path.is_file() && is_image_file(path) {
-                    return Some(candidate);
+        let terminated = text
+            .get(end..)
+            .and_then(|rest| rest.chars().next())
+            .is_none_or(|c| c == '/' || c.is_whitespace());
+
+        if terminated {
+            let mut floor = end.saturating_sub(MAX_PATH_LEN);
+            while floor < end && !text.is_char_boundary(floor) {
+                floor += 1;
+            }
+            if let Some(window) = text.get(floor..end) {
+                for (rel, _) in window.match_indices('/') {
+                    let start = floor + rel;
+                    let preceded_by_boundary = text
+                        .get(..start)
+                        .and_then(|prefix| prefix.chars().next_back())
+                        .is_none_or(|c| c.is_whitespace() || c == '"' || c == '\'');
+                    if !preceded_by_boundary {
+                        continue;
+                    }
+                    let Some(candidate) = text.get(start..end) else {
+                        continue;
+                    };
+                    let path = Path::new(candidate);
+                    if path.is_absolute() && path.is_file() && is_image_file(path) {
+                        return Some(candidate);
+                    }
                 }
             }
         }
@@ -81,8 +101,12 @@ fn find_ascii_ci(haystack: &str, needle: &str, from: usize) -> Option<usize> {
     if nb.is_empty() || hb.len() < nb.len() || from > hb.len() - nb.len() {
         return None;
     }
-    (from..=hb.len() - nb.len())
-        .find(|&i| hb[i..i + nb.len()].iter().zip(nb).all(|(a, b)| a.eq_ignore_ascii_case(b)))
+    (from..=hb.len() - nb.len()).find(|&i| {
+        hb[i..i + nb.len()]
+            .iter()
+            .zip(nb)
+            .all(|(a, b)| a.eq_ignore_ascii_case(b))
+    })
 }
 
 /// Check if a file is actually an image by examining its magic bytes
@@ -210,6 +234,27 @@ mod tests {
         let upper_str = upper.to_str().unwrap();
         let text = format!("see {}", upper_str);
         assert_eq!(detect_image_path(&text), Some(upper_str));
+    }
+
+    #[test]
+    fn test_detect_image_path_ignores_urls_and_longer_extensions() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let png_data = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+        // A real image whose path is a suffix of a URL must not be extracted
+        // from that URL via the `://` separator.
+        let dir = temp_dir.path().to_str().unwrap().trim_start_matches('/');
+        let png_path = temp_dir.path().join("photo.png");
+        std::fs::write(&png_path, png_data).unwrap();
+        let url = format!("https:/{}/photo.png", dir);
+        assert_eq!(detect_image_path(&url), None);
+
+        // A backup file sharing the image extension prefix must not be
+        // truncated to the bare image path.
+        let real = temp_dir.path().join("shot.png");
+        std::fs::write(&real, png_data).unwrap();
+        let backup = format!("{}.backup", real.to_str().unwrap());
+        assert_eq!(detect_image_path(&backup), None);
     }
 
     #[test]


### PR DESCRIPTION
Closes #9576

## Summary
`detect_image_path` dropped any image path containing a space — most importantly macOS screenshots like `Screenshot 2026-05-04 at 10.32.57 PM.png`. Local vision through OpenAI-format providers (LM Studio, Ollama, etc.) then silently received no image, and the model would reply that it couldn't see the file. The function has since moved out of `crates/goose/src/providers/utils.rs` into the new `goose-providers` crate (`crates/goose-providers/src/images.rs`) and was rewritten to split on whitespace there, which reintroduced the same blind spot — this PR re-applies and hardens the fix in its new home.

## Change (`crates/goose-providers/src/images.rs`)
Replace the whitespace split with an extension-anchored scan:

- For each `.png` / `.jpg` / `.jpeg` occurrence (case-insensitive, allocation-free via `find_ascii_ci` so the returned byte index stays valid for slicing), walk backward over `/`-rooted candidates and return one that is an existing image file (`is_absolute` + `is_file` + magic-byte `is_image_file`).
- **Boundary guards** so the heuristic doesn't over-match:
  - The extension must *terminate* the candidate (next char is `/`, whitespace, a quote, or end of input) — so `/tmp/shot.png.backup` isn't truncated to `/tmp/shot.png`.
  - The leading `/` must follow a whitespace/quote boundary — so a local path isn't carved out of a URL like `https://host/some/local/path.png`.
  - Quote characters terminate a candidate, so quoted spaced paths (`"/tmp/Screen Shot.png"`) match.
- **Spaced filenames:** keep the first referenced path, but allow a longer match anchored at the same start to extend it (an earlier extension can be a prefix of the real, longer filename, e.g. `Screen Shot.png edited.jpg`).
- The backward scan is bounded by `MAX_PATH_LEN`, keeping the function linear even on extension-heavy prompts.

## Credit
The `main` merge, the URL/longer-extension boundary hardening, and the `cargo fmt` fix were pushed to this branch by @DOsinga — thank you.

## Test plan (`images.rs` unit tests, all passing)
- [x] `test_detect_image_path` — existing relative / fake / nonexistent behavior preserved
- [x] `test_detect_image_path_with_spaces` — absolute and quoted paths containing spaces
- [x] `test_detect_image_path_ignores_urls_and_longer_extensions` — URL suffix and `.png.backup` not mis-extracted
- [x] `test_detect_image_path_ignores_extension_flood` — bounded scan on extension-heavy input
- [x] `test_load_image_file`
- [x] `cargo fmt` clean; `cargo clippy -p goose-providers --all-targets` and the `images` tests pass locally.
