### PR TITLE
fix(claude-acp): surface terminal tool output

### DIFF
--- a/crates/goose/src/acp/mod.rs
+++ b/crates/goose/src/acp/mod.rs
@@ -6,6 +6,7 @@ mod provider;
 mod response_builder;
 pub mod server;
 pub mod server_factory;
+mod terminal;
 pub(crate) mod tools;
 pub mod transport;
 

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -1,12 +1,15 @@
 use agent_client_protocol::schema::{
-    ClientCapabilities, CloseSessionRequest, ContentBlock, ContentChunk, EnvVariable, HttpHeader,
-    ImageContent, InitializeRequest, InitializeResponse, McpCapabilities, McpServer, McpServerHttp,
-    McpServerStdio, NewSessionRequest, NewSessionResponse, PromptRequest, PromptResponse,
-    ProtocolVersion, RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
+    ClientCapabilities, CloseSessionRequest, ContentBlock, ContentChunk, CreateTerminalRequest,
+    CreateTerminalResponse, EnvVariable, HttpHeader, ImageContent, InitializeRequest,
+    InitializeResponse, KillTerminalRequest, KillTerminalResponse, McpCapabilities, McpServer,
+    McpServerHttp, McpServerStdio, NewSessionRequest, NewSessionResponse, PromptRequest,
+    PromptResponse, ProtocolVersion, ReleaseTerminalRequest, ReleaseTerminalResponse,
+    RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
     SessionConfigKind, SessionConfigOption, SessionConfigOptionCategory,
     SessionConfigSelectOptions, SessionId, SessionNotification, SessionUpdate,
     SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModeResponse, StopReason,
-    TextContent, ToolCallContent, ToolCallStatus, ToolKind,
+    TerminalOutputRequest, TextContent, ToolCallContent, ToolCallStatus, ToolKind,
+    WaitForTerminalExitRequest, WaitForTerminalExitResponse,
 };
 use agent_client_protocol::{Agent, Client, ConnectionTo};
 use agent_client_protocol_schema::Usage as AcpUsage;
@@ -30,6 +33,7 @@ use tokio::process::{Child, Command};
 use tokio::sync::{mpsc, oneshot, Mutex as TokioMutex};
 use tokio_util::compat::{TokioAsyncReadCompatExt as _, TokioAsyncWriteCompatExt as _};
 
+use crate::acp::terminal::TerminalManager;
 use crate::acp::{map_permission_response, PermissionDecision};
 use crate::config::{ExtensionConfig, GooseMode};
 use crate::context_mgmt::format_message_for_compacting;
@@ -44,6 +48,11 @@ use goose_providers::errors::ProviderError;
 /// Sentinel: resolved to the actual model name during connect().
 pub const ACP_CURRENT_MODEL: &str = "current";
 
+/// Priority for bridged tool-result content. The CLI renderer only shows
+/// tool output whose priority is `>= GOOSE_CLI_MIN_PRIORITY` (default 0.0)
+/// and drops content with no priority at all.
+const USER_VISIBLE_PRIORITY: f32 = 0.0;
+
 pub struct AcpProviderConfig {
     pub command: PathBuf,
     pub args: Vec<String>,
@@ -53,6 +62,7 @@ pub struct AcpProviderConfig {
     pub mcp_servers: Vec<McpServer>,
     pub session_mode_id: Option<String>,
     pub mode_mapping: HashMap<GooseMode, String>,
+    pub terminal: bool,
     pub notification_callback: Option<Arc<dyn Fn(SessionNotification) + Send + Sync>>,
 }
 
@@ -716,6 +726,8 @@ impl AcpClientLoop {
         } = self;
         let notification_callback = config.notification_callback.clone();
         let reverse_modes = reverse_mode_mapping(&config.mode_mapping);
+        let terminal_enabled = config.terminal;
+        let terminal_manager = TerminalManager::new(config.work_dir.clone());
 
         Client
             .builder()
@@ -726,6 +738,7 @@ impl AcpClientLoop {
                     let goose_mode = goose_mode.clone();
                     let pending_tool_updates = pending_tool_updates.clone();
                     let context_size = context_size.clone();
+                    let terminal_manager = terminal_manager.clone();
                     async move |notification: SessionNotification, _cx| {
                         if let Some(ref cb) = notification_callback {
                             cb(notification.clone());
@@ -823,7 +836,10 @@ impl AcpClientLoop {
                                         let content = if accumulated.content.is_empty() {
                                             None
                                         } else {
-                                            Some(accumulated.content)
+                                            Some(
+                                                terminal_manager
+                                                    .resolve_content(accumulated.content),
+                                            )
                                         };
                                         let _ = tx.try_send(AcpUpdate::ToolCallComplete {
                                             id,
@@ -869,7 +885,10 @@ impl AcpClientLoop {
                                         let content = if accumulated.content.is_empty() {
                                             None
                                         } else {
-                                            Some(accumulated.content)
+                                            Some(
+                                                terminal_manager
+                                                    .resolve_content(accumulated.content),
+                                            )
                                         };
                                         let _ = tx.try_send(AcpUpdate::ToolCallComplete {
                                             id,
@@ -915,6 +934,97 @@ impl AcpClientLoop {
                             RequestPermissionResponse::new(RequestPermissionOutcome::Cancelled)
                         });
                         responder.respond(response)
+                    }
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_request(
+                {
+                    let terminal_manager = terminal_manager.clone();
+                    async move |request: CreateTerminalRequest, responder, _cx| {
+                        if !terminal_enabled {
+                            return responder.respond_with_error(
+                                agent_client_protocol::Error::method_not_found(),
+                            );
+                        }
+                        match terminal_manager.create(request).await {
+                            Ok(id) => responder.respond(CreateTerminalResponse::new(id)),
+                            Err(e) => {
+                                Err(agent_client_protocol::Error::internal_error()
+                                    .data(e.to_string()))
+                            }
+                        }
+                    }
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_request(
+                {
+                    let terminal_manager = terminal_manager.clone();
+                    async move |request: TerminalOutputRequest, responder, _cx| {
+                        if !terminal_enabled {
+                            return responder.respond_with_error(
+                                agent_client_protocol::Error::method_not_found(),
+                            );
+                        }
+                        match terminal_manager.output(request.terminal_id.0.as_ref()) {
+                            Some(response) => responder.respond(response),
+                            None => Err(agent_client_protocol::Error::internal_error()
+                                .data(format!("unknown terminal {}", request.terminal_id.0))),
+                        }
+                    }
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_request(
+                {
+                    let terminal_manager = terminal_manager.clone();
+                    async move |request: WaitForTerminalExitRequest, responder, _cx| {
+                        if !terminal_enabled {
+                            return responder.respond_with_error(
+                                agent_client_protocol::Error::method_not_found(),
+                            );
+                        }
+                        match terminal_manager
+                            .wait_for_exit(request.terminal_id.0.as_ref())
+                            .await
+                        {
+                            Some(status) => {
+                                responder.respond(WaitForTerminalExitResponse::new(status))
+                            }
+                            None => Err(agent_client_protocol::Error::internal_error()
+                                .data(format!("unknown terminal {}", request.terminal_id.0))),
+                        }
+                    }
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_request(
+                {
+                    let terminal_manager = terminal_manager.clone();
+                    async move |request: KillTerminalRequest, responder, _cx| {
+                        if !terminal_enabled {
+                            return responder.respond_with_error(
+                                agent_client_protocol::Error::method_not_found(),
+                            );
+                        }
+                        terminal_manager.kill(request.terminal_id.0.as_ref());
+                        responder.respond(KillTerminalResponse::new())
+                    }
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_request(
+                {
+                    let terminal_manager = terminal_manager.clone();
+                    async move |request: ReleaseTerminalRequest, responder, _cx| {
+                        if !terminal_enabled {
+                            return responder.respond_with_error(
+                                agent_client_protocol::Error::method_not_found(),
+                            );
+                        }
+                        terminal_manager.release(request.terminal_id.0.as_ref());
+                        responder.respond(ReleaseTerminalResponse::new())
                     }
                 },
                 agent_client_protocol::on_receive_request!(),
@@ -1008,7 +1118,7 @@ async fn handle_requests(
 ) -> Result<(), agent_client_protocol::Error> {
     let mut init_tx = Some(init_tx);
 
-    let client_capabilities = ClientCapabilities::new();
+    let client_capabilities = ClientCapabilities::new().terminal(config.terminal);
     let init_response: InitializeResponse = cx
         .send_request(
             InitializeRequest::new(ProtocolVersion::LATEST)
@@ -1379,7 +1489,17 @@ fn acp_tool_call_content_to_rmcp(
             out.push(RmcpContent::text(text));
         }
     }
-    out
+    // Tag as user-visible: the CLI renderer hides tool-result content that has
+    // no priority annotation, so unannotated bridge output never shows up.
+    out.into_iter()
+        .map(|content| {
+            if content.priority().is_none() {
+                content.with_priority(USER_VISIBLE_PRIORITY)
+            } else {
+                content
+            }
+        })
+        .collect()
 }
 
 fn build_action_required_message(request: &RequestPermissionRequest) -> Option<Message> {
@@ -2006,6 +2126,11 @@ mod tests {
             serialized[3].contains("base64data"),
             "image data lost: {serialized:?}"
         );
+        assert!(
+            out.iter()
+                .all(|c| c.priority() == Some(USER_VISIBLE_PRIORITY)),
+            "every bridged block must be tagged user-visible so the CLI renders it",
+        );
     }
 
     #[test]
@@ -2017,6 +2142,11 @@ mod tests {
         assert!(
             serialized.contains("key"),
             "fallback raw_output lost: {serialized}"
+        );
+        assert_eq!(
+            out[0].priority(),
+            Some(USER_VISIBLE_PRIORITY),
+            "fallback raw_output must be tagged user-visible",
         );
     }
 

--- a/crates/goose/src/acp/terminal.rs
+++ b/crates/goose/src/acp/terminal.rs
@@ -1,0 +1,396 @@
+//! Client-side terminal support for goose acting as an ACP client.
+//!
+//! When goose bridges to an external ACP agent (e.g. Claude Code), the agent
+//! runs shell commands by asking goose — the client — to execute them through
+//! the `terminal/*` methods. goose owns the process, captures its output, and
+//! reports exit status back. Embedding a terminal in a tool call lets the agent
+//! release it while the captured output stays available, so this manager
+//! retains output after release to resolve those embeds into text.
+
+use std::collections::{HashMap, VecDeque};
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use agent_client_protocol::schema::{
+    ContentBlock, CreateTerminalRequest, TerminalExitStatus, TerminalId, TerminalOutputResponse,
+    TextContent, ToolCallContent,
+};
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::process::Command;
+use tokio::sync::{watch, Notify};
+
+use crate::subprocess::configure_subprocess;
+
+/// Output cap applied when the agent does not request one, bounding memory for
+/// commands that emit unbounded output.
+const DEFAULT_OUTPUT_BYTE_LIMIT: usize = 1 << 20;
+
+/// Number of released terminals whose output we keep for tool-call embeds.
+const RETAINED_CAP: usize = 256;
+
+const READ_CHUNK: usize = 8192;
+
+#[derive(Clone)]
+pub(crate) struct TerminalManager {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    sessions: Mutex<HashMap<String, Arc<TerminalSession>>>,
+    retained: Mutex<RetainedOutputs>,
+    next_id: AtomicU64,
+    work_dir: PathBuf,
+}
+
+struct TerminalSession {
+    buffer: Arc<Mutex<TerminalBuffer>>,
+    exit_rx: watch::Receiver<Option<TerminalExitStatus>>,
+    kill: Arc<Notify>,
+}
+
+struct TerminalBuffer {
+    data: Vec<u8>,
+    truncated: bool,
+    byte_limit: usize,
+}
+
+impl TerminalBuffer {
+    fn append(&mut self, bytes: &[u8]) {
+        self.data.extend_from_slice(bytes);
+        if self.data.len() > self.byte_limit {
+            let overflow = self.data.len() - self.byte_limit;
+            self.data.drain(0..overflow);
+            while std::str::from_utf8(&self.data).is_err_and(|e| e.valid_up_to() == 0) {
+                self.data.drain(..1);
+            }
+            self.truncated = true;
+        }
+    }
+
+    fn output(&self) -> String {
+        String::from_utf8_lossy(&self.data).into_owned()
+    }
+}
+
+#[derive(Default)]
+struct RetainedOutputs {
+    map: HashMap<String, String>,
+    order: VecDeque<String>,
+}
+
+impl RetainedOutputs {
+    fn insert(&mut self, id: String, output: String) {
+        if self.map.insert(id.clone(), output).is_none() {
+            self.order.push_back(id);
+            while self.order.len() > RETAINED_CAP {
+                if let Some(old) = self.order.pop_front() {
+                    self.map.remove(&old);
+                }
+            }
+        }
+    }
+}
+
+impl TerminalManager {
+    pub(crate) fn new(work_dir: PathBuf) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                sessions: Mutex::new(HashMap::new()),
+                retained: Mutex::new(RetainedOutputs::default()),
+                next_id: AtomicU64::new(0),
+                work_dir,
+            }),
+        }
+    }
+
+    pub(crate) async fn create(
+        &self,
+        request: CreateTerminalRequest,
+    ) -> std::io::Result<TerminalId> {
+        let cwd = request
+            .cwd
+            .clone()
+            .unwrap_or_else(|| self.inner.work_dir.clone());
+        let byte_limit = request
+            .output_byte_limit
+            .map(|n| n as usize)
+            .unwrap_or(DEFAULT_OUTPUT_BYTE_LIMIT)
+            .max(1);
+
+        let mut cmd = Command::new(&request.command);
+        cmd.args(&request.args)
+            .current_dir(&cwd)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        for var in &request.env {
+            cmd.env(&var.name, &var.value);
+        }
+        configure_subprocess(&mut cmd);
+
+        let mut child = cmd.spawn()?;
+        let stdout = child.stdout.take();
+        let stderr = child.stderr.take();
+
+        let buffer = Arc::new(Mutex::new(TerminalBuffer {
+            data: Vec::new(),
+            truncated: false,
+            byte_limit,
+        }));
+        let (exit_tx, exit_rx) = watch::channel(None);
+        let kill = Arc::new(Notify::new());
+
+        {
+            let buffer = buffer.clone();
+            let kill = kill.clone();
+            tokio::spawn(async move {
+                let pumps = [
+                    stdout.map(|s| tokio::spawn(pump(s, buffer.clone()))),
+                    stderr.map(|s| tokio::spawn(pump(s, buffer.clone()))),
+                ];
+                let status = tokio::select! {
+                    s = child.wait() => s,
+                    _ = kill.notified() => {
+                        let _ = child.start_kill();
+                        child.wait().await
+                    }
+                };
+                for pump in pumps.into_iter().flatten() {
+                    let _ = pump.await;
+                }
+                let _ = exit_tx.send(Some(to_exit_status(status)));
+            });
+        }
+
+        let id = format!(
+            "term-{}",
+            self.inner.next_id.fetch_add(1, Ordering::Relaxed)
+        );
+        if let Ok(mut sessions) = self.inner.sessions.lock() {
+            sessions.insert(
+                id.clone(),
+                Arc::new(TerminalSession {
+                    buffer,
+                    exit_rx,
+                    kill,
+                }),
+            );
+        }
+        Ok(TerminalId::new(id))
+    }
+
+    pub(crate) fn output(&self, id: &str) -> Option<TerminalOutputResponse> {
+        let session = self.inner.sessions.lock().ok()?.get(id).cloned()?;
+        let (output, truncated) = {
+            let buffer = session.buffer.lock().expect("terminal buffer poisoned");
+            (buffer.output(), buffer.truncated)
+        };
+        let exit_status = session.exit_rx.borrow().clone();
+        Some(TerminalOutputResponse::new(output, truncated).exit_status(exit_status))
+    }
+
+    pub(crate) async fn wait_for_exit(&self, id: &str) -> Option<TerminalExitStatus> {
+        let mut exit_rx = self.inner.sessions.lock().ok()?.get(id)?.exit_rx.clone();
+        loop {
+            if let Some(status) = exit_rx.borrow().clone() {
+                return Some(status);
+            }
+            if exit_rx.changed().await.is_err() {
+                return exit_rx.borrow().clone();
+            }
+        }
+    }
+
+    pub(crate) fn kill(&self, id: &str) {
+        if let Ok(sessions) = self.inner.sessions.lock() {
+            if let Some(session) = sessions.get(id) {
+                session.kill.notify_one();
+            }
+        }
+    }
+
+    pub(crate) fn release(&self, id: &str) {
+        let session = self
+            .inner
+            .sessions
+            .lock()
+            .ok()
+            .and_then(|mut sessions| sessions.remove(id));
+        if let Some(session) = session {
+            session.kill.notify_one();
+            let output = session
+                .buffer
+                .lock()
+                .map(|buffer| buffer.output())
+                .unwrap_or_default();
+            if let Ok(mut retained) = self.inner.retained.lock() {
+                retained.insert(id.to_string(), output);
+            }
+        }
+    }
+
+    /// Replace any embedded `terminal/*` references with the terminal's captured
+    /// output so downstream consumers see real text instead of an opaque id.
+    pub(crate) fn resolve_content(&self, content: Vec<ToolCallContent>) -> Vec<ToolCallContent> {
+        content
+            .into_iter()
+            .map(|block| match block {
+                ToolCallContent::Terminal(terminal) => {
+                    let output = self
+                        .resolve_output(terminal.terminal_id.0.as_ref())
+                        .unwrap_or_default();
+                    ToolCallContent::from(ContentBlock::Text(TextContent::new(output)))
+                }
+                other => other,
+            })
+            .collect()
+    }
+
+    fn resolve_output(&self, id: &str) -> Option<String> {
+        if let Ok(sessions) = self.inner.sessions.lock() {
+            if let Some(session) = sessions.get(id) {
+                return Some(
+                    session
+                        .buffer
+                        .lock()
+                        .map(|buffer| buffer.output())
+                        .unwrap_or_default(),
+                );
+            }
+        }
+        self.inner
+            .retained
+            .lock()
+            .ok()
+            .and_then(|retained| retained.map.get(id).cloned())
+    }
+}
+
+async fn pump<R: AsyncRead + Unpin>(mut reader: R, buffer: Arc<Mutex<TerminalBuffer>>) {
+    let mut chunk = [0u8; READ_CHUNK];
+    loop {
+        match reader.read(&mut chunk).await {
+            Ok(0) | Err(_) => break,
+            Ok(n) => {
+                if let Ok(mut buffer) = buffer.lock() {
+                    buffer.append(&chunk[..n]);
+                }
+            }
+        }
+    }
+}
+
+fn to_exit_status(status: std::io::Result<std::process::ExitStatus>) -> TerminalExitStatus {
+    let Ok(status) = status else {
+        return TerminalExitStatus::new();
+    };
+    #[cfg(unix)]
+    let signal = std::os::unix::process::ExitStatusExt::signal(&status).map(|s| s.to_string());
+    #[cfg(not(unix))]
+    let signal: Option<String> = None;
+    TerminalExitStatus::new()
+        .exit_code(status.code().map(|c| c as u32))
+        .signal(signal)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use agent_client_protocol::schema::{SessionId, Terminal};
+
+    fn request(command: &str, args: &[&str]) -> CreateTerminalRequest {
+        CreateTerminalRequest::new(SessionId::new("s"), command)
+            .args(args.iter().map(|a| a.to_string()).collect())
+    }
+
+    #[tokio::test]
+    async fn captures_output_and_exit_status() {
+        let manager = TerminalManager::new(PathBuf::from("."));
+        let id = manager
+            .create(request("sh", &["-c", "printf hello"]))
+            .await
+            .unwrap();
+        let id = id.0.to_string();
+
+        let status = manager.wait_for_exit(&id).await.unwrap();
+        assert_eq!(status.exit_code, Some(0));
+
+        let output = manager.output(&id).unwrap();
+        assert_eq!(output.output, "hello");
+        assert!(!output.truncated);
+        assert_eq!(output.exit_status.unwrap().exit_code, Some(0));
+    }
+
+    #[tokio::test]
+    async fn resolves_embedded_terminal_to_text() {
+        let manager = TerminalManager::new(PathBuf::from("."));
+        let id = manager
+            .create(request("sh", &["-c", "printf done"]))
+            .await
+            .unwrap();
+        manager.wait_for_exit(id.0.as_ref()).await;
+
+        let resolved = manager.resolve_content(vec![ToolCallContent::Terminal(Terminal::new(id))]);
+
+        match &resolved[..] {
+            [ToolCallContent::Content(content)] => match &content.content {
+                ContentBlock::Text(text) => assert_eq!(text.text, "done"),
+                other => panic!("expected text content, got {other:?}"),
+            },
+            other => panic!("expected one resolved content block, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn retains_output_after_release() {
+        let manager = TerminalManager::new(PathBuf::from("."));
+        let id = manager
+            .create(request("sh", &["-c", "printf kept"]))
+            .await
+            .unwrap();
+        let id = id.0.to_string();
+        manager.wait_for_exit(&id).await;
+
+        manager.release(&id);
+        assert!(manager.output(&id).is_none());
+        assert_eq!(manager.resolve_output(&id).as_deref(), Some("kept"));
+    }
+
+    #[tokio::test]
+    async fn nonzero_exit_code_is_reported() {
+        let manager = TerminalManager::new(PathBuf::from("."));
+        let id = manager
+            .create(request("sh", &["-c", "exit 3"]))
+            .await
+            .unwrap();
+        let status = manager.wait_for_exit(id.0.as_ref()).await.unwrap();
+        assert_eq!(status.exit_code, Some(3));
+    }
+
+    #[test]
+    fn buffer_truncates_from_front() {
+        let mut buffer = TerminalBuffer {
+            data: Vec::new(),
+            truncated: false,
+            byte_limit: 4,
+        };
+        buffer.append(b"abcdef");
+        assert_eq!(buffer.output(), "cdef");
+        assert!(buffer.truncated);
+    }
+
+    #[test]
+    fn buffer_truncates_to_utf8_boundary() {
+        let mut buffer = TerminalBuffer {
+            data: Vec::new(),
+            truncated: false,
+            byte_limit: 4,
+        };
+        buffer.append("ééé".as_bytes());
+        assert_eq!(buffer.output(), "éé");
+        assert!(buffer.truncated);
+    }
+}

--- a/crates/goose/src/providers/amp_acp.rs
+++ b/crates/goose/src/providers/amp_acp.rs
@@ -77,6 +77,7 @@ impl ProviderDef for AmpAcpProvider {
                 mcp_servers: extension_configs_to_mcp_servers(&extensions),
                 session_mode_id: Some(mode_mapping[&goose_mode].clone()),
                 mode_mapping,
+                terminal: false,
                 notification_callback: None,
             };
 

--- a/crates/goose/src/providers/claude_acp.rs
+++ b/crates/goose/src/providers/claude_acp.rs
@@ -81,6 +81,7 @@ impl ProviderDef for ClaudeAcpProvider {
                 mcp_servers: extension_configs_to_mcp_servers(&extensions),
                 session_mode_id: Some(mode_mapping[&goose_mode].clone()),
                 mode_mapping,
+                terminal: true,
                 notification_callback: None,
             };
 

--- a/crates/goose/src/providers/codex_acp.rs
+++ b/crates/goose/src/providers/codex_acp.rs
@@ -100,6 +100,7 @@ impl ProviderDef for CodexAcpProvider {
                 // Disabled until https://github.com/zed-industries/codex-acp/issues/179 is fixed.
                 session_mode_id: None,
                 mode_mapping,
+                terminal: false,
                 notification_callback: None,
             };
 

--- a/crates/goose/src/providers/copilot_acp.rs
+++ b/crates/goose/src/providers/copilot_acp.rs
@@ -87,6 +87,7 @@ impl ProviderDef for CopilotAcpProvider {
                 mcp_servers: extension_configs_to_mcp_servers(&extensions),
                 session_mode_id: Some(mode_mapping[&goose_mode].clone()),
                 mode_mapping,
+                terminal: false,
                 notification_callback: None,
             };
 

--- a/crates/goose/src/providers/pi_acp.rs
+++ b/crates/goose/src/providers/pi_acp.rs
@@ -74,6 +74,7 @@ impl ProviderDef for PiAcpProvider {
                 mcp_servers: extension_configs_to_mcp_servers(&extensions),
                 session_mode_id: Some(mode_mapping[&goose_mode].clone()),
                 mode_mapping,
+                terminal: false,
                 notification_callback: None,
             };
 

--- a/crates/goose/tests/acp_fixtures/provider.rs
+++ b/crates/goose/tests/acp_fixtures/provider.rs
@@ -190,6 +190,7 @@ impl Connection for AcpProviderConnection {
                     (mode, mode.to_string())
                 })
                 .collect(),
+            terminal: config.terminal.is_some(),
             notification_callback: Some(Arc::new(move |n| {
                 sink_clone.lock().unwrap().push(n.update.clone());
             })),

--- a/crates/goose/tests/acp_provider_test.rs
+++ b/crates/goose/tests/acp_provider_test.rs
@@ -131,7 +131,6 @@ fn test_shell_terminal_false() {
 }
 
 #[test]
-#[ignore = "provider does not handle terminal delegation requests"]
 fn test_shell_terminal_true() {
     run_test(async { run_shell_terminal_true::<AcpProviderConnection>().await });
 }


### PR DESCRIPTION
## Summary

Fixes Claude ACP terminal-backed tool executions by implementing the ACP client-side terminal lifecycle in the ACP provider bridge.

This builds on #8408, which surfaced ACP tool calls/results to the session bus. Terminal-backed tool output can still arrive as `ToolCallContent::Terminal(id)`, where the actual command output is available through follow-up ACP `terminal/*` requests. Goose previously did not handle those provider-side client terminal requests, so Claude ACP tool execution output could remain hidden or degrade to a terminal id placeholder.

Terminal capability is opt-in through `AcpProviderConfig` and is enabled only for `claude-acp`; other ACP providers explicitly keep it disabled.

## Changes

- Add provider-side ACP terminal handling for:
  - `terminal/create`
  - `terminal/output`
  - `terminal/wait_for_exit`
  - `terminal/kill`
  - `terminal/release`
- Capture terminal stdout/stderr and retain output after release so terminal content embeds can be resolved.
- Resolve `ToolCallContent::Terminal` into captured text before converting ACP tool results into goose tool responses.
- Mark bridged ACP tool-result content as user-visible so CLI rendering shows the output.
- Advertise terminal client capability only when enabled by the provider config.
- Enable terminal capability for `claude-acp` only.
- Enable the existing ACP provider terminal delegation test.
- Add terminal manager unit coverage, including UTF-8-safe truncation.

## Testing

- `cargo fmt`
- `cargo test -p goose acp::terminal --lib`
- `cargo check -p goose --tests`

Note: ACP provider shell integration tests currently fail locally before exercising this change due to an unrelated sqlx runtime feature panic; the existing `test_shell_terminal_false` fails the same way.
