### PR TITLE
fix(desktop): stop the main window growing taller on every launch

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -865,13 +865,16 @@ const createChat = async (app: App, options: CreateChatOptions = {}) => {
     trafficLightPosition: process.platform === 'darwin' ? { x: 20, y: 16 } : undefined,
     vibrancy: process.platform === 'darwin' ? 'window' : undefined,
     frame: process.platform !== 'darwin',
+    // windowStateKeeper persists the outer window bounds (getBounds), so the
+    // window must be restored by outer bounds too. With useContentSize the saved
+    // outer height is reapplied as the content height, growing the window by the
+    // frame height on every launch on framed platforms (#9363).
     x: mainWindowState.x,
     y: mainWindowState.y,
     width: mainWindowState.width,
     height: mainWindowState.height,
     minWidth: 450,
     resizable: true,
-    useContentSize: true,
     icon: path.join(__dirname, '../images/icon.icns'),
     webPreferences: {
       spellcheck: settings.spellcheckEnabled ?? true,


### PR DESCRIPTION
## Summary

On Linux and Windows the main window gets taller every time goose Desktop is launched, eventually filling the available screen height.

The window is created with `useContentSize: true`, so the `width`/`height` passed to the `BrowserWindow` constructor are interpreted as the *content* area. `electron-window-state` (the `windowStateKeeper` used here), however, persists and restores the *outer* window bounds via `win.getBounds()`. Each launch therefore restores the previous outer height as the new content height, and the window grows by the frame / title-bar height every time. macOS is unaffected because it runs frameless (`frame: false`), so outer bounds equal content bounds there.

Removing `useContentSize` makes the persisted (outer) bounds and the restored size use the same coordinate system, so the window reopens at exactly the size it was closed at.

Only the main window is changed. The app window created later (around `main.ts:2640`) also sets `useContentSize: true`, but it is sized from a fixed value on every launch rather than from persisted bounds, so it does not accumulate and is intentionally left untouched.

### Testing

- macOS is unaffected: with `frame: false` the outer and content sizes are identical, so dropping `useContentSize` is a no-op there.
- To verify the fix on Linux/Windows: resize the window, quit, relaunch, and repeat. The window now reopens at its previous size instead of gaining height each launch.

### Related Issues

Fixes #9363