### PR TITLE
docs: add goose-pentest-mcp to extensions registry

### DIFF
--- a/documentation/docs/mcp/goose-pentest-mcp.md
+++ b/documentation/docs/mcp/goose-pentest-mcp.md
@@ -1,0 +1,153 @@
+---
+title: Self-Pentest Extension
+description: Add goose-pentest-mcp MCP Server as a goose Extension
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+
+This tutorial covers how to add the [goose-pentest-mcp](https://github.com/turer73/goose-pentest-mcp)
+MCP server as a goose extension. It exposes six tools so an LLM can list
+allowlisted pentest targets, kick off scans, browse findings, and mark
+them resolved — all against a backend **you** run.
+
+The extension is HTTP-only: it has no shell or filesystem surface of its
+own. It speaks the documented contract in
+[`BACKEND_CONTRACT.md`](https://github.com/turer73/goose-pentest-mcp/blob/main/BACKEND_CONTRACT.md);
+a working Apache-2.0 FastAPI reference implementation is linked from
+the README.
+
+:::tip Quick Install
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  [Launch the installer](goose://extension?cmd=uvx&arg=goose-pentest-mcp&id=goose-pentest-mcp&name=Self-Pentest&description=List%20targets%2C%20trigger%20scans%2C%20and%20manage%20findings%20against%20a%20self-hosted%20pentest%20backend.&env=PENTEST_API_KEY&env=PENTEST_API_BASE)
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+  **Command**
+  ```sh
+  uvx goose-pentest-mcp
+  ```
+  </TabItem>
+</Tabs>
+
+  **Environment Variables**
+  ```
+  PENTEST_API_KEY:  <X-Pentest-Key value your backend accepts>
+  PENTEST_API_BASE: https://your-backend.example.com/api/v1/security
+  ```
+:::
+
+## Configuration
+
+:::info
+You'll need [uv](https://docs.astral.sh/uv/#installation) installed on
+your system to run this command, as it uses `uvx`.
+:::
+
+:::info
+You also need a backend implementing the six endpoints in
+[`BACKEND_CONTRACT.md`](https://github.com/turer73/goose-pentest-mcp/blob/main/BACKEND_CONTRACT.md).
+A working FastAPI reference implementation (Apache-2.0) lives at
+[`turer73/claude-server` `app/api/security.py`](https://github.com/turer73/claude-server/blob/master/app/api/security.py)
+— copy or fork freely.
+:::
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+    <GooseDesktopInstaller
+      extensionId="goose-pentest-mcp"
+      extensionName="Self-Pentest"
+      description="List targets, trigger scans, and manage findings against a self-hosted pentest backend"
+      command="uvx"
+      args={["goose-pentest-mcp"]}
+      envVars={[
+        { name: "PENTEST_API_KEY",  label: "X-Pentest-Key your backend accepts" },
+        { name: "PENTEST_API_BASE", label: "Base URL (e.g. https://your-host/api/v1/security)" }
+      ]}
+    />
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    <CLIExtensionInstructions
+      name="Self-Pentest"
+      description="List targets, trigger scans, and manage findings against a self-hosted pentest backend"
+      command="uvx goose-pentest-mcp"
+      envVars={[
+        { key: "PENTEST_API_KEY",  value: "▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪" },
+        { key: "PENTEST_API_BASE", value: "https://your-host/api/v1/security" }
+      ]}
+      infoNote={
+        <>
+          <code>PENTEST_API_KEY</code> is the value your backend accepts in the
+          <code> X-Pentest-Key </code>header. <code>PENTEST_API_BASE</code> is the
+          full base URL — the six contract paths resolve directly under it.
+        </>
+      }
+    />
+  </TabItem>
+</Tabs>
+
+## Blast radius
+
+The extension's entire surface is the six HTTP endpoints listed in
+`BACKEND_CONTRACT.md`. It cannot:
+
+- shell out (no `exec` / `command` tool),
+- read or write files outside the HTTP contract,
+- escape the API perimeter your backend enforces.
+
+So an LLM using this extension can do at most what an authenticated
+client with `PENTEST_API_KEY` could do. The **target allowlist** is
+enforced on the backend (not in this extension), so a scan request for
+an off-list domain returns HTTP 400 — the LLM sees the error and adjusts.
+
+If you co-install an extension that *does* shell out (e.g. `developer`),
+the above guarantee no longer holds for that combined surface. Choose
+deliberately.
+
+## Example Usage
+
+This walks through driving a self-hosted pentest workflow from goose — listing
+your allowlisted targets, launching a scan, and reading the findings that come
+back. All actions go through the backend; goose never runs scans itself.
+
+### goose Prompt
+
+> List my pentest targets, then start a scan on the first one and tell me
+> when it finishes.
+
+### goose Output
+
+:::note Desktop
+
+```
+[calls pentest_list_targets]
+→ Targets: example.com, shop.example.com, api.example.com (source: targets.txt)
+
+[calls pentest_run_scan domain="example.com"]
+→ job_id=abcd1234, status=running
+
+[polls pentest_get_run job_id="abcd1234" every few seconds]
+→ status=running … status=running … status=completed (exit_code=0)
+
+Scan finished. Would you like me to pull the recent findings?
+```
+
+:::
+
+### Follow-up
+
+> Show me active findings on example.com.
+
+```
+[calls pentest_recent_findings project="example.com" status="active"]
+→ #42  Missing CSP header on /login                 (active, 2026-05-28)
+   #43  Cookie set without Secure on shop.*         (active, 2026-05-28)
+
+The /login one has no Content-Security-Policy header at all. Want details
+on #42 or to mark something resolved?
+```
+
+You can ask goose to fetch the full record (`pentest_get_finding`) or to
+mark a finding resolved (`pentest_resolve_finding`) by id.

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -36,7 +36,7 @@
   {
     "id": "apify",
     "name": "Apify",
-    "description": "Extract data from any website with thousands of scrapers, crawlers, and automations on Apify Store \u26a1",
+    "description": "Extract data from any website with thousands of scrapers, crawlers, and automations on Apify Store ⚡",
     "command": "npx -y @apify/actors-mcp-server",
     "link": "https://github.com/apify/apify-mcp-server",
     "installation_notes": "Install using npx. Requires an Apify API token.",
@@ -369,6 +369,28 @@
     "is_builtin": false,
     "endorsed": false,
     "environmentVariables": []
+  },
+  {
+    "id": "goose-pentest-mcp",
+    "name": "Self-Pentest",
+    "description": "List targets, trigger scans, and manage findings against a self-hosted pentest backend.",
+    "command": "uvx goose-pentest-mcp",
+    "link": "https://github.com/turer73/goose-pentest-mcp",
+    "installation_notes": "Install using uvx (requires uv). HTTP-only extension: you supply a backend implementing BACKEND_CONTRACT.md (in the repo). A working FastAPI reference implementation is linked from the README.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [
+      {
+        "name": "PENTEST_API_KEY",
+        "description": "X-Pentest-Key header value sent to your backend",
+        "required": true
+      },
+      {
+        "name": "PENTEST_API_BASE",
+        "description": "Base URL of your backend (e.g. https://pentest.example.com/api/v1/security)",
+        "required": true
+      }
+    ]
   },
   {
     "id": "gotoHuman-mcp",
@@ -837,7 +859,7 @@
   {
     "id": "cash-app",
     "name": "Cash App",
-    "description": "Cash App brings local food ordering into the AI era. Discover nearby sellers, browse menus with calories and allergen info, customize orders, and complete checkout\u2014all conversationally.",
+    "description": "Cash App brings local food ordering into the AI era. Discover nearby sellers, browse menus with calories and allergen info, customize orders, and complete checkout—all conversationally.",
     "type": "streamable-http",
     "url": "https://connect.squareup.com/v2/mcp/cash-app",
     "link": "",


### PR DESCRIPTION
## Add goose-pentest-mcp — self-pentest workflow extension

This adds a Python MCP server that exposes 6 tools for managing a
self-hosted pentest backend (list targets, run scans, browse findings,
mark them resolved).

The extension is HTTP-only — it has no shell/file surface, just the
documented backend contract. Adopters bring their own backend; a
working FastAPI reference implementation (Apache-2.0) is linked from
the README.

- Repo: https://github.com/turer73/goose-pentest-mcp
- PyPI: https://pypi.org/project/goose-pentest-mcp/ *(reserved, upload pending — see "Draft note" below)*
- Backend contract: see `BACKEND_CONTRACT.md` in the repo
- Blast-radius rationale: README "Blast radius" section
- License: Apache-2.0; no compiled blobs

### Draft note

Opening as **draft** because the PyPI upload (which makes the listed
`uvx goose-pentest-mcp` command resolvable) is not yet complete. I will
mark this Ready for Review the moment `pip index versions goose-pentest-mcp`
returns 0.1.0.

The repo, contract, and code are stable now — only the publish step is
outstanding. Reviewers can inspect the linked repo end-to-end against
the entry in `servers.json`.