### PR TITLE
fix(deepseek): Add V4 support with reasoning_content gating to assistant messages

### DIFF
--- a/crates/goose-server/src/routes/utils.rs
+++ b/crates/goose-server/src/routes/utils.rs
@@ -309,6 +309,7 @@ mod tests {
                 setup_steps: vec![],
                 fast_model: None,
                 preserves_thinking: false,
+                requires_reasoning_content_on_all_messages: false,
             },
             is_editable: false,
         };

--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -105,6 +105,9 @@ pub struct DeclarativeProviderConfig {
     pub fast_model: Option<String>,
     #[serde(default)]
     pub preserves_thinking: bool,
+    /// Always emit `reasoning_content` on assistant messages (even `""`); required by DeepSeek V4.
+    #[serde(default)]
+    pub requires_reasoning_content_on_all_messages: bool,
 }
 
 fn default_requires_auth() -> bool {
@@ -322,6 +325,7 @@ pub fn create_custom_provider(
         setup_steps: vec![],
         fast_model: None,
         preserves_thinking,
+        requires_reasoning_content_on_all_messages: false,
     };
 
     let custom_providers_dir = custom_providers_dir();
@@ -402,6 +406,8 @@ pub fn update_custom_provider(params: UpdateCustomProviderParams) -> Result<()> 
             setup_steps: existing_config.setup_steps,
             fast_model: existing_config.fast_model.clone(),
             preserves_thinking,
+            requires_reasoning_content_on_all_messages: existing_config
+                .requires_reasoning_content_on_all_messages,
         };
 
         let file_path = custom_provider_file_path(&updated_config.name)?;
@@ -720,6 +726,7 @@ mod tests {
             setup_steps: Vec::new(),
             fast_model: None,
             preserves_thinking: true,
+            requires_reasoning_content_on_all_messages: false,
         }
     }
 

--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -443,6 +443,7 @@ mod tests {
             setup_steps: vec![],
             fast_model: None,
             preserves_thinking: false,
+            requires_reasoning_content_on_all_messages: false,
         }
     }
 

--- a/crates/goose/src/providers/declarative/deepseek.json
+++ b/crates/goose/src/providers/declarative/deepseek.json
@@ -7,8 +7,24 @@
   "base_url": "https://api.deepseek.com",
   "models": [
     {
+      "name": "deepseek-v4-flash",
+      "context_limit": 1000000,
+      "input_token_cost": null,
+      "output_token_cost": null,
+      "currency": null,
+      "supports_cache_control": null
+    },
+    {
+      "name": "deepseek-v4-pro",
+      "context_limit": 1000000,
+      "input_token_cost": null,
+      "output_token_cost": null,
+      "currency": null,
+      "supports_cache_control": null
+    },
+    {
       "name": "deepseek-chat",
-      "context_limit": 128000,
+      "context_limit": 1000000,
       "input_token_cost": null,
       "output_token_cost": null,
       "currency": null,
@@ -16,7 +32,7 @@
     },
     {
       "name": "deepseek-reasoner",
-      "context_limit": 128000,
+      "context_limit": 1000000,
       "input_token_cost": null,
       "output_token_cost": null,
       "currency": null,
@@ -26,5 +42,6 @@
   "headers": null,
   "timeout_seconds": null,
   "preserves_thinking": true,
+  "requires_reasoning_content_on_all_messages": true,
   "supports_streaming": true
 }

--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -46,6 +46,8 @@ fn is_reserved_request_param_key(key: &str) -> bool {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct OpenAiFormatOptions {
     pub preserve_thinking_context: bool,
+    /// DeepSeek V4 requires `reasoning_content` on every assistant message (even `""`); Kimi rejects it when empty.
+    pub require_reasoning_content_on_all_messages: bool,
 }
 
 fn merge_reasoning_text(prefix: &str, suffix: &str) -> String {
@@ -169,6 +171,7 @@ pub fn format_messages(messages: &[Message], image_format: &ImageFormat) -> Vec<
         image_format,
         OpenAiFormatOptions {
             preserve_thinking_context: true,
+            ..Default::default()
         },
     )
 }
@@ -408,10 +411,13 @@ pub fn format_messages_with_options(
             }
         }
 
-        // Include reasoning_content only when non-empty. Kimi rejects empty
-        // reasoning_content (""), so we must omit it entirely.
-        if options.preserve_thinking_context && !reasoning_text.is_empty() {
-            converted["reasoning_content"] = json!(reasoning_text);
+        // Kimi rejects empty reasoning_content; DeepSeek V4 requires it on every assistant message.
+        if options.preserve_thinking_context {
+            if !reasoning_text.is_empty() {
+                converted["reasoning_content"] = json!(reasoning_text);
+            } else if options.require_reasoning_content_on_all_messages {
+                converted["reasoning_content"] = json!("");
+            }
         }
 
         if has_message_payload {
@@ -1234,6 +1240,7 @@ pub fn create_request(
         for_streaming,
         OpenAiFormatOptions {
             preserve_thinking_context: true,
+            ..Default::default()
         },
     )
 }
@@ -2898,6 +2905,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
+                ..Default::default()
             },
         );
 
@@ -2956,6 +2964,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: false,
+                ..Default::default()
             },
         );
 
@@ -3018,6 +3027,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
+                ..Default::default()
             },
         );
 
@@ -3048,6 +3058,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
+                ..Default::default()
             },
         );
 
@@ -3076,6 +3087,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
+                ..Default::default()
             },
         );
 
@@ -3100,6 +3112,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
+                ..Default::default()
             },
         );
 
@@ -3337,6 +3350,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
+                ..Default::default()
             },
         );
         assert_eq!(spec.len(), 1);
@@ -3371,6 +3385,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
+                ..Default::default()
             },
         );
         assert_eq!(spec.len(), 1);

--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -412,7 +412,7 @@ pub fn format_messages_with_options(
         }
 
         // Kimi rejects empty reasoning_content; DeepSeek V4 requires it on every assistant message.
-        if options.preserve_thinking_context {
+        if options.preserve_thinking_context && message.role == Role::Assistant {
             if !reasoning_text.is_empty() {
                 converted["reasoning_content"] = json!(reasoning_text);
             } else if options.require_reasoning_content_on_all_messages {
@@ -3468,5 +3468,44 @@ data: [DONE]"#;
         let raw = r#"{"arguments":"{\"k\":1}"}"#;
         let parsed: DeltaToolCallFunction = serde_json::from_str(raw).unwrap();
         assert_eq!(parsed.arguments, "{\"k\":1}");
+    }
+
+    #[test]
+    fn test_reasoning_content_gated_to_assistant_messages() {
+        let options = OpenAiFormatOptions {
+            preserve_thinking_context: true,
+            require_reasoning_content_on_all_messages: true,
+        };
+
+        let messages = vec![
+            Message::user().with_text("What is 2 + 2?"),
+            Message::assistant().with_text("The answer is 4."),
+            Message::user().with_text("Now add 5 to that."),
+        ];
+
+        let formatted = format_messages_with_options(&messages, &ImageFormat::OpenAi, options);
+
+        assert_eq!(formatted.len(), 3, "Should have 3 formatted messages");
+
+        // User message should NOT have reasoning_content
+        assert_eq!(formatted[0]["role"], "user");
+        assert!(
+            formatted[0].get("reasoning_content").is_none(),
+            "User message must not have reasoning_content"
+        );
+
+        // Assistant message should have reasoning_content (empty string)
+        assert_eq!(formatted[1]["role"], "assistant");
+        assert_eq!(
+            formatted[1]["reasoning_content"], "",
+            "Assistant message should have empty reasoning_content when require_reasoning_content_on_all_messages is set"
+        );
+
+        // Second user message should NOT have reasoning_content
+        assert_eq!(formatted[2]["role"], "user");
+        assert!(
+            formatted[2].get("reasoning_content").is_none(),
+            "Second user message must not have reasoning_content"
+        );
     }
 }

--- a/crates/goose/src/providers/huggingface.rs
+++ b/crates/goose/src/providers/huggingface.rs
@@ -564,6 +564,7 @@ mod tests {
             setup_steps: vec![],
             fast_model: None,
             preserves_thinking: true,
+            requires_reasoning_content_on_all_messages: false,
         }
     }
 }

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -123,6 +123,7 @@ pub struct OpenAiProvider {
     dynamic_models: Option<bool>,
     skip_canonical_filtering: bool,
     preserve_thinking_context: bool,
+    require_reasoning_content_on_all_messages: bool,
 }
 
 impl OpenAiProvider {
@@ -277,6 +278,7 @@ impl OpenAiProvider {
             dynamic_models: None,
             skip_canonical_filtering: false,
             preserve_thinking_context: !is_openai,
+            require_reasoning_content_on_all_messages: false,
         })
     }
 
@@ -295,6 +297,7 @@ impl OpenAiProvider {
             dynamic_models: None,
             skip_canonical_filtering: false,
             preserve_thinking_context: false,
+            require_reasoning_content_on_all_messages: false,
         }
     }
 
@@ -432,6 +435,8 @@ impl OpenAiProvider {
             dynamic_models: config.dynamic_models,
             skip_canonical_filtering: config.skip_canonical_filtering,
             preserve_thinking_context: config.preserves_thinking,
+            require_reasoning_content_on_all_messages: config
+                .requires_reasoning_content_on_all_messages,
         })
     }
 
@@ -841,6 +846,8 @@ impl Provider for OpenAiProvider {
                 self.supports_streaming,
                 OpenAiFormatOptions {
                     preserve_thinking_context: self.preserve_thinking_context,
+                    require_reasoning_content_on_all_messages: self
+                        .require_reasoning_content_on_all_messages,
                 },
             )?;
             let payload = self.sanitize_request_for_compat(payload);
@@ -977,6 +984,7 @@ mod tests {
             dynamic_models: None,
             skip_canonical_filtering: false,
             preserve_thinking_context: false,
+            require_reasoning_content_on_all_messages: false,
         }
     }
 
@@ -1276,6 +1284,7 @@ mod tests {
             dynamic_models,
             skip_canonical_filtering: false,
             preserve_thinking_context: false,
+            require_reasoning_content_on_all_messages: false,
         }
     }
 
@@ -1304,6 +1313,7 @@ mod tests {
             setup_steps: vec![],
             fast_model: None,
             preserves_thinking: false,
+            requires_reasoning_content_on_all_messages: false,
         }
     }
 

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -385,6 +385,7 @@ mod tests {
             setup_steps: vec![],
             fast_model: None,
             preserves_thinking: false,
+            requires_reasoning_content_on_all_messages: false,
         }
     }
 

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -4914,6 +4914,10 @@
           "requires_auth": {
             "type": "boolean"
           },
+          "requires_reasoning_content_on_all_messages": {
+            "type": "boolean",
+            "description": "Always emit `reasoning_content` on assistant messages (even `\"\"`); required by DeepSeek V4."
+          },
           "setup_steps": {
             "type": "array",
             "items": {


### PR DESCRIPTION
Fixes #9333.

## Summary

- **Add V4 model names**: `deepseek-v4-flash` and `deepseek-v4-pro` with 1M token context windows, matching the current DeepSeek API
- **Fix context limits**: `deepseek-chat` and `deepseek-reasoner` (now deprecated aliases for `deepseek-v4-flash`) updated from 128K → 1M per the DeepSeek docs
- **Fix multi-turn 400 errors**: DeepSeek V4 requires every assistant message in the history to include a `reasoning_content` field, even when empty. Added a `requires_reasoning_content_on_all_messages` flag to `DeclarativeProviderConfig` and `OpenAiFormatOptions` that ensures this field is always present. Modelled after pi-coding-agent's `requiresReasoningContentOnAssistantMessages` compat flag.

The existing `preserve_thinking_context` path already omits empty `reasoning_content` to avoid breaking Kimi (which rejects empty strings); the new flag is distinct so neither provider is affected by the other's constraint.

## Test plan

- [ ] Configure goose with `DEEPSEEK_API_KEY` and select `deepseek-v4-flash`
- [ ] Run a multi-turn conversation — confirm no 400 error on the second message
- [ ] Confirm `deepseek-v4-pro` is listed as a model option
- [ ] Existing unit tests pass: `cargo test -p goose`

🤖 Generated with [Claude Code](https://claude.com/claude-code)