### PR TITLE
fix: map GGUF architecture to built-in chat template when embedded is missing

### DIFF
--- a/crates/goose/src/providers/local_inference.rs
+++ b/crates/goose/src/providers/local_inference.rs
@@ -27,6 +27,115 @@ use std::sync::{Arc, Mutex as StdMutex, Weak};
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
+pub(super) const DEFAULT_FALLBACK_CHAT_TEMPLATE: &str = "chatml";
+
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub(super) enum ChatTemplateFallbackWarning {
+    KnownArchitecture,
+    Gemma4Unsupported,
+    UnknownArchitecture,
+    MissingArchitecture,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(super) struct BuiltInChatTemplateFallback<'a> {
+    pub template_name: &'static str,
+    pub architecture: Option<&'a str>,
+    pub warning: ChatTemplateFallbackWarning,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(super) enum ChatTemplateSelection<'a, T> {
+    Embedded(T),
+    BuiltIn(BuiltInChatTemplateFallback<'a>),
+}
+
+fn template_for_known_architecture(
+    arch: &str,
+) -> Option<(&'static str, ChatTemplateFallbackWarning)> {
+    match arch {
+        "gemma" | "gemma2" | "gemma3" => {
+            Some(("gemma", ChatTemplateFallbackWarning::KnownArchitecture))
+        }
+        "gemma4" => Some(("gemma", ChatTemplateFallbackWarning::Gemma4Unsupported)),
+        "llama" | "llama2" => Some(("llama2", ChatTemplateFallbackWarning::KnownArchitecture)),
+        "llama3" => Some(("llama3", ChatTemplateFallbackWarning::KnownArchitecture)),
+        "qwen2" => Some(("chatml", ChatTemplateFallbackWarning::KnownArchitecture)),
+        "phi3" => Some(("phi3", ChatTemplateFallbackWarning::KnownArchitecture)),
+        _ => None,
+    }
+}
+
+pub(super) fn select_chat_template<'a, T, E>(
+    embedded: Result<T, E>,
+    architecture: Option<&'a str>,
+) -> ChatTemplateSelection<'a, T> {
+    if let Ok(t) = embedded {
+        return ChatTemplateSelection::Embedded(t);
+    }
+
+    // Use trimmed (case-preserving) slice as the "original" we expose, and a
+    // lowercase copy for matching only.
+    let trimmed = architecture.map(|a| a.trim()).filter(|s| !s.is_empty());
+    let normalized = trimmed.map(|a| a.to_lowercase());
+
+    let fallback = match (trimmed, normalized.as_deref()) {
+        (None, _) => BuiltInChatTemplateFallback {
+            template_name: DEFAULT_FALLBACK_CHAT_TEMPLATE,
+            architecture: None,
+            warning: ChatTemplateFallbackWarning::MissingArchitecture,
+        },
+        (Some(orig), Some(lower)) => match template_for_known_architecture(lower) {
+            Some((template, warning)) => BuiltInChatTemplateFallback {
+                template_name: template,
+                architecture: Some(orig),
+                warning,
+            },
+            None => BuiltInChatTemplateFallback {
+                template_name: DEFAULT_FALLBACK_CHAT_TEMPLATE,
+                architecture: Some(orig),
+                warning: ChatTemplateFallbackWarning::UnknownArchitecture,
+            },
+        },
+        (Some(_), None) => unreachable!(),
+    };
+
+    ChatTemplateSelection::BuiltIn(fallback)
+}
+
+pub(super) fn log_chat_template_fallback(fallback: &BuiltInChatTemplateFallback<'_>) {
+    use tracing::{info, warn};
+    match fallback.warning {
+        ChatTemplateFallbackWarning::KnownArchitecture => {
+            info!(
+                architecture = ?fallback.architecture,
+                template = fallback.template_name,
+                "No embedded chat template; falling back to known-architecture template"
+            );
+        }
+        ChatTemplateFallbackWarning::Gemma4Unsupported => {
+            warn!(
+                architecture = ?fallback.architecture,
+                template = fallback.template_name,
+                "Gemma4 not yet supported by llama.cpp; falling back to gemma template"
+            );
+        }
+        ChatTemplateFallbackWarning::UnknownArchitecture => {
+            warn!(
+                architecture = ?fallback.architecture,
+                template = fallback.template_name,
+                "Unknown architecture; falling back to chatml chat template"
+            );
+        }
+        ChatTemplateFallbackWarning::MissingArchitecture => {
+            warn!(
+                template = fallback.template_name,
+                "No architecture in model metadata; falling back to chatml chat template"
+            );
+        }
+    }
+}
+
 type ModelSlot = Arc<Mutex<Option<Box<dyn BackendLoadedModel>>>>;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -214,7 +323,9 @@ fn strip_image_parts_from_messages(messages: &mut [Value]) {
         }
     }
     if stripped {
-        tracing::warn!("Stripped image content parts from messages — vision encoder not available for this model");
+        tracing::warn!(
+            "Stripped image content parts from messages — vision encoder not available for this model"
+        );
     }
 }
 

--- a/crates/goose/src/providers/local_inference/llamacpp/mod.rs
+++ b/crates/goose/src/providers/local_inference/llamacpp/mod.rs
@@ -25,7 +25,8 @@ use crate::providers::local_inference::backend::{
 use crate::providers::local_inference::multimodal::ExtractedImage;
 use crate::providers::local_inference::tool_parsing::compact_tools_json;
 use crate::providers::local_inference::{
-    build_openai_messages_json, extract_text_content, ResolvedModelPaths,
+    build_openai_messages_json, extract_text_content, log_chat_template_fallback,
+    select_chat_template, ChatTemplateSelection, ResolvedModelPaths,
 };
 
 pub(super) const LLAMACPP_BACKEND_ID: &str = "llamacpp";
@@ -134,18 +135,20 @@ impl LocalInferenceBackend for LlamaCppBackend {
         let model = LlamaModel::load_from_file(&self.backend, model_path, &params)
             .map_err(|e| ProviderError::ExecutionError(e.to_string()))?;
 
-        let template = match model.chat_template(None) {
-            Ok(t) => t,
-            Err(_) => {
-                tracing::warn!("Model has no embedded chat template, falling back to chatml");
-                LlamaChatTemplate::new("chatml").map_err(|e| {
-                    ProviderError::ExecutionError(format!(
-                        "Failed to create fallback chat template: {}",
-                        e
-                    ))
-                })?
-            }
-        };
+        let architecture = model.meta_val_str("general.architecture").ok();
+        let template =
+            match select_chat_template(model.chat_template(None), architecture.as_deref()) {
+                ChatTemplateSelection::Embedded(template) => template,
+                ChatTemplateSelection::BuiltIn(fallback) => {
+                    log_chat_template_fallback(&fallback);
+                    LlamaChatTemplate::new(fallback.template_name).map_err(|e| {
+                        ProviderError::ExecutionError(format!(
+                            "Failed to create fallback chat template: {}",
+                            e
+                        ))
+                    })?
+                }
+            };
 
         let mtmd_ctx = Self::init_mtmd_context(&model, &resolved.mmproj_path, settings);
 

--- a/crates/goose/src/providers/local_inference_tests.rs
+++ b/crates/goose/src/providers/local_inference_tests.rs
@@ -1,0 +1,133 @@
+use super::local_inference::{
+    select_chat_template, ChatTemplateFallbackWarning, ChatTemplateSelection,
+    DEFAULT_FALLBACK_CHAT_TEMPLATE,
+};
+
+#[test]
+fn embedded_chat_template_is_used_unchanged() {
+    let selection = select_chat_template::<_, ()>(Ok("embedded-template"), Some("gemma"));
+
+    assert_eq!(
+        selection,
+        ChatTemplateSelection::Embedded("embedded-template")
+    );
+}
+
+#[test]
+fn no_embedded_template_uses_architecture_fallbacks() {
+    let cases = [
+        (
+            "gemma",
+            "gemma",
+            ChatTemplateFallbackWarning::KnownArchitecture,
+        ),
+        (
+            "gemma2",
+            "gemma",
+            ChatTemplateFallbackWarning::KnownArchitecture,
+        ),
+        (
+            "gemma3",
+            "gemma",
+            ChatTemplateFallbackWarning::KnownArchitecture,
+        ),
+        (
+            "llama",
+            "llama2",
+            ChatTemplateFallbackWarning::KnownArchitecture,
+        ),
+        (
+            "llama2",
+            "llama2",
+            ChatTemplateFallbackWarning::KnownArchitecture,
+        ),
+        (
+            "llama3",
+            "llama3",
+            ChatTemplateFallbackWarning::KnownArchitecture,
+        ),
+        (
+            "qwen2",
+            "chatml",
+            ChatTemplateFallbackWarning::KnownArchitecture,
+        ),
+        (
+            "phi3",
+            "phi3",
+            ChatTemplateFallbackWarning::KnownArchitecture,
+        ),
+    ];
+
+    for (architecture, expected_template, expected_warning) in cases {
+        let selection = select_chat_template::<(), _>(Err(()), Some(architecture));
+        let ChatTemplateSelection::BuiltIn(fallback) = selection else {
+            panic!("expected fallback for {architecture}");
+        };
+
+        assert_eq!(fallback.template_name, expected_template);
+        assert_eq!(fallback.architecture, Some(architecture));
+        assert_eq!(fallback.warning, expected_warning);
+    }
+}
+
+#[test]
+fn architecture_fallback_is_case_and_whitespace_insensitive() {
+    let selection = select_chat_template::<(), _>(Err(()), Some("  LLaMa3  "));
+    let ChatTemplateSelection::BuiltIn(fallback) = selection else {
+        panic!("expected fallback");
+    };
+
+    assert_eq!(fallback.template_name, "llama3");
+    assert_eq!(fallback.architecture, Some("LLaMa3"));
+    assert_eq!(
+        fallback.warning,
+        ChatTemplateFallbackWarning::KnownArchitecture
+    );
+}
+
+#[test]
+fn unknown_architecture_falls_back_to_chatml_with_warning() {
+    let selection = select_chat_template::<(), _>(Err(()), Some("deepseek2"));
+    let ChatTemplateSelection::BuiltIn(fallback) = selection else {
+        panic!("expected fallback");
+    };
+
+    assert_eq!(fallback.template_name, DEFAULT_FALLBACK_CHAT_TEMPLATE);
+    assert_eq!(fallback.architecture, Some("deepseek2"));
+    assert_eq!(
+        fallback.warning,
+        ChatTemplateFallbackWarning::UnknownArchitecture
+    );
+}
+
+#[test]
+fn gemma4_falls_back_to_gemma_with_specific_warning() {
+    let selection = select_chat_template::<(), _>(Err(()), Some("gemma4"));
+    let ChatTemplateSelection::BuiltIn(fallback) = selection else {
+        panic!("expected fallback");
+    };
+
+    assert_eq!(fallback.template_name, "gemma");
+    assert_eq!(fallback.architecture, Some("gemma4"));
+    assert_eq!(
+        fallback.warning,
+        ChatTemplateFallbackWarning::Gemma4Unsupported
+    );
+}
+
+#[test]
+fn missing_architecture_falls_back_to_chatml() {
+    for architecture in [None, Some(""), Some("   ")] {
+        let selection = select_chat_template::<(), _>(Err(()), architecture);
+        let ChatTemplateSelection::BuiltIn(fallback) = selection else {
+            panic!("expected fallback");
+        };
+
+        assert_eq!(fallback.template_name, DEFAULT_FALLBACK_CHAT_TEMPLATE);
+        assert_eq!(fallback.architecture, None);
+        assert_eq!(
+            fallback.warning,
+            ChatTemplateFallbackWarning::MissingArchitecture
+        );
+    }
+}

--- a/crates/goose/src/providers/mod.rs
+++ b/crates/goose/src/providers/mod.rs
@@ -65,3 +65,6 @@ pub use init::{
     refresh_custom_providers,
 };
 pub use retry::{retry_operation, RetryConfig};
+
+#[cfg(all(test, feature = "local-inference"))]
+mod local_inference_tests;


### PR DESCRIPTION
## Summary

Maps the GGUF model architecture metadata to a built-in chat template when the model does not ship an embedded template, instead of unconditionally using chatml. gemma/llama/qwen/phi families now get an architecture-appropriate fallback with a specific warning level per case.

## Why this matters

Issue #9110 reported that local-inference models without an embedded chat template silently defaulted to chatml, which produces wrong outputs for gemma/llama families. The old llamacpp path issued `warn!("Model has no embedded chat template, falling back to chatml")` and continued. For a Gemma-family model that is the wrong template; the response degrades badly.

## Changes

- New `select_chat_template()` in `local_inference.rs` returns either `Embedded(t)` when the embedded template is present or `BuiltIn(BuiltInChatTemplateFallback)` when it is not
- Architecture-aware fallback table: gemma/gemma2/gemma3 -> "gemma" (info), gemma4 -> "gemma" with `Gemma4Unsupported` warning, llama/llama2 -> "llama2", llama3 -> "llama3", qwen2 -> "chatml", phi3 -> "phi3"
- Unknown architecture -> "chatml" with `UnknownArchitecture` warning
- Missing or whitespace-only architecture -> "chatml" with `MissingArchitecture` warning
- Architecture matching is case + whitespace insensitive; original-cased name preserved for the log
- `LlamaCppBackend::load` reads the model arch via `meta_val_str("general.architecture")` and routes through `select_chat_template`
- `log_chat_template_fallback` emits info vs warn based on the fallback variant

## Testing

`cargo test --features local-inference -p goose --lib local_inference_tests` -- 6/6 pass:
- embedded template used unchanged
- 8 known architectures fall back to expected templates with `KnownArchitecture` warning
- LLaMa3 fallback is case + whitespace insensitive (case preserved in result)
- unknown arch -> chatml + warn
- gemma4 -> gemma + `Gemma4Unsupported` warn
- missing/empty/whitespace arch -> chatml + `MissingArchitecture` warn

Fixes #9110