### PR TITLE
desktop: register global New Chat shortcuts

### DIFF
--- a/crates/goose/src/session/extension_data.rs
+++ b/crates/goose/src/session/extension_data.rs
@@ -81,7 +81,13 @@ pub trait ExtensionState: Sized + Serialize + for<'de> Deserialize<'de> {
     }
 }
 
-/// TODO extension state implementation
+/// Extension state utilities for session-scoped extension data.
+///
+/// This file provides a generic container (ExtensionData) for storing
+/// versioned extension state as JSON values, plus a small trait
+/// (ExtensionState) to make it convenient for specific extensions to
+/// serialize/deserialize their state and read/write it from/to
+/// ExtensionData.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TodoState {
     pub content: String,

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -2107,6 +2107,36 @@ const registerGlobalShortcuts = () => {
       console.error('Error registering launcher hotkey:', e);
     }
   }
+
+  // Register New Chat shortcuts so they work even when the menu is not focused.
+  if (shortcuts.newChat) {
+    try {
+      globalShortcut.register(shortcuts.newChat, () => {
+        const focusedWindow = BrowserWindow.getFocusedWindow();
+        if (focusedWindow) {
+          focusedWindow.webContents.send('new-chat');
+        } else {
+          // If no window exists, create a new chat window
+          // We intentionally don't await here to keep the handler synchronous.
+          // createNewWindow will handle opening the app if needed.
+          void createNewWindow(app);
+        }
+      });
+    } catch (e) {
+      console.error('Error registering new-chat hotkey:', e);
+    }
+  }
+
+  if (shortcuts.newChatWindow) {
+    try {
+      globalShortcut.register(shortcuts.newChatWindow, () => {
+        // Create a fresh chat window
+        void createNewWindow(app);
+      });
+    } catch (e) {
+      console.error('Error registering new-chat-window hotkey:', e);
+    }
+  }
 };
 
 async function appMain() {


### PR DESCRIPTION
Register global Cmd/Ctrl+T and New Chat Window accelerators so New Chat works when the menu isn't focused.\n\nThis moves shortcut registration from menu-only to globalShortcut so accelerators like Cmd/Ctrl+T reliably trigger a new chat even when the app menu is not focused (fixes #9523).