### PR TITLE
fix(packaging): disable RPM build-id links

### DIFF
--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -104,6 +104,11 @@ jobs:
             sudo apt-get install -y libasound2
           fi
 
+      - name: Configure RPM packaging
+        run: |
+          echo '%_build_id_links none' > ~/.rpmmacros
+          test "$(rpm --eval '%{_build_id_links}')" = "none"
+
       - name: Setup Flatpak Runtimes
         run: |
           flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
@@ -180,6 +185,14 @@ jobs:
               mv "$package" "${base}-vulkan.${extension}"
             done
           fi
+
+          for package in out/make/rpm/x64/*.rpm; do
+            package_contents="$(rpm -qlp "$package")"
+            if grep -qE '^/usr/lib/\.build-id(/|$)' <<< "$package_contents"; then
+              echo "::error file=$package::RPM contains build-id links"
+              exit 1
+            fi
+          done
 
           echo "Build completed. Checking output..."
           ls -la out/

--- a/ui/desktop/forge.config.ts
+++ b/ui/desktop/forge.config.ts
@@ -113,7 +113,6 @@ module.exports = {
           icon: 'src/images/icon.png',
           prefix: '/opt',
           ...(isLinuxVulkanBuild ? { requires: ['vulkan-loader'] } : {}),
-          fpm: ['--rpm-rpmbuild-define', '_build_id_links none'],
         },
       },
     },


### PR DESCRIPTION
## Summary

- configure `rpmbuild` with `%_build_id_links none` through `~/.rpmmacros` in the Linux packaging job
- remove the unsupported `fpm` option from the Electron Forge RPM configuration
- fail the packaging job if a generated RPM still contains `/usr/lib/.build-id` entries

The current RPM maker uses `electron-installer-redhat`, which invokes `rpmbuild` directly. As a result, the existing `fpm` option is ignored. The v1.37.0 release RPM still contains the exact build-id path reported in the issue.

### Testing

- `actionlint .github/workflows/bundle-desktop-linux.yml`
- parsed the workflow with Ruby YAML
- `git diff --check`
- inspected `Goose-1.37.0-1.x86_64.rpm` and confirmed it contains `/usr/lib/.build-id/f2/1efa6a9c0979ef4eea2b0d873506f78579c48c`
- reproduced the RPM behavior in an Ubuntu 22.04 container using a minimal ELF binary:
  - default `%_build_id_links=compat` produced `/usr/lib/.build-id/...` entries
  - `%_build_id_links none` through `/root/.rpmmacros` produced an RPM with no build-id links
  - the same path-check logic used by the workflow accepted the fixed RPM

### Related Issues

Fixes #9485

### Screenshots/Demos (for UX changes)

N/A