### PR TITLE
fix(agent): ensure tool request timestamp precedes tool response timestamp

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1982,10 +1982,18 @@ impl Agent {
                                                 request.metadata.as_ref(),
                                                 request.tool_meta.clone(),
                                             );
-                                        messages_to_add.push(request_msg);
                                         let final_response = request_to_response_map
                                             .remove(&request.id)
                                             .unwrap_or_else(|| Message::user().with_generated_id());
+                                        // Ensure the tool request timestamp precedes the tool response
+                                        // timestamp. The response placeholder is created before tools
+                                        // execute, so its timestamp can be earlier than the request
+                                        // message built here — which causes the DB to return them out
+                                        // of order and triggers a Claude API 400 error.
+                                        if request_msg.created > final_response.created {
+                                            request_msg.created = final_response.created;
+                                        }
+                                        messages_to_add.push(request_msg);
                                         yield AgentEvent::Message(final_response.clone());
                                         messages_to_add.push(final_response);
                                     } else {

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1985,11 +1985,7 @@ impl Agent {
                                         let final_response = request_to_response_map
                                             .remove(&request.id)
                                             .unwrap_or_else(|| Message::user().with_generated_id());
-                                        // Ensure the tool request timestamp precedes the tool response
-                                        // timestamp. The response placeholder is created before tools
-                                        // execute, so its timestamp can be earlier than the request
-                                        // message built here — which causes the DB to return them out
-                                        // of order and triggers a Claude API 400 error.
+                                        // Response placeholder is created before tools run, so clamp request to avoid inverted ordering.
                                         if request_msg.created > final_response.created {
                                             request_msg.created = final_response.created;
                                         }


### PR DESCRIPTION
## Summary

- Tool response placeholders are created in `agent.rs` before tools execute, so they capture an earlier `Utc::now()` timestamp than the tool request message built afterward
- The session DB retrieves messages with `ORDER BY created_timestamp, id` — when timestamps differ the `id` tiebreaker is irrelevant, so responses sorted before requests
- The Claude API then rejects the conversation with `400 unexpected tool_use_id in tool_result blocks`
- Fix: after building the request message, cap its timestamp to the response timestamp when it is greater; equal timestamps rely on the DB `id` tiebreaker (request is inserted first, so it always sorts first)

Fixes #9461

## Test plan

- [ ] Run a goose session that invokes at least one tool and verify no `400` errors from the Claude API
- [ ] Inspect the session DB to confirm no `user` rows have a lower `created_timestamp` than the preceding `assistant` row for the same tool pair

🤖 Generated with [Claude Code](https://claude.com/claude-code)