### PR TITLE
chore: refresh canonical model registry

### DIFF
--- a/crates/goose-providers/src/canonical/data/canonical_models.json
+++ b/crates/goose-providers/src/canonical/data/canonical_models.json
@@ -2073,10 +2073,10 @@
     }
   },
   {
-    "id": "302ai/grok-4-fast",
-    "name": "grok-4-fast-reasoning",
+    "id": "302ai/grok-4-fast-non-reasoning",
+    "name": "grok-4-fast-non-reasoning",
     "attachment": true,
-    "reasoning": true,
+    "reasoning": false,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-06",
@@ -2102,10 +2102,10 @@
     }
   },
   {
-    "id": "302ai/grok-4-fast-non",
-    "name": "grok-4-fast-non-reasoning",
+    "id": "302ai/grok-4-fast-reasoning",
+    "name": "grok-4-fast-reasoning",
     "attachment": true,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-06",
@@ -2160,36 +2160,7 @@
     }
   },
   {
-    "id": "302ai/grok-4.1-fast",
-    "name": "grok-4-1-fast-reasoning",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-06",
-    "release_date": "2025-11-20",
-    "last_updated": "2025-11-20",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.5
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 30000
-    }
-  },
-  {
-    "id": "302ai/grok-4.1-fast-non",
+    "id": "302ai/grok-4.1-fast-non-reasoning",
     "name": "grok-4-1-fast-non-reasoning",
     "attachment": true,
     "reasoning": false,
@@ -2218,10 +2189,39 @@
     }
   },
   {
-    "id": "302ai/grok-4.20-beta",
-    "name": "grok-4.20-beta-0309-reasoning",
+    "id": "302ai/grok-4.1-fast-reasoning",
+    "name": "grok-4-1-fast-reasoning",
     "attachment": true,
     "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-06",
+    "release_date": "2025-11-20",
+    "last_updated": "2025-11-20",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.2,
+      "output": 0.5
+    },
+    "limit": {
+      "context": 2000000,
+      "output": 30000
+    }
+  },
+  {
+    "id": "302ai/grok-4.20-beta-0309-non-reasoning",
+    "name": "grok-4.20-beta-0309-non-reasoning",
+    "attachment": true,
+    "reasoning": false,
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-03-16",
@@ -2246,10 +2246,10 @@
     }
   },
   {
-    "id": "302ai/grok-4.20-beta-0309-non",
-    "name": "grok-4.20-beta-0309-non-reasoning",
+    "id": "302ai/grok-4.20-beta-0309-reasoning",
+    "name": "grok-4.20-beta-0309-reasoning",
     "attachment": true,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-03-16",
@@ -3997,7 +3997,7 @@
     }
   },
   {
-    "id": "abacus/grok-4-fast-non",
+    "id": "abacus/grok-4-fast-non-reasoning",
     "name": "Grok 4 Fast (Non-Reasoning)",
     "family": "grok",
     "attachment": true,
@@ -4026,7 +4026,7 @@
     }
   },
   {
-    "id": "abacus/grok-4.1-fast-non",
+    "id": "abacus/grok-4.1-fast-non-reasoning",
     "name": "Grok 4.1 Fast (Non-Reasoning)",
     "family": "grok",
     "attachment": true,
@@ -8384,6 +8384,38 @@
     }
   },
   {
+    "id": "alibaba-cn/qwen3.7-plus",
+    "name": "Qwen3.7 Plus",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-06-02",
+    "last_updated": "2026-06-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.5,
+      "output": 3.0,
+      "cache_read": 0.05,
+      "cache_write": 0.625
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 64000
+    }
+  },
+  {
     "id": "alibaba-cn/qwq-32b",
     "name": "QwQ 32B",
     "family": "qwen",
@@ -8924,6 +8956,38 @@
     }
   },
   {
+    "id": "alibaba-coding-plan-cn/qwen3.7-plus",
+    "name": "Qwen3.7 Plus",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-06-02",
+    "last_updated": "2026-06-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 64000
+    }
+  },
+  {
     "id": "alibaba-coding-plan/MiniMax-M2.5",
     "name": "MiniMax-M2.5",
     "family": "minimax",
@@ -9264,6 +9328,456 @@
     "limit": {
       "context": 1000000,
       "output": 65536
+    }
+  },
+  {
+    "id": "alibaba-token-plan/MiniMax-M2.5",
+    "name": "MiniMax-M2.5",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-12",
+    "last_updated": "2026-02-12",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 196608,
+      "output": 24576
+    }
+  },
+  {
+    "id": "alibaba-token-plan/deepseek-v3.2",
+    "name": "DeepSeek V3.2",
+    "family": "deepseek",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-12-03",
+    "last_updated": "2025-12-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 131072,
+      "output": 65536
+    }
+  },
+  {
+    "id": "alibaba-token-plan/deepseek-v4-flash",
+    "name": "DeepSeek V4 Flash",
+    "family": "deepseek-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "alibaba-token-plan/deepseek-v4-pro",
+    "name": "DeepSeek V4 Pro",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "alibaba-token-plan/glm-5",
+    "name": "GLM-5",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-11",
+    "last_updated": "2026-02-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 202752,
+      "output": 16384
+    }
+  },
+  {
+    "id": "alibaba-token-plan/glm-5.1",
+    "name": "GLM-5.1",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-27",
+    "last_updated": "2026-03-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 202752,
+      "output": 128000
+    }
+  },
+  {
+    "id": "alibaba-token-plan/kimi-k2.5",
+    "name": "Kimi K2.5",
+    "family": "kimi",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-01",
+    "last_updated": "2026-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "alibaba-token-plan/kimi-k2.6",
+    "name": "Kimi K2.6",
+    "family": "kimi",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "alibaba-token-plan/qwen-image-2.0",
+    "name": "Qwen Image 2.0",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-03-03",
+    "last_updated": "2026-03-03",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 8192,
+      "output": 0
+    }
+  },
+  {
+    "id": "alibaba-token-plan/qwen-image-2.0-pro",
+    "name": "Qwen Image 2.0 Pro",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-03-03",
+    "last_updated": "2026-03-03",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 8192,
+      "output": 0
+    }
+  },
+  {
+    "id": "alibaba-token-plan/qwen3.6-flash",
+    "name": "Qwen3.6 Flash",
+    "family": "qwen3.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-27",
+    "last_updated": "2026-04-27",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "alibaba-token-plan/qwen3.6-plus",
+    "name": "Qwen3.6 Plus",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "alibaba-token-plan/qwen3.7-max",
+    "name": "Qwen3.7 Max",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-05-21",
+    "last_updated": "2026-05-21",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "alibaba-token-plan/wan2.7-image",
+    "name": "Wan2.7 Image",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-05-29",
+    "last_updated": "2026-05-29",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 8192,
+      "output": 0
+    }
+  },
+  {
+    "id": "alibaba-token-plan/wan2.7-image-pro",
+    "name": "Wan2.7 Image Pro",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-05-29",
+    "last_updated": "2026-05-29",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 8192,
+      "output": 0
     }
   },
   {
@@ -10743,6 +11257,39 @@
     }
   },
   {
+    "id": "alibaba/qwen3.7-plus",
+    "name": "Qwen3.7 Plus",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-06-02",
+    "last_updated": "2026-06-04",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.5,
+      "output": 3.0,
+      "cache_read": 0.05,
+      "cache_write": 0.625
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 16384
+    }
+  },
+  {
     "id": "alibaba/qwq-plus",
     "name": "QwQ Plus",
     "family": "qwen",
@@ -10776,7 +11323,7 @@
     "name": "Nova 2 Lite",
     "family": "nova",
     "attachment": false,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "release_date": "2024-12-01",
@@ -11410,6 +11957,38 @@
     }
   },
   {
+    "id": "amazon-bedrock/eu.anthropic.claude-fable-5",
+    "name": "Claude Fable 5 (EU)",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-09",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 11.0,
+      "output": 55.0,
+      "cache_read": 1.1,
+      "cache_write": 13.75
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "amazon-bedrock/eu.anthropic.claude-haiku-4.5-20251001-v1:0",
     "name": "Claude Haiku 4.5 (EU)",
     "family": "claude-haiku",
@@ -11637,6 +12216,38 @@
     "limit": {
       "context": 1000000,
       "output": 64000
+    }
+  },
+  {
+    "id": "amazon-bedrock/global.anthropic.claude-fable-5",
+    "name": "Claude Fable 5 (Global)",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-09",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
     }
   },
   {
@@ -11891,8 +12502,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.049999999999999996,
-      "output": 0.09999999999999999
+      "input": 0.05,
+      "output": 0.1
     },
     "limit": {
       "context": 131072,
@@ -12749,11 +13360,75 @@
     }
   },
   {
-    "id": "amazon-bedrock/openai.gpt-oss-120b-1:0",
+    "id": "amazon-bedrock/openai.gpt-5.4",
+    "name": "GPT-5.4",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-05",
+    "last_updated": "2026-06-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.75,
+      "output": 16.5,
+      "cache_read": 0.275
+    },
+    "limit": {
+      "context": 272000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "amazon-bedrock/openai.gpt-5.5",
+    "name": "GPT-5.5",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-12-01",
+    "release_date": "2026-04-23",
+    "last_updated": "2026-06-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.5,
+      "output": 33.0,
+      "cache_read": 0.55
+    },
+    "limit": {
+      "context": 272000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "amazon-bedrock/openai.gpt-oss-120b",
     "name": "gpt-oss-120b",
     "family": "gpt-oss",
     "attachment": false,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-08-05",
@@ -12777,11 +13452,67 @@
     }
   },
   {
+    "id": "amazon-bedrock/openai.gpt-oss-120b-1:0",
+    "name": "gpt-oss-120b",
+    "family": "gpt-oss",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-08-05",
+    "last_updated": "2025-08-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.6
+    },
+    "limit": {
+      "context": 128000,
+      "output": 16384
+    }
+  },
+  {
+    "id": "amazon-bedrock/openai.gpt-oss-20b",
+    "name": "gpt-oss-20b",
+    "family": "gpt-oss",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-08-05",
+    "last_updated": "2025-08-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.07,
+      "output": 0.3
+    },
+    "limit": {
+      "context": 128000,
+      "output": 16384
+    }
+  },
+  {
     "id": "amazon-bedrock/openai.gpt-oss-20b-1:0",
     "name": "gpt-oss-20b",
     "family": "gpt-oss",
     "attachment": false,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-08-05",
@@ -13059,6 +13790,38 @@
     "limit": {
       "context": 262000,
       "output": 262000
+    }
+  },
+  {
+    "id": "amazon-bedrock/us.anthropic.claude-fable-5",
+    "name": "Claude Fable 5 (US)",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-09",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
     }
   },
   {
@@ -13343,7 +14106,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 1.35,
       "output": 5.4
@@ -13605,7 +14368,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 1.4,
       "output": 4.4,
@@ -13813,6 +14576,38 @@
     "limit": {
       "context": 200000,
       "output": 64000
+    }
+  },
+  {
+    "id": "anthropic/claude-fable-5",
+    "name": "Claude Fable 5",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-06-09",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
     }
   },
   {
@@ -15458,7 +16253,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 1.4,
       "output": 4.4,
@@ -17126,7 +17921,7 @@
     }
   },
   {
-    "id": "azure-cognitive-services/grok-4-fast",
+    "id": "azure-cognitive-services/grok-4-fast-reasoning",
     "name": "Grok 4 Fast (Reasoning)",
     "family": "grok",
     "attachment": true,
@@ -17389,35 +18184,6 @@
     "cost": {
       "input": 0.2,
       "output": 0.78
-    },
-    "limit": {
-      "context": 128000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "azure-cognitive-services/mai-ds-r1",
-    "name": "MAI-DS-R1",
-    "family": "mai",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2024-06",
-    "release_date": "2025-01-20",
-    "last_updated": "2025-01-20",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.35,
-      "output": 5.4
     },
     "limit": {
       "context": 128000,
@@ -17806,36 +18572,6 @@
     }
   },
   {
-    "id": "azure-cognitive-services/o1-preview",
-    "name": "o1-preview",
-    "family": "o",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2023-09",
-    "release_date": "2024-09-12",
-    "last_updated": "2024-09-12",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 16.5,
-      "output": 66.0,
-      "cache_read": 8.25
-    },
-    "limit": {
-      "context": 128000,
-      "output": 32768
-    }
-  },
-  {
     "id": "azure-cognitive-services/o3",
     "name": "o3",
     "family": "o",
@@ -18218,6 +18954,35 @@
     }
   },
   {
+    "id": "azure-cognitive-services/phi-4-mini-reasoning",
+    "name": "Phi-4-mini-reasoning",
+    "family": "phi",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-10",
+    "release_date": "2024-12-11",
+    "last_updated": "2024-12-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.075,
+      "output": 0.3
+    },
+    "limit": {
+      "context": 128000,
+      "output": 4096
+    }
+  },
+  {
     "id": "azure-cognitive-services/phi-4-multimodal",
     "name": "Phi-4-multimodal",
     "family": "phi",
@@ -18245,6 +19010,35 @@
     },
     "limit": {
       "context": 128000,
+      "output": 4096
+    }
+  },
+  {
+    "id": "azure-cognitive-services/phi-4-reasoning",
+    "name": "Phi-4-reasoning",
+    "family": "phi",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2023-10",
+    "release_date": "2024-12-11",
+    "last_updated": "2024-12-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.125,
+      "output": 0.5
+    },
+    "limit": {
+      "context": 32000,
       "output": 4096
     }
   },
@@ -19926,36 +20720,7 @@
     }
   },
   {
-    "id": "azure/grok-4-20",
-    "name": "Grok 4.20 (Reasoning)",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-09",
-    "release_date": "2026-04-08",
-    "last_updated": "2026-04-08",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 2.0,
-      "output": 6.0
-    },
-    "limit": {
-      "context": 262000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "azure/grok-4-20-non",
+    "id": "azure/grok-4-20-non-reasoning",
     "name": "Grok 4.20 (Non-Reasoning)",
     "family": "grok",
     "attachment": false,
@@ -19984,7 +20749,36 @@
     }
   },
   {
-    "id": "azure/grok-4-fast",
+    "id": "azure/grok-4-20-reasoning",
+    "name": "Grok 4.20 (Reasoning)",
+    "family": "grok",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-09",
+    "release_date": "2026-04-08",
+    "last_updated": "2026-04-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 6.0
+    },
+    "limit": {
+      "context": 262000,
+      "output": 8192
+    }
+  },
+  {
+    "id": "azure/grok-4-fast-reasoning",
     "name": "Grok 4 Fast (Reasoning)",
     "family": "grok",
     "attachment": true,
@@ -20015,11 +20809,11 @@
     }
   },
   {
-    "id": "azure/grok-4.1-fast",
-    "name": "Grok 4.1 Fast (Reasoning)",
+    "id": "azure/grok-4.1-fast-non-reasoning",
+    "name": "Grok 4.1 Fast (Non-Reasoning)",
     "family": "grok",
     "attachment": true,
-    "reasoning": true,
+    "reasoning": false,
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-06-27",
@@ -20045,11 +20839,11 @@
     }
   },
   {
-    "id": "azure/grok-4.1-fast-non",
-    "name": "Grok 4.1 Fast (Non-Reasoning)",
+    "id": "azure/grok-4.1-fast-reasoning",
+    "name": "Grok 4.1 Fast (Reasoning)",
     "family": "grok",
     "attachment": true,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-06-27",
@@ -20307,35 +21101,6 @@
     "cost": {
       "input": 0.2,
       "output": 0.78
-    },
-    "limit": {
-      "context": 128000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "azure/mai-ds-r1",
-    "name": "MAI-DS-R1",
-    "family": "mai",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2024-06",
-    "release_date": "2025-01-20",
-    "last_updated": "2025-01-20",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.35,
-      "output": 5.4
     },
     "limit": {
       "context": 128000,
@@ -20724,36 +21489,6 @@
     }
   },
   {
-    "id": "azure/o1-preview",
-    "name": "o1-preview",
-    "family": "o",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2023-09",
-    "release_date": "2024-09-12",
-    "last_updated": "2024-09-12",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 16.5,
-      "output": 66.0,
-      "cache_read": 8.25
-    },
-    "limit": {
-      "context": 128000,
-      "output": 32768
-    }
-  },
-  {
     "id": "azure/o3",
     "name": "o3",
     "family": "o",
@@ -21136,6 +21871,35 @@
     }
   },
   {
+    "id": "azure/phi-4-mini-reasoning",
+    "name": "Phi-4-mini-reasoning",
+    "family": "phi",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-10",
+    "release_date": "2024-12-11",
+    "last_updated": "2024-12-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.075,
+      "output": 0.3
+    },
+    "limit": {
+      "context": 128000,
+      "output": 4096
+    }
+  },
+  {
     "id": "azure/phi-4-multimodal",
     "name": "Phi-4-multimodal",
     "family": "phi",
@@ -21163,6 +21927,35 @@
     },
     "limit": {
       "context": 128000,
+      "output": 4096
+    }
+  },
+  {
+    "id": "azure/phi-4-reasoning",
+    "name": "Phi-4-reasoning",
+    "family": "phi",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2023-10",
+    "release_date": "2024-12-11",
+    "last_updated": "2024-12-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.125,
+      "output": 0.5
+    },
+    "limit": {
+      "context": 32000,
       "output": 4096
     }
   },
@@ -21364,35 +22157,6 @@
     }
   },
   {
-    "id": "baseten/deepseek-ai/DeepSeek-V3",
-    "name": "DeepSeek V3 0324",
-    "family": "deepseek",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-12",
-    "release_date": "2025-03-24",
-    "last_updated": "2025-03-24",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.77,
-      "output": 0.77
-    },
-    "limit": {
-      "context": 164000,
-      "output": 131000
-    }
-  },
-  {
     "id": "baseten/deepseek-ai/DeepSeek-V3.1",
     "name": "DeepSeek V3.1",
     "family": "deepseek",
@@ -21421,37 +22185,8 @@
     }
   },
   {
-    "id": "baseten/deepseek-ai/DeepSeek-V3.2",
-    "name": "DeepSeek V3.2",
-    "family": "deepseek",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-10",
-    "release_date": "2025-12-01",
-    "last_updated": "2026-03-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.3,
-      "output": 0.45
-    },
-    "limit": {
-      "context": 163800,
-      "output": 131100
-    }
-  },
-  {
     "id": "baseten/deepseek-ai/DeepSeek-V4-Pro",
-    "name": "DeepSeek V4 Pro",
+    "name": "Deepseek V4 Pro",
     "family": "deepseek-thinking",
     "attachment": false,
     "reasoning": true,
@@ -21472,69 +22207,11 @@
     "cost": {
       "input": 1.74,
       "output": 3.48,
-      "cache_read": 0.15
+      "cache_read": 0.145
     },
     "limit": {
-      "context": 1000000,
-      "output": 384000
-    }
-  },
-  {
-    "id": "baseten/moonshotai/Kimi-K2-Instruct",
-    "name": "Kimi K2 Instruct 0905",
-    "family": "kimi",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-08",
-    "release_date": "2025-09-05",
-    "last_updated": "2026-03-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.6,
-      "output": 2.5
-    },
-    "limit": {
-      "context": 262144,
-      "output": 262144
-    }
-  },
-  {
-    "id": "baseten/moonshotai/Kimi-K2-Thinking",
-    "name": "Kimi K2 Thinking",
-    "family": "kimi-thinking",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-08",
-    "release_date": "2025-11-06",
-    "last_updated": "2026-03-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.6,
-      "output": 2.5
-    },
-    "limit": {
-      "context": 262144,
-      "output": 262144
+      "context": 131000,
+      "output": 131000
     }
   },
   {
@@ -21550,7 +22227,8 @@
     "last_updated": "2026-02-12",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image"
       ],
       "output": [
         "text"
@@ -21559,11 +22237,12 @@
     "open_weights": true,
     "cost": {
       "input": 0.6,
-      "output": 3.0
+      "output": 3.0,
+      "cache_read": 0.12
     },
     "limit": {
-      "context": 262144,
-      "output": 8192
+      "context": 262000,
+      "output": 262000
     }
   },
   {
@@ -21580,8 +22259,7 @@
     "modalities": {
       "input": [
         "text",
-        "image",
-        "video"
+        "image"
       ],
       "output": [
         "text"
@@ -21594,13 +22272,42 @@
       "cache_read": 0.16
     },
     "limit": {
-      "context": 262144,
-      "output": 262144
+      "context": 262000,
+      "output": 262000
+    }
+  },
+  {
+    "id": "baseten/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
+    "name": "Nemotron Ultra",
+    "family": "nemotron",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-04",
+    "last_updated": "2026-06-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.6,
+      "output": 2.4,
+      "cache_read": 0.12
+    },
+    "limit": {
+      "context": 202800,
+      "output": 202800
     }
   },
   {
     "id": "baseten/nvidia/Nemotron-120B-A12B",
-    "name": "Nemotron 3 Super",
+    "name": "Nemotron Super",
     "family": "nemotron",
     "attachment": false,
     "reasoning": true,
@@ -21619,17 +22326,18 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.3,
-      "output": 0.75
+      "input": 0.06,
+      "output": 0.75,
+      "cache_read": 0.06
     },
     "limit": {
-      "context": 262144,
-      "output": 32678
+      "context": 202800,
+      "output": 202800
     }
   },
   {
     "id": "baseten/openai/gpt-oss-120b",
-    "name": "GPT OSS 120B",
+    "name": "OpenAI GPT 120B",
     "family": "gpt-oss",
     "attachment": false,
     "reasoning": true,
@@ -21652,42 +22360,13 @@
       "output": 0.5
     },
     "limit": {
-      "context": 128000,
-      "output": 128000
-    }
-  },
-  {
-    "id": "baseten/zai-org/GLM-4.6",
-    "name": "GLM 4.6",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-08-31",
-    "release_date": "2025-09-16",
-    "last_updated": "2025-09-16",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.6,
-      "output": 2.2
-    },
-    "limit": {
-      "context": 200000,
-      "output": 200000
+      "context": 128072,
+      "output": 128072
     }
   },
   {
     "id": "baseten/zai-org/GLM-4.7",
-    "name": "GLM-4.7",
+    "name": "GLM 4.7",
     "family": "glm",
     "attachment": false,
     "reasoning": true,
@@ -21706,17 +22385,18 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.6,
-      "output": 2.2
+      "input": 0.12,
+      "output": 2.2,
+      "cache_read": 0.12
     },
     "limit": {
-      "context": 204800,
-      "output": 131072
+      "context": 200000,
+      "output": 200000
     }
   },
   {
     "id": "baseten/zai-org/GLM-5",
-    "name": "GLM-5",
+    "name": "GLM 5",
     "family": "glm",
     "attachment": false,
     "reasoning": true,
@@ -21736,11 +22416,41 @@
     "open_weights": true,
     "cost": {
       "input": 0.95,
-      "output": 3.15
+      "output": 3.15,
+      "cache_read": 0.2
     },
     "limit": {
-      "context": 202752,
-      "output": 131072
+      "context": 202800,
+      "output": 202800
+    }
+  },
+  {
+    "id": "baseten/zai-org/GLM-5.1",
+    "name": "GLM 5.1",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-27",
+    "last_updated": "2026-03-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.3,
+      "output": 4.3,
+      "cache_read": 0.26
+    },
+    "limit": {
+      "context": 202800,
+      "output": 202800
     }
   },
   {
@@ -21991,7 +22701,7 @@
     "temperature": true,
     "knowledge": "2023-12",
     "release_date": "2025-01-01",
-    "last_updated": "2025-01-01",
+    "last_updated": "2026-05-27",
     "modalities": {
       "input": [
         "text"
@@ -22047,8 +22757,8 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-02-15",
-    "last_updated": "2026-04-25",
+    "release_date": "2026-02-12",
+    "last_updated": "2026-02-12",
     "modalities": {
       "input": [
         "text"
@@ -22222,8 +22932,9 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-04-25",
+    "knowledge": "2025-04",
+    "release_date": "2025-04",
+    "last_updated": "2025-04",
     "modalities": {
       "input": [
         "text"
@@ -22309,8 +23020,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-04-25",
-    "last_updated": "2026-04-25",
+    "knowledge": "2025-04",
+    "release_date": "2025-04",
+    "last_updated": "2025-04",
     "modalities": {
       "input": [
         "text"
@@ -22396,8 +23108,8 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-02-18",
-    "last_updated": "2026-04-25",
+    "release_date": "2026-02-15",
+    "last_updated": "2026-02-15",
     "modalities": {
       "input": [
         "text",
@@ -22426,8 +23138,8 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-04-25",
-    "last_updated": "2026-04-25",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
     "modalities": {
       "input": [
         "text",
@@ -22485,8 +23197,9 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-04-25",
-    "last_updated": "2026-04-25",
+    "knowledge": "2024-12-01",
+    "release_date": "2025-12-16",
+    "last_updated": "2026-02-04",
     "modalities": {
       "input": [
         "text"
@@ -22514,8 +23227,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-04-25",
+    "knowledge": "2024-07",
+    "release_date": "2025-01-20",
+    "last_updated": "2025-05-29",
     "modalities": {
       "input": [
         "text"
@@ -22659,8 +23373,8 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-04-25",
-    "last_updated": "2026-04-25",
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
     "modalities": {
       "input": [
         "text",
@@ -22684,14 +23398,14 @@
   {
     "id": "chutes/moonshotai/Kimi-K2.5-TEE",
     "name": "Kimi K2.5 TEE",
-    "family": "kimi",
+    "family": "kimi-k2.5",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2024-10",
-    "release_date": "2026-01-27",
-    "last_updated": "2026-04-25",
+    "release_date": "2026-01",
+    "last_updated": "2026-01",
     "modalities": {
       "input": [
         "text",
@@ -22716,14 +23430,14 @@
   {
     "id": "chutes/moonshotai/Kimi-K2.6-TEE",
     "name": "Kimi K2.6 TEE",
-    "family": "kimi",
+    "family": "kimi-k2.6",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-12",
-    "release_date": "2026-04-20",
-    "last_updated": "2026-04-25",
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
     "modalities": {
       "input": [
         "text",
@@ -23077,8 +23791,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-12-29",
-    "last_updated": "2026-04-25",
+    "knowledge": "2025-04",
+    "release_date": "2025-12-22",
+    "last_updated": "2025-12-22",
     "modalities": {
       "input": [
         "text"
@@ -23106,8 +23821,8 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-02-14",
-    "last_updated": "2026-04-25",
+    "release_date": "2026-02-11",
+    "last_updated": "2026-02-11",
     "modalities": {
       "input": [
         "text"
@@ -23164,8 +23879,8 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-04-08",
-    "last_updated": "2026-04-25",
+    "release_date": "2026-03-27",
+    "last_updated": "2026-03-27",
     "modalities": {
       "input": [
         "text"
@@ -23867,6 +24582,39 @@
     "limit": {
       "context": 200000,
       "output": 8192
+    }
+  },
+  {
+    "id": "cloudflare-ai-gateway/anthropic/claude-fable-5",
+    "name": "Claude Fable 5",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-09",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
     }
   },
   {
@@ -25963,13 +26711,14 @@
   {
     "id": "cloudflare-workers-ai/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b",
     "name": "Deepseek R1 Distill Qwen 32B",
-    "family": "deepseek",
+    "family": "deepseek-thinking",
     "attachment": false,
     "reasoning": true,
     "tool_call": false,
     "temperature": true,
-    "release_date": "2025-01-22",
-    "last_updated": "2025-01-22",
+    "knowledge": "2024-07",
+    "release_date": "2025-01-20",
+    "last_updated": "2025-05-29",
     "modalities": {
       "input": [
         "text"
@@ -25996,8 +26745,8 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-12-15",
-    "last_updated": "2025-12-15",
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
     "modalities": {
       "input": [
         "text",
@@ -26166,6 +26915,7 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2023-12",
     "release_date": "2024-12-06",
     "last_updated": "2024-12-06",
     "modalities": {
@@ -26194,8 +26944,9 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-04-16",
-    "last_updated": "2025-04-16",
+    "knowledge": "2024-08",
+    "release_date": "2025-04-05",
+    "last_updated": "2025-04-05",
     "modalities": {
       "input": [
         "text",
@@ -26274,14 +27025,14 @@
   {
     "id": "cloudflare-workers-ai/@cf/moonshotai/kimi-k2.6",
     "name": "Kimi K2.6",
-    "family": "kimi",
+    "family": "kimi-k2.6",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-01",
-    "release_date": "2026-04-20",
-    "last_updated": "2026-04-20",
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
     "modalities": {
       "input": [
         "text",
@@ -26627,6 +27378,36 @@
     }
   },
   {
+    "id": "cohere/command-a-plus-05",
+    "name": "Command A Plus",
+    "family": "command-a",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04-01",
+    "release_date": "2026-05-20",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 2.5,
+      "output": 10.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 64000
+    }
+  },
+  {
     "id": "cohere/command-a-reasoning-08",
     "name": "Command A Reasoning",
     "family": "command-a",
@@ -26828,6 +27609,35 @@
     "limit": {
       "context": 128000,
       "output": 4000
+    }
+  },
+  {
+    "id": "cohere/north-mini-code-1.0",
+    "name": "North Mini Code",
+    "family": "north",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-09-23",
+    "release_date": "2026-06-09",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 256000,
+      "output": 64000
     }
   },
   {
@@ -27517,6 +28327,38 @@
     }
   },
   {
+    "id": "cortecs/gpt-5.4",
+    "name": "GPT-5.4",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-05",
+    "last_updated": "2026-03-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 16.13,
+      "cache_read": 0.25
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
     "id": "cortecs/gpt-oss-120b",
     "name": "GPT Oss 120b",
     "family": "gpt-oss",
@@ -27952,6 +28794,7 @@
   {
     "id": "cortecs/nemotron-3-super-120b-a12b",
     "name": "Nemotron 3 Super 120B A12B",
+    "family": "nemotron",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
@@ -28526,7 +29369,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.45,
       "output": 2.15,
@@ -29707,63 +30550,6 @@
     }
   },
   {
-    "id": "deepinfra/MiniMaxAI/MiniMax-M2",
-    "name": "MiniMax M2",
-    "family": "minimax",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-10",
-    "release_date": "2025-11-13",
-    "last_updated": "2025-11-13",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.254,
-      "output": 1.02
-    },
-    "limit": {
-      "context": 262144,
-      "output": 32768
-    }
-  },
-  {
-    "id": "deepinfra/MiniMaxAI/MiniMax-M2.1",
-    "name": "MiniMax M2.1",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-06",
-    "release_date": "2025-12-23",
-    "last_updated": "2025-12-23",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.28,
-      "output": 1.2
-    },
-    "limit": {
-      "context": 196608,
-      "output": 196608
-    }
-  },
-  {
     "id": "deepinfra/MiniMaxAI/MiniMax-M2.5",
     "name": "MiniMax M2.5",
     "family": "minimax",
@@ -29792,35 +30578,6 @@
     "limit": {
       "context": 204800,
       "output": 131072
-    }
-  },
-  {
-    "id": "deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct",
-    "name": "Qwen3 Coder 480B A35B Instruct",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-04",
-    "release_date": "2025-07-23",
-    "last_updated": "2025-07-23",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.4,
-      "output": 1.6
-    },
-    "limit": {
-      "context": 262144,
-      "output": 66536
     }
   },
   {
@@ -29945,64 +30702,66 @@
     }
   },
   {
-    "id": "deepinfra/anthropic/claude-3.7-sonnet",
-    "name": "Claude Sonnet 3.7 (Latest)",
-    "family": "claude-sonnet",
+    "id": "deepinfra/XiaomiMiMo/MiMo-V2.5",
+    "name": "MiMo-V2.5",
+    "family": "mimo",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-10-31",
-    "release_date": "2025-03-13",
-    "last_updated": "2025-03-13",
+    "knowledge": "2024-12",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "audio",
+        "video"
       ],
       "output": [
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
-      "input": 3.3,
-      "output": 16.5,
-      "cache_read": 0.33
+      "input": 0.4,
+      "output": 2.0,
+      "cache_read": 0.08
     },
     "limit": {
-      "context": 200000,
-      "output": 64000
+      "context": 262144,
+      "output": 16384
     }
   },
   {
-    "id": "deepinfra/anthropic/claude-4-opus",
-    "name": "Claude Opus 4",
-    "family": "claude-opus",
-    "attachment": true,
+    "id": "deepinfra/XiaomiMiMo/MiMo-V2.5-Pro",
+    "name": "MiMo-V2.5-Pro",
+    "family": "mimo",
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-03-31",
-    "release_date": "2025-06-12",
-    "last_updated": "2025-06-12",
+    "knowledge": "2024-12",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
     "modalities": {
       "input": [
-        "text",
-        "image"
+        "text"
       ],
       "output": [
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
-      "input": 16.5,
-      "output": 82.5
+      "input": 1.0,
+      "output": 3.0,
+      "cache_read": 0.2
     },
     "limit": {
-      "context": 200000,
-      "output": 32000
+      "context": 1048576,
+      "output": 16384
     }
   },
   {
@@ -30084,13 +30843,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.14,
-      "output": 0.28,
-      "cache_read": 0.0028
+      "input": 0.1,
+      "output": 0.2,
+      "cache_read": 0.02
     },
     "limit": {
-      "context": 1000000,
-      "output": 384000
+      "context": 1048576,
+      "output": 16384
     }
   },
   {
@@ -30114,13 +30873,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.435,
-      "output": 0.87,
-      "cache_read": 0.003625
+      "input": 1.3,
+      "output": 2.6,
+      "cache_read": 0.1
     },
     "limit": {
-      "context": 65536,
-      "output": 65536
+      "context": 1048576,
+      "output": 16384
     }
   },
   {
@@ -30179,114 +30938,6 @@
     "limit": {
       "context": 262144,
       "output": 32768
-    }
-  },
-  {
-    "id": "deepinfra/meta-llama/Llama-3.1-70B-Instruct",
-    "name": "Llama 3.1 70B",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "release_date": "2024-07-23",
-    "last_updated": "2024-07-23",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.4,
-      "output": 0.4
-    },
-    "limit": {
-      "context": 131072,
-      "output": 16384
-    }
-  },
-  {
-    "id": "deepinfra/meta-llama/Llama-3.1-70B-Instruct-Turbo",
-    "name": "Llama 3.1 70B Turbo",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "release_date": "2024-07-23",
-    "last_updated": "2024-07-23",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.4,
-      "output": 0.4
-    },
-    "limit": {
-      "context": 131072,
-      "output": 16384
-    }
-  },
-  {
-    "id": "deepinfra/meta-llama/Llama-3.1-8B-Instruct",
-    "name": "Llama 3.1 8B",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "release_date": "2024-07-23",
-    "last_updated": "2024-07-23",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.02,
-      "output": 0.05
-    },
-    "limit": {
-      "context": 131072,
-      "output": 16384
-    }
-  },
-  {
-    "id": "deepinfra/meta-llama/Llama-3.1-8B-Instruct-Turbo",
-    "name": "Llama 3.1 8B Turbo",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "release_date": "2024-07-23",
-    "last_updated": "2024-07-23",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.02,
-      "output": 0.03
-    },
-    "limit": {
-      "context": 131072,
-      "output": 16384
     }
   },
   {
@@ -30370,64 +31021,6 @@
     "limit": {
       "context": 10000000,
       "output": 16384
-    }
-  },
-  {
-    "id": "deepinfra/moonshotai/Kimi-K2-Instruct",
-    "name": "Kimi K2",
-    "family": "kimi",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-10",
-    "release_date": "2025-07-11",
-    "last_updated": "2025-07-11",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.5,
-      "output": 2.0
-    },
-    "limit": {
-      "context": 131072,
-      "output": 32768
-    }
-  },
-  {
-    "id": "deepinfra/moonshotai/Kimi-K2-Thinking",
-    "name": "Kimi K2 Thinking",
-    "family": "kimi-thinking",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-10",
-    "release_date": "2025-11-06",
-    "last_updated": "2025-11-07",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.47,
-      "output": 2.0
-    },
-    "limit": {
-      "context": 131072,
-      "output": 32768
     }
   },
   {
@@ -30550,98 +31143,6 @@
     }
   },
   {
-    "id": "deepinfra/xiaomi/mimo-v2.5",
-    "name": "MiMo-V2.5",
-    "family": "mimo",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-12",
-    "release_date": "2026-04-22",
-    "last_updated": "2026-04-22",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.4,
-      "output": 2.0,
-      "cache_read": 0.08
-    },
-    "limit": {
-      "context": 262144,
-      "output": 16384
-    }
-  },
-  {
-    "id": "deepinfra/xiaomi/mimo-v2.5-pro",
-    "name": "MiMo-V2.5-Pro",
-    "family": "mimo",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-12",
-    "release_date": "2026-04-22",
-    "last_updated": "2026-04-22",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 1.0,
-      "output": 3.0,
-      "cache_read": 0.2
-    },
-    "limit": {
-      "context": 1048576,
-      "output": 16384
-    }
-  },
-  {
-    "id": "deepinfra/zai-org/GLM-4.5",
-    "name": "GLM-4.5",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-04",
-    "release_date": "2025-07-28",
-    "last_updated": "2025-07-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.6,
-      "output": 2.2
-    },
-    "limit": {
-      "context": 131072,
-      "output": 98304
-    }
-  },
-  {
     "id": "deepinfra/zai-org/GLM-4.6",
     "name": "GLM-4.6",
     "family": "glm",
@@ -30665,36 +31166,6 @@
       "input": 0.43,
       "output": 1.74,
       "cache_read": 0.08
-    },
-    "limit": {
-      "context": 204800,
-      "output": 131072
-    }
-  },
-  {
-    "id": "deepinfra/zai-org/GLM-4.6V",
-    "name": "GLM-4.6V",
-    "family": "glm",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-04",
-    "release_date": "2025-09-30",
-    "last_updated": "2025-09-30",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.3,
-      "output": 0.9
     },
     "limit": {
       "context": 204800,
@@ -30843,7 +31314,7 @@
     "cost": {
       "input": 0.14,
       "output": 0.28,
-      "cache_read": 0.028
+      "cache_read": 0.0028
     },
     "limit": {
       "context": 1000000,
@@ -30873,7 +31344,7 @@
     "cost": {
       "input": 0.14,
       "output": 0.28,
-      "cache_read": 0.028
+      "cache_read": 0.0028
     },
     "limit": {
       "context": 1000000,
@@ -33315,7 +33786,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 1.25,
       "output": 3.89
@@ -33544,7 +34015,7 @@
     },
     "limit": {
       "context": 40960,
-      "output": 40960
+      "output": 4096
     }
   },
   {
@@ -34460,7 +34931,7 @@
     "id": "fireworks-ai/accounts/fireworks/models/kimi-k2p5",
     "name": "Kimi K2.5",
     "family": "kimi-thinking",
-    "attachment": false,
+    "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -34492,7 +34963,7 @@
     "id": "fireworks-ai/accounts/fireworks/models/kimi-k2p6",
     "name": "Kimi K2.6",
     "family": "kimi-thinking",
-    "attachment": false,
+    "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -34602,8 +35073,8 @@
       "cache_read": 0.1
     },
     "limit": {
-      "context": 128000,
-      "output": 8192
+      "context": 262144,
+      "output": 65536
     }
   },
   {
@@ -34636,6 +35107,36 @@
     }
   },
   {
+    "id": "fireworks-ai/accounts/fireworks/routers/kimi-k2p6-fast",
+    "name": "Kimi K2.6 Fast",
+    "family": "kimi-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-17",
+    "last_updated": "2026-06-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 2.0,
+      "output": 8.0,
+      "cache_read": 0.3
+    },
+    "limit": {
+      "context": 262000,
+      "output": 262000
+    }
+  },
+  {
     "id": "fireworks-ai/accounts/fireworks/routers/kimi-k2p6-turbo",
     "name": "Kimi K2.6 Turbo",
     "family": "kimi-thinking",
@@ -34663,6 +35164,301 @@
     "limit": {
       "context": 262000,
       "output": 262000
+    }
+  },
+  {
+    "id": "freemodel/claude-haiku-4.5",
+    "name": "Claude Haiku 4.5",
+    "family": "claude-haiku",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-02-28",
+    "release_date": "2025-10-15",
+    "last_updated": "2025-10-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 5.0,
+      "cache_read": 0.1,
+      "cache_write": 1.25
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "freemodel/claude-opus-4.6",
+    "name": "Claude Opus 4.6",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05-31",
+    "release_date": "2026-02-05",
+    "last_updated": "2026-03-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "freemodel/claude-opus-4.7",
+    "name": "Claude Opus 4.7",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-04-16",
+    "last_updated": "2026-04-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "freemodel/claude-opus-4.8",
+    "name": "Claude Opus 4.8",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-05-28",
+    "last_updated": "2026-05-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "freemodel/claude-sonnet-4.6",
+    "name": "Claude Sonnet 4.6",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-02-17",
+    "last_updated": "2026-03-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "freemodel/gpt-5.3-codex",
+    "name": "GPT-5.3 Codex",
+    "family": "gpt-codex",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-02-05",
+    "last_updated": "2026-02-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.75,
+      "output": 14.0,
+      "cache_read": 0.175,
+      "cache_write": 1.75
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "freemodel/gpt-5.4",
+    "name": "GPT-5.4",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-05",
+    "last_updated": "2026-03-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 15.0,
+      "cache_read": 0.25,
+      "cache_write": 2.5
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "freemodel/gpt-5.4-mini",
+    "name": "GPT-5.4 mini",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 4.5,
+      "cache_read": 0.075,
+      "cache_write": 0.75
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "freemodel/gpt-5.5",
+    "name": "GPT-5.5",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-12-01",
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5,
+      "cache_write": 5.0
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
     }
   },
   {
@@ -35346,11 +36142,11 @@
     }
   },
   {
-    "id": "frogbot/grok-4.1-fast",
-    "name": "Grok 4.1 Fast (Reasoning)",
+    "id": "frogbot/grok-4.1-fast-non-reasoning",
+    "name": "Grok 4.1 Fast (Non-Reasoning)",
     "family": "grok",
     "attachment": true,
-    "reasoning": true,
+    "reasoning": false,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-11",
@@ -35377,11 +36173,11 @@
     }
   },
   {
-    "id": "frogbot/grok-4.1-fast-non",
-    "name": "Grok 4.1 Fast (Non-Reasoning)",
+    "id": "frogbot/grok-4.1-fast-reasoning",
+    "name": "Grok 4.1 Fast (Reasoning)",
     "family": "grok",
     "attachment": true,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-11",
@@ -37269,8 +38065,8 @@
     }
   },
   {
-    "id": "github-models/microsoft/phi-4-mini",
-    "name": "Phi-4-mini-reasoning",
+    "id": "github-models/microsoft/phi-4-mini-instruct",
+    "name": "Phi-4-mini-instruct",
     "family": "phi",
     "attachment": false,
     "reasoning": true,
@@ -37298,8 +38094,8 @@
     }
   },
   {
-    "id": "github-models/microsoft/phi-4-mini-instruct",
-    "name": "Phi-4-mini-instruct",
+    "id": "github-models/microsoft/phi-4-mini-reasoning",
+    "name": "Phi-4-mini-reasoning",
     "family": "phi",
     "attachment": false,
     "reasoning": true,
@@ -37342,6 +38138,35 @@
         "text",
         "image",
         "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 4096
+    }
+  },
+  {
+    "id": "github-models/microsoft/phi-4-reasoning",
+    "name": "Phi-4-Reasoning",
+    "family": "phi",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-10",
+    "release_date": "2024-12-11",
+    "last_updated": "2024-12-11",
+    "modalities": {
+      "input": [
+        "text"
       ],
       "output": [
         "text"
@@ -38682,7 +39507,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.98,
       "output": 3.08,
@@ -38724,72 +39549,6 @@
     "limit": {
       "context": 200000,
       "output": 8192
-    }
-  },
-  {
-    "id": "google-vertex-anthropic/claude-3.5-sonnet",
-    "name": "Claude Sonnet 3.5 v2",
-    "family": "claude-sonnet",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-04-30",
-    "release_date": "2024-10-22",
-    "last_updated": "2024-10-22",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.3,
-      "cache_write": 3.75
-    },
-    "limit": {
-      "context": 200000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "google-vertex-anthropic/claude-3.7-sonnet",
-    "name": "Claude Sonnet 3.7",
-    "family": "claude-sonnet",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-10-31",
-    "release_date": "2025-02-19",
-    "last_updated": "2025-02-19",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.3,
-      "cache_write": 3.75
-    },
-    "limit": {
-      "context": 200000,
-      "output": 64000
     }
   },
   {
@@ -39152,72 +39911,6 @@
     "limit": {
       "context": 200000,
       "output": 8192
-    }
-  },
-  {
-    "id": "google-vertex/claude-3.5-sonnet",
-    "name": "Claude Sonnet 3.5 v2",
-    "family": "claude-sonnet",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-04-30",
-    "release_date": "2024-10-22",
-    "last_updated": "2024-10-22",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.3,
-      "cache_write": 3.75
-    },
-    "limit": {
-      "context": 200000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "google-vertex/claude-3.7-sonnet",
-    "name": "Claude Sonnet 3.7",
-    "family": "claude-sonnet",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-10-31",
-    "release_date": "2025-02-19",
-    "last_updated": "2025-02-19",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.3,
-      "cache_write": 3.75
-    },
-    "limit": {
-      "context": 200000,
-      "output": 64000
     }
   },
   {
@@ -39609,73 +40302,6 @@
     }
   },
   {
-    "id": "google-vertex/gemini-2.0-flash",
-    "name": "Gemini 2.0 Flash",
-    "family": "gemini-flash",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-06",
-    "release_date": "2024-12-11",
-    "last_updated": "2024-12-11",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.15,
-      "output": 0.6,
-      "cache_read": 0.025
-    },
-    "limit": {
-      "context": 1048576,
-      "output": 8192
-    }
-  },
-  {
-    "id": "google-vertex/gemini-2.0-flash-lite",
-    "name": "Gemini 2.0 Flash-Lite",
-    "family": "gemini-flash-lite",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-06",
-    "release_date": "2024-12-11",
-    "last_updated": "2024-12-11",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.075,
-      "output": 0.3
-    },
-    "limit": {
-      "context": 1048576,
-      "output": 8192
-    }
-  },
-  {
     "id": "google-vertex/gemini-2.5-flash",
     "name": "Gemini 2.5 Flash",
     "family": "gemini-flash",
@@ -39745,72 +40371,32 @@
     }
   },
   {
-    "id": "google-vertex/gemini-2.5-flash-lite-preview-06-17",
-    "name": "Gemini 2.5 Flash Lite Preview 06-17",
-    "family": "gemini-flash-lite",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2025-06-17",
-    "last_updated": "2025-06-17",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.1,
-      "output": 0.4,
-      "cache_read": 0.025
-    },
-    "limit": {
-      "context": 65536,
-      "output": 65536
-    }
-  },
-  {
-    "id": "google-vertex/gemini-2.5-flash-preview-09",
-    "name": "Gemini 2.5 Flash Preview 09-25",
+    "id": "google-vertex/gemini-2.5-flash-tts",
+    "name": "Gemini 2.5 Flash TTS",
     "family": "gemini-flash",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
     "knowledge": "2025-01",
-    "release_date": "2025-09-25",
-    "last_updated": "2025-09-25",
+    "release_date": "2025-09-30",
+    "last_updated": "2025-12-10",
     "modalities": {
       "input": [
-        "text",
-        "image",
-        "audio",
-        "video",
-        "pdf"
+        "text"
       ],
       "output": [
-        "text"
+        "audio"
       ]
     },
     "open_weights": false,
     "cost": {
-      "input": 0.3,
-      "output": 2.5,
-      "cache_read": 0.075,
-      "cache_write": 0.383
+      "input": 0.5,
+      "output": 10.0
     },
     "limit": {
-      "context": 1048576,
-      "output": 65536
+      "context": 32768,
+      "output": 16384
     }
   },
   {
@@ -39848,6 +40434,35 @@
     }
   },
   {
+    "id": "google-vertex/gemini-2.5-pro-tts",
+    "name": "Gemini 2.5 Pro TTS",
+    "family": "gemini-pro",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "knowledge": "2025-01",
+    "release_date": "2025-09-30",
+    "last_updated": "2025-12-10",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "audio"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 20.0
+    },
+    "limit": {
+      "context": 32768,
+      "output": 16384
+    }
+  },
+  {
     "id": "google-vertex/gemini-3-flash-preview",
     "name": "Gemini 3 Flash Preview",
     "family": "gemini-flash",
@@ -39875,40 +40490,6 @@
       "input": 0.5,
       "output": 3.0,
       "cache_read": 0.05
-    },
-    "limit": {
-      "context": 1048576,
-      "output": 65536
-    }
-  },
-  {
-    "id": "google-vertex/gemini-3-pro-preview",
-    "name": "Gemini 3 Pro Preview",
-    "family": "gemini-pro",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2025-11-18",
-    "last_updated": "2025-11-18",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video",
-        "audio",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 2.0,
-      "output": 12.0,
-      "cache_read": 0.2
     },
     "limit": {
       "context": 1048576,
@@ -40705,6 +41286,37 @@
     "limit": {
       "context": 1048576,
       "output": 65536
+    }
+  },
+  {
+    "id": "google/gemini-3-pro-image-preview",
+    "name": "Nano Banana Pro",
+    "family": "gemini-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-11-20",
+    "last_updated": "2025-11-20",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 120.0
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
     }
   },
   {
@@ -42030,7 +42642,7 @@
     "cost": {
       "input": 1.0,
       "output": 5.0,
-      "cache_read": 0.09999999999999999,
+      "cache_read": 0.1,
       "cache_write": 1.25
     },
     "limit": {
@@ -42126,7 +42738,7 @@
     "cost": {
       "input": 1.0,
       "output": 5.0,
-      "cache_read": 0.09999999999999999,
+      "cache_read": 0.1,
       "cache_write": 1.25
     },
     "limit": {
@@ -42403,7 +43015,7 @@
     "cost": {
       "input": 0.27,
       "output": 1.0,
-      "cache_read": 0.21600000000000003
+      "cache_read": 0.21600000000000005
     },
     "limit": {
       "context": 128000,
@@ -42522,10 +43134,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.09999999999999999,
-      "output": 0.39999999999999997,
-      "cache_read": 0.024999999999999998,
-      "cache_write": 0.09999999999999999
+      "input": 0.1,
+      "output": 0.4,
+      "cache_read": 0.025,
+      "cache_write": 0.1
     },
     "limit": {
       "context": 1048576,
@@ -42590,7 +43202,7 @@
     "cost": {
       "input": 2.0,
       "output": 12.0,
-      "cache_read": 0.19999999999999998
+      "cache_read": 0.2
     },
     "limit": {
       "context": 1048576,
@@ -42619,8 +43231,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.049999999999999996,
-      "output": 0.09999999999999999
+      "input": 0.05,
+      "output": 0.1
     },
     "limit": {
       "context": 131072,
@@ -42677,7 +43289,7 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.44999999999999996,
+      "input": 0.45,
       "output": 1.5
     },
     "limit": {
@@ -42738,9 +43350,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.39999999999999997,
-      "output": 1.5999999999999999,
-      "cache_read": 0.09999999999999999
+      "input": 0.4,
+      "output": 1.6,
+      "cache_read": 0.1
     },
     "limit": {
       "context": 1047576,
@@ -42769,9 +43381,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.09999999999999999,
-      "output": 0.39999999999999997,
-      "cache_read": 0.024999999999999998
+      "input": 0.1,
+      "output": 0.4,
+      "cache_read": 0.025
     },
     "limit": {
       "context": 1047576,
@@ -42956,7 +43568,7 @@
     "cost": {
       "input": 0.25,
       "output": 2.0,
-      "cache_read": 0.024999999999999998
+      "cache_read": 0.025
     },
     "limit": {
       "context": 400000,
@@ -42985,8 +43597,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.049999999999999996,
-      "output": 0.39999999999999997,
+      "input": 0.05,
+      "output": 0.4,
       "cache_read": 0.005
     },
     "limit": {
@@ -43144,7 +43756,7 @@
     "cost": {
       "input": 0.25,
       "output": 2.0,
-      "cache_read": 0.024999999999999998
+      "cache_read": 0.025
     },
     "limit": {
       "context": 400000,
@@ -43201,8 +43813,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.049999999999999996,
-      "output": 0.19999999999999998
+      "input": 0.05,
+      "output": 0.2
     },
     "limit": {
       "context": 131072,
@@ -43300,38 +43912,7 @@
     }
   },
   {
-    "id": "helicone/grok-4-fast",
-    "name": "xAI: Grok 4 Fast Reasoning",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-09",
-    "release_date": "2025-09-01",
-    "last_updated": "2025-09-01",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.19999999999999998,
-      "output": 0.5,
-      "cache_read": 0.049999999999999996
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 2000000
-    }
-  },
-  {
-    "id": "helicone/grok-4-fast-non",
+    "id": "helicone/grok-4-fast-non-reasoning",
     "name": "xAI Grok 4 Fast Non-Reasoning",
     "family": "grok",
     "attachment": false,
@@ -43353,9 +43934,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.19999999999999998,
+      "input": 0.2,
       "output": 0.5,
-      "cache_read": 0.049999999999999996
+      "cache_read": 0.05
     },
     "limit": {
       "context": 2000000,
@@ -43363,16 +43944,16 @@
     }
   },
   {
-    "id": "helicone/grok-4.1-fast",
-    "name": "xAI Grok 4.1 Fast Reasoning",
+    "id": "helicone/grok-4-fast-reasoning",
+    "name": "xAI: Grok 4 Fast Reasoning",
     "family": "grok",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-11",
-    "release_date": "2025-11-17",
-    "last_updated": "2025-11-17",
+    "knowledge": "2025-09",
+    "release_date": "2025-09-01",
+    "last_updated": "2025-09-01",
     "modalities": {
       "input": [
         "text",
@@ -43384,9 +43965,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.19999999999999998,
+      "input": 0.2,
       "output": 0.5,
-      "cache_read": 0.049999999999999996
+      "cache_read": 0.05
     },
     "limit": {
       "context": 2000000,
@@ -43394,7 +43975,7 @@
     }
   },
   {
-    "id": "helicone/grok-4.1-fast-non",
+    "id": "helicone/grok-4.1-fast-non-reasoning",
     "name": "xAI Grok 4.1 Fast Non-Reasoning",
     "family": "grok",
     "attachment": false,
@@ -43416,13 +43997,44 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.19999999999999998,
+      "input": 0.2,
       "output": 0.5,
-      "cache_read": 0.049999999999999996
+      "cache_read": 0.05
     },
     "limit": {
       "context": 2000000,
       "output": 30000
+    }
+  },
+  {
+    "id": "helicone/grok-4.1-fast-reasoning",
+    "name": "xAI Grok 4.1 Fast Reasoning",
+    "family": "grok",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-11",
+    "release_date": "2025-11-17",
+    "last_updated": "2025-11-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.2,
+      "output": 0.5,
+      "cache_read": 0.05
+    },
+    "limit": {
+      "context": 2000000,
+      "output": 2000000
     }
   },
   {
@@ -43446,7 +44058,7 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.19999999999999998,
+      "input": 0.2,
       "output": 1.5,
       "cache_read": 0.02
     },
@@ -43507,7 +44119,7 @@
     "cost": {
       "input": 0.5,
       "output": 2.0,
-      "cache_read": 0.39999999999999997
+      "cache_read": 0.4
     },
     "limit": {
       "context": 262144,
@@ -43564,7 +44176,7 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.049999999999999996,
+      "input": 0.05,
       "output": 0.08
     },
     "limit": {
@@ -43594,7 +44206,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.02,
-      "output": 0.049999999999999996
+      "output": 0.05
     },
     "limit": {
       "context": 16384,
@@ -44279,7 +44891,7 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.09999999999999999,
+      "input": 0.1,
       "output": 0.3
     },
     "limit": {
@@ -44433,6 +45045,35 @@
     },
     "limit": {
       "context": 200000,
+      "output": 4096
+    }
+  },
+  {
+    "id": "helicone/sonar-reasoning",
+    "name": "Perplexity Sonar Reasoning",
+    "family": "sonar-reasoning",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-01-27",
+    "last_updated": "2025-01-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 5.0
+    },
+    "limit": {
+      "context": 127000,
       "output": 4096
     }
   },
@@ -45779,7 +46420,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 1.4,
       "output": 4.4,
@@ -47588,36 +48229,7 @@
     }
   },
   {
-    "id": "jiekou/grok-4-fast",
-    "name": "grok-4-fast-reasoning",
-    "family": "grok",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-01",
-    "last_updated": "2026-01",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.18,
-      "output": 0.45
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 2000000
-    }
-  },
-  {
-    "id": "jiekou/grok-4-fast-non",
+    "id": "jiekou/grok-4-fast-non-reasoning",
     "name": "grok-4-fast-non-reasoning",
     "family": "grok",
     "attachment": true,
@@ -47646,8 +48258,8 @@
     }
   },
   {
-    "id": "jiekou/grok-4.1-fast",
-    "name": "grok-4-1-fast-reasoning",
+    "id": "jiekou/grok-4-fast-reasoning",
+    "name": "grok-4-fast-reasoning",
     "family": "grok",
     "attachment": true,
     "reasoning": false,
@@ -47675,8 +48287,37 @@
     }
   },
   {
-    "id": "jiekou/grok-4.1-fast-non",
+    "id": "jiekou/grok-4.1-fast-non-reasoning",
     "name": "grok-4-1-fast-non-reasoning",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-01",
+    "last_updated": "2026-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.18,
+      "output": 0.45
+    },
+    "limit": {
+      "context": 2000000,
+      "output": 2000000
+    }
+  },
+  {
+    "id": "jiekou/grok-4.1-fast-reasoning",
+    "name": "grok-4-1-fast-reasoning",
     "family": "grok",
     "attachment": true,
     "reasoning": false,
@@ -49137,7 +49778,7 @@
     }
   },
   {
-    "id": "kilo/arcee-ai/maestro",
+    "id": "kilo/arcee-ai/maestro-reasoning",
     "name": "Arcee AI: Maestro Reasoning",
     "attachment": false,
     "reasoning": false,
@@ -52857,6 +53498,7 @@
   {
     "id": "kilo/nvidia/llama-3.3-nemotron-super-49b-v1.5",
     "name": "NVIDIA: Llama 3.3 Nemotron Super 49B V1.5",
+    "family": "nemotron",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
@@ -52884,6 +53526,7 @@
   {
     "id": "kilo/nvidia/nemotron-3-nano-30b-a3b",
     "name": "NVIDIA: Nemotron 3 Nano 30B A3B",
+    "family": "nemotron",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
@@ -52911,6 +53554,7 @@
   {
     "id": "kilo/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
     "name": "NVIDIA: Nemotron 3 Nano Omni (free)",
+    "family": "nemotron",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
@@ -52941,6 +53585,7 @@
   {
     "id": "kilo/nvidia/nemotron-3-super-120b-a12b",
     "name": "NVIDIA: Nemotron 3 Super",
+    "family": "nemotron",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
@@ -52969,6 +53614,7 @@
   {
     "id": "kilo/nvidia/nemotron-3-super-120b-a12b:free",
     "name": "NVIDIA: Nemotron 3 Super (free)",
+    "family": "nemotron",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
@@ -52996,6 +53642,7 @@
   {
     "id": "kilo/nvidia/nemotron-nano-9b-v2",
     "name": "NVIDIA: Nemotron Nano 9B V2",
+    "family": "nemotron",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
@@ -59381,7 +60028,7 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
       "input": 0.0,
       "output": 0.0,
@@ -59715,7 +60362,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 6.0,
       "output": 24.0,
@@ -60739,69 +61386,7 @@
     }
   },
   {
-    "id": "llmgateway/grok-4-20",
-    "name": "Grok 4.20 (Reasoning)",
-    "family": "grok",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-03-09",
-    "last_updated": "2026-03-09",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.25,
-      "output": 2.5,
-      "cache_read": 0.2
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 30000
-    }
-  },
-  {
-    "id": "llmgateway/grok-4-20-beta",
-    "name": "Grok 4.20 (Reasoning)",
-    "family": "grok",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-03-09",
-    "last_updated": "2026-03-09",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.25,
-      "output": 2.5,
-      "cache_read": 0.2
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 30000
-    }
-  },
-  {
-    "id": "llmgateway/grok-4-20-beta-0309-non",
+    "id": "llmgateway/grok-4-20-beta-0309-non-reasoning",
     "name": "Grok 4.20 (Non-Reasoning)",
     "family": "grok",
     "attachment": true,
@@ -60827,12 +61412,43 @@
       "cache_read": 0.2
     },
     "limit": {
-      "context": 2000000,
+      "context": 1000000,
       "output": 30000
     }
   },
   {
-    "id": "llmgateway/grok-4-20-non",
+    "id": "llmgateway/grok-4-20-beta-0309-reasoning",
+    "name": "Grok 4.20 (Reasoning)",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-09",
+    "last_updated": "2026-03-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 30000
+    }
+  },
+  {
+    "id": "llmgateway/grok-4-20-non-reasoning",
     "name": "Grok 4.20 (Non-Reasoning)",
     "family": "grok",
     "attachment": true,
@@ -60858,12 +61474,43 @@
       "cache_read": 0.2
     },
     "limit": {
-      "context": 2000000,
+      "context": 1000000,
       "output": 30000
     }
   },
   {
-    "id": "llmgateway/grok-4-fast",
+    "id": "llmgateway/grok-4-20-reasoning",
+    "name": "Grok 4.20 (Reasoning)",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-09",
+    "last_updated": "2026-03-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 30000
+    }
+  },
+  {
+    "id": "llmgateway/grok-4-fast-reasoning",
     "name": "Grok 4 Fast Reasoning",
     "family": "grok",
     "attachment": true,
@@ -60893,7 +61540,7 @@
     }
   },
   {
-    "id": "llmgateway/grok-4.1-fast",
+    "id": "llmgateway/grok-4.1-fast-reasoning",
     "name": "Grok 4.1 Fast Reasoning",
     "family": "grok",
     "attachment": true,
@@ -61804,6 +62451,37 @@
     "limit": {
       "context": 204800,
       "output": 131072
+    }
+  },
+  {
+    "id": "llmgateway/minimax-m3",
+    "name": "MiniMax-M3",
+    "family": "minimax",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-01",
+    "last_updated": "2026-06-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.6,
+      "output": 2.4,
+      "cache_read": 0.12
+    },
+    "limit": {
+      "context": 512000,
+      "output": 128000
     }
   },
   {
@@ -62847,7 +63525,7 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
       "input": 1.0,
       "output": 5.0
@@ -63272,6 +63950,38 @@
     "limit": {
       "context": 1000000,
       "output": 65536
+    }
+  },
+  {
+    "id": "llmgateway/qwen3.7-plus",
+    "name": "Qwen3.7 Plus",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-06-02",
+    "last_updated": "2026-06-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.4,
+      "output": 1.6,
+      "cache_read": 0.08,
+      "cache_write": 0.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 64000
     }
   },
   {
@@ -65418,7 +66128,7 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
       "input": 0.4,
       "output": 2.0
@@ -65476,7 +66186,7 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
       "input": 2.0,
       "output": 5.0
@@ -66296,7 +67006,7 @@
     }
   },
   {
-    "id": "merge-gateway/xai/grok-4.20",
+    "id": "merge-gateway/xai/grok-4.20-0309-reasoning",
     "name": "Grok 4.20 (Reasoning)",
     "family": "grok",
     "attachment": true,
@@ -66322,7 +67032,7 @@
       "cache_read": 0.2
     },
     "limit": {
-      "context": 2000000,
+      "context": 1000000,
       "output": 30000
     }
   },
@@ -66590,7 +67300,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 1.4,
       "output": 4.4,
@@ -68075,6 +68785,35 @@
     }
   },
   {
+    "id": "mistralai/open-mistral-nemo",
+    "name": "Open Mistral Nemo",
+    "family": "mistral-nemo",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-07",
+    "release_date": "2024-07-01",
+    "last_updated": "2024-07-01",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.15,
+      "output": 0.15
+    },
+    "limit": {
+      "context": 128000,
+      "output": 128000
+    }
+  },
+  {
     "id": "mistralai/open-mixtral-8x22b",
     "name": "Mixtral 8x22B",
     "family": "mixtral",
@@ -69124,7 +69863,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.08,
-      "output": 0.24000000000000002
+      "output": 0.24
     },
     "limit": {
       "context": 128000,
@@ -69207,33 +69946,6 @@
     "limit": {
       "context": 128000,
       "output": 32768
-    }
-  },
-  {
-    "id": "nano-gpt/CrucibleLab/L3.3-70B-Loki-V2.0",
-    "name": "L3.3 70B Loki v2.0",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2026-01-22",
-    "last_updated": "2026-01-22",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.49299999999999994,
-      "output": 0.49299999999999994
-    },
-    "limit": {
-      "context": 16384,
-      "output": 16384
     }
   },
   {
@@ -69426,188 +70138,6 @@
     }
   },
   {
-    "id": "nano-gpt/GLM-4.5-Air-Derestricted",
-    "name": "GLM 4.5 Air Derestricted",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-07-28",
-    "last_updated": "2025-07-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 202600,
-      "output": 98304
-    }
-  },
-  {
-    "id": "nano-gpt/GLM-4.5-Air-Derestricted-Iceblink",
-    "name": "GLM 4.5 Air Derestricted Iceblink",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-07-28",
-    "last_updated": "2025-07-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 131072,
-      "output": 98304
-    }
-  },
-  {
-    "id": "nano-gpt/GLM-4.5-Air-Derestricted-Iceblink-ReExtract",
-    "name": "GLM 4.5 Air Derestricted Iceblink ReExtract",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-12-12",
-    "last_updated": "2025-12-12",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 131072,
-      "output": 98304
-    }
-  },
-  {
-    "id": "nano-gpt/GLM-4.5-Air-Derestricted-Iceblink-v2",
-    "name": "GLM 4.5 Air Derestricted Iceblink v2",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-07-28",
-    "last_updated": "2025-07-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 158600,
-      "output": 65536
-    }
-  },
-  {
-    "id": "nano-gpt/GLM-4.5-Air-Derestricted-Iceblink-v2-ReExtract",
-    "name": "GLM 4.5 Air Derestricted Iceblink v2 ReExtract",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-12-12",
-    "last_updated": "2025-12-12",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 131072,
-      "output": 65536
-    }
-  },
-  {
-    "id": "nano-gpt/GLM-4.5-Air-Derestricted-Steam",
-    "name": "GLM 4.5 Air Derestricted Steam",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-07-28",
-    "last_updated": "2025-07-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 220600,
-      "output": 65536
-    }
-  },
-  {
-    "id": "nano-gpt/GLM-4.5-Air-Derestricted-Steam-ReExtract",
-    "name": "GLM 4.5 Air Derestricted Steam ReExtract",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-12-12",
-    "last_updated": "2025-12-12",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 131072,
-      "output": 65536
-    }
-  },
-  {
     "id": "nano-gpt/GLM-4.6-Derestricted-v5",
     "name": "GLM 4.6 Derestricted v5",
     "attachment": false,
@@ -69661,16 +70191,18 @@
     }
   },
   {
-    "id": "nano-gpt/Gemma-3-27B-ArliAI-RPMax-v3",
-    "name": "Gemma 3 27B RPMax v3",
-    "attachment": false,
-    "reasoning": false,
+    "id": "nano-gpt/Gemma-4-31B-Claude-4.6-Opus-Reasoning-Distilled",
+    "name": "Gemma 4 31B Claude 4.6 Opus Reasoning Distilled",
+    "attachment": true,
+    "reasoning": true,
     "tool_call": false,
-    "release_date": "2025-07-03",
-    "last_updated": "2025-07-03",
+    "release_date": "2026-05-01",
+    "last_updated": "2026-05-01",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "video"
       ],
       "output": [
         "text"
@@ -69679,24 +70211,27 @@
     "open_weights": false,
     "cost": {
       "input": 0.306,
-      "output": 0.306
+      "output": 0.306,
+      "cache_read": 0.0306
     },
     "limit": {
-      "context": 32768,
+      "context": 262144,
       "output": 16384
     }
   },
   {
-    "id": "nano-gpt/Gemma-3-27B-Big-Tiger-v3",
-    "name": "Gemma 3 27B Big Tiger v3",
-    "attachment": false,
-    "reasoning": false,
+    "id": "nano-gpt/Gemma-4-31B-Cognitive-Unshackled",
+    "name": "Gemma 4 31B Cognitive Unshackled",
+    "attachment": true,
+    "reasoning": true,
     "tool_call": false,
-    "release_date": "2025-08-08",
-    "last_updated": "2025-08-08",
+    "release_date": "2026-05-01",
+    "last_updated": "2026-05-01",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "video"
       ],
       "output": [
         "text"
@@ -69708,21 +70243,23 @@
       "output": 0.306
     },
     "limit": {
-      "context": 32768,
+      "context": 262144,
       "output": 16384
     }
   },
   {
-    "id": "nano-gpt/Gemma-3-27B-CardProjector-v4",
-    "name": "Gemma 3 27B CardProjector v4",
-    "attachment": false,
-    "reasoning": false,
+    "id": "nano-gpt/Gemma-4-31B-DarkIdol",
+    "name": "Gemma 4 31B DarkIdol",
+    "attachment": true,
+    "reasoning": true,
     "tool_call": false,
-    "release_date": "2025-03-10",
-    "last_updated": "2025-03-10",
+    "release_date": "2026-05-01",
+    "last_updated": "2026-05-01",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "video"
       ],
       "output": [
         "text"
@@ -69734,21 +70271,23 @@
       "output": 0.306
     },
     "limit": {
-      "context": 32768,
+      "context": 262144,
       "output": 16384
     }
   },
   {
-    "id": "nano-gpt/Gemma-3-27B-Glitter",
-    "name": "Gemma 3 27B Glitter",
-    "attachment": false,
-    "reasoning": false,
+    "id": "nano-gpt/Gemma-4-31B-GarnetV2",
+    "name": "Gemma 4 31B Garnet V2",
+    "attachment": true,
+    "reasoning": true,
     "tool_call": false,
-    "release_date": "2025-03-10",
-    "last_updated": "2025-03-10",
+    "release_date": "2026-05-01",
+    "last_updated": "2026-05-01",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "video"
       ],
       "output": [
         "text"
@@ -69760,21 +70299,23 @@
       "output": 0.306
     },
     "limit": {
-      "context": 32768,
+      "context": 262144,
       "output": 16384
     }
   },
   {
-    "id": "nano-gpt/Gemma-3-27B-Nidum-Uncensored",
-    "name": "Gemma 3 27B Nidum Uncensored",
-    "attachment": false,
-    "reasoning": false,
+    "id": "nano-gpt/Gemma-4-31B-Gemopus",
+    "name": "Gemma 4 31B Gemopus",
+    "attachment": true,
+    "reasoning": true,
     "tool_call": false,
-    "release_date": "2025-08-08",
-    "last_updated": "2025-08-08",
+    "release_date": "2026-05-01",
+    "last_updated": "2026-05-01",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "video"
       ],
       "output": [
         "text"
@@ -69786,47 +70327,23 @@
       "output": 0.306
     },
     "limit": {
-      "context": 32768,
-      "output": 96000
-    }
-  },
-  {
-    "id": "nano-gpt/Gemma-3-27B-it",
-    "name": "Gemma 3 27B IT",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-03-10",
-    "last_updated": "2025-03-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
+      "context": 262144,
       "output": 16384
     }
   },
   {
-    "id": "nano-gpt/Gemma-3-27B-it-Abliterated",
-    "name": "Gemma 3 27B IT Abliterated",
-    "attachment": false,
-    "reasoning": false,
+    "id": "nano-gpt/Gemma-4-31B-Musica-v1",
+    "name": "Gemma 4 31B Musica v1",
+    "attachment": true,
+    "reasoning": true,
     "tool_call": false,
-    "release_date": "2025-07-03",
-    "last_updated": "2025-07-03",
+    "release_date": "2026-05-01",
+    "last_updated": "2026-05-01",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "video"
       ],
       "output": [
         "text"
@@ -69834,12 +70351,68 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.42,
-      "output": 0.42
+      "input": 0.306,
+      "output": 0.306
     },
     "limit": {
-      "context": 32768,
-      "output": 96000
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Gemma-4-31B-Queen",
+    "name": "Gemma 4 31B Queen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-05-01",
+    "last_updated": "2026-05-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Gemma-4-31B-it",
+    "name": "Gemma 4 31B IT",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-09",
+    "last_updated": "2026-04-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
     }
   },
   {
@@ -69949,32 +70522,6 @@
     }
   },
   {
-    "id": "nano-gpt/KAT-Coder-Pro-V1",
-    "name": "KAT Coder Pro V1",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-10-28",
-    "last_updated": "2025-10-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.5,
-      "output": 6.0
-    },
-    "limit": {
-      "context": 256000,
-      "output": 32768
-    }
-  },
-  {
     "id": "nano-gpt/LLM360/K2-Think",
     "name": "K2-Think",
     "family": "kimi-thinking",
@@ -70025,1124 +70572,6 @@
     },
     "limit": {
       "context": 16384,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3+(3.1v3.3)-70B-Hanami-x1",
-    "name": "Llama 3.3+ 70B Hanami x1",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3+(3.1v3.3)-70B-New-Dawn-v1.1",
-    "name": "Llama 3.3+ 70B New Dawn v1.1",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3+(3v3.3)-70B-TenyxChat-DaybreakStorywriter",
-    "name": "Llama 3.3+ 70B TenyxChat DaybreakStorywriter",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Anthrobomination",
-    "name": "Llama 3.3 70B Anthrobomination",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Argunaut-1-SFT",
-    "name": "Llama 3.3 70B Argunaut 1 SFT",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-ArliAI-RPMax-v1.4",
-    "name": "Llama 3.3 70B RPMax v1.4",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-ArliAI-RPMax-v2",
-    "name": "Llama 3.3 70B ArliAI RPMax v2",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-08-08",
-    "last_updated": "2025-08-08",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-ArliAI-RPMax-v3",
-    "name": "Llama 3.3 70B ArliAI RPMax v3",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Aurora-Borealis",
-    "name": "Llama 3.3 70B Aurora Borealis",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Bigger-Body",
-    "name": "Llama 3.3 70B Bigger Body",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Cirrus-x1",
-    "name": "Llama 3.3 70B Cirrus x1",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Cu-Mai-R1",
-    "name": "Llama 3.3 70B Cu Mai R1",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Damascus-R1",
-    "name": "Damascus R1",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Dark-Ages-v0.1",
-    "name": "Llama 3.3 70B Dark Ages v0.1",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Electra-R1",
-    "name": "Llama 3.3 70B Electra R1",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Electranova-v1.0",
-    "name": "Llama 3.3 70B Electranova v1.0",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Fallen-R1-v1",
-    "name": "Llama 3.3 70B Fallen R1 v1",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Fallen-v1",
-    "name": "Llama 3.3 70B Fallen v1",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Forgotten-Abomination-v5.0",
-    "name": "Llama 3.3 70B Forgotten Abomination v5.0",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Forgotten-Safeword-3.6",
-    "name": "Llama 3.3 70B Forgotten Safeword 3.6",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-GeneticLemonade-Opus",
-    "name": "Llama 3.3 70B GeneticLemonade Opus",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-GeneticLemonade-Unleashed-v3",
-    "name": "Llama 3.3 70B GeneticLemonade Unleashed v3",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Ignition-v0.1",
-    "name": "Llama 3.3 70B Ignition v0.1",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Incandescent-Malevolence",
-    "name": "Llama 3.3 70B Incandescent Malevolence",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Legion-V2.1",
-    "name": "Llama 3.3 70B Legion V2.1",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-MS-Nevoria",
-    "name": "Llama 3.3 70B MS Nevoria",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Magnum-v4-SE",
-    "name": "Llama 3.3 70B Magnum v4 SE",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Magnum-v4-SE-Cirrus-x1-SLERP",
-    "name": "Llama 3.3 70B Magnum v4 SE Cirrus x1 SLERP",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-07-26",
-    "last_updated": "2025-07-26",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Mhnnn-x1",
-    "name": "Llama 3.3 70B Mhnnn x1",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-MiraiFanfare",
-    "name": "Llama 3.3 70b Mirai Fanfare",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-07-26",
-    "last_updated": "2025-07-26",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.493,
-      "output": 0.493
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Mokume-Gane-R1",
-    "name": "Llama 3.3 70B Mokume Gane R1",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Nova",
-    "name": "Llama 3.3 70B Nova",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Predatorial-Extasy",
-    "name": "Llama 3.3 70B Predatorial Extasy",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Progenitor-V3.3",
-    "name": "Llama 3.3 70B Progenitor V3.3",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-07-26",
-    "last_updated": "2025-07-26",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-RAWMAW",
-    "name": "Llama 3.3 70B RAWMAW",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Sapphira-0.1",
-    "name": "Llama 3.3 70B Sapphira 0.1",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Sapphira-0.2",
-    "name": "Llama 3.3 70B Sapphira 0.2",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Shakudo",
-    "name": "Llama 3.3 70B Shakudo",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-StrawberryLemonade-v1.0",
-    "name": "Llama 3.3 70B StrawberryLemonade v1.0",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Strawberrylemonade-v1.2",
-    "name": "Llama 3.3 70B StrawberryLemonade v1.2",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-The-Omega-Directive-Unslop-v2.0",
-    "name": "Llama 3.3 70B Omega Directive Unslop v2.0",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-The-Omega-Directive-Unslop-v2.1",
-    "name": "Llama 3.3 70B Omega Directive Unslop v2.1",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Llama-3.3-70B-Vulpecula-R1",
-    "name": "Llama 3.3 70B Vulpecula R1",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.306,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 32768,
       "output": 16384
     }
   },
@@ -71305,61 +70734,6 @@
     }
   },
   {
-    "id": "nano-gpt/Mistral-Nemo-12B-Instruct",
-    "name": "Mistral Nemo 12B Instruct 2407",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-07-18",
-    "last_updated": "2024-07-18",
-    "modalities": {
-      "input": [
-        "text",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.01,
-      "output": 0.01
-    },
-    "limit": {
-      "context": 16384,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/NeverSleep/Llama-3-Lumimaid-70B-v0.1",
-    "name": "Lumimaid 70b",
-    "family": "llama",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-07-01",
-    "last_updated": "2024-07-01",
-    "modalities": {
-      "input": [
-        "text",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 2.006,
-      "output": 2.006
-    },
-    "limit": {
-      "context": 16384,
-      "output": 8192
-    }
-  },
-  {
     "id": "nano-gpt/NeverSleep/Lumimaid-v0.2-70B",
     "name": "Lumimaid v0.2",
     "family": "llama",
@@ -71387,9 +70761,8 @@
     }
   },
   {
-    "id": "nano-gpt/NousResearch 2/DeepHermes-3-Mistral-24B-Preview",
+    "id": "nano-gpt/NousResearch/DeepHermes-3-Mistral-24B-Preview",
     "name": "DeepHermes-3 Mistral 24B (Preview)",
-    "family": "nousresearch",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
@@ -71414,9 +70787,8 @@
     }
   },
   {
-    "id": "nano-gpt/NousResearch 2/Hermes-4-70B:thinking",
+    "id": "nano-gpt/NousResearch/Hermes-4-70B:thinking",
     "name": "Hermes 4 (Thinking)",
-    "family": "nousresearch",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
@@ -71433,7 +70805,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.2006,
-      "output": 0.39949999999999997
+      "output": 0.3995
     },
     "limit": {
       "context": 128000,
@@ -71441,9 +70813,8 @@
     }
   },
   {
-    "id": "nano-gpt/NousResearch 2/hermes-3-llama-3.1-70b",
+    "id": "nano-gpt/NousResearch/hermes-3-llama-3.1-70b",
     "name": "Hermes 3 70B",
-    "family": "nousresearch",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
@@ -71468,12 +70839,11 @@
     }
   },
   {
-    "id": "nano-gpt/NousResearch 2/hermes-4-405b",
+    "id": "nano-gpt/NousResearch/hermes-4-405b",
     "name": "Hermes 4 Large",
-    "family": "nousresearch",
     "attachment": false,
     "reasoning": false,
-    "tool_call": true,
+    "tool_call": false,
     "release_date": "2025-08-26",
     "last_updated": "2025-08-26",
     "modalities": {
@@ -71495,14 +70865,13 @@
     }
   },
   {
-    "id": "nano-gpt/NousResearch 2/hermes-4-405b:thinking",
+    "id": "nano-gpt/NousResearch/hermes-4-405b:thinking",
     "name": "Hermes 4 Large (Thinking)",
-    "family": "nousresearch",
     "attachment": false,
     "reasoning": false,
-    "tool_call": true,
-    "release_date": "2025-01-01",
-    "last_updated": "2025-01-01",
+    "tool_call": false,
+    "release_date": "2024-01-01",
+    "last_updated": "2024-01-01",
     "modalities": {
       "input": [
         "text"
@@ -71522,9 +70891,8 @@
     }
   },
   {
-    "id": "nano-gpt/NousResearch 2/hermes-4-70b",
+    "id": "nano-gpt/NousResearch/hermes-4-70b",
     "name": "Hermes 4 Medium",
-    "family": "nousresearch",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
@@ -71541,37 +70909,11 @@
     "open_weights": false,
     "cost": {
       "input": 0.2006,
-      "output": 0.39949999999999997
+      "output": 0.3995
     },
     "limit": {
       "context": 128000,
       "output": 8192
-    }
-  },
-  {
-    "id": "nano-gpt/QwQ-32B-ArliAI-RpR-v1",
-    "name": "QwQ 32b Arli V1",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.2
-    },
-    "limit": {
-      "context": 32768,
-      "output": 32768
     }
   },
   {
@@ -71601,6 +70943,846 @@
     }
   },
   {
+    "id": "nano-gpt/Qwen3.5-27B-Anko",
+    "name": "Qwen3.5 27B Anko",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-BlueStar-Derestricted",
+    "name": "Qwen3.5 27B BlueStar Derestricted",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-06",
+    "last_updated": "2026-04-06",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-BlueStar-Derestricted-Lite",
+    "name": "Qwen3.5 27B BlueStar Derestricted Lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-06",
+    "last_updated": "2026-04-06",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-BlueStar-v2-Derestricted",
+    "name": "Qwen3.5 27B BlueStar v2 Derestricted",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-06",
+    "last_updated": "2026-04-06",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-BlueStar-v2-Derestricted-Lite",
+    "name": "Qwen3.5 27B BlueStar v2 Derestricted Lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-06",
+    "last_updated": "2026-04-06",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-BlueStar-v3-Derestricted",
+    "name": "Qwen3.5 27B BlueStar v3 Derestricted",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-BlueStar-v3-Derestricted-Lite",
+    "name": "Qwen3.5 27B BlueStar v3 Derestricted Lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-Derestricted",
+    "name": "Qwen3.5 27B Derestricted",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-Infracelestial",
+    "name": "Qwen3.5 27B Infracelestial",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-Marvin-DPO-V2-Derestricted",
+    "name": "Qwen3.5 27B Marvin DPO V2 Derestricted",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-Marvin-DPO-V2-Derestricted-Lite",
+    "name": "Qwen3.5 27B Marvin DPO V2 Derestricted Lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-Marvin-V2-Derestricted",
+    "name": "Qwen3.5 27B Marvin V2 Derestricted",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-Marvin-V2-Derestricted-Lite",
+    "name": "Qwen3.5 27B Marvin V2 Derestricted Lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-Musica-v1",
+    "name": "Qwen3.5 27B Musica v1",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-03-27",
+    "last_updated": "2026-03-27",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-NaNovel-Derestricted",
+    "name": "Qwen3.5 27B NaNovel Derestricted",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-NaNovel-Derestricted-Lite",
+    "name": "Qwen3.5 27B NaNovel Derestricted Lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-Omega-Evolution-v2.0-Derestricted",
+    "name": "Qwen3.5 27B Omega Evolution v2.0 Derestricted",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-06",
+    "last_updated": "2026-04-06",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-Omega-Evolution-v2.0-Derestricted-Lite",
+    "name": "Qwen3.5 27B Omega Evolution v2.0 Derestricted Lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-06",
+    "last_updated": "2026-04-06",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-Omega-Evolution-v2.2-Derestricted",
+    "name": "Qwen3.5 27B Omega Evolution v2.2 Derestricted",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-05-02",
+    "last_updated": "2026-05-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-Omega-Evolution-v2.2-Derestricted-Lite",
+    "name": "Qwen3.5 27B Omega Evolution v2.2 Derestricted Lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-05-02",
+    "last_updated": "2026-05-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-Queen-Derestricted",
+    "name": "Qwen3.5 27B Queen Derestricted",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-Queen-Derestricted-Lite",
+    "name": "Qwen3.5 27B Queen Derestricted Lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-RpRMax-v1",
+    "name": "Qwen3.5 27B RpRMax v1",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-Vivid-Durian",
+    "name": "Qwen3.5 27B Vivid Durian",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-Writer-Derestricted",
+    "name": "Qwen3.5 27B Writer Derestricted",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-06",
+    "last_updated": "2026-04-06",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-Writer-Derestricted-Lite",
+    "name": "Qwen3.5 27B Writer Derestricted Lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-06",
+    "last_updated": "2026-04-06",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-Writer-V2-Derestricted",
+    "name": "Qwen3.5 27B Writer V2 Derestricted",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-06",
+    "last_updated": "2026-04-06",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-Writer-V2-Derestricted-Lite",
+    "name": "Qwen3.5 27B Writer V2 Derestricted Lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-06",
+    "last_updated": "2026-04-06",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-earica-Derestricted",
+    "name": "Qwen3.5 27B earica Derestricted",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/Qwen3.5-27B-earica-Derestricted-Lite",
+    "name": "Qwen3.5 27B earica Derestricted Lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
     "id": "nano-gpt/ReadyArt/MS3.2-The-Omega-Directive-24B-Unslop-v2.0",
     "name": "Omega Directive 24B Unslop v2.0",
     "family": "llama",
@@ -71625,33 +71807,6 @@
     "limit": {
       "context": 16384,
       "output": 32768
-    }
-  },
-  {
-    "id": "nano-gpt/ReadyArt/The-Omega-Abomination-L-70B-v1.0",
-    "name": "The Omega Abomination V1",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-01",
-    "last_updated": "2024-12-01",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.7,
-      "output": 0.95
-    },
-    "limit": {
-      "context": 16384,
-      "output": 16384
     }
   },
   {
@@ -71952,33 +72107,6 @@
     }
   },
   {
-    "id": "nano-gpt/TEE/deepseek-r1",
-    "name": "DeepSeek R1 0528 TEE",
-    "family": "deepseek",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-05-28",
-    "last_updated": "2025-05-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 2.0,
-      "output": 2.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 65536
-    }
-  },
-  {
     "id": "nano-gpt/TEE/deepseek-v3.1",
     "name": "DeepSeek V3.1 TEE",
     "family": "deepseek",
@@ -72033,6 +72161,60 @@
     }
   },
   {
+    "id": "nano-gpt/TEE/deepseek-v4-pro",
+    "name": "DeepSeek V4 Pro TEE",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-04-25",
+    "last_updated": "2026-04-25",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 5.25,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 800000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/TEE/deepseek-v4-pro:thinking",
+    "name": "DeepSeek V4 Pro Thinking TEE",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-04-29",
+    "last_updated": "2026-04-29",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 5.25,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 800000,
+      "output": 65536
+    }
+  },
+  {
     "id": "nano-gpt/TEE/gemma-3-27b-it",
     "name": "Gemma 3 27B TEE",
     "family": "gemma",
@@ -72060,14 +72242,40 @@
     }
   },
   {
-    "id": "nano-gpt/TEE/glm-4.6",
-    "name": "GLM 4.6 TEE",
-    "family": "glm",
-    "attachment": false,
+    "id": "nano-gpt/TEE/gemma-4-26b-a4b-uncensored",
+    "name": "Gemma 4 26B A4B Uncensored TEE",
+    "attachment": true,
     "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-09-30",
-    "last_updated": "2025-09-30",
+    "tool_call": true,
+    "release_date": "2026-05-23",
+    "last_updated": "2026-05-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.7
+    },
+    "limit": {
+      "context": 65536,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/TEE/gemma-4-31b-it",
+    "name": "Gemma 4 31B IT TEE",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-26",
+    "last_updated": "2026-05-26",
     "modalities": {
       "input": [
         "text"
@@ -72078,12 +72286,64 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.75,
-      "output": 2.0
+      "input": 0.15,
+      "output": 0.46
     },
     "limit": {
-      "context": 203000,
-      "output": 65535
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "nano-gpt/TEE/gemma4-31b",
+    "name": "Gemma 4 31B",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-04-04",
+    "last_updated": "2026-04-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.45,
+      "output": 1.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 131072
+    }
+  },
+  {
+    "id": "nano-gpt/TEE/gemma4-31b:thinking",
+    "name": "Gemma 4 31B Thinking TEE",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-05-02",
+    "last_updated": "2026-05-02",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.45,
+      "output": 1.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 131072
     }
   },
   {
@@ -72168,6 +72428,60 @@
     }
   },
   {
+    "id": "nano-gpt/TEE/glm-5.1",
+    "name": "GLM 5.1 TEE",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-04-20",
+    "last_updated": "2026-04-20",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 5.25,
+      "cache_read": 0.3
+    },
+    "limit": {
+      "context": 202752,
+      "output": 65535
+    }
+  },
+  {
+    "id": "nano-gpt/TEE/glm-5.1-thinking",
+    "name": "GLM 5.1 Thinking TEE",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-04-20",
+    "last_updated": "2026-04-20",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 5.25,
+      "cache_read": 0.3
+    },
+    "limit": {
+      "context": 202752,
+      "output": 65535
+    }
+  },
+  {
     "id": "nano-gpt/TEE/gpt-oss-120b",
     "name": "GPT-OSS 120B TEE",
     "family": "gpt-oss",
@@ -72219,33 +72533,6 @@
     "limit": {
       "context": 131072,
       "output": 8192
-    }
-  },
-  {
-    "id": "nano-gpt/TEE/kimi-k2-thinking",
-    "name": "Kimi K2 Thinking TEE",
-    "family": "kimi-thinking",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-11-06",
-    "last_updated": "2025-11-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 2.0,
-      "output": 2.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 65535
     }
   },
   {
@@ -72303,6 +72590,34 @@
     }
   },
   {
+    "id": "nano-gpt/TEE/kimi-k2.6",
+    "name": "Kimi K2.6 TEE",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 5.25,
+      "cache_read": 0.375
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
     "id": "nano-gpt/TEE/llama3-3-70b",
     "name": "Llama 3.3 70B",
     "family": "llama",
@@ -72330,14 +72645,13 @@
     }
   },
   {
-    "id": "nano-gpt/TEE/minimax-m2.1",
-    "name": "MiniMax M2.1 TEE",
-    "family": "minimax",
+    "id": "nano-gpt/TEE/minimax-m2.5",
+    "name": "MiniMax M2.5 TEE",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
-    "release_date": "2025-12-23",
-    "last_updated": "2025-12-23",
+    "release_date": "2026-04-20",
+    "last_updated": "2026-04-20",
     "modalities": {
       "input": [
         "text"
@@ -72348,11 +72662,11 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.3,
-      "output": 1.2
+      "input": 0.2,
+      "output": 1.38
     },
     "limit": {
-      "context": 200000,
+      "context": 196608,
       "output": 131072
     }
   },
@@ -72404,7 +72718,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.15,
-      "output": 0.44999999999999996
+      "output": 0.45
     },
     "limit": {
       "context": 262000,
@@ -72412,14 +72726,13 @@
     }
   },
   {
-    "id": "nano-gpt/TEE/qwen3-coder",
-    "name": "Qwen3 Coder 480B TEE",
-    "family": "qwen",
+    "id": "nano-gpt/TEE/qwen3.5-122b-a10b",
+    "name": "Qwen3.5 122B A10B TEE",
     "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-07-23",
-    "last_updated": "2025-07-23",
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-26",
+    "last_updated": "2026-05-26",
     "modalities": {
       "input": [
         "text"
@@ -72430,12 +72743,40 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 1.5,
-      "output": 2.0
+      "input": 0.46,
+      "output": 3.68
     },
     "limit": {
-      "context": 128000,
-      "output": 32768
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "nano-gpt/TEE/qwen3.5-27b",
+    "name": "Qwen3.5 27B TEE",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-03-13",
+    "last_updated": "2026-03-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 2.4
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
     }
   },
   {
@@ -72463,6 +72804,33 @@
     "limit": {
       "context": 258048,
       "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/TEE/qwen3.6-35b-a3b-uncensored",
+    "name": "Qwen3.6 35B A3B Uncensored TEE",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-23",
+    "last_updated": "2026-05-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 1.5
+    },
+    "limit": {
+      "context": 131072,
+      "output": 131072
     }
   },
   {
@@ -72574,41 +72942,13 @@
     }
   },
   {
-    "id": "nano-gpt/THUDM/GLM-Z1-Rumination-32B",
-    "name": "GLM Z1 Rumination 32B 0414",
-    "family": "glm-z",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-04-15",
-    "last_updated": "2025-04-15",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.2
-    },
-    "limit": {
-      "context": 32000,
-      "output": 65536
-    }
-  },
-  {
-    "id": "nano-gpt/TheDrummer 2/Anubis-70B-v1",
+    "id": "nano-gpt/TheDrummer/Anubis-70B-v1",
     "name": "Anubis 70B v1",
-    "family": "llama",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "release_date": "2024-07-01",
-    "last_updated": "2024-07-01",
+    "release_date": "2024-01-01",
+    "last_updated": "2024-01-01",
     "modalities": {
       "input": [
         "text"
@@ -72628,14 +72968,13 @@
     }
   },
   {
-    "id": "nano-gpt/TheDrummer 2/Anubis-70B-v1.1",
+    "id": "nano-gpt/TheDrummer/Anubis-70B-v1.1",
     "name": "Anubis 70B v1.1",
-    "family": "llama",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "release_date": "2024-07-01",
-    "last_updated": "2024-07-01",
+    "release_date": "2024-01-01",
+    "last_updated": "2024-01-01",
     "modalities": {
       "input": [
         "text"
@@ -72655,9 +72994,8 @@
     }
   },
   {
-    "id": "nano-gpt/TheDrummer 2/Cydonia-24B-v2",
+    "id": "nano-gpt/TheDrummer/Cydonia-24B-v2",
     "name": "The Drummer Cydonia 24B v2",
-    "family": "llama",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
@@ -72682,9 +73020,8 @@
     }
   },
   {
-    "id": "nano-gpt/TheDrummer 2/Cydonia-24B-v4",
+    "id": "nano-gpt/TheDrummer/Cydonia-24B-v4",
     "name": "The Drummer Cydonia 24B v4",
-    "family": "llama",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
@@ -72709,9 +73046,8 @@
     }
   },
   {
-    "id": "nano-gpt/TheDrummer 2/Cydonia-24B-v4.1",
+    "id": "nano-gpt/TheDrummer/Cydonia-24B-v4.1",
     "name": "The Drummer Cydonia 24B v4.1",
-    "family": "llama",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
@@ -72736,9 +73072,8 @@
     }
   },
   {
-    "id": "nano-gpt/TheDrummer 2/Cydonia-24B-v4.3",
+    "id": "nano-gpt/TheDrummer/Cydonia-24B-v4.3",
     "name": "The Drummer Cydonia 24B v4.3",
-    "family": "llama",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
@@ -72763,9 +73098,8 @@
     }
   },
   {
-    "id": "nano-gpt/TheDrummer 2/Magidonia-24B-v4.3",
+    "id": "nano-gpt/TheDrummer/Magidonia-24B-v4.3",
     "name": "The Drummer Magidonia 24B v4.3",
-    "family": "llama",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
@@ -72790,14 +73124,13 @@
     }
   },
   {
-    "id": "nano-gpt/TheDrummer 2/Rocinante-12B-v1.1",
+    "id": "nano-gpt/TheDrummer/Rocinante-12B-v1.1",
     "name": "Rocinante 12b",
-    "family": "llama",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "release_date": "2024-07-01",
-    "last_updated": "2024-07-01",
+    "release_date": "2024-01-01",
+    "last_updated": "2024-01-01",
     "modalities": {
       "input": [
         "text"
@@ -72817,14 +73150,13 @@
     }
   },
   {
-    "id": "nano-gpt/TheDrummer 2/UnslopNemo-12B-v4.1",
-    "name": "UnslopNemo 12b v4",
-    "family": "llama",
+    "id": "nano-gpt/TheDrummer/Skyfall-31B-v4.2",
+    "name": "TheDrummer Skyfall 31B v4.2",
     "attachment": true,
     "reasoning": false,
     "tool_call": false,
-    "release_date": "2024-07-01",
-    "last_updated": "2024-07-01",
+    "release_date": "2026-03-26",
+    "last_updated": "2026-03-26",
     "modalities": {
       "input": [
         "text",
@@ -72836,8 +73168,35 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.49299999999999994,
-      "output": 0.49299999999999994
+      "input": 0.55,
+      "output": 0.8
+    },
+    "limit": {
+      "context": 131072,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/TheDrummer/UnslopNemo-12B-v4.1",
+    "name": "UnslopNemo 12b v4",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2024-01-01",
+    "last_updated": "2024-01-01",
+    "modalities": {
+      "input": [
+        "text",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.493,
+      "output": 0.493
     },
     "limit": {
       "context": 32768,
@@ -72845,9 +73204,8 @@
     }
   },
   {
-    "id": "nano-gpt/TheDrummer 2/skyfall-36b-v2",
+    "id": "nano-gpt/TheDrummer/skyfall-36b-v2",
     "name": "TheDrummer Skyfall 36B V2",
-    "family": "llama",
     "attachment": true,
     "reasoning": false,
     "tool_call": false,
@@ -72864,8 +73222,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.49299999999999994,
-      "output": 0.49299999999999994
+      "input": 0.493,
+      "output": 0.493
     },
     "limit": {
       "context": 64000,
@@ -72891,12 +73249,38 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.13999999999999999,
+      "input": 0.14,
       "output": 0.6
     },
     "limit": {
       "context": 128000,
       "output": 40960
+    }
+  },
+  {
+    "id": "nano-gpt/Unbabel/M-Prometheus-14B",
+    "name": "M-Prometheus 14B",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-05-29",
+    "last_updated": "2026-05-29",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.2,
+      "output": 0.2
+    },
+    "limit": {
+      "context": 32768,
+      "output": 8192
     }
   },
   {
@@ -73008,6 +73392,59 @@
     }
   },
   {
+    "id": "nano-gpt/aion-labs/aion-2.0",
+    "name": "AionLabs: Aion-2.0",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-02-23",
+    "last_updated": "2026-02-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.8,
+      "output": 1.6
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    }
+  },
+  {
+    "id": "nano-gpt/aion-labs/aion-2.5",
+    "name": "AionLabs: Aion-2.5",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-03-20",
+    "last_updated": "2026-03-20",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 3.0,
+      "cache_read": 0.35
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    }
+  },
+  {
     "id": "nano-gpt/aion-labs/aion-rp-llama-3.1-8b",
     "name": "Llama 3.1 8b (uncensored)",
     "family": "llama",
@@ -73032,6 +73469,62 @@
     "limit": {
       "context": 32768,
       "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/alibaba/qwen3.6-27b",
+    "name": "Qwen3.6 27B",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.203,
+      "output": 2.24
+    },
+    "limit": {
+      "context": 260096,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/alibaba/qwen3.6-27b:thinking",
+    "name": "Qwen3.6 27B Thinking",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.203,
+      "output": 2.24
+    },
+    "limit": {
+      "context": 260096,
+      "output": 65536
     }
   },
   {
@@ -73064,34 +73557,6 @@
     }
   },
   {
-    "id": "nano-gpt/allenai/molmo-2-8b",
-    "name": "Molmo 2 8B",
-    "family": "allenai",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2026-02-14",
-    "last_updated": "2026-02-14",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.2
-    },
-    "limit": {
-      "context": 36864,
-      "output": 36864
-    }
-  },
-  {
     "id": "nano-gpt/allenai/olmo-3-32b-think",
     "name": "Olmo 3 32B Think",
     "family": "allenai",
@@ -73111,64 +73576,10 @@
     "open_weights": false,
     "cost": {
       "input": 0.3,
-      "output": 0.44999999999999996
+      "output": 0.45
     },
     "limit": {
       "context": 128000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nano-gpt/allenai/olmo-3.1-32b-instruct",
-    "name": "Olmo 3.1 32B Instruct",
-    "family": "allenai",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2026-01-25",
-    "last_updated": "2026-01-25",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.6
-    },
-    "limit": {
-      "context": 65536,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nano-gpt/allenai/olmo-3.1-32b-think",
-    "name": "Olmo 3.1 32B Think",
-    "family": "allenai",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
-    "release_date": "2026-01-25",
-    "last_updated": "2026-01-25",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.15,
-      "output": 0.5
-    },
-    "limit": {
-      "context": 65536,
       "output": 8192
     }
   },
@@ -73336,6 +73747,64 @@
     }
   },
   {
+    "id": "nano-gpt/anthropic/claude-haiku",
+    "name": "Claude Haiku Latest",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-03-29",
+    "last_updated": "2026-03-29",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 5.0,
+      "cache_read": 0.1
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "nano-gpt/anthropic/claude-opus",
+    "name": "Claude Opus Latest",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-03-29",
+    "last_updated": "2026-03-29",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 4.998,
+      "output": 25.007,
+      "cache_read": 0.4998
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "nano-gpt/anthropic/claude-opus-4.6",
     "name": "Claude 4.6 Opus",
     "family": "claude-opus",
@@ -73481,6 +73950,151 @@
     }
   },
   {
+    "id": "nano-gpt/anthropic/claude-opus-4.7",
+    "name": "Claude 4.7 Opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-04-16",
+    "last_updated": "2026-04-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 4.998,
+      "output": 25.007,
+      "cache_read": 0.4998
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/anthropic/claude-opus-4.7:thinking",
+    "name": "Claude 4.7 Opus Thinking",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-04-16",
+    "last_updated": "2026-04-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 4.998,
+      "output": 25.007,
+      "cache_read": 0.4998
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/anthropic/claude-opus-4.8",
+    "name": "Claude Opus 4.8",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-28",
+    "last_updated": "2026-05-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 4.998,
+      "output": 25.007,
+      "cache_read": 0.4998
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/anthropic/claude-opus-4.8:thinking",
+    "name": "Claude Opus 4.8 Thinking",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-28",
+    "last_updated": "2026-05-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 4.998,
+      "output": 25.007,
+      "cache_read": 0.4998
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/anthropic/claude-sonnet",
+    "name": "Claude Sonnet Latest",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-03-01",
+    "last_updated": "2026-03-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.992,
+      "output": 14.994,
+      "cache_read": 0.2992
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "nano-gpt/anthropic/claude-sonnet-4.6",
     "name": "Claude Sonnet 4.6",
     "family": "claude-sonnet",
@@ -73541,14 +74155,13 @@
     }
   },
   {
-    "id": "nano-gpt/arcee-ai/trinity-large",
-    "name": "Trinity Large",
-    "family": "trinity",
+    "id": "nano-gpt/arcee-ai/trinity-large-thinking",
+    "name": "Trinity Large Thinking",
     "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-12-01",
-    "last_updated": "2025-12-01",
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-04-01",
+    "last_updated": "2026-04-01",
     "modalities": {
       "input": [
         "text"
@@ -73560,11 +74173,11 @@
     "open_weights": false,
     "cost": {
       "input": 0.25,
-      "output": 1.0
+      "output": 0.9
     },
     "limit": {
-      "context": 131072,
-      "output": 8192
+      "context": 262144,
+      "output": 80000
     }
   },
   {
@@ -73858,33 +74471,6 @@
     }
   },
   {
-    "id": "nano-gpt/baidu/ernie-4.5-300b-a47b",
-    "name": "ERNIE 4.5 300B",
-    "family": "ernie",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-06-30",
-    "last_updated": "2025-06-30",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.35,
-      "output": 1.15
-    },
-    "limit": {
-      "context": 131072,
-      "output": 16384
-    }
-  },
-  {
     "id": "nano-gpt/baidu/ernie-4.5-vl-28b-a3b",
     "name": "ERNIE 4.5 VL 28B",
     "family": "ernie",
@@ -73904,7 +74490,7 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.13999999999999999,
+      "input": 0.14,
       "output": 0.5599999999999999
     },
     "limit": {
@@ -74018,27 +74604,29 @@
     }
   },
   {
-    "id": "nano-gpt/chroma",
-    "name": "Chroma",
-    "attachment": true,
+    "id": "nano-gpt/bytedance-seed/seed-2.0-lite",
+    "name": "ByteDance Seed 2.0 Lite",
+    "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": true,
-    "release_date": "2025-08-12",
-    "last_updated": "2025-08-12",
+    "release_date": "2026-03-10",
+    "last_updated": "2026-03-10",
     "modalities": {
       "input": [
         "text"
       ],
       "output": [
-        "image"
+        "text"
       ]
     },
     "open_weights": false,
-    "cost": {},
+    "cost": {
+      "input": 0.25,
+      "output": 2.0
+    },
     "limit": {
-      "context": 0,
-      "output": 0
+      "context": 262144,
+      "output": 131072
     }
   },
   {
@@ -74097,228 +74685,6 @@
     }
   },
   {
-    "id": "nano-gpt/claude-3.5-sonnet",
-    "name": "Claude 3.5 Sonnet",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "release_date": "2025-08-26",
-    "last_updated": "2025-08-26",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 2.992,
-      "output": 14.994
-    },
-    "limit": {
-      "context": 200000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nano-gpt/claude-3.7-sonnet",
-    "name": "Claude 3.7 Sonnet",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "release_date": "2025-02-19",
-    "last_updated": "2025-02-19",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 2.992,
-      "output": 14.994
-    },
-    "limit": {
-      "context": 200000,
-      "output": 16000
-    }
-  },
-  {
-    "id": "nano-gpt/claude-3.7-sonnet-reasoner",
-    "name": "Claude 3.7 Sonnet Reasoner",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-03-29",
-    "last_updated": "2025-03-29",
-    "modalities": {
-      "input": [
-        "text",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nano-gpt/claude-3.7-sonnet-thinking",
-    "name": "Claude 3.7 Sonnet Thinking",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "release_date": "2025-02-24",
-    "last_updated": "2025-02-24",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 2.992,
-      "output": 14.994
-    },
-    "limit": {
-      "context": 200000,
-      "output": 16000
-    }
-  },
-  {
-    "id": "nano-gpt/claude-3.7-sonnet-thinking:1024",
-    "name": "Claude 3.7 Sonnet Thinking (1K)",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "release_date": "2025-02-24",
-    "last_updated": "2025-02-24",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 2.992,
-      "output": 14.994
-    },
-    "limit": {
-      "context": 200000,
-      "output": 64000
-    }
-  },
-  {
-    "id": "nano-gpt/claude-3.7-sonnet-thinking:128000",
-    "name": "Claude 3.7 Sonnet Thinking (128K)",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "release_date": "2025-02-24",
-    "last_updated": "2025-02-24",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 2.992,
-      "output": 14.994
-    },
-    "limit": {
-      "context": 200000,
-      "output": 64000
-    }
-  },
-  {
-    "id": "nano-gpt/claude-3.7-sonnet-thinking:32768",
-    "name": "Claude 3.7 Sonnet Thinking (32K)",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "release_date": "2025-07-15",
-    "last_updated": "2025-07-15",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 2.992,
-      "output": 14.994
-    },
-    "limit": {
-      "context": 200000,
-      "output": 64000
-    }
-  },
-  {
-    "id": "nano-gpt/claude-3.7-sonnet-thinking:8192",
-    "name": "Claude 3.7 Sonnet Thinking (8K)",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "release_date": "2025-02-24",
-    "last_updated": "2025-02-24",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 2.992,
-      "output": 14.994
-    },
-    "limit": {
-      "context": 200000,
-      "output": 64000
-    }
-  },
-  {
     "id": "nano-gpt/claude-haiku-4.5",
     "name": "Claude Haiku 4.5",
     "attachment": true,
@@ -74340,6 +74706,35 @@
     "cost": {
       "input": 1.0,
       "output": 5.0
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "nano-gpt/claude-haiku-4.5-20251001-thinking",
+    "name": "Claude Haiku 4.5 Thinking",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2025-10-15",
+    "last_updated": "2025-10-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 5.0,
+      "cache_read": 0.1
     },
     "limit": {
       "context": 200000,
@@ -74963,6 +75358,89 @@
     }
   },
   {
+    "id": "nano-gpt/claw-high",
+    "name": "Claw High",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-11",
+    "last_updated": "2026-05-11",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 4.998,
+      "output": 25.007
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/claw-low",
+    "name": "Claw Low",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-11",
+    "last_updated": "2026-05-11",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 1.5,
+      "cache_read": 0.025
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/claw-medium",
+    "name": "Claw Medium",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-11",
+    "last_updated": "2026-05-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2
+    },
+    "limit": {
+      "context": 204800,
+      "output": 131072
+    }
+  },
+  {
     "id": "nano-gpt/cognitivecomputations/dolphin-2.9.2-qwen2-72b",
     "name": "Dolphin 72b",
     "family": "qwen",
@@ -75044,6 +75522,33 @@
     }
   },
   {
+    "id": "nano-gpt/command-a-plus-05",
+    "name": "Cohere Command A+ (05/2026)",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-05-22",
+    "last_updated": "2026-05-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 10.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 64000
+    }
+  },
+  {
     "id": "nano-gpt/command-a-reasoning-08",
     "name": "Cohere Command A (08/2025)",
     "attachment": false,
@@ -75121,33 +75626,6 @@
     "limit": {
       "context": 128000,
       "output": 32768
-    }
-  },
-  {
-    "id": "nano-gpt/deepcogito/cogito-v2.1-671b",
-    "name": "Cogito v2.1 671B MoE",
-    "family": "cogito",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
-    "release_date": "2025-11-19",
-    "last_updated": "2025-11-19",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.25,
-      "output": 1.25
-    },
-    "limit": {
-      "context": 128000,
-      "output": 16384
     }
   },
   {
@@ -75306,7 +75784,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.27999999999999997,
-      "output": 0.42000000000000004
+      "output": 0.42
     },
     "limit": {
       "context": 163840,
@@ -75333,7 +75811,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.27999999999999997,
-      "output": 0.42000000000000004
+      "output": 0.42
     },
     "limit": {
       "context": 163840,
@@ -75551,6 +76029,33 @@
     }
   },
   {
+    "id": "nano-gpt/deepseek/deepseek",
+    "name": "DeepSeek Latest",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-03",
+    "last_updated": "2026-05-03",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.1,
+      "output": 2.2,
+      "cache_read": 0.11
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 384000
+    }
+  },
+  {
     "id": "nano-gpt/deepseek/deepseek-prover-v2-671b",
     "name": "DeepSeek Prover v2 671B",
     "family": "deepseek",
@@ -75598,7 +76103,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.27999999999999997,
-      "output": 0.42000000000000004
+      "output": 0.42
     },
     "limit": {
       "context": 163000,
@@ -75626,7 +76131,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.27999999999999997,
-      "output": 0.42000000000000004
+      "output": 0.42
     },
     "limit": {
       "context": 163000,
@@ -75654,11 +76159,173 @@
     "open_weights": false,
     "cost": {
       "input": 0.27999999999999997,
-      "output": 0.42000000000000004
+      "output": 0.42
     },
     "limit": {
       "context": 163000,
       "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/deepseek/deepseek-v4-flash",
+    "name": "DeepSeek V4 Flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.028
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 384000
+    }
+  },
+  {
+    "id": "nano-gpt/deepseek/deepseek-v4-flash:thinking",
+    "name": "DeepSeek V4 Flash (Thinking)",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.028
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 384000
+    }
+  },
+  {
+    "id": "nano-gpt/deepseek/deepseek-v4-pro",
+    "name": "DeepSeek V4 Pro",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.1,
+      "output": 2.2,
+      "cache_read": 0.11
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 384000
+    }
+  },
+  {
+    "id": "nano-gpt/deepseek/deepseek-v4-pro-cheaper",
+    "name": "DeepSeek V4 Pro Cheaper",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-04-25",
+    "last_updated": "2026-04-25",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.435,
+      "output": 0.87,
+      "cache_read": 0.003625
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 384000
+    }
+  },
+  {
+    "id": "nano-gpt/deepseek/deepseek-v4-pro-cheaper:thinking",
+    "name": "DeepSeek V4 Pro Cheaper (Thinking)",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-04-25",
+    "last_updated": "2026-04-25",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.435,
+      "output": 0.87,
+      "cache_read": 0.003625
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 384000
+    }
+  },
+  {
+    "id": "nano-gpt/deepseek/deepseek-v4-pro:thinking",
+    "name": "DeepSeek V4 Pro (Thinking)",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.1,
+      "output": 2.2,
+      "cache_read": 0.11
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 384000
     }
   },
   {
@@ -76084,32 +76751,6 @@
     }
   },
   {
-    "id": "nano-gpt/doubao-seed-code-preview",
-    "name": "Doubao Seed Code Preview",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
-    "release_date": "2025-11-13",
-    "last_updated": "2025-11-13",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.1,
-      "output": 0.4
-    },
-    "limit": {
-      "context": 256000,
-      "output": 16384
-    }
-  },
-  {
     "id": "nano-gpt/ernie-4.5-8k-preview",
     "name": "Ernie 4.5 8k Preview",
     "attachment": false,
@@ -76190,8 +76831,8 @@
     }
   },
   {
-    "id": "nano-gpt/ernie-5.0-thinking",
-    "name": "Ernie 5.0 Thinking",
+    "id": "nano-gpt/ernie-5.0-thinking-preview",
+    "name": "Ernie 5.0 Thinking Preview",
     "attachment": true,
     "reasoning": true,
     "tool_call": false,
@@ -76217,17 +76858,18 @@
     }
   },
   {
-    "id": "nano-gpt/ernie-5.0-thinking-preview",
-    "name": "Ernie 5.0 Thinking Preview",
+    "id": "nano-gpt/ernie-5.1",
+    "name": "ERNIE 5.1",
     "attachment": true,
-    "reasoning": true,
+    "reasoning": false,
     "tool_call": false,
-    "release_date": "2025-11-18",
-    "last_updated": "2025-11-18",
+    "release_date": "2026-05-10",
+    "last_updated": "2026-05-10",
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "video"
       ],
       "output": [
         "text"
@@ -76235,12 +76877,42 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 1.1,
-      "output": 2.0
+      "input": 0.75,
+      "output": 3.0,
+      "cache_read": 0.75
     },
     "limit": {
-      "context": 128000,
-      "output": 16384
+      "context": 119000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "nano-gpt/ernie-5.1:thinking",
+    "name": "ERNIE 5.1 Thinking",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-05-10",
+    "last_updated": "2026-05-10",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 3.0,
+      "cache_read": 0.75
+    },
+    "limit": {
+      "context": 119000,
+      "output": 64000
     }
   },
   {
@@ -76586,33 +77258,6 @@
     },
     "limit": {
       "context": 32767,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nano-gpt/gemini-2.0-flash-lite",
-    "name": "Gemini 2.0 Flash Lite",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-12-11",
-    "last_updated": "2024-12-11",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.0748,
-      "output": 0.306
-    },
-    "limit": {
-      "context": 1000000,
       "output": 8192
     }
   },
@@ -77214,60 +77859,6 @@
     }
   },
   {
-    "id": "nano-gpt/gemini-3-pro-preview",
-    "name": "Gemini 3 Pro",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "release_date": "2025-11-18",
-    "last_updated": "2025-11-18",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 2.0,
-      "output": 12.0
-    },
-    "limit": {
-      "context": 1048756,
-      "output": 65536
-    }
-  },
-  {
-    "id": "nano-gpt/gemini-3-pro-preview-thinking",
-    "name": "Gemini 3 Pro Thinking",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "release_date": "2025-11-18",
-    "last_updated": "2025-11-18",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 2.0,
-      "output": 12.0
-    },
-    "limit": {
-      "context": 1048756,
-      "output": 65536
-    }
-  },
-  {
     "id": "nano-gpt/gemini-exp",
     "name": "Gemini 2.0 Pro 1206",
     "attachment": true,
@@ -77292,6 +77883,146 @@
     "limit": {
       "context": 2097152,
       "output": 8192
+    }
+  },
+  {
+    "id": "nano-gpt/gemma-4-31B-Fabled",
+    "name": "Gemma 4 31B Fabled",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-05-02",
+    "last_updated": "2026-05-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/gemma-4-31B-Garnet",
+    "name": "Gemma 4 31B Garnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-05-02",
+    "last_updated": "2026-05-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/gemma-4-31B-K1-v5",
+    "name": "Gemma 4 31B K1 v5",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-05-02",
+    "last_updated": "2026-05-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/gemma-4-31B-Larkspur-v0.5",
+    "name": "Gemma 4 31B Larkspur v0.5",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-05-02",
+    "last_updated": "2026-05-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/gemma-4-31B-MeroMero",
+    "name": "Gemma 4 31B MeroMero",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-05-02",
+    "last_updated": "2026-05-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.306,
+      "output": 0.306
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
     }
   },
   {
@@ -77639,6 +78370,232 @@
     }
   },
   {
+    "id": "nano-gpt/google/gemini-3.1-flash-lite",
+    "name": "Gemini 3.1 Flash Lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-03-03",
+    "last_updated": "2026-03-03",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 1.5,
+      "cache_read": 0.025
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/google/gemini-3.1-pro-preview",
+    "name": "Gemini 3.1 Pro (Preview)",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-02-19",
+    "last_updated": "2026-02-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 12.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1048756,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/google/gemini-3.1-pro-preview-customtools",
+    "name": "Gemini 3.1 Pro (Preview Custom Tools)",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-02-27",
+    "last_updated": "2026-02-27",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 12.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1048756,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/google/gemini-3.1-pro-preview-high",
+    "name": "Gemini 3.1 Pro (Preview High)",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-02-21",
+    "last_updated": "2026-02-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 12.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1048756,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/google/gemini-3.1-pro-preview-low",
+    "name": "Gemini 3.1 Pro (Preview Low)",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-02-21",
+    "last_updated": "2026-02-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 12.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1048756,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/google/gemini-3.5-flash",
+    "name": "Gemini 3.5 Flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-19",
+    "last_updated": "2026-05-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 9.0,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/google/gemini-3.5-flash-thinking",
+    "name": "Gemini 3.5 Flash Thinking",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-05-19",
+    "last_updated": "2026-05-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 9.0,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/google/gemini-flash",
+    "name": "Gemini Flash Latest",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-03-29",
+    "last_updated": "2026-03-29",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 9.0,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 1048756,
+      "output": 65536
+    }
+  },
+  {
     "id": "nano-gpt/google/gemini-flash-1.5",
     "name": "Gemini 1.5 Flash",
     "family": "gemini-flash",
@@ -77666,42 +78623,17 @@
     }
   },
   {
-    "id": "nano-gpt/grok-3-beta",
-    "name": "Grok 3 Beta",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-09-29",
-    "last_updated": "2025-09-29",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0
-    },
-    "limit": {
-      "context": 131072,
-      "output": 131072
-    }
-  },
-  {
-    "id": "nano-gpt/grok-3-fast-beta",
-    "name": "Grok 3 Fast Beta",
+    "id": "nano-gpt/google/gemini-flash-lite",
+    "name": "Gemini Flash Lite Latest",
     "attachment": true,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-03-29",
+    "last_updated": "2026-03-29",
     "modalities": {
       "input": [
         "text",
+        "image",
         "pdf"
       ],
       "output": [
@@ -77710,22 +78642,216 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 5.0,
-      "output": 25.0
+      "input": 0.25,
+      "output": 1.5,
+      "cache_read": 0.025
     },
     "limit": {
-      "context": 131072,
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/google/gemini-pro",
+    "name": "Gemini Pro Latest",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-03-29",
+    "last_updated": "2026-03-29",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 12.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1048756,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/google/gemma-4-26b-a4b-it",
+    "name": "Gemma 4 26B A4B",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.13,
+      "output": 0.4
+    },
+    "limit": {
+      "context": 262144,
       "output": 131072
     }
   },
   {
-    "id": "nano-gpt/grok-3-mini-beta",
-    "name": "Grok 3 Mini Beta",
-    "attachment": false,
-    "reasoning": false,
+    "id": "nano-gpt/google/gemma-4-26b-a4b-it:thinking",
+    "name": "Gemma 4 26B A4B Thinking",
+    "attachment": true,
+    "reasoning": true,
     "tool_call": false,
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.13,
+      "output": 0.4
+    },
+    "limit": {
+      "context": 262144,
+      "output": 131072
+    }
+  },
+  {
+    "id": "nano-gpt/google/gemma-4-31b-it",
+    "name": "Gemma 4 31B",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.35
+    },
+    "limit": {
+      "context": 262144,
+      "output": 131072
+    }
+  },
+  {
+    "id": "nano-gpt/google/gemma-4-31b-it:thinking",
+    "name": "Gemma 4 31B Thinking",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.35
+    },
+    "limit": {
+      "context": 262144,
+      "output": 131072
+    }
+  },
+  {
+    "id": "nano-gpt/hermes-high",
+    "name": "Hermes High",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-11",
+    "last_updated": "2026-05-11",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 4.998,
+      "output": 25.007
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/hermes-low",
+    "name": "Hermes Low",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-11",
+    "last_updated": "2026-05-11",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 1.5,
+      "cache_read": 0.025
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/hermes-medium",
+    "name": "Hermes Medium",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-11",
+    "last_updated": "2026-05-11",
     "modalities": {
       "input": [
         "text"
@@ -77737,24 +78863,25 @@
     "open_weights": false,
     "cost": {
       "input": 0.3,
-      "output": 0.5
+      "output": 1.2
     },
     "limit": {
-      "context": 131072,
+      "context": 204800,
       "output": 131072
     }
   },
   {
-    "id": "nano-gpt/grok-3-mini-fast-beta",
-    "name": "Grok 3 Mini Fast Beta",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-02-17",
-    "last_updated": "2025-02-17",
+    "id": "nano-gpt/holo3-35b-a3b",
+    "name": "Holo3-35B-A3B",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2024-01-01",
+    "last_updated": "2024-01-01",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image"
       ],
       "output": [
         "text"
@@ -77762,36 +78889,39 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.6,
-      "output": 4.0
+      "input": 0.25,
+      "output": 1.8
     },
     "limit": {
-      "context": 131072,
-      "output": 131072
+      "context": 65536,
+      "output": 65536
     }
   },
   {
-    "id": "nano-gpt/hidream",
-    "name": "Hidream",
+    "id": "nano-gpt/holo3-35b-a3b:thinking",
+    "name": "Holo3-35B-A3B Thinking",
     "attachment": true,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
+    "reasoning": true,
+    "tool_call": true,
     "release_date": "2024-01-01",
     "last_updated": "2024-01-01",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image"
       ],
       "output": [
-        "image"
+        "text"
       ]
     },
     "open_weights": false,
-    "cost": {},
+    "cost": {
+      "input": 0.25,
+      "output": 1.8
+    },
     "limit": {
-      "context": 0,
-      "output": 0
+      "context": 65536,
+      "output": 65536
     }
   },
   {
@@ -77849,33 +78979,6 @@
     }
   },
   {
-    "id": "nano-gpt/huihui-ai/Llama-3.1-Nemotron-70B-Instruct-HF-abliterated",
-    "name": "Nemotron 3.1 70B abliterated",
-    "family": "nemotron",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-07-23",
-    "last_updated": "2024-07-23",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.7,
-      "output": 0.7
-    },
-    "limit": {
-      "context": 16384,
-      "output": 16384
-    }
-  },
-  {
     "id": "nano-gpt/huihui-ai/Llama-3.3-70B-Instruct-abliterated",
     "name": "Llama 3.3 70B Instruct abliterated",
     "family": "llama",
@@ -77930,32 +79033,6 @@
     }
   },
   {
-    "id": "nano-gpt/hunyuan-t1",
-    "name": "Hunyuan T1",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-03-22",
-    "last_updated": "2025-03-22",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.17,
-      "output": 0.66
-    },
-    "limit": {
-      "context": 256000,
-      "output": 16384
-    }
-  },
-  {
     "id": "nano-gpt/hunyuan-turbos",
     "name": "Hunyuan Turbo S",
     "attachment": false,
@@ -77979,6 +79056,112 @@
     "limit": {
       "context": 24000,
       "output": 8192
+    }
+  },
+  {
+    "id": "nano-gpt/ibm-granite/granite-4.1-8b",
+    "name": "Granite 4.1 8B",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "release_date": "2026-04-29",
+    "last_updated": "2026-04-29",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.05,
+      "output": 0.1,
+      "cache_read": 0.05
+    },
+    "limit": {
+      "context": 131072,
+      "output": 131072
+    }
+  },
+  {
+    "id": "nano-gpt/inclusionai/ling-2.6-1t",
+    "name": "Ling 2.6 1T",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 2.5,
+      "cache_read": 0.06
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "nano-gpt/inclusionai/ling-2.6-flash",
+    "name": "Ling 2.6 Flash",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.08,
+      "output": 0.24
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "nano-gpt/inclusionai/ring-2.6-1t",
+    "name": "Ring 2.6 1T",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-08",
+    "last_updated": "2026-05-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 3.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
     }
   },
   {
@@ -78273,6 +79456,32 @@
     }
   },
   {
+    "id": "nano-gpt/kwaipilot/kat-coder-pro-v2",
+    "name": "KAT Coder Pro V2",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-03-28",
+    "last_updated": "2026-03-28",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2
+    },
+    "limit": {
+      "context": 256000,
+      "output": 80000
+    }
+  },
+  {
     "id": "nano-gpt/learnlm-1.5-pro-experimental",
     "name": "Gemini LearnLM Experimental",
     "attachment": false,
@@ -78296,6 +79505,32 @@
     "limit": {
       "context": 32767,
       "output": 8192
+    }
+  },
+  {
+    "id": "nano-gpt/liquid/lfm-2-24b-a2b",
+    "name": "LFM2 24B A2B",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2025-12-20",
+    "last_updated": "2025-12-20",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.03,
+      "output": 0.12
+    },
+    "limit": {
+      "context": 32768,
+      "output": 32768
     }
   },
   {
@@ -78380,14 +79615,13 @@
     }
   },
   {
-    "id": "nano-gpt/meituan-longcat/LongCat-Flash-Chat-FP8",
-    "name": "LongCat Flash",
-    "family": "longcat",
+    "id": "nano-gpt/mercury-2",
+    "name": "Mercury 2",
     "attachment": false,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
-    "release_date": "2025-08-31",
-    "last_updated": "2025-08-31",
+    "release_date": "2024-01-01",
+    "last_updated": "2024-01-01",
     "modalities": {
       "input": [
         "text"
@@ -78398,12 +79632,13 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.15,
-      "output": 0.7
+      "input": 0.25,
+      "output": 0.75,
+      "cache_read": 0.025
     },
     "limit": {
       "context": 128000,
-      "output": 32768
+      "output": 50000
     }
   },
   {
@@ -78459,33 +79694,6 @@
     "limit": {
       "context": 131072,
       "output": 8192
-    }
-  },
-  {
-    "id": "nano-gpt/meta-llama/llama-3.2-90b-vision-instruct",
-    "name": "Llama 3.2 Medium",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-09-25",
-    "last_updated": "2025-09-25",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.9009999999999999,
-      "output": 0.9009999999999999
-    },
-    "limit": {
-      "context": 131072,
-      "output": 16384
     }
   },
   {
@@ -78572,34 +79780,6 @@
     }
   },
   {
-    "id": "nano-gpt/microsoft/MAI-DS-R1-FP8",
-    "name": "Microsoft DeepSeek R1",
-    "family": "deepseek",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-09-25",
-    "last_updated": "2025-09-25",
-    "modalities": {
-      "input": [
-        "text",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.3,
-      "output": 0.3
-    },
-    "limit": {
-      "context": 128000,
-      "output": 8192
-    }
-  },
-  {
     "id": "nano-gpt/microsoft/wizardlm-2-8x22b",
     "name": "WizardLM-2 8x22B",
     "family": "gpt",
@@ -78628,6 +79808,34 @@
     }
   },
   {
+    "id": "nano-gpt/minimax/minimax",
+    "name": "MiniMax Latest",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-03",
+    "last_updated": "2026-05-03",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.06
+    },
+    "limit": {
+      "context": 512000,
+      "output": 80000
+    }
+  },
+  {
     "id": "nano-gpt/minimax/minimax-01",
     "name": "MiniMax 01",
     "family": "minimax",
@@ -78648,7 +79856,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.1394,
-      "output": 1.1219999999999999
+      "output": 1.122
     },
     "limit": {
       "context": 1000192,
@@ -78675,7 +79883,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.30200000000000005,
-      "output": 1.2069999999999999
+      "output": 1.207
     },
     "limit": {
       "context": 65532,
@@ -78764,14 +79972,147 @@
     }
   },
   {
-    "id": "nano-gpt/miromind-ai/mirothinker-v1.5-235b",
-    "name": "MiroThinker v1.5 235B",
-    "family": "gpt",
+    "id": "nano-gpt/minimax/minimax-m2.7-turbo",
+    "name": "MiniMax M2.7 Turbo",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.6,
+      "output": 2.4
+    },
+    "limit": {
+      "context": 204800,
+      "output": 131072
+    }
+  },
+  {
+    "id": "nano-gpt/minimax/minimax-m3",
+    "name": "MiniMax M3",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "release_date": "2026-06-01",
+    "last_updated": "2026-06-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.06
+    },
+    "limit": {
+      "context": 512000,
+      "output": 80000
+    }
+  },
+  {
+    "id": "nano-gpt/minimax/minimax-m3:thinking",
+    "name": "MiniMax M3 Thinking",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-06-01",
+    "last_updated": "2026-06-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.06
+    },
+    "limit": {
+      "context": 512000,
+      "output": 80000
+    }
+  },
+  {
+    "id": "nano-gpt/mirothinker-1.7-deepresearch",
+    "name": "MiroThinker 1.7 Deep Research",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-05-11",
+    "last_updated": "2026-05-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 4.0,
+      "output": 25.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/mirothinker-1.7-deepresearch-mini",
+    "name": "MiroThinker 1.7 Deep Research Mini",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-05-11",
+    "last_updated": "2026-05-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 10.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/mistral-code",
+    "name": "Mistral Code Latest",
     "attachment": false,
     "reasoning": false,
-    "tool_call": false,
-    "release_date": "2026-01-07",
-    "last_updated": "2026-01-07",
+    "tool_call": true,
+    "release_date": "2026-06-02",
+    "last_updated": "2026-06-02",
     "modalities": {
       "input": [
         "text"
@@ -78783,11 +80124,37 @@
     "open_weights": false,
     "cost": {
       "input": 0.3,
-      "output": 1.2
+      "output": 0.9
     },
     "limit": {
-      "context": 32768,
-      "output": 4000
+      "context": 256000,
+      "output": 32768
+    }
+  },
+  {
+    "id": "nano-gpt/mistral-code-agent",
+    "name": "Mistral Code Agent Latest",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "release_date": "2026-06-02",
+    "last_updated": "2026-06-02",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.4,
+      "output": 2.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
     }
   },
   {
@@ -78815,6 +80182,60 @@
     "limit": {
       "context": 128000,
       "output": 131072
+    }
+  },
+  {
+    "id": "nano-gpt/mistral/mistral-medium-3.5",
+    "name": "Mistral Medium 3.5",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-04-29",
+    "last_updated": "2026-04-29",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 7.5
+    },
+    "limit": {
+      "context": 256000,
+      "output": 32768
+    }
+  },
+  {
+    "id": "nano-gpt/mistral/mistral-medium-3.5:thinking",
+    "name": "Mistral Medium 3.5 Thinking",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 7.5
+    },
+    "limit": {
+      "context": 256000,
+      "output": 32768
     }
   },
   {
@@ -79035,34 +80456,6 @@
     }
   },
   {
-    "id": "nano-gpt/mistralai/mistral-7b-instruct",
-    "name": "Mistral 7B Instruct",
-    "family": "mistral",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-05-27",
-    "last_updated": "2024-05-27",
-    "modalities": {
-      "input": [
-        "text",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.0544,
-      "output": 0.0544
-    },
-    "limit": {
-      "context": 32768,
-      "output": 8192
-    }
-  },
-  {
     "id": "nano-gpt/mistralai/mistral-large",
     "name": "Mistral Large 2411",
     "family": "mistral-large",
@@ -79200,17 +80593,17 @@
     }
   },
   {
-    "id": "nano-gpt/mistralai/mistral-small-creative",
-    "name": "Mistral Small Creative",
-    "family": "mistral-small",
-    "attachment": false,
-    "reasoning": false,
+    "id": "nano-gpt/mistralai/mistral-small-4-119b",
+    "name": "Mistral Small 4 119B",
+    "attachment": true,
+    "reasoning": true,
     "tool_call": true,
-    "release_date": "2025-12-16",
-    "last_updated": "2025-12-16",
+    "release_date": "2026-03-16",
+    "last_updated": "2026-03-16",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image"
       ],
       "output": [
         "text"
@@ -79218,26 +80611,26 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.1,
-      "output": 0.3
+      "input": 0.4,
+      "output": 1.4
     },
     "limit": {
-      "context": 32768,
-      "output": 32768
+      "context": 262144,
+      "output": 16384
     }
   },
   {
-    "id": "nano-gpt/mistralai/mistral-tiny",
-    "name": "Mistral Tiny",
-    "family": "mistral",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2023-12-11",
-    "last_updated": "2024-01-01",
+    "id": "nano-gpt/mistralai/mistral-small-4-119b-2603:thinking",
+    "name": "Mistral Small 4 119B Thinking",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image"
       ],
       "output": [
         "text"
@@ -79245,12 +80638,12 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.25499999999999995,
-      "output": 0.25499999999999995
+      "input": 0.4,
+      "output": 1.4
     },
     "limit": {
-      "context": 32000,
-      "output": 8192
+      "context": 262144,
+      "output": 16384
     }
   },
   {
@@ -79335,34 +80728,6 @@
     }
   },
   {
-    "id": "nano-gpt/moonshotai/Kimi-Dev-72B",
-    "name": "Kimi Dev 72B",
-    "family": "kimi",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-04-15",
-    "last_updated": "2025-04-15",
-    "modalities": {
-      "input": [
-        "text",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.4,
-      "output": 0.4
-    },
-    "limit": {
-      "context": 128000,
-      "output": 131072
-    }
-  },
-  {
     "id": "nano-gpt/moonshotai/Kimi-K2-Instruct",
     "name": "Kimi K2 0905",
     "family": "kimi",
@@ -79387,6 +80752,34 @@
     "limit": {
       "context": 256000,
       "output": 262144
+    }
+  },
+  {
+    "id": "nano-gpt/moonshotai/kimi",
+    "name": "Kimi Latest",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-03",
+    "last_updated": "2026-05-03",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.5,
+      "output": 2.6,
+      "cache_read": 0.125
+    },
+    "limit": {
+      "context": 256000,
+      "output": 65536
     }
   },
   {
@@ -79610,6 +81003,141 @@
     }
   },
   {
+    "id": "nano-gpt/nanogpt/coding-router",
+    "name": "Coding Router",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-12",
+    "last_updated": "2026-05-12",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.1,
+      "output": 2.2,
+      "cache_read": 0.11
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/nanogpt/coding-router:high",
+    "name": "Coding Router High",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-12",
+    "last_updated": "2026-05-12",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.1,
+      "output": 2.2,
+      "cache_read": 0.11
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/nanogpt/coding-router:low",
+    "name": "Coding Router Low",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-12",
+    "last_updated": "2026-05-12",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.028
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/nanogpt/coding-router:max",
+    "name": "Coding Router Max",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-12",
+    "last_updated": "2026-05-12",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/nanogpt/coding-router:medium",
+    "name": "Coding Router Medium",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-12",
+    "last_updated": "2026-05-12",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.028
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "nano-gpt/nex-agi/deepseek-v3.1-nex-n1",
     "name": "DeepSeek V3.1 Nex N1",
     "family": "deepseek",
@@ -79629,7 +81157,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.27999999999999997,
-      "output": 0.42000000000000004
+      "output": 0.42
     },
     "limit": {
       "context": 128000,
@@ -79670,6 +81198,7 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
+    "temperature": true,
     "release_date": "2025-04-15",
     "last_updated": "2025-04-15",
     "modalities": {
@@ -79691,39 +81220,13 @@
     }
   },
   {
-    "id": "nano-gpt/nvidia/Llama-3.1-Nemotron-Ultra-253B-v1",
-    "name": "Nvidia Nemotron Ultra 253B",
-    "family": "nemotron",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-07-03",
-    "last_updated": "2025-07-03",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.4,
-      "output": 0.8
-    },
-    "limit": {
-      "context": 128000,
-      "output": 16384
-    }
-  },
-  {
     "id": "nano-gpt/nvidia/Llama-3.3-Nemotron-Super-49B-v1",
     "name": "Nvidia Nemotron Super 49B",
     "family": "nemotron",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
+    "temperature": true,
     "release_date": "2025-08-08",
     "last_updated": "2025-08-08",
     "modalities": {
@@ -79751,6 +81254,7 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
+    "temperature": true,
     "release_date": "2025-08-08",
     "last_updated": "2025-08-08",
     "modalities": {
@@ -79778,6 +81282,7 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
+    "temperature": true,
     "release_date": "2025-12-15",
     "last_updated": "2025-12-15",
     "modalities": {
@@ -79799,12 +81304,98 @@
     }
   },
   {
+    "id": "nano-gpt/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+    "name": "Nvidia Nemotron 3 Nano Omni",
+    "family": "nemotron",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-28",
+    "last_updated": "2026-04-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.105,
+      "output": 0.42
+    },
+    "limit": {
+      "context": 256000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/nvidia/nemotron-3-super-120b-a12b",
+    "name": "Nvidia Nemotron 3 Super 120B",
+    "family": "nemotron",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-01",
+    "last_updated": "2026-03-01",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.05,
+      "output": 0.25
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/nvidia/nemotron-3-super-120b-a12b:thinking",
+    "name": "Nvidia Nemotron 3 Super 120B Thinking",
+    "family": "nemotron",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-01",
+    "last_updated": "2026-03-01",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.05,
+      "output": 0.25
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
     "id": "nano-gpt/nvidia/nvidia-nemotron-nano-9b-v2",
     "name": "Nvidia Nemotron Nano 9B v2",
     "family": "nemotron",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
+    "temperature": true,
     "release_date": "2025-08-18",
     "last_updated": "2025-08-18",
     "modalities": {
@@ -79826,18 +81417,18 @@
     }
   },
   {
-    "id": "nano-gpt/openai/chatgpt-4o",
-    "name": "ChatGPT 4o",
-    "family": "gpt",
+    "id": "nano-gpt/openai/gpt",
+    "name": "GPT Latest",
     "attachment": true,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
-    "release_date": "2024-05-13",
-    "last_updated": "2024-05-13",
+    "release_date": "2026-03-29",
+    "last_updated": "2026-03-29",
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -79845,12 +81436,13 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 4.998,
-      "output": 14.993999999999998
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5
     },
     "limit": {
-      "context": 128000,
-      "output": 16384
+      "context": 1000000,
+      "output": 128000
     }
   },
   {
@@ -80162,34 +81754,6 @@
     }
   },
   {
-    "id": "nano-gpt/openai/gpt-5-chat",
-    "name": "GPT 5 Chat",
-    "family": "gpt",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": false,
-    "release_date": "2025-08-07",
-    "last_updated": "2025-08-07",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.25,
-      "output": 10.0
-    },
-    "limit": {
-      "context": 400000,
-      "output": 128000
-    }
-  },
-  {
     "id": "nano-gpt/openai/gpt-5-codex",
     "name": "GPT-5 Codex",
     "family": "gpt-codex",
@@ -80330,34 +81894,6 @@
     }
   },
   {
-    "id": "nano-gpt/openai/gpt-5.1-chat",
-    "name": "GPT 5.1 Chat",
-    "family": "gpt",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": false,
-    "release_date": "2025-11-13",
-    "last_updated": "2025-11-13",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.25,
-      "output": 10.0
-    },
-    "limit": {
-      "context": 400000,
-      "output": 128000
-    }
-  },
-  {
     "id": "nano-gpt/openai/gpt-5.1-codex",
     "name": "GPT 5.1 Codex",
     "family": "gpt-codex",
@@ -80472,34 +82008,6 @@
     }
   },
   {
-    "id": "nano-gpt/openai/gpt-5.2-chat",
-    "name": "GPT 5.2 Chat",
-    "family": "gpt",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": false,
-    "release_date": "2026-01-01",
-    "last_updated": "2026-01-01",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.75,
-      "output": 14.0
-    },
-    "limit": {
-      "context": 400000,
-      "output": 16384
-    }
-  },
-  {
     "id": "nano-gpt/openai/gpt-5.2-codex",
     "name": "GPT 5.2 Codex",
     "family": "gpt-codex",
@@ -80551,6 +82059,209 @@
     "cost": {
       "input": 21.0,
       "output": 168.0
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/openai/gpt-5.3-codex",
+    "name": "GPT 5.3 Codex",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-02-24",
+    "last_updated": "2026-02-24",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.75,
+      "output": 14.0,
+      "cache_read": 0.175
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/openai/gpt-5.4",
+    "name": "GPT 5.4",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-03-05",
+    "last_updated": "2026-03-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 15.0,
+      "cache_read": 0.25
+    },
+    "limit": {
+      "context": 922000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/openai/gpt-5.4-mini",
+    "name": "GPT 5.4 Mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 4.5,
+      "cache_read": 0.075
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/openai/gpt-5.4-nano",
+    "name": "GPT 5.4 Nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.2,
+      "output": 1.25,
+      "cache_read": 0.02
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/openai/gpt-5.4-pro",
+    "name": "GPT 5.4 Pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-03-05",
+    "last_updated": "2026-03-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 30.0,
+      "output": 180.0,
+      "cache_read": 3.0
+    },
+    "limit": {
+      "context": 922000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/openai/gpt-5.5",
+    "name": "GPT 5.5",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/openai/gpt-chat",
+    "name": "GPT Chat Latest",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "release_date": "2026-05-03",
+    "last_updated": "2026-05-03",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5
     },
     "limit": {
       "context": 400000,
@@ -80965,6 +82676,32 @@
     }
   },
   {
+    "id": "nano-gpt/owl",
+    "name": "OWL",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "release_date": "2026-05-01",
+    "last_updated": "2026-05-01",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.3
+    },
+    "limit": {
+      "context": 1048756,
+      "output": 262144
+    }
+  },
+  {
     "id": "nano-gpt/pamanseau/OpenReasoning-Nemotron-32B",
     "name": "OpenReasoning Nemotron 32B",
     "family": "nemotron",
@@ -80989,6 +82726,34 @@
     "limit": {
       "context": 32768,
       "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/perceptron/perceptron-mk1",
+    "name": "Perceptron Mk1",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-05-12",
+    "last_updated": "2026-05-12",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 1.5
+    },
+    "limit": {
+      "context": 32768,
+      "output": 8192
     }
   },
   {
@@ -81041,6 +82806,58 @@
     "limit": {
       "context": 128000,
       "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/poolside/laguna-m.1",
+    "name": "Laguna M.1",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-04-29",
+    "last_updated": "2026-04-29",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.3
+    },
+    "limit": {
+      "context": 128000,
+      "output": 32768
+    }
+  },
+  {
+    "id": "nano-gpt/poolside/laguna-xs.2",
+    "name": "Laguna XS.2",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-04-29",
+    "last_updated": "2026-04-29",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.3
+    },
+    "limit": {
+      "context": 128000,
+      "output": 32768
     }
   },
   {
@@ -81097,31 +82914,6 @@
     "limit": {
       "context": 991800,
       "output": 65536
-    }
-  },
-  {
-    "id": "nano-gpt/qwen-image",
-    "name": "Qwen Image",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2025-08-07",
-    "last_updated": "2025-08-07",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "image"
-      ]
-    },
-    "open_weights": false,
-    "cost": {},
-    "limit": {
-      "context": 0,
-      "output": 0
     }
   },
   {
@@ -81230,14 +83022,196 @@
     }
   },
   {
-    "id": "nano-gpt/qwen/Qwen3.6-35B-A3B",
-    "name": "Qwen3.6 35B A3B",
-    "family": "qwen3.6",
+    "id": "nano-gpt/qwen/Qwen2.5-Coder-32B-Instruct",
+    "name": "Qwen 2.5 Coder 32b",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
+    "release_date": "2025-07-03",
+    "last_updated": "2025-07-03",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.2006,
+      "output": 0.2006
+    },
+    "limit": {
+      "context": 32000,
+      "output": 8192
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/Qwen3-235B-A22B-Instruct",
+    "name": "Qwen 3 235b A22B 2507",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "release_date": "2025-07-25",
+    "last_updated": "2025-07-25",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.13,
+      "output": 0.5
+    },
+    "limit": {
+      "context": 256000,
+      "output": 262144
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/Qwen3-235B-A22B-Instruct-2507-TEE",
+    "name": "Qwen 3 235b A22B 2507 (TEE)",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "release_date": "2025-07-25",
+    "last_updated": "2025-07-25",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.13,
+      "output": 0.5
+    },
+    "limit": {
+      "context": 256000,
+      "output": 262144
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/Qwen3-235B-A22B-Thinking",
+    "name": "Qwen 3 235b A22B 2507 Thinking",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2025-09-11",
+    "last_updated": "2025-09-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 0.5
+    },
+    "limit": {
+      "context": 256000,
+      "output": 262144
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/Qwen3-8B",
+    "name": "Qwen 3 8B",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2024-01-01",
+    "last_updated": "2024-01-01",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.47,
+      "output": 0.47
+    },
+    "limit": {
+      "context": 41000,
+      "output": 32768
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/Qwen3-Next-80B-A3B-Instruct",
+    "name": "Qwen3 Next 80B A3B (Instruct)",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "release_date": "2025-09-11",
+    "last_updated": "2025-09-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.65
+    },
+    "limit": {
+      "context": 256000,
+      "output": 262144
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/Qwen3-VL-235B-A22B-Instruct",
+    "name": "Qwen3 VL 235B A22B Instruct",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2024-01-01",
+    "last_updated": "2024-01-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2
+    },
+    "limit": {
+      "context": 128000,
+      "output": 262144
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/Qwen3.6-35B-A3B",
+    "name": "Qwen3.6 35B A3B",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
     "release_date": "2026-04-17",
-    "last_updated": "2026-04-21",
+    "last_updated": "2026-04-17",
     "modalities": {
       "input": [
         "text",
@@ -81248,10 +83222,10 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
-      "input": 0.29,
-      "output": 1.74
+      "input": 0.112,
+      "output": 0.8
     },
     "limit": {
       "context": 262144,
@@ -81261,12 +83235,11 @@
   {
     "id": "nano-gpt/qwen/Qwen3.6-35B-A3B:thinking",
     "name": "Qwen3.6 35B A3B Thinking",
-    "family": "qwen3.6",
-    "attachment": false,
+    "attachment": true,
     "reasoning": true,
     "tool_call": false,
     "release_date": "2026-04-19",
-    "last_updated": "2026-04-21",
+    "last_updated": "2026-04-19",
     "modalities": {
       "input": [
         "text",
@@ -81277,14 +83250,302 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
-      "input": 0.29,
-      "output": 1.74
+      "input": 0.112,
+      "output": 0.8
     },
     "limit": {
       "context": 262144,
       "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/qwen-2.5-72b-instruct",
+    "name": "Qwen2.5 72B",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2025-07-03",
+    "last_updated": "2025-07-03",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.357,
+      "output": 0.408
+    },
+    "limit": {
+      "context": 131072,
+      "output": 8192
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/qwen3-14b",
+    "name": "Qwen 3 14b",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2024-01-01",
+    "last_updated": "2024-01-01",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.08,
+      "output": 0.24
+    },
+    "limit": {
+      "context": 41000,
+      "output": 32768
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/qwen3-235b-a22b",
+    "name": "Qwen 3 235b A22B",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "release_date": "2025-04-29",
+    "last_updated": "2025-04-29",
+    "modalities": {
+      "input": [
+        "text",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 0.5
+    },
+    "limit": {
+      "context": 41000,
+      "output": 32768
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/qwen3-30b-a3b",
+    "name": "Qwen3 30B A3B",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2025-02-27",
+    "last_updated": "2025-02-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.3
+    },
+    "limit": {
+      "context": 41000,
+      "output": 32768
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/qwen3-32b",
+    "name": "Qwen 3 32b",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2024-01-01",
+    "last_updated": "2024-01-01",
+    "modalities": {
+      "input": [
+        "text",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.3
+    },
+    "limit": {
+      "context": 41000,
+      "output": 32768
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/qwen3-coder",
+    "name": "Qwen 3 Coder 480B",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.13,
+      "output": 0.5
+    },
+    "limit": {
+      "context": 262000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/qwen3-coder-flash",
+    "name": "Qwen3 Coder Flash",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2025-09-17",
+    "last_updated": "2025-09-17",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 1.5
+    },
+    "limit": {
+      "context": 128000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/qwen3-coder-next",
+    "name": "Qwen3 Coder Next",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "release_date": "2025-12-08",
+    "last_updated": "2025-12-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 1.5
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/qwen3-coder-plus",
+    "name": "Qwen3 Coder Plus",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2025-09-17",
+    "last_updated": "2025-09-17",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 5.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/qwen3-max",
+    "name": "Qwen3 Max",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2025-09-05",
+    "last_updated": "2025-09-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.08018,
+      "output": 5.4009
+    },
+    "limit": {
+      "context": 256000,
+      "output": 32768
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/qwen3-next-80b-a3b-thinking",
+    "name": "Qwen3 Next 80B A3B (Thinking)",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2024-01-01",
+    "last_updated": "2024-01-01",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.65
+    },
+    "limit": {
+      "context": 256000,
+      "output": 32768
     }
   },
   {
@@ -81314,6 +83575,145 @@
     "limit": {
       "context": 258048,
       "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/qwen3.5-397b-a17b-thinking",
+    "name": "Qwen3.5 397B A17B Thinking",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-02-16",
+    "last_updated": "2026-02-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.6,
+      "output": 3.6
+    },
+    "limit": {
+      "context": 258048,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/qwen3.5-9b",
+    "name": "Qwen3.5 9B",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-03-10",
+    "last_updated": "2026-03-10",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.05,
+      "output": 0.15
+    },
+    "limit": {
+      "context": 256000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/qwen3.5-plus",
+    "name": "Qwen3.5 Plus",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-02-16",
+    "last_updated": "2026-02-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.4,
+      "output": 2.4,
+      "cache_read": 0.04
+    },
+    "limit": {
+      "context": 983616,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/qwen3.5-plus-thinking",
+    "name": "Qwen3.5 Plus Thinking",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-02-16",
+    "last_updated": "2026-02-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.4,
+      "output": 2.4,
+      "cache_read": 0.04
+    },
+    "limit": {
+      "context": 983616,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/qwq-32b-preview",
+    "name": "Qwen QwQ 32B Preview",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2025-02-27",
+    "last_updated": "2025-02-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.2,
+      "output": 0.2
+    },
+    "limit": {
+      "context": 32768,
+      "output": 32768
     }
   },
   {
@@ -81476,6 +83876,288 @@
     }
   },
   {
+    "id": "nano-gpt/qwen3.5-122b-a10b",
+    "name": "Qwen3.5 122B A10B",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-02-24",
+    "last_updated": "2026-02-24",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.36,
+      "output": 2.88
+    },
+    "limit": {
+      "context": 260096,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/qwen3.5-122b-a10b:thinking",
+    "name": "Qwen3.5 122B A10B Thinking",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-02-24",
+    "last_updated": "2026-02-24",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.36,
+      "output": 2.88
+    },
+    "limit": {
+      "context": 260096,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/qwen3.5-27b",
+    "name": "Qwen3.5 27B",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-02-24",
+    "last_updated": "2026-02-24",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.27,
+      "output": 2.16
+    },
+    "limit": {
+      "context": 260096,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/qwen3.5-27b:thinking",
+    "name": "Qwen3.5 27B Thinking",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-02-24",
+    "last_updated": "2026-02-24",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.27,
+      "output": 2.16
+    },
+    "limit": {
+      "context": 260096,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/qwen3.5-35b-a3b",
+    "name": "Qwen3.5 35B A3B",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-02-24",
+    "last_updated": "2026-02-24",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.225,
+      "output": 1.8
+    },
+    "limit": {
+      "context": 260096,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/qwen3.5-35b-a3b:thinking",
+    "name": "Qwen3.5 35B A3B Thinking",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-02-24",
+    "last_updated": "2026-02-24",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.225,
+      "output": 1.8
+    },
+    "limit": {
+      "context": 260096,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/qwen3.5-flash",
+    "name": "Qwen3.5 Flash",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-02-24",
+    "last_updated": "2026-02-24",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.09,
+      "output": 0.36
+    },
+    "limit": {
+      "context": 991808,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/qwen3.5-flash:thinking",
+    "name": "Qwen3.5 Flash Thinking",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-02-24",
+    "last_updated": "2026-02-24",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.09,
+      "output": 0.36
+    },
+    "limit": {
+      "context": 991808,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/qwen3.5-omni-flash",
+    "name": "Qwen3.5 Omni Flash",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-03-30",
+    "last_updated": "2026-03-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 49152,
+      "output": 16384
+    }
+  },
+  {
+    "id": "nano-gpt/qwen3.5-omni-plus",
+    "name": "Qwen3.5 Omni Plus",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-03-30",
+    "last_updated": "2026-03-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 983616,
+      "output": 65536
+    }
+  },
+  {
     "id": "nano-gpt/qwen3.6-max-preview",
     "name": "Qwen3.6 Max Preview",
     "family": "qwen3.6",
@@ -81499,6 +84181,118 @@
     },
     "limit": {
       "context": 245800,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/qwen3.7-max",
+    "name": "Qwen3.7 Max",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-05-21",
+    "last_updated": "2026-05-21",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 7.5,
+      "cache_read": 0.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/qwen3.7-max:thinking",
+    "name": "Qwen3.7 Max Thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-05-21",
+    "last_updated": "2026-05-21",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 7.5,
+      "cache_read": 0.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/qwen3.7-plus",
+    "name": "Qwen3.7 Plus",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-06-01",
+    "last_updated": "2026-06-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.4,
+      "output": 1.6,
+      "cache_read": 0.04
+    },
+    "limit": {
+      "context": 991808,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/qwen3.7-plus:thinking",
+    "name": "Qwen3.7 Plus Thinking",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-06-01",
+    "last_updated": "2026-06-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.4,
+      "output": 1.6,
+      "cache_read": 0.04
+    },
+    "limit": {
+      "context": 983616,
       "output": 65536
     }
   },
@@ -81529,18 +84323,16 @@
     }
   },
   {
-    "id": "nano-gpt/raifle/sorcererlm-8x22b",
-    "name": "SorcererLM 8x22B",
-    "family": "mixtral",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-01-01",
-    "last_updated": "2025-01-01",
+    "id": "nano-gpt/sarvam-105b",
+    "name": "Sarvam 105B",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-12",
+    "last_updated": "2026-05-12",
     "modalities": {
       "input": [
-        "text",
-        "pdf"
+        "text"
       ],
       "output": [
         "text"
@@ -81548,22 +84340,23 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 4.505,
-      "output": 4.505
+      "input": 0.045,
+      "output": 0.177,
+      "cache_read": 0.028
     },
     "limit": {
-      "context": 16000,
-      "output": 8192
+      "context": 131072,
+      "output": 4096
     }
   },
   {
-    "id": "nano-gpt/sarvan-medium",
-    "name": "Sarvam Medium",
+    "id": "nano-gpt/sarvam-30b",
+    "name": "Sarvam 30B",
     "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-01-01",
-    "last_updated": "2025-01-01",
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-12",
+    "last_updated": "2026-05-12",
     "modalities": {
       "input": [
         "text"
@@ -81574,12 +84367,13 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.25,
-      "output": 0.75
+      "input": 0.028,
+      "output": 0.111,
+      "cache_read": 0.017
     },
     "limit": {
-      "context": 128000,
-      "output": 16384
+      "context": 65536,
+      "output": 4096
     }
   },
   {
@@ -81954,17 +84748,18 @@
     }
   },
   {
-    "id": "nano-gpt/stepfun-ai/step-3.5-flash:thinking",
-    "name": "Step 3.5 Flash Thinking",
-    "family": "step",
-    "attachment": false,
+    "id": "nano-gpt/stepfun/step-3.7-flash:thinking",
+    "name": "Step 3.7 Flash Thinking",
+    "attachment": true,
     "reasoning": true,
-    "tool_call": false,
-    "release_date": "2026-02-02",
-    "last_updated": "2026-02-02",
+    "tool_call": true,
+    "release_date": "2026-05-29",
+    "last_updated": "2026-05-29",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "video"
       ],
       "output": [
         "text"
@@ -81973,38 +84768,12 @@
     "open_weights": false,
     "cost": {
       "input": 0.2,
-      "output": 0.5
+      "output": 1.15,
+      "cache_read": 0.04
     },
     "limit": {
       "context": 256000,
       "output": 256000
-    }
-  },
-  {
-    "id": "nano-gpt/study_gpt-chatgpt-4o",
-    "name": "Study Mode",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-05-13",
-    "last_updated": "2024-05-13",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 4.998,
-      "output": 14.994
-    },
-    "limit": {
-      "context": 200000,
-      "output": 16384
     }
   },
   {
@@ -82035,14 +84804,13 @@
     }
   },
   {
-    "id": "nano-gpt/tngtech/DeepSeek-TNG-R1T2-Chimera",
-    "name": "DeepSeek TNG R1T2 Chimera",
-    "family": "tngtech",
+    "id": "nano-gpt/tencent/hy3-preview",
+    "name": "Tencent: Hy3 preview",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "release_date": "2025-09-05",
-    "last_updated": "2025-09-05",
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
     "modalities": {
       "input": [
         "text"
@@ -82053,39 +84821,13 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.31,
-      "output": 0.31
+      "input": 0.066,
+      "output": 0.26,
+      "cache_read": 0.029
     },
     "limit": {
-      "context": 128000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nano-gpt/tngtech/tng-r1t-chimera",
-    "name": "TNG R1T Chimera",
-    "family": "tngtech",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-11-26",
-    "last_updated": "2025-11-26",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.3,
-      "output": 1.2
-    },
-    "limit": {
-      "context": 128000,
-      "output": 65536
+      "context": 262144,
+      "output": 262144
     }
   },
   {
@@ -82109,7 +84851,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.7989999999999999,
-      "output": 1.2069999999999999
+      "output": 1.207
     },
     "limit": {
       "context": 6144,
@@ -82171,33 +84913,6 @@
     }
   },
   {
-    "id": "nano-gpt/unsloth/gemma-3-1b-it",
-    "name": "Gemma 3 1B IT",
-    "family": "unsloth",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-03-10",
-    "last_updated": "2025-03-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.1003,
-      "output": 0.1003
-    },
-    "limit": {
-      "context": 128000,
-      "output": 8192
-    }
-  },
-  {
     "id": "nano-gpt/unsloth/gemma-3-27b-it",
     "name": "Gemma 3 27B IT",
     "family": "unsloth",
@@ -82251,6 +84966,33 @@
     "limit": {
       "context": 128000,
       "output": 8192
+    }
+  },
+  {
+    "id": "nano-gpt/upstage/solar-pro-3",
+    "name": "Solar Pro 3",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-03-03",
+    "last_updated": "2026-03-03",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.6,
+      "cache_read": 0.015
+    },
+    "limit": {
+      "context": 128000,
+      "output": 128000
     }
   },
   {
@@ -82384,14 +85126,13 @@
     }
   },
   {
-    "id": "nano-gpt/x-ai/grok-4-07-09",
-    "name": "Grok 4",
-    "family": "grok",
+    "id": "nano-gpt/x-ai/grok",
+    "name": "Grok Latest",
     "attachment": true,
     "reasoning": true,
-    "tool_call": false,
-    "release_date": "2025-07-09",
-    "last_updated": "2025-07-09",
+    "tool_call": true,
+    "release_date": "2026-05-03",
+    "last_updated": "2026-05-03",
     "modalities": {
       "input": [
         "text",
@@ -82403,123 +85144,123 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 3.0,
-      "output": 15.0
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 1000000
+    }
+  },
+  {
+    "id": "nano-gpt/x-ai/grok-4.20",
+    "name": "Grok 4.20",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-03-31",
+    "last_updated": "2026-03-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 6.0
+    },
+    "limit": {
+      "context": 2000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "nano-gpt/x-ai/grok-4.20-multi-agent",
+    "name": "Grok 4.20 Multi-Agent",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-03-31",
+    "last_updated": "2026-03-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 6.0
+    },
+    "limit": {
+      "context": 2000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "nano-gpt/x-ai/grok-4.3",
+    "name": "Grok 4.3",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 1000000
+    }
+  },
+  {
+    "id": "nano-gpt/x-ai/grok-build-0.1",
+    "name": "Grok Build 0.1",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-20",
+    "last_updated": "2026-05-20",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 2.0,
+      "cache_read": 0.2
     },
     "limit": {
       "context": 256000,
-      "output": 131072
-    }
-  },
-  {
-    "id": "nano-gpt/x-ai/grok-4-fast",
-    "name": "Grok 4 Fast",
-    "family": "grok",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "release_date": "2025-09-20",
-    "last_updated": "2025-09-20",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.5
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 131072
-    }
-  },
-  {
-    "id": "nano-gpt/x-ai/grok-4-fast:thinking",
-    "name": "Grok 4 Fast Thinking",
-    "family": "grok",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "release_date": "2025-07-09",
-    "last_updated": "2025-07-09",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.5
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 131072
-    }
-  },
-  {
-    "id": "nano-gpt/x-ai/grok-4.1-fast",
-    "name": "Grok 4.1 Fast",
-    "family": "grok",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "release_date": "2025-11-20",
-    "last_updated": "2025-11-20",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.5
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 131072
-    }
-  },
-  {
-    "id": "nano-gpt/x-ai/grok-code-fast-1",
-    "name": "Grok Code Fast 1",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
-    "release_date": "2025-08-28",
-    "last_updated": "2025-08-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 1.5
-    },
-    "limit": {
-      "context": 256000,
-      "output": 131072
+      "output": 256000
     }
   },
   {
@@ -82628,6 +85369,119 @@
     "limit": {
       "context": 256000,
       "output": 32768
+    }
+  },
+  {
+    "id": "nano-gpt/xiaomi/mimo-v2-omni",
+    "name": "MiMo V2 Omni",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "release_date": "2026-03-19",
+    "last_updated": "2026-03-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.4,
+      "output": 2.0,
+      "cache_read": 0.08
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/xiaomi/mimo-v2-pro",
+    "name": "MiMo V2 Pro",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-03-19",
+    "last_updated": "2026-03-19",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 3.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "nano-gpt/xiaomi/mimo-v2.5",
+    "name": "MiMo V2.5",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.0028
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "nano-gpt/xiaomi/mimo-v2.5-pro",
+    "name": "MiMo V2.5 Pro",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.435,
+      "output": 0.87,
+      "cache_read": 0.0036
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
     }
   },
   {
@@ -82819,27 +85673,377 @@
     }
   },
   {
-    "id": "nano-gpt/z-image-turbo",
-    "name": "Z Image Turbo",
-    "attachment": true,
+    "id": "nano-gpt/z-ai/glm-5-turbo",
+    "name": "GLM 5 Turbo",
+    "attachment": false,
     "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2025-11-27",
-    "last_updated": "2025-11-27",
+    "tool_call": true,
+    "release_date": "2026-03-15",
+    "last_updated": "2026-03-15",
     "modalities": {
       "input": [
         "text"
       ],
       "output": [
-        "image"
+        "text"
       ]
     },
     "open_weights": false,
-    "cost": {},
+    "cost": {
+      "input": 1.2,
+      "output": 4.0,
+      "cache_read": 0.24
+    },
     "limit": {
-      "context": 0,
-      "output": 0
+      "context": 202800,
+      "output": 131072
+    }
+  },
+  {
+    "id": "nano-gpt/z-ai/glm-5v-turbo",
+    "name": "GLM 5V Turbo",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "release_date": "2026-04-01",
+    "last_updated": "2026-04-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.2,
+      "output": 4.0,
+      "cache_read": 0.24
+    },
+    "limit": {
+      "context": 202800,
+      "output": 131100
+    }
+  },
+  {
+    "id": "nano-gpt/z-ai/glm-5v-turbo:thinking",
+    "name": "GLM 5V Turbo Thinking",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.2,
+      "output": 4.0,
+      "cache_read": 0.24
+    },
+    "limit": {
+      "context": 202800,
+      "output": 131100
+    }
+  },
+  {
+    "id": "nano-gpt/zai-org/GLM-4.5-Air",
+    "name": "GLM 4.5 Air",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "release_date": "2025-04-15",
+    "last_updated": "2025-04-15",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.12,
+      "output": 0.8
+    },
+    "limit": {
+      "context": 128000,
+      "output": 98304
+    }
+  },
+  {
+    "id": "nano-gpt/zai-org/GLM-4.5-Air:thinking",
+    "name": "GLM 4.5 Air (Thinking)",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2024-01-01",
+    "last_updated": "2024-01-01",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.12,
+      "output": 0.8
+    },
+    "limit": {
+      "context": 128000,
+      "output": 98304
+    }
+  },
+  {
+    "id": "nano-gpt/zai-org/GLM-4.5:thinking",
+    "name": "GLM 4.5 (Thinking)",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2024-01-01",
+    "last_updated": "2024-01-01",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 1.3
+    },
+    "limit": {
+      "context": 128000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/zai-org/GLM-4.6-turbo",
+    "name": "GLM 4.6 Turbo",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2025-10-02",
+    "last_updated": "2025-10-02",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 3.0
+    },
+    "limit": {
+      "context": 200000,
+      "output": 204800
+    }
+  },
+  {
+    "id": "nano-gpt/zai-org/GLM-4.6-turbo:thinking",
+    "name": "GLM 4.6 Turbo (Thinking)",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2025-10-02",
+    "last_updated": "2025-10-02",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 3.0
+    },
+    "limit": {
+      "context": 200000,
+      "output": 204800
+    }
+  },
+  {
+    "id": "nano-gpt/zai-org/glm",
+    "name": "GLM Latest",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-05-03",
+    "last_updated": "2026-05-03",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 2.6,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 200000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "nano-gpt/zai-org/glm-4.5",
+    "name": "GLM 4.5",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2025-04-15",
+    "last_updated": "2025-04-15",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 1.3
+    },
+    "limit": {
+      "context": 128000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/zai-org/glm-4.6-original",
+    "name": "GLM 4.6 Original",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2025-12-11",
+    "last_updated": "2025-12-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.35,
+      "output": 1.4
+    },
+    "limit": {
+      "context": 256000,
+      "output": 65535
+    }
+  },
+  {
+    "id": "nano-gpt/zai-org/glm-4.6v",
+    "name": "GLM 4.6V",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2025-12-11",
+    "last_updated": "2025-12-11",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 0.9
+    },
+    "limit": {
+      "context": 128000,
+      "output": 24000
+    }
+  },
+  {
+    "id": "nano-gpt/zai-org/glm-4.6v-flash-original",
+    "name": "GLM 4.6V Flash",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2025-12-08",
+    "last_updated": "2025-12-08",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.4
+    },
+    "limit": {
+      "context": 128000,
+      "output": 24000
+    }
+  },
+  {
+    "id": "nano-gpt/zai-org/glm-4.6v-original",
+    "name": "GLM 4.6V Original",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2025-12-08",
+    "last_updated": "2025-12-08",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.6,
+      "output": 0.9
+    },
+    "limit": {
+      "context": 128000,
+      "output": 24000
     }
   },
   {
@@ -82897,6 +86101,164 @@
     }
   },
   {
+    "id": "nano-gpt/zai-org/glm-4.7-flash-original",
+    "name": "GLM 4.7 Flash Original",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-01-19",
+    "last_updated": "2026-01-19",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.07,
+      "output": 0.4
+    },
+    "limit": {
+      "context": 200000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/zai-org/glm-4.7-flash-original:thinking",
+    "name": "GLM 4.7 Flash Original Thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-01-19",
+    "last_updated": "2026-01-19",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.07,
+      "output": 0.4
+    },
+    "limit": {
+      "context": 200000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/zai-org/glm-4.7-flash:thinking",
+    "name": "GLM 4.7 Flash Thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "release_date": "2026-01-19",
+    "last_updated": "2026-01-19",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.07,
+      "output": 0.4
+    },
+    "limit": {
+      "context": 200000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/zai-org/glm-4.7-original",
+    "name": "GLM 4.7 Original",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2025-12-22",
+    "last_updated": "2025-12-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.6,
+      "output": 2.2,
+      "cache_read": 0.11
+    },
+    "limit": {
+      "context": 200000,
+      "output": 65535
+    }
+  },
+  {
+    "id": "nano-gpt/zai-org/glm-4.7-original:thinking",
+    "name": "GLM 4.7 Original Thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2025-12-22",
+    "last_updated": "2025-12-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.6,
+      "output": 2.2,
+      "cache_read": 0.11
+    },
+    "limit": {
+      "context": 200000,
+      "output": 65535
+    }
+  },
+  {
+    "id": "nano-gpt/zai-org/glm-4.7:thinking",
+    "name": "GLM 4.7 Thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2025-12-22",
+    "last_updated": "2025-12-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.2,
+      "output": 0.8
+    },
+    "limit": {
+      "context": 200000,
+      "output": 65535
+    }
+  },
+  {
     "id": "nano-gpt/zai-org/glm-5",
     "name": "GLM 5",
     "family": "glm",
@@ -82917,6 +86279,60 @@
     "cost": {
       "input": 0.3,
       "output": 2.55
+    },
+    "limit": {
+      "context": 200000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/zai-org/glm-5-original",
+    "name": "GLM 5 Original",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-02-11",
+    "last_updated": "2026-02-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 3.2,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 200000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/zai-org/glm-5-original:thinking",
+    "name": "GLM 5 Original Thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-02-11",
+    "last_updated": "2026-02-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 3.2,
+      "cache_read": 0.2
     },
     "limit": {
       "context": 200000,
@@ -84881,6 +88297,7 @@
   {
     "id": "nebius/nvidia/Llama-3_1-Nemotron-Ultra-253B-v1",
     "name": "Llama-3.1-Nemotron-Ultra-253B-v1",
+    "family": "nemotron",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
@@ -84911,6 +88328,7 @@
   {
     "id": "nebius/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B",
     "name": "Nemotron-3-Nano-30B-A3B",
+    "family": "nemotron",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
@@ -84941,6 +88359,7 @@
   {
     "id": "nebius/nvidia/Nemotron-3-Nano-Omni",
     "name": "Nemotron-3-Nano-Omni",
+    "family": "nemotron",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
@@ -84971,6 +88390,7 @@
   {
     "id": "nebius/nvidia/nemotron-3-super-120b-a12b",
     "name": "Nemotron-3-Super-120B-A12B",
+    "family": "nemotron",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
@@ -89581,6 +93001,7 @@
   {
     "id": "nvidia/mistralai/mistral-nemotron",
     "name": "mistral-nemotron",
+    "family": "nemotron",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
@@ -89948,6 +93369,7 @@
   {
     "id": "nvidia/nvidia/llama-3_1-nemotron-safety-guard-8b-v3",
     "name": "llama-3.1-nemotron-safety-guard-8b-v3",
+    "family": "nemotron",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
@@ -90060,6 +93482,7 @@
   {
     "id": "nvidia/nvidia/llama-nemotron-embed-vl-1b-v2",
     "name": "llama-nemotron-embed-vl-1b-v2",
+    "family": "nemotron",
     "attachment": true,
     "reasoning": false,
     "tool_call": false,
@@ -90088,6 +93511,7 @@
   {
     "id": "nvidia/nvidia/llama-nemotron-rerank-vl-1b-v2",
     "name": "llama-nemotron-rerank-vl-1b-v2",
+    "family": "nemotron",
     "attachment": true,
     "reasoning": false,
     "tool_call": false,
@@ -90144,6 +93568,7 @@
   {
     "id": "nvidia/nvidia/nemotron-3-content-safety",
     "name": "nemotron-3-content-safety",
+    "family": "nemotron",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
@@ -90198,7 +93623,7 @@
     }
   },
   {
-    "id": "nvidia/nvidia/nemotron-3-nano-omni-30b-a3b",
+    "id": "nvidia/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
     "name": "Nemotron 3 Nano Omni",
     "family": "nemotron",
     "attachment": true,
@@ -90258,8 +93683,38 @@
     }
   },
   {
+    "id": "nvidia/nvidia/nemotron-3-ultra-550b-a55b",
+    "name": "Nemotron 3 Ultra 550B A55B",
+    "family": "nemotron",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-04",
+    "last_updated": "2026-06-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.5,
+      "output": 2.5,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
     "id": "nvidia/nvidia/nemotron-content-safety-reasoning-4b",
     "name": "nemotron-content-safety-reasoning-4b",
+    "family": "nemotron",
     "attachment": false,
     "reasoning": true,
     "tool_call": false,
@@ -90287,6 +93742,7 @@
   {
     "id": "nvidia/nvidia/nemotron-mini-4b-instruct",
     "name": "nemotron-mini-4b-instruct",
+    "family": "nemotron",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
@@ -90314,6 +93770,7 @@
   {
     "id": "nvidia/nvidia/nemotron-voicechat",
     "name": "nemotron-voicechat",
+    "family": "nemotron",
     "attachment": true,
     "reasoning": false,
     "tool_call": true,
@@ -91668,7 +95125,7 @@
     "name": "minimax-m2",
     "family": "minimax",
     "attachment": false,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "release_date": "2025-10-23",
     "last_updated": "2026-01-19",
@@ -91764,7 +95221,7 @@
     "id": "ollama-cloud/minimax-m3",
     "name": "minimax-m3",
     "family": "minimax-m3",
-    "attachment": false,
+    "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -91895,6 +95352,7 @@
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
+    "temperature": true,
     "release_date": "2025-12-15",
     "last_updated": "2026-01-19",
     "modalities": {
@@ -91919,6 +95377,7 @@
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
+    "temperature": true,
     "release_date": "2026-03-11",
     "last_updated": "2026-03-12",
     "modalities": {
@@ -91934,6 +95393,31 @@
     "limit": {
       "context": 262144,
       "output": 65536
+    }
+  },
+  {
+    "id": "ollama-cloud/nemotron-3-ultra",
+    "name": "nemotron-3-ultra",
+    "family": "nemotron",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-04",
+    "last_updated": "2026-06-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {},
+    "limit": {
+      "context": 262144,
+      "output": 128000
     }
   },
   {
@@ -93241,66 +96725,6 @@
     }
   },
   {
-    "id": "openai/o1-mini",
-    "name": "o1-mini",
-    "family": "o-mini",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
-    "temperature": false,
-    "knowledge": "2023-09",
-    "release_date": "2024-09-12",
-    "last_updated": "2024-09-12",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.1,
-      "output": 4.4,
-      "cache_read": 0.55
-    },
-    "limit": {
-      "context": 128000,
-      "output": 65536
-    }
-  },
-  {
-    "id": "openai/o1-preview",
-    "name": "o1-preview",
-    "family": "o",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2023-09",
-    "release_date": "2024-09-12",
-    "last_updated": "2024-09-12",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 15.0,
-      "output": 60.0,
-      "cache_read": 7.5
-    },
-    "limit": {
-      "context": 128000,
-      "output": 32768
-    }
-  },
-  {
     "id": "openai/o1-pro",
     "name": "o1-pro",
     "family": "o-pro",
@@ -93995,9 +97419,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.6,
-      "output": 2.4,
-      "cache_read": 0.12
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.06
     },
     "limit": {
       "context": 512000,
@@ -94066,7 +97490,7 @@
       "cache_write": 0.625
     },
     "limit": {
-      "context": 262144,
+      "context": 1000000,
       "output": 65536
     }
   },
@@ -94094,6 +97518,38 @@
       "output": 7.5,
       "cache_read": 0.5,
       "cache_write": 3.125
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "opencode-go/qwen3.7-plus",
+    "name": "Qwen3.7 Plus",
+    "family": "qwen3.7-plus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-02",
+    "last_updated": "2026-06-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.4,
+      "output": 1.6,
+      "cache_read": 0.04,
+      "cache_write": 0.5
     },
     "limit": {
       "context": 1000000,
@@ -94162,6 +97618,39 @@
     "limit": {
       "context": 200000,
       "output": 8192
+    }
+  },
+  {
+    "id": "opencode/claude-fable-5",
+    "name": "Claude Fable 5",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-09",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
     }
   },
   {
@@ -95984,6 +99473,65 @@
     }
   },
   {
+    "id": "opencode/nemotron-3-ultra-free",
+    "name": "Nemotron 3 Ultra Free",
+    "family": "nemotron-free",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2026-02",
+    "release_date": "2026-06-04",
+    "last_updated": "2026-06-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "opencode/north-mini-code-free",
+    "name": "North Mini Code Free",
+    "family": "north-free",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-09-23",
+    "release_date": "2026-06-09",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 256000,
+      "output": 64000
+    }
+  },
+  {
     "id": "opencode/qwen3-coder",
     "name": "Qwen3 Coder",
     "family": "qwen",
@@ -96657,8 +100205,8 @@
     "last_updated": "2025-08-05",
     "modalities": {
       "input": [
-        "image",
         "text",
+        "image",
         "pdf"
       ],
       "output": [
@@ -96690,9 +100238,9 @@
     "last_updated": "2025-11-24",
     "modalities": {
       "input": [
-        "pdf",
+        "text",
         "image",
-        "text"
+        "pdf"
       ],
       "output": [
         "text"
@@ -97032,7 +100580,7 @@
     }
   },
   {
-    "id": "openrouter/arcee-ai/maestro",
+    "id": "openrouter/arcee-ai/maestro-reasoning",
     "name": "Maestro Reasoning",
     "attachment": false,
     "reasoning": false,
@@ -97057,35 +100605,6 @@
     "limit": {
       "context": 131072,
       "output": 32000
-    }
-  },
-  {
-    "id": "openrouter/arcee-ai/spotlight",
-    "name": "Spotlight",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2025-03-31",
-    "release_date": "2025-05-05",
-    "last_updated": "2025-05-05",
-    "modalities": {
-      "input": [
-        "image",
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.18,
-      "output": 0.18
-    },
-    "limit": {
-      "context": 131072,
-      "output": 65537
     }
   },
   {
@@ -97171,65 +100690,6 @@
     "limit": {
       "context": 131072,
       "output": 64000
-    }
-  },
-  {
-    "id": "openrouter/baidu/ernie-4.5-300b-a47b",
-    "name": "ERNIE 4.5 300B A47B ",
-    "family": "ernie",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2025-03-31",
-    "release_date": "2025-06-30",
-    "last_updated": "2025-06-30",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.28,
-      "output": 1.1
-    },
-    "limit": {
-      "context": 123000,
-      "output": 12000
-    }
-  },
-  {
-    "id": "openrouter/baidu/ernie-4.5-vl-28b-a3b",
-    "name": "ERNIE 4.5 VL 28B A3B",
-    "family": "ernie",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-03-31",
-    "release_date": "2025-08-12",
-    "last_updated": "2025-08-12",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.14,
-      "output": 0.56
-    },
-    "limit": {
-      "context": 30000,
-      "output": 8000
     }
   },
   {
@@ -97676,15 +101136,15 @@
   },
   {
     "id": "openrouter/deepseek/deepseek-r1",
-    "name": "R1",
+    "name": "DeepSeek-R1",
     "family": "deepseek-thinking",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-07-31",
+    "knowledge": "2024-07",
     "release_date": "2025-01-20",
-    "last_updated": "2025-01-20",
+    "last_updated": "2025-05-29",
     "modalities": {
       "input": [
         "text"
@@ -97950,11 +101410,11 @@
     "last_updated": "2025-06-05",
     "modalities": {
       "input": [
-        "pdf",
-        "image",
         "text",
+        "image",
         "audio",
-        "video"
+        "video",
+        "pdf"
       ],
       "output": [
         "text"
@@ -97985,12 +101445,12 @@
     "last_updated": "2025-08-26",
     "modalities": {
       "input": [
-        "image",
-        "text"
+        "text",
+        "image"
       ],
       "output": [
-        "image",
-        "text"
+        "text",
+        "image"
       ]
     },
     "open_weights": false,
@@ -98020,9 +101480,9 @@
       "input": [
         "text",
         "image",
-        "pdf",
         "audio",
-        "video"
+        "video",
+        "pdf"
       ],
       "output": [
         "text"
@@ -98090,9 +101550,9 @@
       "input": [
         "text",
         "image",
-        "pdf",
         "audio",
-        "video"
+        "video",
+        "pdf"
       ],
       "output": [
         "text"
@@ -98194,9 +101654,9 @@
       "input": [
         "text",
         "image",
-        "pdf",
+        "video",
         "audio",
-        "video"
+        "pdf"
       ],
       "output": [
         "text"
@@ -98216,22 +101676,23 @@
   },
   {
     "id": "openrouter/google/gemini-3-pro-image-preview",
-    "name": "Nano Banana Pro (Gemini 3 Pro Image Preview)",
-    "family": "gemini",
+    "name": "Nano Banana Pro",
+    "family": "gemini-pro",
     "attachment": true,
     "reasoning": true,
     "tool_call": false,
     "temperature": true,
+    "knowledge": "2025-01",
     "release_date": "2025-11-20",
     "last_updated": "2025-11-20",
     "modalities": {
       "input": [
-        "image",
-        "text"
+        "text",
+        "image"
       ],
       "output": [
-        "image",
-        "text"
+        "text",
+        "image"
       ]
     },
     "open_weights": false,
@@ -98263,8 +101724,8 @@
         "text"
       ],
       "output": [
-        "image",
-        "text"
+        "text",
+        "image"
       ]
     },
     "open_weights": false,
@@ -98293,8 +101754,8 @@
         "text",
         "image",
         "video",
-        "pdf",
-        "audio"
+        "audio",
+        "pdf"
       ],
       "output": [
         "text"
@@ -98328,8 +101789,8 @@
         "text",
         "image",
         "video",
-        "pdf",
-        "audio"
+        "audio",
+        "pdf"
       ],
       "output": [
         "text"
@@ -98360,11 +101821,11 @@
     "last_updated": "2026-02-19",
     "modalities": {
       "input": [
-        "audio",
-        "pdf",
-        "image",
         "text",
-        "video"
+        "image",
+        "video",
+        "audio",
+        "pdf"
       ],
       "output": [
         "text"
@@ -98396,9 +101857,9 @@
     "modalities": {
       "input": [
         "text",
-        "audio",
         "image",
         "video",
+        "audio",
         "pdf"
       ],
       "output": [
@@ -98433,8 +101894,8 @@
         "text",
         "image",
         "video",
-        "pdf",
-        "audio"
+        "audio",
+        "pdf"
       ],
       "output": [
         "text"
@@ -98503,8 +101964,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.04,
-      "output": 0.13
+      "input": 0.05,
+      "output": 0.15
     },
     "limit": {
       "context": 131072,
@@ -98563,8 +102024,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.04,
-      "output": 0.08
+      "input": 0.05,
+      "output": 0.1
     },
     "limit": {
       "context": 131072,
@@ -98683,11 +102144,12 @@
     "open_weights": true,
     "cost": {
       "input": 0.12,
-      "output": 0.37
+      "output": 0.36,
+      "cache_read": 0.09
     },
     "limit": {
-      "context": 262144,
-      "output": 16384
+      "context": 256000,
+      "output": 8192
     }
   },
   {
@@ -98972,9 +102434,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.3,
-      "output": 2.5,
-      "cache_read": 0.06
+      "input": 0.075,
+      "output": 0.625,
+      "cache_read": 0.015
     },
     "limit": {
       "context": 262144,
@@ -99231,8 +102693,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.04,
-      "output": 0.04
+      "input": 0.14,
+      "output": 0.14
     },
     "limit": {
       "context": 8192,
@@ -99290,10 +102752,10 @@
     "open_weights": true,
     "cost": {
       "input": 0.02,
-      "output": 0.05
+      "output": 0.03
     },
     "limit": {
-      "context": 16384,
+      "context": 131072,
       "output": 16384
     }
   },
@@ -99319,8 +102781,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.245,
-      "output": 0.245
+      "input": 0.345,
+      "output": 0.345
     },
     "limit": {
       "context": 131072,
@@ -99524,7 +102986,7 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.08,
+      "input": 0.1,
       "output": 0.3
     },
     "limit": {
@@ -99876,19 +103338,19 @@
     },
     "limit": {
       "context": 196608,
-      "output": 131072
+      "output": 196608
     }
   },
   {
     "id": "openrouter/minimax/minimax-m3",
-    "name": "MiniMax M3",
-    "family": "minimax-m3",
+    "name": "MiniMax-M3",
+    "family": "minimax",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-05-31",
-    "last_updated": "2026-05-31",
+    "release_date": "2026-06-01",
+    "last_updated": "2026-06-01",
     "modalities": {
       "input": [
         "text",
@@ -99899,7 +103361,7 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
       "input": 0.3,
       "output": 1.2,
@@ -100540,13 +104002,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.684,
-      "output": 3.42,
-      "cache_read": 0.144
+      "input": 0.68,
+      "output": 3.41,
+      "cache_read": 0.34
     },
     "limit": {
-      "context": 262144,
-      "output": 262144
+      "context": 262142,
+      "output": 262142
     }
   },
   {
@@ -100636,18 +104098,18 @@
     }
   },
   {
-    "id": "openrouter/nex-agi/deepseek-v3.1-nex-n1",
-    "name": "DeepSeek V3.1 Nex N1",
-    "family": "deepseek",
-    "attachment": false,
-    "reasoning": false,
+    "id": "openrouter/nex-agi/nex-n2-pro:free",
+    "name": "Nex-N2-Pro (free)",
+    "attachment": true,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-12-08",
-    "last_updated": "2025-12-08",
+    "release_date": "2026-06-08",
+    "last_updated": "2026-06-08",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image"
       ],
       "output": [
         "text"
@@ -100655,41 +104117,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.135,
-      "output": 0.5
+      "input": 0.0,
+      "output": 0.0
     },
     "limit": {
-      "context": 131072,
-      "output": 163840
-    }
-  },
-  {
-    "id": "openrouter/nousresearch/hermes-2-pro-llama-3-8b",
-    "name": "Hermes 2 Pro - Llama-3 8B",
-    "family": "nousresearch",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2023-12-31",
-    "release_date": "2024-05-27",
-    "last_updated": "2024-05-27",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.14,
-      "output": 0.14
-    },
-    "limit": {
-      "context": 8192,
-      "output": 8192
+      "context": 262144,
+      "output": 262144
     }
   },
   {
@@ -100771,8 +104204,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.3,
-      "output": 0.3
+      "input": 0.7,
+      "output": 0.7
     },
     "limit": {
       "context": 131072,
@@ -100839,15 +104272,14 @@
   },
   {
     "id": "openrouter/nvidia/llama-3.3-nemotron-super-49b-v1.5",
-    "name": "Llama 3.3 Nemotron Super 49B V1.5",
+    "name": "Llama 3.3 Nemotron Super 49B v1.5",
     "family": "nemotron",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-03-31",
-    "release_date": "2025-10-10",
-    "last_updated": "2025-10-10",
+    "release_date": "2025-07-25",
+    "last_updated": "2025-07-25",
     "modalities": {
       "input": [
         "text"
@@ -100858,7 +104290,7 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.1,
+      "input": 0.4,
       "output": 0.4
     },
     "limit": {
@@ -100874,8 +104306,8 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-12-14",
-    "last_updated": "2025-12-14",
+    "release_date": "2025-12-15",
+    "last_updated": "2025-12-15",
     "modalities": {
       "input": [
         "text"
@@ -100902,9 +104334,8 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-11",
-    "release_date": "2025-12-14",
-    "last_updated": "2025-12-14",
+    "release_date": "2025-12-15",
+    "last_updated": "2025-12-15",
     "modalities": {
       "input": [
         "text"
@@ -100936,15 +104367,15 @@
     "modalities": {
       "input": [
         "text",
-        "audio",
         "image",
-        "video"
+        "video",
+        "audio"
       ],
       "output": [
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.0,
       "output": 0.0
@@ -100956,13 +104387,12 @@
   },
   {
     "id": "openrouter/nvidia/nemotron-3-super-120b-a12b",
-    "name": "Nemotron 3 Super",
+    "name": "Nemotron 3 Super 120B A12B",
     "family": "nemotron",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-04",
     "release_date": "2026-03-11",
     "last_updated": "2026-03-11",
     "modalities": {
@@ -100991,7 +104421,6 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-04",
     "release_date": "2026-03-11",
     "last_updated": "2026-03-11",
     "modalities": {
@@ -101013,6 +104442,92 @@
     }
   },
   {
+    "id": "openrouter/nvidia/nemotron-3-ultra-550b-a55b",
+    "name": "Nemotron 3 Ultra 550B A55B",
+    "family": "nemotron",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-04",
+    "last_updated": "2026-06-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.5,
+      "output": 2.5,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 262144,
+      "output": 16384
+    }
+  },
+  {
+    "id": "openrouter/nvidia/nemotron-3-ultra-550b-a55b:free",
+    "name": "Nemotron 3 Ultra (free)",
+    "family": "nemotron",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-04",
+    "last_updated": "2026-06-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/nvidia/nemotron-3.5-content-safety:free",
+    "name": "Nemotron 3.5 Content Safety (free)",
+    "family": "nemotron",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-06-04",
+    "last_updated": "2026-06-04",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 8192
+    }
+  },
+  {
     "id": "openrouter/nvidia/nemotron-nano-12b-v2-vl:free",
     "name": "Nemotron Nano 12B 2 VL (free)",
     "family": "nemotron",
@@ -101020,13 +104535,12 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-11",
     "release_date": "2025-10-28",
     "last_updated": "2025-10-28",
     "modalities": {
       "input": [
-        "image",
         "text",
+        "image",
         "video"
       ],
       "output": [
@@ -101045,15 +104559,14 @@
   },
   {
     "id": "openrouter/nvidia/nemotron-nano-9b-v2",
-    "name": "Nemotron Nano 9B V2",
+    "name": "Nemotron Nano 9B v2",
     "family": "nemotron",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-03-31",
-    "release_date": "2025-09-05",
-    "last_updated": "2025-09-05",
+    "release_date": "2025-08-18",
+    "last_updated": "2025-08-18",
     "modalities": {
       "input": [
         "text"
@@ -101080,9 +104593,8 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-03-31",
-    "release_date": "2025-09-05",
-    "last_updated": "2025-09-05",
+    "release_date": "2025-08-18",
+    "last_updated": "2025-08-18",
     "modalities": {
       "input": [
         "text"
@@ -101218,35 +104730,6 @@
     }
   },
   {
-    "id": "openrouter/openai/gpt-4-1106-preview",
-    "name": "GPT-4 Turbo (older v1106)",
-    "family": "gpt",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-04-30",
-    "release_date": "2023-11-06",
-    "last_updated": "2023-11-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 10.0,
-      "output": 30.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
     "id": "openrouter/openai/gpt-4-turbo",
     "name": "GPT-4 Turbo",
     "family": "gpt",
@@ -101318,8 +104801,8 @@
     "last_updated": "2025-04-14",
     "modalities": {
       "input": [
-        "image",
         "text",
+        "image",
         "pdf"
       ],
       "output": [
@@ -101350,8 +104833,8 @@
     "last_updated": "2025-04-14",
     "modalities": {
       "input": [
-        "image",
         "text",
+        "image",
         "pdf"
       ],
       "output": [
@@ -101916,8 +105399,8 @@
     "last_updated": "2025-11-13",
     "modalities": {
       "input": [
-        "image",
-        "text"
+        "text",
+        "image"
       ],
       "output": [
         "text"
@@ -102295,9 +105778,9 @@
     "last_updated": "2026-04-23",
     "modalities": {
       "input": [
-        "pdf",
+        "text",
         "image",
-        "text"
+        "pdf"
       ],
       "output": [
         "text"
@@ -102327,9 +105810,9 @@
     "last_updated": "2026-04-23",
     "modalities": {
       "input": [
-        "pdf",
+        "text",
         "image",
-        "text"
+        "pdf"
       ],
       "output": [
         "text"
@@ -102657,8 +106140,8 @@
     "last_updated": "2025-04-16",
     "modalities": {
       "input": [
-        "image",
         "text",
+        "image",
         "pdf"
       ],
       "output": [
@@ -102977,6 +106460,30 @@
     "limit": {
       "context": 200000,
       "output": 8000
+    }
+  },
+  {
+    "id": "openrouter/openrouter/fusion",
+    "name": "Fusion",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2026-05-12",
+    "last_updated": "2026-05-12",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 128000,
+      "output": 128000
     }
   },
   {
@@ -103376,15 +106883,15 @@
   },
   {
     "id": "openrouter/qwen/qwen-plus",
-    "name": "Qwen-Plus",
+    "name": "Qwen Plus",
     "family": "qwen",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-03-31",
-    "release_date": "2025-02-01",
-    "last_updated": "2025-02-01",
+    "knowledge": "2024-04",
+    "release_date": "2024-01-25",
+    "last_updated": "2025-09-11",
     "modalities": {
       "input": [
         "text"
@@ -103496,15 +107003,15 @@
   },
   {
     "id": "openrouter/qwen/qwen3-235b-a22b",
-    "name": "Qwen3 235B A22B",
+    "name": "Qwen3 235B-A22B",
     "family": "qwen",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-03-31",
-    "release_date": "2025-04-28",
-    "last_updated": "2025-04-28",
+    "knowledge": "2025-04",
+    "release_date": "2025-04",
+    "last_updated": "2025-04",
     "modalities": {
       "input": [
         "text"
@@ -103574,12 +107081,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.09,
-      "output": 0.45
+      "input": 0.12,
+      "output": 0.5
     },
     "limit": {
       "context": 40960,
-      "output": 20000
+      "output": 16384
     }
   },
   {
@@ -103603,8 +107110,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.0428,
-      "output": 0.1716
+      "input": 0.04815,
+      "output": 0.19305
     },
     "limit": {
       "context": 128000,
@@ -103649,9 +107156,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-03-31",
-    "release_date": "2025-04-28",
-    "last_updated": "2025-04-28",
+    "knowledge": "2025-04",
+    "release_date": "2025-04",
+    "last_updated": "2025-04",
     "modalities": {
       "input": [
         "text"
@@ -103731,15 +107238,15 @@
   },
   {
     "id": "openrouter/qwen/qwen3-coder-30b-a3b-instruct",
-    "name": "Qwen3 Coder 30B A3B Instruct",
+    "name": "Qwen3-Coder 30B-A3B Instruct",
     "family": "qwen",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-06-30",
-    "release_date": "2025-07-31",
-    "last_updated": "2025-07-31",
+    "knowledge": "2025-04",
+    "release_date": "2025-04",
+    "last_updated": "2025-04",
     "modalities": {
       "input": [
         "text"
@@ -103766,9 +107273,9 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-06-30",
-    "release_date": "2025-09-17",
-    "last_updated": "2025-09-17",
+    "knowledge": "2025-04",
+    "release_date": "2025-07-28",
+    "last_updated": "2025-07-28",
     "modalities": {
       "input": [
         "text"
@@ -103826,9 +107333,9 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-06-30",
-    "release_date": "2025-09-23",
-    "last_updated": "2025-09-23",
+    "knowledge": "2025-04",
+    "release_date": "2025-07-23",
+    "last_updated": "2025-07-23",
     "modalities": {
       "input": [
         "text"
@@ -103886,7 +107393,7 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-06-30",
+    "knowledge": "2025-04",
     "release_date": "2025-09-23",
     "last_updated": "2025-09-23",
     "modalities": {
@@ -103939,15 +107446,15 @@
   },
   {
     "id": "openrouter/qwen/qwen3-next-80b-a3b-instruct",
-    "name": "Qwen3 Next 80B A3B Instruct",
+    "name": "Qwen3-Next 80B-A3B Instruct",
     "family": "qwen",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-09-30",
-    "release_date": "2025-09-11",
-    "last_updated": "2025-09-11",
+    "knowledge": "2025-04",
+    "release_date": "2025-09",
+    "last_updated": "2025-09",
     "modalities": {
       "input": [
         "text"
@@ -103974,9 +107481,9 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-09-30",
-    "release_date": "2025-09-11",
-    "last_updated": "2025-09-11",
+    "knowledge": "2025-04",
+    "release_date": "2025-09",
+    "last_updated": "2025-09",
     "modalities": {
       "input": [
         "text"
@@ -103997,15 +107504,15 @@
   },
   {
     "id": "openrouter/qwen/qwen3-next-80b-a3b-thinking",
-    "name": "Qwen3 Next 80B A3B Thinking",
+    "name": "Qwen3-Next 80B-A3B (Thinking)",
     "family": "qwen",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-09-30",
-    "release_date": "2025-09-11",
-    "last_updated": "2025-09-11",
+    "knowledge": "2025-04",
+    "release_date": "2025-09",
+    "last_updated": "2025-09",
     "modalities": {
       "input": [
         "text"
@@ -104234,14 +107741,14 @@
   },
   {
     "id": "openrouter/qwen/qwen3.5-122b-a10b",
-    "name": "Qwen3.5-122B-A10B",
-    "family": "qwen3.5",
+    "name": "Qwen3.5 122B-A10B",
+    "family": "qwen",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-02-25",
-    "last_updated": "2026-02-25",
+    "release_date": "2026-02-23",
+    "last_updated": "2026-02-23",
     "modalities": {
       "input": [
         "text",
@@ -104264,14 +107771,14 @@
   },
   {
     "id": "openrouter/qwen/qwen3.5-27b",
-    "name": "Qwen3.5-27B",
-    "family": "qwen3.5",
+    "name": "Qwen3.5 27B",
+    "family": "qwen",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-02-25",
-    "last_updated": "2026-02-25",
+    "release_date": "2026-02-23",
+    "last_updated": "2026-02-23",
     "modalities": {
       "input": [
         "text",
@@ -104294,14 +107801,14 @@
   },
   {
     "id": "openrouter/qwen/qwen3.5-35b-a3b",
-    "name": "Qwen3.5-35B-A3B",
-    "family": "qwen3.5",
+    "name": "Qwen3.5 35B-A3B",
+    "family": "qwen",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-02-25",
-    "last_updated": "2026-02-25",
+    "release_date": "2026-02-23",
+    "last_updated": "2026-02-23",
     "modalities": {
       "input": [
         "text",
@@ -104325,15 +107832,14 @@
   },
   {
     "id": "openrouter/qwen/qwen3.5-397b-a17b",
-    "name": "Qwen3.5 397B A17B",
+    "name": "Qwen3.5 397B-A17B",
     "family": "qwen",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-04",
-    "release_date": "2026-02-16",
-    "last_updated": "2026-02-16",
+    "release_date": "2026-02-15",
+    "last_updated": "2026-02-15",
     "modalities": {
       "input": [
         "text",
@@ -104376,12 +107882,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.04,
+      "input": 0.1,
       "output": 0.15
     },
     "limit": {
       "context": 262144,
-      "output": 81920
+      "output": 262144
     }
   },
   {
@@ -104479,13 +107985,13 @@
   {
     "id": "openrouter/qwen/qwen3.6-27b",
     "name": "Qwen3.6 27B",
-    "family": "qwen3.6",
+    "family": "qwen",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-04-27",
-    "last_updated": "2026-04-27",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
     "modalities": {
       "input": [
         "text",
@@ -104498,24 +108004,24 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.29,
-      "output": 3.2
+      "input": 0.289,
+      "output": 2.4
     },
     "limit": {
-      "context": 262140,
-      "output": 262140
+      "context": 131072,
+      "output": 131072
     }
   },
   {
     "id": "openrouter/qwen/qwen3.6-35b-a3b",
-    "name": "Qwen3.6 35B A3B",
-    "family": "qwen3.6",
+    "name": "Qwen3.6 35B-A3B",
+    "family": "qwen",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-04-27",
-    "last_updated": "2026-04-27",
+    "release_date": "2026-04-17",
+    "last_updated": "2026-04-17",
     "modalities": {
       "input": [
         "text",
@@ -104570,13 +108076,14 @@
   {
     "id": "openrouter/qwen/qwen3.6-max-preview",
     "name": "Qwen3.6 Max Preview",
-    "family": "qwen3.6",
+    "family": "qwen",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-04-27",
-    "last_updated": "2026-04-27",
+    "knowledge": "2025-04",
+    "release_date": "2026-04-20",
+    "last_updated": "2026-04-20",
     "modalities": {
       "input": [
         "text"
@@ -104652,6 +108159,38 @@
       "output": 3.75,
       "cache_read": 0.25,
       "cache_write": 1.5625
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3.7-plus",
+    "name": "Qwen3.7 Plus",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-06-02",
+    "last_updated": "2026-06-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.4,
+      "output": 1.6,
+      "cache_read": 0.08,
+      "cache_write": 0.5
     },
     "limit": {
       "context": 1000000,
@@ -104769,35 +108308,6 @@
     "limit": {
       "context": 256000,
       "output": 128000
-    }
-  },
-  {
-    "id": "openrouter/sao10k/l3-euryale-70b",
-    "name": "Llama 3 Euryale 70B v2.1",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-12-31",
-    "release_date": "2024-06-18",
-    "last_updated": "2024-06-18",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 1.48,
-      "output": 1.48
-    },
-    "limit": {
-      "context": 8192,
-      "output": 8192
     }
   },
   {
@@ -104919,14 +108429,13 @@
   {
     "id": "openrouter/stepfun/step-3.5-flash",
     "name": "Step 3.5 Flash",
-    "family": "step",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-01",
     "release_date": "2026-01-29",
-    "last_updated": "2026-01-29",
+    "last_updated": "2026-02-13",
     "modalities": {
       "input": [
         "text"
@@ -104949,13 +108458,13 @@
   {
     "id": "openrouter/stepfun/step-3.7-flash",
     "name": "Step 3.7 Flash",
-    "family": "step",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-05-28",
-    "last_updated": "2026-05-28",
+    "knowledge": "2026-01-01",
+    "release_date": "2026-05-29",
+    "last_updated": "2026-05-29",
     "modalities": {
       "input": [
         "text",
@@ -104966,7 +108475,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.2,
       "output": 1.15,
@@ -105041,8 +108550,8 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-04-22",
-    "last_updated": "2026-04-22",
+    "release_date": "2026-04-20",
+    "last_updated": "2026-04-20",
     "modalities": {
       "input": [
         "text"
@@ -105429,8 +108938,8 @@
     "modalities": {
       "input": [
         "text",
-        "audio",
         "image",
+        "audio",
         "video"
       ],
       "output": [
@@ -105670,8 +109179,8 @@
     "last_updated": "2025-12-08",
     "modalities": {
       "input": [
-        "image",
         "text",
+        "image",
         "video"
       ],
       "output": [
@@ -105770,7 +109279,7 @@
     "open_weights": true,
     "cost": {
       "input": 0.6,
-      "output": 2.08,
+      "output": 1.92,
       "cache_read": 0.12
     },
     "limit": {
@@ -105825,7 +109334,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.98,
       "output": 3.08,
@@ -106053,13 +109562,13 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.684,
-      "output": 3.42,
-      "cache_read": 0.144
+      "input": 0.68,
+      "output": 3.41,
+      "cache_read": 0.34
     },
     "limit": {
-      "context": 262144,
-      "output": 262144
+      "context": 262142,
+      "output": 262142
     }
   },
   {
@@ -108567,7 +112076,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 1.4,
       "output": 4.4,
@@ -109525,7 +113034,7 @@
     }
   },
   {
-    "id": "perplexity-agent/xai/grok-4.1-fast-non",
+    "id": "perplexity-agent/xai/grok-4.1-fast-non-reasoning",
     "name": "Grok 4.1 Fast (Non-Reasoning)",
     "family": "grok",
     "attachment": true,
@@ -113349,37 +116858,7 @@
     }
   },
   {
-    "id": "poe/xai/grok-4-fast",
-    "name": "Grok-4-Fast-Reasoning",
-    "family": "grok",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "release_date": "2025-09-16",
-    "last_updated": "2025-09-16",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.5,
-      "cache_read": 0.05
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 128000
-    }
-  },
-  {
-    "id": "poe/xai/grok-4-fast-non",
+    "id": "poe/xai/grok-4-fast-non-reasoning",
     "name": "Grok-4-Fast-Non-Reasoning",
     "family": "grok",
     "attachment": true,
@@ -113409,11 +116888,41 @@
     }
   },
   {
-    "id": "poe/xai/grok-4.1-fast",
-    "name": "Grok-4.1-Fast-Reasoning",
+    "id": "poe/xai/grok-4-fast-reasoning",
+    "name": "Grok-4-Fast-Reasoning",
     "family": "grok",
     "attachment": true,
     "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2025-09-16",
+    "last_updated": "2025-09-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.2,
+      "output": 0.5,
+      "cache_read": 0.05
+    },
+    "limit": {
+      "context": 2000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "poe/xai/grok-4.1-fast-non-reasoning",
+    "name": "Grok-4.1-Fast-Non-Reasoning",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": false,
     "tool_call": true,
     "temperature": false,
     "release_date": "2025-11-19",
@@ -113435,11 +116944,11 @@
     }
   },
   {
-    "id": "poe/xai/grok-4.1-fast-non",
-    "name": "Grok-4.1-Fast-Non-Reasoning",
+    "id": "poe/xai/grok-4.1-fast-reasoning",
+    "name": "Grok-4.1-Fast-Reasoning",
     "family": "grok",
     "attachment": true,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": false,
     "release_date": "2025-11-19",
@@ -115954,8 +119463,35 @@
     }
   },
   {
-    "id": "qiniu-ai/x-ai/grok-4-fast-non",
+    "id": "qiniu-ai/x-ai/grok-4-fast-non-reasoning",
     "name": "X-Ai/Grok-4-Fast-Non-Reasoning",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-12-18",
+    "last_updated": "2025-12-18",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 2000000,
+      "output": 2000000
+    }
+  },
+  {
+    "id": "qiniu-ai/x-ai/grok-4-fast-reasoning",
+    "name": "X-Ai/Grok-4-Fast-Reasoning",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
@@ -116005,7 +119541,7 @@
     }
   },
   {
-    "id": "qiniu-ai/x-ai/grok-4.1-fast-non",
+    "id": "qiniu-ai/x-ai/grok-4.1-fast-non-reasoning",
     "name": "X-Ai/Grok 4.1 Fast Non Reasoning",
     "attachment": true,
     "reasoning": true,
@@ -116028,6 +119564,33 @@
     "cost": {},
     "limit": {
       "context": 2000000,
+      "output": 2000000
+    }
+  },
+  {
+    "id": "qiniu-ai/x-ai/grok-4.1-fast-reasoning",
+    "name": "X-Ai/Grok 4.1 Fast Reasoning",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-12-19",
+    "last_updated": "2025-12-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 20000000,
       "output": 2000000
     }
   },
@@ -117964,7 +121527,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 1.0,
       "output": 3.0,
@@ -117994,7 +121557,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 1.0,
       "output": 3.0,
@@ -119220,8 +122783,8 @@
     "tool_call": true,
     "temperature": false,
     "knowledge": "2025-08-31",
-    "release_date": "2026-04-27",
-    "last_updated": "2026-04-27",
+    "release_date": "2026-03-05",
+    "last_updated": "2026-03-05",
     "modalities": {
       "input": [
         "text",
@@ -119237,6 +122800,38 @@
       "input": 2.5,
       "output": 15.0,
       "cache_read": 0.25
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "sap-ai-core/gpt-5.5",
+    "name": "gpt-5.5",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-12-01",
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5
     },
     "limit": {
       "context": 1050000,
@@ -126841,14 +130436,14 @@
   },
   {
     "id": "togetherai/deepseek-ai/DeepSeek-R1",
-    "name": "DeepSeek R1",
+    "name": "DeepSeek-R1",
     "family": "deepseek-thinking",
     "attachment": false,
     "reasoning": true,
     "tool_call": false,
     "temperature": true,
     "knowledge": "2024-07",
-    "release_date": "2024-12-26",
+    "release_date": "2025-01-20",
     "last_updated": "2025-03-24",
     "modalities": {
       "input": [
@@ -126870,14 +130465,14 @@
   },
   {
     "id": "togetherai/deepseek-ai/DeepSeek-V3",
-    "name": "DeepSeek V3",
+    "name": "DeepSeek-V3",
     "family": "deepseek",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2024-07",
-    "release_date": "2025-01-20",
+    "release_date": "2024-12-26",
     "last_updated": "2025-05-29",
     "modalities": {
       "input": [
@@ -127106,6 +130701,35 @@
     }
   },
   {
+    "id": "togetherai/nvidia/nemotron-3-ultra-550b-a55b",
+    "name": "Nemotron 3 Ultra 550B A55B",
+    "family": "nemotron",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-04",
+    "last_updated": "2026-06-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.6,
+      "output": 3.6,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 512300,
+      "output": 512300
+    }
+  },
+  {
     "id": "togetherai/openai/gpt-oss-120b",
     "name": "GPT OSS 120B",
     "family": "gpt-oss",
@@ -127244,7 +130868,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.0,
       "output": 0.0,
@@ -128119,7 +131743,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-04-03",
-    "last_updated": "2026-05-25",
+    "last_updated": "2026-06-08",
     "modalities": {
       "input": [
         "text",
@@ -128132,8 +131756,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.155,
-      "output": 0.44
+      "input": 0.12,
+      "output": 0.36,
+      "cache_read": 0.09
     },
     "limit": {
       "context": 256000,
@@ -128504,11 +132129,12 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-06-01",
-    "last_updated": "2026-06-01",
+    "last_updated": "2026-06-04",
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "video"
       ],
       "output": [
         "text"
@@ -128522,7 +132148,7 @@
     },
     "limit": {
       "context": 500000,
-      "output": 32768
+      "output": 131072
     }
   },
   {
@@ -128608,6 +132234,36 @@
     "limit": {
       "context": 128000,
       "output": 16384
+    }
+  },
+  {
+    "id": "venice/nvidia-nemotron-3-ultra-550b-a55b",
+    "name": "NVIDIA Nemotron 3 Ultra",
+    "family": "nemotron",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-04",
+    "last_updated": "2026-06-08",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.625,
+      "output": 3.125,
+      "cache_read": 0.1875
+    },
+    "limit": {
+      "context": 256000,
+      "output": 32768
     }
   },
   {
@@ -129049,6 +132705,38 @@
       "output": 8.05,
       "cache_read": 0.27,
       "cache_write": 3.35
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "venice/qwen-3.7-plus",
+    "name": "Qwen 3.7 Plus",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-02",
+    "last_updated": "2026-06-04",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.5,
+      "output": 2.0,
+      "cache_read": 0.05,
+      "cache_write": 0.625
     },
     "limit": {
       "context": 1000000,
@@ -129591,7 +133279,7 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-04",
-    "release_date": "2025-04",
+    "release_date": "2025-04-01",
     "last_updated": "2025-04",
     "modalities": {
       "input": [
@@ -129603,7 +133291,7 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.06,
+      "input": 0.12,
       "output": 0.24
     },
     "limit": {
@@ -129620,7 +133308,7 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-04",
-    "release_date": "2025-04",
+    "release_date": "2025-04-01",
     "last_updated": "2025-04",
     "modalities": {
       "input": [
@@ -129632,11 +133320,11 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.13,
-      "output": 0.6
+      "input": 0.22,
+      "output": 0.88
     },
     "limit": {
-      "context": 40960,
+      "context": 262144,
       "output": 16384
     }
   },
@@ -129649,7 +133337,7 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-04",
-    "release_date": "2025-04",
+    "release_date": "2025-04-01",
     "last_updated": "2025-04",
     "modalities": {
       "input": [
@@ -129661,8 +133349,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.08,
-      "output": 0.29
+      "input": 0.12,
+      "output": 0.5
     },
     "limit": {
       "context": 40960,
@@ -129678,7 +133366,7 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-04",
-    "release_date": "2025-04",
+    "release_date": "2025-04-01",
     "last_updated": "2025-04",
     "modalities": {
       "input": [
@@ -129690,12 +133378,12 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.1,
-      "output": 0.3
+      "input": 0.16,
+      "output": 0.64
     },
     "limit": {
-      "context": 40960,
-      "output": 16384
+      "context": 128000,
+      "output": 8192
     }
   },
   {
@@ -129711,7 +133399,6 @@
     "modalities": {
       "input": [
         "text",
-        "image",
         "pdf"
       ],
       "output": [
@@ -129739,7 +133426,7 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-04",
-    "release_date": "2025-04",
+    "release_date": "2025-09-24",
     "last_updated": "2025-04",
     "modalities": {
       "input": [
@@ -129753,12 +133440,12 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.3,
-      "output": 2.9
+      "input": 0.4,
+      "output": 4.0
     },
     "limit": {
-      "context": 262114,
-      "output": 262114
+      "context": 131072,
+      "output": 32768
     }
   },
   {
@@ -129770,7 +133457,7 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-04",
-    "release_date": "2025-04",
+    "release_date": "2025-04-01",
     "last_updated": "2025-04",
     "modalities": {
       "input": [
@@ -129782,12 +133469,13 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.38,
-      "output": 1.53
+      "input": 1.5,
+      "output": 7.5,
+      "cache_read": 0.3
     },
     "limit": {
       "context": 262144,
-      "output": 66536
+      "output": 65536
     }
   },
   {
@@ -129799,7 +133487,7 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-04",
-    "release_date": "2025-04",
+    "release_date": "2025-04-01",
     "last_updated": "2025-04",
     "modalities": {
       "input": [
@@ -129811,12 +133499,12 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.07,
-      "output": 0.27
+      "input": 0.15,
+      "output": 0.6
     },
     "limit": {
-      "context": 160000,
-      "output": 32768
+      "context": 262144,
+      "output": 8192
     }
   },
   {
@@ -129869,11 +133557,12 @@
     "open_weights": true,
     "cost": {
       "input": 1.0,
-      "output": 5.0
+      "output": 5.0,
+      "cache_read": 0.2
     },
     "limit": {
       "context": 1000000,
-      "output": 1000000
+      "output": 65536
     }
   },
   {
@@ -129883,7 +133572,7 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
+    "temperature": true,
     "release_date": "2025-11-14",
     "last_updated": "2025-11-14",
     "modalities": {
@@ -129895,10 +133584,7 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.01,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 32768,
       "output": 32768
@@ -129911,7 +133597,7 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
+    "temperature": true,
     "release_date": "2025-06-05",
     "last_updated": "2025-06-05",
     "modalities": {
@@ -129923,10 +133609,7 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.02,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 32768,
       "output": 32768
@@ -129939,7 +133622,7 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
+    "temperature": true,
     "release_date": "2025-06-05",
     "last_updated": "2025-06-05",
     "modalities": {
@@ -129951,10 +133634,7 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.05,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 32768,
       "output": 32768
@@ -129982,7 +133662,8 @@
     "open_weights": false,
     "cost": {
       "input": 1.2,
-      "output": 6.0
+      "output": 6.0,
+      "cache_read": 0.24
     },
     "limit": {
       "context": 262144,
@@ -130059,7 +133740,7 @@
     "temperature": true,
     "knowledge": "2025-04",
     "release_date": "2025-09-12",
-    "last_updated": "2025-09-12",
+    "last_updated": "2025-09",
     "modalities": {
       "input": [
         "text"
@@ -130070,11 +133751,11 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.09,
-      "output": 1.1
+      "input": 0.15,
+      "output": 1.2
     },
     "limit": {
-      "context": 262144,
+      "context": 131072,
       "output": 32768
     }
   },
@@ -130088,7 +133769,7 @@
     "temperature": true,
     "knowledge": "2025-09",
     "release_date": "2025-09-12",
-    "last_updated": "2025-09-12",
+    "last_updated": "2025-09",
     "modalities": {
       "input": [
         "text"
@@ -130100,11 +133781,11 @@
     "open_weights": true,
     "cost": {
       "input": 0.15,
-      "output": 1.5
+      "output": 1.2
     },
     "limit": {
       "context": 131072,
-      "output": 65536
+      "output": 32768
     }
   },
   {
@@ -130120,7 +133801,8 @@
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -130128,8 +133810,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.39999999999999997,
-      "output": 1.5999999999999999
+      "input": 0.4,
+      "output": 1.6
     },
     "limit": {
       "context": 131072,
@@ -130150,7 +133832,8 @@
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -130158,8 +133841,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.7,
-      "output": 2.8
+      "input": 0.4,
+      "output": 1.6
     },
     "limit": {
       "context": 131072,
@@ -130180,7 +133863,8 @@
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -130188,12 +133872,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.7,
-      "output": 8.4
+      "input": 0.4,
+      "output": 4.0
     },
     "limit": {
       "context": 131072,
-      "output": 129024
+      "output": 32768
     }
   },
   {
@@ -130236,8 +133920,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-04",
     "release_date": "2026-02-16",
-    "last_updated": "2026-02-19",
+    "last_updated": "2026-02-16",
     "modalities": {
       "input": [
         "text",
@@ -130269,7 +133954,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-04-22",
-    "last_updated": "2026-05-01",
+    "last_updated": "2026-04-22",
     "modalities": {
       "input": [
         "text",
@@ -130283,7 +133968,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.6,
-      "output": 3.5999999999999996
+      "output": 3.6
     },
     "limit": {
       "context": 256000,
@@ -130298,8 +133983,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-04",
     "release_date": "2026-04-02",
-    "last_updated": "2026-04-03",
+    "last_updated": "2026-04-02",
     "modalities": {
       "input": [
         "text",
@@ -130314,7 +134000,7 @@
     "cost": {
       "input": 0.5,
       "output": 3.0,
-      "cache_read": 0.09999999999999999,
+      "cache_read": 0.1,
       "cache_write": 0.625
     },
     "limit": {
@@ -130335,6 +134021,38 @@
     "modalities": {
       "input": [
         "text",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 3.75,
+      "cache_read": 0.25,
+      "cache_write": 1.5625
+    },
+    "limit": {
+      "context": 991000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "vercel/alibaba/qwen3.7-plus",
+    "name": "Qwen 3.7 Plus",
+    "family": "qwen3.7-plus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-06-01",
+    "last_updated": "2026-06-02",
+    "modalities": {
+      "input": [
+        "text",
         "image",
         "pdf"
       ],
@@ -130344,14 +134062,164 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.5,
-      "output": 7.5,
-      "cache_read": 0.5,
-      "cache_write": 3.125
+      "input": 0.4,
+      "output": 1.6,
+      "cache_read": 0.08,
+      "cache_write": 0.5
     },
     "limit": {
-      "context": 991000,
+      "context": 1000000,
       "output": 64000
+    }
+  },
+  {
+    "id": "vercel/alibaba/wan-v2.5-t2v-preview",
+    "name": "Wan v2.5 Text-to-Video Preview",
+    "family": "o",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-09-24",
+    "last_updated": "2025-09-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/alibaba/wan-v2.6-i2v",
+    "name": "Wan v2.6 Image-to-Video",
+    "family": "o",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-12-16",
+    "last_updated": "2025-12-16",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/alibaba/wan-v2.6-i2v-flash",
+    "name": "Wan v2.6 Image-to-Video Flash",
+    "family": "o",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-12-16",
+    "last_updated": "2025-12-16",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/alibaba/wan-v2.6-r2v",
+    "name": "Wan v2.6 Reference-to-Video",
+    "family": "o",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-12-16",
+    "last_updated": "2025-12-16",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/alibaba/wan-v2.6-r2v-flash",
+    "name": "Wan v2.6 Reference-to-Video Flash",
+    "family": "o",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-12-16",
+    "last_updated": "2025-12-16",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/alibaba/wan-v2.6-t2v",
+    "name": "Wan v2.6 Text-to-Video",
+    "family": "o",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-12-16",
+    "last_updated": "2025-12-16",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
     }
   },
   {
@@ -130377,7 +134245,8 @@
     "open_weights": false,
     "cost": {
       "input": 0.3,
-      "output": 2.5
+      "output": 2.5,
+      "cache_read": 0.075
     },
     "limit": {
       "context": 1000000,
@@ -130485,8 +134354,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
-    "release_date": "2024-04",
+    "temperature": true,
+    "release_date": "2024-04-01",
     "last_updated": "2024-04",
     "modalities": {
       "input": [
@@ -130497,10 +134366,7 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.02,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 8192,
       "output": 1536
@@ -130533,39 +134399,6 @@
       "output": 1.25,
       "cache_read": 0.03,
       "cache_write": 0.3
-    },
-    "limit": {
-      "context": 200000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "vercel/anthropic/claude-3-opus",
-    "name": "Claude Opus 3",
-    "family": "claude-opus",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-08-31",
-    "release_date": "2024-02-29",
-    "last_updated": "2024-02-29",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 15.0,
-      "output": 75.0,
-      "cache_read": 1.5,
-      "cache_write": 18.75
     },
     "limit": {
       "context": 200000,
@@ -130606,49 +134439,16 @@
     }
   },
   {
-    "id": "vercel/anthropic/claude-3.5-sonnet",
-    "name": "Claude Sonnet 3.5 v2",
-    "family": "claude-sonnet",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-04-30",
-    "release_date": "2024-10-22",
-    "last_updated": "2024-10-22",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.3,
-      "cache_write": 3.75
-    },
-    "limit": {
-      "context": 200000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "vercel/anthropic/claude-3.7-sonnet",
-    "name": "Claude Sonnet 3.7",
-    "family": "claude-sonnet",
+    "id": "vercel/anthropic/claude-fable-5",
+    "name": "Claude Fable 5",
+    "family": "claude",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-10-31",
-    "release_date": "2025-02-19",
-    "last_updated": "2025-02-19",
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-09",
+    "last_updated": "2026-06-09",
     "modalities": {
       "input": [
         "text",
@@ -130661,14 +134461,14 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.3,
-      "cache_write": 3.75
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
     },
     "limit": {
-      "context": 200000,
-      "output": 64000
+      "context": 1000000,
+      "output": 128000
     }
   },
   {
@@ -130779,7 +134579,7 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-03-31",
-    "release_date": "2025-11-24",
+    "release_date": "2024-11-24",
     "last_updated": "2025-11-24",
     "modalities": {
       "input": [
@@ -130796,7 +134596,7 @@
       "input": 5.0,
       "output": 25.0,
       "cache_read": 0.5,
-      "cache_write": 18.75
+      "cache_write": 6.25
     },
     "limit": {
       "context": 200000,
@@ -130812,8 +134612,8 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-05-31",
-    "release_date": "2026-02",
-    "last_updated": "2026-02",
+    "release_date": "2026-02-05",
+    "last_updated": "2026-03-13",
     "modalities": {
       "input": [
         "text",
@@ -130843,7 +134643,8 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
+    "knowledge": "2026-01-31",
     "release_date": "2026-04-16",
     "last_updated": "2026-04-16",
     "modalities": {
@@ -130976,7 +134777,7 @@
     "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-17",
-    "last_updated": "2026-02-17",
+    "last_updated": "2026-03-13",
     "modalities": {
       "input": [
         "text",
@@ -131008,7 +134809,7 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2024-10",
-    "release_date": "2025-01",
+    "release_date": "2025-01-01",
     "last_updated": "2025-01",
     "modalities": {
       "input": [
@@ -131065,7 +134866,7 @@
     "tool_call": false,
     "temperature": true,
     "knowledge": "2024-10",
-    "release_date": "2025-12",
+    "release_date": "2025-12-01",
     "last_updated": "2025-12",
     "modalities": {
       "input": [
@@ -131077,12 +134878,137 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.05,
+      "input": 0.045,
       "output": 0.15
     },
     "limit": {
       "context": 131072,
       "output": 131072
+    }
+  },
+  {
+    "id": "vercel/bfl/flux-2-flex",
+    "name": "FLUX.2 [flex]",
+    "family": "flux",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-06-08",
+    "last_updated": "2026-06-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/bfl/flux-2-klein-4b",
+    "name": "FLUX.2 [klein] 4B",
+    "family": "flux",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-06-08",
+    "last_updated": "2026-06-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/bfl/flux-2-klein-9b",
+    "name": "FLUX.2 [klein] 9B",
+    "family": "flux",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-06-08",
+    "last_updated": "2026-06-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/bfl/flux-2-max",
+    "name": "FLUX.2 [max]",
+    "family": "flux",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-06-08",
+    "last_updated": "2026-06-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 67300,
+      "output": 67300
+    }
+  },
+  {
+    "id": "vercel/bfl/flux-2-pro",
+    "name": "FLUX.2 [pro]",
+    "family": "flux",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-06-08",
+    "last_updated": "2026-06-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 67300,
+      "output": 67300
     }
   },
   {
@@ -131092,8 +135018,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
-    "release_date": "2025-06",
+    "temperature": true,
+    "release_date": "2025-06-01",
     "last_updated": "2025-06",
     "modalities": {
       "input": [
@@ -131117,8 +135043,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
-    "release_date": "2025-06",
+    "temperature": true,
+    "release_date": "2025-06-01",
     "last_updated": "2025-06",
     "modalities": {
       "input": [
@@ -131142,8 +135068,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
-    "release_date": "2024-10",
+    "temperature": true,
+    "release_date": "2024-10-01",
     "last_updated": "2024-10",
     "modalities": {
       "input": [
@@ -131167,8 +135093,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
-    "release_date": "2024-10",
+    "temperature": true,
+    "release_date": "2024-10-01",
     "last_updated": "2024-10",
     "modalities": {
       "input": [
@@ -131192,8 +135118,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
-    "release_date": "2024-11",
+    "temperature": true,
+    "release_date": "2024-11-01",
     "last_updated": "2024-11",
     "modalities": {
       "input": [
@@ -131219,7 +135145,7 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2024-10",
-    "release_date": "2025-09",
+    "release_date": "2025-09-01",
     "last_updated": "2025-09",
     "modalities": {
       "input": [
@@ -131249,7 +135175,7 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2024-10",
-    "release_date": "2025-10",
+    "release_date": "2025-09-01",
     "last_updated": "2025-10",
     "modalities": {
       "input": [
@@ -131269,6 +135195,258 @@
     "limit": {
       "context": 256000,
       "output": 64000
+    }
+  },
+  {
+    "id": "vercel/bytedance/seedance-2.0",
+    "name": "Seedance 2.0",
+    "family": "seed",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-04-14",
+    "last_updated": "2026-04-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/bytedance/seedance-2.0-fast",
+    "name": "Seedance 2.0 Fast",
+    "family": "seed",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-04-14",
+    "last_updated": "2026-04-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/bytedance/seedance-v1.0-lite-i2v",
+    "name": "Seedance v1.0 Lite Image-to-Video",
+    "family": "seed",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-06-01",
+    "last_updated": "2025-06-01",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/bytedance/seedance-v1.0-lite-t2v",
+    "name": "Seedance v1.0 Lite Text-to-Video",
+    "family": "seed",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-06-01",
+    "last_updated": "2025-06-01",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/bytedance/seedance-v1.0-pro",
+    "name": "Seedance v1.0 Pro",
+    "family": "seed",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-06-11",
+    "last_updated": "2025-06-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/bytedance/seedance-v1.0-pro-fast",
+    "name": "Seedance v1.0 Pro Fast",
+    "family": "seed",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-10-31",
+    "last_updated": "2025-10-31",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/bytedance/seedance-v1.5-pro",
+    "name": "Seedance v1.5 Pro",
+    "family": "seed",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-12-16",
+    "last_updated": "2025-12-16",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/bytedance/seedream-4.0",
+    "name": "Seedream 4.0",
+    "family": "seed",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-08-28",
+    "last_updated": "2025-08-28",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/bytedance/seedream-4.5",
+    "name": "Seedream 4.5",
+    "family": "seed",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-11-28",
+    "last_updated": "2025-11-28",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/bytedance/seedream-5.0-lite",
+    "name": "Seedream 5.0 Lite",
+    "family": "seed",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-01-28",
+    "last_updated": "2026-01-28",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
     }
   },
   {
@@ -131307,7 +135485,7 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
+    "temperature": true,
     "release_date": "2025-04-15",
     "last_updated": "2025-04-15",
     "modalities": {
@@ -131319,13 +135497,85 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.12,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 8192,
       "output": 1536
+    }
+  },
+  {
+    "id": "vercel/cohere/rerank-v3.5",
+    "name": "Cohere Rerank 3.5",
+    "family": "o",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2024-12-02",
+    "last_updated": "2024-12-02",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 4096,
+      "output": 4096
+    }
+  },
+  {
+    "id": "vercel/cohere/rerank-v4-fast",
+    "name": "Cohere Rerank 4 Fast",
+    "family": "o",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-12-11",
+    "last_updated": "2025-12-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 32000,
+      "output": 32000
+    }
+  },
+  {
+    "id": "vercel/cohere/rerank-v4-pro",
+    "name": "Cohere Rerank 4 Pro",
+    "family": "o",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-12-11",
+    "last_updated": "2025-12-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 32000,
+      "output": 32000
     }
   },
   {
@@ -131378,12 +135628,13 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.77,
-      "output": 0.77
+      "input": 0.27,
+      "output": 1.12,
+      "cache_read": 0.135
     },
     "limit": {
       "context": 163840,
-      "output": 16384
+      "output": 163840
     }
   },
   {
@@ -131407,12 +135658,13 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.3,
-      "output": 1.0
+      "input": 0.56,
+      "output": 1.68,
+      "cache_read": 0.28
     },
     "limit": {
       "context": 163840,
-      "output": 128000
+      "output": 8192
     }
   },
   {
@@ -131437,7 +135689,8 @@
     "open_weights": true,
     "cost": {
       "input": 0.27,
-      "output": 1.0
+      "output": 1.0,
+      "cache_read": 0.135
     },
     "limit": {
       "context": 131072,
@@ -131457,7 +135710,9 @@
     "last_updated": "2025-12-01",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -131465,42 +135720,13 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.27,
-      "output": 0.4,
-      "cache_read": 0.22
+      "input": 0.28,
+      "output": 0.42,
+      "cache_read": 0.028
     },
     "limit": {
-      "context": 163842,
+      "context": 128000,
       "output": 8000
-    }
-  },
-  {
-    "id": "vercel/deepseek/deepseek-v3.2-exp",
-    "name": "DeepSeek V3.2 Exp",
-    "family": "deepseek",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-09",
-    "release_date": "2025-09-29",
-    "last_updated": "2025-09-29",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.27,
-      "output": 0.4
-    },
-    "limit": {
-      "context": 163840,
-      "output": 163840
     }
   },
   {
@@ -131516,7 +135742,9 @@
     "last_updated": "2025-12-01",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -131524,13 +135752,12 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.28,
-      "output": 0.42,
-      "cache_read": 0.03
+      "input": 0.62,
+      "output": 1.85
     },
     "limit": {
       "context": 128000,
-      "output": 64000
+      "output": 8000
     }
   },
   {
@@ -131541,11 +135768,14 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-05",
     "release_date": "2026-04-23",
     "last_updated": "2026-04-24",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -131555,7 +135785,7 @@
     "cost": {
       "input": 0.14,
       "output": 0.28,
-      "cache_read": 0.028
+      "cache_read": 0.0028
     },
     "limit": {
       "context": 1000000,
@@ -131570,11 +135800,13 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-05",
     "release_date": "2026-04-23",
     "last_updated": "2026-04-24",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "pdf"
       ],
       "output": [
         "text"
@@ -131582,80 +135814,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 1.74,
-      "output": 3.48,
-      "cache_read": 0.145
+      "input": 0.435,
+      "output": 0.87,
+      "cache_read": 0.0036
     },
     "limit": {
       "context": 1000000,
       "output": 384000
-    }
-  },
-  {
-    "id": "vercel/google/gemini-2.0-flash",
-    "name": "Gemini 2.0 Flash",
-    "family": "gemini-flash",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-06",
-    "release_date": "2024-12-11",
-    "last_updated": "2024-12-11",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.1,
-      "output": 0.4,
-      "cache_read": 0.025
-    },
-    "limit": {
-      "context": 1048576,
-      "output": 8192
-    }
-  },
-  {
-    "id": "vercel/google/gemini-2.0-flash-lite",
-    "name": "Gemini 2.0 Flash-Lite",
-    "family": "gemini-flash-lite",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-06",
-    "release_date": "2024-12-11",
-    "last_updated": "2024-12-11",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.075,
-      "output": 0.3
-    },
-    "limit": {
-      "context": 1048576,
-      "output": 8192
     }
   },
   {
@@ -131702,7 +135867,7 @@
     "temperature": true,
     "knowledge": "2025-01",
     "release_date": "2025-03-20",
-    "last_updated": "2025-03-20",
+    "last_updated": "2025-08-26",
     "modalities": {
       "input": [
         "text"
@@ -131715,41 +135880,12 @@
     "open_weights": false,
     "cost": {
       "input": 0.3,
-      "output": 2.5
+      "output": 2.5,
+      "cache_read": 0.03
     },
     "limit": {
       "context": 32768,
-      "output": 32768
-    }
-  },
-  {
-    "id": "vercel/google/gemini-2.5-flash-image-preview",
-    "name": "Nano Banana Preview (Gemini 2.5 Flash Image Preview)",
-    "family": "gemini-flash",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2025-03-20",
-    "last_updated": "2025-03-20",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text",
-        "image"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.3,
-      "output": 2.5
-    },
-    "limit": {
-      "context": 32768,
-      "output": 32768
+      "output": 65536
     }
   },
   {
@@ -131767,8 +135903,6 @@
       "input": [
         "text",
         "image",
-        "audio",
-        "video",
         "pdf"
       ],
       "output": [
@@ -131780,75 +135914,6 @@
       "input": 0.1,
       "output": 0.4,
       "cache_read": 0.01
-    },
-    "limit": {
-      "context": 1048576,
-      "output": 65536
-    }
-  },
-  {
-    "id": "vercel/google/gemini-2.5-flash-lite-preview-09",
-    "name": "Gemini 2.5 Flash Lite Preview 09-25",
-    "family": "gemini-flash-lite",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2025-09-25",
-    "last_updated": "2025-09-25",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.1,
-      "output": 0.4,
-      "cache_read": 0.01
-    },
-    "limit": {
-      "context": 1048576,
-      "output": 65536
-    }
-  },
-  {
-    "id": "vercel/google/gemini-2.5-flash-preview-09",
-    "name": "Gemini 2.5 Flash Preview 09-25",
-    "family": "gemini-flash",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2025-09-25",
-    "last_updated": "2025-09-25",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "audio",
-        "video",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.3,
-      "output": 2.5,
-      "cache_read": 0.03,
-      "cache_write": 0.383
     },
     "limit": {
       "context": 1048576,
@@ -131918,7 +135983,7 @@
     },
     "limit": {
       "context": 1000000,
-      "output": 64000
+      "output": 65000
     }
   },
   {
@@ -131930,7 +135995,7 @@
     "tool_call": false,
     "temperature": true,
     "knowledge": "2025-03",
-    "release_date": "2025-09",
+    "release_date": "2025-09-01",
     "last_updated": "2025-09",
     "modalities": {
       "input": [
@@ -131944,7 +136009,8 @@
     "open_weights": false,
     "cost": {
       "input": 2.0,
-      "output": 120.0
+      "output": 12.0,
+      "cache_read": 0.2
     },
     "limit": {
       "context": 65536,
@@ -131966,8 +136032,6 @@
       "input": [
         "text",
         "image",
-        "video",
-        "audio",
         "pdf"
       ],
       "output": [
@@ -131986,15 +136050,15 @@
     }
   },
   {
-    "id": "vercel/google/gemini-3.1-flash-image-preview",
-    "name": "Gemini 3.1 Flash Image Preview (Nano Banana 2)",
+    "id": "vercel/google/gemini-3.1-flash-image",
+    "name": "Gemini 3.1 Flash Image (Nano Banana 2)",
     "family": "gemini",
     "attachment": true,
     "reasoning": true,
     "tool_call": false,
     "temperature": true,
-    "release_date": "2026-02-26",
-    "last_updated": "2026-03-06",
+    "release_date": "2026-05-28",
+    "last_updated": "2026-05-28",
     "modalities": {
       "input": [
         "text",
@@ -132008,7 +136072,40 @@
     "open_weights": false,
     "cost": {
       "input": 0.5,
-      "output": 3.0
+      "output": 3.0,
+      "cache_read": 0.05
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    }
+  },
+  {
+    "id": "vercel/google/gemini-3.1-flash-image-preview",
+    "name": "Gemini 3.1 Flash Image Preview (Nano Banana 2)",
+    "family": "gemini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-02-26",
+    "last_updated": "2026-02-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.5,
+      "output": 3.0,
+      "cache_read": 0.05
     },
     "limit": {
       "context": 131072,
@@ -132023,8 +136120,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-01",
     "release_date": "2026-05-07",
-    "last_updated": "2026-05-08",
+    "last_updated": "2026-05-07",
     "modalities": {
       "input": [
         "text",
@@ -132054,8 +136152,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-01",
     "release_date": "2026-03-03",
-    "last_updated": "2026-03-06",
+    "last_updated": "2026-03-03",
     "modalities": {
       "input": [
         "text",
@@ -132070,8 +136169,7 @@
     "cost": {
       "input": 0.25,
       "output": 1.5,
-      "cache_read": 0.025,
-      "cache_write": 1.0
+      "cache_read": 0.03
     },
     "limit": {
       "context": 1000000,
@@ -132086,8 +136184,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-02-19",
-    "last_updated": "2026-02-24",
+    "knowledge": "2025-01",
+    "release_date": "2025-11-18",
+    "last_updated": "2026-02-19",
     "modalities": {
       "input": [
         "text",
@@ -132117,8 +136216,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-01",
     "release_date": "2026-05-19",
-    "last_updated": "2026-05-21",
+    "last_updated": "2026-05-19",
     "modalities": {
       "input": [
         "text",
@@ -132147,7 +136247,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
+    "temperature": true,
+    "knowledge": "2025-05",
     "release_date": "2025-05-20",
     "last_updated": "2025-05-20",
     "modalities": {
@@ -132159,10 +136260,7 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.15,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 8192,
       "output": 1536
@@ -132202,7 +136300,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-04-02",
-    "last_updated": "2026-04-03",
+    "last_updated": "2026-04-02",
     "modalities": {
       "input": [
         "text",
@@ -132215,8 +136313,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.13,
-      "output": 0.39999999999999997
+      "input": 0.15,
+      "output": 0.6,
+      "cache_read": 0.015
     },
     "limit": {
       "context": 262144,
@@ -132232,7 +136331,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-04-02",
-    "last_updated": "2026-04-03",
+    "last_updated": "2026-04-02",
     "modalities": {
       "input": [
         "text",
@@ -132246,7 +136345,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.14,
-      "output": 0.39999999999999997
+      "output": 0.4
     },
     "limit": {
       "context": 262144,
@@ -132260,8 +136359,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
-    "release_date": "2025-06",
+    "temperature": true,
+    "release_date": "2025-06-01",
     "last_updated": "2025-06",
     "modalities": {
       "input": [
@@ -132335,8 +136434,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
-    "release_date": "2024-08",
+    "temperature": true,
+    "release_date": "2024-08-01",
     "last_updated": "2024-08",
     "modalities": {
       "input": [
@@ -132347,10 +136446,7 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.03,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 8192,
       "output": 1536
@@ -132363,8 +136459,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
-    "release_date": "2024-03",
+    "temperature": true,
+    "release_date": "2024-03-01",
     "last_updated": "2024-03",
     "modalities": {
       "input": [
@@ -132375,13 +136471,110 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.03,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 8192,
       "output": 1536
+    }
+  },
+  {
+    "id": "vercel/google/veo-3.0-fast-generate-001",
+    "name": "Veo 3.0 Fast Generate",
+    "family": "veo",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-06-08",
+    "last_updated": "2026-06-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/google/veo-3.0-generate-001",
+    "name": "Veo 3.0",
+    "family": "veo",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-06-08",
+    "last_updated": "2026-06-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/google/veo-3.1-fast-generate-001",
+    "name": "Veo 3.1 Fast Generate",
+    "family": "veo",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-06-08",
+    "last_updated": "2026-06-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/google/veo-3.1-generate-001",
+    "name": "Veo 3.1",
+    "family": "veo",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-06-08",
+    "last_updated": "2026-06-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
     }
   },
   {
@@ -132406,7 +136599,7 @@
     "cost": {
       "input": 0.25,
       "output": 0.75,
-      "cache_read": 0.024999999999999998
+      "cache_read": 0.025
     },
     "limit": {
       "context": 128000,
@@ -132422,7 +136615,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-02-26",
-    "last_updated": "2026-05-01",
+    "last_updated": "2025-02-26",
     "modalities": {
       "input": [
         "text"
@@ -132439,34 +136632,6 @@
     "limit": {
       "context": 32000,
       "output": 16384
-    }
-  },
-  {
-    "id": "vercel/inception/mercury-edit-2",
-    "name": "Mercury Edit 2",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2026-03-30",
-    "last_updated": "2026-03-30",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.25,
-      "output": 0.75,
-      "cache_read": 0.025
-    },
-    "limit": {
-      "context": 128000,
-      "output": 8192
     }
   },
   {
@@ -132497,6 +136662,206 @@
     }
   },
   {
+    "id": "vercel/klingai/kling-v2.5-turbo-i2v",
+    "name": "Kling v2.5 Turbo Image-to-Video",
+    "family": "ling",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-09-23",
+    "last_updated": "2025-09-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/klingai/kling-v2.5-turbo-t2v",
+    "name": "Kling v2.5 Turbo Text-to-Video",
+    "family": "ling",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-09-23",
+    "last_updated": "2025-09-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/klingai/kling-v2.6-i2v",
+    "name": "Kling v2.6 Image-to-Video",
+    "family": "ling",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-12-21",
+    "last_updated": "2025-12-21",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/klingai/kling-v2.6-motion-control",
+    "name": "Kling v2.6 Motion Control",
+    "family": "ling",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-12-21",
+    "last_updated": "2025-12-21",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/klingai/kling-v2.6-t2v",
+    "name": "Kling v2.6 Text-to-Video",
+    "family": "ling",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-12-21",
+    "last_updated": "2025-12-21",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/klingai/kling-v3.0-i2v",
+    "name": "Kling v3.0 Image-to-Video",
+    "family": "ling",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-02-05",
+    "last_updated": "2026-02-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/klingai/kling-v3.0-motion-control",
+    "name": "Kling v3.0 Motion Control",
+    "family": "ling",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-03-04",
+    "last_updated": "2026-03-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/klingai/kling-v3.0-t2v",
+    "name": "Kling v3.0 Text-to-Video",
+    "family": "ling",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-02-05",
+    "last_updated": "2026-02-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
     "id": "vercel/kwaipilot/kat-coder-pro-v1",
     "name": "KAT-Coder-Pro V1",
     "family": "kat-coder",
@@ -132516,7 +136881,11 @@
       ]
     },
     "open_weights": false,
-    "cost": {},
+    "cost": {
+      "input": 0.03,
+      "output": 1.2,
+      "cache_read": 0.06
+    },
     "limit": {
       "context": 256000,
       "output": 32000
@@ -132574,20 +136943,19 @@
     "cost": {},
     "limit": {
       "context": 128000,
-      "output": 8192
+      "output": 100000
     }
   },
   {
     "id": "vercel/meituan/longcat-flash-thinking",
-    "name": "LongCat Flash Thinking",
+    "name": "LongCat Flash Thinking 2601",
     "family": "longcat",
     "attachment": false,
     "reasoning": true,
-    "tool_call": true,
+    "tool_call": false,
     "temperature": true,
-    "knowledge": "2024-10",
-    "release_date": "2025-09-23",
-    "last_updated": "2025-09-23",
+    "release_date": "2026-03-13",
+    "last_updated": "2026-03-13",
     "modalities": {
       "input": [
         "text"
@@ -132597,13 +136965,10 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.15,
-      "output": 1.5
-    },
+    "cost": {},
     "limit": {
-      "context": 128000,
-      "output": 8192
+      "context": 32768,
+      "output": 32768
     }
   },
   {
@@ -132627,12 +136992,12 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.4,
-      "output": 0.4
+      "input": 0.72,
+      "output": 0.72
     },
     "limit": {
-      "context": 131072,
-      "output": 16384
+      "context": 128000,
+      "output": 8192
     }
   },
   {
@@ -132656,12 +137021,12 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.03,
-      "output": 0.05
+      "input": 0.22,
+      "output": 0.22
     },
     "limit": {
-      "context": 131072,
-      "output": 16384
+      "context": 128000,
+      "output": 8192
     }
   },
   {
@@ -132892,14 +137257,14 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.27,
-      "output": 1.15,
+      "input": 0.3,
+      "output": 1.2,
       "cache_read": 0.03,
-      "cache_write": 0.38
+      "cache_write": 0.375
     },
     "limit": {
-      "context": 262114,
-      "output": 262114
+      "context": 205000,
+      "output": 205000
     }
   },
   {
@@ -132912,7 +137277,7 @@
     "temperature": true,
     "knowledge": "2024-10",
     "release_date": "2025-10-27",
-    "last_updated": "2025-10-27",
+    "last_updated": "2025-12-23",
     "modalities": {
       "input": [
         "text"
@@ -132926,7 +137291,7 @@
       "input": 0.3,
       "output": 1.2,
       "cache_read": 0.03,
-      "cache_write": 0.38
+      "cache_write": 0.375
     },
     "limit": {
       "context": 204800,
@@ -132957,7 +137322,7 @@
       "input": 0.3,
       "output": 2.4,
       "cache_read": 0.03,
-      "cache_write": 0.38
+      "cache_write": 0.375
     },
     "limit": {
       "context": 204800,
@@ -132973,7 +137338,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-02-12",
-    "last_updated": "2026-02-19",
+    "last_updated": "2026-02-12",
     "modalities": {
       "input": [
         "text"
@@ -133003,7 +137368,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-02-12",
-    "last_updated": "2026-03-13",
+    "last_updated": "2026-02-13",
     "modalities": {
       "input": [
         "text"
@@ -133020,8 +137385,8 @@
       "cache_write": 0.375
     },
     "limit": {
-      "context": 0,
-      "output": 0
+      "context": 204800,
+      "output": 131000
     }
   },
   {
@@ -133036,9 +137401,7 @@
     "last_updated": "2026-03-18",
     "modalities": {
       "input": [
-        "text",
-        "image",
-        "pdf"
+        "text"
       ],
       "output": [
         "text"
@@ -133068,8 +137431,7 @@
     "last_updated": "2026-03-18",
     "modalities": {
       "input": [
-        "text",
-        "image"
+        "text"
       ],
       "output": [
         "text"
@@ -133085,6 +137447,37 @@
     "limit": {
       "context": 204800,
       "output": 131100
+    }
+  },
+  {
+    "id": "vercel/minimax/minimax-m3",
+    "name": "MiniMax M3",
+    "family": "minimax-m3",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-05-31",
+    "last_updated": "2026-06-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.06
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 1000000
     }
   },
   {
@@ -133123,7 +137516,7 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
+    "temperature": true,
     "release_date": "2025-05-28",
     "last_updated": "2025-05-28",
     "modalities": {
@@ -133135,10 +137528,7 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.15,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 8192,
       "output": 1536
@@ -133164,7 +137554,10 @@
       ]
     },
     "open_weights": false,
-    "cost": {},
+    "cost": {
+      "input": 0.4,
+      "output": 2.0
+    },
     "limit": {
       "context": 256000,
       "output": 256000
@@ -133219,7 +137612,10 @@
       ]
     },
     "open_weights": false,
-    "cost": {},
+    "cost": {
+      "input": 0.1,
+      "output": 0.3
+    },
     "limit": {
       "context": 256000,
       "output": 256000
@@ -133379,7 +137775,7 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
+    "temperature": true,
     "release_date": "2023-12-11",
     "last_updated": "2023-12-11",
     "modalities": {
@@ -133391,10 +137787,7 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.1,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 8192,
       "output": 1536
@@ -133509,12 +137902,12 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.04,
-      "output": 0.17
+      "input": 0.02,
+      "output": 0.04
     },
     "limit": {
-      "context": 60288,
-      "output": 16000
+      "context": 131072,
+      "output": 131072
     }
   },
   {
@@ -133545,35 +137938,6 @@
     "limit": {
       "context": 256000,
       "output": 256000
-    }
-  },
-  {
-    "id": "vercel/mistral/mixtral-8x22b-instruct",
-    "name": "Mixtral 8x22B",
-    "family": "mixtral",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-04",
-    "release_date": "2024-04-17",
-    "last_updated": "2024-04-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 2.0,
-      "output": 6.0
-    },
-    "limit": {
-      "context": 64000,
-      "output": 64000
     }
   },
   {
@@ -133686,13 +138050,13 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.47,
-      "output": 2.0,
-      "cache_read": 0.14
+      "input": 0.6,
+      "output": 2.5,
+      "cache_read": 0.15
     },
     "limit": {
-      "context": 216144,
-      "output": 216144
+      "context": 262114,
+      "output": 262114
     }
   },
   {
@@ -133746,8 +138110,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.4,
-      "output": 10.0
+      "input": 1.15,
+      "output": 8.0,
+      "cache_read": 0.15
     },
     "limit": {
       "context": 256000,
@@ -133764,12 +138129,11 @@
     "temperature": true,
     "knowledge": "2025-01",
     "release_date": "2026-01-26",
-    "last_updated": "2026-01-26",
+    "last_updated": "2026-01",
     "modalities": {
       "input": [
         "text",
-        "image",
-        "video"
+        "image"
       ],
       "output": [
         "text"
@@ -133778,11 +138142,12 @@
     "open_weights": true,
     "cost": {
       "input": 0.6,
-      "output": 1.2
+      "output": 3.0,
+      "cache_read": 0.1
     },
     "limit": {
-      "context": 262144,
-      "output": 262144
+      "context": 262114,
+      "output": 262114
     }
   },
   {
@@ -133793,8 +138158,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-01",
     "release_date": "2026-04-20",
-    "last_updated": "2026-04-24",
+    "last_updated": "2026-04-21",
     "modalities": {
       "input": [
         "text",
@@ -133881,8 +138247,8 @@
     "tool_call": false,
     "temperature": true,
     "knowledge": "2024-10",
-    "release_date": "2024-12",
-    "last_updated": "2024-12",
+    "release_date": "2024-12-01",
+    "last_updated": "2025-12-15",
     "modalities": {
       "input": [
         "text"
@@ -133893,7 +138259,7 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.06,
+      "input": 0.05,
       "output": 0.24
     },
     "limit": {
@@ -133910,7 +138276,7 @@
     "tool_call": false,
     "temperature": true,
     "release_date": "2026-03-18",
-    "last_updated": "2026-03-30",
+    "last_updated": "2026-03-11",
     "modalities": {
       "input": [
         "text"
@@ -133930,6 +138296,35 @@
     }
   },
   {
+    "id": "vercel/nvidia/nemotron-3-ultra-550b-a55b",
+    "name": "Nemotron 3 Ultra",
+    "family": "nemotron",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-04",
+    "last_updated": "2026-06-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.6,
+      "output": 2.4,
+      "cache_read": 0.12
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65000
+    }
+  },
+  {
     "id": "vercel/nvidia/nemotron-nano-12b-v2-vl",
     "name": "Nvidia Nemotron Nano 12B V2 VL",
     "family": "nemotron",
@@ -133938,8 +138333,8 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2024-10",
-    "release_date": "2024-12",
-    "last_updated": "2024-12",
+    "release_date": "2024-12-01",
+    "last_updated": "2025-10-28",
     "modalities": {
       "input": [
         "text",
@@ -133980,44 +138375,12 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.04,
-      "output": 0.16
+      "input": 0.06,
+      "output": 0.23
     },
     "limit": {
       "context": 131072,
       "output": 131072
-    }
-  },
-  {
-    "id": "vercel/openai/codex-mini",
-    "name": "Codex Mini",
-    "family": "gpt-codex-mini",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-10",
-    "release_date": "2025-05-16",
-    "last_updated": "2025-05-16",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.5,
-      "output": 6.0,
-      "cache_read": 0.38
-    },
-    "limit": {
-      "context": 200000,
-      "output": 100000
     }
   },
   {
@@ -134029,8 +138392,8 @@
     "tool_call": false,
     "temperature": true,
     "knowledge": "2021-09",
-    "release_date": "2023-03-01",
-    "last_updated": "2023-03-01",
+    "release_date": "2023-05-28",
+    "last_updated": "2023-11-06",
     "modalities": {
       "input": [
         "text"
@@ -134058,7 +138421,7 @@
     "tool_call": false,
     "temperature": true,
     "knowledge": "2021-09",
-    "release_date": "2023-03-01",
+    "release_date": "2023-09-28",
     "last_updated": "2023-03-01",
     "modalities": {
       "input": [
@@ -134276,7 +138639,7 @@
     "tool_call": false,
     "temperature": true,
     "knowledge": "2023-09",
-    "release_date": "2025-01",
+    "release_date": "2025-03-12",
     "last_updated": "2025-01",
     "modalities": {
       "input": [
@@ -134353,7 +138716,7 @@
     "cost": {
       "input": 1.25,
       "output": 10.0,
-      "cache_read": 0.13
+      "cache_read": 0.125
     },
     "limit": {
       "context": 128000,
@@ -134463,7 +138826,7 @@
     "temperature": true,
     "knowledge": "2024-10",
     "release_date": "2025-08-07",
-    "last_updated": "2025-08-07",
+    "last_updated": "2025-10-06",
     "modalities": {
       "input": [
         "text",
@@ -134494,8 +138857,8 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2024-10",
-    "release_date": "2025-08-07",
-    "last_updated": "2025-08-07",
+    "release_date": "2025-11-12",
+    "last_updated": "2025-11-13",
     "modalities": {
       "input": [
         "text",
@@ -134510,7 +138873,7 @@
     "cost": {
       "input": 1.25,
       "output": 10.0,
-      "cache_read": 0.13
+      "cache_read": 0.125
     },
     "limit": {
       "context": 400000,
@@ -134526,8 +138889,8 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2024-10",
-    "release_date": "2025-08-07",
-    "last_updated": "2025-08-07",
+    "release_date": "2025-11-19",
+    "last_updated": "2025-11-13",
     "modalities": {
       "input": [
         "text",
@@ -134542,7 +138905,7 @@
     "cost": {
       "input": 1.25,
       "output": 10.0,
-      "cache_read": 0.13
+      "cache_read": 0.125
     },
     "limit": {
       "context": 400000,
@@ -134558,8 +138921,8 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2024-10",
-    "release_date": "2025-05-16",
-    "last_updated": "2025-05-16",
+    "release_date": "2025-11-12",
+    "last_updated": "2025-11-13",
     "modalities": {
       "input": [
         "text",
@@ -134574,7 +138937,7 @@
     "cost": {
       "input": 0.25,
       "output": 2.0,
-      "cache_read": 0.03
+      "cache_read": 0.025
     },
     "limit": {
       "context": 400000,
@@ -134590,7 +138953,7 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2024-10",
-    "release_date": "2025-08-07",
+    "release_date": "2025-11-12",
     "last_updated": "2025-08-07",
     "modalities": {
       "input": [
@@ -134599,15 +138962,14 @@
         "pdf"
       ],
       "output": [
-        "text",
-        "image"
+        "text"
       ]
     },
     "open_weights": false,
     "cost": {
       "input": 1.25,
       "output": 10.0,
-      "cache_read": 0.13
+      "cache_read": 0.125
     },
     "limit": {
       "context": 128000,
@@ -134621,9 +138983,9 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-10",
-    "release_date": "2025-08-07",
+    "release_date": "2025-11-12",
     "last_updated": "2025-08-07",
     "modalities": {
       "input": [
@@ -134640,7 +139002,7 @@
     "cost": {
       "input": 1.25,
       "output": 10.0,
-      "cache_read": 0.13
+      "cache_read": 0.125
     },
     "limit": {
       "context": 400000,
@@ -134656,8 +139018,8 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2024-10",
-    "release_date": "2025-08-07",
-    "last_updated": "2025-08-07",
+    "release_date": "2025-12-11",
+    "last_updated": "2025-12-11",
     "modalities": {
       "input": [
         "text",
@@ -134672,7 +139034,7 @@
     "cost": {
       "input": 1.75,
       "output": 14.0,
-      "cache_read": 0.18
+      "cache_read": 0.175
     },
     "limit": {
       "context": 400000,
@@ -134688,7 +139050,7 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2024-10",
-    "release_date": "2025-08-07",
+    "release_date": "2025-12-11",
     "last_updated": "2025-08-07",
     "modalities": {
       "input": [
@@ -134704,7 +139066,7 @@
     "cost": {
       "input": 1.75,
       "output": 14.0,
-      "cache_read": 0.18
+      "cache_read": 0.175
     },
     "limit": {
       "context": 128000,
@@ -134720,8 +139082,8 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2024-10",
-    "release_date": "2025-12",
-    "last_updated": "2025-12",
+    "release_date": "2025-12-18",
+    "last_updated": "2025-12-11",
     "modalities": {
       "input": [
         "text",
@@ -134752,8 +139114,8 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2024-10",
-    "release_date": "2025-08-07",
-    "last_updated": "2025-08-07",
+    "release_date": "2025-12-11",
+    "last_updated": "2025-12-11",
     "modalities": {
       "input": [
         "text",
@@ -134813,8 +139175,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-08-31",
     "release_date": "2026-02-24",
-    "last_updated": "2026-02-24",
+    "last_updated": "2026-02-05",
     "modalities": {
       "input": [
         "text",
@@ -134844,8 +139207,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
-    "last_updated": "2026-03-06",
+    "last_updated": "2026-03-05",
     "modalities": {
       "input": [
         "text",
@@ -134875,6 +139239,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
     "modalities": {
@@ -134906,6 +139271,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
     "modalities": {
@@ -134920,7 +139286,7 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.19999999999999998,
+      "input": 0.2,
       "output": 1.25,
       "cache_read": 0.02
     },
@@ -134937,8 +139303,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
-    "last_updated": "2026-03-06",
+    "last_updated": "2026-03-05",
     "modalities": {
       "input": [
         "text",
@@ -134967,8 +139334,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-12-01",
     "release_date": "2026-04-24",
-    "last_updated": "2026-04-24",
+    "last_updated": "2026-04-23",
     "modalities": {
       "input": [
         "text",
@@ -134998,8 +139366,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-12-01",
     "release_date": "2026-04-24",
-    "last_updated": "2026-04-24",
+    "last_updated": "2026-04-23",
     "modalities": {
       "input": [
         "text",
@@ -135018,6 +139387,122 @@
     "limit": {
       "context": 1000000,
       "output": 128000
+    }
+  },
+  {
+    "id": "vercel/openai/gpt-image-1",
+    "name": "GPT Image 1",
+    "family": "gpt-image",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-03-25",
+    "last_updated": "2025-03-25",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 40.0,
+      "cache_read": 1.25
+    },
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/openai/gpt-image-1-mini",
+    "name": "GPT Image 1 Mini",
+    "family": "gpt-image",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-10-06",
+    "last_updated": "2025-10-06",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 8.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/openai/gpt-image-1.5",
+    "name": "GPT Image 1.5",
+    "family": "gpt-image",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-12-16",
+    "last_updated": "2025-12-16",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 32.0,
+      "cache_read": 1.25
+    },
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/openai/gpt-image-2",
+    "name": "GPT Image 2",
+    "family": "gpt-image",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 1.25
+    },
+    "limit": {
+      "context": 0,
+      "output": 0
     }
   },
   {
@@ -135041,12 +139526,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.1,
-      "output": 0.5
+      "input": 0.35,
+      "output": 0.75,
+      "cache_read": 0.25
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 131000
     }
   },
   {
@@ -135070,12 +139556,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.07,
-      "output": 0.3
+      "input": 0.05,
+      "output": 0.2
     },
     "limit": {
       "context": 131072,
-      "output": 32768
+      "output": 8192
     }
   },
   {
@@ -135099,9 +139585,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.08,
+      "input": 0.075,
       "output": 0.3,
-      "cache_read": 0.04
+      "cache_read": 0.037
     },
     "limit": {
       "context": 131072,
@@ -135179,7 +139665,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-10",
     "release_date": "2024-06-26",
     "last_updated": "2024-06-26",
@@ -135241,10 +139727,10 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-10",
     "release_date": "2025-04-16",
-    "last_updated": "2025-04-16",
+    "last_updated": "2025-06-10",
     "modalities": {
       "input": [
         "text",
@@ -135303,7 +139789,7 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
+    "temperature": true,
     "release_date": "2024-01-25",
     "last_updated": "2024-01-25",
     "modalities": {
@@ -135315,10 +139801,7 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.13,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 8192,
       "output": 1536
@@ -135331,7 +139814,7 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
+    "temperature": true,
     "release_date": "2024-01-25",
     "last_updated": "2024-01-25",
     "modalities": {
@@ -135343,10 +139826,7 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.02,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 8192,
       "output": 1536
@@ -135359,7 +139839,7 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
+    "temperature": true,
     "release_date": "2022-12-15",
     "last_updated": "2022-12-15",
     "modalities": {
@@ -135371,10 +139851,7 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.1,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 8192,
       "output": 1536
@@ -135401,10 +139878,7 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 1.0,
-      "output": 1.0
-    },
+    "cost": {},
     "limit": {
       "context": 127000,
       "output": 8000
@@ -135431,10 +139905,7 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0
-    },
+    "cost": {},
     "limit": {
       "context": 200000,
       "output": 8000
@@ -135460,42 +139931,35 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 2.0,
-      "output": 8.0
-    },
+    "cost": {},
     "limit": {
       "context": 127000,
       "output": 8000
     }
   },
   {
-    "id": "vercel/prime-intellect/intellect-3",
-    "name": "INTELLECT 3",
-    "family": "intellect",
+    "id": "vercel/prodia/flux-fast-schnell",
+    "name": "Flux Schnell",
+    "family": "flux",
     "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
+    "reasoning": false,
+    "tool_call": false,
     "temperature": true,
-    "knowledge": "2024-10",
-    "release_date": "2025-11-26",
-    "last_updated": "2025-11-26",
+    "release_date": "2026-06-08",
+    "last_updated": "2026-06-08",
     "modalities": {
       "input": [
         "text"
       ],
       "output": [
-        "text"
+        "image"
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 1.1
-    },
+    "cost": {},
     "limit": {
-      "context": 131072,
-      "output": 131072
+      "context": 512,
+      "output": 0
     }
   },
   {
@@ -135505,8 +139969,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
-    "release_date": "2024-03",
+    "temperature": true,
+    "release_date": "2024-03-01",
     "last_updated": "2024-03",
     "modalities": {
       "input": [
@@ -135530,8 +139994,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
-    "release_date": "2024-10",
+    "temperature": true,
+    "release_date": "2024-10-01",
     "last_updated": "2024-10",
     "modalities": {
       "input": [
@@ -135549,15 +140013,196 @@
     }
   },
   {
-    "id": "vercel/vercel/v0-1.0-md",
-    "name": "v0-1.0-md",
-    "family": "v0",
+    "id": "vercel/recraft/recraft-v4",
+    "name": "Recraft V4",
+    "family": "recraft",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-02-17",
+    "last_updated": "2026-02-17",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/recraft/recraft-v4-pro",
+    "name": "Recraft V4 Pro",
+    "family": "recraft",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-02-17",
+    "last_updated": "2026-02-17",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/recraft/recraft-v4.1",
+    "name": "Recraft V4.1",
+    "family": "recraft",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-05-14",
+    "last_updated": "2026-05-14",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/recraft/recraft-v4.1-pro",
+    "name": "Recraft V4.1 Pro",
+    "family": "recraft",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-05-14",
+    "last_updated": "2026-05-14",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/recraft/recraft-v4.1-utility",
+    "name": "Recraft V4.1 Utility",
+    "family": "recraft",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-05-14",
+    "last_updated": "2026-05-14",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/recraft/recraft-v4.1-utility-pro",
+    "name": "Recraft V4.1 Utility Pro",
+    "family": "recraft",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-05-14",
+    "last_updated": "2026-05-14",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/stepfun/step-3.5-flash",
+    "name": "StepFun 3.5 Flash",
+    "family": "step",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-01-29",
+    "last_updated": "2026-02-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.09,
+      "output": 0.3,
+      "cache_write": 0.02
+    },
+    "limit": {
+      "context": 262114,
+      "output": 262114
+    }
+  },
+  {
+    "id": "vercel/stepfun/step-3.7-flash",
+    "name": "Step 3.7 Flash",
+    "family": "step",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-05-22",
-    "last_updated": "2025-05-22",
+    "knowledge": "2026-01-01",
+    "release_date": "2026-05-28",
+    "last_updated": "2026-05-29",
     "modalities": {
       "input": [
         "text",
@@ -135569,40 +140214,62 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 3.0,
-      "output": 15.0
+      "input": 0.2,
+      "output": 1.15,
+      "cache_read": 0.04
     },
     "limit": {
-      "context": 128000,
+      "context": 256000,
+      "output": 256000
+    }
+  },
+  {
+    "id": "vercel/voyage/rerank-2.5",
+    "name": "Voyage Rerank 2.5",
+    "family": "voyage",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2025-08-11",
+    "last_updated": "2025-08-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 32000,
       "output": 32000
     }
   },
   {
-    "id": "vercel/vercel/v0-1.5-md",
-    "name": "v0-1.5-md",
-    "family": "v0",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
+    "id": "vercel/voyage/rerank-2.5-lite",
+    "name": "Voyage Rerank 2.5 Lite",
+    "family": "voyage",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
     "temperature": true,
-    "release_date": "2025-06-09",
-    "last_updated": "2025-06-09",
+    "release_date": "2025-08-11",
+    "last_updated": "2025-08-11",
     "modalities": {
       "input": [
-        "text",
-        "image"
+        "text"
       ],
       "output": [
         "text"
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0
-    },
+    "cost": {},
     "limit": {
-      "context": 128000,
+      "context": 32000,
       "output": 32000
     }
   },
@@ -135613,8 +140280,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
-    "release_date": "2024-09",
+    "temperature": true,
+    "release_date": "2024-09-01",
     "last_updated": "2024-09",
     "modalities": {
       "input": [
@@ -135625,10 +140292,7 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.18,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 8192,
       "output": 1536
@@ -135641,7 +140305,7 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
+    "temperature": true,
     "release_date": "2025-05-20",
     "last_updated": "2025-05-20",
     "modalities": {
@@ -135653,10 +140317,7 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.06,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 8192,
       "output": 1536
@@ -135669,7 +140330,7 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
+    "temperature": true,
     "release_date": "2025-05-20",
     "last_updated": "2025-05-20",
     "modalities": {
@@ -135681,10 +140342,7 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.02,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 8192,
       "output": 1536
@@ -135772,8 +140430,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
-    "release_date": "2024-01",
+    "temperature": true,
+    "release_date": "2024-01-01",
     "last_updated": "2024-01",
     "modalities": {
       "input": [
@@ -135784,10 +140442,7 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.12,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 8192,
       "output": 1536
@@ -135800,8 +140455,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
-    "release_date": "2024-09",
+    "temperature": true,
+    "release_date": "2024-09-01",
     "last_updated": "2024-09",
     "modalities": {
       "input": [
@@ -135812,10 +140467,7 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.18,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 8192,
       "output": 1536
@@ -135828,8 +140480,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
-    "release_date": "2024-03",
+    "temperature": true,
+    "release_date": "2024-03-01",
     "last_updated": "2024-03",
     "modalities": {
       "input": [
@@ -135840,10 +140492,7 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.12,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 8192,
       "output": 1536
@@ -135856,8 +140505,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": false,
-    "release_date": "2024-03",
+    "temperature": true,
+    "release_date": "2024-03-01",
     "last_updated": "2024-03",
     "modalities": {
       "input": [
@@ -135868,77 +140517,14 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.12,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 8192,
       "output": 1536
     }
   },
   {
-    "id": "vercel/xai/grok-4-fast",
-    "name": "Grok 4 Fast Reasoning",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-10",
-    "release_date": "2025-07-09",
-    "last_updated": "2025-07-09",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.5,
-      "cache_read": 0.05
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 256000
-    }
-  },
-  {
-    "id": "vercel/xai/grok-4.1-fast",
-    "name": "Grok 4.1 Fast Reasoning",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-10",
-    "release_date": "2025-07-09",
-    "last_updated": "2025-07-09",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.2,
-      "output": 0.5,
-      "cache_read": 0.05
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 30000
-    }
-  },
-  {
-    "id": "vercel/xai/grok-4.1-fast-non",
+    "id": "vercel/xai/grok-4.1-fast-non-reasoning",
     "name": "Grok 4.1 Fast Non-Reasoning",
     "family": "grok",
     "attachment": false,
@@ -135950,7 +140536,9 @@
     "last_updated": "2025-07-09",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -135963,15 +140551,47 @@
       "cache_read": 0.05
     },
     "limit": {
-      "context": 2000000,
-      "output": 30000
+      "context": 1000000,
+      "output": 1000000
     }
   },
   {
-    "id": "vercel/xai/grok-4.20",
-    "name": "Grok 4.20 Reasoning",
+    "id": "vercel/xai/grok-4.1-fast-reasoning",
+    "name": "Grok 4.1 Fast Reasoning",
     "family": "grok",
-    "attachment": true,
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-10",
+    "release_date": "2025-07-09",
+    "last_updated": "2025-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.2,
+      "output": 0.5,
+      "cache_read": 0.05
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 1000000
+    }
+  },
+  {
+    "id": "vercel/xai/grok-4.20-multi-agent",
+    "name": "Grok 4.20 Multi-Agent",
+    "family": "grok",
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -135989,38 +140609,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.0,
-      "output": 6.0,
-      "cache_read": 0.19999999999999998
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 2000000
-    }
-  },
-  {
-    "id": "vercel/xai/grok-4.20-multi-agent",
-    "name": "Grok 4.20 Multi-Agent",
-    "family": "grok",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-03-09",
-    "last_updated": "2026-03-23",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 2.0,
-      "output": 6.0,
-      "cache_read": 0.19999999999999998
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2
     },
     "limit": {
       "context": 2000000,
@@ -136039,7 +140630,9 @@
     "last_updated": "2026-03-13",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -136047,9 +140640,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.0,
-      "output": 6.0,
-      "cache_read": 0.19999999999999998
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2
     },
     "limit": {
       "context": 2000000,
@@ -136057,7 +140650,7 @@
     }
   },
   {
-    "id": "vercel/xai/grok-4.20-non",
+    "id": "vercel/xai/grok-4.20-non-reasoning",
     "name": "Grok 4.20 Non-Reasoning",
     "family": "grok",
     "attachment": true,
@@ -136078,9 +140671,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.0,
-      "output": 6.0,
-      "cache_read": 0.19999999999999998
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2
     },
     "limit": {
       "context": 2000000,
@@ -136109,9 +140702,40 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.0,
-      "output": 6.0,
-      "cache_read": 0.19999999999999998
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.4
+    },
+    "limit": {
+      "context": 2000000,
+      "output": 2000000
+    }
+  },
+  {
+    "id": "vercel/xai/grok-4.20-reasoning",
+    "name": "Grok 4.20 Reasoning",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-09",
+    "last_updated": "2026-03-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2
     },
     "limit": {
       "context": 2000000,
@@ -136140,9 +140764,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.0,
-      "output": 6.0,
-      "cache_read": 0.19999999999999998
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2
     },
     "limit": {
       "context": 2000000,
@@ -136158,7 +140782,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-04-30",
-    "last_updated": "2026-05-01",
+    "last_updated": "2026-04-17",
     "modalities": {
       "input": [
         "text",
@@ -136173,7 +140797,7 @@
     "cost": {
       "input": 1.25,
       "output": 2.5,
-      "cache_read": 0.19999999999999998
+      "cache_read": 0.2
     },
     "limit": {
       "context": 1000000,
@@ -136189,7 +140813,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-05-20",
-    "last_updated": "2026-05-21",
+    "last_updated": "2026-04-16",
     "modalities": {
       "input": [
         "text",
@@ -136203,7 +140827,7 @@
     "cost": {
       "input": 1.0,
       "output": 2.0,
-      "cache_read": 0.19999999999999998
+      "cache_read": 0.2
     },
     "limit": {
       "context": 256000,
@@ -136237,22 +140861,46 @@
     }
   },
   {
-    "id": "vercel/xai/grok-imagine-image-pro",
-    "name": "Grok Imagine Image Pro",
+    "id": "vercel/xai/grok-imagine-video",
+    "name": "Grok Imagine",
     "family": "grok",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
     "release_date": "2026-01-28",
-    "last_updated": "2026-02-19",
+    "last_updated": "2026-01-28",
     "modalities": {
       "input": [
         "text"
       ],
       "output": [
-        "text",
-        "image"
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/xai/grok-imagine-video-1.5-preview",
+    "name": "Grok Imagine Video 1.5 Preview",
+    "family": "grok",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-05-30",
+    "last_updated": "2026-05-30",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "video"
       ]
     },
     "open_weights": false,
@@ -136272,7 +140920,7 @@
     "temperature": true,
     "knowledge": "2024-10",
     "release_date": "2025-12-17",
-    "last_updated": "2025-12-17",
+    "last_updated": "2026-02-04",
     "modalities": {
       "input": [
         "text"
@@ -136284,7 +140932,8 @@
     "open_weights": false,
     "cost": {
       "input": 0.1,
-      "output": 0.29
+      "output": 0.3,
+      "cache_read": 0.01
     },
     "limit": {
       "context": 262144,
@@ -136299,8 +140948,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2024-12",
     "release_date": "2026-03-18",
-    "last_updated": "2026-03-20",
+    "last_updated": "2026-03-18",
     "modalities": {
       "input": [
         "text"
@@ -136313,7 +140963,7 @@
     "cost": {
       "input": 1.0,
       "output": 3.0,
-      "cache_read": 0.19999999999999998
+      "cache_read": 0.2
     },
     "limit": {
       "context": 1000000,
@@ -136328,14 +140978,14 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2024-12",
     "release_date": "2026-04-22",
-    "last_updated": "2026-05-01",
+    "last_updated": "2026-04-22",
     "modalities": {
       "input": [
         "text",
         "image",
-        "audio",
-        "video"
+        "pdf"
       ],
       "output": [
         "text"
@@ -136343,9 +140993,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.39999999999999997,
-      "output": 2.0,
-      "cache_read": 0.08
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.0028
     },
     "limit": {
       "context": 1050000,
@@ -136360,11 +141010,14 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2024-12",
     "release_date": "2026-04-22",
-    "last_updated": "2026-05-01",
+    "last_updated": "2026-04-22",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -136372,9 +141025,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 1.0,
-      "output": 3.0,
-      "cache_read": 0.19999999999999998
+      "input": 0.435,
+      "output": 0.87,
+      "cache_read": 0.0036
     },
     "limit": {
       "context": 1050000,
@@ -136403,11 +141056,12 @@
     "open_weights": true,
     "cost": {
       "input": 0.6,
-      "output": 2.2
+      "output": 2.2,
+      "cache_read": 0.11
     },
     "limit": {
-      "context": 131072,
-      "output": 131072
+      "context": 128000,
+      "output": 96000
     }
   },
   {
@@ -136432,7 +141086,8 @@
     "open_weights": true,
     "cost": {
       "input": 0.2,
-      "output": 1.1
+      "output": 1.1,
+      "cache_read": 0.03
     },
     "limit": {
       "context": 128000,
@@ -136462,11 +141117,12 @@
     "open_weights": true,
     "cost": {
       "input": 0.6,
-      "output": 1.8
+      "output": 1.8,
+      "cache_read": 0.11
     },
     "limit": {
       "context": 66000,
-      "output": 66000
+      "output": 16000
     }
   },
   {
@@ -136490,8 +141146,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.45,
-      "output": 1.8
+      "input": 0.6,
+      "output": 2.2,
+      "cache_read": 0.11
     },
     "limit": {
       "context": 200000,
@@ -136508,7 +141165,7 @@
     "temperature": true,
     "knowledge": "2024-10",
     "release_date": "2025-09-30",
-    "last_updated": "2025-09-30",
+    "last_updated": "2025-12-08",
     "modalities": {
       "input": [
         "text",
@@ -136579,13 +141236,13 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.43,
-      "output": 1.75,
-      "cache_read": 0.08
+      "input": 2.25,
+      "output": 2.75,
+      "cache_read": 2.25
     },
     "limit": {
-      "context": 202752,
-      "output": 120000
+      "context": 131000,
+      "output": 40000
     }
   },
   {
@@ -136596,8 +141253,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-04",
     "release_date": "2026-03-13",
-    "last_updated": "2026-03-13",
+    "last_updated": "2026-01-19",
     "modalities": {
       "input": [
         "text"
@@ -136609,7 +141267,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.07,
-      "output": 0.39999999999999997
+      "output": 0.4
     },
     "limit": {
       "context": 200000,
@@ -136625,8 +141283,8 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-01",
-    "release_date": "2025-01",
-    "last_updated": "2025-01",
+    "release_date": "2025-01-01",
+    "last_updated": "2026-01-19",
     "modalities": {
       "input": [
         "text"
@@ -136655,7 +141313,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-02-12",
-    "last_updated": "2026-02-19",
+    "last_updated": "2026-02-11",
     "modalities": {
       "input": [
         "text"
@@ -136672,7 +141330,7 @@
     },
     "limit": {
       "context": 202800,
-      "output": 131072
+      "output": 131100
     }
   },
   {
@@ -136684,7 +141342,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-03-15",
-    "last_updated": "2026-03-17",
+    "last_updated": "2026-03-16",
     "modalities": {
       "input": [
         "text"
@@ -136713,7 +141371,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-04-07",
-    "last_updated": "2026-04-16",
+    "last_updated": "2026-03-27",
     "modalities": {
       "input": [
         "text",
@@ -136731,8 +141389,8 @@
       "cache_read": 0.26
     },
     "limit": {
-      "context": 202752,
-      "output": 202752
+      "context": 202800,
+      "output": 64000
     }
   },
   {
@@ -136744,7 +141402,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-04-01",
-    "last_updated": "2026-04-03",
+    "last_updated": "2026-04-01",
     "modalities": {
       "input": [
         "text",
@@ -137368,7 +142026,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.85,
       "output": 3.1
@@ -138103,7 +142761,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 1.4,
       "output": 4.4,
@@ -138116,38 +142774,7 @@
     }
   },
   {
-    "id": "x-ai/grok-4.20",
-    "name": "Grok 4.20 (Reasoning)",
-    "family": "grok",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-03-09",
-    "last_updated": "2026-03-09",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.25,
-      "output": 2.5,
-      "cache_read": 0.2
-    },
-    "limit": {
-      "context": 2000000,
-      "output": 30000
-    }
-  },
-  {
-    "id": "x-ai/grok-4.20-0309-non",
+    "id": "x-ai/grok-4.20-0309-non-reasoning",
     "name": "Grok 4.20 (Non-Reasoning)",
     "family": "grok",
     "attachment": true,
@@ -138173,7 +142800,38 @@
       "cache_read": 0.2
     },
     "limit": {
-      "context": 2000000,
+      "context": 1000000,
+      "output": 30000
+    }
+  },
+  {
+    "id": "x-ai/grok-4.20-0309-reasoning",
+    "name": "Grok 4.20 (Reasoning)",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-09",
+    "last_updated": "2026-03-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1000000,
       "output": 30000
     }
   },
@@ -138204,7 +142862,7 @@
       "cache_read": 0.2
     },
     "limit": {
-      "context": 2000000,
+      "context": 1000000,
       "output": 30000
     }
   },
@@ -138340,6 +142998,7 @@
       "input": [
         "text",
         "image",
+        "video",
         "pdf"
       ],
       "output": [
@@ -139246,6 +143905,37 @@
     }
   },
   {
+    "id": "xpersona/xpersona-gpt-5.5",
+    "name": "GPT-5.5",
+    "family": "gpt",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-12-30",
+    "release_date": "2026-05-29",
+    "last_updated": "2026-05-29",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 18.0,
+      "cache_read": 0.3
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "zai-coding-plan/glm-4.5-air",
     "name": "GLM-4.5-Air",
     "family": "glm-air",
@@ -140056,6 +144746,38 @@
     }
   },
   {
+    "id": "zenmux/anthropic/claude-opus-4.8",
+    "name": "Claude Opus 4.8",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-05-28",
+    "last_updated": "2026-05-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "zenmux/anthropic/claude-sonnet-4",
     "name": "Claude Sonnet 4",
     "attachment": true,
@@ -140459,6 +145181,40 @@
     }
   },
   {
+    "id": "zenmux/google/gemini-3.1-flash-lite",
+    "name": "Gemini 3.1 Flash Lite",
+    "family": "gemini-flash-lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-05-07",
+    "last_updated": "2026-05-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 1.5,
+      "cache_read": 0.025
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
     "id": "zenmux/google/gemini-3.1-flash-lite-preview",
     "name": "Gemini 3.1 Flash Lite Preview",
     "attachment": true,
@@ -140523,6 +145279,40 @@
     }
   },
   {
+    "id": "zenmux/google/gemini-3.5-flash",
+    "name": "Gemini 3.5 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-05-19",
+    "last_updated": "2026-05-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 9.0,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
     "id": "zenmux/inclusionai/ling-1t",
     "name": "Ling-1T",
     "attachment": false,
@@ -140578,6 +145368,35 @@
     "limit": {
       "context": 128000,
       "output": 64000
+    }
+  },
+  {
+    "id": "zenmux/inclusionai/ring-2.6-1t",
+    "name": "inclusionAI: Ring-2.6-1T",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-12-31",
+    "release_date": "2026-05-07",
+    "last_updated": "2026-05-14",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.3,
+      "output": 2.5,
+      "cache_read": 0.06
+    },
+    "limit": {
+      "context": 262000,
+      "output": 65000
     }
   },
   {
@@ -140782,6 +145601,36 @@
     "limit": {
       "context": 204800,
       "output": 131070
+    }
+  },
+  {
+    "id": "zenmux/minimax/minimax-m3",
+    "name": "MiniMax-M3",
+    "family": "minimax",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-01",
+    "last_updated": "2026-06-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.6,
+      "output": 2.4
+    },
+    "limit": {
+      "context": 512000,
+      "output": 128000
     }
   },
   {
@@ -141411,6 +146260,37 @@
     }
   },
   {
+    "id": "zenmux/openai/gpt-5.5-instant",
+    "name": "GPT-5.5 Instant",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-12-01",
+    "release_date": "2026-05-05",
+    "last_updated": "2026-05-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
     "id": "zenmux/openai/gpt-5.5-pro",
     "name": "GPT-5.5 Pro",
     "family": "gpt-pro",
@@ -141587,6 +146467,68 @@
     }
   },
   {
+    "id": "zenmux/qwen/qwen3.7-max",
+    "name": "Qwen3.7 Max",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-05-21",
+    "last_updated": "2026-05-21",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 7.5,
+      "cache_read": 0.5,
+      "cache_write": 3.125
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "zenmux/qwen/qwen3.7-plus",
+    "name": "Qwen3.7 Plus",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-06-02",
+    "last_updated": "2026-06-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.4,
+      "output": 1.6,
+      "cache_read": 0.08,
+      "cache_write": 0.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 64000
+    }
+  },
+  {
     "id": "zenmux/sapiens-ai/agnes-1.5-lite",
     "name": "Agnes 1.5 Lite",
     "attachment": true,
@@ -141724,6 +146666,35 @@
     "limit": {
       "context": 256000,
       "output": 64000
+    }
+  },
+  {
+    "id": "zenmux/stepfun/step-3.7-flash",
+    "name": "Step 3.7 Flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2026-01-01",
+    "release_date": "2026-05-29",
+    "last_updated": "2026-05-29",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.2,
+      "output": 1.15
+    },
+    "limit": {
+      "context": 256000,
+      "output": 256000
     }
   },
   {
@@ -142033,7 +147004,7 @@
     }
   },
   {
-    "id": "zenmux/x-ai/grok-4.1-fast-non",
+    "id": "zenmux/x-ai/grok-4.1-fast-non-reasoning",
     "name": "Grok 4.1 Fast Non Reasoning",
     "attachment": true,
     "reasoning": false,
@@ -142093,7 +147064,7 @@
     }
   },
   {
-    "id": "zenmux/x-ai/grok-4.2-fast-non",
+    "id": "zenmux/x-ai/grok-4.2-fast-non-reasoning",
     "name": "Grok 4.2 Fast Non Reasoning",
     "attachment": true,
     "reasoning": false,
@@ -142120,6 +147091,69 @@
     "limit": {
       "context": 2000000,
       "output": 30000
+    }
+  },
+  {
+    "id": "zenmux/x-ai/grok-4.3",
+    "name": "Grok 4.3",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-17",
+    "last_updated": "2026-04-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 1000000
+    }
+  },
+  {
+    "id": "zenmux/x-ai/grok-build-0.1",
+    "name": "Grok Build 0.1",
+    "family": "grok-build",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-16",
+    "last_updated": "2026-04-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 2.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 256000,
+      "output": 256000
     }
   },
   {

--- a/crates/goose-providers/src/canonical/data/provider_metadata.json
+++ b/crates/goose-providers/src/canonical/data/provider_metadata.json
@@ -1,58 +1,91 @@
 [
   {
-    "id": "upstage",
-    "display_name": "Upstage",
+    "id": "302ai",
+    "display_name": "302.AI",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.upstage.ai/v1/solar",
-    "doc": "https://developers.upstage.ai/docs/apis/chat",
+    "api": "https://api.302.ai/v1",
+    "doc": "https://doc.302.ai",
     "env": [
-      "UPSTAGE_API_KEY"
+      "302AI_API_KEY"
     ],
-    "model_count": 3
+    "model_count": 97
   },
   {
-    "id": "clarifai",
-    "display_name": "Clarifai",
+    "id": "abacus",
+    "display_name": "Abacus",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.clarifai.com/v2/ext/openai/v1",
-    "doc": "https://docs.clarifai.com/compute/inference/",
+    "api": "https://routellm.abacus.ai/v1",
+    "doc": "https://abacus.ai/help/api",
     "env": [
-      "CLARIFAI_PAT"
+      "ABACUS_API_KEY"
+    ],
+    "model_count": 65
+  },
+  {
+    "id": "abliteration-ai",
+    "display_name": "abliteration.ai",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.abliteration.ai/v1",
+    "doc": "https://docs.abliteration.ai/models",
+    "env": [
+      "ABLIT_KEY"
+    ],
+    "model_count": 1
+  },
+  {
+    "id": "alibaba",
+    "display_name": "Alibaba",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+    "doc": "https://www.alibabacloud.com/help/en/model-studio/models",
+    "env": [
+      "DASHSCOPE_API_KEY"
+    ],
+    "model_count": 51
+  },
+  {
+    "id": "alibaba-cn",
+    "display_name": "Alibaba (China)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    "doc": "https://www.alibabacloud.com/help/en/model-studio/models",
+    "env": [
+      "DASHSCOPE_API_KEY"
+    ],
+    "model_count": 83
+  },
+  {
+    "id": "alibaba-coding-plan",
+    "display_name": "Alibaba Coding Plan",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://coding-intl.dashscope.aliyuncs.com/v1",
+    "doc": "https://www.alibabacloud.com/help/en/model-studio/coding-plan",
+    "env": [
+      "ALIBABA_CODING_PLAN_API_KEY"
+    ],
+    "model_count": 11
+  },
+  {
+    "id": "alibaba-coding-plan-cn",
+    "display_name": "Alibaba Coding Plan (China)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://coding.dashscope.aliyuncs.com/v1",
+    "doc": "https://help.aliyun.com/zh/model-studio/coding-plan",
+    "env": [
+      "ALIBABA_CODING_PLAN_API_KEY"
     ],
     "model_count": 12
   },
   {
-    "id": "ollama-cloud",
-    "display_name": "Ollama Cloud",
+    "id": "alibaba-token-plan",
+    "display_name": "Alibaba Token Plan",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://ollama.com/v1",
-    "doc": "https://docs.ollama.com/cloud",
+    "api": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+    "doc": "https://www.alibabacloud.com/help/en/model-studio/token-plan-overview",
     "env": [
-      "OLLAMA_API_KEY"
+      "ALIBABA_TOKEN_PLAN_API_KEY"
     ],
-    "model_count": 40
-  },
-  {
-    "id": "the-grid-ai",
-    "display_name": "The Grid AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.thegrid.ai/v1",
-    "doc": "https://thegrid.ai/docs",
-    "env": [
-      "THEGRIDAI_API_KEY"
-    ],
-    "model_count": 9
-  },
-  {
-    "id": "fireworks-ai",
-    "display_name": "Fireworks AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.fireworks.ai/inference/v1/",
-    "doc": "https://fireworks.ai/docs/",
-    "env": [
-      "FIREWORKS_API_KEY"
-    ],
-    "model_count": 12
+    "model_count": 15
   },
   {
     "id": "ambient",
@@ -66,92 +99,37 @@
     "model_count": 2
   },
   {
-    "id": "stackit",
-    "display_name": "STACKIT",
+    "id": "anyapi",
+    "display_name": "AnyAPI",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1",
-    "doc": "https://docs.stackit.cloud/products/data-and-ai/ai-model-serving/basics/available-shared-models",
+    "api": "https://api.anyapi.ai/v1",
+    "doc": "https://docs.anyapi.ai",
     "env": [
-      "STACKIT_API_KEY"
+      "ANYAPI_API_KEY"
     ],
-    "model_count": 8
+    "model_count": 30
   },
   {
-    "id": "ovhcloud",
-    "display_name": "OVHcloud AI Endpoints",
+    "id": "atomic-chat",
+    "display_name": "Atomic Chat",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1",
-    "doc": "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog//",
+    "api": "http://127.0.0.1:1337/v1",
+    "doc": "https://atomic.chat",
     "env": [
-      "OVHCLOUD_API_KEY"
+      "ATOMIC_CHAT_API_KEY"
+    ],
+    "model_count": 5
+  },
+  {
+    "id": "auriko",
+    "display_name": "Auriko",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.auriko.ai/v1",
+    "doc": "https://docs.auriko.ai",
+    "env": [
+      "AURIKO_API_KEY"
     ],
     "model_count": 15
-  },
-  {
-    "id": "iflowcn",
-    "display_name": "iFlow",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://apis.iflow.cn/v1",
-    "doc": "https://platform.iflow.cn/en/docs",
-    "env": [
-      "IFLOW_API_KEY"
-    ],
-    "model_count": 14
-  },
-  {
-    "id": "302ai",
-    "display_name": "302.AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.302.ai/v1",
-    "doc": "https://doc.302.ai",
-    "env": [
-      "302AI_API_KEY"
-    ],
-    "model_count": 97
-  },
-  {
-    "id": "nano-gpt",
-    "display_name": "NanoGPT",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://nano-gpt.com/api/v1",
-    "doc": "https://docs.nano-gpt.com",
-    "env": [
-      "NANO_GPT_API_KEY"
-    ],
-    "model_count": 525
-  },
-  {
-    "id": "alibaba-cn",
-    "display_name": "Alibaba (China)",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://dashscope.aliyuncs.com/compatible-mode/v1",
-    "doc": "https://www.alibabacloud.com/help/en/model-studio/models",
-    "env": [
-      "DASHSCOPE_API_KEY"
-    ],
-    "model_count": 82
-  },
-  {
-    "id": "digitalocean",
-    "display_name": "DigitalOcean",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://inference.do-ai.run/v1",
-    "doc": "https://docs.digitalocean.com/products/gradient-ai-platform/details/models/",
-    "env": [
-      "DIGITALOCEAN_ACCESS_TOKEN"
-    ],
-    "model_count": 78
-  },
-  {
-    "id": "submodel",
-    "display_name": "submodel",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://llm.submodel.ai/v1",
-    "doc": "https://submodel.gitbook.io",
-    "env": [
-      "SUBMODEL_INSTAGEN_ACCESS_KEY"
-    ],
-    "model_count": 9
   },
   {
     "id": "bailing",
@@ -165,59 +143,116 @@
     "model_count": 2
   },
   {
-    "id": "kimi-for-coding",
-    "display_name": "Kimi For Coding",
-    "npm": "@ai-sdk/anthropic",
-    "api": "https://api.kimi.com/coding/v1",
-    "doc": "https://www.kimi.com/coding/docs/en/third-party-agents.html",
+    "id": "baseten",
+    "display_name": "Baseten",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://inference.baseten.co/v1",
+    "doc": "https://docs.baseten.co/inference/model-apis/overview",
     "env": [
-      "KIMI_API_KEY"
+      "BASETEN_API_KEY"
     ],
-    "model_count": 3
+    "model_count": 11
   },
   {
-    "id": "dinference",
-    "display_name": "DInference",
+    "id": "berget",
+    "display_name": "Berget.AI",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.dinference.com/v1",
-    "doc": "https://dinference.com",
+    "api": "https://api.berget.ai/v1",
+    "doc": "https://api.berget.ai",
     "env": [
-      "DINFERENCE_API_KEY"
+      "BERGET_API_KEY"
+    ],
+    "model_count": 7
+  },
+  {
+    "id": "chutes",
+    "display_name": "Chutes",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://llm.chutes.ai/v1",
+    "doc": "https://llm.chutes.ai/v1/models",
+    "env": [
+      "CHUTES_API_KEY"
+    ],
+    "model_count": 39
+  },
+  {
+    "id": "clarifai",
+    "display_name": "Clarifai",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.clarifai.com/v2/ext/openai/v1",
+    "doc": "https://docs.clarifai.com/compute/inference/",
+    "env": [
+      "CLARIFAI_PAT"
+    ],
+    "model_count": 12
+  },
+  {
+    "id": "claudinio",
+    "display_name": "Claudinio",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.claudin.io/v1",
+    "doc": "https://claudin.io",
+    "env": [
+      "CLAUDINIO_API_KEY"
+    ],
+    "model_count": 1
+  },
+  {
+    "id": "cloudferro-sherlock",
+    "display_name": "CloudFerro Sherlock",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api-sherlock.cloudferro.com/openai/v1/",
+    "doc": "https://docs.sherlock.cloudferro.com/",
+    "env": [
+      "CLOUDFERRO_SHERLOCK_API_KEY"
     ],
     "model_count": 5
   },
   {
-    "id": "novita-ai",
-    "display_name": "NovitaAI",
+    "id": "cloudflare-workers-ai",
+    "display_name": "Cloudflare Workers AI",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.novita.ai/openai",
-    "doc": "https://novita.ai/docs/guides/introduction",
+    "api": "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1",
+    "doc": "https://developers.cloudflare.com/workers-ai/models/",
     "env": [
-      "NOVITA_API_KEY"
+      "CLOUDFLARE_ACCOUNT_ID",
+      "CLOUDFLARE_API_KEY"
     ],
-    "model_count": 104
+    "model_count": 20
   },
   {
-    "id": "kilo",
-    "display_name": "Kilo Gateway",
+    "id": "cortecs",
+    "display_name": "Cortecs",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.kilo.ai/api/gateway",
-    "doc": "https://kilo.ai",
+    "api": "https://api.cortecs.ai/v1",
+    "doc": "https://api.cortecs.ai/v1/models",
     "env": [
-      "KILO_API_KEY"
+      "CORTECS_API_KEY"
     ],
-    "model_count": 345
+    "model_count": 50
   },
   {
-    "id": "regolo-ai",
-    "display_name": "Regolo AI",
+    "id": "crof",
+    "display_name": "CrofAI",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.regolo.ai/v1",
-    "doc": "https://docs.regolo.ai/",
+    "api": "https://crof.ai/v1",
+    "doc": "https://crof.ai/docs",
     "env": [
-      "REGOLO_API_KEY"
+      "CROF_API_KEY"
     ],
-    "model_count": 13
+    "model_count": 21
+  },
+  {
+    "id": "databricks",
+    "display_name": "Databricks",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://${DATABRICKS_HOST}/ai-gateway/mlflow/v1",
+    "doc": "https://docs.databricks.com/aws/en/machine-learning/foundation-models/",
+    "env": [
+      "DATABRICKS_HOST",
+      "DATABRICKS_TOKEN"
+    ],
+    "model_count": 25
   },
   {
     "id": "deepseek",
@@ -231,24 +266,365 @@
     "model_count": 4
   },
   {
-    "id": "orcarouter",
-    "display_name": "OrcaRouter",
+    "id": "digitalocean",
+    "display_name": "DigitalOcean",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.orcarouter.ai/v1",
-    "doc": "https://docs.orcarouter.ai",
+    "api": "https://inference.do-ai.run/v1",
+    "doc": "https://docs.digitalocean.com/products/gradient-ai-platform/details/models/",
     "env": [
-      "ORCAROUTER_API_KEY"
+      "DIGITALOCEAN_ACCESS_TOKEN"
     ],
-    "model_count": 81
+    "model_count": 78
   },
   {
-    "id": "moonshotai-cn",
-    "display_name": "Moonshot AI (China)",
+    "id": "dinference",
+    "display_name": "DInference",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.moonshot.cn/v1",
-    "doc": "https://platform.moonshot.cn/docs/api/chat",
+    "api": "https://api.dinference.com/v1",
+    "doc": "https://dinference.com",
     "env": [
-      "MOONSHOT_API_KEY"
+      "DINFERENCE_API_KEY"
+    ],
+    "model_count": 5
+  },
+  {
+    "id": "drun",
+    "display_name": "D.Run (China)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://chat.d.run/v1",
+    "doc": "https://www.d.run",
+    "env": [
+      "DRUN_API_KEY"
+    ],
+    "model_count": 3
+  },
+  {
+    "id": "evroc",
+    "display_name": "evroc",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://models.think.evroc.com/v1",
+    "doc": "https://docs.evroc.com/products/think/overview.html",
+    "env": [
+      "EVROC_API_KEY"
+    ],
+    "model_count": 13
+  },
+  {
+    "id": "fastrouter",
+    "display_name": "FastRouter",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://go.fastrouter.ai/api/v1",
+    "doc": "https://fastrouter.ai/models",
+    "env": [
+      "FASTROUTER_API_KEY"
+    ],
+    "model_count": 15
+  },
+  {
+    "id": "firepass",
+    "display_name": "Fireworks (Firepass)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.fireworks.ai/inference/v1/",
+    "doc": "https://docs.fireworks.ai/firepass",
+    "env": [
+      "FIREPASS_API_KEY"
+    ],
+    "model_count": 1
+  },
+  {
+    "id": "fireworks-ai",
+    "display_name": "Fireworks AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.fireworks.ai/inference/v1/",
+    "doc": "https://fireworks.ai/docs/",
+    "env": [
+      "FIREWORKS_API_KEY"
+    ],
+    "model_count": 13
+  },
+  {
+    "id": "freemodel",
+    "display_name": "FreeModel",
+    "npm": "@ai-sdk/anthropic",
+    "api": "https://cc.freemodel.dev/v1",
+    "doc": "https://freemodel.dev",
+    "env": [
+      "FREEMODEL_API_KEY"
+    ],
+    "model_count": 9
+  },
+  {
+    "id": "friendli",
+    "display_name": "Friendli",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.friendli.ai/serverless/v1",
+    "doc": "https://friendli.ai/docs/guides/serverless_endpoints/introduction",
+    "env": [
+      "FRIENDLI_TOKEN"
+    ],
+    "model_count": 6
+  },
+  {
+    "id": "frogbot",
+    "display_name": "FrogBot",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://app.frogbot.ai/api/v1",
+    "doc": "https://docs.frogbot.ai",
+    "env": [
+      "FROGBOT_API_KEY"
+    ],
+    "model_count": 26
+  },
+  {
+    "id": "github-copilot",
+    "display_name": "GitHub Copilot",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.githubcopilot.com",
+    "doc": "https://docs.github.com/en/copilot",
+    "env": [
+      "GITHUB_TOKEN"
+    ],
+    "model_count": 22
+  },
+  {
+    "id": "github-models",
+    "display_name": "GitHub Models",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://models.github.ai/inference",
+    "doc": "https://docs.github.com/en/github-models",
+    "env": [
+      "GITHUB_TOKEN"
+    ],
+    "model_count": 55
+  },
+  {
+    "id": "gmicloud",
+    "display_name": "GMI Cloud",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.gmi-serving.com/v1",
+    "doc": "https://docs.gmicloud.ai/inference-engine/api-reference/llm-api-reference",
+    "env": [
+      "GMICLOUD_API_KEY"
+    ],
+    "model_count": 8
+  },
+  {
+    "id": "helicone",
+    "display_name": "Helicone",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://ai-gateway.helicone.ai/v1",
+    "doc": "https://helicone.ai/models",
+    "env": [
+      "HELICONE_API_KEY"
+    ],
+    "model_count": 90
+  },
+  {
+    "id": "hpc-ai",
+    "display_name": "HPC-AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.hpc-ai.com/inference/v1",
+    "doc": "https://www.hpc-ai.com/doc/docs/quickstart/",
+    "env": [
+      "HPC_AI_API_KEY"
+    ],
+    "model_count": 3
+  },
+  {
+    "id": "huggingface",
+    "display_name": "Hugging Face",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://router.huggingface.co/v1",
+    "doc": "https://huggingface.co/docs/inference-providers",
+    "env": [
+      "HF_TOKEN"
+    ],
+    "model_count": 24
+  },
+  {
+    "id": "iflowcn",
+    "display_name": "iFlow",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://apis.iflow.cn/v1",
+    "doc": "https://platform.iflow.cn/en/docs",
+    "env": [
+      "IFLOW_API_KEY"
+    ],
+    "model_count": 14
+  },
+  {
+    "id": "inception",
+    "display_name": "Inception",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.inceptionlabs.ai/v1/",
+    "doc": "https://platform.inceptionlabs.ai/docs",
+    "env": [
+      "INCEPTION_API_KEY"
+    ],
+    "model_count": 2
+  },
+  {
+    "id": "inceptron",
+    "display_name": "Inceptron",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.inceptron.io/v1",
+    "doc": "https://docs.inceptron.io",
+    "env": [
+      "INCEPTRON_API_KEY"
+    ],
+    "model_count": 4
+  },
+  {
+    "id": "inference",
+    "display_name": "Inference",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://inference.net/v1",
+    "doc": "https://inference.net/models",
+    "env": [
+      "INFERENCE_API_KEY"
+    ],
+    "model_count": 9
+  },
+  {
+    "id": "io-net",
+    "display_name": "IO.NET",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.intelligence.io.solutions/api/v1",
+    "doc": "https://io.net/docs/guides/intelligence/io-intelligence",
+    "env": [
+      "IOINTELLIGENCE_API_KEY"
+    ],
+    "model_count": 17
+  },
+  {
+    "id": "jiekou",
+    "display_name": "Jiekou.AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.jiekou.ai/openai",
+    "doc": "https://docs.jiekou.ai/docs/support/quickstart?utm_source=github_models.dev",
+    "env": [
+      "JIEKOU_API_KEY"
+    ],
+    "model_count": 61
+  },
+  {
+    "id": "kilo",
+    "display_name": "Kilo Gateway",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.kilo.ai/api/gateway",
+    "doc": "https://kilo.ai",
+    "env": [
+      "KILO_API_KEY"
+    ],
+    "model_count": 345
+  },
+  {
+    "id": "kimi-for-coding",
+    "display_name": "Kimi For Coding",
+    "npm": "@ai-sdk/anthropic",
+    "api": "https://api.kimi.com/coding/v1",
+    "doc": "https://www.kimi.com/code/docs/en/third-party-tools/other-coding-agents.html",
+    "env": [
+      "KIMI_API_KEY"
+    ],
+    "model_count": 3
+  },
+  {
+    "id": "kuae-cloud-coding-plan",
+    "display_name": "KUAE Cloud Coding Plan",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://coding-plan-endpoint.kuaecloud.net/v1",
+    "doc": "https://docs.mthreads.com/kuaecloud/kuaecloud-doc-online/coding_plan/",
+    "env": [
+      "KUAE_API_KEY"
+    ],
+    "model_count": 1
+  },
+  {
+    "id": "lilac",
+    "display_name": "Lilac",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.getlilac.com/v1",
+    "doc": "https://docs.getlilac.com/inference/models",
+    "env": [
+      "LILAC_API_KEY"
+    ],
+    "model_count": 4
+  },
+  {
+    "id": "meta-llama",
+    "display_name": "Llama",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.llama.com/compat/v1/",
+    "doc": "https://llama.developer.meta.com/docs/models",
+    "env": [
+      "LLAMA_API_KEY"
+    ],
+    "model_count": 7
+  },
+  {
+    "id": "llmgateway",
+    "display_name": "LLM Gateway",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.llmgateway.io/v1",
+    "doc": "https://llmgateway.io/docs",
+    "env": [
+      "LLMGATEWAY_API_KEY"
+    ],
+    "model_count": 191
+  },
+  {
+    "id": "lmstudio",
+    "display_name": "LMStudio",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "http://127.0.0.1:1234/v1",
+    "doc": "https://lmstudio.ai/models",
+    "env": [
+      "LMSTUDIO_API_KEY"
+    ],
+    "model_count": 3
+  },
+  {
+    "id": "lucidquery",
+    "display_name": "LucidQuery AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://lucidquery.com/api/v1",
+    "doc": "https://lucidquery.com/api/docs",
+    "env": [
+      "LUCIDQUERY_API_KEY"
+    ],
+    "model_count": 2
+  },
+  {
+    "id": "meganova",
+    "display_name": "Meganova",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.meganova.ai/v1",
+    "doc": "https://docs.meganova.ai",
+    "env": [
+      "MEGANOVA_API_KEY"
+    ],
+    "model_count": 19
+  },
+  {
+    "id": "minimax",
+    "display_name": "MiniMax (minimax.io)",
+    "npm": "@ai-sdk/anthropic",
+    "api": "https://api.minimax.io/anthropic/v1",
+    "doc": "https://platform.minimax.io/docs/guides/quickstart",
+    "env": [
+      "MINIMAX_API_KEY"
+    ],
+    "model_count": 7
+  },
+  {
+    "id": "minimax-cn",
+    "display_name": "MiniMax (minimaxi.com)",
+    "npm": "@ai-sdk/anthropic",
+    "api": "https://api.minimaxi.com/anthropic/v1",
+    "doc": "https://platform.minimaxi.com/docs/guides/quickstart",
+    "env": [
+      "MINIMAX_API_KEY"
     ],
     "model_count": 7
   },
@@ -264,126 +640,114 @@
     "model_count": 7
   },
   {
-    "id": "inception",
-    "display_name": "Inception",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.inceptionlabs.ai/v1/",
-    "doc": "https://platform.inceptionlabs.ai/docs",
+    "id": "minimax-coding-plan",
+    "display_name": "MiniMax Token Plan (minimax.io)",
+    "npm": "@ai-sdk/anthropic",
+    "api": "https://api.minimax.io/anthropic/v1",
+    "doc": "https://platform.minimax.io/docs/token-plan/intro",
     "env": [
-      "INCEPTION_API_KEY"
+      "MINIMAX_API_KEY"
     ],
-    "model_count": 2
+    "model_count": 7
   },
   {
-    "id": "kuae-cloud-coding-plan",
-    "display_name": "KUAE Cloud Coding Plan",
+    "id": "mixlayer",
+    "display_name": "Mixlayer",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://coding-plan-endpoint.kuaecloud.net/v1",
-    "doc": "https://docs.mthreads.com/kuaecloud/kuaecloud-doc-online/coding_plan/",
+    "api": "https://models.mixlayer.ai/v1",
+    "doc": "https://docs.mixlayer.com",
     "env": [
-      "KUAE_API_KEY"
-    ],
-    "model_count": 1
-  },
-  {
-    "id": "chutes",
-    "display_name": "Chutes",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://llm.chutes.ai/v1",
-    "doc": "https://llm.chutes.ai/v1/models",
-    "env": [
-      "CHUTES_API_KEY"
-    ],
-    "model_count": 39
-  },
-  {
-    "id": "crof",
-    "display_name": "CrofAI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://crof.ai/v1",
-    "doc": "https://crof.ai/docs",
-    "env": [
-      "CROF_API_KEY"
-    ],
-    "model_count": 21
-  },
-  {
-    "id": "frogbot",
-    "display_name": "FrogBot",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://app.frogbot.ai/api/v1",
-    "doc": "https://docs.frogbot.ai",
-    "env": [
-      "FROGBOT_API_KEY"
-    ],
-    "model_count": 26
-  },
-  {
-    "id": "alibaba",
-    "display_name": "Alibaba",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-    "doc": "https://www.alibabacloud.com/help/en/model-studio/models",
-    "env": [
-      "DASHSCOPE_API_KEY"
-    ],
-    "model_count": 50
-  },
-  {
-    "id": "xiaomi",
-    "display_name": "Xiaomi",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.xiaomimimo.com/v1",
-    "doc": "https://platform.xiaomimimo.com/#/docs",
-    "env": [
-      "XIAOMI_API_KEY"
+      "MIXLAYER_API_KEY"
     ],
     "model_count": 5
   },
   {
-    "id": "vivgrid",
-    "display_name": "Vivgrid",
-    "npm": "@ai-sdk/openai",
-    "api": "https://api.vivgrid.com/v1",
-    "doc": "https://docs.vivgrid.com/models",
+    "id": "moark",
+    "display_name": "Moark",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://moark.com/v1",
+    "doc": "https://moark.com/docs/openapi/v1#tag/%E6%96%87%E6%9C%AC%E7%94%9F%E6%88%90",
     "env": [
-      "VIVGRID_API_KEY"
+      "MOARK_API_KEY"
     ],
-    "model_count": 13
+    "model_count": 2
   },
   {
-    "id": "databricks",
-    "display_name": "Databricks",
+    "id": "modelscope",
+    "display_name": "ModelScope",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://${DATABRICKS_HOST}/ai-gateway/mlflow/v1",
-    "doc": "https://docs.databricks.com/aws/en/machine-learning/foundation-models/",
+    "api": "https://api-inference.modelscope.cn/v1",
+    "doc": "https://modelscope.cn/docs/model-service/API-Inference/intro",
     "env": [
-      "DATABRICKS_HOST",
-      "DATABRICKS_TOKEN"
+      "MODELSCOPE_API_KEY"
     ],
-    "model_count": 25
+    "model_count": 7
   },
   {
-    "id": "siliconflow-cn",
-    "display_name": "SiliconFlow (China)",
+    "id": "moonshotai",
+    "display_name": "Moonshot AI",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.siliconflow.cn/v1",
-    "doc": "https://cloud.siliconflow.com/models",
+    "api": "https://api.moonshot.ai/v1",
+    "doc": "https://platform.moonshot.ai/docs/api/chat",
     "env": [
-      "SILICONFLOW_CN_API_KEY"
+      "MOONSHOT_API_KEY"
     ],
-    "model_count": 82
+    "model_count": 7
   },
   {
-    "id": "zhipuai-coding-plan",
-    "display_name": "Zhipu AI Coding Plan",
+    "id": "moonshotai-cn",
+    "display_name": "Moonshot AI (China)",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://open.bigmodel.cn/api/coding/paas/v4",
-    "doc": "https://docs.bigmodel.cn/cn/coding-plan/overview",
+    "api": "https://api.moonshot.cn/v1",
+    "doc": "https://platform.moonshot.cn/docs/api/chat",
     "env": [
-      "ZHIPU_API_KEY"
+      "MOONSHOT_API_KEY"
     ],
-    "model_count": 6
+    "model_count": 7
+  },
+  {
+    "id": "morph",
+    "display_name": "Morph",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.morphllm.com/v1",
+    "doc": "https://docs.morphllm.com/api-reference/introduction",
+    "env": [
+      "MORPH_API_KEY"
+    ],
+    "model_count": 3
+  },
+  {
+    "id": "nano-gpt",
+    "display_name": "NanoGPT",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://nano-gpt.com/api/v1",
+    "doc": "https://docs.nano-gpt.com",
+    "env": [
+      "NANO_GPT_API_KEY"
+    ],
+    "model_count": 617
+  },
+  {
+    "id": "nearai",
+    "display_name": "NEAR AI Cloud",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://cloud-api.near.ai/v1",
+    "doc": "https://docs.near.ai/",
+    "env": [
+      "NEARAI_API_KEY"
+    ],
+    "model_count": 37
+  },
+  {
+    "id": "nebius",
+    "display_name": "Nebius Token Factory",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.tokenfactory.nebius.com/v1",
+    "doc": "https://docs.tokenfactory.nebius.com/",
+    "env": [
+      "NEBIUS_API_KEY"
+    ],
+    "model_count": 31
   },
   {
     "id": "neuralwatt",
@@ -397,48 +761,125 @@
     "model_count": 14
   },
   {
-    "id": "friendli",
-    "display_name": "Friendli",
+    "id": "nova",
+    "display_name": "Nova",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.friendli.ai/serverless/v1",
-    "doc": "https://friendli.ai/docs/guides/serverless_endpoints/introduction",
+    "api": "https://api.nova.amazon.com/v1",
+    "doc": "https://nova.amazon.com/dev/documentation",
     "env": [
-      "FRIENDLI_TOKEN"
+      "NOVA_API_KEY"
     ],
-    "model_count": 6
+    "model_count": 2
   },
   {
-    "id": "github-copilot",
-    "display_name": "GitHub Copilot",
+    "id": "novita-ai",
+    "display_name": "NovitaAI",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.githubcopilot.com",
-    "doc": "https://docs.github.com/en/copilot",
+    "api": "https://api.novita.ai/openai",
+    "doc": "https://novita.ai/docs/guides/introduction",
     "env": [
-      "GITHUB_TOKEN"
+      "NOVITA_API_KEY"
     ],
-    "model_count": 22
+    "model_count": 104
   },
   {
-    "id": "inference",
-    "display_name": "Inference",
+    "id": "nvidia",
+    "display_name": "Nvidia",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://inference.net/v1",
-    "doc": "https://inference.net/models",
+    "api": "https://integrate.api.nvidia.com/v1",
+    "doc": "https://docs.api.nvidia.com/nim/",
     "env": [
-      "INFERENCE_API_KEY"
+      "NVIDIA_API_KEY"
     ],
-    "model_count": 9
+    "model_count": 94
   },
   {
-    "id": "huggingface",
-    "display_name": "Hugging Face",
+    "id": "ollama-cloud",
+    "display_name": "Ollama Cloud",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://router.huggingface.co/v1",
-    "doc": "https://huggingface.co/docs/inference-providers",
+    "api": "https://ollama.com/v1",
+    "doc": "https://docs.ollama.com/cloud",
     "env": [
-      "HF_TOKEN"
+      "OLLAMA_API_KEY"
     ],
-    "model_count": 24
+    "model_count": 41
+  },
+  {
+    "id": "opencode",
+    "display_name": "OpenCode Zen",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://opencode.ai/zen/v1",
+    "doc": "https://opencode.ai/docs/zen",
+    "env": [
+      "OPENCODE_API_KEY"
+    ],
+    "model_count": 69
+  },
+  {
+    "id": "opencode-go",
+    "display_name": "OpenCode Go",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://opencode.ai/zen/go/v1",
+    "doc": "https://opencode.ai/docs/zen",
+    "env": [
+      "OPENCODE_API_KEY"
+    ],
+    "model_count": 17
+  },
+  {
+    "id": "orcarouter",
+    "display_name": "OrcaRouter",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.orcarouter.ai/v1",
+    "doc": "https://docs.orcarouter.ai",
+    "env": [
+      "ORCAROUTER_API_KEY"
+    ],
+    "model_count": 81
+  },
+  {
+    "id": "ovhcloud",
+    "display_name": "OVHcloud AI Endpoints",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1",
+    "doc": "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog//",
+    "env": [
+      "OVHCLOUD_API_KEY"
+    ],
+    "model_count": 15
+  },
+  {
+    "id": "perplexity-agent",
+    "display_name": "Perplexity Agent",
+    "npm": "@ai-sdk/openai",
+    "api": "https://api.perplexity.ai/v1",
+    "doc": "https://docs.perplexity.ai/docs/agent-api/models",
+    "env": [
+      "PERPLEXITY_API_KEY"
+    ],
+    "model_count": 18
+  },
+  {
+    "id": "poe",
+    "display_name": "Poe",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.poe.com/v1",
+    "doc": "https://creator.poe.com/docs/external-applications/openai-compatible-api",
+    "env": [
+      "POE_API_KEY"
+    ],
+    "model_count": 137
+  },
+  {
+    "id": "poolside",
+    "display_name": "Poolside",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://inference.poolside.ai/v1",
+    "doc": "https://platform.poolside.ai",
+    "env": [
+      "POOLSIDE_API_KEY"
+    ],
+    "model_count": 2
   },
   {
     "id": "privatemode-ai",
@@ -453,128 +894,6 @@
     "model_count": 5
   },
   {
-    "id": "snowflake-cortex",
-    "display_name": "Snowflake Cortex",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://${SNOWFLAKE_ACCOUNT}.snowflakecomputing.com/api/v2/cortex/v1",
-    "doc": "https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api",
-    "env": [
-      "SNOWFLAKE_ACCOUNT",
-      "SNOWFLAKE_CORTEX_PAT"
-    ],
-    "model_count": 11
-  },
-  {
-    "id": "moonshotai",
-    "display_name": "Moonshot AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.moonshot.ai/v1",
-    "doc": "https://platform.moonshot.ai/docs/api/chat",
-    "env": [
-      "MOONSHOT_API_KEY"
-    ],
-    "model_count": 7
-  },
-  {
-    "id": "llmgateway",
-    "display_name": "LLM Gateway",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.llmgateway.io/v1",
-    "doc": "https://llmgateway.io/docs",
-    "env": [
-      "LLMGATEWAY_API_KEY"
-    ],
-    "model_count": 189
-  },
-  {
-    "id": "moark",
-    "display_name": "Moark",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://moark.com/v1",
-    "doc": "https://moark.com/docs/openapi/v1#tag/%E6%96%87%E6%9C%AC%E7%94%9F%E6%88%90",
-    "env": [
-      "MOARK_API_KEY"
-    ],
-    "model_count": 2
-  },
-  {
-    "id": "github-models",
-    "display_name": "GitHub Models",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://models.github.ai/inference",
-    "doc": "https://docs.github.com/en/github-models",
-    "env": [
-      "GITHUB_TOKEN"
-    ],
-    "model_count": 55
-  },
-  {
-    "id": "xiaomi-token-plan-cn",
-    "display_name": "Xiaomi Token Plan (China)",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://token-plan-cn.xiaomimimo.com/v1",
-    "doc": "https://platform.xiaomimimo.com/#/docs",
-    "env": [
-      "XIAOMI_API_KEY"
-    ],
-    "model_count": 8
-  },
-  {
-    "id": "lmstudio",
-    "display_name": "LMStudio",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "http://127.0.0.1:1234/v1",
-    "doc": "https://lmstudio.ai/models",
-    "env": [
-      "LMSTUDIO_API_KEY"
-    ],
-    "model_count": 3
-  },
-  {
-    "id": "zenmux",
-    "display_name": "ZenMux",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://zenmux.ai/api/v1",
-    "doc": "https://docs.zenmux.ai",
-    "env": [
-      "ZENMUX_API_KEY"
-    ],
-    "model_count": 96
-  },
-  {
-    "id": "claudinio",
-    "display_name": "Claudinio",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.claudin.io/v1",
-    "doc": "https://claudin.io",
-    "env": [
-      "CLAUDINIO_API_KEY"
-    ],
-    "model_count": 1
-  },
-  {
-    "id": "alibaba-coding-plan",
-    "display_name": "Alibaba Coding Plan",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://coding-intl.dashscope.aliyuncs.com/v1",
-    "doc": "https://www.alibabacloud.com/help/en/model-studio/coding-plan",
-    "env": [
-      "ALIBABA_CODING_PLAN_API_KEY"
-    ],
-    "model_count": 11
-  },
-  {
-    "id": "modelscope",
-    "display_name": "ModelScope",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api-inference.modelscope.cn/v1",
-    "doc": "https://modelscope.cn/docs/model-service/API-Inference/intro",
-    "env": [
-      "MODELSCOPE_API_KEY"
-    ],
-    "model_count": 7
-  },
-  {
     "id": "qihang-ai",
     "display_name": "QiHang",
     "npm": "@ai-sdk/openai-compatible",
@@ -584,424 +903,6 @@
       "QIHANG_API_KEY"
     ],
     "model_count": 9
-  },
-  {
-    "id": "poe",
-    "display_name": "Poe",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.poe.com/v1",
-    "doc": "https://creator.poe.com/docs/external-applications/openai-compatible-api",
-    "env": [
-      "POE_API_KEY"
-    ],
-    "model_count": 137
-  },
-  {
-    "id": "umans-ai-coding-plan",
-    "display_name": "Umans AI Coding Plan",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.code.umans.ai/v1",
-    "doc": "https://app.umans.ai/offers/code/docs",
-    "env": [
-      "UMANS_AI_CODING_PLAN_API_KEY"
-    ],
-    "model_count": 5
-  },
-  {
-    "id": "firepass",
-    "display_name": "Fireworks (Firepass)",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.fireworks.ai/inference/v1/",
-    "doc": "https://docs.fireworks.ai/firepass",
-    "env": [
-      "FIREPASS_API_KEY"
-    ],
-    "model_count": 1
-  },
-  {
-    "id": "gmicloud",
-    "display_name": "GMI Cloud",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.gmi-serving.com/v1",
-    "doc": "https://docs.gmicloud.ai/inference-engine/api-reference/llm-api-reference",
-    "env": [
-      "GMICLOUD_API_KEY"
-    ],
-    "model_count": 8
-  },
-  {
-    "id": "mixlayer",
-    "display_name": "Mixlayer",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://models.mixlayer.ai/v1",
-    "doc": "https://docs.mixlayer.com",
-    "env": [
-      "MIXLAYER_API_KEY"
-    ],
-    "model_count": 5
-  },
-  {
-    "id": "minimax-coding-plan",
-    "display_name": "MiniMax Token Plan (minimax.io)",
-    "npm": "@ai-sdk/anthropic",
-    "api": "https://api.minimax.io/anthropic/v1",
-    "doc": "https://platform.minimax.io/docs/token-plan/intro",
-    "env": [
-      "MINIMAX_API_KEY"
-    ],
-    "model_count": 7
-  },
-  {
-    "id": "evroc",
-    "display_name": "evroc",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://models.think.evroc.com/v1",
-    "doc": "https://docs.evroc.com/products/think/overview.html",
-    "env": [
-      "EVROC_API_KEY"
-    ],
-    "model_count": 13
-  },
-  {
-    "id": "nvidia",
-    "display_name": "Nvidia",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://integrate.api.nvidia.com/v1",
-    "doc": "https://docs.api.nvidia.com/nim/",
-    "env": [
-      "NVIDIA_API_KEY"
-    ],
-    "model_count": 93
-  },
-  {
-    "id": "routing-run",
-    "display_name": "routing.run",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://ai.routing.sh/v1",
-    "doc": "https://docs.routing.run/api-reference/models",
-    "env": [
-      "ROUTING_RUN_API_KEY"
-    ],
-    "model_count": 26
-  },
-  {
-    "id": "xiaomi-token-plan-ams",
-    "display_name": "Xiaomi Token Plan (Europe)",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://token-plan-ams.xiaomimimo.com/v1",
-    "doc": "https://platform.xiaomimimo.com/#/docs",
-    "env": [
-      "XIAOMI_API_KEY"
-    ],
-    "model_count": 8
-  },
-  {
-    "id": "zhipuai",
-    "display_name": "Zhipu AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://open.bigmodel.cn/api/paas/v4",
-    "doc": "https://docs.z.ai/guides/overview/pricing",
-    "env": [
-      "ZHIPU_API_KEY"
-    ],
-    "model_count": 12
-  },
-  {
-    "id": "io-net",
-    "display_name": "IO.NET",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.intelligence.io.solutions/api/v1",
-    "doc": "https://io.net/docs/guides/intelligence/io-intelligence",
-    "env": [
-      "IOINTELLIGENCE_API_KEY"
-    ],
-    "model_count": 17
-  },
-  {
-    "id": "lilac",
-    "display_name": "Lilac",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.getlilac.com/v1",
-    "doc": "https://docs.getlilac.com/inference/models",
-    "env": [
-      "LILAC_API_KEY"
-    ],
-    "model_count": 4
-  },
-  {
-    "id": "stepfun-ai",
-    "display_name": "StepFun",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.stepfun.ai/step_plan/v1",
-    "doc": "https://platform.stepfun.ai/docs/en/step-plan/integrations/open-code",
-    "env": [
-      "STEPFUN_API_KEY"
-    ],
-    "model_count": 2
-  },
-  {
-    "id": "tencent-coding-plan",
-    "display_name": "Tencent Coding Plan (China)",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.lkeap.cloud.tencent.com/coding/v3",
-    "doc": "https://cloud.tencent.com/document/product/1772/128947",
-    "env": [
-      "TENCENT_CODING_PLAN_API_KEY"
-    ],
-    "model_count": 8
-  },
-  {
-    "id": "opencode-go",
-    "display_name": "OpenCode Go",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://opencode.ai/zen/go/v1",
-    "doc": "https://opencode.ai/docs/zen",
-    "env": [
-      "OPENCODE_API_KEY"
-    ],
-    "model_count": 16
-  },
-  {
-    "id": "cortecs",
-    "display_name": "Cortecs",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.cortecs.ai/v1",
-    "doc": "https://api.cortecs.ai/v1/models",
-    "env": [
-      "CORTECS_API_KEY"
-    ],
-    "model_count": 49
-  },
-  {
-    "id": "auriko",
-    "display_name": "Auriko",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.auriko.ai/v1",
-    "doc": "https://docs.auriko.ai",
-    "env": [
-      "AURIKO_API_KEY"
-    ],
-    "model_count": 15
-  },
-  {
-    "id": "wafer.ai",
-    "display_name": "Wafer",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://pass.wafer.ai/v1",
-    "doc": "https://docs.wafer.ai/wafer-pass",
-    "env": [
-      "WAFER_API_KEY"
-    ],
-    "model_count": 7
-  },
-  {
-    "id": "berget",
-    "display_name": "Berget.AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.berget.ai/v1",
-    "doc": "https://api.berget.ai",
-    "env": [
-      "BERGET_API_KEY"
-    ],
-    "model_count": 7
-  },
-  {
-    "id": "requesty",
-    "display_name": "Requesty",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://router.requesty.ai/v1",
-    "doc": "https://requesty.ai/solution/llm-routing/models",
-    "env": [
-      "REQUESTY_API_KEY"
-    ],
-    "model_count": 38
-  },
-  {
-    "id": "atomic-chat",
-    "display_name": "Atomic Chat",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "http://127.0.0.1:1337/v1",
-    "doc": "https://atomic.chat",
-    "env": [
-      "ATOMIC_CHAT_API_KEY"
-    ],
-    "model_count": 5
-  },
-  {
-    "id": "stepfun",
-    "display_name": "StepFun (China)",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.stepfun.com/v1",
-    "doc": "https://platform.stepfun.com/docs/zh/overview/concept",
-    "env": [
-      "STEPFUN_API_KEY"
-    ],
-    "model_count": 4
-  },
-  {
-    "id": "anyapi",
-    "display_name": "AnyAPI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.anyapi.ai/v1",
-    "doc": "https://docs.anyapi.ai",
-    "env": [
-      "ANYAPI_API_KEY"
-    ],
-    "model_count": 30
-  },
-  {
-    "id": "vultr",
-    "display_name": "Vultr",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.vultrinference.com/v1",
-    "doc": "https://api.vultrinference.com/",
-    "env": [
-      "VULTR_API_KEY"
-    ],
-    "model_count": 7
-  },
-  {
-    "id": "zai-coding-plan",
-    "display_name": "Z.AI Coding Plan",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.z.ai/api/coding/paas/v4",
-    "doc": "https://docs.z.ai/devpack/overview",
-    "env": [
-      "ZHIPU_API_KEY"
-    ],
-    "model_count": 5
-  },
-  {
-    "id": "synthetic",
-    "display_name": "Synthetic",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.synthetic.new/openai/v1",
-    "doc": "https://synthetic.new/pricing",
-    "env": [
-      "SYNTHETIC_API_KEY"
-    ],
-    "model_count": 33
-  },
-  {
-    "id": "cloudferro-sherlock",
-    "display_name": "CloudFerro Sherlock",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api-sherlock.cloudferro.com/openai/v1/",
-    "doc": "https://docs.sherlock.cloudferro.com/",
-    "env": [
-      "CLOUDFERRO_SHERLOCK_API_KEY"
-    ],
-    "model_count": 5
-  },
-  {
-    "id": "helicone",
-    "display_name": "Helicone",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://ai-gateway.helicone.ai/v1",
-    "doc": "https://helicone.ai/models",
-    "env": [
-      "HELICONE_API_KEY"
-    ],
-    "model_count": 90
-  },
-  {
-    "id": "zai",
-    "display_name": "Z.AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.z.ai/api/paas/v4",
-    "doc": "https://docs.z.ai/guides/overview/pricing",
-    "env": [
-      "ZHIPU_API_KEY"
-    ],
-    "model_count": 13
-  },
-  {
-    "id": "nova",
-    "display_name": "Nova",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.nova.amazon.com/v1",
-    "doc": "https://nova.amazon.com/dev/documentation",
-    "env": [
-      "NOVA_API_KEY"
-    ],
-    "model_count": 2
-  },
-  {
-    "id": "nearai",
-    "display_name": "NEAR AI Cloud",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://cloud-api.near.ai/v1",
-    "doc": "https://docs.near.ai/",
-    "env": [
-      "NEARAI_API_KEY"
-    ],
-    "model_count": 37
-  },
-  {
-    "id": "inceptron",
-    "display_name": "Inceptron",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.inceptron.io/v1",
-    "doc": "https://docs.inceptron.io",
-    "env": [
-      "INCEPTRON_API_KEY"
-    ],
-    "model_count": 4
-  },
-  {
-    "id": "xpersona",
-    "display_name": "Xpersona",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://www.xpersona.co/v1",
-    "doc": "https://www.xpersona.co/docs",
-    "env": [
-      "XPERSONA_API_KEY"
-    ],
-    "model_count": 1
-  },
-  {
-    "id": "perplexity-agent",
-    "display_name": "Perplexity Agent",
-    "npm": "@ai-sdk/openai",
-    "api": "https://api.perplexity.ai/v1",
-    "doc": "https://docs.perplexity.ai/docs/agent-api/models",
-    "env": [
-      "PERPLEXITY_API_KEY"
-    ],
-    "model_count": 18
-  },
-  {
-    "id": "jiekou",
-    "display_name": "Jiekou.AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.jiekou.ai/openai",
-    "doc": "https://docs.jiekou.ai/docs/support/quickstart?utm_source=github_models.dev",
-    "env": [
-      "JIEKOU_API_KEY"
-    ],
-    "model_count": 61
-  },
-  {
-    "id": "abliteration-ai",
-    "display_name": "abliteration.ai",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.abliteration.ai/v1",
-    "doc": "https://docs.abliteration.ai/models",
-    "env": [
-      "ABLIT_KEY"
-    ],
-    "model_count": 1
-  },
-  {
-    "id": "minimax-cn",
-    "display_name": "MiniMax (minimaxi.com)",
-    "npm": "@ai-sdk/anthropic",
-    "api": "https://api.minimaxi.com/anthropic/v1",
-    "doc": "https://platform.minimaxi.com/docs/guides/quickstart",
-    "env": [
-      "MINIMAX_API_KEY"
-    ],
-    "model_count": 7
   },
   {
     "id": "qiniu-ai",
@@ -1015,114 +916,37 @@
     "model_count": 91
   },
   {
-    "id": "morph",
-    "display_name": "Morph",
+    "id": "regolo-ai",
+    "display_name": "Regolo AI",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.morphllm.com/v1",
-    "doc": "https://docs.morphllm.com/api-reference/introduction",
+    "api": "https://api.regolo.ai/v1",
+    "doc": "https://docs.regolo.ai/",
     "env": [
-      "MORPH_API_KEY"
+      "REGOLO_API_KEY"
     ],
-    "model_count": 3
+    "model_count": 13
   },
   {
-    "id": "xiaomi-token-plan-sgp",
-    "display_name": "Xiaomi Token Plan (Singapore)",
+    "id": "requesty",
+    "display_name": "Requesty",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://token-plan-sgp.xiaomimimo.com/v1",
-    "doc": "https://platform.xiaomimimo.com/#/docs",
+    "api": "https://router.requesty.ai/v1",
+    "doc": "https://requesty.ai/solution/llm-routing/models",
     "env": [
-      "XIAOMI_API_KEY"
+      "REQUESTY_API_KEY"
     ],
-    "model_count": 8
+    "model_count": 38
   },
   {
-    "id": "fastrouter",
-    "display_name": "FastRouter",
+    "id": "routing-run",
+    "display_name": "routing.run",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://go.fastrouter.ai/api/v1",
-    "doc": "https://fastrouter.ai/models",
+    "api": "https://ai.routing.sh/v1",
+    "doc": "https://docs.routing.run/api-reference/models",
     "env": [
-      "FASTROUTER_API_KEY"
+      "ROUTING_RUN_API_KEY"
     ],
-    "model_count": 15
-  },
-  {
-    "id": "siliconflow",
-    "display_name": "SiliconFlow",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.siliconflow.com/v1",
-    "doc": "https://cloud.siliconflow.com/models",
-    "env": [
-      "SILICONFLOW_API_KEY"
-    ],
-    "model_count": 76
-  },
-  {
-    "id": "abacus",
-    "display_name": "Abacus",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://routellm.abacus.ai/v1",
-    "doc": "https://abacus.ai/help/api",
-    "env": [
-      "ABACUS_API_KEY"
-    ],
-    "model_count": 65
-  },
-  {
-    "id": "drun",
-    "display_name": "D.Run (China)",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://chat.d.run/v1",
-    "doc": "https://www.d.run",
-    "env": [
-      "DRUN_API_KEY"
-    ],
-    "model_count": 3
-  },
-  {
-    "id": "wandb",
-    "display_name": "Weights & Biases",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.inference.wandb.ai/v1",
-    "doc": "https://docs.wandb.ai/guides/integrations/inference/",
-    "env": [
-      "WANDB_API_KEY"
-    ],
-    "model_count": 18
-  },
-  {
-    "id": "meganova",
-    "display_name": "Meganova",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.meganova.ai/v1",
-    "doc": "https://docs.meganova.ai",
-    "env": [
-      "MEGANOVA_API_KEY"
-    ],
-    "model_count": 19
-  },
-  {
-    "id": "opencode",
-    "display_name": "OpenCode Zen",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://opencode.ai/zen/v1",
-    "doc": "https://opencode.ai/docs/zen",
-    "env": [
-      "OPENCODE_API_KEY"
-    ],
-    "model_count": 66
-  },
-  {
-    "id": "poolside",
-    "display_name": "Poolside",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://inference.poolside.ai/v1",
-    "doc": "https://platform.poolside.ai",
-    "env": [
-      "POOLSIDE_API_KEY"
-    ],
-    "model_count": 2
+    "model_count": 26
   },
   {
     "id": "sarvam",
@@ -1132,28 +956,6 @@
     "doc": "https://docs.sarvam.ai/api-reference-docs/getting-started/models",
     "env": [
       "SARVAM_API_KEY"
-    ],
-    "model_count": 2
-  },
-  {
-    "id": "baseten",
-    "display_name": "Baseten",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://inference.baseten.co/v1",
-    "doc": "https://docs.baseten.co/development/model-apis/overview",
-    "env": [
-      "BASETEN_API_KEY"
-    ],
-    "model_count": 14
-  },
-  {
-    "id": "lucidquery",
-    "display_name": "LucidQuery AI",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://lucidquery.com/api/v1",
-    "doc": "https://lucidquery.com/api/docs",
-    "env": [
-      "LUCIDQUERY_API_KEY"
     ],
     "model_count": 2
   },
@@ -1169,15 +971,104 @@
     "model_count": 16
   },
   {
-    "id": "hpc-ai",
-    "display_name": "HPC-AI",
+    "id": "siliconflow",
+    "display_name": "SiliconFlow",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.hpc-ai.com/inference/v1",
-    "doc": "https://www.hpc-ai.com/doc/docs/quickstart/",
+    "api": "https://api.siliconflow.com/v1",
+    "doc": "https://cloud.siliconflow.com/models",
     "env": [
-      "HPC_AI_API_KEY"
+      "SILICONFLOW_API_KEY"
     ],
-    "model_count": 3
+    "model_count": 76
+  },
+  {
+    "id": "siliconflow-cn",
+    "display_name": "SiliconFlow (China)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.siliconflow.cn/v1",
+    "doc": "https://cloud.siliconflow.com/models",
+    "env": [
+      "SILICONFLOW_CN_API_KEY"
+    ],
+    "model_count": 82
+  },
+  {
+    "id": "snowflake-cortex",
+    "display_name": "Snowflake Cortex",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://${SNOWFLAKE_ACCOUNT}.snowflakecomputing.com/api/v2/cortex/v1",
+    "doc": "https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api",
+    "env": [
+      "SNOWFLAKE_ACCOUNT",
+      "SNOWFLAKE_CORTEX_PAT"
+    ],
+    "model_count": 11
+  },
+  {
+    "id": "stackit",
+    "display_name": "STACKIT",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1",
+    "doc": "https://docs.stackit.cloud/products/data-and-ai/ai-model-serving/basics/available-shared-models",
+    "env": [
+      "STACKIT_API_KEY"
+    ],
+    "model_count": 8
+  },
+  {
+    "id": "stepfun",
+    "display_name": "StepFun",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.stepfun.com/v1",
+    "doc": "https://platform.stepfun.com/docs/zh/overview/concept",
+    "env": [
+      "STEPFUN_API_KEY"
+    ],
+    "model_count": 4
+  },
+  {
+    "id": "stepfun-ai",
+    "display_name": "StepFun AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.stepfun.ai/step_plan/v1",
+    "doc": "https://platform.stepfun.ai/docs/en/step-plan/integrations/open-code",
+    "env": [
+      "STEPFUN_API_KEY"
+    ],
+    "model_count": 2
+  },
+  {
+    "id": "submodel",
+    "display_name": "submodel",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://llm.submodel.ai/v1",
+    "doc": "https://submodel.gitbook.io",
+    "env": [
+      "SUBMODEL_INSTAGEN_ACCESS_KEY"
+    ],
+    "model_count": 9
+  },
+  {
+    "id": "synthetic",
+    "display_name": "Synthetic",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.synthetic.new/openai/v1",
+    "doc": "https://synthetic.new/pricing",
+    "env": [
+      "SYNTHETIC_API_KEY"
+    ],
+    "model_count": 33
+  },
+  {
+    "id": "tencent-coding-plan",
+    "display_name": "Tencent Coding Plan (China)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.lkeap.cloud.tencent.com/coding/v3",
+    "doc": "https://cloud.tencent.com/document/product/1772/128947",
+    "env": [
+      "TENCENT_CODING_PLAN_API_KEY"
+    ],
+    "model_count": 8
   },
   {
     "id": "tencent-tokenhub",
@@ -1191,59 +1082,190 @@
     "model_count": 1
   },
   {
-    "id": "alibaba-coding-plan-cn",
-    "display_name": "Alibaba Coding Plan (China)",
+    "id": "the-grid-ai",
+    "display_name": "The Grid AI",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://coding.dashscope.aliyuncs.com/v1",
-    "doc": "https://help.aliyun.com/zh/model-studio/coding-plan",
+    "api": "https://api.thegrid.ai/v1",
+    "doc": "https://thegrid.ai/docs",
     "env": [
-      "ALIBABA_CODING_PLAN_API_KEY"
+      "THEGRIDAI_API_KEY"
     ],
-    "model_count": 11
+    "model_count": 9
   },
   {
-    "id": "cloudflare-workers-ai",
-    "display_name": "Cloudflare Workers AI",
+    "id": "umans-ai-coding-plan",
+    "display_name": "Umans AI Coding Plan",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1",
-    "doc": "https://developers.cloudflare.com/workers-ai/models/",
+    "api": "https://api.code.umans.ai/v1",
+    "doc": "https://app.umans.ai/offers/code/docs",
     "env": [
-      "CLOUDFLARE_ACCOUNT_ID",
-      "CLOUDFLARE_API_KEY"
+      "UMANS_AI_CODING_PLAN_API_KEY"
     ],
-    "model_count": 20
+    "model_count": 5
   },
   {
-    "id": "nebius",
-    "display_name": "Nebius Token Factory",
+    "id": "upstage",
+    "display_name": "Upstage",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.tokenfactory.nebius.com/v1",
-    "doc": "https://docs.tokenfactory.nebius.com/",
+    "api": "https://api.upstage.ai/v1/solar",
+    "doc": "https://developers.upstage.ai/docs/apis/chat",
     "env": [
-      "NEBIUS_API_KEY"
+      "UPSTAGE_API_KEY"
     ],
-    "model_count": 31
+    "model_count": 3
   },
   {
-    "id": "minimax",
-    "display_name": "MiniMax (minimax.io)",
-    "npm": "@ai-sdk/anthropic",
-    "api": "https://api.minimax.io/anthropic/v1",
-    "doc": "https://platform.minimax.io/docs/guides/quickstart",
+    "id": "vivgrid",
+    "display_name": "Vivgrid",
+    "npm": "@ai-sdk/openai",
+    "api": "https://api.vivgrid.com/v1",
+    "doc": "https://docs.vivgrid.com/models",
     "env": [
-      "MINIMAX_API_KEY"
+      "VIVGRID_API_KEY"
+    ],
+    "model_count": 13
+  },
+  {
+    "id": "vultr",
+    "display_name": "Vultr",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.vultrinference.com/v1",
+    "doc": "https://api.vultrinference.com/",
+    "env": [
+      "VULTR_API_KEY"
     ],
     "model_count": 7
   },
   {
-    "id": "meta-llama",
-    "display_name": "Llama",
+    "id": "wafer.ai",
+    "display_name": "Wafer",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.llama.com/compat/v1/",
-    "doc": "https://llama.developer.meta.com/docs/models",
+    "api": "https://pass.wafer.ai/v1",
+    "doc": "https://docs.wafer.ai/wafer-pass",
     "env": [
-      "LLAMA_API_KEY"
+      "WAFER_API_KEY"
     ],
     "model_count": 7
+  },
+  {
+    "id": "wandb",
+    "display_name": "Weights & Biases",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.inference.wandb.ai/v1",
+    "doc": "https://docs.wandb.ai/guides/integrations/inference/",
+    "env": [
+      "WANDB_API_KEY"
+    ],
+    "model_count": 18
+  },
+  {
+    "id": "xiaomi",
+    "display_name": "Xiaomi",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.xiaomimimo.com/v1",
+    "doc": "https://platform.xiaomimimo.com/#/docs",
+    "env": [
+      "XIAOMI_API_KEY"
+    ],
+    "model_count": 5
+  },
+  {
+    "id": "xiaomi-token-plan-ams",
+    "display_name": "Xiaomi Token Plan (Europe)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://token-plan-ams.xiaomimimo.com/v1",
+    "doc": "https://platform.xiaomimimo.com/#/docs",
+    "env": [
+      "XIAOMI_API_KEY"
+    ],
+    "model_count": 8
+  },
+  {
+    "id": "xiaomi-token-plan-cn",
+    "display_name": "Xiaomi Token Plan (China)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://token-plan-cn.xiaomimimo.com/v1",
+    "doc": "https://platform.xiaomimimo.com/#/docs",
+    "env": [
+      "XIAOMI_API_KEY"
+    ],
+    "model_count": 8
+  },
+  {
+    "id": "xiaomi-token-plan-sgp",
+    "display_name": "Xiaomi Token Plan (Singapore)",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://token-plan-sgp.xiaomimimo.com/v1",
+    "doc": "https://platform.xiaomimimo.com/#/docs",
+    "env": [
+      "XIAOMI_API_KEY"
+    ],
+    "model_count": 8
+  },
+  {
+    "id": "xpersona",
+    "display_name": "Xpersona",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://www.xpersona.co/v1",
+    "doc": "https://www.xpersona.co/docs",
+    "env": [
+      "XPERSONA_API_KEY"
+    ],
+    "model_count": 2
+  },
+  {
+    "id": "zai",
+    "display_name": "Z.AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.z.ai/api/paas/v4",
+    "doc": "https://docs.z.ai/guides/overview/pricing",
+    "env": [
+      "ZHIPU_API_KEY"
+    ],
+    "model_count": 13
+  },
+  {
+    "id": "zai-coding-plan",
+    "display_name": "Z.AI Coding Plan",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.z.ai/api/coding/paas/v4",
+    "doc": "https://docs.z.ai/devpack/overview",
+    "env": [
+      "ZHIPU_API_KEY"
+    ],
+    "model_count": 5
+  },
+  {
+    "id": "zenmux",
+    "display_name": "ZenMux",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://zenmux.ai/api/v1",
+    "doc": "https://docs.zenmux.ai",
+    "env": [
+      "ZENMUX_API_KEY"
+    ],
+    "model_count": 107
+  },
+  {
+    "id": "zhipuai",
+    "display_name": "Zhipu AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://open.bigmodel.cn/api/paas/v4",
+    "doc": "https://docs.z.ai/guides/overview/pricing",
+    "env": [
+      "ZHIPU_API_KEY"
+    ],
+    "model_count": 12
+  },
+  {
+    "id": "zhipuai-coding-plan",
+    "display_name": "Zhipu AI Coding Plan",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://open.bigmodel.cn/api/coding/paas/v4",
+    "doc": "https://docs.bigmodel.cn/cn/coding-plan/overview",
+    "env": [
+      "ZHIPU_API_KEY"
+    ],
+    "model_count": 6
   }
 ]

--- a/crates/goose-providers/src/canonical/name_builder.rs
+++ b/crates/goose-providers/src/canonical/name_builder.rs
@@ -447,16 +447,16 @@ mod tests {
 
         // === Grok (X.AI) ===
         assert_eq!(
-            map_to_canonical_model("databricks", "grok-4.20", r),
-            Some("x-ai/grok-4.20".to_string())
+            map_to_canonical_model("databricks", "grok-4.3", r),
+            Some("x-ai/grok-4.3".to_string())
         );
         assert_eq!(
-            map_to_canonical_model("databricks", "databricks-grok-4.20", r),
-            Some("x-ai/grok-4.20".to_string())
+            map_to_canonical_model("databricks", "databricks-grok-4.3", r),
+            Some("x-ai/grok-4.3".to_string())
         );
         assert_eq!(
-            map_to_canonical_model("databricks", "kgoose-grok-4.20", r),
-            Some("x-ai/grok-4.20".to_string())
+            map_to_canonical_model("databricks", "kgoose-grok-4.3", r),
+            Some("x-ai/grok-4.3".to_string())
         );
 
         // === Cohere Command ===
@@ -492,8 +492,8 @@ mod tests {
             Some("deepseek/deepseek-chat".to_string())
         );
         assert_eq!(
-            map_to_canonical_model("databricks", "x-ai-grok-4.20", r),
-            Some("x-ai/grok-4.20".to_string())
+            map_to_canonical_model("databricks", "x-ai-grok-4.3", r),
+            Some("x-ai/grok-4.3".to_string())
         );
 
         // === Zhipu AI ===
@@ -514,10 +514,6 @@ mod tests {
         assert_eq!(
             map_to_canonical_model("gcp_vertex_ai", "gemini-2.5-pro", r),
             Some("google-vertex/gemini-2.5-pro".to_string())
-        );
-        assert_eq!(
-            map_to_canonical_model("gcp_vertex_ai", "claude-3-5-sonnet", r),
-            Some("google-vertex/claude-3.5-sonnet".to_string())
         );
         assert_eq!(
             map_to_canonical_model("gcp_vertex_ai", "claude-sonnet-4@20250514", r),


### PR DESCRIPTION
## Why
Refresh the bundled canonical model registry from models.dev without updating the live provider mapping report.

## What
- Regenerate canonical model and provider metadata snapshots
- Update canonical name-builder expectations for refreshed model IDs
- Leave canonical_mapping_report.json unchanged to avoid recording local provider inventory

## Risk Assessment
Low — this updates generated model metadata and associated tests; no runtime provider logic changes.

## References
Validation:
- `cargo fmt`
- `cargo test -p goose-providers`
- `cargo test -p goose --bin build_canonical_models`

Generated with Goose
