### PR TITLE
fix: add option for overriding API Url for Moonshot provider

### DIFF
--- a/crates/goose/src/providers/declarative/moonshot.json
+++ b/crates/goose/src/providers/declarative/moonshot.json
@@ -2,9 +2,18 @@
   "name": "moonshot",
   "engine": "openai",
   "display_name": "Moonshot",
-  "description": "Moonshot AI (Kimi) models",
+  "description": "Moonshot AI (Kimi) models. Set MOONSHOT_BASE_URL to override the default endpoint (e.g. https://api.moonshot.ai for international users).",
   "api_key_env": "MOONSHOT_API_KEY",
-  "base_url": "https://api.moonshot.cn/v1/chat/completions",
+  "base_url": "${MOONSHOT_BASE_URL}",
+  "env_vars": [
+    {
+      "name": "MOONSHOT_BASE_URL",
+      "required": false,
+      "secret": false,
+      "default": "https://api.moonshot.cn/v1/chat/completions",
+      "description": "Moonshot API base URL. Use https://api.moonshot.ai/v1/chat/completions for international access outside China Mainland."
+    }
+  ],
   "models": [
     {"name": "kimi-latest", "context_limit": 131072},
     {"name": "kimi-thinking-preview", "context_limit": 131072},

--- a/crates/goose/src/providers/declarative/moonshot.json
+++ b/crates/goose/src/providers/declarative/moonshot.json
@@ -2,7 +2,7 @@
   "name": "moonshot",
   "engine": "openai",
   "display_name": "Moonshot",
-  "description": "Moonshot AI (Kimi) models. Set MOONSHOT_BASE_URL to override the default endpoint (e.g. https://api.moonshot.ai for international users).",
+  "description": "Moonshot AI (Kimi) models. Set MOONSHOT_BASE_URL to override the default endpoint (e.g. https://api.moonshot.ai/v1 for international users).",
   "api_key_env": "MOONSHOT_API_KEY",
   "base_url": "${MOONSHOT_BASE_URL}",
   "env_vars": [
@@ -11,7 +11,7 @@
       "required": false,
       "secret": false,
       "default": "https://api.moonshot.cn/v1/chat/completions",
-      "description": "Moonshot API base URL. Use https://api.moonshot.ai/v1/chat/completions for international access outside China Mainland."
+      "description": "Moonshot API base URL. Use https://api.moonshot.ai/v1 for international access outside China Mainland."
     }
   ],
   "models": [


### PR DESCRIPTION
## Summary

In the Provider Configuration Settings page, the Moonshot provider uses the hardcoded endpiont https://api.moonshot.cn/v1/chat/completions. Unfortunately, this domain is only accessible to users in China. For international access, the endpoint should be `api.moonshot.ai`.

Without this change, when you use a model by Moonshot, you'll get "Credit exhaused" error and won't be able to use any Moonshot models even though you have enough credit.

<!-- Describe your change -->

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
The new change passes when running `cargo check -p goose...`
