### PR TITLE
fix: forward GOOSE_MODEL from config.yaml to goosed process

### DIFF
--- a/ui/desktop/src/goosed.ts
+++ b/ui/desktop/src/goosed.ts
@@ -281,6 +281,12 @@ export const startGoosed = async (options: StartGoosedOptions): Promise<GoosedRe
     ...buildGoosedEnv(port, serverSecret, goosedPath),
   };
 
+  // Remove GOOSE_MODEL and GOOSE_PROVIDER from the spawned environment so that
+  // goosed reads them from config.yaml rather than inheriting stale values from
+  // the Electron process (e.g. env vars baked in by managed-install tooling).
+  delete spawnEnv['GOOSE_MODEL'];
+  delete spawnEnv['GOOSE_PROVIDER'];
+
   for (const [key, value] of Object.entries(additionalEnv)) {
     if (value !== undefined) {
       spawnEnv[key] = value;


### PR DESCRIPTION
## Summary

Fixes the Desktop app ignoring `GOOSE_MODEL` set in `config.yaml`.

When the Electron main process spawns the `goosed` child process, it inherits the full `process.env`, which can include `GOOSE_MODEL` and `GOOSE_PROVIDER` baked in by managed-install tooling (e.g. Munki). The goosed Rust binary's config resolution gives environment variables the highest priority, so any value inherited from the Electron process silently overrides what the user has set in `~/.config/goose/config.yaml`.

The fix removes `GOOSE_MODEL` and `GOOSE_PROVIDER` from the spawned environment so that goosed always reads them from `config.yaml`, which is the authoritative source for the Desktop app.

### Testing
- Set `GOOSE_MODEL: <your-model>` in `~/.config/goose/config.yaml`
- Launched the Desktop app and verified the correct model was selected
- Confirmed that removing the env vars does not regress normal config.yaml reads

### Related Issues
Closes #9451