### PR TITLE
feat: add Quantized as a declarative provider

### DIFF
--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -1112,6 +1112,22 @@ mod tests {
     }
 
     #[test]
+    fn test_quantized_json_deserializes() {
+        let json = include_str!("../providers/declarative/quantized.json");
+        let config: DeclarativeProviderConfig =
+            serde_json::from_str(json).expect("quantized.json should parse");
+        assert_eq!(config.name, "quantized");
+        assert_eq!(config.display_name, "Quantized");
+        assert!(matches!(config.engine, ProviderEngine::OpenAI));
+        assert_eq!(config.api_key_env, "QUANTIZED_API_KEY");
+        assert_eq!(config.base_url, "https://api.quantized.us/v1");
+        assert_eq!(config.dynamic_models, Some(false));
+        assert!(config.skip_canonical_filtering);
+        assert!(config.preserves_thinking);
+        assert_eq!(config.models[0].name, "anthropic/claude-sonnet-4.6");
+    }
+
+    #[test]
     fn test_expand_env_vars_replaces_placeholder() {
         let _guard = env_lock::lock_env([("TEST_EXPAND_HOST", Some("https://example.com/api"))]);
 

--- a/crates/goose/src/providers/declarative/quantized.json
+++ b/crates/goose/src/providers/declarative/quantized.json
@@ -1,0 +1,21 @@
+{
+  "name": "quantized",
+  "engine": "openai",
+  "display_name": "Quantized",
+  "description": "Quantized unified LLM API by DataWars (OpenAI-compatible).",
+  "api_key_env": "QUANTIZED_API_KEY",
+  "base_url": "https://api.quantized.us/v1",
+  "requires_auth": true,
+  "dynamic_models": false,
+  "skip_canonical_filtering": true,
+  "preserves_thinking": true,
+  "supports_streaming": true,
+  "models": [
+    {"name": "anthropic/claude-sonnet-4.6", "context_limit": 200000},
+    {"name": "anthropic/claude-opus-4.6", "context_limit": 200000},
+    {"name": "anthropic/claude-haiku-4.5", "context_limit": 200000},
+    {"name": "openai/gpt-4o", "context_limit": 128000},
+    {"name": "openai/gpt-4o-mini", "context_limit": 128000},
+    {"name": "deepseek/deepseek-v3.2", "context_limit": 128000}
+  ]
+}


### PR DESCRIPTION
## Summary

Adds [Quantized](https://api.quantized.us) as a built-in declarative provider. Quantized is a unified, OpenAI-compatible LLM API by DataWars that proxies models from multiple upstreams (OpenAI, Anthropic, DeepSeek, and others) behind a single endpoint and API key.

Because Quantized speaks the standard OpenAI chat-completions protocol, this is a pure declarative provider, one JSON file plus a parse test, in the same style as the existing `opencode_go.json` and `atomic_chat.json`.

What it does:

- `crates/goose/src/providers/declarative/quantized.json` — the provider definition (`engine: openai`, base URL `https://api.quantized.us/v1`, key from `QUANTIZED_API_KEY`).
- `crates/goose/src/config/declarative_providers.rs` — a `test_quantized_json_deserializes` unit test matching the existing per-provider test convention.

Design notes:

- `dynamic_models` is `false` with a curated static model list, so Goose does not call `/v1/models` and the listed models work without runtime discovery.
- `skip_canonical_filtering` is `true` because Quantized is not yet in the models.dev catalog; without it the models would be filtered out of the recommended list. Once Quantized is listed on models.dev this can be replaced with `catalog_provider_id` to pull pricing and capability metadata.
- The model list is intentionally small and known-good; it can grow in follow-ups.

### Testing

- `cargo test -p goose --lib declarative_providers::tests::test_quantized_json_deserializes` passes.
- `cargo clippy -p goose --lib` is clean.
- `rustfmt --edition 2021 --check` is clean on the edited file.
- Verified end to end against the live Quantized API with the Goose CLI and desktop app: chat, streaming, and tool calling all work on the listed models.

### Related Issues

No existing issue. New provider addition, following the precedent of AtomicChat (#9050) and `opencode_go`.
