### PR TITLE
fix: respect GOOSE_CONTEXT_LIMIT config as highest-priority token limit

### DIFF
--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -271,7 +271,7 @@ export default function ChatInput({
     null
   ) as React.RefObject<HTMLDivElement>;
   const intl = useIntl();
-  const { getProviders } = useConfig();
+  const { getProviders, read } = useConfig();
   const {
     getCurrentModelAndProvider,
     currentModel: configModel,
@@ -584,7 +584,20 @@ export default function ChatInput({
         return;
       }
 
-      // Priority 1: Check predefined models from environment
+      // Priority 1: GOOSE_CONTEXT_LIMIT from config/env — user explicit override
+      try {
+        const contextLimit = await read('GOOSE_CONTEXT_LIMIT', false);
+        if (contextLimit && Number(contextLimit) > 0) {
+          setTokenLimit(Number(contextLimit));
+          setIsTokenLimitLoaded(true);
+          return;
+        }
+      } catch (err) {
+        console.error('Failed to read GOOSE_CONTEXT_LIMIT from config:', err);
+        // continue to predefined/canonical
+      }
+
+      // Priority 2: Check predefined models from environment
       const predefinedModels = getPredefinedModelsFromEnv();
       const predefinedModel = predefinedModels.find((m) => m.name === model);
       if (predefinedModel?.context_limit) {
@@ -593,7 +606,7 @@ export default function ChatInput({
         return;
       }
 
-      // Priority 2: Check canonical model info (source of truth)
+      // Priority 3: Check canonical model info (source of truth)
       const canonicalInfo = await fetchCanonicalModelInfo(provider, model);
       if (canonicalInfo?.context_limit) {
         setTokenLimit(canonicalInfo.context_limit);
@@ -601,7 +614,7 @@ export default function ChatInput({
         return;
       }
 
-      // Priority 3: Fall back to provider metadata known_models (may be outdated)
+      // Priority 4: Fall back to provider metadata known_models (may be outdated)
       const providers = await getProviders(true);
       const currentProvider = providers.find((p) => p.name === provider);
       if (currentProvider?.metadata?.known_models) {
@@ -613,7 +626,7 @@ export default function ChatInput({
         }
       }
 
-      // Priority 4: Use default if nothing else found
+      // Priority 5: Use default if nothing else found
       setTokenLimit(TOKEN_LIMIT_DEFAULT);
       setIsTokenLimitLoaded(true);
     } catch (err) {


### PR DESCRIPTION
## Summary
When a user explicitly sets `GOOSE_CONTEXT_LIMIT` in config, it now takes priority over
all auto-detected context limits (predefined models, canonical model info, provider
known_models). Previously this config key was consulted only as a last-resort fallback
for unknown custom providers, making it impossible to override the token limit for
well-known models.

Priority chain (highest to lowest):
1. `GOOSE_CONTEXT_LIMIT` config — user explicit override
2. Predefined models from environment
3. Canonical model info (remote source of truth)
4. Provider metadata `known_models`
5. Hardcoded default

### Testing
Manual testing in the desktop app:
- Set `GOOSE_CONTEXT_LIMIT` to a custom value, verified it overrides the model's
  default context limit in the UI token display
- Removed the config key, verified the normal priority chain resumes
- Tested with an invalid/negative value, verified it falls through to the next priority

### Related Issues
N/A

### Screenshots/Demos (for UX changes)
N/A — no visible UI changes