### PR TITLE
Add Firecrawl to the extensions directory

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -332,6 +332,23 @@
     "environmentVariables": []
   },
   {
+    "id": "firecrawl",
+    "name": "Firecrawl",
+    "description": "Web scraping, crawling, and search capabilities for AI agents",
+    "command": "npx -y firecrawl-mcp",
+    "link": "https://github.com/firecrawl/firecrawl-mcp-server",
+    "installation_notes": "Install using npx package manager. Requires a Firecrawl API key.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [
+      {
+        "name": "FIRECRAWL_API_KEY",
+        "description": "API key for Firecrawl web scraping and crawling service",
+        "required": true
+      }
+    ]
+  },
+  {
     "id": "github-mcp",
     "name": "GitHub",
     "description": "GitHub repository management and operations",


### PR DESCRIPTION
## What

Adds **Firecrawl** to the extensions directory (`documentation/static/servers.json`) so it shows up as a browsable, one-click-install card on the [Extensions](https://goose-docs.ai/extensions) page.

## Why

Firecrawl already has a full tutorial at [`/docs/mcp/firecrawl-mcp`](https://goose-docs.ai/docs/mcp/firecrawl-mcp) (with a quick-install deeplink and demo video), but it's missing from `servers.json`, so it never appears in the searchable Extensions directory. Other web search / scraping providers — Exa, Tavily, Browserbase, Apify, AgentQL — are listed there, so this just brings Firecrawl to parity with them.

## Details

- Entry matches the existing schema (`src/types/server.ts`) and the conventions of neighboring entries.
- Install command `npx -y firecrawl-mcp` is unpinned, so it always resolves the latest [`firecrawl-mcp`](https://www.npmjs.com/package/firecrawl-mcp) (search, scrape, crawl, extract, interact).
- `link` points at the canonical [firecrawl/firecrawl-mcp-server](https://github.com/firecrawl/firecrawl-mcp-server) repo.
- Requires `FIRECRAWL_API_KEY`.
- Inserted in alphabetical position (after `figma`); JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
