### PR TITLE
feat(security): enable prompt injection mitigation by default for internal users via non-overridable env vars

### DIFF
--- a/crates/goose-server/src/commands/agent.rs
+++ b/crates/goose-server/src/commands/agent.rs
@@ -47,8 +47,6 @@ pub async fn run() -> Result<()> {
     boot_marker("main entered");
     crate::logging::setup_logging(Some("goosed"))?;
 
-    goose::security::set_security_defaults();
-
     let settings = configuration::Settings::new()?;
 
     let secret_key = std::env::var("GOOSE_SERVER__SECRET_KEY")

--- a/crates/goose/src/security/mod.rs
+++ b/crates/goose/src/security/mod.rs
@@ -10,30 +10,16 @@ use crate::conversation::message::{Message, ToolRequest};
 use crate::permission::permission_judge::PermissionCheckResult;
 use anyhow::Result;
 use scanner::PromptInjectionScanner;
+use std::env;
 use std::sync::OnceLock;
 use uuid::Uuid;
 
-fn set_default_if_not_exist(config: &Config, key: &str, default_env: &str) {
-    if config.get_param::<bool>(key).is_ok() {
-        return;
-    }
-    if let Ok(parsed) = config.get_param::<bool>(default_env) {
-        let _ = config.set_param(key, parsed);
-    }
-}
-
-pub fn set_security_defaults() {
-    let config = Config::global();
-    set_default_if_not_exist(
-        config,
-        "SECURITY_PROMPT_ENABLED",
-        "DEFAULT_SECURITY_PROMPT_ENABLED",
-    );
-    set_default_if_not_exist(
-        config,
-        "SECURITY_COMMAND_CLASSIFIER_ENABLED",
-        "DEFAULT_SECURITY_COMMAND_CLASSIFIER_ENABLED",
-    );
+fn get_override(env_key: &str) -> Option<bool> {
+    env::var(env_key).ok().and_then(|v| match v.as_str() {
+        "true" | "1" => Some(true),
+        "false" | "0" => Some(false),
+        _ => None,
+    })
 }
 
 pub struct SecurityManager {
@@ -52,15 +38,17 @@ pub struct SecurityResult {
 
 impl SecurityManager {
     pub fn new() -> Self {
-        set_security_defaults();
         Self {
             scanner: OnceLock::new(),
         }
     }
 
     pub fn is_prompt_injection_detection_enabled(&self) -> bool {
-        let config = Config::global();
+        if let Some(overridden) = get_override("SECURITY_PROMPT_ENABLED_OVERRIDE") {
+            return overridden;
+        }
 
+        let config = Config::global();
         config
             .get_param::<bool>("SECURITY_PROMPT_ENABLED")
             .unwrap_or(false)
@@ -73,9 +61,15 @@ impl SecurityManager {
             .get_param::<bool>("SECURITY_PROMPT_CLASSIFIER_ENABLED")
             .unwrap_or(false);
 
-        let command_enabled = config
-            .get_param::<bool>("SECURITY_COMMAND_CLASSIFIER_ENABLED")
-            .unwrap_or(false);
+        let command_enabled = if let Some(overridden) =
+            get_override("SECURITY_COMMAND_CLASSIFIER_ENABLED_OVERRIDE")
+        {
+            overridden
+        } else {
+            config
+                .get_param::<bool>("SECURITY_COMMAND_CLASSIFIER_ENABLED")
+                .unwrap_or(false)
+        };
 
         prompt_enabled || command_enabled
     }
@@ -95,9 +89,14 @@ impl SecurityManager {
 
         let scanner = self.scanner.get_or_init(|| {
             let config = Config::global();
-            let command_classifier_enabled = config
-                .get_param::<bool>("SECURITY_COMMAND_CLASSIFIER_ENABLED")
-                .unwrap_or(false);
+            let command_classifier_enabled =
+                if let Some(overridden) = get_override("SECURITY_COMMAND_CLASSIFIER_ENABLED_OVERRIDE") {
+                    overridden
+                } else {
+                    config
+                        .get_param::<bool>("SECURITY_COMMAND_CLASSIFIER_ENABLED")
+                        .unwrap_or(false)
+                };
             let prompt_classifier_enabled = config
                 .get_param::<bool>("SECURITY_PROMPT_CLASSIFIER_ENABLED")
                 .unwrap_or(false);

--- a/crates/goose/src/security/mod.rs
+++ b/crates/goose/src/security/mod.rs
@@ -10,11 +10,16 @@ use crate::conversation::message::{Message, ToolRequest};
 use crate::permission::permission_judge::PermissionCheckResult;
 use anyhow::Result;
 use scanner::PromptInjectionScanner;
+use std::env;
 use std::sync::OnceLock;
 use uuid::Uuid;
 
-pub(crate) fn get_override(key: &str) -> Option<bool> {
-    Config::global().get_param::<bool>(key).ok()
+pub(crate) fn get_override(env_key: &str) -> Option<bool> {
+    env::var(env_key).ok().and_then(|v| match v.as_str() {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    })
 }
 
 pub struct SecurityManager {

--- a/crates/goose/src/security/mod.rs
+++ b/crates/goose/src/security/mod.rs
@@ -10,16 +10,11 @@ use crate::conversation::message::{Message, ToolRequest};
 use crate::permission::permission_judge::PermissionCheckResult;
 use anyhow::Result;
 use scanner::PromptInjectionScanner;
-use std::env;
 use std::sync::OnceLock;
 use uuid::Uuid;
 
-pub(crate) fn get_override(env_key: &str) -> Option<bool> {
-    env::var(env_key).ok().and_then(|v| match v.as_str() {
-        "true" => Some(true),
-        "false" => Some(false),
-        _ => None,
-    })
+pub(crate) fn get_override(key: &str) -> Option<bool> {
+    Config::global().get_param::<bool>(key).ok()
 }
 
 pub struct SecurityManager {

--- a/crates/goose/src/security/mod.rs
+++ b/crates/goose/src/security/mod.rs
@@ -14,10 +14,10 @@ use std::env;
 use std::sync::OnceLock;
 use uuid::Uuid;
 
-fn get_override(env_key: &str) -> Option<bool> {
+pub(crate) fn get_override(env_key: &str) -> Option<bool> {
     env::var(env_key).ok().and_then(|v| match v.as_str() {
-        "true" | "1" => Some(true),
-        "false" | "0" => Some(false),
+        "true" => Some(true),
+        "false" => Some(false),
         _ => None,
     })
 }

--- a/crates/goose/src/security/scanner.rs
+++ b/crates/goose/src/security/scanner.rs
@@ -68,9 +68,19 @@ impl PromptInjectionScanner {
             ClassifierType::Prompt => "PROMPT",
         };
 
-        let enabled = config
-            .get_param::<bool>(&format!("SECURITY_{}_CLASSIFIER_ENABLED", prefix))
-            .unwrap_or(false);
+        let override_key = format!("SECURITY_{}_CLASSIFIER_ENABLED_OVERRIDE", prefix);
+        let enabled = std::env::var(&override_key)
+            .ok()
+            .and_then(|v| match v.as_str() {
+                "true" | "1" => Some(true),
+                "false" | "0" => Some(false),
+                _ => None,
+            })
+            .unwrap_or_else(|| {
+                config
+                    .get_param::<bool>(&format!("SECURITY_{}_CLASSIFIER_ENABLED", prefix))
+                    .unwrap_or(false)
+            });
 
         if !enabled {
             anyhow::bail!("{} classifier not enabled", prefix);

--- a/crates/goose/src/security/scanner.rs
+++ b/crates/goose/src/security/scanner.rs
@@ -68,19 +68,19 @@ impl PromptInjectionScanner {
             ClassifierType::Prompt => "PROMPT",
         };
 
-        let override_key = format!("SECURITY_{}_CLASSIFIER_ENABLED_OVERRIDE", prefix);
-        let enabled = std::env::var(&override_key)
-            .ok()
-            .and_then(|v| match v.as_str() {
-                "true" | "1" => Some(true),
-                "false" | "0" => Some(false),
-                _ => None,
-            })
-            .unwrap_or_else(|| {
-                config
-                    .get_param::<bool>(&format!("SECURITY_{}_CLASSIFIER_ENABLED", prefix))
-                    .unwrap_or(false)
-            });
+        let enabled = match classifier_type {
+            ClassifierType::Command => {
+                crate::security::get_override("SECURITY_COMMAND_CLASSIFIER_ENABLED_OVERRIDE")
+                    .unwrap_or_else(|| {
+                        config
+                            .get_param::<bool>("SECURITY_COMMAND_CLASSIFIER_ENABLED")
+                            .unwrap_or(false)
+                    })
+            }
+            ClassifierType::Prompt => config
+                .get_param::<bool>("SECURITY_PROMPT_CLASSIFIER_ENABLED")
+                .unwrap_or(false),
+        };
 
         if !enabled {
             anyhow::bail!("{} classifier not enabled", prefix);

--- a/ui/desktop/src/components/settings/security/SecurityToggle.tsx
+++ b/ui/desktop/src/components/settings/security/SecurityToggle.tsx
@@ -190,8 +190,12 @@ export const SecurityToggle = () => {
   const commandClassifierOverride = window.appConfig?.get(
     'SECURITY_COMMAND_CLASSIFIER_ENABLED_OVERRIDE'
   ) as string | undefined;
-  const isPromptOverridden = promptEnabledOverride === 'true';
-  const isCommandClassifierOverridden = commandClassifierOverride === 'true';
+  const isPromptOverridden =
+    promptEnabledOverride === 'true' || promptEnabledOverride === 'false';
+  const isCommandClassifierOverridden =
+    commandClassifierOverride === 'true' || commandClassifierOverride === 'false';
+  const promptOverrideValue = promptEnabledOverride === 'true';
+  const commandClassifierOverrideValue = commandClassifierOverride === 'true';
 
   const modelMapping = useMemo(() => {
     const mappingEnv = window.appConfig?.get('SECURITY_ML_MODEL_MAPPING') as string | undefined;
@@ -308,7 +312,7 @@ export const SecurityToggle = () => {
     await upsert('SECURITY_COMMAND_CLASSIFIER_TOKEN', token, true); // true = secret
   };
 
-  const effectiveEnabled = isPromptOverridden || enabled;
+  const effectiveEnabled = isPromptOverridden ? promptOverrideValue : enabled;
 
   return (
     <div className="space-y-4">
@@ -326,7 +330,7 @@ export const SecurityToggle = () => {
         </div>
         <div className={`flex items-center ${isPromptOverridden ? 'opacity-40' : ''}`}>
           <Switch
-            checked={effectiveEnabled}
+            checked={isPromptOverridden ? promptOverrideValue : enabled}
             onCheckedChange={handleToggle}
             disabled={isPromptOverridden}
             variant="mono"
@@ -405,7 +409,11 @@ export const SecurityToggle = () => {
                 className={`flex items-center ${isCommandClassifierOverridden ? 'opacity-40' : ''}`}
               >
                 <Switch
-                  checked={isCommandClassifierOverridden || effectiveCommandClassifierEnabled}
+                  checked={
+                    isCommandClassifierOverridden
+                      ? commandClassifierOverrideValue
+                      : effectiveCommandClassifierEnabled
+                  }
                   onCheckedChange={handleCommandClassifierToggle}
                   disabled={!effectiveEnabled || isCommandClassifierOverridden}
                   variant="mono"
@@ -415,7 +423,9 @@ export const SecurityToggle = () => {
 
             {hasCommandModel ? (
               effectiveEnabled &&
-              (isCommandClassifierOverridden || effectiveCommandClassifierEnabled) && (
+              (isCommandClassifierOverridden
+                ? commandClassifierOverrideValue
+                : effectiveCommandClassifierEnabled) && (
                 <div className="text-sm text-gray-700 dark:text-gray-300 mt-2">
                   ✓ {intl.formatMessage(i18n.commandClassifierActive)}
                 </div>

--- a/ui/desktop/src/components/settings/security/SecurityToggle.tsx
+++ b/ui/desktop/src/components/settings/security/SecurityToggle.tsx
@@ -65,6 +65,15 @@ const i18n = defineMessages({
     id: 'securityToggle.apiTokenDescription',
     defaultMessage: 'Authentication token for the classification service',
   },
+  overrideNotice: {
+    id: 'securityToggle.overrideNotice',
+    defaultMessage: 'This setting is managed by your organization and cannot be changed.',
+  },
+  warpNotice: {
+    id: 'securityToggle.warpNotice',
+    defaultMessage:
+      'Command injection detection works best when connected to WARP (required to reach the classification service).',
+  },
   commandEndpointDescription: {
     id: 'securityToggle.commandEndpointDescription',
     defaultMessage: 'Enter the full URL for your command injection classification service',
@@ -174,6 +183,15 @@ const ClassifierEndpointInputs = ({
 export const SecurityToggle = () => {
   const intl = useIntl();
   const { config, upsert } = useConfig();
+
+  const promptEnabledOverride = window.appConfig?.get('SECURITY_PROMPT_ENABLED_OVERRIDE') as
+    | string
+    | undefined;
+  const commandClassifierOverride = window.appConfig?.get(
+    'SECURITY_COMMAND_CLASSIFIER_ENABLED_OVERRIDE'
+  ) as string | undefined;
+  const isPromptOverridden = promptEnabledOverride === 'true';
+  const isCommandClassifierOverridden = commandClassifierOverride === 'true';
 
   const modelMapping = useMemo(() => {
     const mappingEnv = window.appConfig?.get('SECURITY_ML_MODEL_MAPPING') as string | undefined;
@@ -290,6 +308,8 @@ export const SecurityToggle = () => {
     await upsert('SECURITY_COMMAND_CLASSIFIER_TOKEN', token, true); // true = secret
   };
 
+  const effectiveEnabled = isPromptOverridden || enabled;
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between py-2 px-2 hover:bg-background-secondary rounded-lg transition-all">
@@ -298,22 +318,32 @@ export const SecurityToggle = () => {
           <p className="text-xs text-text-secondary max-w-md mt-[2px]">
             {intl.formatMessage(i18n.promptInjectionDescription)}
           </p>
+          {isPromptOverridden && (
+            <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+              {intl.formatMessage(i18n.overrideNotice)}
+            </p>
+          )}
         </div>
-        <div className="flex items-center">
-          <Switch checked={enabled} onCheckedChange={handleToggle} variant="mono" />
+        <div className={`flex items-center ${isPromptOverridden ? 'opacity-40' : ''}`}>
+          <Switch
+            checked={effectiveEnabled}
+            onCheckedChange={handleToggle}
+            disabled={isPromptOverridden}
+            variant="mono"
+          />
         </div>
       </div>
 
       <div
         className={`overflow-hidden transition-all duration-300 ease-in-out ${
-          enabled ? 'max-h-[1000px] opacity-100' : 'max-h-0 opacity-0'
+          effectiveEnabled ? 'max-h-[1000px] opacity-100' : 'max-h-0 opacity-0'
         }`}
       >
         <div className="space-y-4 px-2 pb-2">
           {/* Detection Threshold */}
-          <div className={enabled ? '' : 'opacity-50'}>
+          <div className={effectiveEnabled ? '' : 'opacity-50'}>
             <label
-              className={`text-sm font-medium ${enabled ? 'text-text-primary' : 'text-text-secondary'}`}
+              className={`text-sm font-medium ${effectiveEnabled ? 'text-text-primary' : 'text-text-secondary'}`}
             >
               {intl.formatMessage(i18n.detectionThreshold)}
             </label>
@@ -338,9 +368,9 @@ export const SecurityToggle = () => {
                   handleThresholdChange(value);
                 }
               }}
-              disabled={!enabled}
+              disabled={!effectiveEnabled}
               className={`w-24 px-2 py-1 text-sm border rounded ${
-                enabled
+                effectiveEnabled
                   ? 'border-border-primary bg-background-primary text-text-primary'
                   : 'border-border-primary bg-background-secondary text-text-secondary cursor-not-allowed'
               }`}
@@ -353,27 +383,39 @@ export const SecurityToggle = () => {
             <div className="flex items-center justify-between py-2 hover:bg-background-secondary rounded-lg transition-all">
               <div>
                 <h4
-                  className={`text-sm font-medium ${enabled ? 'text-text-primary' : 'text-text-secondary'}`}
+                  className={`text-sm font-medium ${effectiveEnabled ? 'text-text-primary' : 'text-text-secondary'}`}
                 >
                   {intl.formatMessage(i18n.enableCommandInjection)}
                 </h4>
                 <p className="text-xs text-text-secondary max-w-md mt-[2px]">
                   {intl.formatMessage(i18n.commandInjectionDescription)}
                 </p>
+                {isCommandClassifierOverridden && (
+                  <>
+                    <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+                      {intl.formatMessage(i18n.overrideNotice)}
+                    </p>
+                    <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+                      {intl.formatMessage(i18n.warpNotice)}
+                    </p>
+                  </>
+                )}
               </div>
-              <div className="flex items-center">
+              <div
+                className={`flex items-center ${isCommandClassifierOverridden ? 'opacity-40' : ''}`}
+              >
                 <Switch
-                  checked={effectiveCommandClassifierEnabled}
+                  checked={isCommandClassifierOverridden || effectiveCommandClassifierEnabled}
                   onCheckedChange={handleCommandClassifierToggle}
-                  disabled={!enabled}
+                  disabled={!effectiveEnabled || isCommandClassifierOverridden}
                   variant="mono"
                 />
               </div>
             </div>
 
             {hasCommandModel ? (
-              enabled &&
-              effectiveCommandClassifierEnabled && (
+              effectiveEnabled &&
+              (isCommandClassifierOverridden || effectiveCommandClassifierEnabled) && (
                 <div className="text-sm text-gray-700 dark:text-gray-300 mt-2">
                   ✓ {intl.formatMessage(i18n.commandClassifierActive)}
                 </div>
@@ -381,12 +423,16 @@ export const SecurityToggle = () => {
             ) : (
               <div
                 className={`overflow-hidden transition-all duration-300 ease-in-out ${
-                  enabled && effectiveCommandClassifierEnabled
+                  effectiveEnabled && effectiveCommandClassifierEnabled
                     ? 'max-h-[32rem] opacity-100 mt-3'
                     : 'max-h-0 opacity-0'
                 }`}
               >
-                <div className={enabled && effectiveCommandClassifierEnabled ? '' : 'opacity-50'}>
+                <div
+                  className={
+                    effectiveEnabled && effectiveCommandClassifierEnabled ? '' : 'opacity-50'
+                  }
+                >
                   <ClassifierEndpointInputs
                     endpointValue={commandEndpointInput}
                     tokenValue={commandTokenInput}
@@ -394,7 +440,7 @@ export const SecurityToggle = () => {
                     onTokenChange={setCommandTokenInput}
                     onEndpointBlur={handleCommandEndpointChange}
                     onTokenBlur={handleCommandTokenChange}
-                    disabled={!enabled || !effectiveCommandClassifierEnabled}
+                    disabled={!effectiveEnabled || !effectiveCommandClassifierEnabled}
                     endpointPlaceholder="https://example.com/classify"
                     tokenPlaceholder="token..."
                     endpointLabel={intl.formatMessage(i18n.classificationEndpoint)}
@@ -412,7 +458,7 @@ export const SecurityToggle = () => {
             <div className="flex items-center justify-between py-2 hover:bg-background-secondary rounded-lg transition-all">
               <div>
                 <h4
-                  className={`text-sm font-medium ${enabled ? 'text-text-primary' : 'text-text-secondary'}`}
+                  className={`text-sm font-medium ${effectiveEnabled ? 'text-text-primary' : 'text-text-secondary'}`}
                 >
                   {intl.formatMessage(i18n.enablePromptInjectionMl)}
                 </h4>
@@ -424,7 +470,7 @@ export const SecurityToggle = () => {
                 <Switch
                   checked={mlEnabled}
                   onCheckedChange={handleMlToggle}
-                  disabled={!enabled}
+                  disabled={!effectiveEnabled}
                   variant="mono"
                 />
               </div>
@@ -433,15 +479,17 @@ export const SecurityToggle = () => {
             {/* Configuration Section */}
             <div
               className={`overflow-hidden transition-all duration-300 ease-in-out ${
-                enabled && mlEnabled ? 'max-h-[32rem] opacity-100 mt-3' : 'max-h-0 opacity-0'
+                effectiveEnabled && mlEnabled
+                  ? 'max-h-[32rem] opacity-100 mt-3'
+                  : 'max-h-0 opacity-0'
               }`}
             >
-              <div className={enabled && mlEnabled ? '' : 'opacity-50'}>
+              <div className={effectiveEnabled && mlEnabled ? '' : 'opacity-50'}>
                 {showModelDropdown ? (
                   <div className="space-y-3">
                     <div>
                       <label
-                        className={`text-sm font-medium ${enabled && mlEnabled ? 'text-text-primary' : 'text-text-secondary'}`}
+                        className={`text-sm font-medium ${effectiveEnabled && mlEnabled ? 'text-text-primary' : 'text-text-secondary'}`}
                       >
                         {intl.formatMessage(i18n.detectionModel)}
                       </label>
@@ -451,9 +499,9 @@ export const SecurityToggle = () => {
                       <select
                         value={effectiveModel}
                         onChange={(e) => handleModelChange(e.target.value)}
-                        disabled={!enabled || !mlEnabled}
+                        disabled={!effectiveEnabled || !mlEnabled}
                         className={`w-full px-3 py-2 text-sm border rounded ${
-                          enabled && mlEnabled
+                          effectiveEnabled && mlEnabled
                             ? 'border-border-primary bg-background-primary text-text-primary'
                             : 'border-border-primary bg-background-secondary text-text-secondary cursor-not-allowed'
                         }`}
@@ -474,7 +522,7 @@ export const SecurityToggle = () => {
                     onTokenChange={setTokenInput}
                     onEndpointBlur={handleEndpointChange}
                     onTokenBlur={handleTokenChange}
-                    disabled={!enabled || !mlEnabled}
+                    disabled={!effectiveEnabled || !mlEnabled}
                     endpointPlaceholder="https://router.huggingface.co/hf-inference/models/protectai/deberta-v3-base-prompt-injection-v2"
                     tokenPlaceholder="hf_..."
                     endpointLabel={intl.formatMessage(i18n.classificationEndpoint)}

--- a/ui/desktop/src/components/settings/security/SecurityToggle.tsx
+++ b/ui/desktop/src/components/settings/security/SecurityToggle.tsx
@@ -399,9 +399,11 @@ export const SecurityToggle = () => {
                     <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
                       {intl.formatMessage(i18n.overrideNotice)}
                     </p>
-                    <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
-                      {intl.formatMessage(i18n.warpNotice)}
-                    </p>
+                    {commandClassifierOverrideValue && (
+                      <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+                        {intl.formatMessage(i18n.warpNotice)}
+                      </p>
+                    )}
                   </>
                 )}
               </div>

--- a/ui/desktop/src/components/settings/security/SecurityToggle.tsx
+++ b/ui/desktop/src/components/settings/security/SecurityToggle.tsx
@@ -246,7 +246,9 @@ export const SecurityToggle = () => {
     return Object.values(modelMapping).some((modelInfo) => modelInfo.model_type === 'command');
   }, [modelMapping]);
 
-  const effectiveCommandClassifierEnabled = commandClassifierEnabled ?? false;
+  const effectiveCommandClassifierEnabled = isCommandClassifierOverridden
+    ? commandClassifierOverrideValue
+    : (commandClassifierEnabled ?? false);
   const effectiveModel = mlModel || availablePromptModels[0]?.value || '';
   const [thresholdInput, setThresholdInput] = useState(configThreshold.toString());
   const [endpointInput, setEndpointInput] = useState(mlEndpoint);
@@ -411,11 +413,7 @@ export const SecurityToggle = () => {
                 className={`flex items-center ${isCommandClassifierOverridden ? 'opacity-40' : ''}`}
               >
                 <Switch
-                  checked={
-                    isCommandClassifierOverridden
-                      ? commandClassifierOverrideValue
-                      : effectiveCommandClassifierEnabled
-                  }
+                  checked={effectiveCommandClassifierEnabled}
                   onCheckedChange={handleCommandClassifierToggle}
                   disabled={!effectiveEnabled || isCommandClassifierOverridden}
                   variant="mono"
@@ -425,9 +423,7 @@ export const SecurityToggle = () => {
 
             {hasCommandModel ? (
               effectiveEnabled &&
-              (isCommandClassifierOverridden
-                ? commandClassifierOverrideValue
-                : effectiveCommandClassifierEnabled) && (
+              effectiveCommandClassifierEnabled && (
                 <div className="text-sm text-gray-700 dark:text-gray-300 mt-2">
                   ✓ {intl.formatMessage(i18n.commandClassifierActive)}
                 </div>

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -3740,6 +3740,9 @@
   "securityToggle.mlTokenDescription": {
     "defaultMessage": "Authentication token for the ML service (e.g., HuggingFace token)"
   },
+  "securityToggle.overrideNotice": {
+    "defaultMessage": "This setting is managed by your organization and cannot be changed."
+  },
   "securityToggle.promptInjectionDescription": {
     "defaultMessage": "Detect and prevent potential prompt injection attacks"
   },
@@ -3748,6 +3751,9 @@
   },
   "securityToggle.thresholdDescription": {
     "defaultMessage": "Higher values are more strict (0.01 = very lenient, 1.0 = maximum strict)"
+  },
+  "securityToggle.warpNotice": {
+    "defaultMessage": "Command injection detection works best when connected to WARP (required to reach the classification service)."
   },
   "sessionHistory.cancel": {
     "defaultMessage": "Cancel"

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -899,6 +899,9 @@ const createChat = async (app: App, options: CreateChatOptions = {}) => {
           recipeParameters: recipeParameters,
           scheduledJobId: scheduledJobId,
           SECURITY_ML_MODEL_MAPPING: process.env.SECURITY_ML_MODEL_MAPPING,
+          SECURITY_PROMPT_ENABLED_OVERRIDE: process.env.SECURITY_PROMPT_ENABLED_OVERRIDE,
+          SECURITY_COMMAND_CLASSIFIER_ENABLED_OVERRIDE:
+            process.env.SECURITY_COMMAND_CLASSIFIER_ENABLED_OVERRIDE,
         }),
       ],
       partition: 'persist:goose',


### PR DESCRIPTION
## Summary

Replaces the old `DEFAULT_SECURITY_*` "seed-once" mechanism with runtime **override** env vars so prompt injection mitigation can be enabled by default for internal users - and kept that way, without users being able to turn it off.

Two env vars now take precedence over user config at runtime:
- `SECURITY_PROMPT_ENABLED_OVERRIDE`: the overarching prompt-injection feature (master gate)
- `SECURITY_COMMAND_CLASSIFIER_ENABLED_OVERRIDE`: command-injection detection

When set (to `true`/`false`), they override whatever the user has configured. When unset, behavior is unchanged and the user's own settings apply.

**Note:** This needs to be merged along with this PR: https://github.com/squareup/goose-releases/pull/233

## Changes

**Backend (`crates/goose`)**
- Removed `set_security_defaults` / `DEFAULT_SECURITY_*` seeding (and its call in `goose-server`).
- Added a single `get_override` helper that reads **strictly from the process environment** (`std::env::var`), never the config store, so a persisted value can't impersonate the org-managed, non-overridable setting. Accepts only `true`/`false`.
- Override consulted in `is_prompt_injection_detection_enabled`, `is_ml_scanning_enabled`, scanner init, and command classifier creation. Override is scoped to the command classifier only - the ML prompt classifier reads its config key directly.

**Desktop UI (`ui/desktop`)**
- Folded the override into `effectiveCommandClassifierEnabled` so the switch, active indicator, and endpoint/token panel all reflect the effective (override-aware) state - the endpoint inputs now open when the override forces command detection on, even if the saved config value was `false`.
- When a setting is overridden, the toggle is locked (disabled + greyed) and shows a "managed by your organization" notice.
- Forwarded the override env vars through `main.ts` so the UI can reflect the effective state.
- WARP guidance shown only when command detection is force-*enabled*.
- Regenerated `en.json` for the two new messages.

## Testing
- `cargo fmt` + `cargo check -p goose` pass.
- UI `i18n:check` in sync (catalog regenerated from source).

## Screenshots
To come shortly

