### PR TITLE
fix: resolve context_limit from canonical data via catalog_provider_id for custom providers

### DIFF
--- a/crates/goose-server/src/routes/agent.rs
+++ b/crates/goose-server/src/routes/agent.rs
@@ -604,6 +604,11 @@ async fn update_agent_provider(
         }
     };
 
+    // Do not apply with_canonical_limits here — normalize_model_config
+    // handles canonical inference as step 3 (after catalog lookup).
+    // Applying canonical limits early would set a positive context_limit
+    // (e.g. Anthropic 200k for claude-sonnet-4) that the catalog guard
+    // would preserve, preventing the correct catalog value from applying.
     let mut model_config = ModelConfig::new(&model)
         .map_err(|e| {
             (
@@ -611,7 +616,6 @@ async fn update_agent_provider(
                 format!("Invalid model config: {}", e),
             )
         })?
-        .with_canonical_limits(&payload.provider)
         .with_context_limit(payload.context_limit);
 
     if let Some(request_params) = payload.request_params {

--- a/crates/goose-server/src/routes/config_management.rs
+++ b/crates/goose-server/src/routes/config_management.rs
@@ -943,7 +943,23 @@ pub async fn get_provider_models(
     let models_result = provider.fetch_recommended_model_info().await;
 
     match models_result {
-        Ok(models) => Ok(Json(models)),
+        Ok(mut models) => {
+            // When catalog_provider_id is set, override each model's
+            // context_limit with the catalog value.  The provider's
+            // fetch_recommended_model_info uses the raw custom name, so
+            // budgets can be stale (e.g. 128k for Xiaomi, 200k for
+            // OpenRouter/Anthropic).
+            if let Some(ref catalog_id) = metadata.catalog_provider_id {
+                for info in &mut models {
+                    if let Some(canonical) = goose::providers::canonical::maybe_get_canonical_model(
+                        catalog_id, &info.name,
+                    ) {
+                        info.context_limit = canonical.limit.context;
+                    }
+                }
+            }
+            Ok(Json(models))
+        }
         Err(provider_error) => Err(provider_error.into()),
     }
 }

--- a/crates/goose-server/src/routes/config_management.rs
+++ b/crates/goose-server/src/routes/config_management.rs
@@ -3,28 +3,28 @@ use crate::routes::utils::check_provider_configured;
 use crate::state::AppState;
 use axum::routing::put;
 use axum::{
-    Json, Router,
     extract::Path,
     routing::{delete, get, post},
+    Json, Router,
 };
 use chrono::{DateTime, TimeZone, Utc};
-use goose::config::ExtensionEntry;
 use goose::config::declarative_providers::LoadedProvider;
 use goose::config::paths::Paths;
+use goose::config::ExtensionEntry;
 use goose::config::{Config, ConfigError};
 use goose::custom_requests::SourceType;
 use goose::model::ModelConfig;
 use goose::providers::base::{ModelInfo, ProviderMetadata, ProviderType};
 use goose::providers::canonical::maybe_get_canonical_model;
 use goose::providers::catalog::{
-    ProviderCatalogEntry, ProviderFormat, ProviderTemplate, get_provider_template,
-    get_providers_by_format,
+    get_provider_template, get_providers_by_format, ProviderCatalogEntry, ProviderFormat,
+    ProviderTemplate,
 };
 use goose::providers::create_with_default_model;
 use goose::providers::huggingface_auth;
 use goose::providers::providers as get_providers;
 use goose::{
-    agents::ExtensionConfig, agents::execute_commands, config::permission::PermissionLevel,
+    agents::execute_commands, agents::ExtensionConfig, config::permission::PermissionLevel,
     slash_commands::recipe_slash_command,
 };
 use serde::{Deserialize, Serialize};

--- a/crates/goose-server/src/routes/config_management.rs
+++ b/crates/goose-server/src/routes/config_management.rs
@@ -971,7 +971,12 @@ pub async fn resolve_provider_model_info(
         )));
     }
 
-    let model_config = ModelConfig::new(model)?.with_canonical_limits(name);
+    let mut model_config = ModelConfig::new(model)?;
+    // Apply catalog_provider_id lookup first (if set), then canonical limits.
+    if let Some(ref catalog_id) = metadata.catalog_provider_id {
+        model_config = model_config.with_catalog_provider_fallback(catalog_id);
+    }
+    model_config = model_config.with_canonical_limits(name);
     let provider = goose::providers::create(name, model_config.clone(), Vec::new()).await?;
     match provider.fetch_model_info(model).await {
         Ok(info) => Ok(info),

--- a/crates/goose-server/src/routes/config_management.rs
+++ b/crates/goose-server/src/routes/config_management.rs
@@ -3,28 +3,28 @@ use crate::routes::utils::check_provider_configured;
 use crate::state::AppState;
 use axum::routing::put;
 use axum::{
+    Json, Router,
     extract::Path,
     routing::{delete, get, post},
-    Json, Router,
 };
 use chrono::{DateTime, TimeZone, Utc};
+use goose::config::ExtensionEntry;
 use goose::config::declarative_providers::LoadedProvider;
 use goose::config::paths::Paths;
-use goose::config::ExtensionEntry;
 use goose::config::{Config, ConfigError};
 use goose::custom_requests::SourceType;
 use goose::model::ModelConfig;
 use goose::providers::base::{ModelInfo, ProviderMetadata, ProviderType};
 use goose::providers::canonical::maybe_get_canonical_model;
 use goose::providers::catalog::{
-    get_provider_template, get_providers_by_format, ProviderCatalogEntry, ProviderFormat,
-    ProviderTemplate,
+    ProviderCatalogEntry, ProviderFormat, ProviderTemplate, get_provider_template,
+    get_providers_by_format,
 };
 use goose::providers::create_with_default_model;
 use goose::providers::huggingface_auth;
 use goose::providers::providers as get_providers;
 use goose::{
-    agents::execute_commands, agents::ExtensionConfig, config::permission::PermissionLevel,
+    agents::ExtensionConfig, agents::execute_commands, config::permission::PermissionLevel,
     slash_commands::recipe_slash_command,
 };
 use serde::{Deserialize, Serialize};
@@ -1008,12 +1008,15 @@ pub async fn resolve_provider_model_info(
             // Override context_limit from the registry-normalized config.
             if metadata.catalog_provider_id.is_some() {
                 info.context_limit = normalized_limit;
+                if let Some(reasoning) = provider.get_model_config().reasoning {
+                    info.reasoning = reasoning;
+                }
             }
             Ok(info)
         }
         Err(error) => {
             let mut info = ModelInfo::new(model, normalized_limit);
-            info.reasoning = model_config.is_reasoning_model();
+            info.reasoning = provider.get_model_config().is_reasoning_model();
             tracing::debug!(
                 provider = name,
                 model,

--- a/crates/goose-server/src/routes/config_management.rs
+++ b/crates/goose-server/src/routes/config_management.rs
@@ -979,7 +979,16 @@ pub async fn resolve_provider_model_info(
     model_config = model_config.with_canonical_limits(name);
     let provider = goose::providers::create(name, model_config.clone(), Vec::new()).await?;
     match provider.fetch_model_info(model).await {
-        Ok(info) => Ok(info),
+        Ok(mut info) => {
+            // When catalog_provider_id is set, the provider's internal
+            // fetch_model_info uses self.get_name() (the raw custom provider
+            // name) to resolve canonical metadata, which misses the catalog.
+            // Override context_limit from the normalized model_config.
+            if metadata.catalog_provider_id.is_some() {
+                info.context_limit = model_config.context_limit();
+            }
+            Ok(info)
+        }
         Err(error) => {
             let mut info = ModelInfo::new(model, model_config.context_limit());
             info.reasoning = model_config.is_reasoning_model();

--- a/crates/goose-server/src/routes/config_management.rs
+++ b/crates/goose-server/src/routes/config_management.rs
@@ -994,19 +994,25 @@ pub async fn resolve_provider_model_info(
     }
     model_config = model_config.with_canonical_limits(name);
     let provider = goose::providers::create(name, model_config.clone(), Vec::new()).await?;
+    // The created provider went through normalize_model_config, which applied
+    // known_models, catalog lookup, and canonical limits.  Use its config as
+    // the authoritative source so that explicit per-model limits from the JSON
+    // config (e.g. a new model with context_limit: 256000 not yet in the
+    // catalog) are reflected in the returned model info.
+    let normalized_limit = provider.get_model_config().context_limit();
     match provider.fetch_model_info(model).await {
         Ok(mut info) => {
             // When catalog_provider_id is set, the provider's internal
             // fetch_model_info uses self.get_name() (the raw custom provider
             // name) to resolve canonical metadata, which misses the catalog.
-            // Override context_limit from the normalized model_config.
+            // Override context_limit from the registry-normalized config.
             if metadata.catalog_provider_id.is_some() {
-                info.context_limit = model_config.context_limit();
+                info.context_limit = normalized_limit;
             }
             Ok(info)
         }
         Err(error) => {
-            let mut info = ModelInfo::new(model, model_config.context_limit());
+            let mut info = ModelInfo::new(model, normalized_limit);
             info.reasoning = model_config.is_reasoning_model();
             tracing::debug!(
                 provider = name,

--- a/crates/goose-server/src/routes/config_management.rs
+++ b/crates/goose-server/src/routes/config_management.rs
@@ -937,7 +937,9 @@ pub async fn get_provider_models(
         )));
     }
 
-    let model_config = ModelConfig::new(&metadata.default_model)?.with_canonical_limits(&name);
+    // Do not pre-fill with canonical limits here — normalize_model_config
+    // inside create handles the full chain: known_models → catalog → canonical.
+    let model_config = ModelConfig::new(&metadata.default_model)?;
     let provider = goose::providers::create(&name, model_config, Vec::new()).await?;
 
     let models_result = provider.fetch_recommended_model_info().await;
@@ -997,18 +999,17 @@ pub async fn resolve_provider_model_info(
         )));
     }
 
-    let mut model_config = ModelConfig::new(model)?;
-    // Apply catalog_provider_id lookup first (if set), then canonical limits.
-    if let Some(ref catalog_id) = metadata.catalog_provider_id {
-        model_config = model_config.with_catalog_provider_fallback(catalog_id);
-    }
-    model_config = model_config.with_canonical_limits(name);
-    let provider = goose::providers::create(name, model_config.clone(), Vec::new()).await?;
-    // The created provider went through normalize_model_config, which applied
-    // known_models, catalog lookup, and canonical limits.  Use its config as
-    // the authoritative source so that explicit per-model limits from the JSON
-    // config (e.g. a new model with context_limit: 256000 not yet in the
-    // catalog) are reflected in the returned model info.
+    // Do not pre-fill context_limit with catalog or canonical values here.
+    // ProviderEntry::normalize_model_config (called inside create) applies
+    // the correct chain:  known_models → catalog → canonical.  Pre-filling
+    // would set a positive value that causes normalize_model_config to skip
+    // the known_models override, losing explicit per-model limits from the
+    // provider's JSON config.
+    let model_config = ModelConfig::new(model)?;
+    let provider = goose::providers::create(name, model_config, Vec::new()).await?;
+    // Use the registry-normalized config as the authoritative source so that
+    // explicit per-model limits from the JSON config (e.g. a custom provider
+    // capping a model at 256k) are reflected in the returned model info.
     let normalized_limit = provider.get_model_config().context_limit();
     match provider.fetch_model_info(model).await {
         Ok(mut info) => {

--- a/crates/goose-server/src/routes/config_management.rs
+++ b/crates/goose-server/src/routes/config_management.rs
@@ -949,8 +949,18 @@ pub async fn get_provider_models(
             // fetch_recommended_model_info uses the raw custom name, so
             // budgets can be stale (e.g. 128k for Xiaomi, 200k for
             // OpenRouter/Anthropic).
-            if let Some(ref catalog_id) = metadata.catalog_provider_id {
-                for info in &mut models {
+            // Apply explicit per-model limits from the provider's JSON
+            // config (known_models) before falling back to the catalog.
+            // This ensures user-configured caps (e.g. 256k for a specific
+            // model) take precedence over the catalog's default.
+            for info in &mut models {
+                let known_override = metadata
+                    .known_models
+                    .iter()
+                    .find(|m| m.name.eq_ignore_ascii_case(&info.name) && m.context_limit > 0);
+                if let Some(known) = known_override {
+                    info.context_limit = known.context_limit;
+                } else if let Some(ref catalog_id) = metadata.catalog_provider_id {
                     if let Some(canonical) = goose::providers::canonical::maybe_get_canonical_model(
                         catalog_id, &info.name,
                     ) {

--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -290,10 +290,12 @@ pub fn create_custom_provider(
         String::new()
     };
 
-    // Use 0 as "not configured" sentinel for context_limit.
-    // The catalog / canonical / known_models fallback chain in
-    // normalize_model_config will fill in the real value later.
-    // Using 0 avoids ambiguity with real 128k limits (the old sentinel).
+    // Use 0 as the "not configured" sentinel for context_limit.
+    // normalize_model_config fills in the real value at runtime via
+    // the known_models → catalog → canonical fallback chain.
+    // The metadata API endpoint resolves 0 to the catalog value
+    // before serving to the desktop UI, so stale cached limits are
+    // never persisted — catalog updates propagate automatically.
     let model_infos: Vec<ModelInfo> = params
         .models
         .into_iter()
@@ -366,7 +368,7 @@ pub fn update_custom_provider(params: UpdateCustomProviderParams) -> Result<()> 
     };
 
     if editable {
-        // Use 0 as "not configured" sentinel — see comment above.
+        // Use 0 sentinel — same as create_custom_provider.
         let model_infos: Vec<ModelInfo> = params
             .models
             .into_iter()

--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -290,10 +290,14 @@ pub fn create_custom_provider(
         String::new()
     };
 
+    // Use 0 as "not configured" sentinel for context_limit.
+    // The catalog / canonical / known_models fallback chain in
+    // normalize_model_config will fill in the real value later.
+    // Using 0 avoids ambiguity with real 128k limits (the old sentinel).
     let model_infos: Vec<ModelInfo> = params
         .models
         .into_iter()
-        .map(|name| ModelInfo::new(name, 128000))
+        .map(|name| ModelInfo::new(name, 0))
         .collect();
 
     let engine = ProviderEngine::from_str(&params.engine)?;
@@ -362,10 +366,11 @@ pub fn update_custom_provider(params: UpdateCustomProviderParams) -> Result<()> 
     };
 
     if editable {
+        // Use 0 as "not configured" sentinel — see comment above.
         let model_infos: Vec<ModelInfo> = params
             .models
             .into_iter()
-            .map(|name| ModelInfo::new(name, 128000))
+            .map(|name| ModelInfo::new(name, 0))
             .collect();
 
         let engine = ProviderEngine::from_str(&params.engine)?;

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -256,18 +256,30 @@ impl ModelConfig {
     /// `catalog_provider_id` (e.g. "xiaomi-token-plan-sgp") as the provider
     /// key.  This is intended as a fallback after `with_canonical_limits`
     /// already failed with the raw config provider name.
+    ///
+    /// When a canonical match is found, it overrides the current
+    /// `context_limit` **unless** the current value was explicitly set
+    /// by the user (i.e. it differs from `DEFAULT_CONTEXT_LIMIT`).
+    /// This handles the desktop flow where the UI sends the stale
+    /// `known_models` placeholder (128 000) via `with_context_limit`.
     pub fn with_catalog_provider_fallback(mut self, catalog_provider_id: &str) -> Self {
-        if self.context_limit.is_some() {
-            return self;
-        }
-
         let canonical = crate::providers::canonical::maybe_get_canonical_model(
             catalog_provider_id,
             &self.model_name,
         );
 
         if let Some(canonical) = canonical {
-            self.context_limit = Some(canonical.limit.context);
+            // Override the context limit when it is unset OR when it
+            // equals the hardcoded placeholder (DEFAULT_CONTEXT_LIMIT).
+            // A non-default value means the user explicitly configured
+            // a limit (e.g. via GOOSE_CONTEXT_LIMIT) — respect it.
+            let dominated = self
+                .context_limit
+                .map(|v| v == DEFAULT_CONTEXT_LIMIT)
+                .unwrap_or(true);
+            if dominated {
+                self.context_limit = Some(canonical.limit.context);
+            }
             if self.max_tokens.is_none() {
                 self.max_tokens = canonical
                     .limit
@@ -1015,19 +1027,39 @@ mod tests {
         }
 
         #[test]
-        fn catalog_provider_id_fallback_does_not_override_existing_limit() {
+        fn catalog_provider_id_fallback_does_not_override_user_limit() {
             let _guard = env_lock::lock_env([
                 ("GOOSE_MAX_TOKENS", None::<&str>),
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
 
+            // A non-default value (e.g. from GOOSE_CONTEXT_LIMIT) must be preserved.
             let mut config = ModelConfig::new_or_fail("mimo-v2.5-pro");
             config.context_limit = Some(512_000);
             let config = config.with_catalog_provider_fallback("xiaomi-token-plan-sgp");
             assert_eq!(
                 config.context_limit,
                 Some(512_000),
-                "catalog_provider_id fallback should not override existing context_limit"
+                "non-default context_limit should not be overridden by catalog fallback"
+            );
+        }
+
+        #[test]
+        fn catalog_provider_id_fallback_overrides_default_placeholder() {
+            let _guard = env_lock::lock_env([
+                ("GOOSE_MAX_TOKENS", None::<&str>),
+                ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+            ]);
+
+            // DEFAULT_CONTEXT_LIMIT (128000) is the hardcoded placeholder
+            // from create_custom_provider — the catalog should override it.
+            let mut config = ModelConfig::new_or_fail("mimo-v2.5-pro");
+            config.context_limit = Some(128_000);
+            let config = config.with_catalog_provider_fallback("xiaomi-token-plan-sgp");
+            assert_eq!(
+                config.context_limit,
+                Some(1_048_576),
+                "placeholder 128000 should be overridden by catalog fallback"
             );
         }
 

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -252,16 +252,19 @@ impl ModelConfig {
         self
     }
 
-    /// Try resolving context_limit from canonical model data using a
-    /// `catalog_provider_id` (e.g. "xiaomi-token-plan-sgp") as the provider
-    /// key.  This is intended as a fallback after `with_canonical_limits`
-    /// already failed with the raw config provider name.
+    /// Try resolving `context_limit` from canonical model data using a
+    /// `catalog_provider_id` (e.g. "openrouter", "xiaomi-token-plan-sgp")
+    /// as the provider key.
     ///
-    /// When a canonical match is found, it overrides the current
-    /// `context_limit` **unless** the current value was explicitly set
-    /// by the user (i.e. it differs from `DEFAULT_CONTEXT_LIMIT`).
-    /// This handles the desktop flow where the UI sends the stale
-    /// `known_models` placeholder (128 000) via `with_context_limit`.
+    /// Called *before* `with_canonical_limits` so the user-configured catalog
+    /// takes priority over the inference path that matches by model name
+    /// alone (e.g. `anthropic/claude-sonnet-4` → Anthropic).
+    ///
+    /// Overrides the current `context_limit` when it is unset **or** when it
+    /// equals `DEFAULT_CONTEXT_LIMIT` (the hardcoded placeholder from
+    /// `create_custom_provider`).  A different non-default value means the
+    /// user explicitly configured a limit (e.g. via `GOOSE_CONTEXT_LIMIT`)
+    /// and is preserved.
     pub fn with_catalog_provider_fallback(mut self, catalog_provider_id: &str) -> Self {
         let canonical = crate::providers::canonical::maybe_get_canonical_model(
             catalog_provider_id,

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -238,10 +238,15 @@ impl ModelConfig {
                 self.context_limit = Some(canonical.limit.context);
             }
             if self.max_tokens.is_none() {
+                // Compare against the effective context_limit (which may
+                // be a lower user override like GOOSE_CONTEXT_LIMIT=65536),
+                // not the raw catalog context.  Otherwise a 65k window
+                // could request 131k output tokens, overrunning the budget.
+                let effective_ctx = self.context_limit.unwrap_or(canonical.limit.context);
                 self.max_tokens = canonical
                     .limit
                     .output
-                    .filter(|&output| output < canonical.limit.context)
+                    .filter(|&output| output < effective_ctx)
                     .map(|output| output as i32);
             }
             if self.reasoning.is_none() {
@@ -283,10 +288,15 @@ impl ModelConfig {
                 self.context_limit = Some(canonical.limit.context);
             }
             if self.max_tokens.is_none() {
+                // Compare against the effective context_limit (which may
+                // be a lower user override like GOOSE_CONTEXT_LIMIT=65536),
+                // not the raw catalog context.  Otherwise a 65k window
+                // could request 131k output tokens, overrunning the budget.
+                let effective_ctx = self.context_limit.unwrap_or(canonical.limit.context);
                 self.max_tokens = canonical
                     .limit
                     .output
-                    .filter(|&output| output < canonical.limit.context)
+                    .filter(|&output| output < effective_ctx)
                     .map(|output| output as i32);
             }
             if self.reasoning.is_none() {
@@ -1064,6 +1074,34 @@ mod tests {
                 config.context_limit,
                 Some(1_048_576),
                 "placeholder 0 should be overridden by catalog fallback"
+            );
+        }
+
+        #[test]
+        fn catalog_output_tokens_capped_to_effective_context() {
+            let _guard = env_lock::lock_env([
+                ("GOOSE_MAX_TOKENS", None::<&str>),
+                ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+            ]);
+
+            // Simulate a user override with GOOSE_CONTEXT_LIMIT=65536
+            // combined with a catalog-backed provider that has a much
+            // larger context (1M) and output limit (131k).
+            let mut config = ModelConfig::new_or_fail("mimo-v2.5-pro");
+            config.context_limit = Some(65_536); // explicit lower limit
+            let config = config.with_catalog_provider_fallback("xiaomi-token-plan-sgp");
+            assert_eq!(
+                config.context_limit,
+                Some(65_536),
+                "explicit context_limit should be preserved"
+            );
+            // Output tokens must be capped to the effective 65k context,
+            // not the catalog's 1M context — otherwise requests would
+            // ask for 131k output tokens in a 65k window.
+            assert!(
+                config.max_tokens.unwrap_or(0) <= 65_536,
+                "max_tokens ({}) should not exceed effective context_limit (65536)",
+                config.max_tokens.unwrap_or(0),
             );
         }
 

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -252,6 +252,37 @@ impl ModelConfig {
         self
     }
 
+    /// Try resolving context_limit from canonical model data using a
+    /// `catalog_provider_id` (e.g. "xiaomi-token-plan-sgp") as the provider
+    /// key.  This is intended as a fallback after `with_canonical_limits`
+    /// already failed with the raw config provider name.
+    pub fn with_catalog_provider_fallback(mut self, catalog_provider_id: &str) -> Self {
+        if self.context_limit.is_some() {
+            return self;
+        }
+
+        let canonical = crate::providers::canonical::maybe_get_canonical_model(
+            catalog_provider_id,
+            &self.model_name,
+        );
+
+        if let Some(canonical) = canonical {
+            self.context_limit = Some(canonical.limit.context);
+            if self.max_tokens.is_none() {
+                self.max_tokens = canonical
+                    .limit
+                    .output
+                    .filter(|&output| output < canonical.limit.context)
+                    .map(|output| output as i32);
+            }
+            if self.reasoning.is_none() {
+                self.reasoning = canonical.reasoning;
+            }
+        }
+
+        self
+    }
+
     fn validate_context_limit(val: &str, env_var: &str) -> Result<usize, ConfigError> {
         let limit = val.parse::<usize>().map_err(|_| {
             ConfigError::InvalidValue(
@@ -956,6 +987,63 @@ mod tests {
             let config =
                 ModelConfig::new_or_fail("gpt-5.4-nano-low").with_canonical_limits("openai");
             assert_eq!(config.context_limit, Some(400_000));
+        }
+
+        #[test]
+        fn catalog_provider_id_fallback_resolves_context_limit() {
+            let _guard = env_lock::lock_env([
+                ("GOOSE_MAX_TOKENS", None::<&str>),
+                ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+            ]);
+
+            // "custom_xiaomi_token_plan__sgp" is NOT a known canonical provider,
+            // so direct lookup should fail.
+            let config = ModelConfig::new_or_fail("mimo-v2.5-pro")
+                .with_canonical_limits("custom_xiaomi_token_plan__sgp");
+            assert_eq!(
+                config.context_limit, None,
+                "raw custom provider name should NOT resolve canonical model"
+            );
+
+            // "xiaomi-token-plan-sgp" IS the catalog_provider_id — fallback should resolve.
+            let config = config.with_catalog_provider_fallback("xiaomi-token-plan-sgp");
+            assert_eq!(
+                config.context_limit,
+                Some(1_048_576),
+                "catalog_provider_id should resolve canonical model context limit"
+            );
+        }
+
+        #[test]
+        fn catalog_provider_id_fallback_does_not_override_existing_limit() {
+            let _guard = env_lock::lock_env([
+                ("GOOSE_MAX_TOKENS", None::<&str>),
+                ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+            ]);
+
+            let mut config = ModelConfig::new_or_fail("mimo-v2.5-pro");
+            config.context_limit = Some(512_000);
+            let config = config.with_catalog_provider_fallback("xiaomi-token-plan-sgp");
+            assert_eq!(
+                config.context_limit,
+                Some(512_000),
+                "catalog_provider_id fallback should not override existing context_limit"
+            );
+        }
+
+        #[test]
+        fn catalog_provider_id_fallback_unknown_id_is_noop() {
+            let _guard = env_lock::lock_env([
+                ("GOOSE_MAX_TOKENS", None::<&str>),
+                ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+            ]);
+
+            let config = ModelConfig::new_or_fail("mimo-v2.5-pro")
+                .with_catalog_provider_fallback("totally-unknown-provider");
+            assert_eq!(
+                config.context_limit, None,
+                "unknown catalog_provider_id should leave context_limit as None"
+            );
         }
     }
 

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -260,14 +260,13 @@ impl ModelConfig {
     /// takes priority over the inference path that matches by model name
     /// alone (e.g. `anthropic/claude-sonnet-4` → Anthropic).
     ///
-    /// When the catalog contains a match for this model the context limit is
-    /// **always** overridden.  Positive values that arrived from the desktop
-    /// model picker are not necessarily explicit user overrides — the picker
-    /// builds model info via the raw custom provider name, so stale budgets
-    /// (e.g. 128 k for Xiaomi, 200 k for OpenRouter/Anthropic) can leak
-    /// through.  The catalog is the authoritative source for catalog-backed
-    /// providers; if the user needs a custom limit they should remove the
-    /// `catalog_provider_id` first.
+    /// Overrides the current `context_limit` when it is unset **or** equals
+    /// the `0` sentinel from `create_custom_provider`.  A different positive
+    /// value means the user or config explicitly set a limit (e.g. via
+    /// `GOOSE_CONTEXT_LIMIT`) and is preserved.  Stale picker values are
+    /// corrected at the source — `get_provider_models` and
+    /// `resolve_provider_model_info` now apply the catalog lookup before
+    /// returning model info to the desktop UI.
     pub fn with_catalog_provider_fallback(mut self, catalog_provider_id: &str) -> Self {
         let canonical = crate::providers::canonical::maybe_get_canonical_model(
             catalog_provider_id,
@@ -275,9 +274,14 @@ impl ModelConfig {
         );
 
         if let Some(canonical) = canonical {
-            // Always override: the catalog is the authoritative source.
-            // Positive values from the model picker can be stale.
-            self.context_limit = Some(canonical.limit.context);
+            // Override when context_limit is unset or is the 0 sentinel
+            // from create_custom_provider.  A positive value means the
+            // user explicitly set a limit (e.g. GOOSE_CONTEXT_LIMIT) —
+            // preserve it.  Stale picker values are now corrected at the
+            // source by get_provider_models / resolve_provider_model_info.
+            if self.context_limit.is_none() || self.context_limit == Some(0) {
+                self.context_limit = Some(canonical.limit.context);
+            }
             if self.max_tokens.is_none() {
                 self.max_tokens = canonical
                     .limit
@@ -1025,22 +1029,22 @@ mod tests {
         }
 
         #[test]
-        fn catalog_provider_id_fallback_always_overrides_with_catalog() {
+        fn catalog_provider_id_fallback_preserves_explicit_user_limit() {
             let _guard = env_lock::lock_env([
                 ("GOOSE_MAX_TOKENS", None::<&str>),
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
 
-            // When catalog_provider_id is set, the catalog is authoritative.
-            // Even a positive value (e.g. from the desktop model picker or a
-            // stale config) is overridden by the catalog.
+            // A non-default positive value (e.g. from GOOSE_CONTEXT_LIMIT)
+            // must be preserved — the catalog should not override it.
+            // Stale picker values are corrected at the source endpoints.
             let mut config = ModelConfig::new_or_fail("mimo-v2.5-pro");
             config.context_limit = Some(512_000);
             let config = config.with_catalog_provider_fallback("xiaomi-token-plan-sgp");
             assert_eq!(
                 config.context_limit,
-                Some(1_048_576),
-                "catalog should override any positive context_limit for catalog-backed providers"
+                Some(512_000),
+                "explicit positive context_limit should not be overridden by catalog fallback"
             );
         }
 

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -261,10 +261,9 @@ impl ModelConfig {
     /// alone (e.g. `anthropic/claude-sonnet-4` → Anthropic).
     ///
     /// Overrides the current `context_limit` when it is unset **or** when it
-    /// equals `DEFAULT_CONTEXT_LIMIT` (the hardcoded placeholder from
-    /// `create_custom_provider`).  A different non-default value means the
-    /// user explicitly configured a limit (e.g. via `GOOSE_CONTEXT_LIMIT`)
-    /// and is preserved.
+    /// equals `0` (the sentinel value from `create_custom_provider` meaning
+    /// "not yet configured").  A different positive value means the user or
+    /// config explicitly set a limit and is preserved.
     pub fn with_catalog_provider_fallback(mut self, catalog_provider_id: &str) -> Self {
         let canonical = crate::providers::canonical::maybe_get_canonical_model(
             catalog_provider_id,
@@ -273,12 +272,12 @@ impl ModelConfig {
 
         if let Some(canonical) = canonical {
             // Override the context limit when it is unset OR when it
-            // equals the hardcoded placeholder (DEFAULT_CONTEXT_LIMIT).
-            // A non-default value means the user explicitly configured
-            // a limit (e.g. via GOOSE_CONTEXT_LIMIT) — respect it.
+            // equals 0 (the "not configured" sentinel from
+            // create_custom_provider).  A positive value means the user
+            // or config explicitly set a limit — respect it.
             let dominated = self
                 .context_limit
-                .map(|v| v == DEFAULT_CONTEXT_LIMIT)
+                .map(|v| v == 0)
                 .unwrap_or(true);
             if dominated {
                 self.context_limit = Some(canonical.limit.context);
@@ -1054,15 +1053,15 @@ mod tests {
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
 
-            // DEFAULT_CONTEXT_LIMIT (128000) is the hardcoded placeholder
-            // from create_custom_provider — the catalog should override it.
+            // 0 is the "not configured" sentinel from create_custom_provider
+            // — the catalog should override it.
             let mut config = ModelConfig::new_or_fail("mimo-v2.5-pro");
-            config.context_limit = Some(128_000);
+            config.context_limit = Some(0);
             let config = config.with_catalog_provider_fallback("xiaomi-token-plan-sgp");
             assert_eq!(
                 config.context_limit,
                 Some(1_048_576),
-                "placeholder 128000 should be overridden by catalog fallback"
+                "placeholder 0 should be overridden by catalog fallback"
             );
         }
 

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -275,10 +275,7 @@ impl ModelConfig {
             // equals 0 (the "not configured" sentinel from
             // create_custom_provider).  A positive value means the user
             // or config explicitly set a limit — respect it.
-            let dominated = self
-                .context_limit
-                .map(|v| v == 0)
-                .unwrap_or(true);
+            let dominated = self.context_limit.map(|v| v == 0).unwrap_or(true);
             if dominated {
                 self.context_limit = Some(canonical.limit.context);
             }

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -181,7 +181,7 @@ impl ModelConfig {
                         "GOOSE_CONTEXT_LIMIT".to_string(),
                         String::new(),
                         e.to_string(),
-                    ))
+                    ));
                 }
             }
         };
@@ -260,10 +260,14 @@ impl ModelConfig {
     /// takes priority over the inference path that matches by model name
     /// alone (e.g. `anthropic/claude-sonnet-4` → Anthropic).
     ///
-    /// Overrides the current `context_limit` when it is unset **or** when it
-    /// equals `0` (the sentinel value from `create_custom_provider` meaning
-    /// "not yet configured").  A different positive value means the user or
-    /// config explicitly set a limit and is preserved.
+    /// When the catalog contains a match for this model the context limit is
+    /// **always** overridden.  Positive values that arrived from the desktop
+    /// model picker are not necessarily explicit user overrides — the picker
+    /// builds model info via the raw custom provider name, so stale budgets
+    /// (e.g. 128 k for Xiaomi, 200 k for OpenRouter/Anthropic) can leak
+    /// through.  The catalog is the authoritative source for catalog-backed
+    /// providers; if the user needs a custom limit they should remove the
+    /// `catalog_provider_id` first.
     pub fn with_catalog_provider_fallback(mut self, catalog_provider_id: &str) -> Self {
         let canonical = crate::providers::canonical::maybe_get_canonical_model(
             catalog_provider_id,
@@ -271,14 +275,9 @@ impl ModelConfig {
         );
 
         if let Some(canonical) = canonical {
-            // Override the context limit when it is unset OR when it
-            // equals 0 (the "not configured" sentinel from
-            // create_custom_provider).  A positive value means the user
-            // or config explicitly set a limit — respect it.
-            let dominated = self.context_limit.map(|v| v == 0).unwrap_or(true);
-            if dominated {
-                self.context_limit = Some(canonical.limit.context);
-            }
+            // Always override: the catalog is the authoritative source.
+            // Positive values from the model picker can be stale.
+            self.context_limit = Some(canonical.limit.context);
             if self.max_tokens.is_none() {
                 self.max_tokens = canonical
                     .limit
@@ -1026,20 +1025,22 @@ mod tests {
         }
 
         #[test]
-        fn catalog_provider_id_fallback_does_not_override_user_limit() {
+        fn catalog_provider_id_fallback_always_overrides_with_catalog() {
             let _guard = env_lock::lock_env([
                 ("GOOSE_MAX_TOKENS", None::<&str>),
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
 
-            // A non-default value (e.g. from GOOSE_CONTEXT_LIMIT) must be preserved.
+            // When catalog_provider_id is set, the catalog is authoritative.
+            // Even a positive value (e.g. from the desktop model picker or a
+            // stale config) is overridden by the catalog.
             let mut config = ModelConfig::new_or_fail("mimo-v2.5-pro");
             config.context_limit = Some(512_000);
             let config = config.with_catalog_provider_fallback("xiaomi-token-plan-sgp");
             assert_eq!(
                 config.context_limit,
-                Some(512_000),
-                "non-default context_limit should not be overridden by catalog fallback"
+                Some(1_048_576),
+                "catalog should override any positive context_limit for catalog-backed providers"
             );
         }
 

--- a/crates/goose/src/providers/base.rs
+++ b/crates/goose/src/providers/base.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
-use futures::future::BoxFuture;
 use futures::Stream;
+use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 
 /// Default HTTP timeout for all provider API calls.
@@ -9,14 +9,14 @@ use serde::{Deserialize, Serialize};
 /// before giving up. Individual providers may override this via their own config key.
 pub const DEFAULT_PROVIDER_TIMEOUT_SECS: u64 = 600;
 
-use super::canonical::{map_to_canonical_model, CanonicalModelRegistry};
+use super::canonical::{CanonicalModelRegistry, map_to_canonical_model};
 use super::errors::ProviderError;
-use super::inventory::{default_inventory_identity, InventoryIdentityInput};
+use super::inventory::{InventoryIdentityInput, default_inventory_identity};
 use super::retry::RetryConfig;
 use crate::config::base::ConfigValue;
 use crate::config::{Config, ExtensionConfig, GooseMode};
-use crate::conversation::message::{Message, MessageContent};
 use crate::conversation::Conversation;
+use crate::conversation::message::{Message, MessageContent};
 use crate::model::ModelConfig;
 use crate::permission::PermissionConfirmation;
 use crate::utils::safe_truncate;
@@ -380,6 +380,11 @@ pub fn get_current_model() -> Option<String> {
 
 pub static MSG_COUNT_FOR_SESSION_NAME_GENERATION: usize = 3;
 
+/// Serde helper: skip serializing usize fields that equal 0.
+fn is_zero_usize(v: &usize) -> bool {
+    *v == 0
+}
+
 /// Information about a model's capabilities
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq)]
 pub struct ModelInfo {
@@ -389,6 +394,7 @@ pub struct ModelInfo {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolved_model: Option<String>,
     /// The maximum context length this model supports
+    #[serde(default, skip_serializing_if = "is_zero_usize")]
     pub context_limit: usize,
     /// Cost per token for input in USD (optional)
     pub input_token_cost: Option<f64>,

--- a/crates/goose/src/providers/base.rs
+++ b/crates/goose/src/providers/base.rs
@@ -496,6 +496,10 @@ pub struct ProviderMetadata {
     /// Hint shown in the model picker when this provider manages its own model selection.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_selection_hint: Option<String>,
+    /// Provider ID used in the canonical model registry (e.g. "xiaomi-token-plan-sgp").
+    /// When set, used as a fallback for resolving context limits from canonical data.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub catalog_provider_id: Option<String>,
 }
 
 impl ProviderMetadata {
@@ -521,6 +525,7 @@ impl ProviderMetadata {
             config_keys,
             setup_steps: vec![],
             model_selection_hint: None,
+            catalog_provider_id: None,
         }
     }
 
@@ -543,6 +548,7 @@ impl ProviderMetadata {
             config_keys,
             setup_steps: vec![],
             model_selection_hint: None,
+            catalog_provider_id: None,
         }
     }
 
@@ -557,6 +563,7 @@ impl ProviderMetadata {
             config_keys: vec![],
             setup_steps: vec![],
             model_selection_hint: None,
+            catalog_provider_id: None,
         }
     }
 

--- a/crates/goose/src/providers/base.rs
+++ b/crates/goose/src/providers/base.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
-use futures::Stream;
 use futures::future::BoxFuture;
+use futures::Stream;
 use serde::{Deserialize, Serialize};
 
 /// Default HTTP timeout for all provider API calls.
@@ -9,14 +9,14 @@ use serde::{Deserialize, Serialize};
 /// before giving up. Individual providers may override this via their own config key.
 pub const DEFAULT_PROVIDER_TIMEOUT_SECS: u64 = 600;
 
-use super::canonical::{CanonicalModelRegistry, map_to_canonical_model};
+use super::canonical::{map_to_canonical_model, CanonicalModelRegistry};
 use super::errors::ProviderError;
-use super::inventory::{InventoryIdentityInput, default_inventory_identity};
+use super::inventory::{default_inventory_identity, InventoryIdentityInput};
 use super::retry::RetryConfig;
 use crate::config::base::ConfigValue;
 use crate::config::{Config, ExtensionConfig, GooseMode};
-use crate::conversation::Conversation;
 use crate::conversation::message::{Message, MessageContent};
+use crate::conversation::Conversation;
 use crate::model::ModelConfig;
 use crate::permission::PermissionConfirmation;
 use crate::utils::safe_truncate;

--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -528,4 +528,69 @@ mod tests {
 
         std::env::remove_var("GOOSE_PATH_ROOT");
     }
+
+    /// Verifies that `catalog_provider_id` lookup takes precedence over
+    /// canonical inference from the raw provider name (r3347579987).
+    ///
+    /// Model `anthropic/claude-sonnet-4` under a custom provider with raw name
+    /// `custom_openrouter_canonical_test`: `with_canonical_limits` infers
+    /// Anthropic (200k) via the model-name inference path.  The explicit
+    /// `catalog_provider_id: "openrouter"` should resolve to OpenRouter's
+    /// canonical entry (1M) instead.
+    #[tokio::test]
+    async fn test_catalog_lookup_precedes_canonical_inference() {
+        let _guard = env_lock::lock_env([("GOOSE_PATH_ROOT", None::<&str>)]);
+        let temp_dir = tempfile::tempdir().expect("tempdir should be created");
+        std::env::set_var("GOOSE_PATH_ROOT", temp_dir.path());
+
+        let custom_dir = Paths::config_dir().join("custom_providers");
+        fs::create_dir_all(&custom_dir).expect("custom providers dir should be created");
+
+        let custom = r#"{
+  "name": "custom_openrouter_canonical_test",
+  "engine": "openai",
+  "display_name": "OpenRouter Canonical Test",
+  "description": "test catalog takes precedence over canonical inference",
+  "api_key_env": "",
+  "base_url": "https://example.invalid/v1/chat/completions",
+  "models": [
+    {"name": "anthropic/claude-sonnet-4", "context_limit": 128000}
+  ],
+  "catalog_provider_id": "openrouter",
+  "requires_auth": false
+}"#;
+        fs::write(
+            custom_dir.join("custom_openrouter_canonical_test.json"),
+            custom,
+        )
+        .expect("custom provider JSON should be written");
+
+        refresh_custom_providers()
+            .await
+            .expect("custom providers should refresh");
+
+        let provider = create_with_named_model(
+            "custom_openrouter_canonical_test",
+            "anthropic/claude-sonnet-4",
+            Vec::new(),
+        )
+        .await
+        .expect("provider should be creatable");
+
+        let config = provider.get_model_config();
+        let limit = config
+            .context_limit
+            .expect("context_limit should be resolved");
+
+        // Must NOT be Anthropic's 200k (inference) or 128k (placeholder).
+        // OpenRouter's canonical entry for anthropic/claude-sonnet-4 is 1M.
+        assert_ne!(
+            limit, 200_000,
+            "should NOT resolve to Anthropic canonical via inference; \
+             catalog_provider_id 'openrouter' should take precedence"
+        );
+        assert_ne!(limit, 128_000, "should NOT keep the hardcoded placeholder");
+
+        std::env::remove_var("GOOSE_PATH_ROOT");
+    }
 }

--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -481,4 +481,51 @@ mod tests {
 
         std::env::remove_var("GOOSE_PATH_ROOT");
     }
+
+    #[tokio::test]
+    async fn test_catalog_provider_id_resolves_canonical_context_limit() {
+        let _guard = env_lock::lock_env([("GOOSE_PATH_ROOT", None::<&str>)]);
+        let temp_dir = tempfile::tempdir().expect("tempdir should be created");
+        std::env::set_var("GOOSE_PATH_ROOT", temp_dir.path());
+
+        let custom_dir = Paths::config_dir().join("custom_providers");
+        fs::create_dir_all(&custom_dir).expect("custom providers dir should be created");
+
+        // Custom provider with catalog_provider_id but NO explicit context_limit.
+        // The hardcoded 128000 from create_custom_provider should be overridden
+        // by the canonical lookup using catalog_provider_id.
+        let custom_xiaomi = r#"{
+  "name": "custom_xiaomi_test",
+  "engine": "openai",
+  "display_name": "Xiaomi Test",
+  "description": "test provider with catalog_provider_id",
+  "api_key_env": "",
+  "base_url": "https://example.invalid/v1/chat/completions",
+  "models": [
+    {"name": "mimo-v2.5-pro", "context_limit": 128000}
+  ],
+  "catalog_provider_id": "xiaomi-token-plan-sgp",
+  "requires_auth": false
+}"#;
+        fs::write(custom_dir.join("custom_xiaomi_test.json"), custom_xiaomi)
+            .expect("custom_xiaomi_test.json should be written");
+
+        refresh_custom_providers()
+            .await
+            .expect("custom providers should refresh");
+
+        let provider = create_with_named_model("custom_xiaomi_test", "mimo-v2.5-pro", Vec::new())
+            .await
+            .expect("custom_xiaomi_test provider should be creatable");
+
+        // Should resolve to 1048576 from canonical data via catalog_provider_id,
+        // NOT the hardcoded 128000 from the JSON config.
+        assert_eq!(
+            provider.get_model_config().context_limit,
+            Some(1_048_576),
+            "catalog_provider_id should resolve canonical context limit for mimo-v2.5-pro"
+        );
+
+        std::env::remove_var("GOOSE_PATH_ROOT");
+    }
 }

--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -492,7 +492,7 @@ mod tests {
         fs::create_dir_all(&custom_dir).expect("custom providers dir should be created");
 
         // Custom provider with catalog_provider_id but NO explicit context_limit.
-        // The hardcoded 128000 from create_custom_provider should be overridden
+        // The sentinel 0 from create_custom_provider should be overridden
         // by the canonical lookup using catalog_provider_id.
         let custom_xiaomi = r#"{
   "name": "custom_xiaomi_test",
@@ -502,7 +502,7 @@ mod tests {
   "api_key_env": "",
   "base_url": "https://example.invalid/v1/chat/completions",
   "models": [
-    {"name": "mimo-v2.5-pro", "context_limit": 128000}
+    {"name": "mimo-v2.5-pro", "context_limit": 0}
   ],
   "catalog_provider_id": "xiaomi-token-plan-sgp",
   "requires_auth": false
@@ -519,7 +519,7 @@ mod tests {
             .expect("custom_xiaomi_test provider should be creatable");
 
         // Should resolve to 1048576 from canonical data via catalog_provider_id,
-        // NOT the hardcoded 128000 from the JSON config.
+        // NOT the sentinel 0 from the JSON config.
         assert_eq!(
             provider.get_model_config().context_limit,
             Some(1_048_576),
@@ -554,7 +554,7 @@ mod tests {
   "api_key_env": "",
   "base_url": "https://example.invalid/v1/chat/completions",
   "models": [
-    {"name": "anthropic/claude-sonnet-4", "context_limit": 128000}
+    {"name": "anthropic/claude-sonnet-4", "context_limit": 0}
   ],
   "catalog_provider_id": "openrouter",
   "requires_auth": false

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -60,6 +60,14 @@ impl ProviderEntry {
     fn normalize_model_config(&self, mut model: ModelConfig) -> ModelConfig {
         model = model.with_canonical_limits(&self.metadata.name);
 
+        // Fallback: try canonical lookup via catalog_provider_id (e.g.
+        // "xiaomi-token-plan-sgp") when the raw config name didn't match.
+        if model.context_limit.is_none() {
+            if let Some(ref catalog_id) = self.metadata.catalog_provider_id {
+                model = model.with_catalog_provider_fallback(catalog_id);
+            }
+        }
+
         if model.context_limit.is_none() {
             if let Some(info) = self
                 .metadata
@@ -288,6 +296,7 @@ impl ProviderRegistry {
             config_keys,
             setup_steps: config.setup_steps.clone(),
             model_selection_hint: None,
+            catalog_provider_id: config.catalog_provider_id.clone(),
         };
         let inventory_config_keys = custom_metadata.config_keys.clone();
         let default_inventory_configured = Arc::new(move || {

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -248,18 +248,37 @@ impl ProviderRegistry {
             .first()
             .map(|m| m.name.clone())
             .unwrap_or_default();
+        // Resolve 0-sentinel context_limits from the catalog on the fly.
+        // This ensures the desktop UI sees the correct limit even though
+        // the stored config uses 0 as the "not configured" sentinel.
+        // Catalog updates propagate automatically without re-saving the
+        // provider — no stale cached limits.
         let known_models: Vec<ModelInfo> = config
             .models
             .iter()
-            .map(|m| ModelInfo {
-                name: m.name.clone(),
-                resolved_model: None,
-                context_limit: m.context_limit,
-                input_token_cost: m.input_token_cost,
-                output_token_cost: m.output_token_cost,
-                currency: m.currency.clone(),
-                supports_cache_control: Some(m.supports_cache_control.unwrap_or(false)),
-                reasoning: m.reasoning,
+            .map(|m| {
+                let context_limit = if m.context_limit == 0 {
+                    config
+                        .catalog_provider_id
+                        .as_deref()
+                        .and_then(|cid| {
+                            crate::providers::canonical::maybe_get_canonical_model(cid, &m.name)
+                                .map(|c| c.limit.context)
+                        })
+                        .unwrap_or(0)
+                } else {
+                    m.context_limit
+                };
+                ModelInfo {
+                    name: m.name.clone(),
+                    resolved_model: None,
+                    context_limit,
+                    input_token_cost: m.input_token_cost,
+                    output_token_cost: m.output_token_cost,
+                    currency: m.currency.clone(),
+                    supports_cache_control: Some(m.supports_cache_control.unwrap_or(false)),
+                    reasoning: m.reasoning,
+                }
             })
             .collect();
 

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -58,6 +58,13 @@ impl ProviderEntry {
     }
 
     fn normalize_model_config(&self, mut model: ModelConfig) -> ModelConfig {
+        // Normalize the 0 sentinel to None so the entire fallback chain
+        // treats it as "not configured".  Without this, providers without
+        // a catalog_provider_id would run with an actual context_limit of 0.
+        if model.context_limit == Some(0) {
+            model.context_limit = None;
+        }
+
         // 1. Check known_models metadata first for explicit per-model limits
         //    (e.g. custom provider JSON with per-model context_limit values,
         //    or desktop UI inventory entries).

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -1,7 +1,7 @@
 use super::base::{ConfigKey, ModelInfo, Provider, ProviderDef, ProviderMetadata, ProviderType};
 use super::inventory::InventoryIdentityInput;
 use crate::config::{DeclarativeProviderConfig, ExtensionConfig};
-use crate::model::{ModelConfig, DEFAULT_CONTEXT_LIMIT};
+use crate::model::ModelConfig;
 use anyhow::Result;
 use futures::future::BoxFuture;
 use std::collections::HashMap;
@@ -69,18 +69,18 @@ impl ProviderEntry {
         //    (e.g. custom provider JSON with per-model context_limit values,
         //    or desktop UI inventory entries).
         //
-        //    Skip entries that use the old 128000 placeholder when the provider
-        //    has a catalog_provider_id — those are stale artifacts from the
-        //    previous create_custom_provider code.  (The catalog in step 2
-        //    would override them anyway, but skipping avoids a pointless
-        //    set-then-override cycle.)
+        //    All positive values are honored, including 128000.  We cannot
+        //    distinguish a stale auto-generated 128k placeholder from a
+        //    hand-authored intentional 128k cap by value alone, so we
+        //    preserve the stored value and let the user update it if they
+        //    want the catalog default.
         if model.context_limit.is_none() {
-            if let Some(info) = self.metadata.known_models.iter().find(|m| {
-                m.name.eq_ignore_ascii_case(&model.model_name)
-                    && m.context_limit > 0
-                    && !(self.metadata.catalog_provider_id.is_some()
-                        && m.context_limit == DEFAULT_CONTEXT_LIMIT)
-            }) {
+            if let Some(info) = self
+                .metadata
+                .known_models
+                .iter()
+                .find(|m| m.name.eq_ignore_ascii_case(&model.model_name) && m.context_limit > 0)
+            {
                 model.context_limit = Some(info.context_limit);
             }
         }

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -58,16 +58,22 @@ impl ProviderEntry {
     }
 
     fn normalize_model_config(&self, mut model: ModelConfig) -> ModelConfig {
-        model = model.with_canonical_limits(&self.metadata.name);
-
-        // Fallback: try canonical lookup via catalog_provider_id (e.g.
-        // "xiaomi-token-plan-sgp") when the raw config name didn't match.
-        if model.context_limit.is_none() {
-            if let Some(ref catalog_id) = self.metadata.catalog_provider_id {
-                model = model.with_catalog_provider_fallback(catalog_id);
-            }
+        // 1. Try the explicit `catalog_provider_id` first.  This is the
+        //    user-configured, authoritative source (e.g. "openrouter").
+        //    Must run *before* `with_canonical_limits` because that method's
+        //    inference path can match by model name alone (stripping prefixes
+        //    like "anthropic/" and inferring the provider), which would set
+        //    context_limit and block this lookup via the `is_none()` guard.
+        if let Some(ref catalog_id) = self.metadata.catalog_provider_id {
+            model = model.with_catalog_provider_fallback(catalog_id);
         }
 
+        // 2. Fall back to canonical limits from the raw provider name.
+        //    Internally guarded by `is_none()`, so won't override a value
+        //    already set by the catalog lookup above.
+        model = model.with_canonical_limits(&self.metadata.name);
+
+        // 3. Fall back to known_models metadata (e.g. desktop UI inventory).
         if model.context_limit.is_none() {
             if let Some(info) = self
                 .metadata

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -58,22 +58,9 @@ impl ProviderEntry {
     }
 
     fn normalize_model_config(&self, mut model: ModelConfig) -> ModelConfig {
-        // 1. Try the explicit `catalog_provider_id` first.  This is the
-        //    user-configured, authoritative source (e.g. "openrouter").
-        //    Must run *before* `with_canonical_limits` because that method's
-        //    inference path can match by model name alone (stripping prefixes
-        //    like "anthropic/" and inferring the provider), which would set
-        //    context_limit and block this lookup via the `is_none()` guard.
-        if let Some(ref catalog_id) = self.metadata.catalog_provider_id {
-            model = model.with_catalog_provider_fallback(catalog_id);
-        }
-
-        // 2. Fall back to canonical limits from the raw provider name.
-        //    Internally guarded by `is_none()`, so won't override a value
-        //    already set by the catalog lookup above.
-        model = model.with_canonical_limits(&self.metadata.name);
-
-        // 3. Fall back to known_models metadata (e.g. desktop UI inventory).
+        // 1. Check known_models metadata first for explicit per-model limits
+        //    (e.g. custom provider JSON with per-model context_limit values).
+        //    These are the most specific and should take highest priority.
         if model.context_limit.is_none() {
             if let Some(info) = self
                 .metadata
@@ -84,6 +71,18 @@ impl ProviderEntry {
                 model.context_limit = Some(info.context_limit);
             }
         }
+
+        // 2. Try the explicit catalog_provider_id (e.g. "openrouter").
+        //    Internally guarded: only overrides when context_limit is unset or
+        //    still equals the 0 sentinel from create_custom_provider.
+        if let Some(ref catalog_id) = self.metadata.catalog_provider_id {
+            model = model.with_catalog_provider_fallback(catalog_id);
+        }
+
+        // 3. Fall back to canonical limits from the raw provider name.
+        //    Internally guarded by is_none(), so won't override a value
+        //    already set by steps 1 or 2.
+        model = model.with_canonical_limits(&self.metadata.name);
 
         model
     }

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -1,7 +1,7 @@
 use super::base::{ConfigKey, ModelInfo, Provider, ProviderDef, ProviderMetadata, ProviderType};
 use super::inventory::InventoryIdentityInput;
 use crate::config::{DeclarativeProviderConfig, ExtensionConfig};
-use crate::model::ModelConfig;
+use crate::model::{ModelConfig, DEFAULT_CONTEXT_LIMIT};
 use anyhow::Result;
 use futures::future::BoxFuture;
 use std::collections::HashMap;
@@ -59,14 +59,24 @@ impl ProviderEntry {
 
     fn normalize_model_config(&self, mut model: ModelConfig) -> ModelConfig {
         // 1. Check known_models metadata first for explicit per-model limits
-        //    (e.g. custom provider JSON with per-model context_limit values).
-        //    These are the most specific and should take highest priority.
+        //    (e.g. custom provider JSON with per-model context_limit values,
+        //    or desktop UI inventory entries).
+        //
+        //    Skip entries that use the old 128000 placeholder when the provider
+        //    has a catalog_provider_id — those are stale artifacts from the
+        //    previous create_custom_provider code and should be overridden by
+        //    the catalog lookup in step 2.
         if model.context_limit.is_none() {
             if let Some(info) = self
                 .metadata
                 .known_models
                 .iter()
-                .find(|m| m.name.eq_ignore_ascii_case(&model.model_name) && m.context_limit > 0)
+                .find(|m| {
+                    m.name.eq_ignore_ascii_case(&model.model_name)
+                        && m.context_limit > 0
+                        && !(self.metadata.catalog_provider_id.is_some()
+                            && m.context_limit == DEFAULT_CONTEXT_LIMIT)
+                })
             {
                 model.context_limit = Some(info.context_limit);
             }

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -86,10 +86,11 @@ impl ProviderEntry {
         }
 
         // 2. Try the explicit catalog_provider_id (e.g. "openrouter").
-        //    The catalog is authoritative: always overrides context_limit
-        //    when it has a match, even if a positive value was already set
-        //    by known_models above.  Positive values from the desktop model
-        // picker can be stale (see PR #9580 review r3349258028).
+        //    Only overrides when context_limit is unset or still the 0
+        //    sentinel.  A positive value from known_models or GOOSE_CONTEXT_LIMIT
+        //    is treated as an explicit override and preserved.  Stale picker
+        //    values are corrected at the source (get_provider_models /
+        //    resolve_provider_model_info now apply catalog lookup).
         if let Some(ref catalog_id) = self.metadata.catalog_provider_id {
             model = model.with_catalog_provider_fallback(catalog_id);
         }

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -71,8 +71,9 @@ impl ProviderEntry {
         //
         //    Skip entries that use the old 128000 placeholder when the provider
         //    has a catalog_provider_id — those are stale artifacts from the
-        //    previous create_custom_provider code and should be overridden by
-        //    the catalog lookup in step 2.
+        //    previous create_custom_provider code.  (The catalog in step 2
+        //    would override them anyway, but skipping avoids a pointless
+        //    set-then-override cycle.)
         if model.context_limit.is_none() {
             if let Some(info) = self.metadata.known_models.iter().find(|m| {
                 m.name.eq_ignore_ascii_case(&model.model_name)
@@ -85,8 +86,10 @@ impl ProviderEntry {
         }
 
         // 2. Try the explicit catalog_provider_id (e.g. "openrouter").
-        //    Internally guarded: only overrides when context_limit is unset or
-        //    still equals the 0 sentinel from create_custom_provider.
+        //    The catalog is authoritative: always overrides context_limit
+        //    when it has a match, even if a positive value was already set
+        //    by known_models above.  Positive values from the desktop model
+        // picker can be stale (see PR #9580 review r3349258028).
         if let Some(ref catalog_id) = self.metadata.catalog_provider_id {
             model = model.with_catalog_provider_fallback(catalog_id);
         }

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -67,17 +67,12 @@ impl ProviderEntry {
         //    previous create_custom_provider code and should be overridden by
         //    the catalog lookup in step 2.
         if model.context_limit.is_none() {
-            if let Some(info) = self
-                .metadata
-                .known_models
-                .iter()
-                .find(|m| {
-                    m.name.eq_ignore_ascii_case(&model.model_name)
-                        && m.context_limit > 0
-                        && !(self.metadata.catalog_provider_id.is_some()
-                            && m.context_limit == DEFAULT_CONTEXT_LIMIT)
-                })
-            {
+            if let Some(info) = self.metadata.known_models.iter().find(|m| {
+                m.name.eq_ignore_ascii_case(&model.model_name)
+                    && m.context_limit > 0
+                    && !(self.metadata.catalog_provider_id.is_some()
+                        && m.context_limit == DEFAULT_CONTEXT_LIMIT)
+            }) {
                 model.context_limit = Some(info.context_limit);
             }
         }

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -375,6 +375,7 @@ mod tests {
                     config_keys: vec![],
                     setup_steps: vec![],
                     model_selection_hint: None,
+                    catalog_provider_id: None,
                 }
             }
 
@@ -544,6 +545,7 @@ mod tests {
                     config_keys: vec![],
                     setup_steps: vec![],
                     model_selection_hint: None,
+                    catalog_provider_id: None,
                 }
             }
 
@@ -897,6 +899,7 @@ mod tests {
                     config_keys: vec![],
                     setup_steps: vec![],
                     model_selection_hint: None,
+                    catalog_provider_id: None,
                 }
             }
 
@@ -1167,6 +1170,7 @@ mod tests {
                     config_keys: vec![],
                     setup_steps: vec![],
                     model_selection_hint: None,
+                    catalog_provider_id: None,
                 }
             }
 

--- a/crates/goose/tests/compaction.rs
+++ b/crates/goose/tests/compaction.rs
@@ -193,6 +193,7 @@ impl ProviderDef for MockCompactionProvider {
             config_keys: vec![],
             setup_steps: vec![],
             model_selection_hint: None,
+            catalog_provider_id: None,
         }
     }
 

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -6720,8 +6720,7 @@
         "type": "object",
         "description": "Information about a model's capabilities",
         "required": [
-          "name",
-          "context_limit"
+          "name"
         ],
         "properties": {
           "context_limit": {

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -7155,6 +7155,11 @@
           "config_keys"
         ],
         "properties": {
+          "catalog_provider_id": {
+            "type": "string",
+            "description": "Provider ID used in the canonical model registry (e.g. \"xiaomi-token-plan-sgp\").\nWhen set, used as a fallback for resolving context limits from canonical data.",
+            "nullable": true
+          },
           "config_keys": {
             "type": "array",
             "items": {

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -989,6 +989,11 @@ export type ProviderEngine = 'openai' | 'ollama' | 'anthropic';
  */
 export type ProviderMetadata = {
     /**
+     * Provider ID used in the canonical model registry (e.g. "xiaomi-token-plan-sgp").
+     * When set, used as a fallback for resolving context limits from canonical data.
+     */
+    catalog_provider_id?: string | null;
+    /**
      * Required configuration keys
      */
     config_keys: Array<ConfigKey>;

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -818,7 +818,7 @@ export type ModelInfo = {
     /**
      * The maximum context length this model supports
      */
-    context_limit: number;
+    context_limit?: number;
     /**
      * Currency for the costs (default: "$")
      */


### PR DESCRIPTION
## Problem

Custom providers with a `catalog_provider_id` (e.g. `"xiaomi-token-plan-sgp"`) always show the **128k** context limit, even when the canonical model registry has the correct value (e.g. 1M for `mimo-v2.5-pro`).

The root cause has two layers:

1. **`create_custom_provider`** hardcodes `ModelInfo::new(name, 128_000)` for every model — the user never inputs a context limit. ([declarative_providers.rs:295](crates/goose/src/config/declarative_providers.rs#L295))
2. **`normalize_model_config`** calls `with_canonical_limits(&self.metadata.name)` using the raw config name (e.g. `custom_xiaomi_token_plan__sgp`), but canonical models are registered under `catalog_provider_id` (e.g. `xiaomi-token-plan-sgp`). The lookup always fails → falls back to the hardcoded 128k.

The canonical data in `canonical_models.json` **already has the correct value**:
```json
{ "id": "xiaomi-token-plan-sgp/mimo-v2.5-pro", "limit": { "context": 1048576 } }
```

Fixes #8780

## Solution

Add a `catalog_provider_id` fallback path through the provider registry:

| File | Change |
|------|--------|
| `model.rs` | New `ModelConfig::with_catalog_provider_fallback(catalog_provider_id)` — tries canonical lookup via the catalog ID when the raw provider name already failed |
| `base.rs` | Add `catalog_provider_id: Option<String>` to `ProviderMetadata` |
| `provider_registry.rs` | Pass `catalog_provider_id` from `DeclarativeProviderConfig` into metadata; call the fallback in `normalize_model_config` when `context_limit` is still `None` |

**Lookup order after the fix:**
1. `with_canonical_limits(raw_provider_name)` — existing path
2. `with_catalog_provider_fallback(catalog_provider_id)` — **new fallback**
3. `known_models` from the JSON config file
4. `DEFAULT_CONTEXT_LIMIT` (128k)

## Tests

4 new tests (TDD — all written as failing tests first):

| Test | File | What it proves |
|------|------|----------------|
| `catalog_provider_id_fallback_resolves_context_limit` | `model.rs` | Raw name returns `None`, fallback resolves `1_048_576` |
| `catalog_provider_id_fallback_does_not_override_existing_limit` | `model.rs` | Existing limit is preserved |
| `catalog_provider_id_fallback_unknown_id_is_noop` | `model.rs` | Unknown catalog ID returns `None` |
| `test_catalog_provider_id_resolves_canonical_context_limit` | `init.rs` | End-to-end: custom provider JSON with 128k → runtime resolves 1M |

**Test results:** 1427 passed (+4 new), 99 failed (all pre-existing sqlx runtime issues on clean `main`), 0 regressions.

## Verification

Stress-tested the actual API at all sizes up to 1M — confirmed the model accepts 946k+ prompt tokens.