### PR TITLE
feat: add `tui` feature flag to gate the tui command

### DIFF
--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -73,6 +73,7 @@ winapi = { workspace = true }
 default = [
     "code-mode",
     "local-inference",
+    "tui",
     "aws-providers",
     "telemetry",
     "nostr",
@@ -90,8 +91,9 @@ telemetry = ["goose/telemetry"]
 nostr = ["goose/nostr"]
 otel = ["goose/otel"]
 system-keyring = ["goose/system-keyring"]
+tui = []
 update = ["dep:sigstore-verify"]
-portable-default = ["rustls-tls", "aws-providers", "telemetry", "otel"]
+portable-default = ["rustls-tls", "aws-providers", "telemetry", "otel", "tui"]
 # disables the update command
 disable-update = []
 rustls-tls = [

--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -971,6 +971,7 @@ enum Command {
     },
 
     /// Launch the goose terminal UI (TUI)
+    #[cfg(feature = "tui")]
     #[command(
         about = "Launch the goose terminal UI",
         long_about = "Launch the goose terminal UI (the @aaif/goose npm package).\n\
@@ -1275,6 +1276,7 @@ fn get_command_name(command: &Option<Command>) -> &'static str {
         Some(Command::Recipe { .. }) => "recipe",
         Some(Command::Plugin { .. }) => "plugin",
         Some(Command::Term { .. }) => "term",
+        #[cfg(feature = "tui")]
         Some(Command::Tui { .. }) => "tui",
         #[cfg(feature = "local-inference")]
         Some(Command::LocalModels { .. }) => "local-models",
@@ -2112,6 +2114,7 @@ pub async fn cli() -> anyhow::Result<()> {
         Some(Command::Recipe { command }) => handle_recipe_subcommand(command),
         Some(Command::Plugin { command }) => handle_plugin_subcommand(command),
         Some(Command::Term { command }) => handle_term_subcommand(command).await,
+        #[cfg(feature = "tui")]
         Some(Command::Tui { args }) => crate::commands::tui::handle_tui(args),
         #[cfg(feature = "local-inference")]
         Some(Command::LocalModels { command }) => handle_local_models_command(command).await,

--- a/crates/goose-cli/src/commands/mod.rs
+++ b/crates/goose-cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod review;
 pub mod schedule;
 pub mod session;
 pub mod term;
+#[cfg(feature = "tui")]
 pub mod tui;
 #[cfg(feature = "update")]
 pub mod update;


### PR DESCRIPTION
## Summary
Allow downstream builds to exclude the `tui` CLI subcommand by disabling the `tui` feature flag. The feature is enabled by default and in `portable-default`.

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

