### PR TITLE
fix: remove redundant thinking-only message when tool calls carry rea…

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1941,23 +1941,9 @@ impl Agent {
                                     }
                                 }
 
-                                // Preserve thinking/reasoning content from the original response
-                                // Gemini (and other thinking models) require thinking to be echoed back
-                                // Kimi/DeepSeek require reasoning_content on assistant tool call messages
-                                let thinking_content: Vec<MessageContent> = response.content.iter()
-                                    .filter(|c| matches!(c, MessageContent::Thinking(_)))
-                                    .cloned()
-                                    .collect();
-                                if !thinking_content.is_empty() {
-                                    let thinking_msg = Message::new(
-                                        response.role.clone(),
-                                        response.created,
-                                        thinking_content,
-                                    ).with_id(format!("msg_{}", Uuid::new_v4()));
-                                    messages_to_add.push(thinking_msg);
-                                }
-
-                                // Collect reasoning content to attach to tool request messages
+                                // Collect reasoning content to attach to tool request messages.
+                                // Kimi/DeepSeek require reasoning_content on all assistant
+                                // messages with tool_calls when thinking mode is enabled.
                                 let reasoning_content: Vec<MessageContent> = response.content.iter()
                                     .filter(|c| matches!(c, MessageContent::Thinking(_)))
                                     .cloned()


### PR DESCRIPTION
## Summary
The agent was creating both a separate thinking-only assistant message
AND attaching the same reasoning to each tool call message. After
merge_consecutive_messages combined them, reasoning_content appeared
twice in the API payload, causing DeepSeek to reject the request with:
"The reasoning_content in the thinking mode must be passed back to the API."

This removes the redundant thinking-only message since the reasoning
is already carried on the tool call messages.

## Summary
The agent was creating both a separate thinking-only assistant message AND attaching the same reasoning to each tool call message. After `merge_consecutive_messages` combined them, `reasoning_content` appeared twice in the API payload, causing DeepSeek to reject the request with: *"The reasoning_content in the thinking mode must be passed back to the API."*

This removes the redundant thinking-only message since the reasoning is already carried on the tool call messages.

### Testing
- `cargo check -p goose` — compiles cleanly
- `cargo clippy -p goose --all-targets` — no new lint warnings
- `cargo test -p goose -- categorize_tool_requests` — existing thinking-preservation tests pass (`categorize_tool_requests_keeps_thinking_when_not_previously_streamed`, `categorize_tool_requests_drops_replayed_thinking_after_streaming`)
- Manual: successful build of `goose.exe` without `local-inference` feature; DeepSeek API integration (OpenAI-compatible provider) compiles unchanged

### Related Issues
Closes #9434