### PR TITLE
desktop: fix new chat shortcut

### DIFF
--- a/ui/desktop/src/App.test.tsx
+++ b/ui/desktop/src/App.test.tsx
@@ -273,6 +273,27 @@ describe('App Component - Brand New State', () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
+  it('should navigate home when the main process emits new-chat', async () => {
+    mockElectron.getConfig.mockReturnValue({
+      GOOSE_DEFAULT_PROVIDER: 'openai',
+      GOOSE_DEFAULT_MODEL: 'gpt-4',
+      GOOSE_ALLOWLIST_WARNING: false,
+    });
+
+    render(<AppInner />, { wrapper: IntlTestWrapper });
+
+    await waitFor(() => {
+      expect(mockElectron.reactReady).toHaveBeenCalled();
+    });
+
+    const newChatHandler = mockElectron.on.mock.calls.find(([channel]) => channel === 'new-chat')?.[1];
+    expect(newChatHandler).toBeDefined();
+
+    newChatHandler?.({} as any);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
+
   it('should seed recipe sessions with the recipe prompt when no initial message is provided', () => {
     expect(
       resolveSessionInitialMessage(

--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -570,12 +570,12 @@ export function AppInner() {
 
   useEffect(() => {
     const handleNewChat = (_event: IpcRendererEvent, ..._args: unknown[]) => {
-      window.dispatchEvent(new CustomEvent(AppEvents.TRIGGER_NEW_CHAT));
+      navigate('/');
     };
 
     window.electron.on('new-chat', handleNewChat);
     return () => window.electron.off('new-chat', handleNewChat);
-  }, []);
+  }, [navigate]);
 
   useEffect(() => {
     const handleFocusInput = (_event: IpcRendererEvent, ..._args: unknown[]) => {


### PR DESCRIPTION
## Summary
- handle the main-process new-chat IPC by navigating the renderer back to the home route
- add regression coverage for the new-chat IPC path used by Cmd/Ctrl+T

Fixes #9523

## Tests
- pnpm test:run -- src/App.test.tsx
- pnpm exec eslint src/App.tsx src/App.test.tsx --max-warnings 0 --no-warn-ignored