### PR TITLE
fix: quote release PR search phrase in pre-release.sh

### DIFF
--- a/scripts/pre-release.sh
+++ b/scripts/pre-release.sh
@@ -14,7 +14,10 @@ else
     SEARCH="chore(release): release version"
 fi
 
-PR=$(gh pr list --repo "$REPO" --search "$SEARCH in:title" --state all --limit 1 --json number,title)
+# Wrap the phrase in quotes so GitHub treats it literally. Without quotes the
+# parentheses in "release):" are interpreted as search operators and the query
+# matches nothing.
+PR=$(gh pr list --repo "$REPO" --search "\"$SEARCH\" in:title" --state all --limit 1 --json number,title)
 PR_NUMBER=$(echo "$PR" | jq -r '.[0].number // empty')
 
 if [[ -z "$PR_NUMBER" ]]; then


### PR DESCRIPTION
## Summary
The release PR search phrase in `pre-release.sh` was unquoted, causing GitHub to interpret the parentheses in `release):` as search operators so the query matched no PRs even when a valid release PR existed — this wraps the phrase in quotes so it is matched literally.

### Testing
Manually verified that `gh pr list --search "\"chore(release): release version\" in:title"` now returns the open release PR, whereas the unquoted query returned nothing.

### Related Issues
None.

### Screenshots/Demos (for UX changes)
N/A — this is a build script change with no UX impact.