### PR TITLE
fix(agents): preserve reasoning content for tool-call responses witho…

### DIFF
--- a/crates/goose-providers/src/formats/openai.rs
+++ b/crates/goose-providers/src/formats/openai.rs
@@ -183,7 +183,18 @@ pub fn format_messages_with_options(
     let mut pending_assistant_reasoning = String::new();
 
     for message in messages {
-        if options.preserve_thinking_context && message.role != Role::Assistant {
+        // Only clear carried-forward reasoning on genuine user turns, not
+        // tool-result messages which are part of the same assistant tool-calling
+        // turn.  Providers like DeepSeek require reasoning_content on every
+        // assistant message with tool_calls, even when the model produced no
+        // new reasoning this turn.
+        if options.preserve_thinking_context
+            && message.role != Role::Assistant
+            && !message
+                .content
+                .iter()
+                .any(|c| matches!(c, MessageContent::ToolResponse(_)))
+        {
             pending_assistant_reasoning.clear();
         }
 

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2145,20 +2145,13 @@ impl Agent {
                                 // When the current response has no reasoning (e.g. DeepSeek V4
                                 // tool-call responses), fall back to the last reasoning_content
                                 // from the current tool-calling turn so it can be echoed back.
-                                // Stop at genuine user turns (non-tool-response user messages)
-                                // to match the boundary that format_messages_with_options uses.
-                                // Search messages_to_add first (not yet committed to conversation),
-                                // then fall through to conversation.messages().
+                                // Only search messages_to_add (not yet committed), not the
+                                // conversation — reasoning from a prior committed tool turn
+                                // should not be reused since the new call may depend on that
+                                // turn's results.
                                 let reasoning_to_attach = if !thinking_content.is_empty() {
                                     thinking_content
                                 } else {
-                                    let is_within_turn =
-                                        |m: &&Message| -> bool {
-                                            m.role == rmcp::model::Role::Assistant
-                                                || m.content
-                                                    .iter()
-                                                    .any(|c| matches!(c, MessageContent::ToolResponse(_)))
-                                        };
                                     let extract_reasoning = |m: &Message| -> Option<Vec<MessageContent>> {
                                         let reasoning: Vec<MessageContent> = m
                                             .content
@@ -2172,19 +2165,18 @@ impl Agent {
                                             Some(reasoning)
                                         }
                                     };
+                                    // Only search messages_to_add (current batch, not yet committed
+                                    // to conversation) for fallback reasoning. Do NOT search the
+                                    // conversation — reasoning from a prior committed tool turn
+                                    // should not be reused for a new tool call that may depend on
+                                    // the previous turn's results. Reusing it causes
+                                    // merge_split_tool_call_messages in the OpenAI formatter to
+                                    // incorrectly merge sequential tool calls into one message.
                                     let fallback = messages_to_add
                                         .messages()
                                         .iter()
                                         .rev()
                                         .find_map(extract_reasoning)
-                                        .or_else(|| {
-                                            conversation
-                                                .messages()
-                                                .iter()
-                                                .rev()
-                                                .take_while(is_within_turn)
-                                                .find_map(extract_reasoning)
-                                        })
                                         .unwrap_or_default();
                                     if fallback.is_empty() {
                                         debug!(

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2144,19 +2144,46 @@ impl Agent {
 
                                 // When the current response has no reasoning (e.g. DeepSeek V4
                                 // tool-call responses), fall back to the last reasoning_content
-                                // from the conversation history so it can be echoed back.
+                                // from the current tool-calling turn so it can be echoed back.
+                                // Stop at genuine user turns (non-tool-response user messages)
+                                // to match the boundary that format_messages_with_options uses.
+                                // Search messages_to_add first (not yet committed to conversation),
+                                // then fall through to conversation.messages().
                                 let reasoning_to_attach = if !thinking_content.is_empty() {
                                     thinking_content
                                 } else {
-                                    let fallback = conversation.messages()
+                                    let is_within_turn =
+                                        |m: &&Message| -> bool {
+                                            m.role == rmcp::model::Role::Assistant
+                                                || m.content
+                                                    .iter()
+                                                    .any(|c| matches!(c, MessageContent::ToolResponse(_)))
+                                        };
+                                    let extract_reasoning = |m: &Message| -> Option<Vec<MessageContent>> {
+                                        let reasoning: Vec<MessageContent> = m
+                                            .content
+                                            .iter()
+                                            .filter(|c| matches!(c, MessageContent::Thinking(_)))
+                                            .cloned()
+                                            .collect();
+                                        if reasoning.is_empty() {
+                                            None
+                                        } else {
+                                            Some(reasoning)
+                                        }
+                                    };
+                                    let fallback = messages_to_add
+                                        .messages()
                                         .iter()
                                         .rev()
-                                        .find_map(|m| {
-                                            let reasoning: Vec<MessageContent> = m.content.iter()
-                                                .filter(|c| matches!(c, MessageContent::Thinking(_)))
-                                                .cloned()
-                                                .collect();
-                                            if reasoning.is_empty() { None } else { Some(reasoning) }
+                                        .find_map(extract_reasoning)
+                                        .or_else(|| {
+                                            conversation
+                                                .messages()
+                                                .iter()
+                                                .rev()
+                                                .take_while(is_within_turn)
+                                                .find_map(extract_reasoning)
                                         })
                                         .unwrap_or_default();
                                     if fallback.is_empty() {

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2137,16 +2137,36 @@ impl Agent {
                                     let thinking_msg = Message::new(
                                         response.role.clone(),
                                         response.created,
-                                        thinking_content,
+                                        thinking_content.clone(),
                                     ).with_id(format!("msg_{}", Uuid::new_v4()));
                                     messages_to_add.push(thinking_msg);
                                 }
 
-                                // Collect reasoning content to attach to tool request messages
-                                let reasoning_content: Vec<MessageContent> = response.content.iter()
-                                    .filter(|c| matches!(c, MessageContent::Thinking(_)))
-                                    .cloned()
-                                    .collect();
+                                // When the current response has no reasoning (e.g. DeepSeek V4
+                                // tool-call responses), fall back to the last reasoning_content
+                                // from the conversation history so it can be echoed back.
+                                let reasoning_to_attach = if !thinking_content.is_empty() {
+                                    thinking_content
+                                } else {
+                                    let fallback = conversation.messages()
+                                        .iter()
+                                        .rev()
+                                        .find_map(|m| {
+                                            let reasoning: Vec<MessageContent> = m.content.iter()
+                                                .filter(|c| matches!(c, MessageContent::Thinking(_)))
+                                                .cloned()
+                                                .collect();
+                                            if reasoning.is_empty() { None } else { Some(reasoning) }
+                                        })
+                                        .unwrap_or_default();
+                                    if fallback.is_empty() {
+                                        debug!(
+                                            "No reasoning content in response or conversation history for tool call messages; \
+                                             this may cause errors with providers that require reasoning_content (e.g. DeepSeek)"
+                                        );
+                                    }
+                                    fallback
+                                };
 
                                 for request in frontend_requests.iter().chain(remaining_requests.iter()) {
                                     if request.tool_call.is_ok() {
@@ -2155,7 +2175,7 @@ impl Agent {
 
                                         // Providers like Kimi require reasoning_content on all assistant
                                         // messages with tool_calls when thinking mode is enabled.
-                                        for rc in &reasoning_content {
+                                        for rc in &reasoning_to_attach {
                                             request_msg = request_msg.with_content(rc.clone());
                                         }
 


### PR DESCRIPTION
Fall back to the last reasoning_content from conversation history when the current response has no thinking (e.g. DeepSeek V4 tool-call responses). Additionally, stop clearing carried-forward reasoning on tool-result messages in the OpenAI format so providers that require reasoning_content on every assistant message with tool_calls work correctly.

## Summary

I can only guarantee that this patch fix the issue #9200. I was using opencode go provider with DeepSeek V4 Pro/Flash and was getting that error. This patch send the required reasoning content when we have tools calls. So DeepSeek is happy.

##Testing

I have replace the test_streaming_tool_call_does_not_duplicate_yielded_reasoning with test_streaming_tool_call_attaches_accumulated_reasoning_after_prior_yields
Related Issues

Relates to #9200
 