### PR TITLE
fix(otel): use reqwest-blocking-client to prevent PeriodicReader/BatchProcessor Tokio panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,8 +82,8 @@ test-case = { version = "3", default-features = false }
 url = { version = "2.5.4", default-features = false, features = ["std"] }
 opentelemetry = { version = "0.32", default-features = false }
 opentelemetry_sdk = { version = "0.32", default-features = false, features = ["metrics"] }
-opentelemetry-http = { version = "0.32", default-features = false, features = ["internal-logs", "reqwest"] }
-opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "internal-logs", "logs", "metrics", "reqwest-client", "trace"] }
+opentelemetry-http = { version = "0.32", default-features = false, features = ["internal-logs", "reqwest-blocking"] }
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "internal-logs", "logs", "metrics", "reqwest-blocking-client", "trace"] }
 opentelemetry-appender-tracing = { version = "0.32", default-features = false, features = ["experimental_span_attributes"] }
 opentelemetry-stdout = { version = "0.32", default-features = false, features = ["trace", "metrics", "logs"] }
 tracing-opentelemetry = { version = "0.33", default-features = false, features = ["metrics"] }

--- a/crates/goose/src/otel/otlp.rs
+++ b/crates/goose/src/otel/otlp.rs
@@ -68,7 +68,7 @@ impl ExporterType {
 /// (matching what `.with_http()` produces in this build).
 ///
 /// goose's `opentelemetry-otlp` build only enables the `http-proto` /
-/// `reqwest-client` transport features — not `grpc-tonic`. If the caller's
+/// `reqwest-blocking-client` transport features — not `grpc-tonic`. If the caller's
 /// environment sets `…_PROTOCOL=grpc`, the `.with_http()` exporter still
 /// builds successfully but its background batch / metric reader threads
 /// panic on the first export with


### PR DESCRIPTION
## Problem

Two background threads panic at startup when OTLP telemetry is enabled in goose v1.37.0:

```
thread 'OpenTelemetry.Metrics.PeriodicReader' panicked: there is no reactor running, must be called from the context of a Tokio 1.x runtime
thread 'OpenTelemetry.Logs.BatchProcessor' panicked: there is no reactor running, must be called from the context of a Tokio 1.x runtime
```

## Root Cause

`Cargo.toml` (workspace root) was selecting the **async** reqwest feature for `opentelemetry-otlp` and `opentelemetry-http`:

```toml
opentelemetry-http = { ..., features = ["internal-logs", "reqwest"] }
opentelemetry-otlp  = { ..., features = ["http-proto", "internal-logs", "logs", "metrics", "reqwest-client", "trace"] }
```

However, goose uses the **standard** (blocking-thread-based) OTel SDK processors — `BatchLogProcessor`, `BatchSpanProcessor`, and `PeriodicReader`. These run on plain OS threads with **no Tokio reactor in scope**. When they try to call the async reqwest HTTP client internally, there is no Tokio runtime context → panic.

The [opentelemetry-otlp upstream documentation](https://docs.rs/opentelemetry-otlp/latest/opentelemetry_otlp/) explicitly states:

> **Async HTTP clients**: Do **not** enable these for the default SDK processors/readers; they require an export path that is driven by a Tokio runtime, such as the experimental async-runtime processors/readers.
>
> Most users should use the default **reqwest-blocking-client**. It is compatible with the SDK's default `BatchSpanProcessor`, `BatchLogProcessor`, and `PeriodicReader`, **including applications that run on Tokio**.

## Fix

Switch from the async to the blocking reqwest features:

```diff
-opentelemetry-http = { version = "0.32", default-features = false, features = ["internal-logs", "reqwest"] }
-opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "internal-logs", "logs", "metrics", "reqwest-client", "trace"] }
+opentelemetry-http = { version = "0.32", default-features = false, features = ["internal-logs", "reqwest-blocking"] }
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "internal-logs", "logs", "metrics", "reqwest-blocking-client", "trace"] }
```

Also updated the corresponding comment in `crates/goose/src/otel/otlp.rs` to reflect the correct feature name.

## Impact

- Fixes the startup panics when `GOOSE_OTLP_*` environment variables are set
- No behaviour change for users without OTLP configured
- The blocking reqwest client spawns its HTTP calls on a dedicated thread pool, which is fully compatible with Tokio applications