### PR TITLE
docs: add RunAPI OpenAI-compatible example

### DIFF
--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -308,6 +308,15 @@ Need to connect to multiple OpenAI-compatible endpoints? [Configure custom provi
     OPENAI_PROJECT=ml-serving
     ```
   </TabItem>
+  <TabItem value="runapi" label="RunAPI">
+    For [RunAPI](https://runapi.ai) as an OpenAI-compatible endpoint for model jobs like AI image, video, music/audio, text-to-speech, and LLM tasks:
+    ```sh
+    OPENAI_HOST=https://api.runapi.ai
+    OPENAI_BASE_PATH=v1
+    OPENAI_API_KEY=your-runapi-api-key
+    ```
+    Choose a model from [RunAPI models](https://runapi.ai/models.md).
+  </TabItem>
   <TabItem value="enterprise" label="Enterprise OpenAI">
     For enterprise OpenAI deployments with governance:
     ```sh

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -311,8 +311,8 @@ Need to connect to multiple OpenAI-compatible endpoints? [Configure custom provi
   <TabItem value="runapi" label="RunAPI">
     For [RunAPI](https://runapi.ai) as an OpenAI-compatible endpoint for model jobs like AI image, video, music/audio, text-to-speech, and LLM tasks:
     ```sh
-    OPENAI_HOST=https://api.runapi.ai
-    OPENAI_BASE_PATH=v1
+    OPENAI_HOST=https://runapi.ai
+    OPENAI_BASE_PATH=v1/chat/completions
     OPENAI_API_KEY=your-runapi-api-key
     ```
     Choose a model from [RunAPI models](https://runapi.ai/models.md).

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -309,13 +309,13 @@ Need to connect to multiple OpenAI-compatible endpoints? [Configure custom provi
     ```
   </TabItem>
   <TabItem value="runapi" label="RunAPI">
-    For [RunAPI](https://runapi.ai) as an OpenAI-compatible endpoint for model jobs like AI image, video, music/audio, text-to-speech, and LLM tasks:
+    For [RunAPI](https://runapi.ai) as an OpenAI-compatible endpoint for LLM chat tasks:
     ```sh
     OPENAI_HOST=https://runapi.ai
     OPENAI_BASE_PATH=v1/chat/completions
     OPENAI_API_KEY=your-runapi-api-key
     ```
-    Choose a model from [RunAPI models](https://runapi.ai/models.md).
+    Choose an OpenAI-compatible chat model from [RunAPI models](https://runapi.ai/models.md).
   </TabItem>
   <TabItem value="enterprise" label="Enterprise OpenAI">
     For enterprise OpenAI deployments with governance:


### PR DESCRIPTION
Adds RunAPI to the custom OpenAI endpoint examples in the provider setup docs.