### PR TITLE
use windows-2022 image for CUDA builds

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -86,7 +86,7 @@ jobs:
           - platform: windows
             architecture: x86_64
             target-suffix: pc-windows-msvc
-            build-on: windows-latest
+            build-on: windows-2022
             variant: cuda
 
     steps:

--- a/.github/workflows/bundle-desktop-windows.yml
+++ b/.github/workflows/bundle-desktop-windows.yml
@@ -44,7 +44,7 @@ permissions:
 jobs:
   build-desktop-windows:
     name: Build Desktop (Windows)
-    runs-on: windows-latest
+    runs-on: ${{ inputs.windows_variant == 'cuda' && 'windows-2022' || 'windows-latest' }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
`windows-latest` and `windows-2025` now use VS 2026, which breaks our build. Pinning to `windows-2022` _should_ be enough to un-block this, according to gpt-5.5...