### PR TITLE
fix(desktop): start new chat in current window from recipe param modal

### DIFF
--- a/ui/desktop/src/components/ParameterInputModal.tsx
+++ b/ui/desktop/src/components/ParameterInputModal.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Parameter } from '../recipe';
 import { Button } from './ui/button';
-import { getInitialWorkingDir } from '../utils/workingDir';
 import { defineMessages, useIntl } from '../i18n';
 
 const i18n = defineMessages({
@@ -126,14 +125,7 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
 
   const handleCancelOption = (option: 'new-chat' | 'back-to-form'): void => {
     if (option === 'new-chat') {
-      try {
-        const workingDir = getInitialWorkingDir();
-        window.electron.createChatWindow({ dir: workingDir });
-        window.electron.hideWindow();
-      } catch (error) {
-        console.error('Error creating new window:', error);
-        onClose();
-      }
+      onClose();
     } else {
       setShowCancelOptions(false); // Go back to the parameter form
     }


### PR DESCRIPTION
## Summary

Fixes #8864.

When cancelling the **Recipe Parameters** modal and choosing **Start New Chat (No Recipe)**, the handler was calling `window.electron.createChatWindow()` and `window.electron.hideWindow()` — which spawned a second Goose window and hid the current one, instead of just dismissing the recipe and continuing in the current window.

