### PR TITLE
Add recipe: Project Context for AGENTS.md

### DIFF
--- a/documentation/src/pages/recipes/data/recipes/project-context-for-agents-md.yaml
+++ b/documentation/src/pages/recipes/data/recipes/project-context-for-agents-md.yaml
@@ -35,12 +35,13 @@ prompt: |
   (or `bunx faf-cli@latest ...`) — the @latest pin matters: package runners
   cache, and this recipe relies on current behavior.
 
-  1. Detect the stack (first run only). If there is no project.faf yet:
-     `npx -y faf-cli@latest init`
-     This writes project.faf and reports what it could not detect on its own —
-     typically who the project is for, why it exists, where it runs.
-     If project.faf already exists, skip this step — your context is preserved;
-     re-running the recipe just refreshes the block in step 3.
+  1. Detect the stack from the project's real files:
+     - First run (no project.faf yet): `npx -y faf-cli@latest init`
+     - Re-run (project.faf already exists): `npx -y faf-cli@latest auto`
+       — re-detects the current stack and keeps the human context you set, so a
+       re-run reflects the current project, not stale fields.
+     Either way it reports what it could not detect on its own — typically who
+     the project is for, why it exists, where it runs.
 
   2. Fill in what only the code can tell you. Read the project, then set each
      flagged field — short, and true to the code, never invented:

--- a/documentation/src/pages/recipes/data/recipes/project-context-for-agents-md.yaml
+++ b/documentation/src/pages/recipes/data/recipes/project-context-for-agents-md.yaml
@@ -2,7 +2,7 @@ version: 1.0.0
 title: Project Context for AGENTS.md
 author:
   contact: Wolfe-Jam
-description: Enhance your AGENTS.md — add structured, machine-readable project context at the top, and keep the Markdown for instructions. Goose stops re-guessing your stack every session and spends its tokens on the work.
+description: Enhance your AGENTS.md — add structured, machine-readable project context at the top, and keep the Markdown for instructions. goose stops re-guessing your stack every session and spends its tokens on the work.
 instructions: |
   Without durable context, every session starts with goose searching the repo
   to work out what the project is — and a fresh search returns slightly
@@ -13,7 +13,7 @@ instructions: |
   This recipe splits the lanes. A compact, structured context block carries the
   facts (language, runtime, build, who the project is for, why it exists) — the
   same answer every request, for almost no tokens. The Markdown below stays
-  yours — freed to provide focused instructions, not facts. Goose reads both
+  yours — freed to provide focused instructions, not facts. goose reads both
   natively.
 
   The block is added non-destructively: everything already written in AGENTS.md

--- a/documentation/src/pages/recipes/data/recipes/project-context-for-agents-md.yaml
+++ b/documentation/src/pages/recipes/data/recipes/project-context-for-agents-md.yaml
@@ -35,10 +35,12 @@ prompt: |
   (or `bunx faf-cli@latest ...`) — the @latest pin matters: package runners
   cache, and this recipe relies on current behavior.
 
-  1. Detect the stack from the project's real files:
+  1. Detect the stack (first run only). If there is no project.faf yet:
      `npx -y faf-cli@latest init`
      This writes project.faf and reports what it could not detect on its own —
      typically who the project is for, why it exists, where it runs.
+     If project.faf already exists, skip this step — your context is preserved;
+     re-running the recipe just refreshes the block in step 3.
 
   2. Fill in what only the code can tell you. Read the project, then set each
      flagged field — short, and true to the code, never invented:

--- a/documentation/src/pages/recipes/data/recipes/project-context-for-agents-md.yaml
+++ b/documentation/src/pages/recipes/data/recipes/project-context-for-agents-md.yaml
@@ -1,0 +1,62 @@
+version: 1.0.0
+title: Project Context for AGENTS.md
+author:
+  contact: Wolfe-Jam
+description: Enhance your AGENTS.md — add structured, machine-readable project context at the top, and keep the Markdown for instructions. Goose stops re-guessing your stack every session and spends its tokens on the work.
+instructions: |
+  Without durable context, every session starts with goose searching the repo
+  to work out what the project is — and a fresh search returns slightly
+  different answers each time. That costs tokens, and worse, it induces drift:
+  the agent's picture of your project varies from one request to the next —
+  even within a single session.
+
+  This recipe splits the lanes. A compact, structured context block carries the
+  facts (language, runtime, build, who the project is for, why it exists) — the
+  same answer every request, for almost no tokens. The Markdown below stays
+  yours — freed to provide focused instructions, not facts. Goose reads both
+  natively.
+
+  The block is added non-destructively: everything already written in AGENTS.md
+  is preserved, and re-runs update the block in place.
+activities:
+  - Detect the project's stack from its real files
+  - Fill in who it's for, why it exists, and how it runs — from the code, never invented
+  - Add a structured context block to AGENTS.md, preserving everything already written
+  - Re-run any time the project changes — the block updates in place
+extensions:
+  - type: builtin
+    name: developer
+    display_name: Developer
+    timeout: 300
+    bundled: true
+prompt: |
+  Enhance this project's AGENTS.md with structured, machine-readable context,
+  preserving every instruction already written in it. Use `npx -y faf-cli@latest ...`
+  (or `bunx faf-cli@latest ...`) — the @latest pin matters: package runners
+  cache, and this recipe relies on current behavior.
+
+  1. Detect the stack from the project's real files:
+     `npx -y faf-cli@latest init`
+     This writes project.faf and reports what it could not detect on its own —
+     typically who the project is for, why it exists, where it runs.
+
+  2. Fill in what only the code can tell you. Read the project, then set each
+     flagged field — short, and true to the code, never invented:
+     `npx -y faf-cli@latest edit human_context.who   "<who it's for>"`
+     `npx -y faf-cli@latest edit human_context.why   "<why it exists>"`
+     `npx -y faf-cli@latest edit human_context.where "<where it runs>"`
+
+  3. Write the context block into AGENTS.md:
+     `npx -y faf-cli@latest export --agents`
+     This is non-destructive: the structured block sits at the top of the file
+     and everything already written below it is preserved. Re-runs update the
+     block in place.
+
+  4. Check completeness:
+     `npx -y faf-cli@latest score`
+     The score is context coverage, not a grade. Low means you're still being
+     asked to guess — more context closes it. At 100%, nothing is guessed.
+
+  Result: one AGENTS.md, two lanes. Structured data defines the project —
+  the same answer every request, no re-searching, no drift. The Markdown provides
+  focused instructions. Spend the tokens on the work.


### PR DESCRIPTION

**What it does**
Enhances a project's `AGENTS.md` with a structured, machine-readable context block at the top — language, runtime, build, who it's for, why it exists — while preserving every instruction already written below. goose answers from the block instead of re-deriving the project each request, and the Markdown is freed for focused instructions.

**Why**
Without durable context, each request re-searches the repo and returns slightly different answers — token cost plus drift from one request to the next, even within a single session. This splits the lanes: structured data defines the project (same answer every request); the Markdown provides focused instructions.

**Non-destructive**
The block is injected between markers; existing AGENTS.md content is preserved, and re-runs update the block in place.

**Tested**
Goose executed the recipe on its own repo, and the 126-line AGENTS.md was preserved verbatim. The agent left fields it couldn't source honestly empty rather than guessing.

**Extension:** `developer` (builtin) only.

— *Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)*