### PR TITLE
Recipe: Herdr terminal multiplexer integration

### DIFF
--- a/documentation/src/pages/recipes/data/recipes/herdr-integration.yaml
+++ b/documentation/src/pages/recipes/data/recipes/herdr-integration.yaml
@@ -1,0 +1,82 @@
+version: 1.0.0
+title: Herdr Terminal Multiplexer Integration
+description: Sets up goose with herdr terminal multiplexer so goose's state (working/blocked/idle) is visible in the herdr sidebar.
+author:
+  contact: modib
+
+activities:
+  - Detect herdr and goose installations
+  - Install the herdr wrapper script
+  - Install the herdr state-reporting skill
+  - Verify the integration
+
+instructions: |
+  You are helping a user set up goose with herdr for agent state reporting.
+  Herdr is a terminal multiplexer (like tmux) that shows AI agent state in its sidebar.
+
+  The integration consists of:
+  1. A wrapper script that replaces the `goose` binary to report start/exit states
+  2. A skill that teaches goose to self-report working/blocked/idle during sessions
+
+  ## Step-by-step
+
+  ### 1. Check prerequisites
+  - Verify herdr is installed: `which herdr` or check `~/.config/herdr/`
+  - Verify goose is installed: `which goose`
+  - If either is missing, ask the user to install it first and stop
+
+  ### 2. Install the integration
+  Run these commands:
+
+  ```bash
+  # Clone the integration
+  git clone https://github.com/modib/agent-toolkit.git /tmp/herdr-setup
+
+  # Run the installer
+  bash /tmp/herdr-setup/plugins/herdr/install.sh
+  ```
+
+  After install.sh completes, verify:
+  - `~/.local/bin/goose` exists and is a script (not the original binary)
+  - `~/.local/bin/goose-original` exists (backup of original binary)
+  - `~/.agents/skills/herdr/SKILL.md` exists
+  - `~/.agents/plugins/herdr/herdr_report.py` exists
+
+  ### 3. Verify the integration
+  Ask the user to:
+  - Start a herdr pane: `herdr`
+  - Run goose inside it and confirm goose appears in the herdr sidebar
+  - State should show as idle when waiting and working when processing
+
+  ### 4. Clean up
+  Remove the temporary clone:
+  ```bash
+  rm -rf /tmp/herdr-setup
+  ```
+
+  ## Caveats
+  - The wrapper only activates when goose runs inside a herdr pane (HERDR_ENV=1)
+  - Outside herdr, goose works exactly as before
+  - The original binary is preserved as goose-original
+
+extensions:
+  - type: builtin
+    name: developer
+    display_name: Developer
+    timeout: 300
+    bundled: true
+    description: For running shell commands, checking installations, and file system access
+
+prompt: |
+  Help the user set up goose with herdr terminal multiplexer.
+
+  First, check that both herdr (`which herdr`) and goose (`which goose`) are installed.
+  If either is missing, tell the user and stop.
+
+  Then:
+  1. Clone the integration: `git clone https://github.com/modib/agent-toolkit.git /tmp/herdr-setup`
+  2. Run the installer: `bash /tmp/herdr-setup/plugins/herdr/install.sh`
+  3. Verify everything is in place
+  4. Clean up: `rm -rf /tmp/herdr-setup`
+
+  Tell the user when it's done and how to test it.

--- a/documentation/src/pages/recipes/data/recipes/herdr-integration.yaml
+++ b/documentation/src/pages/recipes/data/recipes/herdr-integration.yaml
@@ -29,12 +29,13 @@ instructions: |
   Run these commands:
 
   ```bash
-  # Clone the integration at the reviewed tag
-  git clone https://github.com/modib/agent-toolkit.git /tmp/herdr-setup
-  git -C /tmp/herdr-setup checkout v1.0.0
+  # Create a fresh temporary directory and clone the integration at the reviewed tag
+  HERDR_SETUP=$(mktemp -d)
+  git clone https://github.com/modib/agent-toolkit.git "$HERDR_SETUP"
+  git -C "$HERDR_SETUP" checkout v1.0.0
 
   # Run the installer
-  bash /tmp/herdr-setup/goose/plugins/herdr/install.sh
+  bash "$HERDR_SETUP"/goose/plugins/herdr/install.sh
   ```
 
   After install.sh completes, verify:
@@ -52,7 +53,7 @@ instructions: |
   ### 4. Clean up
   Remove the temporary clone:
   ```bash
-  rm -rf /tmp/herdr-setup
+  rm -rf "$HERDR_SETUP"
   ```
 
   ## Caveats
@@ -75,10 +76,10 @@ prompt: |
   If either is missing, tell the user and stop.
 
   Then:
-  1. Clone the integration: `git clone https://github.com/modib/agent-toolkit.git /tmp/herdr-setup`
-  2. Pin to the reviewed tag: `git -C /tmp/herdr-setup checkout v1.0.0`
-  3. Run the installer: `bash /tmp/herdr-setup/goose/plugins/herdr/install.sh`
+  1. Create a fresh temp dir with `HERDR_SETUP=$(mktemp -d)` and clone the integration: `git clone https://github.com/modib/agent-toolkit.git "$HERDR_SETUP"`
+  2. Pin to the reviewed tag: `git -C "$HERDR_SETUP" checkout v1.0.0`
+  3. Run the installer: `bash "$HERDR_SETUP"/goose/plugins/herdr/install.sh`
   4. Verify everything is in place
-  5. Clean up: `rm -rf /tmp/herdr-setup`
+  5. Clean up: `rm -rf "$HERDR_SETUP"`
 
   Tell the user when it's done and how to test it.

--- a/documentation/src/pages/recipes/data/recipes/herdr-integration.yaml
+++ b/documentation/src/pages/recipes/data/recipes/herdr-integration.yaml
@@ -29,8 +29,9 @@ instructions: |
   Run these commands:
 
   ```bash
-  # Clone the integration
+  # Clone the integration at the reviewed tag
   git clone https://github.com/modib/agent-toolkit.git /tmp/herdr-setup
+  git -C /tmp/herdr-setup checkout v1.0.0
 
   # Run the installer
   bash /tmp/herdr-setup/goose/plugins/herdr/install.sh
@@ -75,8 +76,9 @@ prompt: |
 
   Then:
   1. Clone the integration: `git clone https://github.com/modib/agent-toolkit.git /tmp/herdr-setup`
-  2. Run the installer: `bash /tmp/herdr-setup/goose/plugins/herdr/install.sh`
-  3. Verify everything is in place
-  4. Clean up: `rm -rf /tmp/herdr-setup`
+  2. Pin to the reviewed tag: `git -C /tmp/herdr-setup checkout v1.0.0`
+  3. Run the installer: `bash /tmp/herdr-setup/goose/plugins/herdr/install.sh`
+  4. Verify everything is in place
+  5. Clean up: `rm -rf /tmp/herdr-setup`
 
   Tell the user when it's done and how to test it.

--- a/documentation/src/pages/recipes/data/recipes/herdr-integration.yaml
+++ b/documentation/src/pages/recipes/data/recipes/herdr-integration.yaml
@@ -31,7 +31,7 @@ instructions: |
   ```bash
   HERDR_SETUP=$(mktemp -d) && \
   git clone https://github.com/modib/agent-toolkit.git "$HERDR_SETUP" && \
-  git -C "$HERDR_SETUP" checkout v1.0.0 && \
+  git -C "$HERDR_SETUP" checkout bfe921c7608861c58ea37aac981b32eb3032915e && \
   bash "$HERDR_SETUP"/goose/plugins/herdr/install.sh
   ```
 
@@ -73,7 +73,7 @@ prompt: |
   If either is missing, tell the user and stop.
 
   Then:
-  1. Create a fresh temp dir, clone, pin to tag, and run the installer (each step must succeed before the next runs): `HERDR_SETUP=$(mktemp -d) && git clone https://github.com/modib/agent-toolkit.git "$HERDR_SETUP" && git -C "$HERDR_SETUP" checkout v1.0.0 && bash "$HERDR_SETUP"/goose/plugins/herdr/install.sh`
+  1. Create a fresh temp dir, clone, pin to tag, and run the installer (each step must succeed before the next runs): `HERDR_SETUP=$(mktemp -d) && git clone https://github.com/modib/agent-toolkit.git "$HERDR_SETUP" && git -C "$HERDR_SETUP" checkout bfe921c7608861c58ea37aac981b32eb3032915e && bash "$HERDR_SETUP"/goose/plugins/herdr/install.sh`
   2. Verify everything is in place
   3. Clean up: `rm -rf "$HERDR_SETUP"`
 

--- a/documentation/src/pages/recipes/data/recipes/herdr-integration.yaml
+++ b/documentation/src/pages/recipes/data/recipes/herdr-integration.yaml
@@ -33,7 +33,7 @@ instructions: |
   git clone https://github.com/modib/agent-toolkit.git /tmp/herdr-setup
 
   # Run the installer
-  bash /tmp/herdr-setup/plugins/herdr/install.sh
+  bash /tmp/herdr-setup/goose/plugins/herdr/install.sh
   ```
 
   After install.sh completes, verify:
@@ -75,7 +75,7 @@ prompt: |
 
   Then:
   1. Clone the integration: `git clone https://github.com/modib/agent-toolkit.git /tmp/herdr-setup`
-  2. Run the installer: `bash /tmp/herdr-setup/plugins/herdr/install.sh`
+  2. Run the installer: `bash /tmp/herdr-setup/goose/plugins/herdr/install.sh`
   3. Verify everything is in place
   4. Clean up: `rm -rf /tmp/herdr-setup`
 

--- a/documentation/src/pages/recipes/data/recipes/herdr-integration.yaml
+++ b/documentation/src/pages/recipes/data/recipes/herdr-integration.yaml
@@ -29,12 +29,9 @@ instructions: |
   Run these commands:
 
   ```bash
-  # Create a fresh temporary directory and clone the integration at the reviewed tag
-  HERDR_SETUP=$(mktemp -d)
-  git clone https://github.com/modib/agent-toolkit.git "$HERDR_SETUP"
-  git -C "$HERDR_SETUP" checkout v1.0.0
-
-  # Run the installer
+  HERDR_SETUP=$(mktemp -d) && \
+  git clone https://github.com/modib/agent-toolkit.git "$HERDR_SETUP" && \
+  git -C "$HERDR_SETUP" checkout v1.0.0 && \
   bash "$HERDR_SETUP"/goose/plugins/herdr/install.sh
   ```
 
@@ -76,10 +73,8 @@ prompt: |
   If either is missing, tell the user and stop.
 
   Then:
-  1. Create a fresh temp dir with `HERDR_SETUP=$(mktemp -d)` and clone the integration: `git clone https://github.com/modib/agent-toolkit.git "$HERDR_SETUP"`
-  2. Pin to the reviewed tag: `git -C "$HERDR_SETUP" checkout v1.0.0`
-  3. Run the installer: `bash "$HERDR_SETUP"/goose/plugins/herdr/install.sh`
-  4. Verify everything is in place
-  5. Clean up: `rm -rf "$HERDR_SETUP"`
+  1. Create a fresh temp dir, clone, pin to tag, and run the installer (each step must succeed before the next runs): `HERDR_SETUP=$(mktemp -d) && git clone https://github.com/modib/agent-toolkit.git "$HERDR_SETUP" && git -C "$HERDR_SETUP" checkout v1.0.0 && bash "$HERDR_SETUP"/goose/plugins/herdr/install.sh`
+  2. Verify everything is in place
+  3. Clean up: `rm -rf "$HERDR_SETUP"`
 
   Tell the user when it's done and how to test it.


### PR DESCRIPTION
Adds a recipe to integrate goose with herdr terminal multiplexer for agent state reporting.

The recipe guides users through installing a wrapper script that reports goose's state (working/blocked/idle) to herdr's sidebar.

See CONTRIBUTING_RECIPES.md for the contribution format.

## Files
- `documentation/src/pages/recipes/data/recipes/herdr-integration.yaml` — new recipe