### PR TITLE
Add Scholar Sidekick MCP extension

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -845,5 +845,23 @@
     "is_builtin": false,
     "endorsed": true,
     "environmentVariables": []
-  }
+  },
+  {
+  "id": "scholar-sidekick",
+  "name": "Scholar Sidekick",
+  "description": "Resolve, format, export, and verify academic citations (DOI, PMID, ISBN, arXiv) plus retraction and open-access checks",
+  "command": "npx -y scholar-sidekick-mcp@latest",
+  "link": "https://github.com/mlava/scholar-sidekick-mcp",
+  "installation_notes": "Requires a free RapidAPI key. Get one at https://rapidapi.com/scholar-sidekick-scholar-sidekick-api/api/scholar-sidekick and set RAPIDAPI_KEY.",
+  "is_builtin": false,
+  "endorsed": false,
+  "environmentVariables": [
+    {
+      "name": "RAPIDAPI_KEY",
+      "description": "RapidAPI key for the Scholar Sidekick API (free tier available)",
+      "required": true
+    }
+  ]
+}
+
 ]


### PR DESCRIPTION
Adds Scholar Sidekick to the extensions directory.

Scholar Sidekick is an MCP server that resolves scholarly identifiers (DOI, PMID, PMCID, ISBN, ISSN, arXiv, ADS bibcode, WHO IRIS) into formatted citations (Vancouver, APA, IEEE, + 10,000 CSL styles) and bibliography exports (BibTeX, RIS, EndNote, CSV…), and checks retraction, open-access, and citation-fabrication status.

- Source (MIT): https://github.com/mlava/scholar-sidekick-mcp
- Install: `npx -y scholar-sidekick-mcp@latest`
- Auth: requires a free RapidAPI key (`RAPIDAPI_KEY`)
- Published on npm and the official MCP registry (v0.7.3); 6 tools, stdio transport.

## Summary
<!-- Describe your change -->

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

