### PR TITLE
fix(desktop): activate hermit on macOS so STDIO extensions resolve node

### DIFF
--- a/ui/desktop/src/bin/node-setup-common.sh
+++ b/ui/desktop/src/bin/node-setup-common.sh
@@ -23,6 +23,12 @@ trap 'log "An error occurred. Exiting with status $?."' ERR
 
 log "Starting node setup (common)."
 
+# GUI-launched macOS apps inherit a minimal PATH that omits the system sbin
+# directories, so Hermit's bootstrap cannot find tools like `chown` (which lives
+# in /usr/sbin on macOS) and aborts with exit 127. Ensure they are reachable;
+# this is harmless on Linux, where these paths are typically already present.
+export PATH="/usr/sbin:/sbin:${PATH}"
+
 if [ -n "${GOOSE_PATH_ROOT:-}" ]; then
     RESOLVED_GOOSE_CONFIG_DIR="${GOOSE_PATH_ROOT}/config"
 elif [ -n "${GOOSE_CONFIG_DIR:-}" ]; then
@@ -108,11 +114,13 @@ else
     log "Hermit environment already initialized. Skipping init."
 fi
 
-# Activate the environment with output redirected to log
-if [[ "$(uname -s)" == "Linux" ]]; then
-    log "Activating hermit environment."
-    { . "bin/activate-hermit"; } >> "${LOG_FILE}" 2>&1
-fi
+# Activate the environment with output redirected to log.
+# Activation must run on every platform: macOS GUI apps otherwise never get the
+# hermit-managed node/npx onto PATH, so STDIO extensions fail with
+# "env: node: No such file or directory". The Linux-only guard was introduced in
+# #5372 to "preserve existing behavior" on macOS, but that path is now broken.
+log "Activating hermit environment."
+{ . "bin/activate-hermit"; } >> "${LOG_FILE}" 2>&1
 
 # Install Node.js using hermit
 log "Installing Node.js with hermit."


### PR DESCRIPTION
## Summary

STDIO extensions that shell out to `npx` (e.g. `npx mcp-remote ...`) fail to initialize in the **macOS desktop app** because of two PATH problems in the shared Hermit bootstrap shim `ui/desktop/src/bin/node-setup-common.sh`:

1. **`chown: command not found` (exit 127).** Hermit's bootstrap calls `chown`, which lives in `/usr/sbin` on macOS. GUI-launched (Electron) apps inherit a minimal PATH — the reporter's was `/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`, with no `/usr/sbin` or `/sbin` — so the bootstrap aborts.
2. **`env: node: No such file or directory`.** `activate-hermit` is sourced on **Linux only** (the guard was added in #5372 to "preserve existing behavior" on macOS). With that shim path now broken on macOS, the hermit-managed `node`/`npx` never get onto PATH at runtime.

This applies exactly the fix outlined by @DOsinga in #8046:

- Prepend `/usr/sbin:/sbin` to PATH early in the script (harmless on Linux, where these are normally already present).
- Remove the Linux-only guard so `bin/activate-hermit` is sourced on **every** platform — the same activation Linux already relies on.

The wrappers `bin/node` and `bin/npx` both `source` this common script, so both inherit the fix. Net change is +13/-5 in one file.

### Testing
- `bash -n` passes on `node-setup-common.sh`, `node`, and `npx`.
- I do **not** have a macOS machine to verify the runtime path end-to-end. As with the original Linux fix (#5372, whose author also requested macOS testers), I'd appreciate a **macOS (Apple Silicon)** user confirming the fix: build the desktop UI (`just run-ui`), then disable/re-enable an `npx`-based STDIO extension (e.g. `npx mcp-remote https://block.gitmcp.io/goose/`) and check `/tmp/mcp.log` — it should now reach `Node setup (common) completed successfully.` and the extension should load.

### Related Issues
Fixes #8046

### Screenshots/Demos (for UX changes)
N/A — build-time shim change only.

Made with [Cursor](https://cursor.com)