### PR TITLE
[WIP] feat(memory): rolling user profile + cited chat recall

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1569,7 +1569,7 @@ impl Agent {
         if was_plain_user_turn
             && Config::global()
                 .get_param::<bool>("GOOSE_CHAT_RECALL_AUTO")
-                .unwrap_or(false)
+                .unwrap_or(true)
         {
             if let Ok(provider) = self.provider().await {
                 let current_session_type = session_manager
@@ -1763,7 +1763,7 @@ impl Agent {
 
         if Config::global()
             .get_param::<bool>("GOOSE_USER_PROFILE_ENABLED")
-            .unwrap_or(false)
+            .unwrap_or(true)
         {
             let provider = provider.clone();
             let manager_for_spawn = session_manager.clone();

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1497,6 +1497,8 @@ impl Agent {
             .execute_command(&message_text, &session_config.id)
             .await;
 
+        let mut was_plain_user_turn = false;
+
         match command_result {
             Err(e) => {
                 let error_message = Message::assistant()
@@ -1559,8 +1561,51 @@ impl Agent {
                 session_manager
                     .add_message(&session_config.id, &user_message)
                     .await?;
+                was_plain_user_turn = true;
             }
         }
+
+        let mut recall_preamble: Vec<AgentEvent> = Vec::new();
+        if was_plain_user_turn
+            && Config::global()
+                .get_param::<bool>("GOOSE_CHAT_RECALL_AUTO")
+                .unwrap_or(false)
+        {
+            if let Ok(provider) = self.provider().await {
+                let current_session_type = session_manager
+                    .get_session(&session_config.id, false)
+                    .await
+                    .ok()
+                    .map(|s| s.session_type);
+                if let Some(outcome) = crate::agents::auto_recall::recall_for_message(
+                    &session_manager,
+                    &provider,
+                    &session_config.id,
+                    current_session_type,
+                    &message_text,
+                )
+                .await
+                {
+                    session_manager
+                        .add_message(
+                            &session_config.id,
+                            &Message::user()
+                                .with_text(outcome.context_block)
+                                .with_visibility(false, true),
+                        )
+                        .await?;
+                    recall_preamble.push(AgentEvent::Message(
+                        Message::assistant()
+                            .with_system_notification(
+                                SystemNotificationType::InlineMessage,
+                                outcome.user_summary,
+                            )
+                            .with_visibility(true, false),
+                    ));
+                }
+            }
+        }
+
         let session = session_manager
             .get_session(&session_config.id, true)
             .await?;
@@ -1580,6 +1625,10 @@ impl Agent {
         let conversation_to_compact = conversation.clone();
 
         Ok(Box::pin(async_stream::try_stream! {
+            for event in recall_preamble {
+                yield event;
+            }
+
             let final_conversation = if !needs_auto_compact {
                 conversation
             } else {
@@ -1708,6 +1757,21 @@ impl Agent {
                     }
                     Ok(None) => {}
                     Err(e) => warn!("Failed to generate session description: {}", e),
+                }
+            });
+        }
+
+        if Config::global()
+            .get_param::<bool>("GOOSE_USER_PROFILE_ENABLED")
+            .unwrap_or(false)
+        {
+            let provider = provider.clone();
+            let manager_for_spawn = session_manager.clone();
+            tokio::spawn(async move {
+                if let Err(e) =
+                    crate::agents::user_profile::maybe_refresh(&manager_for_spawn, provider).await
+                {
+                    warn!("Failed to refresh user profile: {}", e);
                 }
             });
         }

--- a/crates/goose/src/agents/auto_recall.rs
+++ b/crates/goose/src/agents/auto_recall.rs
@@ -1,0 +1,330 @@
+//! Automatic chat recall — a "Remembering" step that runs before a turn.
+//!
+//! When a user message looks like it references past work ("remind me…",
+//! "what did we decide about…", or just names a topic discussed before), this
+//! retrieves the most relevant past sessions, injects them as grounded context
+//! for the model, and surfaces the sources (title + date) to the user — like
+//! ChatGPT's recall panel.
+//!
+//! It is opt-in (`GOOSE_CHAT_RECALL_AUTO`) and cheap: a fast-model gate decides
+//! whether recall is warranted and extracts search keywords, returning nothing
+//! for trivial messages so most turns pay no recall cost.
+
+use std::sync::Arc;
+
+use crate::providers::base::Provider;
+use crate::session::chat_history_search::{ChatRecallMessage, ChatRecallResult};
+use crate::session::session_manager::{SessionManager, SessionType};
+
+const MAX_RECALLED_SESSIONS: usize = 3;
+const MAX_SNIPPET_CHARS: usize = 300;
+const KEYWORD_GATE_MAX_TOKENS: i32 = 64;
+
+/// A single recalled source, ready to cite.
+pub struct RecalledSource {
+    pub session_id: String,
+    pub title: String,
+    pub date: String,
+    pub snippet: String,
+}
+
+pub struct RecallOutcome {
+    pub sources: Vec<RecalledSource>,
+    /// Agent-visible grounded context to inject before the turn.
+    pub context_block: String,
+    /// User-visible one-liner summarizing what was recalled.
+    pub user_summary: String,
+}
+
+const GATE_SYSTEM_PROMPT: &str = "You decide whether a user's message to an AI assistant would \
+benefit from recalling PAST conversations, and if so, what to search for.\n\n\
+Recall is warranted when the message references prior work, decisions, or facts the user expects \
+you to remember (e.g. 'remind me…', 'what did we decide about…', 'the X we set up', or naming a \
+specific project/topic likely discussed before). It is NOT warranted for greetings, brand-new \
+requests, or self-contained questions.\n\n\
+Reply with ONLY a line of space-separated search keywords (include useful synonyms) if recall is \
+warranted, or exactly the word NONE if it is not. No other text.";
+
+/// Ask the fast model whether to recall and for what keywords.
+/// Returns `None` to skip recall. Falls back to a simple heuristic on error.
+async fn extract_keywords(provider: &Arc<dyn Provider>, user_text: &str) -> Option<String> {
+    if user_text.trim().is_empty() {
+        return None;
+    }
+
+    let model_config = provider
+        .get_model_config()
+        .use_fast_model()
+        .with_max_tokens(Some(KEYWORD_GATE_MAX_TOKENS));
+
+    let message = crate::conversation::message::Message::user().with_text(user_text);
+    let result = provider
+        .complete(
+            &model_config,
+            "auto-recall-gate",
+            GATE_SYSTEM_PROMPT,
+            &[message],
+            &[],
+        )
+        .await;
+
+    match result {
+        Ok((response, _usage)) => {
+            let raw: String = response
+                .content
+                .iter()
+                .filter_map(|c| c.as_text())
+                .collect();
+            let cleaned = raw.trim();
+            if cleaned.is_empty() || cleaned.eq_ignore_ascii_case("none") {
+                None
+            } else {
+                Some(cleaned.split_whitespace().collect::<Vec<_>>().join(" "))
+            }
+        }
+        Err(_) => heuristic_keywords(user_text),
+    }
+}
+
+/// Cheap fallback: only recall when the message explicitly invokes memory.
+fn heuristic_keywords(user_text: &str) -> Option<String> {
+    const TRIGGERS: &[&str] = &[
+        "remind me",
+        "remember",
+        "we discussed",
+        "we decided",
+        "last time",
+        "earlier you",
+        "what did we",
+        "recall",
+    ];
+    let lower = user_text.to_lowercase();
+    if !TRIGGERS.iter().any(|t| lower.contains(t)) {
+        return None;
+    }
+    let keywords: Vec<String> = lower
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|w| w.len() > 3)
+        .take(8)
+        .map(str::to_string)
+        .collect();
+    if keywords.is_empty() {
+        None
+    } else {
+        Some(keywords.join(" "))
+    }
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    let normalized = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    let mut chars = normalized.chars();
+    let mut out: String = chars.by_ref().take(max_chars).collect();
+    if chars.next().is_some() {
+        out.push('…');
+    }
+    out
+}
+
+fn best_snippet(result: &ChatRecallResult) -> String {
+    let pick = result
+        .messages
+        .iter()
+        .find(|m: &&ChatRecallMessage| m.role.eq_ignore_ascii_case("user"))
+        .or_else(|| result.messages.first());
+    pick.map(|m| truncate_chars(&m.content, MAX_SNIPPET_CHARS))
+        .unwrap_or_default()
+}
+
+/// A citable title: the session's generated name, or a short snippet-derived
+/// fallback when the session was never named.
+fn session_title(description: &str, snippet: &str) -> String {
+    let trimmed = description.trim();
+    if !trimmed.is_empty() {
+        return trimmed.to_string();
+    }
+    let fallback = truncate_chars(snippet, 48);
+    if fallback.is_empty() {
+        "Untitled session".to_string()
+    } else {
+        fallback
+    }
+}
+
+fn search_session_types(current: Option<SessionType>) -> Vec<SessionType> {
+    match current {
+        Some(SessionType::Acp) => vec![SessionType::Acp],
+        _ => vec![SessionType::User, SessionType::Scheduled],
+    }
+}
+
+/// Build the grounded-context block injected for the model.
+fn build_context_block(sources: &[RecalledSource]) -> String {
+    let mut block = String::from(
+        "# Recalled context from past sessions\n\
+         The following excerpts come from this user's earlier sessions and may be relevant. \
+         Use them to ground your answer when appropriate, and cite the session title when you rely \
+         on one. If they are not relevant, ignore them.\n\n",
+    );
+    for (i, source) in sources.iter().enumerate() {
+        block.push_str(&format!(
+            "{}. \"{}\" ({})\n   {}\n\n",
+            i + 1,
+            source.title,
+            source.date,
+            source.snippet
+        ));
+    }
+    block
+}
+
+fn build_user_summary(sources: &[RecalledSource]) -> String {
+    let citations = sources
+        .iter()
+        .map(|s| format!("\"{}\" ({})", s.title, s.date))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("🧠 Recalled from past sessions: {citations}")
+}
+
+/// Run the recall step for a user message. Returns `None` when nothing relevant
+/// is found or recall isn't warranted.
+pub async fn recall_for_message(
+    session_manager: &SessionManager,
+    provider: &Arc<dyn Provider>,
+    current_session_id: &str,
+    current_session_type: Option<SessionType>,
+    user_text: &str,
+) -> Option<RecallOutcome> {
+    let keywords = extract_keywords(provider, user_text).await?;
+
+    let results = session_manager
+        .search_chat_history(
+            &keywords,
+            Some(MAX_RECALLED_SESSIONS),
+            None,
+            None,
+            Some(current_session_id.to_string()),
+            search_session_types(current_session_type),
+        )
+        .await
+        .ok()?;
+
+    if results.results.is_empty() {
+        return None;
+    }
+
+    let sources: Vec<RecalledSource> = results
+        .results
+        .iter()
+        .take(MAX_RECALLED_SESSIONS)
+        .map(|r| {
+            let snippet = best_snippet(r);
+            RecalledSource {
+                session_id: r.session_id.clone(),
+                title: session_title(&r.session_description, &snippet),
+                date: r.last_activity.format("%Y-%m-%d").to_string(),
+                snippet,
+            }
+        })
+        .collect();
+
+    if sources.is_empty() {
+        return None;
+    }
+
+    let context_block = build_context_block(&sources);
+    let user_summary = build_user_summary(&sources);
+
+    Some(RecallOutcome {
+        sources,
+        context_block,
+        user_summary,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn source(title: &str, date: &str) -> RecalledSource {
+        RecalledSource {
+            session_id: "s1".to_string(),
+            title: title.to_string(),
+            date: date.to_string(),
+            snippet: "front 27 rear 29 cold".to_string(),
+        }
+    }
+
+    #[test]
+    fn heuristic_triggers_only_on_memory_phrases() {
+        assert!(heuristic_keywords("remind me what tyre pressure to use").is_some());
+        assert!(heuristic_keywords("we decided on the database schema").is_some());
+        assert!(heuristic_keywords("write a new function please").is_none());
+        assert!(heuristic_keywords("hello there").is_none());
+    }
+
+    #[test]
+    fn truncate_collapses_whitespace_and_caps() {
+        assert_eq!(truncate_chars("a   b\n c", 100), "a b c");
+        assert_eq!(truncate_chars("hello world", 5), "hello…");
+    }
+
+    #[test]
+    fn context_block_lists_titles_and_dates() {
+        let sources = vec![source("Tyre Pressure 981", "2026-05-02")];
+        let block = build_context_block(&sources);
+        assert!(block.contains("Recalled context from past sessions"));
+        assert!(block.contains("\"Tyre Pressure 981\" (2026-05-02)"));
+        assert!(block.contains("front 27 rear 29 cold"));
+    }
+
+    #[test]
+    fn user_summary_cites_sources() {
+        let sources = vec![
+            source("Tyre Pressure 981", "2026-05-02"),
+            source("981 Aero Effects", "2026-06-13"),
+        ];
+        let summary = build_user_summary(&sources);
+        assert!(summary.starts_with("🧠 Recalled from past sessions:"));
+        assert!(summary.contains("\"Tyre Pressure 981\" (2026-05-02)"));
+        assert!(summary.contains("\"981 Aero Effects\" (2026-06-13)"));
+    }
+
+    #[test]
+    fn session_title_falls_back_to_snippet_when_unnamed() {
+        assert_eq!(
+            session_title("Tyre Pressure 981", "anything"),
+            "Tyre Pressure 981"
+        );
+        assert_eq!(
+            session_title("  ", "front 27 rear 29 cold"),
+            "front 27 rear 29 cold"
+        );
+        assert_eq!(session_title("", ""), "Untitled session");
+    }
+
+    #[test]
+    fn best_snippet_prefers_user_message() {
+        let result = ChatRecallResult {
+            session_id: "s".to_string(),
+            session_description: "d".to_string(),
+            session_working_dir: "/".to_string(),
+            last_activity: Utc::now(),
+            total_messages_in_session: 2,
+            messages: vec![
+                ChatRecallMessage {
+                    role: "assistant".to_string(),
+                    content: "the answer is 42".to_string(),
+                    timestamp: Utc::now(),
+                },
+                ChatRecallMessage {
+                    role: "user".to_string(),
+                    content: "what is the pressure".to_string(),
+                    timestamp: Utc::now(),
+                },
+            ],
+        };
+        assert_eq!(best_snippet(&result), "what is the pressure");
+    }
+}

--- a/crates/goose/src/agents/mod.rs
+++ b/crates/goose/src/agents/mod.rs
@@ -1,4 +1,5 @@
 mod agent;
+pub mod auto_recall;
 pub mod container;
 pub mod execute_commands;
 pub mod extension;
@@ -20,6 +21,7 @@ pub(crate) mod subagent_task_config;
 mod tool_confirmation_router;
 mod tool_execution;
 pub mod types;
+pub mod user_profile;
 pub mod validate_extensions;
 
 pub use agent::{Agent, AgentConfig, AgentEvent, ExtensionLoadResult, GoosePlatform};

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -27,7 +27,7 @@ use tracing::warn;
 fn user_profile_enabled() -> bool {
     crate::config::Config::global()
         .get_param::<bool>("GOOSE_USER_PROFILE_ENABLED")
-        .unwrap_or(false)
+        .unwrap_or(true)
 }
 
 async fn enhance_model_error(error: ProviderError, provider: &Arc<dyn Provider>) -> ProviderError {

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -24,6 +24,12 @@ use goose_providers::conversation::token_usage::ProviderUsage;
 use rmcp::model::Tool;
 use tracing::warn;
 
+fn user_profile_enabled() -> bool {
+    crate::config::Config::global()
+        .get_param::<bool>("GOOSE_USER_PROFILE_ENABLED")
+        .unwrap_or(false)
+}
+
 async fn enhance_model_error(error: ProviderError, provider: &Arc<dyn Provider>) -> ProviderError {
     let ProviderError::RequestFailed(ref msg) = error else {
         return error;
@@ -230,6 +236,15 @@ impl Agent {
             .with_hints(working_dir)
             .with_goose_mode(goose_mode)
             .build();
+
+        if user_profile_enabled() {
+            if let Some(profile) = crate::agents::user_profile::load_profile() {
+                system_prompt = format!(
+                    "{system_prompt}\n\n{}",
+                    crate::agents::user_profile::system_prompt_section(&profile)
+                );
+            }
+        }
 
         // Handle toolshim if enabled
         let mut toolshim_tools = vec![];

--- a/crates/goose/src/agents/user_profile.rs
+++ b/crates/goose/src/agents/user_profile.rs
@@ -1,0 +1,390 @@
+//! Rolling user profile — a short, auto-generated "about the user" blurb that
+//! is injected into the system prompt at session start.
+//!
+//! The profile distills recent sessions (their generated names plus the opening
+//! user messages) into a compact summary of what the user works on and how they
+//! like to work. It is computed lazily with the fast model: a session injects
+//! whatever profile exists now, then refreshes it in the background so the next
+//! session starts with an up-to-date view.
+//!
+//! Refresh is a *revision*, not a rewrite: the existing profile is fed back to
+//! the model alongside the recent sessions, with instructions to keep durable
+//! facts and long-standing preferences, fold in new signal, and only drop
+//! entries that are clearly stale or one-off.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Result;
+use chrono::{DateTime, Duration, Utc};
+use rmcp::model::Role;
+use serde::{Deserialize, Serialize};
+
+use crate::config::paths::Paths;
+use crate::providers::base::Provider;
+use crate::session::session_manager::{SessionManager, SessionType};
+
+/// Hard cap on profile length, enforced after generation.
+const MAX_PROFILE_LINES: usize = 20;
+/// How many recent sessions to feed the summarizer.
+const RECENT_SESSION_LIMIT: usize = 25;
+/// Opening user messages to sample per session.
+const OPENING_MESSAGES_PER_SESSION: usize = 2;
+/// Characters of each opening message to keep.
+const OPENING_MESSAGE_MAX_CHARS: usize = 400;
+/// Refresh the profile when it is older than this.
+const DEFAULT_REFRESH_HOURS: i64 = 24;
+/// Minimum sessions required before generating a profile at all.
+const MIN_SESSIONS_FOR_PROFILE: usize = 3;
+/// Output token cap for the summary — it's short, so keep this small.
+const PROFILE_MAX_OUTPUT_TOKENS: i32 = 1024;
+
+const PROFILE_FILE: &str = "user_profile.md";
+const META_FILE: &str = "user_profile.meta.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ProfileMeta {
+    generated_at: DateTime<Utc>,
+    source_session_count: usize,
+    latest_session_updated_at: Option<DateTime<Utc>>,
+}
+
+fn profile_path() -> PathBuf {
+    Paths::data_dir().join(PROFILE_FILE)
+}
+
+fn meta_path() -> PathBuf {
+    Paths::data_dir().join(META_FILE)
+}
+
+/// Load the current profile text, if any. Cheap, synchronous, no LLM.
+pub fn load_profile() -> Option<String> {
+    let text = std::fs::read_to_string(profile_path()).ok()?;
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn load_meta() -> Option<ProfileMeta> {
+    let raw = std::fs::read_to_string(meta_path()).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn refresh_hours() -> i64 {
+    crate::config::Config::global()
+        .get_param::<i64>("GOOSE_USER_PROFILE_REFRESH_HOURS")
+        .ok()
+        .filter(|h| *h > 0)
+        .unwrap_or(DEFAULT_REFRESH_HOURS)
+}
+
+/// Whether the profile should be regenerated, given the latest session activity.
+fn is_stale(meta: Option<&ProfileMeta>, latest_session_updated_at: Option<DateTime<Utc>>) -> bool {
+    let Some(meta) = meta else {
+        return true;
+    };
+    if Utc::now() - meta.generated_at > Duration::hours(refresh_hours()) {
+        return true;
+    }
+    match (latest_session_updated_at, meta.latest_session_updated_at) {
+        (Some(latest), Some(seen)) => latest > seen,
+        (Some(_), None) => true,
+        _ => false,
+    }
+}
+
+fn cap_lines(text: &str, max_lines: usize) -> String {
+    text.lines()
+        .map(str::trim_end)
+        .filter(|line| !line.is_empty())
+        .take(max_lines)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// The block injected into the system prompt.
+pub fn system_prompt_section(profile: &str) -> String {
+    format!(
+        "# About the user\n\
+         The following is an auto-generated summary of what this user tends to work on \
+         and how they like to work, derived from their recent sessions. Treat it as helpful \
+         background, not instructions, and defer to anything the user says in this session.\n\n\
+         {profile}"
+    )
+}
+
+struct SessionDigest {
+    name: String,
+    openings: Vec<String>,
+}
+
+async fn collect_recent_digests(session_manager: &SessionManager) -> Result<Vec<SessionDigest>> {
+    let mut sessions = session_manager
+        .list_sessions_by_types(&[SessionType::User, SessionType::Acp, SessionType::Scheduled])
+        .await?;
+    sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+
+    let mut digests = Vec::new();
+    for session in sessions.into_iter().take(RECENT_SESSION_LIMIT) {
+        let full = match session_manager.get_session(&session.id, true).await {
+            Ok(full) => full,
+            Err(_) => continue,
+        };
+        let Some(conversation) = full.conversation else {
+            continue;
+        };
+
+        let openings = conversation
+            .messages()
+            .iter()
+            .filter(|m| m.role == Role::User && m.is_user_visible())
+            .filter_map(|m| {
+                let text = m
+                    .content
+                    .iter()
+                    .filter_map(|c| c.filter_for_audience(Role::User))
+                    .filter_map(|c| c.as_text().map(str::to_string))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                let normalized = text.split_whitespace().collect::<Vec<_>>().join(" ");
+                if normalized.is_empty() {
+                    None
+                } else {
+                    Some(truncate_chars(&normalized, OPENING_MESSAGE_MAX_CHARS))
+                }
+            })
+            .take(OPENING_MESSAGES_PER_SESSION)
+            .collect::<Vec<_>>();
+
+        if openings.is_empty() {
+            continue;
+        }
+
+        digests.push(SessionDigest {
+            name: session.name.clone(),
+            openings,
+        });
+    }
+
+    Ok(digests)
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    let mut chars = text.chars();
+    let mut out: String = chars.by_ref().take(max_chars).collect();
+    if chars.next().is_some() {
+        out.push('…');
+    }
+    out
+}
+
+fn build_revision_input(existing_profile: Option<&str>, digests: &[SessionDigest]) -> String {
+    let mut input = String::new();
+
+    input.push_str("=== EXISTING PROFILE ===\n");
+    match existing_profile {
+        Some(profile) if !profile.trim().is_empty() => {
+            input.push_str(profile.trim());
+            input.push('\n');
+        }
+        _ => input.push_str("(none yet)\n"),
+    }
+
+    input.push_str("\n=== RECENT SESSIONS ===\n");
+    for (i, digest) in digests.iter().enumerate() {
+        input.push_str(&format!("Session {}: {}\n", i + 1, digest.name));
+        for opening in &digest.openings {
+            input.push_str(&format!("  - {opening}\n"));
+        }
+        input.push('\n');
+    }
+    input
+}
+
+const SUMMARIZER_SYSTEM_PROMPT: &str = "You maintain a concise, rolling profile of a user based \
+on their AI assistant sessions. The profile captures what the user works on (recurring projects, \
+codebases, domains, tools, languages) and how they like to work (style, workflow, recurring asks, \
+preferences).\n\n\
+You are given the EXISTING profile (may be empty) and a digest of the user's RECENT sessions \
+(per session: the title and the user's opening message(s)). Produce a REVISED profile.\n\n\
+Treat this as a revision, not a rewrite:\n\
+- Keep existing entries that still seem important, even if recent sessions don't mention them — \
+durable facts and long-standing preferences should persist across revisions.\n\
+- Add new projects, tools, and preferences revealed by the recent sessions.\n\
+- Update entries that have clearly changed, and merge near-duplicates.\n\
+- Only drop an existing entry if it looks like a one-off or clearly stale; when unsure, keep it.\n\
+- Recent activity is a stronger signal of current focus, so order the most relevant entries first.\n\n\
+Rules:\n\
+- Output at most 20 short lines.\n\
+- Be concrete and specific; prefer naming actual projects/tools over generic statements.\n\
+- Use short bullet points starting with '- '.\n\
+- Do NOT invent facts not supported by the existing profile or the recent sessions.\n\
+- Do NOT mention sessions, titles, or that this is a summary or revision.\n\
+- Output ONLY the profile lines, no preamble, no headings.";
+
+/// Regenerate the profile from recent sessions using the fast model and persist it.
+/// Returns the new profile text, or `None` if there isn't enough history yet.
+pub async fn generate_and_save(
+    session_manager: &SessionManager,
+    provider: Arc<dyn Provider>,
+) -> Result<Option<String>> {
+    let digests = collect_recent_digests(session_manager).await?;
+    if digests.len() < MIN_SESSIONS_FOR_PROFILE {
+        return Ok(None);
+    }
+
+    let latest_session_updated_at = session_manager
+        .list_sessions_by_types(&[SessionType::User, SessionType::Acp, SessionType::Scheduled])
+        .await
+        .ok()
+        .and_then(|sessions| sessions.into_iter().map(|s| s.updated_at).max());
+
+    let input = build_revision_input(load_profile().as_deref(), &digests);
+    let message = crate::conversation::message::Message::user().with_text(&input);
+
+    // A 20-line summary needs very little output; cap max_tokens so we don't
+    // inherit the agent's large default (which can exceed a fast model's limit).
+    let model_config = provider
+        .get_model_config()
+        .use_fast_model()
+        .with_max_tokens(Some(PROFILE_MAX_OUTPUT_TOKENS));
+
+    let (response, _usage) = provider
+        .complete(
+            &model_config,
+            "user-profile-generation",
+            SUMMARIZER_SYSTEM_PROMPT,
+            &[message],
+            &[],
+        )
+        .await?;
+
+    let raw: String = response
+        .content
+        .iter()
+        .filter_map(|c| c.as_text())
+        .collect();
+    let profile = cap_lines(&raw, MAX_PROFILE_LINES);
+    if profile.is_empty() {
+        return Ok(None);
+    }
+
+    let data_dir = Paths::data_dir();
+    std::fs::create_dir_all(&data_dir)?;
+    std::fs::write(profile_path(), &profile)?;
+    let meta = ProfileMeta {
+        generated_at: Utc::now(),
+        source_session_count: digests.len(),
+        latest_session_updated_at,
+    };
+    std::fs::write(meta_path(), serde_json::to_string_pretty(&meta)?)?;
+
+    Ok(Some(profile))
+}
+
+/// Refresh the profile if it is stale. Intended to run in the background so it
+/// never blocks session start. The result lands for the next session.
+pub async fn maybe_refresh(
+    session_manager: &SessionManager,
+    provider: Arc<dyn Provider>,
+) -> Result<()> {
+    let latest_session_updated_at = session_manager
+        .list_sessions_by_types(&[SessionType::User, SessionType::Acp, SessionType::Scheduled])
+        .await
+        .ok()
+        .and_then(|sessions| sessions.into_iter().map(|s| s.updated_at).max());
+
+    if !is_stale(load_meta().as_ref(), latest_session_updated_at) {
+        return Ok(());
+    }
+
+    generate_and_save(session_manager, provider).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cap_lines_drops_blanks_and_caps() {
+        let input = "- one\n\n- two\n   \n- three\n- four";
+        assert_eq!(cap_lines(input, 2), "- one\n- two");
+        assert_eq!(cap_lines(input, 10), "- one\n- two\n- three\n- four");
+    }
+
+    #[test]
+    fn truncate_chars_appends_ellipsis_when_cut() {
+        assert_eq!(truncate_chars("hello", 10), "hello");
+        assert_eq!(truncate_chars("hello world", 5), "hello…");
+    }
+
+    #[test]
+    fn stale_when_no_meta() {
+        assert!(is_stale(None, Some(Utc::now())));
+    }
+
+    #[test]
+    fn stale_when_newer_session_exists() {
+        let meta = ProfileMeta {
+            generated_at: Utc::now(),
+            source_session_count: 5,
+            latest_session_updated_at: Some(Utc::now() - Duration::hours(1)),
+        };
+        assert!(is_stale(Some(&meta), Some(Utc::now())));
+    }
+
+    #[test]
+    fn fresh_when_recent_and_no_new_sessions() {
+        let seen = Utc::now() - Duration::hours(2);
+        let meta = ProfileMeta {
+            generated_at: Utc::now(),
+            source_session_count: 5,
+            latest_session_updated_at: Some(seen),
+        };
+        assert!(!is_stale(Some(&meta), Some(seen)));
+    }
+
+    #[test]
+    fn stale_when_old_even_without_new_sessions() {
+        let seen = Utc::now() - Duration::hours(100);
+        let meta = ProfileMeta {
+            generated_at: Utc::now() - Duration::hours(100),
+            source_session_count: 5,
+            latest_session_updated_at: Some(seen),
+        };
+        assert!(is_stale(Some(&meta), Some(seen)));
+    }
+
+    #[test]
+    fn build_input_includes_titles_and_openings() {
+        let digests = vec![SessionDigest {
+            name: "Fix goal command".to_string(),
+            openings: vec!["the goal feature doesn't trigger a turn".to_string()],
+        }];
+        let input = build_revision_input(None, &digests);
+        assert!(input.contains("Session 1: Fix goal command"));
+        assert!(input.contains("- the goal feature doesn't trigger a turn"));
+        assert!(input.contains("(none yet)"));
+    }
+
+    #[test]
+    fn build_input_includes_existing_profile_for_revision() {
+        let digests = vec![SessionDigest {
+            name: "New work".to_string(),
+            openings: vec!["start the new thing".to_string()],
+        }];
+        let input = build_revision_input(
+            Some("- works on goose\n- prefers concise answers"),
+            &digests,
+        );
+        assert!(input.contains("=== EXISTING PROFILE ==="));
+        assert!(input.contains("- works on goose"));
+        assert!(input.contains("- prefers concise answers"));
+        assert!(input.contains("=== RECENT SESSIONS ==="));
+        assert!(input.contains("Session 1: New work"));
+    }
+}

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -1135,6 +1135,8 @@ config_value!(GOOSE_PROMPT_EDITOR, Option<String>);
 config_value!(GOOSE_PROMPT_EDITOR_ALWAYS, Option<bool>);
 config_value!(GOOSE_MAX_ACTIVE_AGENTS, usize);
 config_value!(GOOSE_DISABLE_SESSION_NAMING, bool);
+config_value!(GOOSE_USER_PROFILE_ENABLED, bool);
+config_value!(GOOSE_CHAT_RECALL_AUTO, bool);
 config_value!(GOOSE_DISABLE_TOOL_CALL_SUMMARY, bool);
 config_value!(GOOSE_THINKING_EFFORT, String);
 config_value!(GOOSE_DEFAULT_EXTENSION_TIMEOUT, u64);

--- a/crates/goose/src/session/chat_history_search.rs
+++ b/crates/goose/src/session/chat_history_search.rs
@@ -6,6 +6,20 @@ use serde::Serialize;
 use sqlx::{Pool, Sqlite};
 use std::collections::HashMap;
 
+/// Upper bound on matching messages fetched from SQLite before ranking in Rust.
+/// Decoupled from the caller's `limit`, which bounds returned sessions.
+const CANDIDATE_POOL_SIZE: i64 = 500;
+
+/// Common words filtered from queries so they don't match nearly everything.
+const STOPWORDS: &[&str] = &[
+    "the", "and", "for", "are", "was", "were", "what", "when", "where", "which", "who", "whom",
+    "how", "why", "did", "does", "done", "you", "your", "yours", "our", "ours", "this", "that",
+    "these", "those", "with", "from", "have", "has", "had", "can", "could", "should", "would",
+    "will", "shall", "about", "into", "out", "off", "over", "under", "than", "then", "them",
+    "they", "their", "there", "here", "some", "any", "all", "not", "but", "use", "used", "using",
+    "get", "got", "set", "let", "remind", "remember", "recall", "tell", "show", "find",
+];
+
 #[derive(Debug, Clone, Serialize)]
 pub struct ChatRecallResult {
     pub session_id: String,
@@ -99,7 +113,7 @@ impl<'a> ChatHistorySearch<'a> {
         let mut query_builder = sqlx::query_as::<_, SqlQueryRow>(&sql);
 
         for keyword in keywords {
-            query_builder = query_builder.bind(keyword);
+            query_builder = query_builder.bind(format!("%{keyword}%"));
         }
 
         if let Some(exclude_id) = &self.exclude_session_id {
@@ -117,16 +131,40 @@ impl<'a> ChatHistorySearch<'a> {
             query_builder = query_builder.bind(before);
         }
 
-        query_builder = query_builder.bind(self.limit as i64);
+        // Fetch a generous candidate pool of matching messages, then rank in Rust.
+        // `limit` bounds the number of returned sessions, not raw rows.
+        query_builder = query_builder.bind(CANDIDATE_POOL_SIZE);
 
         Ok(query_builder.fetch_all(self.pool).await?)
     }
 
     fn parse_keywords(&self) -> Vec<String> {
-        self.query
+        let cleaned: Vec<String> = self
+            .query
             .split_whitespace()
-            .map(|word| format!("%{}%", word.to_lowercase()))
-            .collect()
+            .map(|word| {
+                word.to_lowercase()
+                    .trim_matches(|c: char| !c.is_alphanumeric())
+                    .to_string()
+            })
+            .filter(|word| !word.is_empty())
+            .collect();
+
+        let mut keywords: Vec<String> = cleaned
+            .iter()
+            .filter(|word| word.len() >= 3 && !STOPWORDS.contains(&word.as_str()))
+            .cloned()
+            .collect();
+
+        // If filtering removed everything (e.g. a very short query), fall back to
+        // the cleaned words so we still search rather than return nothing.
+        if keywords.is_empty() {
+            keywords = cleaned;
+        }
+
+        keywords.sort();
+        keywords.dedup();
+        keywords
     }
 
     fn build_sql(&self, keywords: &[String]) -> String {
@@ -259,11 +297,15 @@ impl<'a> ChatHistorySearch<'a> {
         session_messages: HashMap<String, SessionMessageGroup>,
         session_totals: HashMap<String, usize>,
     ) -> ChatRecallResults {
-        let mut results: Vec<ChatRecallResult> = session_messages
+        let keywords = self.parse_keywords();
+
+        let mut scored: Vec<(SessionScore, ChatRecallResult)> = session_messages
             .into_iter()
             .map(
                 |(session_id, (description, working_dir, _created_at, messages))| {
-                    let message_vec: Vec<ChatRecallMessage> = messages
+                    // Rank messages within the session by how well each matches,
+                    // so the most relevant message leads (and becomes the snippet).
+                    let mut message_vec: Vec<ChatRecallMessage> = messages
                         .into_iter()
                         .map(|(role, content, timestamp)| ChatRecallMessage {
                             role,
@@ -271,6 +313,12 @@ impl<'a> ChatHistorySearch<'a> {
                             timestamp,
                         })
                         .collect();
+
+                    message_vec.sort_by(|a, b| {
+                        message_relevance(&b.content, &keywords)
+                            .cmp(&message_relevance(&a.content, &keywords))
+                            .then_with(|| b.timestamp.cmp(&a.timestamp))
+                    });
 
                     let last_activity = message_vec
                         .iter()
@@ -281,24 +329,123 @@ impl<'a> ChatHistorySearch<'a> {
                     let total_messages_in_session =
                         session_totals.get(&session_id).copied().unwrap_or(0);
 
-                    ChatRecallResult {
+                    let score = SessionScore::compute(&message_vec, &description, &keywords);
+
+                    let result = ChatRecallResult {
                         session_id,
                         session_description: description,
                         session_working_dir: working_dir,
                         last_activity,
                         total_messages_in_session,
                         messages: message_vec,
-                    }
+                    };
+                    (score, result)
                 },
             )
             .collect();
 
-        results.sort_by(|a, b| b.last_activity.cmp(&a.last_activity));
+        // Rank sessions: keyword coverage first, then total matches, then recency.
+        scored.sort_by(|a, b| {
+            b.0.coverage
+                .cmp(&a.0.coverage)
+                .then_with(|| b.0.total_hits.cmp(&a.0.total_hits))
+                .then_with(|| b.1.last_activity.cmp(&a.1.last_activity))
+        });
+
+        let mut results: Vec<ChatRecallResult> = scored
+            .into_iter()
+            .take(self.limit)
+            .map(|(_, result)| result)
+            .collect();
+
+        // Trim each session's message list to the most relevant few so the
+        // snippet/leading messages are useful rather than the whole transcript.
+        for result in &mut results {
+            result.messages.truncate(MAX_MESSAGES_PER_SESSION);
+        }
 
         let total_matches = results.iter().map(|r| r.messages.len()).sum();
         ChatRecallResults {
             results,
             total_matches,
+        }
+    }
+}
+
+const MAX_MESSAGES_PER_SESSION: usize = 3;
+
+/// Markers identifying compaction/continuation summaries. These messages recap a
+/// whole session, so they are keyword-dense and match almost any query — they
+/// should not outrank a message that actually discusses the topic.
+const SUMMARY_MARKERS: &[&str] = &[
+    "<analysis>",
+    "your context was compacted",
+    "the previous message contains a summary of the conversation",
+];
+
+fn is_summary_message(content: &str) -> bool {
+    let lower = content.to_lowercase();
+    SUMMARY_MARKERS.iter().any(|m| lower.contains(m))
+}
+
+/// Relevance of a single message: distinct keywords matched (weighted heavily)
+/// plus total keyword occurrences. Compaction summaries are penalized so a
+/// message genuinely about the topic wins over a session recap.
+fn message_relevance(content: &str, keywords: &[String]) -> usize {
+    let lower = content.to_lowercase();
+    let distinct = keywords.iter().filter(|k| lower.contains(*k)).count();
+    let occurrences: usize = keywords.iter().map(|k| lower.matches(k).count()).sum();
+    let score = distinct * 10 + occurrences;
+    if is_summary_message(content) {
+        score / 4
+    } else {
+        score
+    }
+}
+
+struct SessionScore {
+    /// Number of distinct query keywords found anywhere in the session.
+    coverage: usize,
+    /// Total keyword occurrences across the session's matched messages.
+    total_hits: usize,
+}
+
+impl SessionScore {
+    fn compute(messages: &[ChatRecallMessage], description: &str, keywords: &[String]) -> Self {
+        // Coverage and hits are computed over non-summary messages so a session
+        // that only matches inside a compaction recap doesn't rank as on-topic.
+        let mut haystack = description.to_lowercase();
+        for m in messages {
+            if is_summary_message(&m.content) {
+                continue;
+            }
+            haystack.push(' ');
+            haystack.push_str(&m.content.to_lowercase());
+        }
+
+        let mut coverage = keywords.iter().filter(|k| haystack.contains(*k)).count();
+        let mut total_hits = keywords.iter().map(|k| haystack.matches(k).count()).sum();
+
+        // Fall back to summary content if that's all a session has, but at a
+        // discount so genuine matches elsewhere win.
+        if coverage == 0 {
+            let summary: String = messages
+                .iter()
+                .filter(|m| is_summary_message(&m.content))
+                .map(|m| m.content.to_lowercase())
+                .collect::<Vec<_>>()
+                .join(" ");
+            coverage = keywords.iter().filter(|k| summary.contains(*k)).count();
+            total_hits = keywords
+                .iter()
+                .map(|k| summary.matches(k).count())
+                .sum::<usize>()
+                / 4;
+        }
+
+        Self {
+            coverage,
+            total_hits,
         }
     }
 }

--- a/crates/goose/src/session/mod.rs
+++ b/crates/goose/src/session/mod.rs
@@ -1,4 +1,4 @@
-mod chat_history_search;
+pub mod chat_history_search;
 mod diagnostics;
 pub mod extension_data;
 pub mod import_formats;

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -2177,9 +2177,158 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(results.results.len(), 1);
+        // `limit` now bounds the number of returned sessions, not raw messages,
+        // so both matching sessions come back. The session with more keyword
+        // hits ranks first.
+        assert_eq!(results.results.len(), 2);
         assert_eq!(results.results[0].session_id, newer_noise);
-        assert_eq!(results.results[0].messages.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_search_ranks_relevant_session_above_recent_noise() {
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+
+        // Older session that is genuinely about the topic.
+        let relevant = create_search_session(
+            &sm,
+            "Tyre pressures",
+            SessionType::User,
+            "2026-05-01T00:00:00Z",
+            &[(
+                "cold tyre pressure for the boxster track day is 27 front 29 rear",
+                "2026-05-01T00:00:00Z",
+            )],
+        )
+        .await;
+
+        // Newer session that merely mentions the keyword once in passing.
+        let _recent_noise = create_search_session(
+            &sm,
+            "Refactor work",
+            SessionType::User,
+            "2026-06-15T00:00:00Z",
+            &[(
+                "while testing I typed the word tyre into a search box",
+                "2026-06-15T00:00:00Z",
+            )],
+        )
+        .await;
+
+        let results = sm
+            .search_chat_history(
+                "cold tyre pressure boxster",
+                Some(5),
+                None,
+                None,
+                None,
+                vec![SessionType::User],
+            )
+            .await
+            .unwrap();
+
+        assert!(!results.results.is_empty());
+        // Despite being older, the on-topic session ranks first by coverage.
+        assert_eq!(results.results[0].session_id, relevant);
+        // The leading message is the best-matching one (used as the snippet).
+        assert!(results.results[0].messages[0]
+            .content
+            .contains("cold tyre pressure"));
+    }
+
+    #[tokio::test]
+    async fn test_search_deprioritizes_compaction_summaries() {
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+
+        // A session that genuinely discusses the goal command turn behavior.
+        let real = create_search_session(
+            &sm,
+            "Goal command fix",
+            SessionType::User,
+            "2026-05-01T00:00:00Z",
+            &[(
+                "the goal command never started a turn so we made it start a turn",
+                "2026-05-01T00:00:00Z",
+            )],
+        )
+        .await;
+
+        // A newer session whose only match is inside a compaction summary recap.
+        let _recap = create_search_session(
+            &sm,
+            "Unrelated diffusion work",
+            SessionType::User,
+            "2026-06-15T00:00:00Z",
+            &[(
+                "<analysis> Reviewing the conversation chronologically: the user \
+                 worked on a goal command turn behavior and many other things </analysis>",
+                "2026-06-15T00:00:00Z",
+            )],
+        )
+        .await;
+
+        let results = sm
+            .search_chat_history(
+                "goal command turn",
+                Some(5),
+                None,
+                None,
+                None,
+                vec![SessionType::User],
+            )
+            .await
+            .unwrap();
+
+        assert!(!results.results.is_empty());
+        // The real discussion outranks the keyword-dense compaction recap.
+        assert_eq!(results.results[0].session_id, real);
+    }
+
+    #[tokio::test]
+    async fn test_search_stopwords_do_not_dominate_ranking() {
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+
+        let on_topic = create_search_session(
+            &sm,
+            "Postgres indexing",
+            SessionType::User,
+            "2026-05-01T00:00:00Z",
+            &[(
+                "what is the best way to add a postgres index for this query",
+                "2026-05-01T00:00:00Z",
+            )],
+        )
+        .await;
+
+        // A session full of stopwords but nothing on-topic should not match.
+        let _filler = create_search_session(
+            &sm,
+            "Chit chat",
+            SessionType::User,
+            "2026-06-15T00:00:00Z",
+            &[(
+                "what is the the the and you should know how to do this",
+                "2026-06-15T00:00:00Z",
+            )],
+        )
+        .await;
+
+        let results = sm
+            .search_chat_history(
+                "what is the best postgres index",
+                Some(5),
+                None,
+                None,
+                None,
+                vec![SessionType::User],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(results.results.len(), 1);
+        assert_eq!(results.results[0].session_id, on_topic);
     }
 
     async fn expected_session_list_ids(sm: &SessionManager, session_ids: &[String]) -> Vec<String> {


### PR DESCRIPTION
**⚠️ WIP — sharing for early feedback, not ready to merge.**

Opt-in-by-default memory features, ChatGPT-style, computed lazily with the fast model.

### What it does
- **User profile** (`GOOSE_USER_PROFILE_ENABLED`, on by default): distills recent sessions into a ~20-line "about the user" blurb injected into the system prompt. Refresh is a *revision* (keeps durable facts, folds in new signal), background-refreshed, stored at `~/.local/share/goose/user_profile.md`. No DB change.
- **Auto chat recall** (`GOOSE_CHAT_RECALL_AUTO`, on by default): a pre-turn "remembering" step — fast-model gate decides if recall is warranted, retrieves relevant past sessions, injects them as grounded context, and surfaces cited sources (title + date) to the user.
- **Search ranking overhaul**: coverage-then-frequency ranking, stopword filtering, best-matching snippets, compaction-summary deprioritization.

### How well it works (measured on a real sessions.db)
- Relevant result in **top-3: ~8/8** topics ✅
- **Top-1: ~5–6/8** — weak on common-word queries ("goal/turn") where LIKE-based ranking lets noise in.

### Known next step (not done yet)
Replace the hand-rolled `LIKE` ranking with **SQLite-native FTS5 + bm25()** (verified it works through sqlx and fixes the exact common-word failures). That's a bigger change (schema migration + FTS table + sync triggers + backfill) — deliberately left out of this WIP.

Flags remain as opt-outs.