### PR TITLE
fix(desktop): re-apply per-session model when switching to a cached chat

### DIFF
--- a/ui/desktop/src/hooks/useChatStream.ts
+++ b/ui/desktop/src/hooks/useChatStream.ts
@@ -12,6 +12,7 @@ import {
   sessionCancel,
   sessionReply,
   TokenState,
+  updateAgentProvider,
   updateFromSession,
   updateSessionUserRecipeValues,
   listApps,
@@ -748,6 +749,24 @@ export function useChatStream({
           },
         },
       });
+      // Re-apply this session's persisted provider/model to the live agent.
+      // The non-cached path does this via resumeAgent({ load_model_and_extensions: true }).
+      // Without it, switching back to an already-visited (cached) chat leaves the agent on
+      // the previously-active model, so the per-session model "sticks" to the last selected.
+      const cachedModelConfig = cached.session?.model_config;
+      const cachedProvider = cached.session?.provider_name;
+      if (cachedModelConfig?.model_name && cachedProvider) {
+        void updateAgentProvider({
+          body: {
+            session_id: sessionId,
+            provider: cachedProvider,
+            model: cachedModelConfig.model_name,
+            context_limit: cachedModelConfig.context_limit,
+          },
+        }).catch((error) => {
+          console.error('Failed to re-apply session provider on cached switch:', error);
+        });
+      }
       window.dispatchEvent(
         new CustomEvent(AppEvents.SESSION_EXTENSIONS_LOADED, { detail: { sessionId } })
       );


### PR DESCRIPTION
## Problem

In Goose Desktop the active model "sticks" to whatever was last selected when you switch **back** to a chat you already opened this session, instead of restoring that chat's own model.

It's intermittent in a specific way:
- **First open of a chat** (not cached) → full `resumeAgent({ load_model_and_extensions: true })` → `restore_provider_from_session` → correct per-chat model ✅
- **Return to an already-opened (cached) chat** → `resultsCache` hit in `useChatStream` returns early **without** re-applying the agent's provider → model sticks to the last selected ❌

## Repro
1. Open chat A, set model **X** (in-chat switcher).
2. Open chat B, set model **Y**.
3. Switch back to A → A is still on **Y**, not X.

(Opening A fresh after a restart works, because that's a clean resume, not a cache hit — which is why it looks intermittent.)

## Root cause

The backend already persists and restores per-session models: `agent.rs` `update_provider()` persists `model_config` to the session, and `restore_provider_from_session()` re-applies it on resume. The gap is purely the Desktop cache path: the session-load effect in `ui/desktop/src/hooks/useChatStream.ts` early-returns on a `resultsCache` hit and never re-applies the live agent's provider for the chat you switched to.

## Fix

On the cache path, re-apply the cached session's persisted provider/model via the existing `updateAgentProvider` API. Falls back to the global default when the session has no `model_config` (behaviour unchanged for those). Frontend-only, one file.

## Testing

- `tsc --noEmit` passes (no errors in the changed file).
- ⚠️ **Not yet runtime-tested on a built app** — would appreciate verification against the 3-step repro above. Keeping this as a **draft** until confirmed.
