### PR TITLE
chore: refresh canonical model registry

### DIFF
--- a/crates/goose-providers/src/canonical/data/provider_metadata.json
+++ b/crates/goose-providers/src/canonical/data/provider_metadata.json
@@ -1,124 +1,25 @@
 [
   {
-    "id": "upstage",
-    "display_name": "Upstage",
+    "id": "requesty",
+    "display_name": "Requesty",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.upstage.ai/v1/solar",
-    "doc": "https://developers.upstage.ai/docs/apis/chat",
+    "api": "https://router.requesty.ai/v1",
+    "doc": "https://requesty.ai/solution/llm-routing/models",
     "env": [
-      "UPSTAGE_API_KEY"
+      "REQUESTY_API_KEY"
     ],
-    "model_count": 3
+    "model_count": 38
   },
   {
-    "id": "clarifai",
-    "display_name": "Clarifai",
+    "id": "qiniu-ai",
+    "display_name": "Qiniu",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.clarifai.com/v2/ext/openai/v1",
-    "doc": "https://docs.clarifai.com/compute/inference/",
+    "api": "https://api.qnaigc.com/v1",
+    "doc": "https://developer.qiniu.com/aitokenapi",
     "env": [
-      "CLARIFAI_PAT"
+      "QINIU_API_KEY"
     ],
-    "model_count": 12
-  },
-  {
-    "id": "ollama-cloud",
-    "display_name": "Ollama Cloud",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://ollama.com/v1",
-    "doc": "https://docs.ollama.com/cloud",
-    "env": [
-      "OLLAMA_API_KEY"
-    ],
-    "model_count": 40
-  },
-  {
-    "id": "the-grid-ai",
-    "display_name": "The Grid AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.thegrid.ai/v1",
-    "doc": "https://thegrid.ai/docs",
-    "env": [
-      "THEGRIDAI_API_KEY"
-    ],
-    "model_count": 9
-  },
-  {
-    "id": "fireworks-ai",
-    "display_name": "Fireworks AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.fireworks.ai/inference/v1/",
-    "doc": "https://fireworks.ai/docs/",
-    "env": [
-      "FIREWORKS_API_KEY"
-    ],
-    "model_count": 12
-  },
-  {
-    "id": "ambient",
-    "display_name": "Ambient",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.ambient.xyz/v1",
-    "doc": "https://ambient.xyz",
-    "env": [
-      "AMBIENT_API_KEY"
-    ],
-    "model_count": 2
-  },
-  {
-    "id": "stackit",
-    "display_name": "STACKIT",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1",
-    "doc": "https://docs.stackit.cloud/products/data-and-ai/ai-model-serving/basics/available-shared-models",
-    "env": [
-      "STACKIT_API_KEY"
-    ],
-    "model_count": 8
-  },
-  {
-    "id": "ovhcloud",
-    "display_name": "OVHcloud AI Endpoints",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1",
-    "doc": "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog//",
-    "env": [
-      "OVHCLOUD_API_KEY"
-    ],
-    "model_count": 15
-  },
-  {
-    "id": "iflowcn",
-    "display_name": "iFlow",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://apis.iflow.cn/v1",
-    "doc": "https://platform.iflow.cn/en/docs",
-    "env": [
-      "IFLOW_API_KEY"
-    ],
-    "model_count": 14
-  },
-  {
-    "id": "302ai",
-    "display_name": "302.AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.302.ai/v1",
-    "doc": "https://doc.302.ai",
-    "env": [
-      "302AI_API_KEY"
-    ],
-    "model_count": 97
-  },
-  {
-    "id": "nano-gpt",
-    "display_name": "NanoGPT",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://nano-gpt.com/api/v1",
-    "doc": "https://docs.nano-gpt.com",
-    "env": [
-      "NANO_GPT_API_KEY"
-    ],
-    "model_count": 525
+    "model_count": 91
   },
   {
     "id": "alibaba-cn",
@@ -129,84 +30,7 @@
     "env": [
       "DASHSCOPE_API_KEY"
     ],
-    "model_count": 82
-  },
-  {
-    "id": "digitalocean",
-    "display_name": "DigitalOcean",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://inference.do-ai.run/v1",
-    "doc": "https://docs.digitalocean.com/products/gradient-ai-platform/details/models/",
-    "env": [
-      "DIGITALOCEAN_ACCESS_TOKEN"
-    ],
-    "model_count": 78
-  },
-  {
-    "id": "submodel",
-    "display_name": "submodel",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://llm.submodel.ai/v1",
-    "doc": "https://submodel.gitbook.io",
-    "env": [
-      "SUBMODEL_INSTAGEN_ACCESS_KEY"
-    ],
-    "model_count": 9
-  },
-  {
-    "id": "bailing",
-    "display_name": "Bailing",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.tbox.cn/api/llm/v1/chat/completions",
-    "doc": "https://alipaytbox.yuque.com/sxs0ba/ling/intro",
-    "env": [
-      "BAILING_API_TOKEN"
-    ],
-    "model_count": 2
-  },
-  {
-    "id": "kimi-for-coding",
-    "display_name": "Kimi For Coding",
-    "npm": "@ai-sdk/anthropic",
-    "api": "https://api.kimi.com/coding/v1",
-    "doc": "https://www.kimi.com/coding/docs/en/third-party-agents.html",
-    "env": [
-      "KIMI_API_KEY"
-    ],
-    "model_count": 3
-  },
-  {
-    "id": "dinference",
-    "display_name": "DInference",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.dinference.com/v1",
-    "doc": "https://dinference.com",
-    "env": [
-      "DINFERENCE_API_KEY"
-    ],
-    "model_count": 5
-  },
-  {
-    "id": "novita-ai",
-    "display_name": "NovitaAI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.novita.ai/openai",
-    "doc": "https://novita.ai/docs/guides/introduction",
-    "env": [
-      "NOVITA_API_KEY"
-    ],
-    "model_count": 104
-  },
-  {
-    "id": "kilo",
-    "display_name": "Kilo Gateway",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.kilo.ai/api/gateway",
-    "doc": "https://kilo.ai",
-    "env": [
-      "KILO_API_KEY"
-    ],
-    "model_count": 345
+    "model_count": 83
   },
   {
     "id": "regolo-ai",
@@ -220,212 +44,24 @@
     "model_count": 13
   },
   {
-    "id": "deepseek",
-    "display_name": "DeepSeek",
+    "id": "stackit",
+    "display_name": "STACKIT",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.deepseek.com",
-    "doc": "https://api-docs.deepseek.com/quick_start/pricing",
+    "api": "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1",
+    "doc": "https://docs.stackit.cloud/products/data-and-ai/ai-model-serving/basics/available-shared-models",
     "env": [
-      "DEEPSEEK_API_KEY"
+      "STACKIT_API_KEY"
     ],
-    "model_count": 4
+    "model_count": 8
   },
   {
-    "id": "orcarouter",
-    "display_name": "OrcaRouter",
+    "id": "submodel",
+    "display_name": "submodel",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.orcarouter.ai/v1",
-    "doc": "https://docs.orcarouter.ai",
+    "api": "https://llm.submodel.ai/v1",
+    "doc": "https://submodel.gitbook.io",
     "env": [
-      "ORCAROUTER_API_KEY"
-    ],
-    "model_count": 81
-  },
-  {
-    "id": "moonshotai-cn",
-    "display_name": "Moonshot AI (China)",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.moonshot.cn/v1",
-    "doc": "https://platform.moonshot.cn/docs/api/chat",
-    "env": [
-      "MOONSHOT_API_KEY"
-    ],
-    "model_count": 7
-  },
-  {
-    "id": "minimax-cn-coding-plan",
-    "display_name": "MiniMax Token Plan (minimaxi.com)",
-    "npm": "@ai-sdk/anthropic",
-    "api": "https://api.minimaxi.com/anthropic/v1",
-    "doc": "https://platform.minimaxi.com/docs/token-plan/intro",
-    "env": [
-      "MINIMAX_API_KEY"
-    ],
-    "model_count": 7
-  },
-  {
-    "id": "inception",
-    "display_name": "Inception",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.inceptionlabs.ai/v1/",
-    "doc": "https://platform.inceptionlabs.ai/docs",
-    "env": [
-      "INCEPTION_API_KEY"
-    ],
-    "model_count": 2
-  },
-  {
-    "id": "kuae-cloud-coding-plan",
-    "display_name": "KUAE Cloud Coding Plan",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://coding-plan-endpoint.kuaecloud.net/v1",
-    "doc": "https://docs.mthreads.com/kuaecloud/kuaecloud-doc-online/coding_plan/",
-    "env": [
-      "KUAE_API_KEY"
-    ],
-    "model_count": 1
-  },
-  {
-    "id": "chutes",
-    "display_name": "Chutes",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://llm.chutes.ai/v1",
-    "doc": "https://llm.chutes.ai/v1/models",
-    "env": [
-      "CHUTES_API_KEY"
-    ],
-    "model_count": 39
-  },
-  {
-    "id": "crof",
-    "display_name": "CrofAI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://crof.ai/v1",
-    "doc": "https://crof.ai/docs",
-    "env": [
-      "CROF_API_KEY"
-    ],
-    "model_count": 21
-  },
-  {
-    "id": "frogbot",
-    "display_name": "FrogBot",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://app.frogbot.ai/api/v1",
-    "doc": "https://docs.frogbot.ai",
-    "env": [
-      "FROGBOT_API_KEY"
-    ],
-    "model_count": 26
-  },
-  {
-    "id": "alibaba",
-    "display_name": "Alibaba",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-    "doc": "https://www.alibabacloud.com/help/en/model-studio/models",
-    "env": [
-      "DASHSCOPE_API_KEY"
-    ],
-    "model_count": 50
-  },
-  {
-    "id": "xiaomi",
-    "display_name": "Xiaomi",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.xiaomimimo.com/v1",
-    "doc": "https://platform.xiaomimimo.com/#/docs",
-    "env": [
-      "XIAOMI_API_KEY"
-    ],
-    "model_count": 5
-  },
-  {
-    "id": "vivgrid",
-    "display_name": "Vivgrid",
-    "npm": "@ai-sdk/openai",
-    "api": "https://api.vivgrid.com/v1",
-    "doc": "https://docs.vivgrid.com/models",
-    "env": [
-      "VIVGRID_API_KEY"
-    ],
-    "model_count": 13
-  },
-  {
-    "id": "databricks",
-    "display_name": "Databricks",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://${DATABRICKS_HOST}/ai-gateway/mlflow/v1",
-    "doc": "https://docs.databricks.com/aws/en/machine-learning/foundation-models/",
-    "env": [
-      "DATABRICKS_HOST",
-      "DATABRICKS_TOKEN"
-    ],
-    "model_count": 25
-  },
-  {
-    "id": "siliconflow-cn",
-    "display_name": "SiliconFlow (China)",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.siliconflow.cn/v1",
-    "doc": "https://cloud.siliconflow.com/models",
-    "env": [
-      "SILICONFLOW_CN_API_KEY"
-    ],
-    "model_count": 82
-  },
-  {
-    "id": "zhipuai-coding-plan",
-    "display_name": "Zhipu AI Coding Plan",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://open.bigmodel.cn/api/coding/paas/v4",
-    "doc": "https://docs.bigmodel.cn/cn/coding-plan/overview",
-    "env": [
-      "ZHIPU_API_KEY"
-    ],
-    "model_count": 6
-  },
-  {
-    "id": "neuralwatt",
-    "display_name": "Neuralwatt",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.neuralwatt.com/v1",
-    "doc": "https://portal.neuralwatt.com/docs",
-    "env": [
-      "NEURALWATT_API_KEY"
-    ],
-    "model_count": 14
-  },
-  {
-    "id": "friendli",
-    "display_name": "Friendli",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.friendli.ai/serverless/v1",
-    "doc": "https://friendli.ai/docs/guides/serverless_endpoints/introduction",
-    "env": [
-      "FRIENDLI_TOKEN"
-    ],
-    "model_count": 6
-  },
-  {
-    "id": "github-copilot",
-    "display_name": "GitHub Copilot",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.githubcopilot.com",
-    "doc": "https://docs.github.com/en/copilot",
-    "env": [
-      "GITHUB_TOKEN"
-    ],
-    "model_count": 22
-  },
-  {
-    "id": "inference",
-    "display_name": "Inference",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://inference.net/v1",
-    "doc": "https://inference.net/models",
-    "env": [
-      "INFERENCE_API_KEY"
+      "SUBMODEL_INSTAGEN_ACCESS_KEY"
     ],
     "model_count": 9
   },
@@ -441,6 +77,28 @@
     "model_count": 24
   },
   {
+    "id": "minimax-coding-plan",
+    "display_name": "MiniMax Token Plan (minimax.io)",
+    "npm": "@ai-sdk/anthropic",
+    "api": "https://api.minimax.io/anthropic/v1",
+    "doc": "https://platform.minimax.io/docs/token-plan/intro",
+    "env": [
+      "MINIMAX_API_KEY"
+    ],
+    "model_count": 7
+  },
+  {
+    "id": "novita-ai",
+    "display_name": "NovitaAI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.novita.ai/openai",
+    "doc": "https://novita.ai/docs/guides/introduction",
+    "env": [
+      "NOVITA_API_KEY"
+    ],
+    "model_count": 104
+  },
+  {
     "id": "privatemode-ai",
     "display_name": "Privatemode AI",
     "npm": "@ai-sdk/openai-compatible",
@@ -451,6 +109,238 @@
       "PRIVATEMODE_ENDPOINT"
     ],
     "model_count": 5
+  },
+  {
+    "id": "drun",
+    "display_name": "D.Run (China)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://chat.d.run/v1",
+    "doc": "https://www.d.run",
+    "env": [
+      "DRUN_API_KEY"
+    ],
+    "model_count": 3
+  },
+  {
+    "id": "moonshotai",
+    "display_name": "Moonshot AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.moonshot.ai/v1",
+    "doc": "https://platform.moonshot.ai/docs/api/chat",
+    "env": [
+      "MOONSHOT_API_KEY"
+    ],
+    "model_count": 7
+  },
+  {
+    "id": "fireworks-ai",
+    "display_name": "Fireworks AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.fireworks.ai/inference/v1/",
+    "doc": "https://fireworks.ai/docs/",
+    "env": [
+      "FIREWORKS_API_KEY"
+    ],
+    "model_count": 13
+  },
+  {
+    "id": "vultr",
+    "display_name": "Vultr",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.vultrinference.com/v1",
+    "doc": "https://api.vultrinference.com/",
+    "env": [
+      "VULTR_API_KEY"
+    ],
+    "model_count": 7
+  },
+  {
+    "id": "302ai",
+    "display_name": "302.AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.302.ai/v1",
+    "doc": "https://doc.302.ai",
+    "env": [
+      "302AI_API_KEY"
+    ],
+    "model_count": 97
+  },
+  {
+    "id": "zhipuai",
+    "display_name": "Zhipu AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://open.bigmodel.cn/api/paas/v4",
+    "doc": "https://docs.z.ai/guides/overview/pricing",
+    "env": [
+      "ZHIPU_API_KEY"
+    ],
+    "model_count": 12
+  },
+  {
+    "id": "cortecs",
+    "display_name": "Cortecs",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.cortecs.ai/v1",
+    "doc": "https://api.cortecs.ai/v1/models",
+    "env": [
+      "CORTECS_API_KEY"
+    ],
+    "model_count": 50
+  },
+  {
+    "id": "nebius",
+    "display_name": "Nebius Token Factory",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.tokenfactory.nebius.com/v1",
+    "doc": "https://docs.tokenfactory.nebius.com/",
+    "env": [
+      "NEBIUS_API_KEY"
+    ],
+    "model_count": 31
+  },
+  {
+    "id": "auriko",
+    "display_name": "Auriko",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.auriko.ai/v1",
+    "doc": "https://docs.auriko.ai",
+    "env": [
+      "AURIKO_API_KEY"
+    ],
+    "model_count": 15
+  },
+  {
+    "id": "stepfun-ai",
+    "display_name": "StepFun AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.stepfun.ai/step_plan/v1",
+    "doc": "https://platform.stepfun.ai/docs/en/step-plan/integrations/open-code",
+    "env": [
+      "STEPFUN_API_KEY"
+    ],
+    "model_count": 2
+  },
+  {
+    "id": "vivgrid",
+    "display_name": "Vivgrid",
+    "npm": "@ai-sdk/openai",
+    "api": "https://api.vivgrid.com/v1",
+    "doc": "https://docs.vivgrid.com/models",
+    "env": [
+      "VIVGRID_API_KEY"
+    ],
+    "model_count": 13
+  },
+  {
+    "id": "cloudflare-workers-ai",
+    "display_name": "Cloudflare Workers AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1",
+    "doc": "https://developers.cloudflare.com/workers-ai/models/",
+    "env": [
+      "CLOUDFLARE_ACCOUNT_ID",
+      "CLOUDFLARE_API_KEY"
+    ],
+    "model_count": 20
+  },
+  {
+    "id": "bailing",
+    "display_name": "Bailing",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.tbox.cn/api/llm/v1/chat/completions",
+    "doc": "https://alipaytbox.yuque.com/sxs0ba/ling/intro",
+    "env": [
+      "BAILING_API_TOKEN"
+    ],
+    "model_count": 2
+  },
+  {
+    "id": "firepass",
+    "display_name": "Fireworks (Firepass)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.fireworks.ai/inference/v1/",
+    "doc": "https://docs.fireworks.ai/firepass",
+    "env": [
+      "FIREPASS_API_KEY"
+    ],
+    "model_count": 1
+  },
+  {
+    "id": "anyapi",
+    "display_name": "AnyAPI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.anyapi.ai/v1",
+    "doc": "https://docs.anyapi.ai",
+    "env": [
+      "ANYAPI_API_KEY"
+    ],
+    "model_count": 30
+  },
+  {
+    "id": "opencode-go",
+    "display_name": "OpenCode Go",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://opencode.ai/zen/go/v1",
+    "doc": "https://opencode.ai/docs/zen",
+    "env": [
+      "OPENCODE_API_KEY"
+    ],
+    "model_count": 17
+  },
+  {
+    "id": "digitalocean",
+    "display_name": "DigitalOcean",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://inference.do-ai.run/v1",
+    "doc": "https://docs.digitalocean.com/products/gradient-ai-platform/details/models/",
+    "env": [
+      "DIGITALOCEAN_ACCESS_TOKEN"
+    ],
+    "model_count": 78
+  },
+  {
+    "id": "lmstudio",
+    "display_name": "LMStudio",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "http://127.0.0.1:1234/v1",
+    "doc": "https://lmstudio.ai/models",
+    "env": [
+      "LMSTUDIO_API_KEY"
+    ],
+    "model_count": 3
+  },
+  {
+    "id": "poolside",
+    "display_name": "Poolside",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://inference.poolside.ai/v1",
+    "doc": "https://platform.poolside.ai",
+    "env": [
+      "POOLSIDE_API_KEY"
+    ],
+    "model_count": 2
+  },
+  {
+    "id": "zenmux",
+    "display_name": "ZenMux",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://zenmux.ai/api/v1",
+    "doc": "https://docs.zenmux.ai",
+    "env": [
+      "ZENMUX_API_KEY"
+    ],
+    "model_count": 107
+  },
+  {
+    "id": "berget",
+    "display_name": "Berget.AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.berget.ai/v1",
+    "doc": "https://api.berget.ai",
+    "env": [
+      "BERGET_API_KEY"
+    ],
+    "model_count": 7
   },
   {
     "id": "snowflake-cortex",
@@ -465,39 +355,6 @@
     "model_count": 11
   },
   {
-    "id": "moonshotai",
-    "display_name": "Moonshot AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.moonshot.ai/v1",
-    "doc": "https://platform.moonshot.ai/docs/api/chat",
-    "env": [
-      "MOONSHOT_API_KEY"
-    ],
-    "model_count": 7
-  },
-  {
-    "id": "llmgateway",
-    "display_name": "LLM Gateway",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.llmgateway.io/v1",
-    "doc": "https://llmgateway.io/docs",
-    "env": [
-      "LLMGATEWAY_API_KEY"
-    ],
-    "model_count": 189
-  },
-  {
-    "id": "moark",
-    "display_name": "Moark",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://moark.com/v1",
-    "doc": "https://moark.com/docs/openapi/v1#tag/%E6%96%87%E6%9C%AC%E7%94%9F%E6%88%90",
-    "env": [
-      "MOARK_API_KEY"
-    ],
-    "model_count": 2
-  },
-  {
     "id": "github-models",
     "display_name": "GitHub Models",
     "npm": "@ai-sdk/openai-compatible",
@@ -509,70 +366,26 @@
     "model_count": 55
   },
   {
-    "id": "xiaomi-token-plan-cn",
-    "display_name": "Xiaomi Token Plan (China)",
+    "id": "neuralwatt",
+    "display_name": "Neuralwatt",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://token-plan-cn.xiaomimimo.com/v1",
-    "doc": "https://platform.xiaomimimo.com/#/docs",
+    "api": "https://api.neuralwatt.com/v1",
+    "doc": "https://portal.neuralwatt.com/docs",
     "env": [
-      "XIAOMI_API_KEY"
+      "NEURALWATT_API_KEY"
     ],
-    "model_count": 8
+    "model_count": 14
   },
   {
-    "id": "lmstudio",
-    "display_name": "LMStudio",
+    "id": "siliconflow-cn",
+    "display_name": "SiliconFlow (China)",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "http://127.0.0.1:1234/v1",
-    "doc": "https://lmstudio.ai/models",
+    "api": "https://api.siliconflow.cn/v1",
+    "doc": "https://cloud.siliconflow.com/models",
     "env": [
-      "LMSTUDIO_API_KEY"
+      "SILICONFLOW_CN_API_KEY"
     ],
-    "model_count": 3
-  },
-  {
-    "id": "zenmux",
-    "display_name": "ZenMux",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://zenmux.ai/api/v1",
-    "doc": "https://docs.zenmux.ai",
-    "env": [
-      "ZENMUX_API_KEY"
-    ],
-    "model_count": 96
-  },
-  {
-    "id": "claudinio",
-    "display_name": "Claudinio",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.claudin.io/v1",
-    "doc": "https://claudin.io",
-    "env": [
-      "CLAUDINIO_API_KEY"
-    ],
-    "model_count": 1
-  },
-  {
-    "id": "alibaba-coding-plan",
-    "display_name": "Alibaba Coding Plan",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://coding-intl.dashscope.aliyuncs.com/v1",
-    "doc": "https://www.alibabacloud.com/help/en/model-studio/coding-plan",
-    "env": [
-      "ALIBABA_CODING_PLAN_API_KEY"
-    ],
-    "model_count": 11
-  },
-  {
-    "id": "modelscope",
-    "display_name": "ModelScope",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api-inference.modelscope.cn/v1",
-    "doc": "https://modelscope.cn/docs/model-service/API-Inference/intro",
-    "env": [
-      "MODELSCOPE_API_KEY"
-    ],
-    "model_count": 7
+    "model_count": 82
   },
   {
     "id": "qihang-ai",
@@ -586,48 +399,26 @@
     "model_count": 9
   },
   {
-    "id": "poe",
-    "display_name": "Poe",
+    "id": "xiaomi-token-plan-ams",
+    "display_name": "Xiaomi Token Plan (Europe)",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.poe.com/v1",
-    "doc": "https://creator.poe.com/docs/external-applications/openai-compatible-api",
+    "api": "https://token-plan-ams.xiaomimimo.com/v1",
+    "doc": "https://platform.xiaomimimo.com/#/docs",
     "env": [
-      "POE_API_KEY"
-    ],
-    "model_count": 137
-  },
-  {
-    "id": "umans-ai-coding-plan",
-    "display_name": "Umans AI Coding Plan",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.code.umans.ai/v1",
-    "doc": "https://app.umans.ai/offers/code/docs",
-    "env": [
-      "UMANS_AI_CODING_PLAN_API_KEY"
-    ],
-    "model_count": 5
-  },
-  {
-    "id": "firepass",
-    "display_name": "Fireworks (Firepass)",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.fireworks.ai/inference/v1/",
-    "doc": "https://docs.fireworks.ai/firepass",
-    "env": [
-      "FIREPASS_API_KEY"
-    ],
-    "model_count": 1
-  },
-  {
-    "id": "gmicloud",
-    "display_name": "GMI Cloud",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.gmi-serving.com/v1",
-    "doc": "https://docs.gmicloud.ai/inference-engine/api-reference/llm-api-reference",
-    "env": [
-      "GMICLOUD_API_KEY"
+      "XIAOMI_API_KEY"
     ],
     "model_count": 8
+  },
+  {
+    "id": "modelscope",
+    "display_name": "ModelScope",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api-inference.modelscope.cn/v1",
+    "doc": "https://modelscope.cn/docs/model-service/API-Inference/intro",
+    "env": [
+      "MODELSCOPE_API_KEY"
+    ],
+    "model_count": 7
   },
   {
     "id": "mixlayer",
@@ -641,257 +432,15 @@
     "model_count": 5
   },
   {
-    "id": "minimax-coding-plan",
-    "display_name": "MiniMax Token Plan (minimax.io)",
-    "npm": "@ai-sdk/anthropic",
-    "api": "https://api.minimax.io/anthropic/v1",
-    "doc": "https://platform.minimax.io/docs/token-plan/intro",
-    "env": [
-      "MINIMAX_API_KEY"
-    ],
-    "model_count": 7
-  },
-  {
-    "id": "evroc",
-    "display_name": "evroc",
+    "id": "orcarouter",
+    "display_name": "OrcaRouter",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://models.think.evroc.com/v1",
-    "doc": "https://docs.evroc.com/products/think/overview.html",
+    "api": "https://api.orcarouter.ai/v1",
+    "doc": "https://docs.orcarouter.ai",
     "env": [
-      "EVROC_API_KEY"
+      "ORCAROUTER_API_KEY"
     ],
-    "model_count": 13
-  },
-  {
-    "id": "nvidia",
-    "display_name": "Nvidia",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://integrate.api.nvidia.com/v1",
-    "doc": "https://docs.api.nvidia.com/nim/",
-    "env": [
-      "NVIDIA_API_KEY"
-    ],
-    "model_count": 93
-  },
-  {
-    "id": "routing-run",
-    "display_name": "routing.run",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://ai.routing.sh/v1",
-    "doc": "https://docs.routing.run/api-reference/models",
-    "env": [
-      "ROUTING_RUN_API_KEY"
-    ],
-    "model_count": 26
-  },
-  {
-    "id": "xiaomi-token-plan-ams",
-    "display_name": "Xiaomi Token Plan (Europe)",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://token-plan-ams.xiaomimimo.com/v1",
-    "doc": "https://platform.xiaomimimo.com/#/docs",
-    "env": [
-      "XIAOMI_API_KEY"
-    ],
-    "model_count": 8
-  },
-  {
-    "id": "zhipuai",
-    "display_name": "Zhipu AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://open.bigmodel.cn/api/paas/v4",
-    "doc": "https://docs.z.ai/guides/overview/pricing",
-    "env": [
-      "ZHIPU_API_KEY"
-    ],
-    "model_count": 12
-  },
-  {
-    "id": "io-net",
-    "display_name": "IO.NET",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.intelligence.io.solutions/api/v1",
-    "doc": "https://io.net/docs/guides/intelligence/io-intelligence",
-    "env": [
-      "IOINTELLIGENCE_API_KEY"
-    ],
-    "model_count": 17
-  },
-  {
-    "id": "lilac",
-    "display_name": "Lilac",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.getlilac.com/v1",
-    "doc": "https://docs.getlilac.com/inference/models",
-    "env": [
-      "LILAC_API_KEY"
-    ],
-    "model_count": 4
-  },
-  {
-    "id": "stepfun-ai",
-    "display_name": "StepFun",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.stepfun.ai/step_plan/v1",
-    "doc": "https://platform.stepfun.ai/docs/en/step-plan/integrations/open-code",
-    "env": [
-      "STEPFUN_API_KEY"
-    ],
-    "model_count": 2
-  },
-  {
-    "id": "tencent-coding-plan",
-    "display_name": "Tencent Coding Plan (China)",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.lkeap.cloud.tencent.com/coding/v3",
-    "doc": "https://cloud.tencent.com/document/product/1772/128947",
-    "env": [
-      "TENCENT_CODING_PLAN_API_KEY"
-    ],
-    "model_count": 8
-  },
-  {
-    "id": "opencode-go",
-    "display_name": "OpenCode Go",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://opencode.ai/zen/go/v1",
-    "doc": "https://opencode.ai/docs/zen",
-    "env": [
-      "OPENCODE_API_KEY"
-    ],
-    "model_count": 16
-  },
-  {
-    "id": "cortecs",
-    "display_name": "Cortecs",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.cortecs.ai/v1",
-    "doc": "https://api.cortecs.ai/v1/models",
-    "env": [
-      "CORTECS_API_KEY"
-    ],
-    "model_count": 49
-  },
-  {
-    "id": "auriko",
-    "display_name": "Auriko",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.auriko.ai/v1",
-    "doc": "https://docs.auriko.ai",
-    "env": [
-      "AURIKO_API_KEY"
-    ],
-    "model_count": 15
-  },
-  {
-    "id": "wafer.ai",
-    "display_name": "Wafer",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://pass.wafer.ai/v1",
-    "doc": "https://docs.wafer.ai/wafer-pass",
-    "env": [
-      "WAFER_API_KEY"
-    ],
-    "model_count": 7
-  },
-  {
-    "id": "berget",
-    "display_name": "Berget.AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.berget.ai/v1",
-    "doc": "https://api.berget.ai",
-    "env": [
-      "BERGET_API_KEY"
-    ],
-    "model_count": 7
-  },
-  {
-    "id": "requesty",
-    "display_name": "Requesty",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://router.requesty.ai/v1",
-    "doc": "https://requesty.ai/solution/llm-routing/models",
-    "env": [
-      "REQUESTY_API_KEY"
-    ],
-    "model_count": 38
-  },
-  {
-    "id": "atomic-chat",
-    "display_name": "Atomic Chat",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "http://127.0.0.1:1337/v1",
-    "doc": "https://atomic.chat",
-    "env": [
-      "ATOMIC_CHAT_API_KEY"
-    ],
-    "model_count": 5
-  },
-  {
-    "id": "stepfun",
-    "display_name": "StepFun (China)",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.stepfun.com/v1",
-    "doc": "https://platform.stepfun.com/docs/zh/overview/concept",
-    "env": [
-      "STEPFUN_API_KEY"
-    ],
-    "model_count": 4
-  },
-  {
-    "id": "anyapi",
-    "display_name": "AnyAPI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.anyapi.ai/v1",
-    "doc": "https://docs.anyapi.ai",
-    "env": [
-      "ANYAPI_API_KEY"
-    ],
-    "model_count": 30
-  },
-  {
-    "id": "vultr",
-    "display_name": "Vultr",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.vultrinference.com/v1",
-    "doc": "https://api.vultrinference.com/",
-    "env": [
-      "VULTR_API_KEY"
-    ],
-    "model_count": 7
-  },
-  {
-    "id": "zai-coding-plan",
-    "display_name": "Z.AI Coding Plan",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.z.ai/api/coding/paas/v4",
-    "doc": "https://docs.z.ai/devpack/overview",
-    "env": [
-      "ZHIPU_API_KEY"
-    ],
-    "model_count": 5
-  },
-  {
-    "id": "synthetic",
-    "display_name": "Synthetic",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.synthetic.new/openai/v1",
-    "doc": "https://synthetic.new/pricing",
-    "env": [
-      "SYNTHETIC_API_KEY"
-    ],
-    "model_count": 33
-  },
-  {
-    "id": "cloudferro-sherlock",
-    "display_name": "CloudFerro Sherlock",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api-sherlock.cloudferro.com/openai/v1/",
-    "doc": "https://docs.sherlock.cloudferro.com/",
-    "env": [
-      "CLOUDFERRO_SHERLOCK_API_KEY"
-    ],
-    "model_count": 5
+    "model_count": 81
   },
   {
     "id": "helicone",
@@ -916,17 +465,6 @@
     "model_count": 13
   },
   {
-    "id": "nova",
-    "display_name": "Nova",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.nova.amazon.com/v1",
-    "doc": "https://nova.amazon.com/dev/documentation",
-    "env": [
-      "NOVA_API_KEY"
-    ],
-    "model_count": 2
-  },
-  {
     "id": "nearai",
     "display_name": "NEAR AI Cloud",
     "npm": "@ai-sdk/openai-compatible",
@@ -938,125 +476,26 @@
     "model_count": 37
   },
   {
-    "id": "inceptron",
-    "display_name": "Inceptron",
+    "id": "llmgateway",
+    "display_name": "LLM Gateway",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.inceptron.io/v1",
-    "doc": "https://docs.inceptron.io",
+    "api": "https://api.llmgateway.io/v1",
+    "doc": "https://llmgateway.io/docs",
     "env": [
-      "INCEPTRON_API_KEY"
+      "LLMGATEWAY_API_KEY"
     ],
-    "model_count": 4
+    "model_count": 191
   },
   {
-    "id": "xpersona",
-    "display_name": "Xpersona",
+    "id": "alibaba-coding-plan-cn",
+    "display_name": "Alibaba Coding Plan (China)",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://www.xpersona.co/v1",
-    "doc": "https://www.xpersona.co/docs",
+    "api": "https://coding.dashscope.aliyuncs.com/v1",
+    "doc": "https://help.aliyun.com/zh/model-studio/coding-plan",
     "env": [
-      "XPERSONA_API_KEY"
+      "ALIBABA_CODING_PLAN_API_KEY"
     ],
-    "model_count": 1
-  },
-  {
-    "id": "perplexity-agent",
-    "display_name": "Perplexity Agent",
-    "npm": "@ai-sdk/openai",
-    "api": "https://api.perplexity.ai/v1",
-    "doc": "https://docs.perplexity.ai/docs/agent-api/models",
-    "env": [
-      "PERPLEXITY_API_KEY"
-    ],
-    "model_count": 18
-  },
-  {
-    "id": "jiekou",
-    "display_name": "Jiekou.AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.jiekou.ai/openai",
-    "doc": "https://docs.jiekou.ai/docs/support/quickstart?utm_source=github_models.dev",
-    "env": [
-      "JIEKOU_API_KEY"
-    ],
-    "model_count": 61
-  },
-  {
-    "id": "abliteration-ai",
-    "display_name": "abliteration.ai",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.abliteration.ai/v1",
-    "doc": "https://docs.abliteration.ai/models",
-    "env": [
-      "ABLIT_KEY"
-    ],
-    "model_count": 1
-  },
-  {
-    "id": "minimax-cn",
-    "display_name": "MiniMax (minimaxi.com)",
-    "npm": "@ai-sdk/anthropic",
-    "api": "https://api.minimaxi.com/anthropic/v1",
-    "doc": "https://platform.minimaxi.com/docs/guides/quickstart",
-    "env": [
-      "MINIMAX_API_KEY"
-    ],
-    "model_count": 7
-  },
-  {
-    "id": "qiniu-ai",
-    "display_name": "Qiniu",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.qnaigc.com/v1",
-    "doc": "https://developer.qiniu.com/aitokenapi",
-    "env": [
-      "QINIU_API_KEY"
-    ],
-    "model_count": 91
-  },
-  {
-    "id": "morph",
-    "display_name": "Morph",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.morphllm.com/v1",
-    "doc": "https://docs.morphllm.com/api-reference/introduction",
-    "env": [
-      "MORPH_API_KEY"
-    ],
-    "model_count": 3
-  },
-  {
-    "id": "xiaomi-token-plan-sgp",
-    "display_name": "Xiaomi Token Plan (Singapore)",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://token-plan-sgp.xiaomimimo.com/v1",
-    "doc": "https://platform.xiaomimimo.com/#/docs",
-    "env": [
-      "XIAOMI_API_KEY"
-    ],
-    "model_count": 8
-  },
-  {
-    "id": "fastrouter",
-    "display_name": "FastRouter",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://go.fastrouter.ai/api/v1",
-    "doc": "https://fastrouter.ai/models",
-    "env": [
-      "FASTROUTER_API_KEY"
-    ],
-    "model_count": 15
-  },
-  {
-    "id": "siliconflow",
-    "display_name": "SiliconFlow",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.siliconflow.com/v1",
-    "doc": "https://cloud.siliconflow.com/models",
-    "env": [
-      "SILICONFLOW_API_KEY"
-    ],
-    "model_count": 76
+    "model_count": 12
   },
   {
     "id": "abacus",
@@ -1070,37 +509,125 @@
     "model_count": 65
   },
   {
-    "id": "drun",
-    "display_name": "D.Run (China)",
+    "id": "cloudferro-sherlock",
+    "display_name": "CloudFerro Sherlock",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://chat.d.run/v1",
-    "doc": "https://www.d.run",
+    "api": "https://api-sherlock.cloudferro.com/openai/v1/",
+    "doc": "https://docs.sherlock.cloudferro.com/",
     "env": [
-      "DRUN_API_KEY"
+      "CLOUDFERRO_SHERLOCK_API_KEY"
+    ],
+    "model_count": 5
+  },
+  {
+    "id": "ollama-cloud",
+    "display_name": "Ollama Cloud",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://ollama.com/v1",
+    "doc": "https://docs.ollama.com/cloud",
+    "env": [
+      "OLLAMA_API_KEY"
+    ],
+    "model_count": 41
+  },
+  {
+    "id": "moonshotai-cn",
+    "display_name": "Moonshot AI (China)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.moonshot.cn/v1",
+    "doc": "https://platform.moonshot.cn/docs/api/chat",
+    "env": [
+      "MOONSHOT_API_KEY"
+    ],
+    "model_count": 7
+  },
+  {
+    "id": "morph",
+    "display_name": "Morph",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.morphllm.com/v1",
+    "doc": "https://docs.morphllm.com/api-reference/introduction",
+    "env": [
+      "MORPH_API_KEY"
     ],
     "model_count": 3
   },
   {
-    "id": "wandb",
-    "display_name": "Weights & Biases",
+    "id": "zai-coding-plan",
+    "display_name": "Z.AI Coding Plan",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.inference.wandb.ai/v1",
-    "doc": "https://docs.wandb.ai/guides/integrations/inference/",
+    "api": "https://api.z.ai/api/coding/paas/v4",
+    "doc": "https://docs.z.ai/devpack/overview",
     "env": [
-      "WANDB_API_KEY"
+      "ZHIPU_API_KEY"
     ],
-    "model_count": 18
+    "model_count": 5
   },
   {
-    "id": "meganova",
-    "display_name": "Meganova",
+    "id": "nvidia",
+    "display_name": "Nvidia",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.meganova.ai/v1",
-    "doc": "https://docs.meganova.ai",
+    "api": "https://integrate.api.nvidia.com/v1",
+    "doc": "https://docs.api.nvidia.com/nim/",
     "env": [
-      "MEGANOVA_API_KEY"
+      "NVIDIA_API_KEY"
     ],
-    "model_count": 19
+    "model_count": 94
+  },
+  {
+    "id": "evroc",
+    "display_name": "evroc",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://models.think.evroc.com/v1",
+    "doc": "https://docs.evroc.com/products/think/overview.html",
+    "env": [
+      "EVROC_API_KEY"
+    ],
+    "model_count": 13
+  },
+  {
+    "id": "xiaomi",
+    "display_name": "Xiaomi",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.xiaomimimo.com/v1",
+    "doc": "https://platform.xiaomimimo.com/#/docs",
+    "env": [
+      "XIAOMI_API_KEY"
+    ],
+    "model_count": 5
+  },
+  {
+    "id": "inception",
+    "display_name": "Inception",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.inceptionlabs.ai/v1/",
+    "doc": "https://platform.inceptionlabs.ai/docs",
+    "env": [
+      "INCEPTION_API_KEY"
+    ],
+    "model_count": 2
+  },
+  {
+    "id": "tencent-coding-plan",
+    "display_name": "Tencent Coding Plan (China)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.lkeap.cloud.tencent.com/coding/v3",
+    "doc": "https://cloud.tencent.com/document/product/1772/128947",
+    "env": [
+      "TENCENT_CODING_PLAN_API_KEY"
+    ],
+    "model_count": 8
+  },
+  {
+    "id": "freemodel",
+    "display_name": "FreeModel",
+    "npm": "@ai-sdk/anthropic",
+    "api": "https://cc.freemodel.dev/v1",
+    "doc": "https://freemodel.dev",
+    "env": [
+      "FREEMODEL_API_KEY"
+    ],
+    "model_count": 9
   },
   {
     "id": "opencode",
@@ -1111,18 +638,40 @@
     "env": [
       "OPENCODE_API_KEY"
     ],
-    "model_count": 66
+    "model_count": 68
   },
   {
-    "id": "poolside",
-    "display_name": "Poolside",
+    "id": "inference",
+    "display_name": "Inference",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://inference.poolside.ai/v1",
-    "doc": "https://platform.poolside.ai",
+    "api": "https://inference.net/v1",
+    "doc": "https://inference.net/models",
     "env": [
-      "POOLSIDE_API_KEY"
+      "INFERENCE_API_KEY"
     ],
-    "model_count": 2
+    "model_count": 9
+  },
+  {
+    "id": "inceptron",
+    "display_name": "Inceptron",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.inceptron.io/v1",
+    "doc": "https://docs.inceptron.io",
+    "env": [
+      "INCEPTRON_API_KEY"
+    ],
+    "model_count": 4
+  },
+  {
+    "id": "meta-llama",
+    "display_name": "Llama",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.llama.com/compat/v1/",
+    "doc": "https://llama.developer.meta.com/docs/models",
+    "env": [
+      "LLAMA_API_KEY"
+    ],
+    "model_count": 7
   },
   {
     "id": "sarvam",
@@ -1136,37 +685,15 @@
     "model_count": 2
   },
   {
-    "id": "baseten",
-    "display_name": "Baseten",
+    "id": "stepfun",
+    "display_name": "StepFun",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://inference.baseten.co/v1",
-    "doc": "https://docs.baseten.co/development/model-apis/overview",
+    "api": "https://api.stepfun.com/v1",
+    "doc": "https://platform.stepfun.com/docs/zh/overview/concept",
     "env": [
-      "BASETEN_API_KEY"
+      "STEPFUN_API_KEY"
     ],
-    "model_count": 14
-  },
-  {
-    "id": "lucidquery",
-    "display_name": "LucidQuery AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://lucidquery.com/api/v1",
-    "doc": "https://lucidquery.com/api/docs",
-    "env": [
-      "LUCIDQUERY_API_KEY"
-    ],
-    "model_count": 2
-  },
-  {
-    "id": "scaleway",
-    "display_name": "Scaleway",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.scaleway.ai/v1",
-    "doc": "https://www.scaleway.com/en/docs/generative-apis/",
-    "env": [
-      "SCALEWAY_API_KEY"
-    ],
-    "model_count": 16
+    "model_count": 4
   },
   {
     "id": "hpc-ai",
@@ -1180,6 +707,160 @@
     "model_count": 3
   },
   {
+    "id": "minimax-cn",
+    "display_name": "MiniMax (minimaxi.com)",
+    "npm": "@ai-sdk/anthropic",
+    "api": "https://api.minimaxi.com/anthropic/v1",
+    "doc": "https://platform.minimaxi.com/docs/guides/quickstart",
+    "env": [
+      "MINIMAX_API_KEY"
+    ],
+    "model_count": 7
+  },
+  {
+    "id": "alibaba-coding-plan",
+    "display_name": "Alibaba Coding Plan",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://coding-intl.dashscope.aliyuncs.com/v1",
+    "doc": "https://www.alibabacloud.com/help/en/model-studio/coding-plan",
+    "env": [
+      "ALIBABA_CODING_PLAN_API_KEY"
+    ],
+    "model_count": 11
+  },
+  {
+    "id": "poe",
+    "display_name": "Poe",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.poe.com/v1",
+    "doc": "https://creator.poe.com/docs/external-applications/openai-compatible-api",
+    "env": [
+      "POE_API_KEY"
+    ],
+    "model_count": 137
+  },
+  {
+    "id": "kimi-for-coding",
+    "display_name": "Kimi For Coding",
+    "npm": "@ai-sdk/anthropic",
+    "api": "https://api.kimi.com/coding/v1",
+    "doc": "https://www.kimi.com/code/docs/en/third-party-tools/other-coding-agents.html",
+    "env": [
+      "KIMI_API_KEY"
+    ],
+    "model_count": 3
+  },
+  {
+    "id": "dinference",
+    "display_name": "DInference",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.dinference.com/v1",
+    "doc": "https://dinference.com",
+    "env": [
+      "DINFERENCE_API_KEY"
+    ],
+    "model_count": 5
+  },
+  {
+    "id": "perplexity-agent",
+    "display_name": "Perplexity Agent",
+    "npm": "@ai-sdk/openai",
+    "api": "https://api.perplexity.ai/v1",
+    "doc": "https://docs.perplexity.ai/docs/agent-api/models",
+    "env": [
+      "PERPLEXITY_API_KEY"
+    ],
+    "model_count": 18
+  },
+  {
+    "id": "siliconflow",
+    "display_name": "SiliconFlow",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.siliconflow.com/v1",
+    "doc": "https://cloud.siliconflow.com/models",
+    "env": [
+      "SILICONFLOW_API_KEY"
+    ],
+    "model_count": 76
+  },
+  {
+    "id": "umans-ai-coding-plan",
+    "display_name": "Umans AI Coding Plan",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.code.umans.ai/v1",
+    "doc": "https://app.umans.ai/offers/code/docs",
+    "env": [
+      "UMANS_AI_CODING_PLAN_API_KEY"
+    ],
+    "model_count": 5
+  },
+  {
+    "id": "io-net",
+    "display_name": "IO.NET",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.intelligence.io.solutions/api/v1",
+    "doc": "https://io.net/docs/guides/intelligence/io-intelligence",
+    "env": [
+      "IOINTELLIGENCE_API_KEY"
+    ],
+    "model_count": 17
+  },
+  {
+    "id": "gmicloud",
+    "display_name": "GMI Cloud",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.gmi-serving.com/v1",
+    "doc": "https://docs.gmicloud.ai/inference-engine/api-reference/llm-api-reference",
+    "env": [
+      "GMICLOUD_API_KEY"
+    ],
+    "model_count": 8
+  },
+  {
+    "id": "xiaomi-token-plan-cn",
+    "display_name": "Xiaomi Token Plan (China)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://token-plan-cn.xiaomimimo.com/v1",
+    "doc": "https://platform.xiaomimimo.com/#/docs",
+    "env": [
+      "XIAOMI_API_KEY"
+    ],
+    "model_count": 8
+  },
+  {
+    "id": "scaleway",
+    "display_name": "Scaleway",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.scaleway.ai/v1",
+    "doc": "https://www.scaleway.com/en/docs/generative-apis/",
+    "env": [
+      "SCALEWAY_API_KEY"
+    ],
+    "model_count": 16
+  },
+  {
+    "id": "ovhcloud",
+    "display_name": "OVHcloud AI Endpoints",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1",
+    "doc": "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog//",
+    "env": [
+      "OVHCLOUD_API_KEY"
+    ],
+    "model_count": 15
+  },
+  {
+    "id": "friendli",
+    "display_name": "Friendli",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.friendli.ai/serverless/v1",
+    "doc": "https://friendli.ai/docs/guides/serverless_endpoints/introduction",
+    "env": [
+      "FRIENDLI_TOKEN"
+    ],
+    "model_count": 6
+  },
+  {
     "id": "tencent-tokenhub",
     "display_name": "Tencent TokenHub",
     "npm": "@ai-sdk/openai-compatible",
@@ -1191,38 +872,313 @@
     "model_count": 1
   },
   {
-    "id": "alibaba-coding-plan-cn",
-    "display_name": "Alibaba Coding Plan (China)",
+    "id": "wandb",
+    "display_name": "Weights & Biases",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://coding.dashscope.aliyuncs.com/v1",
-    "doc": "https://help.aliyun.com/zh/model-studio/coding-plan",
+    "api": "https://api.inference.wandb.ai/v1",
+    "doc": "https://docs.wandb.ai/guides/integrations/inference/",
     "env": [
-      "ALIBABA_CODING_PLAN_API_KEY"
+      "WANDB_API_KEY"
+    ],
+    "model_count": 18
+  },
+  {
+    "id": "kuae-cloud-coding-plan",
+    "display_name": "KUAE Cloud Coding Plan",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://coding-plan-endpoint.kuaecloud.net/v1",
+    "doc": "https://docs.mthreads.com/kuaecloud/kuaecloud-doc-online/coding_plan/",
+    "env": [
+      "KUAE_API_KEY"
+    ],
+    "model_count": 1
+  },
+  {
+    "id": "kilo",
+    "display_name": "Kilo Gateway",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.kilo.ai/api/gateway",
+    "doc": "https://kilo.ai",
+    "env": [
+      "KILO_API_KEY"
+    ],
+    "model_count": 345
+  },
+  {
+    "id": "lucidquery",
+    "display_name": "LucidQuery AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://lucidquery.com/api/v1",
+    "doc": "https://lucidquery.com/api/docs",
+    "env": [
+      "LUCIDQUERY_API_KEY"
+    ],
+    "model_count": 2
+  },
+  {
+    "id": "meganova",
+    "display_name": "Meganova",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.meganova.ai/v1",
+    "doc": "https://docs.meganova.ai",
+    "env": [
+      "MEGANOVA_API_KEY"
+    ],
+    "model_count": 19
+  },
+  {
+    "id": "frogbot",
+    "display_name": "FrogBot",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://app.frogbot.ai/api/v1",
+    "doc": "https://docs.frogbot.ai",
+    "env": [
+      "FROGBOT_API_KEY"
+    ],
+    "model_count": 26
+  },
+  {
+    "id": "jiekou",
+    "display_name": "Jiekou.AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.jiekou.ai/openai",
+    "doc": "https://docs.jiekou.ai/docs/support/quickstart?utm_source=github_models.dev",
+    "env": [
+      "JIEKOU_API_KEY"
+    ],
+    "model_count": 61
+  },
+  {
+    "id": "nova",
+    "display_name": "Nova",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.nova.amazon.com/v1",
+    "doc": "https://nova.amazon.com/dev/documentation",
+    "env": [
+      "NOVA_API_KEY"
+    ],
+    "model_count": 2
+  },
+  {
+    "id": "alibaba-token-plan",
+    "display_name": "Alibaba Token Plan",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+    "doc": "https://www.alibabacloud.com/help/en/model-studio/token-plan-overview",
+    "env": [
+      "ALIBABA_TOKEN_PLAN_API_KEY"
+    ],
+    "model_count": 15
+  },
+  {
+    "id": "alibaba",
+    "display_name": "Alibaba",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+    "doc": "https://www.alibabacloud.com/help/en/model-studio/models",
+    "env": [
+      "DASHSCOPE_API_KEY"
+    ],
+    "model_count": 51
+  },
+  {
+    "id": "databricks",
+    "display_name": "Databricks",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://${DATABRICKS_HOST}/ai-gateway/mlflow/v1",
+    "doc": "https://docs.databricks.com/aws/en/machine-learning/foundation-models/",
+    "env": [
+      "DATABRICKS_HOST",
+      "DATABRICKS_TOKEN"
+    ],
+    "model_count": 25
+  },
+  {
+    "id": "crof",
+    "display_name": "CrofAI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://crof.ai/v1",
+    "doc": "https://crof.ai/docs",
+    "env": [
+      "CROF_API_KEY"
+    ],
+    "model_count": 21
+  },
+  {
+    "id": "fastrouter",
+    "display_name": "FastRouter",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://go.fastrouter.ai/api/v1",
+    "doc": "https://fastrouter.ai/models",
+    "env": [
+      "FASTROUTER_API_KEY"
+    ],
+    "model_count": 15
+  },
+  {
+    "id": "abliteration-ai",
+    "display_name": "abliteration.ai",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.abliteration.ai/v1",
+    "doc": "https://docs.abliteration.ai/models",
+    "env": [
+      "ABLIT_KEY"
+    ],
+    "model_count": 1
+  },
+  {
+    "id": "xpersona",
+    "display_name": "Xpersona",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://www.xpersona.co/v1",
+    "doc": "https://www.xpersona.co/docs",
+    "env": [
+      "XPERSONA_API_KEY"
+    ],
+    "model_count": 2
+  },
+  {
+    "id": "baseten",
+    "display_name": "Baseten",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://inference.baseten.co/v1",
+    "doc": "https://docs.baseten.co/inference/model-apis/overview",
+    "env": [
+      "BASETEN_API_KEY"
     ],
     "model_count": 11
   },
   {
-    "id": "cloudflare-workers-ai",
-    "display_name": "Cloudflare Workers AI",
+    "id": "atomic-chat",
+    "display_name": "Atomic Chat",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1",
-    "doc": "https://developers.cloudflare.com/workers-ai/models/",
+    "api": "http://127.0.0.1:1337/v1",
+    "doc": "https://atomic.chat",
     "env": [
-      "CLOUDFLARE_ACCOUNT_ID",
-      "CLOUDFLARE_API_KEY"
+      "ATOMIC_CHAT_API_KEY"
     ],
-    "model_count": 20
+    "model_count": 5
   },
   {
-    "id": "nebius",
-    "display_name": "Nebius Token Factory",
+    "id": "routing-run",
+    "display_name": "routing.run",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.tokenfactory.nebius.com/v1",
-    "doc": "https://docs.tokenfactory.nebius.com/",
+    "api": "https://ai.routing.sh/v1",
+    "doc": "https://docs.routing.run/api-reference/models",
     "env": [
-      "NEBIUS_API_KEY"
+      "ROUTING_RUN_API_KEY"
     ],
-    "model_count": 31
+    "model_count": 26
+  },
+  {
+    "id": "nano-gpt",
+    "display_name": "NanoGPT",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://nano-gpt.com/api/v1",
+    "doc": "https://docs.nano-gpt.com",
+    "env": [
+      "NANO_GPT_API_KEY"
+    ],
+    "model_count": 617
+  },
+  {
+    "id": "moark",
+    "display_name": "Moark",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://moark.com/v1",
+    "doc": "https://moark.com/docs/openapi/v1#tag/%E6%96%87%E6%9C%AC%E7%94%9F%E6%88%90",
+    "env": [
+      "MOARK_API_KEY"
+    ],
+    "model_count": 2
+  },
+  {
+    "id": "lilac",
+    "display_name": "Lilac",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.getlilac.com/v1",
+    "doc": "https://docs.getlilac.com/inference/models",
+    "env": [
+      "LILAC_API_KEY"
+    ],
+    "model_count": 4
+  },
+  {
+    "id": "ambient",
+    "display_name": "Ambient",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.ambient.xyz/v1",
+    "doc": "https://ambient.xyz",
+    "env": [
+      "AMBIENT_API_KEY"
+    ],
+    "model_count": 2
+  },
+  {
+    "id": "upstage",
+    "display_name": "Upstage",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.upstage.ai/v1/solar",
+    "doc": "https://developers.upstage.ai/docs/apis/chat",
+    "env": [
+      "UPSTAGE_API_KEY"
+    ],
+    "model_count": 3
+  },
+  {
+    "id": "zhipuai-coding-plan",
+    "display_name": "Zhipu AI Coding Plan",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://open.bigmodel.cn/api/coding/paas/v4",
+    "doc": "https://docs.bigmodel.cn/cn/coding-plan/overview",
+    "env": [
+      "ZHIPU_API_KEY"
+    ],
+    "model_count": 6
+  },
+  {
+    "id": "chutes",
+    "display_name": "Chutes",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://llm.chutes.ai/v1",
+    "doc": "https://llm.chutes.ai/v1/models",
+    "env": [
+      "CHUTES_API_KEY"
+    ],
+    "model_count": 39
+  },
+  {
+    "id": "minimax-cn-coding-plan",
+    "display_name": "MiniMax Token Plan (minimaxi.com)",
+    "npm": "@ai-sdk/anthropic",
+    "api": "https://api.minimaxi.com/anthropic/v1",
+    "doc": "https://platform.minimaxi.com/docs/token-plan/intro",
+    "env": [
+      "MINIMAX_API_KEY"
+    ],
+    "model_count": 7
+  },
+  {
+    "id": "deepseek",
+    "display_name": "DeepSeek",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.deepseek.com",
+    "doc": "https://api-docs.deepseek.com/quick_start/pricing",
+    "env": [
+      "DEEPSEEK_API_KEY"
+    ],
+    "model_count": 4
+  },
+  {
+    "id": "wafer.ai",
+    "display_name": "Wafer",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://pass.wafer.ai/v1",
+    "doc": "https://docs.wafer.ai/wafer-pass",
+    "env": [
+      "WAFER_API_KEY"
+    ],
+    "model_count": 7
   },
   {
     "id": "minimax",
@@ -1236,14 +1192,80 @@
     "model_count": 7
   },
   {
-    "id": "meta-llama",
-    "display_name": "Llama",
+    "id": "github-copilot",
+    "display_name": "GitHub Copilot",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.llama.com/compat/v1/",
-    "doc": "https://llama.developer.meta.com/docs/models",
+    "api": "https://api.githubcopilot.com",
+    "doc": "https://docs.github.com/en/copilot",
     "env": [
-      "LLAMA_API_KEY"
+      "GITHUB_TOKEN"
     ],
-    "model_count": 7
+    "model_count": 22
+  },
+  {
+    "id": "clarifai",
+    "display_name": "Clarifai",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.clarifai.com/v2/ext/openai/v1",
+    "doc": "https://docs.clarifai.com/compute/inference/",
+    "env": [
+      "CLARIFAI_PAT"
+    ],
+    "model_count": 12
+  },
+  {
+    "id": "the-grid-ai",
+    "display_name": "The Grid AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.thegrid.ai/v1",
+    "doc": "https://thegrid.ai/docs",
+    "env": [
+      "THEGRIDAI_API_KEY"
+    ],
+    "model_count": 9
+  },
+  {
+    "id": "synthetic",
+    "display_name": "Synthetic",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.synthetic.new/openai/v1",
+    "doc": "https://synthetic.new/pricing",
+    "env": [
+      "SYNTHETIC_API_KEY"
+    ],
+    "model_count": 33
+  },
+  {
+    "id": "iflowcn",
+    "display_name": "iFlow",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://apis.iflow.cn/v1",
+    "doc": "https://platform.iflow.cn/en/docs",
+    "env": [
+      "IFLOW_API_KEY"
+    ],
+    "model_count": 14
+  },
+  {
+    "id": "xiaomi-token-plan-sgp",
+    "display_name": "Xiaomi Token Plan (Singapore)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://token-plan-sgp.xiaomimimo.com/v1",
+    "doc": "https://platform.xiaomimimo.com/#/docs",
+    "env": [
+      "XIAOMI_API_KEY"
+    ],
+    "model_count": 8
+  },
+  {
+    "id": "claudinio",
+    "display_name": "Claudinio",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.claudin.io/v1",
+    "doc": "https://claudin.io",
+    "env": [
+      "CLAUDINIO_API_KEY"
+    ],
+    "model_count": 1
   }
 ]

--- a/crates/goose-providers/src/canonical/name_builder.rs
+++ b/crates/goose-providers/src/canonical/name_builder.rs
@@ -69,7 +69,8 @@ pub fn map_to_canonical_model(
         if let Some(canonical) = registry.get(registry_provider, model) {
             return Some(canonical.id.clone());
         }
-        if model.starts_with("gemini-") {
+        let model_lower = model.to_lowercase();
+        if model_lower.starts_with("gemini-") || model_lower.contains("claude") {
             return None;
         }
     }
@@ -447,16 +448,16 @@ mod tests {
 
         // === Grok (X.AI) ===
         assert_eq!(
-            map_to_canonical_model("databricks", "grok-4.20", r),
-            Some("x-ai/grok-4.20".to_string())
+            map_to_canonical_model("databricks", "grok-4.3", r),
+            Some("x-ai/grok-4.3".to_string())
         );
         assert_eq!(
-            map_to_canonical_model("databricks", "databricks-grok-4.20", r),
-            Some("x-ai/grok-4.20".to_string())
+            map_to_canonical_model("databricks", "databricks-grok-4.3", r),
+            Some("x-ai/grok-4.3".to_string())
         );
         assert_eq!(
-            map_to_canonical_model("databricks", "kgoose-grok-4.20", r),
-            Some("x-ai/grok-4.20".to_string())
+            map_to_canonical_model("databricks", "kgoose-grok-4.3", r),
+            Some("x-ai/grok-4.3".to_string())
         );
 
         // === Cohere Command ===
@@ -492,8 +493,8 @@ mod tests {
             Some("deepseek/deepseek-chat".to_string())
         );
         assert_eq!(
-            map_to_canonical_model("databricks", "x-ai-grok-4.20", r),
-            Some("x-ai/grok-4.20".to_string())
+            map_to_canonical_model("databricks", "x-ai-grok-4.3", r),
+            Some("x-ai/grok-4.3".to_string())
         );
 
         // === Zhipu AI ===
@@ -517,7 +518,7 @@ mod tests {
         );
         assert_eq!(
             map_to_canonical_model("gcp_vertex_ai", "claude-3-5-sonnet", r),
-            Some("google-vertex/claude-3.5-sonnet".to_string())
+            None
         );
         assert_eq!(
             map_to_canonical_model("gcp_vertex_ai", "claude-sonnet-4@20250514", r),


### PR DESCRIPTION
## Why
Refresh the bundled canonical model registry from models.dev so Goose picks up newly published model metadata, including Claude Fable.

## What
- Regenerate canonical model data, provider metadata, and the mapping report
- Include `anthropic/claude-fable-5` and related hosted-provider entries
- Prevent GCP Vertex Claude lookups from falling back to Anthropic when Vertex lacks a matching model
- Update canonical mapping tests for refreshed model availability

## Risk Assessment
Low to medium — this updates bundled model metadata and canonical mapping behavior. The code change narrows GCP Vertex fallback behavior to avoid incorrectly mapping unavailable Claude Vertex models.

## References
- Ran `just build-canonical-models`
- Ran `cargo run --bin build_canonical_models -- --do-check`
- Ran `cargo test -p goose-providers test_map_to_canonical_model`
- Confirmed no added canonical model object contains `EAP`, `early access`, or `early-access`
- Confirmed `anthropic/claude-fable-5` is present with name `Claude Fable 5`

Generated with Goose
