### PR TITLE
docs(extensions): add Coati Linux system tools MCP extension

### DIFF
--- a/documentation/docs/mcp/coati-mcp.mdx
+++ b/documentation/docs/mcp/coati-mcp.mdx
@@ -1,0 +1,76 @@
+---
+title: Coati Extension
+description: Add the Coati MCP Server as a goose extension for typed Linux system tools
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+
+This tutorial covers how to add the [Coati MCP Server](https://github.com/JuanMarchetto/coati) as a goose extension, giving goose a small set of safe, typed Linux system tools:
+
+- `exec` — run a program (arguments passed literally — no shell, no piping or redirection)
+- `read_file` — read a file up to a byte limit
+- `list_dir` — list a directory (non-recursive)
+- `query_logs` — fetch recent `journalctl` lines for a systemd unit (the unit name is allowlist-validated)
+- `explain_error` — package a failed command's output into a focused analysis prompt
+
+:::info Prerequisite
+Coati's MCP server is written in Rust. Install it once with [cargo](https://www.rust-lang.org/tools/install):
+```sh
+cargo install --git https://github.com/JuanMarchetto/coati --bin coati-mcp
+```
+This puts a `coati-mcp` binary on your `PATH`.
+:::
+
+## Configuration
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+    <GooseDesktopInstaller
+      extensionId="coati"
+      extensionName="Coati"
+      description="Typed Linux system tools: exec, read_file, list_dir, query_logs, explain_error"
+      type="stdio"
+      command="coati-mcp"
+      args={[]}
+      timeout={300}
+    />
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    <CLIExtensionInstructions
+      name="Coati"
+      description="Typed Linux system tools: exec, read_file, list_dir, query_logs, explain_error"
+      type="stdio"
+      command="coati-mcp"
+      timeout={300}
+    />
+  </TabItem>
+</Tabs>
+
+:::tip Read-only mode
+Run the server as `coati-mcp --read-only` to expose only the inspection tools (`read_file`, `list_dir`, `query_logs`, `explain_error`) and disable program execution.
+:::
+
+## Example Usage
+
+Coati keeps the user in control: its `exec` tool runs programs directly (no shell, so there is no shell-injection surface), and goose asks you to approve a tool call before it runs. A natural use is diagnosing a misbehaving service.
+
+### goose Prompt
+
+> _Use Coati to read the last 50 log lines for `nginx.service` and tell me whether anything looks wrong._
+
+### goose Output
+
+:::note Desktop
+
+I called Coati's `query_logs` tool for `nginx.service`. The recent entries show:
+
+```
+nginx: [emerg] bind() to 0.0.0.0:80 failed (98: Address already in use)
+```
+
+The service is failing because port 80 is already taken by another process. Find the offending process with `sudo lsof -i :80`, stop it, then restart nginx. Review the commands before running them.
+
+:::

--- a/documentation/docs/mcp/coati-mcp.mdx
+++ b/documentation/docs/mcp/coati-mcp.mdx
@@ -19,7 +19,7 @@ This tutorial covers how to add the [Coati MCP Server](https://github.com/JuanMa
 :::info Prerequisite
 Coati's MCP server is written in Rust. Install it once with [cargo](https://www.rust-lang.org/tools/install):
 ```sh
-cargo install --git https://github.com/JuanMarchetto/coati --bin coati-mcp
+cargo install --git https://github.com/JuanMarchetto/coati coati-mcp-server
 ```
 This puts a `coati-mcp` binary on your `PATH`.
 :::

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -146,6 +146,17 @@
     ]
   },
   {
+    "id": "coati",
+    "name": "Coati",
+    "description": "Typed Linux system tools: run a program (no shell), read a file, list a directory, query systemd service logs, and diagnose a failed command",
+    "command": "coati-mcp",
+    "link": "https://github.com/JuanMarchetto/coati",
+    "installation_notes": "Coati's MCP server is written in Rust. Install it once with: cargo install --git https://github.com/JuanMarchetto/coati --bin coati-mcp. Add the --read-only argument to expose only inspection tools (no program execution).",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": []
+  },
+  {
     "id": "cognee-mcp",
     "name": "Cognee",
     "description": "Knowledge graph and cognitive AI capabilities (requires local server setup)",

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -151,7 +151,7 @@
     "description": "Typed Linux system tools: run a program (no shell), read a file, list a directory, query systemd service logs, and diagnose a failed command",
     "command": "coati-mcp",
     "link": "https://github.com/JuanMarchetto/coati",
-    "installation_notes": "Coati's MCP server is written in Rust. Install it once with: cargo install --git https://github.com/JuanMarchetto/coati --bin coati-mcp. Add the --read-only argument to expose only inspection tools (no program execution).",
+    "installation_notes": "Coati's MCP server is written in Rust. Install it once with: cargo install --git https://github.com/JuanMarchetto/coati coati-mcp-server. Add the --read-only argument to expose only inspection tools (no program execution).",
     "is_builtin": false,
     "endorsed": false,
     "environmentVariables": []


### PR DESCRIPTION
## Summary
Adds the **Coati** MCP server to the extensions directory: a `servers.json` entry plus a tutorial page.

[Coati](https://github.com/JuanMarchetto/coati) is an open-source (Apache-2.0) Rust Linux copilot. Its MCP server exposes a small set of safe, typed system tools over stdio: `exec` (runs a program with **no shell interpretation**), `read_file`, `list_dir`, `query_logs` (systemd journal, with allowlist-validated unit names), and `explain_error`.

## Changes
- `documentation/static/servers.json`: new `coati` entry (alphabetical; STDIO; no env vars; `is_builtin: false`, `endorsed: false`).
- `documentation/docs/mcp/coati-mcp.mdx`: install + configuration (Desktop + CLI) and an example, based on `_template_.mdx`.

## Notes
- Install: `cargo install --git https://github.com/JuanMarchetto/coati --bin coati-mcp` (Rust). A `--read-only` flag disables `exec`.
- JSON validated; entry inserted alphabetically.