### PR TITLE
feat: add 24-hour clock display option

### DIFF
--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -52,6 +52,7 @@ import { View, ViewOptions } from './utils/navigationUtils';
 import { useNavigation } from './hooks/useNavigation';
 import { errorMessage } from './utils/conversionUtils';
 import { getInitialWorkingDir } from './utils/workingDir';
+import { initTimeFormat } from './utils/timeUtils';
 import { usePageViewTracking } from './hooks/useAnalytics';
 import { trackErrorWithContext } from './utils/analytics';
 import { AppEvents } from './constants/events';
@@ -411,6 +412,10 @@ export function AppInner() {
   }, []);
 
   const { addExtension } = useConfig();
+
+  useEffect(() => {
+    window.electron.getSetting('use24HourClock').then((v) => initTimeFormat(v));
+  }, []);
 
   useEffect(() => {
     try {

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import ImagePreview from './ImagePreview';
+import { AppEvents } from '../constants/events';
 import { formatMessageTimestamp } from '../utils/timeUtils';
 import MarkdownContent from './MarkdownContent';
 import ThinkingContent from './ThinkingContent';
@@ -47,11 +48,22 @@ export default function GooseMessage({
   submitElicitationResponse,
 }: GooseMessageProps) {
   const contentRef = useRef<HTMLDivElement | null>(null);
+  const [clockFormatVersion, setClockFormatVersion] = useState(0);
+
+  useEffect(() => {
+    const handler = () => setClockFormatVersion((v) => v + 1);
+    window.addEventListener(AppEvents.CLOCK_FORMAT_CHANGED, handler);
+    return () => window.removeEventListener(AppEvents.CLOCK_FORMAT_CHANGED, handler);
+  }, []);
 
   const { textContent: displayText, imagePaths } = getTextAndImageContent(message);
   const thinkingContent = getThinkingContent(message);
 
-  const timestamp = useMemo(() => formatMessageTimestamp(message.created), [message.created]);
+  const timestamp = useMemo(
+    () => formatMessageTimestamp(message.created),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [message.created, clockFormatVersion]
+  );
   const toolRequests = getToolRequests(message);
   const messageIndex = messages.findIndex((msg) => msg.id === message.id);
   const toolConfirmationContent = getToolConfirmationContent(message);

--- a/ui/desktop/src/components/UserMessage.tsx
+++ b/ui/desktop/src/components/UserMessage.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ImagePreview from './ImagePreview';
 import MarkdownContent from './MarkdownContent';
 import { getTextAndImageContent } from '../types/message';
 import { Message } from '../api';
 import MessageCopyLink from './MessageCopyLink';
+import { AppEvents } from '../constants/events';
 import { formatMessageTimestamp } from '../utils/timeUtils';
 import Edit from './icons/Edit';
 import { Button } from './ui/button';
@@ -84,9 +85,17 @@ export default function UserMessage({ message, onMessageUpdate }: UserMessagePro
   const [isEditing, setIsEditing] = useState(false);
   const [editContent, setEditContent] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [clockFormatVersion, setClockFormatVersion] = useState(0);
+
+  useEffect(() => {
+    const handler = () => setClockFormatVersion((v) => v + 1);
+    window.addEventListener(AppEvents.CLOCK_FORMAT_CHANGED, handler);
+    return () => window.removeEventListener(AppEvents.CLOCK_FORMAT_CHANGED, handler);
+  }, []);
 
   const { textContent, imagePaths } = getTextAndImageContent(message);
-  const timestamp = formatMessageTimestamp(message.created);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const timestamp = useMemo(() => formatMessageTimestamp(message.created), [message.created, clockFormatVersion]);
 
   // Effect to handle message content changes and ensure persistence
   useEffect(() => {

--- a/ui/desktop/src/components/settings/chat/ChatSettingsSection.tsx
+++ b/ui/desktop/src/components/settings/chat/ChatSettingsSection.tsx
@@ -4,6 +4,7 @@ import { SecurityToggle } from '../security/SecurityToggle';
 import { ResponseStylesSection } from '../response_styles/ResponseStylesSection';
 import { GoosehintsSection } from './GoosehintsSection';
 import { SpellcheckToggle } from './SpellcheckToggle';
+import { TimeFormatToggle } from './TimeFormatToggle';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../ui/card';
 import { defineMessages, useIntl } from '../../../i18n';
 
@@ -51,6 +52,7 @@ export default function ChatSettingsSection({ sessionId }: { sessionId?: string 
         <CardContent className="px-2">
           <DictationSettings />
           <SpellcheckToggle />
+          <TimeFormatToggle />
         </CardContent>
       </Card>
 

--- a/ui/desktop/src/components/settings/chat/TimeFormatToggle.tsx
+++ b/ui/desktop/src/components/settings/chat/TimeFormatToggle.tsx
@@ -1,0 +1,49 @@
+import { useState, useEffect } from 'react';
+import { Switch } from '../../ui/switch';
+import { defineMessages, useIntl } from '../../../i18n';
+import { setTimeFormat } from '../../../utils/timeUtils';
+
+const i18n = defineMessages({
+  title: {
+    id: 'timeFormatToggle.title',
+    defaultMessage: 'Use 24-Hour Clock',
+  },
+  description: {
+    id: 'timeFormatToggle.description',
+    defaultMessage: 'Display message timestamps in 24-hour format.',
+  },
+});
+
+export const TimeFormatToggle = () => {
+  const intl = useIntl();
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    const loadState = async () => {
+      const value = await window.electron.getSetting('use24HourClock');
+      setEnabled(value);
+      setTimeFormat(value);
+    };
+    loadState();
+  }, []);
+
+  const handleToggle = async (checked: boolean) => {
+    setEnabled(checked);
+    setTimeFormat(checked);
+    await window.electron.setSetting('use24HourClock', checked);
+  };
+
+  return (
+    <div className="flex items-center justify-between py-2 px-2 hover:bg-background-secondary rounded-lg transition-all">
+      <div>
+        <h3 className="text-text-primary">{intl.formatMessage(i18n.title)}</h3>
+        <p className="text-xs text-text-secondary max-w-md mt-[2px]">
+          {intl.formatMessage(i18n.description)}
+        </p>
+      </div>
+      <div className="flex items-center">
+        <Switch checked={enabled} onCheckedChange={handleToggle} variant="mono" />
+      </div>
+    </div>
+  );
+};

--- a/ui/desktop/src/constants/events.ts
+++ b/ui/desktop/src/constants/events.ts
@@ -16,4 +16,5 @@ export enum AppEvents {
   SCROLL_CHAT_TO_BOTTOM = 'scroll-chat-to-bottom',
   HIDE_ALERT_POPOVER = 'hide-alert-popover',
   RESPONSE_STYLE_CHANGED = 'responseStyleChanged',
+  CLOCK_FORMAT_CHANGED = 'clock-format-changed',
 }

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -4502,6 +4502,12 @@
   "themeSelector.theme": {
     "defaultMessage": "Theme"
   },
+  "timeFormatToggle.description": {
+    "defaultMessage": "Display message timestamps in 24-hour format."
+  },
+  "timeFormatToggle.title": {
+    "defaultMessage": "Use 24-Hour Clock"
+  },
   "toolApprovalButtons.allowOnce": {
     "defaultMessage": "Allow Once"
   },

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -902,6 +902,7 @@ const createChat = async (app: App, options: CreateChatOptions = {}) => {
           SECURITY_PROMPT_ENABLED_OVERRIDE: process.env.SECURITY_PROMPT_ENABLED_OVERRIDE,
           SECURITY_COMMAND_CLASSIFIER_ENABLED_OVERRIDE:
             process.env.SECURITY_COMMAND_CLASSIFIER_ENABLED_OVERRIDE,
+          GOOSE_USE_24H_CLOCK: settings.use24HourClock,
         }),
       ],
       partition: 'persist:goose',

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -1614,6 +1614,7 @@ const validSettingKeys: Set<string> = new Set([
   'enableWakelock',
   'enableNotifications',
   'spellcheckEnabled',
+  'use24HourClock',
   'externalGoosed',
   'globalShortcut',
   'keyboardShortcuts',

--- a/ui/desktop/src/utils/settings.ts
+++ b/ui/desktop/src/utils/settings.ts
@@ -35,6 +35,7 @@ export interface Settings {
   enableWakelock: boolean;
   enableNotifications: boolean;
   spellcheckEnabled: boolean;
+  use24HourClock: boolean;
   externalGoosed: ExternalGoosedConfig;
   globalShortcut?: string | null;
   keyboardShortcuts: KeyboardShortcuts;
@@ -71,6 +72,7 @@ export const defaultSettings: Settings = {
   enableWakelock: false,
   enableNotifications: true,
   spellcheckEnabled: true,
+  use24HourClock: false,
   keyboardShortcuts: defaultKeyboardShortcuts,
   externalGoosed: {
     enabled: false,

--- a/ui/desktop/src/utils/timeUtils.ts
+++ b/ui/desktop/src/utils/timeUtils.ts
@@ -1,6 +1,9 @@
 import { currentLocale } from '../i18n';
 
-let use24HourClock = false;
+let use24HourClock: boolean =
+  typeof window !== 'undefined' && window.appConfig
+    ? (window.appConfig.get('GOOSE_USE_24H_CLOCK') as boolean) ?? false
+    : false;
 
 export function initTimeFormat(use24h: boolean): void {
   use24HourClock = use24h;
@@ -17,7 +20,7 @@ export function formatMessageTimestamp(timestamp?: number): string {
   const timeStr = date.toLocaleTimeString(currentLocale, {
     hour: 'numeric',
     minute: '2-digit',
-    hour12: !use24HourClock,
+    ...(use24HourClock ? { hour12: false } : {}),
   });
 
   // Check if the message is from today

--- a/ui/desktop/src/utils/timeUtils.ts
+++ b/ui/desktop/src/utils/timeUtils.ts
@@ -1,3 +1,4 @@
+import { AppEvents } from '../constants/events';
 import { currentLocale } from '../i18n';
 
 let use24HourClock: boolean =
@@ -11,6 +12,7 @@ export function initTimeFormat(use24h: boolean): void {
 
 export function setTimeFormat(use24h: boolean): void {
   use24HourClock = use24h;
+  window.dispatchEvent(new CustomEvent(AppEvents.CLOCK_FORMAT_CHANGED));
 }
 
 export function formatMessageTimestamp(timestamp?: number): string {

--- a/ui/desktop/src/utils/timeUtils.ts
+++ b/ui/desktop/src/utils/timeUtils.ts
@@ -1,13 +1,23 @@
 import { currentLocale } from '../i18n';
 
+let use24HourClock = false;
+
+export function initTimeFormat(use24h: boolean): void {
+  use24HourClock = use24h;
+}
+
+export function setTimeFormat(use24h: boolean): void {
+  use24HourClock = use24h;
+}
+
 export function formatMessageTimestamp(timestamp?: number): string {
   const date = timestamp ? new Date(timestamp * 1000) : new Date();
   const now = new Date();
 
-  // Format time using locale's default hour cycle
   const timeStr = date.toLocaleTimeString(currentLocale, {
     hour: 'numeric',
     minute: '2-digit',
+    hour12: !use24HourClock,
   });
 
   // Check if the message is from today


### PR DESCRIPTION
## Summary
Adds a 24-hour clock toggle to Chat Settings so users can display timestamps in 24-hour format instead of the locale default.

- Adds `use24HourClock: boolean` to the `Settings` interface and `defaultSettings`
- Adds `validSettingKeys` entry in `main.ts` so the setting persists
- Introduces `initTimeFormat`/`setTimeFormat` helpers in `timeUtils.ts` and passes `hour12` to timestamp formatting
- New `TimeFormatToggle` component modelled after `SpellcheckToggle` — reads/writes the setting via `window.electron.getSetting/setSetting`
- Mounts `TimeFormatToggle` in `ChatSettingsSection` next to `SpellcheckToggle`
- Calls `initTimeFormat` on app startup in `AppInner` so timestamps are formatted correctly before the Settings pane is ever opened

### Testing
- Toggled the setting in Chat Settings and confirmed timestamps update on next component mount
- Manual testing: enabled 24-hour mode, verified message timestamps show HH:MM format

### Related Issues
Closes #9492