### PR TITLE
fix(model): read GOOSE_FAST_MODEL from config.yaml

### DIFF
--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -372,7 +372,11 @@ impl ModelConfig {
         fast_model_name: &str,
         provider_name: &str,
     ) -> Result<Self, ConfigError> {
-        let name = std::env::var("GOOSE_FAST_MODEL")
+        // Using Config::global().get_param() reads from both environment
+        // variables and config.yaml, so users can set `GOOSE_FAST_MODEL: ...`
+        // in config.yaml instead of exporting an env var. See #9646.
+        let name = crate::config::Config::global()
+            .get_param::<String>("GOOSE_FAST_MODEL")
             .ok()
             .map(|v| v.trim().to_string())
             .filter(|v| !v.is_empty())
@@ -633,6 +637,50 @@ mod tests {
             config_without_params
                 .get_config_param::<String>("nonexistent", "NONEXISTENT_CONFIG_KEY"),
             None
+        );
+    }
+
+    #[test]
+    fn test_with_fast_uses_goose_fast_model_override() {
+        let _guard = env_lock::lock_env([
+            ("GOOSE_FAST_MODEL", Some("openrouter/owl-alpha")),
+            ("GOOSE_MAX_TOKENS", None::<&str>),
+            ("GOOSE_TEMPERATURE", None::<&str>),
+            ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+            ("GOOSE_TOOLSHIM", None::<&str>),
+            ("GOOSE_TOOLSHIM_OLLAMA_MODEL", None::<&str>),
+        ]);
+
+        let config = ModelConfig::new("primary-model")
+            .unwrap()
+            .with_fast("google/gemini-2.5-flash", "openrouter")
+            .unwrap();
+
+        assert_eq!(
+            config.fast_model_config.as_ref().unwrap().model_name,
+            "openrouter/owl-alpha"
+        );
+    }
+
+    #[test]
+    fn test_with_fast_falls_back_to_provider_default() {
+        let _guard = env_lock::lock_env([
+            ("GOOSE_FAST_MODEL", None::<&str>),
+            ("GOOSE_MAX_TOKENS", None::<&str>),
+            ("GOOSE_TEMPERATURE", None::<&str>),
+            ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+            ("GOOSE_TOOLSHIM", None::<&str>),
+            ("GOOSE_TOOLSHIM_OLLAMA_MODEL", None::<&str>),
+        ]);
+
+        let config = ModelConfig::new("primary-model")
+            .unwrap()
+            .with_fast("google/gemini-2.5-flash", "openrouter")
+            .unwrap();
+
+        assert_eq!(
+            config.fast_model_config.as_ref().unwrap().model_name,
+            "google/gemini-2.5-flash"
         );
     }
 

--- a/documentation/docs/guides/environment-variables.md
+++ b/documentation/docs/guides/environment-variables.md
@@ -30,7 +30,8 @@ export GOOSE_PROVIDER="anthropic"
 export GOOSE_MODEL="claude-sonnet-4-5-20250929"
 export GOOSE_TEMPERATURE=0.7
 
-# Override the fast model used for auxiliary calls (tool-selection, classification, etc.)
+# Override the fast model used for auxiliary calls (tool-selection, classification, session titles, etc.)
+# Can also be set as `GOOSE_FAST_MODEL: "gpt-4o-mini"` in config.yaml
 export GOOSE_FAST_MODEL="gpt-4o-mini"
 
 # Set a lower limit for shorter interactions


### PR DESCRIPTION
## Summary

`ModelConfig::with_fast` only checked the raw `GOOSE_FAST_MODEL` environment variable via `std::env::var`, so users who set it in `config.yaml` (the way `GOOSE_CONTEXT_LIMIT` and other settings already support) had it silently ignored — the provider's hardcoded default fast model (e.g. `google/gemini-2.5-flash` for OpenRouter) was used instead for auxiliary calls like session naming.

This routes the lookup through `Config::global().get_param()`, which checks both the environment variable and `config.yaml`, matching the precedent already established for `GOOSE_CONTEXT_LIMIT` (see the comment near `ModelConfig::new_base`).

Also clarifies the environment variables guide to mention that `GOOSE_FAST_MODEL` can be set in `config.yaml`.

### Testing
Added `test_with_fast_uses_goose_fast_model_override` and `test_with_fast_falls_back_to_provider_default` to `crates/goose/src/model.rs`, mirroring the existing `GOOSE_MAX_TOKENS` env-var tests. Ran `cargo test -p goose --lib model::` — all 42 tests pass. `cargo clippy -p goose --lib --tests -- -D warnings` reports no issues for the changed files.

### Related Issues
Relates to #9646