### PR TITLE
Add StackQL to extensions directory

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -716,6 +716,17 @@
     ]
   },
   {
+    "id": "stackql",
+    "name": "StackQL",
+    "description": "Query and provision cloud and SaaS resources across 60+ providers using SQL",
+    "command": "npx -y @stackql/mcp-server",
+    "link": "https://github.com/stackql/stackql",
+    "installation_notes": "Install using npx (Node.js required). The launcher downloads the signed stackql binary on first run and verifies its SHA-256. Defaults to read_only mode; provider credentials are supplied via standard cloud environment variables in the client config. See https://stackql.io/docs/installing-stackql#installing-the-mcp-server",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": []
+  },
+  {
     "id": "summon",
     "name": "Summon",
     "description": "Load skills and delegate tasks to subagents",


### PR DESCRIPTION
## Summary
Adds StackQL to the extensions directory (`documentation/static/servers.json`).

StackQL is an open-source, SQL-native query and provisioning engine for cloud
and SaaS control planes, covering multiple providers (AWS, Azure, Google, Cloudflare, Databricks,
Snowflake, Okta, GitHub, ...). The MCP server exposes that interface to agents so
they can query and, optionally, provision infrastructure using SQL.

Listing details:
- Launcher: `npx -y @stackql/mcp-server` (Node.js required; no global install)
- The launcher downloads the signed `stackql` binary on first run and verifies
  its SHA-256 before use.
- Defaults to `read_only` mode; provider credentials are supplied via standard
  cloud environment variables in the client config.
- `endorsed` is set to `false`, leaving the endorsement decision to maintainers.

Provenance:
- Official MCP Registry: `io.github.stackql/stackql-mcp`
- npm: https://www.npmjs.com/package/@stackql/mcp-server
- Source: https://github.com/stackql/stackql
- Install docs: https://stackql.io/docs/installing-stackql#installing-the-mcp-server

### Testing
Data-only change (no build impact). Validated locally:
- `servers.json` parses as valid JSON and the new object follows the existing
  entry schema.
- `npx -y @stackql/mcp-server` starts the server over stdio and responds to an
  MCP `tools/list` request.

### Related Issues
N/A

### Screenshots/Demos (for UX changes)
N/A (directory data entry; card renders from the standard schema)