### PR TITLE
fix(providers): use adaptive thinking for Fable 5 and Opus 4.7/4.8

### DIFF
--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -68,9 +68,24 @@ impl AnthropicFormatOptions {
     }
 }
 
+/// Models where adaptive thinking is always on and cannot be disabled, so
+/// `thinking: {type: "adaptive"}` is the only valid mode regardless of effort.
+pub fn always_on_adaptive_thinking(model_name: &str) -> bool {
+    let lower = model_name.to_lowercase();
+    lower.contains("claude-fable-5")
+        || lower.contains("claude-mythos-5")
+        || lower.contains("claude-mythos-preview")
+}
+
+/// Models that use adaptive thinking instead of manual `thinking: {type: "enabled"}`.
+/// On Opus 4.7/4.8 and the always-on models, manual `enabled` is rejected with a 400.
 pub fn supports_adaptive_thinking(model_name: &str) -> bool {
     let lower = model_name.to_lowercase();
-    lower.contains("claude-opus-4-6") || lower.contains("claude-sonnet-4-6")
+    always_on_adaptive_thinking(model_name)
+        || lower.contains("claude-opus-4-6")
+        || lower.contains("claude-sonnet-4-6")
+        || lower.contains("claude-opus-4-7")
+        || lower.contains("claude-opus-4-8")
 }
 
 pub fn thinking_type(model_config: &ModelConfig) -> ThinkingType {
@@ -79,11 +94,19 @@ pub fn thinking_type(model_config: &ModelConfig) -> ThinkingType {
         return ThinkingType::Disabled;
     }
 
+    if always_on_adaptive_thinking(&model_config.model_name) {
+        return ThinkingType::Adaptive;
+    }
+
     let is_adaptive_model = supports_adaptive_thinking(&model_config.model_name);
     let effort = model_config.thinking_effort();
 
     if effort.is_none() && legacy_thinking_budget_tokens().is_some() {
-        return ThinkingType::Enabled;
+        return if is_adaptive_model {
+            ThinkingType::Adaptive
+        } else {
+            ThinkingType::Enabled
+        };
     }
 
     match effort.unwrap_or(ThinkingEffort::Off) {
@@ -1559,6 +1582,37 @@ mod tests {
             thinking_type(&cfg_with_effort("claude-3-7-sonnet-20250219", "off")),
             ThinkingType::Disabled
         );
+        // Opus 4.7/4.8 are adaptive-only (manual `enabled` is rejected by the API)
+        assert_eq!(
+            thinking_type(&cfg_with_effort("claude-opus-4-7", "high")),
+            ThinkingType::Adaptive
+        );
+        assert_eq!(
+            thinking_type(&cfg_with_effort("databricks-claude-opus-4-8", "high")),
+            ThinkingType::Adaptive
+        );
+    }
+
+    #[test]
+    fn test_thinking_type_always_on_adaptive() {
+        let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
+        // Fable 5 / Mythos 5 cannot disable thinking — always adaptive, even with off or unset.
+        for name in [
+            "databricks-claude-fable-5",
+            "global.anthropic.claude-fable-5",
+            "claude-mythos-5",
+            "claude-mythos-preview",
+        ] {
+            assert_eq!(thinking_type(&cfg(name)), ThinkingType::Adaptive);
+            assert_eq!(
+                thinking_type(&cfg_with_effort(name, "off")),
+                ThinkingType::Adaptive
+            );
+            assert_eq!(
+                thinking_type(&cfg_with_effort(name, "high")),
+                ThinkingType::Adaptive
+            );
+        }
     }
 
     #[test]

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -538,6 +538,17 @@ pub fn thinking_effort(model_config: &ModelConfig) -> ThinkingEffort {
         .unwrap_or(ThinkingEffort::High)
 }
 
+/// Effort to send in `output_config.effort` for adaptive thinking. Adaptive
+/// thinking does not accept an "off" effort; the only way the adaptive branch
+/// sees "off" is an always-on model that cannot be disabled, so fall back to the
+/// default "high".
+pub fn adaptive_output_effort(model_config: &ModelConfig) -> ThinkingEffort {
+    match thinking_effort(model_config) {
+        ThinkingEffort::Off => ThinkingEffort::High,
+        other => other,
+    }
+}
+
 pub fn thinking_budget_tokens(model_config: &ModelConfig) -> i32 {
     if let Some(request_param) = model_config
         .request_params
@@ -584,7 +595,7 @@ fn apply_thinking_config(
     match thinking_type(model_config) {
         ThinkingType::Adaptive => {
             obj.insert("thinking".to_string(), json!({"type": "adaptive"}));
-            let effort = thinking_effort(model_config).to_string();
+            let effort = adaptive_output_effort(model_config).to_string();
             obj.insert("output_config".to_string(), json!({"effort": effort}));
         }
         ThinkingType::Enabled => {

--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -1201,6 +1201,24 @@ mod tests {
     }
 
     #[test]
+    fn test_create_request_fable_5_omits_temperature() -> anyhow::Result<()> {
+        let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
+        let mut model_config = ModelConfig::new_or_fail("databricks-claude-fable-5");
+        model_config.max_tokens = Some(4096);
+        model_config.temperature = Some(0.7);
+
+        let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
+
+        assert_eq!(request["thinking"]["type"], "adaptive");
+        assert!(
+            request.get("temperature").is_none(),
+            "fable-5 does not support the temperature parameter"
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn test_create_request_enabled_thinking_with_budget() -> anyhow::Result<()> {
         let mut model_config = ModelConfig::new_or_fail("databricks-claude-3-7-sonnet");
         model_config.max_tokens = Some(4096);

--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -1,7 +1,7 @@
 use crate::conversation::message::{Message, MessageContent};
 use crate::model::ModelConfig;
 use crate::providers::formats::anthropic::{
-    thinking_budget_tokens, thinking_effort, thinking_type, ThinkingType,
+    adaptive_output_effort, thinking_budget_tokens, thinking_type, ThinkingType,
 };
 
 use anyhow::{anyhow, Error};
@@ -251,7 +251,7 @@ fn apply_claude_thinking_config(payload: &mut Value, model_config: &ModelConfig)
             obj.insert("thinking".to_string(), json!({ "type": "adaptive" }));
             obj.insert(
                 "output_config".to_string(),
-                json!({ "effort": thinking_effort(model_config).to_string() }),
+                json!({ "effort": adaptive_output_effort(model_config).to_string() }),
             );
             obj.insert(
                 "max_completion_tokens".to_string(),
@@ -1213,6 +1213,27 @@ mod tests {
         assert!(
             request.get("temperature").is_none(),
             "fable-5 does not support the temperature parameter"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_request_always_on_adaptive_off_effort_falls_back_to_high() -> anyhow::Result<()>
+    {
+        let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
+        let mut model_config = ModelConfig::new_or_fail("databricks-claude-fable-5");
+        model_config.max_tokens = Some(4096);
+        let mut params = std::collections::HashMap::new();
+        params.insert("thinking_effort".to_string(), serde_json::json!("off"));
+        model_config.request_params = Some(params);
+
+        let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
+
+        assert_eq!(request["thinking"]["type"], "adaptive");
+        assert_eq!(
+            request["output_config"]["effort"], "high",
+            "always-on adaptive models cannot disable thinking, so off must not be sent"
         );
 
         Ok(())


### PR DESCRIPTION
## Problem

Using `databricks-claude-fable-5` fails with:

```
Request failed: Bad request (400): BAD_REQUEST: Model global.anthropic.claude-fable-5 does not support the temperature parameter
```

Per the [adaptive thinking docs](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking):

- **Claude Fable 5 / Mythos 5 / Mythos Preview** — adaptive thinking is always on and cannot be disabled; these models reject the `temperature` parameter.
- **Opus 4.7 / 4.8** — adaptive-only; manual `thinking: {type: "enabled"}` is rejected with a 400.

goose's `supports_adaptive_thinking()` only recognized `claude-opus-4-6` and `claude-sonnet-4-6`. With any `thinking_effort` set (e.g. `GOOSE_THINKING_EFFORT`), Fable 5 fell into the `Enabled` thinking path, which hard-codes `temperature: 2` (`formats/databricks.rs`) → the 400 above.

## Fix

- Add `always_on_adaptive_thinking()` for `claude-fable-5`, `claude-mythos-5`, `claude-mythos-preview` — `thinking_type()` returns `Adaptive` regardless of effort (they can't be disabled).
- Expand `supports_adaptive_thinking()` to also include `claude-opus-4-7` and `claude-opus-4-8`.
- Route adaptive models away from the legacy-budget `Enabled` path.

The adaptive path never sends `temperature`, resolving the rejection.

## Tests

- `anthropic`: `test_thinking_type_always_on_adaptive`, expanded `test_thinking_type_from_effort` (covers 4-7/4-8).
- `databricks`: `test_create_request_fable_5_omits_temperature` — asserts no `temperature` even when one is configured.

`cargo fmt`, `cargo clippy --lib` clean; targeted tests pass.