### PR TITLE
feat: add configurable legal disclaimer support for providers

### DIFF
--- a/crates/goose-cli/src/scenario_tests/scenario_runner.rs
+++ b/crates/goose-cli/src/scenario_tests/scenario_runner.rs
@@ -262,6 +262,7 @@ where
         None,
         None,
         "text".to_string(),
+        None,
     )
     .await;
 

--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -5,7 +5,7 @@ use super::CliSession;
 use console::style;
 use goose::agents::{Agent, Container, ExtensionError};
 use goose::config::resolve_extensions_for_new_session;
-use goose::config::{Config, ExtensionConfig, GooseMode};
+use goose::config::{get_provider_disclaimers, Config, ExtensionConfig, GooseMode};
 use goose::providers::create;
 use goose::recipe::Recipe;
 use goose::session::session_manager::SessionType;
@@ -596,6 +596,8 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
 
     let debug_mode = session_config.debug || config.get_param("GOOSE_DEBUG").unwrap_or(false);
 
+    let disclaimers = get_provider_disclaimers(&resolved.provider_name);
+
     let session = CliSession::new(
         Arc::try_unwrap(agent_ptr).unwrap_or_else(|_| panic!("There should be no more references")),
         session_id.clone(),
@@ -605,6 +607,7 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
         edit_mode,
         recipe.and_then(|r| r.retry.clone()),
         session_config.output_format.clone(),
+        disclaimers.response,
     )
     .await;
 
@@ -617,6 +620,9 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
             &resolved.model_name,
             &Some(session_id),
         );
+        if let Some(ref text) = disclaimers.startup {
+            output::display_disclaimer(text);
+        }
     }
     session
 }

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -172,6 +172,7 @@ pub struct CliSession {
     edit_mode: Option<EditMode>,
     retry_config: Option<RetryConfig>,
     output_format: String,
+    response_disclaimer: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -250,6 +251,7 @@ impl CliSession {
         edit_mode: Option<EditMode>,
         retry_config: Option<RetryConfig>,
         output_format: String,
+        response_disclaimer: Option<String>,
     ) -> Self {
         let messages = agent
             .config
@@ -271,6 +273,7 @@ impl CliSession {
             edit_mode,
             retry_config,
             output_format,
+            response_disclaimer,
         }
     }
 
@@ -710,6 +713,10 @@ impl CliSession {
                 let elapsed = start_time.elapsed();
                 let elapsed_str = format_elapsed_time(elapsed);
                 println!("{}", console::style(format!("  ⏱ {}", elapsed_str)).dim());
+
+                if let Some(ref disclaimer) = self.response_disclaimer {
+                    output::display_disclaimer(disclaimer);
+                }
             }
             RunMode::Plan => {
                 let mut plan_messages = self.messages.clone();
@@ -1128,6 +1135,14 @@ impl CliSession {
         let result = self
             .process_message(message, CancellationToken::default(), false)
             .await;
+
+        let is_json_mode = self.output_format == "json" || self.output_format == "stream-json";
+        if !is_json_mode {
+            if let Some(ref disclaimer) = self.response_disclaimer {
+                output::display_disclaimer(disclaimer);
+            }
+        }
+
         self.agent
             .emit_hook(goose::hooks::HookEvent::SessionEnd, &self.session_id)
             .await;

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -1349,6 +1349,16 @@ pub fn display_session_info(
     );
 }
 
+pub fn display_disclaimer(text: &str) {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+    for line in trimmed.lines() {
+        println!("  {}", style(line).yellow().dim());
+    }
+}
+
 fn set_terminal_title() {
     if !std::io::stdout().is_terminal() {
         return;

--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -104,6 +104,25 @@ pub struct DeclarativeProviderConfig {
     pub fast_model: Option<String>,
     #[serde(default)]
     pub preserves_thinking: bool,
+    #[serde(default, deserialize_with = "deserialize_non_empty_string")]
+    pub startup_disclaimer: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_non_empty_string")]
+    pub response_disclaimer: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DisclaimerConfig {
+    pub startup: Option<String>,
+    pub response: Option<String>,
+}
+
+pub fn get_provider_disclaimers(provider_name: &str) -> DisclaimerConfig {
+    load_provider(provider_name)
+        .map(|loaded| DisclaimerConfig {
+            startup: loaded.config.startup_disclaimer,
+            response: loaded.config.response_disclaimer,
+        })
+        .unwrap_or_default()
 }
 
 fn default_requires_auth() -> bool {
@@ -321,6 +340,8 @@ pub fn create_custom_provider(
         setup_steps: vec![],
         fast_model: None,
         preserves_thinking,
+        startup_disclaimer: None,
+        response_disclaimer: None,
     };
 
     let custom_providers_dir = custom_providers_dir();
@@ -401,6 +422,8 @@ pub fn update_custom_provider(params: UpdateCustomProviderParams) -> Result<()> 
             setup_steps: existing_config.setup_steps,
             fast_model: existing_config.fast_model.clone(),
             preserves_thinking,
+            startup_disclaimer: existing_config.startup_disclaimer,
+            response_disclaimer: existing_config.response_disclaimer,
         };
 
         let file_path = custom_provider_file_path(&updated_config.name)?;

--- a/crates/goose/src/config/mod.rs
+++ b/crates/goose/src/config/mod.rs
@@ -14,7 +14,9 @@ pub mod signup_tetrate;
 
 pub use crate::agents::ExtensionConfig;
 pub use base::{merge_config_values, Config, ConfigError};
-pub use declarative_providers::DeclarativeProviderConfig;
+pub use declarative_providers::{
+    get_provider_disclaimers, DeclarativeProviderConfig, DisclaimerConfig,
+};
 pub use experiments::ExperimentManager;
 pub use extensions::{
     get_all_extension_names, get_all_extensions, get_enabled_extensions, get_extension_by_name,

--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -443,6 +443,8 @@ mod tests {
             setup_steps: vec![],
             fast_model: None,
             preserves_thinking: false,
+            startup_disclaimer: None,
+            response_disclaimer: None,
         }
     }
 

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -1304,6 +1304,8 @@ mod tests {
             setup_steps: vec![],
             fast_model: None,
             preserves_thinking: false,
+            startup_disclaimer: None,
+            response_disclaimer: None,
         }
     }
 


### PR DESCRIPTION
## Feature purpose
Goose is increasingly adopted by organizations with legal and compliance requirements around AI-generated content. Today, any distributor needing to display legal disclaimers (e.g., warnings about AI accuracy, data privacy notices, or usage terms) must maintain source patches against the CLI output code — patches that break on every upstream update.

This change makes disclaimer messages a first-class, optional configuration in the existing custom provider JSON format. Distributors can define a startup disclaimer (shown once at session start) and a per-response disclaimer (shown after each AI response) without modifying any source code. When no disclaimers are configured, behavior is unchanged, preserving full backward compatibility.

## Implementation summary
Add optional `startup_disclaimer` and `response_disclaimer` fields to `DeclarativeProviderConfig`, allowing distributors to configure legal disclaimer messages through custom provider JSON configs without patching the source.

- `startup_disclaimer`: shown once after the session greeting
- `response_disclaimer`: shown after each agent response

When no disclaimers are configured, no messages are displayed, preserving full backward compatibility.

## Sample config for startup and response disclaimers
```
{
    "name": "custom_disclaimer",
    "engine": "openai",
    "display_name": "custom_disclaimer_demo",
    "description": "Required AI usage disclaimers",
    "api_key_env": "",
    "base_url": "http://127.0.0.1:7080",
    "base_path": "v1/chat/completions",
    "models": [
        {
            "name": "demo_model,
            "context_limit": 128000
        }
    ],
    "headers": {},
    "timeout_seconds": null,
    "supports_streaming": true,
    "requires_auth": true,
    "startup_disclaimer": "IMPORTANT: This tool uses AI technology.\nAI-generated output may be inaccurate or incomplete.\nDo not input personal or confidential data.",
    "response_disclaimer": "Always review AI-generated content prior to use."
}
```

## Example usage screenshot
<img width="444" height="243" alt="goose_screenshot" src="https://github.com/user-attachments/assets/c80e2501-41db-4aef-9dc8-6a0681713ef1" />

### Testing
The feature has been tested manually.