### PR TITLE
fix(desktop): preserve Windows backslash paths in custom extension command

### DIFF
--- a/ui/desktop/src/components/settings/extensions/utils.test.ts
+++ b/ui/desktop/src/components/settings/extensions/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   nameToKey,
   getDefaultFormData,
@@ -345,6 +345,36 @@ describe('Extension Utils', () => {
       ['', { cmd: '', args: [] }],
     ])('splits %j correctly', (input, expected) => {
       expect(splitCmdAndArgs(input)).toEqual(expected);
+    });
+
+    describe('on Windows', () => {
+      beforeEach(() => {
+        vi.stubGlobal('window', { electron: { platform: 'win32' } });
+      });
+      afterEach(() => {
+        vi.unstubAllGlobals();
+      });
+
+      it('preserves backslashes in a Windows path', () => {
+        expect(splitCmdAndArgs('C:\\Users\\name\\path\\to\\extension.js')).toEqual({
+          cmd: 'C:\\Users\\name\\path\\to\\extension.js',
+          args: [],
+        });
+      });
+
+      it('preserves backslashes in cmd and args', () => {
+        expect(splitCmdAndArgs('node C:\\Users\\name\\ext.js')).toEqual({
+          cmd: 'node',
+          args: ['C:\\Users\\name\\ext.js'],
+        });
+      });
+
+      it('handles a quoted Windows path containing spaces', () => {
+        expect(splitCmdAndArgs('"C:\\Program Files\\app\\ext.js"')).toEqual({
+          cmd: 'C:\\Program Files\\app\\ext.js',
+          args: [],
+        });
+      });
     });
   });
 

--- a/ui/desktop/src/components/settings/extensions/utils.ts
+++ b/ui/desktop/src/components/settings/extensions/utils.ts
@@ -168,13 +168,23 @@ export function createExtensionConfig(formData: ExtensionFormData): ExtensionCon
   }
 }
 
+function isWindowsPlatform(): boolean {
+  return typeof window !== 'undefined' && window.electron?.platform === 'win32';
+}
+
 export function splitCmdAndArgs(str: string): { cmd: string; args: string[] } {
   const trimmed = str.trim();
   if (!trimmed) {
     return { cmd: '', args: [] };
   }
 
-  const parsed = parseShellQuote(trimmed);
+  // shell-quote treats `\` as a POSIX escape character, so a Windows path like
+  // `C:\Users\name\ext.js` would lose its backslashes and become `C:Usersnameext.js`.
+  // Doubling backslashes on Windows lets them survive parsing (shell-quote unescapes
+  // `\\` back to `\`), while still honoring quotes for paths containing spaces.
+  const toParse = isWindowsPlatform() ? trimmed.replace(/\\/g, '\\\\') : trimmed;
+
+  const parsed = parseShellQuote(toParse);
   const words = parsed.filter((item): item is string => typeof item === 'string').map(String);
 
   const cmd = words[0] || '';


### PR DESCRIPTION
Closes #9698

## Problem
On Windows, entering a custom extension command with a native path like `C:\Users\name\ext.js` corrupts it — the backslashes are stripped, producing `C:Usersnameext.js`, so the extension fails to launch.

## Root cause
`splitCmdAndArgs` parses the Command field with the `shell-quote` library, which treats `\` as a POSIX escape character. Sequences like `\U`, `\n`, `\t` get unescaped, dropping the backslashes entirely.

## Fix
On Windows only, double backslashes before parsing so they survive (`shell-quote` unescapes `\\` back to `\`). Quoted paths with spaces and forward-slash paths still work; non-Windows behavior is unchanged.

## Testing
Added unit tests covering a bare Windows path, cmd + arg, and a quoted path with spaces. Full `pnpm lint:check` (typecheck + eslint + i18n) and vitest pass.

Reproduced from the issue's diagnostic bundle (OS: Windows 11, app v1.37.0).

Assisted by mic and goose.