### PR TITLE
Add openapi feature flag

### DIFF
--- a/crates/goose-server/Cargo.toml
+++ b/crates/goose-server/Cargo.toml
@@ -19,9 +19,11 @@ default = [
     "telemetry",
     "nostr",
     "otel",
+    "openapi",
     "rustls-tls",
     "system-keyring",
 ]
+openapi = []
 code-mode = ["goose/code-mode"]
 local-inference = ["goose/local-inference"]
 aws-providers = ["goose/aws-providers"]
@@ -101,6 +103,7 @@ path = "src/main.rs"
 [[bin]]
 name = "generate_schema"
 path = "src/bin/generate_schema.rs"
+required-features = ["openapi"]
 
 [dev-dependencies]
 tower = { version = "0.5.2", default-features = false }

--- a/crates/goose-server/src/lib.rs
+++ b/crates/goose-server/src/lib.rs
@@ -7,6 +7,7 @@ compile_error!("Features `rustls-tls` and `native-tls` are mutually exclusive");
 pub mod auth;
 pub mod configuration;
 pub mod error;
+#[cfg(feature = "openapi")]
 pub mod openapi;
 pub mod routes;
 pub mod session_event_bus;
@@ -16,5 +17,6 @@ pub mod tls;
 pub mod tunnel;
 
 // Re-export commonly used items
+#[cfg(feature = "openapi")]
 pub use openapi::*;
 pub use state::*;

--- a/crates/goose-server/src/main.rs
+++ b/crates/goose-server/src/main.rs
@@ -2,6 +2,7 @@ mod commands;
 mod configuration;
 mod error;
 mod logging;
+#[cfg(feature = "openapi")]
 mod openapi;
 mod routes;
 mod session_event_bus;

--- a/crates/goose-server/src/routes/agent.rs
+++ b/crates/goose-server/src/routes/agent.rs
@@ -147,6 +147,7 @@ pub struct CallToolRequest {
 #[allow(dead_code)]
 pub enum ContentBlock {}
 
+#[cfg(feature = "openapi")]
 impl<'s> utoipa::ToSchema<'s> for ContentBlock {
     fn schema() -> (
         &'s str,


### PR DESCRIPTION
## Summary
Add a new `openapi` feature flag to allow packagers to build without the `openapi` module and the `generate_schema` binary, reducing package size.

### Testing
Tested building with and without the feature flag enabled.
```
> cargo build -p goose-server --no-default-features --features rustls-tls
```

Verified that the `generate_scheam` binary was not compiled.

### Related Issues
None


### Screenshots/Demos (for UX changes)
N/A

