### PR TITLE
feat(providers): add Alibaba (Qwen via DashScope) declarative provider

### DIFF
--- a/crates/goose/src/providers/declarative/alibaba.json
+++ b/crates/goose/src/providers/declarative/alibaba.json
@@ -1,0 +1,60 @@
+{
+  "name": "alibaba",
+  "engine": "openai",
+  "display_name": "Alibaba (Qwen)",
+  "description": "Alibaba Qwen models via DashScope's OpenAI-compatible API.",
+  "api_key_env": "DASHSCOPE_API_KEY",
+  "base_url": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+  "catalog_provider_id": "alibaba",
+  "dynamic_models": true,
+  "models": [
+    {
+      "name": "qwen3.7-max",
+      "context_limit": 262144
+    },
+    {
+      "name": "qwen3.7-max-preview",
+      "context_limit": 262144
+    },
+    {
+      "name": "qwen3.6-max-preview",
+      "context_limit": 262144
+    },
+    {
+      "name": "qwen3.6-plus",
+      "context_limit": 1000000
+    },
+    {
+      "name": "qwen3-max",
+      "context_limit": 262144
+    },
+    {
+      "name": "qwen-plus",
+      "context_limit": 1000000
+    },
+    {
+      "name": "qwen-turbo",
+      "context_limit": 1000000
+    },
+    {
+      "name": "qwen-flash",
+      "context_limit": 1000000
+    },
+    {
+      "name": "qwen3-coder-plus",
+      "context_limit": 1048576
+    },
+    {
+      "name": "qwen3-coder-flash",
+      "context_limit": 1000000
+    }
+  ],
+  "preserves_thinking": true,
+  "supports_streaming": true,
+  "model_doc_link": "https://www.alibabacloud.com/help/en/model-studio/models",
+  "setup_steps": [
+    "Sign in to https://modelstudio.console.alibabacloud.com (international) or https://bailian.console.aliyun.com (China)",
+    "Open API Keys in the left sidebar and create a new key",
+    "Copy the key and paste it above"
+  ]
+}

--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -315,6 +315,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_alibaba_declarative_provider_registry_wiring() {
+        let alibaba = get_from_registry("alibaba")
+            .await
+            .expect("alibaba provider should be registered");
+        let meta = alibaba.metadata();
+
+        assert_eq!(alibaba.provider_type(), ProviderType::Declarative);
+        assert!(alibaba.supports_inventory_refresh());
+        assert_eq!(meta.display_name, "Alibaba (Qwen)");
+        assert_eq!(meta.default_model, "qwen3.7-max");
+        assert_eq!(
+            meta.model_doc_link,
+            "https://www.alibabacloud.com/help/en/model-studio/models"
+        );
+        assert!(!meta.setup_steps.is_empty());
+
+        let api_key = meta
+            .config_keys
+            .iter()
+            .find(|k| k.name == "DASHSCOPE_API_KEY")
+            .expect("DASHSCOPE_API_KEY config key should exist");
+        assert!(api_key.required, "DASHSCOPE_API_KEY should be required");
+        assert!(api_key.secret, "DASHSCOPE_API_KEY should be secret");
+        assert!(api_key.primary, "DASHSCOPE_API_KEY should be primary");
+    }
+
+    #[tokio::test]
     async fn test_openai_compatible_providers_config_keys() {
         let providers_list = providers().await;
         let required_api_key_cases = vec![


### PR DESCRIPTION
## Summary

- Adds `crates/goose/src/providers/declarative/alibaba.json` so Alibaba (Qwen models via DashScope) shows up as a one-click provider in the picker — currently users have to manually configure an `openai_compatible` provider pointing at DashScope, even though `provider_metadata.json` already has the canonical entry.
- Adds a wiring test in `init.rs` following the existing `tanzu` / `nvidia` / `nearai` pattern.

## Why

DashScope exposes an OpenAI-compatible API at `https://dashscope-intl.aliyuncs.com/compatible-mode/v1` and is a popular path for accessing the Qwen family — the canonical metadata already lists it (`id: alibaba`, 48 models), but no declarative JSON was shipped.

Verified end-to-end against the live endpoint:

- `POST /v1/chat/completions` with `qwen-plus` → returns OpenAI-shaped response, `choices[0].message.content` populated.
- `GET /v1/models` → returns 163 models, 149 of them Qwen variants, supporting `dynamic_models: true`.

## Defaults

- **Default model**: `qwen3.7-max` (current flagship, 262K ctx, reasoning).
- **Static list**: covers the production families — `qwen-plus`/`turbo`/`flash` (1M ctx), `qwen3-max` and `qwen3.6`/`3.7` max variants (reasoning), `qwen3-coder-plus`/`flash` for code.
- **`dynamic_models: true`** so the live `/v1/models` list is also surfaced.
- **API key env**: `DASHSCOPE_API_KEY`.
- **Console links** (in `setup_steps`): `https://modelstudio.console.alibabacloud.com` (international) and `https://bailian.console.aliyun.com` (China).

## Test plan

- [x] `cargo test -p goose --lib providers::init::tests::test_alibaba_declarative_provider_registry_wiring` passes
- [x] All neighbouring declarative-provider wiring tests still pass (`providers::init::tests`)
- [x] `cargo fmt` clean
- [x] Live verified: `chat/completions` returns expected reply
- [x] Live verified: `/v1/models` returns the qwen catalogue

DCO sign-off included on the commit.