### PR TITLE
[RFC] feat(goose-embed): embedding SDK for the agent loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4640,6 +4640,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "goose-embed"
+version = "1.36.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "futures",
+ "goose",
+ "serde_yaml",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "goose-mcp"
 version = "1.36.0"
 dependencies = [

--- a/crates/goose-embed/Cargo.toml
+++ b/crates/goose-embed/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "goose-embed"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Embeddable Rust SDK for the goose AI agent. Build your own Rust program that runs goose's agent loop with custom providers, extensions, recipes, and skills."
+
+[lints]
+workspace = true
+
+[dependencies]
+goose = { path = "../goose" }
+anyhow = { workspace = true }
+async-stream = { workspace = true }
+async-trait = { workspace = true }
+futures = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+serde_yaml = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/goose-embed/README.md
+++ b/crates/goose-embed/README.md
@@ -1,0 +1,144 @@
+# goose-embed
+
+Embeddable Rust SDK for the [goose](https://github.com/aaif-goose/goose) AI agent.
+
+Use this crate to run goose's agent loop inside your own Rust program — with
+your own provider, MCP extensions, recipes, and skills — without shelling out
+to the `goose` binary or talking ACP over a subprocess.
+
+## Status — Spike
+
+This crate is an **API-discovery spike**, not a production-ready SDK. It is
+implemented as a thin facade over the full [`goose`] crate, so depending on it
+pulls the same dependency tree as depending on `goose` directly. The crate's
+purpose is to validate the public API surface against real examples before a
+slim `goose-core` crate is carved out of `goose`. See
+[`docs/brainstorms/2026-05-28-goose-embed-rust-sdk.md`](../../docs/brainstorms/2026-05-28-goose-embed-rust-sdk.md)
+for the roadmap.
+
+If you need the embed story today and don't care about dep weight, this is
+the right crate. If dep weight matters, wait for `goose-core`.
+
+## Quick start
+
+```rust,no_run
+use futures::StreamExt;
+use goose_embed::prelude::*;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let goose = Goose::builder()
+        .provider("anthropic", "claude-sonnet-4")
+        .working_dir(std::env::current_dir()?)
+        .build()
+        .await?;
+
+    let mut stream = goose.reply("What is 2 + 2?").await?;
+    while let Some(event) = stream.next().await {
+        if let Ok(AgentEvent::Message(message)) = event {
+            println!("{}", message.as_concat_text());
+        }
+    }
+    Ok(())
+}
+```
+
+Run the example with a real provider:
+
+```bash
+GOOSE_EMBED_PROVIDER=anthropic \
+GOOSE_EMBED_MODEL=claude-sonnet-4 \
+cargo run -p goose-embed --example hello_agent
+```
+
+## Concepts
+
+### Builder
+
+[`Goose::builder()`](crate::Goose::builder) returns a [`GooseBuilder`] with
+chainable setters:
+
+| Method | Purpose |
+|---|---|
+| `.provider(name, model)` | Pick the LLM provider and model. |
+| `.extension(ExtensionConfig)` | Register a single MCP extension. |
+| `.extensions(iter)` | Register many at once. |
+| `.recipe(Recipe)` | Apply a recipe: extensions, response schema, and (optionally) provider/model from `settings`. |
+| `.working_dir(path)` | Set the working directory the agent sees. |
+| `.session_name(name)` | Override the default `goose-embed-<pid>` session name. |
+| `.permission_decider(impl PermissionDecider)` | Install a custom permission policy. Defaults to [`AutoApprove`]. |
+| `.max_turns(n)` | Cap the number of tool-loop turns per `reply()`. |
+
+`.build()` is async and returns a [`Goose`] handle.
+
+### Replying
+
+[`Goose::reply(prompt)`](crate::Goose::reply) sends a prompt and returns a
+[`ReplyStream`] that yields [`AgentEvent`]s as the agent produces them.
+Tool-confirmation requests are intercepted automatically and routed through
+the configured [`PermissionDecider`].
+
+### Permission deciders
+
+When the agent needs to confirm a tool call, the configured decider is
+asked. Built-in impls:
+
+| Type | Behavior |
+|---|---|
+| [`AutoApprove`] | Grants `AllowOnce` for everything. The default. |
+| [`DenyAll`] | Denies every tool call. Useful as a safe default while wiring up real policy. |
+
+Implement [`PermissionDecider`] yourself for anything more interesting:
+
+```rust,ignore
+use async_trait::async_trait;
+use goose_embed::prelude::*;
+
+struct AllowOnlyReads;
+
+#[async_trait]
+impl PermissionDecider for AllowOnlyReads {
+    async fn decide(&self, request: PermissionRequest) -> Permission {
+        if request.tool_name.contains("read") {
+            Permission::AllowOnce
+        } else {
+            Permission::DenyOnce
+        }
+    }
+}
+```
+
+### Recipes
+
+Pass a [`Recipe`] to `.recipe(...)` and the builder will register its
+extensions and (if you haven't set provider/model explicitly) read them from
+`settings.goose_provider` / `settings.goose_model`. See
+[`examples/with_recipe.rs`](examples/with_recipe.rs) for an end-to-end
+example.
+
+## What this crate does NOT do (v0)
+
+- **Does not minimize dependencies.** Pulls everything `crates/goose` pulls.
+  Use this crate when ergonomics matter more than binary size; wait for
+  `goose-core` if you need a small dep graph.
+- **Does not handle elicitations.** If the agent requests structured input
+  via MCP elicitation, the request is logged as a warning and the agent
+  stalls. Coming in v1.
+- **Does not expose the embedded agent as an ACP server.** If you want
+  other clients to connect to your composed agent over ACP, depend on
+  `goose` directly and use `goose acp`. A `goose-acp-server` bridge crate
+  may follow once `goose-core` exists.
+- **Does not provide multi-language bindings.** Rust-only. Cross-language
+  embedding goes through ACP via the existing `goose-sdk` crates.
+
+## Roadmap
+
+1. **This crate (today).** Validate the embed API surface.
+2. **`goose-core`.** Carve out a lean crate containing only the agent loop,
+   `Provider` trait, MCP utils, `Recipe`, `Skill`, `conversation`,
+   `context_mgmt`, `permission`. Heavy deps (sqlx, scheduler, OAuth, AWS,
+   candle) stay in the `goose` runtime crate.
+3. **Re-emerge `goose-embed` on top of `goose-core`.** Same public API as
+   today; orders-of-magnitude smaller dep graph.
+4. **`goose-acp-server` bridge.** Optional crate for embedders that want to
+   re-expose their composed agent over ACP.

--- a/crates/goose-embed/examples/hello_agent.rs
+++ b/crates/goose-embed/examples/hello_agent.rs
@@ -1,0 +1,54 @@
+//! Minimal goose-embed example: spin up an agent, send one prompt, stream
+//! the response to stdout.
+//!
+//! ```bash
+//! GOOSE_EMBED_PROVIDER=anthropic \
+//! GOOSE_EMBED_MODEL=claude-sonnet-4 \
+//! cargo run -p goose-embed --example hello_agent
+//! ```
+//!
+//! If `GOOSE_EMBED_PROVIDER` or `GOOSE_EMBED_MODEL` are unset, the example
+//! prints a friendly hint and exits cleanly so it remains CI-friendly.
+
+use futures::StreamExt;
+
+use goose_embed::prelude::*;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let Some((provider, model)) = provider_from_env() else {
+        eprintln!(
+            "Set GOOSE_EMBED_PROVIDER and GOOSE_EMBED_MODEL to run this example.\n\
+             Example: GOOSE_EMBED_PROVIDER=anthropic GOOSE_EMBED_MODEL=claude-sonnet-4 cargo run -p goose-embed --example hello_agent"
+        );
+        return Ok(());
+    };
+
+    let goose = Goose::builder()
+        .provider(provider, model)
+        .working_dir(std::env::current_dir()?)
+        .build()
+        .await?;
+
+    let prompt = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "What is 2 + 2? Answer in a single sentence.".to_string());
+
+    let mut stream = goose.reply(prompt).await?;
+    while let Some(event) = stream.next().await {
+        if let Ok(AgentEvent::Message(message)) = event {
+            let text = message.as_concat_text();
+            if !text.is_empty() {
+                println!("{text}");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn provider_from_env() -> Option<(String, String)> {
+    let provider = std::env::var("GOOSE_EMBED_PROVIDER").ok()?;
+    let model = std::env::var("GOOSE_EMBED_MODEL").ok()?;
+    Some((provider, model))
+}

--- a/crates/goose-embed/examples/with_recipe.rs
+++ b/crates/goose-embed/examples/with_recipe.rs
@@ -1,0 +1,73 @@
+//! Load a goose recipe from a YAML file and run it inside an embedded agent.
+//!
+//! ```bash
+//! GOOSE_EMBED_PROVIDER=anthropic \
+//! GOOSE_EMBED_MODEL=claude-sonnet-4 \
+//! cargo run -p goose-embed --example with_recipe -- path/to/recipe.yaml
+//! ```
+//!
+//! Provider and model come from `GOOSE_EMBED_PROVIDER` / `GOOSE_EMBED_MODEL`
+//! if set, otherwise from the recipe's `settings.goose_provider` /
+//! `settings.goose_model`. If neither is available the example prints a hint
+//! and exits 0.
+
+use std::path::PathBuf;
+
+use anyhow::Context;
+use futures::StreamExt;
+
+use goose_embed::prelude::*;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let Some(recipe_path) = std::env::args().nth(1).map(PathBuf::from) else {
+        eprintln!("Usage: cargo run -p goose-embed --example with_recipe -- <path/to/recipe.yaml>");
+        return Ok(());
+    };
+
+    let recipe_text = std::fs::read_to_string(&recipe_path)
+        .with_context(|| format!("reading recipe at {}", recipe_path.display()))?;
+    let recipe: Recipe = serde_yaml::from_str(&recipe_text)
+        .with_context(|| format!("parsing recipe at {}", recipe_path.display()))?;
+
+    let mut builder = Goose::builder()
+        .working_dir(std::env::current_dir()?)
+        .recipe(recipe.clone());
+
+    if let (Ok(provider), Ok(model)) = (
+        std::env::var("GOOSE_EMBED_PROVIDER"),
+        std::env::var("GOOSE_EMBED_MODEL"),
+    ) {
+        builder = builder.provider(provider, model);
+    } else if recipe
+        .settings
+        .as_ref()
+        .and_then(|s| s.goose_provider.as_ref())
+        .is_none()
+    {
+        eprintln!(
+            "Set GOOSE_EMBED_PROVIDER and GOOSE_EMBED_MODEL or provide settings.goose_provider / settings.goose_model in the recipe."
+        );
+        return Ok(());
+    }
+
+    let goose = builder.build().await?;
+
+    let prompt = recipe
+        .prompt
+        .clone()
+        .or_else(|| recipe.instructions.clone())
+        .unwrap_or_else(|| "Run this recipe.".to_string());
+
+    let mut stream = goose.reply(prompt).await?;
+    while let Some(event) = stream.next().await {
+        if let Ok(AgentEvent::Message(message)) = event {
+            let text = message.as_concat_text();
+            if !text.is_empty() {
+                println!("{text}");
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/goose-embed/src/builder.rs
+++ b/crates/goose-embed/src/builder.rs
@@ -1,0 +1,296 @@
+//! Builder and runtime handle for an embedded goose agent.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{bail, Context, Result};
+use async_stream::try_stream;
+use futures::StreamExt;
+use tracing::warn;
+
+use goose::agents::extension::ExtensionConfig;
+use goose::agents::{Agent, AgentConfig, AgentEvent, GoosePlatform, SessionConfig};
+use goose::config::permission::PermissionManager;
+use goose::config::GooseMode;
+use goose::conversation::message::{ActionRequiredData, Message, MessageContent};
+use goose::providers::create_with_named_model;
+use goose::recipe::Recipe;
+use goose::session::session_manager::{SessionManager, SessionType};
+
+use crate::handle::ReplyStream;
+use crate::permission::{confirmation_for, AutoApprove, PermissionDecider, PermissionRequest};
+
+/// Handle to an embedded goose agent ready to receive prompts.
+///
+/// Construct with [`Goose::builder`]. Drive with [`Goose::reply`].
+pub struct Goose {
+    agent: Arc<Agent>,
+    session_id: String,
+    decider: Arc<dyn PermissionDecider>,
+    max_turns: Option<u32>,
+}
+
+impl Goose {
+    pub fn builder() -> GooseBuilder {
+        GooseBuilder::default()
+    }
+
+    /// Send a prompt and stream the agent's events.
+    ///
+    /// The returned stream yields [`AgentEvent`]s as the agent produces them.
+    /// Tool-confirmation requests are intercepted: the configured
+    /// [`PermissionDecider`] is consulted and the decision is delivered back
+    /// to the agent automatically. The originating event is still yielded so
+    /// the caller can observe what happened.
+    ///
+    /// Elicitation requests are not supported in v0 — they're logged as a
+    /// warning and the agent stalls waiting for input that never arrives. If
+    /// you need elicitations, supply a custom permission decider and handle
+    /// the event yourself by holding the stream.
+    pub async fn reply(&self, prompt: impl Into<String>) -> Result<ReplyStream<'_>> {
+        let user_message = Message::user().with_text(prompt.into());
+        let session_config = SessionConfig {
+            id: self.session_id.clone(),
+            schedule_id: None,
+            max_turns: self.max_turns,
+            retry_config: None,
+        };
+
+        let inner = self.agent.reply(user_message, session_config, None).await?;
+        let agent = Arc::clone(&self.agent);
+        let decider = Arc::clone(&self.decider);
+
+        let wrapped = try_stream! {
+            tokio::pin!(inner);
+            while let Some(event) = inner.next().await {
+                let event = event?;
+                if let AgentEvent::Message(message) = &event {
+                    if let Some(request) = find_tool_confirmation(message) {
+                        let request_id = request.request_id.clone();
+                        let permission = decider.decide(request).await;
+                        agent
+                            .handle_confirmation(request_id, confirmation_for(permission))
+                            .await;
+                    } else if contains_elicitation(message) {
+                        warn!(
+                            "Elicitation requested but goose-embed v0 has no elicitation handler; agent will stall waiting for input"
+                        );
+                    }
+                }
+                yield event;
+            }
+        };
+
+        Ok(ReplyStream {
+            inner: Box::pin(wrapped),
+        })
+    }
+
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    pub fn agent(&self) -> &Arc<Agent> {
+        &self.agent
+    }
+}
+
+fn find_tool_confirmation(message: &Message) -> Option<PermissionRequest> {
+    message.content.iter().find_map(|content| {
+        if let MessageContent::ActionRequired(action) = content {
+            if let ActionRequiredData::ToolConfirmation {
+                id,
+                tool_name,
+                prompt,
+                ..
+            } = &action.data
+            {
+                return Some(PermissionRequest {
+                    request_id: id.clone(),
+                    tool_name: tool_name.clone(),
+                    security_prompt: prompt.clone(),
+                });
+            }
+        }
+        None
+    })
+}
+
+fn contains_elicitation(message: &Message) -> bool {
+    message.content.iter().any(|content| {
+        if let MessageContent::ActionRequired(action) = content {
+            matches!(&action.data, ActionRequiredData::Elicitation { .. })
+        } else {
+            false
+        }
+    })
+}
+
+/// Builder for [`Goose`]. Construct via [`Goose::builder`].
+#[derive(Default)]
+pub struct GooseBuilder {
+    provider_name: Option<String>,
+    provider_model: Option<String>,
+    extensions: Vec<ExtensionConfig>,
+    recipe: Option<Recipe>,
+    working_dir: Option<PathBuf>,
+    session_name: Option<String>,
+    decider: Option<Arc<dyn PermissionDecider>>,
+    max_turns: Option<u32>,
+}
+
+impl GooseBuilder {
+    /// Pick the LLM provider and model. Both must be set before
+    /// [`build`](Self::build) unless a recipe with `settings.goose_provider`
+    /// and `settings.goose_model` is supplied via [`recipe`](Self::recipe).
+    pub fn provider(mut self, name: impl Into<String>, model: impl Into<String>) -> Self {
+        self.provider_name = Some(name.into());
+        self.provider_model = Some(model.into());
+        self
+    }
+
+    pub fn extension(mut self, config: ExtensionConfig) -> Self {
+        self.extensions.push(config);
+        self
+    }
+
+    pub fn extensions(mut self, configs: impl IntoIterator<Item = ExtensionConfig>) -> Self {
+        self.extensions.extend(configs);
+        self
+    }
+
+    /// Attach a recipe. The recipe's extensions are added to the agent and
+    /// its response schema (if any) is installed. If the builder hasn't set a
+    /// provider/model explicitly, the recipe's `settings.goose_provider` and
+    /// `settings.goose_model` are used.
+    pub fn recipe(mut self, recipe: Recipe) -> Self {
+        self.recipe = Some(recipe);
+        self
+    }
+
+    pub fn working_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.working_dir = Some(dir.into());
+        self
+    }
+
+    pub fn session_name(mut self, name: impl Into<String>) -> Self {
+        self.session_name = Some(name.into());
+        self
+    }
+
+    /// Install a [`PermissionDecider`]. Defaults to
+    /// [`AutoApprove`](crate::AutoApprove) when omitted.
+    pub fn permission_decider<D>(mut self, decider: D) -> Self
+    where
+        D: PermissionDecider + 'static,
+    {
+        self.decider = Some(Arc::new(decider));
+        self
+    }
+
+    pub fn max_turns(mut self, n: u32) -> Self {
+        self.max_turns = Some(n);
+        self
+    }
+
+    pub async fn build(mut self) -> Result<Goose> {
+        let (provider_name, provider_model) = resolve_provider(&self)?;
+
+        let provider = create_with_named_model(&provider_name, &provider_model, vec![])
+            .await
+            .with_context(|| {
+                format!("constructing provider '{provider_name}' with model '{provider_model}'")
+            })?;
+
+        let agent_config = AgentConfig::new(
+            Arc::new(SessionManager::instance()),
+            PermissionManager::instance(),
+            None,
+            GooseMode::Auto,
+            true,
+            GoosePlatform::GooseCli,
+        );
+        let agent = Arc::new(Agent::with_config(agent_config));
+
+        let working_dir = self
+            .working_dir
+            .take()
+            .or_else(|| std::env::current_dir().ok())
+            .unwrap_or_default();
+        let session_name = self
+            .session_name
+            .take()
+            .unwrap_or_else(|| format!("goose-embed-{}", std::process::id()));
+
+        let session = agent
+            .config
+            .session_manager
+            .create_session(
+                working_dir,
+                session_name,
+                SessionType::Hidden,
+                GooseMode::Auto,
+            )
+            .await
+            .context("creating embed session")?;
+
+        agent
+            .update_provider(provider, &session.id)
+            .await
+            .context("setting agent provider")?;
+
+        let mut all_extensions = Vec::new();
+        if let Some(recipe) = self.recipe.take() {
+            agent.apply_recipe_components(recipe.response, false).await;
+            if let Some(recipe_extensions) = recipe.extensions {
+                all_extensions.extend(recipe_extensions);
+            }
+        }
+        all_extensions.extend(self.extensions);
+
+        for ext in all_extensions {
+            let name = ext.name();
+            agent
+                .add_extension(ext, &session.id)
+                .await
+                .with_context(|| format!("adding extension '{name}'"))?;
+        }
+
+        let decider = self
+            .decider
+            .unwrap_or_else(|| Arc::new(AutoApprove) as Arc<dyn PermissionDecider>);
+
+        Ok(Goose {
+            agent,
+            session_id: session.id,
+            decider,
+            max_turns: self.max_turns,
+        })
+    }
+}
+
+fn resolve_provider(builder: &GooseBuilder) -> Result<(String, String)> {
+    let mut name = builder.provider_name.clone();
+    let mut model = builder.provider_model.clone();
+
+    if let Some(recipe) = &builder.recipe {
+        if let Some(settings) = &recipe.settings {
+            if name.is_none() {
+                name = settings.goose_provider.clone();
+            }
+            if model.is_none() {
+                model = settings.goose_model.clone();
+            }
+        }
+    }
+
+    match (name, model) {
+        (Some(n), Some(m)) => Ok((n, m)),
+        (None, _) => {
+            bail!("provider name is required: call .provider(name, model) or supply a recipe with settings.goose_provider")
+        }
+        (_, None) => {
+            bail!("model name is required: call .provider(name, model) or supply a recipe with settings.goose_model")
+        }
+    }
+}

--- a/crates/goose-embed/src/handle.rs
+++ b/crates/goose-embed/src/handle.rs
@@ -1,0 +1,26 @@
+//! Stream type returned from [`crate::Goose::reply`].
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures::stream::BoxStream;
+use futures::Stream;
+
+use goose::agents::AgentEvent;
+
+/// Stream of [`AgentEvent`]s produced by an embedded agent.
+///
+/// Yielded by [`crate::Goose::reply`]. The stream borrows from the parent
+/// [`crate::Goose`] handle, so keep the handle alive for as long as you're
+/// reading from the stream.
+pub struct ReplyStream<'a> {
+    pub(crate) inner: BoxStream<'a, anyhow::Result<AgentEvent>>,
+}
+
+impl<'a> Stream for ReplyStream<'a> {
+    type Item = anyhow::Result<AgentEvent>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
+    }
+}

--- a/crates/goose-embed/src/lib.rs
+++ b/crates/goose-embed/src/lib.rs
@@ -1,0 +1,62 @@
+//! # goose-embed
+//!
+//! Embeddable Rust SDK for the goose AI agent.
+//!
+//! Use this crate to build your own Rust program that runs goose's agent loop
+//! with custom providers, MCP extensions, recipes, and skills, without
+//! shelling out to the `goose` binary or talking ACP over stdio.
+//!
+//! ## Status — Spike
+//!
+//! This is an API-discovery spike. It is implemented as a thin facade over the
+//! full [`goose`] crate, so depending on it pulls the same dependency tree as
+//! depending on `goose` directly. The dependency-minimization story comes later,
+//! when a slim `goose-core` crate is carved out and `goose-embed` is re-emerged
+//! on top of it. See `docs/brainstorms/2026-05-28-goose-embed-rust-sdk.md` for
+//! the roadmap.
+//!
+//! ## Quick start
+//!
+//! ```no_run
+//! use futures::StreamExt;
+//! use goose_embed::prelude::*;
+//!
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     let goose = Goose::builder()
+//!         .provider("anthropic", "claude-sonnet-4")
+//!         .working_dir(std::env::current_dir()?)
+//!         .build()
+//!         .await?;
+//!
+//!     let mut stream = goose.reply("What is 2 + 2?").await?;
+//!     while let Some(event) = stream.next().await {
+//!         if let Ok(AgentEvent::Message(message)) = event {
+//!             println!("{}", message.as_concat_text());
+//!         }
+//!     }
+//!     Ok(())
+//! }
+//! ```
+
+pub mod builder;
+pub mod permission;
+
+mod handle;
+
+pub use builder::{Goose, GooseBuilder};
+pub use handle::ReplyStream;
+pub use permission::{AutoApprove, DenyAll, PermissionDecider, PermissionRequest};
+
+/// Re-exports of the goose types you'll most commonly need when wiring up an
+/// embedded agent. Glob-import via `use goose_embed::prelude::*;`.
+pub mod prelude {
+    pub use crate::{
+        AutoApprove, DenyAll, Goose, GooseBuilder, PermissionDecider, PermissionRequest,
+        ReplyStream,
+    };
+    pub use goose::agents::{AgentEvent, ExtensionConfig};
+    pub use goose::conversation::message::Message;
+    pub use goose::permission::{Permission, PermissionConfirmation};
+    pub use goose::recipe::Recipe;
+}

--- a/crates/goose-embed/src/permission.rs
+++ b/crates/goose-embed/src/permission.rs
@@ -1,0 +1,65 @@
+//! Permission handling for embedded agents.
+//!
+//! When a tool call needs confirmation, goose's agent loop pauses and waits for
+//! a decision. In the CLI this is a TUI prompt; in the desktop app it's a
+//! modal. For an embedded agent, the host program supplies a
+//! [`PermissionDecider`] that decides programmatically.
+
+use async_trait::async_trait;
+
+use goose::permission::permission_confirmation::PrincipalType;
+pub use goose::permission::{Permission, PermissionConfirmation};
+
+/// A pending permission request surfaced to the embedder.
+#[derive(Debug, Clone)]
+pub struct PermissionRequest {
+    pub request_id: String,
+    pub tool_name: String,
+    pub security_prompt: Option<String>,
+}
+
+/// Decides what permission to grant for a tool call.
+///
+/// Embedders implement this trait to decide programmatically. Two ready-made
+/// impls are provided: [`AutoApprove`] (grants `AllowOnce` for everything) and
+/// [`DenyAll`] (denies everything).
+///
+/// Implementations must be `Send + Sync` — the decider is called from inside
+/// the stream wrapper returned by [`crate::Goose::reply`], which may be polled
+/// on any executor thread.
+#[async_trait]
+pub trait PermissionDecider: Send + Sync {
+    async fn decide(&self, request: PermissionRequest) -> Permission;
+}
+
+/// Grants `AllowOnce` for every tool call. Useful for trusted automation
+/// pipelines, tests, and the smallest possible embed example.
+///
+/// Do not use in adversarial or multi-tenant settings — every tool call will
+/// be approved, including ones the model invented on its own.
+pub struct AutoApprove;
+
+#[async_trait]
+impl PermissionDecider for AutoApprove {
+    async fn decide(&self, _request: PermissionRequest) -> Permission {
+        Permission::AllowOnce
+    }
+}
+
+/// Denies every tool call. Useful as a safety default while wiring up a real
+/// decision policy.
+pub struct DenyAll;
+
+#[async_trait]
+impl PermissionDecider for DenyAll {
+    async fn decide(&self, _request: PermissionRequest) -> Permission {
+        Permission::DenyOnce
+    }
+}
+
+pub(crate) fn confirmation_for(permission: Permission) -> PermissionConfirmation {
+    PermissionConfirmation {
+        principal_type: PrincipalType::Tool,
+        permission,
+    }
+}

--- a/crates/goose-embed/tests/builder.rs
+++ b/crates/goose-embed/tests/builder.rs
@@ -1,0 +1,50 @@
+//! Smoke tests for the builder validation surface.
+//!
+//! These tests intentionally do not touch the network or instantiate a real
+//! provider — they just check that the builder rejects obviously-broken
+//! configurations with helpful error messages.
+
+use goose_embed::prelude::*;
+
+#[tokio::test]
+async fn build_without_provider_or_recipe_errors() {
+    let result = Goose::builder().build().await;
+    let err = match result {
+        Ok(_) => panic!("expected builder to reject missing provider"),
+        Err(e) => e,
+    };
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("provider"),
+        "error should mention provider, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn build_without_model_errors() {
+    let recipe = Recipe {
+        version: "1.0.0".to_string(),
+        title: "no model".to_string(),
+        description: "recipe without a model setting".to_string(),
+        instructions: Some("hello".to_string()),
+        prompt: None,
+        extensions: None,
+        settings: None,
+        activities: None,
+        author: None,
+        parameters: None,
+        response: None,
+        sub_recipes: None,
+        retry: None,
+    };
+    let result = Goose::builder().recipe(recipe).build().await;
+    let err = match result {
+        Ok(_) => panic!("expected builder to reject missing model"),
+        Err(e) => e,
+    };
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("provider") || msg.contains("model"),
+        "error should mention provider or model, got: {msg}"
+    );
+}

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -53,6 +53,7 @@ use crate::session::extension_data::{EnabledExtensionsState, ExtensionState};
 use crate::session::{Session, SessionManager, SessionNameUpdate};
 use crate::tool_inspection::ToolInspectionManager;
 use crate::tool_monitor::RepetitionInspector;
+use crate::traits::{SessionContextProvider, SessionUpdate};
 use crate::utils::is_token_cancelled;
 use regex::Regex;
 use rmcp::model::{
@@ -1017,11 +1018,12 @@ impl Agent {
             return Err(anyhow!("Extension state serialization failed: {}", e));
         }
 
-        session_manager
-            .update(&session.id)
-            .extension_data(session_data.extension_data)
-            .apply()
-            .await?;
+        SessionContextProvider::apply_update(
+            session_manager.as_ref(),
+            &session.id,
+            SessionUpdate::default().extension_data(session_data.extension_data),
+        )
+        .await?;
 
         Ok(())
     }
@@ -1039,11 +1041,12 @@ impl Agent {
             .to_extension_data(&mut extension_data)
             .map_err(|e| anyhow!("Failed to serialize extension state: {}", e))?;
 
-        session_manager
-            .update(session_id)
-            .extension_data(extension_data)
-            .apply()
-            .await?;
+        SessionContextProvider::apply_update(
+            session_manager.as_ref(),
+            session_id,
+            SessionUpdate::default().extension_data(extension_data),
+        )
+        .await?;
 
         Ok(())
     }
@@ -2320,15 +2323,15 @@ impl Agent {
         let mut current_provider = self.provider.lock().await;
         *current_provider = Some(provider);
 
-        self.config
-            .session_manager
-            .clone()
-            .update(session_id)
-            .provider_name(&provider_name)
-            .model_config(model_config)
-            .apply()
-            .await
-            .context("Failed to persist provider config to session")
+        SessionContextProvider::apply_update(
+            self.config.session_manager.as_ref(),
+            session_id,
+            SessionUpdate::default()
+                .provider_name(&provider_name)
+                .model_config(model_config),
+        )
+        .await
+        .context("Failed to persist provider config to session")
     }
 
     pub async fn update_goose_mode(&self, mode: GooseMode, session_id: &str) -> Result<()> {
@@ -2339,14 +2342,13 @@ impl Agent {
                 .map_err(|e| anyhow::anyhow!("Provider rejected mode update: {e}"))?;
         }
         *self.current_goose_mode.lock().await = mode;
-        self.config
-            .session_manager
-            .clone()
-            .update(session_id)
-            .goose_mode(mode)
-            .apply()
-            .await
-            .context("Failed to persist goose_mode to session")
+        SessionContextProvider::apply_update(
+            self.config.session_manager.as_ref(),
+            session_id,
+            SessionUpdate::default().goose_mode(mode),
+        )
+        .await
+        .context("Failed to persist goose_mode to session")
     }
 
     pub async fn goose_mode(&self) -> GooseMode {
@@ -2430,14 +2432,14 @@ impl Agent {
                 )
             })?;
 
-            if let Err(e) = self
-                .config
-                .session_manager
-                .update(&session.id)
-                .provider_name(&fallback_provider_name)
-                .model_config(fallback_model_config)
-                .apply()
-                .await
+            if let Err(e) = SessionContextProvider::apply_update(
+                self.config.session_manager.as_ref(),
+                &session.id,
+                SessionUpdate::default()
+                    .provider_name(&fallback_provider_name)
+                    .model_config(fallback_model_config),
+            )
+            .await
             {
                 tracing::warn!("Failed to update session provider: {}", e);
             }

--- a/crates/goose/src/agents/execute_commands.rs
+++ b/crates/goose/src/agents/execute_commands.rs
@@ -5,6 +5,7 @@ use anyhow::{anyhow, Result};
 use crate::context_mgmt::compact_messages;
 use crate::conversation::message::{Message, SystemNotificationType};
 use crate::slash_commands::{recipe_slash_command, skill_slash_command};
+use crate::traits::{SessionContextProvider, SessionUpdate};
 
 use super::Agent;
 
@@ -164,13 +165,15 @@ impl Agent {
             .replace_conversation(session_id, &Conversation::default())
             .await?;
 
-        manager
-            .update(session_id)
-            .total_tokens(Some(0))
-            .input_tokens(Some(0))
-            .output_tokens(Some(0))
-            .apply()
-            .await?;
+        SessionContextProvider::apply_update(
+            manager.as_ref(),
+            session_id,
+            SessionUpdate::default()
+                .total_tokens(Some(0))
+                .input_tokens(Some(0))
+                .output_tokens(Some(0)),
+        )
+        .await?;
 
         Ok(Some(Message::assistant().with_system_notification(
             SystemNotificationType::InlineMessage,

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -41,14 +41,14 @@ use crate::builtin_extension::get_builtin_extension;
 use crate::config::extensions::name_to_key;
 use crate::config::search_path::SearchPaths;
 use crate::config::{get_all_extensions, Config};
-use crate::oauth::{oauth_flow, GooseCredentialStore};
+use crate::oauth::GOOSE_USER_AGENT;
 use crate::prompt_template;
 use crate::subprocess::configure_subprocess;
+use crate::traits::OAuthProvider;
 use rmcp::model::{
     CallToolRequestParams, CallToolResult, Content, ErrorCode, ErrorData, GetPromptResult, Meta,
     Prompt, Resource, ResourceContents, ServerInfo, Tool,
 };
-use rmcp::transport::auth::{AuthClient, CredentialStore};
 use schemars::_private::NoSerialize;
 use serde_json::Value;
 
@@ -140,6 +140,7 @@ pub struct ExtensionManager {
     extensions: Mutex<HashMap<String, Extension>>,
     context: PlatformExtensionContext,
     provider: SharedProvider,
+    oauth_provider: Arc<dyn crate::traits::OAuthProvider>,
     tools_cache: Mutex<Option<Arc<Vec<Tool>>>>,
     tools_cache_version: AtomicU64,
     client_name: String,
@@ -502,48 +503,6 @@ pub(crate) fn substitute_env_vars(value: &str, env_map: &HashMap<String, String>
     result
 }
 
-const GOOSE_USER_AGENT: reqwest::header::HeaderValue =
-    reqwest::header::HeaderValue::from_static(concat!("goose/", env!("CARGO_PKG_VERSION")));
-
-#[allow(clippy::too_many_arguments)]
-async fn connect_with_auth(
-    auth_manager: rmcp::transport::AuthorizationManager,
-    uri: &str,
-    timeout: Duration,
-    provider: SharedProvider,
-    client_name: String,
-    capabilities: GooseMcpClientCapabilities,
-    roots_dir: &std::path::Path,
-) -> ExtensionResult<Box<dyn McpClientTrait>> {
-    let mut auth_headers = HeaderMap::new();
-    auth_headers.insert(reqwest::header::USER_AGENT, GOOSE_USER_AGENT);
-    #[allow(unused_mut)]
-    let mut auth_client_builder = reqwest::Client::builder().default_headers(auth_headers);
-    #[cfg(target_os = "linux")]
-    {
-        auth_client_builder = auth_client_builder.tcp_user_timeout(Some(timeout));
-    }
-    let auth_http_client = auth_client_builder
-        .build()
-        .map_err(|_| ExtensionError::ConfigError("could not construct http client".to_string()))?;
-    let auth_client = AuthClient::new(auth_http_client, auth_manager);
-    let transport = StreamableHttpClientTransport::with_client(
-        auth_client,
-        StreamableHttpClientTransportConfig::with_uri(uri),
-    );
-    Ok(Box::new(
-        McpClient::connect(
-            transport,
-            timeout,
-            provider,
-            client_name,
-            capabilities,
-            roots_dir.to_path_buf(),
-        )
-        .await?,
-    ))
-}
-
 #[allow(clippy::too_many_arguments)]
 async fn create_streamable_http_client(
     uri: &str,
@@ -555,6 +514,7 @@ async fn create_streamable_http_client(
     client_name: String,
     capabilities: GooseMcpClientCapabilities,
     roots_dir: &std::path::Path,
+    oauth_provider: &dyn OAuthProvider,
 ) -> ExtensionResult<Box<dyn McpClientTrait>> {
     #[cfg(unix)]
     if let Some(socket_path) = socket {
@@ -611,21 +571,20 @@ async fn create_streamable_http_client(
 
     // If we have stored OAuth credentials, try refreshing and connecting directly.
     // This avoids the unnecessary 401 → browser re-auth cycle on every new session.
-    let credential_store = GooseCredentialStore::new(name.to_string());
-    if credential_store.load().await.is_ok_and(|c| c.is_some()) {
-        match oauth_flow(&uri.to_string(), &name.to_string()).await {
-            Ok(auth_manager) => {
-                return connect_with_auth(
-                    auth_manager,
-                    uri,
-                    timeout_duration,
-                    provider,
-                    client_name,
-                    capabilities,
-                    roots_dir,
-                )
-                .await;
-            }
+    if oauth_provider.has_stored_credentials(name).await {
+        match oauth_provider
+            .connect_authenticated(
+                name,
+                uri,
+                timeout_duration,
+                provider.clone(),
+                client_name.clone(),
+                capabilities.clone(),
+                roots_dir,
+            )
+            .await
+        {
+            Ok(client) => return Ok(client),
             Err(e) => {
                 warn!(
                     "[OAuth:{}] Proactive refresh failed: {}, falling back to unauthenticated attempt",
@@ -646,19 +605,19 @@ async fn create_streamable_http_client(
     .await;
 
     if should_attempt_oauth_fallback(&client_res) {
-        match oauth_flow(&uri.to_string(), &name.to_string()).await {
-            Ok(auth_manager) => {
-                connect_with_auth(
-                    auth_manager,
-                    uri,
-                    timeout_duration,
-                    provider,
-                    client_name,
-                    capabilities,
-                    roots_dir,
-                )
-                .await
-            }
+        match oauth_provider
+            .connect_authenticated(
+                name,
+                uri,
+                timeout_duration,
+                provider,
+                client_name,
+                capabilities,
+                roots_dir,
+            )
+            .await
+        {
+            Ok(client) => Ok(client),
             Err(_) => Ok(Box::new(client_res?)),
         }
     } else {
@@ -743,6 +702,24 @@ impl ExtensionManager {
         capabilities: ExtensionManagerCapabilities,
         use_login_shell_path: bool,
     ) -> Self {
+        Self::new_with_oauth_provider(
+            provider,
+            session_manager,
+            client_name,
+            capabilities,
+            use_login_shell_path,
+            Arc::new(crate::oauth::RuntimeOAuthProvider),
+        )
+    }
+
+    pub fn new_with_oauth_provider(
+        provider: SharedProvider,
+        session_manager: Arc<crate::session::SessionManager>,
+        client_name: String,
+        capabilities: ExtensionManagerCapabilities,
+        use_login_shell_path: bool,
+        oauth_provider: Arc<dyn crate::traits::OAuthProvider>,
+    ) -> Self {
         Self {
             extensions: Mutex::new(HashMap::new()),
             context: PlatformExtensionContext {
@@ -752,6 +729,7 @@ impl ExtensionManager {
                 use_login_shell_path,
             },
             provider,
+            oauth_provider,
             tools_cache: Mutex::new(None),
             tools_cache_version: AtomicU64::new(0),
             client_name,
@@ -858,6 +836,7 @@ impl ExtensionManager {
                     self.client_name.clone(),
                     self.mcp_client_capabilities(),
                     &effective_working_dir,
+                    &*self.oauth_provider,
                 )
                 .await?
             }

--- a/crates/goose/src/agents/platform_extensions/todo.rs
+++ b/crates/goose/src/agents/platform_extensions/todo.rs
@@ -3,6 +3,7 @@ use crate::agents::mcp_client::{Error, McpClientTrait};
 use crate::agents::tool_execution::ToolCallContext;
 use crate::session::extension_data;
 use crate::session::extension_data::ExtensionState;
+use crate::traits::{SessionContextProvider, SessionUpdate};
 use anyhow::Result;
 use async_trait::async_trait;
 use indoc::indoc;
@@ -89,11 +90,12 @@ impl TodoClient {
                     .to_extension_data(&mut session.extension_data)
                     .is_ok()
                 {
-                    match manager
-                        .update(session_id)
-                        .extension_data(session.extension_data)
-                        .apply()
-                        .await
+                    match SessionContextProvider::apply_update(
+                        manager.as_ref(),
+                        session_id,
+                        SessionUpdate::default().extension_data(session.extension_data),
+                    )
+                    .await
                     {
                         Ok(_) => Ok(vec![Content::text(format!(
                             "Updated ({} chars)",

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -20,6 +20,7 @@ use crate::providers::toolshim::{
     augment_message_with_selected_tool_interpreter, convert_tool_messages_to_text,
     modify_system_prompt_for_tool_json, sanitize_residual_markers,
 };
+use crate::traits::{SessionContextProvider, SessionUpdate};
 use rmcp::model::Tool;
 use tracing::warn;
 
@@ -545,18 +546,20 @@ impl Agent {
             )
         };
 
-        manager
-            .update(session_id)
-            .schedule_id(schedule_id)
-            .total_tokens(current_total)
-            .input_tokens(current_input)
-            .output_tokens(current_output)
-            .accumulated_total_tokens(accumulated_total)
-            .accumulated_input_tokens(accumulated_input)
-            .accumulated_output_tokens(accumulated_output)
-            .accumulated_cost(accumulated_cost)
-            .apply()
-            .await?;
+        SessionContextProvider::apply_update(
+            manager.as_ref(),
+            session_id,
+            SessionUpdate::default()
+                .schedule_id(schedule_id)
+                .total_tokens(current_total)
+                .input_tokens(current_input)
+                .output_tokens(current_output)
+                .accumulated_total_tokens(accumulated_total)
+                .accumulated_input_tokens(accumulated_input)
+                .accumulated_output_tokens(accumulated_output)
+                .accumulated_cost(accumulated_cost),
+        )
+        .await?;
 
         Ok(())
     }

--- a/crates/goose/src/lib.rs
+++ b/crates/goose/src/lib.rs
@@ -47,4 +47,5 @@ pub mod token_counter;
 pub mod tool_inspection;
 pub mod tool_monitor;
 pub mod tracing;
+pub mod traits;
 pub mod utils;

--- a/crates/goose/src/oauth/mod.rs
+++ b/crates/goose/src/oauth/mod.rs
@@ -1,6 +1,8 @@
 mod persist;
+pub mod runtime;
 
 pub use persist::GooseCredentialStore;
+pub use runtime::{RuntimeOAuthProvider, GOOSE_USER_AGENT};
 
 use axum::extract::{Query, State};
 use axum::response::Html;

--- a/crates/goose/src/oauth/runtime.rs
+++ b/crates/goose/src/oauth/runtime.rs
@@ -1,0 +1,84 @@
+//! Runtime impl of [`crate::traits::OAuthProvider`] backed by the existing
+//! [`oauth_flow`](super::oauth_flow) function and [`GooseCredentialStore`](super::GooseCredentialStore).
+//!
+//! This is the concrete impl that `crates/goose` exposes to consumers of the
+//! `OAuthProvider` trait. It hides `rmcp::transport::AuthorizationManager` and
+//! the credential store behind the trait so `agents/extension_manager.rs`
+//! (eventually `goose-core`) does not have to import them directly.
+
+use std::path::Path;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use axum::http::HeaderMap;
+use rmcp::transport::auth::{AuthClient, CredentialStore};
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+use rmcp::transport::StreamableHttpClientTransport;
+use tracing::warn;
+
+use crate::agents::extension::{ExtensionError, ExtensionResult};
+use crate::agents::mcp_client::{GooseMcpClientCapabilities, McpClient, McpClientTrait};
+use crate::agents::types::SharedProvider;
+use crate::oauth::{oauth_flow, GooseCredentialStore};
+use crate::traits::OAuthProvider;
+
+pub const GOOSE_USER_AGENT: reqwest::header::HeaderValue =
+    reqwest::header::HeaderValue::from_static(concat!("goose/", env!("CARGO_PKG_VERSION")));
+
+/// Runtime [`OAuthProvider`] impl. Stateless; construct directly with `RuntimeOAuthProvider`.
+#[derive(Default, Clone, Copy)]
+pub struct RuntimeOAuthProvider;
+
+#[async_trait]
+impl OAuthProvider for RuntimeOAuthProvider {
+    async fn has_stored_credentials(&self, extension_name: &str) -> bool {
+        let store = GooseCredentialStore::new(extension_name.to_string());
+        store.load().await.is_ok_and(|c| c.is_some())
+    }
+
+    async fn connect_authenticated(
+        &self,
+        extension_name: &str,
+        uri: &str,
+        timeout: Duration,
+        provider: SharedProvider,
+        client_name: String,
+        capabilities: GooseMcpClientCapabilities,
+        roots_dir: &Path,
+    ) -> ExtensionResult<Box<dyn McpClientTrait>> {
+        let auth_manager = oauth_flow(&uri.to_string(), &extension_name.to_string())
+            .await
+            .map_err(|e| {
+                warn!("[OAuth:{}] flow failed: {}", extension_name, e);
+                ExtensionError::ConfigError(format!("oauth flow failed: {e}"))
+            })?;
+
+        let mut auth_headers = HeaderMap::new();
+        auth_headers.insert(reqwest::header::USER_AGENT, GOOSE_USER_AGENT);
+        #[allow(unused_mut)]
+        let mut auth_client_builder = reqwest::Client::builder().default_headers(auth_headers);
+        #[cfg(target_os = "linux")]
+        {
+            auth_client_builder = auth_client_builder.tcp_user_timeout(Some(timeout));
+        }
+        let auth_http_client = auth_client_builder.build().map_err(|_| {
+            ExtensionError::ConfigError("could not construct http client".to_string())
+        })?;
+        let auth_client = AuthClient::new(auth_http_client, auth_manager);
+        let transport = StreamableHttpClientTransport::with_client(
+            auth_client,
+            StreamableHttpClientTransportConfig::with_uri(uri),
+        );
+        Ok(Box::new(
+            McpClient::connect(
+                transport,
+                timeout,
+                provider,
+                client_name,
+                capabilities,
+                roots_dir.to_path_buf(),
+            )
+            .await?,
+        ))
+    }
+}

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -2019,6 +2019,74 @@ fn merge_tool_meta(
     serde_json::Value::Object(base)
 }
 
+#[async_trait::async_trait]
+impl crate::traits::SessionContextProvider for SessionManager {
+    async fn get_session(&self, id: &str, include_messages: bool) -> Result<Session> {
+        SessionManager::get_session(self, id, include_messages).await
+    }
+
+    async fn create_session(
+        &self,
+        working_dir: PathBuf,
+        name: String,
+        session_type: SessionType,
+        goose_mode: GooseMode,
+    ) -> Result<Session> {
+        SessionManager::create_session(self, working_dir, name, session_type, goose_mode).await
+    }
+
+    async fn add_message(&self, id: &str, message: &Message) -> Result<()> {
+        SessionManager::add_message(self, id, message).await
+    }
+
+    async fn replace_conversation(&self, id: &str, conversation: &Conversation) -> Result<()> {
+        SessionManager::replace_conversation(self, id, conversation).await
+    }
+
+    async fn apply_update(&self, id: &str, update: crate::traits::SessionUpdate) -> Result<()> {
+        let mut builder = self.update(id);
+        if let Some(data) = update.extension_data {
+            builder = builder.extension_data(data);
+        }
+        if let Some(name) = update.provider_name {
+            builder = builder.provider_name(name);
+        }
+        if update.clear_model_config {
+            builder = builder.clear_model_config();
+        } else if let Some(model_config) = update.model_config {
+            builder = builder.model_config(model_config);
+        }
+        if let Some(mode) = update.goose_mode {
+            builder = builder.goose_mode(mode);
+        }
+        if let Some(tokens) = update.total_tokens {
+            builder = builder.total_tokens(tokens);
+        }
+        if let Some(tokens) = update.input_tokens {
+            builder = builder.input_tokens(tokens);
+        }
+        if let Some(tokens) = update.output_tokens {
+            builder = builder.output_tokens(tokens);
+        }
+        if let Some(tokens) = update.accumulated_total_tokens {
+            builder = builder.accumulated_total_tokens(tokens);
+        }
+        if let Some(tokens) = update.accumulated_input_tokens {
+            builder = builder.accumulated_input_tokens(tokens);
+        }
+        if let Some(tokens) = update.accumulated_output_tokens {
+            builder = builder.accumulated_output_tokens(tokens);
+        }
+        if let Some(cost) = update.accumulated_cost {
+            builder = builder.accumulated_cost(cost);
+        }
+        if let Some(id) = update.schedule_id {
+            builder = builder.schedule_id(id);
+        }
+        builder.apply().await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/goose/src/traits/mod.rs
+++ b/crates/goose/src/traits/mod.rs
@@ -1,0 +1,15 @@
+//! Trait abstractions that decouple `goose`'s embeddable primitives (currently
+//! in `agents/`, `providers/`, `mcp_utils`, `skills`, `recipe`, `conversation`,
+//! `context_mgmt`, `permission`) from the application-runtime pieces that will
+//! stay in this crate (`session/`, `oauth/`, `scheduler/`, `posthog`, etc.).
+//!
+//! These traits are the contract that the future `goose-core` crate will export
+//! and that `crates/goose` will keep implementing. Today, both live here — this
+//! module is the first step of the carve-out series described in
+//! `docs/brainstorms/2026-05-28-goose-core-carve-out.md`.
+
+pub mod oauth;
+pub mod session;
+
+pub use oauth::{OAuthError, OAuthProvider};
+pub use session::{SessionContextProvider, SessionUpdate};

--- a/crates/goose/src/traits/oauth.rs
+++ b/crates/goose/src/traits/oauth.rs
@@ -1,0 +1,66 @@
+//! `OAuthProvider` — abstracts the OAuth flow so the extension manager doesn't
+//! have to depend directly on the `oauth2` crate or on `rmcp::transport::AuthorizationManager`.
+//!
+//! The runtime impl in this crate ([`crate::oauth::RuntimeOAuthProvider`]) wraps
+//! the existing [`crate::oauth::oauth_flow`] function and the keychain-backed
+//! credential store. `goose-core` consumers will only see the trait.
+
+use std::path::Path;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+use crate::agents::extension::{ExtensionError, ExtensionResult};
+use crate::agents::mcp_client::{GooseMcpClientCapabilities, McpClientTrait};
+use crate::agents::types::SharedProvider;
+
+#[derive(Debug, Error)]
+pub enum OAuthError {
+    #[error("OAuth flow failed: {0}")]
+    Flow(String),
+    #[error("credential store error: {0}")]
+    Store(String),
+}
+
+/// Connect to an MCP server that requires OAuth, hiding the underlying
+/// auth manager and credential store types.
+///
+/// The trait method does the whole flow: check stored credentials, attempt
+/// silent refresh, fall back to interactive auth if needed, then return a
+/// ready-to-use MCP client transport. Callers get a `Box<dyn McpClientTrait>`,
+/// they never see `AuthorizationManager` or `GooseCredentialStore`.
+#[async_trait]
+pub trait OAuthProvider: Send + Sync {
+    /// True if the credential store already has credentials for this extension.
+    /// Cheap check — does not perform any OAuth network calls.
+    async fn has_stored_credentials(&self, extension_name: &str) -> bool;
+
+    /// Connect to `uri` with OAuth authentication.
+    ///
+    /// Returns a connected MCP client. The implementation handles credential
+    /// loading, token refresh, and interactive browser auth as needed.
+    #[allow(clippy::too_many_arguments)]
+    async fn connect_authenticated(
+        &self,
+        extension_name: &str,
+        uri: &str,
+        timeout: Duration,
+        provider: SharedProvider,
+        client_name: String,
+        capabilities: GooseMcpClientCapabilities,
+        roots_dir: &Path,
+    ) -> ExtensionResult<Box<dyn McpClientTrait>>;
+}
+
+impl From<anyhow::Error> for OAuthError {
+    fn from(err: anyhow::Error) -> Self {
+        OAuthError::Flow(err.to_string())
+    }
+}
+
+impl From<OAuthError> for ExtensionError {
+    fn from(err: OAuthError) -> Self {
+        ExtensionError::ConfigError(err.to_string())
+    }
+}

--- a/crates/goose/src/traits/session.rs
+++ b/crates/goose/src/traits/session.rs
@@ -1,0 +1,136 @@
+//! `SessionContextProvider` — the trait that abstracts session storage so the
+//! agent loop doesn't have to depend on a concrete `SessionManager`.
+//!
+//! The runtime impl in this crate ([`crate::session::SessionManager`]) keeps
+//! the SQLite-backed storage that `goose-cli` and `goose-server` use. The
+//! `goose-core` carve-out reads the trait, not the impl.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::config::GooseMode;
+use crate::conversation::message::Message;
+use crate::conversation::Conversation;
+use crate::model::ModelConfig;
+use crate::session::extension_data::ExtensionData;
+use crate::session::session_manager::SessionType;
+use crate::session::Session;
+
+/// Pending mutations to apply to a session in one transactional call.
+///
+/// Use the chainable setters and pass the result to
+/// [`SessionContextProvider::apply_update`]. Fields default to `None`,
+/// meaning "leave the existing value untouched". The token / cost fields are
+/// double-`Option` so a caller can distinguish "don't touch" (outer `None`)
+/// from "set to `None`" (`Some(None)`).
+#[derive(Default, Debug, Clone)]
+pub struct SessionUpdate {
+    pub extension_data: Option<ExtensionData>,
+    pub provider_name: Option<String>,
+    pub model_config: Option<ModelConfig>,
+    pub clear_model_config: bool,
+    pub goose_mode: Option<GooseMode>,
+    pub total_tokens: Option<Option<i32>>,
+    pub input_tokens: Option<Option<i32>>,
+    pub output_tokens: Option<Option<i32>>,
+    pub accumulated_total_tokens: Option<Option<i32>>,
+    pub accumulated_input_tokens: Option<Option<i32>>,
+    pub accumulated_output_tokens: Option<Option<i32>>,
+    pub accumulated_cost: Option<Option<f64>>,
+    pub schedule_id: Option<Option<String>>,
+}
+
+impl SessionUpdate {
+    pub fn extension_data(mut self, data: ExtensionData) -> Self {
+        self.extension_data = Some(data);
+        self
+    }
+
+    pub fn provider_name(mut self, name: impl Into<String>) -> Self {
+        self.provider_name = Some(name.into());
+        self
+    }
+
+    pub fn model_config(mut self, model_config: ModelConfig) -> Self {
+        self.model_config = Some(model_config);
+        self.clear_model_config = false;
+        self
+    }
+
+    pub fn clear_model_config(mut self) -> Self {
+        self.clear_model_config = true;
+        self.model_config = None;
+        self
+    }
+
+    pub fn goose_mode(mut self, mode: GooseMode) -> Self {
+        self.goose_mode = Some(mode);
+        self
+    }
+
+    pub fn total_tokens(mut self, tokens: Option<i32>) -> Self {
+        self.total_tokens = Some(tokens);
+        self
+    }
+
+    pub fn input_tokens(mut self, tokens: Option<i32>) -> Self {
+        self.input_tokens = Some(tokens);
+        self
+    }
+
+    pub fn output_tokens(mut self, tokens: Option<i32>) -> Self {
+        self.output_tokens = Some(tokens);
+        self
+    }
+
+    pub fn accumulated_total_tokens(mut self, tokens: Option<i32>) -> Self {
+        self.accumulated_total_tokens = Some(tokens);
+        self
+    }
+
+    pub fn accumulated_input_tokens(mut self, tokens: Option<i32>) -> Self {
+        self.accumulated_input_tokens = Some(tokens);
+        self
+    }
+
+    pub fn accumulated_output_tokens(mut self, tokens: Option<i32>) -> Self {
+        self.accumulated_output_tokens = Some(tokens);
+        self
+    }
+
+    pub fn accumulated_cost(mut self, cost: Option<f64>) -> Self {
+        self.accumulated_cost = Some(cost);
+        self
+    }
+
+    pub fn schedule_id(mut self, id: Option<String>) -> Self {
+        self.schedule_id = Some(id);
+        self
+    }
+}
+
+/// Read and mutate session state without depending on a concrete storage backend.
+///
+/// The runtime impl is [`crate::session::SessionManager`]. `goose-core` consumers
+/// will eventually depend only on this trait, not on `SessionManager`'s
+/// SQLite-backed storage.
+#[async_trait]
+pub trait SessionContextProvider: Send + Sync {
+    async fn get_session(&self, id: &str, include_messages: bool) -> Result<Session>;
+
+    async fn create_session(
+        &self,
+        working_dir: PathBuf,
+        name: String,
+        session_type: SessionType,
+        goose_mode: GooseMode,
+    ) -> Result<Session>;
+
+    async fn add_message(&self, id: &str, message: &Message) -> Result<()>;
+
+    async fn replace_conversation(&self, id: &str, conversation: &Conversation) -> Result<()>;
+
+    async fn apply_update(&self, id: &str, update: SessionUpdate) -> Result<()>;
+}

--- a/crates/goose/tests/providers.rs
+++ b/crates/goose/tests/providers.rs
@@ -161,6 +161,7 @@ impl ProviderTestConfig {
         self
     }
 
+    #[allow(dead_code)] // used only by aws-providers gated tests
     fn clear_env(mut self, vars: &'static [&'static str]) -> Self {
         self.clear_env = vars;
         self

--- a/docs/brainstorms/2026-05-28-goose-core-carve-out.md
+++ b/docs/brainstorms/2026-05-28-goose-core-carve-out.md
@@ -1,0 +1,78 @@
+# goose-core carve-out
+
+> Brainstorm captured 2026-05-28. Follow-up to [`2026-05-28-goose-embed-rust-sdk.md`](2026-05-28-goose-embed-rust-sdk.md) (Approach B in that doc).
+
+## Clarified Problem Statement
+
+**Goal:** Extract the embeddable primitives of `crates/goose` into a new `goose-core` crate so that embedders (today: `goose-embed`; tomorrow: anyone) can `cargo add goose-core` and get a meaningfully smaller dep tree than depending on `crates/goose`. `crates/goose` becomes the application runtime (sessions, scheduler, oauth, telemetry).
+
+**Constraints:**
+- `goose-cli`, `goose-server`, and `goose-embed` must keep working at every step. No big-bang merge.
+- DCO sign-off (`git commit -s`), conventional commits, workspace MSRV (1.91.1).
+- No public API changes for `goose-cli` / `goose-server` consumers. This is a layering change, not a refactor of behavior.
+- The crate carving must actually reduce dep weight for embedders — the test is `cargo tree -p goose-embed` after the work landing significantly smaller than today.
+
+**Pinned design decisions:**
+- **Provider policy:** all built-in providers ship in `goose-core`, gated behind the same features they're gated behind today (`aws-providers`, `local-inference`, etc.). Embedders pay only for what they opt into.
+- **Sequencing:** two-phase. PR 1 extracts the new traits (`SessionContextProvider`, `OAuthProvider`) inside `crates/goose`. PR 2 (or a series) physically moves modules into `goose-core`. Workspace stays green throughout.
+- **`goose-embed` migration:** leave it on `crates/goose` for the entire carve-out series. Final PR re-points it at `goose-core` once the surface is stable.
+
+**Non-goals:**
+- No new public APIs. The shape of `Agent::reply`, `Provider`, `Recipe`, etc. stays exactly as today.
+- No behavior changes anywhere (no perf tuning, no error-handling rewrites). Pure relayering.
+- No multi-language bindings. `goose-core` is Rust; cross-language continues over ACP.
+- No refactor of `platform_extensions/` — they stay in `crates/goose` because they consume `Session` state.
+- No semver split. `goose-core` tracks the workspace version (same as every other crate today).
+
+**Success criteria:**
+- `cargo build -p goose-cli` and `cargo build -p goose-server` continue to pass with no behavior diff.
+- `cargo tree -p goose-core` does not include `sqlx`, `tokio-cron-scheduler`, `oauth2`, `axum`, `posthog`, `keyring` in its default-feature build.
+- `goose-embed` migrates to depend on `goose-core` (not `goose`) and its `cargo tree` shrinks accordingly. Public API of `goose-embed` is unchanged.
+- All existing tests pass at every step of the series.
+- `crates/goose` modules retained: `session/`, `scheduler*`, `oauth/`, `posthog`, `otel/`, `dictation/`, `download_manager/`, `doctor`, `platform_extensions/`, `goose_apps/`, `recipe_deeplink/`, `slash_commands/`, plus `Config` (full version).
+- `crates/goose-core` gets: `agents/`, `providers/` (trait + all impls, feature-gated as today), `mcp_utils`, `skills/`, `recipe/` (the data model + execution, not file-discovery), `conversation/`, `context_mgmt/`, `permission/`, plus new `traits/` module for the extracted boundaries.
+
+## Approaches Considered
+
+### Approach A: Minimal carve, lift later ⭐ recommended
+- **Sketch:** Extract the smallest traits needed to break the three boundary violations identified in the C-spike (`agents/agent.rs:52-53`, `extension_manager.rs:44`, `tool_execution.rs:60`). Move only what's listed under "Success criteria" above; nothing else. `Config` stays as a runtime singleton in `crates/goose`; `goose-core` types accept the values they need as explicit constructor params (Agent builds from an injected `AgentConfig`, providers from `ModelConfig`, etc.). No generalization beyond what's strictly required.
+- **Affected files:** [crates/goose/src/agents/agent.rs](../../crates/goose/src/agents/agent.rs) (decoupling), [crates/goose/src/agents/extension_manager.rs](../../crates/goose/src/agents/extension_manager.rs), [crates/goose/src/agents/tool_execution.rs](../../crates/goose/src/agents/tool_execution.rs), [crates/goose/src/scheduler_trait.rs](../../crates/goose/src/scheduler_trait.rs) (already a trait, just moves), new `crates/goose-core/`, import rewrites in [crates/goose-cli](../../crates/goose-cli) and [crates/goose-server](../../crates/goose-server).
+- **Tradeoffs:** Smallest review surface; fastest to ship; matches the brainstormed sequencing. Risk: each module move PR has to keep all consumers green, so import-rewrite churn is spread across many PRs. The new traits are designed for "just enough" and may need follow-up generalization later if more boundary problems appear.
+- **Effort:** L (multi-PR series, but each PR is M).
+
+### Approach B: Idiomatic split with full trait families
+- **Sketch:** Same carve-out target, but design proper trait families upfront: a `Persistence` trait covering session storage (so embedders can swap in-memory / S3 / etc.), an `Auth` trait covering OAuth credential storage, a `Scheduler` trait (already exists, just formalize). Move `Config` into `goose-core` as a slim `GooseCoreConfig`; `crates/goose` extends with `Config { core: GooseCoreConfig, runtime: ... }`. Split `platform_extensions/` per file: leaf ones (`final_output_tool`) move to core, stateful ones (`chatrecall`, `todo`) stay.
+- **Affected files:** Everything in Approach A, plus new `crates/goose-core/traits/persistence.rs`, `auth.rs`, the `Config` split, and per-file decisions on `platform_extensions/`.
+- **Tradeoffs:** Cleaner long-term contract; embedders get pluggable persistence and auth out of the box. Costs: significantly more design discussion, more code to review, more places where the carve can stall on bikeshedding. Risk: the trait families end up over-engineered for a single embedder (`goose-embed`) and the second consumer reveals they're shaped wrong anyway.
+- **Effort:** L+ (probably 2-3x A).
+
+### Approach C: Stateless-only core, `Agent` stays in `goose`
+- **Sketch:** Different scope entirely. `goose-core` contains only stateless primitives — `Provider` trait + impls, `Conversation`, `Recipe`, `Skill`, MCP utilities, `context_mgmt`, `permission`. `Agent` (which has all the boundary violations) stays in `crates/goose`. Embedders that want primitives without the loop depend on `goose-core`; embedders that want a full agent depend on `goose` directly (or `goose-embed`).
+- **Affected files:** New `crates/goose-core/` with only the leaf modules. No trait extraction needed (because `Agent` isn't moving). No changes to `agents/`. `crates/goose-cli` and `crates/goose-server` keep their `goose` deps as-is.
+- **Tradeoffs:** Drastically smaller carve — probably one M-sized PR instead of a series. No risky `Agent` decoupling. But `goose-core` is less useful — you can build agent *components* but not a working loop, so embedders still end up pulling `goose` for anything real. Defeats the C-spike's purpose: `goose-embed` would still need `goose` as a transitive dep.
+- **Effort:** M.
+
+## Recommendation
+
+**Approach A.** It matches the pinned sequencing decision (two-phase, traits-first), keeps every PR reviewable, and actually delivers the dep-minimization win the C-spike's brainstorm demanded. Approach B is a tempting future state but the only consumer right now is `goose-embed`, so designing trait families for hypothetical second consumers is premature — let real usage drive that. Approach C is a fork in the road that abandons the original goal: if `goose-core` doesn't include `Agent`, embedders still depend on `goose`, and the C-spike's whole motivation evaporates.
+
+The order matters too: do PR 1 (trait extraction inside `goose`, workspace still green, no new crate) before opening PR 2 (the physical move). PR 1 is the high-risk piece — if the trait shape is wrong, we fix it cheaply before any consumers are touching `goose-core`.
+
+## Sequencing (concrete PR plan)
+
+1. **PR 1 — Trait extraction inside `crates/goose`.** Add `crate::traits::{SessionContextProvider, OAuthProvider}` (and confirm `SchedulerTrait` stays as-is). Refactor `Agent`, `ExtensionManager`, `ToolCallContext` to use the new traits via injection. `crates/goose` provides the concrete impls. No new crate yet. Acceptance: `cargo test --workspace` passes; CLI/server/embed behavior unchanged.
+2. **PR 2 — Stand up `crates/goose-core` skeleton.** Move leaf modules with no dependencies on `session`/`oauth`/`scheduler`: `conversation`, `mcp_utils`, `permission`, `context_mgmt`. `crates/goose` re-exports them so downstream imports keep working. Acceptance: `cargo tree -p goose-core` doesn't include `sqlx`, `oauth2`, `axum`.
+3. **PR 3 — Move `providers/`, `skills/`, `recipe/`.** Preserve feature flags exactly. Same re-export pattern. Acceptance: feature matrix builds (`--no-default-features`, `--features aws-providers`, `--features local-inference`).
+4. **PR 4 — Move `agents/` (the hard one).** Carries the trait extraction from PR 1. `crates/goose` keeps the concrete trait impls (`SessionContextProvider impl` over `SessionManager`, `OAuthProvider impl` over `oauth_flow`). Acceptance: `goose-cli session start` and `goose-server` HTTP routes work end-to-end.
+5. **PR 5 — Re-point `goose-embed` at `goose-core`.** Drop the `goose` dep where possible. Acceptance: `cargo tree -p goose-embed` shrinks measurably and `cargo test -p goose-embed` still passes.
+
+Each PR is independently mergeable and rollback-safe. If PR 3 stalls in review, PRs 1-2 are still useful.
+
+## Open questions
+
+- **`Config` singleton.** Stays in `crates/goose` per the recommendation. But `goose-core` types (Agent, providers) need values that today come from `Config::global()` — model overrides, mode, etc. Cleanest fix: every `goose-core` type that needs config takes it as an explicit constructor param. Existing `Agent::new()` keeps the singleton path; new public API uses `Agent::with_config()` exclusively. C-spike already does this — good signal it works.
+- **`apply_recipe_components` lives on `Agent`.** Currently a one-liner that calls into `final_output_tool`. Moves with `agents/` in PR 4 — no special handling.
+- **`hooks` module.** Used by `Agent::hook_manager` (loaded from CWD on construction). Either stays in `crates/goose` and gets injected via a trait, or moves to `goose-core`. Lean toward moving — it's pure machinery, no heavy deps. Confirm during PR 4.
+- **`security/`** (`AdversaryInspector`, `EgressInspector`, `SecurityInspector`). Used by `Agent`. Probably moves with `agents/` since it's tightly coupled.
+- **Feature flag naming.** `goose-core` should keep the same feature names as `goose` (`aws-providers`, `local-inference`, etc.) so the migration is transparent for consumers. Documented in PR 2.
+- **`ExtensionConfig` definition location.** Lives in `agents/extension.rs` today. Moves to `goose-core` with `agents/`. But `Recipe::extensions: Option<Vec<ExtensionConfig>>` would then live in `goose-core::recipe`, which is fine — recipe and extension are both core concepts.

--- a/docs/brainstorms/2026-05-28-goose-embed-rust-sdk.md
+++ b/docs/brainstorms/2026-05-28-goose-embed-rust-sdk.md
@@ -1,0 +1,77 @@
+# Embeddable Rust SDK for goose
+
+> Brainstorm captured 2026-05-28. Source: `/brainstorm what about goose will expose an SDK that allow to write agents?`
+
+## Clarified Problem Statement
+
+**Goal:** Expose goose's core agent capabilities as an embeddable Rust crate so a third-party Rust program can `cargo add` it, plug in a provider + MCP extensions + skills + recipes, and run an agent loop — without shelling out to the `goose` binary or talking ACP over stdio.
+
+**Constraints:**
+- Rust-only at v1. TS/Python come later, via ACP if at all.
+- Must not break `goose-cli`, `goose-server`, or the existing `goose acp` server mode.
+- **Hard constraint — minimize the dependency surface exposed to embedders.** If `cargo add goose-sdk-thing` ends up pulling everything `crates/goose` pulls today (AWS SDK, candle, OAuth, sqlx, OTel, scheduler, dictation, download manager, …), the SDK isn't worth shipping — embedders may as well depend on `goose` directly. Dep minimization is the test of whether the SDK earns its existence.
+- Today's `Agent` is coupled to a global `Config` singleton, an on-disk `SessionManager`, and a scheduler. The SDK must let embedders inject or override these (or accept lean defaults).
+- `Recipe` and `Skill` are first-class concepts of the SDK — embedders should be able to load, compose, and run them from the public API, not just via file paths read by the CLI.
+- `Config` is exposed and configurable from the embedder side — assume the embedder will want to tune at least provider, extensions, and permissioning.
+
+**Non-goals:**
+- Multi-language bindings at v1 — ACP already covers cross-language embedding via subprocess.
+- A new "agent definition format" — reuse `Recipe` + `skills`.
+- Replacing the existing `goose-sdk` crate (that one is an ACP *client* wrapper; this is an *embedding* SDK — different audience, different shape).
+- A WASM/plugin runtime.
+
+**Success criteria:**
+- A ≤ 50-line `examples/embed.rs` that constructs a provider, registers an MCP extension, loads a recipe + skill, sends a prompt, and streams `AgentEvent`s — compiles against published crates.
+- `cargo tree` on the example shows a meaningfully smaller dep graph than depending on `crates/goose` directly. Default features pull no AWS, no candle, no OTel, no scheduler.
+- `Recipe` and `Skill` are reachable through `pub` types in the SDK's prelude — not through the runtime crate.
+- `Config` is constructible by the embedder; no global singleton required to build an `Agent`.
+- `goose-cli` is refactored to consume the same public API it ships (dogfooding — proves the surface is real).
+- Public API has a documented semver contract; internals stay free to churn.
+
+## Approaches Considered
+
+### Approach A: Curated facade inside `crates/goose`
+- **Sketch:** Add `goose::embed` (or `goose::prelude`) that re-exports a hand-picked stable subset: `Agent`, `AgentConfig`, `ExtensionConfig`, the `Provider` trait, MCP client helpers, `Recipe`, `skills::*`. Mark every other `pub mod` as `#[doc(hidden)]` or move under `pub(crate)`. Tighten cargo features so heavy deps are opt-in.
+- **Affected files:** [crates/goose/src/lib.rs](../../crates/goose/src/lib.rs), new `crates/goose/src/embed/mod.rs`, [crates/goose/Cargo.toml](../../crates/goose/Cargo.toml) feature flags.
+- **Tradeoffs:** Ships fast, no consumer migration. But embedders still depend on the full `goose` crate — **fails the dep-minimization constraint outright** unless we also aggressively gate every heavy module behind a default-off cargo feature, which is its own large refactor.
+- **Effort:** M (but the only way to actually shrink deps from here is to repeat most of Approach B's work).
+
+### Approach B: Carve out `goose-core` ⭐ recommended
+- **Sketch:** Extract the embeddable primitives into a new lean crate `goose-core` — `agents::Agent`, `extension_manager`, `mcp_utils`, `providers` (trait + a minimal set of built-ins, the rest behind features), `conversation`, `context_mgmt`, `skills`, `recipe`. `crates/goose` becomes "application runtime" (on-disk sessions, scheduler, recipes-from-disk, telemetry, doctor, OAuth flows, dictation, download manager) and depends on `goose-core`. `goose-cli` and `goose-server` keep working unchanged; their imports shift downward where appropriate.
+- **Affected files:** new `crates/goose-core/`, refactor in [crates/goose/src/lib.rs](../../crates/goose/src/lib.rs), import rewrites across [crates/goose-cli/](../../crates/goose-cli/) and [crates/goose-server/](../../crates/goose-server/). `Config` singleton becomes an injected handle in `goose-core` (the singleton can stay in the runtime crate as a thin wrapper).
+- **Tradeoffs:** The only approach that actually delivers on the dep-minimization constraint. Real public-API boundary enforced by the crate split, sets long-term direction, semver contract becomes credible. Costs: big refactor; the `Config` and `SessionManager` singletons reach far and need to become injectable; circular-dep risk during the transition; the carve-out forces some interface decisions under time pressure.
+- **Effort:** L
+
+### Approach C: New `goose-embed` crate on top of `goose`
+- **Sketch:** Pure additive. New crate `goose-embed` depends on `goose` and ships ergonomic builders — `Goose::builder().provider(p).extension(cfg).recipe(r).skill(s).build()` returns a small handle that exposes `reply(prompt) -> Stream<AgentEvent>`. No changes to `crates/goose` internals. The crate hides the `Config`/`SessionManager` plumbing behind sensible defaults (in-memory session store, no scheduler).
+- **Affected files:** new `crates/goose-embed/` with `src/lib.rs`, `examples/`, README. Optional thin patches in `crates/goose` only if the in-memory `SessionManager` doesn't already exist.
+- **Tradeoffs:** Ships in days, validates the API shape with real users before committing to a refactor, zero risk to existing consumers. **But it fails the dep-minimization constraint** — embedders pull the whole `goose` crate transitively, so the SDK has no weight advantage over just depending on `goose` and writing a thin builder yourself.
+- **Effort:** S/M
+- **Best use:** as a *prototyping* spike that's explicitly thrown away once Approach B lands. Use it to discover the API shape (which builders, which defaults, which callbacks for permissions), then re-emerge the same surface from `goose-core` in B.
+
+## Recommendation
+
+**Do Approach B.** The new dep-minimization constraint is decisive: A and C both keep embedders bolted to the full `crates/goose` dependency tree, which defeats the point of having an SDK at all. Only the crate carve-out actually makes `cargo add goose-core` lighter than `cargo add goose`.
+
+Sensible sequencing:
+
+1. Spike Approach C in a branch for ~1 week (don't merge) to nail the public API ergonomics with a real example — what's the builder shape, how do permissions get handled headlessly, how do recipes load, etc.
+2. Use that API surface as the *contract* for `goose-core`. Carve out per Approach B, lifting the surface as-validated.
+3. Throw away the C spike when B lands.
+4. Refactor `goose-cli` to consume the public API. If it can't, the API isn't done.
+
+Skip A entirely — it's a refactor of `crates/goose` with no payoff in dep weight.
+
+## Decisions captured from clarifying round
+
+- **Recipes & Skills:** first-class in the SDK. Public types reachable through the prelude, not just file-path loading.
+- **Config:** exposed and configurable from the embedder. No global singleton required to construct an `Agent`.
+- **ACP server export:** undecided. Leave out of v1 to keep `goose-core` lean; embedders that want to re-expose their composed agent over ACP can depend on a future `goose-acp-server` crate that bridges `goose-core` → ACP. Revisit once a real embedder asks for it.
+- **Headless permissions:** not yet decided. The spike (C) should drive the answer — likely a callback trait the embedder implements, or an `async` channel.
+
+## Open questions
+
+- Where exactly does the line fall between `goose-core` and runtime-only modules? First-pass candidates for **runtime** (stay in `crates/goose`): `scheduler*`, `session::*` disk backend, `doctor`, `download_manager`, `dictation`, `oauth`, `posthog`, `otel`, `goose_apps`, `recipe_deeplink`, `slash_commands`. **Core** candidates: `agents`, `conversation`, `context_mgmt`, `providers` trait + minimal built-ins, `mcp_utils`, `skills`, `recipe` (definition + execution, not file discovery), `permission` (trait + types), `tool_inspection`, `tool_monitor`. Needs a per-module dep audit before the carve.
+- The `Provider` trait pulls in `reqwest`, OAuth, AWS, candle depending on which providers are enabled. Need to decide: do all built-in providers live in `goose-core`, or only the trait + a single reference impl (e.g. OpenAI-compatible), with each vendor in its own `goose-provider-*` crate?
+- How do we keep `goose-cli` and `goose-server` from accidentally bypassing the public API and reaching into `goose-core` internals during the migration? Consider a `#[deny(missing_docs)]` + `pub use` prelude pattern, or feature-gated re-exports.
+- Versioning: does `goose-core` track `goose`'s version, or get its own semver track? Independent track is more honest but means coordinating two releases.

--- a/docs/plans/2026-05-28-goose-embed-c-spike.md
+++ b/docs/plans/2026-05-28-goose-embed-c-spike.md
@@ -1,0 +1,77 @@
+# Plan: goose-embed C-spike
+
+> Generated 2026-05-28 from `/ship --from-brainstorm docs/brainstorms/2026-05-28-goose-embed-rust-sdk.md`.
+> Related: [brainstorm](../brainstorms/2026-05-28-goose-embed-rust-sdk.md).
+
+## Goal
+
+Ship a new `crates/goose-embed` crate that exposes an ergonomic builder API for programmatically constructing and driving a goose `Agent` from a plain Rust program. This is the **API-discovery spike** the brainstorm calls for as step 1 — it does NOT carve out `goose-core` (that's the follow-up). The spike validates the public surface against a real working example, so the eventual `goose-core` knows what it must export.
+
+## Affected files
+
+All new except the workspace root `Cargo.toml`:
+
+- `crates/goose-embed/Cargo.toml` — new workspace crate; depends on `goose`, `tokio`, `futures`, `anyhow`, `async-trait`
+- `crates/goose-embed/src/lib.rs` — `Goose` handle, `Goose::builder()` entry, prelude re-exporting `AgentEvent`, `Message`, `ExtensionConfig`, `Recipe`, skill types from `goose`
+- `crates/goose-embed/src/builder.rs` — `GooseBuilder` with `.provider()`, `.extension()`, `.recipe()`, `.working_dir()`, `.permission_decider()`, `.build()`
+- `crates/goose-embed/src/permission.rs` — `PermissionDecider` trait + `AutoApprove` default impl; bridges into goose's `ToolConfirmationRouter` via a background task
+- `crates/goose-embed/examples/hello_agent.rs` — minimal end-to-end: provider → prompt → stream `AgentEvent`s to stdout
+- `crates/goose-embed/examples/with_recipe.rs` — loads a recipe from disk and runs it (proves Recipe is first-class)
+- `crates/goose-embed/README.md` — what it is, what it explicitly is NOT (no dep minimization in v0), and the roadmap to `goose-core`
+- `Cargo.toml` (workspace root) — add `crates/goose-embed` to `members`
+
+## Approach
+
+1. Stand up the new crate and a `Goose::builder()` facade. The builder constructs an `AgentConfig` from explicit pieces (provider name + model resolved via `goose::providers::create_with_named_model`, extension list, permission decider, working dir), then calls `Agent::with_config()` — avoiding the `Agent::new()` path that touches `Config::global()`. Where singletons remain (`SessionManager`, `PermissionManager`), v0 uses `.instance()` internally and documents this as a known limitation in the README.
+2. Wrap the existing `Agent::reply()` stream in a thin `Goose::reply(prompt) -> impl Stream<Item = AgentEvent>` that handles `SessionConfig` construction and prompt-to-`Message` conversion.
+3. Implement `PermissionDecider` as a trait inside `goose-embed`. v0 wires it via a background task that polls/responds to `Agent::handle_confirmation()`. If a wall is hit and a tiny `pub` patch to `crates/goose` is needed, do it in the same PR; otherwise zero edits to `crates/goose`.
+4. Two examples: `hello_agent.rs` (provider only, prints streamed text) and `with_recipe.rs` (loads a YAML recipe, runs it).
+5. README clearly frames this as a spike: depends on the full `goose` crate, doesn't deliver dep minimization, will be re-emerged from `goose-core` later.
+
+## Edge cases
+
+- **API keys for the example:** don't require any at compile time. Read provider + model from env vars (`GOOSE_EMBED_PROVIDER`, `GOOSE_EMBED_MODEL`) with sensible defaults; if env is missing, the example prints a friendly hint and exits 0 so CI stays green.
+- **Session pollution:** `SessionManager::instance()` writes to `~/.local/share/goose/sessions/sessions.db`. v0 uses `SessionType::Hidden` so embed sessions don't show up in user-visible session lists.
+- **Stream lifetime:** `Agent::reply()` returns `BoxStream<'_, Result<AgentEvent>>` borrowing `&self`. The `Goose` handle must own the `Agent` so the stream is usable from typical async code.
+- **Async trait:** `PermissionDecider` uses `async_trait` (or AFIT if stable in workspace MSRV). Must use the same `async_trait` version `crates/goose` uses to avoid double-include.
+- **Tokio runtime:** library is runtime-agnostic in surface, but `goose::Agent` is tokio-based, so embedders must run a tokio runtime. Examples use `#[tokio::main]`.
+
+## Test plan
+
+- `cargo build -p goose-embed` — compiles in workspace
+- `cargo build -p goose-embed --examples` — both examples compile
+- `cargo clippy -p goose-embed --all-targets -- -D warnings` — clean
+- `cargo fmt` — clean
+- `cargo test -p goose-embed` — smoke test asserting the builder rejects missing-provider configurations; no live network tests in CI
+- **Manual sign-off before push:** run `cargo run -p goose-embed --example hello_agent` against a real provider locally
+
+## Conventions to follow
+
+From [AGENTS.md](../../AGENTS.md):
+
+- DCO sign-off on commits (`git commit -s`)
+- Use `cargo add` for new dependencies, not manual `Cargo.toml` edits
+- `anyhow::Result` for fallible functions
+- Self-documenting code; no comments restating what the code does
+- No comments on getters / setters / constructors / standard Rust idioms
+- Run `cargo fmt` always; `cargo clippy --all-targets -- -D warnings` before commit
+- Tests in `crates/goose-embed/tests/` not `src/`
+- Don't make things `Option` that don't need to be; booleans default to `false`
+
+## Open questions / risks
+
+- **Recipe + Skill surface depth:** if the public types from `goose::skills` turn out to be too thin to re-export cleanly, that's a finding to document for the eventual `goose-core` carve-out — not a blocker for this spike.
+- **`crates/goose` patches:** the goal is zero blast radius. If a single targeted `pub` exposure is needed, keep it minimal and in the same PR. If multiple patches start accumulating, stop and reassess.
+- **CI workflow re-discovery:** adding a new workspace member may trigger CI to start running checks on it. Verify locally first.
+
+## Estimated size
+
+**M** — ~400-600 LOC across 7 new files plus a 1-line workspace `Cargo.toml` edit. Purely additive; no production breakage.
+
+## Out of scope (explicit)
+
+- Creating `goose-core` (Approach B — separate PR series)
+- Minimizing dependency weight (embedders still inherit all of `crates/goose`'s deps; acknowledged in README)
+- Refactoring `Agent::with_config()` or singleton wiring inside `crates/goose`
+- Multi-language bindings (Rust v1 only)
+- Exposing the embedded agent as an ACP server (deferred per brainstorm)


### PR DESCRIPTION
## Summary

- New crate `crates/goose-embed/` exposes a builder API to construct and drive goose's agent loop from a plain Rust program -- no `goose` binary subprocess, no ACP over stdio
- `Goose::builder()` wraps `Agent::with_config` directly so the global `Config` is not touched. `SessionManager` / `PermissionManager` singletons are still used internally for now
- `PermissionDecider` async trait for headless tool-confirmation decisions, with `AutoApprove` and `DenyAll` built-ins
- `Recipe` first-class via the prelude -- `.recipe(r)` applies extensions, response schema, and (if not set explicitly) provider/model from `settings`
- Two examples (`hello_agent`, `with_recipe`) and one smoke test on builder validation

## Why

External Rust programs that want to embed goose today either spawn `goose acp` as a subprocess (works, but a lot of ceremony for a Rust-to-Rust call) or depend on `crates/goose` and reach into it (no stable surface, singletons everywhere). This RFC adds a thin facade so you can `cargo add goose-embed`, build a `Goose`, and drive the loop.

This is the **PoC**. I am not minimizing deps in this PR -- the crate inherits the full `goose` dep tree. The actual dep work lands in a follow-up `goose-core` carve-out. I want feedback on the surface before doing that so it has a contract to lift to. See `docs/brainstorms/2026-05-28-goose-embed-rust-sdk.md` for the longer story.

## Caveats

- Elicitations are not handled. If the agent requests structured input via MCP, it stalls with a warning. Richer decider API to come.
- No ACP server export. If you want to re-expose your embedded agent over ACP, use `goose acp` directly. A `goose-acp-server` bridge could follow once `goose-core` exists.
- Rust only. Other languages stay on ACP via the existing `goose-sdk` crates.

## Questions for reviewers

- Name -- `goose-embed` vs `goose-runtime` vs `goose-rs-sdk`. IDK, no strong preference.
- `PermissionDecider` is a `Send + Sync` async trait that hides the in-stream confirmation routing. Shape look right, or would you prefer a callback with `oneshot` channels?

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p goose-embed`
- [x] Remote CI green
- [ ] Manual: `GOOSE_EMBED_PROVIDER=anthropic GOOSE_EMBED_MODEL=claude-sonnet-4 cargo run -p goose-embed --example hello_agent`