### PR TITLE
fix(codex,agent,review): surface provider failures instead of hiding them

### DIFF
--- a/crates/goose-cli/src/commands/review/orchestrator.rs
+++ b/crates/goose-cli/src/commands/review/orchestrator.rs
@@ -286,7 +286,43 @@ async fn run_subprocess_for_findings(
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Defense-in-depth: when the agent loop terminates because of a
+    // ProviderError it ought to propagate as a non-zero exit (see
+    // `process_agent_response` + `SystemNotificationType::ProviderError`),
+    // but if any error path slips through and leaves the rendered
+    // notification on stdout while exiting 0, surface a clear error
+    // here instead of feeding the English text into `parse_findings`
+    // and getting an inscrutable `parse check JSON: …` failure.
+    if let Some(err) = detect_provider_error_in_stdout(&stdout) {
+        anyhow::bail!("{label} hit a provider error: {err}");
+    }
+
     parse_findings(&stdout)
+}
+
+/// Heuristic for "the goose subprocess exited 0 but stdout is actually
+/// an agent error report, not findings JSON". Conservative on
+/// purpose: we only match the exact prefix the agent loop uses in
+/// [`crates/goose/src/agents/agent.rs`](../../../goose/src/agents/agent.rs)
+/// so a legitimate model response that happens to mention the phrase
+/// in passing isn't mis-classified. Returns the trimmed first line of
+/// the error, or `None` when the output looks like a normal response.
+fn detect_provider_error_in_stdout(stdout: &str) -> Option<String> {
+    const ERROR_PREFIX: &str = "Ran into this error:";
+    let trimmed = stdout.trim_start();
+    if !trimmed.starts_with(ERROR_PREFIX) {
+        return None;
+    }
+    // Stop at the standard retry-hint blank line so we don't drag the
+    // whole stdout into the error message.
+    let first_para = trimmed
+        .split("\n\n")
+        .next()
+        .unwrap_or(trimmed)
+        .trim()
+        .to_string();
+    Some(first_para)
 }
 
 /// Run the main correctness pass as N parallel subprocesses, one per
@@ -996,6 +1032,39 @@ mod tests {
         assert_eq!(Severity::from_str("critical").unwrap(), Severity::Critical);
         assert!(Severity::from_str("info").is_err());
         assert!(Severity::from_str("").is_err());
+    }
+
+    #[test]
+    fn detect_provider_error_in_stdout_matches_agent_prefix() {
+        // Exact prefix the agent loop emits when a provider call fails.
+        // We check `Some(_)` rather than the full first line so this
+        // doesn't have to track wording tweaks to the agent message.
+        let stdout = "Ran into this error: Request failed: Failed to write to stdin: Broken pipe (os error 32).\n\nPlease retry if you think this is a transient or recoverable error.";
+        let detected = detect_provider_error_in_stdout(stdout);
+        assert!(detected.is_some());
+        let msg = detected.unwrap();
+        assert!(msg.starts_with("Ran into this error:"));
+        // The post-blank-line "Please retry…" hint is dropped so the
+        // surfaced error stays compact.
+        assert!(!msg.contains("Please retry"));
+    }
+
+    #[test]
+    fn detect_provider_error_in_stdout_ignores_normal_responses() {
+        // Findings JSON — not an error.
+        assert!(detect_provider_error_in_stdout(r#"{"findings":[]}"#).is_none());
+        // Plain prose — not an error.
+        assert!(detect_provider_error_in_stdout("Here are the findings I spotted.").is_none());
+        // Empty stdout — not an error (caught elsewhere as parse failure).
+        assert!(detect_provider_error_in_stdout("").is_none());
+    }
+
+    #[test]
+    fn detect_provider_error_in_stdout_tolerates_leading_whitespace() {
+        // The agent rendering path adds a leading newline; make sure
+        // the detector still matches.
+        let stdout = "\n\nRan into this error: oh no.";
+        assert!(detect_provider_error_in_stdout(stdout).is_some());
     }
 
     #[test]

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -43,7 +43,9 @@ use rmcp::model::{ErrorCode, ErrorData};
 use strum::VariantNames;
 
 use goose::config::paths::Paths;
-use goose::conversation::message::{ActionRequiredData, Message, MessageContent};
+use goose::conversation::message::{
+    ActionRequiredData, Message, MessageContent, SystemNotificationType,
+};
 use rustyline::EditMode;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -1176,6 +1178,14 @@ impl CliSession {
         let mut markdown_buffer = streaming_buffer::MarkdownBuffer::new();
         let mut prompted_credits_urls: HashSet<String> = HashSet::new();
         let mut thinking_header_shown = false;
+        // Captures a `ProviderError` SystemNotification emitted by the
+        // agent loop (e.g. an LLM subprocess died, auth failed). In
+        // non-interactive mode we use this to return Err from this
+        // function so `goose run` exits non-zero — without it,
+        // downstream consumers (the review orchestrator, scripts that
+        // pipe `goose run` output into a parser) silently feed the
+        // English error text into whatever expected structured output.
+        let mut provider_error_msg: Option<String> = None;
 
         use futures::StreamExt;
         loop {
@@ -1292,6 +1302,10 @@ impl CliSession {
                                         &mut prompted_credits_urls,
                                     );
                                 }
+
+                                if let Some(err_msg) = find_provider_error(&message) {
+                                    provider_error_msg = Some(err_msg);
+                                }
                             }
                         }
                         Some(Ok(AgentEvent::McpNotification((extension_id, notification)))) => {
@@ -1390,6 +1404,16 @@ impl CliSession {
             });
         } else {
             println!();
+        }
+
+        // Surface a provider-side failure to non-interactive callers
+        // (`goose run`, the review orchestrator) as a non-zero exit.
+        // Interactive sessions keep going — the user already saw the
+        // rendered notification and can decide to retry or quit.
+        if !interactive {
+            if let Some(msg) = provider_error_msg {
+                return Err(anyhow::anyhow!(msg));
+            }
         }
 
         Ok(())
@@ -1802,6 +1826,20 @@ fn find_tool_confirmation(message: &Message) -> Option<(String, Option<String>)>
         if let MessageContent::ActionRequired(action) = content {
             if let ActionRequiredData::ToolConfirmation { id, prompt, .. } = &action.data {
                 return Some((id.clone(), prompt.clone()));
+            }
+        }
+        None
+    })
+}
+
+/// Find a `ProviderError` SystemNotification on the message, if any,
+/// and return its `msg` text. Used by [`process_agent_response`] to
+/// propagate provider failures as a non-zero exit in headless mode.
+fn find_provider_error(message: &Message) -> Option<String> {
+    message.content.iter().find_map(|content| {
+        if let MessageContent::SystemNotification(notification) = content {
+            if notification.notification_type == SystemNotificationType::ProviderError {
+                return Some(notification.msg.clone());
             }
         }
         None

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -258,6 +258,10 @@ pub fn render_message(message: &Message, debug: bool) {
                     SystemNotificationType::CreditsExhausted => {
                         render_credits_exhausted_notification(notification);
                     }
+                    SystemNotificationType::ProviderError => {
+                        hide_thinking();
+                        eprintln!("\n{}", style(&notification.msg).yellow());
+                    }
                 }
             }
             _ => {
@@ -341,6 +345,11 @@ pub fn render_message_streaming(
                     SystemNotificationType::CreditsExhausted => {
                         flush_markdown_buffer(buffer, theme);
                         render_credits_exhausted_notification(notification);
+                    }
+                    SystemNotificationType::ProviderError => {
+                        flush_markdown_buffer(buffer, theme);
+                        hide_thinking();
+                        eprintln!("\n{}", style(&notification.msg).yellow());
                     }
                 }
             }

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2203,9 +2203,14 @@ impl Agent {
                             #[cfg(feature = "telemetry")]
                             crate::posthog::emit_error(provider_err.telemetry_type(), &provider_err.to_string());
                             error!("Error: {}", provider_err);
+                            let notification_data = serde_json::json!({
+                                "telemetry_type": provider_err.telemetry_type(),
+                            });
                             yield AgentEvent::Message(
-                                Message::assistant().with_text(
-                                    format!("Ran into this error: {provider_err}.\n\nPlease retry if you think this is a transient or recoverable error.")
+                                Message::assistant().with_system_notification_with_data(
+                                    SystemNotificationType::ProviderError,
+                                    format!("Ran into this error: {provider_err}.\n\nPlease retry if you think this is a transient or recoverable error."),
+                                    notification_data,
                                 )
                             );
                             break;

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2203,15 +2203,19 @@ impl Agent {
                             #[cfg(feature = "telemetry")]
                             crate::posthog::emit_error(provider_err.telemetry_type(), &provider_err.to_string());
                             error!("Error: {}", provider_err);
+                            let user_msg = format!("Ran into this error: {provider_err}.\n\nPlease retry if you think this is a transient or recoverable error.");
                             let notification_data = serde_json::json!({
                                 "telemetry_type": provider_err.telemetry_type(),
                             });
                             yield AgentEvent::Message(
                                 Message::assistant().with_system_notification_with_data(
                                     SystemNotificationType::ProviderError,
-                                    format!("Ran into this error: {provider_err}.\n\nPlease retry if you think this is a transient or recoverable error."),
+                                    user_msg.clone(),
                                     notification_data,
                                 )
+                            );
+                            yield AgentEvent::Message(
+                                Message::assistant().with_text(user_msg)
                             );
                             break;
                         }

--- a/crates/goose/src/conversation/message.rs
+++ b/crates/goose/src/conversation/message.rs
@@ -246,6 +246,16 @@ pub enum SystemNotificationType {
     ThinkingMessage,
     InlineMessage,
     CreditsExhausted,
+    /// The agent loop terminated because the provider returned an error
+    /// (e.g. subprocess died, auth failed, transient API error). Carries
+    /// the same human-readable text we used to emit as an assistant
+    /// `with_text(...)` message, but as a notification so headless
+    /// consumers (`goose run`, the review orchestrator) can detect the
+    /// failure and surface a non-zero exit instead of feeding the
+    /// error text into a JSON parser. `data` carries the
+    /// `ProviderError::telemetry_type()` slug so programmatic consumers
+    /// can branch without re-parsing the message.
+    ProviderError,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]

--- a/crates/goose/src/providers/codex.rs
+++ b/crates/goose/src/providers/codex.rs
@@ -210,22 +210,14 @@ impl CodexProvider {
             ))
         })?;
 
-        // Write prompt to stdin
-        if let Some(mut stdin) = child.stdin.take() {
-            use tokio::io::AsyncWriteExt;
-            stdin.write_all(prompt.as_bytes()).await.map_err(|e| {
-                ProviderError::RequestFailed(format!("Failed to write to stdin: {}", e))
-            })?;
-            // Close stdin to signal end of input
-            drop(stdin);
-        }
-
-        let stdout = child
-            .stdout
-            .take()
-            .ok_or_else(|| ProviderError::RequestFailed("Failed to capture stdout".to_string()))?;
-
-        // Drain stderr concurrently to prevent pipe buffer deadlock
+        // Drain stderr concurrently to prevent pipe buffer deadlock.
+        // This MUST happen before we try to write to stdin: if the codex
+        // CLI exits early (auth failure, bad flag, panic, OpenAI 401 /
+        // rate-limit), its stderr is the only signal we have for *why*,
+        // and the write_all below will fail with EPIPE before we ever
+        // reach the wait/stderr-collect path. Spawning the stderr drain
+        // up front lets us recover that diagnostic and attach it to the
+        // ProviderError instead of dropping it on the floor.
         let stderr_handle = {
             let stderr = child.stderr.take();
             tokio::spawn(async move {
@@ -237,6 +229,26 @@ impl CodexProvider {
                 output
             })
         };
+
+        // Write prompt to stdin
+        if let Some(mut stdin) = child.stdin.take() {
+            use tokio::io::AsyncWriteExt;
+            if let Err(write_err) = stdin.write_all(prompt.as_bytes()).await {
+                // Codex exited (or closed stdin) before we finished
+                // writing the prompt. Collect whatever exit status and
+                // stderr we can to surface the actual cause to the
+                // caller, then drop the error in a single message.
+                drop(stdin);
+                return Err(diagnose_early_exit(child, stderr_handle, write_err).await);
+            }
+            // Close stdin to signal end of input
+            drop(stdin);
+        }
+
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| ProviderError::RequestFailed("Failed to capture stdout".to_string()))?;
 
         let mut reader = BufReader::new(stdout);
         let mut lines = Vec::new();
@@ -441,6 +453,81 @@ impl CodexProvider {
 
         Ok((message, usage))
     }
+}
+
+/// Build a rich [`ProviderError`] for the case where the codex CLI
+/// exited before we finished writing the prompt to its stdin. We
+/// bound how long we wait on the child / stderr drain so a wedged
+/// codex process can't hang the whole agent loop.
+#[allow(clippy::string_slice)] // Manual UTF-8 boundary walk for the stderr cap.
+async fn diagnose_early_exit(
+    mut child: tokio::process::Child,
+    stderr_handle: tokio::task::JoinHandle<String>,
+    write_err: std::io::Error,
+) -> ProviderError {
+    // The child has either exited or closed stdin. Either way we want
+    // its exit status and stderr, but with a cap — if the process is
+    // genuinely wedged (rare, but possible if stdin closed without
+    // exiting), we still want to surface a useful error promptly
+    // rather than blocking forever.
+    const EARLY_EXIT_WAIT: std::time::Duration = std::time::Duration::from_secs(5);
+
+    let exit_status = match tokio::time::timeout(EARLY_EXIT_WAIT, child.wait()).await {
+        Ok(Ok(status)) => Some(status),
+        Ok(Err(_)) => None,
+        Err(_) => {
+            // Child didn't exit in time — kill it so we don't leak.
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            None
+        }
+    };
+
+    let stderr_text = match tokio::time::timeout(EARLY_EXIT_WAIT, stderr_handle).await {
+        Ok(Ok(s)) => s,
+        _ => String::new(),
+    };
+    let stderr_trimmed = stderr_text.trim();
+
+    let mut msg = format!(
+        "Codex CLI exited before reading prompt from stdin ({}).",
+        write_err
+    );
+    if let Some(status) = exit_status {
+        if let Some(code) = status.code() {
+            msg.push_str(&format!(" Exit code: {}.", code));
+        } else {
+            msg.push_str(&format!(" Exit status: {}.", status));
+        }
+    } else {
+        msg.push_str(" Exit status: unavailable.");
+    }
+    if !stderr_trimmed.is_empty() {
+        // Cap stderr so a chatty codex panic doesn't blow the error
+        // message size out (and downstream into LD config / Datadog
+        // tags, etc.). Walk back to a char boundary so non-ASCII
+        // codex output (panic messages, file paths) doesn't panic
+        // the slice.
+        const STDERR_CAP: usize = 2048;
+        let snippet = if stderr_trimmed.len() > STDERR_CAP {
+            let mut cut = STDERR_CAP;
+            while cut > 0 && !stderr_trimmed.is_char_boundary(cut) {
+                cut -= 1;
+            }
+            format!(
+                "{}…[truncated {} bytes]",
+                &stderr_trimmed[..cut],
+                stderr_trimmed.len() - cut
+            )
+        } else {
+            stderr_trimmed.to_string()
+        };
+        msg.push_str("\nCodex stderr:\n");
+        msg.push_str(&snippet);
+    } else {
+        msg.push_str(" Codex stderr was empty.");
+    }
+    ProviderError::RequestFailed(msg)
 }
 
 /// Builds the text prompt and extracts images to temp files in a single pass.
@@ -1327,5 +1414,52 @@ mod tests {
             .map(|a| a.to_str().unwrap())
             .collect();
         assert_eq!(args, expected);
+    }
+
+    /// Simulates the broken-pipe path: spawn a tiny child that prints
+    /// a recognizable line on stderr and exits immediately, then ask
+    /// `diagnose_early_exit` to format the error. The expectation is
+    /// the resulting message includes the exit code AND the stderr
+    /// snippet — i.e. the diagnostic that the old code path silently
+    /// discarded is now surfaced to the caller.
+    #[tokio::test]
+    async fn diagnose_early_exit_includes_stderr_and_exit_code() {
+        use std::process::Stdio;
+        use tokio::io::AsyncReadExt;
+        let mut child = tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg("echo 'codex: invalid model gpt-5.5' 1>&2; exit 17")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn helper process");
+
+        let stderr = child.stderr.take();
+        let stderr_handle = tokio::spawn(async move {
+            let mut out = String::new();
+            if let Some(mut s) = stderr {
+                let _ = s.read_to_string(&mut out).await;
+            }
+            out
+        });
+
+        // Synthetic write error to plug into the function under test —
+        // matches what we'd see if a real `write_all` returned EPIPE.
+        let write_err =
+            std::io::Error::new(std::io::ErrorKind::BrokenPipe, "Broken pipe (os error 32)");
+
+        let err = diagnose_early_exit(child, stderr_handle, write_err).await;
+        let msg = err.to_string();
+
+        // Must mention the original write error, the exit code, and
+        // the stderr snippet — every piece of information the old
+        // path threw away.
+        assert!(msg.contains("Broken pipe"), "missing write error: {msg}");
+        assert!(msg.contains("Exit code: 17"), "missing exit code: {msg}");
+        assert!(
+            msg.contains("codex: invalid model gpt-5.5"),
+            "missing stderr snippet: {msg}"
+        );
     }
 }

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -8786,7 +8786,8 @@
         "enum": [
           "thinkingMessage",
           "inlineMessage",
-          "creditsExhausted"
+          "creditsExhausted",
+          "providerError"
         ]
       },
       "TaskSupport": {

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -1498,7 +1498,7 @@ export type SystemNotificationContent = {
     notificationType: SystemNotificationType;
 };
 
-export type SystemNotificationType = 'thinkingMessage' | 'inlineMessage' | 'creditsExhausted';
+export type SystemNotificationType = 'thinkingMessage' | 'inlineMessage' | 'creditsExhausted' | 'providerError';
 
 export type TaskSupport = 'forbidden' | 'optional' | 'required';
 


### PR DESCRIPTION
Three connected fixes for a silent failure mode that surfaces as the
inscrutable `parse check JSON: Ran into this error: Request failed:
Failed to write to stdin: Broken pipe (os error 32)` in `goose
review`. Reproduced twice against squareup/agents#3609 — the actual
root cause is the codex CLI exiting before reading its prompt, but
the diagnostic that would tell us *why* (auth failure, rate limit,
panic, bad flag) was discarded by `CodexProvider` and then the
formatted error was disguised as a model response by the agent loop.

## What was happening

```
goose review orchestrator
  → spawns `goose run --provider codex --model gpt-5.5`
    → CodexProvider spawns `codex exec ... -`, write_all(prompt) → EPIPE
      ❌ codex stderr captured but discarded (codex.rs:269)
    → ProviderError::RequestFailed("Failed to write to stdin: ...")
  → agent.rs catch-all wraps it as
      Message::assistant().with_text("Ran into this error: …")
    → goose run prints that text on stdout, exits 0
  → orchestrator.parse_findings(stdout) tries to JSON-parse English →
      "parse check JSON: Ran into this error: …"
```

## The three fixes

### 1. `crates/goose/src/providers/codex.rs` — keep codex's stderr

Spawn the stderr drain task **before** writing to stdin, and on
write failure call a new `diagnose_early_exit()` that bounds the
wait on child + stderr and attaches the exit code and a capped
stderr snippet to the returned `ProviderError`. Before this fix the
stderr drain was spawned *after* `write_all` and awaited only
after `child.wait()` — neither of which we reach when the write
fails, so the one piece of information that would diagnose every
broken-pipe failure was silently dropped.

### 2. `crates/goose/src/agents/agent.rs` + `conversation/message.rs` + `goose-cli/src/session/output.rs` — distinguish provider errors from model responses

Add `SystemNotificationType::ProviderError` and emit a notification
(carrying the `telemetry_type` slug in `data`) instead of an
assistant `with_text(...)` message. The two exhaustive matches in
`output.rs` get a new arm that renders the notification on stderr
in yellow (same visibility as `InlineMessage`).

### 3. `crates/goose-cli/src/session/mod.rs` + `commands/review/orchestrator.rs` — propagate the failure

`process_agent_response` detects the `ProviderError` notification
and, in **non-interactive** mode, returns `Err` so `goose run`
exits non-zero. Interactive sessions keep going — the user already
saw the rendered notification and can decide to retry.

As defense-in-depth for any agent-error path that still leaves
English text on stdout, the review orchestrator detects the exact
`"Ran into this error:"` prefix and bails with a clean
`"<label> hit a provider error: …"` message instead of feeding it
into `serde_json`.

## Before / after

**Before:**
```
parse check JSON: Ran into this error: Request failed: Failed to
write to stdin: Broken pipe (os error 32). Please retry if you
think this is a transient or recoverable error.
```

**After (illustrative — actual codex stderr will appear in real failures):**
```
main:foo.rs hit a provider error: Ran into this error: Request
failed: Codex CLI exited before reading prompt from stdin
(Broken pipe (os error 32)). Exit code: 1.
Codex stderr:
Error: Unauthorized (401): API key not found in ~/.codex/auth.json
```

## Tests

- `diagnose_early_exit_includes_stderr_and_exit_code` spawns a
  helper that writes a recognizable stderr line and exits 17,
  then asserts the synthesized error mentions the write error,
  the exit code, AND the stderr snippet — i.e. every piece of
  information the old path threw away.
- `detect_provider_error_in_stdout_{matches_agent_prefix, ignores_normal_responses, tolerates_leading_whitespace}` pins
  the orchestrator's heuristic to exactly the agent's prefix
  without mis-classifying ordinary model output.

## Validation

- `cargo test -p goose --lib providers::codex` — 52 passed
- `cargo test -p goose-cli --lib commands::review` — 43 passed
- `cargo test -p goose-cli --lib` — 250 passed (full goose-cli library tests)
- `cargo clippy --workspace --all-targets --no-deps` — clean
- `cargo fmt --all --check` — clean

(The repo's `--lib` tests for `goose` itself surface pre-existing
sqlx runtime-feature failures on plain `cargo test` invocations
unrelated to this PR; the same failures reproduce on
`upstream/main` without any changes applied.)

## Tracking

- Square-internal Linear: [AGNTOPS-194](https://linear.app/squareup/issue/AGNTOPS-194/upstream-goose-surface-codex-cli-early-exit-errors-instead-of-dropping)
