### PR TITLE
fix(recipe): validate recipe structs without a lossy YAML round-trip

### DIFF
--- a/crates/goose-server/src/routes/recipe.rs
+++ b/crates/goose-server/src/routes/recipe.rs
@@ -588,7 +588,45 @@ pub fn routes(state: Arc<AppState>) -> Router {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use goose::recipe::Recipe;
+    use goose::recipe::{
+        Recipe, RecipeParameter, RecipeParameterInputType, RecipeParameterRequirement,
+    };
+
+    #[tokio::test]
+    async fn test_decode_recipe_with_params_in_multiline_instructions() {
+        let instructions = concat!(
+            "Process the {{ product_type }} request.   \n",
+            "Run this query which is intentionally longer than eighty characters so the YAML emitter may fold it: {{ sql_query }}\n",
+            "Use priority {{ priority }} when filing the request.\n",
+        );
+        let parameters = ["product_type", "sql_query", "priority"]
+            .into_iter()
+            .map(|key| RecipeParameter {
+                key: key.to_string(),
+                input_type: RecipeParameterInputType::String,
+                requirement: RecipeParameterRequirement::Required,
+                description: format!("the {}", key),
+                default: None,
+                options: None,
+            })
+            .collect();
+        let original_recipe = Recipe::builder()
+            .title("Param Recipe")
+            .description("Recipe with parameters in multi-line instructions")
+            .instructions(instructions)
+            .parameters(parameters)
+            .build()
+            .unwrap();
+
+        let encoded = recipe_deeplink::encode(&original_recipe).unwrap();
+        let response = decode_recipe(Json(DecodeRecipeRequest { deeplink: encoded })).await;
+
+        let decoded = response
+            .expect("decoding a valid recipe deeplink should succeed")
+            .0
+            .recipe;
+        assert_eq!(decoded.instructions, original_recipe.instructions);
+    }
 
     #[tokio::test]
     async fn test_decode_and_encode_recipe() {

--- a/crates/goose-server/src/routes/recipe_utils.rs
+++ b/crates/goose-server/src/routes/recipe_utils.rs
@@ -11,7 +11,7 @@ use goose::recipe::build_recipe::{build_recipe_from_template, RecipeError};
 use goose::recipe::local_recipes::get_recipe_library_dir;
 pub use goose::recipe::manifest::short_id_from_path;
 use goose::recipe::manifest::{list_recipe_file_manifests, load_recipe_from_path};
-use goose::recipe::validate_recipe::validate_recipe_template_from_content;
+use goose::recipe::validate_recipe::validate_recipe_struct;
 use goose::recipe::Recipe;
 use serde::Serialize;
 use tracing::error;
@@ -50,25 +50,14 @@ pub fn get_all_recipes_manifests() -> Result<Vec<RecipeManifest>> {
 }
 
 pub fn validate_recipe(recipe: &Recipe) -> Result<(), RecipeValidationError> {
-    let recipe_yaml = recipe.to_yaml().map_err(|err| {
-        let message = err.to_string();
-        error!("Failed to serialize recipe for validation: {}", message);
-        RecipeValidationError {
-            status: StatusCode::BAD_REQUEST,
-            message,
-        }
-    })?;
-
-    validate_recipe_template_from_content(&recipe_yaml, None).map_err(|err| {
+    validate_recipe_struct(recipe).map_err(|err| {
         let message = err.to_string();
         error!("Recipe validation failed: {}", message);
         RecipeValidationError {
             status: StatusCode::BAD_REQUEST,
             message,
         }
-    })?;
-
-    Ok(())
+    })
 }
 
 pub async fn get_recipe_file_path_by_id(

--- a/crates/goose/src/recipe/template_recipe.rs
+++ b/crates/goose/src/recipe/template_recipe.rs
@@ -160,6 +160,13 @@ fn get_env_with_template_variables(
     Ok((env, template_variables))
 }
 
+pub(crate) fn collect_template_variables(content: &str) -> Result<HashSet<String>> {
+    let preprocessed_content = preprocess_template_variables(content)?;
+    let (_, template_variables) =
+        get_env_with_template_variables(&preprocessed_content, None, UndefinedBehavior::Lenient)?;
+    Ok(template_variables)
+}
+
 fn uses_template_inheritance(content: &str) -> bool {
     let re = Regex::new(r"\{%-?\s*(extends|include)").unwrap();
     re.is_match(content)

--- a/crates/goose/src/recipe/validate_recipe.rs
+++ b/crates/goose/src/recipe/validate_recipe.rs
@@ -1,5 +1,5 @@
 use crate::recipe::read_recipe_file_content::RecipeFile;
-use crate::recipe::template_recipe::parse_recipe_content;
+use crate::recipe::template_recipe::{collect_template_variables, parse_recipe_content};
 use crate::recipe::{
     Recipe, RecipeParameter, RecipeParameterInputType, RecipeParameterRequirement,
     BUILT_IN_RECIPE_DIR_PARAM,
@@ -52,6 +52,50 @@ pub fn validate_recipe_template_from_content(
     }
 
     Ok(recipe)
+}
+
+/// Validates a recipe that already exists as a struct (e.g. decoded from a
+/// deeplink) without round-tripping it through YAML, which can mangle
+/// multi-line template content and hide `{{ }}` variables from the scanner.
+pub fn validate_recipe_struct(recipe: &Recipe) -> Result<()> {
+    let recipe_json = serde_json::to_value(recipe)?;
+    let mut template_variables = HashSet::new();
+    collect_template_variables_from_json(&recipe_json, &mut template_variables)?;
+
+    validate_optional_parameters(&recipe.parameters)?;
+    validate_parameters_in_template(&recipe.parameters, &template_variables)?;
+    validate_prompt_or_instructions(recipe)?;
+    validate_retry_config(recipe)?;
+    if let Some(response) = &recipe.response {
+        if let Some(json_schema) = &response.json_schema {
+            validate_json_schema(json_schema)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn collect_template_variables_from_json(
+    value: &serde_json::Value,
+    template_variables: &mut HashSet<String>,
+) -> Result<()> {
+    match value {
+        serde_json::Value::String(content) => {
+            template_variables.extend(collect_template_variables(content)?);
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                collect_template_variables_from_json(item, template_variables)?;
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for item in map.values() {
+                collect_template_variables_from_json(item, template_variables)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
 }
 
 fn validate_retry_config(recipe: &Recipe) -> Result<()> {
@@ -209,5 +253,87 @@ parameters:
         assert_eq!(recipe.description, "A test recipe for validation");
         assert!(recipe.instructions.is_some());
         println!("Recipe: {:?}", recipe.prompt);
+    }
+
+    fn recipe_with_multiline_instructions() -> Recipe {
+        let instructions = concat!(
+            "Process the {{ product_type }} request.   \n",
+            "Run this query which is intentionally longer than eighty characters so the YAML emitter may fold it: {{ sql_query }}\n",
+            "Use priority {{ priority }} when filing the request.\n",
+        );
+        let parameters = ["product_type", "sql_query", "priority"]
+            .into_iter()
+            .map(|key| RecipeParameter {
+                key: key.to_string(),
+                input_type: RecipeParameterInputType::String,
+                requirement: RecipeParameterRequirement::Required,
+                description: format!("the {}", key),
+                default: None,
+                options: None,
+            })
+            .collect();
+        Recipe::builder()
+            .title("Param Recipe")
+            .description("Recipe with parameters in multi-line instructions")
+            .instructions(instructions)
+            .parameters(parameters)
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn test_validate_recipe_struct_with_params_in_multiline_instructions() {
+        let recipe = recipe_with_multiline_instructions();
+        let result = validate_recipe_struct(&recipe);
+        assert!(result.is_ok(), "Validation failed: {:?}", result.err());
+    }
+
+    #[test]
+    fn test_validate_recipe_struct_after_deeplink_round_trip() {
+        let recipe = recipe_with_multiline_instructions();
+        let encoded = crate::recipe_deeplink::encode(&recipe).unwrap();
+        let decoded = crate::recipe_deeplink::decode(&encoded).unwrap();
+        assert_eq!(decoded.instructions, recipe.instructions);
+
+        let result = validate_recipe_struct(&decoded);
+        assert!(result.is_ok(), "Validation failed: {:?}", result.err());
+    }
+
+    #[test]
+    fn test_validate_recipe_struct_rejects_unused_parameter() {
+        let recipe = Recipe::builder()
+            .title("Unused Param Recipe")
+            .description("Recipe declaring a parameter it never uses")
+            .instructions("No template variables here")
+            .parameters(vec![RecipeParameter {
+                key: "unused_param".to_string(),
+                input_type: RecipeParameterInputType::String,
+                requirement: RecipeParameterRequirement::Required,
+                description: "never used".to_string(),
+                default: None,
+                options: None,
+            }])
+            .build()
+            .unwrap();
+
+        let err = validate_recipe_struct(&recipe).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Unnecessary parameter definitions: unused_param"));
+    }
+
+    #[test]
+    fn test_validate_recipe_struct_rejects_missing_parameter_definition() {
+        let recipe = Recipe::builder()
+            .title("Missing Param Recipe")
+            .description("Recipe using a variable it never declares")
+            .instructions("Do something with {{ undeclared_var }}")
+            .build()
+            .unwrap();
+
+        let err = validate_recipe_struct(&recipe).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Missing definitions for parameters in the recipe file: undeclared_var"));
     }
 }


### PR DESCRIPTION
## Summary

Refs #9702

The server validates already-decoded `Recipe` structs (deeplink decode, `start_agent`, save, schedule) by re-serializing them with `to_yaml()` and re-scanning that string for `{{ }}` template variables. `to_yaml()` relies on a line-based reformatting pass over `serde_yaml` output that can mangle multi-line `instructions`/`prompt` content, hiding template variables from the scanner. When that happens, every declared parameter is reported as `Unnecessary parameter definitions` even though the CLI validates the same recipe successfully from its original file text (the reported symptom in #9702).

## Approach

Add `validate_recipe_struct`, which runs the same checks directly against the struct's string fields with no serialization round-trip, and use it for all server-side struct validation. Content-based validation paths (CLI files, raw YAML requests) are unchanged.

## Honest caveat on reproduction

I was not able to reproduce the reporter's *exact* failure from code inspection alone — I probed ~20 content shapes (trailing whitespace, CRLF, tabs, unicode separators, long lines, quoted Jinja filter expressions) and none triggered the divergence on the current `to_yaml()` path. What is certain is that the server validates a re-serialized copy while the CLI validates the original text, and that round-trip is the only place the two paths diverge. This change removes that divergence entirely by validating the struct directly.

**I'd appreciate the reporter (or a maintainer) confirming against the original recipe** — if it still reproduces, the failing recipe would pin down the remaining `to_yaml()` issue (which I've noted as a possible follow-up).

## Testing

- New `validate_recipe_struct` tests in `crates/goose/src/recipe/validate_recipe.rs`: multi-line instructions with params, deeplink encode→decode→validate round trip, plus rejection of genuinely-unused and genuinely-missing parameters.
- Extended the server's `test_decode_*` coverage with a params-in-multiline-instructions recipe.
- `cargo fmt`, `cargo test -p goose --lib recipe::validate_recipe`, `cargo test -p goose-server --lib routes::recipe` (all passing).