### PR TITLE
fix(desktop): refresh provider list in Switch Models picker

### DIFF
--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
@@ -477,7 +477,10 @@ export const SwitchModelModal = ({
 
     (async () => {
       try {
-        const providersResponse = await getProviders(false);
+        // Force a refresh so the list reflects providers (un)configured since the
+        // cache was populated; otherwise a provider deleted in Settings still
+        // shows up here (#9364).
+        const providersResponse = await getProviders(true);
         const activeProviders = providersResponse.filter((provider) => provider.is_configured);
         setActiveProvidersList(activeProviders);
         setProviderOptions([


### PR DESCRIPTION
## Summary

The "Switch models" picker (Settings > Models > Switch Models, and "Change Model" in a chat, both rendered by `SwitchModelModal`) builds its provider dropdown from `getProviders(false)`, i.e. the in-memory cache populated when `ConfigContext` first mounts. Deleting a provider in "Configure Providers" removes its config but never invalidates that cache, so the deleted provider keeps showing in the picker (it is still cached as `is_configured: true`).

Every other consumer that shows the provider list to the user already forces a refresh with `getProviders(true)`:

- `src/components/ChatInput.tsx`
- `src/components/settings/providers/ProviderSettingsPage.tsx`
- `src/components/settings/models/ModelsSection.tsx`
- `src/components/onboarding/OnboardingGuard.tsx`

`SwitchModelModal` was the only consumer still reading the stale cache. This change makes it consistent so the list always reflects the current provider configuration.

The `/providers` fetch is a cheap local call; it does not load model lists or contact HuggingFace, so it does not reintroduce the panel open delay fixed in #8626 (that delay came from `list_local_models` and eager per-provider model fetching, both untouched here).

### Testing

- Verified by inspection: `getProviders` is typed `(forceRefresh: boolean) => Promise<ProviderDetails[]>`, and the four call sites above establish `true` as the established pattern for user-facing provider lists. The change adds no strings and no imports, so typecheck, eslint and i18n checks are unaffected.
- To verify the behavior: configure two providers, delete one under Settings > Models > Configure Providers, then open Switch Models. The deleted provider no longer appears; re-adding it brings it back.

### Related Issues

Fixes #9364