### PR TITLE
feat(nix): package Goose Desktop (Electron UI + goosed)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768305791,
-        "narHash": "sha256-AIdl6WAn9aymeaH/NvBj0H9qM+XuAuYbGMZaP0zcXAQ=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1412caf7bf9e660f2f962917c14b1ea1c3bc695e",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
+        "owner": "NixOS",
         "ref": "nixos-unstable",
-        "type": "indirect"
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    nixpkgs.url = "nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
   outputs = { self, nixpkgs, flake-utils, rust-overlay }:
@@ -105,6 +105,11 @@
             license = licenses.asl20;  # Maps from "Apache-2.0" in Cargo.toml
             mainProgram = "goose";
           };
+        };
+
+        # Goose Desktop (Electron UI + the `goosed` backend). Linux x86_64 only.
+        packages.goose-desktop = pkgs.callPackage ./nix/goose-desktop {
+          gooseSrc = self;
         };
 
         devShells.default = pkgs.mkShell {

--- a/nix/goose-desktop/default.nix
+++ b/nix/goose-desktop/default.nix
@@ -1,0 +1,195 @@
+# Goose Desktop — the Electron UI, bundling the `goosed` backend (./goosed.nix).
+#
+# Called from the flake as
+#   pkgs.callPackage ./nix/goose-desktop { gooseSrc = self; }
+# Linux x86_64 only; Goose Desktop is not packaged for other platforms here.
+{
+  lib,
+  callPackage,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  nodejs_24,
+  pnpm_10,
+  pkg-config,
+  protobuf,
+  makeWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
+  electron_41,
+  zip,
+  gitMinimal,
+  python3,
+  bash,
+  coreutils,
+  curl,
+  gnused,
+  gzip,
+  which,
+  wtype,
+  wl-clipboard,
+  stdenvNoCC,
+  gooseSrc,
+  extraWrapperArgs ? [],
+}: let
+  stdenv = stdenvNoCC;
+  electron = electron_41;
+  nodejs = nodejs_24;
+  pnpm = pnpm_10.override {inherit nodejs;};
+
+  goosed = callPackage ./goosed.nix {inherit gooseSrc;};
+
+  workspaceCargo = builtins.fromTOML (builtins.readFile "${gooseSrc}/Cargo.toml");
+  inherit (workspaceCargo.workspace.package) version;
+in
+  stdenv.mkDerivation (finalAttrs: {
+    pname = "goose-desktop";
+    inherit version;
+    src = "${gooseSrc}/ui";
+
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs) pname version src;
+      inherit pnpm;
+      fetcherVersion = 3;
+      hash = "sha256-xFW9NUN/oR7c7bBwydHksASfPywuIQFP++Y0u7hYTBs=";
+    };
+
+    strictDeps = true;
+
+    nativeBuildInputs = [
+      pnpmConfigHook
+      makeWrapper
+      copyDesktopItems
+      nodejs
+      pnpm
+      pkg-config
+      protobuf
+      python3
+      gitMinimal
+      zip
+    ];
+
+    env = {
+      ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+    };
+
+    # The packaged app lives in the Nix store and cannot update itself.
+    postPatch = ''
+      substituteInPlace desktop/src/updates.ts \
+        --replace-fail "export const UPDATES_ENABLED = true;" "export const UPDATES_ENABLED = false;"
+    '';
+
+    buildPhase = ''
+      runHook preBuild
+
+      export HOME=$(mktemp -d)
+      export npm_config_nodedir=${electron.headers}
+      export ELECTRON_PLATFORM=linux
+      export ELECTRON_ARCH=x64
+
+      # The @aaif/goose-sdk workspace package is normally built by a pnpm
+      # postinstall hook (skipped here for determinism). Its schema generator
+      # reads crates/goose/acp-{schema,meta}.json, which live outside this ui/
+      # source tree, so stage them where the generator resolves them
+      # (repo root == the parent of this source root) and build the SDK.
+      mkdir -p ../crates/goose
+      install -Dm644 ${gooseSrc}/crates/goose/acp-schema.json ../crates/goose/acp-schema.json
+      install -Dm644 ${gooseSrc}/crates/goose/acp-meta.json ../crates/goose/acp-meta.json
+      pnpm --filter @aaif/goose-sdk run build
+
+      # electron-forge resolves the Electron version from node_modules; pin it
+      # to the nixpkgs Electron we package against.
+      substituteInPlace node_modules/@electron-forge/core-utils/dist/electron-version.js \
+        --replace-fail "return version" "return '${electron.version}'"
+
+      # Provide Electron offline as a local zip so the packager does not fetch.
+      cp -r ${electron.dist} electron-dist
+      chmod -R u+w electron-dist
+      pushd electron-dist
+      zip -0Xqr ../electron.zip .
+      popd
+      rm -r electron-dist
+
+      substituteInPlace node_modules/@electron/packager/dist/packager.js \
+        --replace-fail "await this.getElectronZipPath(downloadOpts)" "'$(pwd)/electron.zip'"
+
+      install -Dm755 ${lib.getExe goosed} desktop/src/bin/goosed
+      patchShebangs desktop/node_modules desktop/node_modules/.bin
+      patchShebangs desktop/src/bin
+
+      node desktop/scripts/prepare-platform-binaries.js
+      pnpm --dir desktop run generate-api
+      pnpm --dir desktop run i18n:compile
+      pnpm --dir desktop exec electron-forge package --platform=linux --arch=x64
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      buildDir=$(find desktop/out -maxdepth 1 -mindepth 1 -type d -name '*-linux-x64' | head -n1)
+      if [ -z "$buildDir" ]; then
+        echo "Goose desktop output not found"
+        exit 1
+      fi
+
+      mkdir -p $out/opt/goose-desktop
+      cp -r "$buildDir/resources" $out/opt/goose-desktop/
+
+      install -Dm644 desktop/src/images/icon.png \
+        $out/share/icons/hicolor/256x256/apps/goose-desktop.png
+      install -Dm644 desktop/src/images/icon.svg \
+        $out/share/icons/hicolor/scalable/apps/goose-desktop.svg
+
+      makeWrapper ${lib.getExe electron} $out/bin/goose-desktop \
+        --run "cd $out/opt/goose-desktop/resources" \
+        --add-flags $out/opt/goose-desktop/resources/app.asar \
+        --set ELECTRON_FORCE_IS_PACKAGED 1 \
+        --set GOOSED_BINARY $out/opt/goose-desktop/resources/bin/goosed \
+        --prefix PATH : ${lib.makeBinPath [
+        bash
+        python3
+        coreutils
+        curl
+        gnused
+        gzip
+        which
+        wtype
+        wl-clipboard
+      ]} \
+        ${lib.escapeShellArgs extraWrapperArgs} \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+        --inherit-argv0
+
+      runHook postInstall
+    '';
+
+    desktopItems = [
+      (makeDesktopItem {
+        name = "goose-desktop";
+        desktopName = "Goose";
+        comment = "Open source extensible AI agent";
+        exec = "goose-desktop %U";
+        icon = "goose-desktop";
+        categories = [
+          "Development"
+        ];
+        startupWMClass = "Goose";
+        mimeTypes = [
+          "x-scheme-handler/goose"
+        ];
+      })
+    ];
+
+    passthru = {
+      inherit goosed;
+    };
+
+    meta = {
+      description = "Goose Desktop";
+      homepage = "https://github.com/aaif-goose/goose";
+      license = lib.licenses.asl20;
+      mainProgram = "goose-desktop";
+      platforms = ["x86_64-linux"];
+    };
+  })

--- a/nix/goose-desktop/goosed.nix
+++ b/nix/goose-desktop/goosed.nix
@@ -1,0 +1,71 @@
+# `goosed` — the Goose Desktop backend server (the `goose-server` crate).
+{
+  lib,
+  rustPlatform,
+  fetchurl,
+  pkg-config,
+  protobuf,
+  clang,
+  cmake,
+  openssl,
+  cacert,
+  libxcb,
+  dbus,
+  libsecret,
+  libclang,
+  gooseSrc,
+}: let
+  workspaceCargo = builtins.fromTOML (builtins.readFile "${gooseSrc}/Cargo.toml");
+  inherit (workspaceCargo.workspace.package) version;
+  cargoLock = builtins.fromTOML (builtins.readFile "${gooseSrc}/Cargo.lock");
+  rustyV8Version = (builtins.head (builtins.filter (pkg: pkg.name == "v8") cargoLock.package)).version;
+  rustyV8Archive = fetchurl {
+    url = "https://github.com/denoland/rusty_v8/releases/download/v${rustyV8Version}/librusty_v8_release_x86_64-unknown-linux-gnu.a.gz";
+    sha256 = "sha256-chV1PAx40UH3Ute5k3lLrgfhih39Rm3KqE+mTna6ysE=";
+  };
+in
+  rustPlatform.buildRustPackage {
+    pname = "goosed";
+    inherit version;
+    src = gooseSrc;
+    cargoLock = {
+      lockFile = "${gooseSrc}/Cargo.lock";
+      outputHashes = {
+        "cudaforge-0.1.6" = "sha256-w0e/mfx08BkphDEFEWxuyxyZu/gHiG0m6RHx+3BLzDY=";
+      };
+    };
+    LIBCLANG_PATH = "${libclang.lib}/lib";
+    RUSTY_V8_ARCHIVE = rustyV8Archive;
+
+    cargoBuildFlags = [
+      "--package"
+      "goose-server"
+      "--bin"
+      "goosed"
+    ];
+
+    nativeBuildInputs = [
+      pkg-config
+      protobuf
+      clang
+      cmake
+    ];
+
+    buildInputs = [
+      openssl
+      cacert
+      libxcb
+      dbus
+      libsecret
+    ];
+
+    doCheck = false;
+
+    meta = {
+      description = "Goose Desktop backend server";
+      homepage = "https://github.com/aaif-goose/goose";
+      license = lib.licenses.asl20;
+      mainProgram = "goosed";
+      platforms = ["x86_64-linux"];
+    };
+  }


### PR DESCRIPTION
## What

Adds `packages.goose-desktop` (Linux x86_64) to the flake — the Electron desktop app bundled with its `goosed` backend server. Sources live under `nix/goose-desktop/`:

- `goosed.nix` — the `goose-server` `goosed` binary
- `default.nix` — the Electron app (pnpm + electron-forge, packaged fully offline)

```console
$ nix build .#packages.x86_64-linux.goose-desktop
$ ./result/bin/goose-desktop
```

## Why

There's no reproducible way to build/install Goose Desktop on Nix today — only the CLI (`packages.default`). This packages the UI so it can be installed declaratively. It also composes with the Home Manager module (#9517): `programs.goose.desktop.package` defaults to `packages.goose-desktop or null`, so enabling the desktop just works once both land.

## How it works

- **`goosed`** is built with `rustPlatform.buildRustPackage` (`--package goose-server --bin goosed`), reusing the same pinned `librusty_v8` archive as `packages.default`. The one git dependency (`cudaforge`) is pinned via `cargoLock.outputHashes`.
- **Electron** is supplied offline from nixpkgs `electron_41` (matching `ui/desktop`'s pinned Electron `41.0.0`) — the packager is pointed at a local zip of `electron.dist` so it never hits the network. The auto-updater is disabled (`UPDATES_ENABLED = false`) since a store-installed app can't update itself.
- **`@aaif/goose-sdk`** (a `ui/` workspace package the desktop depends on) is normally built by a pnpm `postinstall` hook, which is skipped here for determinism. It's built explicitly before packaging. Its schema generator reads `crates/goose/acp-{schema,meta}.json`, which sit outside the `ui/` source tree, so those two files are staged into the location the generator resolves.
- The result wraps `electron` with `app.asar`, points `GOOSED_BINARY` at the bundled server, adds the runtime tools Goose shells out to onto `PATH`, and ships a `.desktop` entry + icons. Wayland ozone hints are passed through when `NIXOS_OZONE_WL`/`WAYLAND_DISPLAY` are set.

## nixpkgs bump

The previously locked `nixpkgs` predates `electron_41`, so `flake.lock` is bumped to a revision providing `electron_41`/`pnpm_10`. The `nixpkgs` input URL is also pinned to `github:NixOS/nixpkgs/nixos-unstable` so it resolves without relying on the local flake registry. `packages.default` and the devShell still evaluate/build against the bumped pin.

## Testing

Built `.#packages.x86_64-linux.goose-desktop` end to end on x86_64-linux — produces `bin/goose-desktop`, the bundled `goosed`, the packaged `app.asar`, icons, and the `.desktop` file.

x86_64-linux only for now (`meta.platforms`); other platforms can follow.