### PR TITLE
fix: remove hard-coded React alias that points to the wrong location and break the dev render

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,6 +173,17 @@ The app opens a window and displays first-time setup. After completing setup, go
 
 Make GUI changes in `ui/desktop`.
 
+#### Troubleshooting: blank screen on `just run-ui`
+
+If the app opens to a blank window (logs show `Cannot read properties of null (reading 'useRef')`), your `node_modules` is out of date and is loading two copies of React. Delete it and reinstall:
+
+```
+rm -rf ui/desktop/node_modules
+cd ui && pnpm install
+```
+
+See #8757.
+
 ### Regenerating the OpenAPI schema
 
 The file `ui/desktop/openapi.json` is automatically generated during the build.

--- a/ui/desktop/vite.renderer.config.mts
+++ b/ui/desktop/vite.renderer.config.mts
@@ -1,6 +1,5 @@
 import { defineConfig } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
-import { resolve } from 'path';
 
 // https://vitejs.dev/config
 export default defineConfig({
@@ -9,14 +8,6 @@ export default defineConfig({
   },
 
   plugins: [tailwindcss()],
-
-  resolve: {
-    dedupe: ['react', 'react-dom'],
-    alias: {
-      react: resolve(__dirname, 'node_modules/react'),
-      'react-dom': resolve(__dirname, 'node_modules/react-dom'),
-    },
-  },
 
   build: {
     target: 'esnext'


### PR DESCRIPTION
## Summary

`just run-ui` fails on a clean install with `Failed to resolve import "react/jsx-dev-runtime"`. Reverts #9631's `resolve` block from `vite.renderer.config.mts`.

### Root Cause

The alias points to the wrong path. #9631 hard-coded React to `ui/desktop/node_modules/react`, but this repo uses `node-linker=hoisted` — React actually lives at `ui/node_modules/react`. So that path doesn't exist on a clean install and Vite can't resolve `react`. It only worked on stale trees that still had a leftover copy there (also the source of #8757's duplicate-React blank screen).

## Changes
- `vite.renderer.config.mts` — remove the `resolve` block (back to pre-#9631; one React copy under hoisted, so normal resolution works).
- `CONTRIBUTING.md` — troubleshooting note: blank screen → stale `node_modules` → reinstall.

### Testing
Ran "just run-ui"

