### PR TITLE
fix(local-inference): stop generation on non-EOG control tokens

### DIFF
--- a/crates/goose/src/providers/local_inference/llamacpp/inference_engine.rs
+++ b/crates/goose/src/providers/local_inference/llamacpp/inference_engine.rs
@@ -10,6 +10,7 @@ use llama_cpp_2::model::{AddBos, ChatTemplateResult, LlamaChatTemplate, LlamaMod
 use llama_cpp_2::mtmd::{MtmdBitmap, MtmdContext, MtmdInputText};
 use llama_cpp_2::openai::OpenAIChatTemplateParams;
 use llama_cpp_2::sampling::LlamaSampler;
+use llama_cpp_2::token_type::LlamaTokenAttr;
 use std::num::NonZeroU32;
 
 use super::super::StreamSender;
@@ -659,6 +660,25 @@ pub(super) fn generation_loop(
         if model.is_eog_token(token) {
             exhausted_loop = false;
             break;
+        }
+
+        // A non-EOG control token (e.g. ChatML `<|im_start|>`) usually means the
+        // model is opening a fresh turn instead of ending its own — upstream
+        // llama.cpp leaves `additional_stops` empty for ChatML, so nothing else
+        // catches it and it leaks into content / runs away generating fake turns.
+        // Stop before emitting it — EXCEPT tool-call boundary markers (e.g. Qwen
+        // `<tool_call>`/`</tool_call>`, which llama.cpp also flags `Control`): those
+        // must reach the streaming parser, so let them through to be emitted below.
+        // (EOG control tokens like `<|im_end|>` are already handled above.)
+        if model.token_attr(token).contains(LlamaTokenAttr::Control) {
+            let mut probe = encoding_rs::UTF_8.new_decoder();
+            let marker = model
+                .token_to_piece(token, &mut probe, true, None)
+                .unwrap_or_default();
+            if !marker.contains("tool_call") {
+                exhausted_loop = false;
+                break;
+            }
         }
 
         output_token_count += 1;


### PR DESCRIPTION
## Problem

Some local GGUF models (observed with Qwen2.5-Coder-32B) sample a ChatML turn delimiter `<|im_start|>` in the *middle* of a generation — attempting to open a fresh turn instead of ending their own. Two things then go wrong:

1. **It isn't stopped.** `<|im_start|>` is a control token but not end-of-generation, so `is_eog_token` returns false. For a ChatML / content-only chat format, `common_chat_params::additional_stops` is left empty upstream, so the text-stop path doesn't catch it either. The model keeps sampling and rolls straight into a fabricated new turn (a runaway — 132 tool executions observed in a single turn).
2. **It leaks.** The loop decodes tokens with `special = true`, which renders the control token as its literal surface form (`<|im_start|>`), so it surfaces verbatim in the assistant's streamed content.

## Fix

In `generation_loop` (`providers/local_inference/llamacpp/inference_engine.rs`), right after the existing `is_eog_token` check, also break on any token whose vocab attribute is `Control` — *before* decoding/emitting it. EOG control tokens (`<|im_end|>`, `<|endoftext|>`) are already handled by the `is_eog_token` check above and never reach this point, so this catches exactly the non-EOG control tokens (turn delimiters) that should end the assistant's turn. Keyed off the token attribute, so it's template- and model-agnostic.

## Result

- Qwen2.5-Coder-7B: unaffected — clean single tool call, terminates normally.
- Qwen2.5-Coder-32B: `<|im_start|>` no longer leaks into content; the runaway collapsed from 132 iterations to a handful of distinct steps.

## Caveat for reviewers

This stops on **all** non-EOG `Control`-attribute tokens. For a model whose in-band delimiters (e.g. tool-call markers) are emitted as special tokens flagged `Control`, this would end generation at that token. In practice such delimiters are typically `UserDefined` rather than `Control`, so the risk is low — but flagging it explicitly in case a maintainer knows of a model that relies on emitting a non-EOG `Control` token mid-generation. If preferred, the check can be narrowed to the specific turn-start token derived from the active chat template — happy to adjust.
