### PR TITLE
pin goose-sdk package in tui

### DIFF
--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -404,8 +404,8 @@ importers:
   text:
     dependencies:
       '@aaif/goose-sdk':
-        specifier: workspace:*
-        version: link:../sdk
+        specifier: 0.20.2
+        version: 0.20.2(@agentclientprotocol/sdk@0.19.0(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@agentclientprotocol/sdk':
         specifier: ^0.19.0
         version: 0.19.0(zod@4.3.6)
@@ -451,6 +451,41 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@aaif/goose-binary-darwin-arm64@0.20.2':
+    resolution: {integrity: sha512-0wv6UcYxg/dZXRuIUBTL+64Hz0D50PfUA2mJiUEBhWkBmiBCgS/Iymore0gYuayxVV7MzQhKrHqdDPBoo0lqIg==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@aaif/goose-binary-darwin-x64@0.20.2':
+    resolution: {integrity: sha512-dZG6H1QF/lv/kVc1YmHVKRGJCZtoe9o0N2q4vgvDK0Lz+ZJp/ehKcIxUSqE/zebXDqLb4yWByDGelq5Ud2rnCw==}
+    cpu: [x64]
+    os: [darwin]
+    hasBin: true
+
+  '@aaif/goose-binary-linux-arm64@0.20.2':
+    resolution: {integrity: sha512-DLbm8r21v4c39dGbLepjXDmXNLsdWw0PFFpRbQtBd2m5Q+xIBgYOx1jNm3EygDQT9yGV9R3WS6SW3LvMJLA3xw==}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
+  '@aaif/goose-binary-linux-x64@0.20.2':
+    resolution: {integrity: sha512-+TgB2+MKj18kbw5PBnDMAWvuy8ZijNxXQL4qRBeMebcx07W3dIf6zoy9xD5mSyce61ugG9vsLt9a+3Pm8qZaRw==}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+
+  '@aaif/goose-binary-win32-x64@0.20.2':
+    resolution: {integrity: sha512-P0GrtagS0U/98XW4VuzQ77Fy02bw4wFhzyRWWbR9LDVwY+lLG+AkE5m0Ml/KGKgDWS6gd8BtkAqRxdFw3PM9RQ==}
+    cpu: [x64]
+    os: [win32]
+    hasBin: true
+
+  '@aaif/goose-sdk@0.20.2':
+    resolution: {integrity: sha512-HhsspN1OycRqgKgnUBWC/5xOpJ8zuKWmABax0Br0ZfND94AKKZbsBlya8e+pSM+CvztWLXHRz2KxPQuXYoGyBQ==}
+    peerDependencies:
+      '@agentclientprotocol/sdk': ^0.19.0
 
   '@acemir/cssom@0.9.31':
     resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
@@ -7274,6 +7309,39 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@aaif/goose-binary-darwin-arm64@0.20.2':
+    optional: true
+
+  '@aaif/goose-binary-darwin-x64@0.20.2':
+    optional: true
+
+  '@aaif/goose-binary-linux-arm64@0.20.2':
+    optional: true
+
+  '@aaif/goose-binary-linux-x64@0.20.2':
+    optional: true
+
+  '@aaif/goose-binary-win32-x64@0.20.2':
+    optional: true
+
+  '@aaif/goose-sdk@0.20.2(@agentclientprotocol/sdk@0.19.0(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@agentclientprotocol/sdk': 0.19.0(zod@4.3.6)
+      '@modelcontextprotocol/ext-apps': 0.3.1(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
+      zod: 3.25.76
+    optionalDependencies:
+      '@aaif/goose-binary-darwin-arm64': 0.20.2
+      '@aaif/goose-binary-darwin-x64': 0.20.2
+      '@aaif/goose-binary-linux-arm64': 0.20.2
+      '@aaif/goose-binary-linux-x64': 0.20.2
+      '@aaif/goose-binary-win32-x64': 0.20.2
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - react
+      - react-dom
+      - supports-color
 
   '@acemir/cssom@0.9.31': {}
 

--- a/ui/text/README.md
+++ b/ui/text/README.md
@@ -7,33 +7,35 @@ https://github.com/aaif-goose/goose/discussions/7309
 
 ## Running
 
-The TUI automatically launches the goose ACP server using the `goose acp` command.
+The TUI launches the goose ACP server by spawning `goose acp`. Which binary it spawns is resolved by `@aaif/goose-sdk`:
 
-### Development (from source)
-
-When running from source, `npm start` automatically builds the Rust binary from the workspace root if needed:
+1. the `GOOSE_BINARY` environment variable, if set, otherwise
+2. the platform's prebuilt `@aaif/goose-binary-*` package (an optional dependency of the pinned `@aaif/goose-sdk`).
 
 ```bash
 cd ui/text
-npm i
-npm run start
+pnpm install   # pulls the pinned @aaif/goose-sdk and its matching @aaif/goose-binary-* package
+pnpm start     # tsx src/tui.tsx — runs against the released binary, no Rust build
 ```
 
-The `dev:binary` script checks if the Rust binary needs rebuilding by comparing timestamps of:
-- `target/release/goose` binary
-- `Cargo.toml` and `Cargo.lock` 
-- `crates/goose-cli/Cargo.toml`
+The TUI pins a specific `@aaif/goose-sdk` version, so `pnpm start` always runs against a goose binary that matches the SDK.
 
-If any source files are newer, it runs `cargo build --release -p goose-cli` automatically.
+### Building goose from local source
 
-### Production (with prebuilt binaries)
+To test local Rust changes, run the dev launcher directly. It builds a debug binary (`cargo build -p goose-cli` → `target/debug/goose`) from the workspace root and points the TUI at it via `GOOSE_BINARY`:
 
-In production, the TUI uses prebuilt binaries from the `@aaif/goose-binary-*` packages installed via `postinstall`.
+```bash
+node scripts/dev-start.mjs
+```
+
+If your changes touch the ACP schema, also point the TUI at the in-repo SDK so the two stay matched: set `@aaif/goose-sdk` to `workspace:*` in `package.json` and re-run `pnpm install`. Otherwise the locally built binary may not match the pinned published SDK's schema. Revert that change before committing — the TUI is meant to stay frozen on its pinned SDK version.
+
+To run any other prebuilt binary, set `GOOSE_BINARY=/path/to/goose` and use `pnpm start`.
 
 ### Custom server URL
 
-To use a custom server URL instead of the built-in binary:
+To connect to an already-running server instead of spawning a binary:
 
 ```bash
-npm run start -- --server http://localhost:8080
+pnpm start -- --server http://localhost:8080
 ```

--- a/ui/text/package.json
+++ b/ui/text/package.json
@@ -23,11 +23,11 @@
   ],
   "scripts": {
     "build": "tsc",
-    "start": "node scripts/dev-start.mjs",
+    "start": "tsx src/tui.tsx",
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@aaif/goose-sdk": "workspace:*",
+    "@aaif/goose-sdk": "0.20.2",
     "@agentclientprotocol/sdk": "^0.19.0",
     "@inkjs/ui": "^2.0.0",
     "ink": "^6.8.0",


### PR DESCRIPTION
## Summary
Since TUI are not in active development now, we pin the goose-sdk package so that it won't be impacted by the ACP schema changes

### Testing
Local testing