### PR TITLE
fix: disable extended thinking for fast-model operations

### DIFF
--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -340,7 +340,8 @@ impl ModelConfig {
             .map(|v| v.trim().to_string())
             .filter(|v| !v.is_empty())
             .unwrap_or_else(|| fast_model_name.to_string());
-        let fast_config = ModelConfig::new(&name)?.with_canonical_limits(provider_name);
+        let mut fast_config = ModelConfig::new(&name)?.with_canonical_limits(provider_name);
+        fast_config.reasoning = Some(false);
         self.fast_model_config = Some(Box::new(fast_config));
         Ok(self)
     }
@@ -469,6 +470,10 @@ impl ModelConfig {
                 serde_json::json!(effort.to_string()),
             );
         }
+    }
+
+    pub fn reasoning_disabled(&self) -> bool {
+        self.reasoning == Some(false)
     }
 
     pub fn thinking_effort(&self) -> Option<ThinkingEffort> {
@@ -665,6 +670,17 @@ mod tests {
         assert_eq!(fast_config.context_limit, Some(4096));
         assert_eq!(fast_config.max_tokens, Some(1024));
         assert_eq!(config.use_fast_model().model_name, "fast-model");
+    }
+
+    #[test]
+    fn with_fast_disables_thinking_even_when_effort_set() {
+        let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", Some("high"))]);
+        let config = ModelConfig::new("claude-sonnet-4-5")
+            .unwrap()
+            .with_fast("claude-haiku-4-5", "anthropic")
+            .unwrap();
+
+        assert_eq!(config.use_fast_model().reasoning, Some(false));
     }
 
     mod thinking_effort_tests {

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -615,7 +615,7 @@ fn apply_thinking_config(
         ThinkingType::Disabled => {}
     }
 
-    if options.preserve_thinking_context {
+    if options.preserve_thinking_context && !model_config.reasoning_disabled() {
         if !obj.contains_key("thinking") {
             let budget_tokens = thinking_budget_tokens(model_config);
             obj.insert("max_tokens".to_string(), json!(max_tokens + budget_tokens));

--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -621,7 +621,7 @@ pub fn create_request_for_provider(
 
     let (model_name, legacy_reasoning_effort) = extract_reasoning_effort(&model_config.model_name);
     let is_openai_reasoning_model = is_openai_responses_model(&model_name);
-    let reasoning_effort = if is_openai_reasoning_model {
+    let reasoning_effort = if is_openai_reasoning_model && !model_config.reasoning_disabled() {
         model_config
             .thinking_effort()
             .map_or(legacy_reasoning_effort, |effort| {

--- a/crates/goose/src/providers/formats/google.rs
+++ b/crates/goose/src/providers/formats/google.rs
@@ -530,6 +530,9 @@ struct GoogleRequest<'a> {
 }
 
 fn get_thinking_config(model_config: &ModelConfig) -> Option<ThinkingConfig> {
+    if model_config.reasoning_disabled() {
+        return None;
+    }
     let model_name = model_config.model_name.to_lowercase();
     let is_gemini_3 = model_name.starts_with("gemini-3");
     let is_gemini_25 = model_name.starts_with("gemini-2.5");

--- a/crates/goose/src/providers/formats/openai_responses.rs
+++ b/crates/goose/src/providers/formats/openai_responses.rs
@@ -557,7 +557,7 @@ pub fn create_responses_request(
     // by the API for reasoning models regardless of whether an explicit
     // effort suffix was provided.
     let is_reasoning_model = is_openai_responses_model(&model_name);
-    let reasoning_effort = if is_reasoning_model {
+    let reasoning_effort = if is_reasoning_model && !model_config.reasoning_disabled() {
         if let Some(effort) = legacy_reasoning_effort.as_deref() {
             effort
                 .parse()


### PR DESCRIPTION
### What this fixes

Fast-model utility calls (compaction summaries, session naming, orchestrator routing) were inheriting `GOOSE_THINKING_EFFORT`, even though they're mechanical operations that gain nothing from extended thinking. On Anthropic, for a fast model already at its output cap (`claude-haiku-4-5`, 64k), the inherited budget was added on top of `max_tokens` → `max_tokens: 74000`, over the cap → every fast-model compaction returned a deterministic 400 and silently fell back to the slower, costlier session model. The cheap compaction path never worked for Anthropic users with thinking enabled.

### The fix

`ModelConfig::with_fast()` now sets `reasoning = Some(false)` on the fast config, disabling thinking at the source for fast-model operations; a `reasoning_disabled()` helper is honored across the anthropic, google, databricks, and openai_responses formats. This is also correct independent of the bug- fast/utility ops should stay cheap and fast, not burn thinking tokens.

Addresses the fast-model compaction 400 in #8642 (does not close the umbrella issue).

#### Out of scope

Two related, pre-existing issues are intentionally **not** addressed here:

1. **Output-cap 400s are misclassified as `ContextLengthExceeded`** (`http_status.rs`), which can trigger a phantom auto-compaction loop (`agent.rs`) — the likely source of #8642's "context limit reached at low usage" reports.
2. **`apply_thinking_config` still adds the thinking budget on top of `max_tokens`** without respecting the output cap, so a non-adaptive thinking model used as the *main* model can still 400. The durable fix is an answer-budget-aware clamp.



assisted by claude code
