### PR TITLE
fix(desktop): restore new chat shortcut navigation

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -2284,7 +2284,7 @@ async function appMain() {
           accelerator: shortcuts.newChat,
           click() {
             const focusedWindow = BrowserWindow.getFocusedWindow();
-            if (focusedWindow) focusedWindow.webContents.send('new-chat');
+            if (focusedWindow) focusedWindow.webContents.send('set-view', '');
           },
         })
       );


### PR DESCRIPTION
﻿## Summary
- restore the File > New Chat shortcut to the existing Home navigation path
- keep the current shortcut setting and menu wiring unchanged

## Root cause
The menu item was sending a `new-chat` renderer event. The renderer only translated that into `TRIGGER_NEW_CHAT`, and there is no active listener for that app event, so Cmd/Ctrl+T did not move the user back to the Home screen.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter goose-app run typecheck`
- `pnpm --filter goose-app exec eslint src/main.ts --max-warnings 0 --no-warn-ignored`
- `pnpm --filter goose-app exec prettier --check src/main.ts`
- `git diff --check`
