### PR TITLE
feat(cli): interactive session picker for `session --resume`

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -1424,6 +1424,7 @@ async fn handle_session_subcommand(command: SessionCommand) -> Result<()> {
                     &session_manager,
                     "Select a session to export:",
                     None,
+                    false,
                 )
                 .await
                 {
@@ -1455,6 +1456,7 @@ async fn handle_session_subcommand(command: SessionCommand) -> Result<()> {
                     &session_manager,
                     "Select a session to view diagnostics for:",
                     None,
+                    false,
                 )
                 .await
                 {
@@ -1471,7 +1473,15 @@ async fn handle_session_subcommand(command: SessionCommand) -> Result<()> {
     Ok(())
 }
 
-async fn resolve_resume_selection(all: bool) -> Result<Identifier> {
+/// Outcome of the interactive `--select` resume picker.
+enum ResumeSelection {
+    /// Resume the session identified by the wrapped identifier.
+    Resume(Identifier),
+    /// Start a fresh session in the current directory instead of resuming.
+    NewSession,
+}
+
+async fn resolve_resume_selection(all: bool) -> Result<ResumeSelection> {
     let session_manager = SessionManager::instance();
     let filter_dir = if all {
         None
@@ -1482,13 +1492,19 @@ async fn resolve_resume_selection(all: bool) -> Result<Identifier> {
         &session_manager,
         "Select a session to resume:",
         filter_dir.as_deref(),
+        true,
     )
     .await?;
-    Ok(Identifier {
+
+    if id == crate::commands::session::NEW_SESSION_SELECTION {
+        return Ok(ResumeSelection::NewSession);
+    }
+
+    Ok(ResumeSelection::Resume(Identifier {
         name: None,
         session_id: Some(id),
         path: None,
-    })
+    }))
 }
 
 async fn handle_interactive_session(
@@ -2158,16 +2174,19 @@ pub async fn cli() -> anyhow::Result<()> {
             session_opts,
             extension_opts,
         }) => {
-            let identifier = if select {
+            let (identifier, resume) = if select {
                 match resolve_resume_selection(all).await {
-                    Ok(id) => Some(id),
+                    Ok(ResumeSelection::Resume(id)) => (Some(id), resume),
+                    // Starting fresh: drop any identifier and don't resume, so a
+                    // brand new session is created in the current directory.
+                    Ok(ResumeSelection::NewSession) => (None, false),
                     Err(e) => {
                         eprintln!("Error: {}", e);
                         return Ok(());
                     }
                 }
             } else {
-                identifier
+                (identifier, resume)
             };
             handle_interactive_session(
                 identifier,

--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -2174,19 +2174,21 @@ pub async fn cli() -> anyhow::Result<()> {
             session_opts,
             extension_opts,
         }) => {
-            let (identifier, resume) = if select {
+            let (identifier, resume, fork) = if select {
                 match resolve_resume_selection(all).await {
-                    Ok(ResumeSelection::Resume(id)) => (Some(id), resume),
-                    // Starting fresh: drop any identifier and don't resume, so a
-                    // brand new session is created in the current directory.
-                    Ok(ResumeSelection::NewSession) => (None, false),
+                    Ok(ResumeSelection::Resume(id)) => (Some(id), resume, fork),
+                    // Starting fresh: drop any identifier and don't resume or
+                    // fork, so a brand new session is created in the current
+                    // directory. Leaving `fork` set here would copy the empty
+                    // new session and leave a stray unused session behind.
+                    Ok(ResumeSelection::NewSession) => (None, false, false),
                     Err(e) => {
                         eprintln!("Error: {}", e);
                         return Ok(());
                     }
                 }
             } else {
-                (identifier, resume)
+                (identifier, resume, fork)
             };
             handle_interactive_session(
                 identifier,

--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -858,6 +858,24 @@ enum Command {
         )]
         resume: bool,
 
+        /// Interactively pick which session to resume
+        #[arg(
+            long,
+            requires = "resume",
+            conflicts_with_all = ["name", "session_id", "path"],
+            help = "Interactively pick which session to resume from a list",
+            long_help = "When resuming, show a list of recent sessions and let you pick one instead of defaulting to the most recent. By default only sessions started in the current directory are shown; pass --all to pick from any directory. Cannot be combined with --name/--session-id."
+        )]
+        select: bool,
+
+        /// With --select, list sessions from every directory, not just the current one
+        #[arg(
+            long,
+            requires = "select",
+            help = "With --select, list sessions from all directories instead of only the current one"
+        )]
+        all: bool,
+
         /// Fork a previous session (creates new session with copied history)
         #[arg(
             long,
@@ -1404,6 +1422,8 @@ async fn handle_session_subcommand(command: SessionCommand) -> Result<()> {
             } else {
                 match crate::commands::session::prompt_interactive_session_selection(
                     &session_manager,
+                    "Select a session to export:",
+                    None,
                 )
                 .await
                 {
@@ -1433,6 +1453,8 @@ async fn handle_session_subcommand(command: SessionCommand) -> Result<()> {
             } else {
                 match crate::commands::session::prompt_interactive_session_selection(
                     &session_manager,
+                    "Select a session to view diagnostics for:",
+                    None,
                 )
                 .await
                 {
@@ -1447,6 +1469,26 @@ async fn handle_session_subcommand(command: SessionCommand) -> Result<()> {
         }
     }
     Ok(())
+}
+
+async fn resolve_resume_selection(all: bool) -> Result<Identifier> {
+    let session_manager = SessionManager::instance();
+    let filter_dir = if all {
+        None
+    } else {
+        Some(std::env::current_dir()?)
+    };
+    let id = crate::commands::session::prompt_interactive_session_selection(
+        &session_manager,
+        "Select a session to resume:",
+        filter_dir.as_deref(),
+    )
+    .await?;
+    Ok(Identifier {
+        name: None,
+        session_id: Some(id),
+        path: None,
+    })
 }
 
 async fn handle_interactive_session(
@@ -2109,11 +2151,24 @@ pub async fn cli() -> anyhow::Result<()> {
             command: None,
             identifier,
             resume,
+            select,
+            all,
             fork,
             history,
             session_opts,
             extension_opts,
         }) => {
+            let identifier = if select {
+                match resolve_resume_selection(all).await {
+                    Ok(id) => Some(id),
+                    Err(e) => {
+                        eprintln!("Error: {}", e);
+                        return Ok(());
+                    }
+                }
+            } else {
+                identifier
+            };
             handle_interactive_session(
                 identifier,
                 resume,

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -425,55 +425,69 @@ fn export_session_to_markdown(
 
 /// Prompt the user to interactively select a session
 ///
-/// Shows a list of available sessions and lets the user select one
+/// Shows a list of available sessions and lets the user select one. When
+/// `filter_dir` is provided, only sessions whose working directory matches it
+/// are shown (and the path is omitted from each row since it is identical).
 pub async fn prompt_interactive_session_selection(
     session_manager: &SessionManager,
+    prompt: &str,
+    filter_dir: Option<&Path>,
 ) -> Result<String> {
-    let sessions = session_manager.list_sessions().await?;
+    let mut sessions = session_manager.list_sessions().await?;
+
+    if let Some(dir) = filter_dir {
+        let target = canonical_or_owned(dir);
+        sessions.retain(|s| canonical_or_owned(&s.working_dir) == target);
+    }
 
     if sessions.is_empty() {
-        return Err(anyhow::anyhow!("No sessions found"));
+        return Err(match filter_dir {
+            Some(dir) => anyhow::anyhow!(
+                "No sessions found for {}. Use --all to pick from sessions in any directory.",
+                display_path_with_tilde(dir)
+            ),
+            None => anyhow::anyhow!("No sessions found"),
+        });
     }
 
     // Build the selection prompt
-    let mut selector = select("Select a session to export:");
+    let mut selector = select(prompt);
 
-    // Map to display text
-    let display_map: std::collections::HashMap<String, Session> = sessions
-        .iter()
-        .map(|s| {
-            let desc = if s.name.is_empty() {
-                "(no name)"
-            } else {
-                &s.name
-            };
-            let truncated_desc = safe_truncate(desc, TRUNCATED_DESC_LENGTH);
+    // Build options in the order returned by list_sessions (most recent first),
+    // keyed by session id so the display text can be anything.
+    for s in &sessions {
+        let desc = if s.name.is_empty() {
+            "(no name)"
+        } else {
+            &s.name
+        };
+        let truncated_desc = safe_truncate(desc, TRUNCATED_DESC_LENGTH);
 
-            let display_text = format!("{} - {} ({})", s.updated_at, truncated_desc, s.id);
-            (display_text, s.clone())
-        })
-        .collect();
-
-    // Add each session as an option
-    for display_text in display_map.keys() {
-        selector = selector.item(display_text.clone(), display_text.clone(), "");
+        let display_text = if filter_dir.is_some() {
+            format!("{} - {}", s.updated_at, truncated_desc)
+        } else {
+            format!(
+                "{} - {} - {}",
+                s.updated_at,
+                truncated_desc,
+                display_path_with_tilde(&s.working_dir)
+            )
+        };
+        selector = selector.item(s.id.clone(), display_text, "");
     }
 
-    // Add a cancel option
     let cancel_value = String::from("cancel");
-    selector = selector.item(cancel_value, "Cancel", "Cancel export");
+    selector = selector.item(cancel_value.clone(), "Cancel", "");
 
-    // Get user selection
-    let selected_display_text: String = selector.interact()?;
+    let selected = selector.interact()?;
 
-    if selected_display_text == "cancel" {
-        return Err(anyhow::anyhow!("Export canceled"));
+    if selected == cancel_value {
+        return Err(anyhow::anyhow!("Selection canceled"));
     }
 
-    // Retrieve the selected session
-    if let Some(session) = display_map.get(&selected_display_text) {
-        Ok(session.id.clone())
-    } else {
-        Err(anyhow::anyhow!("Invalid selection"))
-    }
+    Ok(selected)
+}
+
+fn canonical_or_owned(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -450,8 +450,18 @@ pub async fn prompt_interactive_session_selection(
         });
     }
 
-    // Build the selection prompt
-    let mut selector = select(prompt);
+    // Build the selection prompt.
+    //
+    // Cap the visible rows to the terminal height so the list scrolls instead of
+    // overflowing on short terminals, and enable fuzzy filtering (matching the
+    // convention used by the configure command's long lists). We reserve a few
+    // lines for the prompt header, filter input, and footer, and clamp to a sane
+    // minimum so the picker stays usable even on tiny windows.
+    let max_rows = console::Term::stderr()
+        .size_checked()
+        .map(|(rows, _cols)| (rows as usize).saturating_sub(6).max(3))
+        .unwrap_or(10);
+    let mut selector = select(prompt).max_rows(max_rows).filter_mode();
 
     // Build options in the order returned by list_sessions (most recent first),
     // keyed by session id so the display text can be anything.

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -464,15 +464,19 @@ pub async fn prompt_interactive_session_selection(
     // Build the selection prompt.
     //
     // Cap the visible rows to the terminal height so the list scrolls instead of
-    // overflowing on short terminals, and enable fuzzy filtering (matching the
-    // convention used by the configure command's long lists). We reserve a few
-    // lines for the prompt header, filter input, and footer, and clamp to a sane
-    // minimum so the picker stays usable even on tiny windows.
+    // overflowing on short terminals. We reserve a few lines for the prompt
+    // header and footer, and clamp to a sane minimum so the picker stays usable
+    // even on tiny windows.
+    //
+    // Note: we intentionally do not enable `filter_mode()` here. In cliclack the
+    // filter captures every character key as type-to-filter input, which would
+    // break vim-style `j`/`k`/`h`/`l` navigation. Scrolling via `max_rows` is
+    // enough to keep long lists usable.
     let max_rows = console::Term::stderr()
         .size_checked()
         .map(|(rows, _cols)| (rows as usize).saturating_sub(6).max(3))
         .unwrap_or(10);
-    let mut selector = select(prompt).max_rows(max_rows).filter_mode();
+    let mut selector = select(prompt).max_rows(max_rows);
 
     // Offer starting a fresh session as the first option when allowed. A new
     // session always uses the current working directory, so this behaves the

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -423,15 +423,26 @@ fn export_session_to_markdown(
     markdown_output
 }
 
+/// Sentinel value returned by [`prompt_interactive_session_selection`] when the
+/// user chooses to start a new session in the current directory instead of
+/// resuming an existing one. This is only offered when `allow_new` is set. The
+/// leading NUL byte guarantees it can never collide with a real session id.
+pub const NEW_SESSION_SELECTION: &str = "\0new-session";
+
 /// Prompt the user to interactively select a session
 ///
 /// Shows a list of available sessions and lets the user select one. When
 /// `filter_dir` is provided, only sessions whose working directory matches it
 /// are shown (and the path is omitted from each row since it is identical).
+///
+/// When `allow_new` is set, a "Start a new session" entry is shown first and
+/// selecting it returns [`NEW_SESSION_SELECTION`]. In that mode an empty session
+/// list is not an error, since the user can always start fresh.
 pub async fn prompt_interactive_session_selection(
     session_manager: &SessionManager,
     prompt: &str,
     filter_dir: Option<&Path>,
+    allow_new: bool,
 ) -> Result<String> {
     let mut sessions = session_manager.list_sessions().await?;
 
@@ -440,7 +451,7 @@ pub async fn prompt_interactive_session_selection(
         sessions.retain(|s| canonical_or_owned(&s.working_dir) == target);
     }
 
-    if sessions.is_empty() {
+    if sessions.is_empty() && !allow_new {
         return Err(match filter_dir {
             Some(dir) => anyhow::anyhow!(
                 "No sessions found for {}. Use --all to pick from sessions in any directory.",
@@ -462,6 +473,17 @@ pub async fn prompt_interactive_session_selection(
         .map(|(rows, _cols)| (rows as usize).saturating_sub(6).max(3))
         .unwrap_or(10);
     let mut selector = select(prompt).max_rows(max_rows).filter_mode();
+
+    // Offer starting a fresh session as the first option when allowed. A new
+    // session always uses the current working directory, so this behaves the
+    // same with or without a directory filter.
+    if allow_new {
+        selector = selector.item(
+            NEW_SESSION_SELECTION.to_string(),
+            "Start a new session (in current directory)",
+            "",
+        );
+    }
 
     // Build options in the order returned by list_sessions (most recent first),
     // keyed by session id so the display text can be anything.


### PR DESCRIPTION
## Summary
Adds `goose session --resume --select`, an interactive picker for resuming sessions instead of needing the exact name/id or silently defaulting to the most recent one.

- By default the picker lists only sessions started in the **current directory** (matching where you're working), shown most-recent-first.
- Pass `--all` to widen it to sessions from **any directory** (paths are then shown on each row, home-abbreviated to `~`).
- `--select` requires `--resume` and conflicts with `--name`/`--session-id`/`--path`; `--all` requires `--select`.

Implementation reuses the existing interactive picker (previously only wired into `session export`) by generalizing it to take a prompt label and an optional working-directory filter — now shared by resume, export, and diagnostics. This also fixes a latent bug where the picker was keyed by a `HashMap`, randomizing row order; it now preserves `list_sessions()` order (newest-first).

<img width="762" height="633" alt="image" src="https://github.com/user-attachments/assets/6f4f6ac4-041d-4238-9a33-5ba57203d1ce" />

### Testing
Manual:
- `goose session --resume --select` in a project dir → scoped, sorted list.
- `--all` → sessions across dirs with paths shown.
- Empty current dir → friendly error pointing to `--all`.
- clap rules verified: `--select` requires `--resume` & conflicts with `--name`/`--session-id`; `--all` requires `--select`.

`cargo fmt`, `cargo build -p goose-cli`, and `cargo clippy -p goose-cli --all-targets -- -D warnings` all pass.

### Related Issues
None found.