### PR TITLE
Add OptionsAhoy MCP server

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -568,6 +568,17 @@
     ]
   },
   {
+    "id": "optionsahoy",
+    "name": "OptionsAhoy",
+    "description": "Equity-compensation tax optimizer: ISO/AMT exercise scheduling, NSO, RSU sell-vs-hold, QSBS eligibility, single-stock concentration, and protective puts/collars across federal and 50-state tax code",
+    "command": "npx -y optionsahoy-mcp",
+    "link": "https://github.com/AlvisoOculus/optionsahoy-mcp",
+    "installation_notes": "Install using npx package manager. No API key required.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": []
+  },
+  {
     "id": "pdf_read",
     "name": "PDF Reader",
     "description": "Read large and complex PDF documents",


### PR DESCRIPTION
## Summary
Adds OptionsAhoy to the extensions directory (`documentation/static/servers.json`).

OptionsAhoy is an equity-compensation tax optimizer exposed as an MCP server. It covers ISO/AMT exercise scheduling, NSO, RSU sell-vs-hold, QSBS eligibility, single-stock concentration, and protective puts/collars, computed against the full federal tax code plus all 50 states and DC. MIT licensed, no API key required.

Installs via `npx -y optionsahoy-mcp`.

### Testing
Verified the published package starts as an stdio MCP server via `npx -y optionsahoy-mcp` and lists its 7 tools over the MCP protocol. The entry was inserted in alphabetical position and the resulting `servers.json` was validated as well-formed JSON; the diff is limited to the single new entry.

### Related Issues
N/A — directory addition.
