### PR TITLE
fix: classify Bedrock ValidationException as ExecutionError

### DIFF
--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -290,6 +290,10 @@ impl BedrockProvider {
                         err
                     ))
                 }
+                ConverseError::ValidationException(err) => ProviderError::ExecutionError(format!(
+                    "Bedrock validation error: {}",
+                    err.message().unwrap_or("unknown validation error")
+                )),
                 ConverseError::ModelErrorException(err) => {
                     ProviderError::ExecutionError(format!("Failed to call Bedrock: {:?}", err))
                 }


### PR DESCRIPTION
helps #9732.

Bedrock `ValidationException` was hitting the catch-all arm and getting mapped to `ServerError`, which `should_retry` treats as transient. Non-retryable validation errors (e.g. models with data retention requirements) then spun in a silent ~2 minute retry loop before surfacing.

Now mapped to `ExecutionError` so it fails fast with the underlying message.

Assisted by mic and goose.