### PR TITLE
perf(build): drop debug info for dependencies in the dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,3 +113,12 @@ icu_locale = { version = "=2.1.1", default-features = false }
 [patch.crates-io]
 v8 = { path = "vendor/v8" }
 cudaforge = { git = "https://github.com/jbg/cudaforge", rev = "e7c1967340e40673db98dc9e17da0f04834a456f" }
+
+# Dependencies don't need debug info. You rarely step-debug into third-party
+# crates, but their DWARF dominates `target/debug` — roughly 50-70% of each
+# dependency rlib in this workspace is debug info. Dropping it for dependencies
+# only shrinks the debug build substantially and speeds linking. The "*" spec
+# matches all dependencies but NOT workspace members, so first-party crates keep
+# full debug info and stay fully debuggable; release builds are unaffected.
+[profile.dev.package."*"]
+debug = false


### PR DESCRIPTION
## What

Compile dependencies without debug info in the `dev` profile, while keeping full debug info for workspace crates:

```toml
[profile.dev.package."*"]
debug = false
```

## Why

Debug info dominates `target/debug` in this workspace, and almost all of it belongs to third-party dependencies that are rarely (if ever) step-debugged. Measured on a current macOS debug build (`strip -S` on the compiled rlibs, so this is just the DWARF):

| dependency rlib | size | stripped | debug info |
|---|---:|---:|---:|
| `swc_ecma_parser` | 20 MB | 6 MB | **71%** |
| `aws_sdk_bedrockruntime` | 33 MB | 11 MB | **67%** |
| `v8_goose` (vendored C++) | 133 MB | 90 MB | 32% |

So roughly **half to two-thirds of every pure-Rust dependency artifact** is debug info for code you don't debug. Dropping it for dependencies shrinks the debug build substantially and reduces link time (less DWARF to read and relocate) — for every contributor and in CI.

## Scope & safety

- `[profile.dev.package."*"]` matches **dependencies only** — [it explicitly excludes workspace members](https://doc.rust-lang.org/cargo/reference/profiles.html#overrides), so first-party crates keep full debug info and stay fully debuggable (breakpoints, variable inspection in your own code are unchanged).
- Backtraces through dependencies still show **function names** (symbol tables are untouched); only dep-internal file/line/variable info is dropped.
- `release` and all other profiles are unaffected.
- MSRV-safe — `debug = false` has been stable for years.

## Testing

- `cargo check` clean with the override applied.
- `Cargo.toml`-only change; no code touched.
