### PR TITLE
fix(desktop): align session history scrollbar with window edge

### DIFF
--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -1030,9 +1030,9 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
               </div>
             </div>
 
-            <div className="flex-1 min-h-0 relative px-8">
+            <div className="flex-1 min-h-0 relative">
               <ScrollArea handleScroll={handleScroll} className="h-full" data-search-scroll-area>
-                <div ref={containerRef} className="h-full relative">
+                <div ref={containerRef} className="h-full relative px-8">
                   <SearchView
                     onSearch={handleSearch}
                     onNavigate={handleSearchNavigation}


### PR DESCRIPTION
Move horizontal padding inside ScrollArea so the scrollbar sits at the panel edge instead of overlapping session cards.

## Summary
<!-- Describe your change -->

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

