### PR TITLE
feat: forward images through delegate to subagents

### DIFF
--- a/crates/goose/src/agents/platform_extensions/summon.rs
+++ b/crates/goose/src/agents/platform_extensions/summon.rs
@@ -21,7 +21,7 @@ use rmcp::model::{
     CallToolResult, Content, Implementation, InitializeResult, JsonObject, ListToolsResult, Meta,
     ServerCapabilities, ServerNotification, Tool,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
@@ -48,6 +48,14 @@ fn kind_plural(kind: SourceType) -> &'static str {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ImageContentData {
+    /// Base64-encoded image data
+    pub data: String,
+    /// MIME type of the image, e.g. "image/png"
+    pub mime_type: String,
+}
+
 #[derive(Debug, Default, Deserialize)]
 pub struct DelegateParams {
     pub instructions: Option<String>,
@@ -60,6 +68,9 @@ pub struct DelegateParams {
     pub max_turns: Option<usize>,
     #[serde(default)]
     pub r#async: bool,
+    /// Images to forward to the subagent
+    #[serde(default)]
+    pub images: Option<Vec<ImageContentData>>,
 }
 
 pub struct BackgroundTask {
@@ -538,6 +549,18 @@ impl SummonClient {
                     "type": "boolean",
                     "default": false,
                     "description": "Run in background (default: false)."
+                },
+                "images": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "data": {"type": "string"},
+                            "mime_type": {"type": "string"}
+                        },
+                        "required": ["data", "mime_type"]
+                    },
+                    "description": "Images to forward to the subagent. Each image needs a base64-encoded data string and mime_type. Omit if no images to forward."
                 }
             }
         });
@@ -1122,6 +1145,7 @@ impl SummonClient {
             cancellation_token: Some(cancellation_token),
             on_message: None,
             notification_tx: Some(notif_tx),
+            images: params.images.clone().unwrap_or_default(),
         })
         .await;
 
@@ -1642,6 +1666,7 @@ impl SummonClient {
                 cancellation_token: Some(task_token_clone),
                 on_message: Some(on_message),
                 notification_tx: Some(notif_tx),
+                images: params.images.clone().unwrap_or_default(),
             })
             .await
         });
@@ -1820,6 +1845,7 @@ impl McpClientTrait for SummonClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use serial_test::serial;
     use std::collections::{HashMap, HashSet};
     use std::fs;
@@ -2489,5 +2515,23 @@ You review code."#;
             .lock()
             .await
             .contains_key("20260204_1"));
+    }
+
+    #[test]
+    fn delegate_tool_schema_includes_images_property() {
+        let client = SummonClient::new(create_test_context()).unwrap();
+        let tool = client.create_delegate_tool();
+
+        let schema = &tool.input_schema;
+        let properties = schema
+            .get("properties")
+            .expect("schema should have properties");
+        assert!(
+            properties.get("images").is_some(),
+            "delegate tool schema must include 'images' property"
+        );
+
+        let images_prop = properties.get("images").unwrap();
+        assert_eq!(images_prop.get("type").unwrap(), "array");
     }
 }

--- a/crates/goose/src/agents/subagent_handler.rs
+++ b/crates/goose/src/agents/subagent_handler.rs
@@ -43,6 +43,8 @@ pub struct SubagentRunParams {
     pub cancellation_token: Option<CancellationToken>,
     pub on_message: Option<OnMessageCallback>,
     pub notification_tx: Option<tokio::sync::mpsc::UnboundedSender<ServerNotification>>,
+    /// Images to forward to the subagent's initial user message
+    pub images: Vec<crate::agents::platform_extensions::summon::ImageContentData>,
 }
 
 pub async fn run_subagent_task(params: SubagentRunParams) -> Result<String, anyhow::Error> {
@@ -129,7 +131,8 @@ fn get_agent_messages(params: SubagentRunParams) -> AgentMessagesFuture {
             cancellation_token,
             on_message,
             notification_tx,
-            ..
+            return_last_only: _,
+            images,
         } = params;
 
         let system_instructions = recipe.instructions.clone().unwrap_or_default();
@@ -164,7 +167,10 @@ fn get_agent_messages(params: SubagentRunParams) -> AgentMessagesFuture {
             build_subagent_prompt(&agent, &task_config, &session_id, system_instructions).await?;
         agent.override_system_prompt(subagent_prompt).await;
 
-        let user_message = Message::user().with_text(user_task);
+        let mut user_message = Message::user().with_text(user_task);
+        for img in &images {
+            user_message = user_message.with_image(img.data.clone(), img.mime_type.clone());
+        }
         let mut conversation = Conversation::new_unvalidated(vec![user_message.clone()]);
 
         if let Some(activities) = recipe.activities {
@@ -342,5 +348,39 @@ mod tests {
     fn create_tool_notification_ignores_non_tool_request() {
         let content = MessageContent::text("hello");
         assert!(create_tool_notification(&content, "session_1").is_none());
+    }
+
+    #[test]
+    fn user_message_includes_delegate_images() {
+        use super::super::platform_extensions::summon::ImageContentData;
+        use crate::conversation::message::Message;
+
+        let images = vec![
+            ImageContentData {
+                data: "iVBORw0KGgo=".to_string(),
+                mime_type: "image/png".to_string(),
+            },
+            ImageContentData {
+                data: "/9j/4AAQ".to_string(),
+                mime_type: "image/jpeg".to_string(),
+            },
+        ];
+
+        let mut user_message = Message::user().with_text("describe these images");
+        for img in &images {
+            user_message = user_message.with_image(img.data.clone(), img.mime_type.clone());
+        }
+
+        assert_eq!(user_message.content.len(), 3);
+
+        use crate::conversation::message::MessageContent;
+        match &user_message.content[1] {
+            MessageContent::Image(img) => assert_eq!(img.mime_type, "image/png"),
+            other => panic!("expected Image, got {:?}", other),
+        }
+        match &user_message.content[2] {
+            MessageContent::Image(img) => assert_eq!(img.mime_type, "image/jpeg"),
+            other => panic!("expected Image, got {:?}", other),
+        }
     }
 }

--- a/crates/goose/tests/delegate_image_forwarding_test.rs
+++ b/crates/goose/tests/delegate_image_forwarding_test.rs
@@ -1,0 +1,77 @@
+/// Test: DelegateParams must deserialize an images array from JSON.
+/// This is the core contract — the delegate tool receives images from the LLM.
+#[test]
+fn delegate_params_deserializes_images_array() {
+    let json = r#"{
+        "instructions": "describe this image",
+        "images": [
+            { "data": "iVBORw0KGgo=", "mime_type": "image/png" }
+        ]
+    }"#;
+
+    let params: goose::agents::platform_extensions::summon::DelegateParams =
+        serde_json::from_str(json).expect("deserialization should succeed");
+
+    let images = params.images.as_ref().expect("images should be Some");
+    assert_eq!(images.len(), 1);
+    assert_eq!(images[0].data, "iVBORw0KGgo=");
+    assert_eq!(images[0].mime_type, "image/png");
+}
+
+/// Test: DelegateParams defaults images to empty vec when omitted.
+/// Backward compatibility — existing callers don't send images.
+#[test]
+fn delegate_params_defaults_images_to_empty() {
+    let json = r#"{
+        "instructions": "do something"
+    }"#;
+
+    let params: goose::agents::platform_extensions::summon::DelegateParams =
+        serde_json::from_str(json).expect("deserialization should succeed");
+
+    assert!(params.images.is_none());
+}
+
+/// Test: DelegateParams supports multiple images.
+#[test]
+fn delegate_params_deserializes_multiple_images() {
+    let json = r#"{
+        "images": [
+            { "data": "aaa", "mime_type": "image/png" },
+            { "data": "bbb", "mime_type": "image/jpeg" },
+            { "data": "ccc", "mime_type": "image/webp" }
+        ]
+    }"#;
+
+    let params: goose::agents::platform_extensions::summon::DelegateParams =
+        serde_json::from_str(json).expect("deserialization should succeed");
+
+    let images = params.images.as_ref().expect("images should be Some");
+    assert_eq!(images.len(), 3);
+    assert_eq!(images[1].mime_type, "image/jpeg");
+}
+
+/// Test: Message::with_image produces ImageContent on the message.
+/// This is the building block — images get attached to the subagent's user message.
+#[test]
+fn message_builder_with_image_creates_image_content() {
+    use goose::conversation::message::{Message, MessageContent};
+
+    let msg = Message::user()
+        .with_text("describe this")
+        .with_image("base64data", "image/png");
+
+    assert_eq!(msg.content.len(), 2);
+
+    match &msg.content[0] {
+        MessageContent::Text(t) => assert_eq!(t.text, "describe this"),
+        other => panic!("expected Text, got {:?}", other),
+    }
+
+    match &msg.content[1] {
+        MessageContent::Image(img) => {
+            assert_eq!(img.mime_type, "image/png");
+        }
+        other => panic!("expected Image, got {:?}", other),
+    }
+}


### PR DESCRIPTION
## Problem

The `delegate` tool only forwards text instructions to subagents. Any images attached by the user (pasted screenshots, file-path images) are silently dropped. This makes vision-capable subagent models (e.g. `mimo-v2.5`) unable to analyze images when invoked via delegate.

**Use case:** Run `mimo-v2.5-pro` (text-only) as main session model, with `mimo-v2.5` (vision) as delegate for image analysis tasks. Currently the images never reach the subagent.

## Root Cause

| Layer | Location | Problem |
|-------|----------|---------|
| `DelegateParams` | `summon.rs` | No `images` field |
| `SubagentRunParams` | `subagent_handler.rs` | No `images` field |
| `get_agent_messages` | `subagent_handler.rs` | `Message::user().with_text()` — no images attached |

## Changes

- **`summon.rs`**: Added `ImageContentData` struct + `images: Vec<ImageContentData>` on `DelegateParams`, wired through both sync and async `SubagentRunParams` constructions
- **`subagent_handler.rs`**: Added `images` to `SubagentRunParams`, forwarded onto the subagent initial user message via `Message::with_image()`
- **`delegate_image_forwarding_test.rs`**: 5 new tests (4 integration + 1 unit)

## Tests (TDD, all passing)

```
delegate_params_deserializes_images_array
delegate_params_defaults_images_to_empty
delegate_params_deserializes_multiple_images
message_builder_with_image_creates_image_content
user_message_includes_delegate_images
```

## Verification

- `cargo fmt` — clean
- `cargo clippy -p goose --lib -- -D warnings` — clean
- Pre-existing `LazyLock` test failures confirmed on `main` (unrelated)
