### PR TITLE
fix(providers): tolerate missing Responses output

### DIFF
--- a/crates/goose/src/providers/formats/openai_responses.rs
+++ b/crates/goose/src/providers/formats/openai_responses.rs
@@ -273,6 +273,7 @@ pub struct ResponseMetadata {
     pub created_at: i64,
     pub status: String,
     pub model: String,
+    #[serde(default)]
     pub output: Vec<ResponseOutputItemInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub usage: Option<ResponseUsage>,
@@ -977,6 +978,46 @@ mod tests {
         assert_eq!(usage.usage.input_tokens, Some(10));
         assert_eq!(usage.usage.output_tokens, Some(4));
         assert_eq!(usage.usage.total_tokens, Some(14));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_responses_completed_accepts_missing_output() -> anyhow::Result<()> {
+        let lines = vec![
+            r#"data: {"type":"response.created","sequence_number":1,"response":{"id":"resp_1","object":"response","created_at":1737368310,"status":"in_progress","model":"gpt-5.5","output":[]}}"#.to_string(),
+            r#"data: {"type":"response.output_text.delta","sequence_number":2,"item_id":"msg_1","output_index":0,"content_index":0,"delta":"Done"}"#.to_string(),
+            r#"data: {"type":"response.completed","sequence_number":3,"response":{"id":"resp_1","object":"response","created_at":1737368310,"status":"completed","model":"gpt-5.5","usage":{"input_tokens":18,"output_tokens":7,"total_tokens":25}}}"#.to_string(),
+            "data: [DONE]".to_string(),
+        ];
+
+        let response_stream = tokio_stream::iter(lines.into_iter().map(Ok));
+        let messages = responses_api_to_streaming_message(response_stream);
+        futures::pin_mut!(messages);
+
+        let mut text_parts = Vec::new();
+        let mut usage: Option<ProviderUsage> = None;
+
+        while let Some(item) = messages.next().await {
+            let (message, maybe_usage) = item?;
+            if let Some(msg) = message {
+                for content in msg.content {
+                    if let MessageContent::Text(text) = content {
+                        text_parts.push(text.text.clone());
+                    }
+                }
+            }
+            if let Some(final_usage) = maybe_usage {
+                usage = Some(final_usage);
+            }
+        }
+
+        assert_eq!(text_parts.concat(), "Done");
+        let usage = usage.expect("usage should be present at completion");
+        assert_eq!(usage.model, "gpt-5.5");
+        assert_eq!(usage.usage.input_tokens, Some(18));
+        assert_eq!(usage.usage.output_tokens, Some(7));
+        assert_eq!(usage.usage.total_tokens, Some(25));
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Fixes #9446.

`chatgpt_codex` / Responses streaming can receive a terminal `response.completed` event that includes usage metadata but omits `response.output`. Goose currently treats that as a fatal serde error before it can use text already accumulated from earlier stream events.

This makes `ResponseMetadata.output` default to an empty list when omitted and adds a regression that streams text first, then completes with no `response.output` field.

### Testing

- `source bin/activate-hermit && cargo test -p goose test_responses_completed -- --nocapture`
  - `31 passed; 0 failed` for `providers::formats::openai_responses::tests`
- `source bin/activate-hermit && cargo fmt --check`

Observed existing unrelated warning during tests: `method clear_env is never used` in `crates/goose/tests/providers.rs`.

### Related Issues

Fixes #9446
Discussion: n/a

### Screenshots/Demos (for UX changes)

Before: n/a

After: n/a