### PR TITLE
feat: Async Job Infrastructure, Process Management & Real-Time Notifications

### DIFF
--- a/crates/goose-cli/src/session/input_thread.rs
+++ b/crates/goose-cli/src/session/input_thread.rs
@@ -1,0 +1,174 @@
+use super::completion::GooseCompleter;
+use super::input::{self, InputResult};
+use super::HistoryManager;
+use rustyline::ExternalPrinter;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+
+/// Commands sent TO the input thread from the async event loop.
+#[derive(Debug)]
+pub enum InputCommand {
+    /// Shut down the input thread.
+    Shutdown,
+    /// Resume prompting (after async processing is complete).
+    Resume,
+}
+
+/// Events sent FROM the input thread to the async event loop.
+#[derive(Debug)]
+pub enum InputEvent {
+    /// User submitted a line of input (processed into InputResult).
+    Input(InputResult),
+    /// The input thread has exited.
+    Closed,
+}
+
+/// Shared state for interrupt coordination between the async loop
+/// and the ConditionalEventHandler inside readline.
+#[allow(dead_code)]
+pub struct InterruptState {
+    /// When true, the next keypress should save the buffer and interrupt readline.
+    pub interrupt_requested: AtomicBool,
+    /// The saved line buffer captured by the handler before interrupting.
+    pub saved_line: Mutex<String>,
+}
+
+impl InterruptState {
+    pub fn new() -> Self {
+        Self {
+            interrupt_requested: AtomicBool::new(false),
+            saved_line: Mutex::new(String::new()),
+        }
+    }
+}
+
+/// Handle to communicate with the input thread and print above the prompt.
+pub struct InputHandle {
+    /// Send commands to the input thread (std channel — works from async context).
+    pub command_tx: std::sync::mpsc::Sender<InputCommand>,
+    /// Receive events from the input thread (tokio channel — works in select!).
+    pub event_rx: mpsc::UnboundedReceiver<InputEvent>,
+    /// Print messages above the prompt without disturbing user input.
+    pub printer: Printer,
+    /// Shared interrupt state (for future forced-turn approval mechanism).
+    #[allow(dead_code)]
+    pub interrupt_state: Arc<InterruptState>,
+    /// Join handle for the input thread.
+    join_handle: Option<std::thread::JoinHandle<()>>,
+}
+
+/// Wrapper around rustyline's ExternalPrinter that is Send-safe.
+pub struct Printer {
+    inner: Box<dyn ExternalPrinter + Send>,
+}
+
+impl Printer {
+    /// Print a message above the prompt without disturbing user input.
+    pub fn print(&mut self, msg: String) {
+        let _ = self.inner.print(msg);
+    }
+}
+
+impl InputHandle {
+    /// Send a shutdown command and wait for the thread to exit.
+    pub fn shutdown(&mut self) {
+        let _ = self.command_tx.send(InputCommand::Shutdown);
+        if let Some(handle) = self.join_handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Drop for InputHandle {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+/// Spawn the input thread. Returns an InputHandle for the async loop to use.
+///
+/// The input thread owns the rustyline Editor and processes readline in a loop.
+/// The ExternalPrinter is created BEFORE the editor moves to the thread —
+/// it stays on the async side for non-blocking output above the prompt.
+pub fn spawn_input_thread(
+    mut editor: rustyline::Editor<GooseCompleter, rustyline::history::DefaultHistory>,
+) -> InputHandle {
+    let (command_tx, command_rx) = std::sync::mpsc::channel::<InputCommand>();
+    let (event_tx, event_rx) = mpsc::unbounded_channel::<InputEvent>();
+    let interrupt_state = Arc::new(InterruptState::new());
+
+    // Create ExternalPrinter BEFORE moving editor to the thread.
+    // This gives us a handle to print above the prompt from the async side.
+    let printer = editor
+        .create_external_printer()
+        .expect("Failed to create ExternalPrinter — terminal may not be a TTY");
+
+    let handle = std::thread::Builder::new()
+        .name("goose-input".into())
+        .spawn(move || {
+            input_thread_main(editor, command_rx, event_tx);
+        })
+        .expect("Failed to spawn input thread");
+
+    InputHandle {
+        command_tx,
+        event_rx,
+        printer: Printer {
+            inner: Box::new(printer),
+        },
+        interrupt_state,
+        join_handle: Some(handle),
+    }
+}
+
+/// Main loop of the input thread.
+fn input_thread_main(
+    mut editor: rustyline::Editor<GooseCompleter, rustyline::history::DefaultHistory>,
+    command_rx: std::sync::mpsc::Receiver<InputCommand>,
+    event_tx: mpsc::UnboundedSender<InputEvent>,
+) {
+    let history_manager = HistoryManager::new();
+    history_manager.load(&mut editor);
+
+    loop {
+        // Check for pending commands before starting readline
+        match command_rx.try_recv() {
+            Ok(InputCommand::Shutdown) => break,
+            Ok(InputCommand::Resume) => {} // stale Resume, ignore
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => break,
+            Err(std::sync::mpsc::TryRecvError::Empty) => {}
+        }
+
+        // Run readline (blocks until user submits or interrupts)
+        let result = input::get_input(&mut editor, None);
+
+        match result {
+            Ok(input_result) => {
+                let is_exit = matches!(input_result, InputResult::Exit);
+                let is_retry = matches!(input_result, InputResult::Retry);
+                history_manager.save(&mut editor);
+                if event_tx.send(InputEvent::Input(input_result)).is_err() {
+                    break;
+                }
+                if is_exit {
+                    break;
+                }
+                // After sending a non-trivial event, wait for the async side
+                // to signal Resume before re-prompting.
+                if !is_retry {
+                    match command_rx.recv() {
+                        Ok(InputCommand::Resume) => {}
+                        Ok(InputCommand::Shutdown) | Err(_) => break,
+                    }
+                }
+            }
+            Err(_) => {
+                let _ = event_tx.send(InputEvent::Closed);
+                break;
+            }
+        }
+    }
+
+    let _ = event_tx.send(InputEvent::Closed);
+}

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -4,6 +4,7 @@ mod editor;
 mod elicitation;
 mod export;
 mod input;
+mod input_thread;
 mod output;
 pub mod streaming_buffer;
 mod task_execution_display;
@@ -113,20 +114,20 @@ pub enum RunMode {
     Plan,
 }
 
-struct HistoryManager {
+pub(super) struct HistoryManager {
     history_file: PathBuf,
     old_history_file: PathBuf,
 }
 
 impl HistoryManager {
-    fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self {
             history_file: Paths::state_dir().join("history.txt"),
             old_history_file: Paths::config_dir().join("history.txt"),
         }
     }
 
-    fn load(
+    pub(super) fn load(
         &self,
         editor: &mut rustyline::Editor<GooseCompleter, rustyline::history::DefaultHistory>,
     ) {
@@ -146,7 +147,7 @@ impl HistoryManager {
         }
     }
 
-    fn save(
+    pub(super) fn save(
         &self,
         editor: &mut rustyline::Editor<GooseCompleter, rustyline::history::DefaultHistory>,
     ) {
@@ -508,34 +509,338 @@ impl CliSession {
 
         self.update_completion_cache().await?;
 
-        let mut editor = self.create_editor()?;
-        let history_manager = HistoryManager::new();
-        history_manager.load(&mut editor);
+        let editor = self.create_editor()?;
+        let mut input_handle = input_thread::spawn_input_thread(editor);
+
+        // Take the job event receiver for listening to actionable events
+        let mut job_event_rx = self.agent.take_job_event_rx().await;
+
+        // Subscribe to MCP notifications for real-time display
+        let mut notification_rx = self.agent.extension_manager.subscribe_notifications();
+
+        // Display initial context usage once before the prompt
+        self.display_context_usage().await?;
 
         loop {
-            self.display_context_usage().await?;
-
-            let conversation_strings: Vec<String> = self
-                .messages
-                .iter()
-                .map(|msg| {
-                    let role = match msg.role {
-                        rmcp::model::Role::User => "User",
-                        rmcp::model::Role::Assistant => "Assistant",
-                    };
-                    format!("## {}: {}", role, msg.as_concat_text())
-                })
-                .collect();
-
             output::run_status_hook("waiting");
-            let input = input::get_input(&mut editor, Some(&conversation_strings))?;
-            if matches!(input, InputResult::Exit) {
-                break;
+
+            tokio::select! {
+                event = input_handle.event_rx.recv() => {
+                    match event {
+                        Some(input_thread::InputEvent::Input(input_result)) => {
+                            if matches!(input_result, InputResult::Exit) {
+                                break;
+                            }
+                            let is_message = matches!(input_result, InputResult::Message(_));
+                            self.handle_input_async(input_result).await?;
+                            if is_message {
+                                self.display_context_usage().await?;
+                            }
+                            let _ = input_handle.command_tx.send(input_thread::InputCommand::Resume);
+                        }
+                        Some(input_thread::InputEvent::Closed) | None => {
+                            break;
+                        }
+                    }
+                }
+                Some(job_event) = async {
+                    match job_event_rx.as_mut() {
+                        Some(rx) => rx.recv().await,
+                        None => std::future::pending::<Option<goose::jobs::JobEvent>>().await,
+                    }
+                } => {
+                    self.handle_job_event(job_event, &mut input_handle.printer).await?;
+                }
+                Ok((extension_name, notification)) = notification_rx.recv() => {
+                    if let Some(uri) = Self::notification_interrupt_uri(&notification) {
+                        input_handle.printer.print(format!(
+                            "⚡ {} interrupted: {}\n", extension_name, uri
+                        ));
+                        let prompt = format!(
+                            "System: Resource notification from '{}' with interrupt — uri: {}",
+                            extension_name, uri
+                        );
+                        let msg = Message::user().with_text(&prompt);
+                        self.process_message(msg, CancellationToken::default(), true)
+                            .await?;
+                        self.display_context_usage().await?;
+                        let _ = input_handle.command_tx.send(input_thread::InputCommand::Resume);
+                    } else {
+                        Self::handle_notification(&extension_name, &notification, &mut input_handle.printer);
+                    }
+                }
             }
-            self.handle_input(input, &history_manager, &mut editor, &conversation_strings)
-                .await?;
         }
 
+        let _ = input_handle
+            .command_tx
+            .send(input_thread::InputCommand::Shutdown);
+        Ok(())
+    }
+
+    /// Display an MCP notification to the user via ExternalPrinter (non-blocking).
+    fn handle_notification(
+        extension_name: &str,
+        notification: &ServerNotification,
+        printer: &mut input_thread::Printer,
+    ) {
+        use rmcp::model::ServerNotification as SN;
+        let msg = match notification {
+            SN::ProgressNotification(p) => {
+                let progress_msg = p.params.message.as_deref().unwrap_or("in progress");
+                format!("  {} {}\n", extension_name, progress_msg)
+            }
+            SN::ResourceUpdatedNotification(r) => {
+                format!("  {} resource updated: {}\n", extension_name, r.params.uri)
+            }
+            SN::LoggingMessageNotification(_) => return, // Route to log file only
+            _ => return,
+        };
+        printer.print(msg);
+    }
+
+    /// Check if a notification carries interrupt=true, returning the URI if so.
+    fn notification_interrupt_uri(notification: &ServerNotification) -> Option<&str> {
+        use rmcp::model::ServerNotification as SN;
+        if let SN::ResourceUpdatedNotification(r) = notification {
+            if r.params.uri.contains("interrupt=true") {
+                return Some(&r.params.uri);
+            }
+        }
+        None
+    }
+
+    /// Handle an actionable job event (batch completed, job finished, etc.)
+    async fn handle_job_event(
+        &mut self,
+        event: goose::jobs::JobEvent,
+        printer: &mut input_thread::Printer,
+    ) -> Result<()> {
+        match event {
+            goose::jobs::JobEvent::BatchCompleted {
+                batch_id,
+                job_summaries,
+            } => {
+                let summary_text: Vec<String> = job_summaries
+                    .iter()
+                    .map(|s| {
+                        let status = match s.state {
+                            goose::jobs::JobState::Completed => "✓ completed",
+                            goose::jobs::JobState::Failed => "✗ failed",
+                            _ => "unknown",
+                        };
+                        format!(
+                            "  • {} \"{}\": {} ({:.0?})",
+                            s.id, s.description, status, s.duration
+                        )
+                    })
+                    .collect();
+
+                let prompt = format!(
+                    "System: All background tasks in batch '{}' have completed:\n{}\n\n\
+                     Use load(source: \"<id>\") to examine results and determine next steps.",
+                    batch_id,
+                    summary_text.join("\n")
+                );
+
+                printer.print(
+                    "⚡ All background tasks complete. Assistant responding...\n".to_string(),
+                );
+                let msg = Message::user().with_text(&prompt);
+                self.process_message(msg, CancellationToken::default(), true)
+                    .await?;
+            }
+            goose::jobs::JobEvent::JobCompleted { job } => {
+                let status = match job.state {
+                    goose::jobs::JobState::Completed => "✓ completed",
+                    goose::jobs::JobState::Failed => "✗ failed",
+                    _ => "finished",
+                };
+                let follow_up = match job.source {
+                    goose::jobs::JobSource::Process => {
+                        format!(
+                            "Use process__read_output(process_id: \"{}\") to see the output.",
+                            job.id
+                        )
+                    }
+                    goose::jobs::JobSource::Timer => {
+                        format!("The reminder message was: \"{}\"", job.description)
+                    }
+                    _ => {
+                        format!("Use load(source: \"{}\") to examine the result.", job.id)
+                    }
+                };
+                let prompt = format!(
+                    "System: Background task {} \"{}\" has {} ({:.0?}).\n{}",
+                    job.id, job.description, status, job.duration, follow_up
+                );
+
+                printer.print(format!(
+                    "⚡ Task '{}' completed. Assistant responding...\n",
+                    job.description
+                ));
+                let msg = Message::user().with_text(&prompt);
+                self.process_message(msg, CancellationToken::default(), true)
+                    .await?;
+            }
+            goose::jobs::JobEvent::JobNeedsInput { job_id, question } => {
+                let prompt = format!(
+                    "System: Background task '{}' needs your input: {}",
+                    job_id, question
+                );
+                printer.print(format!("❓ Task '{}' has a question\n", job_id));
+                let msg = Message::user().with_text(&prompt);
+                self.process_message(msg, CancellationToken::default(), true)
+                    .await?;
+            }
+            goose::jobs::JobEvent::PatternMatched {
+                job_id,
+                pattern,
+                context,
+            } => {
+                let prompt = format!(
+                    "System: Background task '{}' matched pattern \"{}\": {}",
+                    job_id, pattern, context
+                );
+                printer.print(format!(
+                    "⚡ Task '{}' matched '{}'. Assistant responding...\n",
+                    job_id, pattern
+                ));
+                let msg = Message::user().with_text(&prompt);
+                self.process_message(msg, CancellationToken::default(), true)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Handle input from the async input thread. Like handle_input but without
+    /// editor/history references (those are managed by the input thread).
+    async fn handle_input_async(&mut self, input: InputResult) -> Result<()> {
+        match input {
+            InputResult::Message(content) => match self.run_mode {
+                RunMode::Normal => {
+                    self.push_message(Message::user().with_text(&content));
+
+                    if let Err(e) = crate::project_tracker::update_project_tracker(
+                        Some(&content),
+                        Some(&self.session_id),
+                    ) {
+                        eprintln!(
+                            "Warning: Failed to update project tracker with instruction: {}",
+                            e
+                        );
+                    }
+
+                    let _provider = self.agent.provider().await?;
+
+                    println!();
+                    output::run_status_hook("thinking");
+                    output::show_thinking();
+                    let start_time = Instant::now();
+                    self.process_agent_response(true, CancellationToken::default())
+                        .await?;
+                    output::hide_thinking();
+
+                    let elapsed = start_time.elapsed();
+                    let elapsed_str = format_elapsed_time(elapsed);
+                    println!("{}", console::style(format!("  ⏱ {}", elapsed_str)).dim());
+                }
+                RunMode::Plan => {
+                    let mut plan_messages = self.messages.clone();
+                    plan_messages.push(Message::user().with_text(&content));
+                    let reasoner = get_reasoner().await?;
+                    self.plan_with_reasoner_model(plan_messages, reasoner)
+                        .await?;
+                }
+            },
+            InputResult::Exit => unreachable!("Exit is handled in the main loop"),
+            InputResult::AddExtension(cmd) => match self.add_extension(cmd.clone()).await {
+                Ok(_) => output::render_extension_success(&cmd),
+                Err(e) => output::render_extension_error(&cmd, &e.to_string()),
+            },
+            InputResult::AddBuiltin(names) => match self.add_builtin(names.clone()).await {
+                Ok(_) => output::render_builtin_success(&names),
+                Err(e) => output::render_builtin_error(&names, &e.to_string()),
+            },
+            InputResult::ToggleTheme => {
+                self.handle_toggle_theme();
+            }
+            InputResult::ToggleFullToolOutput => {
+                self.handle_toggle_full_tool_output();
+            }
+            InputResult::SelectTheme(theme_name) => {
+                self.handle_select_theme(&theme_name);
+            }
+            InputResult::Retry => {}
+            InputResult::ListPrompts(extension) => match self.list_prompts(extension).await {
+                Ok(prompts) => output::render_prompts(&prompts),
+                Err(e) => output::render_error(&e.to_string()),
+            },
+            InputResult::GooseMode(mode) => {
+                self.handle_goose_mode(&mode).await?;
+            }
+            InputResult::Model(model) => {
+                self.handle_model(model.as_deref()).await?;
+            }
+            InputResult::Plan(options) => {
+                self.handle_plan_mode(options).await?;
+            }
+            InputResult::EndPlan => {
+                self.run_mode = RunMode::Normal;
+                output::render_exit_plan_mode();
+            }
+            InputResult::Clear => {
+                self.handle_clear().await?;
+            }
+            InputResult::PromptCommand(opts) => {
+                self.handle_prompt_command(opts).await?;
+            }
+            InputResult::Recipe(filepath_opt) => {
+                self.handle_recipe(filepath_opt).await;
+            }
+            InputResult::Compact => {
+                self.handle_compact().await?;
+            }
+            InputResult::Edit(prefill) => match crate::session::editor::resolve_editor_command() {
+                Some(editor_cmd) => {
+                    let messages: Vec<String> = self
+                        .messages
+                        .iter()
+                        .map(|msg| msg.as_concat_text())
+                        .collect();
+                    let message_refs: Vec<&str> = messages.iter().map(|s| s.as_str()).collect();
+                    match crate::session::editor::get_editor_input(
+                        &editor_cmd,
+                        &message_refs,
+                        prefill.as_deref(),
+                    ) {
+                        Ok((message, true)) => {
+                            let msg = Message::user().with_text(&message);
+                            self.process_message(msg, CancellationToken::default(), true)
+                                .await?;
+                        }
+                        Ok((_, false)) => {}
+                        Err(e) => {
+                            output::render_error(&format!("Failed to open editor: {}", e));
+                        }
+                    }
+                }
+                None => {
+                    output::render_error(
+                        "No editor found. Set one with:\n  \
+                                 goose configure set goose_prompt_editor \"vim\"\n  \
+                                 or set $VISUAL or $EDITOR in your shell.",
+                    );
+                }
+            },
+            InputResult::LoadSkills(names) => {
+                self.handle_load_skills(&names).await?;
+            }
+            InputResult::ListSkills => {
+                self.handle_list_skills().await?;
+            }
+        }
         Ok(())
     }
 
@@ -556,170 +861,6 @@ impl CliSession {
         let completer = GooseCompleter::new(self.completion_cache.clone());
         editor.set_helper(Some(completer));
         Ok(editor)
-    }
-
-    async fn handle_input(
-        &mut self,
-        input: InputResult,
-        history: &HistoryManager,
-        editor: &mut rustyline::Editor<GooseCompleter, rustyline::history::DefaultHistory>,
-        conversation_messages: &[String],
-    ) -> Result<()> {
-        match input {
-            InputResult::Message(content) => {
-                self.handle_message_input(&content, history, editor).await?;
-            }
-            InputResult::Exit => unreachable!("Exit is handled in the main loop"),
-            InputResult::AddExtension(cmd) => {
-                history.save(editor);
-                match self.add_extension(cmd.clone()).await {
-                    Ok(_) => output::render_extension_success(&cmd),
-                    Err(e) => output::render_extension_error(&cmd, &e.to_string()),
-                }
-            }
-            InputResult::AddBuiltin(names) => {
-                history.save(editor);
-                match self.add_builtin(names.clone()).await {
-                    Ok(_) => output::render_builtin_success(&names),
-                    Err(e) => output::render_builtin_error(&names, &e.to_string()),
-                }
-            }
-            InputResult::ToggleTheme => {
-                history.save(editor);
-                self.handle_toggle_theme();
-            }
-            InputResult::ToggleFullToolOutput => {
-                history.save(editor);
-                self.handle_toggle_full_tool_output();
-            }
-            InputResult::SelectTheme(theme_name) => {
-                history.save(editor);
-                self.handle_select_theme(&theme_name);
-            }
-            InputResult::Retry => {}
-            InputResult::ListPrompts(extension) => {
-                history.save(editor);
-                match self.list_prompts(extension).await {
-                    Ok(prompts) => output::render_prompts(&prompts),
-                    Err(e) => output::render_error(&e.to_string()),
-                }
-            }
-            InputResult::GooseMode(mode) => {
-                history.save(editor);
-                self.handle_goose_mode(&mode).await?;
-            }
-            InputResult::Model(model) => {
-                history.save(editor);
-                self.handle_model(model.as_deref()).await?;
-            }
-            InputResult::Plan(options) => {
-                self.handle_plan_mode(options).await?;
-            }
-            InputResult::EndPlan => {
-                self.run_mode = RunMode::Normal;
-                output::render_exit_plan_mode();
-            }
-            InputResult::Clear => {
-                history.save(editor);
-                self.handle_clear().await?;
-            }
-            InputResult::PromptCommand(opts) => {
-                history.save(editor);
-                self.handle_prompt_command(opts).await?;
-            }
-            InputResult::Recipe(filepath_opt) => {
-                history.save(editor);
-                self.handle_recipe(filepath_opt).await;
-            }
-            InputResult::Compact => {
-                history.save(editor);
-                self.handle_compact().await?;
-            }
-            InputResult::Edit(prefill) => {
-                history.save(editor);
-                match crate::session::editor::resolve_editor_command() {
-                    Some(editor_cmd) => {
-                        let messages: Vec<&str> =
-                            conversation_messages.iter().map(|s| s.as_str()).collect();
-                        match crate::session::editor::get_editor_input(
-                            &editor_cmd,
-                            &messages,
-                            prefill.as_deref(),
-                        ) {
-                            Ok((message, true)) => {
-                                self.handle_message_input(&message, history, editor).await?;
-                            }
-                            Ok((_, false)) => {}
-                            Err(e) => {
-                                output::render_error(&format!("Failed to open editor: {}", e));
-                            }
-                        }
-                    }
-                    None => {
-                        output::render_error(
-                            "No editor found. Set one with:\n  \
-                                 goose configure set goose_prompt_editor \"vim\"\n  \
-                                 or set $VISUAL or $EDITOR in your shell.",
-                        );
-                    }
-                }
-            }
-            InputResult::LoadSkills(names) => {
-                history.save(editor);
-                self.handle_load_skills(&names).await?;
-            }
-            InputResult::ListSkills => {
-                history.save(editor);
-                self.handle_list_skills().await?;
-            }
-        }
-        Ok(())
-    }
-
-    async fn handle_message_input(
-        &mut self,
-        content: &str,
-        history: &HistoryManager,
-        editor: &mut rustyline::Editor<GooseCompleter, rustyline::history::DefaultHistory>,
-    ) -> Result<()> {
-        match self.run_mode {
-            RunMode::Normal => {
-                history.save(editor);
-                self.push_message(Message::user().with_text(content));
-
-                if let Err(e) = crate::project_tracker::update_project_tracker(
-                    Some(content),
-                    Some(&self.session_id),
-                ) {
-                    eprintln!(
-                        "Warning: Failed to update project tracker with instruction: {}",
-                        e
-                    );
-                }
-
-                let _provider = self.agent.provider().await?;
-
-                println!();
-                output::run_status_hook("thinking");
-                output::show_thinking();
-                let start_time = Instant::now();
-                self.process_agent_response(true, CancellationToken::default())
-                    .await?;
-                output::hide_thinking();
-
-                let elapsed = start_time.elapsed();
-                let elapsed_str = format_elapsed_time(elapsed);
-                println!("{}", console::style(format!("  ⏱ {}", elapsed_str)).dim());
-            }
-            RunMode::Plan => {
-                let mut plan_messages = self.messages.clone();
-                plan_messages.push(Message::user().with_text(content));
-                let reasoner = get_reasoner().await?;
-                self.plan_with_reasoner_model(plan_messages, reasoner)
-                    .await?;
-            }
-        }
-        Ok(())
     }
 
     fn handle_toggle_theme(&self) {

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -242,6 +242,9 @@ pub struct Agent {
     pub(super) retry_manager: RetryManager,
     pub(super) tool_inspection_manager: ToolInspectionManager,
     pub(super) hook_manager: crate::hooks::HookManager,
+    pub job_registry: crate::jobs::SharedJobRegistry,
+    /// Job event receiver — take this once to listen for actionable events.
+    pub job_event_rx: Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<crate::jobs::JobEvent>>>,
     #[cfg(test)]
     stop_hook_block_cap_override: Option<u32>,
     container: Mutex<Option<Container>>,
@@ -339,6 +342,7 @@ impl Agent {
         let use_login_shell_path = config
             .use_login_shell_path
             .unwrap_or(matches!(goose_platform, GoosePlatform::GooseDesktop));
+        let (job_registry_handle, job_event_rx) = crate::jobs::create_job_registry();
         Self {
             provider: provider.clone(),
             config,
@@ -349,6 +353,7 @@ impl Agent {
                 client_name,
                 capabilities,
                 use_login_shell_path,
+                job_registry_handle.clone(),
             )),
             final_output_tool: Arc::new(Mutex::new(None)),
             frontend_extensions: Mutex::new(HashMap::new()),
@@ -364,6 +369,8 @@ impl Agent {
                 provider.clone(),
             ),
             hook_manager: crate::hooks::HookManager::load(std::env::current_dir().ok().as_deref()),
+            job_registry: job_registry_handle,
+            job_event_rx: Mutex::new(Some(job_event_rx)),
             #[cfg(test)]
             stop_hook_block_cap_override: None,
             container: Mutex::new(None),
@@ -371,6 +378,15 @@ impl Agent {
             grind: Mutex::new(None),
             pending_steers: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Take the job event receiver. Call once to get the channel for listening
+    /// to actionable job events (batch completion, critical failures, etc.).
+    /// Returns None if already taken.
+    pub async fn take_job_event_rx(
+        &self,
+    ) -> Option<tokio::sync::mpsc::UnboundedReceiver<crate::jobs::JobEvent>> {
+        self.job_event_rx.lock().await.take()
     }
 
     /// Emit a lifecycle hook event with no extra context. Useful for events

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -144,6 +144,13 @@ pub struct ExtensionManager {
     tools_cache_version: AtomicU64,
     client_name: String,
     capabilities: ExtensionManagerCapabilities,
+    /// Broadcast channel for all MCP notifications (extension_name, notification).
+    /// Consumers (CLI, Job Registry) subscribe to receive real-time notifications.
+    notification_broadcast:
+        tokio::sync::broadcast::Sender<(String, rmcp::model::ServerNotification)>,
+    /// Buffer for MOIM context injection. Drained each turn so the LLM sees recent activity.
+    notification_buffer:
+        Mutex<tokio::sync::broadcast::Receiver<(String, rmcp::model::ServerNotification)>>,
 }
 
 /// A flattened representation of a resource used by the agent to prepare inference
@@ -325,6 +332,7 @@ struct ResolvedTool {
     resource_uri: Option<String>,
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn child_process_client(
     mut command: Command,
     timeout: &Option<u64>,
@@ -333,6 +341,10 @@ async fn child_process_client(
     docker_container: Option<String>,
     client_name: String,
     capabilities: GooseMcpClientCapabilities,
+    notification_broadcast: Option<
+        tokio::sync::broadcast::Sender<(String, rmcp::model::ServerNotification)>,
+    >,
+    extension_name: Option<String>,
 ) -> ExtensionResult<McpClient> {
     configure_subprocess(&mut command);
 
@@ -363,7 +375,7 @@ async fn child_process_client(
         Ok::<String, std::io::Error>(String::from_utf8_lossy(&all_stderr).into())
     });
 
-    let client_result = McpClient::connect_with_container(
+    let client_result = McpClient::connect_with_options(
         transport,
         Duration::from_secs(resolve_timeout(*timeout)),
         provider,
@@ -371,6 +383,8 @@ async fn child_process_client(
         client_name,
         capabilities,
         working_dir.clone(),
+        notification_broadcast,
+        extension_name,
     )
     .await;
 
@@ -515,6 +529,9 @@ async fn connect_with_auth(
     client_name: String,
     capabilities: GooseMcpClientCapabilities,
     roots_dir: &std::path::Path,
+    notification_broadcast: Option<
+        tokio::sync::broadcast::Sender<(String, rmcp::model::ServerNotification)>,
+    >,
 ) -> ExtensionResult<Box<dyn McpClientTrait>> {
     let mut auth_headers = HeaderMap::new();
     auth_headers.insert(reqwest::header::USER_AGENT, GOOSE_USER_AGENT);
@@ -542,13 +559,16 @@ async fn connect_with_auth(
         StreamableHttpClientTransportConfig::with_uri(uri),
     );
     Ok(Box::new(
-        McpClient::connect(
+        McpClient::connect_with_options(
             transport,
             timeout,
             provider,
+            None,
             client_name,
             capabilities,
             roots_dir.to_path_buf(),
+            notification_broadcast,
+            None,
         )
         .await?,
     ))
@@ -566,6 +586,9 @@ async fn create_streamable_http_client(
     client_name: String,
     capabilities: GooseMcpClientCapabilities,
     roots_dir: &std::path::Path,
+    notification_broadcast: Option<
+        tokio::sync::broadcast::Sender<(String, rmcp::model::ServerNotification)>,
+    >,
 ) -> ExtensionResult<Box<dyn McpClientTrait>> {
     #[cfg(unix)]
     if let Some(socket_path) = socket {
@@ -579,6 +602,7 @@ async fn create_streamable_http_client(
             client_name,
             capabilities,
             roots_dir,
+            notification_broadcast,
         )
         .await;
     }
@@ -634,6 +658,7 @@ async fn create_streamable_http_client(
                     client_name,
                     capabilities,
                     roots_dir,
+                    notification_broadcast,
                 )
                 .await;
             }
@@ -646,13 +671,16 @@ async fn create_streamable_http_client(
         }
     }
 
-    let client_res = McpClient::connect(
+    let client_res = McpClient::connect_with_options(
         transport,
         timeout_duration,
         provider.clone(),
+        None,
         client_name.clone(),
         capabilities.clone(),
         roots_dir.to_path_buf(),
+        notification_broadcast.clone(),
+        Some(name.to_string()),
     )
     .await;
 
@@ -668,6 +696,7 @@ async fn create_streamable_http_client(
                     client_name,
                     capabilities,
                     roots_dir,
+                    notification_broadcast,
                 )
                 .await
             }
@@ -690,6 +719,9 @@ async fn create_unix_socket_http_client(
     client_name: String,
     capabilities: GooseMcpClientCapabilities,
     roots_dir: &std::path::Path,
+    notification_broadcast: Option<
+        tokio::sync::broadcast::Sender<(String, rmcp::model::ServerNotification)>,
+    >,
 ) -> ExtensionResult<Box<dyn McpClientTrait>> {
     use rmcp::transport::UnixSocketHttpClient;
 
@@ -720,13 +752,16 @@ async fn create_unix_socket_http_client(
 
     let timeout_duration = Duration::from_secs(resolve_timeout(timeout));
 
-    let client_res = McpClient::connect(
+    let client_res = McpClient::connect_with_options(
         transport,
         timeout_duration,
         provider.clone(),
+        None,
         client_name.clone(),
         capabilities.clone(),
         roots_dir.to_path_buf(),
+        notification_broadcast,
+        Some(name.to_string()),
     )
     .await;
 
@@ -754,7 +789,10 @@ impl ExtensionManager {
         client_name: String,
         capabilities: ExtensionManagerCapabilities,
         use_login_shell_path: bool,
+        job_registry: crate::jobs::SharedJobRegistry,
     ) -> Self {
+        let (notification_broadcast, _) = tokio::sync::broadcast::channel(256);
+        let notification_buffer = Mutex::new(notification_broadcast.subscribe());
         Self {
             extensions: Mutex::new(HashMap::new()),
             context: PlatformExtensionContext {
@@ -762,17 +800,21 @@ impl ExtensionManager {
                 session_manager,
                 session: None,
                 use_login_shell_path,
+                job_registry: Some(job_registry),
             },
             provider,
             tools_cache: Mutex::new(None),
             tools_cache_version: AtomicU64::new(0),
             client_name,
             capabilities,
+            notification_broadcast,
+            notification_buffer,
         }
     }
 
     pub fn new_without_provider(data_dir: std::path::PathBuf) -> Self {
         let session_manager = Arc::new(crate::session::SessionManager::new(data_dir));
+        let (job_registry, _) = crate::jobs::create_job_registry();
         Self::new(
             Arc::new(Mutex::new(None)),
             session_manager,
@@ -782,11 +824,27 @@ impl ExtensionManager {
                 host_info: None,
             },
             false,
+            job_registry,
         )
     }
 
     pub fn get_context(&self) -> &PlatformExtensionContext {
         &self.context
+    }
+
+    /// Subscribe to the notification broadcast channel.
+    /// Returns a receiver that gets all MCP notifications from all extensions.
+    pub fn subscribe_notifications(
+        &self,
+    ) -> tokio::sync::broadcast::Receiver<(String, rmcp::model::ServerNotification)> {
+        self.notification_broadcast.subscribe()
+    }
+
+    /// Get a clone of the notification broadcast sender (for passing to MCP clients).
+    pub fn notification_sender(
+        &self,
+    ) -> tokio::sync::broadcast::Sender<(String, rmcp::model::ServerNotification)> {
+        self.notification_broadcast.clone()
     }
 
     pub fn get_provider(&self) -> &SharedProvider {
@@ -871,6 +929,7 @@ impl ExtensionManager {
                     self.client_name.clone(),
                     self.mcp_client_capabilities(),
                     &effective_working_dir,
+                    Some(self.notification_broadcast.clone()),
                 )
                 .await?
             }
@@ -928,6 +987,8 @@ impl ExtensionManager {
                             Some(container_id.to_string()),
                             self.client_name.clone(),
                             self.mcp_client_capabilities(),
+                            Some(self.notification_broadcast.clone()),
+                            Some(sanitized_name.clone()),
                         )
                         .await?;
                         Box::new(client)
@@ -937,13 +998,16 @@ impl ExtensionManager {
                         extension_fn(server_read, server_write);
 
                         Box::new(
-                            McpClient::connect(
+                            McpClient::connect_with_options(
                                 (client_read, client_write),
                                 Duration::from_secs(timeout_secs),
                                 self.provider.clone(),
+                                None,
                                 self.client_name.clone(),
                                 self.mcp_client_capabilities(),
                                 effective_working_dir.clone(),
+                                Some(self.notification_broadcast.clone()),
+                                Some(sanitized_name.clone()),
                             )
                             .await?,
                         )
@@ -1000,6 +1064,8 @@ impl ExtensionManager {
                     container.map(|c| c.id().to_string()),
                     self.client_name.clone(),
                     self.mcp_client_capabilities(),
+                    Some(self.notification_broadcast.clone()),
+                    Some(sanitized_name.clone()),
                 )
                 .await?;
                 Box::new(client)
@@ -1032,6 +1098,8 @@ impl ExtensionManager {
                     container.map(|c| c.id().to_string()),
                     self.client_name.clone(),
                     self.mcp_client_capabilities(),
+                    Some(self.notification_broadcast.clone()),
+                    Some(sanitized_name.clone()),
                 )
                 .await?;
 
@@ -1973,6 +2041,53 @@ impl ExtensionManager {
             }
         }
 
+        // Drain buffered notifications for LLM context
+        {
+            let mut rx = self.notification_buffer.lock().await;
+            let mut notifications = Vec::new();
+            loop {
+                match rx.try_recv() {
+                    Ok((ext, notif)) => {
+                        use rmcp::model::ServerNotification;
+                        match &notif {
+                            ServerNotification::ResourceUpdatedNotification(_)
+                            | ServerNotification::ResourceListChangedNotification(_)
+                            | ServerNotification::ToolListChangedNotification(_)
+                            | ServerNotification::PromptListChangedNotification(_) => {
+                                notifications.push((ext, notif));
+                            }
+                            _ => {}
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::TryRecvError::Empty) => break,
+                    Err(tokio::sync::broadcast::error::TryRecvError::Closed) => break,
+                    Err(tokio::sync::broadcast::error::TryRecvError::Lagged(_)) => continue,
+                }
+            }
+            if !notifications.is_empty() {
+                content.push_str("\nBackground activity since last turn:\n");
+                for (ext, notif) in &notifications {
+                    use rmcp::model::ServerNotification;
+                    let desc = match notif {
+                        ServerNotification::ResourceUpdatedNotification(r) => {
+                            format!("{}: resource updated ({})", ext, r.params.uri)
+                        }
+                        ServerNotification::ResourceListChangedNotification(_) => {
+                            format!("{}: resource list changed", ext)
+                        }
+                        ServerNotification::ToolListChangedNotification(_) => {
+                            format!("{}: tools changed", ext)
+                        }
+                        ServerNotification::PromptListChangedNotification(_) => {
+                            format!("{}: prompts changed", ext)
+                        }
+                        _ => format!("{}: notification", ext),
+                    };
+                    content.push_str(&format!("  • {}\n", desc));
+                }
+            }
+        }
+
         content.push_str("\n</info-msg>");
 
         Some(content)
@@ -2748,6 +2863,7 @@ mod tests {
             "goose-test".to_string(),
             capabilities,
             temp_dir.path(),
+            None,
         )
         .await;
 
@@ -2783,6 +2899,7 @@ mod tests {
             "goose-test".to_string(),
             capabilities,
             temp_dir.path(),
+            None,
         )
         .await;
 
@@ -2829,6 +2946,7 @@ mod tests {
             "goose-test".to_string(),
             capabilities,
             temp_dir.path(),
+            None,
         )
         .await;
 
@@ -2910,6 +3028,7 @@ mod tests {
             "goose-test".to_string(),
             capabilities,
             temp_dir.path(),
+            None,
         )
         .await;
 

--- a/crates/goose/src/agents/mcp_client.rs
+++ b/crates/goose/src/agents/mcp_client.rs
@@ -143,6 +143,8 @@ pub trait McpClientTrait: Send + Sync {
 
 pub struct GooseClient {
     notification_handlers: Arc<Mutex<Vec<Sender<ServerNotification>>>>,
+    notification_broadcast: Option<tokio::sync::broadcast::Sender<(String, ServerNotification)>>,
+    extension_name: String,
     provider: SharedProvider,
     session_id: Mutex<Option<String>>,
     client_name: String,
@@ -160,12 +162,25 @@ impl GooseClient {
     ) -> Self {
         GooseClient {
             notification_handlers: handlers,
+            notification_broadcast: None,
+            extension_name: client_name.clone(),
             provider,
             session_id: Mutex::new(None),
             client_name,
             capabilities,
             working_dir: Arc::new(tokio::sync::RwLock::new(working_dir)),
         }
+    }
+
+    /// Attach a broadcast sender for forwarding all notifications to a central bus.
+    pub fn with_notification_broadcast(
+        mut self,
+        sender: tokio::sync::broadcast::Sender<(String, ServerNotification)>,
+        extension_name: String,
+    ) -> Self {
+        self.notification_broadcast = Some(sender);
+        self.extension_name = extension_name;
+        self
     }
 
     pub fn shared_working_dir(&self) -> Arc<tokio::sync::RwLock<PathBuf>> {
@@ -203,15 +218,21 @@ impl GooseClient {
     fn resolved_extensions(&self) -> ExtensionCapabilities {
         if let Some(host_info) = &self.capabilities.host_info {
             if host_info.explicit_extensions {
-                return host_info.extensions.clone();
+                let mut ext = host_info.extensions.clone();
+                ext.insert("io.goose/interruptable".to_string(), JsonObject::new());
+                return ext;
             }
         }
 
         if self.capabilities.mcpui {
-            return default_mcp_apps_ui_extensions();
+            let mut ext = default_mcp_apps_ui_extensions();
+            ext.insert("io.goose/interruptable".to_string(), JsonObject::new());
+            return ext;
         }
 
-        ExtensionCapabilities::new()
+        let mut ext = ExtensionCapabilities::new();
+        ext.insert("io.goose/interruptable".to_string(), JsonObject::new());
+        ext
     }
 
     fn resolved_client_info(&self) -> Implementation {
@@ -255,14 +276,18 @@ impl ClientHandler for GooseClient {
         params: rmcp::model::ProgressNotificationParam,
         context: rmcp::service::NotificationContext<rmcp::RoleClient>,
     ) {
+        let mut not = Notification::new(params.clone());
+        not.extensions = context.extensions.clone();
+        let notification = ServerNotification::ProgressNotification(not);
+        if let Some(ref broadcast) = self.notification_broadcast {
+            let _ = broadcast.send((self.extension_name.clone(), notification.clone()));
+        }
         self.notification_handlers
             .lock()
             .await
             .iter()
             .for_each(|handler| {
-                let mut not = Notification::new(params.clone());
-                not.extensions = context.extensions.clone();
-                let _ = handler.try_send(ServerNotification::ProgressNotification(not));
+                let _ = handler.try_send(notification.clone());
             });
     }
 
@@ -271,16 +296,42 @@ impl ClientHandler for GooseClient {
         params: rmcp::model::LoggingMessageNotificationParam,
         context: rmcp::service::NotificationContext<rmcp::RoleClient>,
     ) {
+        let mut notification = LoggingMessageNotification::new(params.clone());
+        notification.extensions = context.extensions.clone();
+        let server_notification = ServerNotification::LoggingMessageNotification(notification);
+        if let Some(ref broadcast) = self.notification_broadcast {
+            let _ = broadcast.send((self.extension_name.clone(), server_notification.clone()));
+        }
         self.notification_handlers
             .lock()
             .await
             .iter()
             .for_each(|handler| {
-                let mut notification = LoggingMessageNotification::new(params.clone());
-                notification.extensions = context.extensions.clone();
-                let _ =
-                    handler.try_send(ServerNotification::LoggingMessageNotification(notification));
+                let _ = handler.try_send(server_notification.clone());
             });
+    }
+
+    async fn on_resource_updated(
+        &self,
+        params: rmcp::model::ResourceUpdatedNotificationParam,
+        _context: rmcp::service::NotificationContext<rmcp::RoleClient>,
+    ) {
+        let notification = rmcp::model::ResourceUpdatedNotification::new(params.clone());
+        let server_notification = ServerNotification::ResourceUpdatedNotification(notification);
+        if let Some(ref broadcast) = self.notification_broadcast {
+            let _ = broadcast.send((self.extension_name.clone(), server_notification.clone()));
+        }
+        self.notification_handlers
+            .lock()
+            .await
+            .iter()
+            .for_each(|handler| {
+                let _ = handler.try_send(server_notification.clone());
+            });
+        tracing::info!(
+            uri = %params.uri,
+            "MCP resource updated notification received"
+        );
     }
 
     async fn create_message(
@@ -303,6 +354,12 @@ impl ClientHandler for GooseClient {
         // Prefer explicit MCP metadata, then the active request scope.
         let session_id = self.resolve_session_id(&context.extensions).await;
 
+        // Emit notification that sampling was requested
+        tracing::info!(
+            client = %self.client_name,
+            "MCP server requested sampling/createMessage"
+        );
+
         let provider_ready_messages: Vec<crate::conversation::message::Message> = params
             .messages
             .iter()
@@ -324,6 +381,9 @@ impl ClientHandler for GooseClient {
             .as_deref()
             .unwrap_or("You are a general-purpose AI agent called goose");
 
+        // Pass through tools from the requesting MCP server (Track 6)
+        let tools = params.tools.as_deref().unwrap_or(&[]);
+
         let model_config = provider.get_model_config();
         let (response, usage) = provider
             .complete(
@@ -331,7 +391,7 @@ impl ClientHandler for GooseClient {
                 session_id.as_deref().unwrap_or(""),
                 system_prompt,
                 &provider_ready_messages,
-                &[],
+                tools,
             )
             .await
             .map_err(|e| {
@@ -341,6 +401,10 @@ impl ClientHandler for GooseClient {
                     Some(Value::from(e.to_string())),
                 )
             })?;
+
+        // TODO: If response contains tool_calls, route them back to the requesting
+        // server and loop until a final text response. For now, we return whatever
+        // the LLM produces (may include tool_call content that the server can handle).
 
         Ok(CreateMessageResult::new(
             SamplingMessage::new(
@@ -477,16 +541,52 @@ impl McpClient {
         T: IntoTransport<RoleClient, E, A>,
         E: std::error::Error + From<std::io::Error> + Send + Sync + 'static,
     {
+        Self::connect_with_options(
+            transport,
+            timeout,
+            provider,
+            docker_container,
+            client_name,
+            capabilities,
+            working_dir,
+            None,
+            None,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn connect_with_options<T, E, A>(
+        transport: T,
+        timeout: std::time::Duration,
+        provider: SharedProvider,
+        docker_container: Option<String>,
+        client_name: String,
+        capabilities: GooseMcpClientCapabilities,
+        working_dir: PathBuf,
+        notification_broadcast: Option<
+            tokio::sync::broadcast::Sender<(String, ServerNotification)>,
+        >,
+        extension_name: Option<String>,
+    ) -> Result<Self, ClientInitializeError>
+    where
+        T: IntoTransport<RoleClient, E, A>,
+        E: std::error::Error + From<std::io::Error> + Send + Sync + 'static,
+    {
         let notification_subscribers =
             Arc::new(Mutex::new(Vec::<mpsc::Sender<ServerNotification>>::new()));
 
-        let client = GooseClient::new(
+        let mut client = GooseClient::new(
             notification_subscribers.clone(),
             provider,
             client_name.clone(),
             capabilities.clone(),
             working_dir,
         );
+        if let Some(broadcast) = notification_broadcast {
+            let ext_name = extension_name.unwrap_or_else(|| client_name.clone());
+            client = client.with_notification_broadcast(broadcast, ext_name);
+        }
         let client: rmcp::service::RunningService<rmcp::RoleClient, GooseClient> =
             client.serve(transport).await?;
         let server_info = client.peer_info().cloned();

--- a/crates/goose/src/agents/platform_extensions/analyze/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/analyze/mod.rs
@@ -284,6 +284,7 @@ mod tests {
             session_manager: Arc::new(SessionManager::new(std::env::temp_dir())),
             session: None,
             use_login_shell_path: false,
+            job_registry: None,
         }
     }
 

--- a/crates/goose/src/agents/platform_extensions/developer/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/mod.rs
@@ -267,6 +267,7 @@ mod tests {
             session_manager: Arc::new(SessionManager::new(data_dir)),
             session: None,
             use_login_shell_path: false,
+            job_registry: None,
         }
     }
 

--- a/crates/goose/src/agents/platform_extensions/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/mod.rs
@@ -6,6 +6,7 @@ pub mod code_execution;
 pub mod developer;
 pub mod ext_manager;
 pub mod orchestrator;
+pub mod process;
 pub mod summarize;
 pub mod summon;
 pub mod todo;
@@ -190,6 +191,20 @@ pub static PLATFORM_EXTENSIONS: Lazy<HashMap<&'static str, PlatformExtensionDef>
         );
 
         map.insert(
+            process::EXTENSION_NAME,
+            PlatformExtensionDef {
+                name: process::EXTENSION_NAME,
+                display_name: "Process Manager",
+                description:
+                    "Start and manage long-running background processes with stdin/stdout interaction",
+                default_enabled: false,
+                unprefixed_tools: false,
+                hidden: false,
+                client_factory: |ctx| Box::new(process::ProcessClient::new(ctx).unwrap()),
+            },
+        );
+
+        map.insert(
             crate::skills::EXTENSION_NAME,
             PlatformExtensionDef {
                 name: crate::skills::EXTENSION_NAME,
@@ -213,6 +228,7 @@ pub struct PlatformExtensionContext {
     pub session_manager: std::sync::Arc<crate::session::SessionManager>,
     pub session: Option<std::sync::Arc<Session>>,
     pub use_login_shell_path: bool,
+    pub job_registry: Option<crate::jobs::SharedJobRegistry>,
 }
 
 impl PlatformExtensionContext {

--- a/crates/goose/src/agents/platform_extensions/process.rs
+++ b/crates/goose/src/agents/platform_extensions/process.rs
@@ -1,0 +1,630 @@
+use crate::agents::extension::PlatformExtensionContext;
+use crate::agents::mcp_client::{Error, McpClientTrait};
+use crate::agents::tool_execution::ToolCallContext;
+use crate::jobs::{Job, JobSource, JobState, NotifyPolicy};
+use anyhow::Result;
+use async_trait::async_trait;
+use rmcp::model::{
+    CallToolResult, Content, Implementation, InitializeResult, JsonObject, ListToolsResult,
+    ServerCapabilities, Tool,
+};
+use std::collections::HashMap;
+use std::process::Stdio;
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+pub static EXTENSION_NAME: &str = "process";
+
+#[allow(dead_code)]
+struct ManagedProcess {
+    child: Child,
+    stdin: Option<tokio::process::ChildStdin>,
+    output_lines: Arc<Mutex<Vec<String>>>,
+    description: String,
+}
+
+pub struct ProcessClient {
+    info: InitializeResult,
+    context: PlatformExtensionContext,
+    processes: Arc<Mutex<HashMap<String, ManagedProcess>>>,
+    next_id: Arc<Mutex<u32>>,
+}
+
+impl ProcessClient {
+    pub fn new(context: PlatformExtensionContext) -> Result<Self> {
+        let info = InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(
+                Implementation::new(EXTENSION_NAME, "1.0.0").with_title("Process Manager"),
+            )
+            .with_instructions(
+                "Manage background processes and scheduled reminders. Start processes, read output, write stdin, stop them. Schedule timed reminders that interrupt you with a message after a delay. List all active jobs.",
+            );
+
+        Ok(Self {
+            info,
+            context,
+            processes: Arc::new(Mutex::new(HashMap::new())),
+            next_id: Arc::new(Mutex::new(1)),
+        })
+    }
+
+    async fn handle_start(&self, arguments: Option<JsonObject>) -> Result<CallToolResult, String> {
+        let args = arguments.ok_or("Missing arguments")?;
+        let command = args
+            .get("command")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing 'command' argument")?;
+        let wait_for = args
+            .get("wait_for")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let mut id_lock = self.next_id.lock().await;
+        let id = format!("proc_{}", *id_lock);
+        *id_lock += 1;
+        drop(id_lock);
+
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg(command)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("Failed to start process: {}", e))?;
+
+        let stdin = child.stdin.take();
+        let stdout = child.stdout.take();
+        let stderr = child.stderr.take();
+
+        let output_lines: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+
+        // Channel to signal when stdout closes (process exited)
+        let (stdout_done_tx, stdout_done_rx) = tokio::sync::oneshot::channel::<()>();
+
+        // Spawn stdout reader with optional pattern matching
+        if let Some(stdout) = stdout {
+            let lines = Arc::clone(&output_lines);
+            let pattern = wait_for.clone();
+            let registry = self.context.job_registry.clone();
+            let job_id = id.clone();
+            tokio::spawn(async move {
+                let reader = BufReader::new(stdout);
+                let mut lines_stream = reader.lines();
+                let mut pattern_fired = false;
+                while let Ok(Some(line)) = lines_stream.next_line().await {
+                    lines.lock().await.push(format!("[stdout] {}", line));
+                    if !pattern_fired {
+                        if let Some(ref pat) = pattern {
+                            if line.contains(pat.as_str()) {
+                                pattern_fired = true;
+                                if let Some(ref reg) = registry {
+                                    reg.lock().await.pattern_matched(
+                                        &job_id,
+                                        pat.clone(),
+                                        line.clone(),
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+                // Stdout closed — process exited
+                let _ = stdout_done_tx.send(());
+            });
+        }
+        if let Some(stderr) = stderr {
+            let lines = Arc::clone(&output_lines);
+            tokio::spawn(async move {
+                let reader = BufReader::new(stderr);
+                let mut lines_stream = reader.lines();
+                while let Ok(Some(line)) = lines_stream.next_line().await {
+                    lines.lock().await.push(format!("[stderr] {}", line));
+                }
+            });
+        }
+
+        // Spawn completion watcher — waits for stdout to close then marks job complete/failed
+        if let Some(ref registry) = self.context.job_registry {
+            let registry = Arc::clone(registry);
+            let job_id = id.clone();
+            let processes = Arc::clone(&self.processes);
+            tokio::spawn(async move {
+                let _ = stdout_done_rx.await;
+                // Small delay to let stderr drain and child to exit
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                // Try to get exit code from the child
+                let code = {
+                    let mut procs = processes.lock().await;
+                    if let Some(proc) = procs.get_mut(&job_id) {
+                        proc.child.try_wait().ok().flatten().and_then(|s| s.code())
+                    } else {
+                        None
+                    }
+                };
+                let mut reg = registry.lock().await;
+                if let Some(job) = reg.get(&job_id) {
+                    if !job.state.is_terminal() {
+                        if code.unwrap_or(0) == 0 {
+                            reg.complete(&job_id, None);
+                        } else {
+                            reg.fail(&job_id, Some(format!("exit code: {}", code.unwrap_or(-1))));
+                        }
+                    }
+                }
+            });
+        }
+
+        let description = if command.len() > 60 {
+            format!("{}...", &command.chars().take(60).collect::<String>())
+        } else {
+            command.to_string()
+        };
+
+        // Register in job registry BEFORE watcher can fire
+        if let Some(ref registry) = self.context.job_registry {
+            let job = Job {
+                id: id.clone(),
+                source: JobSource::Process,
+                description: description.clone(),
+                state: JobState::Working,
+                batch_id: None,
+                notify_policy: NotifyPolicy::OnCompletion,
+                meta: crate::jobs::JobMeta::default(),
+                created_at: std::time::Instant::now(),
+                last_activity: std::time::Instant::now(),
+                notifications: Vec::new(),
+                result_summary: None,
+            };
+            registry.lock().await.register(job);
+        }
+
+        let managed = ManagedProcess {
+            child,
+            stdin,
+            output_lines: output_lines.clone(),
+            description: description.clone(),
+        };
+
+        // Store the output_lines reference for read_output
+        // We'll read from the Arc in read_output
+        self.processes.lock().await.insert(id.clone(), managed);
+
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Process started with handle: {}\nCommand: {}\n\nUse read_output(\"{}\") to check output, write_stdin(\"{}\", ...) to send input, stop_process(\"{}\") to terminate.",
+            id, command, id, id, id
+        ))]))
+    }
+
+    async fn handle_read_output(
+        &self,
+        arguments: Option<JsonObject>,
+    ) -> Result<CallToolResult, String> {
+        let args = arguments.ok_or("Missing arguments")?;
+        let process_id = args
+            .get("process_id")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing 'process_id' argument")?;
+
+        let processes = self.processes.lock().await;
+        let proc = processes
+            .get(process_id)
+            .ok_or_else(|| format!("Process '{}' not found", process_id))?;
+
+        let is_running = proc.child.id().is_some();
+        let lines = proc.output_lines.lock().await;
+        let tail_count = 50;
+        let output = if lines.len() > tail_count {
+            format!(
+                "({} lines total, showing last {})\n{}",
+                lines.len(),
+                tail_count,
+                lines[lines.len() - tail_count..].join("\n")
+            )
+        } else {
+            lines.join("\n")
+        };
+
+        let status = if is_running { "running" } else { "exited" };
+
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "# Process {} ({})\n\n{}\n\n---\n{} lines total",
+            process_id,
+            status,
+            output,
+            lines.len()
+        ))]))
+    }
+
+    async fn handle_write_stdin(
+        &self,
+        arguments: Option<JsonObject>,
+    ) -> Result<CallToolResult, String> {
+        let args = arguments.ok_or("Missing arguments")?;
+        let process_id = args
+            .get("process_id")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing 'process_id' argument")?;
+        let input = args
+            .get("input")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing 'input' argument")?;
+
+        let mut processes = self.processes.lock().await;
+        let proc = processes
+            .get_mut(process_id)
+            .ok_or_else(|| format!("Process '{}' not found", process_id))?;
+
+        let stdin = proc
+            .stdin
+            .as_mut()
+            .ok_or("Process stdin not available (already closed)")?;
+
+        stdin
+            .write_all(input.as_bytes())
+            .await
+            .map_err(|e| format!("Failed to write to stdin: {}", e))?;
+        stdin
+            .write_all(b"\n")
+            .await
+            .map_err(|e| format!("Failed to write newline: {}", e))?;
+        stdin
+            .flush()
+            .await
+            .map_err(|e| format!("Failed to flush stdin: {}", e))?;
+
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Wrote to {}: {}",
+            process_id, input
+        ))]))
+    }
+
+    async fn handle_stop(&self, arguments: Option<JsonObject>) -> Result<CallToolResult, String> {
+        let args = arguments.ok_or("Missing arguments")?;
+        let process_id = args
+            .get("process_id")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing 'process_id' argument")?;
+
+        let mut processes = self.processes.lock().await;
+        if let Some(mut proc) = processes.remove(process_id) {
+            let _ = proc.child.kill().await;
+            let status = proc.child.wait().await.ok();
+            let exit_code = status.and_then(|s| s.code());
+
+            if let Some(ref registry) = self.context.job_registry {
+                registry.lock().await.cancel(process_id);
+            }
+
+            Ok(CallToolResult::success(vec![Content::text(format!(
+                "Process {} stopped. Exit code: {:?}",
+                process_id, exit_code
+            ))]))
+        } else {
+            drop(processes);
+            if let Some(ref registry) = self.context.job_registry {
+                let mut reg = registry.lock().await;
+                if reg.get(process_id).is_some() {
+                    reg.cancel(process_id);
+                    return Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Job {} canceled.",
+                        process_id
+                    ))]));
+                }
+            }
+            Err(format!("Job '{}' not found", process_id))
+        }
+    }
+
+    async fn handle_schedule_reminder(
+        &self,
+        arguments: Option<JsonObject>,
+    ) -> Result<CallToolResult, String> {
+        let args = arguments.ok_or("Missing arguments")?;
+        let delay_str = args
+            .get("delay")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing 'delay' argument")?;
+        let message = args
+            .get("message")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing 'message' argument")?
+            .to_string();
+
+        let duration = parse_duration(delay_str)
+            .ok_or_else(|| format!("Invalid delay '{}'. Use e.g. 30s, 5m, 2h, 1h30m", delay_str))?;
+
+        let mut id_lock = self.next_id.lock().await;
+        let id = format!("timer_{}", *id_lock);
+        *id_lock += 1;
+        drop(id_lock);
+
+        let registry = self
+            .context
+            .job_registry
+            .as_ref()
+            .ok_or("Job registry not available")?;
+
+        let deadline = std::time::Instant::now() + duration;
+        let job = Job {
+            id: id.clone(),
+            source: JobSource::Timer,
+            description: message.clone(),
+            state: JobState::Working,
+            batch_id: None,
+            notify_policy: NotifyPolicy::OnCompletion,
+            meta: crate::jobs::JobMeta {
+                deadline: Some(deadline),
+                ..Default::default()
+            },
+            created_at: std::time::Instant::now(),
+            last_activity: std::time::Instant::now(),
+            notifications: Vec::new(),
+            result_summary: None,
+        };
+        registry.lock().await.register(job);
+
+        let reg = Arc::clone(registry);
+        let job_id = id.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(duration).await;
+            reg.lock().await.complete(&job_id, Some(message));
+        });
+
+        let human_dur = format_duration(duration);
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Reminder scheduled: {} (fires in {}). Job ID: {}",
+            args.get("message").unwrap().as_str().unwrap(),
+            human_dur,
+            id
+        ))]))
+    }
+
+    async fn handle_list_jobs(&self) -> Result<CallToolResult, String> {
+        let registry = self
+            .context
+            .job_registry
+            .as_ref()
+            .ok_or("Job registry not available")?;
+
+        let reg = registry.lock().await;
+        let jobs = reg.running();
+        if jobs.is_empty() {
+            return Ok(CallToolResult::success(vec![Content::text(
+                "No active jobs.",
+            )]));
+        }
+
+        let now = std::time::Instant::now();
+        let lines: Vec<String> = jobs
+            .iter()
+            .map(|j| {
+                let state_str = match j.state {
+                    JobState::Working => {
+                        if let Some(deadline) = j.meta.deadline {
+                            if deadline > now {
+                                let remaining = deadline - now;
+                                format!("Working ({} remaining)", format_duration(remaining))
+                            } else {
+                                "Working (firing...)".to_string()
+                            }
+                        } else {
+                            "Working".to_string()
+                        }
+                    }
+                    _ => format!("{:?}", j.state),
+                };
+                let source = match j.source {
+                    JobSource::Timer => "timer",
+                    JobSource::Process => "process",
+                    JobSource::Subagent => "subagent",
+                    _ => "job",
+                };
+                format!(
+                    "• {} [{}] {}: \"{}\"",
+                    j.id, source, state_str, j.description
+                )
+            })
+            .collect();
+
+        Ok(CallToolResult::success(vec![Content::text(
+            lines.join("\n"),
+        )]))
+    }
+}
+
+fn parse_duration(s: &str) -> Option<std::time::Duration> {
+    let s = s.trim().to_lowercase();
+    let mut total_secs: u64 = 0;
+    let mut num_buf = String::new();
+
+    for c in s.chars() {
+        if c.is_ascii_digit() {
+            num_buf.push(c);
+        } else {
+            let n: u64 = num_buf.parse().ok()?;
+            num_buf.clear();
+            match c {
+                's' => total_secs += n,
+                'm' => total_secs += n * 60,
+                'h' => total_secs += n * 3600,
+                'd' => total_secs += n * 86400,
+                _ => return None,
+            }
+        }
+    }
+    // Handle bare number (assume seconds)
+    if !num_buf.is_empty() {
+        let n: u64 = num_buf.parse().ok()?;
+        total_secs += n;
+    }
+    if total_secs == 0 {
+        return None;
+    }
+    Some(std::time::Duration::from_secs(total_secs))
+}
+
+fn format_duration(d: std::time::Duration) -> String {
+    let secs = d.as_secs();
+    if secs >= 3600 {
+        let h = secs / 3600;
+        let m = (secs % 3600) / 60;
+        if m > 0 {
+            format!("{}h{}m", h, m)
+        } else {
+            format!("{}h", h)
+        }
+    } else if secs >= 60 {
+        let m = secs / 60;
+        let s = secs % 60;
+        if s > 0 {
+            format!("{}m{}s", m, s)
+        } else {
+            format!("{}m", m)
+        }
+    } else {
+        format!("{}s", secs)
+    }
+}
+
+#[async_trait]
+impl McpClientTrait for ProcessClient {
+    async fn list_tools(
+        &self,
+        _session_id: &str,
+        _next_cursor: Option<String>,
+        _cancel_token: CancellationToken,
+    ) -> Result<ListToolsResult, Error> {
+        let tools = vec![
+            Tool::new(
+                "start_process",
+                "Start a long-running process in the background. Returns a process handle for monitoring and interaction.".to_string(),
+                serde_json::json!({
+                    "type": "object",
+                    "required": ["command"],
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "description": "Shell command to run"
+                        },
+                        "wait_for": {
+                            "type": "string",
+                            "description": "Optional pattern to watch for in stdout. When matched, triggers a PatternMatched event (forced turn). The process keeps running."
+                        }
+                    }
+                }).as_object().unwrap().clone(),
+            ),
+            Tool::new(
+                "read_output",
+                "Read recent output (stdout/stderr) from a running process.".to_string(),
+                serde_json::json!({
+                    "type": "object",
+                    "required": ["process_id"],
+                    "properties": {
+                        "process_id": {
+                            "type": "string",
+                            "description": "Process handle from start_process"
+                        }
+                    }
+                }).as_object().unwrap().clone(),
+            ),
+            Tool::new(
+                "write_stdin",
+                "Write input to a running process's stdin.".to_string(),
+                serde_json::json!({
+                    "type": "object",
+                    "required": ["process_id", "input"],
+                    "properties": {
+                        "process_id": {
+                            "type": "string",
+                            "description": "Process handle from start_process"
+                        },
+                        "input": {
+                            "type": "string",
+                            "description": "Text to send to the process stdin"
+                        }
+                    }
+                }).as_object().unwrap().clone(),
+            ),
+            Tool::new(
+                "stop_process",
+                "Stop/kill a running process and get its exit status.".to_string(),
+                serde_json::json!({
+                    "type": "object",
+                    "required": ["process_id"],
+                    "properties": {
+                        "process_id": {
+                            "type": "string",
+                            "description": "Process handle from start_process"
+                        }
+                    }
+                }).as_object().unwrap().clone(),
+            ),
+            Tool::new(
+                "schedule_reminder",
+                "Schedule a timed reminder. Creates a job that fires after a delay, interrupting you with the given message. Use for checking back on async work, polling status, or any deferred action.".to_string(),
+                serde_json::json!({
+                    "type": "object",
+                    "required": ["delay", "message"],
+                    "properties": {
+                        "delay": {
+                            "type": "string",
+                            "description": "How long to wait before firing. Examples: 30s, 5m, 2h, 1h30m"
+                        },
+                        "message": {
+                            "type": "string",
+                            "description": "Reminder context injected when the timer fires"
+                        }
+                    }
+                }).as_object().unwrap().clone(),
+            ),
+            Tool::new(
+                "list_jobs",
+                "List all active background jobs (processes, timers, subagents) with their current status and time remaining.".to_string(),
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {}
+                }).as_object().unwrap().clone(),
+            ),
+        ];
+
+        Ok(ListToolsResult {
+            tools,
+            next_cursor: None,
+            meta: None,
+        })
+    }
+
+    async fn call_tool(
+        &self,
+        _ctx: &ToolCallContext,
+        name: &str,
+        arguments: Option<JsonObject>,
+        _cancel_token: CancellationToken,
+    ) -> Result<CallToolResult, Error> {
+        let result = match name {
+            "start_process" => self.handle_start(arguments).await,
+            "read_output" => self.handle_read_output(arguments).await,
+            "write_stdin" => self.handle_write_stdin(arguments).await,
+            "stop_process" => self.handle_stop(arguments).await,
+            "schedule_reminder" => self.handle_schedule_reminder(arguments).await,
+            "list_jobs" => self.handle_list_jobs().await,
+            _ => Err(format!("Unknown tool: {}", name)),
+        };
+
+        match result {
+            Ok(r) => Ok(r),
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Error: {}",
+                e
+            ))])),
+        }
+    }
+
+    fn get_info(&self) -> Option<&InitializeResult> {
+        Some(&self.info)
+    }
+}

--- a/crates/goose/src/agents/platform_extensions/summon.rs
+++ b/crates/goose/src/agents/platform_extensions/summon.rs
@@ -68,6 +68,7 @@ pub struct BackgroundTask {
     pub started_at: Instant,
     pub turns: Arc<AtomicU32>,
     pub last_activity: Arc<AtomicU64>,
+    pub last_message: Arc<std::sync::Mutex<String>>,
     pub handle: JoinHandle<Result<String>>,
     pub cancellation_token: CancellationToken,
     pub notification_buffer: Arc<Mutex<Vec<ServerNotification>>>,
@@ -475,6 +476,11 @@ impl SummonClient {
                     "type": "boolean",
                     "default": false,
                     "description": "For running background tasks: cancel and return output."
+                },
+                "peek": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Get a quick status snapshot of a background task without blocking or consuming it."
                 }
             }
         });
@@ -485,11 +491,13 @@ impl SummonClient {
              Call with no arguments to list all available sources (subrecipes, recipes, agents).\n\
              Call with a source name to load its content into your context.\n\
              For background tasks: load(source: \"task_id\") waits for the task and returns the result.\n\
-             To cancel a running task: load(source: \"task_id\", cancel: true) stops and returns output.\n\n\
+             To cancel a running task: load(source: \"task_id\", cancel: true) stops and returns output.\n\
+             To check status without blocking: load(source: \"task_id\", peek: true) returns a quick snapshot.\n\n\
              Examples:\n\
              - load() → Lists available sources\n\
              - load(source: \"deploy\") → Loads the deploy recipe\n\
-             - load(source: \"20260219_1\") → Waits for background task, then returns result"
+             - load(source: \"20260219_1\") → Waits for background task, then returns result\n\
+             - load(source: \"20260219_1\", peek: true) → Quick status check (non-blocking)"
                 .to_string(),
             schema.as_object().unwrap().clone(),
         )
@@ -555,7 +563,12 @@ impl SummonClient {
              - Parallel: async: true, then load(taskId) to wait and get results. Single: sync.\n\n\
              Research (read-only): parallelize freely - delegates explore and report back.\n\
              Work (writes): partition files strictly - no two delegates touch the same file.\n\n\
-             Decompose → async delegates → load(taskId) for each → synthesize."
+             Best practices:\n\
+             - Use async: true for builds, tests, deploys, and any task expected to take >30 seconds\n\
+             - After delegating async, continue working with the user\n\
+             - Use load(source: \"taskId\", peek: true) to check progress without blocking\n\
+             - Only use load(source: \"taskId\") (without peek) when you need the full result\n\n\
+             Decompose → async delegates → peek to monitor → load to collect → synthesize."
                 .to_string(),
             schema.as_object().unwrap().clone(),
         )
@@ -765,6 +778,12 @@ impl SummonClient {
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
+        let peek = arguments
+            .as_ref()
+            .and_then(|args| args.get("peek"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
         let working_dir = self.get_working_dir(session_id).await;
 
         if source_name.is_none() {
@@ -777,6 +796,12 @@ impl SummonClient {
         let name = source_name.unwrap();
 
         if is_session_id(name) {
+            if peek {
+                return self
+                    .handle_peek_task(name)
+                    .await
+                    .map(CallToolResult::success);
+            }
             let content = self.handle_load_task_result(name, cancel).await?;
             let mut meta = Meta::new();
             meta.0.insert(
@@ -915,6 +940,74 @@ impl SummonClient {
                     ));
                 }
             }
+        }
+
+        Err(format!("Task '{}' not found.", task_id))
+    }
+
+    async fn handle_peek_task(&self, task_id: &str) -> Result<Vec<Content>, String> {
+        // Check completed tasks first
+        let completed = self.completed_tasks.lock().await;
+        if let Some(task) = completed.get(task_id) {
+            let status = if task.result.is_ok() {
+                "✓ Completed"
+            } else {
+                "✗ Failed"
+            };
+            return Ok(vec![Content::text(format!(
+                "# Task Status: {}\n\n\
+                 **Task:** {}\n\
+                 **Status:** {}\n\
+                 **Duration:** {}\n\
+                 **Turns:** {}",
+                task_id,
+                task.description,
+                status,
+                round_duration(task.duration),
+                task.turns_taken,
+            ))]);
+        }
+        drop(completed);
+
+        // Check running tasks (read-only — no removal)
+        let running = self.background_tasks.lock().await;
+        if let Some(task) = running.get(task_id) {
+            let elapsed = task.started_at.elapsed();
+            let turns = task.turns.load(Ordering::Relaxed);
+            let now = current_epoch_millis();
+            let idle_ms = now.saturating_sub(task.last_activity.load(Ordering::Relaxed));
+            let last_msg = task.last_message.lock().unwrap().clone();
+            let notif_count = task.notification_buffer.lock().await.len();
+
+            let status = if task.handle.is_finished() {
+                "Completed (pending collection)"
+            } else {
+                "Running"
+            };
+
+            let mut output = format!(
+                "# Task Status: {}\n\n\
+                 **Task:** {}\n\
+                 **Status:** {}\n\
+                 **Duration:** {}\n\
+                 **Turns:** {}\n\
+                 **Idle:** {}",
+                task_id,
+                task.description,
+                status,
+                round_duration(elapsed),
+                turns,
+                round_duration(Duration::from_millis(idle_ms)),
+            );
+
+            if !last_msg.is_empty() {
+                output.push_str(&format!("\n**Last message:** {}", last_msg));
+            }
+            if notif_count > 0 {
+                output.push_str(&format!("\n**Buffered notifications:** {}", notif_count));
+            }
+
+            return Ok(vec![Content::text(output)]);
         }
 
         Err(format!("Task '{}' not found.", task_id))
@@ -1531,13 +1624,23 @@ impl SummonClient {
             completed.insert(
                 id.clone(),
                 CompletedTask {
-                    id,
+                    id: id.clone(),
                     description: task.description,
                     result,
                     turns_taken,
                     duration,
                 },
             );
+
+            // Update job registry
+            if let Some(ref registry) = self.context.job_registry {
+                let is_success = completed.get(&id).is_some_and(|t| t.result.is_ok());
+                if is_success {
+                    registry.lock().await.complete(&id, None);
+                } else {
+                    registry.lock().await.fail(&id, None);
+                }
+            }
         }
     }
 
@@ -1611,13 +1714,26 @@ impl SummonClient {
 
         let turns = Arc::new(AtomicU32::new(0));
         let last_activity = Arc::new(AtomicU64::new(current_epoch_millis()));
+        let last_message = Arc::new(std::sync::Mutex::new(String::new()));
 
         let turns_clone = Arc::clone(&turns);
         let last_activity_clone = Arc::clone(&last_activity);
+        let last_message_clone = Arc::clone(&last_message);
 
-        let on_message: OnMessageCallback = Arc::new(move |_msg| {
+        let on_message: OnMessageCallback = Arc::new(move |msg| {
             turns_clone.fetch_add(1, Ordering::Relaxed);
             last_activity_clone.store(current_epoch_millis(), Ordering::Relaxed);
+            if msg.role == rmcp::model::Role::Assistant {
+                let text = msg.as_concat_text();
+                if !text.is_empty() {
+                    let snippet = if text.len() > 200 {
+                        format!("{}...", &text.chars().take(200).collect::<String>())
+                    } else {
+                        text
+                    };
+                    *last_message_clone.lock().unwrap() = snippet;
+                }
+            }
         });
 
         let task_token = CancellationToken::new();
@@ -1652,6 +1768,7 @@ impl SummonClient {
             started_at: Instant::now(),
             turns,
             last_activity,
+            last_message,
             handle,
             cancellation_token: task_token,
             notification_buffer,
@@ -1661,6 +1778,50 @@ impl SummonClient {
             .lock()
             .await
             .insert(task_id.clone(), task);
+
+        // Register in the unified job registry
+        if let Some(ref registry) = self.context.job_registry {
+            let job = crate::jobs::Job {
+                id: task_id.clone(),
+                source: crate::jobs::JobSource::Subagent,
+                description: description.clone(),
+                state: crate::jobs::JobState::Working,
+                batch_id: None,
+                notify_policy: crate::jobs::NotifyPolicy::OnCompletion,
+                meta: crate::jobs::JobMeta::default(),
+                created_at: std::time::Instant::now(),
+                last_activity: std::time::Instant::now(),
+                notifications: Vec::new(),
+                result_summary: None,
+            };
+            registry.lock().await.register(job);
+
+            // Spawn watcher to drive job completion when the delegate finishes.
+            // We poll the JoinHandle via a separate spawned task that holds nothing
+            // from self — just the registry and a handle to the spawned future.
+            let registry_clone = Arc::clone(registry);
+            let watcher_id = task_id.clone();
+            let watcher_handle = {
+                let tasks = self.background_tasks.lock().await;
+                let task_ref = tasks.get(&watcher_id).unwrap();
+                task_ref.handle.abort_handle()
+            };
+            tokio::spawn(async move {
+                // Poll until the task finishes (abort handle lets us check without owning)
+                loop {
+                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                    if watcher_handle.is_finished() {
+                        let mut reg = registry_clone.lock().await;
+                        if let Some(job) = reg.get(&watcher_id) {
+                            if !job.state.is_terminal() {
+                                reg.complete(&watcher_id, None);
+                            }
+                        }
+                        break;
+                    }
+                }
+            });
+        }
 
         let content = vec![Content::text(format!(
             "Task {} started in background: \"{}\"\n\
@@ -1808,7 +1969,7 @@ impl McpClientTrait for SummonClient {
 
         if !running.is_empty() {
             lines.push(
-                "\n→ Use load(source: \"<id>\") to wait for a task, or load(source: \"<id>\", cancel: true) to stop it"
+                "\n→ peek: load(source: \"<id>\", peek: true) | collect: load(source: \"<id>\") | cancel: load(source: \"<id>\", cancel: true)"
                     .to_string(),
             );
         }
@@ -1832,6 +1993,7 @@ mod tests {
             session_manager: Arc::new(crate::session::SessionManager::instance()),
             session: None,
             use_login_shell_path: false,
+            job_registry: None,
         }
     }
 
@@ -2344,6 +2506,7 @@ You review code."#;
                     started_at: Instant::now(),
                     turns: Arc::new(AtomicU32::new(2)),
                     last_activity: Arc::new(AtomicU64::new(current_epoch_millis())),
+                    last_message: Arc::new(std::sync::Mutex::new(String::new())),
                     handle: tokio::spawn(async {
                         tokio::time::sleep(Duration::from_millis(50)).await;
                         Ok("done".to_string())
@@ -2465,6 +2628,7 @@ You review code."#;
                     started_at: Instant::now(),
                     turns: Arc::new(AtomicU32::new(3)),
                     last_activity: Arc::new(AtomicU64::new(current_epoch_millis())),
+                    last_message: Arc::new(std::sync::Mutex::new(String::new())),
                     handle: tokio::spawn(async {
                         tokio::time::sleep(Duration::from_secs(1000)).await;
                         Ok("should not see this".to_string())

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -467,6 +467,7 @@ mod tests {
             session_manager,
             session: Some(Arc::new(session)),
             use_login_shell_path: false,
+            job_registry: None,
         };
 
         let mut extensions: Vec<ExtensionInfo> = PLATFORM_EXTENSIONS

--- a/crates/goose/src/jobs.rs
+++ b/crates/goose/src/jobs.rs
@@ -1,0 +1,392 @@
+//! Unified Job Registry for tracking all async work in goose.
+//!
+//! Every background operation (subagent, process, MCP resource subscription,
+//! long-running tool call) is represented as a Job with consistent lifecycle,
+//! notification, and tracking semantics.
+//!
+//! ## State Machine
+//!
+//! ```text
+//! Working → Complete
+//! Working → Failed
+//! Working → Canceled
+//! Working → InputRequired → Working (after input provided)
+//! Working → (event: PatternMatched) → still Working
+//! ```
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::{mpsc, Mutex};
+
+/// Unique identifier for a job.
+pub type JobId = String;
+
+/// Unique identifier for a batch of related jobs.
+pub type BatchId = String;
+
+/// The source/type of a job.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JobSource {
+    /// A subagent spawned via delegate(async: true)
+    Subagent,
+    /// A long-running process (shell command, build, etc.)
+    Process,
+    /// An MCP resource subscription being watched
+    McpResource,
+    /// A long-running MCP tool call
+    McpTool,
+    /// An orchestrator-managed swarm agent
+    SwarmAgent,
+    /// A scheduled timer/reminder
+    Timer,
+}
+
+/// Current state of a job.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JobState {
+    /// Actively running / in progress.
+    Working,
+    /// The job needs input from the user or parent agent to continue.
+    InputRequired,
+    /// Successfully completed.
+    Completed,
+    /// Errored or crashed.
+    Failed,
+    /// Explicitly canceled by user or agent.
+    Canceled,
+}
+
+// Compat alias
+impl JobState {
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Completed | Self::Failed | Self::Canceled)
+    }
+}
+
+/// Which state transitions should trigger an interrupt (forced turn).
+#[derive(Debug, Clone)]
+pub struct InterruptPolicy {
+    pub on_complete: bool,
+    pub on_failed: bool,
+    pub on_input_required: bool,
+    pub on_pattern_matched: bool,
+}
+
+impl Default for InterruptPolicy {
+    fn default() -> Self {
+        Self {
+            on_complete: true,
+            on_failed: true,
+            on_input_required: true,
+            on_pattern_matched: true,
+        }
+    }
+}
+
+/// Metadata hints for job polling/retention behavior.
+#[derive(Debug, Clone)]
+pub struct JobMeta {
+    /// Don't poll more often than this.
+    pub min_poll_interval_ms: u64,
+    /// After reaching a terminal state, data is retained for this long.
+    pub ttl_after_completion_s: u64,
+    /// Which transitions trigger a forced turn.
+    pub interrupt_on: InterruptPolicy,
+    /// For timer jobs: when the timer fires.
+    pub deadline: Option<Instant>,
+}
+
+impl Default for JobMeta {
+    fn default() -> Self {
+        Self {
+            min_poll_interval_ms: 1000,
+            ttl_after_completion_s: 300,
+            interrupt_on: InterruptPolicy::default(),
+            deadline: None,
+        }
+    }
+}
+
+/// Policy for when a job's completion should trigger an assistant turn.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum NotifyPolicy {
+    /// Only surface in MOIM. Never force a turn on its own.
+    Informational,
+    /// Force assistant turn when THIS specific job completes/fails.
+    OnCompletion,
+    /// Force assistant turn only when ALL jobs in the same batch are done.
+    #[default]
+    OnBatchCompletion,
+}
+
+/// A timestamped notification from a job.
+#[derive(Debug, Clone)]
+pub struct JobNotification {
+    pub timestamp: Instant,
+    pub message: String,
+}
+
+/// A single tracked job.
+#[derive(Debug)]
+pub struct Job {
+    pub id: JobId,
+    pub source: JobSource,
+    pub description: String,
+    pub state: JobState,
+    pub batch_id: Option<BatchId>,
+    pub notify_policy: NotifyPolicy,
+    pub meta: JobMeta,
+    pub created_at: Instant,
+    pub last_activity: Instant,
+    pub notifications: Vec<JobNotification>,
+    pub result_summary: Option<String>,
+}
+
+/// Event emitted when an actionable condition is met.
+#[derive(Debug, Clone)]
+pub enum JobEvent {
+    /// A batch of jobs has fully completed.
+    BatchCompleted {
+        batch_id: BatchId,
+        job_summaries: Vec<JobSummary>,
+    },
+    /// A single job completed with OnCompletion policy.
+    JobCompleted { job: JobSummary },
+    /// A job needs input to continue.
+    JobNeedsInput { job_id: JobId, question: String },
+    /// A pattern was matched in the job's output stream (job still working).
+    PatternMatched {
+        job_id: JobId,
+        pattern: String,
+        context: String,
+    },
+}
+
+/// Summary of a completed job (for event payloads).
+#[derive(Debug, Clone)]
+pub struct JobSummary {
+    pub id: JobId,
+    pub source: JobSource,
+    pub description: String,
+    pub state: JobState,
+    pub duration: Duration,
+}
+
+/// The Job Registry — tracks all async work for a session.
+pub struct JobRegistry {
+    jobs: HashMap<JobId, Job>,
+    event_tx: mpsc::UnboundedSender<JobEvent>,
+}
+
+impl JobRegistry {
+    pub fn new() -> (Self, mpsc::UnboundedReceiver<JobEvent>) {
+        let (event_tx, event_rx) = mpsc::unbounded_channel();
+        (
+            Self {
+                jobs: HashMap::new(),
+                event_tx,
+            },
+            event_rx,
+        )
+    }
+
+    pub fn register(&mut self, job: Job) {
+        self.jobs.insert(job.id.clone(), job);
+    }
+
+    pub fn get(&self, id: &str) -> Option<&Job> {
+        self.jobs.get(id)
+    }
+
+    pub fn get_mut(&mut self, id: &str) -> Option<&mut Job> {
+        self.jobs.get_mut(id)
+    }
+
+    /// Mark a job as completed.
+    pub fn complete(&mut self, id: &str, summary: Option<String>) {
+        self.transition(id, JobState::Completed, summary);
+    }
+
+    /// Mark a job as failed.
+    pub fn fail(&mut self, id: &str, summary: Option<String>) {
+        self.transition(id, JobState::Failed, summary);
+    }
+
+    /// Mark a job as canceled.
+    pub fn cancel(&mut self, id: &str) {
+        self.transition(id, JobState::Canceled, Some("canceled".into()));
+    }
+
+    /// Transition a job to InputRequired and emit event.
+    pub fn needs_input(&mut self, id: &str, question: String) {
+        if let Some(job) = self.jobs.get_mut(id) {
+            job.state = JobState::InputRequired;
+            job.last_activity = Instant::now();
+            if job.meta.interrupt_on.on_input_required {
+                let _ = self.event_tx.send(JobEvent::JobNeedsInput {
+                    job_id: id.to_string(),
+                    question,
+                });
+            }
+        }
+    }
+
+    /// Resume a job from InputRequired back to Working.
+    pub fn resume(&mut self, id: &str) {
+        if let Some(job) = self.jobs.get_mut(id) {
+            if job.state == JobState::InputRequired {
+                job.state = JobState::Working;
+                job.last_activity = Instant::now();
+            }
+        }
+    }
+
+    /// Emit a pattern-matched event (job stays Working).
+    pub fn pattern_matched(&mut self, id: &str, pattern: String, context: String) {
+        if let Some(job) = self.jobs.get_mut(id) {
+            job.last_activity = Instant::now();
+            job.notifications.push(JobNotification {
+                timestamp: Instant::now(),
+                message: format!("pattern matched: {}", pattern),
+            });
+            if job.meta.interrupt_on.on_pattern_matched {
+                let _ = self.event_tx.send(JobEvent::PatternMatched {
+                    job_id: id.to_string(),
+                    pattern,
+                    context,
+                });
+            }
+        }
+    }
+
+    /// Add a notification to a job's log.
+    pub fn notify(&mut self, id: &str, message: String) {
+        if let Some(job) = self.jobs.get_mut(id) {
+            job.last_activity = Instant::now();
+            job.notifications.push(JobNotification {
+                timestamp: Instant::now(),
+                message,
+            });
+        }
+    }
+
+    pub fn list(&self) -> Vec<&Job> {
+        self.jobs.values().collect()
+    }
+
+    pub fn running(&self) -> Vec<&Job> {
+        self.jobs
+            .values()
+            .filter(|j| j.state == JobState::Working)
+            .collect()
+    }
+
+    pub fn finished(&self) -> Vec<&Job> {
+        self.jobs
+            .values()
+            .filter(|j| j.state.is_terminal())
+            .collect()
+    }
+
+    pub fn remove(&mut self, id: &str) -> Option<Job> {
+        self.jobs.remove(id)
+    }
+
+    /// Garbage collect jobs past their TTL.
+    pub fn gc(&mut self) {
+        let now = Instant::now();
+        self.jobs.retain(|_, job| {
+            if job.state.is_terminal() {
+                let elapsed = now.duration_since(job.last_activity);
+                elapsed.as_secs() < job.meta.ttl_after_completion_s
+            } else {
+                true
+            }
+        });
+    }
+
+    fn transition(&mut self, id: &str, new_state: JobState, summary: Option<String>) {
+        let (notify_policy, batch_id, should_interrupt) = {
+            let Some(job) = self.jobs.get_mut(id) else {
+                return;
+            };
+            if job.state.is_terminal() {
+                return;
+            }
+            job.state = new_state.clone();
+            job.last_activity = Instant::now();
+            job.result_summary = summary;
+            let should_interrupt = match &new_state {
+                JobState::Completed => job.meta.interrupt_on.on_complete,
+                JobState::Failed => job.meta.interrupt_on.on_failed,
+                _ => false,
+            };
+            (
+                job.notify_policy.clone(),
+                job.batch_id.clone(),
+                should_interrupt,
+            )
+        };
+
+        match notify_policy {
+            NotifyPolicy::OnCompletion => {
+                if should_interrupt {
+                    if let Some(job) = self.jobs.get(id) {
+                        let _ = self.event_tx.send(JobEvent::JobCompleted {
+                            job: self.make_summary(job),
+                        });
+                    }
+                }
+            }
+            NotifyPolicy::OnBatchCompletion => {
+                if let Some(batch_id) = batch_id {
+                    self.check_batch_completion(&batch_id);
+                }
+            }
+            NotifyPolicy::Informational => {}
+        }
+    }
+
+    fn check_batch_completion(&self, batch_id: &str) {
+        let batch_jobs: Vec<&Job> = self
+            .jobs
+            .values()
+            .filter(|j| j.batch_id.as_deref() == Some(batch_id))
+            .collect();
+
+        if batch_jobs.is_empty() {
+            return;
+        }
+
+        let all_done = batch_jobs.iter().all(|j| j.state.is_terminal());
+
+        if all_done {
+            let summaries: Vec<JobSummary> =
+                batch_jobs.iter().map(|j| self.make_summary(j)).collect();
+            let _ = self.event_tx.send(JobEvent::BatchCompleted {
+                batch_id: batch_id.to_string(),
+                job_summaries: summaries,
+            });
+        }
+    }
+
+    fn make_summary(&self, job: &Job) -> JobSummary {
+        JobSummary {
+            id: job.id.clone(),
+            source: job.source.clone(),
+            description: job.description.clone(),
+            state: job.state.clone(),
+            duration: job.created_at.elapsed(),
+        }
+    }
+}
+
+/// Thread-safe handle to the job registry.
+pub type SharedJobRegistry = Arc<Mutex<JobRegistry>>;
+
+/// Create a new shared job registry and its event receiver.
+pub fn create_job_registry() -> (SharedJobRegistry, mpsc::UnboundedReceiver<JobEvent>) {
+    let (registry, event_rx) = JobRegistry::new();
+    (Arc::new(Mutex::new(registry)), event_rx)
+}

--- a/crates/goose/src/lib.rs
+++ b/crates/goose/src/lib.rs
@@ -21,6 +21,7 @@ pub mod goose_apps;
 pub mod hints;
 pub mod hooks;
 pub mod instance_id;
+pub mod jobs;
 pub mod logging;
 pub mod mcp_utils;
 pub mod model;

--- a/crates/goose/src/skills/client.rs
+++ b/crates/goose/src/skills/client.rs
@@ -277,6 +277,7 @@ mod tests {
             session_manager: Arc::new(crate::session::SessionManager::instance()),
             session: Some(session),
             use_login_shell_path: false,
+            job_registry: None,
         })
         .unwrap();
 
@@ -304,6 +305,7 @@ mod tests {
             session_manager: Arc::new(crate::session::SessionManager::instance()),
             session: None,
             use_login_shell_path: false,
+            job_registry: None,
         })
         .unwrap();
 

--- a/crates/goose/tests/mcp_integration_test.rs
+++ b/crates/goose/tests/mcp_integration_test.rs
@@ -257,6 +257,7 @@ async fn test_replayed_session(
     let session_manager = Arc::new(goose::session::SessionManager::new(
         temp_dir.path().to_path_buf(),
     ));
+    let (job_registry, _job_rx) = goose::jobs::create_job_registry();
     let extension_manager = Arc::new(ExtensionManager::new(
         provider,
         session_manager,
@@ -266,6 +267,7 @@ async fn test_replayed_session(
             host_info: None,
         },
         true,
+        job_registry,
     ));
 
     #[allow(clippy::redundant_closure_call)]


### PR DESCRIPTION
## feat: Async Job Infrastructure, Process Management & Real-Time Notifications

### Summary

This PR introduces foundational infrastructure for managing background async work in goose — processes, timers, subagents — with real-time MCP notification routing and a fully async CLI event loop.

The core idea: goose should be able to kick off background work (builds, tests, servers, subagent research), continue interacting with the user, and seamlessly handle completions/interrupts when results arrive.

**Key capabilities added:**

- **Unified Job Registry** — A state machine for tracking all async work (processes, subagents, timers) with lifecycle events, batch completion, and GC
- **Process Management Extension** — Start/stop/interact with background processes, schedule timed reminders, list active jobs
- **MCP Notification Broadcast** — All MCP server notifications flow through a central broadcast channel for real-time routing
- **Async CLI Event Loop** — Input thread architecture with `tokio::select!` over user input, job events, and MCP notifications simultaneously
- **Subagent `peek`** — Non-blocking status check for background delegate tasks
- **Sampling tool pass-through** — MCP `createMessage` now forwards tools from the requesting server (Track 6)
- **Resource update notifications** — `on_resource_updated` handler wired into the notification system
- **MOIM notification drain** — Background activity surfaced to the LLM as context each turn

### Architecture

```
┌──────────────────────────────────────────────────────────────┐
│                        CLI Event Loop                        │
│  tokio::select! {                                            │
│    user_input   ← input_thread (blocking readline)           │
│    job_events   ← JobRegistry channel                        │
│    notifications← ExtensionManager broadcast                 │
│  }                                                           │
└──────────┬──────────────────┬───────────────────┬────────────┘
           │                  │                   │
    ┌──────▼───────┐   ┌──────▼──────┐   ┌────────▼──────┐
    │ Input Thread │   │ Job Registry│   │ Notification  │
    │ (rustyline)  │   │ (state mach)│   │  Broadcast    │
    │ ExternalPrint│   │ events→turns│   │ MCP→CLI/MOIM  │
    └──────────────┘   └─────────────┘   └───────────────┘
```

### Changes by Area

#### New Modules
| File | Lines | Description |
|------|-------|-------------|
| `crates/goose/src/jobs.rs` | +389 | Job registry: state machine, batch tracking, GC, event channel |
| `crates/goose/src/agents/platform_extensions/process.rs` | +615 | Process management extension (start/stop/stdin/stdout/timers) |
| `crates/goose-cli/src/session/input_thread.rs` | +174 | Async input thread with ExternalPrinter for non-blocking output |

#### Modified
| File | Description |
|------|-------------|
| `session/mod.rs` | Rewrote main loop to async `select!` over 3 event sources |
| `extension_manager.rs` | Added notification broadcast channel + MOIM drain + `subscribe_notifications()` |
| `mcp_client.rs` | Notification broadcast forwarding, `on_resource_updated`, tool pass-through in sampling, `connect_with_options` |
| `agent.rs` | Wire job registry + event receiver into Agent |
| `summon.rs` | `peek` for background tasks, job registry integration |
| `platform_extensions/mod.rs` | Register process extension, add `job_registry` to context |

### Testing

- **cargo fmt** — Clean
- **cargo clippy --all-targets -- -D warnings** — Zero warnings
- **cargo test** — 1350 passed, no new failures introduced
  - 104 pre-existing failures on main (sqlx `runtime-tokio` feature issue)
  - 9 pre-existing provider test failures (reasoning effort tests on main)
- **Manual testing** — Process management, timer scheduling, async subagent peek, notification routing all tested in interactive CLI sessions

### Known Limitations & Future Work

- **Process extension is `default_enabled: false`** — Deliberately disabled pending further testing. No user-facing activation path yet (follow-up to add CLI toggle or config key).
- **`interrupt=true` URI convention** — Forced turns triggered by checking `uri.contains("interrupt=true")`. Functional but fragile; future improvement would use MCP notification extension fields.
- **`io.goose/interruptable` always advertised** — This capability extension is unconditionally sent to all MCP servers. Correct default behavior but not opt-out-able yet.
- **No tool-call routing loop in sampling** — When `createMessage` response contains tool calls, they're returned as-is. Future: route back to requesting server and loop until final text.
- **`InterruptState` scaffolding** — Input thread has interrupt coordination structure defined but not yet wired (for future forced-turn approval UX).

### Screenshots/Demos (for UX changes)

#### Async Process Management & Timers
<!-- TODO: Screen recording showing:
  - start_process("cargo build") running in background
  - schedule_reminder("5m", "check build status")
  - list_jobs showing active processes and timers
  - Timer firing and interrupting with forced turn
-->
📹 *Video coming soon*

#### Non-Blocking Notifications Above Prompt
<!-- TODO: Screen recording showing:
  - User typing at prompt
  - MCP progress notifications appearing above without disrupting input
  - ExternalPrinter rendering live build output while user continues typing
-->
📹 *Video coming soon*

#### Subagent Peek (Non-Blocking Status)
<!-- TODO: Screen recording showing:
  - delegate(async: true) kicking off parallel research tasks
  - load(source: "task_id", peek: true) showing live status
  - Batch completion triggering forced turn with results
-->
📹 *Video coming soon*

#### Forced Turn on Job Completion
<!-- TODO: Screen recording showing:
  - Background build completing
  - CLI automatically injecting system message and triggering agent response
  - Agent summarizing results without user needing to ask
-->
📹 *Video coming soon*

### Video Recording Suggestions

| Feature | Demo Scenario | Impact |
|---------|--------------|--------|
| Process Manager | Start a `cargo build`, read output, schedule reminder to check in 2min | Shows the "fire and forget" workflow |
| Parallel Delegates | 3 async research tasks → peek progress → collect results | Shows the orchestration power |
| Live Notifications | MCP server emitting progress while user types | Shows non-blocking UX |
| Timer Interrupts | Set reminder → continue chatting → timer fires → agent reacts | Shows proactive agent behavior |
| End-to-End Workflow | "Build this, test it, deploy if green" with full async pipeline | The money shot |


---

*29 commits, ~1919 lines across 15 files*

