### PR TITLE
Add Doxa MCP extension

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -862,6 +862,16 @@
       "required": true
     }
   ]
-}
-
+},
+  {
+    "id": "doxa-mcp",
+    "name": "Doxa",
+    "description": "Christian encouragement and Bible lookup for any MCP client. Three tools grounded in the Berean Standard Bible (public domain): Scripture, summoned.",
+    "command": "npx -y mcp-remote https://doxa.app/mcp/v1",
+    "link": "https://github.com/The-Doxa-Way/doxa-mcp-schema",
+    "installation_notes": "No local setup required. Connects to the free hosted Doxa MCP server at https://doxa.app/mcp/v1 via mcp-remote; no API key needed. Bring your own LLM key for unlimited use. Requires Node.js.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": []
+  }
 ]


### PR DESCRIPTION
## Add Doxa MCP extension

This adds Doxa to `documentation/static/servers.json` as a new extension entry. The format matches the existing entries: 2-space object indent, 4-space property indent, appended as the final element of the array.

### What Doxa is

A free hosted, remote (streamable HTTP) Model Context Protocol server for Christian encouragement and Bible lookup, usable from goose and any MCP client. The free hosted tier needs no credentials; bring your own licence (one header) unlocks unlimited use.

### Tools

All three are grounded in the Berean Standard Bible (public domain):

- `doxa_encourage`: Scripture-grounded encouragement.
- `doxa_scripture`: BSB verse lookup with deep links.
- `doxa_way_movement`: guidance through the Doxa Way.

### Connection

- Endpoint: https://doxa.app/mcp/v1
- Landing page: https://doxa.app/mcp
- Schema repo: https://github.com/The-Doxa-Way/doxa-mcp-schema
- npm client: `@thedoxaway/mcp-client`

Install snippet for any MCP client config:

```json
{"mcpServers":{"doxa":{"command":"npx","args":["-y","mcp-remote","https://doxa.app/mcp/v1"]}}}
```

### Note

Doxa is the only Christian MCP publishing a public 5/5 pass on the independent faith.tools Christian-AI safety rubric, including crisis handling.
