### PR TITLE
Fix scheduled recipe session params

### DIFF
--- a/crates/goose-server/src/routes/agent.rs
+++ b/crates/goose-server/src/routes/agent.rs
@@ -468,27 +468,35 @@ async fn update_from_session(
             status: StatusCode::INTERNAL_SERVER_ERROR,
         })?;
     if let Some(recipe) = session.recipe {
-        match build_recipe_with_parameter_values(
-            &recipe,
-            session.user_recipe_values.unwrap_or_default(),
-        )
-        .await
-        {
-            Ok(Some(recipe)) => {
-                if let Some(prompt) = apply_recipe_to_agent(&agent, &recipe, true).await {
-                    agent
-                        .extend_system_prompt("recipe".to_string(), prompt)
-                        .await;
+        if session.session_type == SessionType::Scheduled {
+            if let Some(prompt) = apply_recipe_to_agent(&agent, &recipe, true).await {
+                agent
+                    .extend_system_prompt("recipe".to_string(), prompt)
+                    .await;
+            }
+        } else {
+            match build_recipe_with_parameter_values(
+                &recipe,
+                session.user_recipe_values.unwrap_or_default(),
+            )
+            .await
+            {
+                Ok(Some(recipe)) => {
+                    if let Some(prompt) = apply_recipe_to_agent(&agent, &recipe, true).await {
+                        agent
+                            .extend_system_prompt("recipe".to_string(), prompt)
+                            .await;
+                    }
                 }
-            }
-            Ok(None) => {
-                // Recipe has missing parameters
-            }
-            Err(e) => {
-                return Err(ErrorResponse {
-                    message: e.to_string(),
-                    status: StatusCode::INTERNAL_SERVER_ERROR,
-                });
+                Ok(None) => {
+                    // Recipe has missing parameters
+                }
+                Err(e) => {
+                    return Err(ErrorResponse {
+                        message: e.to_string(),
+                        status: StatusCode::INTERNAL_SERVER_ERROR,
+                    });
+                }
             }
         }
     }
@@ -758,27 +766,35 @@ async fn restart_agent_internal(
     })?;
 
     if let Some(ref recipe) = session.recipe {
-        match build_recipe_with_parameter_values(
-            recipe,
-            session.user_recipe_values.clone().unwrap_or_default(),
-        )
-        .await
-        {
-            Ok(Some(recipe)) => {
-                if let Some(prompt) = apply_recipe_to_agent(&agent, &recipe, true).await {
-                    agent
-                        .extend_system_prompt("recipe".to_string(), prompt)
-                        .await;
+        if session.session_type == SessionType::Scheduled {
+            if let Some(prompt) = apply_recipe_to_agent(&agent, recipe, true).await {
+                agent
+                    .extend_system_prompt("recipe".to_string(), prompt)
+                    .await;
+            }
+        } else {
+            match build_recipe_with_parameter_values(
+                recipe,
+                session.user_recipe_values.clone().unwrap_or_default(),
+            )
+            .await
+            {
+                Ok(Some(recipe)) => {
+                    if let Some(prompt) = apply_recipe_to_agent(&agent, &recipe, true).await {
+                        agent
+                            .extend_system_prompt("recipe".to_string(), prompt)
+                            .await;
+                    }
                 }
-            }
-            Ok(None) => {
-                // Recipe has missing parameters
-            }
-            Err(e) => {
-                return Err(ErrorResponse {
-                    message: e.to_string(),
-                    status: StatusCode::INTERNAL_SERVER_ERROR,
-                });
+                Ok(None) => {
+                    // Recipe has missing parameters
+                }
+                Err(e) => {
+                    return Err(ErrorResponse {
+                        message: e.to_string(),
+                        status: StatusCode::INTERNAL_SERVER_ERROR,
+                    });
+                }
             }
         }
     }

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -135,7 +135,7 @@ export default function BaseChat({
     return initialMessage;
   }, [initialMessage, recipe?.prompt, session?.user_recipe_values]);
 
-  const canAutoSubmit = !recipe || hasNotAcceptedRecipe === false;
+  const canAutoSubmit = session?.session_type === 'scheduled' || !recipe || hasNotAcceptedRecipe === false;
 
   useAutoSubmit({
     sessionId,
@@ -208,7 +208,7 @@ export default function BaseChat({
   }, [messages]);
 
   useEffect(() => {
-    if (!recipe || !isActiveSession) return;
+    if (!recipe || !isActiveSession || session?.session_type === 'scheduled') return;
 
     (async () => {
       const accepted = await window.electron.hasAcceptedRecipeBefore(recipe);
@@ -219,7 +219,7 @@ export default function BaseChat({
         setHasRecipeSecurityWarnings(scanResult.has_security_warnings);
       }
     })();
-  }, [recipe, isActiveSession]);
+  }, [recipe, isActiveSession, session?.session_type]);
 
   const handleRecipeAccept = async (accept: boolean) => {
     if (recipe && accept) {
@@ -527,7 +527,7 @@ export default function BaseChat({
         </ChatInputCard>
       </MainPanelLayout>
 
-      {recipe && isActiveSession && (
+      {recipe && isActiveSession && session?.session_type !== 'scheduled' && (
         <RecipeWarningModal
           isOpen={!!hasNotAcceptedRecipe}
           onConfirm={() => handleRecipeAccept(true)}
@@ -541,7 +541,10 @@ export default function BaseChat({
         />
       )}
 
-      {recipe?.parameters && recipe.parameters.length > 0 && !session?.user_recipe_values && (
+      {recipe?.parameters &&
+        recipe.parameters.length > 0 &&
+        !session?.user_recipe_values &&
+        session?.session_type !== 'scheduled' && (
         <ParameterInputModal
           parameters={recipe.parameters}
           onSubmit={setRecipeUserParams}

--- a/ui/desktop/src/hooks/useAutoSubmit.ts
+++ b/ui/desktop/src/hooks/useAutoSubmit.ts
@@ -53,6 +53,10 @@ export function useAutoSubmit({
   }, [sessionId]);
 
   const hasUnfilledParameters = useCallback((session: Session) => {
+    if (session.session_type === 'scheduled') {
+      return false;
+    }
+
     const recipe = session.recipe;
     return recipe?.parameters && recipe.parameters.length > 0 && !session.user_recipe_values;
   }, []);


### PR DESCRIPTION
Completed scheduled recipe sessions were being treated like fresh interactive recipe runs when opened in the UI, causing unnecessary parameter/trust prompts and recipe re-validation errors even though the recipe had already executed.

This fix:
- stops prompting for recipe params when opening completed scheduled sessions
- skips recipe re-templating for scheduled sessions on load/restart

