### PR TITLE
chore: pause tui release

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -100,9 +100,6 @@ jobs:
           cd ui/sdk
           pnpm run build:ts
 
-          cd ../text
-          pnpm run build
-
       - name: Compatibility check (TUI client ↔ goose binary)
         env:
           GOOSE_BINARY: ${{ github.workspace }}/ui/goose-binary/goose-binary-linux-x64/bin/goose
@@ -135,7 +132,7 @@ jobs:
             echo ""
             echo "### npm Packages"
             cd ui
-            for pkg in sdk text goose-binary/*/; do
+            for pkg in sdk goose-binary/*/; do
               if [ -f "$pkg/package.json" ]; then
                 name=$(jq -r '.name' "$pkg/package.json")
                 version=$(jq -r '.version' "$pkg/package.json")
@@ -177,7 +174,7 @@ jobs:
           # Publish each package individually so one failure doesn't abort the rest.
           # Skips packages whose version is already published (409/403).
           failed=0
-          for pkg in sdk goose-binary/*/ text; do
+          for pkg in sdk goose-binary/*/; do
             if [ -f "$pkg/package.json" ]; then
               name=$(jq -r '.name' "$pkg/package.json")
               version=$(jq -r '.version' "$pkg/package.json")
@@ -207,7 +204,7 @@ jobs:
           {
             echo "## 🚀 Published Packages"
             echo ""
-            for pkg in sdk text goose-binary/*/; do
+            for pkg in sdk goose-binary/*/; do
               if [ -f "$pkg/package.json" ]; then
                 name=$(jq -r '.name' "$pkg/package.json")
                 version=$(jq -r '.version' "$pkg/package.json")

--- a/ui/goose-binary/goose-binary-darwin-arm64/package.json
+++ b/ui/goose-binary/goose-binary-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaif/goose-binary-darwin-arm64",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Goose binary for macOS ARM64",
   "license": "Apache-2.0",
   "repository": {

--- a/ui/goose-binary/goose-binary-darwin-x64/package.json
+++ b/ui/goose-binary/goose-binary-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaif/goose-binary-darwin-x64",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Goose binary for macOS x64",
   "license": "Apache-2.0",
   "repository": {

--- a/ui/goose-binary/goose-binary-linux-arm64/package.json
+++ b/ui/goose-binary/goose-binary-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaif/goose-binary-linux-arm64",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Goose binary for Linux ARM64",
   "license": "Apache-2.0",
   "repository": {

--- a/ui/goose-binary/goose-binary-linux-x64/package.json
+++ b/ui/goose-binary/goose-binary-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaif/goose-binary-linux-x64",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Goose binary for Linux x64",
   "license": "Apache-2.0",
   "repository": {

--- a/ui/goose-binary/goose-binary-win32-x64/package.json
+++ b/ui/goose-binary/goose-binary-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaif/goose-binary-win32-x64",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Goose binary for Windows x64",
   "license": "Apache-2.0",
   "repository": {

--- a/ui/sdk/package.json
+++ b/ui/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaif/goose-sdk",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Agent Client Protocol (ACP) SDK for Goose AI agent",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
The Goose SDK is changing frequently, and we’ve decided to pause active development for ui/text for now so that we can focus on getting the goose Acp+ in a stable status and migrating ui/desktop to ACP+

In this PR, we removed ui/text from the release process, and  to release a new version of the Goose SDK

After that we are going to update the local ui/text package to point to and pin that SDK version so that it will compatible version of goose-sdk


### Testing
will do testing on local after the new release

