### PR TITLE
fix: correctly map ollama_cloud to canonical provider and update max_…

### DIFF
--- a/crates/goose-providers/src/canonical/name_builder.rs
+++ b/crates/goose-providers/src/canonical/name_builder.rs
@@ -49,6 +49,7 @@ pub fn map_provider_name(provider: &str) -> &str {
         "zhipu" => "zhipuai",
         "novita" => "novita-ai",
         "opencode_go" => "opencode-go",
+        "ollama_cloud" => "ollama-cloud",
         _ => provider,
     }
 }

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -241,7 +241,7 @@ impl ModelConfig {
                 self.max_tokens = canonical
                     .limit
                     .output
-                    .filter(|&output| output <= canonical.limit.context)
+                    .filter(|&output| output < canonical.limit.context)
                     .map(|output| output as i32);
             }
             if self.reasoning.is_none() {

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -241,7 +241,7 @@ impl ModelConfig {
                 self.max_tokens = canonical
                     .limit
                     .output
-                    .filter(|&output| output < canonical.limit.context)
+                    .filter(|&output| output <= canonical.limit.context)
                     .map(|output| output as i32);
             }
             if self.reasoning.is_none() {


### PR DESCRIPTION
## Summary
This PR fixes an issue where `ollama_cloud` providers were not correctly mapped to their canonical model names, causing them to fall back to the default context limit (128K) instead of the model's specific capacity.

**Note on the `max_tokens` logic:**
I initially attempted to change the `max_tokens` filter from `<` to `<=` to ensure canonical output limits were applied. However, it was discovered that for models where `output_limit == context_limit`, setting `max_tokens` to the full window results in `Prompt Tokens + Max Tokens > Total Context`, which causes API providers to reject the request. The strict `<` filter is necessary as a safety guard to let the provider dynamically calculate the available output space.

### Testing
**Manual Testing:**
- Launched the CLI using `GOOSE_MODEL=gemma4:31b goose`.
- Verified that the status bar correctly displays the expanded context window (e.g., `0/262k`) instead of the 128k default.
- Confirmed that requests to the model do not trigger context window overflow errors.

### Related Issues
Relates to #8780


