### PR TITLE
fix(agent): bound repeated tool calls

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -51,7 +51,7 @@ use crate::security::security_inspector::SecurityInspector;
 use crate::session::extension_data::{EnabledExtensionsState, ExtensionState};
 use crate::session::{Session, SessionManager, SessionNameUpdate};
 use crate::tool_inspection::ToolInspectionManager;
-use crate::tool_monitor::RepetitionInspector;
+use crate::tool_monitor::{RepetitionInspector, DEFAULT_MAX_TOOL_REPETITIONS};
 use crate::utils::is_token_cancelled;
 use goose_providers::errors::ProviderError;
 use goose_providers::thinking::ThinkingEffort;
@@ -584,7 +584,9 @@ impl Agent {
         )));
 
         // Add repetition inspector (lower priority - basic repetition checking)
-        tool_inspection_manager.add_inspector(Box::new(RepetitionInspector::new(None)));
+        tool_inspection_manager.add_inspector(Box::new(RepetitionInspector::new(Some(
+            DEFAULT_MAX_TOOL_REPETITIONS,
+        ))));
 
         tool_inspection_manager
     }

--- a/crates/goose/src/tool_monitor.rs
+++ b/crates/goose/src/tool_monitor.rs
@@ -1,9 +1,9 @@
 use crate::config::GooseMode;
-use crate::conversation::message::{Message, ToolRequest};
+use crate::conversation::message::{Message, MessageContent, ToolRequest};
 use crate::tool_inspection::{InspectionAction, InspectionResult, ToolInspector};
 use anyhow::Result;
 use async_trait::async_trait;
-use rmcp::model::CallToolRequestParams;
+use rmcp::model::{CallToolRequestParams, Role};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -44,6 +44,7 @@ struct RepetitionState {
     last_call: Option<InternalToolCall>,
     repeat_count: u32,
     call_counts: HashMap<String, u32>,
+    last_user_input_index: Option<usize>,
 }
 
 impl RepetitionInspector {
@@ -54,6 +55,7 @@ impl RepetitionInspector {
                 last_call: None,
                 repeat_count: 0,
                 call_counts: HashMap::new(),
+                last_user_input_index: None,
             }),
         }
     }
@@ -74,6 +76,15 @@ impl RepetitionInspector {
 }
 
 impl RepetitionState {
+    fn reset_for_user_input(&mut self, user_input_index: Option<usize>) {
+        if self.last_user_input_index != user_input_index {
+            self.last_call = None;
+            self.repeat_count = 0;
+            self.call_counts.clear();
+            self.last_user_input_index = user_input_index;
+        }
+    }
+
     fn check_tool_call(
         &mut self,
         tool_call: CallToolRequestParams,
@@ -113,7 +124,18 @@ impl RepetitionState {
         self.last_call = None;
         self.repeat_count = 0;
         self.call_counts.clear();
+        self.last_user_input_index = None;
     }
+}
+
+fn last_user_input_index(messages: &[Message]) -> Option<usize> {
+    messages.iter().rposition(|message| {
+        message.role == Role::User
+            && message
+                .content
+                .iter()
+                .any(|content| !matches!(content, MessageContent::ToolResponse(_)))
+    })
 }
 
 #[async_trait]
@@ -130,7 +152,7 @@ impl ToolInspector for RepetitionInspector {
         &self,
         _session_id: &str,
         tool_requests: &[ToolRequest],
-        _messages: &[Message],
+        messages: &[Message],
         _goose_mode: GooseMode,
     ) -> Result<Vec<InspectionResult>> {
         let mut results = Vec::new();
@@ -138,6 +160,7 @@ impl ToolInspector for RepetitionInspector {
             .state
             .lock()
             .expect("repetition inspector state should not be poisoned");
+        state.reset_for_user_input(last_user_input_index(messages));
 
         // Check repetition limits for each tool request
         for tool_request in tool_requests {

--- a/crates/goose/src/tool_monitor.rs
+++ b/crates/goose/src/tool_monitor.rs
@@ -6,6 +6,9 @@ use async_trait::async_trait;
 use rmcp::model::CallToolRequestParams;
 use serde_json::Value;
 use std::collections::HashMap;
+use std::sync::Mutex;
+
+pub const DEFAULT_MAX_TOOL_REPETITIONS: u32 = 2;
 
 // Helper struct for internal tracking
 #[derive(Debug, Clone)]
@@ -33,6 +36,11 @@ impl InternalToolCall {
 #[derive(Debug)]
 pub struct RepetitionInspector {
     max_repetitions: Option<u32>,
+    state: Mutex<RepetitionState>,
+}
+
+#[derive(Debug)]
+struct RepetitionState {
     last_call: Option<InternalToolCall>,
     repeat_count: u32,
     call_counts: HashMap<String, u32>,
@@ -42,13 +50,35 @@ impl RepetitionInspector {
     pub fn new(max_repetitions: Option<u32>) -> Self {
         Self {
             max_repetitions,
-            last_call: None,
-            repeat_count: 0,
-            call_counts: HashMap::new(),
+            state: Mutex::new(RepetitionState {
+                last_call: None,
+                repeat_count: 0,
+                call_counts: HashMap::new(),
+            }),
         }
     }
 
     pub fn check_tool_call(&mut self, tool_call: CallToolRequestParams) -> bool {
+        self.state
+            .get_mut()
+            .expect("repetition inspector state should not be poisoned")
+            .check_tool_call(tool_call, self.max_repetitions)
+    }
+
+    pub fn reset(&mut self) {
+        self.state
+            .get_mut()
+            .expect("repetition inspector state should not be poisoned")
+            .reset();
+    }
+}
+
+impl RepetitionState {
+    fn check_tool_call(
+        &mut self,
+        tool_call: CallToolRequestParams,
+        max_repetitions: Option<u32>,
+    ) -> bool {
         let internal_call = InternalToolCall::from_tool_call(&tool_call);
         let total_calls = self
             .call_counts
@@ -56,7 +86,7 @@ impl RepetitionInspector {
             .or_insert(0);
         *total_calls += 1;
 
-        if self.max_repetitions.is_none() {
+        if max_repetitions.is_none() {
             self.last_call = Some(internal_call);
             self.repeat_count = 1;
             return true;
@@ -65,7 +95,7 @@ impl RepetitionInspector {
         if let Some(last) = &self.last_call {
             if last.matches(&internal_call) {
                 self.repeat_count += 1;
-                if self.repeat_count > self.max_repetitions.unwrap() {
+                if self.repeat_count > max_repetitions.unwrap() {
                     return false;
                 }
             } else {
@@ -79,7 +109,7 @@ impl RepetitionInspector {
         true
     }
 
-    pub fn reset(&mut self) {
+    fn reset(&mut self) {
         self.last_call = None;
         self.repeat_count = 0;
         self.call_counts.clear();
@@ -104,17 +134,15 @@ impl ToolInspector for RepetitionInspector {
         _goose_mode: GooseMode,
     ) -> Result<Vec<InspectionResult>> {
         let mut results = Vec::new();
+        let mut state = self
+            .state
+            .lock()
+            .expect("repetition inspector state should not be poisoned");
 
         // Check repetition limits for each tool request
         for tool_request in tool_requests {
             if let Ok(tool_call) = &tool_request.tool_call {
-                // Create a temporary clone to check without modifying state
-                let mut temp_inspector = RepetitionInspector::new(self.max_repetitions);
-                temp_inspector.last_call = self.last_call.clone();
-                temp_inspector.repeat_count = self.repeat_count;
-                temp_inspector.call_counts = self.call_counts.clone();
-
-                if !temp_inspector.check_tool_call(tool_call.clone()) {
+                if !state.check_tool_call(tool_call.clone(), self.max_repetitions) {
                     results.push(InspectionResult {
                         tool_request_id: tool_request.id.clone(),
                         action: InspectionAction::Deny,

--- a/crates/goose/tests/repetition_inspector_tests.rs
+++ b/crates/goose/tests/repetition_inspector_tests.rs
@@ -1,7 +1,7 @@
 use goose::tool_monitor::RepetitionInspector;
 use goose::{
     config::GooseMode,
-    conversation::message::{MessageContent, ToolRequest},
+    conversation::message::{Message, MessageContent, ToolRequest},
     tool_inspection::{InspectionAction, ToolInspector},
 };
 use rmcp::model::CallToolRequestParams;
@@ -80,6 +80,52 @@ async fn inspect_persists_repetition_state_between_calls() {
     assert_eq!(results[0].tool_request_id, "call_3");
     assert_eq!(results[0].action, InspectionAction::Deny);
     assert_eq!(results[0].inspector_name, "repetition");
+}
+
+#[tokio::test]
+async fn inspect_resets_repetition_state_for_new_user_input() {
+    let inspector = RepetitionInspector::new(Some(2));
+    let tool_call =
+        CallToolRequestParams::new("developer__shell").with_arguments(object!({"command": "pwd"}));
+    let first_turn = [Message::user().with_content(MessageContent::text("check pwd"))];
+
+    assert!(inspector
+        .inspect(
+            "test-session",
+            &[tool_request("call_1", tool_call.clone())],
+            &first_turn,
+            GooseMode::Auto,
+        )
+        .await
+        .unwrap()
+        .is_empty());
+    assert!(inspector
+        .inspect(
+            "test-session",
+            &[tool_request("call_2", tool_call.clone())],
+            &first_turn,
+            GooseMode::Auto,
+        )
+        .await
+        .unwrap()
+        .is_empty());
+
+    let second_turn = [
+        Message::user().with_content(MessageContent::text("check pwd")),
+        Message::assistant().with_content(MessageContent::text("done")),
+        Message::user().with_content(MessageContent::text("check pwd again")),
+    ];
+
+    assert!(inspector
+        .inspect(
+            "test-session",
+            &[tool_request("call_3", tool_call)],
+            &second_turn,
+            GooseMode::Auto,
+        )
+        .await
+        .unwrap()
+        .is_empty());
 }
 
 fn tool_request(id: &str, tool_call: CallToolRequestParams) -> ToolRequest {

--- a/crates/goose/tests/repetition_inspector_tests.rs
+++ b/crates/goose/tests/repetition_inspector_tests.rs
@@ -1,4 +1,9 @@
 use goose::tool_monitor::RepetitionInspector;
+use goose::{
+    config::GooseMode,
+    conversation::message::{MessageContent, ToolRequest},
+    tool_inspection::{InspectionAction, ToolInspector},
+};
 use rmcp::model::CallToolRequestParams;
 use rmcp::object;
 
@@ -32,4 +37,54 @@ fn test_repetition_inspector_denies_after_exceeding_and_resets_on_param_change()
 
     // One more identical call with new params → denied again
     assert!(!inspector.check_tool_call(call_v2));
+}
+
+#[tokio::test]
+async fn inspect_persists_repetition_state_between_calls() {
+    let inspector = RepetitionInspector::new(Some(2));
+    let tool_call =
+        CallToolRequestParams::new("developer__shell").with_arguments(object!({"command": "pwd"}));
+
+    assert!(inspector
+        .inspect(
+            "test-session",
+            &[tool_request("call_1", tool_call.clone())],
+            &[],
+            GooseMode::Auto,
+        )
+        .await
+        .unwrap()
+        .is_empty());
+    assert!(inspector
+        .inspect(
+            "test-session",
+            &[tool_request("call_2", tool_call.clone())],
+            &[],
+            GooseMode::Auto,
+        )
+        .await
+        .unwrap()
+        .is_empty());
+
+    let results = inspector
+        .inspect(
+            "test-session",
+            &[tool_request("call_3", tool_call)],
+            &[],
+            GooseMode::Auto,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].tool_request_id, "call_3");
+    assert_eq!(results[0].action, InspectionAction::Deny);
+    assert_eq!(results[0].inspector_name, "repetition");
+}
+
+fn tool_request(id: &str, tool_call: CallToolRequestParams) -> ToolRequest {
+    match MessageContent::tool_request(id, Ok(tool_call)) {
+        MessageContent::ToolRequest(request) => request,
+        _ => unreachable!("tool_request constructor should return ToolRequest content"),
+    }
 }


### PR DESCRIPTION
## Summary
- make `RepetitionInspector` keep state across real `ToolInspector::inspect` calls instead of checking a temporary clone
- enable the default agent repetition inspector with a small shared cap
- add a regression test for repeated identical tool calls through the inspector trait path

### Testing
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p goose --test repetition_inspector_tests`

Also attempted `cargo test -p goose test_tool_inspection_manager_has_all_inspectors`, but my local run is blocked by an existing `sqlx` runtime feature panic during `Agent::new()` setup, before this change's behavior is exercised.

### Related Issues
Relates to #9758

### Screenshots/Demos (for UX changes)
Before: N/A

After: N/A
