### PR TITLE
fix: refresh session name in sidebar after rename

### DIFF
--- a/ui/desktop/src/components/Layout/NavigationPanel.tsx
+++ b/ui/desktop/src/components/Layout/NavigationPanel.tsx
@@ -105,6 +105,11 @@ const SessionRow: React.FC<SessionRowProps> = ({ session, active, status, onClic
             path: { session_id: session.id },
             body: { name: newName },
           });
+          window.dispatchEvent(
+            new CustomEvent(AppEvents.SESSION_RENAMED, {
+              detail: { sessionId: session.id, newName },
+            })
+          );
           onRenamed();
         }}
         placeholder={intl.formatMessage(i18n.untitledSession)}

--- a/ui/desktop/src/components/Layout/NavigationPanel.tsx
+++ b/ui/desktop/src/components/Layout/NavigationPanel.tsx
@@ -107,7 +107,7 @@ const SessionRow: React.FC<SessionRowProps> = ({ session, active, status, onClic
           });
           window.dispatchEvent(
             new CustomEvent(AppEvents.SESSION_RENAMED, {
-              detail: { sessionId: session.id, newName },
+              detail: { sessionId: session.id, newName, userInitiated: true },
             })
           );
           onRenamed();

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -499,7 +499,9 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
     const handleModalSave = useCallback(async (sessionId: string, newDescription: string) => {
       // Update state immediately for optimistic UI
       setSessions((prevSessions) =>
-        prevSessions.map((s) => (s.id === sessionId ? { ...s, name: newDescription } : s))
+        prevSessions.map((s) =>
+          s.id === sessionId ? { ...s, name: newDescription, user_set_name: true } : s
+        )
       );
       window.dispatchEvent(
         new CustomEvent(AppEvents.SESSION_RENAMED, {

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -505,7 +505,7 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
       );
       window.dispatchEvent(
         new CustomEvent(AppEvents.SESSION_RENAMED, {
-          detail: { sessionId, newName: newDescription },
+          detail: { sessionId, newName: newDescription, userInitiated: true },
         })
       );
     }, []);

--- a/ui/desktop/src/hooks/useNavigationSessions.ts
+++ b/ui/desktop/src/hooks/useNavigationSessions.ts
@@ -130,12 +130,15 @@ export function useNavigationSessions() {
     };
 
     const handleSessionRenamed = (event: Event) => {
-      const { sessionId, newName } = (event as CustomEvent<{ sessionId: string; newName: string }>)
-        .detail;
+      const { sessionId, newName, userInitiated } = (
+        event as CustomEvent<{ sessionId: string; newName: string; userInitiated?: boolean }>
+      ).detail;
 
       setRecentSessions((prev) =>
         prev.map((session) =>
-          session.id === sessionId ? { ...session, name: newName, user_set_name: true } : session
+          session.id === sessionId
+            ? { ...session, name: newName, ...(userInitiated && { user_set_name: true }) }
+            : session
         )
       );
     };

--- a/ui/desktop/src/hooks/useNavigationSessions.ts
+++ b/ui/desktop/src/hooks/useNavigationSessions.ts
@@ -134,7 +134,9 @@ export function useNavigationSessions() {
         .detail;
 
       setRecentSessions((prev) =>
-        prev.map((session) => (session.id === sessionId ? { ...session, name: newName } : session))
+        prev.map((session) =>
+          session.id === sessionId ? { ...session, name: newName, user_set_name: true } : session
+        )
       );
     };
 


### PR DESCRIPTION
## Summary

After renaming a session that has no messages (message_count = 0), the sidebar would still display New Chat because the local state update after rename only updated the name field, not user_set_name. The getSessionDisplayName function checks user_set_name first; when it is false and message_count is 0, shouldShowNewChatTitle returns true and overrides the name with New Chat.

This fix:
- Sets user_set_name: true alongside name when handling the SESSION_RENAMED event in useNavigationSessions (sidebar list update)
- Sets user_set_name: true in the optimistic state update in SessionListView after a successful rename
- Fires SESSION_RENAMED from the NavigationPanel inline rename so other consumers are also notified

### Testing
- Manual: create a new chat (message_count = 0), rename it via Edit Session Name, and verify the new name appears immediately in both the sidebar and the chat history list
- Existing UI tests pass

### Related Issues
Relates to #9369

### Screenshots/Demos (for UX changes)
Before: Session name in sidebar remains New Chat after rename when no messages exist
After: Session name in sidebar updates immediately after rename