### PR TITLE
expose ACP thinking effort config option

### DIFF
--- a/crates/goose-sdk-types/src/custom_requests.rs
+++ b/crates/goose-sdk-types/src/custom_requests.rs
@@ -314,6 +314,7 @@ pub struct PreferencesRemoveRequest {
 pub enum PreferenceKey {
     #[default]
     AutoCompactThreshold,
+    GooseThinkingEffort,
     VoiceAutoSubmitPhrases,
     VoiceDictationProvider,
     VoiceDictationPreferredMic,

--- a/crates/goose/acp-schema.json
+++ b/crates/goose/acp-schema.json
@@ -1915,6 +1915,7 @@
       "type": "string",
       "enum": [
         "autoCompactThreshold",
+        "gooseThinkingEffort",
         "voiceAutoSubmitPhrases",
         "voiceDictationProvider",
         "voiceDictationPreferredMic"

--- a/crates/goose/src/acp/response_builder.rs
+++ b/crates/goose/src/acp/response_builder.rs
@@ -9,6 +9,7 @@ use agent_client_protocol::schema::{
     SessionUpdate, UnstructuredCommandInput,
 };
 use agent_client_protocol::{Client, ConnectionTo};
+use goose_providers::thinking::ThinkingEffort;
 use strum::{EnumMessage, VariantNames};
 
 use super::server::{build_usage_updates, DEFAULT_PROVIDER_ID, DEFAULT_PROVIDER_LABEL};
@@ -174,14 +175,14 @@ pub(super) fn build_config_options(
         .iter()
         .map(|m| SessionConfigSelectOption::new(m.model_id.0.clone(), m.name.clone()))
         .collect();
-    let thinking_effort_options = ["off", "low", "medium", "high", "max"]
-        .into_iter()
-        .map(|effort| SessionConfigSelectOption::new(effort, effort))
+    let thinking_effort_options = thinking_effort_values(model_config)
+        .iter()
+        .map(|effort| {
+            let effort = effort.to_string();
+            SessionConfigSelectOption::new(effort.clone(), effort)
+        })
         .collect::<Vec<_>>();
-    let current_thinking_effort = model_config
-        .thinking_effort()
-        .map(|effort| effort.to_string())
-        .unwrap_or_else(|| "off".to_string());
+    let current_thinking_effort = current_thinking_effort_value(model_config);
     vec![
         SessionConfigOption::select(
             "provider",
@@ -212,6 +213,31 @@ pub(super) fn build_config_options(
         .description("Controls reasoning effort for models that support extended thinking.")
         .category(SessionConfigOptionCategory::ThoughtLevel),
     ]
+}
+
+fn thinking_effort_values(model_config: &ModelConfig) -> &'static [ThinkingEffort] {
+    if model_config.is_reasoning_model() {
+        &[
+            ThinkingEffort::Off,
+            ThinkingEffort::Low,
+            ThinkingEffort::Medium,
+            ThinkingEffort::High,
+            ThinkingEffort::Max,
+        ]
+    } else {
+        &[ThinkingEffort::Off]
+    }
+}
+
+fn current_thinking_effort_value(model_config: &ModelConfig) -> String {
+    if model_config.is_reasoning_model() {
+        model_config
+            .thinking_effort()
+            .map(|effort| effort.to_string())
+            .unwrap_or_else(|| "off".to_string())
+    } else {
+        "off".to_string()
+    }
 }
 
 fn available_commands_update(working_dir: &std::path::Path) -> AvailableCommandsUpdate {
@@ -385,13 +411,7 @@ mod tests {
             ).category(SessionConfigOptionCategory::Model),
             SessionConfigOption::select(
                 "thinking_effort", "Thinking effort", "off",
-                vec![
-                    SessionConfigSelectOption::new("off", "off"),
-                    SessionConfigSelectOption::new("low", "low"),
-                    SessionConfigSelectOption::new("medium", "medium"),
-                    SessionConfigSelectOption::new("high", "high"),
-                    SessionConfigSelectOption::new("max", "max"),
-                ],
+                vec![SessionConfigSelectOption::new("off", "off")],
             )
             .description("Controls reasoning effort for models that support extended thinking.")
             .category(SessionConfigOptionCategory::ThoughtLevel),
@@ -423,13 +443,7 @@ mod tests {
             ).category(SessionConfigOptionCategory::Model),
             SessionConfigOption::select(
                 "thinking_effort", "Thinking effort", "off",
-                vec![
-                    SessionConfigSelectOption::new("off", "off"),
-                    SessionConfigSelectOption::new("low", "low"),
-                    SessionConfigSelectOption::new("medium", "medium"),
-                    SessionConfigSelectOption::new("high", "high"),
-                    SessionConfigSelectOption::new("max", "max"),
-                ],
+                vec![SessionConfigSelectOption::new("off", "off")],
             )
             .description("Controls reasoning effort for models that support extended thinking.")
             .category(SessionConfigOptionCategory::ThoughtLevel),
@@ -463,11 +477,14 @@ mod tests {
     fn test_build_config_options_uses_current_thinking_effort() {
         let mode_state = build_mode_state(GooseMode::Auto).unwrap();
         let model_state = SessionModelState::new(
-            ModelId::new("gpt-4"),
-            vec![ModelInfo::new(ModelId::new("gpt-4"), "gpt-4")],
+            ModelId::new("claude-sonnet-4"),
+            vec![ModelInfo::new(
+                ModelId::new("claude-sonnet-4"),
+                "claude-sonnet-4",
+            )],
         );
         let model_config = ModelConfig {
-            model_name: "gpt-4".to_string(),
+            model_name: "claude-sonnet-4".to_string(),
             request_params: Some(std::collections::HashMap::from([(
                 "thinking_effort".to_string(),
                 serde_json::json!("high"),
@@ -492,5 +509,47 @@ mod tests {
         };
 
         assert_eq!(select.current_value.0.as_ref(), "high");
+    }
+
+    #[test]
+    fn test_build_config_options_masks_non_reasoning_thinking_effort() {
+        let mode_state = build_mode_state(GooseMode::Auto).unwrap();
+        let model_state = SessionModelState::new(
+            ModelId::new("gpt-4"),
+            vec![ModelInfo::new(ModelId::new("gpt-4"), "gpt-4")],
+        );
+        let model_config = ModelConfig {
+            model_name: "gpt-4".to_string(),
+            request_params: Some(std::collections::HashMap::from([(
+                "thinking_effort".to_string(),
+                serde_json::json!("high"),
+            )])),
+            reasoning: Some(false),
+            ..Default::default()
+        };
+
+        let options = build_config_options(
+            &mode_state,
+            &model_state,
+            &model_config,
+            "openai",
+            vec![SessionConfigSelectOption::new("openai", "openai")],
+        );
+        let option = options
+            .iter()
+            .find(|option| option.id.0.as_ref() == "thinking_effort")
+            .expect("thinking_effort option");
+        let select = match &option.kind {
+            SessionConfigKind::Select(select) => select,
+            _ => panic!("thinking_effort should be a select option"),
+        };
+
+        assert_eq!(select.current_value.0.as_ref(), "off");
+        assert_eq!(
+            select.options,
+            agent_client_protocol::schema::SessionConfigSelectOptions::Ungrouped(vec![
+                SessionConfigSelectOption::new("off", "off")
+            ])
+        );
     }
 }

--- a/crates/goose/src/acp/response_builder.rs
+++ b/crates/goose/src/acp/response_builder.rs
@@ -1,4 +1,5 @@
 use crate::config::GooseMode;
+use crate::model::ModelConfig;
 use crate::providers::inventory::{ProviderInventoryEntry, ProviderInventoryService};
 use crate::session::Session;
 use agent_client_protocol::schema::{
@@ -146,6 +147,7 @@ pub(super) async fn build_session_setup_config(
     let config_options = build_config_options(
         &mode_state,
         &model_state,
+        model_config,
         provider_selection,
         provider_options,
     );
@@ -155,6 +157,7 @@ pub(super) async fn build_session_setup_config(
 pub(super) fn build_config_options(
     mode_state: &SessionModeState,
     model_state: &SessionModelState,
+    model_config: &ModelConfig,
     provider_selection: &str,
     provider_options: Vec<SessionConfigSelectOption>,
 ) -> Vec<SessionConfigOption> {
@@ -171,6 +174,14 @@ pub(super) fn build_config_options(
         .iter()
         .map(|m| SessionConfigSelectOption::new(m.model_id.0.clone(), m.name.clone()))
         .collect();
+    let thinking_effort_options = ["off", "low", "medium", "high", "max"]
+        .into_iter()
+        .map(|effort| SessionConfigSelectOption::new(effort, effort))
+        .collect::<Vec<_>>();
+    let current_thinking_effort = model_config
+        .thinking_effort()
+        .map(|effort| effort.to_string())
+        .unwrap_or_else(|| "off".to_string());
     vec![
         SessionConfigOption::select(
             "provider",
@@ -192,6 +203,14 @@ pub(super) fn build_config_options(
             model_options,
         )
         .category(SessionConfigOptionCategory::Model),
+        SessionConfigOption::select(
+            "thinking_effort",
+            "Thinking effort",
+            current_thinking_effort,
+            thinking_effort_options,
+        )
+        .description("Controls reasoning effort for models that support extended thinking.")
+        .category(SessionConfigOptionCategory::ThoughtLevel),
     ]
 }
 
@@ -236,6 +255,7 @@ pub(super) fn send_session_setup_notifications(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use agent_client_protocol::schema::SessionConfigKind;
     use test_case::test_case;
 
     #[test_case(
@@ -363,6 +383,18 @@ mod tests {
                     SessionConfigSelectOption::new("gpt-3.5", "gpt-3.5"),
                 ],
             ).category(SessionConfigOptionCategory::Model),
+            SessionConfigOption::select(
+                "thinking_effort", "Thinking effort", "off",
+                vec![
+                    SessionConfigSelectOption::new("off", "off"),
+                    SessionConfigSelectOption::new("low", "low"),
+                    SessionConfigSelectOption::new("medium", "medium"),
+                    SessionConfigSelectOption::new("high", "high"),
+                    SessionConfigSelectOption::new("max", "max"),
+                ],
+            )
+            .description("Controls reasoning effort for models that support extended thinking.")
+            .category(SessionConfigOptionCategory::ThoughtLevel),
         ]
         ; "auto mode with multiple models"
     )]
@@ -389,6 +421,18 @@ mod tests {
                 "model", "Model", "only-model",
                 vec![SessionConfigSelectOption::new("only-model", "only-model")],
             ).category(SessionConfigOptionCategory::Model),
+            SessionConfigOption::select(
+                "thinking_effort", "Thinking effort", "off",
+                vec![
+                    SessionConfigSelectOption::new("off", "off"),
+                    SessionConfigSelectOption::new("low", "low"),
+                    SessionConfigSelectOption::new("medium", "medium"),
+                    SessionConfigSelectOption::new("high", "high"),
+                    SessionConfigSelectOption::new("max", "max"),
+                ],
+            )
+            .description("Controls reasoning effort for models that support extended thinking.")
+            .category(SessionConfigOptionCategory::ThoughtLevel),
         ]
         ; "approve mode with single model"
     )]
@@ -398,6 +442,55 @@ mod tests {
         provider_options: Vec<SessionConfigSelectOption>,
         model_state: SessionModelState,
     ) -> Vec<SessionConfigOption> {
-        build_config_options(&mode_state, &model_state, provider_name, provider_options)
+        let model_config = ModelConfig {
+            model_name: model_state.current_model_id.0.to_string(),
+            request_params: Some(std::collections::HashMap::from([(
+                "thinking_effort".to_string(),
+                serde_json::json!("off"),
+            )])),
+            ..Default::default()
+        };
+        build_config_options(
+            &mode_state,
+            &model_state,
+            &model_config,
+            provider_name,
+            provider_options,
+        )
+    }
+
+    #[test]
+    fn test_build_config_options_uses_current_thinking_effort() {
+        let mode_state = build_mode_state(GooseMode::Auto).unwrap();
+        let model_state = SessionModelState::new(
+            ModelId::new("gpt-4"),
+            vec![ModelInfo::new(ModelId::new("gpt-4"), "gpt-4")],
+        );
+        let model_config = ModelConfig {
+            model_name: "gpt-4".to_string(),
+            request_params: Some(std::collections::HashMap::from([(
+                "thinking_effort".to_string(),
+                serde_json::json!("high"),
+            )])),
+            ..Default::default()
+        };
+
+        let options = build_config_options(
+            &mode_state,
+            &model_state,
+            &model_config,
+            "openai",
+            vec![SessionConfigSelectOption::new("openai", "openai")],
+        );
+        let option = options
+            .iter()
+            .find(|option| option.id.0.as_ref() == "thinking_effort")
+            .expect("thinking_effort option");
+        let select = match &option.kind {
+            SessionConfigKind::Select(select) => select,
+            _ => panic!("thinking_effort should be a select option"),
+        };
+
+        assert_eq!(select.current_value.0.as_ref(), "high");
     }
 }

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -2752,43 +2752,11 @@ impl GooseAcpAgent {
                 agent_client_protocol::Error::invalid_params()
                     .data(format!("Invalid thinking effort: {}", effort_id))
             })?;
-        let config = self.config()?;
         let agent = self.get_session_agent(session_id, None).await?;
-        let current_provider = agent
-            .provider()
-            .await
-            .internal_err_ctx("Failed to get provider")?;
-        let provider_name = current_provider.get_name().to_string();
-        let current_model_config = current_provider.get_model_config();
-        let model_config = current_model_config.with_merged_request_params(HashMap::from([(
-            "thinking_effort".to_string(),
-            serde_json::json!(effort.to_string()),
-        )]));
-        let extensions =
-            EnabledExtensionsState::for_session(&self.session_manager, session_id, config).await;
-        let session = self
-            .session_manager
-            .get_session(session_id, false)
-            .await
-            .internal_err_ctx("Failed to get session")?;
-        let provider = self
-            .create_provider(
-                &provider_name,
-                model_config,
-                extensions,
-                Some(session.working_dir),
-            )
-            .await
-            .internal_err_ctx("Failed to create provider")?;
         agent
-            .update_provider(provider, session_id)
+            .update_thinking_effort(session_id, effort)
             .await
-            .internal_err_ctx("Failed to update provider")?;
-        let mode = agent.goose_mode().await;
-        agent
-            .update_goose_mode(mode, session_id)
-            .await
-            .internal_err_ctx("Failed to propagate mode")?;
+            .internal_err_ctx("Failed to update thinking effort")?;
 
         Ok(())
     }

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -2691,7 +2691,8 @@ impl GooseAcpAgent {
             .await
             .internal_err_ctx("Failed to get provider")?;
         let provider_name = provider.get_name().to_string();
-        let current_model = provider.get_model_config().model_name.clone();
+        let current_model_config = provider.get_model_config();
+        let current_model = current_model_config.model_name.clone();
         let goose_mode = agent.goose_mode().await;
         let inventory = self
             .provider_inventory
@@ -2708,6 +2709,7 @@ impl GooseAcpAgent {
         let config_options = build_config_options(
             &mode_state,
             &model_state,
+            &current_model_config,
             session_provider_selection(&session),
             provider_options,
         );
@@ -2737,6 +2739,58 @@ impl GooseAcpAgent {
         // goose_mode is already updated on the session above.
 
         Ok(SetSessionModeResponse::new())
+    }
+
+    async fn on_set_thinking_effort(
+        &self,
+        session_id: &str,
+        effort_id: &str,
+    ) -> Result<(), agent_client_protocol::Error> {
+        let effort = effort_id
+            .parse::<goose_providers::thinking::ThinkingEffort>()
+            .map_err(|_| {
+                agent_client_protocol::Error::invalid_params()
+                    .data(format!("Invalid thinking effort: {}", effort_id))
+            })?;
+        let config = self.config()?;
+        let agent = self.get_session_agent(session_id, None).await?;
+        let current_provider = agent
+            .provider()
+            .await
+            .internal_err_ctx("Failed to get provider")?;
+        let provider_name = current_provider.get_name().to_string();
+        let current_model_config = current_provider.get_model_config();
+        let model_config = current_model_config.with_merged_request_params(HashMap::from([(
+            "thinking_effort".to_string(),
+            serde_json::json!(effort.to_string()),
+        )]));
+        let extensions =
+            EnabledExtensionsState::for_session(&self.session_manager, session_id, config).await;
+        let session = self
+            .session_manager
+            .get_session(session_id, false)
+            .await
+            .internal_err_ctx("Failed to get session")?;
+        let provider = self
+            .create_provider(
+                &provider_name,
+                model_config,
+                extensions,
+                Some(session.working_dir),
+            )
+            .await
+            .internal_err_ctx("Failed to create provider")?;
+        agent
+            .update_provider(provider, session_id)
+            .await
+            .internal_err_ctx("Failed to update provider")?;
+        let mode = agent.goose_mode().await;
+        agent
+            .update_goose_mode(mode, session_id)
+            .await
+            .internal_err_ctx("Failed to propagate mode")?;
+
+        Ok(())
     }
 
     async fn update_provider(

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -908,34 +908,6 @@ fn builtin_to_extension_config(name: &str) -> ExtensionConfig {
     }
 }
 
-fn with_preserved_session_request_params(
-    mut model_config: crate::model::ModelConfig,
-    current_model_config: Option<&crate::model::ModelConfig>,
-    request_params: Option<HashMap<String, serde_json::Value>>,
-) -> crate::model::ModelConfig {
-    let has_model_effort = model_config
-        .request_params
-        .as_ref()
-        .and_then(|params| params.get("thinking_effort"))
-        .is_some();
-    if !has_model_effort {
-        if let Some(thinking_effort) = current_model_config
-            .and_then(|config| config.request_params.as_ref())
-            .and_then(|params| params.get("thinking_effort"))
-            .cloned()
-        {
-            model_config = model_config.with_merged_request_params(HashMap::from([(
-                "thinking_effort".into(),
-                thinking_effort,
-            )]));
-        }
-    }
-    if let Some(request_params) = request_params {
-        model_config = model_config.with_merged_request_params(request_params);
-    }
-    model_config
-}
-
 fn to_nonnegative_u64(value: Option<i32>) -> Option<u64> {
     value.and_then(|v| u64::try_from(v).ok())
 }
@@ -2634,7 +2606,6 @@ impl GooseAcpAgent {
         session_id: &str,
         model_id: &str,
     ) -> Result<SetSessionModelResponse, agent_client_protocol::Error> {
-        let config = self.config()?;
         let agent = self.get_session_agent(session_id, None).await?;
         let current_provider = agent
             .provider()
@@ -2642,36 +2613,15 @@ impl GooseAcpAgent {
             .internal_err_ctx("Failed to get provider")?;
         let provider_name = current_provider.get_name().to_string();
         let current_model_config = current_provider.get_model_config();
-        let extensions =
-            EnabledExtensionsState::for_session(&self.session_manager, session_id, config).await;
         let model_config = crate::model::ModelConfig::new(model_id)
             .invalid_params_err_ctx("Invalid model config")?
             .with_canonical_limits(&provider_name);
         let model_config =
-            with_preserved_session_request_params(model_config, Some(&current_model_config), None);
-        let session = self
-            .session_manager
-            .get_session(session_id, false)
-            .await
-            .internal_err_ctx("Failed to get session")?;
-        let provider = self
-            .create_provider(
-                &provider_name,
-                model_config,
-                extensions,
-                Some(session.working_dir),
-            )
-            .await
-            .internal_err_ctx("Failed to create provider")?;
+            model_config.with_inherited_session_settings_from(Some(&current_model_config), None);
         agent
-            .update_provider(provider, session_id)
+            .recreate_provider_for_session(session_id, &provider_name, model_config)
             .await
-            .internal_err_ctx("Failed to update provider")?;
-        let mode = agent.goose_mode().await;
-        agent
-            .update_goose_mode(mode, session_id)
-            .await
-            .internal_err_ctx("Failed to propagate mode")?;
+            .internal_err_ctx("Failed to recreate provider")?;
         // model_config is already updated on the session by the agent's update_provider call.
         Ok(SetSessionModelResponse::new())
     }
@@ -2803,37 +2753,13 @@ impl GooseAcpAgent {
             .invalid_params_err_ctx("Invalid model config")?
             .with_canonical_limits(&resolved_provider_name)
             .with_context_limit(context_limit);
-        model_config = with_preserved_session_request_params(
-            model_config,
-            (!is_changing_provider).then_some(&current_model_config),
-            request_params,
-        );
+        model_config = model_config
+            .with_inherited_session_settings_from(Some(&current_model_config), request_params);
 
-        let extensions =
-            EnabledExtensionsState::for_session(&self.session_manager, session_id, config).await;
-        let session = self
-            .session_manager
-            .get_session(session_id, false)
-            .await
-            .internal_err_ctx("Failed to get session")?;
-        let new_provider = self
-            .create_provider(
-                &resolved_provider_name,
-                model_config,
-                extensions,
-                Some(session.working_dir),
-            )
-            .await
-            .internal_err_ctx("Failed to create provider")?;
         agent
-            .update_provider(new_provider, session_id)
+            .recreate_provider_for_session(session_id, &resolved_provider_name, model_config)
             .await
-            .internal_err_ctx("Failed to update provider")?;
-        let mode = agent.goose_mode().await;
-        agent
-            .update_goose_mode(mode, session_id)
-            .await
-            .internal_err_ctx("Failed to propagate mode")?;
+            .internal_err_ctx("Failed to recreate provider")?;
 
         // provider_name is already updated on the session by the agent's update_provider call.
         Ok(())

--- a/crates/goose/src/acp/server/config.rs
+++ b/crates/goose/src/acp/server/config.rs
@@ -1,4 +1,5 @@
 use super::*;
+use goose_providers::thinking::ThinkingEffort;
 
 impl GooseAcpAgent {
     pub(super) async fn on_preferences_read(
@@ -37,8 +38,8 @@ impl GooseAcpAgent {
 
         for preference in &req.values {
             let def = preference_def(preference.key)?;
-            (def.validate)(&preference.value)?;
-            updates.push((def.config_key.to_string(), preference.value.clone()));
+            let value = (def.prepare)(&preference.value)?;
+            updates.push((def.config_key.to_string(), value));
         }
 
         config.set_param_values(&updates).internal_err()?;
@@ -131,29 +132,34 @@ impl GooseAcpAgent {
 struct PreferenceDef {
     key: PreferenceKey,
     config_key: &'static str,
-    validate: fn(&serde_json::Value) -> Result<(), agent_client_protocol::Error>,
+    prepare: fn(&serde_json::Value) -> Result<serde_json::Value, agent_client_protocol::Error>,
 }
 
 const PREFERENCE_DEFS: &[PreferenceDef] = &[
     PreferenceDef {
         key: PreferenceKey::AutoCompactThreshold,
         config_key: "GOOSE_AUTO_COMPACT_THRESHOLD",
-        validate: validate_auto_compact_threshold,
+        prepare: prepare_auto_compact_threshold,
+    },
+    PreferenceDef {
+        key: PreferenceKey::GooseThinkingEffort,
+        config_key: "GOOSE_THINKING_EFFORT",
+        prepare: prepare_thinking_effort,
     },
     PreferenceDef {
         key: PreferenceKey::VoiceAutoSubmitPhrases,
         config_key: "VOICE_AUTO_SUBMIT_PHRASES",
-        validate: validate_voice_auto_submit_phrases,
+        prepare: prepare_voice_auto_submit_phrases,
     },
     PreferenceDef {
         key: PreferenceKey::VoiceDictationProvider,
         config_key: "VOICE_DICTATION_PROVIDER",
-        validate: validate_voice_dictation_provider,
+        prepare: prepare_voice_dictation_provider,
     },
     PreferenceDef {
         key: PreferenceKey::VoiceDictationPreferredMic,
         config_key: "VOICE_DICTATION_PREFERRED_MIC",
-        validate: validate_voice_dictation_preferred_mic,
+        prepare: prepare_voice_dictation_preferred_mic,
     },
 ];
 
@@ -169,35 +175,50 @@ fn preference_def(
         })
 }
 
-fn validate_auto_compact_threshold(
+fn prepare_auto_compact_threshold(
     value: &serde_json::Value,
-) -> Result<(), agent_client_protocol::Error> {
-    let Some(value) = value.as_f64() else {
+) -> Result<serde_json::Value, agent_client_protocol::Error> {
+    let Some(threshold) = value.as_f64() else {
         return Err(agent_client_protocol::Error::invalid_params()
             .data("autoCompactThreshold must be a number"));
     };
-    if !value.is_finite() || value <= 0.0 || value > 1.0 {
+    if !threshold.is_finite() || threshold <= 0.0 || threshold > 1.0 {
         return Err(agent_client_protocol::Error::invalid_params()
             .data("autoCompactThreshold must be greater than 0 and at most 1"));
     }
 
-    Ok(())
+    Ok(value.clone())
 }
 
-fn validate_voice_auto_submit_phrases(
+fn prepare_thinking_effort(
     value: &serde_json::Value,
-) -> Result<(), agent_client_protocol::Error> {
+) -> Result<serde_json::Value, agent_client_protocol::Error> {
+    let Some(value) = value.as_str() else {
+        return Err(agent_client_protocol::Error::invalid_params()
+            .data("gooseThinkingEffort must be a string"));
+    };
+    let effort = value.parse::<ThinkingEffort>().map_err(|err| {
+        agent_client_protocol::Error::invalid_params()
+            .data(format!("Invalid gooseThinkingEffort: {err}"))
+    })?;
+
+    Ok(serde_json::Value::String(effort.to_string()))
+}
+
+fn prepare_voice_auto_submit_phrases(
+    value: &serde_json::Value,
+) -> Result<serde_json::Value, agent_client_protocol::Error> {
     if !value.is_string() {
         return Err(agent_client_protocol::Error::invalid_params()
             .data("voiceAutoSubmitPhrases must be a string"));
     }
 
-    Ok(())
+    Ok(value.clone())
 }
 
-fn validate_voice_dictation_provider(
+fn prepare_voice_dictation_provider(
     value: &serde_json::Value,
-) -> Result<(), agent_client_protocol::Error> {
+) -> Result<serde_json::Value, agent_client_protocol::Error> {
     let Some(value) = value.as_str() else {
         return Err(agent_client_protocol::Error::invalid_params()
             .data("voiceDictationProvider must be a string"));
@@ -207,12 +228,12 @@ fn validate_voice_dictation_provider(
             .data("voiceDictationProvider is not supported"));
     }
 
-    Ok(())
+    Ok(serde_json::Value::String(value.to_string()))
 }
 
-fn validate_voice_dictation_preferred_mic(
+fn prepare_voice_dictation_preferred_mic(
     value: &serde_json::Value,
-) -> Result<(), agent_client_protocol::Error> {
+) -> Result<serde_json::Value, agent_client_protocol::Error> {
     let Some(value) = value.as_str() else {
         return Err(agent_client_protocol::Error::invalid_params()
             .data("voiceDictationPreferredMic must be a string"));
@@ -222,7 +243,7 @@ fn validate_voice_dictation_preferred_mic(
             .data("voiceDictationPreferredMic must be non-empty"));
     }
 
-    Ok(())
+    Ok(serde_json::Value::String(value.to_string()))
 }
 
 fn is_supported_voice_dictation_provider(value: &str) -> bool {

--- a/crates/goose/src/acp/server/dispatch.rs
+++ b/crates/goose/src/acp/server/dispatch.rs
@@ -143,6 +143,12 @@ impl HandleDispatchFrom<Client> for GooseAcpHandler {
                                         Err(e) => { responder.respond_with_error(e)?; return Ok(()); }
                                     }
                                 }
+                                "thinking_effort" => {
+                                    match agent.on_set_thinking_effort(&session_id.0, &value_id.0).await {
+                                        Ok(_) => {}
+                                        Err(e) => { responder.respond_with_error(e)?; return Ok(()); }
+                                    }
+                                }
                                 other => {
                                     responder.respond_with_error(
                                         agent_client_protocol::Error::invalid_params().data(format!("Unsupported config option: {}", other))

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2491,10 +2491,11 @@ impl Agent {
         *self.current_goose_mode.lock().await
     }
 
-    pub async fn update_thinking_effort(
+    pub async fn recreate_provider_for_session(
         &self,
         session_id: &str,
-        effort: ThinkingEffort,
+        provider_name: &str,
+        model_config: crate::model::ModelConfig,
     ) -> Result<()> {
         let session = self
             .config
@@ -2503,19 +2504,13 @@ impl Agent {
             .await
             .context("Failed to get session")?;
 
-        let current_provider = self.provider().await?;
-        let provider_name = current_provider.get_name().to_string();
-        let model_config = current_provider
-            .get_model_config()
-            .with_thinking_effort(effort);
-
         let extensions = EnabledExtensionsState::extensions_or_default(
             Some(&session.extension_data),
             Config::global(),
         );
 
         let provider = crate::providers::create_with_working_dir(
-            &provider_name,
+            provider_name,
             model_config,
             extensions,
             session.working_dir.clone(),
@@ -2527,6 +2522,21 @@ impl Agent {
 
         let mode = self.goose_mode().await;
         self.update_goose_mode(mode, session_id).await
+    }
+
+    pub async fn update_thinking_effort(
+        &self,
+        session_id: &str,
+        effort: ThinkingEffort,
+    ) -> Result<()> {
+        let current_provider = self.provider().await?;
+        let provider_name = current_provider.get_name().to_string();
+        let model_config = current_provider
+            .get_model_config()
+            .with_thinking_effort(effort);
+
+        self.recreate_provider_for_session(session_id, &provider_name, model_config)
+            .await
     }
 
     /// Restore the provider from session data or fall back to global config

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -54,6 +54,7 @@ use crate::tool_inspection::ToolInspectionManager;
 use crate::tool_monitor::RepetitionInspector;
 use crate::utils::is_token_cancelled;
 use goose_providers::errors::ProviderError;
+use goose_providers::thinking::ThinkingEffort;
 use regex::Regex;
 use rmcp::model::{
     CallToolRequestParams, CallToolResult, Content, ErrorCode, ErrorData, GetPromptResult, Prompt,
@@ -2488,6 +2489,44 @@ impl Agent {
 
     pub async fn goose_mode(&self) -> GooseMode {
         *self.current_goose_mode.lock().await
+    }
+
+    pub async fn update_thinking_effort(
+        &self,
+        session_id: &str,
+        effort: ThinkingEffort,
+    ) -> Result<()> {
+        let session = self
+            .config
+            .session_manager
+            .get_session(session_id, false)
+            .await
+            .context("Failed to get session")?;
+
+        let current_provider = self.provider().await?;
+        let provider_name = current_provider.get_name().to_string();
+        let model_config = current_provider
+            .get_model_config()
+            .with_thinking_effort(effort);
+
+        let extensions = EnabledExtensionsState::extensions_or_default(
+            Some(&session.extension_data),
+            Config::global(),
+        );
+
+        let provider = crate::providers::create_with_working_dir(
+            &provider_name,
+            model_config,
+            extensions,
+            session.working_dir.clone(),
+        )
+        .await
+        .map_err(|e| anyhow!("Could not create provider: {}", e))?;
+
+        self.update_provider(provider, session_id).await?;
+
+        let mode = self.goose_mode().await;
+        self.update_goose_mode(mode, session_id).await
     }
 
     /// Restore the provider from session data or fall back to global config

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -368,23 +368,33 @@ impl ModelConfig {
         self
     }
 
-    pub fn with_preserved_session_settings_from(mut self, previous: &ModelConfig) -> Self {
-        let has_thinking_effort = self
-            .request_params
-            .as_ref()
-            .and_then(|params| params.get("thinking_effort"))
-            .is_some();
-
-        if !has_thinking_effort {
-            if let Some(thinking_effort) = previous
+    pub fn with_inherited_session_settings_from(
+        mut self,
+        previous: Option<&ModelConfig>,
+        request_params: Option<HashMap<String, Value>>,
+    ) -> Self {
+        if let Some(previous) = previous {
+            let has_thinking_effort = self
                 .request_params
                 .as_ref()
                 .and_then(|params| params.get("thinking_effort"))
-                .cloned()
-            {
-                let params = self.request_params.get_or_insert_with(HashMap::new);
-                params.insert("thinking_effort".to_string(), thinking_effort);
+                .is_some();
+
+            if !has_thinking_effort {
+                if let Some(thinking_effort) = previous
+                    .request_params
+                    .as_ref()
+                    .and_then(|params| params.get("thinking_effort"))
+                    .cloned()
+                {
+                    let params = self.request_params.get_or_insert_with(HashMap::new);
+                    params.insert("thinking_effort".to_string(), thinking_effort);
+                }
             }
+        }
+
+        if let Some(request_params) = request_params {
+            self = self.with_merged_request_params(request_params);
         }
 
         self
@@ -727,7 +737,7 @@ mod tests {
                 model_name: "next".to_string(),
                 ..Default::default()
             }
-            .with_preserved_session_settings_from(&previous);
+            .with_inherited_session_settings_from(Some(&previous), None);
 
             assert_eq!(
                 config
@@ -756,7 +766,7 @@ mod tests {
                 )])),
                 ..Default::default()
             }
-            .with_preserved_session_settings_from(&previous);
+            .with_inherited_session_settings_from(Some(&previous), None);
 
             assert_eq!(
                 config
@@ -781,7 +791,7 @@ mod tests {
                 model_name: "next".to_string(),
                 ..Default::default()
             }
-            .with_preserved_session_settings_from(&previous);
+            .with_inherited_session_settings_from(Some(&previous), None);
 
             assert!(config.request_params.is_none());
         }
@@ -797,9 +807,40 @@ mod tests {
                 model_name: "next".to_string(),
                 ..Default::default()
             }
-            .with_preserved_session_settings_from(&previous);
+            .with_inherited_session_settings_from(Some(&previous), None);
 
             assert!(config.request_params.is_none());
+        }
+
+        #[test]
+        fn explicit_request_params_override_preserved_session_settings() {
+            let previous = ModelConfig {
+                model_name: "previous".to_string(),
+                request_params: Some(HashMap::from([(
+                    "thinking_effort".to_string(),
+                    serde_json::json!("high"),
+                )])),
+                ..Default::default()
+            };
+            let config = ModelConfig {
+                model_name: "next".to_string(),
+                ..Default::default()
+            }
+            .with_inherited_session_settings_from(
+                Some(&previous),
+                Some(HashMap::from([(
+                    "thinking_effort".to_string(),
+                    serde_json::json!("low"),
+                )])),
+            );
+
+            assert_eq!(
+                config
+                    .request_params
+                    .as_ref()
+                    .and_then(|params| params.get("thinking_effort")),
+                Some(&serde_json::json!("low"))
+            );
         }
 
         #[test]

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -359,6 +359,37 @@ impl ModelConfig {
         self
     }
 
+    pub fn with_thinking_effort(mut self, effort: ThinkingEffort) -> Self {
+        let params = self.request_params.get_or_insert_with(HashMap::new);
+        params.insert(
+            "thinking_effort".to_string(),
+            serde_json::json!(effort.to_string()),
+        );
+        self
+    }
+
+    pub fn with_preserved_session_settings_from(mut self, previous: &ModelConfig) -> Self {
+        let has_thinking_effort = self
+            .request_params
+            .as_ref()
+            .and_then(|params| params.get("thinking_effort"))
+            .is_some();
+
+        if !has_thinking_effort {
+            if let Some(thinking_effort) = previous
+                .request_params
+                .as_ref()
+                .and_then(|params| params.get("thinking_effort"))
+                .cloned()
+            {
+                let params = self.request_params.get_or_insert_with(HashMap::new);
+                params.insert("thinking_effort".to_string(), thinking_effort);
+            }
+        }
+
+        self
+    }
+
     pub fn use_fast_model(&self) -> Self {
         if let Some(fast_config) = &self.fast_model_config {
             *fast_config.clone()
@@ -663,6 +694,112 @@ mod tests {
                 ..Default::default()
             };
             assert_eq!(config.thinking_effort(), Some(ThinkingEffort::Low));
+        }
+
+        #[test]
+        fn with_thinking_effort_sets_request_param() {
+            let config = ModelConfig {
+                model_name: "test".to_string(),
+                ..Default::default()
+            }
+            .with_thinking_effort(ThinkingEffort::High);
+
+            assert_eq!(
+                config
+                    .request_params
+                    .as_ref()
+                    .and_then(|params| params.get("thinking_effort")),
+                Some(&serde_json::json!("high"))
+            );
+        }
+
+        #[test]
+        fn preserves_explicit_thinking_effort() {
+            let previous = ModelConfig {
+                model_name: "previous".to_string(),
+                request_params: Some(HashMap::from([(
+                    "thinking_effort".to_string(),
+                    serde_json::json!("high"),
+                )])),
+                ..Default::default()
+            };
+            let config = ModelConfig {
+                model_name: "next".to_string(),
+                ..Default::default()
+            }
+            .with_preserved_session_settings_from(&previous);
+
+            assert_eq!(
+                config
+                    .request_params
+                    .as_ref()
+                    .and_then(|params| params.get("thinking_effort")),
+                Some(&serde_json::json!("high"))
+            );
+        }
+
+        #[test]
+        fn does_not_override_existing_thinking_effort() {
+            let previous = ModelConfig {
+                model_name: "previous".to_string(),
+                request_params: Some(HashMap::from([(
+                    "thinking_effort".to_string(),
+                    serde_json::json!("high"),
+                )])),
+                ..Default::default()
+            };
+            let config = ModelConfig {
+                model_name: "next".to_string(),
+                request_params: Some(HashMap::from([(
+                    "thinking_effort".to_string(),
+                    serde_json::json!("low"),
+                )])),
+                ..Default::default()
+            }
+            .with_preserved_session_settings_from(&previous);
+
+            assert_eq!(
+                config
+                    .request_params
+                    .as_ref()
+                    .and_then(|params| params.get("thinking_effort")),
+                Some(&serde_json::json!("low"))
+            );
+        }
+
+        #[test]
+        fn does_not_preserve_unrelated_request_params() {
+            let previous = ModelConfig {
+                model_name: "previous".to_string(),
+                request_params: Some(HashMap::from([(
+                    "provider_specific".to_string(),
+                    serde_json::json!("old"),
+                )])),
+                ..Default::default()
+            };
+            let config = ModelConfig {
+                model_name: "next".to_string(),
+                ..Default::default()
+            }
+            .with_preserved_session_settings_from(&previous);
+
+            assert!(config.request_params.is_none());
+        }
+
+        #[test]
+        fn does_not_materialize_env_thinking_effort() {
+            let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", Some("high"))]);
+            let previous = ModelConfig {
+                model_name: "previous".to_string(),
+                ..Default::default()
+            };
+            let config = ModelConfig {
+                model_name: "next".to_string(),
+                ..Default::default()
+            }
+            .with_preserved_session_settings_from(&previous);
+
+            assert!(config.request_params.is_none());
         }
 
         #[test]

--- a/crates/goose/tests/acp_custom_requests_test.rs
+++ b/crates/goose/tests/acp_custom_requests_test.rs
@@ -78,26 +78,6 @@ impl Provider for MockProvider {
     }
 }
 
-fn mock_provider_factory() -> AcpProviderFactory {
-    Arc::new(|provider_name, model_config, _extensions, _working_dir| {
-        Box::pin(async move {
-            let recommended_models = match provider_name.as_str() {
-                "anthropic" => vec![
-                    "claude-3-7-sonnet-latest".to_string(),
-                    "claude-3-5-haiku-latest".to_string(),
-                ],
-                _ => vec!["gpt-4o".to_string(), "o4-mini".to_string()],
-            };
-            Ok(Arc::new(MockProvider {
-                name: provider_name,
-                model_config,
-                supported_models: recommended_models.clone(),
-                recommended_models,
-            }) as Arc<dyn Provider>)
-        })
-    })
-}
-
 #[test]
 #[serial]
 fn test_custom_get_tools() {
@@ -668,11 +648,11 @@ fn test_raw_config_and_secret_methods_are_removed() {
 #[test]
 #[serial]
 fn test_provider_switching_updates_session_state() {
+    let _env = env_lock::lock_env([("ANTHROPIC_API_KEY", Some("test-key"))]);
     write_acp_global_config(DEFAULT_ACP_TEST_CONFIG);
     run_test(async {
         let openai = OpenAiFixture::new(vec![], Arc::new(EnforceSessionId::default())).await;
         let config = TestConnectionConfig {
-            provider_factory: Some(mock_provider_factory()),
             current_model: "gpt-4o".to_string(),
             ..Default::default()
         };

--- a/crates/goose/tests/acp_custom_requests_test.rs
+++ b/crates/goose/tests/acp_custom_requests_test.rs
@@ -366,7 +366,7 @@ fn test_custom_provider_inventory_includes_metadata() {
 #[serial]
 fn test_custom_preferences_read_save_remove() {
     let config_dir = write_acp_global_config(
-        "GOOSE_MODEL: gpt-4o\nGOOSE_PROVIDER: openai\nGOOSE_AUTO_COMPACT_THRESHOLD: 0.7\nVOICE_AUTO_SUBMIT_PHRASES: send it\n",
+        "GOOSE_MODEL: gpt-4o\nGOOSE_PROVIDER: openai\nGOOSE_AUTO_COMPACT_THRESHOLD: 0.7\nGOOSE_THINKING_EFFORT: high\nVOICE_AUTO_SUBMIT_PHRASES: send it\n",
     );
 
     run_test(async move {
@@ -383,6 +383,7 @@ fn test_custom_preferences_read_save_remove() {
             serde_json::json!({
                 "keys": [
                     "autoCompactThreshold",
+                    "gooseThinkingEffort",
                     "voiceAutoSubmitPhrases",
                     "voiceDictationPreferredMic"
                 ],
@@ -394,6 +395,7 @@ fn test_custom_preferences_read_save_remove() {
             response.get("values"),
             Some(&serde_json::json!([
                 { "key": "autoCompactThreshold", "value": 0.7 },
+                { "key": "gooseThinkingEffort", "value": "high" },
                 { "key": "voiceAutoSubmitPhrases", "value": "send it" },
                 { "key": "voiceDictationPreferredMic", "value": null },
             ]))
@@ -404,6 +406,7 @@ fn test_custom_preferences_read_save_remove() {
             "_goose/unstable/preferences/save",
             serde_json::json!({
                 "values": [
+                    { "key": "gooseThinkingEffort", "value": "disabled" },
                     { "key": "voiceDictationProvider", "value": "__disabled__" },
                     { "key": "voiceDictationPreferredMic", "value": "mic-1" }
                 ],
@@ -426,7 +429,7 @@ fn test_custom_preferences_read_save_remove() {
             conn.cx(),
             "_goose/unstable/preferences/read",
             serde_json::json!({
-                "keys": ["voiceDictationProvider", "voiceDictationPreferredMic"],
+                "keys": ["gooseThinkingEffort", "voiceDictationProvider", "voiceDictationPreferredMic"],
             }),
         )
         .await
@@ -434,6 +437,7 @@ fn test_custom_preferences_read_save_remove() {
         assert_eq!(
             response.get("values"),
             Some(&serde_json::json!([
+                { "key": "gooseThinkingEffort", "value": "off" },
                 { "key": "voiceDictationProvider", "value": null },
                 { "key": "voiceDictationPreferredMic", "value": "mic-1" },
             ]))
@@ -455,6 +459,12 @@ fn test_custom_preferences_save_rejects_invalid_values() {
             }),
             serde_json::json!({
                 "values": [{ "key": "autoCompactThreshold", "value": 1.1 }],
+            }),
+            serde_json::json!({
+                "values": [{ "key": "gooseThinkingEffort", "value": "bogus" }],
+            }),
+            serde_json::json!({
+                "values": [{ "key": "gooseThinkingEffort", "value": ["high"] }],
             }),
             serde_json::json!({
                 "values": [{ "key": "voiceAutoSubmitPhrases", "value": ["send"] }],

--- a/crates/goose/tests/acp_server_test.rs
+++ b/crates/goose/tests/acp_server_test.rs
@@ -187,8 +187,14 @@ fn test_config_option_thinking_effort_set() {
             <AcpServerConnection as Connection>::expected_session_id(),
         )
         .await;
-        let mut conn =
-            <AcpServerConnection as Connection>::new(TestConnectionConfig::default(), openai).await;
+        let mut conn = <AcpServerConnection as Connection>::new(
+            TestConnectionConfig {
+                current_model: "claude-sonnet-4".to_string(),
+                ..Default::default()
+            },
+            openai,
+        )
+        .await;
         let data = conn.new_session().await.unwrap();
 
         let response = conn

--- a/crates/goose/tests/acp_server_test.rs
+++ b/crates/goose/tests/acp_server_test.rs
@@ -1,10 +1,13 @@
 #[allow(dead_code)]
 #[path = "acp_common_tests/mod.rs"]
 mod common_tests;
-use agent_client_protocol::schema::{ListSessionsRequest, ListSessionsResponse};
+use agent_client_protocol::schema::{
+    ListSessionsRequest, ListSessionsResponse, SessionConfigKind, SessionConfigOptionCategory,
+    SessionConfigOptionValue, SetSessionConfigOptionRequest,
+};
 use agent_client_protocol::ErrorCode;
 use common_tests::fixtures::server::AcpServerConnection;
-use common_tests::fixtures::{run_test, Connection, OpenAiFixture, TestConnectionConfig};
+use common_tests::fixtures::{run_test, Connection, OpenAiFixture, Session, TestConnectionConfig};
 #[cfg(feature = "code-mode")]
 use common_tests::run_prompt_codemode;
 use common_tests::{
@@ -174,6 +177,47 @@ fn test_close_session() {
 #[test]
 fn test_config_option_model_set() {
     run_test(async { run_config_option_model_set::<AcpServerConnection>().await });
+}
+
+#[test]
+fn test_config_option_thinking_effort_set() {
+    run_test(async {
+        let openai = OpenAiFixture::new(
+            vec![],
+            <AcpServerConnection as Connection>::expected_session_id(),
+        )
+        .await;
+        let mut conn =
+            <AcpServerConnection as Connection>::new(TestConnectionConfig::default(), openai).await;
+        let data = conn.new_session().await.unwrap();
+
+        let response = conn
+            .cx()
+            .send_request(SetSessionConfigOptionRequest::new(
+                data.session.session_id().clone(),
+                "thinking_effort".to_string(),
+                SessionConfigOptionValue::value_id("high".to_string()),
+            ))
+            .block_task()
+            .await
+            .unwrap();
+
+        let option = response
+            .config_options
+            .iter()
+            .find(|option| option.id.0.as_ref() == "thinking_effort")
+            .expect("thinking_effort option");
+        assert_eq!(
+            option.category,
+            Some(SessionConfigOptionCategory::ThoughtLevel)
+        );
+        let select = match &option.kind {
+            SessionConfigKind::Select(select) => select,
+            _ => panic!("thinking_effort should be a select option"),
+        };
+
+        assert_eq!(select.current_value.0.as_ref(), "high");
+    });
 }
 
 #[test]

--- a/ui/sdk/src/generated/types.gen.ts
+++ b/ui/sdk/src/generated/types.gen.ts
@@ -794,7 +794,7 @@ export type PreferencesReadRequest_unstable = {
     keys?: Array<PreferenceKey>;
 };
 
-export type PreferenceKey = 'autoCompactThreshold' | 'voiceAutoSubmitPhrases' | 'voiceDictationProvider' | 'voiceDictationPreferredMic';
+export type PreferenceKey = 'autoCompactThreshold' | 'gooseThinkingEffort' | 'voiceAutoSubmitPhrases' | 'voiceDictationProvider' | 'voiceDictationPreferredMic';
 
 export type PreferencesReadResponse_unstable = {
     values: Array<PreferenceValue>;

--- a/ui/sdk/src/generated/zod.gen.ts
+++ b/ui/sdk/src/generated/zod.gen.ts
@@ -98,7 +98,10 @@ export const zSessionSystemPromptMode = z.union([
 export const zSetSessionSystemPromptRequest_unstable = z.object({
     sessionId: z.string(),
     mode: zSessionSystemPromptMode.optional().default('append'),
-    key: z.string().nullish(),
+    key: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
     text: z.string()
 });
 
@@ -120,7 +123,10 @@ export const zGetConfigExtensionsRequest_unstable = z.record(z.unknown());
 export const zHttpHeader = z.object({
     name: z.string(),
     value: z.string(),
-    _meta: z.record(z.unknown()).nullish()
+    _meta: z.union([
+        z.record(z.unknown()),
+        z.null()
+    ]).optional()
 });
 
 /**
@@ -130,7 +136,10 @@ export const zMcpServerHttp = z.object({
     name: z.string(),
     url: z.string(),
     headers: z.array(zHttpHeader),
-    _meta: z.record(z.unknown()).nullish(),
+    _meta: z.union([
+        z.record(z.unknown()),
+        z.null()
+    ]).optional(),
     type: z.literal('http')
 });
 
@@ -141,7 +150,10 @@ export const zMcpServerSse = z.object({
     name: z.string(),
     url: z.string(),
     headers: z.array(zHttpHeader),
-    _meta: z.record(z.unknown()).nullish(),
+    _meta: z.union([
+        z.record(z.unknown()),
+        z.null()
+    ]).optional(),
     type: z.literal('sse')
 });
 
@@ -151,7 +163,10 @@ export const zMcpServerSse = z.object({
 export const zEnvVariable = z.object({
     name: z.string(),
     value: z.string(),
-    _meta: z.record(z.unknown()).nullish()
+    _meta: z.union([
+        z.record(z.unknown()),
+        z.null()
+    ]).optional()
 });
 
 /**
@@ -162,7 +177,10 @@ export const zMcpServerStdio = z.object({
     command: z.string(),
     args: z.array(z.string()),
     env: z.array(zEnvVariable),
-    _meta: z.record(z.unknown()).nullish()
+    _meta: z.union([
+        z.record(z.unknown()),
+        z.null()
+    ]).optional()
 });
 
 /**
@@ -182,26 +200,59 @@ export const zMcpServer = z.union([
 export const zGooseExtension = z.union([
     z.object({
         name: z.string(),
-        description: z.string().nullish(),
-        display_name: z.string().nullish(),
-        timeout: z.number().int().gte(0).nullish(),
-        bundled: z.boolean().nullish(),
+        description: z.union([
+            z.string(),
+            z.null()
+        ]).optional(),
+        display_name: z.union([
+            z.string(),
+            z.null()
+        ]).optional(),
+        timeout: z.union([
+            z.number().int().gte(0),
+            z.null()
+        ]).optional(),
+        bundled: z.union([
+            z.boolean(),
+            z.null()
+        ]).optional(),
         type: z.literal('builtin')
     }),
     z.object({
         name: z.string(),
-        description: z.string().nullish(),
-        display_name: z.string().nullish(),
-        bundled: z.boolean().nullish(),
+        description: z.union([
+            z.string(),
+            z.null()
+        ]).optional(),
+        display_name: z.union([
+            z.string(),
+            z.null()
+        ]).optional(),
+        bundled: z.union([
+            z.boolean(),
+            z.null()
+        ]).optional(),
         type: z.literal('platform')
     }),
     z.object({
         server: zMcpServer,
         envKeys: z.array(z.string()).optional(),
-        description: z.string().nullish(),
-        timeout: z.number().int().gte(0).nullish(),
-        socket: z.string().nullish(),
-        bundled: z.boolean().nullish(),
+        description: z.union([
+            z.string(),
+            z.null()
+        ]).optional(),
+        timeout: z.union([
+            z.number().int().gte(0),
+            z.null()
+        ]).optional(),
+        socket: z.union([
+            z.string(),
+            z.null()
+        ]).optional(),
+        bundled: z.union([
+            z.boolean(),
+            z.null()
+        ]).optional(),
         type: z.literal('mcp')
     })
 ]);
@@ -209,7 +260,10 @@ export const zGooseExtension = z.union([
 export const zGooseExtensionEntry = z.object({
     extension: zGooseExtension,
     enabled: z.boolean(),
-    configKey: z.string().nullish()
+    configKey: z.union([
+        z.string(),
+        z.null()
+    ]).optional()
 });
 
 /**
@@ -273,7 +327,10 @@ export const zProviderConfigKey = z.object({
     name: z.string(),
     required: z.boolean(),
     secret: z.boolean(),
-    default: z.string().nullish().default(null),
+    default: z.union([
+        z.string(),
+        z.null()
+    ]).optional().default(null),
     oauthFlow: z.boolean().optional().default(false),
     deviceCodeFlow: z.boolean().optional().default(false),
     primary: z.boolean().optional().default(false)
@@ -285,9 +342,18 @@ export const zProviderConfigKey = z.object({
 export const zProviderInventoryModelDto = z.object({
     id: z.string(),
     name: z.string(),
-    family: z.string().nullish(),
-    contextLimit: z.number().int().gte(0).nullish(),
-    reasoning: z.boolean().nullish(),
+    family: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
+    contextLimit: z.union([
+        z.number().int().gte(0),
+        z.null()
+    ]).optional(),
+    reasoning: z.union([
+        z.boolean(),
+        z.null()
+    ]).optional(),
     recommended: z.boolean().optional().default(false)
 });
 
@@ -307,11 +373,23 @@ export const zProviderInventoryEntryDto = z.object({
     supportsRefresh: z.boolean(),
     refreshing: z.boolean(),
     models: z.array(zProviderInventoryModelDto),
-    lastUpdatedAt: z.string().nullish(),
-    lastRefreshAttemptAt: z.string().nullish(),
-    lastRefreshError: z.string().nullish(),
+    lastUpdatedAt: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
+    lastRefreshAttemptAt: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
+    lastRefreshError: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
     stale: z.boolean(),
-    modelSelectionHint: z.string().nullish()
+    modelSelectionHint: z.union([
+        z.string(),
+        z.null()
+    ]).optional()
 });
 
 /**
@@ -337,7 +415,10 @@ export const zProviderSupportedModelsListResponse_unstable = z.object({
  * List custom-provider catalog entries. Omit `format` to list all formats.
  */
 export const zProviderCatalogListRequest_unstable = z.object({
-    format: z.string().nullish()
+    format: z.union([
+        z.string(),
+        z.null()
+    ]).optional()
 });
 
 export const zProviderTemplateCatalogEntryDto = z.object({
@@ -376,8 +457,14 @@ export const zProviderSetupFieldDto = z.object({
     label: z.string(),
     secret: z.boolean(),
     required: z.boolean(),
-    placeholder: z.string().nullish(),
-    defaultValue: z.string().nullish()
+    placeholder: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
+    defaultValue: z.union([
+        z.string(),
+        z.null()
+    ]).optional()
 });
 
 export const zProviderSetupGroupDto = z.enum(['default', 'additional']);
@@ -388,10 +475,19 @@ export const zProviderSetupCatalogEntryDto = z.object({
     category: zProviderSetupCategoryDto,
     description: z.string(),
     setupMethod: zProviderSetupMethodDto,
-    nativeConnectQuery: z.string().nullish(),
+    nativeConnectQuery: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
     fields: z.array(zProviderSetupFieldDto).optional().default([]),
-    binaryName: z.string().nullish(),
-    docUrl: z.string().nullish(),
+    binaryName: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
+    docUrl: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
     group: zProviderSetupGroupDto,
     showOnlyWhenInstalled: z.boolean(),
     aliases: z.array(z.string()).optional().default([]),
@@ -448,14 +544,29 @@ export const zCustomProviderCreateRequest_unstable = z.object({
     engine: z.string(),
     displayName: z.string(),
     apiUrl: z.string(),
-    apiKey: z.string().nullish(),
+    apiKey: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
     models: z.array(z.string()).optional().default([]),
-    supportsStreaming: z.boolean().nullish(),
+    supportsStreaming: z.union([
+        z.boolean(),
+        z.null()
+    ]).optional(),
     headers: z.record(z.string()).optional().default({}),
     requiresAuth: z.boolean(),
-    catalogProviderId: z.string().nullish(),
-    basePath: z.string().nullish(),
-    preservesThinking: z.boolean().nullish()
+    catalogProviderId: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
+    basePath: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
+    preservesThinking: z.union([
+        z.boolean(),
+        z.null()
+    ]).optional()
 });
 
 export const zProviderConfigStatusDto = z.object({
@@ -502,12 +613,24 @@ export const zCustomProviderConfigDto = z.object({
     displayName: z.string(),
     apiUrl: z.string(),
     models: z.array(z.string()).optional().default([]),
-    supportsStreaming: z.boolean().nullish(),
+    supportsStreaming: z.union([
+        z.boolean(),
+        z.null()
+    ]).optional(),
     headers: z.record(z.string()).optional().default({}),
     requiresAuth: z.boolean(),
-    catalogProviderId: z.string().nullish(),
-    basePath: z.string().nullish(),
-    apiKeyEnv: z.string().nullish(),
+    catalogProviderId: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
+    basePath: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
+    apiKeyEnv: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
     apiKeySet: z.boolean(),
     preservesThinking: z.boolean()
 });
@@ -526,14 +649,29 @@ export const zCustomProviderUpdateRequest_unstable = z.object({
     engine: z.string(),
     displayName: z.string(),
     apiUrl: z.string(),
-    apiKey: z.string().nullish(),
+    apiKey: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
     models: z.array(z.string()).optional().default([]),
-    supportsStreaming: z.boolean().nullish(),
+    supportsStreaming: z.union([
+        z.boolean(),
+        z.null()
+    ]).optional(),
     headers: z.record(z.string()).optional().default({}),
     requiresAuth: z.boolean(),
-    catalogProviderId: z.string().nullish(),
-    basePath: z.string().nullish(),
-    preservesThinking: z.boolean().nullish()
+    catalogProviderId: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
+    basePath: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
+    preservesThinking: z.union([
+        z.boolean(),
+        z.null()
+    ]).optional()
 });
 
 export const zCustomProviderUpdateResponse_unstable = z.object({
@@ -570,7 +708,10 @@ export const zProviderConfigReadRequest_unstable = z.object({
 
 export const zProviderConfigFieldValueDto = z.object({
     key: z.string(),
-    value: z.string().nullish().default(null),
+    value: z.union([
+        z.string(),
+        z.null()
+    ]).optional().default(null),
     isSet: z.boolean(),
     isSecret: z.boolean(),
     required: z.boolean()
@@ -667,8 +808,14 @@ export const zPreferencesRemoveRequest_unstable = z.object({
 export const zDefaultsReadRequest_unstable = z.record(z.unknown());
 
 export const zDefaultsReadResponse_unstable = z.object({
-    providerId: z.string().nullish(),
-    modelId: z.string().nullish()
+    providerId: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
+    modelId: z.union([
+        z.string(),
+        z.null()
+    ]).optional()
 });
 
 /**
@@ -676,7 +823,10 @@ export const zDefaultsReadResponse_unstable = z.object({
  */
 export const zDefaultsSaveRequest_unstable = z.object({
     providerId: z.string(),
-    modelId: z.string().nullish()
+    modelId: z.union([
+        z.string(),
+        z.null()
+    ]).optional()
 });
 
 /**
@@ -725,7 +875,10 @@ export const zOnboardingImportApplyResponse_unstable = z.object({
     imported: zOnboardingImportCounts,
     skipped: zOnboardingImportCounts,
     warnings: z.array(z.string()).optional().default([]),
-    providerDefaults: zDefaultsReadResponse_unstable.nullish()
+    providerDefaults: z.union([
+        zDefaultsReadResponse_unstable,
+        z.null()
+    ]).optional()
 });
 
 /**
@@ -754,8 +907,14 @@ export const zImportSessionRequest_unstable = z.object({
  */
 export const zImportSessionResponse_unstable = z.object({
     sessionId: z.string(),
-    title: z.string().nullish(),
-    updatedAt: z.string().nullish(),
+    title: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
+    updatedAt: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
     messageCount: z.number().int().gte(0)
 });
 
@@ -773,7 +932,10 @@ export const zElicitationRespondRequest_unstable = z.object({
  */
 export const zUpdateSessionProjectRequest_unstable = z.object({
     sessionId: z.string(),
-    projectId: z.string().nullish()
+    projectId: z.union([
+        z.string(),
+        z.null()
+    ]).optional()
 });
 
 /**
@@ -869,8 +1031,14 @@ export const zCreateSourceResponse_unstable = z.object({
  * skills.
  */
 export const zListSourcesRequest_unstable = z.object({
-    type: zSourceType.nullish(),
-    projectDir: z.string().nullish(),
+    type: z.union([
+        zSourceType,
+        z.null()
+    ]).optional(),
+    projectDir: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
     includeProjectSources: z.boolean().optional().default(false)
 });
 
@@ -887,7 +1055,10 @@ export const zUpdateSourceRequest_unstable = z.object({
     name: z.string(),
     description: z.string(),
     content: z.string(),
-    properties: z.record(z.unknown()).nullish()
+    properties: z.union([
+        z.record(z.unknown()),
+        z.null()
+    ]).optional()
 });
 
 export const zUpdateSourceResponse_unstable = z.object({
@@ -961,14 +1132,32 @@ export const zDictationModelOption = z.object({
  */
 export const zDictationProviderStatusEntry = z.object({
     configured: z.boolean(),
-    host: z.string().nullish(),
+    host: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
     description: z.string(),
     usesProviderConfig: z.boolean(),
-    settingsPath: z.string().nullish(),
-    configKey: z.string().nullish(),
-    modelConfigKey: z.string().nullish(),
-    defaultModel: z.string().nullish(),
-    selectedModel: z.string().nullish(),
+    settingsPath: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
+    configKey: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
+    modelConfigKey: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
+    defaultModel: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
+    selectedModel: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
     availableModels: z.array(zDictationModelOption).optional().default([])
 });
 
@@ -1031,11 +1220,17 @@ export const zDictationDownloadProgress = z.object({
     totalBytes: z.number().int().gte(0),
     progressPercent: z.number(),
     status: z.string(),
-    error: z.string().nullish()
+    error: z.union([
+        z.string(),
+        z.null()
+    ]).optional()
 });
 
 export const zDictationModelDownloadProgressResponse_unstable = z.object({
-    progress: zDictationDownloadProgress.nullish()
+    progress: z.union([
+        zDictationDownloadProgress,
+        z.null()
+    ]).optional()
 });
 
 /**
@@ -1068,7 +1263,10 @@ export const zSessionUsageUpdate = z.object({
     contextLimit: z.number().int().gte(0),
     accumulatedInputTokens: z.number().int().gte(0),
     accumulatedOutputTokens: z.number().int().gte(0),
-    accumulatedCost: z.number().nullish()
+    accumulatedCost: z.union([
+        z.number(),
+        z.null()
+    ]).optional()
 });
 
 export const zStatusMessage = z.union([
@@ -1095,7 +1293,10 @@ export const zInteractionState = z.enum(['pending', 'submitted']);
 export const zInteraction = z.object({
     id: z.string(),
     state: zInteractionState,
-    message: z.string().nullish(),
+    message: z.union([
+        z.string(),
+        z.null()
+    ]).optional(),
     requestedSchema: z.unknown().optional(),
     type: z.literal('elicitation')
 });
@@ -1199,8 +1400,11 @@ export const zExtRequest = z.object({
             zDictationModelDeleteRequest_unstable,
             zDictationModelSelectRequest_unstable
         ]),
-        z.record(z.unknown())
-    ]).nullish()
+        z.union([
+            z.record(z.unknown()),
+            z.null()
+        ])
+    ]).optional()
 });
 
 export const zExtResponse = z.union([
@@ -1261,6 +1465,9 @@ export const zExtNotification = z.object({
     method: z.string(),
     params: z.union([
         zGooseSessionNotification_unstable,
-        z.record(z.unknown())
-    ]).nullish()
+        z.union([
+            z.record(z.unknown()),
+            z.null()
+        ])
+    ]).optional()
 });

--- a/ui/sdk/src/generated/zod.gen.ts
+++ b/ui/sdk/src/generated/zod.gen.ts
@@ -98,10 +98,7 @@ export const zSessionSystemPromptMode = z.union([
 export const zSetSessionSystemPromptRequest_unstable = z.object({
     sessionId: z.string(),
     mode: zSessionSystemPromptMode.optional().default('append'),
-    key: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
+    key: z.string().nullish(),
     text: z.string()
 });
 
@@ -123,10 +120,7 @@ export const zGetConfigExtensionsRequest_unstable = z.record(z.unknown());
 export const zHttpHeader = z.object({
     name: z.string(),
     value: z.string(),
-    _meta: z.union([
-        z.record(z.unknown()),
-        z.null()
-    ]).optional()
+    _meta: z.record(z.unknown()).nullish()
 });
 
 /**
@@ -136,10 +130,7 @@ export const zMcpServerHttp = z.object({
     name: z.string(),
     url: z.string(),
     headers: z.array(zHttpHeader),
-    _meta: z.union([
-        z.record(z.unknown()),
-        z.null()
-    ]).optional(),
+    _meta: z.record(z.unknown()).nullish(),
     type: z.literal('http')
 });
 
@@ -150,10 +141,7 @@ export const zMcpServerSse = z.object({
     name: z.string(),
     url: z.string(),
     headers: z.array(zHttpHeader),
-    _meta: z.union([
-        z.record(z.unknown()),
-        z.null()
-    ]).optional(),
+    _meta: z.record(z.unknown()).nullish(),
     type: z.literal('sse')
 });
 
@@ -163,10 +151,7 @@ export const zMcpServerSse = z.object({
 export const zEnvVariable = z.object({
     name: z.string(),
     value: z.string(),
-    _meta: z.union([
-        z.record(z.unknown()),
-        z.null()
-    ]).optional()
+    _meta: z.record(z.unknown()).nullish()
 });
 
 /**
@@ -177,10 +162,7 @@ export const zMcpServerStdio = z.object({
     command: z.string(),
     args: z.array(z.string()),
     env: z.array(zEnvVariable),
-    _meta: z.union([
-        z.record(z.unknown()),
-        z.null()
-    ]).optional()
+    _meta: z.record(z.unknown()).nullish()
 });
 
 /**
@@ -200,59 +182,26 @@ export const zMcpServer = z.union([
 export const zGooseExtension = z.union([
     z.object({
         name: z.string(),
-        description: z.union([
-            z.string(),
-            z.null()
-        ]).optional(),
-        display_name: z.union([
-            z.string(),
-            z.null()
-        ]).optional(),
-        timeout: z.union([
-            z.number().int().gte(0),
-            z.null()
-        ]).optional(),
-        bundled: z.union([
-            z.boolean(),
-            z.null()
-        ]).optional(),
+        description: z.string().nullish(),
+        display_name: z.string().nullish(),
+        timeout: z.number().int().gte(0).nullish(),
+        bundled: z.boolean().nullish(),
         type: z.literal('builtin')
     }),
     z.object({
         name: z.string(),
-        description: z.union([
-            z.string(),
-            z.null()
-        ]).optional(),
-        display_name: z.union([
-            z.string(),
-            z.null()
-        ]).optional(),
-        bundled: z.union([
-            z.boolean(),
-            z.null()
-        ]).optional(),
+        description: z.string().nullish(),
+        display_name: z.string().nullish(),
+        bundled: z.boolean().nullish(),
         type: z.literal('platform')
     }),
     z.object({
         server: zMcpServer,
         envKeys: z.array(z.string()).optional(),
-        description: z.union([
-            z.string(),
-            z.null()
-        ]).optional(),
-        timeout: z.union([
-            z.number().int().gte(0),
-            z.null()
-        ]).optional(),
-        socket: z.union([
-            z.string(),
-            z.null()
-        ]).optional(),
-        bundled: z.union([
-            z.boolean(),
-            z.null()
-        ]).optional(),
+        description: z.string().nullish(),
+        timeout: z.number().int().gte(0).nullish(),
+        socket: z.string().nullish(),
+        bundled: z.boolean().nullish(),
         type: z.literal('mcp')
     })
 ]);
@@ -260,10 +209,7 @@ export const zGooseExtension = z.union([
 export const zGooseExtensionEntry = z.object({
     extension: zGooseExtension,
     enabled: z.boolean(),
-    configKey: z.union([
-        z.string(),
-        z.null()
-    ]).optional()
+    configKey: z.string().nullish()
 });
 
 /**
@@ -327,10 +273,7 @@ export const zProviderConfigKey = z.object({
     name: z.string(),
     required: z.boolean(),
     secret: z.boolean(),
-    default: z.union([
-        z.string(),
-        z.null()
-    ]).optional().default(null),
+    default: z.string().nullish().default(null),
     oauthFlow: z.boolean().optional().default(false),
     deviceCodeFlow: z.boolean().optional().default(false),
     primary: z.boolean().optional().default(false)
@@ -342,18 +285,9 @@ export const zProviderConfigKey = z.object({
 export const zProviderInventoryModelDto = z.object({
     id: z.string(),
     name: z.string(),
-    family: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
-    contextLimit: z.union([
-        z.number().int().gte(0),
-        z.null()
-    ]).optional(),
-    reasoning: z.union([
-        z.boolean(),
-        z.null()
-    ]).optional(),
+    family: z.string().nullish(),
+    contextLimit: z.number().int().gte(0).nullish(),
+    reasoning: z.boolean().nullish(),
     recommended: z.boolean().optional().default(false)
 });
 
@@ -373,23 +307,11 @@ export const zProviderInventoryEntryDto = z.object({
     supportsRefresh: z.boolean(),
     refreshing: z.boolean(),
     models: z.array(zProviderInventoryModelDto),
-    lastUpdatedAt: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
-    lastRefreshAttemptAt: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
-    lastRefreshError: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
+    lastUpdatedAt: z.string().nullish(),
+    lastRefreshAttemptAt: z.string().nullish(),
+    lastRefreshError: z.string().nullish(),
     stale: z.boolean(),
-    modelSelectionHint: z.union([
-        z.string(),
-        z.null()
-    ]).optional()
+    modelSelectionHint: z.string().nullish()
 });
 
 /**
@@ -415,10 +337,7 @@ export const zProviderSupportedModelsListResponse_unstable = z.object({
  * List custom-provider catalog entries. Omit `format` to list all formats.
  */
 export const zProviderCatalogListRequest_unstable = z.object({
-    format: z.union([
-        z.string(),
-        z.null()
-    ]).optional()
+    format: z.string().nullish()
 });
 
 export const zProviderTemplateCatalogEntryDto = z.object({
@@ -457,14 +376,8 @@ export const zProviderSetupFieldDto = z.object({
     label: z.string(),
     secret: z.boolean(),
     required: z.boolean(),
-    placeholder: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
-    defaultValue: z.union([
-        z.string(),
-        z.null()
-    ]).optional()
+    placeholder: z.string().nullish(),
+    defaultValue: z.string().nullish()
 });
 
 export const zProviderSetupGroupDto = z.enum(['default', 'additional']);
@@ -475,19 +388,10 @@ export const zProviderSetupCatalogEntryDto = z.object({
     category: zProviderSetupCategoryDto,
     description: z.string(),
     setupMethod: zProviderSetupMethodDto,
-    nativeConnectQuery: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
+    nativeConnectQuery: z.string().nullish(),
     fields: z.array(zProviderSetupFieldDto).optional().default([]),
-    binaryName: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
-    docUrl: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
+    binaryName: z.string().nullish(),
+    docUrl: z.string().nullish(),
     group: zProviderSetupGroupDto,
     showOnlyWhenInstalled: z.boolean(),
     aliases: z.array(z.string()).optional().default([]),
@@ -544,29 +448,14 @@ export const zCustomProviderCreateRequest_unstable = z.object({
     engine: z.string(),
     displayName: z.string(),
     apiUrl: z.string(),
-    apiKey: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
+    apiKey: z.string().nullish(),
     models: z.array(z.string()).optional().default([]),
-    supportsStreaming: z.union([
-        z.boolean(),
-        z.null()
-    ]).optional(),
+    supportsStreaming: z.boolean().nullish(),
     headers: z.record(z.string()).optional().default({}),
     requiresAuth: z.boolean(),
-    catalogProviderId: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
-    basePath: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
-    preservesThinking: z.union([
-        z.boolean(),
-        z.null()
-    ]).optional()
+    catalogProviderId: z.string().nullish(),
+    basePath: z.string().nullish(),
+    preservesThinking: z.boolean().nullish()
 });
 
 export const zProviderConfigStatusDto = z.object({
@@ -613,24 +502,12 @@ export const zCustomProviderConfigDto = z.object({
     displayName: z.string(),
     apiUrl: z.string(),
     models: z.array(z.string()).optional().default([]),
-    supportsStreaming: z.union([
-        z.boolean(),
-        z.null()
-    ]).optional(),
+    supportsStreaming: z.boolean().nullish(),
     headers: z.record(z.string()).optional().default({}),
     requiresAuth: z.boolean(),
-    catalogProviderId: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
-    basePath: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
-    apiKeyEnv: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
+    catalogProviderId: z.string().nullish(),
+    basePath: z.string().nullish(),
+    apiKeyEnv: z.string().nullish(),
     apiKeySet: z.boolean(),
     preservesThinking: z.boolean()
 });
@@ -649,29 +526,14 @@ export const zCustomProviderUpdateRequest_unstable = z.object({
     engine: z.string(),
     displayName: z.string(),
     apiUrl: z.string(),
-    apiKey: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
+    apiKey: z.string().nullish(),
     models: z.array(z.string()).optional().default([]),
-    supportsStreaming: z.union([
-        z.boolean(),
-        z.null()
-    ]).optional(),
+    supportsStreaming: z.boolean().nullish(),
     headers: z.record(z.string()).optional().default({}),
     requiresAuth: z.boolean(),
-    catalogProviderId: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
-    basePath: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
-    preservesThinking: z.union([
-        z.boolean(),
-        z.null()
-    ]).optional()
+    catalogProviderId: z.string().nullish(),
+    basePath: z.string().nullish(),
+    preservesThinking: z.boolean().nullish()
 });
 
 export const zCustomProviderUpdateResponse_unstable = z.object({
@@ -708,10 +570,7 @@ export const zProviderConfigReadRequest_unstable = z.object({
 
 export const zProviderConfigFieldValueDto = z.object({
     key: z.string(),
-    value: z.union([
-        z.string(),
-        z.null()
-    ]).optional().default(null),
+    value: z.string().nullish().default(null),
     isSet: z.boolean(),
     isSecret: z.boolean(),
     required: z.boolean()
@@ -766,6 +625,7 @@ export const zProviderConfigAuthenticateRequest_unstable = z.object({
 
 export const zPreferenceKey = z.enum([
     'autoCompactThreshold',
+    'gooseThinkingEffort',
     'voiceAutoSubmitPhrases',
     'voiceDictationProvider',
     'voiceDictationPreferredMic'
@@ -807,14 +667,8 @@ export const zPreferencesRemoveRequest_unstable = z.object({
 export const zDefaultsReadRequest_unstable = z.record(z.unknown());
 
 export const zDefaultsReadResponse_unstable = z.object({
-    providerId: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
-    modelId: z.union([
-        z.string(),
-        z.null()
-    ]).optional()
+    providerId: z.string().nullish(),
+    modelId: z.string().nullish()
 });
 
 /**
@@ -822,10 +676,7 @@ export const zDefaultsReadResponse_unstable = z.object({
  */
 export const zDefaultsSaveRequest_unstable = z.object({
     providerId: z.string(),
-    modelId: z.union([
-        z.string(),
-        z.null()
-    ]).optional()
+    modelId: z.string().nullish()
 });
 
 /**
@@ -874,10 +725,7 @@ export const zOnboardingImportApplyResponse_unstable = z.object({
     imported: zOnboardingImportCounts,
     skipped: zOnboardingImportCounts,
     warnings: z.array(z.string()).optional().default([]),
-    providerDefaults: z.union([
-        zDefaultsReadResponse_unstable,
-        z.null()
-    ]).optional()
+    providerDefaults: zDefaultsReadResponse_unstable.nullish()
 });
 
 /**
@@ -906,14 +754,8 @@ export const zImportSessionRequest_unstable = z.object({
  */
 export const zImportSessionResponse_unstable = z.object({
     sessionId: z.string(),
-    title: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
-    updatedAt: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
+    title: z.string().nullish(),
+    updatedAt: z.string().nullish(),
     messageCount: z.number().int().gte(0)
 });
 
@@ -931,10 +773,7 @@ export const zElicitationRespondRequest_unstable = z.object({
  */
 export const zUpdateSessionProjectRequest_unstable = z.object({
     sessionId: z.string(),
-    projectId: z.union([
-        z.string(),
-        z.null()
-    ]).optional()
+    projectId: z.string().nullish()
 });
 
 /**
@@ -1030,14 +869,8 @@ export const zCreateSourceResponse_unstable = z.object({
  * skills.
  */
 export const zListSourcesRequest_unstable = z.object({
-    type: z.union([
-        zSourceType,
-        z.null()
-    ]).optional(),
-    projectDir: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
+    type: zSourceType.nullish(),
+    projectDir: z.string().nullish(),
     includeProjectSources: z.boolean().optional().default(false)
 });
 
@@ -1054,10 +887,7 @@ export const zUpdateSourceRequest_unstable = z.object({
     name: z.string(),
     description: z.string(),
     content: z.string(),
-    properties: z.union([
-        z.record(z.unknown()),
-        z.null()
-    ]).optional()
+    properties: z.record(z.unknown()).nullish()
 });
 
 export const zUpdateSourceResponse_unstable = z.object({
@@ -1131,32 +961,14 @@ export const zDictationModelOption = z.object({
  */
 export const zDictationProviderStatusEntry = z.object({
     configured: z.boolean(),
-    host: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
+    host: z.string().nullish(),
     description: z.string(),
     usesProviderConfig: z.boolean(),
-    settingsPath: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
-    configKey: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
-    modelConfigKey: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
-    defaultModel: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
-    selectedModel: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
+    settingsPath: z.string().nullish(),
+    configKey: z.string().nullish(),
+    modelConfigKey: z.string().nullish(),
+    defaultModel: z.string().nullish(),
+    selectedModel: z.string().nullish(),
     availableModels: z.array(zDictationModelOption).optional().default([])
 });
 
@@ -1219,17 +1031,11 @@ export const zDictationDownloadProgress = z.object({
     totalBytes: z.number().int().gte(0),
     progressPercent: z.number(),
     status: z.string(),
-    error: z.union([
-        z.string(),
-        z.null()
-    ]).optional()
+    error: z.string().nullish()
 });
 
 export const zDictationModelDownloadProgressResponse_unstable = z.object({
-    progress: z.union([
-        zDictationDownloadProgress,
-        z.null()
-    ]).optional()
+    progress: zDictationDownloadProgress.nullish()
 });
 
 /**
@@ -1262,10 +1068,7 @@ export const zSessionUsageUpdate = z.object({
     contextLimit: z.number().int().gte(0),
     accumulatedInputTokens: z.number().int().gte(0),
     accumulatedOutputTokens: z.number().int().gte(0),
-    accumulatedCost: z.union([
-        z.number(),
-        z.null()
-    ]).optional()
+    accumulatedCost: z.number().nullish()
 });
 
 export const zStatusMessage = z.union([
@@ -1292,10 +1095,7 @@ export const zInteractionState = z.enum(['pending', 'submitted']);
 export const zInteraction = z.object({
     id: z.string(),
     state: zInteractionState,
-    message: z.union([
-        z.string(),
-        z.null()
-    ]).optional(),
+    message: z.string().nullish(),
     requestedSchema: z.unknown().optional(),
     type: z.literal('elicitation')
 });
@@ -1399,11 +1199,8 @@ export const zExtRequest = z.object({
             zDictationModelDeleteRequest_unstable,
             zDictationModelSelectRequest_unstable
         ]),
-        z.union([
-            z.record(z.unknown()),
-            z.null()
-        ])
-    ]).optional()
+        z.record(z.unknown())
+    ]).nullish()
 });
 
 export const zExtResponse = z.union([
@@ -1464,9 +1261,6 @@ export const zExtNotification = z.object({
     method: z.string(),
     params: z.union([
         zGooseSessionNotification_unstable,
-        z.union([
-            z.record(z.unknown()),
-            z.null()
-        ])
-    ]).optional()
+        z.record(z.unknown())
+    ]).nullish()
 });


### PR DESCRIPTION
**Category:** new-feature
**User Impact:** Users can now adjust reasoning effort for supported ACP-backed Goose sessions from a session config control.
**Problem:** Goose already understands model-level thinking effort, but ACP clients could not discover or update that setting per session. This meant UI clients had no backend-supported control for changing reasoning effort without relying on global configuration.
**Solution:** This exposes a `thinking_effort` ACP session config option, applies updates by merging the selected effort into the session model request params, and returns the refreshed config state after changes.

<details>
<summary>File changes</summary>

**crates/goose/src/acp/response_builder.rs**
Adds the ACP `thinking_effort` select option in the thought-level category and derives its current value from the active model config. Extends unit coverage so the option renders and reflects non-default effort values.

**crates/goose/src/acp/server.rs**
Carries the current model config through config update building and adds session-local handling for thinking effort changes. The setter recreates the provider with merged request params so existing model config behavior is reused.

**crates/goose/src/acp/server/dispatch.rs**
Routes `session/set_config_option` requests for `thinking_effort` to the new server handler.

**crates/goose/tests/acp_server_test.rs**
Adds an ACP server integration test proving that setting `thinking_effort` returns the updated thought-level config option.

</details>

### Screenshots/Demos