### PR TITLE
Prefer goose aliases for Databricks v2 inventory

### DIFF
--- a/crates/goose/src/providers/inventory/mod.rs
+++ b/crates/goose/src/providers/inventory/mod.rs
@@ -881,10 +881,10 @@ fn enrich_model_ids_with_canonical(
         models.push(model);
     }
 
-    // For databricks, prefer goose- prefixed model_ids when there are duplicates.
+    // For Databricks providers, prefer goose- prefixed model_ids when there are duplicates.
     // Re-scan: if a later model_id with "goose-" prefix maps to the same display name,
     // swap it in.
-    if provider_family == "databricks" {
+    if matches!(provider_family, "databricks" | "databricks_v2") {
         let mut name_to_idx: HashMap<String, usize> = HashMap::new();
         for (idx, model) in models.iter().enumerate() {
             name_to_idx.insert(model.name.clone(), idx);
@@ -1176,6 +1176,26 @@ mod tests {
 
         assert_eq!(models.len(), 1);
         assert!(models[0].name.contains("Claude"));
+    }
+
+    #[test]
+    fn databricks_v2_inventory_prefers_goose_model_ids_for_duplicate_names() {
+        let models = enrich_model_ids_with_canonical(
+            "databricks_v2",
+            &[
+                "databricks-gpt-5-5".to_string(),
+                "goose-gpt-5-5".to_string(),
+            ],
+        );
+
+        assert!(
+            models.iter().any(|model| model.id == "goose-gpt-5-5"),
+            "expected goose-gpt-5-5 to win duplicate canonical-name tie, got {models:?}"
+        );
+        assert!(
+            !models.iter().any(|model| model.id == "databricks-gpt-5-5"),
+            "expected databricks-gpt-5-5 to be replaced by goose-gpt-5-5, got {models:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Extend the existing Databricks inventory tie-breaker to `databricks_v2`
- Prefer `goose-*` endpoint aliases when Databricks v2 returns duplicate canonical model names
- Add a regression test covering `databricks_v2` duplicate normalization

## Testing

- `cargo fmt`
- `cargo test -p goose providers::inventory::tests::databricks_v2_inventory_prefers_goose_model_ids_for_duplicate_names`
