### PR TITLE
fix: keep tool request before its response in session ordering

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2135,10 +2135,19 @@ impl Agent {
                                                 request.metadata.as_ref(),
                                                 request.tool_meta.clone(),
                                             );
-                                        messages_to_add.push(request_msg);
                                         let final_response = request_to_response_map
                                             .remove(&request.id)
                                             .unwrap_or_else(|| Message::user().with_generated_id());
+
+                                        // The response placeholder is created before tools run, so its
+                                        // timestamp is earlier than the request message built afterwards.
+                                        // Session retrieval orders by (created_timestamp, id); align the
+                                        // request to the response's second so the insertion-order id
+                                        // tiebreaker keeps the request ahead of its response. Otherwise the
+                                        // response can sort first and providers reject the tool_use ordering.
+                                        request_msg.created = request_msg.created.min(final_response.created);
+
+                                        messages_to_add.push(request_msg);
                                         yield AgentEvent::Message(final_response.clone());
                                         messages_to_add.push(final_response);
                                     } else {

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -2762,6 +2762,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_same_second_messages_keep_insertion_order() {
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+
+        let session = sm
+            .create_session(
+                PathBuf::from("/tmp/test"),
+                "ordering".to_string(),
+                SessionType::User,
+                GooseMode::default(),
+            )
+            .await
+            .unwrap();
+
+        // Tool request (assistant) and tool response (user) sharing the same
+        // second must retain insertion order: request before response.
+        let created = 1_700_000_000;
+        sm.add_message(
+            &session.id,
+            &Message {
+                id: Some("req".to_string()),
+                role: Role::Assistant,
+                created,
+                content: vec![MessageContent::text("tool request")],
+                metadata: Default::default(),
+            },
+        )
+        .await
+        .unwrap();
+        sm.add_message(
+            &session.id,
+            &Message {
+                id: Some("resp".to_string()),
+                role: Role::User,
+                created,
+                content: vec![MessageContent::text("tool response")],
+                metadata: Default::default(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let conversation = sm
+            .get_session(&session.id, true)
+            .await
+            .unwrap()
+            .conversation
+            .unwrap();
+        let messages = conversation.messages();
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].role, Role::Assistant);
+        assert_eq!(messages[1].role, Role::User);
+    }
+
+    #[tokio::test]
     async fn test_list_sessions_filters_by_type() {
         let temp_dir = TempDir::new().unwrap();
         let sm = SessionManager::new(temp_dir.path().to_path_buf());


### PR DESCRIPTION
Tool response placeholders are created before tools run, while the tool request message is built afterwards. With second-grained timestamps and retrieval ordered by `(created_timestamp, id)`, the request can land in a later second than its response and sort after it — causing providers like Claude to reject the conversation with `unexpected tool_use_id in tool_result blocks`.

Align the request's timestamp to its response's so both share a second and the insertion-order id tiebreaker keeps the request ahead of the response.

Closes #9461

Assisted by mic and goose.