### PR TITLE
feat(security): Re-adjust pattern-based detection for prompt injection detection confidence scores

### DIFF
--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -237,7 +237,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "unicode_obfuscation",
-        pattern: r"(\\u[0-9a-fA-F]{4}){3,}|(\\U[0-9a-fA-F]{8}){3,}",
+        pattern: r"(\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8}){3,}",
         description: "Unicode character obfuscation (3+ consecutive escapes)",
         risk_level: RiskLevel::Medium,
         category: ThreatCategory::CommandInjection,
@@ -524,5 +524,7 @@ mod tests {
         // Runs of 3+ consecutive escapes (obfuscation) should match
         assert!(matches(pat, r"\u0041\u0042\u0043"));
         assert!(matches(pat, r"\U00000041\U00000042\U00000043"));
+        // Mixed 4-digit and 8-digit forms should also match
+        assert!(matches(pat, r"\u0065\U00000076\u0061"));
     }
 }

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -232,14 +232,14 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
         name: "indirect_command_execution",
         pattern: r"\$\([^)]*\$\([^)]*\)[^)]*\)|`[^`]*`[^`]*`",
         description: "Nested command substitution",
-        risk_level: RiskLevel::Medium,
+        risk_level: RiskLevel::Low,
         category: ThreatCategory::CommandInjection,
     },
     ThreatPattern {
         name: "unicode_obfuscation",
         pattern: r"\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8}",
         description: "Unicode character obfuscation",
-        risk_level: RiskLevel::Medium,
+        risk_level: RiskLevel::Low,
         category: ThreatCategory::CommandInjection,
     },
     ThreatPattern {
@@ -274,7 +274,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
         name: "log_manipulation",
         pattern: r"(truncate.*log|rm\s+((--[a-zA-Z][a-zA-Z\-]*|--|-[a-zA-Z]+)\s+)*/var/log(/|\s|[;&|]|$)|echo\s*>\s*/var/log)",
         description: "Log file manipulation or deletion",
-        risk_level: RiskLevel::Medium,
+        risk_level: RiskLevel::Low,
         category: ThreatCategory::SystemModification,
     },
     ThreatPattern {

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -237,9 +237,9 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "unicode_obfuscation",
-        pattern: r"\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8}",
-        description: "Unicode character obfuscation",
-        risk_level: RiskLevel::Low,
+        pattern: r"(\\u[0-9a-fA-F]{4}){3,}|(\\U[0-9a-fA-F]{8}){3,}",
+        description: "Unicode character obfuscation (3+ consecutive escapes)",
+        risk_level: RiskLevel::Medium,
         category: ThreatCategory::CommandInjection,
     },
     ThreatPattern {
@@ -513,5 +513,16 @@ mod tests {
         // Similar-looking paths outside /var/log should NOT match
         assert!(!matches(pat, "rm -rf /var/log-backup"));
         assert!(!matches(pat, "rm -rf /var/logs"));
+    }
+
+    #[test]
+    fn unicode_obfuscation_requires_consecutive_escapes() {
+        let pat = "unicode_obfuscation";
+        // Isolated escapes in legitimate code/strings should NOT match
+        assert!(!matches(pat, r"\u0041"));
+        assert!(!matches(pat, r"echo \u00e9 \u00e8"));
+        // Runs of 3+ consecutive escapes (obfuscation) should match
+        assert!(matches(pat, r"\u0041\u0042\u0043"));
+        assert!(matches(pat, r"\U00000041\U00000042\U00000043"));
     }
 }

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -274,7 +274,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
         name: "log_manipulation",
         pattern: r"(truncate.*log|rm\s+((--[a-zA-Z][a-zA-Z\-]*|--|-[a-zA-Z]+)\s+)*/var/log(/|\s|[;&|]|$)|echo\s*>\s*/var/log)",
         description: "Log file manipulation or deletion",
-        risk_level: RiskLevel::Low,
+        risk_level: RiskLevel::Medium,
         category: ThreatCategory::SystemModification,
     },
     ThreatPattern {


### PR DESCRIPTION
## Summary
Pattern-based threat detection generates significant false positives, particularly for users who configure lower security thresholds. In the last 7 days:

- unicode_obfuscatio: 42 FPs - triggers on any single \uXXXX in commands (emojis in Slack messages, ANSI color codes, JSON unicode escapes)
- indirect_command_executio: 42 FPs - triggers on any nested $(...) (extremely common in normal shell: $(dirname $(which node)), $(cat <<'EOF'...EOF))

These patterns fire at Medium risk (0.60), meaning any user with threshold ≤0.60 sees a flood of false alerts on routine commands.

### Changes
unicode_obfuscation: tightened pattern (Medium → Medium)

Changed from matching any single \uXXXX to requiring 3+ consecutive unicode escapes. A single \u2764 (heart emoji) or \u001b[31m (ANSI red) is normal usage. But \u0072\u006d\u0020\u002d\u0072\u0066 (obfuscated rm -rf) is genuinely suspicious.

Before: r"\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8}"
After:  r"(\\u[0-9a-fA-F]{4}){3,}|(\\U[0-9a-fA-F]{8}){3,}"
Kept at Medium (0.60) since when it fires now, it's a strong signal.

indirect_command_execution — lowered risk (Medium → Low)

Nested command substitution ($(...) inside $(...)) is standard shell usage — build tools, path resolution, heredoc commit messages. The ML classifier handles actual injection attempts with 98%+ accuracy. Lowered to Low (0.45) so it only fires for users with very aggressive thresholds.

### What's NOT changed
- log_manipulation stays at Medium (0.60) - the pattern is already narrowed to /var/log specifically, and rm -rf /var/log is genuinely dangerous at balanced thresholds
- All Critical patterns unchanged (rm_rf_root_bare, curl_bash_execution, rm_rf_home_or_root, etc.)

### Impact
At the default threshold (0.80): no change — these patterns already don't fire.

At threshold 0.50 ("balanced" mode):

- unicode_obfuscation: eliminates ~42 FPs/week from emoji/ANSI/JSON, still catches real obfuscation
- indirect_command_execution: eliminates ~42 FPs/week from nested $(...), ML model covers this

## Tests
Added unicode_obfuscation_requires_consecutive_escapes test verifying:
- Single escapes (\u0041, echo \u00e9 \u00e8) do NOT match
- Consecutive runs (\u0041\u0042\u0043) still match
