### PR TITLE
openai: read meta.n_ctx from /v1/models to fix context limit for local servers

### DIFF
--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -634,9 +634,9 @@ impl OpenAiProvider {
         Ok(models)
     }
 
-    /// Read `meta.n_ctx` from the `/v1/models` response for the given model name.
-    /// llama.cpp and Ollama include this non-standard field with the actual allocated
-    /// context window size. Returns `None` if the field is absent (e.g. real OpenAI).
+    /// llama.cpp and Ollama expose the actual allocated context window in the
+    /// non-standard `meta.n_ctx` field of `/v1/models`. Returns `None` when absent
+    /// (e.g. real OpenAI).
     async fn fetch_n_ctx_from_api(&self, model_name: &str) -> Option<usize> {
         let models_path =
             Self::map_base_path(&self.base_path, "models", OPEN_AI_DEFAULT_MODELS_PATH);

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -1488,17 +1488,6 @@ mod tests {
     }
 
     #[test]
-    fn parse_n_ctx_matches_model_by_id() {
-        let body = json!({
-            "data": [
-                { "id": "other-model", "meta": { "n_ctx": 4096 } },
-                { "id": "my-model", "meta": { "n_ctx": 8192 } }
-            ]
-        });
-        assert_eq!(parse_n_ctx_from_models(&body, "my-model"), Some(8192));
-    }
-
-    #[test]
     fn parse_n_ctx_falls_back_to_sole_entry_when_id_differs() {
         let body = json!({
             "data": [
@@ -1517,11 +1506,5 @@ mod tests {
             ]
         });
         assert_eq!(parse_n_ctx_from_models(&body, "model-c"), None);
-    }
-
-    #[test]
-    fn parse_n_ctx_absent_when_meta_missing() {
-        let body = json!({ "data": [ { "id": "my-model" } ] });
-        assert_eq!(parse_n_ctx_from_models(&body, "my-model"), None);
     }
 }

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -264,7 +264,7 @@ impl OpenAiProvider {
             api_client = api_client.with_headers(header_map)?;
         }
 
-        let provider = Self {
+        let mut provider = Self {
             api_client,
             base_path,
             organization,
@@ -279,46 +279,26 @@ impl OpenAiProvider {
             preserve_thinking_context: !is_openai,
         };
 
-        // When no context limit is otherwise known, read meta.n_ctx from the server's
-        // /v1/models response and use it. llama.cpp and Ollama report the actual
-        // allocated context window there, which fixes auto-compaction for local servers
-        // that would otherwise fall back to DEFAULT_CONTEXT_LIMIT (128k).
-        //
-        // We only fill when `context_limit` is still `None`, mirroring how
-        // `with_canonical_limits` fills derived limits. This deliberately preserves any
-        // already-set value, which by provider-construction time may be an explicit
-        // override from GOOSE_CONTEXT_LIMIT, an ACP/server per-session
-        // `with_context_limit`, or a `GOOSE_PREDEFINED_MODELS` entry — all of which a
-        // user set on purpose to cap compaction or correct an inaccurate meta.n_ctx.
-        // Those sources are indistinguishable from a registry default on the
-        // ModelConfig itself, so the safe choice is to never overwrite an existing
-        // value. Fails silently for hosts that don't expose meta.n_ctx (e.g. OpenAI).
-        //
-        // The probe is bounded by a short timeout so it can never stall provider
-        // construction. The shared ApiClient uses OPENAI_TIMEOUT (default 600s), which
-        // would otherwise block Goose startup / model switching for up to 10 minutes if
-        // the endpoint is reachable but /v1/models hangs. On timeout we silently fall
-        // back to the previous behavior (DEFAULT_CONTEXT_LIMIT).
-        const N_CTX_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
-        let provider = if provider.model.context_limit.is_none() {
+        // Only fill the context limit when nothing else set it: an existing value may be
+        // an explicit GOOSE_CONTEXT_LIMIT, an ACP/server per-session override, or a
+        // GOOSE_PREDEFINED_MODELS entry, none of which we should overwrite. llama.cpp and
+        // Ollama report the real allocated window via the non-standard meta.n_ctx field;
+        // reading it fixes auto-compaction for local servers that would otherwise fall
+        // back to DEFAULT_CONTEXT_LIMIT. The probe is bounded by a short timeout so a
+        // hung /v1/models can't stall provider construction (the shared ApiClient uses
+        // OPENAI_TIMEOUT, up to 600s).
+        if provider.model.context_limit.is_none() {
+            const N_CTX_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
             let model_name = provider.model.model_name.clone();
-            let n_ctx = tokio::time::timeout(
+            if let Ok(Some(n_ctx)) = tokio::time::timeout(
                 N_CTX_PROBE_TIMEOUT,
                 provider.fetch_n_ctx_from_api(&model_name),
             )
             .await
-            .ok()
-            .flatten();
-            if let Some(n_ctx) = n_ctx {
-                let mut p = provider;
-                p.model.context_limit = Some(n_ctx);
-                p
-            } else {
-                provider
+            {
+                provider.model.context_limit = Some(n_ctx);
             }
-        } else {
-            provider
-        };
+        }
 
         Ok(provider)
     }
@@ -667,30 +647,35 @@ impl OpenAiProvider {
             .await
             .ok()?;
         let json = handle_response_openai_compat(response).await.ok()?;
-        let data = json.get("data")?.as_array()?;
-        for entry in data {
-            let Some(id) = entry.get("id").and_then(|v| v.as_str()) else {
-                continue;
-            };
-            if id == model_name {
-                return entry
-                    .get("meta")
-                    .and_then(|m| m.get("n_ctx"))
-                    .and_then(|v| v.as_u64())
-                    .map(|v| v as usize);
-            }
-        }
-        // No entry matched by id. For single-model servers without --alias, llama.cpp
-        // reports the loaded model file path as id rather than the alias used by the
-        // client, so the loop above never matches. Fall back to the sole entry's n_ctx.
-        if data.len() == 1 {
-            return data[0]
-                .get("meta")
-                .and_then(|m| m.get("n_ctx"))
-                .and_then(|v| v.as_u64())
-                .map(|v| v as usize);
-        }
-        None
+        parse_n_ctx_from_models(&json, model_name)
+    }
+}
+
+/// Extract `meta.n_ctx` for `model_name` from a `/v1/models` response body.
+fn parse_n_ctx_from_models(json: &serde_json::Value, model_name: &str) -> Option<usize> {
+    let data = json.get("data")?.as_array()?;
+
+    let n_ctx = |entry: &serde_json::Value| -> Option<usize> {
+        entry
+            .get("meta")?
+            .get("n_ctx")?
+            .as_u64()
+            .map(|v| v as usize)
+    };
+
+    if let Some(entry) = data
+        .iter()
+        .find(|e| e.get("id").and_then(|v| v.as_str()) == Some(model_name))
+    {
+        return n_ctx(entry);
+    }
+
+    // For single-model servers without --alias, llama.cpp reports the loaded model
+    // file path as id rather than the client's alias, so no entry matches above.
+    // Fall back to the sole entry's n_ctx.
+    match data.as_slice() {
+        [only] => n_ctx(only),
+        _ => None,
     }
 }
 
@@ -1500,5 +1485,43 @@ mod tests {
             .unwrap(),
             None
         );
+    }
+
+    #[test]
+    fn parse_n_ctx_matches_model_by_id() {
+        let body = json!({
+            "data": [
+                { "id": "other-model", "meta": { "n_ctx": 4096 } },
+                { "id": "my-model", "meta": { "n_ctx": 8192 } }
+            ]
+        });
+        assert_eq!(parse_n_ctx_from_models(&body, "my-model"), Some(8192));
+    }
+
+    #[test]
+    fn parse_n_ctx_falls_back_to_sole_entry_when_id_differs() {
+        let body = json!({
+            "data": [
+                { "id": "/models/qwen3.gguf", "meta": { "n_ctx": 32768 } }
+            ]
+        });
+        assert_eq!(parse_n_ctx_from_models(&body, "qwen3"), Some(32768));
+    }
+
+    #[test]
+    fn parse_n_ctx_no_fallback_with_multiple_unmatched_entries() {
+        let body = json!({
+            "data": [
+                { "id": "model-a", "meta": { "n_ctx": 4096 } },
+                { "id": "model-b", "meta": { "n_ctx": 8192 } }
+            ]
+        });
+        assert_eq!(parse_n_ctx_from_models(&body, "model-c"), None);
+    }
+
+    #[test]
+    fn parse_n_ctx_absent_when_meta_missing() {
+        let body = json!({ "data": [ { "id": "my-model" } ] });
+        assert_eq!(parse_n_ctx_from_models(&body, "my-model"), None);
     }
 }

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -279,24 +279,21 @@ impl OpenAiProvider {
             preserve_thinking_context: !is_openai,
         };
 
-        // For non-OpenAI hosts (local llama.cpp, Ollama, etc.) try to read meta.n_ctx
-        // from /v1/models and use it as the context limit. This overrides values that
-        // come from the canonical registry / known-models list, which matters when a
-        // local server uses an alias matching a known OpenAI model name (e.g.
-        // --alias gpt-3.5-turbo) but runs a different context size.
+        // When no context limit is otherwise known, read meta.n_ctx from the server's
+        // /v1/models response and use it. llama.cpp and Ollama report the actual
+        // allocated context window there, which fixes auto-compaction for local servers
+        // that would otherwise fall back to DEFAULT_CONTEXT_LIMIT (128k).
         //
-        // It must NOT override an explicit user limit, though. `context_limit` may have
-        // been set from GOOSE_CONTEXT_LIMIT (the documented escape hatch for capping
-        // compaction below the server's advertised window, or for correcting a wrong
-        // meta.n_ctx) — that takes priority. We re-check the config the same way
-        // ModelConfig::new_base does, since by this point an explicit override and a
-        // canonical-registry default are indistinguishable on the ModelConfig itself.
-        // Fails silently for hosts that don't expose meta.n_ctx.
-        let has_explicit_limit = matches!(
-            config.get_param::<usize>("GOOSE_CONTEXT_LIMIT"),
-            Ok(limit) if limit > 0
-        );
-        let provider = if !is_openai && !has_explicit_limit {
+        // We only fill when `context_limit` is still `None`, mirroring how
+        // `with_canonical_limits` fills derived limits. This deliberately preserves any
+        // already-set value, which by provider-construction time may be an explicit
+        // override from GOOSE_CONTEXT_LIMIT, an ACP/server per-session
+        // `with_context_limit`, or a `GOOSE_PREDEFINED_MODELS` entry — all of which a
+        // user set on purpose to cap compaction or correct an inaccurate meta.n_ctx.
+        // Those sources are indistinguishable from a registry default on the
+        // ModelConfig itself, so the safe choice is to never overwrite an existing
+        // value. Fails silently for hosts that don't expose meta.n_ctx (e.g. OpenAI).
+        let provider = if provider.model.context_limit.is_none() {
             let model_name = provider.model.model_name.clone();
             if let Some(n_ctx) = provider.fetch_n_ctx_from_api(&model_name).await {
                 let mut p = provider;

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -302,11 +302,13 @@ impl OpenAiProvider {
         const N_CTX_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
         let provider = if provider.model.context_limit.is_none() {
             let model_name = provider.model.model_name.clone();
-            let n_ctx =
-                tokio::time::timeout(N_CTX_PROBE_TIMEOUT, provider.fetch_n_ctx_from_api(&model_name))
-                    .await
-                    .ok()
-                    .flatten();
+            let n_ctx = tokio::time::timeout(
+                N_CTX_PROBE_TIMEOUT,
+                provider.fetch_n_ctx_from_api(&model_name),
+            )
+            .await
+            .ok()
+            .flatten();
             if let Some(n_ctx) = n_ctx {
                 let mut p = provider;
                 p.model.context_limit = Some(n_ctx);

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -264,7 +264,7 @@ impl OpenAiProvider {
             api_client = api_client.with_headers(header_map)?;
         }
 
-        Ok(Self {
+        let provider = Self {
             api_client,
             base_path,
             organization,
@@ -277,7 +277,26 @@ impl OpenAiProvider {
             dynamic_models: None,
             skip_canonical_filtering: false,
             preserve_thinking_context: !is_openai,
-        })
+        };
+
+        // If no context limit was set via config/env, try to read meta.n_ctx from the
+        // server's /v1/models response. llama.cpp and Ollama include this non-standard
+        // field with the actual allocated context window, fixing auto-compaction for
+        // local servers. Fails silently — real OpenAI servers simply won't have it.
+        let provider = if provider.model.context_limit.is_none() {
+            let model_name = provider.model.model_name.clone();
+            if let Some(n_ctx) = provider.fetch_n_ctx_from_api(&model_name).await {
+                let mut p = provider;
+                p.model.context_limit = Some(n_ctx);
+                p
+            } else {
+                provider
+            }
+        } else {
+            provider
+        };
+
+        Ok(provider)
     }
 
     #[doc(hidden)]
@@ -609,6 +628,35 @@ impl OpenAiProvider {
             .collect();
         models.sort();
         Ok(models)
+    }
+
+    /// Read `meta.n_ctx` from the `/v1/models` response for the given model name.
+    /// llama.cpp and Ollama include this non-standard field with the actual allocated
+    /// context window size. Returns `None` if the field is absent (e.g. real OpenAI).
+    async fn fetch_n_ctx_from_api(&self, model_name: &str) -> Option<usize> {
+        let models_path =
+            Self::map_base_path(&self.base_path, "models", OPEN_AI_DEFAULT_MODELS_PATH);
+        let response = self
+            .api_client
+            .request(None, &models_path)
+            .response_get()
+            .await
+            .ok()?;
+        let json = handle_response_openai_compat(response).await.ok()?;
+        let data = json.get("data")?.as_array()?;
+        for entry in data {
+            let Some(id) = entry.get("id").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            if id == model_name {
+                return entry
+                    .get("meta")
+                    .and_then(|m| m.get("n_ctx"))
+                    .and_then(|v| v.as_u64())
+                    .map(|v| v as usize);
+            }
+        }
+        None
     }
 }
 

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -280,11 +280,23 @@ impl OpenAiProvider {
         };
 
         // For non-OpenAI hosts (local llama.cpp, Ollama, etc.) try to read meta.n_ctx
-        // from /v1/models and use it as the authoritative context limit. This overrides
-        // any canonical registry value, which matters when a local server uses an alias
-        // that matches a known OpenAI model name (e.g. --alias gpt-3.5-turbo) but runs
-        // a different context size. Fails silently for hosts that don't expose meta.n_ctx.
-        let provider = if !is_openai {
+        // from /v1/models and use it as the context limit. This overrides values that
+        // come from the canonical registry / known-models list, which matters when a
+        // local server uses an alias matching a known OpenAI model name (e.g.
+        // --alias gpt-3.5-turbo) but runs a different context size.
+        //
+        // It must NOT override an explicit user limit, though. `context_limit` may have
+        // been set from GOOSE_CONTEXT_LIMIT (the documented escape hatch for capping
+        // compaction below the server's advertised window, or for correcting a wrong
+        // meta.n_ctx) — that takes priority. We re-check the config the same way
+        // ModelConfig::new_base does, since by this point an explicit override and a
+        // canonical-registry default are indistinguishable on the ModelConfig itself.
+        // Fails silently for hosts that don't expose meta.n_ctx.
+        let has_explicit_limit = matches!(
+            config.get_param::<usize>("GOOSE_CONTEXT_LIMIT"),
+            Ok(limit) if limit > 0
+        );
+        let provider = if !is_openai && !has_explicit_limit {
             let model_name = provider.model.model_name.clone();
             if let Some(n_ctx) = provider.fetch_n_ctx_from_api(&model_name).await {
                 let mut p = provider;

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -293,9 +293,21 @@ impl OpenAiProvider {
         // Those sources are indistinguishable from a registry default on the
         // ModelConfig itself, so the safe choice is to never overwrite an existing
         // value. Fails silently for hosts that don't expose meta.n_ctx (e.g. OpenAI).
+        //
+        // The probe is bounded by a short timeout so it can never stall provider
+        // construction. The shared ApiClient uses OPENAI_TIMEOUT (default 600s), which
+        // would otherwise block Goose startup / model switching for up to 10 minutes if
+        // the endpoint is reachable but /v1/models hangs. On timeout we silently fall
+        // back to the previous behavior (DEFAULT_CONTEXT_LIMIT).
+        const N_CTX_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
         let provider = if provider.model.context_limit.is_none() {
             let model_name = provider.model.model_name.clone();
-            if let Some(n_ctx) = provider.fetch_n_ctx_from_api(&model_name).await {
+            let n_ctx =
+                tokio::time::timeout(N_CTX_PROBE_TIMEOUT, provider.fetch_n_ctx_from_api(&model_name))
+                    .await
+                    .ok()
+                    .flatten();
+            if let Some(n_ctx) = n_ctx {
                 let mut p = provider;
                 p.model.context_limit = Some(n_ctx);
                 p

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -279,11 +279,12 @@ impl OpenAiProvider {
             preserve_thinking_context: !is_openai,
         };
 
-        // If no context limit was set via config/env, try to read meta.n_ctx from the
-        // server's /v1/models response. llama.cpp and Ollama include this non-standard
-        // field with the actual allocated context window, fixing auto-compaction for
-        // local servers. Fails silently — real OpenAI servers simply won't have it.
-        let provider = if provider.model.context_limit.is_none() {
+        // For non-OpenAI hosts (local llama.cpp, Ollama, etc.) try to read meta.n_ctx
+        // from /v1/models and use it as the authoritative context limit. This overrides
+        // any canonical registry value, which matters when a local server uses an alias
+        // that matches a known OpenAI model name (e.g. --alias gpt-3.5-turbo) but runs
+        // a different context size. Fails silently for hosts that don't expose meta.n_ctx.
+        let provider = if !is_openai {
             let model_name = provider.model.model_name.clone();
             if let Some(n_ctx) = provider.fetch_n_ctx_from_api(&model_name).await {
                 let mut p = provider;
@@ -655,6 +656,16 @@ impl OpenAiProvider {
                     .and_then(|v| v.as_u64())
                     .map(|v| v as usize);
             }
+        }
+        // No entry matched by id. For single-model servers without --alias, llama.cpp
+        // reports the loaded model file path as id rather than the alias used by the
+        // client, so the loop above never matches. Fall back to the sole entry's n_ctx.
+        if data.len() == 1 {
+            return data[0]
+                .get("meta")
+                .and_then(|m| m.get("n_ctx"))
+                .and_then(|v| v.as_u64())
+                .map(|v| v as usize);
         }
         None
     }


### PR DESCRIPTION
## Summary

Fixes #9529 (related: #8835).

When Goose is pointed at a local llama.cpp or Ollama server, auto-compaction never fires correctly because the context limit falls back to `DEFAULT_CONTEXT_LIMIT = 128_000` — even though the server reports the actual window via a non-standard `meta.n_ctx` field in the `/v1/models` response.

**Changes:**

- Add `fetch_n_ctx_from_api(&self, model_name: &str) -> Option<usize>` to `OpenAiProvider` — hits the models endpoint, finds the entry matching the active model, and returns `meta.n_ctx` if present.
- In `from_env()`, after construction, if `model.context_limit` is still `None` (no `GOOSE_CONTEXT_LIMIT` config and no canonical registry match), call `fetch_n_ctx_from_api` and set `context_limit` from the result.
- Fails silently — real OpenAI servers don't include `meta`, so this is a no-op for cloud usage.

**Example response from llama.cpp:**
```json
{
  "meta": {
    "n_ctx": 32768,
    "n_ctx_train": 262144
  }
}
```
With this change, `context_limit` is set to `32768` instead of `128000`, so auto-compaction fires at the correct threshold.

## Test plan

- [ ] `cargo check -p goose` passes
- [ ] Pointing Goose at a llama.cpp server (without `GOOSE_CONTEXT_LIMIT` set) shows the correct context window size
- [ ] Pointing Goose at real OpenAI shows no change in behavior (field absent, falls back to canonical/default as before)
- [ ] Existing tests in `openai.rs` pass