### PR TITLE
fix: Mention menu icon to open the sidebar

### DIFF
--- a/documentation/docs/guides/context-engineering/using-goosehints.md
+++ b/documentation/docs/guides/context-engineering/using-goosehints.md
@@ -6,7 +6,7 @@ sidebar_label: Using goosehints
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import { PanelLeft } from 'lucide-react';
+import { Menu } from 'lucide-react';
 
 `.goosehints` is a text file used to provide additional context about your project and improve the communication with goose. The use of `.goosehints` ensures that goose understands your requirements better and can execute tasks more effectively.
 
@@ -51,7 +51,7 @@ You can use other agent rule files with goose by using the [`CONTEXT_FILE_NAMES`
     #### Local hints file
 
     1. Click the directory path at the bottom of the app and open the directory where you want to create the file
-    2. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar
+    2. Click the hamburger button <Menu className="inline" size={16} /> in the top-left to open the sidebar
     3. Click `Settings` in the sidebar
     4. Click `Chat`
     5. Scroll down to the `Project Hints (.goosehints)` section and click `Configure`


### PR DESCRIPTION
## Summary
<!-- Describe your change -->

This is a small typo fix.

On the [Using goosehints](https://goose-docs.ai/docs/guides/context-engineering/using-goosehints) page, the Left Panel button is mentioned as the the clickable button on Goose Desktop that  will open the sidebar.

However, the icon currently used by Goose Desktop to indicate menu is the hamburger button. So I've change the menu name accordingly.


### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
Manual testing

### Related Issues
N/A


### Screenshots/Demos (for UX changes)
Before:  

<img width="871" height="540" alt="Screenshot from 2026-06-06 21-19-16" src="https://github.com/user-attachments/assets/cbe26386-c301-4c11-8819-84cb0c6fb267" />


After:   

<img width="879" height="560" alt="Screenshot from 2026-06-06 21-18-23" src="https://github.com/user-attachments/assets/21409bdc-8b41-478a-b827-34f6743f6c0e" />

