### PR TITLE
fix(anthropic): use adaptive thinking for Claude 4.6+ served outside the canonical registry

### DIFF
--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -76,6 +76,52 @@ fn canonical_thinking_mode(provider_name: &str, model_name: &str) -> Option<Thin
     maybe_get_canonical_model(provider_name, model_name).and_then(|model| model.thinking_mode)
 }
 
+/// Infer adaptive thinking support from the model name when the canonical
+/// registry has no entry for it.
+///
+/// The registry only carries `thinking_mode` for the first-party `anthropic/`
+/// model IDs. The same Claude models served through other providers (Bedrock,
+/// Vertex, Azure) or through fully custom Anthropic-compatible providers have
+/// no registry entry, so without this fallback they send the deprecated
+/// `{"type": "enabled"}` thinking shape — which Claude Opus 4.7+ rejects with a
+/// 400 ("thinking.type.enabled is not supported for this model"). Adaptive
+/// thinking is supported on Claude Opus and Sonnet 4.6 and later, and is always
+/// on for the Fable family.
+fn inferred_adaptive_thinking_mode(model_name: &str) -> Option<ThinkingMode> {
+    let name = model_name.to_lowercase();
+    if !name.contains("claude") {
+        return None;
+    }
+    if name.contains("fable") {
+        return Some(ThinkingMode::AlwaysOnAdaptive);
+    }
+
+    let family = if name.contains("opus") {
+        "opus"
+    } else if name.contains("sonnet") {
+        "sonnet"
+    } else {
+        return None;
+    };
+
+    claude_family_version(&name, family)
+        .filter(|&(major, minor)| major <= 9 && (major, minor) >= (4, 6))
+        .map(|_| ThinkingMode::Adaptive)
+}
+
+/// Parse the `(major, minor)` version that follows the family token in a
+/// 4.x-style Claude model name (e.g. `claude-opus-4-7`, `claude-sonnet-4.6`,
+/// `claude-opus-4.8-fast`). Names that place a date after the family
+/// (`claude-3-opus-20240229`) yield an implausibly large major, which callers
+/// reject. Returns `None` when no version follows the family token.
+fn claude_family_version(name: &str, family: &str) -> Option<(u32, u32)> {
+    let after = name.split_once(family)?.1.trim_start_matches(['-', '.']);
+    let mut parts = after.split(['-', '.']);
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+    Some((major, minor))
+}
+
 fn canonical_reasoning(provider_name: &str, model_config: &ModelConfig) -> Option<bool> {
     maybe_get_canonical_model(provider_name, &model_config.model_name)
         .and_then(|model| model.reasoning)
@@ -92,7 +138,8 @@ pub fn thinking_type(model_config: &ModelConfig) -> ThinkingType {
 }
 
 pub fn thinking_type_for_provider(provider_name: &str, model_config: &ModelConfig) -> ThinkingType {
-    let mode = canonical_thinking_mode(provider_name, &model_config.model_name);
+    let mode = canonical_thinking_mode(provider_name, &model_config.model_name)
+        .or_else(|| inferred_adaptive_thinking_mode(&model_config.model_name));
     let reasoning = model_config
         .reasoning
         .or_else(|| canonical_reasoning(provider_name, model_config));
@@ -1712,6 +1759,84 @@ mod tests {
         ]);
         let config = cfg_with_effort("claude-3-7-sonnet-20250219", "high");
         assert_eq!(thinking_budget_tokens(&config), 8192);
+    }
+
+    fn cfg_reasoning_with_effort(name: &str, effort: &str) -> ModelConfig {
+        let mut params = std::collections::HashMap::new();
+        params.insert("thinking_effort".to_string(), json!(effort));
+        ModelConfig {
+            model_name: name.to_string(),
+            request_params: Some(params),
+            reasoning: Some(true),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_inferred_adaptive_thinking_mode() {
+        // 4.6+ Opus/Sonnet infer adaptive regardless of separator or suffix
+        for name in [
+            "claude-opus-4-6",
+            "claude-opus-4-7",
+            "claude-opus-4-8",
+            "claude-opus-4.8-fast",
+            "claude-sonnet-4-6",
+            "claude-opus-4-9",
+            "claude-opus-5-0",
+        ] {
+            assert_eq!(
+                inferred_adaptive_thinking_mode(name),
+                Some(ThinkingMode::Adaptive),
+                "{name} should infer adaptive"
+            );
+        }
+        assert_eq!(
+            inferred_adaptive_thinking_mode("claude-fable-5"),
+            Some(ThinkingMode::AlwaysOnAdaptive)
+        );
+        // Pre-4.6 and date-suffixed legacy names must not infer adaptive
+        for name in [
+            "claude-opus-4-5",
+            "claude-opus-4-1",
+            "claude-opus-4",
+            "claude-sonnet-4-5",
+            "claude-3-7-sonnet-20250219",
+            "claude-3-opus-20240229",
+            "claude-3-5-sonnet-20241022",
+            "gpt-4o",
+        ] {
+            assert_eq!(
+                inferred_adaptive_thinking_mode(name),
+                None,
+                "{name} should not infer adaptive"
+            );
+        }
+    }
+
+    #[test]
+    fn test_thinking_type_adaptive_for_non_registry_provider() {
+        let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
+        // Claude Opus 4.7/4.8 served through a provider with no canonical
+        // registry entry (e.g. a custom Anthropic-compatible endpoint) must
+        // still use adaptive thinking, not the deprecated enabled shape.
+        for name in ["claude-opus-4-7", "claude-opus-4-8"] {
+            assert_eq!(
+                thinking_type_for_provider(
+                    "custom-anthropic-compatible",
+                    &cfg_reasoning_with_effort(name, "high"),
+                ),
+                ThinkingType::Adaptive,
+                "{name} via custom provider should be adaptive"
+            );
+        }
+        // A pre-adaptive model through the same provider still uses enabled.
+        assert_eq!(
+            thinking_type_for_provider(
+                "custom-anthropic-compatible",
+                &cfg_reasoning_with_effort("claude-opus-4-5", "high"),
+            ),
+            ThinkingType::Enabled
+        );
     }
 
     #[test]

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -105,15 +105,17 @@ fn inferred_adaptive_thinking_mode(model_name: &str) -> Option<ThinkingMode> {
     };
 
     claude_family_version(&name, family)
-        .filter(|&(major, minor)| major <= 9 && (major, minor) >= (4, 6))
+        .filter(|&(major, minor)| major <= 9 && minor < 100 && (major, minor) >= (4, 6))
         .map(|_| ThinkingMode::Adaptive)
 }
 
 /// Parse the `(major, minor)` version that follows the family token in a
 /// 4.x-style Claude model name (e.g. `claude-opus-4-7`, `claude-sonnet-4.6`,
 /// `claude-opus-4.8-fast`). Names that place a date after the family
-/// (`claude-3-opus-20240229`) yield an implausibly large major, which callers
-/// reject. Returns `None` when no version follows the family token.
+/// (`claude-3-opus-20240229`) yield an implausibly large major, and
+/// date-suffixed Claude 4 IDs (`claude-opus-4-20250514`) yield an implausibly
+/// large minor; callers reject both with `major <= 9 && minor < 100`. Returns
+/// `None` when no version follows the family token.
 fn claude_family_version(name: &str, family: &str) -> Option<(u32, u32)> {
     let after = name.split_once(family)?.1.trim_start_matches(['-', '.']);
     let mut parts = after.split(['-', '.']);
@@ -1782,6 +1784,7 @@ mod tests {
             "claude-opus-4.8-fast",
             "claude-sonnet-4-6",
             "claude-opus-4-9",
+            "claude-opus-4-10",
             "claude-opus-5-0",
         ] {
             assert_eq!(
@@ -1800,6 +1803,10 @@ mod tests {
             "claude-opus-4-1",
             "claude-opus-4",
             "claude-sonnet-4-5",
+            "claude-opus-4-20250514",
+            "claude-sonnet-4-20250514",
+            "us.anthropic.claude-sonnet-4-20250514-v1:0",
+            "claude-opus-4-1-20250805",
             "claude-3-7-sonnet-20250219",
             "claude-3-opus-20240229",
             "claude-3-5-sonnet-20241022",


### PR DESCRIPTION
## Summary

Fixes #9746

Claude Opus 4.7 and 4.8 require adaptive thinking and reject the deprecated manual shape with a 400:

```
"thinking.type.enabled" is not supported for this model.
Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.
```

`thinking_type_for_provider` decides between `adaptive` and `enabled` from the canonical model registry's `thinking_mode`. That field is only populated for the **first-party `anthropic/`** model IDs (`anthropic/claude-opus-4.7`, `anthropic/claude-opus-4.8`, …). The same models served through another provider — Bedrock, Vertex, Azure, or a fully custom Anthropic-compatible endpoint — have no registry `thinking_mode`, so they fall through to `{"type": "enabled"}` and 400. That's exactly why the reporter saw 4.6 work but 4.7/4.8 fail via Azure AI Foundry.

A pure registry/data fix wouldn't help a *custom* provider whose model isn't in the registry at all, so the fix belongs at the decision point.

## Changes

`crates/goose/src/providers/formats/anthropic.rs`:

- Add `inferred_adaptive_thinking_mode(model_name)`, used **only as a fallback** when the registry returns no `thinking_mode`. Claude Opus/Sonnet **4.6 and later** infer `Adaptive`; the **Fable** family infers `AlwaysOnAdaptive`; pre-4.6 and date-suffixed legacy names (`claude-3-opus-20240229`, Sonnet 4.5) stay on the enabled path.
- The version parse is separator-agnostic (`opus-4-7`, `opus-4.7`, `opus-4.8-fast`) and forward-compatible, so future releases (4.9, 5.x) are covered without another change — addressing the issue's "should apply to any future Claude".
- The registry still wins whenever it has a value; this only fills the gap.

## Testing

- `test_inferred_adaptive_thinking_mode` — unit coverage for the name parser across separators, suffixes, the Fable family, and the pre-4.6 / legacy-date negatives.
- `test_thinking_type_adaptive_for_non_registry_provider` — Opus 4.7/4.8 through a provider with no registry entry now resolve to `Adaptive`, while Opus 4.5 still resolves to `Enabled`.
- `cargo fmt`, `cargo test -p goose --lib providers::formats::anthropic` (38/38), `cargo clippy -p goose --lib --tests --features aws-providers -- -D warnings` all clean.

## Note

The build-time registry inference (`inferred_thinking_mode` in `build_canonical_models.rs`) has the same first-party-only matching. I kept this PR to the runtime path since that's what fixes custom/compatible providers and doesn't require regenerating the whole `canonical_models.json`; aligning the build-time inference could be a small follow-up.