### PR TITLE
fix(i18n): add 63 missing zh-CN translations

### DIFF
--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -44,6 +44,66 @@
   "appsView.title": {
     "defaultMessage": "应用"
   },
+  "authSettings.activeProviderWarning": {
+    "defaultMessage": "这是当前正在使用的提供商。在你配置另一份凭据之前，新的请求可能会失败。"
+  },
+  "authSettings.cancel": {
+    "defaultMessage": "取消"
+  },
+  "authSettings.delete": {
+    "defaultMessage": "删除"
+  },
+  "authSettings.deleteCredential": {
+    "defaultMessage": "删除凭据"
+  },
+  "authSettings.deleteMessage": {
+    "defaultMessage": "确定要删除 {provider} 的 {name} 凭据吗？"
+  },
+  "authSettings.deleteTitle": {
+    "defaultMessage": "删除凭据"
+  },
+  "authSettings.deleted": {
+    "defaultMessage": "凭据已删除"
+  },
+  "authSettings.description": {
+    "defaultMessage": "管理 goose 在本地存储的提供商凭据。"
+  },
+  "authSettings.empty": {
+    "defaultMessage": "未找到本地存储的提供商凭据。"
+  },
+  "authSettings.expiresAt": {
+    "defaultMessage": "过期时间 {date}"
+  },
+  "authSettings.failedToConfigure": {
+    "defaultMessage": "配置凭据失败：{error}"
+  },
+  "authSettings.failedToDelete": {
+    "defaultMessage": "删除凭据失败：{error}"
+  },
+  "authSettings.failedToLoad": {
+    "defaultMessage": "加载提供商凭据失败"
+  },
+  "authSettings.loading": {
+    "defaultMessage": "正在加载凭据…"
+  },
+  "authSettings.reauthorize": {
+    "defaultMessage": "重新授权"
+  },
+  "authSettings.signIn": {
+    "defaultMessage": "登录"
+  },
+  "authSettings.signedIn": {
+    "defaultMessage": "凭据已配置"
+  },
+  "authSettings.storageProviderCache": {
+    "defaultMessage": "提供商缓存"
+  },
+  "authSettings.storageSecretStore": {
+    "defaultMessage": "密钥库"
+  },
+  "authSettings.title": {
+    "defaultMessage": "提供商凭据"
+  },
   "backButton.back": {
     "defaultMessage": "返回"
   },
@@ -506,11 +566,20 @@
   "cronPicker.august": {
     "defaultMessage": "八月"
   },
+  "cronPicker.cronExpression": {
+    "defaultMessage": "Cron 表达式"
+  },
+  "cronPicker.custom": {
+    "defaultMessage": "自定义 cron"
+  },
   "cronPicker.day": {
     "defaultMessage": "日"
   },
   "cronPicker.december": {
     "defaultMessage": "十二月"
+  },
+  "cronPicker.emptyCronError": {
+    "defaultMessage": "Cron 表达式不能为空"
   },
   "cronPicker.every": {
     "defaultMessage": "每"
@@ -526,6 +595,9 @@
   },
   "cronPicker.inMonth": {
     "defaultMessage": "于"
+  },
+  "cronPicker.invalidDayOfMonth": {
+    "defaultMessage": "日期必须在 1 到 {max} 之间"
   },
   "cronPicker.january": {
     "defaultMessage": "一月"
@@ -545,6 +617,9 @@
   "cronPicker.minute": {
     "defaultMessage": "分"
   },
+  "cronPicker.mode": {
+    "defaultMessage": "模式"
+  },
   "cronPicker.monday": {
     "defaultMessage": "周一"
   },
@@ -563,11 +638,17 @@
   "cronPicker.onDay": {
     "defaultMessage": "于第几日"
   },
+  "cronPicker.quarter": {
+    "defaultMessage": "季度"
+  },
   "cronPicker.saturday": {
     "defaultMessage": "周六"
   },
   "cronPicker.september": {
     "defaultMessage": "九月"
+  },
+  "cronPicker.startingMonth": {
+    "defaultMessage": "起始月份"
   },
   "cronPicker.sunday": {
     "defaultMessage": "周日"
@@ -884,8 +965,29 @@
   "dictationSettings.voiceDictationProvider": {
     "defaultMessage": "语音输入提供商"
   },
+  "dirSwitcher.chooseDirectory": {
+    "defaultMessage": "选择目录…"
+  },
+  "dirSwitcher.currentDirectory": {
+    "defaultMessage": "当前目录"
+  },
   "dirSwitcher.failedToUpdateWorkingDir": {
     "defaultMessage": "更新工作目录失败"
+  },
+  "dirSwitcher.gitWorktrees": {
+    "defaultMessage": "Git 工作树"
+  },
+  "dirSwitcher.noWorktreesFound": {
+    "defaultMessage": "未找到工作树"
+  },
+  "dirSwitcher.openInFinder": {
+    "defaultMessage": "在文件管理器中打开"
+  },
+  "dirSwitcher.recentDirectories": {
+    "defaultMessage": "最近访问的目录"
+  },
+  "elicitationRequest.accept": {
+    "defaultMessage": "接受"
   },
   "elicitationRequest.cancelled": {
     "defaultMessage": "信息请求已取消。"
@@ -1379,6 +1481,15 @@
   "headersSection.value": {
     "defaultMessage": "值"
   },
+  "hub.goodAfternoon": {
+    "defaultMessage": "下午好"
+  },
+  "hub.goodEvening": {
+    "defaultMessage": "晚上好"
+  },
+  "hub.goodMorning": {
+    "defaultMessage": "早上好"
+  },
   "huggingFaceModelSearch.download": {
     "defaultMessage": "下载"
   },
@@ -1414,6 +1525,21 @@
   },
   "huggingFaceModelSearch.tooLarge": {
     "defaultMessage": "可能超出内存（模型 {size}，可用 {available}）"
+  },
+  "huggingFaceSignInPrompt.failedToConfigure": {
+    "defaultMessage": "登录 Hugging Face 失败：{error}"
+  },
+  "huggingFaceSignInPrompt.signIn": {
+    "defaultMessage": "登录"
+  },
+  "huggingFaceSignInPrompt.signedIn": {
+    "defaultMessage": "已登录 Hugging Face"
+  },
+  "huggingFaceSignInPrompt.signingIn": {
+    "defaultMessage": "正在登录…"
+  },
+  "huggingFaceSignInPrompt.title": {
+    "defaultMessage": "Hugging Face"
   },
   "imagePreview.altText": {
     "defaultMessage": "goose 图片"
@@ -1753,6 +1879,9 @@
   },
   "localInferenceSettings.featuredModels": {
     "defaultMessage": "推荐模型"
+  },
+  "localInferenceSettings.huggingFaceSignInNote": {
+    "defaultMessage": "登录后可提高搜索和下载模型时的速率限制，并可访问私有或受限的 Hugging Face 仓库。"
   },
   "localInferenceSettings.modelSettings": {
     "defaultMessage": "模型设置"
@@ -2321,11 +2450,26 @@
   "navigation.itemScheduler": {
     "defaultMessage": "调度"
   },
+  "navigation.itemSessions": {
+    "defaultMessage": "会话历史"
+  },
   "navigation.itemSettings": {
     "defaultMessage": "设置"
   },
   "navigation.itemSkills": {
     "defaultMessage": "技能"
+  },
+  "navigationPanel.chats": {
+    "defaultMessage": "对话"
+  },
+  "navigationPanel.collapseSidebar": {
+    "defaultMessage": "折叠侧边栏"
+  },
+  "navigationPanel.noChats": {
+    "defaultMessage": "暂无最近对话"
+  },
+  "navigationPanel.untitledSession": {
+    "defaultMessage": "未命名会话"
   },
   "onboardingGuard.checkProviderErrorDescription": {
     "defaultMessage": "服务器可能正在启动或暂时不可用。"
@@ -2734,6 +2878,9 @@
   },
   "providerConfigurationModal.goBack": {
     "defaultMessage": "返回"
+  },
+  "providerConfigurationModal.huggingFaceOAuthDescription": {
+    "defaultMessage": "登录后即可使用 Hugging Face Inference Providers，无需手动输入 API 令牌。"
   },
   "providerConfigurationModal.oauthLoginFailed": {
     "defaultMessage": "OAuth 登录失败：{error}"
@@ -3749,6 +3896,9 @@
   "sessions.action.openNewWindow": {
     "defaultMessage": "在新窗口中打开"
   },
+  "sessions.action.shareNostr": {
+    "defaultMessage": "分享加密 Nostr 链接"
+  },
   "sessions.cancel": {
     "defaultMessage": "取消"
   },
@@ -3757,6 +3907,9 @@
   },
   "sessions.chatHistoryDesc": {
     "defaultMessage": "查看并搜索你与 Goose 的过往对话。按 {shortcut} 搜索。"
+  },
+  "sessions.close": {
+    "defaultMessage": "关闭"
   },
   "sessions.delete.message": {
     "defaultMessage": "确定要删除会话“{name}”吗？此操作无法撤销。"
@@ -3788,6 +3941,21 @@
   "sessions.import": {
     "defaultMessage": "导入会话"
   },
+  "sessions.importNostr": {
+    "defaultMessage": "导入链接"
+  },
+  "sessions.importNostr.description": {
+    "defaultMessage": "粘贴一个 Goose Nostr 分享链接，以获取、解密并导入该会话。"
+  },
+  "sessions.importNostr.placeholder": {
+    "defaultMessage": "goose://sessions/nostr?nevent=...&key=..."
+  },
+  "sessions.importNostr.title": {
+    "defaultMessage": "导入 Nostr 会话"
+  },
+  "sessions.importing": {
+    "defaultMessage": "正在导入…"
+  },
   "sessions.loadingMore": {
     "defaultMessage": "正在加载更多会话…"
   },
@@ -3805,6 +3973,15 @@
   },
   "sessions.searchPlaceholder": {
     "defaultMessage": "搜索历史…"
+  },
+  "sessions.shareNostr.description": {
+    "defaultMessage": "持有此链接的任何人都可以获取并解密该会话，请将其视为秘密妥善保管。"
+  },
+  "sessions.shareNostr.title": {
+    "defaultMessage": "加密 Nostr 分享链接"
+  },
+  "sessions.toast.copied": {
+    "defaultMessage": "已复制到剪贴板"
   },
   "sessions.toast.deleteFailed": {
     "defaultMessage": "删除会话“{name}”失败：{error}"
@@ -3826,6 +4003,12 @@
   },
   "sessions.toast.imported": {
     "defaultMessage": "会话导入成功"
+  },
+  "sessions.toast.shareNostr": {
+    "defaultMessage": "已创建加密 Nostr 分享链接"
+  },
+  "sessions.toast.shareNostrFailed": {
+    "defaultMessage": "创建 Nostr 分享链接失败：{error}"
   },
   "sessions.toast.updateFailed": {
     "defaultMessage": "更新会话描述失败：{error}"
@@ -3952,6 +4135,9 @@
   },
   "settingsView.tabApp": {
     "defaultMessage": "应用"
+  },
+  "settingsView.tabAuth": {
+    "defaultMessage": "认证"
   },
   "settingsView.tabChat": {
     "defaultMessage": "聊天"
@@ -4252,6 +4438,9 @@
   },
   "switchModelModal.thinkingEffort": {
     "defaultMessage": "思考努力"
+  },
+  "switchModelModal.thinkingEffortOff": {
+    "defaultMessage": "关闭 - 不使用扩展思考"
   },
   "switchModelModal.thinkingLevel": {
     "defaultMessage": "思考级别"


### PR DESCRIPTION
## Summary

`ui/desktop/src/i18n/messages/zh-CN.json` was missing 63 keys that exist in `en.json`. For Chinese users this surfaced as English fallbacks (or `MISSING_TRANSLATION` warnings — cf. #9294) in several places:

- `authSettings.*` — the new provider-credentials settings panel (20 keys)
- `cronPicker.*` — Cron expression / Quarter / starting month / day-of-month error (7 keys)
- `dirSwitcher.*` — directory switcher (current/recent/worktrees, file manager) (6 keys)
- `hub.goodMorning/Afternoon/Evening` — time-of-day greetings (3 keys)
- `huggingFaceSignInPrompt.*` + `providerConfigurationModal.huggingFaceOAuthDescription` + `localInferenceSettings.huggingFaceSignInNote` — Hugging Face OAuth sign-in flow (7 keys)
- `navigation.itemSessions`, `navigationPanel.{chats,collapseSidebar,noChats,untitledSession}` (5 keys)
- `sessions.{close,importing,toast.copied,action.shareNostr,importNostr*,shareNostr*,toast.shareNostr*}` — encrypted Nostr session sharing + small misc (12 keys)
- `settingsView.tabAuth`, `switchModelModal.thinkingEffortOff`, `elicitationRequest.accept` (3 keys)

Translations follow the wording and tone already established in the file (e.g. lowercase `goose`, `API 密钥` / `API 令牌`, `登录`, `凭据`, `…` ellipsis, full-width colon for sentence punctuation). ICU placeholders (`{name}`, `{error}`, `{max}`, `{date}`, `{provider}`) are preserved; word order was adjusted for `authSettings.deleteMessage` to read naturally in Chinese (`{provider}` 的 `{name}` 凭据).

### Testing

- `python -m json.tool ui/desktop/src/i18n/messages/zh-CN.json` — parses cleanly, 1589 keys total (matches `en.json`).
- Diff against `en.json`: no missing keys, no orphan keys, all ICU variable sets match per key.
- Diff is purely additive (189 insertions, 0 deletions); existing translations and their positions are untouched.

### Related Issues

- Related to the missing-translation warnings addressed in #9294.

### Screenshots/Demos (for UX changes)

N/A — purely a translation catalog change; no visible behavior changes outside of strings now rendering in zh-CN instead of falling back to en.

> Drafted with AI assistance; verified by author before publishing.