### PR TITLE
fix(local-inference): size context to the turn, not the model's full limit

### DIFF
--- a/crates/goose/src/providers/local_inference/llamacpp/inference_engine.rs
+++ b/crates/goose/src/providers/local_inference/llamacpp/inference_engine.rs
@@ -282,16 +282,25 @@ pub(super) fn effective_context_size(
     memory_max_ctx: Option<usize>,
 ) -> usize {
     let limit = context_cap(settings, context_limit, n_ctx_train, memory_max_ctx);
-    let min_generation_headroom = 512;
-    if prompt_token_count + min_generation_headroom > limit {
+
+    // Size the context to what THIS turn actually needs (prompt + generation
+    // headroom), not the model's full advertised limit. Allocating the full limit
+    // (e.g. 128k for Qwen) builds a Metal compute graph large enough that macOS
+    // aborts the GPU command buffer ("Impacting Interactivity" -> command buffer
+    // status 5 -> "failed to decode, ret = -3"), which then poisons the backend for
+    // the rest of the session. `limit` (which honors an explicit `context_size`
+    // setting and the memory cap) stays the upper bound.
+    let headroom = settings.max_output_tokens.unwrap_or(8192).max(2048);
+    let sized = prompt_token_count.saturating_add(headroom).min(limit);
+
+    if prompt_token_count + 512 > limit {
         tracing::warn!(
-            "Prompt ({} tokens) + minimum headroom ({}) exceeds context limit ({})",
+            "Prompt ({} tokens) + minimum headroom (512) exceeds context limit ({})",
             prompt_token_count,
-            min_generation_headroom,
             limit,
         );
     }
-    limit
+    sized
 }
 
 pub(super) fn build_context_params(


### PR DESCRIPTION
## Problem

On local inference through the llama.cpp Metal backend, a multi-turn session can fail mid-stream with:

```
Prefill decode failed: Decode Error -3: unknown
```

and the underlying log shows the macOS GPU watchdog aborting the command buffer:

```
kIOGPUCommandBufferCallbackErrorImpactingInteractivity
command buffer 0 failed with status 5
failed to decode, ret = -3
```

Once this fires, the backend is poisoned for the rest of the session — every subsequent decode also returns `-3`.

## Root cause

`effective_context_size()` returned the model's *full advertised* context limit (e.g. 128k for Qwen2.5) on every turn. Allocating a KV/compute graph that large builds a Metal command buffer big enough that, as the conversation grows, macOS's GPU watchdog ("Impacting Interactivity") kills it — surfacing as `ret = -3`. It looks intermittent because it only trips once the running context crosses the threshold, but it's deterministic per conversation size, not flaky.

## Fix

Size the per-turn context to what the turn actually needs — `prompt_token_count + generation headroom` — and keep the configured limit (explicit `context_size` / memory cap) as the **upper bound**, not the default allocation. This keeps the compute graph proportional to real usage and well under the watchdog ceiling.

```rust
let headroom = settings.max_output_tokens.unwrap_or(8192).max(2048);
prompt_token_count.saturating_add(headroom).min(limit)
```

One file, `inference_engine.rs`, +14/-5.

## Testing

- A multi-turn growing conversation that reliably hit `Decode Error -3` (around the 4th turn) now completes cleanly through many turns, no `-3`.
- `cargo check -p goose` green.

Metal-specific in symptom, but sizing context to the turn rather than the model max is a reasonable default for any backend.
