### PR TITLE
Add Scholar Sidekick tutorial page + anonymous-default auth (v0.8.0)

### DIFF
--- a/documentation/docs/mcp/scholar-sidekick-mcp.md
+++ b/documentation/docs/mcp/scholar-sidekick-mcp.md
@@ -1,0 +1,131 @@
+---
+title: Scholar Sidekick Extension
+description: Add Scholar Sidekick MCP Server as a goose Extension
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+
+This tutorial covers how to add the [Scholar Sidekick MCP Server](https://github.com/mlava/scholar-sidekick-mcp) as a goose extension to resolve, format, export, and verify academic citations from any scholarly identifier — DOI, PMID, PMCID, ISBN, ISSN, arXiv ID, ADS bibcode, or WHO IRIS URL — plus retraction (Crossref + Retraction Watch) and open-access (Unpaywall) checks.
+
+:::tip Quick Install
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=scholar-sidekick-mcp%40latest&id=scholar-sidekick&name=Scholar%20Sidekick&description=Resolve%2C%20format%2C%20export%2C%20and%20verify%20academic%20citations%20plus%20retraction%20and%20open-access%20checks&env=RAPIDAPI_KEY%3DRapidAPI%20key%20for%20the%20Scholar%20Sidekick%20API%20%28free%20tier%20available%29&timeout=300)
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+  **Command**
+  ```sh
+  npx -y scholar-sidekick-mcp@latest
+  ```
+  </TabItem>
+</Tabs>
+  **Environment Variable**
+  ```
+  RAPIDAPI_KEY: <YOUR_API_KEY>
+  ```
+:::
+
+## Configuration
+
+:::info
+Note that you'll need [Node.js](https://nodejs.org/) installed on your system to run this command, as it uses `npx`. You'll also need a free [RapidAPI key for Scholar Sidekick](https://rapidapi.com/scholar-sidekick-scholar-sidekick-api/api/scholar-sidekick) — the free tier is enough for most personal use.
+:::
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+    <GooseDesktopInstaller
+      extensionId="scholar-sidekick"
+      extensionName="Scholar Sidekick"
+      description="Resolve, format, export, and verify academic citations plus retraction and open-access checks."
+      type="stdio"
+      command="npx"
+      args={["-y", "scholar-sidekick-mcp@latest"]}
+      timeout={300}
+      envVars={[
+        { name: "RAPIDAPI_KEY", label: "RapidAPI key for the Scholar Sidekick API" }
+      ]}
+      apiKeyLink="https://rapidapi.com/scholar-sidekick-scholar-sidekick-api/api/scholar-sidekick"
+      apiKeyLinkText="RapidAPI Key"
+    />
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    <CLIExtensionInstructions
+      name="Scholar Sidekick"
+      description="Resolve, format, export, and verify academic citations plus retraction and open-access checks."
+      type="stdio"
+      command="npx -y scholar-sidekick-mcp@latest"
+      timeout={300}
+      envVars={[
+        { key: "RAPIDAPI_KEY", value: "▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪" }
+      ]}
+      infoNote={
+        <>
+          Get your API key from{" "}
+          <a href="https://rapidapi.com/scholar-sidekick-scholar-sidekick-api/api/scholar-sidekick" target="_blank" rel="noopener noreferrer">
+            RapidAPI
+          </a> and paste it in.
+        </>
+      }
+    />
+  </TabItem>
+</Tabs>
+
+## What You Can Do
+
+Scholar Sidekick exposes six tools that turn any scholarly identifier into clean citations, exports, and integrity checks. Five built-in citation styles (Vancouver, AMA, APA, IEEE, CSE) plus the full CSL catalogue of 10,000+ styles.
+
+### Format a citation from any identifier
+
+Paste a DOI, PMID, PMCID, ISBN, ISSN, arXiv ID, ADS bibcode, or WHO IRIS URL and get a formatted reference in your chosen style. Detection is automatic — pass identifiers verbatim (no need to strip `PMID:`, `arXiv:`, or `https://doi.org/` prefixes).
+
+**Prompt:**
+
+```
+Format 10.1056/NEJMoa2033700 as a Vancouver-style citation.
+```
+
+### Export a bibliography for your reference manager
+
+Pass one or more identifiers and get a ready-to-import file in BibTeX, RIS, EndNote XML, RefWorks, NBIB, Zotero RDF, CSV, or CSL-JSON. Drop straight into Zotero, Mendeley, EndNote, JabRef, or Citavi.
+
+**Prompt:**
+
+```
+Take these three DOIs and export them as BibTeX:
+10.1056/NEJMoa2033700
+10.1038/s41586-020-2649-2
+10.1016/S0140-6736(20)32661-1
+```
+
+### Check whether a paper has been retracted
+
+Cross-references Crossref and Retraction Watch for retractions, corrections, and expressions of concern. Returns status, reason, and date.
+
+**Prompt:**
+
+```
+Has 10.1016/S0140-6736(97)11096-0 been retracted?
+```
+
+### Find an open-access copy
+
+Looks up Unpaywall to surface the best legal free version of a paper — repository copy, publisher OA, or preprint — with the licence and version (accepted vs published).
+
+**Prompt:**
+
+```
+Is there a free open-access copy of 10.1371/journal.pone.0173664?
+```
+
+### Verify whether a citation is real
+
+Cross-checks a *claimed* citation (title, optional authors/year) against the metadata actually resolved from its identifier. Catches the dominant LLM-fabrication pattern — a real, resolvable DOI paired with an invented title and authors — documented by Topaz et al. (Lancet, 2026). Use this when an AI-generated bibliography "looks plausible but…".
+
+**Prompt:**
+
+```
+Is this citation real? "A Unified Theory of Everything", Smith J, Nature, 2010, 10.1038/nphys1170
+```

--- a/documentation/docs/mcp/scholar-sidekick-mcp.md
+++ b/documentation/docs/mcp/scholar-sidekick-mcp.md
@@ -13,7 +13,7 @@ This tutorial covers how to add the [Scholar Sidekick MCP Server](https://github
 :::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
-  [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=scholar-sidekick-mcp%40latest&id=scholar-sidekick&name=Scholar%20Sidekick&description=Resolve%2C%20format%2C%20export%2C%20and%20verify%20academic%20citations%20plus%20retraction%20and%20open-access%20checks&env=RAPIDAPI_KEY%3DRapidAPI%20key%20for%20the%20Scholar%20Sidekick%20API%20%28free%20tier%20available%29&timeout=300)
+  [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=scholar-sidekick-mcp%40latest&id=scholar-sidekick&name=Scholar%20Sidekick&description=Resolve%2C%20format%2C%20export%2C%20and%20verify%20academic%20citations%20plus%20retraction%20and%20open-access%20checks&timeout=300)
   </TabItem>
   <TabItem value="cli" label="goose CLI">
   **Command**
@@ -22,16 +22,13 @@ This tutorial covers how to add the [Scholar Sidekick MCP Server](https://github
   ```
   </TabItem>
 </Tabs>
-  **Environment Variable**
-  ```
-  RAPIDAPI_KEY: <YOUR_API_KEY>
-  ```
+  **No API key required** — the server works anonymously on a free, rate-limited tier. Optionally set `SCHOLAR_API_KEY` (a free `ssk_` key from [scholar-sidekick.com/account](https://scholar-sidekick.com/account)) for higher limits, or `RAPIDAPI_KEY` for paid tiers. See [Optional: higher rate limits](#optional-higher-rate-limits).
 :::
 
 ## Configuration
 
 :::info
-Note that you'll need [Node.js](https://nodejs.org/) installed on your system to run this command, as it uses `npx`. You'll also need a free [RapidAPI key for Scholar Sidekick](https://rapidapi.com/scholar-sidekick-scholar-sidekick-api/api/scholar-sidekick) — the free tier is enough for most personal use.
+You'll need [Node.js](https://nodejs.org/) installed (the command uses `npx`). **No API key is required** — Scholar Sidekick works anonymously on a free, rate-limited tier. For higher limits, add a free first-party key (`SCHOLAR_API_KEY`, an `ssk_` key from [scholar-sidekick.com/account](https://scholar-sidekick.com/account)); for paid/managed tiers, add a [RapidAPI key](https://rapidapi.com/scholar-sidekick-scholar-sidekick-api/api/scholar-sidekick) (`RAPIDAPI_KEY`). See [Optional: higher rate limits](#optional-higher-rate-limits) below.
 :::
 
 <Tabs groupId="interface">
@@ -44,11 +41,6 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
       command="npx"
       args={["-y", "scholar-sidekick-mcp@latest"]}
       timeout={300}
-      envVars={[
-        { name: "RAPIDAPI_KEY", label: "RapidAPI key for the Scholar Sidekick API" }
-      ]}
-      apiKeyLink="https://rapidapi.com/scholar-sidekick-scholar-sidekick-api/api/scholar-sidekick"
-      apiKeyLinkText="RapidAPI Key"
     />
   </TabItem>
   <TabItem value="cli" label="goose CLI">
@@ -58,20 +50,18 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
       type="stdio"
       command="npx -y scholar-sidekick-mcp@latest"
       timeout={300}
-      envVars={[
-        { key: "RAPIDAPI_KEY", value: "▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪" }
-      ]}
-      infoNote={
-        <>
-          Get your API key from{" "}
-          <a href="https://rapidapi.com/scholar-sidekick-scholar-sidekick-api/api/scholar-sidekick" target="_blank" rel="noopener noreferrer">
-            RapidAPI
-          </a> and paste it in.
-        </>
-      }
     />
   </TabItem>
 </Tabs>
+
+## Optional: higher rate limits
+
+Scholar Sidekick runs **without any key** on a free, rate-limited tier — fine for normal interactive use. To raise your limits, add one environment variable to the extension (goose Desktop: extension settings → Environment Variables; CLI: `goose configure` → the extension's env):
+
+- **`SCHOLAR_API_KEY`** — a **free** first-party key (prefixed `ssk_`). Create one at [scholar-sidekick.com/account](https://scholar-sidekick.com/account). Sent as `Authorization: Bearer`; raises your rate limit and unlocks the verifier's optional LLM screen.
+- **`RAPIDAPI_KEY`** — for paid/managed tiers via the [RapidAPI gateway](https://rapidapi.com/scholar-sidekick-scholar-sidekick-api/api/scholar-sidekick). When set, calls route through RapidAPI instead of the anonymous/first-party endpoint.
+
+Neither is required, and you never need both — if both are set, RapidAPI takes precedence.
 
 ## What You Can Do
 

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -852,14 +852,19 @@
   "description": "Resolve, format, export, and verify academic citations (DOI, PMID, ISBN, arXiv) plus retraction and open-access checks",
   "command": "npx -y scholar-sidekick-mcp@latest",
   "link": "https://github.com/mlava/scholar-sidekick-mcp",
-  "installation_notes": "Requires a free RapidAPI key. Get one at https://rapidapi.com/scholar-sidekick-scholar-sidekick-api/api/scholar-sidekick and set RAPIDAPI_KEY.",
+  "installation_notes": "No API key required — works anonymously on a free, rate-limited tier. Optionally set SCHOLAR_API_KEY (a free first-party ssk_ key from https://scholar-sidekick.com/account) for higher limits, or RAPIDAPI_KEY for paid tiers via RapidAPI.",
   "is_builtin": false,
   "endorsed": false,
   "environmentVariables": [
     {
+      "name": "SCHOLAR_API_KEY",
+      "description": "Optional first-party API key (ssk_) from https://scholar-sidekick.com/account; raises rate limits. Sent as Authorization: Bearer.",
+      "required": false
+    },
+    {
       "name": "RAPIDAPI_KEY",
-      "description": "RapidAPI key for the Scholar Sidekick API (free tier available)",
-      "required": true
+      "description": "Optional RapidAPI key for paid/managed tiers; routes calls through the RapidAPI gateway.",
+      "required": false
     }
   ]
 }


### PR DESCRIPTION
Adds the missing tutorial page for the already-merged Scholar Sidekick entry (servers.json #9433) — the book/tutorial icon on the extension detail page currently 404s because `documentation/docs/mcp/scholar-sidekick-mcp.md` doesn't exist. Content mirrors the canonical shape from #9463 (`GooseDesktopInstaller` + `CLIExtensionInstructions`).

Also brings the Scholar Sidekick surface up to **scholar-sidekick-mcp v0.8.0**, which now works **anonymously** (no API key required) against the public API on a free, rate-limited tier. Previously both the tutorial and the merged `servers.json` entry stated `RAPIDAPI_KEY` was required — that's no longer true.

## Summary
- **New:** `documentation/docs/mcp/scholar-sidekick-mcp.md` — install (Desktop + CLI), an "Optional: higher rate limits" section, and six tool walkthroughs (format, export, resolve, retraction, open-access, verify).
- **Fix:** `documentation/static/servers.json` — `environmentVariables` are now optional; added `SCHOLAR_API_KEY` (free first-party `ssk_` key); `installation_notes` updated to the anonymous-default posture.
- Zero-config one-click install (no forced env var). `SCHOLAR_API_KEY` (free, higher limits) and `RAPIDAPI_KEY` (paid tiers) are documented as optional upgrades.

### Testing
`servers.json` validated as JSON. Tutorial follows the same MDX component shape as existing extension pages (#9463).

### Related
servers.json entry merged in #9433.