### PR TITLE
feat(desktop): make file paths in chat messages clickable

### DIFF
--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -29,7 +29,7 @@ const customOneDarkTheme = {
 import { Check, Copy } from './icons';
 import { wrapHTMLInCodeBlock } from '../utils/htmlSecurity';
 import { isProtocolSafe, getProtocol, BLOCKED_PROTOCOLS } from '../utils/urlSecurity';
-import { remarkLinkifyPaths, OPEN_FILE_PROTOCOL } from '../utils/linkifyPaths';
+import { remarkLinkifyPaths, OPEN_FILE_PROTOCOL, isTrustedGeneratedFileLink, decodeFileLinkHref } from '../utils/linkifyPaths';
 import { ConfirmationModal } from './ui/ConfirmationModal';
 import { defineMessages, useIntl } from '../i18n';
 
@@ -198,6 +198,19 @@ const customUrlTransform = (url: string): string => {
   return url;
 };
 
+function getAnchorText(children: React.ReactNode): string {
+  if (typeof children === 'string' || typeof children === 'number') {
+    return String(children);
+  }
+  if (Array.isArray(children)) {
+    return children.map(getAnchorText).join('');
+  }
+  if (React.isValidElement<{ children?: React.ReactNode }>(children)) {
+    return getAnchorText(children.props.children);
+  }
+  return '';
+};
+
 const MarkdownContent = memo(function MarkdownContent({
   content,
   className = '',
@@ -274,13 +287,9 @@ const MarkdownContent = memo(function MarkdownContent({
             a: (props) => {
               const href = props.href;
               if (href && href.startsWith(OPEN_FILE_PROTOCOL)) {
-                let filePath: string | undefined;
-                try {
-                  filePath = decodeURIComponent(href.slice(OPEN_FILE_PROTOCOL.length));
-                } catch {
-                  filePath = undefined;
-                }
-                if (filePath) {
+                const filePath = decodeFileLinkHref(href);
+                const label = getAnchorText(props.children);
+                if (filePath && isTrustedGeneratedFileLink(href, label)) {
                   return (
                     <a
                       {...props}

--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -284,7 +284,7 @@ const MarkdownContent = memo(function MarkdownContent({
                   return (
                     <a
                       {...props}
-                      href={undefined}
+                      href={href}
                       onClick={(e) => {
                         e.preventDefault();
                         e.stopPropagation();

--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -274,20 +274,27 @@ const MarkdownContent = memo(function MarkdownContent({
             a: (props) => {
               const href = props.href;
               if (href && href.startsWith(OPEN_FILE_PROTOCOL)) {
-                const filePath = decodeURIComponent(href.slice(OPEN_FILE_PROTOCOL.length));
-                return (
-                  <a
-                    {...props}
-                    href={undefined}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      window.electron.openPathInExplorer(filePath);
-                    }}
-                    className="file-path-link"
-                    title={`Show in Finder: ${filePath}`}
-                  />
-                );
+                let filePath: string | undefined;
+                try {
+                  filePath = decodeURIComponent(href.slice(OPEN_FILE_PROTOCOL.length));
+                } catch {
+                  filePath = undefined;
+                }
+                if (filePath) {
+                  return (
+                    <a
+                      {...props}
+                      href={undefined}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        window.electron.openPathInExplorer(filePath);
+                      }}
+                      className="file-path-link"
+                      title={`Show in Finder: ${filePath}`}
+                    />
+                  );
+                }
               }
               return (
                 <a

--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -29,6 +29,7 @@ const customOneDarkTheme = {
 import { Check, Copy } from './icons';
 import { wrapHTMLInCodeBlock } from '../utils/htmlSecurity';
 import { isProtocolSafe, getProtocol, BLOCKED_PROTOCOLS } from '../utils/urlSecurity';
+import { remarkLinkifyPaths, OPEN_FILE_PROTOCOL } from '../utils/linkifyPaths';
 import { ConfirmationModal } from './ui/ConfirmationModal';
 import { defineMessages, useIntl } from '../i18n';
 
@@ -258,7 +259,7 @@ const MarkdownContent = memo(function MarkdownContent({
       >
         <ReactMarkdown
           urlTransform={customUrlTransform}
-          remarkPlugins={[remarkGfm, remarkBreaks, [remarkMath, { singleDollarTextMath: false }]]}
+          remarkPlugins={[remarkGfm, remarkBreaks, remarkLinkifyPaths, [remarkMath, { singleDollarTextMath: false }]]}
           rehypePlugins={[
             [
               rehypeKatex,
@@ -271,6 +272,23 @@ const MarkdownContent = memo(function MarkdownContent({
           ]}
           components={{
             a: (props) => {
+              const href = props.href;
+              if (href && href.startsWith(OPEN_FILE_PROTOCOL)) {
+                const filePath = decodeURIComponent(href.slice(OPEN_FILE_PROTOCOL.length));
+                return (
+                  <a
+                    {...props}
+                    href={undefined}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      window.electron.openPathInExplorer(filePath);
+                    }}
+                    className="file-path-link"
+                    title={`Show in Finder: ${filePath}`}
+                  />
+                );
+              }
               return (
                 <a
                   {...props}

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -2781,7 +2781,7 @@ async function appMain() {
 
   ipcMain.handle('open-path-in-explorer', async (_event, path: string) => {
     try {
-      shell.showItemInFolder(path);
+      shell.showItemInFolder(expandTilde(path));
       return true;
     } catch (error) {
       console.error('Error showing path in explorer:', error);

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -2779,6 +2779,16 @@ async function appMain() {
     }
   });
 
+  ipcMain.handle('open-path-in-explorer', async (_event, path: string) => {
+    try {
+      shell.showItemInFolder(path);
+      return true;
+    } catch (error) {
+      console.error('Error showing path in explorer:', error);
+      return false;
+    }
+  });
+
   ipcMain.handle('launch-app', async (event, gooseApp: GooseApp) => {
     try {
       const launchingWindow = BrowserWindow.fromWebContents(event.sender);

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -186,6 +186,7 @@ type ElectronAPI = {
   hasAcceptedRecipeBefore: (recipe: Recipe) => Promise<boolean>;
   recordRecipeHash: (recipe: Recipe) => Promise<boolean>;
   openDirectoryInExplorer: (directoryPath: string) => Promise<boolean>;
+  openPathInExplorer: (filePath: string) => Promise<boolean>;
   launchApp: (app: GooseApp) => Promise<void>;
   refreshApp: (app: GooseApp) => Promise<void>;
   closeApp: (appName: string) => Promise<void>;
@@ -344,6 +345,8 @@ const electronAPI: ElectronAPI = {
   recordRecipeHash: (recipe: Recipe) => ipcRenderer.invoke('record-recipe-hash', recipe),
   openDirectoryInExplorer: (directoryPath: string) =>
     ipcRenderer.invoke('open-directory-in-explorer', directoryPath),
+  openPathInExplorer: (filePath: string) =>
+    ipcRenderer.invoke('open-path-in-explorer', filePath),
   launchApp: (app: GooseApp) => ipcRenderer.invoke('launch-app', app),
   refreshApp: (app: GooseApp) => ipcRenderer.invoke('refresh-app', app),
   closeApp: (appName: string) => ipcRenderer.invoke('close-app', appName),

--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -581,6 +581,18 @@ pre:has(> code.bg-inline-code) {
   content: '';
 }
 
+a.file-path-link {
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  border-bottom: 1px dashed currentColor;
+}
+
+a.file-path-link:hover {
+  border-bottom-style: solid;
+  opacity: 0.8;
+}
+
 .user-message p {
   margin-bottom: 0 !important;
 }

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -10,9 +10,14 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe('/home/user/project/src/main.rs');
     });
 
-    it('does not match single-segment paths', () => {
+    it('does not match bare root path', () => {
       const matches = findPaths('Go to / for root');
       expect(matches).toHaveLength(0);
+    });
+
+    it('detects top-level absolute directories', () => {
+      expect(findPaths('Saved to /tmp')[0][1]).toBe('/tmp');
+      expect(findPaths('Saved to /workspace')[0][1]).toBe('/workspace');
     });
 
     it('detects multiple paths in one line', () => {

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -127,5 +127,15 @@ describe('path linkification', () => {
       expect(matches).toHaveLength(1);
       expect(matches[0][1]).toBe('/usr/local/bin/node');
     });
+
+    it('returns no matches for long prose without paths', () => {
+      const prose = 'word '.repeat(10_000);
+      const start = performance.now();
+      const matches = findPaths(prose);
+      const elapsed = performance.now() - start;
+
+      expect(matches).toHaveLength(0);
+      expect(elapsed).toBeLessThan(500);
+    });
   });
 });

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -100,6 +100,16 @@ describe('path linkification', () => {
 
     it('strips trailing line and column suffixes from paths', () => {
       expect(findPaths('error at /workspace/src/lib.rs:42:7')[0][1]).toBe('/workspace/src/lib.rs');
+      expect(findPaths('error at /workspace/src/lib.rs:42')[0][1]).toBe('/workspace/src/lib.rs');
+    });
+
+    it('preserves colon-number suffixes in filenames', () => {
+      expect(findPaths('Saved /tmp/snapshot:1')[0][1]).toBe('/tmp/snapshot:1');
+      expect(findPaths('Saved /tmp/2026-06-18T18:30:00')[0][1]).toBe('/tmp/2026-06-18T18:30:00');
+    });
+
+    it('detects paths followed by tab-separated text', () => {
+      expect(findPaths('See /tmp/out\tOK')[0][1]).toBe('/tmp/out');
     });
 
     it('detects paths with dots and underscores', () => {

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -84,6 +84,10 @@ describe('path linkification', () => {
       expect(findPaths('Saved /tmp/report[1]')[0][1]).toBe('/tmp/report[1]');
     });
 
+    it('detects paths with bracketed suffixes after spaced filename segments', () => {
+      expect(findPaths('Saved /tmp/My report[1].pdf')[0][1]).toBe('/tmp/My report[1].pdf');
+    });
+
     it('detects paths with dots and underscores', () => {
       const matches = findPaths('Read /home/user/.env.local');
       expect(matches).toHaveLength(1);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -80,6 +80,10 @@ describe('path linkification', () => {
       expect(findPaths('Saved /tmp/what?now.txt')[0][1]).toBe('/tmp/what?now.txt');
     });
 
+    it('detects paths with bracketed suffixes without extension', () => {
+      expect(findPaths('Saved /tmp/report[1]')[0][1]).toBe('/tmp/report[1]');
+    });
+
     it('detects paths with dots and underscores', () => {
       const matches = findPaths('Read /home/user/.env.local');
       expect(matches).toHaveLength(1);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -74,6 +74,11 @@ describe('path linkification', () => {
       expect(matches).toHaveLength(1);
       expect(matches[0][1]).toBe('C:\\Users\\dev\\My Project\\index.ts');
     });
+
+    it('does not treat prose labels as Windows paths', () => {
+      expect(findPaths('Option A:retry')).toHaveLength(0);
+      expect(findPaths('Status C:passed')).toHaveLength(0);
+    });
   });
 
   describe('Edge cases', () => {

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -171,6 +171,12 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe('/Users/me/Downloads/report (1)');
     });
 
+    it('does not append prose after parenthesized filename suffixes', () => {
+      const matches = findPaths('Saved /tmp/report (1) successfully.');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/tmp/report (1)');
+    });
+
     it('detects paths with commas in filenames', () => {
       const matches = findPaths('Saved /tmp/report,final.txt');
       expect(matches).toHaveLength(1);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -93,6 +93,12 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe('/tmp/a');
     });
 
+    it('does not extend short basenames with following prose', () => {
+      const matches = findPaths('See /tmp/my for details');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/tmp/my');
+    });
+
     it('includes spaced folder names before sentence punctuation', () => {
       const matches = findPaths('Saved to /home/user/my documents.');
       expect(matches).toHaveLength(1);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -112,6 +112,14 @@ describe('path linkification', () => {
       expect(findPaths('See /tmp/out\tOK')[0][1]).toBe('/tmp/out');
     });
 
+    it('detects paths with spaced bracket suffixes', () => {
+      expect(findPaths('Saved /tmp/log [draft]')[0][1]).toBe('/tmp/log [draft]');
+    });
+
+    it('does not absorb explanatory parentheticals after paths', () => {
+      expect(findPaths('Created /tmp/out (temporary) for debugging')[0][1]).toBe('/tmp/out');
+    });
+
     it('detects paths with dots and underscores', () => {
       const matches = findPaths('Read /home/user/.env.local');
       expect(matches).toHaveLength(1);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -186,6 +186,17 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe('/home/user/my documents');
     });
 
+    it('includes spaced folder names before newline terminators', () => {
+      expect(findPaths('Saved /home/user/my documents\nDone')[0][1]).toBe(
+        '/home/user/my documents'
+      );
+    });
+
+    it('detects paths after assignment separators', () => {
+      expect(findPaths('artifact=/tmp/out.log')[0][1]).toBe('/tmp/out.log');
+      expect(findPaths('--output=/tmp/out')[0][1]).toBe('/tmp/out');
+    });
+
     it('does not match URLs', () => {
       const matches = findPaths('Visit https://example.com/page for info');
       expect(matches).toHaveLength(0);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -305,6 +305,30 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe('/Users/me/Downloads/report (v2).pdf');
     });
 
+    it('detects paths with dotted version parenthesized suffixes', () => {
+      expect(findPaths('Saved /tmp/report (v1.2).pdf')[0][1]).toBe('/tmp/report (v1.2).pdf');
+      expect(findPaths('Saved /tmp/report (v1.2.3).pdf')[0][1]).toBe('/tmp/report (v1.2.3).pdf');
+      expect(findPaths('Saved /tmp/report(v1.2).pdf')[0][1]).toBe('/tmp/report(v1.2).pdf');
+    });
+
+    it('detects paths with underscored parenthesized suffixes', () => {
+      expect(findPaths('Saved /tmp/report (final_v2).pdf')[0][1]).toBe('/tmp/report (final_v2).pdf');
+      expect(findPaths('Saved /tmp/report (draft_v2).pdf')[0][1]).toBe('/tmp/report (draft_v2).pdf');
+      expect(findPaths('Saved /tmp/report(final_v2).pdf')[0][1]).toBe('/tmp/report(final_v2).pdf');
+    });
+
+    it('detects paths with spaced version parenthesized suffixes', () => {
+      expect(findPaths('Saved /tmp/report (final copy v2).pdf')[0][1]).toBe(
+        '/tmp/report (final copy v2).pdf'
+      );
+    });
+
+    it('does not absorb dotted parenthetical prose without extension', () => {
+      expect(findPaths('Created /tmp/out (temporary) for debugging')[0][1]).toBe('/tmp/out');
+      expect(findPaths('Created /tmp/report (temp) for debugging')[0][1]).toBe('/tmp/report');
+      expect(findPaths('Created /tmp/out(temporary) for debugging')[0][1]).toBe('/tmp/out');
+    });
+
     it('preserves closing parens in parenthesized paths without extension', () => {
       const matches = findPaths('Saved /Users/me/Downloads/report (1)');
       expect(matches).toHaveLength(1);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -191,6 +191,13 @@ describe('path linkification', () => {
       expect(matches[1][1]).toBe('/tmp/logs');
     });
 
+    it('detects paths with spaced directory names before separators', () => {
+      expect(findPaths('/Users/me/Library/Application Support/Goose')[0][1]).toBe(
+        '/Users/me/Library/Application Support/Goose'
+      );
+      expect(findPaths('See C:\\Program Files\\Goose')[0][1]).toBe('C:\\Program Files\\Goose');
+    });
+
     it('includes spaced folder names before sentence punctuation', () => {
       const matches = findPaths('Saved to /home/user/my documents.');
       expect(matches).toHaveLength(1);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -69,6 +69,12 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe('/var/log/app.log');
     });
 
+    it('detects paths wrapped in parentheses or brackets', () => {
+      expect(findPaths('See (/tmp/out)')[0][1]).toBe('/tmp/out');
+      expect(findPaths('See (C:\\Users\\dev\\file.txt)')[0][1]).toBe('C:\\Users\\dev\\file.txt');
+      expect(findPaths('See [/tmp/out]')[0][1]).toBe('/tmp/out');
+    });
+
     it('detects paths with dots and underscores', () => {
       const matches = findPaths('Read /home/user/.env.local');
       expect(matches).toHaveLength(1);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -154,6 +154,30 @@ describe('path linkification', () => {
       );
     });
 
+    it('detects multi-word spaced filenames after titlecase basenames', () => {
+      expect(findPaths('Saved /tmp/Project notes draft.txt')[0][1]).toBe(
+        '/tmp/Project notes draft.txt'
+      );
+      expect(findPaths('Saved /tmp/Project notes draft.txt.')[0][1]).toBe(
+        '/tmp/Project notes draft.txt'
+      );
+      expect(findPaths('Saved /tmp/Project notes Draft.txt')[0][1]).toBe(
+        '/tmp/Project notes Draft.txt'
+      );
+    });
+
+    it('detects multi-word spaced filenames after acronym basenames', () => {
+      expect(findPaths('Saved /tmp/API response data.json')[0][1]).toBe(
+        '/tmp/API response data.json'
+      );
+      expect(findPaths('Saved /tmp/API response data.json.')[0][1]).toBe(
+        '/tmp/API response data.json'
+      );
+      expect(findPaths('Saved /tmp/API response DATA.json')[0][1]).toBe(
+        '/tmp/API response DATA.json'
+      );
+    });
+
     it('detects paths with mixed-case multi-word filenames ending in extension', () => {
       expect(findPaths('Saved /tmp/project notes draft Final.txt')[0][1]).toBe(
         '/tmp/project notes draft Final.txt'

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -177,6 +177,12 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe("/tmp/it's.txt");
     });
 
+    it('detects paths with colons in timestamped filenames', () => {
+      const matches = findPaths('Saved /tmp/2026-06-18T18:30:00.log');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/tmp/2026-06-18T18:30:00.log');
+    });
+
     it('does not extend paths across comma-separated prose', () => {
       const matches = findPaths('Created /tmp/report, then continued');
       expect(matches).toHaveLength(1);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -103,6 +103,16 @@ describe('path linkification', () => {
       expect(findPaths('Saved /tmp/report[1]')[0][1]).toBe('/tmp/report[1]');
     });
 
+    it('detects paths with inline parenthesized suffixes in filenames', () => {
+      expect(findPaths('Saved /tmp/report(1).pdf')[0][1]).toBe('/tmp/report(1).pdf');
+      expect(findPaths('Saved /tmp/foo(bar).txt')[0][1]).toBe('/tmp/foo(bar).txt');
+    });
+
+    it('does not absorb inline parenthetical prose without extension', () => {
+      expect(findPaths('Created /tmp/out(temporary) for debugging')[0][1]).toBe('/tmp/out');
+      expect(findPaths('Created /tmp/report(temp) for debugging')[0][1]).toBe('/tmp/report');
+    });
+
     it('detects paths with bracketed suffixes after spaced filename segments', () => {
       expect(findPaths('Saved /tmp/My report[1].pdf')[0][1]).toBe('/tmp/My report[1].pdf');
     });

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -96,6 +96,9 @@ describe('path linkification', () => {
       expect(findPaths('Saved /tmp/project notes draft.txt')[0][1]).toBe(
         '/tmp/project notes draft.txt'
       );
+      expect(findPaths('Saved /tmp/project notes draft.txt.')[0][1]).toBe(
+        '/tmp/project notes draft.txt'
+      );
     });
 
     it('strips trailing line and column suffixes from paths', () => {

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -75,6 +75,11 @@ describe('path linkification', () => {
       expect(findPaths('See [/tmp/out]')[0][1]).toBe('/tmp/out');
     });
 
+    it('detects paths with brackets and question marks in filenames', () => {
+      expect(findPaths('Saved /tmp/report[1].pdf')[0][1]).toBe('/tmp/report[1].pdf');
+      expect(findPaths('Saved /tmp/what?now.txt')[0][1]).toBe('/tmp/what?now.txt');
+    });
+
     it('detects paths with dots and underscores', () => {
       const matches = findPaths('Read /home/user/.env.local');
       expect(matches).toHaveLength(1);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -92,6 +92,16 @@ describe('path linkification', () => {
       expect(findPaths('Saved /tmp/project notes.txt')[0][1]).toBe('/tmp/project notes.txt');
     });
 
+    it('detects paths with multiple lowercase spaced filename words', () => {
+      expect(findPaths('Saved /tmp/project notes draft.txt')[0][1]).toBe(
+        '/tmp/project notes draft.txt'
+      );
+    });
+
+    it('strips trailing line and column suffixes from paths', () => {
+      expect(findPaths('error at /workspace/src/lib.rs:42:7')[0][1]).toBe('/workspace/src/lib.rs');
+    });
+
     it('detects paths with dots and underscores', () => {
       const matches = findPaths('Read /home/user/.env.local');
       expect(matches).toHaveLength(1);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -101,6 +101,10 @@ describe('path linkification', () => {
     it('strips trailing line and column suffixes from paths', () => {
       expect(findPaths('error at /workspace/src/lib.rs:42:7')[0][1]).toBe('/workspace/src/lib.rs');
       expect(findPaths('error at /workspace/src/lib.rs:42')[0][1]).toBe('/workspace/src/lib.rs');
+      expect(findPaths('error at /workspace/goose/Cargo.toml:12:5')[0][1]).toBe(
+        '/workspace/goose/Cargo.toml'
+      );
+      expect(findPaths('See /project/README.md:3 for details')[0][1]).toBe('/project/README.md');
     });
 
     it('preserves colon-number suffixes in filenames', () => {
@@ -114,6 +118,10 @@ describe('path linkification', () => {
 
     it('detects paths with spaced bracket suffixes', () => {
       expect(findPaths('Saved /tmp/log [draft]')[0][1]).toBe('/tmp/log [draft]');
+    });
+
+    it('does not absorb bracket status annotations after paths', () => {
+      expect(findPaths('Created /tmp/out [OK] for upload')[0][1]).toBe('/tmp/out');
     });
 
     it('does not absorb explanatory parentheticals after paths', () => {

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -111,6 +111,18 @@ describe('path linkification', () => {
       expect(findPaths('Saved /tmp/project notes.txt')[0][1]).toBe('/tmp/project notes.txt');
     });
 
+    it('detects extension-bearing spaced filenames after titlecase basenames', () => {
+      expect(findPaths('Saved /tmp/Project notes.txt')[0][1]).toBe('/tmp/Project notes.txt');
+    });
+
+    it('detects extension-bearing spaced filenames after acronym basenames', () => {
+      expect(findPaths('Saved /tmp/API response.json')[0][1]).toBe('/tmp/API response.json');
+    });
+
+    it('detects multi-dot extension-bearing spaced filenames', () => {
+      expect(findPaths('Saved /tmp/My draft.final.md')[0][1]).toBe('/tmp/My draft.final.md');
+    });
+
     it('detects paths with multiple lowercase spaced filename words', () => {
       expect(findPaths('Saved /tmp/project notes draft.txt')[0][1]).toBe(
         '/tmp/project notes draft.txt'
@@ -335,6 +347,14 @@ describe('path linkification', () => {
       const matches = findPaths('Created /tmp/out 2 files');
       expect(matches).toHaveLength(1);
       expect(matches[0][1]).toBe('/tmp/out');
+    });
+
+    it('does not extend paths with bare 4+ digit prose counts', () => {
+      expect(findPaths('Created /tmp/out 2026 files')[0][1]).toBe('/tmp/out');
+    });
+
+    it('does not extend capitalized basenames with bare 4+ digit prose counts', () => {
+      expect(findPaths('Created /tmp/Report 2026 files')[0][1]).toBe('/tmp/Report');
     });
 
     it('does not extend capitalized paths with short numeric counts', () => {

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -153,6 +153,12 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe('/Users/me/Downloads/report (final).pdf');
     });
 
+    it('detects paths with alphanumeric parenthesized filename suffixes', () => {
+      const matches = findPaths('Saved /Users/me/Downloads/report (v2).pdf');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/Users/me/Downloads/report (v2).pdf');
+    });
+
     it('preserves closing parens in parenthesized paths without extension', () => {
       const matches = findPaths('Saved /Users/me/Downloads/report (1)');
       expect(matches).toHaveLength(1);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -155,6 +155,13 @@ describe('path linkification', () => {
       expect(findPaths('error at /workspace/Dockerfile:12')[0][1]).toBe('/workspace/Dockerfile');
       expect(findPaths('error at /workspace/Makefile:8:1')[0][1]).toBe('/workspace/Makefile');
       expect(findPaths('See /project/README:5 for details')[0][1]).toBe('/project/README');
+      expect(findPaths('error at /crates/goose-sdk/justfile:12')[0][1]).toBe(
+        '/crates/goose-sdk/justfile'
+      );
+      expect(findPaths('error at /repo/dockerfile:3:1')[0][1]).toBe('/repo/dockerfile');
+      expect(findPaths('error at /repo/makefile:42')[0][1]).toBe('/repo/makefile');
+      expect(findPaths('error at /ci/Jenkinsfile:7')[0][1]).toBe('/ci/Jenkinsfile');
+      expect(findPaths('error at /app/Procfile:2')[0][1]).toBe('/app/Procfile');
     });
 
     it('preserves colon-number suffixes in filenames', () => {
@@ -252,6 +259,16 @@ describe('path linkification', () => {
     it('does not linkify paths inside URL query values', () => {
       expect(findPaths('See `https://host/download?file=/tmp/out`')).toHaveLength(0);
       expect(findPaths('Visit example.com?file=/tmp/out')).toHaveLength(0);
+      expect(findPaths('Visit example.com?artifact=/tmp/out.log')).toHaveLength(0);
+      expect(findPaths('Visit example.com?path=/tmp/out&other=1')).toHaveLength(0);
+    });
+
+    it('does not linkify paths inside URL fragment or path-parameter values', () => {
+      expect(findPaths('See https://host/page#file=/tmp/out')).toHaveLength(0);
+      expect(findPaths('See https://host/download;file=/tmp/out')).toHaveLength(0);
+      expect(findPaths('See https://host/page#artifact=/tmp/out.log')).toHaveLength(0);
+      expect(findPaths('See https://host/download;output=/tmp/out')).toHaveLength(0);
+      expect(findPaths('See https://host/page#path=/tmp/out&other=1')).toHaveLength(0);
     });
 
     it('does not match URLs', () => {

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { Root } from 'mdast';
-import { findPaths, OPEN_FILE_PROTOCOL, remarkLinkifyPaths } from './linkifyPaths';
+import { findPaths, OPEN_FILE_PROTOCOL, remarkLinkifyPaths, isTrustedGeneratedFileLink } from './linkifyPaths';
 
 describe('path linkification', () => {
   describe('Unix absolute paths', () => {
@@ -171,6 +171,15 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe('/Users/me/Project 2026');
     });
 
+    it('detects paths with @ and percent-encoded characters in filenames', () => {
+      expect(findPaths('File /tmp/foo@bar.txt')[0][1]).toBe('/tmp/foo@bar.txt');
+      expect(findPaths('File /tmp/foo%20bar.txt')[0][1]).toBe('/tmp/foo%20bar.txt');
+    });
+
+    it('does not linkify partial paths before unsupported characters', () => {
+      expect(findPaths('See /tmp/foo#bar.txt')).toHaveLength(0);
+    });
+
     it('detects paths with Unicode segment names', () => {
       const matches = findPaths('Saved /Users/me/デスクトップ/out.txt');
       expect(matches).toHaveLength(1);
@@ -267,5 +276,18 @@ describe('remarkLinkifyPaths', () => {
     expect(link.children[0].type).toBe('strong');
     if (link.children[0].type !== 'strong') return;
     expect(link.children[0].children[0]).toEqual({ type: 'text', value: '/tmp/out' });
+  });
+});
+
+describe('file link trust', () => {
+  it('trusts links whose label matches the decoded path', () => {
+    const path = '/Users/me/My Project/file.txt';
+    const href = OPEN_FILE_PROTOCOL + encodeURI(path);
+    expect(isTrustedGeneratedFileLink(href, path)).toBe(true);
+  });
+
+  it('rejects authored links with mismatched labels', () => {
+    const href = OPEN_FILE_PROTOCOL + encodeURI('/Users/me/Secrets');
+    expect(isTrustedGeneratedFileLink(href, 'release notes')).toBe(false);
   });
 });

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -148,6 +148,7 @@ describe('path linkification', () => {
 
     it('does not absorb explanatory parentheticals after paths', () => {
       expect(findPaths('Created /tmp/out (temporary) for debugging')[0][1]).toBe('/tmp/out');
+      expect(findPaths('Created /tmp/out (temp) for debugging')[0][1]).toBe('/tmp/out');
     });
 
     it('detects paths with dots and underscores', () => {
@@ -313,6 +314,10 @@ describe('path linkification', () => {
       const matches = findPaths('See /tmp/out Please review.');
       expect(matches).toHaveLength(1);
       expect(matches[0][1]).toBe('/tmp/out');
+    });
+
+    it('does not extend capitalized basenames with following prose', () => {
+      expect(findPaths('See /tmp/Result Please review.')[0][1]).toBe('/tmp/Result');
     });
 
     it('detects paths with @ and percent-encoded characters in filenames', () => {

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -336,6 +336,13 @@ describe('path linkification', () => {
       expect(findPaths('See https://host/page#path=/tmp/out&other=1')).toHaveLength(0);
     });
 
+    it('does not linkify paths inside URL query values with hyphenated keys', () => {
+      expect(findPaths('See https://host/download?file-name=/tmp/out')).toHaveLength(0);
+      expect(findPaths('See https://host/download?content-type=/tmp/out.log')).toHaveLength(0);
+      expect(findPaths('See https://host/download?x-custom-param=/tmp/out')).toHaveLength(0);
+      expect(findPaths('Visit example.com?file-name=/tmp/out&other=1')).toHaveLength(0);
+    });
+
     it('does not match URLs', () => {
       const matches = findPaths('Visit https://example.com/page for info');
       expect(matches).toHaveLength(0);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { OPEN_FILE_PROTOCOL } from './linkifyPaths';
+
+const UNIX_PATH_RE = /(?:^|[\s('"`\[(,;]|\/\*.*?\*\/)()(\/(?:[a-zA-Z0-9._+-]+\/){1,}[a-zA-Z0-9._+-]+)/g;
+const TILDE_PATH_RE = /(?:^|[\s('"`\[(,;]|\/\*.*?\*\/)()(~\/(?:[a-zA-Z0-9._+-]+\/)*[a-zA-Z0-9._+-]+)/g;
+const WIN_PATH_RE = /(?:^|[\s('"`\[(,;]|\/\*.*?\*\/)()([A-Za-z]:[\\/](?:[a-zA-Z0-9._+-]+[\\/])+[a-zA-Z0-9._+-]+)/g;
+
+type PathMatch = [index: number, path: string];
+
+function findPaths(text: string): PathMatch[] {
+  const matches: PathMatch[] = [];
+  for (const re of [UNIX_PATH_RE, TILDE_PATH_RE, WIN_PATH_RE]) {
+    let m: RegExpExecArray | null;
+    const localRe = new RegExp(re.source, 'g');
+    while ((m = localRe.exec(text)) !== null) {
+      const prefixLen = m[1].length;
+      const path = m[2];
+      const index = m.index + prefixLen;
+      matches.push([index, path]);
+    }
+  }
+  matches.sort((a, b) => a[0] - b[0]);
+  const result: PathMatch[] = [];
+  let lastEnd = 0;
+  for (const [index, path] of matches) {
+    if (index < lastEnd) continue;
+    result.push([index, path]);
+    lastEnd = index + path.length;
+  }
+  return result;
+}
+
+describe('path linkification', () => {
+  describe('Unix absolute paths', () => {
+    it('detects Unix absolute paths', () => {
+      const matches = findPaths('Created file at /home/user/project/src/main.rs');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/home/user/project/src/main.rs');
+    });
+
+    it('does not match single-segment paths', () => {
+      const matches = findPaths('Go to / for root');
+      expect(matches).toHaveLength(0);
+    });
+
+    it('detects multiple paths in one line', () => {
+      const matches = findPaths('Compare /etc/hosts and /etc/resolv.conf');
+      expect(matches).toHaveLength(2);
+      expect(matches[0][1]).toBe('/etc/hosts');
+      expect(matches[1][1]).toBe('/etc/resolv.conf');
+    });
+  });
+
+  describe('Tilde paths', () => {
+    it('detects tilde paths', () => {
+      const matches = findPaths('Config at ~/.config/app/settings.json');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('~/.config/app/settings.json');
+    });
+
+    it('does not match bare tilde', () => {
+      const matches = findPaths('Go to ~ for home');
+      expect(matches).toHaveLength(0);
+    });
+  });
+
+  describe('Windows paths', () => {
+    it('detects Windows paths', () => {
+      const matches = findPaths('File at C:\\Users\\dev\\project\\index.ts');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('C:\\Users\\dev\\project\\index.ts');
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('detects paths after punctuation', () => {
+      const matches = findPaths('Saved to "/var/log/app.log"');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/var/log/app.log');
+    });
+
+    it('detects paths with dots and underscores', () => {
+      const matches = findPaths('Read /home/user/.env.local');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/home/user/.env.local');
+    });
+
+    it('does not match URLs', () => {
+      const matches = findPaths('Visit https://example.com/page for info');
+      expect(matches).toHaveLength(0);
+    });
+
+    it('generates correct open-file URLs', () => {
+      const path = '/home/user/project/src/main.rs';
+      expect(OPEN_FILE_PROTOCOL + path).toBe('open-file:///home/user/project/src/main.rs');
+    });
+
+    it('handles paths with hyphens', () => {
+      const matches = findPaths('Check /usr/local/lib/my-app/config.yaml');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/usr/local/lib/my-app/config.yaml');
+    });
+  });
+});

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -460,6 +460,28 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe("/tmp/it's.txt");
     });
 
+    it('detects paths with apostrophes in parenthesized filename suffixes', () => {
+      expect(findPaths("Saved /tmp/report (John's copy).pdf")[0][1]).toBe(
+        "/tmp/report (John's copy).pdf"
+      );
+      expect(findPaths("Saved /tmp/report(John's).pdf")[0][1]).toBe("/tmp/report(John's).pdf");
+    });
+
+    it('detects paths with Unicode in parenthesized filename suffixes', () => {
+      expect(findPaths('Saved /tmp/report (最終).pdf')[0][1]).toBe('/tmp/report (最終).pdf');
+      expect(findPaths('Saved /tmp/report(最終).pdf')[0][1]).toBe('/tmp/report(最終).pdf');
+      expect(findPaths('Saved /tmp/report (コピー v2).pdf')[0][1]).toBe(
+        '/tmp/report (コピー v2).pdf'
+      );
+    });
+
+    it('still rejects prose parentheticals without extension evidence', () => {
+      expect(findPaths('Created /tmp/out (temporary) for debugging')[0][1]).toBe('/tmp/out');
+      expect(findPaths('Created /tmp/report (temp) for debugging')[0][1]).toBe('/tmp/report');
+      expect(findPaths('Created /tmp/out (temporary).')[0][1]).toBe('/tmp/out');
+      expect(findPaths('Created /tmp/report (see notes) for review')[0][1]).toBe('/tmp/report');
+    });
+
     it('detects paths with colons in timestamped filenames', () => {
       const matches = findPaths('Saved /tmp/2026-06-18T18:30:00.log');
       expect(matches).toHaveLength(1);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -142,6 +142,26 @@ describe('path linkification', () => {
       );
     });
 
+    it('detects spaced filenames with hyphenated or underscored intermediate words', () => {
+      expect(findPaths('Saved /tmp/project release-notes draft.txt')[0][1]).toBe(
+        '/tmp/project release-notes draft.txt'
+      );
+      expect(findPaths('Saved /tmp/project release_notes draft.txt')[0][1]).toBe(
+        '/tmp/project release_notes draft.txt'
+      );
+      expect(findPaths('Saved /tmp/project release-notes draft.txt.')[0][1]).toBe(
+        '/tmp/project release-notes draft.txt'
+      );
+      expect(findPaths('Saved /tmp/Project release-notes draft.txt')[0][1]).toBe(
+        '/tmp/Project release-notes draft.txt'
+      );
+    });
+
+    it('still rejects prose after two-char basenames with spaced filename lookahead', () => {
+      expect(findPaths('Created /tmp/ui successfully.')[0][1]).toBe('/tmp/ui');
+      expect(findPaths('Check /tmp/go output')[0][1]).toBe('/tmp/go');
+    });
+
     it('detects paths with uppercase extension words after spaced segments', () => {
       expect(findPaths('Saved /tmp/project notes Draft.txt')[0][1]).toBe(
         '/tmp/project notes Draft.txt'
@@ -353,6 +373,23 @@ describe('path linkification', () => {
       expect(findPaths('See https://host/download?content-type=/tmp/out.log')).toHaveLength(0);
       expect(findPaths('See https://host/download?x-custom-param=/tmp/out')).toHaveLength(0);
       expect(findPaths('Visit example.com?file-name=/tmp/out&other=1')).toHaveLength(0);
+    });
+
+    it('does not linkify paths inside URL path assignment values', () => {
+      expect(findPaths('See https://host/download/file=/tmp/out')).toHaveLength(0);
+      expect(findPaths('See https://host/download/output=/tmp/out.log')).toHaveLength(0);
+      expect(findPaths('Visit example.com/download/file=/tmp/out')).toHaveLength(0);
+      expect(findPaths('Visit example.com/path/to/output=/tmp/out')).toHaveLength(0);
+    });
+
+    it('still linkifies assignment-style paths outside URL context', () => {
+      expect(findPaths('artifact=/tmp/out')[0][1]).toBe('/tmp/out');
+      expect(findPaths('--output=/tmp/out')[0][1]).toBe('/tmp/out');
+      expect(findPaths('See ?file=/tmp/out')).toHaveLength(0);
+      expect(findPaths('See #file=/tmp/out')).toHaveLength(0);
+      expect(findPaths('See ;file=/tmp/out')).toHaveLength(0);
+      expect(findPaths('See ?file[]=/tmp/out')).toHaveLength(0);
+      expect(findPaths('See ?file-name=/tmp/out')).toHaveLength(0);
     });
 
     it('does not match URLs', () => {

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -147,6 +147,12 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe('/Users/me/Downloads/report (1).pdf');
     });
 
+    it('detects paths with word parenthesized filename suffixes', () => {
+      const matches = findPaths('Saved /Users/me/Downloads/report (final).pdf');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/Users/me/Downloads/report (final).pdf');
+    });
+
     it('preserves closing parens in parenthesized paths without extension', () => {
       const matches = findPaths('Saved /Users/me/Downloads/report (1)');
       expect(matches).toHaveLength(1);
@@ -163,6 +169,12 @@ describe('path linkification', () => {
       const matches = findPaths('Saved /tmp/report,final.txt');
       expect(matches).toHaveLength(1);
       expect(matches[0][1]).toBe('/tmp/report,final.txt');
+    });
+
+    it('detects paths with apostrophes in filenames', () => {
+      const matches = findPaths("Saved /tmp/it's.txt");
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe("/tmp/it's.txt");
     });
 
     it('does not extend paths across comma-separated prose', () => {

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -239,6 +239,13 @@ describe('path linkification', () => {
       expect(findPaths('See C:\\Program Files\\Goose')[0][1]).toBe('C:\\Program Files\\Goose');
     });
 
+    it('detects paths with parenthesized spaced directory names before separators', () => {
+      expect(findPaths('See C:\\Program Files (x86)\\Goose')[0][1]).toBe(
+        'C:\\Program Files (x86)\\Goose'
+      );
+      expect(findPaths('/Users/me/Apps (Beta)/app')[0][1]).toBe('/Users/me/Apps (Beta)/app');
+    });
+
     it('includes spaced folder names before sentence punctuation', () => {
       const matches = findPaths('Saved to /home/user/my documents.');
       expect(matches).toHaveLength(1);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -218,6 +218,12 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe('/Users/me/Project 2026');
     });
 
+    it('does not extend paths with trailing numeric counts', () => {
+      const matches = findPaths('Created /tmp/out 2 files');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/tmp/out');
+    });
+
     it('detects paths with @ and percent-encoded characters in filenames', () => {
       expect(findPaths('File /tmp/foo@bar.txt')[0][1]).toBe('/tmp/foo@bar.txt');
       expect(findPaths('File /tmp/foo%20bar.txt')[0][1]).toBe('/tmp/foo%20bar.txt');

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -141,6 +141,18 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe('/Users/me/Downloads/report (1).pdf');
     });
 
+    it('detects paths with commas in filenames', () => {
+      const matches = findPaths('Saved /tmp/report,final.txt');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/tmp/report,final.txt');
+    });
+
+    it('does not extend paths across comma-separated prose', () => {
+      const matches = findPaths('Created /tmp/report, then continued');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/tmp/report');
+    });
+
     it('detects paths with numeric suffixes in segment names', () => {
       const matches = findPaths('Saved /Users/me/Project 2026.');
       expect(matches).toHaveLength(1);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -268,6 +268,15 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe('/Users/me/Downloads/report (final).pdf');
     });
 
+    it('detects paths with spaced or hyphenated parenthesized suffixes', () => {
+      expect(findPaths('Saved /Users/me/Downloads/report (final copy).pdf')[0][1]).toBe(
+        '/Users/me/Downloads/report (final copy).pdf'
+      );
+      expect(findPaths('Saved /tmp/report (final-draft).pdf')[0][1]).toBe(
+        '/tmp/report (final-draft).pdf'
+      );
+    });
+
     it('detects paths with alphanumeric parenthesized filename suffixes', () => {
       const matches = findPaths('Saved /Users/me/Downloads/report (v2).pdf');
       expect(matches).toHaveLength(1);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -151,6 +151,12 @@ describe('path linkification', () => {
       expect(findPaths('See /project/README.md:3 for details')[0][1]).toBe('/project/README.md');
     });
 
+    it('strips line and column suffixes from extensionless diagnostic filenames', () => {
+      expect(findPaths('error at /workspace/Dockerfile:12')[0][1]).toBe('/workspace/Dockerfile');
+      expect(findPaths('error at /workspace/Makefile:8:1')[0][1]).toBe('/workspace/Makefile');
+      expect(findPaths('See /project/README:5 for details')[0][1]).toBe('/project/README');
+    });
+
     it('preserves colon-number suffixes in filenames', () => {
       expect(findPaths('Saved /tmp/snapshot:1')[0][1]).toBe('/tmp/snapshot:1');
       expect(findPaths('Saved /tmp/2026-06-18T18:30:00')[0][1]).toBe('/tmp/2026-06-18T18:30:00');
@@ -171,6 +177,12 @@ describe('path linkification', () => {
     it('does not absorb explanatory parentheticals after paths', () => {
       expect(findPaths('Created /tmp/out (temporary) for debugging')[0][1]).toBe('/tmp/out');
       expect(findPaths('Created /tmp/out (temp) for debugging')[0][1]).toBe('/tmp/out');
+    });
+
+    it('does not absorb parentheticals followed only by sentence punctuation', () => {
+      expect(findPaths('Created /tmp/out (temporary).')[0][1]).toBe('/tmp/out');
+      expect(findPaths('Created /tmp/report (temp).')[0][1]).toBe('/tmp/report');
+      expect(findPaths('Created /tmp/out(temporary).')[0][1]).toBe('/tmp/out');
     });
 
     it('detects paths with dots and underscores', () => {

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -80,6 +80,18 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe('/tmp/result.txt');
     });
 
+    it('does not include trailing prose before sentence punctuation', () => {
+      const matches = findPaths('Created /tmp/result successfully.');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/tmp/result');
+    });
+
+    it('includes spaced folder names before sentence punctuation', () => {
+      const matches = findPaths('Saved to /home/user/my documents.');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/home/user/my documents');
+    });
+
     it('does not match URLs', () => {
       const matches = findPaths('Visit https://example.com/page for info');
       expect(matches).toHaveLength(0);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { OPEN_FILE_PROTOCOL } from './linkifyPaths';
 
-const UNIX_PATH_RE = /(?:^|[\s('"`\[(,;]|\/\*.*?\*\/)()(\/(?:[a-zA-Z0-9._+-]+\/){1,}[a-zA-Z0-9._+-]+)/g;
-const TILDE_PATH_RE = /(?:^|[\s('"`\[(,;]|\/\*.*?\*\/)()(~\/(?:[a-zA-Z0-9._+-]+\/)*[a-zA-Z0-9._+-]+)/g;
-const WIN_PATH_RE = /(?:^|[\s('"`\[(,;]|\/\*.*?\*\/)()([A-Za-z]:[\\/](?:[a-zA-Z0-9._+-]+[\\/])+[a-zA-Z0-9._+-]+)/g;
+const UNIX_PATH_RE = /(?:^|[\s('"`[(,;]|\/\*.*?\*\/)?(\/(?:[a-zA-Z0-9._+-]+\/){1,}[a-zA-Z0-9._+-]+)/g;
+const TILDE_PATH_RE = /(?:^|[\s('"`[(,;]|\/\*.*?\*\/)?(~\/(?:[a-zA-Z0-9._+-]+\/)*[a-zA-Z0-9._+-]+)/g;
+const WIN_PATH_RE = /(?:^|[\s('"`[(,;]|\/\*.*?\*\/)?([A-Za-z]:[\\/](?:[a-zA-Z0-9._+-]+[\\/])+[a-zA-Z0-9._+-]+)/g;
 
 type PathMatch = [index: number, path: string];
 
@@ -99,6 +99,17 @@ describe('path linkification', () => {
       const matches = findPaths('Check /usr/local/lib/my-app/config.yaml');
       expect(matches).toHaveLength(1);
       expect(matches[0][1]).toBe('/usr/local/lib/my-app/config.yaml');
+    });
+
+    it('does not match content inside code blocks', () => {
+      const matches = findPaths('Use `Array<T>` for generics');
+      expect(matches).toHaveLength(0);
+    });
+
+    it('matches paths inside inline code markers', () => {
+      const matches = findPaths('`/usr/local/bin/node`');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/usr/local/bin/node');
     });
   });
 });

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -134,6 +134,17 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe('/usr/local/bin/node');
     });
 
+    it('detects paths with Unicode segment names', () => {
+      const matches = findPaths('Saved /Users/me/デスクトップ/out.txt');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/Users/me/デスクトップ/out.txt');
+    });
+
+    it('does not linkify partial paths before unsupported characters', () => {
+      const matches = findPaths('See /Users/me/🎉/out.txt');
+      expect(matches).toHaveLength(0);
+    });
+
     it('returns no matches for long prose without paths', () => {
       const prose = 'word '.repeat(10_000);
       const start = Date.now();

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -88,6 +88,10 @@ describe('path linkification', () => {
       expect(findPaths('Saved /tmp/My report[1].pdf')[0][1]).toBe('/tmp/My report[1].pdf');
     });
 
+    it('detects paths with long lowercase spaced filename segments', () => {
+      expect(findPaths('Saved /tmp/project notes.txt')[0][1]).toBe('/tmp/project notes.txt');
+    });
+
     it('detects paths with dots and underscores', () => {
       const matches = findPaths('Read /home/user/.env.local');
       expect(matches).toHaveLength(1);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -141,6 +141,18 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe('/Users/me/Downloads/report (1).pdf');
     });
 
+    it('preserves closing parens in parenthesized paths without extension', () => {
+      const matches = findPaths('Saved /Users/me/Downloads/report (1)');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/Users/me/Downloads/report (1)');
+    });
+
+    it('strips sentence punctuation after parenthesized paths', () => {
+      const matches = findPaths('Saved /Users/me/Downloads/report (1).');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/Users/me/Downloads/report (1)');
+    });
+
     it('detects paths with commas in filenames', () => {
       const matches = findPaths('Saved /tmp/report,final.txt');
       expect(matches).toHaveLength(1);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -215,6 +215,11 @@ describe('path linkification', () => {
       expect(findPaths('--output=/tmp/out')[0][1]).toBe('/tmp/out');
     });
 
+    it('does not linkify paths inside URL query values', () => {
+      expect(findPaths('See `https://host/download?file=/tmp/out`')).toHaveLength(0);
+      expect(findPaths('Visit example.com?file=/tmp/out')).toHaveLength(0);
+    });
+
     it('does not match URLs', () => {
       const matches = findPaths('Visit https://example.com/page for info');
       expect(matches).toHaveLength(0);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -272,6 +272,10 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe('/tmp/out');
     });
 
+    it('does not extend capitalized paths with short numeric counts', () => {
+      expect(findPaths('Created /tmp/Out 2 files')[0][1]).toBe('/tmp/Out');
+    });
+
     it('does not extend paths with capitalized prose', () => {
       const matches = findPaths('See /tmp/out Please review.');
       expect(matches).toHaveLength(1);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -135,6 +135,12 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe('/usr/local/bin/node');
     });
 
+    it('detects paths with parenthesized download suffixes', () => {
+      const matches = findPaths('Saved /Users/me/Downloads/report (1).pdf');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/Users/me/Downloads/report (1).pdf');
+    });
+
     it('detects paths with numeric suffixes in segment names', () => {
       const matches = findPaths('Saved /Users/me/Project 2026.');
       expect(matches).toHaveLength(1);
@@ -197,5 +203,45 @@ describe('remarkLinkifyPaths', () => {
 
     expect(linkRef.children).toHaveLength(1);
     expect(linkRef.children[0]).toEqual({ type: 'text', value: 'log /tmp/out' });
+  });
+
+  it('does not linkify paths inside formatted link labels', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'link',
+              url: 'https://example.com',
+              children: [
+                {
+                  type: 'strong',
+                  children: [{ type: 'text', value: '/tmp/out' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const transform = (remarkLinkifyPaths as unknown as () => (tree: Root) => void)();
+    transform(tree);
+
+    const paragraph = tree.children[0];
+    expect(paragraph.type).toBe('paragraph');
+    if (paragraph.type !== 'paragraph') return;
+
+    const link = paragraph.children[0];
+    expect(link.type).toBe('link');
+    if (link.type !== 'link') return;
+
+    expect(link.url).toBe('https://example.com');
+    expect(link.children).toHaveLength(1);
+    expect(link.children[0].type).toBe('strong');
+    if (link.children[0].type !== 'strong') return;
+    expect(link.children[0].children[0]).toEqual({ type: 'text', value: '/tmp/out' });
   });
 });

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -1,34 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { OPEN_FILE_PROTOCOL } from './linkifyPaths';
-
-const UNIX_PATH_RE = /(?:^|[\s('"`[(,;]|\/\*.*?\*\/)?(\/(?:[a-zA-Z0-9._+-]+\/){1,}[a-zA-Z0-9._+-]+)/g;
-const TILDE_PATH_RE = /(?:^|[\s('"`[(,;]|\/\*.*?\*\/)?(~\/(?:[a-zA-Z0-9._+-]+\/)*[a-zA-Z0-9._+-]+)/g;
-const WIN_PATH_RE = /(?:^|[\s('"`[(,;]|\/\*.*?\*\/)?([A-Za-z]:[\\/](?:[a-zA-Z0-9._+-]+[\\/])+[a-zA-Z0-9._+-]+)/g;
-
-type PathMatch = [index: number, path: string];
-
-function findPaths(text: string): PathMatch[] {
-  const matches: PathMatch[] = [];
-  for (const re of [UNIX_PATH_RE, TILDE_PATH_RE, WIN_PATH_RE]) {
-    let m: RegExpExecArray | null;
-    const localRe = new RegExp(re.source, 'g');
-    while ((m = localRe.exec(text)) !== null) {
-      const prefixLen = m[1].length;
-      const path = m[2];
-      const index = m.index + prefixLen;
-      matches.push([index, path]);
-    }
-  }
-  matches.sort((a, b) => a[0] - b[0]);
-  const result: PathMatch[] = [];
-  let lastEnd = 0;
-  for (const [index, path] of matches) {
-    if (index < lastEnd) continue;
-    result.push([index, path]);
-    lastEnd = index + path.length;
-  }
-  return result;
-}
+import { findPaths, OPEN_FILE_PROTOCOL } from './linkifyPaths';
 
 describe('path linkification', () => {
   describe('Unix absolute paths', () => {
@@ -83,6 +54,12 @@ describe('path linkification', () => {
       const matches = findPaths('Read /home/user/.env.local');
       expect(matches).toHaveLength(1);
       expect(matches[0][1]).toBe('/home/user/.env.local');
+    });
+
+    it('strips trailing sentence punctuation', () => {
+      const matches = findPaths('Created /tmp/result.txt.');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/tmp/result.txt');
     });
 
     it('does not match URLs', () => {

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { findPaths, OPEN_FILE_PROTOCOL } from './linkifyPaths';
+import type { Root } from 'mdast';
+import { findPaths, OPEN_FILE_PROTOCOL, remarkLinkifyPaths } from './linkifyPaths';
 
 describe('path linkification', () => {
   describe('Unix absolute paths', () => {
@@ -134,6 +135,12 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe('/usr/local/bin/node');
     });
 
+    it('detects paths with numeric suffixes in segment names', () => {
+      const matches = findPaths('Saved /Users/me/Project 2026.');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/Users/me/Project 2026');
+    });
+
     it('detects paths with Unicode segment names', () => {
       const matches = findPaths('Saved /Users/me/デスクトップ/out.txt');
       expect(matches).toHaveLength(1);
@@ -154,5 +161,41 @@ describe('path linkification', () => {
       expect(matches).toHaveLength(0);
       expect(elapsed).toBeLessThan(500);
     });
+  });
+});
+
+describe('remarkLinkifyPaths', () => {
+  it('does not linkify paths inside link references', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'linkReference',
+              identifier: 'log',
+              label: 'log',
+              referenceType: 'full',
+              children: [{ type: 'text', value: 'log /tmp/out' }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const transform = (remarkLinkifyPaths as unknown as () => (tree: Root) => void)();
+    transform(tree);
+
+    const paragraph = tree.children[0];
+    expect(paragraph.type).toBe('paragraph');
+    if (paragraph.type !== 'paragraph') return;
+
+    const linkRef = paragraph.children[0];
+    expect(linkRef.type).toBe('linkReference');
+    if (linkRef.type !== 'linkReference') return;
+
+    expect(linkRef.children).toHaveLength(1);
+    expect(linkRef.children[0]).toEqual({ type: 'text', value: 'log /tmp/out' });
   });
 });

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -224,6 +224,12 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe('/tmp/out');
     });
 
+    it('does not extend paths with capitalized prose', () => {
+      const matches = findPaths('See /tmp/out Please review.');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/tmp/out');
+    });
+
     it('detects paths with @ and percent-encoded characters in filenames', () => {
       expect(findPaths('File /tmp/foo@bar.txt')[0][1]).toBe('/tmp/foo@bar.txt');
       expect(findPaths('File /tmp/foo%20bar.txt')[0][1]).toBe('/tmp/foo%20bar.txt');

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -181,6 +181,16 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe('/tmp/my');
     });
 
+    it('does not extend short basenames with generic nouns', () => {
+      expect(findPaths('Check /tmp/log file for details')[0][1]).toBe('/tmp/log');
+    });
+
+    it('does not extend paths through connective prose before another slash', () => {
+      const matches = findPaths('Review /tmp/output and/or /tmp/logs');
+      expect(matches[0][1]).toBe('/tmp/output');
+      expect(matches[1][1]).toBe('/tmp/logs');
+    });
+
     it('includes spaced folder names before sentence punctuation', () => {
       const matches = findPaths('Saved to /home/user/my documents.');
       expect(matches).toHaveLength(1);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -20,6 +20,18 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe('/etc/hosts');
       expect(matches[1][1]).toBe('/etc/resolv.conf');
     });
+
+    it('detects paths with spaces in segment names', () => {
+      const matches = findPaths('Saved /Users/me/My Project/result.txt for review');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/Users/me/My Project/result.txt');
+    });
+
+    it('detects lowercase folder names with spaces at end of path', () => {
+      const matches = findPaths('Output in /home/user/my documents');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/home/user/my documents');
+    });
   });
 
   describe('Tilde paths', () => {
@@ -40,6 +52,12 @@ describe('path linkification', () => {
       const matches = findPaths('File at C:\\Users\\dev\\project\\index.ts');
       expect(matches).toHaveLength(1);
       expect(matches[0][1]).toBe('C:\\Users\\dev\\project\\index.ts');
+    });
+
+    it('detects Windows paths with spaces in segment names', () => {
+      const matches = findPaths('File at C:\\Users\\dev\\My Project\\index.ts');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('C:\\Users\\dev\\My Project\\index.ts');
     });
   });
 
@@ -69,7 +87,16 @@ describe('path linkification', () => {
 
     it('generates correct open-file URLs', () => {
       const path = '/home/user/project/src/main.rs';
-      expect(OPEN_FILE_PROTOCOL + path).toBe('open-file:///home/user/project/src/main.rs');
+      expect(OPEN_FILE_PROTOCOL + encodeURI(path)).toBe(
+        'open-file:///home/user/project/src/main.rs'
+      );
+    });
+
+    it('encodes spaces in open-file URLs', () => {
+      const path = '/Users/me/My Project/result.txt';
+      expect(OPEN_FILE_PROTOCOL + encodeURI(path)).toBe(
+        'open-file:///Users/me/My%20Project/result.txt'
+      );
     });
 
     it('handles paths with hyphens', () => {

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -86,6 +86,12 @@ describe('path linkification', () => {
       expect(matches[0][1]).toBe('/tmp/result');
     });
 
+    it('does not extend short single-char basenames with prose', () => {
+      const matches = findPaths('Created /tmp/a successfully.');
+      expect(matches).toHaveLength(1);
+      expect(matches[0][1]).toBe('/tmp/a');
+    });
+
     it('includes spaced folder names before sentence punctuation', () => {
       const matches = findPaths('Saved to /home/user/my documents.');
       expect(matches).toHaveLength(1);
@@ -130,9 +136,9 @@ describe('path linkification', () => {
 
     it('returns no matches for long prose without paths', () => {
       const prose = 'word '.repeat(10_000);
-      const start = performance.now();
+      const start = Date.now();
       const matches = findPaths(prose);
-      const elapsed = performance.now() - start;
+      const elapsed = Date.now() - start;
 
       expect(matches).toHaveLength(0);
       expect(elapsed).toBeLessThan(500);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -142,6 +142,27 @@ describe('path linkification', () => {
       );
     });
 
+    it('detects paths with uppercase extension words after spaced segments', () => {
+      expect(findPaths('Saved /tmp/project notes Draft.txt')[0][1]).toBe(
+        '/tmp/project notes Draft.txt'
+      );
+      expect(findPaths('Saved /tmp/project notes FINAL.pdf')[0][1]).toBe(
+        '/tmp/project notes FINAL.pdf'
+      );
+      expect(findPaths('Saved /tmp/My Project Report.DOCX')[0][1]).toBe(
+        '/tmp/My Project Report.DOCX'
+      );
+    });
+
+    it('detects paths with mixed-case multi-word filenames ending in extension', () => {
+      expect(findPaths('Saved /tmp/project notes draft Final.txt')[0][1]).toBe(
+        '/tmp/project notes draft Final.txt'
+      );
+      expect(findPaths('Saved /tmp/project notes Draft.txt.')[0][1]).toBe(
+        '/tmp/project notes Draft.txt'
+      );
+    });
+
     it('strips trailing line and column suffixes from paths', () => {
       expect(findPaths('error at /workspace/src/lib.rs:42:7')[0][1]).toBe('/workspace/src/lib.rs');
       expect(findPaths('error at /workspace/src/lib.rs:42')[0][1]).toBe('/workspace/src/lib.rs');
@@ -268,6 +289,19 @@ describe('path linkification', () => {
       expect(findPaths('Visit example.com?file=/tmp/out')).toHaveLength(0);
       expect(findPaths('Visit example.com?artifact=/tmp/out.log')).toHaveLength(0);
       expect(findPaths('Visit example.com?path=/tmp/out&other=1')).toHaveLength(0);
+    });
+
+    it('does not linkify paths inside URL query values with bracketed keys', () => {
+      expect(findPaths('See https://host/download?file[]=/tmp/out')).toHaveLength(0);
+      expect(findPaths('See https://host/download?items[0]=/tmp/out')).toHaveLength(0);
+      expect(findPaths('See https://host/download?data[key]=/tmp/out.log')).toHaveLength(0);
+      expect(findPaths('Visit example.com?file[]=/tmp/out&other=1')).toHaveLength(0);
+    });
+
+    it('does not linkify paths inside URL query values with percent-encoded keys', () => {
+      expect(findPaths('See https://host/download?file%5B%5D=/tmp/out')).toHaveLength(0);
+      expect(findPaths('See https://host/download?items%5B0%5D=/tmp/out.log')).toHaveLength(0);
+      expect(findPaths('Visit example.com?file%5B%5D=/tmp/out')).toHaveLength(0);
     });
 
     it('does not linkify paths inside URL fragment or path-parameter values', () => {

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -20,6 +20,15 @@ describe('path linkification', () => {
       expect(findPaths('Saved to /workspace')[0][1]).toBe('/workspace');
     });
 
+    it('detects paths in questions with trailing question marks', () => {
+      expect(findPaths('Can you check /tmp/out?')[0][1]).toBe('/tmp/out');
+    });
+
+    it('detects single-segment Windows absolute directories', () => {
+      expect(findPaths('See C:\\Users for details')[0][1]).toBe('C:\\Users');
+      expect(findPaths('See C:\\Windows for details')[0][1]).toBe('C:\\Windows');
+    });
+
     it('detects multiple paths in one line', () => {
       const matches = findPaths('Compare /etc/hosts and /etc/resolv.conf');
       expect(matches).toHaveLength(2);

--- a/ui/desktop/src/utils/linkifyPaths.test.ts
+++ b/ui/desktop/src/utils/linkifyPaths.test.ts
@@ -271,6 +271,18 @@ describe('path linkification', () => {
       expect(findPaths('Check /tmp/log file for details')[0][1]).toBe('/tmp/log');
     });
 
+    it('does not extend two-char basenames with following prose', () => {
+      expect(findPaths('Created /tmp/ui successfully.')[0][1]).toBe('/tmp/ui');
+      expect(findPaths('Check /tmp/go output')[0][1]).toBe('/tmp/go');
+      expect(findPaths('Created /tmp/ui successfully for review')[0][1]).toBe('/tmp/ui');
+      expect(findPaths('Check /tmp/go output please')[0][1]).toBe('/tmp/go');
+    });
+
+    it('still detects determiner-led spaced folder names after two-char tokens', () => {
+      expect(findPaths('Output in /home/user/my documents')[0][1]).toBe('/home/user/my documents');
+      expect(findPaths('Saved /tmp/my backup data')[0][1]).toBe('/tmp/my backup');
+    });
+
     it('does not extend paths through connective prose before another slash', () => {
       const matches = findPaths('Review /tmp/output and/or /tmp/logs');
       expect(matches[0][1]).toBe('/tmp/output');

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -10,7 +10,8 @@ type PathMatch = [index: number, path: string];
 type Separator = '/' | '\\';
 
 function isPathChar(char: string): boolean {
-  return /[a-zA-Z0-9._+-]/.test(char);
+  if (/[a-zA-Z0-9._+-]/.test(char)) return true;
+  return /\p{L}|\p{N}/u.test(char);
 }
 
 function stripTrailingPunctuation(path: string): string {
@@ -57,9 +58,8 @@ function getLastToken(text: string, segmentStart: number, beforeIndex: number): 
 }
 
 function isPathLikeSpacedWord(word: string, prevToken: string): boolean {
-  if (/[A-Z0-9._+-]/.test(word)) return true;
+  if (!/^[a-z0-9]+$/.test(word)) return true;
   return (
-    /^[a-z][a-z0-9]*$/.test(word) &&
     prevToken.length >= 2 &&
     prevToken.length <= 3 &&
     !prevToken.includes('.')
@@ -144,7 +144,15 @@ function parsePathAt(text: string, index: number): PathMatch | null {
   let segmentCount = 0;
   while (i < text.length) {
     const segment = readSegment(text, i, separator);
-    if (!segment) break;
+    if (!segment) {
+      if (segmentCount >= minSegments && i < text.length) {
+        const next = text[i];
+        if (next !== separator && next !== ' ' && !/[.,;:!?)'\]"]/.test(next)) {
+          return null;
+        }
+      }
+      break;
+    }
     i = segment.end;
     segmentCount++;
     if (i < text.length && text[i] === separator) {

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -58,12 +58,17 @@ function getLastToken(text: string, segmentStart: number, beforeIndex: number): 
 }
 
 function isPathLikeSpacedWord(word: string, prevToken: string): boolean {
+  if (/^\d+$/.test(word)) return true;
   if (!/^[a-z0-9]+$/.test(word)) return true;
   return (
     prevToken.length >= 2 &&
     prevToken.length <= 3 &&
     !prevToken.includes('.')
   );
+}
+
+function isLinkLikeParent(parent: Parent | undefined): boolean {
+  return parent?.type === 'link' || parent?.type === 'linkReference';
 }
 
 function readSpacedContinuation(
@@ -254,7 +259,7 @@ export const remarkLinkifyPaths: Plugin<[], Root> = function () {
       if (node.type !== 'text' && node.type !== 'inlineCode') {
         return undefined;
       }
-      if (index === undefined || !parent || parent.type === 'link') {
+      if (index === undefined || !parent || isLinkLikeParent(parent)) {
         return undefined;
       }
       linkifyNode(node, index, parent);

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -19,7 +19,13 @@ function stripTrailingPunctuation(path: string): string {
 }
 
 function stripLineColumnSuffix(path: string): string {
-  return path.replace(/:\d+(?::\d+)?$/, '');
+  const match = path.match(
+    /\.(?:rs|c|cpp|cxx|cc|h|hpp|go|java|js|jsx|ts|tsx|py|rb|swift|kt|scala|cs|php|m|mm|vue|svelte)(:\d+(?::\d+)?)$/i
+  );
+  if (match) {
+    return path.slice(0, -match[1].length);
+  }
+  return path;
 }
 
 function isUrlPathAt(text: string, index: number): boolean {
@@ -248,6 +254,10 @@ function isPathTerminator(char: string): boolean {
   return /[.,;:!'"`)\]]/.test(char);
 }
 
+function isPathBoundary(char: string): boolean {
+  return /\s/.test(char) || isPathTerminator(char);
+}
+
 function parsePathAt(text: string, index: number): PathMatch | null {
   let i = index;
   let separator: Separator = '/';
@@ -276,7 +286,7 @@ function parsePathAt(text: string, index: number): PathMatch | null {
     if (!segment) {
       if (segmentCount >= minSegments && i < text.length) {
         const next = text[i];
-        if (next !== separator && next !== ' ' && !isPathTerminator(next)) {
+        if (next !== separator && !isPathBoundary(next)) {
           return null;
         }
       }
@@ -288,7 +298,7 @@ function parsePathAt(text: string, index: number): PathMatch | null {
       i++;
       continue;
     }
-    if (i < text.length && text[i] !== ' ' && !isPathTerminator(text[i])) {
+    if (i < text.length && !isPathBoundary(text[i])) {
       return null;
     }
     break;

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -114,6 +114,9 @@ function isSpacedFilenameContinuation(
   text: string,
   endIndex: number
 ): boolean {
+  if (/^\[[^\]]+\]$/.test(word)) {
+    return prevToken.length >= 2;
+  }
   if (isPathLikeSpacedWord(word, prevToken)) return true;
   return (
     /^[a-z][a-z0-9]*$/.test(word) &&
@@ -144,10 +147,20 @@ function readParenthesizedSuffix(text: string, spaceIndex: number): number {
   if (!/^[a-zA-Z0-9]+$/.test(content)) return spaceIndex;
 
   i++;
+  const afterParen = i;
   while (i < text.length && isPathChar(text[i])) {
     i++;
   }
-  return i;
+  if (/^\d+$/.test(content)) {
+    return i;
+  }
+  if (i > afterParen) {
+    return i;
+  }
+  if (/^[a-zA-Z0-9]{1,4}$/.test(content)) {
+    return afterParen;
+  }
+  return spaceIndex;
 }
 
 function readSpacedContinuation(
@@ -169,7 +182,7 @@ function readSpacedContinuation(
       j++;
     }
   }
-  while (j > spaceIndex + 1 && /[.,;:!?)'\]"]/.test(text[j - 1] ?? '')) {
+  while (j > spaceIndex + 1 && /[.,;:!?)'"]/.test(text[j - 1] ?? '')) {
     j--;
   }
   if (j === spaceIndex + 1) return spaceIndex;

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -131,12 +131,28 @@ function readSpacedContinuation(
   return spaceIndex;
 }
 
+function isFilenamePunctuation(char: string): boolean {
+  return char === ',';
+}
+
 function readSegment(text: string, start: number, separator: Separator): { end: number } | null {
   let i = start;
   if (i >= text.length || !isPathChar(text[i])) return null;
 
-  while (i < text.length && isPathChar(text[i])) {
-    i++;
+  while (i < text.length) {
+    if (isPathChar(text[i])) {
+      i++;
+      continue;
+    }
+    if (
+      isFilenamePunctuation(text[i]) &&
+      i + 1 < text.length &&
+      isPathChar(text[i + 1])
+    ) {
+      i++;
+      continue;
+    }
+    break;
   }
 
   while (i < text.length && text[i] === ' ') {

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -19,10 +19,18 @@ function stripTrailingPunctuation(path: string): string {
 }
 
 function stripLineColumnSuffix(path: string): string {
-  const match = path.match(/\.[A-Za-z0-9]+(:\d+(?::\d+)?)$/);
-  if (match) {
-    return path.slice(0, -match[1].length);
+  const extMatch = path.match(/\.[A-Za-z0-9]+(:\d+(?::\d+)?)$/);
+  if (extMatch) {
+    return path.slice(0, -extMatch[1].length);
   }
+
+  const lastSep = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+  const basename = path.slice(lastSep + 1);
+  const lineColMatch = basename.match(/^([A-Z][A-Za-z0-9_-]*)(:\d+(?::\d+)?)$/);
+  if (lineColMatch) {
+    return path.slice(0, -lineColMatch[2].length);
+  }
+
   return path;
 }
 
@@ -161,6 +169,11 @@ function isParenthesizedFilenameContent(content: string): boolean {
   return /^[a-zA-Z0-9._]+(?:[ -][a-zA-Z0-9._]+)*$/.test(content);
 }
 
+function hasFilenameSuffixAfterParen(text: string, afterParen: number, endIndex: number): boolean {
+  const suffix = text.slice(afterParen, endIndex).replace(TRAILING_PUNCTUATION_RE, '');
+  return suffix.length > 0 && hasFileExtension(suffix);
+}
+
 function readParenthesizedContent(text: string, openIndex: number): number {
   let i = openIndex + 1;
   const contentStart = i;
@@ -181,7 +194,7 @@ function readParenthesizedContent(text: string, openIndex: number): number {
   if (/^\d+$/.test(content)) {
     return i;
   }
-  if (i > afterParen) {
+  if (i > afterParen && hasFilenameSuffixAfterParen(text, afterParen, i)) {
     return i;
   }
   if (!/[ -]/.test(content) && /^[a-zA-Z0-9]{1,4}$/.test(content) && /\d/.test(content)) {

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -59,7 +59,10 @@ function getLastToken(text: string, segmentStart: number, beforeIndex: number): 
 function isPathLikeSpacedWord(word: string, prevToken: string): boolean {
   if (/[A-Z0-9._+-]/.test(word)) return true;
   return (
-    /^[a-z][a-z0-9]*$/.test(word) && prevToken.length <= 3 && !prevToken.includes('.')
+    /^[a-z][a-z0-9]*$/.test(word) &&
+    prevToken.length >= 2 &&
+    prevToken.length <= 3 &&
+    !prevToken.includes('.')
   );
 }
 
@@ -237,12 +240,17 @@ export const remarkLinkifyPaths: Plugin<[], Root> = function () {
         if (url?.startsWith(OPEN_FILE_PROTOCOL)) {
           return SKIP;
         }
-        return;
+        return undefined;
       }
 
-      if (node.type !== 'text' && node.type !== 'inlineCode') return;
-      if (index === undefined || !parent || parent.type === 'link') return;
+      if (node.type !== 'text' && node.type !== 'inlineCode') {
+        return undefined;
+      }
+      if (index === undefined || !parent || parent.type === 'link') {
+        return undefined;
+      }
       linkifyNode(node, index, parent);
+      return undefined;
     });
   };
 };

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -1,12 +1,12 @@
 import { visit } from 'unist-util-visit';
 import type { Plugin } from 'unified';
-import type { Root, Text, Link, Parent } from 'mdast';
+import type { Root, Text, InlineCode, Link, Parent } from 'mdast';
 
 const OPEN_FILE_PROTOCOL = 'open-file://';
 
-const UNIX_PATH_RE = /(?:^|[\s('"`\[(,;]|\/\*.*?\*\/)()(\/(?:[a-zA-Z0-9._+-]+\/){1,}[a-zA-Z0-9._+-]+)/g;
-const TILDE_PATH_RE = /(?:^|[\s('"`\[(,;]|\/\*.*?\*\/)()(~\/(?:[a-zA-Z0-9._+-]+\/)*[a-zA-Z0-9._+-]+)/g;
-const WIN_PATH_RE = /(?:^|[\s('"`\[(,;]|\/\*.*?\*\/)()([A-Za-z]:[\\/](?:[a-zA-Z0-9._+-]+[\\/])+[a-zA-Z0-9._+-]+)/g;
+const UNIX_PATH_RE = /(?:^|[\s('"`[(,;]|\/\*.*?\*\/)?(\/(?:[a-zA-Z0-9._+-]+\/){1,}[a-zA-Z0-9._+-]+)/g;
+const TILDE_PATH_RE = /(?:^|[\s('"`[(,;]|\/\*.*?\*\/)?(~\/(?:[a-zA-Z0-9._+-]+\/)*[a-zA-Z0-9._+-]+)/g;
+const WIN_PATH_RE = /(?:^|[\s('"`[(,;]|\/\*.*?\*\/)?([A-Za-z]:[\\/](?:[a-zA-Z0-9._+-]+[\\/])+[a-zA-Z0-9._+-]+)/g;
 
 type PathMatch = [index: number, path: string];
 
@@ -33,43 +33,51 @@ function findPaths(text: string): PathMatch[] {
   return result;
 }
 
+function linkifyNode(node: Text | InlineCode, index: number, parent: Parent): void {
+  const text = node.value;
+  const paths = findPaths(text);
+  if (paths.length === 0) return;
+
+  const newNodes: Array<Text | InlineCode | Link> = [];
+  let lastIndex = 0;
+  for (const [pathIndex, path] of paths) {
+    if (pathIndex > lastIndex) {
+      newNodes.push({
+        type: node.type,
+        value: text.slice(lastIndex, pathIndex),
+      } as Text | InlineCode);
+    }
+    newNodes.push({
+      type: 'link',
+      url: OPEN_FILE_PROTOCOL + path,
+      title: null,
+      children: [
+        {
+          type: 'text',
+          value: path,
+        },
+      ],
+    });
+    lastIndex = pathIndex + path.length;
+  }
+  if (lastIndex < text.length) {
+    newNodes.push({
+      type: node.type,
+      value: text.slice(lastIndex),
+    } as Text | InlineCode);
+  }
+  parent.children.splice(index, 1, ...newNodes);
+}
+
 export const remarkLinkifyPaths: Plugin<[], Root> = function () {
   return (tree: Root) => {
     visit(tree, 'text', (node: Text, index: number | undefined, parent: Parent | undefined) => {
       if (index === undefined || !parent) return;
-
-      const paths = findPaths(node.value);
-      if (paths.length === 0) return;
-
-      const newNodes: Array<Text | Link> = [];
-      let lastIndex = 0;
-      for (const [pathIndex, path] of paths) {
-        if (pathIndex > lastIndex) {
-          newNodes.push({
-            type: 'text',
-            value: node.value.slice(lastIndex, pathIndex),
-          });
-        }
-        newNodes.push({
-          type: 'link',
-          url: OPEN_FILE_PROTOCOL + path,
-          title: null,
-          children: [
-            {
-              type: 'text',
-              value: path,
-            },
-          ],
-        });
-        lastIndex = pathIndex + path.length;
-      }
-      if (lastIndex < node.value.length) {
-        newNodes.push({
-          type: 'text',
-          value: node.value.slice(lastIndex),
-        });
-      }
-      parent.children.splice(index, 1, ...newNodes);
+      linkifyNode(node, index, parent);
+    });
+    visit(tree, 'inlineCode', (node: InlineCode, index: number | undefined, parent: Parent | undefined) => {
+      if (index === undefined || !parent) return;
+      linkifyNode(node, index, parent);
     });
   };
 };

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -176,7 +176,7 @@ function readSegment(text: string, start: number, separator: Separator): { end: 
 }
 
 function isPathTerminator(char: string): boolean {
-  return /[.,;:!?'"`]/.test(char);
+  return /[.,;:!?'"`[\])]/.test(char);
 }
 
 function parsePathAt(text: string, index: number): PathMatch | null {

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -19,9 +19,7 @@ function stripTrailingPunctuation(path: string): string {
 }
 
 function stripLineColumnSuffix(path: string): string {
-  const match = path.match(
-    /\.(?:rs|c|cpp|cxx|cc|h|hpp|go|java|js|jsx|ts|tsx|py|rb|swift|kt|scala|cs|php|m|mm|vue|svelte)(:\d+(?::\d+)?)$/i
-  );
+  const match = path.match(/\.[A-Za-z0-9]+(:\d+(?::\d+)?)$/);
   if (match) {
     return path.slice(0, -match[1].length);
   }
@@ -115,7 +113,11 @@ function isSpacedFilenameContinuation(
   endIndex: number
 ): boolean {
   if (/^\[[^\]]+\]$/.test(word)) {
-    return prevToken.length >= 2;
+    const inner = word.slice(1, -1);
+    return (
+      prevToken.length >= 2 &&
+      (/^[a-z][a-z0-9]*$/.test(inner) || /^\d+$/.test(inner))
+    );
   }
   if (isPathLikeSpacedWord(word, prevToken)) return true;
   return (

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -1,0 +1,77 @@
+import { visit } from 'unist-util-visit';
+import type { Plugin } from 'unified';
+import type { Root, Text, Link, Parent } from 'mdast';
+
+const OPEN_FILE_PROTOCOL = 'open-file://';
+
+const UNIX_PATH_RE = /(?:^|[\s('"`\[(,;]|\/\*.*?\*\/)()(\/(?:[a-zA-Z0-9._+-]+\/){1,}[a-zA-Z0-9._+-]+)/g;
+const TILDE_PATH_RE = /(?:^|[\s('"`\[(,;]|\/\*.*?\*\/)()(~\/(?:[a-zA-Z0-9._+-]+\/)*[a-zA-Z0-9._+-]+)/g;
+const WIN_PATH_RE = /(?:^|[\s('"`\[(,;]|\/\*.*?\*\/)()([A-Za-z]:[\\/](?:[a-zA-Z0-9._+-]+[\\/])+[a-zA-Z0-9._+-]+)/g;
+
+type PathMatch = [index: number, path: string];
+
+function findPaths(text: string): PathMatch[] {
+  const matches: PathMatch[] = [];
+  for (const re of [UNIX_PATH_RE, TILDE_PATH_RE, WIN_PATH_RE]) {
+    let m: RegExpExecArray | null;
+    const localRe = new RegExp(re.source, 'g');
+    while ((m = localRe.exec(text)) !== null) {
+      const prefixLen = m[1].length;
+      const path = m[2];
+      const index = m.index + prefixLen;
+      matches.push([index, path]);
+    }
+  }
+  matches.sort((a, b) => a[0] - b[0]);
+  const result: PathMatch[] = [];
+  let lastEnd = 0;
+  for (const [index, path] of matches) {
+    if (index < lastEnd) continue;
+    result.push([index, path]);
+    lastEnd = index + path.length;
+  }
+  return result;
+}
+
+export const remarkLinkifyPaths: Plugin<[], Root> = function () {
+  return (tree: Root) => {
+    visit(tree, 'text', (node: Text, index: number | undefined, parent: Parent | undefined) => {
+      if (index === undefined || !parent) return;
+
+      const paths = findPaths(node.value);
+      if (paths.length === 0) return;
+
+      const newNodes: Array<Text | Link> = [];
+      let lastIndex = 0;
+      for (const [pathIndex, path] of paths) {
+        if (pathIndex > lastIndex) {
+          newNodes.push({
+            type: 'text',
+            value: node.value.slice(lastIndex, pathIndex),
+          });
+        }
+        newNodes.push({
+          type: 'link',
+          url: OPEN_FILE_PROTOCOL + path,
+          title: null,
+          children: [
+            {
+              type: 'text',
+              value: path,
+            },
+          ],
+        });
+        lastIndex = pathIndex + path.length;
+      }
+      if (lastIndex < node.value.length) {
+        newNodes.push({
+          type: 'text',
+          value: node.value.slice(lastIndex),
+        });
+      }
+      parent.children.splice(index, 1, ...newNodes);
+    });
+  };
+};
+
+export { OPEN_FILE_PROTOCOL };

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -161,22 +161,17 @@ function isParenthesizedFilenameContent(content: string): boolean {
   return /^[a-zA-Z0-9]+(?:[ -][a-zA-Z0-9]+)*$/.test(content);
 }
 
-function readParenthesizedSuffix(text: string, spaceIndex: number): number {
-  if (text[spaceIndex] !== ' ') return spaceIndex;
-
-  let i = spaceIndex + 1;
-  if (text[i] !== '(') return spaceIndex;
-
-  i++;
+function readParenthesizedContent(text: string, openIndex: number): number {
+  let i = openIndex + 1;
   const contentStart = i;
   while (i < text.length && text[i] !== ')') {
-    if (text[i] === '(') return spaceIndex;
+    if (text[i] === '(') return openIndex;
     i++;
   }
-  if (i >= text.length) return spaceIndex;
+  if (i >= text.length) return openIndex;
 
   const content = text.slice(contentStart, i);
-  if (!isParenthesizedFilenameContent(content)) return spaceIndex;
+  if (!isParenthesizedFilenameContent(content)) return openIndex;
 
   i++;
   const afterParen = i;
@@ -192,7 +187,19 @@ function readParenthesizedSuffix(text: string, spaceIndex: number): number {
   if (!/[ -]/.test(content) && /^[a-zA-Z0-9]{1,4}$/.test(content) && /\d/.test(content)) {
     return afterParen;
   }
-  return spaceIndex;
+  return openIndex;
+}
+
+function readParenthesizedInlineSuffix(text: string, parenIndex: number): number {
+  if (text[parenIndex] !== '(') return parenIndex;
+  return readParenthesizedContent(text, parenIndex);
+}
+
+function readParenthesizedSuffix(text: string, spaceIndex: number): number {
+  if (text[spaceIndex] !== ' ') return spaceIndex;
+  if (text[spaceIndex + 1] !== '(') return spaceIndex;
+  const end = readParenthesizedContent(text, spaceIndex + 1);
+  return end > spaceIndex + 1 ? end : spaceIndex;
 }
 
 function isConnectiveSpacedWord(word: string): boolean {
@@ -278,6 +285,11 @@ function readSegment(text: string, start: number, separator: Separator): { end: 
       i = bracketEnd;
       continue;
     }
+    const parenEnd = readParenthesizedInlineSuffix(text, i);
+    if (parenEnd > i) {
+      i = parenEnd;
+      continue;
+    }
     if (
       isFilenamePunctuation(text[i]) &&
       i + 1 < text.length &&
@@ -304,7 +316,7 @@ function readSegment(text: string, start: number, separator: Separator): { end: 
 }
 
 function isPathTerminator(char: string): boolean {
-  return /[.,;:!?'"`)\]]/.test(char);
+  return /[.,;:!?'"`()\]]/.test(char);
 }
 
 function isPathBoundary(char: string): boolean {

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -138,7 +138,7 @@ function readSpacedContinuation(
 }
 
 function isFilenamePunctuation(char: string): boolean {
-  return char === ',' || char === "'" || char === ':';
+  return char === ',' || char === "'" || char === ':' || char === '[' || char === ']' || char === '?';
 }
 
 function readSegment(text: string, start: number, separator: Separator): { end: number } | null {
@@ -176,7 +176,7 @@ function readSegment(text: string, start: number, separator: Separator): { end: 
 }
 
 function isPathTerminator(char: string): boolean {
-  return /[.,;:!?'"`[\])]/.test(char);
+  return /[.,;:!'"`)\]]/.test(char);
 }
 
 function parsePathAt(text: string, index: number): PathMatch | null {

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -182,7 +182,7 @@ function isSpacedFilenameContinuation(
   if (isPathLikeSpacedWord(word, prevToken, text[endIndex])) return true;
   return (
     /^[a-z][a-z0-9]*$/.test(word) &&
-    /^[a-z]/.test(prevToken) &&
+    /^[A-Za-z]/.test(prevToken) &&
     readExtensionWordAhead(text, endIndex)
   );
 }

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -4,7 +4,7 @@ import type { Root, Text, InlineCode, Link, Parent } from 'mdast';
 
 const OPEN_FILE_PROTOCOL = 'open-file://';
 
-const TRAILING_PUNCTUATION_RE = /[.,;:!?)'\]"]+$/;
+const TRAILING_PUNCTUATION_RE = /[.,;:!?'"]+$/;
 
 type PathMatch = [index: number, path: string];
 type Separator = '/' | '\\';

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -173,6 +173,10 @@ function readParenthesizedSuffix(text: string, spaceIndex: number): number {
   return spaceIndex;
 }
 
+function isConnectiveSpacedWord(word: string): boolean {
+  return /^(?:and|or)$/i.test(word);
+}
+
 function readSpacedContinuation(
   text: string,
   spaceIndex: number,
@@ -202,7 +206,7 @@ function readSpacedContinuation(
   const after = text[j];
 
   if (after === separator) {
-    return isSpacedFilenameContinuation(word, prevToken, text, j) ? j : spaceIndex;
+    return isConnectiveSpacedWord(word) ? spaceIndex : j;
   }
 
   if (after === undefined || /[.,;:!?)'\]"]/.test(after)) {

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -8,17 +8,30 @@ const UNIX_PATH_RE = /(?:^|[\s('"`[(,;]|\/\*.*?\*\/)?(\/(?:[a-zA-Z0-9._+-]+\/){1
 const TILDE_PATH_RE = /(?:^|[\s('"`[(,;]|\/\*.*?\*\/)?(~\/(?:[a-zA-Z0-9._+-]+\/)*[a-zA-Z0-9._+-]+)/g;
 const WIN_PATH_RE = /(?:^|[\s('"`[(,;]|\/\*.*?\*\/)?([A-Za-z]:[\\/](?:[a-zA-Z0-9._+-]+[\\/])+[a-zA-Z0-9._+-]+)/g;
 
+const TRAILING_PUNCTUATION_RE = /[.,;:!?)'\]"]+$/;
+
 type PathMatch = [index: number, path: string];
 
-function findPaths(text: string): PathMatch[] {
+function stripTrailingPunctuation(path: string): string {
+  return path.replace(TRAILING_PUNCTUATION_RE, '');
+}
+
+function isUrlPath(text: string, index: number): boolean {
+  const before = text.slice(0, index);
+  return /[a-zA-Z][a-zA-Z0-9+.-]*:\/\/?$/.test(before);
+}
+
+export function findPaths(text: string): PathMatch[] {
   const matches: PathMatch[] = [];
   for (const re of [UNIX_PATH_RE, TILDE_PATH_RE, WIN_PATH_RE]) {
     let m: RegExpExecArray | null;
     const localRe = new RegExp(re.source, 'g');
     while ((m = localRe.exec(text)) !== null) {
-      const prefixLen = m[1].length;
-      const path = m[2];
+      const path = stripTrailingPunctuation(m[1]);
+      if (path.length === 0) continue;
+      const prefixLen = m[0].length - m[1].length;
       const index = m.index + prefixLen;
+      if (isUrlPath(text, index)) continue;
       matches.push([index, path]);
     }
   }
@@ -72,11 +85,11 @@ function linkifyNode(node: Text | InlineCode, index: number, parent: Parent): vo
 export const remarkLinkifyPaths: Plugin<[], Root> = function () {
   return (tree: Root) => {
     visit(tree, 'text', (node: Text, index: number | undefined, parent: Parent | undefined) => {
-      if (index === undefined || !parent) return;
+      if (index === undefined || !parent || parent.type === 'link') return;
       linkifyNode(node, index, parent);
     });
     visit(tree, 'inlineCode', (node: InlineCode, index: number | undefined, parent: Parent | undefined) => {
-      if (index === undefined || !parent) return;
+      if (index === undefined || !parent || parent.type === 'link') return;
       linkifyNode(node, index, parent);
     });
   };

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -72,7 +72,7 @@ function isParenthesizedSuffix(token: string): boolean {
 function isPathLikeSpacedWord(word: string, prevToken: string): boolean {
   if (isParenthesizedSuffix(prevToken)) return false;
   if (/^\d+$/.test(word)) {
-    return word.length >= 4 || /^[A-Z]/.test(prevToken);
+    return word.length >= 4;
   }
   if (/^[A-Z]/.test(word)) {
     return /^[A-Z]/.test(prevToken);

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -50,7 +50,7 @@ function isCandidatePathStart(text: string, index: number, afterBlockComment: bo
   if (index === 0) return true;
   if (isUrlPathAt(text, index)) return false;
   const prev = text[index - 1];
-  if (/[\s('"`[(,;]/.test(prev)) return true;
+  if (/[\s('"`[(,;=]/.test(prev)) return true;
   return afterBlockComment;
 }
 
@@ -199,9 +199,11 @@ function readSpacedContinuation(
     return isSpacedFilenameContinuation(word, prevToken, text, j) ? j : spaceIndex;
   }
 
-  if (after === ' ') {
-    const rest = text.slice(j).trimStart();
-    if (rest.startsWith(separator)) return spaceIndex;
+  if (after !== undefined && /\s/.test(after)) {
+    if (after === ' ') {
+      const rest = text.slice(j).trimStart();
+      if (rest.startsWith(separator)) return spaceIndex;
+    }
     return isSpacedFilenameContinuation(word, prevToken, text, j) ? j : spaceIndex;
   }
 

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -18,6 +18,10 @@ function stripTrailingPunctuation(path: string): string {
   return path.replace(TRAILING_PUNCTUATION_RE, '');
 }
 
+function stripLineColumnSuffix(path: string): string {
+  return path.replace(/:\d+(?::\d+)?$/, '');
+}
+
 function isUrlPathAt(text: string, index: number): boolean {
   let i = index - 1;
   if (i < 0) return false;
@@ -80,6 +84,38 @@ function isPathLikeSpacedWord(word: string, prevToken: string): boolean {
   );
 }
 
+function readExtensionWordAhead(text: string, fromIndex: number): boolean {
+  let i = fromIndex;
+  while (i < text.length) {
+    if (text[i] !== ' ') return false;
+    i++;
+    let j = i;
+    while (j < text.length && isPathChar(text[j])) {
+      j++;
+    }
+    if (j === i) return false;
+    const word = text.slice(i, j);
+    if (/\.[A-Za-z0-9]+$/.test(word) && /^[a-z]/.test(word)) return true;
+    if (!/^[a-z][a-z0-9]*$/.test(word)) return false;
+    i = j;
+  }
+  return false;
+}
+
+function isSpacedFilenameContinuation(
+  word: string,
+  prevToken: string,
+  text: string,
+  endIndex: number
+): boolean {
+  if (isPathLikeSpacedWord(word, prevToken)) return true;
+  return (
+    /^[a-z][a-z0-9]*$/.test(word) &&
+    /^[a-z]/.test(prevToken) &&
+    readExtensionWordAhead(text, endIndex)
+  );
+}
+
 function isLinkLikeParent(parent: Parent | undefined): boolean {
   return parent?.type === 'link' || parent?.type === 'linkReference';
 }
@@ -139,13 +175,13 @@ function readSpacedContinuation(
   if (after === separator) return j;
 
   if (after === undefined || /[.,;:!?)'\]"]/.test(after)) {
-    return isPathLikeSpacedWord(word, prevToken) ? j : spaceIndex;
+    return isSpacedFilenameContinuation(word, prevToken, text, j) ? j : spaceIndex;
   }
 
   if (after === ' ') {
     const rest = text.slice(j).trimStart();
     if (rest.startsWith(separator)) return spaceIndex;
-    return isPathLikeSpacedWord(word, prevToken) ? j : spaceIndex;
+    return isSpacedFilenameContinuation(word, prevToken, text, j) ? j : spaceIndex;
   }
 
   return spaceIndex;
@@ -260,7 +296,7 @@ function parsePathAt(text: string, index: number): PathMatch | null {
 
   if (segmentCount < minSegments) return null;
 
-  const path = stripTrailingPunctuation(text.slice(index, i));
+  const path = stripLineColumnSuffix(stripTrailingPunctuation(text.slice(index, i)));
   if (path.length === 0) return null;
 
   return [index, path];

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -61,6 +61,7 @@ function isPathLikeSpacedWord(word: string, prevToken: string): boolean {
   if (/^\d+$/.test(word)) return true;
   if (!/^[a-z0-9]+$/.test(word)) return true;
   return (
+    word.length >= 4 &&
     prevToken.length >= 2 &&
     prevToken.length <= 3 &&
     !prevToken.includes('.')

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -78,7 +78,7 @@ function isUrlPathAt(text: string, index: number): boolean {
 }
 
 function isQueryParamKeyChar(char: string): boolean {
-  return /[-a-zA-Z0-9_.$\[\]%]/.test(char);
+  return /[-a-zA-Z0-9_.$[\]%]/.test(char);
 }
 
 function isAssignmentEqualsStart(text: string, index: number): boolean {

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -71,6 +71,30 @@ function isLinkLikeParent(parent: Parent | undefined): boolean {
   return parent?.type === 'link' || parent?.type === 'linkReference';
 }
 
+function readParenthesizedSuffix(text: string, spaceIndex: number): number {
+  if (text[spaceIndex] !== ' ') return spaceIndex;
+
+  let i = spaceIndex + 1;
+  if (text[i] !== '(') return spaceIndex;
+
+  i++;
+  const contentStart = i;
+  while (i < text.length && text[i] !== ')') {
+    if (text[i] === '(') return spaceIndex;
+    i++;
+  }
+  if (i >= text.length) return spaceIndex;
+
+  const content = text.slice(contentStart, i);
+  if (!/^\d+$/.test(content)) return spaceIndex;
+
+  i++;
+  while (i < text.length && isPathChar(text[i])) {
+    i++;
+  }
+  return i;
+}
+
 function readSpacedContinuation(
   text: string,
   spaceIndex: number,
@@ -116,6 +140,11 @@ function readSegment(text: string, start: number, separator: Separator): { end: 
   }
 
   while (i < text.length && text[i] === ' ') {
+    const parenEnd = readParenthesizedSuffix(text, i);
+    if (parenEnd > i) {
+      i = parenEnd;
+      continue;
+    }
     const continuationEnd = readSpacedContinuation(text, i, start, separator);
     if (continuationEnd === i) break;
     i = continuationEnd;
@@ -248,12 +277,8 @@ function linkifyNode(node: Text | InlineCode, index: number, parent: Parent): vo
 export const remarkLinkifyPaths: Plugin<[], Root> = function () {
   return (tree: Root) => {
     visit(tree, (node, index, parent) => {
-      if (node.type === 'link') {
-        const url = 'url' in node ? node.url : undefined;
-        if (url?.startsWith(OPEN_FILE_PROTOCOL)) {
-          return SKIP;
-        }
-        return undefined;
+      if (node.type === 'link' || node.type === 'linkReference') {
+        return SKIP;
       }
 
       if (node.type !== 'text' && node.type !== 'inlineCode') {

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -10,7 +10,7 @@ type PathMatch = [index: number, path: string];
 type Separator = '/' | '\\';
 
 function isPathChar(char: string): boolean {
-  if (/[a-zA-Z0-9._+-]/.test(char)) return true;
+  if (/[a-zA-Z0-9._+@%-]/.test(char)) return true;
   return /\p{L}|\p{N}/u.test(char);
 }
 
@@ -169,6 +169,10 @@ function readSegment(text: string, start: number, separator: Separator): { end: 
   return i > start ? { end: i } : null;
 }
 
+function isPathTerminator(char: string): boolean {
+  return /[.,;:!?'"`]/.test(char);
+}
+
 function parsePathAt(text: string, index: number): PathMatch | null {
   let i = index;
   let separator: Separator = '/';
@@ -197,7 +201,7 @@ function parsePathAt(text: string, index: number): PathMatch | null {
     if (!segment) {
       if (segmentCount >= minSegments && i < text.length) {
         const next = text[i];
-        if (next !== separator && next !== ' ' && !/[.,;:!?)'\]"]/.test(next)) {
+        if (next !== separator && next !== ' ' && !isPathTerminator(next)) {
           return null;
         }
       }
@@ -208,6 +212,9 @@ function parsePathAt(text: string, index: number): PathMatch | null {
     if (i < text.length && text[i] === separator) {
       i++;
       continue;
+    }
+    if (i < text.length && text[i] !== ' ' && !isPathTerminator(text[i])) {
+      return null;
     }
     break;
   }
@@ -310,3 +317,17 @@ export const remarkLinkifyPaths: Plugin<[], Root> = function () {
 };
 
 export { OPEN_FILE_PROTOCOL };
+
+export function decodeFileLinkHref(href: string): string | undefined {
+  if (!href.startsWith(OPEN_FILE_PROTOCOL)) return undefined;
+  try {
+    return decodeURIComponent(href.slice(OPEN_FILE_PROTOCOL.length));
+  } catch {
+    return undefined;
+  }
+}
+
+export function isTrustedGeneratedFileLink(href: string, label: string): boolean {
+  const filePath = decodeFileLinkHref(href);
+  return filePath !== undefined && label === filePath;
+}

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -142,7 +142,21 @@ function readSpacedContinuation(
 }
 
 function isFilenamePunctuation(char: string): boolean {
-  return char === ',' || char === "'" || char === ':' || char === '[' || char === ']' || char === '?';
+  return char === ',' || char === "'" || char === ':' || char === '?';
+}
+
+function readBracketedSuffix(text: string, bracketIndex: number): number {
+  if (text[bracketIndex] !== '[') return bracketIndex;
+
+  let j = bracketIndex + 1;
+  if (j >= text.length) return bracketIndex;
+
+  while (j < text.length && isPathChar(text[j])) {
+    j++;
+  }
+  if (j >= text.length || text[j] !== ']') return bracketIndex;
+
+  return j + 1;
 }
 
 function readSegment(text: string, start: number, separator: Separator): { end: number } | null {
@@ -152,6 +166,11 @@ function readSegment(text: string, start: number, separator: Separator): { end: 
   while (i < text.length) {
     if (isPathChar(text[i])) {
       i++;
+      continue;
+    }
+    const bracketEnd = readBracketedSuffix(text, i);
+    if (bracketEnd > i) {
+      i = bracketEnd;
       continue;
     }
     if (

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -77,10 +77,14 @@ function isUrlPathAt(text: string, index: number): boolean {
   return scheme.length > 0 && /[a-zA-Z]/.test(scheme[0]);
 }
 
+function isQueryParamKeyChar(char: string): boolean {
+  return /[a-zA-Z0-9_.$\[\]%-]/.test(char);
+}
+
 function isAssignmentEqualsStart(text: string, index: number): boolean {
   if (text[index - 1] !== '=') return false;
   let i = index - 2;
-  while (i >= 0 && /[a-zA-Z0-9_.$-]/.test(text[i])) {
+  while (i >= 0 && isQueryParamKeyChar(text[i])) {
     i--;
   }
   return !(i >= 0 && URL_PARAM_DELIMITERS.has(text[i]));
@@ -155,7 +159,7 @@ function readExtensionWordAhead(text: string, fromIndex: number): boolean {
     }
     if (j === i) return false;
     const word = text.slice(i, j).replace(TRAILING_PUNCTUATION_RE, '');
-    if (hasFileExtension(word) && /^[a-z]/.test(word)) return true;
+    if (hasFileExtension(word)) return true;
     if (!/^[a-z][a-z0-9]*$/.test(word)) return false;
     i = j;
   }

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -57,7 +57,12 @@ function getLastToken(text: string, segmentStart: number, beforeIndex: number): 
   return lastSpace === -1 ? segment : segment.slice(lastSpace + 1);
 }
 
+function isParenthesizedSuffix(token: string): boolean {
+  return /^\([^)]+\)$/.test(token);
+}
+
 function isPathLikeSpacedWord(word: string, prevToken: string): boolean {
+  if (isParenthesizedSuffix(prevToken)) return false;
   if (/^\d+$/.test(word)) return true;
   if (!/^[a-z0-9]+$/.test(word)) return true;
   return (

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -126,7 +126,24 @@ function canContinueWithNumericWord(word: string, prevToken: string, after: stri
   );
 }
 
-function isPathLikeSpacedWord(word: string, prevToken: string, after: string | undefined): boolean {
+function hasFollowingSeparator(text: string, endIndex: number, separator: Separator): boolean {
+  let i = endIndex;
+  while (i < text.length && text[i] === ' ') i++;
+  return i < text.length && text[i] === separator;
+}
+
+function isDeterminerLedSpacedFilename(prevToken: string, word: string): boolean {
+  return prevToken === 'my' && /^[a-z][a-z0-9]*$/.test(word) && word.length >= 4;
+}
+
+function isPathLikeSpacedWord(
+  word: string,
+  prevToken: string,
+  after: string | undefined,
+  text: string,
+  endIndex: number,
+  separator: Separator
+): boolean {
   if (isParenthesizedSuffix(prevToken)) return false;
   if (/^\d+$/.test(word)) {
     return canContinueWithNumericWord(word, prevToken, after);
@@ -140,12 +157,18 @@ function isPathLikeSpacedWord(word: string, prevToken: string, after: string | u
       prevToken.length <= 3
     );
   }
-  return (
+  if (
     word.length >= 4 &&
     prevToken.length >= 2 &&
     prevToken.length <= 2 &&
     !prevToken.includes('.')
-  );
+  ) {
+    return (
+      readExtensionWordAhead(text, endIndex) ||
+      hasFollowingSeparator(text, endIndex, separator)
+    );
+  }
+  return false;
 }
 
 function readExtensionWordAhead(text: string, fromIndex: number): boolean {
@@ -170,7 +193,8 @@ function isSpacedFilenameContinuation(
   word: string,
   prevToken: string,
   text: string,
-  endIndex: number
+  endIndex: number,
+  separator: Separator
 ): boolean {
   if (/^\[[^\]]+\]$/.test(word)) {
     const inner = word.slice(1, -1);
@@ -179,7 +203,10 @@ function isSpacedFilenameContinuation(
       (/^[a-z][a-z0-9]*$/.test(inner) || /^\d+$/.test(inner))
     );
   }
-  if (isPathLikeSpacedWord(word, prevToken, text[endIndex])) return true;
+  if (isDeterminerLedSpacedFilename(prevToken, word)) return true;
+  if (isPathLikeSpacedWord(word, prevToken, text[endIndex], text, endIndex, separator)) {
+    return true;
+  }
   return (
     /^[a-z][a-z0-9]*$/.test(word) &&
     /^[A-Za-z]/.test(prevToken) &&
@@ -307,7 +334,7 @@ function readSpacedContinuation(
   }
 
   if (after === undefined || /[.,;:!?)'\]"]/.test(after)) {
-    return isSpacedFilenameContinuation(word, prevToken, text, j) ? j : spaceIndex;
+    return isSpacedFilenameContinuation(word, prevToken, text, j, separator) ? j : spaceIndex;
   }
 
   if (after !== undefined && /\s/.test(after)) {
@@ -316,7 +343,7 @@ function readSpacedContinuation(
       if (rest.startsWith(separator)) return spaceIndex;
       if (hasParenthesizedDirectoryBeforeSeparator(text, j, separator)) return j;
     }
-    return isSpacedFilenameContinuation(word, prevToken, text, j) ? j : spaceIndex;
+    return isSpacedFilenameContinuation(word, prevToken, text, j, separator) ? j : spaceIndex;
   }
 
   return spaceIndex;

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -6,6 +6,25 @@ const OPEN_FILE_PROTOCOL = 'open-file://';
 
 const TRAILING_PUNCTUATION_RE = /[.,;:!?'"]+$/;
 
+const EXTENSIONLESS_DIAGNOSTIC_FILENAMES = new Set([
+  'dockerfile',
+  'justfile',
+  'makefile',
+  'jenkinsfile',
+  'rakefile',
+  'gemfile',
+  'procfile',
+  'vagrantfile',
+  'brewfile',
+  'fastfile',
+  'containerfile',
+  'snakefile',
+  'cmakelists',
+  'gnumakefile',
+]);
+
+const URL_PARAM_DELIMITERS = new Set(['?', '&', '#', ';']);
+
 type PathMatch = [index: number, path: string];
 type Separator = '/' | '\\';
 
@@ -26,9 +45,13 @@ function stripLineColumnSuffix(path: string): string {
 
   const lastSep = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
   const basename = path.slice(lastSep + 1);
-  const lineColMatch = basename.match(/^([A-Z][A-Za-z0-9_-]*)(:\d+(?::\d+)?)$/);
+  const lineColMatch = basename.match(/^([A-Za-z][A-Za-z0-9_-]*)(:\d+(?::\d+)?)$/);
   if (lineColMatch) {
-    return path.slice(0, -lineColMatch[2].length);
+    const name = lineColMatch[1];
+    const suffix = lineColMatch[2];
+    if (/^[A-Z]/.test(name) || EXTENSIONLESS_DIAGNOSTIC_FILENAMES.has(name.toLowerCase())) {
+      return path.slice(0, -suffix.length);
+    }
   }
 
   return path;
@@ -60,7 +83,7 @@ function isAssignmentEqualsStart(text: string, index: number): boolean {
   while (i >= 0 && /[a-zA-Z0-9_.$-]/.test(text[i])) {
     i--;
   }
-  return !(i >= 0 && (text[i] === '?' || text[i] === '&'));
+  return !(i >= 0 && URL_PARAM_DELIMITERS.has(text[i]));
 }
 
 function isCandidatePathStart(text: string, index: number, afterBlockComment: boolean): boolean {

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -87,7 +87,7 @@ function readParenthesizedSuffix(text: string, spaceIndex: number): number {
   if (i >= text.length) return spaceIndex;
 
   const content = text.slice(contentStart, i);
-  if (!/^\d+$/.test(content)) return spaceIndex;
+  if (!/^(\d+|[a-zA-Z]+)$/.test(content)) return spaceIndex;
 
   i++;
   while (i < text.length && isPathChar(text[i])) {
@@ -133,7 +133,7 @@ function readSpacedContinuation(
 }
 
 function isFilenamePunctuation(char: string): boolean {
-  return char === ',';
+  return char === ',' || char === "'";
 }
 
 function readSegment(text: string, start: number, separator: Separator): { end: number } | null {

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -79,24 +79,31 @@ function isParenthesizedSuffix(token: string): boolean {
   return /^\([^)]+\)$/.test(token);
 }
 
-function isPathLikeSpacedWord(word: string, prevToken: string): boolean {
+function hasFileExtension(word: string): boolean {
+  return /\.[A-Za-z0-9]+$/.test(word);
+}
+
+function canContinueWithNumericWord(word: string, prevToken: string, after: string | undefined): boolean {
+  return (
+    word.length >= 4 &&
+    /^[A-Z]/.test(prevToken) &&
+    (after === undefined || isPathTerminator(after))
+  );
+}
+
+function isPathLikeSpacedWord(word: string, prevToken: string, after: string | undefined): boolean {
   if (isParenthesizedSuffix(prevToken)) return false;
   if (/^\d+$/.test(word)) {
-    return word.length >= 4;
+    return canContinueWithNumericWord(word, prevToken, after);
   }
+  if (hasFileExtension(word)) return true;
   if (/^[A-Z]/.test(word)) {
-    if (/\.[A-Za-z0-9]+$/.test(word)) {
-      return /^[A-Z]/.test(prevToken);
-    }
     return (
       /^[A-Z]/.test(prevToken) &&
       word.length >= 4 &&
       prevToken.length >= 2 &&
       prevToken.length <= 3
     );
-  }
-  if (/\.[A-Za-z0-9]+$/.test(word) && /^[a-z]/.test(prevToken)) {
-    return true;
   }
   return (
     word.length >= 4 &&
@@ -117,7 +124,7 @@ function readExtensionWordAhead(text: string, fromIndex: number): boolean {
     }
     if (j === i) return false;
     const word = text.slice(i, j).replace(TRAILING_PUNCTUATION_RE, '');
-    if (/\.[A-Za-z0-9]+$/.test(word) && /^[a-z]/.test(word)) return true;
+    if (hasFileExtension(word) && /^[a-z]/.test(word)) return true;
     if (!/^[a-z][a-z0-9]*$/.test(word)) return false;
     i = j;
   }
@@ -137,7 +144,7 @@ function isSpacedFilenameContinuation(
       (/^[a-z][a-z0-9]*$/.test(inner) || /^\d+$/.test(inner))
     );
   }
-  if (isPathLikeSpacedWord(word, prevToken)) return true;
+  if (isPathLikeSpacedWord(word, prevToken, text[endIndex])) return true;
   return (
     /^[a-z][a-z0-9]*$/.test(word) &&
     /^[a-z]/.test(prevToken) &&

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -149,6 +149,11 @@ function isLinkLikeParent(parent: Parent | undefined): boolean {
   return parent?.type === 'link' || parent?.type === 'linkReference';
 }
 
+function isParenthesizedFilenameContent(content: string): boolean {
+  if (/^\d+$/.test(content)) return true;
+  return /^[a-zA-Z0-9]+(?:[ -][a-zA-Z0-9]+)*$/.test(content);
+}
+
 function readParenthesizedSuffix(text: string, spaceIndex: number): number {
   if (text[spaceIndex] !== ' ') return spaceIndex;
 
@@ -164,7 +169,7 @@ function readParenthesizedSuffix(text: string, spaceIndex: number): number {
   if (i >= text.length) return spaceIndex;
 
   const content = text.slice(contentStart, i);
-  if (!/^[a-zA-Z0-9]+$/.test(content)) return spaceIndex;
+  if (!isParenthesizedFilenameContent(content)) return spaceIndex;
 
   i++;
   const afterParen = i;
@@ -177,7 +182,7 @@ function readParenthesizedSuffix(text: string, spaceIndex: number): number {
   if (i > afterParen) {
     return i;
   }
-  if (/^[a-zA-Z0-9]{1,4}$/.test(content) && /\d/.test(content)) {
+  if (!/[ -]/.test(content) && /^[a-zA-Z0-9]{1,4}$/.test(content) && /\d/.test(content)) {
     return afterParen;
   }
   return spaceIndex;

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -98,7 +98,7 @@ function readExtensionWordAhead(text: string, fromIndex: number): boolean {
       j++;
     }
     if (j === i) return false;
-    const word = text.slice(i, j);
+    const word = text.slice(i, j).replace(TRAILING_PUNCTUATION_RE, '');
     if (/\.[A-Za-z0-9]+$/.test(word) && /^[a-z]/.test(word)) return true;
     if (!/^[a-z][a-z0-9]*$/.test(word)) return false;
     i = j;

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -63,7 +63,9 @@ function isParenthesizedSuffix(token: string): boolean {
 
 function isPathLikeSpacedWord(word: string, prevToken: string): boolean {
   if (isParenthesizedSuffix(prevToken)) return false;
-  if (/^\d+$/.test(word)) return true;
+  if (/^\d+$/.test(word)) {
+    return word.length >= 4 || /^[A-Z]/.test(prevToken);
+  }
   if (!/^[a-z0-9]+$/.test(word)) return true;
   return (
     word.length >= 4 &&

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -75,7 +75,15 @@ function isPathLikeSpacedWord(word: string, prevToken: string): boolean {
     return word.length >= 4;
   }
   if (/^[A-Z]/.test(word)) {
-    return /^[A-Z]/.test(prevToken);
+    if (/\.[A-Za-z0-9]+$/.test(word)) {
+      return /^[A-Z]/.test(prevToken);
+    }
+    return (
+      /^[A-Z]/.test(prevToken) &&
+      word.length >= 4 &&
+      prevToken.length >= 2 &&
+      prevToken.length <= 3
+    );
   }
   if (/\.[A-Za-z0-9]+$/.test(word) && /^[a-z]/.test(prevToken)) {
     return true;
@@ -159,7 +167,7 @@ function readParenthesizedSuffix(text: string, spaceIndex: number): number {
   if (i > afterParen) {
     return i;
   }
-  if (/^[a-zA-Z0-9]{1,4}$/.test(content)) {
+  if (/^[a-zA-Z0-9]{1,4}$/.test(content) && /\d/.test(content)) {
     return afterParen;
   }
   return spaceIndex;

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -280,7 +280,7 @@ function parsePathAt(text: string, index: number): PathMatch | null {
 
   if (text[i] === '/') {
     i++;
-    minSegments = 2;
+    minSegments = 1;
   } else if (text[i] === '~' && text[i + 1] === '/') {
     i += 2;
     minSegments = 1;

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -266,7 +266,7 @@ function readSegment(text: string, start: number, separator: Separator): { end: 
 }
 
 function isPathTerminator(char: string): boolean {
-  return /[.,;:!'"`)\]]/.test(char);
+  return /[.,;:!?'"`)\]]/.test(char);
 }
 
 function isPathBoundary(char: string): boolean {
@@ -290,7 +290,7 @@ function parsePathAt(text: string, index: number): PathMatch | null {
       separator = text[i] as Separator;
       i++;
     }
-    minSegments = 2;
+    minSegments = 1;
   } else {
     return null;
   }

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -87,7 +87,7 @@ function readParenthesizedSuffix(text: string, spaceIndex: number): number {
   if (i >= text.length) return spaceIndex;
 
   const content = text.slice(contentStart, i);
-  if (!/^(\d+|[a-zA-Z]+)$/.test(content)) return spaceIndex;
+  if (!/^[a-zA-Z0-9]+$/.test(content)) return spaceIndex;
 
   i++;
   while (i < text.length && isPathChar(text[i])) {

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -133,7 +133,7 @@ function readSpacedContinuation(
 }
 
 function isFilenamePunctuation(char: string): boolean {
-  return char === ',' || char === "'";
+  return char === ',' || char === "'" || char === ':';
 }
 
 function readSegment(text: string, start: number, separator: Separator): { end: number } | null {

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -158,7 +158,7 @@ function isLinkLikeParent(parent: Parent | undefined): boolean {
 
 function isParenthesizedFilenameContent(content: string): boolean {
   if (/^\d+$/.test(content)) return true;
-  return /^[a-zA-Z0-9]+(?:[ -][a-zA-Z0-9]+)*$/.test(content);
+  return /^[a-zA-Z0-9._]+(?:[ -][a-zA-Z0-9._]+)*$/.test(content);
 }
 
 function readParenthesizedContent(text: string, openIndex: number): number {

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -46,11 +46,21 @@ function isUrlPathAt(text: string, index: number): boolean {
   return scheme.length > 0 && /[a-zA-Z]/.test(scheme[0]);
 }
 
+function isAssignmentEqualsStart(text: string, index: number): boolean {
+  if (text[index - 1] !== '=') return false;
+  let i = index - 2;
+  while (i >= 0 && /[a-zA-Z0-9_.$-]/.test(text[i])) {
+    i--;
+  }
+  return !(i >= 0 && (text[i] === '?' || text[i] === '&'));
+}
+
 function isCandidatePathStart(text: string, index: number, afterBlockComment: boolean): boolean {
   if (index === 0) return true;
   if (isUrlPathAt(text, index)) return false;
   const prev = text[index - 1];
-  if (/[\s('"`[(,;=]/.test(prev)) return true;
+  if (prev === '=') return isAssignmentEqualsStart(text, index);
+  if (/[\s('"`[(,;]/.test(prev)) return true;
   return afterBlockComment;
 }
 

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -4,13 +4,14 @@ import type { Root, Text, InlineCode, Link, Parent } from 'mdast';
 
 const OPEN_FILE_PROTOCOL = 'open-file://';
 
-const UNIX_PATH_RE = /(?:^|[\s('"`[(,;]|\/\*.*?\*\/)?(\/(?:[a-zA-Z0-9._+-]+\/){1,}[a-zA-Z0-9._+-]+)/g;
-const TILDE_PATH_RE = /(?:^|[\s('"`[(,;]|\/\*.*?\*\/)?(~\/(?:[a-zA-Z0-9._+-]+\/)*[a-zA-Z0-9._+-]+)/g;
-const WIN_PATH_RE = /(?:^|[\s('"`[(,;]|\/\*.*?\*\/)?([A-Za-z]:[\\/](?:[a-zA-Z0-9._+-]+[\\/])+[a-zA-Z0-9._+-]+)/g;
-
 const TRAILING_PUNCTUATION_RE = /[.,;:!?)'\]"]+$/;
 
 type PathMatch = [index: number, path: string];
+type Separator = '/' | '\\';
+
+function isPathChar(char: string): boolean {
+  return /[a-zA-Z0-9._+-]/.test(char);
+}
 
 function stripTrailingPunctuation(path: string): string {
   return path.replace(TRAILING_PUNCTUATION_RE, '');
@@ -21,29 +22,116 @@ function isUrlPath(text: string, index: number): boolean {
   return /[a-zA-Z][a-zA-Z0-9+.-]*:\/\/?$/.test(before);
 }
 
+function isValidPathStart(text: string, index: number): boolean {
+  if (index === 0) return true;
+  if (isUrlPath(text, index)) return false;
+  const prev = text[index - 1];
+  if (/[\s('"`[(,;]/.test(prev)) return true;
+  const before = text.slice(0, index);
+  return /\/\*.*?\*\/$/.test(before);
+}
+
+function readSpacedContinuation(text: string, spaceIndex: number, separator: Separator): number {
+  if (text[spaceIndex] !== ' ') return spaceIndex;
+
+  let j = spaceIndex + 1;
+  while (j < text.length && isPathChar(text[j])) {
+    j++;
+  }
+  if (j === spaceIndex + 1) return spaceIndex;
+
+  const after = text[j];
+  if (after === separator) return j;
+  if (after === undefined || /[.,;:!?)'\]"]/.test(after)) return j;
+
+  if (after === ' ') {
+    const rest = text.slice(j).trimStart();
+    if (rest.startsWith(separator)) return spaceIndex;
+
+    const word = text.slice(spaceIndex + 1, j);
+    if (/[A-Z0-9._+-]/.test(word)) return j;
+
+    if (/^[a-z][a-z0-9]*$/.test(word) && (rest === '' || /^[.,;:!?)'\]"]/.test(rest))) {
+      return j;
+    }
+    return spaceIndex;
+  }
+
+  return spaceIndex;
+}
+
+function readSegment(text: string, start: number, separator: Separator): { end: number } | null {
+  let i = start;
+  if (i >= text.length || !isPathChar(text[i])) return null;
+
+  while (i < text.length && isPathChar(text[i])) {
+    i++;
+  }
+
+  while (i < text.length && text[i] === ' ') {
+    const continuationEnd = readSpacedContinuation(text, i, separator);
+    if (continuationEnd === i) break;
+    i = continuationEnd;
+  }
+
+  return i > start ? { end: i } : null;
+}
+
+function tryParsePath(text: string, index: number): PathMatch | null {
+  if (!isValidPathStart(text, index)) return null;
+
+  let i = index;
+  let separator: Separator = '/';
+  let minSegments: number;
+
+  if (text[i] === '/') {
+    i++;
+    minSegments = 2;
+  } else if (text[i] === '~' && text[i + 1] === '/') {
+    i += 2;
+    minSegments = 1;
+  } else if (/[A-Za-z]/.test(text[i] ?? '') && text[i + 1] === ':') {
+    i += 2;
+    if (text[i] === '/' || text[i] === '\\') {
+      separator = text[i] as Separator;
+      i++;
+    }
+    minSegments = 2;
+  } else {
+    return null;
+  }
+
+  let segmentCount = 0;
+  while (i < text.length) {
+    const segment = readSegment(text, i, separator);
+    if (!segment) break;
+    i = segment.end;
+    segmentCount++;
+    if (i < text.length && text[i] === separator) {
+      i++;
+      continue;
+    }
+    break;
+  }
+
+  if (segmentCount < minSegments) return null;
+
+  const path = stripTrailingPunctuation(text.slice(index, i));
+  if (path.length === 0) return null;
+
+  return [index, path];
+}
+
 export function findPaths(text: string): PathMatch[] {
   const matches: PathMatch[] = [];
-  for (const re of [UNIX_PATH_RE, TILDE_PATH_RE, WIN_PATH_RE]) {
-    let m: RegExpExecArray | null;
-    const localRe = new RegExp(re.source, 'g');
-    while ((m = localRe.exec(text)) !== null) {
-      const path = stripTrailingPunctuation(m[1]);
-      if (path.length === 0) continue;
-      const prefixLen = m[0].length - m[1].length;
-      const index = m.index + prefixLen;
-      if (isUrlPath(text, index)) continue;
-      matches.push([index, path]);
+  for (let i = 0; i < text.length; i++) {
+    const match = tryParsePath(text, i);
+    if (match) {
+      matches.push(match);
+      i = match[0] + match[1].length - 1;
     }
   }
-  matches.sort((a, b) => a[0] - b[0]);
-  const result: PathMatch[] = [];
-  let lastEnd = 0;
-  for (const [index, path] of matches) {
-    if (index < lastEnd) continue;
-    result.push([index, path]);
-    lastEnd = index + path.length;
-  }
-  return result;
+  return matches;
 }
 
 function linkifyNode(node: Text | InlineCode, index: number, parent: Parent): void {
@@ -62,7 +150,7 @@ function linkifyNode(node: Text | InlineCode, index: number, parent: Parent): vo
     }
     newNodes.push({
       type: 'link',
-      url: OPEN_FILE_PROTOCOL + path,
+      url: OPEN_FILE_PROTOCOL + encodeURI(path),
       title: null,
       children: [
         {

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -286,10 +286,11 @@ function parsePathAt(text: string, index: number): PathMatch | null {
     minSegments = 1;
   } else if (/[A-Za-z]/.test(text[i] ?? '') && text[i + 1] === ':') {
     i += 2;
-    if (text[i] === '/' || text[i] === '\\') {
-      separator = text[i] as Separator;
-      i++;
+    if (text[i] !== '/' && text[i] !== '\\') {
+      return null;
     }
+    separator = text[i] as Separator;
+    i++;
     minSegments = 1;
   } else {
     return null;

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -91,7 +91,7 @@ function isPathLikeSpacedWord(word: string, prevToken: string): boolean {
   return (
     word.length >= 4 &&
     prevToken.length >= 2 &&
-    prevToken.length <= 3 &&
+    prevToken.length <= 2 &&
     !prevToken.includes('.')
   );
 }
@@ -201,7 +201,9 @@ function readSpacedContinuation(
   const prevToken = getLastToken(text, segmentStart, spaceIndex);
   const after = text[j];
 
-  if (after === separator) return j;
+  if (after === separator) {
+    return isSpacedFilenameContinuation(word, prevToken, text, j) ? j : spaceIndex;
+  }
 
   if (after === undefined || /[.,;:!?)'\]"]/.test(after)) {
     return isSpacedFilenameContinuation(word, prevToken, text, j) ? j : spaceIndex;

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -69,6 +69,9 @@ function isPathLikeSpacedWord(word: string, prevToken: string): boolean {
   if (/^[A-Z]/.test(word)) {
     return /^[A-Z]/.test(prevToken);
   }
+  if (/\.[A-Za-z0-9]+$/.test(word) && /^[a-z]/.test(prevToken)) {
+    return true;
+  }
   return (
     word.length >= 4 &&
     prevToken.length >= 2 &&

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -81,11 +81,42 @@ function isQueryParamKeyChar(char: string): boolean {
   return /[-a-zA-Z0-9_.$[\]%]/.test(char);
 }
 
+function isUrlPathSlashBeforeAssignment(text: string, slashPos: number): boolean {
+  if (text[slashPos] !== '/') return false;
+
+  let i = slashPos - 1;
+  while (i >= 0 && /[a-zA-Z0-9._-]/.test(text[i])) {
+    i--;
+  }
+  if (i >= 2 && text[i] === '/' && text[i - 1] === '/' && text[i - 2] === ':') {
+    let j = i - 3;
+    while (j >= 0 && /[a-zA-Z0-9+.-]/.test(text[j])) {
+      j--;
+    }
+    const scheme = text.slice(j + 1, i - 2);
+    if (scheme.length > 0 && /[a-zA-Z]/.test(scheme[0])) {
+      return true;
+    }
+  }
+  if (i >= 0 && text[i] === '/') {
+    return isUrlPathSlashBeforeAssignment(text, i);
+  }
+  const token = text.slice(i + 1, slashPos);
+  return (
+    token.length > 0 &&
+    /^[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+$/.test(token) &&
+    /\.[a-zA-Z]{2,}$/.test(token)
+  );
+}
+
 function isAssignmentEqualsStart(text: string, index: number): boolean {
   if (text[index - 1] !== '=') return false;
   let i = index - 2;
   while (i >= 0 && isQueryParamKeyChar(text[i])) {
     i--;
+  }
+  if (i >= 0 && text[i] === '/' && isUrlPathSlashBeforeAssignment(text, i)) {
+    return false;
   }
   return !(i >= 0 && URL_PARAM_DELIMITERS.has(text[i]));
 }
@@ -116,6 +147,10 @@ function isParenthesizedSuffix(token: string): boolean {
 
 function hasFileExtension(word: string): boolean {
   return /\.[A-Za-z0-9]+$/.test(word);
+}
+
+function isSpacedFilenameWord(word: string): boolean {
+  return /^[a-z][a-z0-9_-]*$/.test(word);
 }
 
 function canContinueWithNumericWord(word: string, prevToken: string, after: string | undefined): boolean {
@@ -183,7 +218,7 @@ function readExtensionWordAhead(text: string, fromIndex: number): boolean {
     if (j === i) return false;
     const word = text.slice(i, j).replace(TRAILING_PUNCTUATION_RE, '');
     if (hasFileExtension(word)) return true;
-    if (!/^[a-z][a-z0-9]*$/.test(word)) return false;
+    if (!isSpacedFilenameWord(word)) return false;
     i = j;
   }
   return false;
@@ -208,7 +243,7 @@ function isSpacedFilenameContinuation(
     return true;
   }
   return (
-    /^[a-z][a-z0-9]*$/.test(word) &&
+    isSpacedFilenameWord(word) &&
     /^[A-Za-z]/.test(prevToken) &&
     readExtensionWordAhead(text, endIndex)
   );

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -117,6 +117,13 @@ function readSpacedContinuation(
   while (j < text.length && isPathChar(text[j])) {
     j++;
   }
+  const bracketEnd = readBracketedSuffix(text, j);
+  if (bracketEnd > j) {
+    j = bracketEnd;
+    while (j < text.length && isPathChar(text[j])) {
+      j++;
+    }
+  }
   while (j > spaceIndex + 1 && /[.,;:!?)'\]"]/.test(text[j - 1] ?? '')) {
     j--;
   }

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -191,9 +191,22 @@ function isLinkLikeParent(parent: Parent | undefined): boolean {
   return parent?.type === 'link' || parent?.type === 'linkReference';
 }
 
+function isParenthesizedFilenameChar(char: string): boolean {
+  if (char === ' ' || char === '-' || char === "'") return true;
+  return isPathChar(char);
+}
+
 function isParenthesizedFilenameContent(content: string): boolean {
   if (/^\d+$/.test(content)) return true;
-  return /^[a-zA-Z0-9._]+(?:[ -][a-zA-Z0-9._]+)*$/.test(content);
+  if (content.length === 0) return false;
+  let hasSubstantive = false;
+  for (const char of content) {
+    if (!isParenthesizedFilenameChar(char)) return false;
+    if (/[\p{L}\p{N}a-zA-Z0-9._]/u.test(char)) {
+      hasSubstantive = true;
+    }
+  }
+  return hasSubstantive;
 }
 
 function hasFilenameSuffixAfterParen(text: string, afterParen: number, endIndex: number): boolean {

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -78,7 +78,7 @@ function isUrlPathAt(text: string, index: number): boolean {
 }
 
 function isQueryParamKeyChar(char: string): boolean {
-  return /[a-zA-Z0-9_.$\[\]%-]/.test(char);
+  return /[-a-zA-Z0-9_.$\[\]%]/.test(char);
 }
 
 function isAssignmentEqualsStart(text: string, index: number): boolean {

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -66,7 +66,9 @@ function isPathLikeSpacedWord(word: string, prevToken: string): boolean {
   if (/^\d+$/.test(word)) {
     return word.length >= 4 || /^[A-Z]/.test(prevToken);
   }
-  if (!/^[a-z0-9]+$/.test(word)) return true;
+  if (/^[A-Z]/.test(word)) {
+    return /^[A-Z]/.test(prevToken);
+  }
   return (
     word.length >= 4 &&
     prevToken.length >= 2 &&

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -31,30 +31,50 @@ function isValidPathStart(text: string, index: number): boolean {
   return /\/\*.*?\*\/$/.test(before);
 }
 
-function readSpacedContinuation(text: string, spaceIndex: number, separator: Separator): number {
+function getLastToken(text: string, segmentStart: number, beforeIndex: number): string {
+  const segment = text.slice(segmentStart, beforeIndex);
+  const lastSpace = segment.lastIndexOf(' ');
+  return lastSpace === -1 ? segment : segment.slice(lastSpace + 1);
+}
+
+function isPathLikeSpacedWord(word: string, prevToken: string): boolean {
+  if (/[A-Z0-9._+-]/.test(word)) return true;
+  return (
+    /^[a-z][a-z0-9]*$/.test(word) && prevToken.length <= 3 && !prevToken.includes('.')
+  );
+}
+
+function readSpacedContinuation(
+  text: string,
+  spaceIndex: number,
+  segmentStart: number,
+  separator: Separator
+): number {
   if (text[spaceIndex] !== ' ') return spaceIndex;
 
   let j = spaceIndex + 1;
   while (j < text.length && isPathChar(text[j])) {
     j++;
   }
+  while (j > spaceIndex + 1 && /[.,;:!?)'\]"]/.test(text[j - 1] ?? '')) {
+    j--;
+  }
   if (j === spaceIndex + 1) return spaceIndex;
 
+  const word = text.slice(spaceIndex + 1, j);
+  const prevToken = getLastToken(text, segmentStart, spaceIndex);
   const after = text[j];
+
   if (after === separator) return j;
-  if (after === undefined || /[.,;:!?)'\]"]/.test(after)) return j;
+
+  if (after === undefined || /[.,;:!?)'\]"]/.test(after)) {
+    return isPathLikeSpacedWord(word, prevToken) ? j : spaceIndex;
+  }
 
   if (after === ' ') {
     const rest = text.slice(j).trimStart();
     if (rest.startsWith(separator)) return spaceIndex;
-
-    const word = text.slice(spaceIndex + 1, j);
-    if (/[A-Z0-9._+-]/.test(word)) return j;
-
-    if (/^[a-z][a-z0-9]*$/.test(word) && (rest === '' || /^[.,;:!?)'\]"]/.test(rest))) {
-      return j;
-    }
-    return spaceIndex;
+    return isPathLikeSpacedWord(word, prevToken) ? j : spaceIndex;
   }
 
   return spaceIndex;
@@ -69,7 +89,7 @@ function readSegment(text: string, start: number, separator: Separator): { end: 
   }
 
   while (i < text.length && text[i] === ' ') {
-    const continuationEnd = readSpacedContinuation(text, i, separator);
+    const continuationEnd = readSpacedContinuation(text, i, start, separator);
     if (continuationEnd === i) break;
     i = continuationEnd;
   }

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -1,4 +1,4 @@
-import { visit } from 'unist-util-visit';
+import { visit, SKIP } from 'unist-util-visit';
 import type { Plugin } from 'unified';
 import type { Root, Text, InlineCode, Link, Parent } from 'mdast';
 
@@ -17,18 +17,37 @@ function stripTrailingPunctuation(path: string): string {
   return path.replace(TRAILING_PUNCTUATION_RE, '');
 }
 
-function isUrlPath(text: string, index: number): boolean {
-  const before = text.slice(0, index);
-  return /[a-zA-Z][a-zA-Z0-9+.-]*:\/\/?$/.test(before);
+function isUrlPathAt(text: string, index: number): boolean {
+  let i = index - 1;
+  if (i < 0) return false;
+
+  if (text[i] === '/') {
+    i--;
+    if (i >= 0 && text[i] === '/') i--;
+  }
+  if (i < 0 || text[i] !== ':') return false;
+
+  i--;
+  const schemeEnd = i;
+  while (i >= 0 && /[a-zA-Z0-9+.-]/.test(text[i])) {
+    i--;
+  }
+
+  const scheme = text.slice(i + 1, schemeEnd + 1);
+  return scheme.length > 0 && /[a-zA-Z]/.test(scheme[0]);
 }
 
-function isValidPathStart(text: string, index: number): boolean {
+function isCandidatePathStart(text: string, index: number, afterBlockComment: boolean): boolean {
   if (index === 0) return true;
-  if (isUrlPath(text, index)) return false;
+  if (isUrlPathAt(text, index)) return false;
   const prev = text[index - 1];
   if (/[\s('"`[(,;]/.test(prev)) return true;
-  const before = text.slice(0, index);
-  return /\/\*.*?\*\/$/.test(before);
+  return afterBlockComment;
+}
+
+function couldStartPath(text: string, index: number): boolean {
+  const char = text[index];
+  return char === '/' || char === '~' || /[A-Za-z]/.test(char);
 }
 
 function getLastToken(text: string, segmentStart: number, beforeIndex: number): string {
@@ -97,9 +116,7 @@ function readSegment(text: string, start: number, separator: Separator): { end: 
   return i > start ? { end: i } : null;
 }
 
-function tryParsePath(text: string, index: number): PathMatch | null {
-  if (!isValidPathStart(text, index)) return null;
-
+function parsePathAt(text: string, index: number): PathMatch | null {
   let i = index;
   let separator: Separator = '/';
   let minSegments: number;
@@ -144,13 +161,35 @@ function tryParsePath(text: string, index: number): PathMatch | null {
 
 export function findPaths(text: string): PathMatch[] {
   const matches: PathMatch[] = [];
+  let afterBlockComment = false;
+
   for (let i = 0; i < text.length; i++) {
-    const match = tryParsePath(text, i);
-    if (match) {
-      matches.push(match);
-      i = match[0] + match[1].length - 1;
+    if (text[i] === '/' && text[i + 1] === '*') {
+      i += 2;
+      while (i < text.length - 1 && !(text[i] === '*' && text[i + 1] === '/')) {
+        i++;
+      }
+      i += 1;
+      afterBlockComment = true;
+      continue;
     }
+
+    if (
+      couldStartPath(text, i) &&
+      isCandidatePathStart(text, i, afterBlockComment)
+    ) {
+      const match = parsePathAt(text, i);
+      if (match) {
+        matches.push(match);
+        i = match[0] + match[1].length - 1;
+        afterBlockComment = false;
+        continue;
+      }
+    }
+
+    afterBlockComment = false;
   }
+
   return matches;
 }
 
@@ -192,11 +231,16 @@ function linkifyNode(node: Text | InlineCode, index: number, parent: Parent): vo
 
 export const remarkLinkifyPaths: Plugin<[], Root> = function () {
   return (tree: Root) => {
-    visit(tree, 'text', (node: Text, index: number | undefined, parent: Parent | undefined) => {
-      if (index === undefined || !parent || parent.type === 'link') return;
-      linkifyNode(node, index, parent);
-    });
-    visit(tree, 'inlineCode', (node: InlineCode, index: number | undefined, parent: Parent | undefined) => {
+    visit(tree, (node, index, parent) => {
+      if (node.type === 'link') {
+        const url = 'url' in node ? node.url : undefined;
+        if (url?.startsWith(OPEN_FILE_PROTOCOL)) {
+          return SKIP;
+        }
+        return;
+      }
+
+      if (node.type !== 'text' && node.type !== 'inlineCode') return;
       if (index === undefined || !parent || parent.type === 'link') return;
       linkifyNode(node, index, parent);
     });

--- a/ui/desktop/src/utils/linkifyPaths.ts
+++ b/ui/desktop/src/utils/linkifyPaths.ts
@@ -211,6 +211,9 @@ function readParenthesizedContent(text: string, openIndex: number): number {
 
   i++;
   const afterParen = i;
+  if (text[i] === '/' || text[i] === '\\') {
+    return afterParen;
+  }
   while (i < text.length && isPathChar(text[i])) {
     i++;
   }
@@ -236,6 +239,18 @@ function readParenthesizedSuffix(text: string, spaceIndex: number): number {
   if (text[spaceIndex + 1] !== '(') return spaceIndex;
   const end = readParenthesizedContent(text, spaceIndex + 1);
   return end > spaceIndex + 1 ? end : spaceIndex;
+}
+
+function hasParenthesizedDirectoryBeforeSeparator(
+  text: string,
+  fromIndex: number,
+  separator: Separator
+): boolean {
+  let i = fromIndex;
+  while (i < text.length && text[i] === ' ') i++;
+  if (text[i] !== '(') return false;
+  const end = readParenthesizedContent(text, i);
+  return end > i && text[end] === separator;
 }
 
 function isConnectiveSpacedWord(word: string): boolean {
@@ -282,6 +297,7 @@ function readSpacedContinuation(
     if (after === ' ') {
       const rest = text.slice(j).trimStart();
       if (rest.startsWith(separator)) return spaceIndex;
+      if (hasParenthesizedDirectoryBeforeSeparator(text, j, separator)) return j;
     }
     return isSpacedFilenameContinuation(word, prevToken, text, j) ? j : spaceIndex;
   }

--- a/ui/desktop/src/utils/urlSecurity.ts
+++ b/ui/desktop/src/utils/urlSecurity.ts
@@ -64,7 +64,6 @@ export const SAFE_PROTOCOLS = [
   'firefox:',
   'safari:',
   'goose:',
-  'open-file:',
 ];
 
 /**

--- a/ui/desktop/src/utils/urlSecurity.ts
+++ b/ui/desktop/src/utils/urlSecurity.ts
@@ -64,6 +64,7 @@ export const SAFE_PROTOCOLS = [
   'firefox:',
   'safari:',
   'goose:',
+  'open-file:',
 ];
 
 /**


### PR DESCRIPTION
## Summary

Make file paths in chat messages clickable in the desktop app. A remark plugin detects Unix (`/home/user/file.rs`), tilde (`~/.config/app/settings.json`), and Windows (`C:\Users\dev\project\index.ts`) paths in markdown text and inline code, and renders them as `open-file://` links. Clicking a path reveals the file in Finder/Explorer via `shell.showItemInFolder()`.

Rebased onto latest `main`; duplicate scrollbar commit from #9601 removed.

### Testing

- `pnpm test -- src/utils/linkifyPaths.test.ts` — 14 unit tests (path detection, edge cases, trailing punctuation)
- Full desktop test suite passes locally (396 tests)
- Manual: click Unix, tilde, and Windows paths in chat messages

### Related Issues

N/A — happy to open a discussion/issue if you'd prefer to track this separately.

### Screenshots/Demos (for UX changes)

Before: file paths in chat are plain text, not clickable.

After: paths render as links; clicking opens the file location in the system file manager.

### Screenshots/Demos (for UX changes)
Before:  
<img width="183" height="45" alt="image" src="https://github.com/user-attachments/assets/2f38fd78-ca87-49f1-a474-5d6038f846a9" />
After:   
<img width="371" height="76" alt="image" src="https://github.com/user-attachments/assets/10217303-8617-4654-a20b-15178be9a454" />

