### PR TITLE
fix(ui): dedupe React to prevent multiple instances in renderer

### DIFF
--- a/ui/desktop/vite.renderer.config.mts
+++ b/ui/desktop/vite.renderer.config.mts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
+import { resolve } from 'path';
 
 // https://vitejs.dev/config
 export default defineConfig({
@@ -8,6 +9,14 @@ export default defineConfig({
   },
 
   plugins: [tailwindcss()],
+
+  resolve: {
+    dedupe: ['react', 'react-dom'],
+    alias: {
+      react: resolve(__dirname, 'node_modules/react'),
+      'react-dom': resolve(__dirname, 'node_modules/react-dom'),
+    },
+  },
 
   build: {
     target: 'esnext'


### PR DESCRIPTION
Adds resolve aliases to pin react and react-dom to the desktop app's node_modules, preventing duplicate React instances that cause hooks and context errors.

## Summary
I've not been able to get a successful build in developer mode with `just run-ui` for about two months -> #8757
And I finally found the fix for me to successfully build it in developer mode. Btw, I'm also wondering that why it doesn't seem to happen to many contributors here. Is it just my machine (macOS 15.7.7 M3 pro) or just me. 😢 

Anyway, I found out that there were actually two React instances been created during developer mode (Not sure about the production mode but since all the release builds are working this bug might just happen to the developer build). 

```text
ui/                          ← workspace root
  ├── node_modules/
  │   ├── react/               ← Copy A
  │   └── react-intl/          ← installed here, resolves React from ../react
  └── desktop/
      └── node_modules/
          └── react/           ← Copy B (the app's React)
```
React hooks (like useRef) store state on an internal shared object. When react-intl calls useRef, it uses Copy A of React, but the app's component tree was created by Copy B. Copy A's internal state is null because no component tree was ever mounted with it — hence the error Cannot read properties of null (reading 'useRef'). This causes a blank screen when I launch my developer build. After the patch in `vite.renderer.config.mts`, it ensures there is only one React instance at runtime and all the `import 'react'` point to `ui/desktop/node_modules/react` which solves the problem!

I also checkout out both `http://localhost:5173/node_modules/.vite/deps/react.js` and `http://localhost:5173/node_modules/.vite/deps/react-intl.js` and we can see before this patch they refer to different chunks for react.

### Before patch
#### react-intl.js
<img width="303" height="95" alt="react-intl-broken" src="https://github.com/user-attachments/assets/8c24d62e-bfe2-4975-9f24-57008c1bfa51" />

#### react.js
<img width="301" height="105" alt="react-broken" src="https://github.com/user-attachments/assets/af4221f5-6bd9-4be1-92b7-c22d147a62f2" />

### After patch
#### react-intl.js
<img width="300" height="135" alt="react-intl-fixed" src="https://github.com/user-attachments/assets/fb04be7f-4271-4ef6-959d-2bdf621cafba" />

#### react.js
<img width="307" height="98" alt="react-fixed" src="https://github.com/user-attachments/assets/140c9bbb-cbbc-4cc9-b1af-5c7316ef429e" />


Here is the screen recording to show that the patch works.

https://github.com/user-attachments/assets/a4263a22-1f37-4a6a-a635-bb19909e95d4



### Testing
Run the developer build with `just run-ui` or `pnpm run start-gui` from `ui/desktop` if you already had the binary in `ui/desktop/src/bin` and everything should work like a charm instead of a blank screen. 😁 

### Related Issues
Relates to #8757




