### PR TITLE
Add canonical thinking modes

### DIFF
--- a/crates/goose-providers/src/canonical.rs
+++ b/crates/goose-providers/src/canonical.rs
@@ -3,7 +3,7 @@ mod model;
 mod name_builder;
 mod registry;
 
-pub use model::{CanonicalModel, Limit, Modalities, Modality, Pricing};
+pub use model::{CanonicalModel, Limit, Modalities, Modality, Pricing, ThinkingMode};
 pub use name_builder::{
     canonical_name, map_provider_name, map_to_canonical_model, strip_version_suffix,
 };

--- a/crates/goose-providers/src/canonical/data/canonical_models.json
+++ b/crates/goose-providers/src/canonical/data/canonical_models.json
@@ -11286,7 +11286,7 @@
     },
     "limit": {
       "context": 1000000,
-      "output": 16384
+      "output": 65536
     }
   },
   {
@@ -12502,8 +12502,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.05,
-      "output": 0.1
+      "input": 0.049999999999999996,
+      "output": 0.09999999999999999
     },
     "limit": {
       "context": 131072,
@@ -14584,6 +14584,7 @@
     "family": "claude-fable",
     "attachment": true,
     "reasoning": true,
+    "thinking_mode": "always_on_adaptive",
     "tool_call": true,
     "temperature": false,
     "release_date": "2026-06-09",
@@ -14781,6 +14782,7 @@
     "family": "claude-opus",
     "attachment": true,
     "reasoning": true,
+    "thinking_mode": "adaptive",
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-05-31",
@@ -14814,6 +14816,7 @@
     "family": "claude-opus",
     "attachment": true,
     "reasoning": true,
+    "thinking_mode": "adaptive",
     "tool_call": true,
     "temperature": false,
     "knowledge": "2026-01-31",
@@ -14847,6 +14850,7 @@
     "family": "claude-opus",
     "attachment": true,
     "reasoning": true,
+    "thinking_mode": "adaptive",
     "tool_call": true,
     "temperature": false,
     "release_date": "2026-05-28",
@@ -14978,6 +14982,7 @@
     "family": "claude-sonnet",
     "attachment": true,
     "reasoning": true,
+    "thinking_mode": "adaptive",
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-08-31",
@@ -19153,6 +19158,39 @@
     }
   },
   {
+    "id": "azure/claude-fable-5",
+    "name": "Claude Fable 5",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-09",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "azure/claude-haiku-4.5",
     "name": "Claude Haiku 4.5",
     "family": "claude-haiku",
@@ -19724,6 +19762,64 @@
     "limit": {
       "context": 128000,
       "output": 128000
+    }
+  },
+  {
+    "id": "azure/deepseek-v4-flash",
+    "name": "DeepSeek-V4-Flash",
+    "family": "deepseek-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.74,
+      "output": 3.48
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "azure/deepseek-v4-pro",
+    "name": "DeepSeek-V4-Pro",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.19,
+      "output": 0.51
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
     }
   },
   {
@@ -27829,6 +27925,38 @@
     }
   },
   {
+    "id": "cortecs/claude-opus4-8",
+    "name": "Claude Opus 4.8",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-05-28",
+    "last_updated": "2026-05-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.64,
+      "output": 28.198,
+      "cache_read": 0.563,
+      "cache_write": 7.049
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "cortecs/claude-sonnet-4",
     "name": "Claude Sonnet 4",
     "family": "claude-sonnet",
@@ -34328,6 +34456,36 @@
     }
   },
   {
+    "id": "fastrouter/anthropic/claude-opus-4.8",
+    "name": "Claude Opus 4.8",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-05-28",
+    "last_updated": "2026-05-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "fastrouter/anthropic/claude-sonnet-4",
     "name": "Claude Sonnet 4",
     "family": "claude-sonnet",
@@ -34361,6 +34519,63 @@
     }
   },
   {
+    "id": "fastrouter/anthropic/claude-sonnet-4.6",
+    "name": "Claude Sonnet 4.6",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-02-17",
+    "last_updated": "2026-03-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "fastrouter/bytedance/seedance-2",
+    "name": "Seedance 2",
+    "family": "seed",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2026-04-01",
+    "last_updated": "2026-04-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 4096,
+      "output": 0
+    }
+  },
+  {
     "id": "fastrouter/deepseek-ai/deepseek-r1-distill-llama-70b",
     "name": "DeepSeek R1 Distill Llama 70B",
     "family": "deepseek-thinking",
@@ -34387,6 +34602,35 @@
     "limit": {
       "context": 131072,
       "output": 131072
+    }
+  },
+  {
+    "id": "fastrouter/deepseek/deepseek-v4-pro",
+    "name": "DeepSeek V4 Pro",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.74,
+      "output": 3.48
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
     }
   },
   {
@@ -34454,6 +34698,400 @@
     }
   },
   {
+    "id": "fastrouter/google/gemini-3-pro-image-preview",
+    "name": "Nano Banana Pro",
+    "family": "gemini-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-11-20",
+    "last_updated": "2025-11-20",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 12.0
+    },
+    "limit": {
+      "context": 65536,
+      "output": 32768
+    }
+  },
+  {
+    "id": "fastrouter/google/gemini-3.1-flash-image-preview",
+    "name": "Nano Banana 2",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-02-26",
+    "last_updated": "2026-02-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.5,
+      "output": 3.0
+    },
+    "limit": {
+      "context": 65536,
+      "output": 65536
+    }
+  },
+  {
+    "id": "fastrouter/google/gemini-3.1-pro-preview",
+    "name": "Gemini 3.1 Pro Preview",
+    "family": "gemini-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-02-19",
+    "last_updated": "2026-02-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 12.0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "fastrouter/google/gemini-3.5-flash",
+    "name": "Gemini 3.5 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-05-19",
+    "last_updated": "2026-05-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 9.0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "fastrouter/google/gemma-4-31b-it",
+    "name": "Gemma 4 31B IT",
+    "family": "gemma",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.13,
+      "output": 0.38
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "fastrouter/google/imagen-4.0-fast",
+    "name": "Imagen 4 Fast",
+    "family": "imagen",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2025-05-20",
+    "last_updated": "2025-05-20",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 480,
+      "output": 0
+    }
+  },
+  {
+    "id": "fastrouter/google/imagen-4.0-ultra",
+    "name": "Imagen 4 Ultra",
+    "family": "imagen",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2025-05-20",
+    "last_updated": "2025-05-20",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 480,
+      "output": 0
+    }
+  },
+  {
+    "id": "fastrouter/google/veo3.1",
+    "name": "Veo 3.1",
+    "family": "veo",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2026-05-01",
+    "last_updated": "2026-05-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 400000,
+      "output": 0
+    }
+  },
+  {
+    "id": "fastrouter/google/veo3.1-fast",
+    "name": "Veo 3.1 Fast",
+    "family": "veo",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2026-05-01",
+    "last_updated": "2026-05-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 400000,
+      "output": 0
+    }
+  },
+  {
+    "id": "fastrouter/google/veo3.1-lite",
+    "name": "Veo 3.1 Lite",
+    "family": "veo",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2026-05-01",
+    "last_updated": "2026-05-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 400000,
+      "output": 0
+    }
+  },
+  {
+    "id": "fastrouter/leonardo-ai/lucid-origin",
+    "name": "Lucid Origin",
+    "family": "lucid",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2025-06-01",
+    "last_updated": "2025-06-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 4096,
+      "output": 0
+    }
+  },
+  {
+    "id": "fastrouter/leonardo-ai/lucid-realism",
+    "name": "Lucid Realism",
+    "family": "lucid",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2025-06-01",
+    "last_updated": "2025-06-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 4096,
+      "output": 0
+    }
+  },
+  {
+    "id": "fastrouter/minimax/minimax-m2.7",
+    "name": "MiniMax-M2.7",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2
+    },
+    "limit": {
+      "context": 204800,
+      "output": 131072
+    }
+  },
+  {
+    "id": "fastrouter/minimax/minimax-m2.7-highspeed",
+    "name": "MiniMax-M2.7-highspeed",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.6,
+      "output": 2.4
+    },
+    "limit": {
+      "context": 204800,
+      "output": 131072
+    }
+  },
+  {
     "id": "fastrouter/moonshotai/kimi-k2",
     "name": "Kimi K2",
     "family": "kimi",
@@ -34480,6 +35118,37 @@
     "limit": {
       "context": 131072,
       "output": 32768
+    }
+  },
+  {
+    "id": "fastrouter/moonshotai/kimi-k2.6",
+    "name": "Kimi K2.6",
+    "family": "kimi-k2.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.75,
+      "output": 3.5
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
     }
   },
   {
@@ -34607,6 +35276,185 @@
     }
   },
   {
+    "id": "fastrouter/openai/gpt-5.3-codex",
+    "name": "GPT-5.3 Codex",
+    "family": "gpt-codex",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-02-05",
+    "last_updated": "2026-02-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.75,
+      "output": 14.0
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "fastrouter/openai/gpt-5.4-mini",
+    "name": "GPT-5.4 mini",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 4.5
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "fastrouter/openai/gpt-5.4-nano",
+    "name": "GPT-5.4 nano",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.2,
+      "output": 1.25
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "fastrouter/openai/gpt-5.5",
+    "name": "GPT-5.5",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-12-01",
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "fastrouter/openai/gpt-5.5-pro",
+    "name": "GPT-5.5 Pro",
+    "family": "gpt-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-12-01",
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 30.0,
+      "output": 180.0
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "fastrouter/openai/gpt-image-2",
+    "name": "GPT Image 2",
+    "family": "gpt-image",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 128000,
+      "output": 0
+    }
+  },
+  {
     "id": "fastrouter/openai/gpt-oss-120b",
     "name": "GPT OSS 120B",
     "family": "gpt-oss",
@@ -34663,6 +35511,37 @@
     }
   },
   {
+    "id": "fastrouter/openai/gpt-realtime-1.5",
+    "name": "GPT Realtime 1.5",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-06-01",
+    "last_updated": "2025-06-01",
+    "modalities": {
+      "input": [
+        "text",
+        "audio",
+        "image"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 4.0,
+      "output": 16.0
+    },
+    "limit": {
+      "context": 32000,
+      "output": 4096
+    }
+  },
+  {
     "id": "fastrouter/qwen/qwen3-coder",
     "name": "Qwen3 Coder",
     "family": "qwen",
@@ -34689,6 +35568,87 @@
     "limit": {
       "context": 262144,
       "output": 66536
+    }
+  },
+  {
+    "id": "fastrouter/sarvam/sarvam-105b",
+    "name": "Sarvam 105B",
+    "family": "sarvam",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-09-01",
+    "last_updated": "2025-09-01",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.04,
+      "output": 0.16
+    },
+    "limit": {
+      "context": 131072,
+      "output": 131072
+    }
+  },
+  {
+    "id": "fastrouter/sarvam/sarvam-30b",
+    "name": "Sarvam 30B",
+    "family": "sarvam",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-18",
+    "last_updated": "2026-02-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.02,
+      "output": 0.1
+    },
+    "limit": {
+      "context": 128000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "fastrouter/wanx/wan-v2-6",
+    "name": "Wan 2.6",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2025-12-01",
+    "last_updated": "2025-12-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": true,
+    "cost": {},
+    "limit": {
+      "context": 400000,
+      "output": 0
     }
   },
   {
@@ -34723,6 +35683,66 @@
     }
   },
   {
+    "id": "fastrouter/x-ai/grok-4.3",
+    "name": "Grok 4.3",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-17",
+    "last_updated": "2026-04-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 2.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 30000
+    }
+  },
+  {
+    "id": "fastrouter/x-ai/grok-build-0.1",
+    "name": "Grok Build 0.1",
+    "family": "grok-build",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-16",
+    "last_updated": "2026-04-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 2.0
+    },
+    "limit": {
+      "context": 256000,
+      "output": 256000
+    }
+  },
+  {
     "id": "fastrouter/z-ai/glm-5",
     "name": "GLM-5",
     "family": "glm",
@@ -34747,6 +35767,34 @@
     },
     "limit": {
       "context": 204800,
+      "output": 131072
+    }
+  },
+  {
+    "id": "fastrouter/z-ai/glm-5.1",
+    "name": "GLM-5.1",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-27",
+    "last_updated": "2026-03-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.05,
+      "output": 3.5
+    },
+    "limit": {
+      "context": 200000,
       "output": 131072
     }
   },
@@ -35164,6 +36212,39 @@
     "limit": {
       "context": 262000,
       "output": 262000
+    }
+  },
+  {
+    "id": "freemodel/claude-fable-5",
+    "name": "Claude Fable 5",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-09",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
     }
   },
   {
@@ -38746,6 +39827,39 @@
     }
   },
   {
+    "id": "gitlab/duo-chat-fable-5",
+    "name": "Agentic Chat (Claude Fable 5)",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-09",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "gitlab/duo-chat-gpt-5-codex",
     "name": "Agentic Chat (GPT-5 Codex)",
     "family": "gpt-codex",
@@ -41705,43 +42819,13 @@
     }
   },
   {
-    "id": "groq/allam-2-7b",
-    "name": "ALLaM-2-7b",
-    "family": "allam",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2024-09",
-    "release_date": "2024-09",
-    "last_updated": "2024-09",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 4096,
-      "output": 4096
-    }
-  },
-  {
     "id": "groq/canopylabs/orpheus-arabic-saudi",
-    "name": "Orpheus Arabic Saudi",
+    "name": "Canopy Labs Orpheus Arabic Saudi",
     "family": "canopylabs",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": true,
-    "knowledge": "2025-12-16",
+    "temperature": false,
     "release_date": "2025-12-16",
     "last_updated": "2025-12-16",
     "modalities": {
@@ -41753,10 +42837,7 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 40.0,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 4000,
       "output": 50000
@@ -41764,13 +42845,12 @@
   },
   {
     "id": "groq/canopylabs/orpheus-v1-english",
-    "name": "Orpheus V1 English",
+    "name": "Canopy Labs Orpheus V1 English",
     "family": "canopylabs",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": true,
-    "knowledge": "2025-12-19",
+    "temperature": false,
     "release_date": "2025-12-19",
     "last_updated": "2025-12-19",
     "modalities": {
@@ -41782,71 +42862,10 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 4000,
       "output": 50000
-    }
-  },
-  {
-    "id": "groq/deepseek-r1-distill-llama-70b",
-    "name": "DeepSeek R1 Distill Llama 70B",
-    "family": "deepseek-thinking",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-07",
-    "release_date": "2025-01-20",
-    "last_updated": "2025-01-20",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.75,
-      "output": 0.99
-    },
-    "limit": {
-      "context": 131072,
-      "output": 8192
-    }
-  },
-  {
-    "id": "groq/gemma2-9b-it",
-    "name": "Gemma 2 9B",
-    "family": "gemma",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-06",
-    "release_date": "2024-06-27",
-    "last_updated": "2024-06-27",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.2,
-      "output": 0.2
-    },
-    "limit": {
-      "context": 8192,
-      "output": 8192
     }
   },
   {
@@ -41854,10 +42873,9 @@
     "name": "Compound",
     "family": "groq",
     "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
+    "reasoning": false,
+    "tool_call": false,
     "temperature": true,
-    "knowledge": "2025-09-04",
     "release_date": "2025-09-04",
     "last_updated": "2025-09-04",
     "modalities": {
@@ -41869,10 +42887,7 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 131072,
       "output": 8192
@@ -41883,10 +42898,9 @@
     "name": "Compound Mini",
     "family": "groq",
     "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
+    "reasoning": false,
+    "tool_call": false,
     "temperature": true,
-    "knowledge": "2025-09-04",
     "release_date": "2025-09-04",
     "last_updated": "2025-09-04",
     "modalities": {
@@ -41898,10 +42912,7 @@
       ]
     },
     "open_weights": false,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
       "context": 131072,
       "output": 8192
@@ -41909,7 +42920,7 @@
   },
   {
     "id": "groq/llama-3.1-8b-instant",
-    "name": "Llama 3.1 8B Instant",
+    "name": "Llama 3.1 8B",
     "family": "llama",
     "attachment": false,
     "reasoning": false,
@@ -41938,7 +42949,7 @@
   },
   {
     "id": "groq/llama-3.3-70b-versatile",
-    "name": "Llama 3.3 70B Versatile",
+    "name": "Llama 3.3 70B",
     "family": "llama",
     "attachment": false,
     "reasoning": false,
@@ -41966,126 +42977,10 @@
     }
   },
   {
-    "id": "groq/llama-guard-3-8b",
-    "name": "Llama Guard 3 8B",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2024-07-23",
-    "last_updated": "2024-07-23",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.2,
-      "output": 0.2
-    },
-    "limit": {
-      "context": 8192,
-      "output": 8192
-    }
-  },
-  {
-    "id": "groq/llama3-70b",
-    "name": "Llama 3 70B",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-03",
-    "release_date": "2024-04-18",
-    "last_updated": "2024-04-18",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.59,
-      "output": 0.79
-    },
-    "limit": {
-      "context": 8192,
-      "output": 8192
-    }
-  },
-  {
-    "id": "groq/llama3-8b",
-    "name": "Llama 3 8B",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-03",
-    "release_date": "2024-04-18",
-    "last_updated": "2024-04-18",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.05,
-      "output": 0.08
-    },
-    "limit": {
-      "context": 8192,
-      "output": 8192
-    }
-  },
-  {
-    "id": "groq/meta-llama/llama-4-maverick-17b-128e-instruct",
-    "name": "Llama 4 Maverick 17B",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-08",
-    "release_date": "2025-04-05",
-    "last_updated": "2025-04-05",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.2,
-      "output": 0.6
-    },
-    "limit": {
-      "context": 131072,
-      "output": 8192
-    }
-  },
-  {
     "id": "groq/meta-llama/llama-4-scout-17b-16e-instruct",
-    "name": "Llama 4 Scout 17B",
+    "name": "Llama 4 Scout 17B 16E",
     "family": "llama",
-    "attachment": false,
+    "attachment": true,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
@@ -42112,45 +43007,15 @@
     }
   },
   {
-    "id": "groq/meta-llama/llama-guard-4-12b",
-    "name": "Llama Guard 4 12B",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2025-04-05",
-    "last_updated": "2025-04-05",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.2,
-      "output": 0.2
-    },
-    "limit": {
-      "context": 131072,
-      "output": 1024
-    }
-  },
-  {
     "id": "groq/meta-llama/llama-prompt-guard-2-22m",
     "name": "Llama Prompt Guard 2 22M",
     "family": "llama",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": true,
-    "knowledge": "2024-10",
-    "release_date": "2024-10-01",
-    "last_updated": "2024-10-01",
+    "temperature": false,
+    "release_date": "2025-05-29",
+    "last_updated": "2025-05-29",
     "modalities": {
       "input": [
         "text"
@@ -42171,15 +43036,14 @@
   },
   {
     "id": "groq/meta-llama/llama-prompt-guard-2-86m",
-    "name": "Llama Prompt Guard 2 86M",
+    "name": "Prompt Guard 2 86M",
     "family": "llama",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": true,
-    "knowledge": "2024-10",
-    "release_date": "2024-10-01",
-    "last_updated": "2024-10-01",
+    "temperature": false,
+    "release_date": "2025-05-29",
+    "last_updated": "2025-05-29",
     "modalities": {
       "input": [
         "text"
@@ -42199,64 +43063,6 @@
     }
   },
   {
-    "id": "groq/mistral-saba-24b",
-    "name": "Mistral Saba 24B",
-    "family": "mistral",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-08",
-    "release_date": "2025-02-06",
-    "last_updated": "2025-02-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.79,
-      "output": 0.79
-    },
-    "limit": {
-      "context": 32768,
-      "output": 32768
-    }
-  },
-  {
-    "id": "groq/moonshotai/kimi-k2-instruct",
-    "name": "Kimi K2 Instruct",
-    "family": "kimi",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-10",
-    "release_date": "2025-07-14",
-    "last_updated": "2025-07-14",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 1.0,
-      "output": 3.0
-    },
-    "limit": {
-      "context": 131072,
-      "output": 16384
-    }
-  },
-  {
     "id": "groq/openai/gpt-oss-120b",
     "name": "GPT OSS 120B",
     "family": "gpt-oss",
@@ -42265,7 +43071,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-08-05",
-    "last_updated": "2026-05-27",
+    "last_updated": "2025-10-21",
     "modalities": {
       "input": [
         "text"
@@ -42294,7 +43100,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-08-05",
-    "last_updated": "2026-05-27",
+    "last_updated": "2025-09-25",
     "modalities": {
       "input": [
         "text"
@@ -42322,8 +43128,8 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-03-05",
-    "last_updated": "2025-03-05",
+    "release_date": "2025-10-29",
+    "last_updated": "2025-10-29",
     "modalities": {
       "input": [
         "text"
@@ -42344,45 +43150,15 @@
     }
   },
   {
-    "id": "groq/qwen-qwq-32b",
-    "name": "Qwen QwQ 32B",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-09",
-    "release_date": "2024-11-27",
-    "last_updated": "2024-11-27",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.29,
-      "output": 0.39
-    },
-    "limit": {
-      "context": 131072,
-      "output": 16384
-    }
-  },
-  {
     "id": "groq/qwen/qwen3-32b",
-    "name": "Qwen3 32B",
+    "name": "Qwen3-32B",
     "family": "qwen",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-11-08",
-    "release_date": "2024-12-23",
-    "last_updated": "2024-12-23",
+    "release_date": "2025-06-11",
+    "last_updated": "2025-06-12",
     "modalities": {
       "input": [
         "text"
@@ -42403,13 +43179,12 @@
   },
   {
     "id": "groq/whisper-large-v3",
-    "name": "Whisper Large V3",
+    "name": "Whisper",
     "family": "whisper",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
-    "knowledge": "2023-09",
     "release_date": "2023-09-01",
     "last_updated": "2025-09-05",
     "modalities": {
@@ -42421,24 +43196,20 @@
       ]
     },
     "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
-      "context": 448,
-      "output": 448
+      "context": 0,
+      "output": 0
     }
   },
   {
     "id": "groq/whisper-large-v3-turbo",
-    "name": "Whisper Large v3 Turbo",
+    "name": "Whisper Large V3 Turbo",
     "family": "whisper",
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
     "temperature": true,
-    "knowledge": "2024-10",
     "release_date": "2024-10-01",
     "last_updated": "2024-10-01",
     "modalities": {
@@ -42450,13 +43221,10 @@
       ]
     },
     "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
+    "cost": {},
     "limit": {
-      "context": 448,
-      "output": 448
+      "context": 0,
+      "output": 0
     }
   },
   {
@@ -42642,7 +43410,7 @@
     "cost": {
       "input": 1.0,
       "output": 5.0,
-      "cache_read": 0.1,
+      "cache_read": 0.09999999999999999,
       "cache_write": 1.25
     },
     "limit": {
@@ -42738,7 +43506,7 @@
     "cost": {
       "input": 1.0,
       "output": 5.0,
-      "cache_read": 0.1,
+      "cache_read": 0.09999999999999999,
       "cache_write": 1.25
     },
     "limit": {
@@ -43015,7 +43783,7 @@
     "cost": {
       "input": 0.27,
       "output": 1.0,
-      "cache_read": 0.21600000000000005
+      "cache_read": 0.21600000000000003
     },
     "limit": {
       "context": 128000,
@@ -43134,10 +43902,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.1,
-      "output": 0.4,
-      "cache_read": 0.025,
-      "cache_write": 0.1
+      "input": 0.09999999999999999,
+      "output": 0.39999999999999997,
+      "cache_read": 0.024999999999999998,
+      "cache_write": 0.09999999999999999
     },
     "limit": {
       "context": 1048576,
@@ -43202,7 +43970,7 @@
     "cost": {
       "input": 2.0,
       "output": 12.0,
-      "cache_read": 0.2
+      "cache_read": 0.19999999999999998
     },
     "limit": {
       "context": 1048576,
@@ -43231,8 +43999,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.05,
-      "output": 0.1
+      "input": 0.049999999999999996,
+      "output": 0.09999999999999999
     },
     "limit": {
       "context": 131072,
@@ -43289,7 +44057,7 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.45,
+      "input": 0.44999999999999996,
       "output": 1.5
     },
     "limit": {
@@ -43350,9 +44118,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.4,
-      "output": 1.6,
-      "cache_read": 0.1
+      "input": 0.39999999999999997,
+      "output": 1.5999999999999999,
+      "cache_read": 0.09999999999999999
     },
     "limit": {
       "context": 1047576,
@@ -43381,9 +44149,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.1,
-      "output": 0.4,
-      "cache_read": 0.025
+      "input": 0.09999999999999999,
+      "output": 0.39999999999999997,
+      "cache_read": 0.024999999999999998
     },
     "limit": {
       "context": 1047576,
@@ -43568,7 +44336,7 @@
     "cost": {
       "input": 0.25,
       "output": 2.0,
-      "cache_read": 0.025
+      "cache_read": 0.024999999999999998
     },
     "limit": {
       "context": 400000,
@@ -43597,8 +44365,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.05,
-      "output": 0.4,
+      "input": 0.049999999999999996,
+      "output": 0.39999999999999997,
       "cache_read": 0.005
     },
     "limit": {
@@ -43756,7 +44524,7 @@
     "cost": {
       "input": 0.25,
       "output": 2.0,
-      "cache_read": 0.025
+      "cache_read": 0.024999999999999998
     },
     "limit": {
       "context": 400000,
@@ -43813,8 +44581,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.05,
-      "output": 0.2
+      "input": 0.049999999999999996,
+      "output": 0.19999999999999998
     },
     "limit": {
       "context": 131072,
@@ -43934,9 +44702,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.2,
+      "input": 0.19999999999999998,
       "output": 0.5,
-      "cache_read": 0.05
+      "cache_read": 0.049999999999999996
     },
     "limit": {
       "context": 2000000,
@@ -43965,9 +44733,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.2,
+      "input": 0.19999999999999998,
       "output": 0.5,
-      "cache_read": 0.05
+      "cache_read": 0.049999999999999996
     },
     "limit": {
       "context": 2000000,
@@ -43997,9 +44765,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.2,
+      "input": 0.19999999999999998,
       "output": 0.5,
-      "cache_read": 0.05
+      "cache_read": 0.049999999999999996
     },
     "limit": {
       "context": 2000000,
@@ -44028,9 +44796,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.2,
+      "input": 0.19999999999999998,
       "output": 0.5,
-      "cache_read": 0.05
+      "cache_read": 0.049999999999999996
     },
     "limit": {
       "context": 2000000,
@@ -44058,7 +44826,7 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.2,
+      "input": 0.19999999999999998,
       "output": 1.5,
       "cache_read": 0.02
     },
@@ -44119,7 +44887,7 @@
     "cost": {
       "input": 0.5,
       "output": 2.0,
-      "cache_read": 0.4
+      "cache_read": 0.39999999999999997
     },
     "limit": {
       "context": 262144,
@@ -44176,7 +44944,7 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.05,
+      "input": 0.049999999999999996,
       "output": 0.08
     },
     "limit": {
@@ -44206,7 +44974,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.02,
-      "output": 0.05
+      "output": 0.049999999999999996
     },
     "limit": {
       "context": 16384,
@@ -44891,7 +45659,7 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.1,
+      "input": 0.09999999999999999,
       "output": 0.3
     },
     "limit": {
@@ -64254,6 +65022,174 @@
     }
   },
   {
+    "id": "llmtr/gemma-4",
+    "name": "Gemma 4",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 5.0,
+      "output": 10.0
+    },
+    "limit": {
+      "context": 32768,
+      "output": 8192
+    }
+  },
+  {
+    "id": "llmtr/magibu-11b-v8",
+    "name": "Magibu 11B v8",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-06-05",
+    "last_updated": "2026-06-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 8192,
+      "output": 4096
+    }
+  },
+  {
+    "id": "llmtr/medgemma-4b",
+    "name": "MedGemma 4B",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-04-26",
+    "last_updated": "2026-04-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 3.0,
+      "output": 5.0
+    },
+    "limit": {
+      "context": 8192,
+      "output": 4096
+    }
+  },
+  {
+    "id": "llmtr/qwen3-6-35b",
+    "name": "Qwen3.6 35B-A3B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-17",
+    "last_updated": "2026-04-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 5.0,
+      "output": 10.0
+    },
+    "limit": {
+      "context": 16384,
+      "output": 65536
+    }
+  },
+  {
+    "id": "llmtr/sincap",
+    "name": "Sincap",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-05-05",
+    "last_updated": "2026-05-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 8192
+    }
+  },
+  {
+    "id": "llmtr/trendyol-7b",
+    "name": "Trendyol 7B",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-06-06",
+    "last_updated": "2026-06-06",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 32768,
+      "output": 8192
+    }
+  },
+  {
     "id": "lmstudio/openai/gpt-oss-20b",
     "name": "GPT OSS 20B",
     "family": "gpt-oss",
@@ -69863,7 +70799,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.08,
-      "output": 0.24
+      "output": 0.24000000000000002
     },
     "limit": {
       "context": 128000,
@@ -72718,7 +73654,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.15,
-      "output": 0.45
+      "output": 0.44999999999999996
     },
     "limit": {
       "context": 262000,
@@ -73249,7 +74185,7 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.14,
+      "input": 0.13999999999999999,
       "output": 0.6
     },
     "limit": {
@@ -73576,7 +74512,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.3,
-      "output": 0.45
+      "output": 0.44999999999999996
     },
     "limit": {
       "context": 128000,
@@ -74490,7 +75426,7 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.14,
+      "input": 0.13999999999999999,
       "output": 0.5599999999999999
     },
     "limit": {
@@ -75784,7 +76720,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.27999999999999997,
-      "output": 0.42
+      "output": 0.42000000000000004
     },
     "limit": {
       "context": 163840,
@@ -75811,7 +76747,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.27999999999999997,
-      "output": 0.42
+      "output": 0.42000000000000004
     },
     "limit": {
       "context": 163840,
@@ -76103,7 +77039,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.27999999999999997,
-      "output": 0.42
+      "output": 0.42000000000000004
     },
     "limit": {
       "context": 163000,
@@ -76131,7 +77067,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.27999999999999997,
-      "output": 0.42
+      "output": 0.42000000000000004
     },
     "limit": {
       "context": 163000,
@@ -76159,7 +77095,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.27999999999999997,
-      "output": 0.42
+      "output": 0.42000000000000004
     },
     "limit": {
       "context": 163000,
@@ -79856,7 +80792,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.1394,
-      "output": 1.122
+      "output": 1.1219999999999999
     },
     "limit": {
       "context": 1000192,
@@ -79883,7 +80819,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.30200000000000005,
-      "output": 1.207
+      "output": 1.2069999999999999
     },
     "limit": {
       "context": 65532,
@@ -81157,7 +82093,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.27999999999999997,
-      "output": 0.42
+      "output": 0.42000000000000004
     },
     "limit": {
       "context": 128000,
@@ -84851,7 +85787,7 @@
     "open_weights": false,
     "cost": {
       "input": 0.7989999999999999,
-      "output": 1.207
+      "output": 1.2069999999999999
     },
     "limit": {
       "context": 6144,
@@ -90412,7 +91348,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 32768
     }
   },
   {
@@ -92143,64 +93079,6 @@
     }
   },
   {
-    "id": "nvidia/deepseek-ai/deepseek-v3.1-terminus",
-    "name": "DeepSeek V3.1 Terminus",
-    "family": "deepseek",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2025-09-22",
-    "last_updated": "2025-09-22",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nvidia/deepseek-ai/deepseek-v3.2",
-    "name": "DeepSeek V3.2",
-    "family": "deepseek",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-07",
-    "release_date": "2025-12-01",
-    "last_updated": "2025-12-01",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 163840,
-      "output": 65536
-    }
-  },
-  {
     "id": "nvidia/deepseek-ai/deepseek-v4-flash",
     "name": "DeepSeek V4 Flash",
     "family": "deepseek-flash",
@@ -92285,36 +93163,6 @@
     "limit": {
       "context": 128000,
       "output": 4096
-    }
-  },
-  {
-    "id": "nvidia/google/gemma-3-27b-it",
-    "name": "Gemma-3-27B-IT",
-    "family": "gemma",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-12",
-    "release_date": "2024-12-01",
-    "last_updated": "2025-09-05",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 131072,
-      "output": 8192
     }
   },
   {
@@ -92748,8 +93596,8 @@
     "id": "nvidia/microsoft/phi-4-mini-instruct",
     "name": "Phi-4-Mini",
     "family": "phi",
-    "attachment": true,
-    "reasoning": true,
+    "attachment": false,
+    "reasoning": false,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2024-12",
@@ -92757,15 +93605,13 @@
     "last_updated": "2025-09-05",
     "modalities": {
       "input": [
-        "text",
-        "image",
-        "audio"
+        "text"
       ],
       "output": [
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.0,
       "output": 0.0
@@ -92802,35 +93648,6 @@
     }
   },
   {
-    "id": "nvidia/minimaxai/minimax-m2.5",
-    "name": "MiniMax-M2.5",
-    "family": "minimax",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-08",
-    "release_date": "2026-02-12",
-    "last_updated": "2026-02-12",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 204800,
-      "output": 131072
-    }
-  },
-  {
     "id": "nvidia/minimaxai/minimax-m2.7",
     "name": "MiniMax-M2.7",
     "family": "minimax",
@@ -92856,35 +93673,6 @@
     "limit": {
       "context": 204800,
       "output": 131072
-    }
-  },
-  {
-    "id": "nvidia/mistralai/devstral-2-123b-instruct",
-    "name": "Devstral-2-123B-Instruct-2512",
-    "family": "devstral",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-12",
-    "release_date": "2025-12-08",
-    "last_updated": "2025-12-09",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 262144,
-      "output": 262144
     }
   },
   {
@@ -93029,15 +93817,16 @@
   {
     "id": "nvidia/mistralai/mistral-small-4-119b",
     "name": "mistral-small-4-119b-2603",
-    "attachment": false,
-    "reasoning": false,
+    "attachment": true,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-03-16",
     "last_updated": "2026-03-16",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image"
       ],
       "output": [
         "text"
@@ -93109,44 +93898,15 @@
   },
   {
     "id": "nvidia/moonshotai/kimi-k2-instruct",
-    "name": "Kimi K2 Instruct",
+    "name": "Kimi K2 0905",
     "family": "kimi",
     "attachment": false,
-    "reasoning": true,
+    "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-01",
-    "release_date": "2025-01-01",
+    "knowledge": "2024-10",
+    "release_date": "2025-09-05",
     "last_updated": "2025-09-05",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nvidia/moonshotai/kimi-k2-thinking",
-    "name": "Kimi K2 Thinking",
-    "family": "kimi-thinking",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
-    "release_date": "2025-11",
-    "last_updated": "2025-12",
     "modalities": {
       "input": [
         "text"
@@ -93158,9 +93918,7 @@
     "open_weights": true,
     "cost": {
       "input": 0.0,
-      "output": 0.0,
-      "cache_read": 0.0,
-      "cache_write": 0.0
+      "output": 0.0
     },
     "limit": {
       "context": 262144,
@@ -93419,64 +94177,6 @@
     "limit": {
       "context": 32768,
       "output": 2048
-    }
-  },
-  {
-    "id": "nvidia/nvidia/llama-3_3-nemotron-super-49b-v1",
-    "name": "Llama 3.3 Nemotron Super 49B v1",
-    "family": "nemotron",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-12",
-    "release_date": "2025-04-07",
-    "last_updated": "2025-04-07",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 131072,
-      "output": 131072
-    }
-  },
-  {
-    "id": "nvidia/nvidia/llama-3_3-nemotron-super-49b-v1_5",
-    "name": "Llama 3.3 Nemotron Super 49B v1.5",
-    "family": "nemotron",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-12",
-    "release_date": "2025-07-25",
-    "last_updated": "2025-07-25",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 131072,
-      "output": 131072
     }
   },
   {
@@ -94099,9 +94799,9 @@
     "id": "nvidia/openai/gpt-oss-120b",
     "name": "GPT-OSS-120B",
     "family": "gpt-oss",
-    "attachment": true,
+    "attachment": false,
     "reasoning": true,
-    "tool_call": false,
+    "tool_call": true,
     "temperature": true,
     "knowledge": "2025-08",
     "release_date": "2025-08-04",
@@ -94114,7 +94814,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.0,
       "output": 0.0
@@ -94325,35 +95025,6 @@
     }
   },
   {
-    "id": "nvidia/qwen/qwen3-next-80b-a3b-thinking",
-    "name": "Qwen3-Next-80B-A3B-Thinking",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-12",
-    "release_date": "2024-12-01",
-    "last_updated": "2025-09-05",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 262144,
-      "output": 16384
-    }
-  },
-  {
     "id": "nvidia/qwen/qwen3.5-122b-a10b",
     "name": "Qwen3.5 122B-A10B",
     "family": "qwen",
@@ -94548,35 +95219,6 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
-    }
-  },
-  {
-    "id": "nvidia/z-ai/glm4.7",
-    "name": "GLM-4.7",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-04",
-    "release_date": "2025-12-22",
-    "last_updated": "2025-12-22",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 204800,
       "output": 131072
     }
   },
@@ -97972,7 +98614,7 @@
     "cost": {
       "input": 0.14,
       "output": 0.28,
-      "cache_read": 0.03
+      "cache_read": 0.028
     },
     "limit": {
       "context": 1000000,
@@ -98007,6 +98649,36 @@
     "limit": {
       "context": 200000,
       "output": 128000
+    }
+  },
+  {
+    "id": "opencode/deepseek-v4-pro",
+    "name": "DeepSeek V4 Pro",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.74,
+      "output": 3.84,
+      "cache_read": 0.145
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
     }
   },
   {
@@ -100127,6 +100799,39 @@
     }
   },
   {
+    "id": "openrouter/anthropic/claude-fable-5",
+    "name": "Claude Fable 5",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-09",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "openrouter/anthropic/claude-haiku-4.5",
     "name": "Claude Haiku 4.5 (latest)",
     "family": "claude-haiku",
@@ -100577,34 +101282,6 @@
     "limit": {
       "context": 32768,
       "output": 32768
-    }
-  },
-  {
-    "id": "openrouter/arcee-ai/maestro-reasoning",
-    "name": "Maestro Reasoning",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2025-03-31",
-    "release_date": "2025-05-05",
-    "last_updated": "2025-05-05",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.9,
-      "output": 3.3
-    },
-    "limit": {
-      "context": 131072,
-      "output": 32000
     }
   },
   {
@@ -101100,7 +101777,7 @@
       "cache_read": 0.135
     },
     "limit": {
-      "context": 163840,
+      "context": 32768,
       "output": 16384
     }
   },
@@ -103306,7 +103983,8 @@
     "open_weights": true,
     "cost": {
       "input": 0.15,
-      "output": 1.15
+      "output": 0.9,
+      "cache_read": 0.05
     },
     "limit": {
       "context": 196608,
@@ -103333,12 +104011,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.279,
-      "output": 1.2
+      "input": 0.27,
+      "output": 1.08,
+      "cache_read": 0.054
     },
     "limit": {
-      "context": 196608,
-      "output": 196608
+      "context": 204800,
+      "output": 131072
     }
   },
   {
@@ -104009,36 +104688,6 @@
     "limit": {
       "context": 262142,
       "output": 262142
-    }
-  },
-  {
-    "id": "openrouter/moonshotai/kimi-k2.6:free",
-    "name": "Kimi K2.6 (free)",
-    "family": "kimi-k2.6",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2025-01",
-    "release_date": "2026-04-21",
-    "last_updated": "2026-04-21",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 262144,
-      "output": 262144
     }
   },
   {
@@ -108988,35 +109637,6 @@
     }
   },
   {
-    "id": "openrouter/z-ai/glm-4-32b",
-    "name": "GLM 4 32B ",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-06-30",
-    "release_date": "2025-07-24",
-    "last_updated": "2025-07-24",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.1,
-      "output": 0.1
-    },
-    "limit": {
-      "context": 128000,
-      "output": 128000
-    }
-  },
-  {
     "id": "openrouter/z-ai/glm-4.5",
     "name": "GLM-4.5",
     "family": "glm",
@@ -109074,35 +109694,6 @@
     "limit": {
       "context": 131070,
       "output": 131070
-    }
-  },
-  {
-    "id": "openrouter/z-ai/glm-4.5-air:free",
-    "name": "GLM 4.5 Air (free)",
-    "family": "glm-air",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-04",
-    "release_date": "2025-07-28",
-    "last_updated": "2025-07-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 131072,
-      "output": 96000
     }
   },
   {
@@ -109191,11 +109782,11 @@
     "cost": {
       "input": 0.3,
       "output": 0.9,
-      "cache_read": 0.05
+      "cache_read": 0.055
     },
     "limit": {
       "context": 131072,
-      "output": 24000
+      "output": 32768
     }
   },
   {
@@ -109312,7 +109903,7 @@
       "cache_read": 0.24
     },
     "limit": {
-      "context": 202752,
+      "context": 262144,
       "output": 131072
     }
   },
@@ -109346,20 +109937,20 @@
     }
   },
   {
-    "id": "openrouter/z-ai/glm-5v-turbo",
-    "name": "GLM-5V-Turbo",
-    "family": "glm",
+    "id": "openrouter/~anthropic/claude-fable",
+    "name": "Claude Fable Latest",
+    "family": "claude-fable",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-04-01",
-    "last_updated": "2026-04-01",
+    "temperature": false,
+    "release_date": "2026-06-09",
+    "last_updated": "2026-06-09",
     "modalities": {
       "input": [
-        "image",
         "text",
-        "video"
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -109367,13 +109958,14 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 1.2,
-      "output": 4.0,
-      "cache_read": 0.24
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
     },
     "limit": {
-      "context": 202752,
-      "output": 131072
+      "context": 1000000,
+      "output": 128000
     }
   },
   {
@@ -131120,13 +131712,11 @@
   {
     "id": "venice/aion-labs-aion-2.0",
     "name": "Aion 2.0",
-    "family": "o",
     "attachment": false,
     "reasoning": true,
     "tool_call": false,
-    "temperature": true,
     "release_date": "2026-03-24",
-    "last_updated": "2026-04-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -131153,9 +131743,8 @@
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
     "release_date": "2026-04-02",
-    "last_updated": "2026-04-04",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -131176,6 +131765,38 @@
     }
   },
   {
+    "id": "venice/claude-fable-5",
+    "name": "Claude Fable 5",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-10",
+    "last_updated": "2026-06-11",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 12.0,
+      "output": 60.0,
+      "cache_read": 1.2,
+      "cache_write": 15.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "venice/claude-opus-4.5",
     "name": "Claude Opus 4.5",
     "family": "claude-opus",
@@ -131183,8 +131804,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-03-31",
     "release_date": "2025-12-06",
-    "last_updated": "2026-04-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -131216,7 +131838,7 @@
     "temperature": true,
     "knowledge": "2025-05-31",
     "release_date": "2026-02-05",
-    "last_updated": "2026-03-16",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -131248,7 +131870,7 @@
     "temperature": true,
     "knowledge": "2025-05-31",
     "release_date": "2026-04-08",
-    "last_updated": "2026-04-08",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -131278,8 +131900,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01-31",
     "release_date": "2026-04-16",
-    "last_updated": "2026-04-16",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -131308,9 +131931,10 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
     "release_date": "2026-05-14",
-    "last_updated": "2026-05-14",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -131339,9 +131963,9 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
     "release_date": "2026-05-28",
-    "last_updated": "2026-05-28",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -131370,9 +131994,9 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
     "release_date": "2026-05-28",
-    "last_updated": "2026-05-28",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -131402,8 +132026,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-07-31",
     "release_date": "2025-01-15",
-    "last_updated": "2026-04-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -131435,7 +132060,7 @@
     "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-17",
-    "last_updated": "2026-03-16",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -131464,10 +132089,8 @@
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-10",
     "release_date": "2025-12-04",
-    "last_updated": "2026-03-24",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -131490,13 +132113,14 @@
   {
     "id": "venice/deepseek-v4-flash",
     "name": "DeepSeek V4 Flash",
-    "family": "deepseek-flash",
+    "family": "deepseek",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-05",
     "release_date": "2026-04-24",
-    "last_updated": "2026-04-29",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -131524,8 +132148,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-05",
     "release_date": "2026-04-24",
-    "last_updated": "2026-04-29",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -131548,20 +132173,20 @@
   {
     "id": "venice/gemini-3-flash-preview",
     "name": "Gemini 3 Flash Preview",
-    "family": "gemini-flash",
+    "family": "gemini",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-01",
     "release_date": "2025-12-19",
-    "last_updated": "2026-03-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
         "image",
-        "audio",
         "video",
+        "audio",
         "pdf"
       ],
       "output": [
@@ -131582,13 +132207,14 @@
   {
     "id": "venice/gemini-3.1-pro-preview",
     "name": "Gemini 3.1 Pro Preview",
-    "family": "gemini-pro",
+    "family": "gemini",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-01",
     "release_date": "2026-02-19",
-    "last_updated": "2026-03-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -131615,13 +132241,14 @@
   {
     "id": "venice/gemini-3.5-flash",
     "name": "Gemini 3.5 Flash",
-    "family": "gemini-flash",
+    "family": "gemini",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-01",
     "release_date": "2026-05-22",
-    "last_updated": "2026-05-25",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -131652,9 +132279,8 @@
     "attachment": true,
     "reasoning": false,
     "tool_call": true,
-    "temperature": true,
     "release_date": "2026-04-13",
-    "last_updated": "2026-04-19",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -131681,10 +132307,8 @@
     "attachment": true,
     "reasoning": false,
     "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
     "release_date": "2025-11-04",
-    "last_updated": "2026-03-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -131713,7 +132337,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-04-02",
-    "last_updated": "2026-04-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -131743,7 +132367,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-04-03",
-    "last_updated": "2026-06-08",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -131772,9 +132396,8 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
     "release_date": "2026-03-12",
-    "last_updated": "2026-05-07",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -131802,9 +132425,8 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": false,
-    "temperature": true,
     "release_date": "2026-03-12",
-    "last_updated": "2026-05-07",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -131834,7 +132456,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-04-18",
-    "last_updated": "2026-05-04",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -131864,7 +132486,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-05-21",
-    "last_updated": "2026-05-22",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -131892,10 +132514,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "temperature": true,
-    "knowledge": "2024-04",
     "release_date": "2025-09-25",
-    "last_updated": "2026-03-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -131921,10 +132541,10 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
     "knowledge": "2024-04",
     "release_date": "2026-01-27",
-    "last_updated": "2026-04-30",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -131953,8 +132573,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-01",
     "release_date": "2026-04-20",
-    "last_updated": "2026-04-30",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -131982,10 +132603,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-12",
     "release_date": "2024-10-03",
-    "last_updated": "2026-03-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -132011,10 +132630,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-12",
     "release_date": "2025-04-06",
-    "last_updated": "2026-03-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -132040,9 +132657,8 @@
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
     "release_date": "2026-02-20",
-    "last_updated": "2026-04-09",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -132071,7 +132687,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-02-12",
-    "last_updated": "2026-04-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -132080,7 +132696,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.34,
       "output": 1.19,
@@ -132100,7 +132716,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-03-18",
-    "last_updated": "2026-04-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -132109,11 +132725,11 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.375,
       "output": 1.5,
-      "cache_read": 0.075
+      "cache_read": 0.06875
     },
     "limit": {
       "context": 198000,
@@ -132129,7 +132745,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-06-01",
-    "last_updated": "2026-06-04",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -132159,8 +132775,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-06",
     "release_date": "2026-03-16",
-    "last_updated": "2026-04-09",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -132187,9 +132804,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
-    "temperature": true,
     "release_date": "2026-01-15",
-    "last_updated": "2026-03-16",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -132217,7 +132833,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-01-27",
-    "last_updated": "2026-03-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -132240,16 +132856,15 @@
     "id": "venice/nvidia-nemotron-3-ultra-550b-a55b",
     "name": "NVIDIA Nemotron 3 Ultra",
     "family": "nemotron",
-    "attachment": true,
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-06-04",
-    "last_updated": "2026-06-08",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
-        "text",
-        "image"
+        "text"
       ],
       "output": [
         "text"
@@ -132275,7 +132890,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-03-24",
-    "last_updated": "2026-04-09",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -132297,13 +132912,12 @@
   {
     "id": "venice/olafangensan-glm-4.7-flash-heretic",
     "name": "GLM 4.7 Flash Heretic",
-    "family": "glm-flash",
+    "family": "glm",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
     "release_date": "2026-02-04",
-    "last_updated": "2026-03-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -132330,8 +132944,9 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2023-09",
     "release_date": "2026-02-28",
-    "last_updated": "2026-03-06",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -132354,13 +132969,14 @@
   {
     "id": "venice/openai-gpt-4o-mini",
     "name": "GPT-4o Mini",
-    "family": "gpt-mini",
+    "family": "gpt",
     "attachment": true,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2023-09",
     "release_date": "2026-02-28",
-    "last_updated": "2026-03-06",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -132388,10 +133004,10 @@
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
     "knowledge": "2025-08-31",
     "release_date": "2025-12-13",
-    "last_updated": "2026-03-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -132414,14 +133030,14 @@
   {
     "id": "venice/openai-gpt-52-codex",
     "name": "GPT-5.2 Codex",
-    "family": "gpt-codex",
+    "family": "gpt",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
     "knowledge": "2025-08",
     "release_date": "2025-01-15",
-    "last_updated": "2026-03-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -132445,13 +133061,14 @@
   {
     "id": "venice/openai-gpt-53-codex",
     "name": "GPT-5.3 Codex",
-    "family": "gpt-codex",
+    "family": "gpt",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
     "release_date": "2026-02-24",
-    "last_updated": "2026-03-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -132479,9 +133096,10 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
-    "last_updated": "2026-03-09",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -132505,13 +133123,14 @@
   {
     "id": "venice/openai-gpt-54-mini",
     "name": "GPT-5.4 Mini",
-    "family": "gpt-mini",
+    "family": "gpt",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
     "release_date": "2026-03-27",
-    "last_updated": "2026-03-31",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -132535,13 +133154,14 @@
   {
     "id": "venice/openai-gpt-54-pro",
     "name": "GPT-5.4 Pro",
-    "family": "gpt-pro",
+    "family": "gpt",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
-    "last_updated": "2026-03-09",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -132568,9 +133188,10 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
+    "knowledge": "2025-12-01",
     "release_date": "2026-04-23",
-    "last_updated": "2026-04-25",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -132594,13 +133215,14 @@
   {
     "id": "venice/openai-gpt-55-pro",
     "name": "GPT-5.5 Pro",
-    "family": "gpt-pro",
+    "family": "gpt",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
+    "knowledge": "2025-12-01",
     "release_date": "2026-04-24",
-    "last_updated": "2026-04-25",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -132627,10 +133249,8 @@
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
     "release_date": "2025-11-06",
-    "last_updated": "2026-05-06",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -132657,8 +133277,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-04",
     "release_date": "2026-04-06",
-    "last_updated": "2026-04-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -132690,7 +133311,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-05-22",
-    "last_updated": "2026-05-25",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -132719,8 +133340,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-04",
     "release_date": "2026-06-02",
-    "last_updated": "2026-06-04",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -132750,10 +133372,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
     "release_date": "2025-04-29",
-    "last_updated": "2026-03-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -132779,10 +133399,8 @@
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
     "release_date": "2025-04-29",
-    "last_updated": "2026-03-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -132810,7 +133428,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-02-25",
-    "last_updated": "2026-05-25",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -132841,7 +133459,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-02-16",
-    "last_updated": "2026-04-16",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -132869,9 +133487,8 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
     "release_date": "2026-03-05",
-    "last_updated": "2026-04-19",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -132900,7 +133517,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-04-24",
-    "last_updated": "2026-04-29",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -132928,9 +133545,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
-    "temperature": true,
     "release_date": "2026-01-27",
-    "last_updated": "2026-02-26",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -132957,10 +133573,8 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
     "release_date": "2025-04-29",
-    "last_updated": "2026-03-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -132982,13 +133596,11 @@
   {
     "id": "venice/qwen3-vl-235b-a22b",
     "name": "Qwen3 VL 235B",
-    "family": "qwen",
     "attachment": true,
     "reasoning": false,
     "tool_call": true,
-    "temperature": true,
     "release_date": "2026-01-16",
-    "last_updated": "2026-03-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -133009,15 +133621,43 @@
     }
   },
   {
+    "id": "venice/tencent-hy3-preview",
+    "name": "Hy3 Preview",
+    "family": "hy3",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-08",
+    "last_updated": "2026-06-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.063,
+      "output": 0.21,
+      "cache_read": 0.021
+    },
+    "limit": {
+      "context": 256000,
+      "output": 32768
+    }
+  },
+  {
     "id": "venice/venice-uncensored-1.2",
     "name": "Venice Uncensored 1.2",
     "family": "venice",
     "attachment": true,
     "reasoning": false,
     "tool_call": true,
-    "temperature": true,
     "release_date": "2026-04-01",
-    "last_updated": "2026-04-19",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -133044,9 +133684,8 @@
     "attachment": true,
     "reasoning": false,
     "tool_call": true,
-    "temperature": true,
     "release_date": "2026-02-20",
-    "last_updated": "2026-03-16",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -133075,7 +133714,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-03-15",
-    "last_updated": "2026-04-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -133098,13 +133737,13 @@
   {
     "id": "venice/z-ai-glm-5v-turbo",
     "name": "GLM 5V Turbo",
-    "family": "glmv",
+    "family": "glm",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-04-01",
-    "last_updated": "2026-04-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text",
@@ -133133,8 +133772,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-04",
     "release_date": "2024-04-01",
-    "last_updated": "2026-04-04",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -133164,7 +133804,7 @@
     "temperature": true,
     "knowledge": "2025-04",
     "release_date": "2025-12-24",
-    "last_updated": "2026-03-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -133187,13 +133827,14 @@
   {
     "id": "venice/zai-org-glm-4.7-flash",
     "name": "GLM 4.7 Flash",
-    "family": "glm-flash",
+    "family": "glm",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-04",
     "release_date": "2026-01-29",
-    "last_updated": "2026-03-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -133221,7 +133862,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-02-11",
-    "last_updated": "2026-03-12",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -133250,7 +133891,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-04-07",
-    "last_updated": "2026-04-08",
+    "last_updated": "2026-06-11",
     "modalities": {
       "input": [
         "text"
@@ -136599,7 +137240,7 @@
     "cost": {
       "input": 0.25,
       "output": 0.75,
-      "cache_read": 0.025
+      "cache_read": 0.024999999999999998
     },
     "limit": {
       "context": 128000,
@@ -138008,9 +138649,8 @@
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-10",
-    "release_date": "2025-07-14",
-    "last_updated": "2025-07-14",
+    "release_date": "2025-09-05",
+    "last_updated": "2025-09-05",
     "modalities": {
       "input": [
         "text"
@@ -138019,14 +138659,14 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
-      "input": 1.0,
-      "output": 3.0
+      "input": 0.57,
+      "output": 2.3
     },
     "limit": {
       "context": 131072,
-      "output": 16384
+      "output": 131072
     }
   },
   {
@@ -143875,6 +144515,36 @@
     }
   },
   {
+    "id": "xiaomi/mimo-v2.5-pro-ultraspeed",
+    "name": "MiMo-V2.5-Pro-UltraSpeed",
+    "family": "mimo",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-06-08",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.305,
+      "output": 2.61,
+      "cache_read": 0.0108
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
     "id": "xpersona/xpersona-frieren-coder",
     "name": "Xpersona Frieren 1",
     "attachment": false,
@@ -144553,6 +145223,39 @@
     "limit": {
       "context": 200000,
       "output": 64000
+    }
+  },
+  {
+    "id": "zenmux/anthropic/claude-fable-5",
+    "name": "Claude Fable 5",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-09",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
     }
   },
   {
@@ -146641,34 +147344,6 @@
     }
   },
   {
-    "id": "zenmux/stepfun/step-3.5-flash-free",
-    "name": "Step 3.5 Flash (Free)",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-01-01",
-    "release_date": "2026-02-02",
-    "last_updated": "2026-02-02",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 256000,
-      "output": 64000
-    }
-  },
-  {
     "id": "zenmux/stepfun/step-3.7-flash",
     "name": "Step 3.7 Flash",
     "attachment": true,
@@ -146691,6 +147366,35 @@
     "cost": {
       "input": 0.2,
       "output": 1.15
+    },
+    "limit": {
+      "context": 256000,
+      "output": 256000
+    }
+  },
+  {
+    "id": "zenmux/stepfun/step-3.7-flash-free",
+    "name": "Step 3.7 Flash (Free)",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2026-01-01",
+    "release_date": "2026-05-29",
+    "last_updated": "2026-05-29",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
     },
     "limit": {
       "context": 256000,

--- a/crates/goose-providers/src/canonical/data/provider_metadata.json
+++ b/crates/goose-providers/src/canonical/data/provider_metadata.json
@@ -229,7 +229,7 @@
     "env": [
       "CORTECS_API_KEY"
     ],
-    "model_count": 50
+    "model_count": 51
   },
   {
     "id": "crof",
@@ -318,7 +318,7 @@
     "env": [
       "FASTROUTER_API_KEY"
     ],
-    "model_count": 15
+    "model_count": 47
   },
   {
     "id": "firepass",
@@ -351,7 +351,7 @@
     "env": [
       "FREEMODEL_API_KEY"
     ],
-    "model_count": 9
+    "model_count": 10
   },
   {
     "id": "friendli",
@@ -552,17 +552,6 @@
     "model_count": 4
   },
   {
-    "id": "meta-llama",
-    "display_name": "Llama",
-    "npm": "@ai-sdk/openai-compatible",
-    "api": "https://api.llama.com/compat/v1/",
-    "doc": "https://llama.developer.meta.com/docs/models",
-    "env": [
-      "LLAMA_API_KEY"
-    ],
-    "model_count": 7
-  },
-  {
     "id": "llmgateway",
     "display_name": "LLM Gateway",
     "npm": "@ai-sdk/openai-compatible",
@@ -572,6 +561,17 @@
       "LLMGATEWAY_API_KEY"
     ],
     "model_count": 191
+  },
+  {
+    "id": "llmtr",
+    "display_name": "LLMTR",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://llmtr.com/v1",
+    "doc": "https://llmtr.com/docs",
+    "env": [
+      "LLMTR_API_KEY"
+    ],
+    "model_count": 6
   },
   {
     "id": "lmstudio",
@@ -605,6 +605,17 @@
       "MEGANOVA_API_KEY"
     ],
     "model_count": 19
+  },
+  {
+    "id": "meta-llama",
+    "display_name": "Llama",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.llama.com/compat/v1/",
+    "doc": "https://llama.developer.meta.com/docs/models",
+    "env": [
+      "LLAMA_API_KEY"
+    ],
+    "model_count": 7
   },
   {
     "id": "minimax",
@@ -791,7 +802,7 @@
     "env": [
       "NVIDIA_API_KEY"
     ],
-    "model_count": 94
+    "model_count": 83
   },
   {
     "id": "ollama-cloud",
@@ -813,7 +824,7 @@
     "env": [
       "OPENCODE_API_KEY"
     ],
-    "model_count": 69
+    "model_count": 70
   },
   {
     "id": "opencode-go",
@@ -1167,7 +1178,7 @@
     "env": [
       "XIAOMI_API_KEY"
     ],
-    "model_count": 5
+    "model_count": 6
   },
   {
     "id": "xiaomi-token-plan-ams",
@@ -1244,7 +1255,7 @@
     "env": [
       "ZENMUX_API_KEY"
     ],
-    "model_count": 107
+    "model_count": 108
   },
   {
     "id": "zhipuai",

--- a/crates/goose-providers/src/canonical/model.rs
+++ b/crates/goose-providers/src/canonical/model.rs
@@ -62,6 +62,14 @@ pub struct Limit {
     pub output: Option<usize>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ThinkingMode {
+    Enabled,
+    Adaptive,
+    AlwaysOnAdaptive,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CanonicalModel {
     /// Model identifier (e.g., "anthropic/claude-3-5-sonnet")
@@ -81,6 +89,10 @@ pub struct CanonicalModel {
     /// Whether the model supports reasoning/thinking
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<bool>,
+
+    /// Request shape to use when enabling thinking/reasoning.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking_mode: Option<ThinkingMode>,
 
     /// Whether the model supports tool calling
     #[serde(default)]

--- a/crates/goose/src/bin/build_canonical_models.rs
+++ b/crates/goose/src/bin/build_canonical_models.rs
@@ -12,7 +12,7 @@ use clap::Parser;
 use goose::providers::create_with_named_model;
 use goose_providers::canonical::{
     canonical_name, CanonicalModel, CanonicalModelRegistry, Limit, Modalities, Modality,
-    ModelMapping, Pricing,
+    ModelMapping, Pricing, ThinkingMode,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -346,6 +346,25 @@ fn get_string(value: &Value, field: &str) -> Option<String> {
     value.get(field).and_then(|v| v.as_str()).map(String::from)
 }
 
+fn get_thinking_mode(canonical_id: &str, value: &Value) -> Option<ThinkingMode> {
+    value
+        .get("thinking_mode")
+        .and_then(|v| v.as_str())
+        .and_then(|mode| serde_json::from_value(Value::String(mode.to_string())).ok())
+        .or_else(|| inferred_thinking_mode(canonical_id))
+}
+
+fn inferred_thinking_mode(canonical_id: &str) -> Option<ThinkingMode> {
+    match canonical_id {
+        "anthropic/claude-fable-5" => Some(ThinkingMode::AlwaysOnAdaptive),
+        "anthropic/claude-opus-4.6" => Some(ThinkingMode::Adaptive),
+        "anthropic/claude-opus-4.7" => Some(ThinkingMode::Adaptive),
+        "anthropic/claude-opus-4.8" => Some(ThinkingMode::Adaptive),
+        "anthropic/claude-sonnet-4.6" => Some(ThinkingMode::Adaptive),
+        _ => None,
+    }
+}
+
 fn parse_modalities(model_data: &Value, field: &str) -> Vec<Modality> {
     model_data
         .get("modalities")
@@ -412,6 +431,7 @@ fn process_model(
         family: get_string(model_data, "family"),
         attachment: model_data.get("attachment").and_then(|v| v.as_bool()),
         reasoning: model_data.get("reasoning").and_then(|v| v.as_bool()),
+        thinking_mode: get_thinking_mode(&canonical_id, model_data),
         tool_call: model_data
             .get("tool_call")
             .and_then(|v| v.as_bool())
@@ -497,6 +517,7 @@ fn collect_provider_metadata(
         println!("  Added {} ({}) - {} models", provider_id, npm, model_count);
     }
 
+    metadata_list.sort_by(|a, b| a.id.cmp(&b.id));
     metadata_list
 }
 
@@ -722,6 +743,7 @@ mod tests {
                 family: None,
                 attachment: None,
                 reasoning: None,
+                thinking_mode: None,
                 tool_call: false,
                 temperature: None,
                 knowledge: None,

--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -12,8 +12,8 @@ use tokio_util::io::StreamReader;
 use super::api_client::{ApiClient, AuthMethod};
 use super::base::{ConfigKey, MessageStream, ModelInfo, Provider, ProviderDef, ProviderMetadata};
 use super::formats::anthropic::{
-    create_request_with_options, response_to_streaming_message, thinking_type,
-    AnthropicFormatOptions, ThinkingType,
+    create_request_with_options_for_provider, response_to_streaming_message, thinking_type,
+    AnthropicFormatOptions, ThinkingType, ANTHROPIC_PROVIDER_NAME,
 };
 use super::inventory::{config_secret_value, serialize_string_map, InventoryIdentityInput};
 use super::openai_compatible::handle_status;
@@ -26,7 +26,6 @@ use crate::providers::utils::RequestLog;
 use futures::future::BoxFuture;
 use rmcp::model::Tool;
 
-const ANTHROPIC_PROVIDER_NAME: &str = "anthropic";
 pub const ANTHROPIC_DEFAULT_MODEL: &str = "claude-sonnet-4-5";
 const ANTHROPIC_DEFAULT_FAST_MODEL: &str = "claude-haiku-4-5";
 const ANTHROPIC_KNOWN_MODELS: &[&str] = &[
@@ -341,7 +340,8 @@ impl Provider for AnthropicProvider {
         messages: &[Message],
         tools: &[Tool],
     ) -> Result<MessageStream, ProviderError> {
-        let mut payload = create_request_with_options(
+        let mut payload = create_request_with_options_for_provider(
+            ANTHROPIC_PROVIDER_NAME,
             model_config,
             system,
             messages,

--- a/crates/goose/src/providers/databricks.rs
+++ b/crates/goose/src/providers/databricks.rs
@@ -18,7 +18,7 @@ use super::base::{
 };
 use super::databricks_auth::{DatabricksAuth, DatabricksAuthProvider};
 use super::embedding::EmbeddingCapable;
-use super::formats::databricks::create_request;
+use super::formats::databricks::{create_request_for_provider, DATABRICKS_PROVIDER_NAME};
 use super::formats::openai_responses::create_responses_request;
 use super::openai_compatible::{
     handle_response_openai_compat, handle_status, map_http_error_to_provider_error, sanitize_url,
@@ -58,7 +58,6 @@ struct CachedDatabricksEndpointInfo {
     fetched_at: Instant,
 }
 
-const DATABRICKS_PROVIDER_NAME: &str = "databricks";
 const DATABRICKS_ENDPOINT_METADATA_TTL_SECS: u64 = 60;
 static DATABRICKS_ENDPOINT_INFO_CACHE: LazyLock<
     Mutex<std::collections::HashMap<String, CachedDatabricksEndpointInfo>>,
@@ -670,7 +669,8 @@ impl Provider for DatabricksProvider {
                 model_config
             };
 
-            let mut payload = create_request(
+            let mut payload = create_request_for_provider(
+                DATABRICKS_PROVIDER_NAME,
                 request_model_config,
                 system,
                 messages,

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -1,7 +1,9 @@
 use crate::conversation::message::{Message, MessageContent};
 use crate::mcp_utils::extract_text_from_resource;
 use crate::model::ModelConfig;
+use crate::providers::canonical::maybe_get_canonical_model;
 use anyhow::{anyhow, Result};
+use goose_providers::canonical::ThinkingMode;
 use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
 use goose_providers::errors::ProviderError;
 use goose_providers::images::{convert_image, ImageFormat};
@@ -13,6 +15,8 @@ use std::collections::HashSet;
 use std::fmt;
 use std::str::FromStr;
 use std::sync::Arc;
+
+pub(crate) const ANTHROPIC_PROVIDER_NAME: &str = "anthropic";
 
 macro_rules! string_enum {
     ($name:ident { $($variant:ident => $str:literal),+ $(,)? }) => {
@@ -68,27 +72,51 @@ impl AnthropicFormatOptions {
     }
 }
 
-pub fn supports_adaptive_thinking(model_name: &str) -> bool {
-    let lower = model_name.to_lowercase();
-    lower.contains("claude-opus-4-6") || lower.contains("claude-sonnet-4-6")
+fn canonical_thinking_mode(provider_name: &str, model_name: &str) -> Option<ThinkingMode> {
+    maybe_get_canonical_model(provider_name, model_name).and_then(|model| model.thinking_mode)
+}
+
+fn canonical_reasoning(provider_name: &str, model_config: &ModelConfig) -> Option<bool> {
+    maybe_get_canonical_model(provider_name, &model_config.model_name)
+        .and_then(|model| model.reasoning)
+}
+
+pub fn model_supports_temperature(provider_name: &str, model_config: &ModelConfig) -> bool {
+    maybe_get_canonical_model(provider_name, &model_config.model_name)
+        .and_then(|model| model.temperature)
+        .unwrap_or(true)
 }
 
 pub fn thinking_type(model_config: &ModelConfig) -> ThinkingType {
-    let model_lower = model_config.model_name.to_lowercase();
-    if !model_lower.contains("claude") {
+    thinking_type_for_provider(ANTHROPIC_PROVIDER_NAME, model_config)
+}
+
+pub fn thinking_type_for_provider(provider_name: &str, model_config: &ModelConfig) -> ThinkingType {
+    let mode = canonical_thinking_mode(provider_name, &model_config.model_name);
+    let reasoning = model_config
+        .reasoning
+        .or_else(|| canonical_reasoning(provider_name, model_config));
+
+    if reasoning != Some(true) {
         return ThinkingType::Disabled;
     }
 
-    let is_adaptive_model = supports_adaptive_thinking(&model_config.model_name);
+    if mode == Some(ThinkingMode::AlwaysOnAdaptive) {
+        return ThinkingType::Adaptive;
+    }
+
     let effort = model_config.thinking_effort();
 
     if effort.is_none() && legacy_thinking_budget_tokens().is_some() {
-        return ThinkingType::Enabled;
+        return match mode {
+            Some(ThinkingMode::Adaptive) => ThinkingType::Adaptive,
+            _ => ThinkingType::Enabled,
+        };
     }
 
     match effort.unwrap_or(ThinkingEffort::Off) {
         ThinkingEffort::Off => ThinkingType::Disabled,
-        _ if is_adaptive_model => ThinkingType::Adaptive,
+        _ if mode == Some(ThinkingMode::Adaptive) => ThinkingType::Adaptive,
         _ => ThinkingType::Enabled,
     }
 }
@@ -515,6 +543,13 @@ pub fn thinking_effort(model_config: &ModelConfig) -> ThinkingEffort {
         .unwrap_or(ThinkingEffort::High)
 }
 
+pub fn adaptive_output_effort(model_config: &ModelConfig) -> ThinkingEffort {
+    match thinking_effort(model_config) {
+        ThinkingEffort::Off => ThinkingEffort::High,
+        effort => effort,
+    }
+}
+
 pub fn thinking_budget_tokens(model_config: &ModelConfig) -> i32 {
     if let Some(request_param) = model_config
         .request_params
@@ -553,15 +588,16 @@ fn legacy_thinking_budget_tokens() -> Option<i32> {
 
 fn apply_thinking_config(
     payload: &mut Value,
+    provider_name: &str,
     model_config: &ModelConfig,
     max_tokens: i32,
     options: AnthropicFormatOptions,
 ) {
     let obj = payload.as_object_mut().unwrap();
-    match thinking_type(model_config) {
+    match thinking_type_for_provider(provider_name, model_config) {
         ThinkingType::Adaptive => {
             obj.insert("thinking".to_string(), json!({"type": "adaptive"}));
-            let effort = thinking_effort(model_config).to_string();
+            let effort = adaptive_output_effort(model_config).to_string();
             obj.insert("output_config".to_string(), json!({"effort": effort}));
         }
         ThinkingType::Enabled => {
@@ -621,6 +657,24 @@ pub fn create_request_with_options(
     tools: &[Tool],
     options: AnthropicFormatOptions,
 ) -> Result<Value> {
+    create_request_with_options_for_provider(
+        ANTHROPIC_PROVIDER_NAME,
+        model_config,
+        system,
+        messages,
+        tools,
+        options,
+    )
+}
+
+pub fn create_request_with_options_for_provider(
+    provider_name: &str,
+    model_config: &ModelConfig,
+    system: &str,
+    messages: &[Message],
+    tools: &[Tool],
+    options: AnthropicFormatOptions,
+) -> Result<Value> {
     let options = options.for_model(model_config);
     let anthropic_messages = format_messages_with_options(messages, options);
     let tool_specs = format_tools(tools);
@@ -651,14 +705,22 @@ pub fn create_request_with_options(
             .insert("tools".to_string(), json!(tool_specs));
     }
 
-    if let Some(temp) = model_config.temperature {
-        payload
-            .as_object_mut()
-            .unwrap()
-            .insert("temperature".to_string(), json!(temp));
+    if model_supports_temperature(provider_name, model_config) {
+        if let Some(temp) = model_config.temperature {
+            payload
+                .as_object_mut()
+                .unwrap()
+                .insert("temperature".to_string(), json!(temp));
+        }
     }
 
-    apply_thinking_config(&mut payload, model_config, max_tokens, options);
+    apply_thinking_config(
+        &mut payload,
+        provider_name,
+        model_config,
+        max_tokens,
+        options,
+    );
 
     Ok(payload)
 }
@@ -1544,6 +1606,14 @@ mod tests {
             thinking_type(&cfg_with_effort("claude-opus-4-6", "high")),
             ThinkingType::Adaptive
         );
+        assert_eq!(
+            thinking_type(&cfg_with_effort("claude-opus-4-7", "high")),
+            ThinkingType::Adaptive
+        );
+        assert_eq!(
+            thinking_type(&cfg_with_effort("claude-opus-4-8", "high")),
+            ThinkingType::Adaptive
+        );
         // Adaptive model with off → disabled
         assert_eq!(
             thinking_type(&cfg_with_effort("claude-opus-4-6", "off")),
@@ -1559,6 +1629,41 @@ mod tests {
             thinking_type(&cfg_with_effort("claude-3-7-sonnet-20250219", "off")),
             ThinkingType::Disabled
         );
+    }
+
+    #[test]
+    fn test_thinking_type_always_on_adaptive() {
+        let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
+
+        assert_eq!(
+            thinking_type(&cfg("claude-fable-5")),
+            ThinkingType::Adaptive
+        );
+        assert_eq!(
+            thinking_type(&cfg_with_effort("claude-fable-5", "off")),
+            ThinkingType::Adaptive
+        );
+        assert_eq!(
+            thinking_type(&cfg_with_effort("claude-fable-5", "high")),
+            ThinkingType::Adaptive
+        );
+    }
+
+    #[test]
+    fn test_create_request_fable_5_omits_temperature() -> Result<()> {
+        let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
+        let mut config = cfg("claude-fable-5");
+        config.max_tokens = Some(4096);
+        config.temperature = Some(0.7);
+        let messages = vec![Message::user().with_text("Hello")];
+
+        let payload = create_request(&config, "system", &messages, &[])?;
+
+        assert_eq!(payload["thinking"]["type"], "adaptive");
+        assert!(payload.get("temperature").is_none());
+        assert_eq!(payload["output_config"]["effort"], "high");
+
+        Ok(())
     }
 
     #[test]

--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -1,7 +1,8 @@
 use crate::conversation::message::{Message, MessageContent};
 use crate::model::ModelConfig;
 use crate::providers::formats::anthropic::{
-    thinking_budget_tokens, thinking_effort, thinking_type, ThinkingType,
+    adaptive_output_effort, model_supports_temperature, thinking_budget_tokens,
+    thinking_type_for_provider, ThinkingType,
 };
 
 use anyhow::{anyhow, Error};
@@ -18,6 +19,8 @@ use rmcp::model::{
 use serde::Serialize;
 use serde_json::{json, Value};
 use std::borrow::Cow;
+
+pub(crate) const DATABRICKS_PROVIDER_NAME: &str = "databricks";
 
 #[derive(Serialize)]
 struct DatabricksMessage {
@@ -243,15 +246,19 @@ fn format_messages(messages: &[Message], image_format: &ImageFormat) -> Vec<Data
     result
 }
 
-fn apply_claude_thinking_config(payload: &mut Value, model_config: &ModelConfig) {
+fn apply_claude_thinking_config(
+    payload: &mut Value,
+    provider_name: &str,
+    model_config: &ModelConfig,
+) {
     let obj = payload.as_object_mut().unwrap();
 
-    match thinking_type(model_config) {
+    match thinking_type_for_provider(provider_name, model_config) {
         ThinkingType::Adaptive => {
             obj.insert("thinking".to_string(), json!({ "type": "adaptive" }));
             obj.insert(
                 "output_config".to_string(),
-                json!({ "effort": thinking_effort(model_config).to_string() }),
+                json!({ "effort": adaptive_output_effort(model_config).to_string() }),
             );
             obj.insert(
                 "max_completion_tokens".to_string(),
@@ -272,8 +279,10 @@ fn apply_claude_thinking_config(payload: &mut Value, model_config: &ModelConfig)
             obj.insert("temperature".to_string(), json!(2));
         }
         ThinkingType::Disabled => {
-            if let Some(temp) = model_config.temperature {
-                obj.insert("temperature".to_string(), json!(temp));
+            if model_supports_temperature(provider_name, model_config) {
+                if let Some(temp) = model_config.temperature {
+                    obj.insert("temperature".to_string(), json!(temp));
+                }
             }
             obj.insert(
                 "max_completion_tokens".to_string(),
@@ -586,6 +595,24 @@ pub fn create_request(
     tools: &[Tool],
     image_format: &ImageFormat,
 ) -> anyhow::Result<Value, Error> {
+    create_request_for_provider(
+        DATABRICKS_PROVIDER_NAME,
+        model_config,
+        system,
+        messages,
+        tools,
+        image_format,
+    )
+}
+
+pub fn create_request_for_provider(
+    provider_name: &str,
+    model_config: &ModelConfig,
+    system: &str,
+    messages: &[Message],
+    tools: &[Tool],
+    image_format: &ImageFormat,
+) -> anyhow::Result<Value, Error> {
     if model_config.model_name.starts_with("o1-mini") {
         return Err(anyhow!(
             "o1-mini model is not currently supported since goose uses tool calling and o1-mini does not support it. Please use o1 or o3 models instead."
@@ -644,10 +671,10 @@ pub fn create_request(
     }
 
     if is_claude_model(&model_config.model_name) {
-        apply_claude_thinking_config(&mut payload, model_config);
+        apply_claude_thinking_config(&mut payload, provider_name, model_config);
     } else {
         // open ai reasoning models currently don't support temperature
-        if !is_openai_reasoning_model {
+        if !is_openai_reasoning_model && model_supports_temperature(provider_name, model_config) {
             if let Some(temp) = model_config.temperature {
                 payload
                     .as_object_mut()
@@ -1196,6 +1223,51 @@ mod tests {
         assert!(request.get("temperature").is_none());
         assert_eq!(request["max_completion_tokens"], 4096);
         assert!(request.get("max_tokens").is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_request_adaptive_thinking_for_new_anthropic_models() -> anyhow::Result<()> {
+        let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
+
+        for name in [
+            "databricks-claude-opus-4-7",
+            "databricks-claude-opus-4-8",
+            "databricks-claude-fable-5",
+            "global.anthropic.claude-fable-5",
+        ] {
+            let mut model_config = ModelConfig::new_or_fail(name);
+            model_config.max_tokens = Some(4096);
+            let mut params = std::collections::HashMap::new();
+            params.insert("thinking_effort".to_string(), serde_json::json!("high"));
+            model_config.request_params = Some(params);
+
+            let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
+
+            assert_eq!(request["thinking"]["type"], "adaptive", "{name}");
+            assert!(request.get("temperature").is_none(), "{name}");
+            assert_eq!(request["max_completion_tokens"], 4096, "{name}");
+            assert!(request.get("max_tokens").is_none(), "{name}");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_request_always_on_adaptive_off_effort_falls_back_to_high() -> anyhow::Result<()>
+    {
+        let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
+        let mut model_config = ModelConfig::new_or_fail("databricks-claude-fable-5");
+        model_config.max_tokens = Some(4096);
+        let mut params = std::collections::HashMap::new();
+        params.insert("thinking_effort".to_string(), serde_json::json!("off"));
+        model_config.request_params = Some(params);
+
+        let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
+
+        assert_eq!(request["thinking"]["type"], "adaptive");
+        assert_eq!(request["output_config"]["effort"], "high");
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
- add canonical thinking mode metadata for Anthropic adaptive and always-on adaptive models
- route Anthropic and Databricks thinking request shaping through canonical metadata
- omit temperature for canonical models that do not support it, including Fable and newer Opus models
- ran canonical model generation

## Validation
- cargo fmt
- git diff --check