### PR TITLE
feat(recipes): add diagnose-systemd-service recipe

### DIFF
--- a/documentation/src/pages/recipes/data/recipes/diagnose-systemd-service.yaml
+++ b/documentation/src/pages/recipes/data/recipes/diagnose-systemd-service.yaml
@@ -1,0 +1,46 @@
+version: "1.0.0"
+title: "Diagnose a Failed systemd Service"
+author:
+  contact: JuanMarchetto
+description: "Investigate why a systemd service is failing and suggest a fix — strictly read-only, never restarts or changes anything itself."
+instructions: |
+  You are a Linux systems expert helping diagnose a failed or misbehaving
+  systemd service. Work strictly read-only: never restart, stop, enable,
+  disable, or modify any unit yourself. Only the user runs changes, after
+  reviewing your suggestion.
+
+  Steps:
+  1. Check the unit's current state:
+     systemctl status {{ service }} --no-pager
+  2. Read its most recent logs:
+     journalctl -u {{ service }} -n 100 --no-pager
+  3. If helpful, show the unit definition so its configuration can be inspected:
+     systemctl cat {{ service }}
+  4. Identify the most likely root cause (failed dependency, bad configuration,
+     missing binary or permission, port already in use, out-of-memory, etc.) and
+     cite the specific log lines that support your conclusion.
+  5. Present a concrete, copy-pasteable fix for the user to review and run
+     themselves. If the fix needs elevated privileges, show the exact sudo
+     command but DO NOT run it — ask the user to review and run it.
+
+  Keep the diagnosis focused and evidence-based. Never invent log output; only
+  reason over what the commands actually returned.
+prompt: |
+  Diagnose why the systemd service {{ service }} is failing. Inspect its status
+  and recent logs (read-only), explain the most likely root cause with evidence
+  from the logs, and suggest a fix for me to review and run myself.
+parameters:
+  - key: service
+    input_type: string
+    requirement: required
+    description: "The systemd unit to diagnose, e.g. nginx.service"
+activities:
+  - "Diagnose a failed systemd service"
+  - "Why did nginx.service fail to start?"
+  - "Check the logs for a crashed systemd unit and suggest a fix"
+  - "Find the root cause of a service that keeps restarting"
+extensions:
+  - type: builtin
+    name: developer
+    timeout: 300
+    bundled: true


### PR DESCRIPTION
## Summary
Adds a recipe, **Diagnose a Failed systemd Service**, that walks goose through diagnosing a failing systemd unit using the builtin `developer` extension.

## Why
A very common Linux task. The recipe is strictly **read-only**: it inspects `systemctl status`, `journalctl`, and `systemctl cat`, identifies the root cause with evidence from the logs, and presents a fix for the user to review and run themselves. It never restarts, enables, or modifies a unit on its own, and it shows (but never executes) any `sudo` command.

## Testing
- YAML parses and includes all required fields (version, title, description, instructions, prompt, extensions, activities).
- Unique filename; takes one `service` parameter.
- Read-only / no destructive actions.

File: `documentation/src/pages/recipes/data/recipes/diagnose-systemd-service.yaml`