### PR TITLE
test(providers): isolate reasoning-effort tests from GOOSE_THINKING_EFFORT

### DIFF
--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -1126,6 +1126,7 @@ mod tests {
 
     #[test]
     fn test_create_request_reasoning_effort_xhigh() -> anyhow::Result<()> {
+        let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
         let model_config = ModelConfig {
             model_name: "o3-xhigh".to_string(),
             context_limit: Some(4096),
@@ -1145,6 +1146,7 @@ mod tests {
 
     #[test]
     fn test_create_request_reasoning_effort_none() -> anyhow::Result<()> {
+        let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
         let model_config = ModelConfig {
             model_name: "o3-none".to_string(),
             context_limit: Some(4096),
@@ -1164,6 +1166,7 @@ mod tests {
 
     #[test]
     fn test_create_request_reasoning_effort_for_prefixed_gpt5_model() -> anyhow::Result<()> {
+        let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
         let model_config = ModelConfig {
             model_name: "databricks-gpt-5.4-high".to_string(),
             context_limit: Some(4096),


### PR DESCRIPTION
## Problem

Three databricks reasoning-effort tests fail when `GOOSE_THINKING_EFFORT` is set in the environment:

- `test_create_request_reasoning_effort_xhigh`
- `test_create_request_reasoning_effort_none`
- `test_create_request_reasoning_effort_for_prefixed_gpt5_model`

These build a `ModelConfig` with `request_params: None`, so `thinking_effort()` falls through to the `GOOSE_THINKING_EFFORT` env var. When the var is set (common for developers who run goose locally), it overrides the model-name-suffix-derived effort and the assertions fail, e.g.:

```
left: String("high"), right: "xhigh"
```

The sibling tests that pass set `thinking_effort` explicitly in `request_params`, which takes precedence over the env var.

## Fix

Guard the three env-sensitive tests with `env_lock::lock_env` to clear `GOOSE_THINKING_EFFORT` for the duration of the test — the same pattern already used in the anthropic format tests.

## Verification

Previously these failed with `GOOSE_THINKING_EFFORT` set; they now pass:

```
GOOSE_THINKING_EFFORT=max cargo test -p goose --lib providers::formats::databricks::tests::test_create_request_reasoning_effort
test result: ok. 4 passed; 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)