### PR TITLE
feat: use provider-reported cost (usage.cost) for accurate cost tracking

### DIFF
--- a/crates/goose-providers/src/conversation/token_usage.rs
+++ b/crates/goose-providers/src/conversation/token_usage.rs
@@ -30,6 +30,12 @@ pub struct Usage {
     pub total_tokens: Option<i32>,
     pub cache_read_input_tokens: Option<i32>,
     pub cache_write_input_tokens: Option<i32>,
+    /// Provider-reported cost for this usage, in USD. Populated only when the
+    /// provider/gateway includes a `cost` field in its `usage` object (e.g.
+    /// OpenRouter, or an Anthropic-compatible gateway). `None` => the cost is
+    /// computed from the local pricing catalog instead.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost: Option<f64>,
 }
 
 fn sum_optionals<T>(a: Option<T>, b: Option<T>) -> Option<T>
@@ -60,6 +66,11 @@ impl Add for Usage {
                 other.cache_write_input_tokens,
             ),
         )
+        // Cost is a total for the usage that carries it (e.g. the final
+        // message_delta), not an additive per-field count — take the latest
+        // non-None value rather than summing, so merging message_start (no cost)
+        // with message_delta (total cost) yields the total, not a doubled value.
+        .with_cost(other.cost.or(self.cost))
     }
 }
 
@@ -92,6 +103,7 @@ impl Usage {
             total_tokens: calculated_total,
             cache_read_input_tokens: None,
             cache_write_input_tokens: None,
+            cost: None,
         }
     }
 
@@ -102,6 +114,13 @@ impl Usage {
     ) -> Self {
         self.cache_read_input_tokens = cache_read_input_tokens;
         self.cache_write_input_tokens = cache_write_input_tokens;
+        self
+    }
+
+    /// Attach a provider-reported cost (USD) for this usage. `None` leaves the
+    /// cost to be computed from the local pricing catalog downstream.
+    pub fn with_cost(mut self, cost: Option<f64>) -> Self {
+        self.cost = cost;
         self
     }
 }
@@ -144,5 +163,37 @@ mod tests {
         assert_eq!(combined.total_tokens, Some(178));
         assert_eq!(combined.cache_read_input_tokens, Some(14));
         assert_eq!(combined.cache_write_input_tokens, Some(6));
+        // No provider cost on either side -> None.
+        assert_eq!(combined.cost, None);
+    }
+
+    #[test]
+    fn test_provider_cost_field() {
+        // Defaults to None and is omitted from JSON when absent.
+        let bare = Usage::new(Some(10), Some(20), Some(30));
+        assert_eq!(bare.cost, None);
+        let json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&bare).unwrap()).unwrap();
+        assert!(json.get("cost").is_none());
+
+        // Deserializes from a provider `usage` that includes `cost`.
+        let with_cost: Usage =
+            serde_json::from_value(json!({"input_tokens": 10, "output_tokens": 20, "cost": 0.0123}))
+                .unwrap();
+        assert_eq!(with_cost.cost, Some(0.0123));
+    }
+
+    #[test]
+    fn test_cost_merge_takes_latest_non_none_not_sum() {
+        // message_start has no cost; the final message_delta carries the total.
+        let start = Usage::new(Some(100), Some(0), Some(100));
+        let delta = Usage::new(Some(0), Some(50), Some(50)).with_cost(Some(0.42));
+        let merged = start + delta;
+        // Total cost wins (not summed, not lost).
+        assert_eq!(merged.cost, Some(0.42));
+
+        // And when the accumulator already had a cost, the newer one replaces it.
+        let next = Usage::new(Some(0), Some(10), Some(10)).with_cost(Some(0.10));
+        assert_eq!((merged + next).cost, Some(0.10));
     }
 }

--- a/crates/goose-providers/src/conversation/token_usage.rs
+++ b/crates/goose-providers/src/conversation/token_usage.rs
@@ -177,9 +177,10 @@ mod tests {
         assert!(json.get("cost").is_none());
 
         // Deserializes from a provider `usage` that includes `cost`.
-        let with_cost: Usage =
-            serde_json::from_value(json!({"input_tokens": 10, "output_tokens": 20, "cost": 0.0123}))
-                .unwrap();
+        let with_cost: Usage = serde_json::from_value(
+            json!({"input_tokens": 10, "output_tokens": 20, "cost": 0.0123}),
+        )
+        .unwrap();
         assert_eq!(with_cost.cost, Some(0.0123));
     }
 

--- a/crates/goose-providers/src/formats/openai.rs
+++ b/crates/goose-providers/src/formats/openai.rs
@@ -733,6 +733,9 @@ pub fn get_usage(usage: &Value) -> Usage {
 
     Usage::new(input_tokens, output_tokens, total_tokens)
         .with_cache_tokens(cache_read_input_tokens, cache_write_input_tokens)
+        // Provider-reported cost (USD), e.g. OpenRouter's `usage.cost`. Falls back
+        // to catalog pricing when absent.
+        .with_cost(usage.get("cost").and_then(|v| v.as_f64()))
 }
 
 fn extract_usage_with_output_tokens(

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -560,6 +560,14 @@ impl Agent {
         usage: &ProviderUsage,
         provider_name: &str,
     ) -> Option<f64> {
+        // Prefer a provider-reported cost when present (e.g. OpenRouter's
+        // `usage.cost`, or an Anthropic-compatible gateway). This reflects the
+        // model/route actually served — including failover and cache discounts —
+        // which a local price catalog can't know. Falls back to the catalog below.
+        if let Some(provider_cost) = usage.usage.cost {
+            return Some(existing.unwrap_or(0.0) + provider_cost);
+        }
+
         let canonical =
             crate::providers::canonical::maybe_get_canonical_model(provider_name, &usage.model)?;
 

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -884,7 +884,11 @@ where
                                 (None, None) => None,
                             };
 
-                            let merged_usage = Usage::new(merged_input, merged_output, merged_total);
+                            // Preserve a provider-reported cost: it typically arrives
+                            // on this message_delta, not the earlier message_start, so
+                            // take the delta's cost first, then any prior cost.
+                            let merged_usage = Usage::new(merged_input, merged_output, merged_total)
+                                .with_cost(delta_usage.cost.or(existing_usage.usage.cost));
                             final_usage = Some(ProviderUsage::new(existing_usage.model.clone(), merged_usage));
                         } else {
                             let model = event.data.get("model")

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -449,7 +449,10 @@ pub fn get_usage(data: &Value) -> Result<Usage> {
             Some(total_input_i32),
             Some(output_tokens_i32),
             Some(total_tokens_i32),
-        ))
+        )
+        // Provider-reported cost (USD), when an Anthropic-compatible gateway adds
+        // `cost` to its usage object. Falls back to catalog pricing when absent.
+        .with_cost(usage.get("cost").and_then(|v| v.as_f64())))
     } else if data.as_object().is_some() {
         // Check if the data itself is the usage object (for message_delta events that might have usage at top level)
         let input_tokens = data
@@ -492,7 +495,8 @@ pub fn get_usage(data: &Value) -> Result<Usage> {
                 Some(total_input_i32),
                 Some(output_tokens_i32),
                 Some(total_tokens_i32),
-            ))
+            )
+            .with_cost(data.get("cost").and_then(|v| v.as_f64())))
         } else {
             tracing::debug!("🔍 Anthropic no token data found in object");
             Ok(Usage::new(None, None, None))

--- a/ui/desktop/src/components/bottom_menu/CostTracker.tsx
+++ b/ui/desktop/src/components/bottom_menu/CostTracker.tsx
@@ -160,20 +160,37 @@ export function CostTracker({
 
   // Build tooltip content
   const getTooltipContent = (): string => {
-    if (pricingFailed) {
-      return intl.formatMessage(i18n.pricingUnavailable, { model: `${currentProvider}/${currentModel}` });
-    }
-
     const currency = costInfo?.currency || '$';
 
+    // A provider-reported cost (accumulatedCost) is authoritative — show it even
+    // when the local pricing catalog has no entry for this model (pricingFailed),
+    // e.g. a custom/self-hosted model id served via a gateway.
     if (accumulatedCost != null) {
-      return intl.formatMessage(i18n.totalSessionCost, { cost: `${currency}${totalCost.toFixed(4)}` })
-        + `\n` + intl.formatMessage(i18n.inputOutputTooltip, {
+      const total = intl.formatMessage(i18n.totalSessionCost, {
+        cost: `${currency}${totalCost.toFixed(4)}`,
+      });
+      // Only append the per-token breakdown when the catalog actually has prices;
+      // otherwise the breakdown would read $0.000000 and mislead.
+      if (
+        costInfo?.input_token_cost === undefined &&
+        costInfo?.output_token_cost === undefined
+      ) {
+        return total;
+      }
+      return (
+        total +
+        `\n` +
+        intl.formatMessage(i18n.inputOutputTooltip, {
           inputTokens: inputTokens.toLocaleString(),
           inputCost: `${currency}${((inputTokens * (costInfo?.input_token_cost || 0)) / 1_000_000).toFixed(6)}`,
           outputTokens: outputTokens.toLocaleString(),
           outputCost: `${currency}${((outputTokens * (costInfo?.output_token_cost || 0)) / 1_000_000).toFixed(6)}`,
-        });
+        })
+      );
+    }
+
+    if (pricingFailed) {
+      return intl.formatMessage(i18n.pricingUnavailable, { model: `${currentProvider}/${currentModel}` });
     }
 
     const inputCostStr = `${currency}${((inputTokens * (costInfo?.input_token_cost || 0)) / 1_000_000).toFixed(6)}`;


### PR DESCRIPTION
## Summary

Today goose computes session cost as `tokens × catalog_price`, looking the price up from the canonical (models.dev) catalog by `(provider, model)`. For any model id that isn't in that catalog — custom or self-hosted ids, or anything served through a gateway — the lookup misses and the cost tracker shows **"Pricing data unavailable for {model}"**, even though the gateway knows the exact cost.

This change lets goose use a **provider-reported cost** when one is present: if the provider/gateway includes a `cost` field (USD) in its `usage` object — exactly as **OpenRouter** already does (`usage.cost`), and as an Anthropic-compatible gateway can — goose uses that number. It reflects the model/route *actually served* (including failover and cache discounts), which a static catalog keyed by model id structurally can't.

It's fully backward-compatible and provider-agnostic:

- Add an optional `cost: Option<f64>` to `Usage` (`#[serde(default, skip_serializing_if = ...)]`), parsed from `usage.cost` in both the Anthropic (`providers/formats/anthropic.rs`) and OpenAI-compatible (`formats/openai.rs`) `get_usage` paths. On merge it takes the latest non-`None` value (the total carried on the final `message_delta`), not a sum.
- `Agent::accumulate_cost` prefers the provider-reported cost when present and falls back to the existing catalog computation otherwise.
- Desktop `CostTracker`: a provider-reported cost now also wins the tooltip, so a catalog miss no longer reads "Pricing data unavailable" when the real cost is known. No generated-type changes — the value flows through the existing `TokenState.accumulatedCost`.

### Testing

- Added unit tests in `token_usage.rs`: `cost` defaults to `None` and is omitted from JSON when absent; deserializes from a `usage` that includes `cost`; and the merge takes the latest non-`None` cost rather than summing (so `message_start` + final `message_delta` yields the total).
- Manually traced the data flow: `get_usage` → `ProviderUsage` → `accumulate_cost` → `session.accumulated_cost` → `TokenState.accumulatedCost` → `CostTracker`.
- Transparency: I don't have a Rust/Node toolchain on my dev box, so I couldn't run `cargo test` / `pnpm` locally — relying on CI to validate the build/tests. The change is small and mechanical; happy to iterate on any CI feedback.

### Related Issues

Relates to gateway/custom-endpoint cost tracking (e.g. routing goose through an Anthropic-compatible proxy or OpenRouter-style gateway, where the cost is known per-request but the model id isn't in the public catalog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)