### PR TITLE
Add Korean localization to desktop app

### DIFF
--- a/ui/desktop/src/components/settings/app/AppSettingsSection.tsx
+++ b/ui/desktop/src/components/settings/app/AppSettingsSection.tsx
@@ -82,6 +82,7 @@ const i18n = defineMessages({
   languageHindi: { id: 'settings.language.hindi', defaultMessage: 'Hindi' },
   languageJapanese: { id: 'settings.language.japanese', defaultMessage: 'Japanese' },
   languageSpanish: { id: 'settings.language.spanish', defaultMessage: 'Spanish' },
+  languageKorean: { id: 'settings.language.korean', defaultMessage: 'Korean' },
   helpTitle: { id: 'settings.help.title', defaultMessage: 'Help & feedback' },
   helpDesc: {
     id: 'settings.help.description',
@@ -148,6 +149,7 @@ const LANGUAGE_OPTIONS: Array<{ value: LanguageSetting; message: keyof typeof i1
   { value: 'es', message: 'languageSpanish' },
   { value: 'hi', message: 'languageHindi' },
   { value: 'ja', message: 'languageJapanese' },
+  { value: 'ko', message: 'languageKorean' },
   { value: 'ru', message: 'languageRussian' },
   { value: 'tr', message: 'languageTurkish' },
   { value: 'zh-CN', message: 'languageChineseSimplified' },

--- a/ui/desktop/src/i18n/i18n.test.ts
+++ b/ui/desktop/src/i18n/i18n.test.ts
@@ -73,6 +73,23 @@ describe('getLocale', () => {
     expect(getLocale()).toEqual({ locale: 'tr', messageLocale: 'tr' });
   });
 
+  it('supports Korean from navigator.languages', () => {
+    vi.stubGlobal('navigator', { languages: ['ko-KR'] });
+    expect(getLocale()).toEqual({ locale: 'ko-KR', messageLocale: 'ko' });
+  });
+
+  it('supports explicit Korean locale', () => {
+    mockAppConfig({ GOOSE_LOCALE: 'ko' });
+    vi.stubGlobal('navigator', { languages: ['xx-XX'] });
+    expect(getLocale()).toEqual({ locale: 'ko', messageLocale: 'ko' });
+  });
+
+  it('supports POSIX-style Korean locale from GOOSE_LOCALE', () => {
+    mockAppConfig({ GOOSE_LOCALE: 'ko_KR' });
+    vi.stubGlobal('navigator', { languages: ['xx-XX'] });
+    expect(getLocale()).toEqual({ locale: 'ko-KR', messageLocale: 'ko' });
+  });
+
   it('supports Japanese from navigator.languages', () => {
     vi.stubGlobal('navigator', { languages: ['ja-JP'] });
     expect(getLocale()).toEqual({ locale: 'ja-JP', messageLocale: 'ja' });

--- a/ui/desktop/src/i18n/index.ts
+++ b/ui/desktop/src/i18n/index.ts
@@ -15,7 +15,7 @@
 export { defineMessages, useIntl } from 'react-intl';
 
 /** The set of locales that have translation catalogs. */
-export const SUPPORTED_LOCALES = ['en', 'es', 'hi', 'ja', 'ru', 'tr', 'zh-CN'] as const;
+export const SUPPORTED_LOCALES = ['en', 'es', 'hi', 'ja', 'ko', 'ru', 'tr', 'zh-CN'] as const;
 export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
 const SUPPORTED_LOCALE_SET = new Set<string>(SUPPORTED_LOCALES);
 

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -4097,6 +4097,9 @@
   "settings.language.japanese": {
     "defaultMessage": "Japanese"
   },
+  "settings.language.korean": {
+    "defaultMessage": "Korean"
+  },
   "settings.language.russian": {
     "defaultMessage": "Russian"
   },

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -4097,6 +4097,9 @@
   "settings.language.japanese": {
     "defaultMessage": "Japonés"
   },
+  "settings.language.korean": {
+    "defaultMessage": "Coreano"
+  },
   "settings.language.russian": {
     "defaultMessage": "Ruso"
   },

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -4097,6 +4097,9 @@
   "settings.language.japanese": {
     "defaultMessage": "जापानी"
   },
+  "settings.language.korean": {
+    "defaultMessage": "कोरियाई"
+  },
   "settings.language.russian": {
     "defaultMessage": "रूसी"
   },

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -4097,6 +4097,9 @@
   "settings.language.japanese": {
     "defaultMessage": "日本語"
   },
+  "settings.language.korean": {
+    "defaultMessage": "韓国語"
+  },
   "settings.language.russian": {
     "defaultMessage": "ロシア語"
   },

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -992,6 +992,9 @@
   "elicitationRequest.submit": {
     "defaultMessage": "제출"
   },
+  "elicitationRequest.submitError": {
+    "defaultMessage": "이 요청은 더 이상 활성 상태가 아닙니다. 익스텐션에서 다시 요청해야 합니다."
+  },
   "elicitationRequest.submitted": {
     "defaultMessage": "제출된 정보"
   },

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -1,0 +1,4832 @@
+{
+  "alertBox.autoCompactAt": {
+    "defaultMessage": "자동 압축 기준"
+  },
+  "alertBox.compactNow": {
+    "defaultMessage": "지금 압축"
+  },
+  "alertBox.failedToSaveThreshold": {
+    "defaultMessage": "임계값 저장 실패: {error}"
+  },
+  "announcementModal.gotIt": {
+    "defaultMessage": "알았어요!"
+  },
+  "appLayout.openNavigation": {
+    "defaultMessage": "탐색 열기"
+  },
+  "appsView.customApp": {
+    "defaultMessage": "사용자 지정 앱"
+  },
+  "appsView.description": {
+    "defaultMessage": "MCP 서버의 애플리케이션과 goose 자체에서 구축한 앱입니다. 채팅 인터페이스를 통해 새 앱을 생성하도록 요청할 수 있으며 여기에 표시됩니다."
+  },
+  "appsView.errorLoading": {
+    "defaultMessage": "앱 로딩 오류: {error}"
+  },
+  "appsView.importApp": {
+    "defaultMessage": "앱 가져오기"
+  },
+  "appsView.launch": {
+    "defaultMessage": "실행"
+  },
+  "appsView.loading": {
+    "defaultMessage": "앱 로드 중..."
+  },
+  "appsView.noAppsDescription": {
+    "defaultMessage": "채팅을 열고 원하는 앱을 goose에 요청하세요. goose가 앱을 만들어 주면 여기에 표시됩니다. 또는 누군가가 앱을 공유한 경우 위 버튼을 사용하여 가져올 수 있습니다."
+  },
+  "appsView.noAppsTitle": {
+    "defaultMessage": "사용 가능한 앱이 없습니다."
+  },
+  "appsView.retry": {
+    "defaultMessage": "다시 시도"
+  },
+  "appsView.title": {
+    "defaultMessage": "앱"
+  },
+  "authSettings.activeProviderWarning": {
+    "defaultMessage": "현재 사용 중인 제공업체입니다. 다른 자격 증명을 설정할 때까지 새 요청이 실패할 수 있습니다."
+  },
+  "authSettings.cancel": {
+    "defaultMessage": "취소"
+  },
+  "authSettings.delete": {
+    "defaultMessage": "삭제"
+  },
+  "authSettings.deleteCredential": {
+    "defaultMessage": "자격 증명 삭제"
+  },
+  "authSettings.deleteMessage": {
+    "defaultMessage": "{provider}의 {name} 자격 증명을 삭제하시겠습니까?"
+  },
+  "authSettings.deleteTitle": {
+    "defaultMessage": "자격 증명 삭제"
+  },
+  "authSettings.deleted": {
+    "defaultMessage": "자격 증명이 삭제되었습니다."
+  },
+  "authSettings.description": {
+    "defaultMessage": "goose에 로컬로 저장된 제공업체 자격 증명을 관리합니다."
+  },
+  "authSettings.empty": {
+    "defaultMessage": "로컬에 저장된 제공업체 자격 증명을 찾을 수 없습니다."
+  },
+  "authSettings.expiresAt": {
+    "defaultMessage": "{date} 만료"
+  },
+  "authSettings.failedToConfigure": {
+    "defaultMessage": "자격 증명 구성 실패: {error}"
+  },
+  "authSettings.failedToDelete": {
+    "defaultMessage": "자격 증명 삭제 실패: {error}"
+  },
+  "authSettings.failedToLoad": {
+    "defaultMessage": "제공업체 자격 증명을 로드하지 못했습니다."
+  },
+  "authSettings.loading": {
+    "defaultMessage": "자격 증명을 불러오는 중..."
+  },
+  "authSettings.reauthorize": {
+    "defaultMessage": "재승인"
+  },
+  "authSettings.signIn": {
+    "defaultMessage": "로그인"
+  },
+  "authSettings.signedIn": {
+    "defaultMessage": "자격 증명이 설정되었습니다."
+  },
+  "authSettings.storageProviderCache": {
+    "defaultMessage": "제공업체 캐시"
+  },
+  "authSettings.storageSecretStore": {
+    "defaultMessage": "비밀 저장소"
+  },
+  "authSettings.title": {
+    "defaultMessage": "제공업체 자격 증명"
+  },
+  "backButton.back": {
+    "defaultMessage": "뒤로"
+  },
+  "baseChat.failedToLoadSession": {
+    "defaultMessage": "세션을 로드하지 못했습니다."
+  },
+  "baseChat.goHome": {
+    "defaultMessage": "홈으로 이동"
+  },
+  "baseChat.noSession": {
+    "defaultMessage": "세션 없음"
+  },
+  "baseChat.recipeCreatedMessage": {
+    "defaultMessage": "\"{title}\"이 저장되어 사용할 수 있습니다."
+  },
+  "baseChat.recipeCreatedTitle": {
+    "defaultMessage": "레시피가 성공적으로 생성되었습니다!"
+  },
+  "bottomMenuExtensionSelection.extensionToggleError": {
+    "defaultMessage": "익스텐션 토글 오류"
+  },
+  "bottomMenuExtensionSelection.extensionUpdated": {
+    "defaultMessage": "익스텐션이 업데이트되었습니다."
+  },
+  "bottomMenuExtensionSelection.extensionWillBeDisabled": {
+    "defaultMessage": "{name}은 새 채팅에서 비활성화됩니다."
+  },
+  "bottomMenuExtensionSelection.extensionWillBeEnabled": {
+    "defaultMessage": "{name}은 새 채팅에서 활성화됩니다."
+  },
+  "bottomMenuExtensionSelection.extensionsForNewChats": {
+    "defaultMessage": "새 채팅에 사용할 익스텐션"
+  },
+  "bottomMenuExtensionSelection.extensionsForThisSession": {
+    "defaultMessage": "이 채팅 세션의 익스텐션"
+  },
+  "bottomMenuExtensionSelection.manageExtensions": {
+    "defaultMessage": "익스텐션 관리"
+  },
+  "bottomMenuExtensionSelection.noActiveSession": {
+    "defaultMessage": "활성 세션을 찾을 수 없습니다. 먼저 채팅 세션을 시작하세요."
+  },
+  "bottomMenuExtensionSelection.noExtensionsAvailable": {
+    "defaultMessage": "사용 가능한 익스텐션 없음"
+  },
+  "bottomMenuExtensionSelection.noExtensionsFound": {
+    "defaultMessage": "익스텐션이 없습니다"
+  },
+  "bottomMenuExtensionSelection.searchExtensions": {
+    "defaultMessage": "익스텐션 검색..."
+  },
+  "cardButtons.configure": {
+    "defaultMessage": "구성"
+  },
+  "cardButtons.launch": {
+    "defaultMessage": "실행"
+  },
+  "chat.notification.taskComplete.body": {
+    "defaultMessage": "Goose에 다시 초점을 맞추려면 여기를 클릭하세요."
+  },
+  "chat.notification.taskComplete.title": {
+    "defaultMessage": "goose가 작업을 완료했습니다."
+  },
+  "chatInput.contextWindow": {
+    "defaultMessage": "컨텍스트 창"
+  },
+  "chatInput.createRecipeFromSession": {
+    "defaultMessage": "세션에서 레시피 생성"
+  },
+  "chatInput.dictationError": {
+    "defaultMessage": "받아쓰기 오류"
+  },
+  "chatInput.failedToReadImage": {
+    "defaultMessage": "이미지 파일을 읽지 못했습니다."
+  },
+  "chatInput.navigationShortcut": {
+    "defaultMessage": "{prefix}↑/{prefix}↓ 메시지 탐색"
+  },
+  "chatInput.processingDroppedFiles": {
+    "defaultMessage": "끌어다 놓은 파일을 처리하는 중..."
+  },
+  "chatInput.recording": {
+    "defaultMessage": "녹음..."
+  },
+  "chatInput.removeFile": {
+    "defaultMessage": "파일 제거"
+  },
+  "chatInput.removeImage": {
+    "defaultMessage": "이미지 삭제"
+  },
+  "chatInput.restartingSession": {
+    "defaultMessage": "세션을 다시 시작하는 중..."
+  },
+  "chatInput.send": {
+    "defaultMessage": "보내기"
+  },
+  "chatInput.tooManyTools": {
+    "defaultMessage": "도구가 너무 많으면 성능이 저하될 수 있습니다. 도구 수: {toolCount} (권장: {recommended})"
+  },
+  "chatInput.transcribing": {
+    "defaultMessage": "음성을 텍스트로 변환 중..."
+  },
+  "chatInput.typeMessage": {
+    "defaultMessage": "보낼 메시지를 입력하세요"
+  },
+  "chatInput.unknownType": {
+    "defaultMessage": "알 수 없는 유형"
+  },
+  "chatInput.viewEditRecipe": {
+    "defaultMessage": "레시피 보기/편집"
+  },
+  "chatInput.viewExtensions": {
+    "defaultMessage": "익스텐션 보기"
+  },
+  "chatInput.waitingForImages": {
+    "defaultMessage": "이미지 저장을 기다리는 중..."
+  },
+  "chatSettings.modeDescription": {
+    "defaultMessage": "goose가 도구 및 익스텐션과 상호작용하는 방식을 설정합니다."
+  },
+  "chatSettings.modeTitle": {
+    "defaultMessage": "모드"
+  },
+  "chatSettings.responseStylesDescription": {
+    "defaultMessage": "goose가 응답을 구성하고 표시하는 방식을 선택합니다."
+  },
+  "chatSettings.responseStylesTitle": {
+    "defaultMessage": "응답 스타일"
+  },
+  "configSettings.configReset": {
+    "defaultMessage": "구성 재설정"
+  },
+  "configSettings.configResetMsg": {
+    "defaultMessage": "모든 변경사항이 되돌려졌습니다."
+  },
+  "configSettings.configUpdated": {
+    "defaultMessage": "구성이 업데이트되었습니다."
+  },
+  "configSettings.configUpdatedMsg": {
+    "defaultMessage": "\"{name}\"을(를) 저장했습니다."
+  },
+  "configSettings.configurationEditor": {
+    "defaultMessage": "구성 편집기"
+  },
+  "configSettings.description": {
+    "defaultMessage": "goose 구성 설정을 편집합니다."
+  },
+  "configSettings.descriptionWithProvider": {
+    "defaultMessage": "goose 구성 설정을 편집합니다. 현재 설정: {provider}"
+  },
+  "configSettings.done": {
+    "defaultMessage": "완료"
+  },
+  "configSettings.editConfiguration": {
+    "defaultMessage": "구성 편집"
+  },
+  "configSettings.enterValue": {
+    "defaultMessage": "{name}을 입력하세요"
+  },
+  "configSettings.noSettings": {
+    "defaultMessage": "구성 설정을 찾을 수 없습니다."
+  },
+  "configSettings.resetChanges": {
+    "defaultMessage": "변경 사항 재설정"
+  },
+  "configSettings.saveFailed": {
+    "defaultMessage": "저장 실패"
+  },
+  "configSettings.saveFailedMsg": {
+    "defaultMessage": "\"{name}\" 저장에 실패했습니다."
+  },
+  "configSettings.saving": {
+    "defaultMessage": "저장 중..."
+  },
+  "configSettings.title": {
+    "defaultMessage": "구성"
+  },
+  "configureApproveMode.cancel": {
+    "defaultMessage": "취소"
+  },
+  "configureApproveMode.description": {
+    "defaultMessage": "모든 도구 요청에 승인을 요구하거나, 위험도에 따라 승인 필요 여부를 판단할 수 있습니다."
+  },
+  "configureApproveMode.manualApproval": {
+    "defaultMessage": "수동 승인"
+  },
+  "configureApproveMode.manualApprovalDescription": {
+    "defaultMessage": "모든 도구, 익스텐션, 파일 수정에는 사용자 승인이 필요합니다."
+  },
+  "configureApproveMode.save": {
+    "defaultMessage": "저장"
+  },
+  "configureApproveMode.saving": {
+    "defaultMessage": "저장 중..."
+  },
+  "configureApproveMode.smartApproval": {
+    "defaultMessage": "스마트 승인"
+  },
+  "configureApproveMode.smartApprovalDescription": {
+    "defaultMessage": "위험 수준에 따라 승인이 필요한 작업을 지능적으로 판단합니다."
+  },
+  "configureApproveMode.title": {
+    "defaultMessage": "승인 모드 구성"
+  },
+  "confirmationModal.defaultCancel": {
+    "defaultMessage": "아니요"
+  },
+  "confirmationModal.defaultConfirm": {
+    "defaultMessage": "예"
+  },
+  "confirmationModal.processing": {
+    "defaultMessage": "처리 중..."
+  },
+  "conversationLimitsDropdown.conversationLimits": {
+    "defaultMessage": "대화 제한"
+  },
+  "conversationLimitsDropdown.maxTurns": {
+    "defaultMessage": "최대 턴"
+  },
+  "conversationLimitsDropdown.maxTurnsDescription": {
+    "defaultMessage": "goose가 사용자 입력을 요청하기 전 최대 에이전트 턴 수"
+  },
+  "costTracker.costUnavailable": {
+    "defaultMessage": "{model}({inputTokens} 입력, {outputTokens} 출력 토큰)에 대한 비용 데이터는 제공되지 않습니다."
+  },
+  "costTracker.inputOutputTooltip": {
+    "defaultMessage": "입력: {inputTokens} 토큰({inputCost}) | 출력: {outputTokens} 토큰({outputCost})"
+  },
+  "costTracker.pricingUnavailable": {
+    "defaultMessage": "{model}에 대한 가격 데이터가 없습니다."
+  },
+  "costTracker.totalSessionCost": {
+    "defaultMessage": "총 세션 비용: {cost}"
+  },
+  "createEditRecipe.clickToGenerateDeeplink": {
+    "defaultMessage": "딥링크를 생성하려면 클릭하세요."
+  },
+  "createEditRecipe.close": {
+    "defaultMessage": "닫기"
+  },
+  "createEditRecipe.copied": {
+    "defaultMessage": "복사되었습니다!"
+  },
+  "createEditRecipe.copy": {
+    "defaultMessage": "복사"
+  },
+  "createEditRecipe.copyLinkDescription": {
+    "defaultMessage": "이 링크를 복사하여 친구와 공유하거나 Chrome에 직접 붙여넣어 엽니다."
+  },
+  "createEditRecipe.createRecipeTitle": {
+    "defaultMessage": "레시피 생성"
+  },
+  "createEditRecipe.createSubtitle": {
+    "defaultMessage": "재사용 가능한 채팅 세션에서 에이전트의 동작과 기능을 정의하는 새 레시피를 만듭니다."
+  },
+  "createEditRecipe.editSubtitle": {
+    "defaultMessage": "아래 레시피를 편집하여 새 세션에서 에이전트의 동작을 변경할 수 있습니다."
+  },
+  "createEditRecipe.generatingDeeplink": {
+    "defaultMessage": "딥링크 생성 중..."
+  },
+  "createEditRecipe.learnMore": {
+    "defaultMessage": "자세히 알아보기"
+  },
+  "createEditRecipe.recipeSavedAndLaunchedMsg": {
+    "defaultMessage": "레시피가 저장되고 성공적으로 실행되었습니다."
+  },
+  "createEditRecipe.recipeSavedMsg": {
+    "defaultMessage": "레시피가 성공적으로 저장되었습니다."
+  },
+  "createEditRecipe.saveAndRunFailed": {
+    "defaultMessage": "저장 및 실행 실패"
+  },
+  "createEditRecipe.saveAndRunFailedMsg": {
+    "defaultMessage": "레시피 저장 및 실행 실패: {error}"
+  },
+  "createEditRecipe.saveAndRunRecipe": {
+    "defaultMessage": "레시피 저장 및 실행"
+  },
+  "createEditRecipe.saveFailed": {
+    "defaultMessage": "저장 실패"
+  },
+  "createEditRecipe.saveFailedMsg": {
+    "defaultMessage": "레시피 저장 실패: {error}"
+  },
+  "createEditRecipe.saveRecipe": {
+    "defaultMessage": "레시피 저장"
+  },
+  "createEditRecipe.saving": {
+    "defaultMessage": "저장 중..."
+  },
+  "createEditRecipe.validationFailed": {
+    "defaultMessage": "검증 실패"
+  },
+  "createEditRecipe.validationMsg": {
+    "defaultMessage": "필수 필드를 모두 입력하고 JSON 스키마가 유효한지 확인하세요."
+  },
+  "createEditRecipe.viewEditRecipeTitle": {
+    "defaultMessage": "레시피 보기/수정"
+  },
+  "createRecipeFromSession.analyzingTitle": {
+    "defaultMessage": "대화 분석 중"
+  },
+  "createRecipeFromSession.cancel": {
+    "defaultMessage": "취소"
+  },
+  "createRecipeFromSession.createAndRunRecipe": {
+    "defaultMessage": "레시피 생성 및 실행"
+  },
+  "createRecipeFromSession.createRecipe": {
+    "defaultMessage": "레시피 생성"
+  },
+  "createRecipeFromSession.creating": {
+    "defaultMessage": "생성 중..."
+  },
+  "createRecipeFromSession.extractingInsights": {
+    "defaultMessage": "채팅에서 통찰력 추출"
+  },
+  "createRecipeFromSession.failedToCreateDefaultMsg": {
+    "defaultMessage": "레시피를 생성하는 중에 예상치 못한 오류가 발생했습니다. 다시 시도해 주세요."
+  },
+  "createRecipeFromSession.failedToCreateTitle": {
+    "defaultMessage": "레시피를 생성하지 못했습니다."
+  },
+  "createRecipeFromSession.stageComplete": {
+    "defaultMessage": "완료!"
+  },
+  "createRecipeFromSession.stageExtracting": {
+    "defaultMessage": "주요 주제 추출 중..."
+  },
+  "createRecipeFromSession.stageFinalizing": {
+    "defaultMessage": "세부정보를 마무리하는 중..."
+  },
+  "createRecipeFromSession.stageGenerating": {
+    "defaultMessage": "레시피 구조 생성 중..."
+  },
+  "createRecipeFromSession.stageIdentifying": {
+    "defaultMessage": "주요 패턴 식별 중..."
+  },
+  "createRecipeFromSession.stageReading": {
+    "defaultMessage": "대화를 읽는 중..."
+  },
+  "createRecipeFromSession.subtitle": {
+    "defaultMessage": "현재 대화를 기반으로 재사용 가능한 레시피를 만드세요."
+  },
+  "createRecipeFromSession.title": {
+    "defaultMessage": "세션에서 레시피 생성"
+  },
+  "createSubRecipeInline.cancel": {
+    "defaultMessage": "취소"
+  },
+  "createSubRecipeInline.closeModal": {
+    "defaultMessage": "하위 레시피 생성 모달 닫기"
+  },
+  "createSubRecipeInline.createAndAdd": {
+    "defaultMessage": "하위 레시피 생성 및 추가"
+  },
+  "createSubRecipeInline.createdSuccess": {
+    "defaultMessage": "하위 레시피가 성공적으로 생성되었습니다."
+  },
+  "createSubRecipeInline.creating": {
+    "defaultMessage": "생성 중..."
+  },
+  "createSubRecipeInline.duplicateName": {
+    "defaultMessage": "중복된 이름"
+  },
+  "createSubRecipeInline.duplicateNameMsg": {
+    "defaultMessage": "\"{name}\"이라는 하위 레시피가 이미 존재합니다. 고유한 이름을 사용하세요."
+  },
+  "createSubRecipeInline.instructionsLabel": {
+    "defaultMessage": "지침"
+  },
+  "createSubRecipeInline.instructionsPlaceholder": {
+    "defaultMessage": "이 하위 레시피가 호출될 때 AI에 제공할 지침..."
+  },
+  "createSubRecipeInline.nameHint": {
+    "defaultMessage": "도구 이름을 생성하는 데 사용되는 고유 식별자"
+  },
+  "createSubRecipeInline.nameLabel": {
+    "defaultMessage": "이름"
+  },
+  "createSubRecipeInline.namePlaceholder": {
+    "defaultMessage": "예: security_scan"
+  },
+  "createSubRecipeInline.preconfiguredValues": {
+    "defaultMessage": "사전 구성된 값"
+  },
+  "createSubRecipeInline.preconfiguredValuesHint": {
+    "defaultMessage": "항상 하위 레시피에 전달되는 선택적 매개변수 값"
+  },
+  "createSubRecipeInline.recipeDescriptionLabel": {
+    "defaultMessage": "레시피 설명"
+  },
+  "createSubRecipeInline.recipeDescriptionPlaceholder": {
+    "defaultMessage": "이 레시피가 실행될 때 수행되는 작업"
+  },
+  "createSubRecipeInline.recipeTitleLabel": {
+    "defaultMessage": "레시피 제목"
+  },
+  "createSubRecipeInline.recipeTitlePlaceholder": {
+    "defaultMessage": "예: 보안 분석 도구"
+  },
+  "createSubRecipeInline.saveFailed": {
+    "defaultMessage": "저장 실패"
+  },
+  "createSubRecipeInline.saveFailedMsg": {
+    "defaultMessage": "하위 레시피 저장 실패: {error}"
+  },
+  "createSubRecipeInline.sequentialHint": {
+    "defaultMessage": "(여러 인스턴스를 순차적으로 강제 실행)"
+  },
+  "createSubRecipeInline.sequentialLabel": {
+    "defaultMessage": "반복 시 순차 실행"
+  },
+  "createSubRecipeInline.subtitle": {
+    "defaultMessage": "기본 레시피에서 호출 가능한 도구로 사용할 간단한 레시피를 만듭니다."
+  },
+  "createSubRecipeInline.title": {
+    "defaultMessage": "새 하위 레시피 생성"
+  },
+  "createSubRecipeInline.toolDescriptionLabel": {
+    "defaultMessage": "도구 설명"
+  },
+  "createSubRecipeInline.toolDescriptionPlaceholder": {
+    "defaultMessage": "도구로 호출될 때 표시되는 선택적 설명"
+  },
+  "createSubRecipeInline.validationFailed": {
+    "defaultMessage": "검증 실패"
+  },
+  "createSubRecipeInline.validationMsg": {
+    "defaultMessage": "이름, 제목, 레시피 설명, 지침이 필요합니다."
+  },
+  "creditsExhaustedNotification.addCredits": {
+    "defaultMessage": "크레딧 추가"
+  },
+  "creditsExhaustedNotification.insufficientCredits": {
+    "defaultMessage": "부족한 크레딧"
+  },
+  "cronPicker.april": {
+    "defaultMessage": "4월"
+  },
+  "cronPicker.at": {
+    "defaultMessage": "에"
+  },
+  "cronPicker.atMinute": {
+    "defaultMessage": "분에"
+  },
+  "cronPicker.atSecond": {
+    "defaultMessage": "초에"
+  },
+  "cronPicker.august": {
+    "defaultMessage": "8월"
+  },
+  "cronPicker.cronExpression": {
+    "defaultMessage": "cron 표현식"
+  },
+  "cronPicker.custom": {
+    "defaultMessage": "사용자 지정 cron"
+  },
+  "cronPicker.day": {
+    "defaultMessage": "일"
+  },
+  "cronPicker.december": {
+    "defaultMessage": "12월"
+  },
+  "cronPicker.emptyCronError": {
+    "defaultMessage": "크론 표현식은 비워둘 수 없습니다."
+  },
+  "cronPicker.every": {
+    "defaultMessage": "모든"
+  },
+  "cronPicker.february": {
+    "defaultMessage": "2월"
+  },
+  "cronPicker.friday": {
+    "defaultMessage": "금요일"
+  },
+  "cronPicker.hour": {
+    "defaultMessage": "시간"
+  },
+  "cronPicker.inMonth": {
+    "defaultMessage": "에"
+  },
+  "cronPicker.invalidDayOfMonth": {
+    "defaultMessage": "일은 1에서 {max} 사이여야 합니다."
+  },
+  "cronPicker.january": {
+    "defaultMessage": "1월"
+  },
+  "cronPicker.july": {
+    "defaultMessage": "7월"
+  },
+  "cronPicker.june": {
+    "defaultMessage": "6월"
+  },
+  "cronPicker.march": {
+    "defaultMessage": "3월"
+  },
+  "cronPicker.may": {
+    "defaultMessage": "5월"
+  },
+  "cronPicker.minute": {
+    "defaultMessage": "분"
+  },
+  "cronPicker.mode": {
+    "defaultMessage": "모드"
+  },
+  "cronPicker.monday": {
+    "defaultMessage": "월요일"
+  },
+  "cronPicker.month": {
+    "defaultMessage": "월"
+  },
+  "cronPicker.november": {
+    "defaultMessage": "11월"
+  },
+  "cronPicker.october": {
+    "defaultMessage": "10월"
+  },
+  "cronPicker.on": {
+    "defaultMessage": "에"
+  },
+  "cronPicker.onDay": {
+    "defaultMessage": "일에"
+  },
+  "cronPicker.quarter": {
+    "defaultMessage": "분기"
+  },
+  "cronPicker.saturday": {
+    "defaultMessage": "토요일"
+  },
+  "cronPicker.september": {
+    "defaultMessage": "9월"
+  },
+  "cronPicker.startingMonth": {
+    "defaultMessage": "시작 월"
+  },
+  "cronPicker.sunday": {
+    "defaultMessage": "일요일"
+  },
+  "cronPicker.thursday": {
+    "defaultMessage": "목요일"
+  },
+  "cronPicker.tuesday": {
+    "defaultMessage": "화요일"
+  },
+  "cronPicker.wednesday": {
+    "defaultMessage": "수요일"
+  },
+  "cronPicker.week": {
+    "defaultMessage": "주"
+  },
+  "cronPicker.year": {
+    "defaultMessage": "연도"
+  },
+  "customProviderForm.add": {
+    "defaultMessage": "추가"
+  },
+  "customProviderForm.anthropicCompatible": {
+    "defaultMessage": "Anthropic 호환 가능"
+  },
+  "customProviderForm.apiBasePath": {
+    "defaultMessage": "API 기본 경로(선택)"
+  },
+  "customProviderForm.apiBasePathHint": {
+    "defaultMessage": "기본 API 경로를 재정의합니다. 제공업체의 기본 경로를 사용하려면 비워 두세요."
+  },
+  "customProviderForm.apiBasePathPlaceholder": {
+    "defaultMessage": "예: v1/chat/completions 또는 project_id/v1"
+  },
+  "customProviderForm.apiKey": {
+    "defaultMessage": "API 키"
+  },
+  "customProviderForm.apiKeyPlaceholderExisting": {
+    "defaultMessage": "기존 키를 유지하려면 비워 두세요."
+  },
+  "customProviderForm.apiKeyPlaceholderNew": {
+    "defaultMessage": "API 키"
+  },
+  "customProviderForm.apiKeyRequired": {
+    "defaultMessage": "API 키가 필요합니다"
+  },
+  "customProviderForm.apiUrl": {
+    "defaultMessage": "API URL"
+  },
+  "customProviderForm.apiUrlPlaceholder": {
+    "defaultMessage": "https://api.example.com"
+  },
+  "customProviderForm.apiUrlRequired": {
+    "defaultMessage": "API URL은 필수입니다"
+  },
+  "customProviderForm.attachments": {
+    "defaultMessage": "첨부파일"
+  },
+  "customProviderForm.authHint": {
+    "defaultMessage": "Ollama와 같은 로컬 LLM에는 일반적으로 API 키가 필요하지 않습니다."
+  },
+  "customProviderForm.authentication": {
+    "defaultMessage": "인증"
+  },
+  "customProviderForm.availableModels": {
+    "defaultMessage": "사용 가능한 모델(쉼표로 구분)"
+  },
+  "customProviderForm.back": {
+    "defaultMessage": "← 뒤로"
+  },
+  "customProviderForm.cancel": {
+    "defaultMessage": "취소"
+  },
+  "customProviderForm.cannotDeleteActive": {
+    "defaultMessage": "현재 사용 중인 동안에는 이 제공업체를 삭제할 수 없습니다. 먼저 다른 모델로 전환해 보세요."
+  },
+  "customProviderForm.chooseSetup": {
+    "defaultMessage": "제공업체 설정 방법을 선택하세요."
+  },
+  "customProviderForm.clear": {
+    "defaultMessage": "지우기"
+  },
+  "customProviderForm.configureManually": {
+    "defaultMessage": "수동으로 구성"
+  },
+  "customProviderForm.configureManuallyDesc": {
+    "defaultMessage": "모든 제공업체 세부정보를 직접 입력하세요."
+  },
+  "customProviderForm.confirmDelete": {
+    "defaultMessage": "삭제 확인"
+  },
+  "customProviderForm.createProvider": {
+    "defaultMessage": "제공업체 생성"
+  },
+  "customProviderForm.customHeaders": {
+    "defaultMessage": "사용자 지정 헤더"
+  },
+  "customProviderForm.customHeadersHint": {
+    "defaultMessage": "제공업체에 보내는 요청에 포함할 사용자 지정 HTTP 헤더를 추가합니다. 두 필드를 모두 채운 뒤 \"+\" 버튼을 클릭해 추가하세요."
+  },
+  "customProviderForm.deleteConfirmation": {
+    "defaultMessage": "이 사용자 지정 제공업체를 삭제하시겠습니까? 제공업체와 저장된 API 키가 영구적으로 삭제되며, 이 작업은 취소할 수 없습니다."
+  },
+  "customProviderForm.deleteProvider": {
+    "defaultMessage": "제공업체 삭제"
+  },
+  "customProviderForm.displayName": {
+    "defaultMessage": "표시 이름"
+  },
+  "customProviderForm.displayNamePlaceholder": {
+    "defaultMessage": "제공업체 이름"
+  },
+  "customProviderForm.displayNameRequired": {
+    "defaultMessage": "표시 이름은 필수 항목입니다."
+  },
+  "customProviderForm.docs": {
+    "defaultMessage": "문서"
+  },
+  "customProviderForm.headerBothRequired": {
+    "defaultMessage": "헤더 이름과 값을 모두 입력해야 합니다."
+  },
+  "customProviderForm.headerDuplicate": {
+    "defaultMessage": "이 이름을 가진 헤더가 이미 존재합니다."
+  },
+  "customProviderForm.headerNamePlaceholder": {
+    "defaultMessage": "헤더 이름"
+  },
+  "customProviderForm.headerNoSpaces": {
+    "defaultMessage": "헤더 이름에는 공백이 포함될 수 없습니다."
+  },
+  "customProviderForm.modelsPlaceholder": {
+    "defaultMessage": "모델-a, 모델-b, 모델-c"
+  },
+  "customProviderForm.modelsRequired": {
+    "defaultMessage": "모델이 1개 이상 필요합니다."
+  },
+  "customProviderForm.ollamaCompatible": {
+    "defaultMessage": "Ollama 호환 가능"
+  },
+  "customProviderForm.openaiCompatible": {
+    "defaultMessage": "OpenAI 호환 가능"
+  },
+  "customProviderForm.providerType": {
+    "defaultMessage": "제공업체 유형"
+  },
+  "customProviderForm.reasoning": {
+    "defaultMessage": "추론"
+  },
+  "customProviderForm.requiresApiKey": {
+    "defaultMessage": "이 제공업체에는 API 키가 필요합니다"
+  },
+  "customProviderForm.startFromTemplate": {
+    "defaultMessage": "제공업체 템플릿에서 시작"
+  },
+  "customProviderForm.startFromTemplateDesc": {
+    "defaultMessage": "알려진 제공업체를 선택하면 구성이 자동으로 채워집니다."
+  },
+  "customProviderForm.submitError": {
+    "defaultMessage": "제공업체를 저장하지 못했습니다. 설정을 확인하고 다시 시도하세요."
+  },
+  "customProviderForm.supportsStreaming": {
+    "defaultMessage": "제공업체는 스트리밍 응답을 지원합니다."
+  },
+  "customProviderForm.toolCalling": {
+    "defaultMessage": "도구 호출"
+  },
+  "customProviderForm.updateProvider": {
+    "defaultMessage": "제공업체 업데이트"
+  },
+  "customProviderForm.usingTemplate": {
+    "defaultMessage": "템플릿 사용: {name}"
+  },
+  "customProviderForm.valuePlaceholder": {
+    "defaultMessage": "값"
+  },
+  "defaultCardButtons.configureSettings": {
+    "defaultMessage": "{name} 설정 구성"
+  },
+  "defaultCardButtons.deleteSettings": {
+    "defaultMessage": "{name} 설정 삭제"
+  },
+  "defaultCardButtons.editSettings": {
+    "defaultMessage": "{name} 설정 편집"
+  },
+  "defaultCardButtons.getStarted": {
+    "defaultMessage": "goose 시작하기!"
+  },
+  "defaultProviderSetupForm.apiHostLabel": {
+    "defaultMessage": "API 호스트"
+  },
+  "defaultProviderSetupForm.apiHostPlaceholder": {
+    "defaultMessage": "https://api.example.com"
+  },
+  "defaultProviderSetupForm.apiKeyLabel": {
+    "defaultMessage": "API 키"
+  },
+  "defaultProviderSetupForm.apiKeyPlaceholder": {
+    "defaultMessage": "API 키"
+  },
+  "defaultProviderSetupForm.hideOptions": {
+    "defaultMessage": "{count} 옵션 숨기기"
+  },
+  "defaultProviderSetupForm.loadingConfig": {
+    "defaultMessage": "구성 값 로드 중..."
+  },
+  "defaultProviderSetupForm.modelsLabel": {
+    "defaultMessage": "모델"
+  },
+  "defaultProviderSetupForm.modelsPlaceholder": {
+    "defaultMessage": "모델-a, 모델-b"
+  },
+  "defaultProviderSetupForm.noConfigParameters": {
+    "defaultMessage": "이 제공업체에 대한 구성 매개변수가 없습니다."
+  },
+  "defaultProviderSetupForm.showOptions": {
+    "defaultMessage": "{count} 옵션 표시"
+  },
+  "diagnosticsModal.attachHint": {
+    "defaultMessage": "버그를 신고하는 경우 진단 보고서를 첨부해 보세요."
+  },
+  "diagnosticsModal.cancel": {
+    "defaultMessage": "취소"
+  },
+  "diagnosticsModal.configSettings": {
+    "defaultMessage": "구성 설정"
+  },
+  "diagnosticsModal.description": {
+    "defaultMessage": "진단 zip 파일을 다운로드하여 팀과 공유하거나 시스템 세부 정보가 미리 입력된 상태로 GitHub에 직접 버그를 신고할 수 있습니다. 진단 보고서에는 다음이 포함됩니다."
+  },
+  "diagnosticsModal.diagnosticsErrorMsg": {
+    "defaultMessage": "진단을 다운로드하지 못했습니다."
+  },
+  "diagnosticsModal.diagnosticsErrorTitle": {
+    "defaultMessage": "진단 오류"
+  },
+  "diagnosticsModal.download": {
+    "defaultMessage": "다운로드"
+  },
+  "diagnosticsModal.downloading": {
+    "defaultMessage": "다운로드 중..."
+  },
+  "diagnosticsModal.fileBug": {
+    "defaultMessage": "GitHub에 버그 신고"
+  },
+  "diagnosticsModal.logFiles": {
+    "defaultMessage": "최근 로그 파일"
+  },
+  "diagnosticsModal.opening": {
+    "defaultMessage": "열기..."
+  },
+  "diagnosticsModal.reportProblem": {
+    "defaultMessage": "문제 신고"
+  },
+  "diagnosticsModal.sensitiveWarning": {
+    "defaultMessage": "세션에 민감한 정보가 포함되어 있는 경우 진단 파일을 공개적으로 공유하지 마십시오."
+  },
+  "diagnosticsModal.sessionMessages": {
+    "defaultMessage": "현재 세션 메시지"
+  },
+  "diagnosticsModal.systemInfo": {
+    "defaultMessage": "기본 시스템 정보"
+  },
+  "diagnosticsModal.systemInfoErrorMsg": {
+    "defaultMessage": "시스템 정보를 가져오지 못했습니다."
+  },
+  "diagnosticsModal.systemInfoErrorTitle": {
+    "defaultMessage": "오류"
+  },
+  "dialog.close": {
+    "defaultMessage": "닫기"
+  },
+  "dictationSettings.addApiKey": {
+    "defaultMessage": "API 키 추가"
+  },
+  "dictationSettings.apiKey": {
+    "defaultMessage": "API 키"
+  },
+  "dictationSettings.cancel": {
+    "defaultMessage": "취소"
+  },
+  "dictationSettings.chooseVoiceConversion": {
+    "defaultMessage": "음성을 텍스트로 변환하는 방식을 선택합니다."
+  },
+  "dictationSettings.configureApiKey": {
+    "defaultMessage": "<b>{settingsPath}</b>에서 API 키를 설정합니다."
+  },
+  "dictationSettings.configured": {
+    "defaultMessage": "(설정됨)"
+  },
+  "dictationSettings.configuredIn": {
+    "defaultMessage": "✓ {settingsPath}에 설정됨"
+  },
+  "dictationSettings.disabled": {
+    "defaultMessage": "사용 안 함"
+  },
+  "dictationSettings.enterApiKey": {
+    "defaultMessage": "API 키를 입력하세요"
+  },
+  "dictationSettings.notConfigured": {
+    "defaultMessage": "(설정되지 않음)"
+  },
+  "dictationSettings.removeApiKey": {
+    "defaultMessage": "API 키 제거"
+  },
+  "dictationSettings.requiredForTranscription": {
+    "defaultMessage": "텍스트 변환에 필요"
+  },
+  "dictationSettings.save": {
+    "defaultMessage": "저장"
+  },
+  "dictationSettings.updateApiKey": {
+    "defaultMessage": "API 키 업데이트"
+  },
+  "dictationSettings.voiceDictationProvider": {
+    "defaultMessage": "음성 받아쓰기 제공업체"
+  },
+  "dirSwitcher.chooseDirectory": {
+    "defaultMessage": "디렉터리 선택…"
+  },
+  "dirSwitcher.currentDirectory": {
+    "defaultMessage": "현재 디렉터리"
+  },
+  "dirSwitcher.failedToUpdateWorkingDir": {
+    "defaultMessage": "작업 디렉터리를 업데이트하지 못했습니다."
+  },
+  "dirSwitcher.gitWorktrees": {
+    "defaultMessage": "Git 워크트리"
+  },
+  "dirSwitcher.noWorktreesFound": {
+    "defaultMessage": "작업 트리를 찾을 수 없습니다."
+  },
+  "dirSwitcher.openInFinder": {
+    "defaultMessage": "파일 관리자에서 열기"
+  },
+  "dirSwitcher.recentDirectories": {
+    "defaultMessage": "최근 디렉터리"
+  },
+  "elicitationRequest.accept": {
+    "defaultMessage": "수락"
+  },
+  "elicitationRequest.cancelled": {
+    "defaultMessage": "정보 요청이 취소되었습니다."
+  },
+  "elicitationRequest.defaultMessage": {
+    "defaultMessage": "Goose에 추가 정보가 필요합니다."
+  },
+  "elicitationRequest.expired": {
+    "defaultMessage": "이 요청은 만료되었습니다. 익스텐션에서 다시 질문해야 합니다."
+  },
+  "elicitationRequest.submit": {
+    "defaultMessage": "제출"
+  },
+  "elicitationRequest.submitted": {
+    "defaultMessage": "제출된 정보"
+  },
+  "elicitationRequest.waitingForResponse": {
+    "defaultMessage": "답변을 기다리는 중입니다. ({timeRemaining} 남음)"
+  },
+  "envVarsSection.add": {
+    "defaultMessage": "추가"
+  },
+  "envVarsSection.bothRequired": {
+    "defaultMessage": "변수 이름과 값을 모두 입력해야 합니다."
+  },
+  "envVarsSection.envVarsDescription": {
+    "defaultMessage": "환경 변수에 대한 키-값 쌍을 추가합니다. 두 필드를 모두 채운 후 \"+\" 버튼을 클릭하여 추가하세요. 기존 비밀 값의 경우 편집 버튼을 클릭하여 수정하세요."
+  },
+  "envVarsSection.environmentVariables": {
+    "defaultMessage": "환경 변수"
+  },
+  "envVarsSection.noSpaces": {
+    "defaultMessage": "변수 이름에는 공백이 포함될 수 없습니다."
+  },
+  "envVarsSection.value": {
+    "defaultMessage": "값"
+  },
+  "envVarsSection.variableName": {
+    "defaultMessage": "변수 이름"
+  },
+  "environmentBadge.dev": {
+    "defaultMessage": "Dev"
+  },
+  "errorBoundary.errorGeneric": {
+    "defaultMessage": "오류가 발생했습니다."
+  },
+  "errorBoundary.errorWithVersion": {
+    "defaultMessage": "Goose v{version}에서 오류가 발생했습니다."
+  },
+  "errorBoundary.heading": {
+    "defaultMessage": "꽥!"
+  },
+  "errorBoundary.reload": {
+    "defaultMessage": "새로고침"
+  },
+  "extensionConfigFields.commandLabel": {
+    "defaultMessage": "명령"
+  },
+  "extensionConfigFields.commandPlaceholder": {
+    "defaultMessage": "예: npx -y @modelcontextprotocol/my-extension [filepath]"
+  },
+  "extensionConfigFields.commandRequired": {
+    "defaultMessage": "명령이 필요합니다"
+  },
+  "extensionConfigFields.endpointLabel": {
+    "defaultMessage": "엔드포인트"
+  },
+  "extensionConfigFields.endpointPlaceholder": {
+    "defaultMessage": "엔드포인트 URL 입력..."
+  },
+  "extensionConfigFields.endpointRequired": {
+    "defaultMessage": "엔드포인트 URL이 필요합니다"
+  },
+  "extensionInfoFields.descriptionLabel": {
+    "defaultMessage": "설명"
+  },
+  "extensionInfoFields.descriptionPlaceholder": {
+    "defaultMessage": "선택적 설명..."
+  },
+  "extensionInfoFields.extensionName": {
+    "defaultMessage": "익스텐션 이름"
+  },
+  "extensionInfoFields.extensionNamePlaceholder": {
+    "defaultMessage": "익스텐션 이름을 입력하세요..."
+  },
+  "extensionInfoFields.nameRequired": {
+    "defaultMessage": "이름은 필수입니다"
+  },
+  "extensionInfoFields.typeHttp": {
+    "defaultMessage": "HTTP"
+  },
+  "extensionInfoFields.typeLabel": {
+    "defaultMessage": "유형"
+  },
+  "extensionInfoFields.typeSseUnsupported": {
+    "defaultMessage": "SSE (미지원)"
+  },
+  "extensionInfoFields.typeStandardIo": {
+    "defaultMessage": "표준 IO(STDIO)"
+  },
+  "extensionInfoFields.typeStdio": {
+    "defaultMessage": "STDIO"
+  },
+  "extensionInfoFields.typeStreamableHttp": {
+    "defaultMessage": "스트리밍 가능 HTTP"
+  },
+  "extensionInstallModal.alreadyInstalledMessage": {
+    "defaultMessage": "''{name}'' 익스텐션이 이미 설치되었습니다. 사용하려면 새 채팅 세션을 시작하세요."
+  },
+  "extensionInstallModal.alreadyInstalledTitle": {
+    "defaultMessage": "''{name}'' 익스텐션이 이미 설치되어 있습니다."
+  },
+  "extensionInstallModal.blockedMessage": {
+    "defaultMessage": "이 익스텐션 명령은 허용 목록에 없으며 설치가 차단됩니다. 익스텐션: {name} 명령: {command} 이 익스텐션에 대한 승인을 요청하려면 관리자에게 문의하세요."
+  },
+  "extensionInstallModal.blockedTitle": {
+    "defaultMessage": "익스텐션 설치가 차단되었습니다."
+  },
+  "extensionInstallModal.cancel": {
+    "defaultMessage": "취소"
+  },
+  "extensionInstallModal.installAnyway": {
+    "defaultMessage": "그래도 설치"
+  },
+  "extensionInstallModal.installing": {
+    "defaultMessage": "설치 중..."
+  },
+  "extensionInstallModal.no": {
+    "defaultMessage": "아니요"
+  },
+  "extensionInstallModal.ok": {
+    "defaultMessage": "좋아요"
+  },
+  "extensionInstallModal.trustedMessage": {
+    "defaultMessage": "{name} 익스텐션을 설치하시겠습니까? 명령: {command}"
+  },
+  "extensionInstallModal.trustedTitle": {
+    "defaultMessage": "익스텐션 설치 확인"
+  },
+  "extensionInstallModal.unknownCommand": {
+    "defaultMessage": "알 수 없는 명령"
+  },
+  "extensionInstallModal.untrustedMessageWithCommand": {
+    "defaultMessage": "{securityMessage} 익스텐션: {name} 명령: {command} 이 내용에 대해 확실하지 않은 경우 관리자에게 문의하세요."
+  },
+  "extensionInstallModal.untrustedMessageWithUrl": {
+    "defaultMessage": "{securityMessage} 익스텐션: {name} URL: {url} 이에 대해 확실하지 않은 경우 관리자에게 문의하세요."
+  },
+  "extensionInstallModal.untrustedSecurityMessage": {
+    "defaultMessage": "이 익스텐션 명령은 허용 목록에 없으며 대화에 액세스하고 추가 기능을 제공할 수 있습니다. 신뢰할 수 없는 소스의 익스텐션을 설치하면 보안 위험이 발생할 수 있습니다."
+  },
+  "extensionInstallModal.untrustedTitle": {
+    "defaultMessage": "신뢰할 수 없는 익스텐션을 설치하시겠습니까?"
+  },
+  "extensionInstallModal.yes": {
+    "defaultMessage": "예"
+  },
+  "extensionItem.configureExtension": {
+    "defaultMessage": "{name} 익스텐션 구성"
+  },
+  "extensionItem.toggleExtension": {
+    "defaultMessage": "{name} 익스텐션 켜기/끄기"
+  },
+  "extensionList.availableExtensions": {
+    "defaultMessage": "사용 가능한 익스텐션({count})"
+  },
+  "extensionList.builtInExtension": {
+    "defaultMessage": "내장 익스텐션"
+  },
+  "extensionList.defaultExtensions": {
+    "defaultMessage": "기본 익스텐션({count})"
+  },
+  "extensionList.noExtensions": {
+    "defaultMessage": "사용 가능한 익스텐션이 없습니다."
+  },
+  "extensionModal.cancel": {
+    "defaultMessage": "취소"
+  },
+  "extensionModal.closeWithoutSaving": {
+    "defaultMessage": "저장하지 않고 닫기"
+  },
+  "extensionModal.confirmRemoval": {
+    "defaultMessage": "제거 확인"
+  },
+  "extensionModal.deleteDescription": {
+    "defaultMessage": "이 익스텐션과 모든 설정이 영구적으로 삭제됩니다."
+  },
+  "extensionModal.deleteExtensionTitle": {
+    "defaultMessage": "익스텐션 \"{name}\" 삭제"
+  },
+  "extensionModal.installationNotes": {
+    "defaultMessage": "설치 참고 사항"
+  },
+  "extensionModal.removeExtension": {
+    "defaultMessage": "익스텐션 제거"
+  },
+  "extensionModal.unsavedChangesMessage": {
+    "defaultMessage": "익스텐션 구성에 저장되지 않은 변경사항이 있습니다. 저장하지 않고 닫으시겠습니까?"
+  },
+  "extensionModal.unsavedChangesTitle": {
+    "defaultMessage": "저장되지 않은 변경사항"
+  },
+  "extensionTimeoutField.timeoutLabel": {
+    "defaultMessage": "시간 초과"
+  },
+  "extensionsSection.addCustomExtension": {
+    "defaultMessage": "사용자 지정 익스텐션 추가"
+  },
+  "extensionsSection.addExtension": {
+    "defaultMessage": "익스텐션 추가"
+  },
+  "extensionsSection.browseExtensions": {
+    "defaultMessage": "익스텐션 찾아보기"
+  },
+  "extensionsSection.saveChanges": {
+    "defaultMessage": "변경 사항 저장"
+  },
+  "extensionsSection.updateExtension": {
+    "defaultMessage": "익스텐션 업데이트"
+  },
+  "extensionsView.addCustomExtension": {
+    "defaultMessage": "사용자 지정 익스텐션 추가"
+  },
+  "extensionsView.addExtension": {
+    "defaultMessage": "익스텐션 추가"
+  },
+  "extensionsView.browseExtensions": {
+    "defaultMessage": "익스텐션 찾아보기"
+  },
+  "extensionsView.defaultNote": {
+    "defaultMessage": "여기에서 켠 익스텐션은 새 채팅의 기본값으로 사용됩니다. 채팅 중에도 익스텐션을 켜거나 끌 수 있습니다."
+  },
+  "extensionsView.description": {
+    "defaultMessage": "이 익스텐션은 Model Context Protocol(MCP)을 사용합니다. 프롬프트, 리소스, 도구의 세 가지 주요 구성 요소로 goose의 기능을 확장합니다. {searchShortcut}로 검색할 수 있습니다."
+  },
+  "extensionsView.heading": {
+    "defaultMessage": "익스텐션"
+  },
+  "extensionsView.searchPlaceholder": {
+    "defaultMessage": "익스텐션 검색..."
+  },
+  "externalBackendSection.certFingerprint": {
+    "defaultMessage": "인증서 지문(선택 사항)"
+  },
+  "externalBackendSection.certFingerprintHelp": {
+    "defaultMessage": "특정 TLS 인증서 지문을 고정하세요. 생략할 경우 최초 사용 시 인증서를 신뢰합니다(TOFU)."
+  },
+  "externalBackendSection.certFingerprintPlaceholder": {
+    "defaultMessage": "AA:BB:CC:... 또는 sha256/base64"
+  },
+  "externalBackendSection.description": {
+    "defaultMessage": "기본적으로 goose가 서버를 자동으로 실행합니다. 외부 goose 서버에 연결하려면 이 옵션을 사용하세요."
+  },
+  "externalBackendSection.restartNote": {
+    "defaultMessage": "변경 사항을 적용하려면 goose를 다시 시작해야 합니다. 새 채팅 창은 외부 서버에 연결됩니다."
+  },
+  "externalBackendSection.secretKey": {
+    "defaultMessage": "비밀 키"
+  },
+  "externalBackendSection.secretKeyHelp": {
+    "defaultMessage": "goosed 서버에 설정된 비밀 키 (GOOSE_SERVER__SECRET_KEY)"
+  },
+  "externalBackendSection.secretKeyPlaceholder": {
+    "defaultMessage": "서버의 비밀 키를 입력하세요"
+  },
+  "externalBackendSection.serverUrl": {
+    "defaultMessage": "서버 URL"
+  },
+  "externalBackendSection.title": {
+    "defaultMessage": "goose 서버"
+  },
+  "externalBackendSection.urlFormatError": {
+    "defaultMessage": "잘못된 URL 형식입니다."
+  },
+  "externalBackendSection.urlProtocolError": {
+    "defaultMessage": "URL은 반드시 http 또는 https 프로토콜을 사용해야 합니다."
+  },
+  "externalBackendSection.useExternalServer": {
+    "defaultMessage": "외부 서버 사용"
+  },
+  "externalBackendSection.useExternalServerDescription": {
+    "defaultMessage": "다른 곳에서 실행 중인 goose 서버에 연결합니다. 앱을 다시 시작해야 합니다."
+  },
+  "freeOptionCards.chooseOption": {
+    "defaultMessage": "시작하려면 옵션을 선택하세요."
+  },
+  "freeOptionCards.freeAndPrivate": {
+    "defaultMessage": "무료 및 비공개"
+  },
+  "freeOptionCards.localModelDescription": {
+    "defaultMessage": "모델을 다운로드하고 컴퓨터에서 완전히 실행하세요. API 키도 없고 계정도 없습니다."
+  },
+  "freeOptionCards.localModelTitle": {
+    "defaultMessage": "로컬 모델 사용"
+  },
+  "freeOptionCards.nanogptDescription": {
+    "defaultMessage": "7일 동안 6천만 개의 무료 토큰을 받으려면 등록하세요."
+  },
+  "freeOptionCards.nanogptTitle": {
+    "defaultMessage": "나노GPT"
+  },
+  "freeOptionCards.retry": {
+    "defaultMessage": "다시 시도"
+  },
+  "freeOptionCards.tetrateDescription": {
+    "defaultMessage": "자동 설정을 통해 여러 AI 모델에 액세스하세요. $10 크레딧을 받으려면 등록하세요."
+  },
+  "freeOptionCards.tetrateTitle": {
+    "defaultMessage": "Tetrate의 에이전트 라우터"
+  },
+  "freeOptionCards.unexpectedError": {
+    "defaultMessage": "설정 중에 예상치 못한 오류가 발생했습니다."
+  },
+  "gatewaySettings.botFatherInstructions": {
+    "defaultMessage": "휴대폰에서 @BotFather를 열고 /newbot을 보낸 뒤, 안내에 따라 봇 이름을 지정하세요. BotFather가 API 토큰을 보내면 아래에 붙여넣으세요."
+  },
+  "gatewaySettings.close": {
+    "defaultMessage": "닫기"
+  },
+  "gatewaySettings.expiresIn": {
+    "defaultMessage": "{time} 후 만료"
+  },
+  "gatewaySettings.failedToGeneratePairingCode": {
+    "defaultMessage": "페어링 코드를 생성하지 못했습니다."
+  },
+  "gatewaySettings.failedToRemove": {
+    "defaultMessage": "제거하지 못했습니다."
+  },
+  "gatewaySettings.failedToStart": {
+    "defaultMessage": "시작하지 못했습니다."
+  },
+  "gatewaySettings.failedToStop": {
+    "defaultMessage": "중지하지 못했습니다."
+  },
+  "gatewaySettings.failedToUnpairUser": {
+    "defaultMessage": "사용자 페어링을 해제하지 못했습니다."
+  },
+  "gatewaySettings.loading": {
+    "defaultMessage": "로드 중..."
+  },
+  "gatewaySettings.pairDevice": {
+    "defaultMessage": "기기 페어링"
+  },
+  "gatewaySettings.pairedUsers": {
+    "defaultMessage": "페어링된 사용자"
+  },
+  "gatewaySettings.pairingCode": {
+    "defaultMessage": "페어링 코드"
+  },
+  "gatewaySettings.pasteBotToken": {
+    "defaultMessage": "봇 토큰을 여기에 붙여넣으세요"
+  },
+  "gatewaySettings.remove": {
+    "defaultMessage": "제거"
+  },
+  "gatewaySettings.running": {
+    "defaultMessage": "실행 중"
+  },
+  "gatewaySettings.sendCodeToPair": {
+    "defaultMessage": "페어링하려면 이 코드를 {gatewayType} 봇에 보내세요."
+  },
+  "gatewaySettings.start": {
+    "defaultMessage": "시작"
+  },
+  "gatewaySettings.stop": {
+    "defaultMessage": "중지"
+  },
+  "gatewaySettings.stopped": {
+    "defaultMessage": "중지됨"
+  },
+  "gatewaySettings.telegram": {
+    "defaultMessage": "Telegram"
+  },
+  "goosehintsModal.close": {
+    "defaultMessage": "닫기"
+  },
+  "goosehintsModal.developer": {
+    "defaultMessage": "개발자"
+  },
+  "goosehintsModal.dialogDescription": {
+    "defaultMessage": "goose와의 커뮤니케이션을 개선할 수 있도록 프로젝트에 대한 추가 컨텍스트를 제공하세요."
+  },
+  "goosehintsModal.dialogTitle": {
+    "defaultMessage": "프로젝트 힌트 구성(.goosehints)"
+  },
+  "goosehintsModal.errorReading": {
+    "defaultMessage": ".goosehints 파일 읽기 오류: {error}"
+  },
+  "goosehintsModal.failedToAccess": {
+    "defaultMessage": ".goosehints 파일에 액세스하지 못했습니다."
+  },
+  "goosehintsModal.failedToSave": {
+    "defaultMessage": ".goosehints 파일을 저장하지 못했습니다."
+  },
+  "goosehintsModal.fileCreating": {
+    "defaultMessage": "새 .goosehints 파일 생성: {filePath}"
+  },
+  "goosehintsModal.fileFound": {
+    "defaultMessage": ".goosehints 파일 위치: {filePath}"
+  },
+  "goosehintsModal.helpText1": {
+    "defaultMessage": ".goosehints는 프로젝트에 대한 추가 컨텍스트를 제공하고 goose와의 커뮤니케이션을 개선하는 데 사용되는 텍스트 파일입니다."
+  },
+  "goosehintsModal.helpText2": {
+    "defaultMessage": "익스텐션 페이지에서 {bold} 익스텐션이 활성화되어 있는지 확인하세요. .goosehints를 사용하려면 이 익스텐션이 필요합니다. .goosehints 업데이트를 적용하려면 세션을 다시 시작해야 합니다."
+  },
+  "goosehintsModal.helpText3": {
+    "defaultMessage": "자세한 내용은 {link}를 참조하세요."
+  },
+  "goosehintsModal.helpTextLink": {
+    "defaultMessage": ".goosehints 사용"
+  },
+  "goosehintsModal.placeholder": {
+    "defaultMessage": "여기에 프로젝트 힌트를 입력하세요..."
+  },
+  "goosehintsModal.save": {
+    "defaultMessage": "저장"
+  },
+  "goosehintsModal.savedSuccessfully": {
+    "defaultMessage": "성공적으로 저장되었습니다"
+  },
+  "goosehintsModal.saving": {
+    "defaultMessage": "저장 중..."
+  },
+  "goosehintsSection.configure": {
+    "defaultMessage": "설정"
+  },
+  "goosehintsSection.description": {
+    "defaultMessage": "프로젝트의 .goosehints 파일을 설정하여 goose에 추가 컨텍스트를 제공합니다."
+  },
+  "goosehintsSection.title": {
+    "defaultMessage": "프로젝트 힌트 (.goosehints)"
+  },
+  "groupedExtensionLoadingToast.askGoose": {
+    "defaultMessage": "goose에게 묻기"
+  },
+  "groupedExtensionLoadingToast.collapseDetails": {
+    "defaultMessage": "세부정보 접기"
+  },
+  "groupedExtensionLoadingToast.copied": {
+    "defaultMessage": "복사되었습니다!"
+  },
+  "groupedExtensionLoadingToast.copyError": {
+    "defaultMessage": "복사 오류"
+  },
+  "groupedExtensionLoadingToast.expandDetails": {
+    "defaultMessage": "세부정보 펼치기"
+  },
+  "groupedExtensionLoadingToast.failedToAddExtension": {
+    "defaultMessage": "익스텐션을 추가하지 못했습니다."
+  },
+  "groupedExtensionLoadingToast.failedToLoad": {
+    "defaultMessage": "{count,plural,one{#개의 익스텐션을 로드하지 못했습니다} other{#개의 익스텐션을 로드하지 못했습니다}}"
+  },
+  "groupedExtensionLoadingToast.loadingExtensions": {
+    "defaultMessage": "{count,plural,one{#개의 익스텐션을 로드하는 중...} other{#개의 익스텐션을 로드하는 중...}}"
+  },
+  "groupedExtensionLoadingToast.partiallyLoaded": {
+    "defaultMessage": "{totalCount,plural,one{익스텐션 {successCount}/#개 로드됨} other{익스텐션 {successCount}/#개 로드됨}}"
+  },
+  "groupedExtensionLoadingToast.showDetails": {
+    "defaultMessage": "세부정보 표시"
+  },
+  "groupedExtensionLoadingToast.showLess": {
+    "defaultMessage": "간략히 보기"
+  },
+  "groupedExtensionLoadingToast.successfullyLoaded": {
+    "defaultMessage": "{count,plural,one{#개의 익스텐션을 성공적으로 로드했습니다} other{#개의 익스텐션을 성공적으로 로드했습니다}}"
+  },
+  "headersSection.add": {
+    "defaultMessage": "추가"
+  },
+  "headersSection.bothRequired": {
+    "defaultMessage": "헤더 이름과 값을 모두 입력해야 합니다."
+  },
+  "headersSection.duplicateHeader": {
+    "defaultMessage": "이 이름을 가진 헤더가 이미 존재합니다."
+  },
+  "headersSection.headerName": {
+    "defaultMessage": "헤더 이름"
+  },
+  "headersSection.headersDescription": {
+    "defaultMessage": "MCP 서버로 보내는 요청에 포함할 사용자 지정 HTTP 헤더를 추가합니다. 두 필드를 모두 채운 뒤 \"+\" 버튼을 클릭해 추가하세요."
+  },
+  "headersSection.noSpaces": {
+    "defaultMessage": "헤더 이름에는 공백이 포함될 수 없습니다."
+  },
+  "headersSection.requestHeaders": {
+    "defaultMessage": "요청 헤더"
+  },
+  "headersSection.value": {
+    "defaultMessage": "값"
+  },
+  "hub.goodAfternoon": {
+    "defaultMessage": "좋은 오후예요"
+  },
+  "hub.goodEvening": {
+    "defaultMessage": "좋은 저녁이에요"
+  },
+  "hub.goodMorning": {
+    "defaultMessage": "좋은 아침이에요"
+  },
+  "huggingFaceModelSearch.download": {
+    "defaultMessage": "다운로드"
+  },
+  "huggingFaceModelSearch.downloaded": {
+    "defaultMessage": "다운로드됨"
+  },
+  "huggingFaceModelSearch.downloading": {
+    "defaultMessage": "다운로드 중…"
+  },
+  "huggingFaceModelSearch.loadingVariants": {
+    "defaultMessage": "변형 로드 중..."
+  },
+  "huggingFaceModelSearch.noGgufModels": {
+    "defaultMessage": "이 검색어와 호환되는 로컬 모델을 찾을 수 없습니다."
+  },
+  "huggingFaceModelSearch.recommended": {
+    "defaultMessage": "추천"
+  },
+  "huggingFaceModelSearch.searchError": {
+    "defaultMessage": "검색 오류: {details}"
+  },
+  "huggingFaceModelSearch.searchFailed": {
+    "defaultMessage": "검색에 실패했습니다. 다시 시도해 주세요."
+  },
+  "huggingFaceModelSearch.searchHuggingFace": {
+    "defaultMessage": "Hugging Face 검색"
+  },
+  "huggingFaceModelSearch.searchNoData": {
+    "defaultMessage": "검색 결과 데이터가 없습니다."
+  },
+  "huggingFaceModelSearch.searchPlaceholder": {
+    "defaultMessage": "로컬 모델 검색..."
+  },
+  "huggingFaceModelSearch.tooLarge": {
+    "defaultMessage": "메모리에 맞지 않을 수 있습니다. ({size} 모델, {available} 사용 가능)"
+  },
+  "huggingFaceSignInPrompt.failedToConfigure": {
+    "defaultMessage": "Hugging Face에 로그인하지 못했습니다: {error}"
+  },
+  "huggingFaceSignInPrompt.signIn": {
+    "defaultMessage": "로그인"
+  },
+  "huggingFaceSignInPrompt.signedIn": {
+    "defaultMessage": "Hugging Face 로그인됨"
+  },
+  "huggingFaceSignInPrompt.signingIn": {
+    "defaultMessage": "로그인 중..."
+  },
+  "huggingFaceSignInPrompt.title": {
+    "defaultMessage": "Hugging Face"
+  },
+  "imagePreview.altText": {
+    "defaultMessage": "goose 이미지"
+  },
+  "imagePreview.clickToCollapse": {
+    "defaultMessage": "접으려면 클릭하세요."
+  },
+  "imagePreview.clickToExpand": {
+    "defaultMessage": "펼치려면 클릭하세요."
+  },
+  "imagePreview.unableToLoad": {
+    "defaultMessage": "이미지를 로드할 수 없습니다."
+  },
+  "importRecipeForm.cancel": {
+    "defaultMessage": "취소"
+  },
+  "importRecipeForm.deeplinkHint": {
+    "defaultMessage": "\"goose://recipe?config=\"로 시작하는 레시피 딥링크를 붙여넣으세요."
+  },
+  "importRecipeForm.deeplinkPlaceholder": {
+    "defaultMessage": "goose://recipe?config=... 딥링크를 여기에 붙여넣으세요."
+  },
+  "importRecipeForm.example": {
+    "defaultMessage": "예"
+  },
+  "importRecipeForm.expectedRecipeStructure": {
+    "defaultMessage": "예상 레시피 구조"
+  },
+  "importRecipeForm.importRecipeButton": {
+    "defaultMessage": "레시피 가져오기"
+  },
+  "importRecipeForm.importRecipeTitle": {
+    "defaultMessage": "레시피 가져오기"
+  },
+  "importRecipeForm.importing": {
+    "defaultMessage": "가져오는 중..."
+  },
+  "importRecipeForm.or": {
+    "defaultMessage": "또는"
+  },
+  "importRecipeForm.recipeDeeplinkLabel": {
+    "defaultMessage": "레시피 딥링크"
+  },
+  "importRecipeForm.recipeFileHint": {
+    "defaultMessage": "레시피 구조가 포함된 YAML 또는 JSON 파일을 업로드하세요."
+  },
+  "importRecipeForm.recipeFileLabel": {
+    "defaultMessage": "레시피 파일"
+  },
+  "importRecipeForm.reviewWarning": {
+    "defaultMessage": "goose 인터페이스에 레시피 파일을 추가하기 전에 레시피 파일의 내용을 검토하세요."
+  },
+  "importRecipeForm.schemaDescription": {
+    "defaultMessage": "YAML 또는 JSON 파일은 이 구조를 따라야 합니다. 필수 필드는 제목, 설명, 지침 또는 프롬프트입니다."
+  },
+  "inlineEditText.clickToEdit": {
+    "defaultMessage": "편집하려면 클릭하세요"
+  },
+  "inlineEditText.doubleClickToEdit": {
+    "defaultMessage": "편집하려면 두 번 클릭하세요."
+  },
+  "inlineEditText.enterText": {
+    "defaultMessage": "텍스트를 입력하세요"
+  },
+  "inlineEditText.failedToSave": {
+    "defaultMessage": "저장하지 못했습니다."
+  },
+  "instructionsEditor.cancel": {
+    "defaultMessage": "취소"
+  },
+  "instructionsEditor.insertExample": {
+    "defaultMessage": "예시 삽입"
+  },
+  "instructionsEditor.label": {
+    "defaultMessage": "지침"
+  },
+  "instructionsEditor.placeholder": {
+    "defaultMessage": "사용자에게 숨겨진 AI에 대한 자세한 지침"
+  },
+  "instructionsEditor.save": {
+    "defaultMessage": "지침 저장"
+  },
+  "instructionsEditor.syntaxHelp": {
+    "defaultMessage": "{code} 구문을 사용하여 사용자가 입력할 수 있는 매개변수를 정의하세요."
+  },
+  "instructionsEditor.title": {
+    "defaultMessage": "지침 편집기"
+  },
+  "jsonSchemaEditor.cancel": {
+    "defaultMessage": "취소"
+  },
+  "jsonSchemaEditor.description": {
+    "defaultMessage": "JSON Schema 형식을 이용하여 예상되는 AI의 응답 구조를 정의합니다."
+  },
+  "jsonSchemaEditor.insertExample": {
+    "defaultMessage": "예시 삽입"
+  },
+  "jsonSchemaEditor.invalidJson": {
+    "defaultMessage": "잘못된 JSON 형식입니다."
+  },
+  "jsonSchemaEditor.label": {
+    "defaultMessage": "응답 JSON 스키마"
+  },
+  "jsonSchemaEditor.save": {
+    "defaultMessage": "스키마 저장"
+  },
+  "jsonSchemaEditor.title": {
+    "defaultMessage": "JSON 스키마 편집기"
+  },
+  "jsonSchemaForm.cancel": {
+    "defaultMessage": "취소"
+  },
+  "jsonSchemaForm.fieldRequired": {
+    "defaultMessage": "이 필드는 필수입니다"
+  },
+  "jsonSchemaForm.maxLength": {
+    "defaultMessage": "최대 길이는 {maxLength}입니다"
+  },
+  "jsonSchemaForm.maxValue": {
+    "defaultMessage": "최대값은 {maximum}입니다"
+  },
+  "jsonSchemaForm.minLength": {
+    "defaultMessage": "최소 길이는 {minLength}입니다"
+  },
+  "jsonSchemaForm.minValue": {
+    "defaultMessage": "최소값은 {minimum}입니다"
+  },
+  "jsonSchemaForm.noFields": {
+    "defaultMessage": "표시할 필드가 없습니다."
+  },
+  "jsonSchemaForm.selectPlaceholder": {
+    "defaultMessage": "선택..."
+  },
+  "jsonSchemaForm.submit": {
+    "defaultMessage": "제출"
+  },
+  "keyValueEditor.addValue": {
+    "defaultMessage": "사전 구성된 값 추가"
+  },
+  "keyValueEditor.defaultKeyPlaceholder": {
+    "defaultMessage": "매개변수 이름..."
+  },
+  "keyValueEditor.defaultValuePlaceholder": {
+    "defaultMessage": "매개변수 값..."
+  },
+  "keyValueEditor.removeValue": {
+    "defaultMessage": "사전 구성된 값 제거: {key}"
+  },
+  "keyboardShortcuts.alwaysOnTopDescription": {
+    "defaultMessage": "창을 항상 위에 표시할지 전환합니다."
+  },
+  "keyboardShortcuts.alwaysOnTopLabel": {
+    "defaultMessage": "항상 위에 표시"
+  },
+  "keyboardShortcuts.cancel": {
+    "defaultMessage": "취소"
+  },
+  "keyboardShortcuts.categoryApplication": {
+    "defaultMessage": "앱 단축키"
+  },
+  "keyboardShortcuts.categoryApplicationDescription": {
+    "defaultMessage": "Goose가 활성 앱일 때 작동하는 단축키입니다."
+  },
+  "keyboardShortcuts.categoryGlobal": {
+    "defaultMessage": "전역 단축키"
+  },
+  "keyboardShortcuts.categoryGlobalDescription": {
+    "defaultMessage": "Goose가 활성화되어 있지 않아도 시스템 전체에서 작동하는 단축키입니다."
+  },
+  "keyboardShortcuts.categorySearch": {
+    "defaultMessage": "검색 단축키"
+  },
+  "keyboardShortcuts.categorySearchDescription": {
+    "defaultMessage": "대화에서 검색할 때 작동하는 단축키입니다."
+  },
+  "keyboardShortcuts.categoryWindow": {
+    "defaultMessage": "창 단축키"
+  },
+  "keyboardShortcuts.categoryWindowDescription": {
+    "defaultMessage": "창 동작을 제어하는 단축키입니다."
+  },
+  "keyboardShortcuts.change": {
+    "defaultMessage": "변경"
+  },
+  "keyboardShortcuts.disabled": {
+    "defaultMessage": "사용 안 함"
+  },
+  "keyboardShortcuts.dismiss": {
+    "defaultMessage": "닫기"
+  },
+  "keyboardShortcuts.findDescription": {
+    "defaultMessage": "대화 내 검색을 엽니다."
+  },
+  "keyboardShortcuts.findLabel": {
+    "defaultMessage": "찾기"
+  },
+  "keyboardShortcuts.findNextDescription": {
+    "defaultMessage": "다음 검색 결과로 이동합니다."
+  },
+  "keyboardShortcuts.findNextLabel": {
+    "defaultMessage": "다음 찾기"
+  },
+  "keyboardShortcuts.findPreviousDescription": {
+    "defaultMessage": "이전 검색 결과로 이동합니다."
+  },
+  "keyboardShortcuts.findPreviousLabel": {
+    "defaultMessage": "이전 찾기"
+  },
+  "keyboardShortcuts.focusWindowDescription": {
+    "defaultMessage": "어디서든 Goose 창을 앞으로 가져옵니다."
+  },
+  "keyboardShortcuts.focusWindowLabel": {
+    "defaultMessage": "Goose 창 포커스"
+  },
+  "keyboardShortcuts.loading": {
+    "defaultMessage": "로드 중..."
+  },
+  "keyboardShortcuts.newChatDescription": {
+    "defaultMessage": "현재 창에서 새 채팅을 만듭니다."
+  },
+  "keyboardShortcuts.newChatLabel": {
+    "defaultMessage": "새 채팅"
+  },
+  "keyboardShortcuts.newChatWindowDescription": {
+    "defaultMessage": "새 Goose 창을 엽니다."
+  },
+  "keyboardShortcuts.newChatWindowLabel": {
+    "defaultMessage": "새 채팅 창"
+  },
+  "keyboardShortcuts.openDirectoryDescription": {
+    "defaultMessage": "디렉터리 선택 대화상자를 엽니다."
+  },
+  "keyboardShortcuts.openDirectoryLabel": {
+    "defaultMessage": "디렉터리 열기"
+  },
+  "keyboardShortcuts.quickLauncherDescription": {
+    "defaultMessage": "빠른 실행기 오버레이를 엽니다."
+  },
+  "keyboardShortcuts.quickLauncherLabel": {
+    "defaultMessage": "빠른 실행기"
+  },
+  "keyboardShortcuts.reassignShortcut": {
+    "defaultMessage": "단축키 재지정"
+  },
+  "keyboardShortcuts.resetAllShortcuts": {
+    "defaultMessage": "모든 단축키 재설정"
+  },
+  "keyboardShortcuts.resetShortcutsDetail": {
+    "defaultMessage": "모든 단축키를 원래 설정으로 복원합니다."
+  },
+  "keyboardShortcuts.resetShortcutsMessage": {
+    "defaultMessage": "모든 키보드 단축키를 기본값으로 재설정하시겠습니까?"
+  },
+  "keyboardShortcuts.resetShortcutsTitle": {
+    "defaultMessage": "키보드 단축키 재설정"
+  },
+  "keyboardShortcuts.resetToDefaultsDescription": {
+    "defaultMessage": "모든 키보드 단축키를 원래 설정으로 되돌립니다."
+  },
+  "keyboardShortcuts.resetToDefaultsHeading": {
+    "defaultMessage": "기본값으로 재설정"
+  },
+  "keyboardShortcuts.restartDescription": {
+    "defaultMessage": "애플리케이션 단축키(예: 새 채팅, 설정 등)의 변경 사항을 적용하려면 goose를 다시 시작해야 합니다. 전역 단축키(창 포커스, 빠른 실행기)는 즉시 적용됩니다."
+  },
+  "keyboardShortcuts.restartRequired": {
+    "defaultMessage": "다시 시작 필요"
+  },
+  "keyboardShortcuts.settingsDescription": {
+    "defaultMessage": "설정 패널을 엽니다."
+  },
+  "keyboardShortcuts.settingsLabel": {
+    "defaultMessage": "설정"
+  },
+  "keyboardShortcuts.shortcutConflictSaveDetail": {
+    "defaultMessage": "이를 저장하면 \"{conflictLabel}\"에서 단축키가 제거되고 \"{targetLabel}\"에 할당됩니다. 계속하시겠습니까?"
+  },
+  "keyboardShortcuts.shortcutConflictTitle": {
+    "defaultMessage": "단축키 충돌"
+  },
+  "keyboardShortcuts.shortcutConflictToggleDetail": {
+    "defaultMessage": "이 기능을 활성화하면 \"{conflictLabel}\"에서 단축키가 제거되고 \"{targetLabel}\"에 할당됩니다. 계속하시겠습니까?"
+  },
+  "keyboardShortcuts.shortcutConflictToggleMessage": {
+    "defaultMessage": "단축키 {shortcut}은 이미 \"{conflictLabel}\"에 할당되어 있습니다."
+  },
+  "keyboardShortcuts.toggleNavigationDescription": {
+    "defaultMessage": "탐색 메뉴를 표시하거나 숨깁니다."
+  },
+  "keyboardShortcuts.toggleNavigationLabel": {
+    "defaultMessage": "탐색 메뉴 전환"
+  },
+  "launcher.placeholder": {
+    "defaultMessage": "goose에게 무엇이든 물어보세요..."
+  },
+  "loadingGoose.compacting": {
+    "defaultMessage": "goose가 대화를 압축하고 있습니다..."
+  },
+  "loadingGoose.idle": {
+    "defaultMessage": "goose가 작업 중…"
+  },
+  "loadingGoose.loadingConversation": {
+    "defaultMessage": "대화 로드 중..."
+  },
+  "loadingGoose.restartingAgent": {
+    "defaultMessage": "세션 다시 시작 중..."
+  },
+  "loadingGoose.streaming": {
+    "defaultMessage": "goose가 작업 중…"
+  },
+  "loadingGoose.thinking": {
+    "defaultMessage": "goose가 생각 중…"
+  },
+  "loadingGoose.waiting": {
+    "defaultMessage": "goose가 기다리고 있습니다…"
+  },
+  "localInferenceSettings.deleteConfirm": {
+    "defaultMessage": "이 모델을 삭제하시겠습니까? 나중에 다시 다운로드할 수 있습니다."
+  },
+  "localInferenceSettings.description": {
+    "defaultMessage": "API 키 없이 추론에 사용할 로컬 LLM 모델을 다운로드하고 관리하세요. Hugging Face에서 GGUF 또는 MLX 모델을 검색하거나 아래 추천 모델을 사용하세요."
+  },
+  "localInferenceSettings.dismiss": {
+    "defaultMessage": "닫기"
+  },
+  "localInferenceSettings.download": {
+    "defaultMessage": "다운로드"
+  },
+  "localInferenceSettings.downloadCancelled": {
+    "defaultMessage": "다운로드가 취소되었습니다."
+  },
+  "localInferenceSettings.downloadFailed": {
+    "defaultMessage": "다운로드 실패"
+  },
+  "localInferenceSettings.downloadProgress": {
+    "defaultMessage": "{downloaded} / {total} ({percent}%)"
+  },
+  "localInferenceSettings.downloadedModels": {
+    "defaultMessage": "다운로드한 모델"
+  },
+  "localInferenceSettings.downloading": {
+    "defaultMessage": "다운로드 중"
+  },
+  "localInferenceSettings.featuredModels": {
+    "defaultMessage": "주요 모델"
+  },
+  "localInferenceSettings.huggingFaceSignInNote": {
+    "defaultMessage": "모델 검색 및 다운로드 시 속도 제한 한도를 높이고 비공개 또는 접근 제한된 Hugging Face 리포지토리에 액세스하려면 로그인하세요."
+  },
+  "localInferenceSettings.modelSettings": {
+    "defaultMessage": "모델 설정"
+  },
+  "localInferenceSettings.modelSettingsTitle": {
+    "defaultMessage": "모델 설정"
+  },
+  "localInferenceSettings.noModels": {
+    "defaultMessage": "사용 가능한 모델이 없습니다."
+  },
+  "localInferenceSettings.recommended": {
+    "defaultMessage": "추천"
+  },
+  "localInferenceSettings.remaining": {
+    "defaultMessage": "{time} 남음"
+  },
+  "localInferenceSettings.retry": {
+    "defaultMessage": "다시 시도"
+  },
+  "localInferenceSettings.showAllFeatured": {
+    "defaultMessage": "모든 추천 항목 표시({count}개 이상)"
+  },
+  "localInferenceSettings.showRecommendedOnly": {
+    "defaultMessage": "추천만 표시"
+  },
+  "localInferenceSettings.title": {
+    "defaultMessage": "로컬 추론 모델"
+  },
+  "localInferenceSettings.vision": {
+    "defaultMessage": "비전"
+  },
+  "localInferenceSettings.visionEncoderDownloading": {
+    "defaultMessage": "Vision 인코더 다운로드 중…"
+  },
+  "localInferenceSettings.visionEncoderNotDownloaded": {
+    "defaultMessage": "비전 인코더가 다운로드되지 않았습니다."
+  },
+  "localModelManager.active": {
+    "defaultMessage": "활성"
+  },
+  "localModelManager.deleteConfirm": {
+    "defaultMessage": "이 모델을 삭제하시겠습니까? 나중에 다시 다운로드할 수 있습니다."
+  },
+  "localModelManager.download": {
+    "defaultMessage": "다운로드"
+  },
+  "localModelManager.downloaded": {
+    "defaultMessage": "다운로드됨"
+  },
+  "localModelManager.gpuAcceleration": {
+    "defaultMessage": "GPU 가속을 지원합니다(NVIDIA의 경우 CUDA, Apple Silicon의 경우 Metal). GPU 하드웨어 가속을 위해서는 빌드 시 기능을 활성화해야 합니다."
+  },
+  "localModelManager.noModels": {
+    "defaultMessage": "사용 가능한 모델이 없습니다."
+  },
+  "localModelManager.recommended": {
+    "defaultMessage": "추천"
+  },
+  "localModelManager.recommendedForHardware": {
+    "defaultMessage": "하드웨어에 권장됨"
+  },
+  "localModelManager.showAllModels": {
+    "defaultMessage": "모든 모델 보기({count}개 더 보기)"
+  },
+  "localModelManager.showRecommendedOnly": {
+    "defaultMessage": "추천만 표시"
+  },
+  "localModelPicker.back": {
+    "defaultMessage": "뒤로"
+  },
+  "localModelPicker.bestForMachine": {
+    "defaultMessage": "이 기기에 가장 적합"
+  },
+  "localModelPicker.cancelDownload": {
+    "defaultMessage": "다운로드 취소"
+  },
+  "localModelPicker.checkingModels": {
+    "defaultMessage": "사용 가능한 모델을 확인하는 중..."
+  },
+  "localModelPicker.downloadModel": {
+    "defaultMessage": "{modelId} 다운로드 ({size})"
+  },
+  "localModelPicker.downloading": {
+    "defaultMessage": "{modelId} 다운로드 중"
+  },
+  "localModelPicker.failedToLoad": {
+    "defaultMessage": "사용 가능한 모델을 로드하지 못했습니다. 다시 시도해 주세요."
+  },
+  "localModelPicker.failedToStartDownload": {
+    "defaultMessage": "다운로드를 시작하지 못했습니다. 다시 시도해 주세요."
+  },
+  "localModelPicker.hideOtherSizes": {
+    "defaultMessage": "다른 사이즈 숨기기"
+  },
+  "localModelPicker.localModelsNote": {
+    "defaultMessage": "로컬 모델은 완전한 개인 정보 보호를 위해 모든 것을 컴퓨터에 보관합니다. 성능 및 컨텍스트 창 크기는 하드웨어 및 모델 크기에 따라 클라우드 제공업체와 다를 수 있습니다."
+  },
+  "localModelPicker.lostConnection": {
+    "defaultMessage": "다운로드 연결이 끊겼습니다. 다시 시도해 주세요."
+  },
+  "localModelPicker.modelNotFound": {
+    "defaultMessage": "모델을 찾을 수 없습니다"
+  },
+  "localModelPicker.ready": {
+    "defaultMessage": "준비됨"
+  },
+  "localModelPicker.selectModel": {
+    "defaultMessage": "모델을 선택하세요"
+  },
+  "localModelPicker.showOtherSizes": {
+    "defaultMessage": "다른 사이즈 {count}개 보기"
+  },
+  "localModelPicker.startingDownload": {
+    "defaultMessage": "다운로드 시작 중..."
+  },
+  "localModelPicker.tryAgain": {
+    "defaultMessage": "다시 시도"
+  },
+  "localModelPicker.useModel": {
+    "defaultMessage": "{modelId} 사용"
+  },
+  "markdownContent.cancel": {
+    "defaultMessage": "취소"
+  },
+  "markdownContent.copyCode": {
+    "defaultMessage": "코드 복사"
+  },
+  "markdownContent.failedToOpenLink": {
+    "defaultMessage": "링크를 열지 못했습니다."
+  },
+  "markdownContent.noApplicationFound": {
+    "defaultMessage": "이 링크를 열 수 있는 애플리케이션을 찾을 수 없습니다."
+  },
+  "markdownContent.open": {
+    "defaultMessage": "열기"
+  },
+  "markdownContent.openExternalLink": {
+    "defaultMessage": "외부 링크 열기"
+  },
+  "markdownContent.openProtocolLink": {
+    "defaultMessage": "{protocol} 링크를 열까요?"
+  },
+  "markdownContent.thisWillOpen": {
+    "defaultMessage": "열립니다: {href}"
+  },
+  "mcpAppRenderer.appFallbackTitle": {
+    "defaultMessage": "앱"
+  },
+  "mcpAppRenderer.cancelButton": {
+    "defaultMessage": "취소"
+  },
+  "mcpAppRenderer.close": {
+    "defaultMessage": "닫기"
+  },
+  "mcpAppRenderer.exitFullscreen": {
+    "defaultMessage": "전체 화면 종료"
+  },
+  "mcpAppRenderer.exitFullscreenTitle": {
+    "defaultMessage": "전체 화면 종료(Esc)"
+  },
+  "mcpAppRenderer.failedToInitSandbox": {
+    "defaultMessage": "샌드박스 프록시를 초기화하지 못했습니다."
+  },
+  "mcpAppRenderer.failedToLoadResource": {
+    "defaultMessage": "리소스를 로드하지 못했습니다."
+  },
+  "mcpAppRenderer.fullscreen": {
+    "defaultMessage": "전체 화면"
+  },
+  "mcpAppRenderer.invalidUrl": {
+    "defaultMessage": "유효하지 않은 URL"
+  },
+  "mcpAppRenderer.movePipWindow": {
+    "defaultMessage": "Picture-in-Picture 창 이동(화살표 키 사용)"
+  },
+  "mcpAppRenderer.openButton": {
+    "defaultMessage": "열기"
+  },
+  "mcpAppRenderer.openExternalLinkTitle": {
+    "defaultMessage": "외부 링크 열기"
+  },
+  "mcpAppRenderer.openLinkDetail": {
+    "defaultMessage": "열립니다: {url}"
+  },
+  "mcpAppRenderer.openProtocolLink": {
+    "defaultMessage": "{protocol} 링크를 열까요?"
+  },
+  "mcpAppRenderer.pictureInPicture": {
+    "defaultMessage": "PIP(Picture-in-Picture)"
+  },
+  "mcpAppRenderer.playingInPip": {
+    "defaultMessage": "PIP(Picture-in-Picture)에서 재생 중"
+  },
+  "mcpUIResourceRenderer.cancelButton": {
+    "defaultMessage": "취소"
+  },
+  "mcpUIResourceRenderer.openButton": {
+    "defaultMessage": "열기"
+  },
+  "mcpUIResourceRenderer.openExternalLinkTitle": {
+    "defaultMessage": "외부 링크 열기"
+  },
+  "mcpUIResourceRenderer.openLinkDetail": {
+    "defaultMessage": "열립니다: {url}"
+  },
+  "mcpUIResourceRenderer.openProtocolLink": {
+    "defaultMessage": "{protocol} 링크를 열까요?"
+  },
+  "mcpUIResourceRenderer.toastMessageReceived": {
+    "defaultMessage": "{message}에 대한 메시지가 수신되었습니다."
+  },
+  "mcpUIResourceRenderer.toastTitle": {
+    "defaultMessage": "MCP-UI {messageType} 메시지"
+  },
+  "mcpUIResourceRenderer.toastUnsupported": {
+    "defaultMessage": "{message}에 대한 메시지가 수신되었습니다. {messageType} 메시지는 아직 지원되지 않습니다. 자세한 내용은 콘솔을 참조하세요."
+  },
+  "mentionPopover.itemsFound": {
+    "defaultMessage": "{count,plural,one{#개 항목 발견} other{#개 항목 발견}}"
+  },
+  "mentionPopover.loadingCommands": {
+    "defaultMessage": "명령 로드 중..."
+  },
+  "mentionPopover.noCommandsFound": {
+    "defaultMessage": "\"{query}\"과 일치하는 명령을 찾을 수 없습니다."
+  },
+  "mentionPopover.noItemsFound": {
+    "defaultMessage": "\"{query}\"과(와) 일치하는 항목이 없습니다."
+  },
+  "mentionPopover.scanningFiles": {
+    "defaultMessage": "파일을 스캔하는 중..."
+  },
+  "messageCopyLink.copied": {
+    "defaultMessage": "복사되었습니다!"
+  },
+  "messageCopyLink.copy": {
+    "defaultMessage": "복사"
+  },
+  "messageQueue.cancel": {
+    "defaultMessage": "취소"
+  },
+  "messageQueue.cannotSendWhileEditing": {
+    "defaultMessage": "수정 중에는 보낼 수 없습니다."
+  },
+  "messageQueue.clearAll": {
+    "defaultMessage": "모두 지우기"
+  },
+  "messageQueue.clickToEdit": {
+    "defaultMessage": "{content} (수정하려면 클릭하세요)"
+  },
+  "messageQueue.collapseQueue": {
+    "defaultMessage": "대기열 축소"
+  },
+  "messageQueue.dragToReorder": {
+    "defaultMessage": "메시지를 드래그하여 우선순위를 재정렬하세요"
+  },
+  "messageQueue.expandQueue": {
+    "defaultMessage": "대기열 확장"
+  },
+  "messageQueue.messageCount": {
+    "defaultMessage": "{count,plural,one{#개 메시지 {status}} other{#개 메시지 {status}}}"
+  },
+  "messageQueue.messageQueue": {
+    "defaultMessage": "메시지 대기열"
+  },
+  "messageQueue.next": {
+    "defaultMessage": "다음"
+  },
+  "messageQueue.paused": {
+    "defaultMessage": "일시중지됨"
+  },
+  "messageQueue.queuePaused": {
+    "defaultMessage": "대기열이 일시중지되었습니다."
+  },
+  "messageQueue.queuePausedCompact": {
+    "defaultMessage": "대기열이 일시중지되었습니다. 재개하려면 '보내기'를 클릭하거나 새 메시지를 추가하세요."
+  },
+  "messageQueue.queuePausedExpanded": {
+    "defaultMessage": "중단으로 인해 대기열이 일시중지되었습니다. 재개하려면 \"지금 보내기\"를 사용하거나 새 메시지를 추가하세요."
+  },
+  "messageQueue.queued": {
+    "defaultMessage": "대기 중"
+  },
+  "messageQueue.removeFromQueue": {
+    "defaultMessage": "대기열에서 이 메시지 제거"
+  },
+  "messageQueue.save": {
+    "defaultMessage": "저장"
+  },
+  "messageQueue.sendNow": {
+    "defaultMessage": "지금 이 메시지 보내기"
+  },
+  "messageQueue.stopAndSend": {
+    "defaultMessage": "현재 처리를 중지하고 이 메시지 지금 보내기"
+  },
+  "messageQueue.waiting": {
+    "defaultMessage": "대기 중"
+  },
+  "microphoneSelector.chooseDescription": {
+    "defaultMessage": "받아쓰기에 사용할 마이크 선택"
+  },
+  "microphoneSelector.grantAccess": {
+    "defaultMessage": "액세스 권한 부여"
+  },
+  "microphoneSelector.grantAccessDescription": {
+    "defaultMessage": "사용 가능한 마이크를 보려면 액세스 권한을 부여하세요."
+  },
+  "microphoneSelector.microphone": {
+    "defaultMessage": "마이크"
+  },
+  "microphoneSelector.microphoneLabel": {
+    "defaultMessage": "마이크 {index}"
+  },
+  "microphoneSelector.selectedMicrophone": {
+    "defaultMessage": "선택한 마이크"
+  },
+  "microphoneSelector.speakToTest": {
+    "defaultMessage": "말해서 마이크를 테스트해 보세요. ({seconds}s)"
+  },
+  "microphoneSelector.stop": {
+    "defaultMessage": "중지"
+  },
+  "microphoneSelector.systemDefault": {
+    "defaultMessage": "시스템 기본값"
+  },
+  "microphoneSelector.test": {
+    "defaultMessage": "테스트"
+  },
+  "modeSelectionItem.autonomousDescription": {
+    "defaultMessage": "파일을 자유롭게 편집, 생성, 삭제할 수 있습니다."
+  },
+  "modeSelectionItem.autonomousLabel": {
+    "defaultMessage": "자율"
+  },
+  "modeSelectionItem.chatOnlyDescription": {
+    "defaultMessage": "도구나 익스텐션을 사용하지 않고 선택한 제공업체와 대화합니다."
+  },
+  "modeSelectionItem.chatOnlyLabel": {
+    "defaultMessage": "채팅 전용"
+  },
+  "modeSelectionItem.manualDescription": {
+    "defaultMessage": "모든 도구, 익스텐션, 파일 수정에는 사용자 승인이 필요합니다."
+  },
+  "modeSelectionItem.manualLabel": {
+    "defaultMessage": "수동"
+  },
+  "modeSelectionItem.smartDescription": {
+    "defaultMessage": "위험 수준에 따라 승인이 필요한 작업을 지능적으로 판단합니다."
+  },
+  "modeSelectionItem.smartLabel": {
+    "defaultMessage": "스마트"
+  },
+  "modelAndProviderContext.modelChangeFailed": {
+    "defaultMessage": "{provider}/{model} 실패"
+  },
+  "modelAndProviderContext.modelChangedTitle": {
+    "defaultMessage": "모델 변경됨"
+  },
+  "modelAndProviderContext.selectModel": {
+    "defaultMessage": "모델 선택"
+  },
+  "modelAndProviderContext.switchModelSuccess": {
+    "defaultMessage": "모델이 전환되었습니다 — {provider}의 {model} 사용 중"
+  },
+  "modelAndProviderContext.unknownProviderMsg": {
+    "defaultMessage": "구성에 알 수 없는 제공업체가 있습니다 -- config.yaml을 확인하세요"
+  },
+  "modelAndProviderContext.unknownProviderTitle": {
+    "defaultMessage": "제공업체 이름 조회"
+  },
+  "modelSettingsButtons.configureProviders": {
+    "defaultMessage": "제공업체 설정"
+  },
+  "modelSettingsButtons.switchModels": {
+    "defaultMessage": "모델 전환"
+  },
+  "modelSettingsPanel.batchSize": {
+    "defaultMessage": "배치 크기"
+  },
+  "modelSettingsPanel.batchSizeDescription": {
+    "defaultMessage": "프롬프트 처리 배치"
+  },
+  "modelSettingsPanel.builtinChatTemplate": {
+    "defaultMessage": "내장 템플릿"
+  },
+  "modelSettingsPanel.builtinChatTemplateDescription": {
+    "defaultMessage": "llama.cpp 내장 템플릿 이름을 선택하세요."
+  },
+  "modelSettingsPanel.chatTemplate": {
+    "defaultMessage": "채팅 템플릿"
+  },
+  "modelSettingsPanel.chatTemplateBuiltin": {
+    "defaultMessage": "내장"
+  },
+  "modelSettingsPanel.chatTemplateCustomInline": {
+    "defaultMessage": "사용자 지정 인라인"
+  },
+  "modelSettingsPanel.chatTemplateDescription": {
+    "defaultMessage": "내장된 GGUF 메타데이터, llama.cpp 내장 템플릿 또는 인라인 Jinja를 사용하세요."
+  },
+  "modelSettingsPanel.chatTemplateEmbedded": {
+    "defaultMessage": "임베디드"
+  },
+  "modelSettingsPanel.contextAndGeneration": {
+    "defaultMessage": "컨텍스트 및 생성"
+  },
+  "modelSettingsPanel.contextSize": {
+    "defaultMessage": "컨텍스트 크기"
+  },
+  "modelSettingsPanel.contextSizeDescription": {
+    "defaultMessage": "최대 컨텍스트 창(0 = 모델 기본값)"
+  },
+  "modelSettingsPanel.customChatTemplate": {
+    "defaultMessage": "사용자 지정 채팅 템플릿"
+  },
+  "modelSettingsPanel.customChatTemplateDescription": {
+    "defaultMessage": "전체 Jinja 채팅 템플릿 소스를 붙여넣으세요."
+  },
+  "modelSettingsPanel.etaLearningRate": {
+    "defaultMessage": "Eta(학습률)"
+  },
+  "modelSettingsPanel.flashAttention": {
+    "defaultMessage": "Flash Attention"
+  },
+  "modelSettingsPanel.flashAttentionDescription": {
+    "defaultMessage": "Flash Attention 최적화 켜기"
+  },
+  "modelSettingsPanel.frequencyPenalty": {
+    "defaultMessage": "Frequency Penalty"
+  },
+  "modelSettingsPanel.frequencyPenaltyDescription": {
+    "defaultMessage": "0.0 = 꺼짐"
+  },
+  "modelSettingsPanel.gpuLayers": {
+    "defaultMessage": "GPU 레이어"
+  },
+  "modelSettingsPanel.gpuLayersDescription": {
+    "defaultMessage": "GPU로 오프로드할 레이어"
+  },
+  "modelSettingsPanel.loadingSettings": {
+    "defaultMessage": "설정 로드 중..."
+  },
+  "modelSettingsPanel.lockModelInRam": {
+    "defaultMessage": "모델을 RAM에 고정(mlock)"
+  },
+  "modelSettingsPanel.lockModelInRamDescription": {
+    "defaultMessage": "모델이 디스크로 스왑되는 것을 방지"
+  },
+  "modelSettingsPanel.maxOutputTokens": {
+    "defaultMessage": "최대 출력 토큰"
+  },
+  "modelSettingsPanel.maxOutputTokensDescription": {
+    "defaultMessage": "생성할 토큰 수 제한"
+  },
+  "modelSettingsPanel.minP": {
+    "defaultMessage": "Min P"
+  },
+  "modelSettingsPanel.performance": {
+    "defaultMessage": "성능"
+  },
+  "modelSettingsPanel.presencePenalty": {
+    "defaultMessage": "Presence Penalty"
+  },
+  "modelSettingsPanel.presencePenaltyDescription": {
+    "defaultMessage": "0.0 = 꺼짐"
+  },
+  "modelSettingsPanel.repeatPenalty": {
+    "defaultMessage": "Repeat Penalty"
+  },
+  "modelSettingsPanel.repeatPenaltyDescription": {
+    "defaultMessage": "1.0 = 꺼짐"
+  },
+  "modelSettingsPanel.repeatWindow": {
+    "defaultMessage": "Repeat Window"
+  },
+  "modelSettingsPanel.repeatWindowDescription": {
+    "defaultMessage": "되돌아볼 토큰"
+  },
+  "modelSettingsPanel.repetitionPenalty": {
+    "defaultMessage": "Repetition Penalty"
+  },
+  "modelSettingsPanel.reset": {
+    "defaultMessage": "재설정"
+  },
+  "modelSettingsPanel.resetToDefaults": {
+    "defaultMessage": "기본값으로 재설정"
+  },
+  "modelSettingsPanel.samplingStrategy": {
+    "defaultMessage": "샘플링 전략"
+  },
+  "modelSettingsPanel.saving": {
+    "defaultMessage": "저장 중..."
+  },
+  "modelSettingsPanel.seed": {
+    "defaultMessage": "Seed"
+  },
+  "modelSettingsPanel.tauTargetEntropy": {
+    "defaultMessage": "Tau(목표 엔트로피)"
+  },
+  "modelSettingsPanel.temperature": {
+    "defaultMessage": "Temperature"
+  },
+  "modelSettingsPanel.threads": {
+    "defaultMessage": "스레드"
+  },
+  "modelSettingsPanel.threadsDescription": {
+    "defaultMessage": "생성에 사용할 CPU 스레드"
+  },
+  "modelSettingsPanel.toolCalling": {
+    "defaultMessage": "도구 호출"
+  },
+  "modelSettingsPanel.toolCallingAuto": {
+    "defaultMessage": "자동"
+  },
+  "modelSettingsPanel.toolCallingDescription": {
+    "defaultMessage": "로컬 모델이 네이티브 도구 호출과 에뮬레이션된 도구 호출 중 어떤 방식을 사용할지 선택하세요."
+  },
+  "modelSettingsPanel.toolCallingForceEmulated": {
+    "defaultMessage": "에뮬레이션 강제"
+  },
+  "modelSettingsPanel.toolCallingForceNative": {
+    "defaultMessage": "네이티브 강제"
+  },
+  "modelSettingsPanel.topK": {
+    "defaultMessage": "Top K"
+  },
+  "modelSettingsPanel.topP": {
+    "defaultMessage": "Top P"
+  },
+  "modelsBottomBar.changeModel": {
+    "defaultMessage": "모델 변경"
+  },
+  "modelsBottomBar.currentModel": {
+    "defaultMessage": "현재 모델"
+  },
+  "modelsBottomBar.loadingModel": {
+    "defaultMessage": "모델 로드 중..."
+  },
+  "modelsBottomBar.localModelSettings": {
+    "defaultMessage": "로컬 모델 설정"
+  },
+  "modelsBottomBar.localModelSettingsTitle": {
+    "defaultMessage": "로컬 모델 설정 — {modelName}"
+  },
+  "modelsBottomBar.resolvedModel": {
+    "defaultMessage": "확인된 모델"
+  },
+  "modelsBottomBar.selectModel": {
+    "defaultMessage": "모델 선택"
+  },
+  "modelsSection.resetDescription": {
+    "defaultMessage": "선택한 모델 및 제공업체 설정을 지우고 새로 시작합니다."
+  },
+  "modelsSection.resetTitle": {
+    "defaultMessage": "제공업체 및 모델 초기화"
+  },
+  "navigation.itemApps": {
+    "defaultMessage": "앱"
+  },
+  "navigation.itemExtensions": {
+    "defaultMessage": "익스텐션"
+  },
+  "navigation.itemHome": {
+    "defaultMessage": "새 채팅"
+  },
+  "navigation.itemRecipes": {
+    "defaultMessage": "레시피"
+  },
+  "navigation.itemScheduler": {
+    "defaultMessage": "스케줄러"
+  },
+  "navigation.itemSessions": {
+    "defaultMessage": "채팅 기록"
+  },
+  "navigation.itemSettings": {
+    "defaultMessage": "설정"
+  },
+  "navigation.itemSkills": {
+    "defaultMessage": "스킬"
+  },
+  "navigationPanel.chats": {
+    "defaultMessage": "채팅"
+  },
+  "navigationPanel.collapseSidebar": {
+    "defaultMessage": "사이드바 접기"
+  },
+  "navigationPanel.noChats": {
+    "defaultMessage": "최근 채팅 없음"
+  },
+  "navigationPanel.untitledSession": {
+    "defaultMessage": "제목 없는 세션"
+  },
+  "onboardingGuard.checkProviderErrorDescription": {
+    "defaultMessage": "서버가 시작 중이거나 일시적으로 사용할 수 없습니다."
+  },
+  "onboardingGuard.checkProviderErrorTitle": {
+    "defaultMessage": "Goose 서버에 접속할 수 없습니다"
+  },
+  "onboardingGuard.retry": {
+    "defaultMessage": "다시 시도"
+  },
+  "onboardingGuard.welcomeDescription": {
+    "defaultMessage": "로컬 AI 에이전트입니다. 시작하려면 AI 모델 제공업체를 연결하세요."
+  },
+  "onboardingGuard.welcomeTitle": {
+    "defaultMessage": "goose에 오신 것을 환영합니다"
+  },
+  "onboardingSuccess.allSet": {
+    "defaultMessage": "goose를 사용할 준비가 모두 완료되었습니다."
+  },
+  "onboardingSuccess.connectedTo": {
+    "defaultMessage": "{providerName}에 연결됨"
+  },
+  "onboardingSuccess.getStarted": {
+    "defaultMessage": "시작하기"
+  },
+  "onboardingSuccess.learnMore": {
+    "defaultMessage": "자세히 알아보기"
+  },
+  "onboardingSuccess.localModelReady": {
+    "defaultMessage": "로컬 모델 준비됨"
+  },
+  "onboardingSuccess.privacyDescription": {
+    "defaultMessage": "익명의 사용 데이터는 goose 개선에 도움이 됩니다. 대화, 코드 또는 개인 데이터는 수집하지 않습니다."
+  },
+  "onboardingSuccess.privacyTitle": {
+    "defaultMessage": "개인정보 보호"
+  },
+  "onboardingSuccess.shareUsageData": {
+    "defaultMessage": "익명의 사용 데이터 공유"
+  },
+  "parameterInput.defaultValue": {
+    "defaultMessage": "기본값"
+  },
+  "parameterInput.defaultValuePlaceholder": {
+    "defaultMessage": "기본값을 입력하세요"
+  },
+  "parameterInput.deleteParameter": {
+    "defaultMessage": "매개변수 삭제: {key}"
+  },
+  "parameterInput.description": {
+    "defaultMessage": "설명"
+  },
+  "parameterInput.descriptionHelp": {
+    "defaultMessage": "최종 사용자에게 표시되는 메시지입니다."
+  },
+  "parameterInput.descriptionPlaceholder": {
+    "defaultMessage": "예: \"새 구성요소의 이름을 입력하세요.\""
+  },
+  "parameterInput.inputType": {
+    "defaultMessage": "입력 유형"
+  },
+  "parameterInput.optional": {
+    "defaultMessage": "선택 사항"
+  },
+  "parameterInput.optionsHelp": {
+    "defaultMessage": "각 옵션을 새 줄에 입력하세요. 드롭다운 선택지로 표시됩니다."
+  },
+  "parameterInput.optionsLabel": {
+    "defaultMessage": "옵션(한 줄에 하나씩)"
+  },
+  "parameterInput.optionsPlaceholder": {
+    "defaultMessage": "옵션 1 옵션 2 옵션 3"
+  },
+  "parameterInput.required": {
+    "defaultMessage": "필수"
+  },
+  "parameterInput.requirement": {
+    "defaultMessage": "요구 사항"
+  },
+  "parameterInput.typeBoolean": {
+    "defaultMessage": "부울"
+  },
+  "parameterInput.typeNumber": {
+    "defaultMessage": "숫자"
+  },
+  "parameterInput.typeSelect": {
+    "defaultMessage": "선택"
+  },
+  "parameterInput.typeString": {
+    "defaultMessage": "문자열"
+  },
+  "parameterInput.unused": {
+    "defaultMessage": "미사용"
+  },
+  "parameterInput.unusedWarningTitle": {
+    "defaultMessage": "이 매개변수는 지침이나 프롬프트에서 사용되지 않습니다. 수동 입력에 사용할 수 있지만 필요하지 않을 수도 있습니다."
+  },
+  "parameterInputModal.backToForm": {
+    "defaultMessage": "매개변수 양식으로 돌아가기"
+  },
+  "parameterInputModal.cancel": {
+    "defaultMessage": "취소"
+  },
+  "parameterInputModal.cancelRecipeSetup": {
+    "defaultMessage": "레시피 설정 취소"
+  },
+  "parameterInputModal.enterValue": {
+    "defaultMessage": "{key}에 대한 값을 입력하세요..."
+  },
+  "parameterInputModal.false": {
+    "defaultMessage": "거짓"
+  },
+  "parameterInputModal.recipeParameters": {
+    "defaultMessage": "레시피 매개변수"
+  },
+  "parameterInputModal.select": {
+    "defaultMessage": "선택..."
+  },
+  "parameterInputModal.selectOption": {
+    "defaultMessage": "옵션을 선택하세요..."
+  },
+  "parameterInputModal.startNewChat": {
+    "defaultMessage": "새 채팅 시작(레시피 없음)"
+  },
+  "parameterInputModal.startRecipe": {
+    "defaultMessage": "레시피 시작"
+  },
+  "parameterInputModal.true": {
+    "defaultMessage": "참"
+  },
+  "parameterInputModal.whatToDo": {
+    "defaultMessage": "무엇을 하고 싶나요?"
+  },
+  "permissionModal.alwaysAllow": {
+    "defaultMessage": "항상 허용"
+  },
+  "permissionModal.askBefore": {
+    "defaultMessage": "먼저 묻기"
+  },
+  "permissionModal.cancel": {
+    "defaultMessage": "취소"
+  },
+  "permissionModal.close": {
+    "defaultMessage": "닫기"
+  },
+  "permissionModal.failedToLoadTools": {
+    "defaultMessage": "도구를 로드하지 못했습니다."
+  },
+  "permissionModal.failedToLoadToolsDescription": {
+    "defaultMessage": "이 익스텐션의 도구를 로드할 수 없습니다. 현재 세션에 익스텐션이 로드되지 않았을 수 있습니다."
+  },
+  "permissionModal.neverAllow": {
+    "defaultMessage": "절대 허용하지 않음"
+  },
+  "permissionModal.noActiveSession": {
+    "defaultMessage": "활성 세션 없음"
+  },
+  "permissionModal.noActiveSessionDescription": {
+    "defaultMessage": "이 익스텐션에 대한 도구 권한을 구성하려면 먼저 채팅 세션을 시작하세요. 도구 권한은 활성 세션의 익스텐션에서 로드됩니다."
+  },
+  "permissionModal.noToolsAvailable": {
+    "defaultMessage": "이 익스텐션에 사용할 수 있는 도구가 없습니다."
+  },
+  "permissionModal.saveChanges": {
+    "defaultMessage": "변경 사항 저장"
+  },
+  "permissionRulesModal.description": {
+    "defaultMessage": "익스텐션이 시스템과 상호 작용하는 방식을 제어하려면 도구 권한을 구성하세요."
+  },
+  "permissionRulesModal.extensionRules": {
+    "defaultMessage": "익스텐션 규칙"
+  },
+  "permissionRulesModal.title": {
+    "defaultMessage": "권한 규칙"
+  },
+  "permissionSetting.extensionRules": {
+    "defaultMessage": "익스텐션 규칙"
+  },
+  "permissionSetting.permissionRules": {
+    "defaultMessage": "권한 규칙"
+  },
+  "permissionSetting.permissionRulesDescription": {
+    "defaultMessage": "응답에 컨텍스트를 추가하고 지시하는 데 도움이 되도록 제공업체에게 전달되는 숨겨진 지침입니다."
+  },
+  "privacyInfoModal.collectErrors": {
+    "defaultMessage": "오류 유형(예: 'rate_limit', 'auth' - 세부정보 없음)"
+  },
+  "privacyInfoModal.collectExtensions": {
+    "defaultMessage": "익스텐션 및 도구 사용 횟수(이름만)"
+  },
+  "privacyInfoModal.collectOs": {
+    "defaultMessage": "운영 체제, 버전 및 아키텍처"
+  },
+  "privacyInfoModal.collectProvider": {
+    "defaultMessage": "사용된 제공업체 및 모델"
+  },
+  "privacyInfoModal.collectSession": {
+    "defaultMessage": "세션 지표(기간, 상호 작용 횟수, 토큰 사용량)"
+  },
+  "privacyInfoModal.collectVersion": {
+    "defaultMessage": "goose 버전 및 설치 방법"
+  },
+  "privacyInfoModal.description": {
+    "defaultMessage": "익명의 사용 데이터는 goose가 어떻게 사용되는지 이해하고 개선이 필요한 부분을 파악하는 데 도움이 됩니다."
+  },
+  "privacyInfoModal.neverCollect": {
+    "defaultMessage": "대화, 코드, 도구 인수, 오류 메시지 또는 개인 데이터는 수집하지 않습니다. 언제든지 설정에서 이 설정을 변경할 수 있습니다."
+  },
+  "privacyInfoModal.title": {
+    "defaultMessage": "개인정보 보호 세부정보"
+  },
+  "privacyInfoModal.whatWeCollect": {
+    "defaultMessage": "수집하는 항목:"
+  },
+  "progressiveMessageList.loadingMessages": {
+    "defaultMessage": "메시지 로드 중... ({renderedCount}/{totalCount})"
+  },
+  "progressiveMessageList.modelChanged": {
+    "defaultMessage": "모델 변경 : {previousModel} → {currentModel}"
+  },
+  "progressiveMessageList.searchHint": {
+    "defaultMessage": "검색을 위해 모든 메시지를 즉시 로드하려면 Cmd/Ctrl+F를 누르세요."
+  },
+  "promptsSettings.allPromptsReset": {
+    "defaultMessage": "모든 프롬프트가 기본값으로 재설정됩니다."
+  },
+  "promptsSettings.backToList": {
+    "defaultMessage": "목록으로 돌아가기"
+  },
+  "promptsSettings.confirmReplaceWithDefault": {
+    "defaultMessage": "현재 콘텐츠를 기본값으로 바꾸시겠습니까? 변경사항이 손실됩니다."
+  },
+  "promptsSettings.confirmResetAll": {
+    "defaultMessage": "모든 프롬프트를 기본값으로 재설정하시겠습니까? 이 작업은 취소할 수 없습니다."
+  },
+  "promptsSettings.confirmResetOne": {
+    "defaultMessage": "이 프롬프트를 기본값으로 재설정하시겠습니까? 이 작업은 취소할 수 없습니다."
+  },
+  "promptsSettings.confirmUnsavedBack": {
+    "defaultMessage": "저장되지 않은 변경사항이 있습니다. 정말 돌아가시겠어요?"
+  },
+  "promptsSettings.customized": {
+    "defaultMessage": "사용자 지정됨"
+  },
+  "promptsSettings.edit": {
+    "defaultMessage": "편집"
+  },
+  "promptsSettings.editPromptTitle": {
+    "defaultMessage": "편집: {name}"
+  },
+  "promptsSettings.editingLabel": {
+    "defaultMessage": "편집: {name}"
+  },
+  "promptsSettings.enterPromptContent": {
+    "defaultMessage": "프롬프트 내용을 입력하세요..."
+  },
+  "promptsSettings.failedToLoadPrompt": {
+    "defaultMessage": "프롬프트를 로드하지 못했습니다."
+  },
+  "promptsSettings.failedToLoadPrompts": {
+    "defaultMessage": "프롬프트를 로드하지 못했습니다."
+  },
+  "promptsSettings.failedToResetPrompt": {
+    "defaultMessage": "프롬프트를 재설정하지 못했습니다."
+  },
+  "promptsSettings.failedToResetPrompts": {
+    "defaultMessage": "프롬프트를 재설정하지 못했습니다."
+  },
+  "promptsSettings.failedToSavePrompt": {
+    "defaultMessage": "프롬프트를 저장하지 못했습니다."
+  },
+  "promptsSettings.promptEditingDescription": {
+    "defaultMessage": "다양한 상황에서 goose의 동작을 정의하는 프롬프트를 사용자 지정하세요. 이 프롬프트는 Jinja2 템플릿 구문을 사용합니다. 잘못된 변경으로 인해 기능이 중단될 수 있으므로 템플릿 변수를 수정할 때는 주의하세요. 개선 사항을 커뮤니티와 공유해 주세요."
+  },
+  "promptsSettings.promptEditingTitle": {
+    "defaultMessage": "프롬프트 편집"
+  },
+  "promptsSettings.promptResetToDefault": {
+    "defaultMessage": "기본값으로 프롬프트 재설정"
+  },
+  "promptsSettings.promptSaved": {
+    "defaultMessage": "프롬프트가 저장되었습니다"
+  },
+  "promptsSettings.resetAll": {
+    "defaultMessage": "모두 재설정"
+  },
+  "promptsSettings.resetToDefault": {
+    "defaultMessage": "기본값으로 재설정"
+  },
+  "promptsSettings.restoreDefault": {
+    "defaultMessage": "기본값 복원"
+  },
+  "promptsSettings.save": {
+    "defaultMessage": "저장"
+  },
+  "promptsSettings.templateTip": {
+    "defaultMessage": "{extensionsExample} 또는 {forExample}과 같은 템플릿 변수는 런타임 시 실제 값으로 대체됩니다. 필수 변수를 제거하지 않도록 주의하세요."
+  },
+  "promptsSettings.unsavedChanges": {
+    "defaultMessage": "저장되지 않은 변경사항이 있습니다."
+  },
+  "providerCard.noMetadata": {
+    "defaultMessage": "ProviderCard 오류: 메타데이터가 제공되지 않았습니다."
+  },
+  "providerCard.unknownProvider": {
+    "defaultMessage": "알 수 없는 제공업체"
+  },
+  "providerCatalogPicker.anthropicCompatible": {
+    "defaultMessage": "Anthropic 호환 가능"
+  },
+  "providerCatalogPicker.apiFormat": {
+    "defaultMessage": "API 형식"
+  },
+  "providerCatalogPicker.cancel": {
+    "defaultMessage": "취소"
+  },
+  "providerCatalogPicker.chooseProvider": {
+    "defaultMessage": "제공업체 선택"
+  },
+  "providerCatalogPicker.errorPrefix": {
+    "defaultMessage": "오류: {error}"
+  },
+  "providerCatalogPicker.loadingProviders": {
+    "defaultMessage": "제공업체 로드 중..."
+  },
+  "providerCatalogPicker.modelsAvailable": {
+    "defaultMessage": "{count}개 모델 사용 가능"
+  },
+  "providerCatalogPicker.noProvidersAvailable": {
+    "defaultMessage": "이용 가능한 제공업체가 없습니다."
+  },
+  "providerCatalogPicker.noProvidersFound": {
+    "defaultMessage": "\"{query}\"에 대한 제공업체를 찾을 수 없습니다."
+  },
+  "providerCatalogPicker.openaiCompatible": {
+    "defaultMessage": "OpenAI 호환 가능"
+  },
+  "providerCatalogPicker.requiresEnvVar": {
+    "defaultMessage": "• {envVar} 필요"
+  },
+  "providerCatalogPicker.searchProviders": {
+    "defaultMessage": "제공업체 검색..."
+  },
+  "providerCatalogPicker.selectFormatDescription": {
+    "defaultMessage": "API 형식과 제공업체를 선택하세요. 구성이 자동으로 채워집니다."
+  },
+  "providerConfigForm.browserWindowOpen": {
+    "defaultMessage": "로그인을 완료할 수 있는 브라우저 창이 열립니다."
+  },
+  "providerConfigForm.configuring": {
+    "defaultMessage": "구성 중..."
+  },
+  "providerConfigForm.continue": {
+    "defaultMessage": "계속"
+  },
+  "providerConfigForm.deviceCodeFlowHint": {
+    "defaultMessage": "브라우저 창이 열리고 인증 코드가 클립보드에 복사됩니다. 로그인을 완료하려면 브라우저에 붙여넣으세요."
+  },
+  "providerConfigForm.noApiKey": {
+    "defaultMessage": "API 키가 없나요?"
+  },
+  "providerConfigForm.signInWith": {
+    "defaultMessage": "{providerName}으로 로그인"
+  },
+  "providerConfigForm.signingIn": {
+    "defaultMessage": "로그인 중..."
+  },
+  "providerConfigurationModal.addApiKeyDescription": {
+    "defaultMessage": "이 제공업체를 goose에 연동하려면 API 키를 추가하세요."
+  },
+  "providerConfigurationModal.browserWindowHint": {
+    "defaultMessage": "로그인을 완료할 수 있는 브라우저 창이 열립니다."
+  },
+  "providerConfigurationModal.cancel": {
+    "defaultMessage": "취소"
+  },
+  "providerConfigurationModal.cannotDeleteActive": {
+    "defaultMessage": "현재 사용 중인 동안에는 이 제공업체를 삭제할 수 없습니다. 먼저 다른 모델로 전환해 보세요."
+  },
+  "providerConfigurationModal.checkConfigAgain": {
+    "defaultMessage": "이 제공업체를 사용하려면 구성을 다시 확인하세요."
+  },
+  "providerConfigurationModal.close": {
+    "defaultMessage": "닫기"
+  },
+  "providerConfigurationModal.configureHeader": {
+    "defaultMessage": "{providerName} 설정"
+  },
+  "providerConfigurationModal.deleteConfigHeader": {
+    "defaultMessage": "{providerName}에 대한 구성 삭제"
+  },
+  "providerConfigurationModal.deleteConfirmation": {
+    "defaultMessage": "현재 제공업체 구성이 영구적으로 삭제됩니다."
+  },
+  "providerConfigurationModal.deviceCodeFlowHint": {
+    "defaultMessage": "브라우저 창이 열리고 인증 코드가 클립보드에 복사됩니다. 로그인을 완료하려면 브라우저에 붙여넣으세요."
+  },
+  "providerConfigurationModal.errorCheckingConfig": {
+    "defaultMessage": "이 제공업체 구성을 확인하는 동안 오류가 발생했습니다."
+  },
+  "providerConfigurationModal.errorTitle": {
+    "defaultMessage": "오류"
+  },
+  "providerConfigurationModal.externalSetupIntro": {
+    "defaultMessage": "이 제공업체는 goose 외부에 구성되어 있습니다. 다음 단계를 따르세요."
+  },
+  "providerConfigurationModal.goBack": {
+    "defaultMessage": "돌아가기"
+  },
+  "providerConfigurationModal.huggingFaceOAuthDescription": {
+    "defaultMessage": "API 토큰을 수동으로 입력하지 않고도 Hugging Face 추론 제공업체를 사용하려면 로그인하세요."
+  },
+  "providerConfigurationModal.oauthLoginFailed": {
+    "defaultMessage": "OAuth 로그인 실패: {error}"
+  },
+  "providerConfigurationModal.oauthSignInDescription": {
+    "defaultMessage": "이 제공업체를 이용하려면 {providerName} 계정으로 로그인하세요."
+  },
+  "providerConfigurationModal.parameterRequired": {
+    "defaultMessage": "{paramName}은 필수입니다"
+  },
+  "providerConfigurationModal.removeConfiguration": {
+    "defaultMessage": "구성 제거"
+  },
+  "providerConfigurationModal.seeDocumentation": {
+    "defaultMessage": "자세한 내용은 <link>문서</link>를 참조하세요."
+  },
+  "providerConfigurationModal.signInWith": {
+    "defaultMessage": "{providerName}으로 로그인"
+  },
+  "providerConfigurationModal.signingIn": {
+    "defaultMessage": "로그인 중..."
+  },
+  "providerGrid.addProvider": {
+    "defaultMessage": "제공업체 추가"
+  },
+  "providerGrid.addProviderTitle": {
+    "defaultMessage": "제공업체 추가"
+  },
+  "providerGrid.chooseModel": {
+    "defaultMessage": "모델 선택"
+  },
+  "providerGrid.configureProvider": {
+    "defaultMessage": "제공업체 구성"
+  },
+  "providerGrid.editProvider": {
+    "defaultMessage": "제공업체 편집"
+  },
+  "providerGrid.fromTemplateOrManual": {
+    "defaultMessage": "템플릿 또는 수동 설정으로 시작"
+  },
+  "providerLogo.alt": {
+    "defaultMessage": "{providerName} 로고"
+  },
+  "providerSelector.addCustomProvider": {
+    "defaultMessage": "사용자 지정 제공업체 추가"
+  },
+  "providerSelector.addCustomProviderTitle": {
+    "defaultMessage": "사용자 지정 제공업체 추가"
+  },
+  "providerSelector.connectProvider": {
+    "defaultMessage": "제공업체에 연결"
+  },
+  "providerSelector.connectProviderDescription": {
+    "defaultMessage": "OpenAI, Anthropic, Google 등을 연결합니다."
+  },
+  "providerSelector.freeLocalDescription": {
+    "defaultMessage": "무료 크레딧이 있는 로컬 모델이나 제공업체를 사용하세요."
+  },
+  "providerSelector.selectProvider": {
+    "defaultMessage": "제공업체 선택"
+  },
+  "providerSelector.useFreeLocal": {
+    "defaultMessage": "무료/로컬 제공업체 이용"
+  },
+  "providerSettings.configurationSettings": {
+    "defaultMessage": "제공업체 구성 설정"
+  },
+  "providerSettings.loadingProviders": {
+    "defaultMessage": "제공업체 로드 중..."
+  },
+  "providerSettings.onboardingDescription": {
+    "defaultMessage": "goose를 시작하려면 AI 모델 제공업체를 선택하세요. 각 제공업체가 생성한 API 키를 사용해야 하며 암호화되어 로컬에 저장됩니다. 설정에서 언제든지 제공업체를 변경할 수 있습니다."
+  },
+  "providerSettings.otherProviders": {
+    "defaultMessage": "기타 제공업체"
+  },
+  "providerSetupActions.cancel": {
+    "defaultMessage": "취소"
+  },
+  "providerSetupActions.cannotDeleteActive": {
+    "defaultMessage": "현재 사용 중인 {providerName}은 삭제할 수 없습니다. 이 제공업체를 삭제하기 전에 다른 모델로 전환하세요."
+  },
+  "providerSetupActions.confirmDelete": {
+    "defaultMessage": "삭제 확인"
+  },
+  "providerSetupActions.confirmDeleteMessage": {
+    "defaultMessage": "{providerName}의 구성 매개변수를 삭제하시겠습니까? 이 작업은 취소할 수 없습니다."
+  },
+  "providerSetupActions.deleteProvider": {
+    "defaultMessage": "제공업체 삭제"
+  },
+  "providerSetupActions.enableProvider": {
+    "defaultMessage": "제공업체 활성화"
+  },
+  "providerSetupActions.ok": {
+    "defaultMessage": "좋아요"
+  },
+  "providerSetupActions.submit": {
+    "defaultMessage": "제출"
+  },
+  "recipeActivityEditor.activitiesDescription": {
+    "defaultMessage": "레시피 채팅 창에 표시되는 상단 프롬프트와 활동 버튼입니다."
+  },
+  "recipeActivityEditor.activitiesLabel": {
+    "defaultMessage": "활동"
+  },
+  "recipeActivityEditor.activityButtonsDescription": {
+    "defaultMessage": "사용자가 레시피와 상호작용하는 데 도움이 되도록 메시지 아래에 표시되는 클릭 가능한 버튼입니다."
+  },
+  "recipeActivityEditor.activityButtonsLabel": {
+    "defaultMessage": "활동 버튼"
+  },
+  "recipeActivityEditor.addActivity": {
+    "defaultMessage": "활동 추가"
+  },
+  "recipeActivityEditor.addNewActivityPlaceholder": {
+    "defaultMessage": "새 활동 추가..."
+  },
+  "recipeActivityEditor.messageDescription": {
+    "defaultMessage": "레시피 상단에 표시되는 서식이 적용된 메시지입니다. 마크다운 형식을 지원합니다."
+  },
+  "recipeActivityEditor.messageLabel": {
+    "defaultMessage": "메시지"
+  },
+  "recipeActivityEditor.messagePlaceholder": {
+    "defaultMessage": "사용자에게 표시되는 레시피 소개 메시지를 입력하세요(**굵게**, *기울임꼴*, `code` 등 지원)."
+  },
+  "recipeExtensionSelector.description": {
+    "defaultMessage": "이 레시피를 실행할 때 사용할 수 있는 익스텐션을 선택하세요. 기본 익스텐션을 사용하려면 비워 두세요."
+  },
+  "recipeExtensionSelector.extensionsSelected": {
+    "defaultMessage": "{count,plural,one{#개의 익스텐션 선택됨} other{#개의 익스텐션 선택됨}}"
+  },
+  "recipeExtensionSelector.label": {
+    "defaultMessage": "익스텐션(선택사항)"
+  },
+  "recipeExtensionSelector.noExtensionsAvailable": {
+    "defaultMessage": "사용 가능한 익스텐션이 없습니다."
+  },
+  "recipeExtensionSelector.noExtensionsFound": {
+    "defaultMessage": "익스텐션이 없습니다."
+  },
+  "recipeExtensionSelector.searchPlaceholder": {
+    "defaultMessage": "익스텐션 검색..."
+  },
+  "recipeFormFields.addParameter": {
+    "defaultMessage": "매개변수 추가"
+  },
+  "recipeFormFields.advancedOptions": {
+    "defaultMessage": "고급 옵션"
+  },
+  "recipeFormFields.advancedOptionsHint": {
+    "defaultMessage": "활동, 매개변수, 모델, 익스텐션, 응답 스키마, 하위 레시피"
+  },
+  "recipeFormFields.descriptionLabel": {
+    "defaultMessage": "설명"
+  },
+  "recipeFormFields.descriptionPlaceholder": {
+    "defaultMessage": "이 레시피의 기능에 대한 간략한 설명"
+  },
+  "recipeFormFields.enterValueFor": {
+    "defaultMessage": "{key}에 대한 값을 입력하세요."
+  },
+  "recipeFormFields.initialPrompt": {
+    "defaultMessage": "초기 프롬프트"
+  },
+  "recipeFormFields.instructionsLabel": {
+    "defaultMessage": "지침"
+  },
+  "recipeFormFields.instructionsPlaceholder": {
+    "defaultMessage": "사용자에게 숨겨진 AI에 대한 자세한 지침"
+  },
+  "recipeFormFields.openEditor": {
+    "defaultMessage": "편집기 열기"
+  },
+  "recipeFormFields.parameterNamePlaceholder": {
+    "defaultMessage": "매개변수 이름을 입력하세요..."
+  },
+  "recipeFormFields.parametersDescription": {
+    "defaultMessage": "매개변수는 지침/프롬프트/활동의 '{{parameter_name}}' 구문에서 자동으로 감지되거나 아래에서 수동으로 추가할 수 있습니다."
+  },
+  "recipeFormFields.parametersLabel": {
+    "defaultMessage": "매개변수"
+  },
+  "recipeFormFields.promptOptionalHint": {
+    "defaultMessage": "(선택사항 - 지침 또는 프롬프트가 필요함)"
+  },
+  "recipeFormFields.promptPlaceholder": {
+    "defaultMessage": "레시피 시작 시 미리 채워질 프롬프트"
+  },
+  "recipeFormFields.responseJsonSchema": {
+    "defaultMessage": "응답 JSON 스키마"
+  },
+  "recipeFormFields.responseJsonSchemaDescription": {
+    "defaultMessage": "JSON Schema 형식을 이용하여 예상되는 AI의 응답 구조를 정의합니다."
+  },
+  "recipeFormFields.templateVarHint": {
+    "defaultMessage": "레시피 실행 시 입력할 수 있는 매개변수를 정의하려면 '{{parameter_name}}'을 사용하세요."
+  },
+  "recipeFormFields.titleLabel": {
+    "defaultMessage": "제목"
+  },
+  "recipeFormFields.titlePlaceholder": {
+    "defaultMessage": "레시피 제목"
+  },
+  "recipeHeader.recipeLabel": {
+    "defaultMessage": "레시피"
+  },
+  "recipeModelSelector.backToModelList": {
+    "defaultMessage": "모델 목록으로 돌아가기"
+  },
+  "recipeModelSelector.enterCustomModel": {
+    "defaultMessage": "모델 이름을 입력하세요."
+  },
+  "recipeModelSelector.enterModelNotListed": {
+    "defaultMessage": "목록에 없는 모델을 입력하세요..."
+  },
+  "recipeModelSelector.fetchError": {
+    "defaultMessage": "모델을 가져오지 못했습니다. 나중에 다시 시도해 주세요."
+  },
+  "recipeModelSelector.loadingModels": {
+    "defaultMessage": "모델 로드 중…"
+  },
+  "recipeModelSelector.modelHint": {
+    "defaultMessage": "선택한 제공업체의 기본 모델을 사용하려면 비워 두세요."
+  },
+  "recipeModelSelector.modelLabel": {
+    "defaultMessage": "모델(선택사항)"
+  },
+  "recipeModelSelector.providerHint": {
+    "defaultMessage": "설정에 구성된 기본 제공업체를 사용하려면 비워 두세요."
+  },
+  "recipeModelSelector.providerLabel": {
+    "defaultMessage": "제공업체(선택사항)"
+  },
+  "recipeModelSelector.selectModel": {
+    "defaultMessage": "모델을 선택하세요"
+  },
+  "recipeModelSelector.selectProvider": {
+    "defaultMessage": "제공업체 선택"
+  },
+  "recipeModelSelector.useDefaultProvider": {
+    "defaultMessage": "기본 제공업체 사용"
+  },
+  "recipeNameField.defaultLabel": {
+    "defaultMessage": "레시피 이름"
+  },
+  "recipeNameField.formatHint": {
+    "defaultMessage": "자동으로 형식이 지정됩니다(소문자, 공백은 대시로 변환)."
+  },
+  "recipeWarningModal.cancel": {
+    "defaultMessage": "취소"
+  },
+  "recipeWarningModal.descriptionLabel": {
+    "defaultMessage": "설명:"
+  },
+  "recipeWarningModal.firstTimeDescription": {
+    "defaultMessage": "이전에 실행한 적이 없는 레시피를 실행하려고 합니다."
+  },
+  "recipeWarningModal.hiddenCharsWarning": {
+    "defaultMessage": "이 레시피에는 악의적인 목적으로 사용될 수 있으므로 안전을 위해 무시되는 숨겨진 문자가 포함되어 있습니다."
+  },
+  "recipeWarningModal.instructionsLabel": {
+    "defaultMessage": "지침:"
+  },
+  "recipeWarningModal.newRecipeWarningTitle": {
+    "defaultMessage": "⚠️ 새로운 레시피 경고"
+  },
+  "recipeWarningModal.recipePreview": {
+    "defaultMessage": "레시피 미리보기:"
+  },
+  "recipeWarningModal.securityWarningTitle": {
+    "defaultMessage": "⚠️ 보안 경고"
+  },
+  "recipeWarningModal.titleLabel": {
+    "defaultMessage": "제목:"
+  },
+  "recipeWarningModal.trustAndExecute": {
+    "defaultMessage": "신뢰하고 실행"
+  },
+  "recipeWarningModal.trustSource": {
+    "defaultMessage": "이 레시피의 출처를 신뢰하는 경우에만 진행하세요."
+  },
+  "recipesView.addSchedule": {
+    "defaultMessage": "일정 추가"
+  },
+  "recipesView.addSlashCommand": {
+    "defaultMessage": "슬래시 명령 추가"
+  },
+  "recipesView.adjustSearchTerms": {
+    "defaultMessage": "검색어를 조정해 보세요."
+  },
+  "recipesView.allFiles": {
+    "defaultMessage": "모든 파일"
+  },
+  "recipesView.cancel": {
+    "defaultMessage": "취소"
+  },
+  "recipesView.copyDeeplink": {
+    "defaultMessage": "딥링크 복사"
+  },
+  "recipesView.copyDeeplinkFailedMsg": {
+    "defaultMessage": "딥링크를 클립보드에 복사하지 못했습니다."
+  },
+  "recipesView.copyFailedTitle": {
+    "defaultMessage": "복사 실패"
+  },
+  "recipesView.copyYaml": {
+    "defaultMessage": "YAML 복사"
+  },
+  "recipesView.copyYamlFailedMsg": {
+    "defaultMessage": "레시피 YAML을 클립보드에 복사하지 못했습니다."
+  },
+  "recipesView.createRecipe": {
+    "defaultMessage": "레시피 생성"
+  },
+  "recipesView.deeplinkCopiedMsg": {
+    "defaultMessage": "레시피 딥링크가 클립보드에 복사되었습니다."
+  },
+  "recipesView.deeplinkCopiedTitle": {
+    "defaultMessage": "딥링크 복사됨"
+  },
+  "recipesView.deleteRecipe": {
+    "defaultMessage": "레시피 삭제"
+  },
+  "recipesView.deleteRecipeConfirm": {
+    "defaultMessage": "\"{title}\"을(를) 삭제하시겠습니까?"
+  },
+  "recipesView.deleteRecipeDetail": {
+    "defaultMessage": "레시피 파일이 삭제됩니다."
+  },
+  "recipesView.deleteRecipeTitle": {
+    "defaultMessage": "레시피 삭제"
+  },
+  "recipesView.editRecipe": {
+    "defaultMessage": "레시피 편집"
+  },
+  "recipesView.editSchedule": {
+    "defaultMessage": "일정 수정"
+  },
+  "recipesView.editSlashCommand": {
+    "defaultMessage": "슬래시 명령 편집"
+  },
+  "recipesView.errorLoadingRecipes": {
+    "defaultMessage": "레시피를 로드하는 중 오류가 발생했습니다."
+  },
+  "recipesView.exportFailedMsg": {
+    "defaultMessage": "레시피를 파일로 내보내지 못했습니다."
+  },
+  "recipesView.exportFailedTitle": {
+    "defaultMessage": "내보내기 실패"
+  },
+  "recipesView.exportRecipeDialogTitle": {
+    "defaultMessage": "레시피 내보내기"
+  },
+  "recipesView.exportToFile": {
+    "defaultMessage": "파일로 내보내기"
+  },
+  "recipesView.noMatchingRecipes": {
+    "defaultMessage": "일치하는 레시피가 없습니다."
+  },
+  "recipesView.noSavedRecipes": {
+    "defaultMessage": "저장된 레시피가 없습니다."
+  },
+  "recipesView.noSavedRecipesDescription": {
+    "defaultMessage": "채팅에서 저장된 레시피가 여기에 표시됩니다."
+  },
+  "recipesView.openInNewWindow": {
+    "defaultMessage": "새 창에서 열기"
+  },
+  "recipesView.recipeDeletedSuccess": {
+    "defaultMessage": "레시피가 삭제되었습니다."
+  },
+  "recipesView.recipeExportedMsg": {
+    "defaultMessage": "{filePath}에 레시피가 저장되었습니다."
+  },
+  "recipesView.recipeExportedTitle": {
+    "defaultMessage": "레시피를 내보냈습니다."
+  },
+  "recipesView.recipesDescription": {
+    "defaultMessage": "저장된 레시피를 확인·관리하고, 미리 정의된 구성으로 새 세션을 빠르게 시작하세요. {shortcut}로 검색할 수 있습니다."
+  },
+  "recipesView.recipesTitle": {
+    "defaultMessage": "레시피"
+  },
+  "recipesView.remove": {
+    "defaultMessage": "제거"
+  },
+  "recipesView.removeSchedule": {
+    "defaultMessage": "일정 삭제"
+  },
+  "recipesView.runs": {
+    "defaultMessage": "{schedule} 실행"
+  },
+  "recipesView.save": {
+    "defaultMessage": "저장"
+  },
+  "recipesView.scheduleDialogTitle": {
+    "defaultMessage": "{action} 일정"
+  },
+  "recipesView.scheduleRemovedMsg": {
+    "defaultMessage": "레시피가 더 이상 자동으로 실행되지 않습니다."
+  },
+  "recipesView.scheduleRemovedTitle": {
+    "defaultMessage": "일정이 삭제되었습니다."
+  },
+  "recipesView.scheduleSavedMsg": {
+    "defaultMessage": "레시피가 {schedule} 실행됩니다."
+  },
+  "recipesView.scheduleSavedTitle": {
+    "defaultMessage": "일정이 저장되었습니다."
+  },
+  "recipesView.searchRecipesPlaceholder": {
+    "defaultMessage": "레시피 검색..."
+  },
+  "recipesView.shareRecipe": {
+    "defaultMessage": "레시피 공유"
+  },
+  "recipesView.slashCommandDescription": {
+    "defaultMessage": "모든 채팅에서 이 레시피를 빠르게 실행하려면 슬래시 명령을 설정하세요."
+  },
+  "recipesView.slashCommandPlaceholder": {
+    "defaultMessage": "명령 이름"
+  },
+  "recipesView.slashCommandRemovedMsg": {
+    "defaultMessage": "레시피 슬래시 명령이 제거되었습니다."
+  },
+  "recipesView.slashCommandRemovedTitle": {
+    "defaultMessage": "슬래시 명령이 제거되었습니다."
+  },
+  "recipesView.slashCommandSavedMsg": {
+    "defaultMessage": "이 레시피 실행: /{command}"
+  },
+  "recipesView.slashCommandSavedTitle": {
+    "defaultMessage": "슬래시 명령이 저장되었습니다."
+  },
+  "recipesView.slashCommandTitle": {
+    "defaultMessage": "슬래시 명령"
+  },
+  "recipesView.slashCommandUsageHint": {
+    "defaultMessage": "채팅에서 /{command}로 이 레시피 실행"
+  },
+  "recipesView.tryAgain": {
+    "defaultMessage": "다시 시도"
+  },
+  "recipesView.useRecipe": {
+    "defaultMessage": "레시피 사용"
+  },
+  "recipesView.yamlCopiedMsg": {
+    "defaultMessage": "레시피 YAML이 클립보드에 복사되었습니다"
+  },
+  "recipesView.yamlCopiedTitle": {
+    "defaultMessage": "YAML 복사됨"
+  },
+  "recipesView.yamlFiles": {
+    "defaultMessage": "YAML 파일"
+  },
+  "resetProviderSection.resetButton": {
+    "defaultMessage": "제공업체 및 모델 초기화"
+  },
+  "resetProviderSection.resetDescription": {
+    "defaultMessage": "선택한 모델 및 제공업체 설정이 지워집니다. 사용 가능한 기본값이 없으면, 다시 설정할 수 있도록 시작 화면으로 이동합니다."
+  },
+  "responseStyle.conciseDescription": {
+    "defaultMessage": "도구 호출은 기본적으로 접혀 있으며 사용된 도구만 표시됩니다."
+  },
+  "responseStyle.conciseLabel": {
+    "defaultMessage": "간결하게"
+  },
+  "responseStyle.detailedDescription": {
+    "defaultMessage": "도구 호출은 기본적으로 펼쳐져 세부 정보가 표시됩니다."
+  },
+  "responseStyle.detailedLabel": {
+    "defaultMessage": "자세히"
+  },
+  "scheduleDetailView.actions": {
+    "defaultMessage": "작업"
+  },
+  "scheduleDetailView.cannotModifyRunning": {
+    "defaultMessage": "이미 실행 중인 일정은 트리거하거나 수정할 수 없습니다."
+  },
+  "scheduleDetailView.created": {
+    "defaultMessage": "생성일: {date}"
+  },
+  "scheduleDetailView.cronExpression": {
+    "defaultMessage": "cron 표현식:"
+  },
+  "scheduleDetailView.currentSession": {
+    "defaultMessage": "현재 세션:"
+  },
+  "scheduleDetailView.currentlyRunning": {
+    "defaultMessage": "현재 실행 중"
+  },
+  "scheduleDetailView.dir": {
+    "defaultMessage": "디렉터리: {path}"
+  },
+  "scheduleDetailView.editSchedule": {
+    "defaultMessage": "일정 편집"
+  },
+  "scheduleDetailView.errorPrefix": {
+    "defaultMessage": "오류: {error}"
+  },
+  "scheduleDetailView.failedToLoadSession": {
+    "defaultMessage": "세션을 로드하지 못했습니다."
+  },
+  "scheduleDetailView.idLabel": {
+    "defaultMessage": "ID:"
+  },
+  "scheduleDetailView.inspectJobError": {
+    "defaultMessage": "작업 검사 오류"
+  },
+  "scheduleDetailView.inspectNoInfo": {
+    "defaultMessage": "자세한 정보가 없습니다."
+  },
+  "scheduleDetailView.inspectRunningJob": {
+    "defaultMessage": "실행 중인 작업 검사"
+  },
+  "scheduleDetailView.jobCancelled": {
+    "defaultMessage": "작업이 취소되었습니다."
+  },
+  "scheduleDetailView.jobCancelledMsg": {
+    "defaultMessage": "시작하는 동안 작업이 취소되었습니다."
+  },
+  "scheduleDetailView.jobInspection": {
+    "defaultMessage": "작업 검사"
+  },
+  "scheduleDetailView.jobKilled": {
+    "defaultMessage": "작업 종료됨"
+  },
+  "scheduleDetailView.killJobError": {
+    "defaultMessage": "작업 종료 오류"
+  },
+  "scheduleDetailView.killRunningJob": {
+    "defaultMessage": "실행 중인 작업 종료"
+  },
+  "scheduleDetailView.lastRun": {
+    "defaultMessage": "마지막 실행:"
+  },
+  "scheduleDetailView.loadingSchedule": {
+    "defaultMessage": "일정 로드 중..."
+  },
+  "scheduleDetailView.loadingSessions": {
+    "defaultMessage": "세션 로드 중..."
+  },
+  "scheduleDetailView.messages": {
+    "defaultMessage": "메시지: {count}"
+  },
+  "scheduleDetailView.newSession": {
+    "defaultMessage": "새 세션: {sessionId}"
+  },
+  "scheduleDetailView.noScheduleId": {
+    "defaultMessage": "제공된 일정 ID가 없습니다. 일정 목록으로 돌아갑니다."
+  },
+  "scheduleDetailView.noSessions": {
+    "defaultMessage": "이 일정에 대한 세션을 찾을 수 없습니다."
+  },
+  "scheduleDetailView.pauseSchedule": {
+    "defaultMessage": "일정 일시 중지"
+  },
+  "scheduleDetailView.pauseUnpauseError": {
+    "defaultMessage": "일시중지/일시중지 해제 오류"
+  },
+  "scheduleDetailView.paused": {
+    "defaultMessage": "일시중지됨"
+  },
+  "scheduleDetailView.pausedMsg": {
+    "defaultMessage": "\"{id}\" 일시 중지됨"
+  },
+  "scheduleDetailView.pausedWarning": {
+    "defaultMessage": "이 일정은 일시 중지되어 자동으로 실행되지 않습니다. 수동으로 실행하려면 \"지금 일정 실행\"을 사용하거나, 자동 실행을 재개하려면 일시 중지를 해제하세요."
+  },
+  "scheduleDetailView.processStarted": {
+    "defaultMessage": "프로세스 시작:"
+  },
+  "scheduleDetailView.recentSessions": {
+    "defaultMessage": "최근 세션"
+  },
+  "scheduleDetailView.recipeSource": {
+    "defaultMessage": "레시피 소스:"
+  },
+  "scheduleDetailView.runScheduleError": {
+    "defaultMessage": "일정 실행 오류"
+  },
+  "scheduleDetailView.runScheduleNow": {
+    "defaultMessage": "지금 일정 실행"
+  },
+  "scheduleDetailView.scheduleDetails": {
+    "defaultMessage": "일정 세부정보"
+  },
+  "scheduleDetailView.scheduleInformation": {
+    "defaultMessage": "일정 정보"
+  },
+  "scheduleDetailView.scheduleLabel": {
+    "defaultMessage": "일정:"
+  },
+  "scheduleDetailView.scheduleNotFound": {
+    "defaultMessage": "일정을 찾을 수 없습니다"
+  },
+  "scheduleDetailView.scheduleNotFoundError": {
+    "defaultMessage": "일정을 찾을 수 없습니다"
+  },
+  "scheduleDetailView.schedulePaused": {
+    "defaultMessage": "일정이 일시 중지됨"
+  },
+  "scheduleDetailView.scheduleTriggered": {
+    "defaultMessage": "일정이 실행됨"
+  },
+  "scheduleDetailView.scheduleUnpaused": {
+    "defaultMessage": "일정 일시중지 해제됨"
+  },
+  "scheduleDetailView.scheduleUpdated": {
+    "defaultMessage": "일정이 업데이트되었습니다"
+  },
+  "scheduleDetailView.sessionId": {
+    "defaultMessage": "세션 ID: {id}"
+  },
+  "scheduleDetailView.tokens": {
+    "defaultMessage": "토큰: {count}"
+  },
+  "scheduleDetailView.unpauseSchedule": {
+    "defaultMessage": "일정 일시중지 해제"
+  },
+  "scheduleDetailView.unpausedMsg": {
+    "defaultMessage": "\"{id}\" 일시중지 해제됨"
+  },
+  "scheduleDetailView.updateScheduleError": {
+    "defaultMessage": "일정 업데이트 오류"
+  },
+  "scheduleDetailView.updatedMsg": {
+    "defaultMessage": "\"{id}\" 업데이트됨"
+  },
+  "scheduleDetailView.viewingScheduleId": {
+    "defaultMessage": "일정 ID 보기: {id}"
+  },
+  "scheduleModal.browseYaml": {
+    "defaultMessage": "YAML 파일 찾아보기..."
+  },
+  "scheduleModal.cancel": {
+    "defaultMessage": "취소"
+  },
+  "scheduleModal.createNewSchedule": {
+    "defaultMessage": "새 일정 생성"
+  },
+  "scheduleModal.createSchedule": {
+    "defaultMessage": "일정 생성"
+  },
+  "scheduleModal.creating": {
+    "defaultMessage": "생성 중..."
+  },
+  "scheduleModal.deepLink": {
+    "defaultMessage": "딥링크"
+  },
+  "scheduleModal.deepLinkPlaceholder": {
+    "defaultMessage": "goose://recipe 링크를 여기에 붙여넣으세요..."
+  },
+  "scheduleModal.editSchedule": {
+    "defaultMessage": "일정 편집"
+  },
+  "scheduleModal.failedParseRecipe": {
+    "defaultMessage": "파일에서 레시피를 구문 분석하지 못했습니다."
+  },
+  "scheduleModal.failedReadFile": {
+    "defaultMessage": "선택한 파일을 읽지 못했습니다."
+  },
+  "scheduleModal.invalidDeepLink": {
+    "defaultMessage": "딥링크가 잘못되었습니다. goose://recipe 링크를 이용해 주세요."
+  },
+  "scheduleModal.invalidFileType": {
+    "defaultMessage": "잘못된 파일 형식: YAML 파일(.yaml 또는 .yml)을 선택하세요."
+  },
+  "scheduleModal.nameLabel": {
+    "defaultMessage": "이름:"
+  },
+  "scheduleModal.namePlaceholder": {
+    "defaultMessage": "예: 일일 요약 작업"
+  },
+  "scheduleModal.provideValidRecipe": {
+    "defaultMessage": "유효한 레시피 소스를 입력하세요."
+  },
+  "scheduleModal.recipeDescription": {
+    "defaultMessage": "설명: {description}"
+  },
+  "scheduleModal.recipeParsed": {
+    "defaultMessage": "레시피가 성공적으로 파싱되었습니다."
+  },
+  "scheduleModal.recipeTitle": {
+    "defaultMessage": "제목: {title}"
+  },
+  "scheduleModal.scheduleIdRequired": {
+    "defaultMessage": "일정 ID가 필요합니다."
+  },
+  "scheduleModal.scheduleLabel": {
+    "defaultMessage": "일정:"
+  },
+  "scheduleModal.selected": {
+    "defaultMessage": "선택됨: {path}"
+  },
+  "scheduleModal.sourceLabel": {
+    "defaultMessage": "소스:"
+  },
+  "scheduleModal.updateSchedule": {
+    "defaultMessage": "일정 업데이트"
+  },
+  "scheduleModal.updating": {
+    "defaultMessage": "업데이트 중..."
+  },
+  "scheduleModal.yaml": {
+    "defaultMessage": "YAML"
+  },
+  "schedulesView.confirmDelete": {
+    "defaultMessage": "일정 \"{id}\"을(를) 삭제하시겠습니까? 레시피는 유지됩니다."
+  },
+  "schedulesView.createSchedule": {
+    "defaultMessage": "일정 생성"
+  },
+  "schedulesView.description": {
+    "defaultMessage": "지정된 시간에 자동으로 레시피를 실행하는 예약된 작업을 생성하고 관리하세요."
+  },
+  "schedulesView.edit": {
+    "defaultMessage": "편집"
+  },
+  "schedulesView.errorPrefix": {
+    "defaultMessage": "오류: {error}"
+  },
+  "schedulesView.inspect": {
+    "defaultMessage": "검사"
+  },
+  "schedulesView.inspectError": {
+    "defaultMessage": "작업 오류 검사"
+  },
+  "schedulesView.inspectNoInfo": {
+    "defaultMessage": "이 작업에 대한 자세한 정보가 없습니다."
+  },
+  "schedulesView.jobInspection": {
+    "defaultMessage": "작업 검사"
+  },
+  "schedulesView.jobKilled": {
+    "defaultMessage": "작업 종료됨"
+  },
+  "schedulesView.kill": {
+    "defaultMessage": "종료"
+  },
+  "schedulesView.killError": {
+    "defaultMessage": "작업 종료 오류"
+  },
+  "schedulesView.lastRun": {
+    "defaultMessage": "마지막 실행: {date}"
+  },
+  "schedulesView.noSchedules": {
+    "defaultMessage": "아직 일정이 없습니다"
+  },
+  "schedulesView.pause": {
+    "defaultMessage": "일시 중지"
+  },
+  "schedulesView.pauseError": {
+    "defaultMessage": "일정 일시 중지 오류"
+  },
+  "schedulesView.paused": {
+    "defaultMessage": "일시중지됨"
+  },
+  "schedulesView.refresh": {
+    "defaultMessage": "새로고침"
+  },
+  "schedulesView.refreshing": {
+    "defaultMessage": "새로고침 중..."
+  },
+  "schedulesView.resume": {
+    "defaultMessage": "재개"
+  },
+  "schedulesView.running": {
+    "defaultMessage": "실행 중"
+  },
+  "schedulesView.schedulePaused": {
+    "defaultMessage": "일정이 일시 중지됨"
+  },
+  "schedulesView.schedulePausedMsg": {
+    "defaultMessage": "일정 \"{id}\"을(를) 일시중지했습니다."
+  },
+  "schedulesView.scheduleUnpaused": {
+    "defaultMessage": "일정 일시중지 해제됨"
+  },
+  "schedulesView.scheduleUnpausedMsg": {
+    "defaultMessage": "일정 \"{id}\"의 일시중지를 해제했습니다."
+  },
+  "schedulesView.scheduleUpdated": {
+    "defaultMessage": "일정이 업데이트되었습니다"
+  },
+  "schedulesView.scheduleUpdatedMsg": {
+    "defaultMessage": "\"{id}\" 일정이 업데이트되었습니다."
+  },
+  "schedulesView.scheduler": {
+    "defaultMessage": "스케줄러"
+  },
+  "schedulesView.unpauseError": {
+    "defaultMessage": "일시중지 해제 일정 오류"
+  },
+  "searchBar.caseSensitive": {
+    "defaultMessage": "대소문자 구분"
+  },
+  "searchBar.close": {
+    "defaultMessage": "닫기({shortcut})"
+  },
+  "searchBar.next": {
+    "defaultMessage": "다음({shortcut})"
+  },
+  "searchBar.placeholder": {
+    "defaultMessage": "대화 검색..."
+  },
+  "searchBar.previous": {
+    "defaultMessage": "이전 ({shortcut})"
+  },
+  "secureStorageNotice.defaultMessage": {
+    "defaultMessage": "키는 키체인에 안전하게 저장됩니다."
+  },
+  "securityToggle.apiTokenDescription": {
+    "defaultMessage": "분류 서비스에 대한 인증 토큰"
+  },
+  "securityToggle.apiTokenOptional": {
+    "defaultMessage": "API 토큰(선택)"
+  },
+  "securityToggle.classificationEndpoint": {
+    "defaultMessage": "분류 엔드포인트"
+  },
+  "securityToggle.classificationEndpointDescription": {
+    "defaultMessage": "분류 서비스의 전체 URL을 입력하세요."
+  },
+  "securityToggle.commandClassifierActive": {
+    "defaultMessage": "명령 분류기 활성화됨(환경에서 자동 설정)"
+  },
+  "securityToggle.commandEndpointDescription": {
+    "defaultMessage": "명령 인젝션 분류 서비스의 전체 URL을 입력하세요."
+  },
+  "securityToggle.commandInjectionDescription": {
+    "defaultMessage": "ML 모델을 사용하여 악성 셸 명령 감지"
+  },
+  "securityToggle.detectionModel": {
+    "defaultMessage": "탐지 모델"
+  },
+  "securityToggle.detectionModelDescription": {
+    "defaultMessage": "프롬프트 인젝션 감지에 사용할 ML 모델을 선택하세요."
+  },
+  "securityToggle.detectionThreshold": {
+    "defaultMessage": "감지 임계값"
+  },
+  "securityToggle.enableCommandInjection": {
+    "defaultMessage": "명령 인젝션 ML 감지 켜기"
+  },
+  "securityToggle.enablePromptInjection": {
+    "defaultMessage": "프롬프트 인젝션 감지 켜기"
+  },
+  "securityToggle.enablePromptInjectionMl": {
+    "defaultMessage": "프롬프트 인젝션 ML 감지 켜기"
+  },
+  "securityToggle.mlEndpointDescription": {
+    "defaultMessage": "ML 분류 서비스의 전체 URL을 입력하세요(모델 식별자 포함)."
+  },
+  "securityToggle.mlTokenDescription": {
+    "defaultMessage": "ML 서비스에 대한 인증 토큰(예: HuggingFace 토큰)"
+  },
+  "securityToggle.overrideNotice": {
+    "defaultMessage": "이 설정은 조직에서 관리하며 변경할 수 없습니다."
+  },
+  "securityToggle.promptInjectionDescription": {
+    "defaultMessage": "잠재적인 프롬프트 인젝션 공격을 감지하고 방지합니다."
+  },
+  "securityToggle.promptInjectionMlDescription": {
+    "defaultMessage": "ML 모델을 사용하여 채팅에서 잠재적인 프롬프트 인젝션을 감지합니다."
+  },
+  "securityToggle.thresholdDescription": {
+    "defaultMessage": "값이 높을수록 더 엄격합니다(0.01 = 매우 관대함, 1.0 = 가장 엄격)."
+  },
+  "securityToggle.warpNotice": {
+    "defaultMessage": "명령 인젝션 감지는 WARP에 연결했을 때 가장 잘 작동합니다. 분류 서비스에 연결하려면 WARP가 필요합니다."
+  },
+  "sessionActionsHeader.close": {
+    "defaultMessage": "닫기"
+  },
+  "sessionActionsHeader.copiedJson": {
+    "defaultMessage": "세션 JSON 복사됨"
+  },
+  "sessionActionsHeader.copiedText": {
+    "defaultMessage": "텍스트가 복사되었습니다."
+  },
+  "sessionActionsHeader.copyJson": {
+    "defaultMessage": "JSON 복사"
+  },
+  "sessionActionsHeader.copyText": {
+    "defaultMessage": "텍스트 복사"
+  },
+  "sessionActionsHeader.fullTextTitle": {
+    "defaultMessage": "텍스트 값"
+  },
+  "sessionActionsHeader.jsonFailed": {
+    "defaultMessage": "세션 JSON을 불러오지 못했습니다: {error}"
+  },
+  "sessionActionsHeader.jsonTitle": {
+    "defaultMessage": "세션 JSON"
+  },
+  "sessionActionsHeader.loadingJson": {
+    "defaultMessage": "JSON 불러오는 중..."
+  },
+  "sessionActionsHeader.viewJson": {
+    "defaultMessage": "세션 JSON 보기"
+  },
+  "sessionHistory.cancel": {
+    "defaultMessage": "취소"
+  },
+  "sessionHistory.copy": {
+    "defaultMessage": "복사"
+  },
+  "sessionHistory.empty.description": {
+    "defaultMessage": "이 세션에는 메시지가 없습니다."
+  },
+  "sessionHistory.empty.title": {
+    "defaultMessage": "메시지를 찾을 수 없습니다."
+  },
+  "sessionHistory.error.loading": {
+    "defaultMessage": "세션 세부정보를 로드하는 중 오류가 발생했습니다."
+  },
+  "sessionHistory.error.tryAgain": {
+    "defaultMessage": "다시 시도"
+  },
+  "sessionHistory.loading": {
+    "defaultMessage": "세션 세부정보 로드 중..."
+  },
+  "sessionHistory.resume": {
+    "defaultMessage": "재개"
+  },
+  "sessionHistory.searchPlaceholder": {
+    "defaultMessage": "기록 검색..."
+  },
+  "sessionHistory.share": {
+    "defaultMessage": "공유"
+  },
+  "sessionHistory.shareModal.description": {
+    "defaultMessage": "이 세션 링크를 공유하여 다른 사람이 goose 채팅을 읽기 전용으로 볼 수 있게 하세요."
+  },
+  "sessionHistory.shareModal.title": {
+    "defaultMessage": "공유 세션(베타)"
+  },
+  "sessionHistory.shareTooltip": {
+    "defaultMessage": "세션 공유를 활성화하려면 <b>설정</b> > <b>세션</b> > <b>세션 공유</b>로 이동하세요."
+  },
+  "sessionHistory.sharing": {
+    "defaultMessage": "공유 중..."
+  },
+  "sessionHistory.toast.copyFailed": {
+    "defaultMessage": "링크를 클립보드에 복사하지 못했습니다."
+  },
+  "sessionHistory.toast.launchFailed": {
+    "defaultMessage": "세션을 시작할 수 없습니다: {error}"
+  },
+  "sessionHistory.toast.shareFailed": {
+    "defaultMessage": "세션 공유 실패: {error}"
+  },
+  "sessionIndicators.error": {
+    "defaultMessage": "세션에 오류가 발생했습니다."
+  },
+  "sessionIndicators.newActivity": {
+    "defaultMessage": "새로운 활동 있음"
+  },
+  "sessionIndicators.streaming": {
+    "defaultMessage": "스트리밍"
+  },
+  "sessionSharingSection.alreadyConfigured": {
+    "defaultMessage": "세션 공유가 이미 구성되었습니다."
+  },
+  "sessionSharingSection.baseUrl": {
+    "defaultMessage": "기본 URL"
+  },
+  "sessionSharingSection.connectionFailed": {
+    "defaultMessage": "연결에 실패했습니다."
+  },
+  "sessionSharingSection.connectionSuccess": {
+    "defaultMessage": "연결 성공!"
+  },
+  "sessionSharingSection.connectionTimedOut": {
+    "defaultMessage": "연결 시간이 초과되었습니다. 서버가 느리거나 연결이 불가능할 수 있습니다."
+  },
+  "sessionSharingSection.descriptionConfigured": {
+    "defaultMessage": "세션 공유가 설정되었지만, 세션은 공유 버튼을 직접 클릭할 때만 공유됩니다."
+  },
+  "sessionSharingSection.descriptionDefault": {
+    "defaultMessage": "세션 공유를 켜면 내 세션을 다른 사람과 공유할 수 있습니다."
+  },
+  "sessionSharingSection.enableSharing": {
+    "defaultMessage": "세션 공유 켜기"
+  },
+  "sessionSharingSection.invalidUrl": {
+    "defaultMessage": "URL 형식이 잘못되었습니다. 올바른 URL을 입력하세요(예: https://example.com/api)."
+  },
+  "sessionSharingSection.serverError": {
+    "defaultMessage": "서버 오류: HTTP {status}. 서버가 올바르게 구성되지 않았을 수 있습니다."
+  },
+  "sessionSharingSection.testConnection": {
+    "defaultMessage": "연결 테스트"
+  },
+  "sessionSharingSection.testing": {
+    "defaultMessage": "테스트 중..."
+  },
+  "sessionSharingSection.testingConnection": {
+    "defaultMessage": "연결 테스트 중..."
+  },
+  "sessionSharingSection.title": {
+    "defaultMessage": "세션 공유"
+  },
+  "sessionSharingSection.unknownError": {
+    "defaultMessage": "알 수 없는 오류가 발생했습니다."
+  },
+  "sessionSharingSection.unreachableServer": {
+    "defaultMessage": "서버에 연결할 수 없습니다. URL과 네트워크 연결을 확인해주세요."
+  },
+  "sessionSharingSection.urlPlaceholder": {
+    "defaultMessage": "https://example.com/api"
+  },
+  "sessionViewComponents.empty.description": {
+    "defaultMessage": "이 세션에는 메시지가 없습니다."
+  },
+  "sessionViewComponents.empty.title": {
+    "defaultMessage": "메시지를 찾을 수 없습니다."
+  },
+  "sessionViewComponents.error.loading": {
+    "defaultMessage": "세션 세부정보를 로드하는 중 오류가 발생했습니다."
+  },
+  "sessionViewComponents.error.tryAgain": {
+    "defaultMessage": "다시 시도"
+  },
+  "sessionViewComponents.role.assistant": {
+    "defaultMessage": "Goose"
+  },
+  "sessionViewComponents.role.user": {
+    "defaultMessage": "나"
+  },
+  "sessions.action.delete": {
+    "defaultMessage": "세션 삭제"
+  },
+  "sessions.action.duplicate": {
+    "defaultMessage": "세션 복제"
+  },
+  "sessions.action.editName": {
+    "defaultMessage": "세션 이름 편집"
+  },
+  "sessions.action.export": {
+    "defaultMessage": "세션 내보내기"
+  },
+  "sessions.action.openNewWindow": {
+    "defaultMessage": "새 창에서 열기"
+  },
+  "sessions.action.shareNostr": {
+    "defaultMessage": "암호화된 Nostr 링크 공유"
+  },
+  "sessions.cancel": {
+    "defaultMessage": "취소"
+  },
+  "sessions.chatHistory": {
+    "defaultMessage": "채팅 기록"
+  },
+  "sessions.chatHistoryDesc": {
+    "defaultMessage": "goose와 나눈 이전 대화를 확인하고 검색하세요. {shortcut}로 검색할 수 있습니다."
+  },
+  "sessions.close": {
+    "defaultMessage": "닫기"
+  },
+  "sessions.delete.message": {
+    "defaultMessage": "\"{name}\" 세션을 삭제하시겠습니까? 이 작업은 취소할 수 없습니다."
+  },
+  "sessions.delete.title": {
+    "defaultMessage": "세션 삭제"
+  },
+  "sessions.edit.placeholder": {
+    "defaultMessage": "세션 설명 입력"
+  },
+  "sessions.edit.title": {
+    "defaultMessage": "세션 설명 편집"
+  },
+  "sessions.empty.description": {
+    "defaultMessage": "채팅 기록이 여기에 표시됩니다"
+  },
+  "sessions.empty.title": {
+    "defaultMessage": "채팅 세션을 찾을 수 없습니다."
+  },
+  "sessions.error.loading": {
+    "defaultMessage": "세션을 로드하는 중 오류가 발생했습니다."
+  },
+  "sessions.error.tryAgain": {
+    "defaultMessage": "다시 시도"
+  },
+  "sessions.import": {
+    "defaultMessage": "세션 가져오기"
+  },
+  "sessions.importNostr": {
+    "defaultMessage": "링크 가져오기"
+  },
+  "sessions.importNostr.description": {
+    "defaultMessage": "Goose Nostr 공유 링크를 붙여넣어 세션을 가져오고 복호화한 뒤 불러오세요."
+  },
+  "sessions.importNostr.placeholder": {
+    "defaultMessage": "goose://sessions/nostr?nevent=...&key=..."
+  },
+  "sessions.importNostr.title": {
+    "defaultMessage": "Nostr 세션 가져오기"
+  },
+  "sessions.importing": {
+    "defaultMessage": "가져오는 중..."
+  },
+  "sessions.loadingMore": {
+    "defaultMessage": "추가 세션 로드 중..."
+  },
+  "sessions.save": {
+    "defaultMessage": "저장"
+  },
+  "sessions.saving": {
+    "defaultMessage": "저장 중..."
+  },
+  "sessions.search.noResults": {
+    "defaultMessage": "일치하는 세션이 없습니다."
+  },
+  "sessions.search.noResultsDesc": {
+    "defaultMessage": "검색어를 조정해 보세요."
+  },
+  "sessions.searchPlaceholder": {
+    "defaultMessage": "기록 검색..."
+  },
+  "sessions.shareNostr.description": {
+    "defaultMessage": "이 링크가 있는 사람은 누구나 세션을 가져오고 복호화할 수 있습니다. 비밀처럼 다루세요."
+  },
+  "sessions.shareNostr.title": {
+    "defaultMessage": "암호화된 Nostr 공유 링크"
+  },
+  "sessions.toast.copied": {
+    "defaultMessage": "클립보드에 복사됨"
+  },
+  "sessions.toast.deleteFailed": {
+    "defaultMessage": "\"{name}\" 세션 삭제 실패: {error}"
+  },
+  "sessions.toast.deleted": {
+    "defaultMessage": "세션이 삭제되었습니다."
+  },
+  "sessions.toast.duplicateFailed": {
+    "defaultMessage": "세션 복제 실패: {error}"
+  },
+  "sessions.toast.duplicated": {
+    "defaultMessage": "세션 \"{name}\"이(가) 성공적으로 복제되었습니다."
+  },
+  "sessions.toast.exported": {
+    "defaultMessage": "세션을 성공적으로 내보냈습니다."
+  },
+  "sessions.toast.importFailed": {
+    "defaultMessage": "세션 가져오기 실패: {error}"
+  },
+  "sessions.toast.imported": {
+    "defaultMessage": "세션을 성공적으로 가져왔습니다."
+  },
+  "sessions.toast.shareNostr": {
+    "defaultMessage": "암호화된 Nostr 공유 링크가 생성되었습니다."
+  },
+  "sessions.toast.shareNostrFailed": {
+    "defaultMessage": "Nostr 공유 링크 생성 실패: {error}"
+  },
+  "sessions.toast.updateFailed": {
+    "defaultMessage": "세션 설명 업데이트 실패: {error}"
+  },
+  "sessions.toast.updated": {
+    "defaultMessage": "세션 설명이 업데이트되었습니다."
+  },
+  "sessionsView.error.failedToLoad": {
+    "defaultMessage": "세션 세부정보를 로드하지 못했습니다. 나중에 다시 시도해 주세요."
+  },
+  "sessionsView.loading": {
+    "defaultMessage": "로드 중..."
+  },
+  "settings.appearance.description": {
+    "defaultMessage": "시스템에서 goose가 표시되는 방식을 설정합니다."
+  },
+  "settings.appearance.title": {
+    "defaultMessage": "모양"
+  },
+  "settings.close": {
+    "defaultMessage": "닫기"
+  },
+  "settings.costTracking.description": {
+    "defaultMessage": "모델 가격 및 사용 비용을 표시합니다."
+  },
+  "settings.costTracking.title": {
+    "defaultMessage": "비용 추적"
+  },
+  "settings.dockIcon.description": {
+    "defaultMessage": "Dock에 goose를 표시합니다."
+  },
+  "settings.dockIcon.title": {
+    "defaultMessage": "Dock 아이콘"
+  },
+  "settings.help.description": {
+    "defaultMessage": "문제를 신고하거나 새 기능을 요청하여 goose 개선에 도움을 주세요."
+  },
+  "settings.help.reportBug": {
+    "defaultMessage": "버그 신고"
+  },
+  "settings.help.requestFeature": {
+    "defaultMessage": "기능 요청"
+  },
+  "settings.help.title": {
+    "defaultMessage": "도움말 및 피드백"
+  },
+  "settings.language.description": {
+    "defaultMessage": "goose의 표시 언어를 선택하세요"
+  },
+  "settings.language.english": {
+    "defaultMessage": "영어"
+  },
+  "settings.language.hindi": {
+    "defaultMessage": "힌디어"
+  },
+  "settings.language.japanese": {
+    "defaultMessage": "일본어"
+  },
+  "settings.language.korean": {
+    "defaultMessage": "한국어"
+  },
+  "settings.language.russian": {
+    "defaultMessage": "러시아어"
+  },
+  "settings.language.spanish": {
+    "defaultMessage": "스페인어"
+  },
+  "settings.language.systemDefault": {
+    "defaultMessage": "시스템 기본값"
+  },
+  "settings.language.title": {
+    "defaultMessage": "언어"
+  },
+  "settings.language.turkish": {
+    "defaultMessage": "터키어"
+  },
+  "settings.language.zhCN": {
+    "defaultMessage": "중국어(간체)"
+  },
+  "settings.menuBarIcon.description": {
+    "defaultMessage": "메뉴 막대에 goose를 표시합니다."
+  },
+  "settings.menuBarIcon.title": {
+    "defaultMessage": "메뉴 막대 아이콘"
+  },
+  "settings.notifications.configGuide": {
+    "defaultMessage": "구성 가이드"
+  },
+  "settings.notifications.description": {
+    "defaultMessage": "알림은 운영체제에서 관리됩니다 — {link}"
+  },
+  "settings.notifications.modal.macInstructions": {
+    "defaultMessage": "macOS에서 알림을 켜려면:"
+  },
+  "settings.notifications.modal.macStep1": {
+    "defaultMessage": "시스템 환경설정 열기"
+  },
+  "settings.notifications.modal.macStep2": {
+    "defaultMessage": "알림을 클릭하세요"
+  },
+  "settings.notifications.modal.macStep3": {
+    "defaultMessage": "애플리케이션 목록에서 goose를 찾아 선택하세요"
+  },
+  "settings.notifications.modal.macStep4": {
+    "defaultMessage": "원하는 대로 알림을 활성화하고 설정을 조정합니다."
+  },
+  "settings.notifications.modal.title": {
+    "defaultMessage": "알림 활성화 방법"
+  },
+  "settings.notifications.modal.winInstructions": {
+    "defaultMessage": "Windows에서 알림을 켜려면:"
+  },
+  "settings.notifications.modal.winStep1": {
+    "defaultMessage": "설정 열기"
+  },
+  "settings.notifications.modal.winStep2": {
+    "defaultMessage": "시스템 > 알림으로 이동"
+  },
+  "settings.notifications.modal.winStep3": {
+    "defaultMessage": "애플리케이션 목록에서 goose를 찾아 선택하세요"
+  },
+  "settings.notifications.modal.winStep4": {
+    "defaultMessage": "알림을 켜고 원하는 대로 설정을 조정하세요."
+  },
+  "settings.notifications.openSettings": {
+    "defaultMessage": "설정 열기"
+  },
+  "settings.notifications.task.description": {
+    "defaultMessage": "창이 백그라운드에 있을 때 goose가 작업을 완료하면 알림을 보냅니다."
+  },
+  "settings.notifications.task.title": {
+    "defaultMessage": "작업 완료 알림"
+  },
+  "settings.notifications.title": {
+    "defaultMessage": "알림"
+  },
+  "settings.preventSleep.description": {
+    "defaultMessage": "goose가 작업을 실행하는 동안 컴퓨터가 잠자기 상태로 전환되지 않도록 합니다. 화면은 잠길 수 있습니다."
+  },
+  "settings.preventSleep.title": {
+    "defaultMessage": "잠자기 방지"
+  },
+  "settings.theme.description": {
+    "defaultMessage": "goose의 모양과 느낌을 사용자화합니다."
+  },
+  "settings.theme.title": {
+    "defaultMessage": "테마"
+  },
+  "settings.updates.description": {
+    "defaultMessage": "goose가 최상의 상태로 실행되도록 업데이트를 확인하고 설치합니다."
+  },
+  "settings.updates.title": {
+    "defaultMessage": "업데이트"
+  },
+  "settings.version.title": {
+    "defaultMessage": "버전"
+  },
+  "settingsView.tabApp": {
+    "defaultMessage": "앱"
+  },
+  "settingsView.tabAuth": {
+    "defaultMessage": "인증"
+  },
+  "settingsView.tabChat": {
+    "defaultMessage": "채팅"
+  },
+  "settingsView.tabKeyboard": {
+    "defaultMessage": "키보드"
+  },
+  "settingsView.tabLocalInference": {
+    "defaultMessage": "로컬 추론"
+  },
+  "settingsView.tabModels": {
+    "defaultMessage": "모델"
+  },
+  "settingsView.tabPrompts": {
+    "defaultMessage": "프롬프트"
+  },
+  "settingsView.tabSession": {
+    "defaultMessage": "세션"
+  },
+  "settingsView.title": {
+    "defaultMessage": "설정"
+  },
+  "sharedSession.loading": {
+    "defaultMessage": "세션 세부정보 로드 중..."
+  },
+  "sharedSession.title": {
+    "defaultMessage": "공유 세션"
+  },
+  "sheet.close": {
+    "defaultMessage": "닫기"
+  },
+  "shortcutRecorder.cancel": {
+    "defaultMessage": "취소"
+  },
+  "shortcutRecorder.clickToRecord": {
+    "defaultMessage": "단축키를 기록하려면 클릭하세요..."
+  },
+  "shortcutRecorder.conflictWarning": {
+    "defaultMessage": "{label}에서 이미 사용하고 있는 단축키입니다. 저장하면 이 작업에 다시 할당됩니다."
+  },
+  "shortcutRecorder.pressShortcut": {
+    "defaultMessage": "단축키를 누르세요..."
+  },
+  "shortcutRecorder.save": {
+    "defaultMessage": "저장"
+  },
+  "skillsView.addSkill": {
+    "defaultMessage": "스킬 추가"
+  },
+  "skillsView.adjustSearchTerms": {
+    "defaultMessage": "검색어를 조정해 보세요."
+  },
+  "skillsView.comingSoon": {
+    "defaultMessage": "곧 출시 예정"
+  },
+  "skillsView.errorLoadingSkills": {
+    "defaultMessage": "스킬 로딩 오류"
+  },
+  "skillsView.noMatchingSkills": {
+    "defaultMessage": "일치하는 스킬을 찾을 수 없습니다."
+  },
+  "skillsView.noSkillsDescription": {
+    "defaultMessage": "스킬은 ~/.config/agents/skills/, .goose/skills/ 또는 기타 지원되는 디렉터리의 SKILL.md 파일에서 로드됩니다."
+  },
+  "skillsView.noSkillsInstalled": {
+    "defaultMessage": "설치된 스킬 없음"
+  },
+  "skillsView.searchSkillsPlaceholder": {
+    "defaultMessage": "스킬 검색..."
+  },
+  "skillsView.skillsDescription": {
+    "defaultMessage": "Goose 기능을 확장하는 설치된 스킬을 확인하세요. {shortcut}로 검색할 수 있습니다."
+  },
+  "skillsView.skillsTitle": {
+    "defaultMessage": "스킬"
+  },
+  "skillsView.tryAgain": {
+    "defaultMessage": "다시 시도"
+  },
+  "spellcheckToggle.description": {
+    "defaultMessage": "채팅 입력창의 맞춤법을 검사합니다. 적용하려면 다시 시작해야 합니다."
+  },
+  "spellcheckToggle.title": {
+    "defaultMessage": "맞춤법 검사 켜기"
+  },
+  "standaloneAppView.failedToLoad": {
+    "defaultMessage": "앱을 로드하지 못했습니다."
+  },
+  "standaloneAppView.initializing": {
+    "defaultMessage": "앱 초기화 중..."
+  },
+  "standaloneAppView.missingParams": {
+    "defaultMessage": "필수 매개변수가 누락되었습니다."
+  },
+  "stringUtils.configuredProvider": {
+    "defaultMessage": "{name} 제공업체가 구성되었습니다."
+  },
+  "stringUtils.ollamaApp": {
+    "defaultMessage": "Ollama 앱"
+  },
+  "stringUtils.ollamaNotConfiguredPrefix": {
+    "defaultMessage": "사용하려면"
+  },
+  "stringUtils.ollamaNotConfiguredSuffix": {
+    "defaultMessage": "을(를) 컴퓨터에 설치하고 열어야 합니다. 또는 OLLAMA_HOST 값을 입력해야 합니다."
+  },
+  "subRecipeEditor.addExisting": {
+    "defaultMessage": "기존 하위 레시피 추가"
+  },
+  "subRecipeEditor.createNew": {
+    "defaultMessage": "새 하위 레시피 생성"
+  },
+  "subRecipeEditor.deleteSubrecipe": {
+    "defaultMessage": "{name} 하위 레시피 삭제"
+  },
+  "subRecipeEditor.description": {
+    "defaultMessage": "하위 레시피는 실행 중 도구로 호출할 수 있는 레시피입니다. 다단계 워크플로와 재사용 가능한 구성 요소를 만들 수 있습니다."
+  },
+  "subRecipeEditor.duplicateName": {
+    "defaultMessage": "중복된 이름"
+  },
+  "subRecipeEditor.duplicateNameMsg": {
+    "defaultMessage": "\"{name}\"이라는 하위 레시피가 이미 존재합니다. 고유한 이름을 사용하세요."
+  },
+  "subRecipeEditor.editSubrecipe": {
+    "defaultMessage": "{name} 하위 레시피 편집"
+  },
+  "subRecipeEditor.label": {
+    "defaultMessage": "하위 레시피"
+  },
+  "subRecipeEditor.preconfiguredValues": {
+    "defaultMessage": "사전 구성된 값:"
+  },
+  "subRecipeEditor.sequential": {
+    "defaultMessage": "순차 실행"
+  },
+  "subRecipeModal.addTitle": {
+    "defaultMessage": "하위 레시피 추가"
+  },
+  "subRecipeModal.apply": {
+    "defaultMessage": "적용"
+  },
+  "subRecipeModal.browse": {
+    "defaultMessage": "찾아보기"
+  },
+  "subRecipeModal.cancel": {
+    "defaultMessage": "취소"
+  },
+  "subRecipeModal.closeModal": {
+    "defaultMessage": "하위 레시피 모달 닫기"
+  },
+  "subRecipeModal.configureTitle": {
+    "defaultMessage": "하위 레시피 설정"
+  },
+  "subRecipeModal.descriptionLabel": {
+    "defaultMessage": "설명"
+  },
+  "subRecipeModal.descriptionPlaceholder": {
+    "defaultMessage": "이 하위 레시피의 기능에 대한 선택적 설명..."
+  },
+  "subRecipeModal.invalidFile": {
+    "defaultMessage": "잘못된 파일"
+  },
+  "subRecipeModal.invalidFileMsg": {
+    "defaultMessage": "YAML 파일(.yaml 또는 .yml)을 선택하세요."
+  },
+  "subRecipeModal.nameHint": {
+    "defaultMessage": "도구 이름을 생성하는 데 사용되는 고유 식별자"
+  },
+  "subRecipeModal.nameLabel": {
+    "defaultMessage": "이름"
+  },
+  "subRecipeModal.namePlaceholder": {
+    "defaultMessage": "예: security_scan"
+  },
+  "subRecipeModal.pathHint": {
+    "defaultMessage": "기존 레시피 파일을 찾아보거나 경로를 수동으로 입력하세요."
+  },
+  "subRecipeModal.pathLabel": {
+    "defaultMessage": "경로"
+  },
+  "subRecipeModal.pathPlaceholder": {
+    "defaultMessage": "예: ./subrecipes/security-analysis.yaml"
+  },
+  "subRecipeModal.preconfiguredValues": {
+    "defaultMessage": "사전 구성된 값"
+  },
+  "subRecipeModal.preconfiguredValuesHint": {
+    "defaultMessage": "항상 하위 레시피에 전달되는 선택적 매개변수 값"
+  },
+  "subRecipeModal.sequentialHint": {
+    "defaultMessage": "(여러 하위 레시피 인스턴스의 순차 실행을 강제합니다)"
+  },
+  "subRecipeModal.sequentialLabel": {
+    "defaultMessage": "반복 시 순차 실행"
+  },
+  "subRecipeModal.subtitle": {
+    "defaultMessage": "레시피 실행 시 도구로 호출할 수 있는 서브레시피를 구성합니다."
+  },
+  "switchModelModal.backToModelList": {
+    "defaultMessage": "모델 목록으로 돌아가기"
+  },
+  "switchModelModal.cancel": {
+    "defaultMessage": "취소"
+  },
+  "switchModelModal.checkProviderConfig": {
+    "defaultMessage": "설정 → 제공업체에서 제공업체 구성을 확인하세요."
+  },
+  "switchModelModal.chooseModel": {
+    "defaultMessage": "모델을 선택하세요:"
+  },
+  "switchModelModal.claudeAdaptive": {
+    "defaultMessage": "적응형 — Claude가 언제 얼마나 추론할지 결정합니다."
+  },
+  "switchModelModal.claudeDisabled": {
+    "defaultMessage": "끔 — 확장 추론 없음"
+  },
+  "switchModelModal.claudeEffortHigh": {
+    "defaultMessage": "높음 — 심층 추론 (기본값)"
+  },
+  "switchModelModal.claudeEffortLow": {
+    "defaultMessage": "낮음 — 최소 추론, 가장 빠른 응답"
+  },
+  "switchModelModal.claudeEffortMax": {
+    "defaultMessage": "최대 — 추론 깊이 제한 없음"
+  },
+  "switchModelModal.claudeEffortMedium": {
+    "defaultMessage": "중간 — 보통 수준의 추론"
+  },
+  "switchModelModal.claudeEnabled": {
+    "defaultMessage": "켬 — 추론에 고정 토큰 예산 사용"
+  },
+  "switchModelModal.couldNotContactProvider": {
+    "defaultMessage": "제공업체에 연결할 수 없습니다."
+  },
+  "switchModelModal.customModelName": {
+    "defaultMessage": "모델 이름"
+  },
+  "switchModelModal.description": {
+    "defaultMessage": "대화에 사용할 제공업체 및 모델을 선택하세요."
+  },
+  "switchModelModal.enterModelNotListed": {
+    "defaultMessage": "목록에 없는 모델을 입력하세요..."
+  },
+  "switchModelModal.extendedThinking": {
+    "defaultMessage": "확장 추론"
+  },
+  "switchModelModal.geminiOnly": {
+    "defaultMessage": "(Gemini 3 모델만 해당)"
+  },
+  "switchModelModal.goToSettings": {
+    "defaultMessage": "설정으로 이동"
+  },
+  "switchModelModal.loadingModels": {
+    "defaultMessage": "모델 로드 중…"
+  },
+  "switchModelModal.localModelsDescription": {
+    "defaultMessage": "로컬 추론을 사용하려면 먼저 모델을 컴퓨터에 다운로드해야 합니다. 로컬 모델을 관리하려면 설정 → 모델로 이동하세요."
+  },
+  "switchModelModal.localModelsTitle": {
+    "defaultMessage": "로컬 모델을 먼저 다운로드해야 합니다."
+  },
+  "switchModelModal.providerPlaceholder": {
+    "defaultMessage": "제공업체 검색"
+  },
+  "switchModelModal.quickStartGuide": {
+    "defaultMessage": "빠른 시작 가이드"
+  },
+  "switchModelModal.recommended": {
+    "defaultMessage": "추천"
+  },
+  "switchModelModal.selectEffortLevel": {
+    "defaultMessage": "추론 강도 선택"
+  },
+  "switchModelModal.selectModel": {
+    "defaultMessage": "모델을 선택하세요."
+  },
+  "switchModelModal.selectModelButton": {
+    "defaultMessage": "모델 선택"
+  },
+  "switchModelModal.selectModelPlaceholder": {
+    "defaultMessage": "모델 선택 또는 검색"
+  },
+  "switchModelModal.selectOrEnterModel": {
+    "defaultMessage": "모델을 선택하거나 입력하세요."
+  },
+  "switchModelModal.selectProvider": {
+    "defaultMessage": "제공업체를 선택하세요."
+  },
+  "switchModelModal.selectThinkingLevel": {
+    "defaultMessage": "추론 수준 선택"
+  },
+  "switchModelModal.selectThinkingMode": {
+    "defaultMessage": "추론 모드 선택"
+  },
+  "switchModelModal.thinkingBudget": {
+    "defaultMessage": "추론 예산(토큰)"
+  },
+  "switchModelModal.thinkingEffort": {
+    "defaultMessage": "추론 강도"
+  },
+  "switchModelModal.thinkingEffortOff": {
+    "defaultMessage": "끔 — 확장 추론 없음"
+  },
+  "switchModelModal.thinkingLevel": {
+    "defaultMessage": "추론 수준"
+  },
+  "switchModelModal.thinkingLevelHigh": {
+    "defaultMessage": "높음 — 더 깊은 추론, 지연 시간 증가"
+  },
+  "switchModelModal.thinkingLevelLow": {
+    "defaultMessage": "낮음 — 지연 시간 감소, 가벼운 추론"
+  },
+  "switchModelModal.title": {
+    "defaultMessage": "모델 전환"
+  },
+  "switchModelModal.typeModelName": {
+    "defaultMessage": "여기에 모델 이름을 입력하세요."
+  },
+  "switchModelModal.useOtherProvider": {
+    "defaultMessage": "다른 제공업체 이용"
+  },
+  "telemetryConsentPrompt.description": {
+    "defaultMessage": "goose 개선을 위해 익명의 사용 데이터를 공유하시겠습니까? 대화, 코드 또는 개인 데이터는 수집하지 않습니다."
+  },
+  "telemetryConsentPrompt.heading": {
+    "defaultMessage": "goose 개선에 도움을 주세요"
+  },
+  "telemetryConsentPrompt.learnMore": {
+    "defaultMessage": "자세히 알아보기"
+  },
+  "telemetryConsentPrompt.optIn": {
+    "defaultMessage": "예, 익명의 사용 데이터를 공유합니다"
+  },
+  "telemetryConsentPrompt.optOut": {
+    "defaultMessage": "아니요"
+  },
+  "telemetrySettings.configErrorTitle": {
+    "defaultMessage": "구성 오류"
+  },
+  "telemetrySettings.description": {
+    "defaultMessage": "데이터 사용 방식을 관리합니다."
+  },
+  "telemetrySettings.learnMore": {
+    "defaultMessage": "자세히 알아보기"
+  },
+  "telemetrySettings.loadError": {
+    "defaultMessage": "원격 분석 설정을 로드하지 못했습니다."
+  },
+  "telemetrySettings.title": {
+    "defaultMessage": "개인정보 보호"
+  },
+  "telemetrySettings.toggleDescription": {
+    "defaultMessage": "익명 사용 통계를 공유하여 goose 개선에 도움을 주세요."
+  },
+  "telemetrySettings.toggleLabel": {
+    "defaultMessage": "익명 사용 데이터"
+  },
+  "telemetrySettings.updateError": {
+    "defaultMessage": "원격 분석 설정을 업데이트하지 못했습니다."
+  },
+  "themeSelector.dark": {
+    "defaultMessage": "다크"
+  },
+  "themeSelector.light": {
+    "defaultMessage": "라이트"
+  },
+  "themeSelector.system": {
+    "defaultMessage": "시스템"
+  },
+  "themeSelector.theme": {
+    "defaultMessage": "테마"
+  },
+  "toolApprovalButtons.allowOnce": {
+    "defaultMessage": "한 번만 허용"
+  },
+  "toolApprovalButtons.allowedOnce": {
+    "defaultMessage": "한 번 허용됨"
+  },
+  "toolApprovalButtons.alwaysAllow": {
+    "defaultMessage": "항상 허용"
+  },
+  "toolApprovalButtons.alwaysAllowed": {
+    "defaultMessage": "항상 허용됨"
+  },
+  "toolApprovalButtons.cancelled": {
+    "defaultMessage": "취소됨"
+  },
+  "toolApprovalButtons.denied": {
+    "defaultMessage": "거부됨"
+  },
+  "toolApprovalButtons.deniedOnce": {
+    "defaultMessage": "한 번 거부됨"
+  },
+  "toolApprovalButtons.deny": {
+    "defaultMessage": "거부"
+  },
+  "toolCallStatusIndicator.toolStatus": {
+    "defaultMessage": "도구 상태: {status}"
+  },
+  "toolCallWithResponse.activityCount": {
+    "defaultMessage": "활동({count})"
+  },
+  "toolCallWithResponse.code": {
+    "defaultMessage": "코드"
+  },
+  "toolCallWithResponse.loadingSpinner": {
+    "defaultMessage": "로딩 스피너"
+  },
+  "toolCallWithResponse.logs": {
+    "defaultMessage": "로그"
+  },
+  "toolCallWithResponse.mcpUiExperimental": {
+    "defaultMessage": "MCP UI는 실험적이며 언제든지 변경될 수 있습니다."
+  },
+  "toolCallWithResponse.output": {
+    "defaultMessage": "출력"
+  },
+  "toolCallWithResponse.toolDetails": {
+    "defaultMessage": "도구 세부정보"
+  },
+  "toolCallWithResponse.toolResultAlt": {
+    "defaultMessage": "도구 결과"
+  },
+  "toolCallWithResponse.viewSubagentSession": {
+    "defaultMessage": "하위 에이전트 세션 보기"
+  },
+  "toolConfirmation.allowToolCallWithName": {
+    "defaultMessage": "{toolName}을 허용하시겠습니까?"
+  },
+  "toolConfirmation.gooseWouldLikeToCallWithName": {
+    "defaultMessage": "goose가 {toolName}을 호출하려고 합니다. 허용하시겠습니까?"
+  },
+  "tunnelSection.appStoreQrInstructions": {
+    "defaultMessage": "QR 코드를 iPhone 카메라로 스캔하여 App Store에서 goose 모바일 앱을 설치하세요."
+  },
+  "tunnelSection.close": {
+    "defaultMessage": "닫기"
+  },
+  "tunnelSection.connectionDetails": {
+    "defaultMessage": "연결 세부정보"
+  },
+  "tunnelSection.downloadIosApp": {
+    "defaultMessage": "goose iOS 앱 다운로드"
+  },
+  "tunnelSection.failedToLoadStatus": {
+    "defaultMessage": "터널 상태를 로드하지 못했습니다."
+  },
+  "tunnelSection.failedToStartTunnel": {
+    "defaultMessage": "터널을 시작하지 못했습니다."
+  },
+  "tunnelSection.failedToStopTunnel": {
+    "defaultMessage": "터널을 중지하지 못했습니다."
+  },
+  "tunnelSection.getIosApp": {
+    "defaultMessage": "iOS 앱 받기"
+  },
+  "tunnelSection.mobileApp": {
+    "defaultMessage": "모바일 앱"
+  },
+  "tunnelSection.mobileAppConnection": {
+    "defaultMessage": "모바일 앱 연결"
+  },
+  "tunnelSection.openInAppStore": {
+    "defaultMessage": "앱 스토어에서 열기"
+  },
+  "tunnelSection.or": {
+    "defaultMessage": "또는"
+  },
+  "tunnelSection.previewDescription": {
+    "defaultMessage": "보안 터널링을 사용해 모바일 기기에서 goose에 원격으로 접속할 수 있습니다."
+  },
+  "tunnelSection.previewFeature": {
+    "defaultMessage": "미리 보기 기능:"
+  },
+  "tunnelSection.qrCodeInstructions": {
+    "defaultMessage": "QR 코드를 goose 모바일 앱으로 스캔하세요. 이 코드는 개인 액세스용이므로 다른 사람과 공유하지 마세요."
+  },
+  "tunnelSection.retry": {
+    "defaultMessage": "다시 시도"
+  },
+  "tunnelSection.scanQrCode": {
+    "defaultMessage": "QR 코드 스캔"
+  },
+  "tunnelSection.secretKey": {
+    "defaultMessage": "비밀 키"
+  },
+  "tunnelSection.showQrCode": {
+    "defaultMessage": "QR 코드 표시"
+  },
+  "tunnelSection.startTunnel": {
+    "defaultMessage": "터널 시작"
+  },
+  "tunnelSection.starting": {
+    "defaultMessage": "시작 중..."
+  },
+  "tunnelSection.statusDisabled": {
+    "defaultMessage": "터널이 비활성화되었습니다."
+  },
+  "tunnelSection.statusError": {
+    "defaultMessage": "터널에 오류가 발생했습니다."
+  },
+  "tunnelSection.statusIdle": {
+    "defaultMessage": "터널이 실행 중이 아닙니다."
+  },
+  "tunnelSection.statusRunning": {
+    "defaultMessage": "터널이 활성화되었습니다"
+  },
+  "tunnelSection.statusStarting": {
+    "defaultMessage": "터널 시작 중..."
+  },
+  "tunnelSection.stopTunnel": {
+    "defaultMessage": "터널 중지"
+  },
+  "tunnelSection.tunnelStatus": {
+    "defaultMessage": "터널 상태"
+  },
+  "tunnelSection.tunnelUrl": {
+    "defaultMessage": "터널 URL"
+  },
+  "tunnelSection.url": {
+    "defaultMessage": "URL:"
+  },
+  "updateSection.autoDownload": {
+    "defaultMessage": "업데이트는 백그라운드에서 자동으로 다운로드됩니다."
+  },
+  "updateSection.autoInstallNote": {
+    "defaultMessage": "앱을 종료하면 업데이트가 자동으로 설치됩니다."
+  },
+  "updateSection.checkForUpdates": {
+    "defaultMessage": "업데이트 확인"
+  },
+  "updateSection.checking": {
+    "defaultMessage": "업데이트 확인 중..."
+  },
+  "updateSection.currentVersion": {
+    "defaultMessage": "현재 버전"
+  },
+  "updateSection.downloadReady": {
+    "defaultMessage": "업데이트가 다운로드되었으며 설치 준비가 완료되었습니다!"
+  },
+  "updateSection.downloadingProgress": {
+    "defaultMessage": "업데이트 다운로드 중... {percent}%"
+  },
+  "updateSection.downloadingUpdate": {
+    "defaultMessage": "업데이트 다운로드 중..."
+  },
+  "updateSection.installAndRestart": {
+    "defaultMessage": "설치 및 다시 시작"
+  },
+  "updateSection.installNowHint": {
+    "defaultMessage": "또는 지금 업데이트하려면 \"설치 및 다시 시작\"을 클릭하세요."
+  },
+  "updateSection.latestVersion": {
+    "defaultMessage": "최신 버전을 사용 중입니다!"
+  },
+  "updateSection.loading": {
+    "defaultMessage": "로드 중..."
+  },
+  "updateSection.manualInstallNote": {
+    "defaultMessage": "다운로드한 후에는 업데이트를 수동으로 설치해야 합니다."
+  },
+  "updateSection.manualInstallRequired": {
+    "defaultMessage": "이 업데이트 방법에는 수동 설치가 필요합니다."
+  },
+  "updateSection.readyInstallAuto": {
+    "defaultMessage": "✓ 업데이트가 준비되었습니다! Goose 종료 시 설치됩니다."
+  },
+  "updateSection.readyInstallManual": {
+    "defaultMessage": "✓ 업데이트가 준비되었습니다! 설치 지침을 보려면 \"설치 및 다시 시작\"을 클릭하세요."
+  },
+  "updateSection.upToDate": {
+    "defaultMessage": "최신 상태"
+  },
+  "updateSection.updateAvailable": {
+    "defaultMessage": "업데이트가 있습니다!"
+  },
+  "updateSection.versionAvailable": {
+    "defaultMessage": "→ {version} 사용 가능"
+  },
+  "updateSection.versionIsAvailable": {
+    "defaultMessage": "버전 {version}을 사용할 수 있습니다."
+  },
+  "userMessage.cancel": {
+    "defaultMessage": "취소"
+  },
+  "userMessage.cancelAriaLabel": {
+    "defaultMessage": "편집 취소"
+  },
+  "userMessage.editAriaLabel": {
+    "defaultMessage": "메시지 내용 편집"
+  },
+  "userMessage.editButton": {
+    "defaultMessage": "편집"
+  },
+  "userMessage.editInPlace": {
+    "defaultMessage": "바로 편집"
+  },
+  "userMessage.editInPlaceAriaLabel": {
+    "defaultMessage": "메시지를 바로 편집"
+  },
+  "userMessage.editInPlaceDescription": {
+    "defaultMessage": "<b>바로 편집</b>은 이 세션을 업데이트합니다 • <b>세션 포크</b>는 새 세션을 만듭니다"
+  },
+  "userMessage.editInPlaceTitle": {
+    "defaultMessage": "이 세션의 메시지 업데이트"
+  },
+  "userMessage.editMessageAriaLabel": {
+    "defaultMessage": "메시지 수정: {preview}"
+  },
+  "userMessage.editMessageTitle": {
+    "defaultMessage": "메시지 편집"
+  },
+  "userMessage.editPlaceholder": {
+    "defaultMessage": "메시지를 편집하세요..."
+  },
+  "userMessage.emptyError": {
+    "defaultMessage": "메시지는 비워둘 수 없습니다."
+  },
+  "userMessage.forkSession": {
+    "defaultMessage": "세션 포크"
+  },
+  "userMessage.forkSessionAriaLabel": {
+    "defaultMessage": "편집한 메시지로 세션 포크"
+  },
+  "userMessage.forkSessionTitle": {
+    "defaultMessage": "편집한 메시지로 새 세션 만들기"
+  }
+}

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -4097,6 +4097,9 @@
   "settings.language.japanese": {
     "defaultMessage": "Японский"
   },
+  "settings.language.korean": {
+    "defaultMessage": "Корейский"
+  },
   "settings.language.russian": {
     "defaultMessage": "Русский"
   },

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -4097,6 +4097,9 @@
   "settings.language.japanese": {
     "defaultMessage": "Japonca"
   },
+  "settings.language.korean": {
+    "defaultMessage": "Korece"
+  },
   "settings.language.russian": {
     "defaultMessage": "Rusça"
   },

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -4097,6 +4097,9 @@
   "settings.language.japanese": {
     "defaultMessage": "日语"
   },
+  "settings.language.korean": {
+    "defaultMessage": "韩语"
+  },
   "settings.language.russian": {
     "defaultMessage": "俄语"
   },

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -174,6 +174,7 @@ const validLanguageSettings = new Set<Settings['language']>([
   'es',
   'hi',
   'ja',
+  'ko',
   'ru',
   'tr',
   'zh-CN',

--- a/ui/desktop/src/utils/settings.ts
+++ b/ui/desktop/src/utils/settings.ts
@@ -28,7 +28,7 @@ export interface SessionSharingConfig {
   baseUrl: string;
 }
 
-export type LanguageSetting = 'system' | 'en' | 'es' | 'hi' | 'ja' | 'ru' | 'tr' | 'zh-CN';
+export type LanguageSetting = 'system' | 'en' | 'es' | 'hi' | 'ja' | 'ko' | 'ru' | 'tr' | 'zh-CN';
 
 export interface Settings {
   // Desktop app settings


### PR DESCRIPTION
## Summary

Adds Korean (`ko`) localization support to the desktop app.

This change:
- Registers `ko` as a supported desktop locale
- Adds Korean to the persisted language setting type and runtime validation
- Adds Korean to Settings > App > Language
- Adds Korean locale resolution tests for `ko`, `ko-KR`, and `ko_KR`
- Adds a full Korean desktop message catalog
- Adds the Korean language label to existing translated catalogs

### Testing

- `pnpm run i18n:validate-locale ko`
- `pnpm run i18n:compile`
- `pnpm exec vitest run src/i18n/i18n.test.ts`

Manual testing:
- Verified Korean appears in the desktop language selector
- Reviewed Korean terminology for desktop settings, AI/provider/model terminology, extensions, keyboard shortcuts, local inference, and schedule/session UI

### Related Issues

N/A

### Screenshots/Demos (for UX changes)

N/A
