### PR TITLE
feat(desktop): isolate session workspaces and add artifacts panel

### DIFF
--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -16,7 +16,7 @@ import { toast, ToastContainer } from 'react-toastify';
 import AnnouncementModal from './components/AnnouncementModal';
 import TelemetryConsentPrompt from './components/TelemetryConsentPrompt';
 import OnboardingGuard from './components/onboarding/OnboardingGuard';
-import { createSession } from './sessions';
+import { createSessionWithWorkspace } from './sessions';
 
 import { ChatType } from './types/chat';
 import Hub from './components/Hub';
@@ -115,12 +115,17 @@ const PairRouteWrapper = ({
 
       (async () => {
         try {
-          const newSession = await createSession(getInitialWorkingDir(), {
+          const { session: newSession, userInput } = await createSessionWithWorkspace({
+            workingDir: getInitialWorkingDir(),
+            userInput: initialMessage,
             recipeDeeplink: recipeDeeplinkFromConfig,
             recipeId: recipeIdFromConfig,
             allExtensions: extensionsList,
           });
-          const sessionInitialMessage = resolveSessionInitialMessage(newSession, initialMessage);
+          const sessionInitialMessage = resolveSessionInitialMessage(
+            newSession,
+            userInput ?? initialMessage
+          );
 
           window.dispatchEvent(
             new CustomEvent(AppEvents.ADD_ACTIVE_SESSION, {

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -100,7 +100,13 @@ export default function BaseChat({
   const isNavCollapsed = !navContext?.isNavExpanded;
   const contentClassName = cn('pr-1 pb-10 pt-12', (isMobile || isNavCollapsed) && 'pt-16');
   const { droppedFiles, setDroppedFiles, handleDrop, handleDragOver } = useFileDrop();
-  const onStreamFinish = useCallback(() => {}, []);
+  const refreshArtifactsRef = useRef<(() => Promise<void>) | null>(null);
+  const isArtifactsOpenRef = useRef(false);
+  const onStreamFinish = useCallback(() => {
+    if (isArtifactsOpenRef.current) {
+      void refreshArtifactsRef.current?.();
+    }
+  }, []);
   const [isCreateRecipeModalOpen, setIsCreateRecipeModalOpen] = useState(false);
 
   const {
@@ -131,6 +137,26 @@ export default function BaseChat({
     refresh: refreshArtifacts,
     fileCount: artifactsFileCount,
   } = useArtifactsPanel(sessionId, session?.working_dir);
+
+  useEffect(() => {
+    isArtifactsOpenRef.current = isArtifactsOpen;
+  }, [isArtifactsOpen]);
+
+  useEffect(() => {
+    refreshArtifactsRef.current = refreshArtifacts;
+  }, [refreshArtifacts]);
+
+  const prevChatStateRef = useRef(chatState);
+  useEffect(() => {
+    const wasActive =
+      prevChatStateRef.current === ChatState.Streaming ||
+      prevChatStateRef.current === ChatState.Thinking ||
+      prevChatStateRef.current === ChatState.Compacting;
+    if (wasActive && chatState === ChatState.Idle && isArtifactsOpen) {
+      void refreshArtifacts();
+    }
+    prevChatStateRef.current = chatState;
+  }, [chatState, isArtifactsOpen, refreshArtifacts]);
 
   const recipe = session?.recipe;
 

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -34,6 +34,8 @@ import { useAutoSubmit } from '../hooks/useAutoSubmit';
 import { Goose } from './icons';
 import EnvironmentBadge from './GooseSidebar/EnvironmentBadge';
 import SessionActionsHeader from './SessionActionsHeader';
+import SessionArtifactsPanel from './session/SessionArtifactsPanel';
+import { useArtifactsPanel } from '../hooks/useArtifactsPanel';
 
 const i18n = defineMessages({
   failedToLoadSession: {
@@ -119,6 +121,16 @@ export default function BaseChat({
     sessionId,
     onStreamFinish,
   });
+
+  const {
+    isOpen: isArtifactsOpen,
+    setIsOpen: setArtifactsOpen,
+    toggle: toggleArtifacts,
+    artifacts,
+    isLoading: isArtifactsLoading,
+    refresh: refreshArtifacts,
+    fileCount: artifactsFileCount,
+  } = useArtifactsPanel(sessionId, session?.working_dir);
 
   const recipe = session?.recipe;
 
@@ -417,127 +429,170 @@ export default function BaseChat({
         {renderHeader && renderHeader()}
 
         {/* Chat container with sticky recipe header */}
-        <div className="flex flex-col flex-1 min-h-0 relative">
-          {/* Goose watermark - top right */}
-          <div className="absolute top-[14px] right-4 z-[60] flex flex-row items-center gap-1">
-            <a
-              href="https://goose-docs.ai"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="no-drag flex flex-row items-center gap-1 hover:opacity-80 transition-opacity"
+        <div className="flex flex-row flex-1 min-h-0">
+          <div className="flex min-w-0 flex-1 flex-col min-h-0">
+            <div className="flex flex-col flex-1 min-h-0 relative">
+              {/* Goose watermark - top right */}
+              <div className="absolute top-[14px] right-4 z-[60] flex flex-row items-center gap-1">
+                <a
+                  href="https://goose-docs.ai"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="no-drag flex flex-row items-center gap-1 hover:opacity-80 transition-opacity"
+                >
+                  <Goose className="size-5 goose-icon-animation" />
+                  <span className="text-sm leading-none text-text-secondary -translate-y-px">
+                    goose
+                  </span>
+                </a>
+                <EnvironmentBadge className="translate-y-px" />
+              </div>
+
+              <SessionActionsHeader
+                session={session}
+                artifactsOpen={isArtifactsOpen}
+                artifactsFileCount={artifactsFileCount}
+                onArtifactsToggle={toggleArtifacts}
+              />
+
+              <ScrollArea
+                ref={scrollRef}
+                className={`flex-1 min-h-0 relative ${contentClassName}`}
+                autoScroll
+                onDrop={handleDrop}
+                onDragOver={handleDragOver}
+                data-drop-zone="true"
+                paddingX={6}
+                paddingY={0}
+              >
+                {recipe?.title && (
+                  <div className="sticky top-0 z-10 bg-background-primary px-0 -mx-6 mb-6 pt-6">
+                    <RecipeHeader title={recipe.title} />
+                  </div>
+                )}
+
+                {recipe && (
+                  <div className={hasStartedUsingRecipe ? 'mb-6' : ''}>
+                    <RecipeActivities
+                      append={(text: string) => handleSubmit({ msg: text, images: [] })}
+                      activities={Array.isArray(recipe.activities) ? recipe.activities : null}
+                      title={recipe.title}
+                      parameterValues={session?.user_recipe_values || {}}
+                    />
+                  </div>
+                )}
+
+                {messages.length > 0 || recipe ? (
+                  <>
+                    <SearchView>
+                      <ProgressiveMessageList
+                        messages={messages}
+                        chat={{ sessionId }}
+                        toolCallNotifications={toolCallNotifications}
+                        append={(text: string) => handleSubmit({ msg: text, images: [] })}
+                        isUserMessage={(m: Message) => m.role === 'user'}
+                        isStreamingMessage={chatState !== ChatState.Idle}
+                        onRenderingComplete={handleRenderingComplete}
+                        onMessageUpdate={onMessageUpdate}
+                        submitElicitationResponse={submitElicitationResponse}
+                      />
+                    </SearchView>
+
+                    <div className="block h-8" />
+                  </>
+                ) : null}
+              </ScrollArea>
+
+              {chatState !== ChatState.Idle && (
+                <div className="absolute bottom-1 left-4 z-20 pointer-events-none">
+                  <LoadingGoose
+                    chatState={chatState}
+                    message={
+                      messages.length > 0
+                        ? getThinkingMessage(messages[messages.length - 1])
+                        : undefined
+                    }
+                  />
+                </div>
+              )}
+            </div>
+
+            <ChatInputCard
+              className={cn(
+                'relative z-10 mx-4 mb-4',
+                !disableAnimation && 'animate-[fadein_400ms_ease-in_forwards]'
+              )}
             >
-              <Goose className="size-5 goose-icon-animation" />
-              <span className="text-sm leading-none text-text-secondary -translate-y-px">
-                goose
-              </span>
-            </a>
-            <EnvironmentBadge className="translate-y-px" />
+              <ChatInput
+                inputRef={chatInputRef}
+                sessionId={sessionId}
+                handleSubmit={chatInputSubmit}
+                chatState={chatState}
+                setChatState={setChatState}
+                onStop={stopStreaming}
+                pauseQueueOnStop={pauseQueueOnStop}
+                commandHistory={commandHistory}
+                initialValue={initialPrompt}
+                setView={setView}
+                totalTokens={tokenState?.totalTokens ?? session?.total_tokens ?? undefined}
+                accumulatedInputTokens={
+                  tokenState?.accumulatedInputTokens ?? session?.accumulated_input_tokens ?? undefined
+                }
+                accumulatedOutputTokens={
+                  tokenState?.accumulatedOutputTokens ??
+                  session?.accumulated_output_tokens ??
+                  undefined
+                }
+                accumulatedCost={
+                  tokenState?.accumulatedCost ?? session?.accumulated_cost ?? undefined
+                }
+                droppedFiles={droppedFiles}
+                onFilesProcessed={() => setDroppedFiles([])}
+                messages={messages}
+                disableAnimation={disableAnimation}
+                recipe={recipe}
+                recipeAccepted={!hasNotAcceptedRecipe}
+                initialPrompt={initialPrompt}
+                toolCount={toolCount || 0}
+                sessionModel={sessionModel}
+                sessionProvider={sessionProvider}
+                sessionLoaded={sessionLoaded}
+                latestInference={latestInference}
+                {...customChatInputProps}
+              />
+            </ChatInputCard>
           </div>
 
-          <SessionActionsHeader session={session} />
-
-          <ScrollArea
-            ref={scrollRef}
-            className={`flex-1 min-h-0 relative ${contentClassName}`}
-            autoScroll
-            onDrop={handleDrop}
-            onDragOver={handleDragOver}
-            data-drop-zone="true"
-            paddingX={6}
-            paddingY={0}
-          >
-            {recipe?.title && (
-              <div className="sticky top-0 z-10 bg-background-primary px-0 -mx-6 mb-6 pt-6">
-                <RecipeHeader title={recipe.title} />
-              </div>
-            )}
-
-            {recipe && (
-              <div className={hasStartedUsingRecipe ? 'mb-6' : ''}>
-                <RecipeActivities
-                  append={(text: string) => handleSubmit({ msg: text, images: [] })}
-                  activities={Array.isArray(recipe.activities) ? recipe.activities : null}
-                  title={recipe.title}
-                  parameterValues={session?.user_recipe_values || {}}
-                />
-              </div>
-            )}
-
-            {messages.length > 0 || recipe ? (
-              <>
-                <SearchView>
-                  <ProgressiveMessageList
-                    messages={messages}
-                    chat={{ sessionId }}
-                    toolCallNotifications={toolCallNotifications}
-                    append={(text: string) => handleSubmit({ msg: text, images: [] })}
-                    isUserMessage={(m: Message) => m.role === 'user'}
-                    isStreamingMessage={chatState !== ChatState.Idle}
-                    onRenderingComplete={handleRenderingComplete}
-                    onMessageUpdate={onMessageUpdate}
-                    submitElicitationResponse={submitElicitationResponse}
-                  />
-                </SearchView>
-
-                <div className="block h-8" />
-              </>
-            ) : null}
-          </ScrollArea>
-
-          {chatState !== ChatState.Idle && (
-            <div className="absolute bottom-1 left-4 z-20 pointer-events-none">
-              <LoadingGoose
-                chatState={chatState}
-                message={
-                  messages.length > 0
-                    ? getThinkingMessage(messages[messages.length - 1])
-                    : undefined
-                }
+          {isArtifactsOpen && !isMobile && (
+            <div className="shrink-0 transition-[width] duration-200 ease-in-out">
+              <SessionArtifactsPanel
+                artifacts={artifacts}
+                isLoading={isArtifactsLoading}
+                onRefresh={() => void refreshArtifacts()}
               />
             </div>
           )}
         </div>
 
-        <ChatInputCard
-          className={cn(
-            'relative z-10 mx-4 mb-4',
-            !disableAnimation && 'animate-[fadein_400ms_ease-in_forwards]'
-          )}
-        >
-          <ChatInput
-            inputRef={chatInputRef}
-            sessionId={sessionId}
-            handleSubmit={chatInputSubmit}
-            chatState={chatState}
-            setChatState={setChatState}
-            onStop={stopStreaming}
-            pauseQueueOnStop={pauseQueueOnStop}
-            commandHistory={commandHistory}
-            initialValue={initialPrompt}
-            setView={setView}
-            totalTokens={tokenState?.totalTokens ?? session?.total_tokens ?? undefined}
-            accumulatedInputTokens={
-              tokenState?.accumulatedInputTokens ?? session?.accumulated_input_tokens ?? undefined
-            }
-            accumulatedOutputTokens={
-              tokenState?.accumulatedOutputTokens ?? session?.accumulated_output_tokens ?? undefined
-            }
-            accumulatedCost={tokenState?.accumulatedCost ?? session?.accumulated_cost ?? undefined}
-            droppedFiles={droppedFiles}
-            onFilesProcessed={() => setDroppedFiles([])} // Clear dropped files after processing
-            messages={messages}
-            disableAnimation={disableAnimation}
-            recipe={recipe}
-            recipeAccepted={!hasNotAcceptedRecipe}
-            initialPrompt={initialPrompt}
-            toolCount={toolCount || 0}
-            sessionModel={sessionModel}
-            sessionProvider={sessionProvider}
-            sessionLoaded={sessionLoaded}
-            latestInference={latestInference}
-            {...customChatInputProps}
-          />
-        </ChatInputCard>
+        {isArtifactsOpen && isMobile && (
+          <>
+            <button
+              type="button"
+              className="fixed inset-0 z-[70] bg-black/40"
+              aria-label="Close artifacts panel"
+              onClick={() => setArtifactsOpen(false)}
+            />
+            <div className="fixed inset-y-0 right-0 z-[80] w-[min(360px,90vw)] shadow-xl">
+              <SessionArtifactsPanel
+                artifacts={artifacts}
+                isLoading={isArtifactsLoading}
+                onRefresh={() => void refreshArtifacts()}
+                onClose={() => setArtifactsOpen(false)}
+                className="w-full"
+              />
+            </div>
+          </>
+        )}
       </MainPanelLayout>
 
       {recipe && isActiveSession && session?.session_type !== 'scheduled' && (

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -1106,7 +1106,13 @@ export default function ChatInput({
           }
         }
 
-        handleSubmit({ msg: textToSend, images: imageData });
+        handleSubmit({
+          msg: textToSend,
+          images: imageData,
+          filePaths: allDroppedFiles
+            .filter((file) => !file.isImage && !file.error && !file.isLoading)
+            .map((file) => file.path),
+        });
 
         // Auto-resume queue after sending a NON-interruption message (if it was paused due to interruption)
         if (

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -1290,9 +1290,16 @@ export default function ChatInput({
     } else {
       trackFileAttached('file');
       const path = window.electron.getPathForFile(file);
-      const newValue = displayValue.trim() ? `${displayValue.trim()} ${path}` : path;
-      setDisplayValue(newValue);
-      setValue(newValue);
+      setLocalDroppedFiles((prev) => [
+        ...prev,
+        {
+          id: `picked-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+          path,
+          name: file.name,
+          type: file.type,
+          isImage: false,
+        },
+      ]);
     }
 
     textAreaRef.current?.focus();

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -1109,9 +1109,7 @@ export default function ChatInput({
         if (displayValue.trim()) {
           LocalMessageStorage.addMessage(displayValue);
         } else {
-          const droppedFilePaths = allDroppedFiles
-            .filter((file) => !file.isImage && !file.error && !file.isLoading)
-            .map((file) => file.path);
+          const droppedFilePaths = getSubmittableFilePaths();
           if (droppedFilePaths.length > 0) {
             LocalMessageStorage.addMessage(droppedFilePaths.join(' '));
           }

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -389,7 +389,11 @@ export default function ChatInput({
 
       if (shouldProcessQueue) {
         LocalMessageStorage.addMessage(messageToSend.content);
-        handleSubmit({ msg: messageToSend.content, images: messageToSend.images });
+        handleSubmit({
+          msg: messageToSend.content,
+          images: messageToSend.images,
+          filePaths: messageToSend.filePaths,
+        });
         if (shouldSendAfterStop) {
           clearPendingSendAfterStop(messageToSend.id);
         }
@@ -807,11 +811,15 @@ export default function ChatInput({
     return [...pastedImageData, ...droppedImageData];
   }, [pastedImages, allDroppedFiles]);
 
+  const getSubmittableFilePaths = useCallback((): string[] => {
+    return allDroppedFiles
+      .filter((file) => !file.isImage && !file.error && !file.isLoading)
+      .map((file) => file.path);
+  }, [allDroppedFiles]);
+
   const appendDroppedFilePaths = useCallback(
     (text: string): string => {
-      const droppedFilePaths = allDroppedFiles
-        .filter((file) => !file.isImage && !file.error && !file.isLoading)
-        .map((file) => file.path);
+      const droppedFilePaths = getSubmittableFilePaths();
 
       if (droppedFilePaths.length > 0) {
         const pathsString = droppedFilePaths.join(' ');
@@ -819,7 +827,7 @@ export default function ChatInput({
       }
       return text;
     },
-    [allDroppedFiles]
+    [getSubmittableFilePaths]
   );
 
   const clearInputState = useCallback(() => {
@@ -1039,6 +1047,7 @@ export default function ChatInput({
 
     const imageData = convertImagesToImageData();
     const contentToQueue = appendDroppedFilePaths(displayValue.trim());
+    const filePaths = getSubmittableFilePaths();
 
     const interruptionMatch = detectInterruption(displayValue.trim());
 
@@ -1054,6 +1063,7 @@ export default function ChatInput({
         content: contentToQueue,
         timestamp: Date.now(),
         images: imageData,
+        filePaths: filePaths.length > 0 ? filePaths : undefined,
       };
 
       // Add the interruption message to the front of the queue so it gets sent first
@@ -1068,6 +1078,7 @@ export default function ChatInput({
       content: contentToQueue,
       timestamp: Date.now(),
       images: imageData,
+      filePaths: filePaths.length > 0 ? filePaths : undefined,
     };
     setQueuedMessages((prev) => {
       const newQueue = [...prev, newMessage];
@@ -1109,9 +1120,7 @@ export default function ChatInput({
         handleSubmit({
           msg: textToSend,
           images: imageData,
-          filePaths: allDroppedFiles
-            .filter((file) => !file.isImage && !file.error && !file.isLoading)
-            .map((file) => file.path),
+          filePaths: getSubmittableFilePaths(),
         });
 
         // Auto-resume queue after sending a NON-interruption message (if it was paused due to interruption)
@@ -1135,8 +1144,8 @@ export default function ChatInput({
     [
       convertImagesToImageData,
       appendDroppedFilePaths,
+      getSubmittableFilePaths,
       displayValue,
-      allDroppedFiles,
       handleSubmit,
       lastInterruption,
       clearInputState,
@@ -1370,7 +1379,11 @@ export default function ChatInput({
     if (!isLoading) {
       setQueuedMessages((prev) => removeQueuedMessage(prev, messageId));
       LocalMessageStorage.addMessage(messageToSend.content);
-      handleSubmit({ msg: messageToSend.content, images: messageToSend.images });
+      handleSubmit({
+        msg: messageToSend.content,
+        images: messageToSend.images,
+        filePaths: messageToSend.filePaths,
+      });
       return;
     }
 
@@ -1393,7 +1406,11 @@ export default function ChatInput({
     if (!isLoading && queuedMessages.length > 0) {
       const nextMessage = queuedMessages[0];
       LocalMessageStorage.addMessage(nextMessage.content);
-      handleSubmit({ msg: nextMessage.content, images: nextMessage.images });
+      handleSubmit({
+        msg: nextMessage.content,
+        images: nextMessage.images,
+        filePaths: nextMessage.filePaths,
+      });
       setQueuedMessages((prev) => {
         const newQueue = prev.slice(1);
         // If queue becomes empty after processing, clear the paused state

--- a/ui/desktop/src/components/Hub.tsx
+++ b/ui/desktop/src/components/Hub.tsx
@@ -26,6 +26,8 @@ import { createSessionWithWorkspace } from '../sessions';
 import LoadingGoose from './LoadingGoose';
 import { UserInput } from '../types/message';
 import { ExternalFileStrategyPrompt, useExternalFileStrategyPrompt } from './workspace/ExternalFileStrategyPrompt';
+import { WorkspaceProfilePicker } from './workspace/WorkspaceProfilePicker';
+import type { WorkspaceProfile } from '../workspace/types';
 import type { DroppedFile } from '../hooks/useFileDrop';
 
 const i18n = defineMessages({
@@ -71,6 +73,7 @@ export default function Hub({
   const [directoryExplicitlyChosen, setDirectoryExplicitlyChosen] = useState(Boolean(requestDir));
   const [isCreatingSession, setIsCreatingSession] = useState(false);
   const [pendingDroppedFiles, setPendingDroppedFiles] = useState<DroppedFile[]>([]);
+  const [sessionWorkspaceProfile, setSessionWorkspaceProfile] = useState<WorkspaceProfile>('auto');
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const { time, meridiem, hour } = useClock();
   const { open: strategyPromptOpen, prompt: promptStrategy, handleChoose, handleCancel } =
@@ -83,10 +86,9 @@ export default function Hub({
   }, [intl, hour]);
 
   useEffect(() => {
-    const frameId = requestAnimationFrame(() => {
-      inputRef.current?.focus();
+    void window.electron.getSetting('workspaceProfile').then((profile) => {
+      setSessionWorkspaceProfile(profile);
     });
-    return () => cancelAnimationFrame(frameId);
   }, []);
 
   useEffect(() => {
@@ -102,9 +104,24 @@ export default function Hub({
     };
   }, []);
 
+  useEffect(() => {
+    const frameId = requestAnimationFrame(() => {
+      inputRef.current?.focus();
+    });
+    return () => cancelAnimationFrame(frameId);
+  }, []);
+
+  const recommendedProfile = useMemo((): WorkspaceProfile | null => {
+    if (directoryExplicitlyChosen || pendingDroppedFiles.length === 0) {
+      return null;
+    }
+    return 'auto';
+  }, [directoryExplicitlyChosen, pendingDroppedFiles.length]);
+
   const handleWorkingDirChange = (newDir: string) => {
     setWorkingDir(newDir);
     setDirectoryExplicitlyChosen(true);
+    setSessionWorkspaceProfile('direct');
   };
 
   const handleSubmit = async (input: UserInput) => {
@@ -119,6 +136,7 @@ export default function Hub({
       const { session, userInput } = await createSessionWithWorkspace({
         workingDir,
         directoryExplicitlyChosen,
+        workspaceProfile: sessionWorkspaceProfile,
         userInput: input,
         extensionConfigs,
         allExtensions: extensionConfigs.length > 0 ? undefined : extensionsList,
@@ -164,7 +182,16 @@ export default function Hub({
           </span>
           <span className="text-2xl font-light text-text-secondary">{meridiem}</span>
         </div>
-        <p className="text-xl text-text-secondary mb-6">{greeting}</p>
+        <p className="text-xl text-text-secondary mb-4">{greeting}</p>
+
+        <div className="mb-3 flex justify-center">
+          <WorkspaceProfilePicker
+            value={sessionWorkspaceProfile}
+            onChange={setSessionWorkspaceProfile}
+            disabled={isCreatingSession}
+            recommended={recommendedProfile}
+          />
+        </div>
 
         <ChatInputCard>
           <ChatInput

--- a/ui/desktop/src/components/Hub.tsx
+++ b/ui/desktop/src/components/Hub.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { IpcRendererEvent } from 'electron';
 import { defineMessages, useIntl } from '../i18n';
 import { AppEvents } from '../constants/events';
 import ChatInput from './ChatInput';
@@ -21,9 +22,11 @@ import {
   getExtensionConfigsWithOverrides,
 } from '../store/extensionOverrides';
 import { getInitialWorkingDir } from '../utils/workingDir';
-import { createSession } from '../sessions';
+import { createSessionWithWorkspace } from '../sessions';
 import LoadingGoose from './LoadingGoose';
 import { UserInput } from '../types/message';
+import { ExternalFileStrategyPrompt, useExternalFileStrategyPrompt } from './workspace/ExternalFileStrategyPrompt';
+import type { DroppedFile } from '../hooks/useFileDrop';
 
 const i18n = defineMessages({
   goodMorning: { id: 'hub.goodMorning', defaultMessage: 'Good morning' },
@@ -46,6 +49,16 @@ function useClock(): { time: string; meridiem: string; hour: number } {
   return { time, meridiem, hour };
 }
 
+function pathsToDroppedFiles(paths: string[]): DroppedFile[] {
+  return paths.map((filePath, index) => ({
+    id: `pending-${index}-${filePath}`,
+    path: filePath,
+    name: filePath.split('/').pop() || filePath,
+    type: '',
+    isImage: false,
+  }));
+}
+
 export default function Hub({
   setView,
 }: {
@@ -54,9 +67,14 @@ export default function Hub({
   const intl = useIntl();
   const { extensionsList } = useConfig();
   const [workingDir, setWorkingDir] = useState(getInitialWorkingDir());
+  const requestDir = window.appConfig?.get('REQUEST_DIR') as string | undefined;
+  const [directoryExplicitlyChosen, setDirectoryExplicitlyChosen] = useState(Boolean(requestDir));
   const [isCreatingSession, setIsCreatingSession] = useState(false);
+  const [pendingDroppedFiles, setPendingDroppedFiles] = useState<DroppedFile[]>([]);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const { time, meridiem, hour } = useClock();
+  const { open: strategyPromptOpen, prompt: promptStrategy, handleChoose, handleCancel } =
+    useExternalFileStrategyPrompt();
 
   const greeting = useMemo(() => {
     if (hour < 12) return intl.formatMessage(i18n.goodMorning);
@@ -64,13 +82,30 @@ export default function Hub({
     return intl.formatMessage(i18n.goodEvening);
   }, [intl, hour]);
 
-  // rAF is more reliable than autoFocus across async render boundaries.
   useEffect(() => {
     const frameId = requestAnimationFrame(() => {
       inputRef.current?.focus();
     });
     return () => cancelAnimationFrame(frameId);
   }, []);
+
+  useEffect(() => {
+    const handlePendingFiles = (_event: IpcRendererEvent, ...args: unknown[]) => {
+      const filePaths = args[0];
+      if (Array.isArray(filePaths) && filePaths.length > 0) {
+        setPendingDroppedFiles(pathsToDroppedFiles(filePaths as string[]));
+      }
+    };
+    window.electron.on('set-pending-dropped-files', handlePendingFiles);
+    return () => {
+      window.electron.off('set-pending-dropped-files', handlePendingFiles);
+    };
+  }, []);
+
+  const handleWorkingDirChange = (newDir: string) => {
+    setWorkingDir(newDir);
+    setDirectoryExplicitlyChosen(true);
+  };
 
   const handleSubmit = async (input: UserInput) => {
     const { msg: userMessage, images } = input;
@@ -81,24 +116,34 @@ export default function Hub({
     setIsCreatingSession(true);
 
     try {
-      const session = await createSession(workingDir, {
+      const { session, userInput } = await createSessionWithWorkspace({
+        workingDir,
+        directoryExplicitlyChosen,
+        userInput: input,
         extensionConfigs,
         allExtensions: extensionConfigs.length > 0 ? undefined : extensionsList,
+        resolveExternalFileStrategy: promptStrategy,
       });
+
+      const initialMessage = userInput ?? { msg: userMessage, images };
 
       window.dispatchEvent(new CustomEvent(AppEvents.SESSION_CREATED));
       window.dispatchEvent(
         new CustomEvent(AppEvents.ADD_ACTIVE_SESSION, {
-          detail: { sessionId: session.id, initialMessage: { msg: userMessage, images } },
+          detail: { sessionId: session.id, initialMessage },
         })
       );
 
       setView('pair', {
         disableAnimation: true,
         resumeSessionId: session.id,
-        initialMessage: { msg: userMessage, images },
+        initialMessage,
       });
     } catch (error) {
+      if (error instanceof Error && error.message === 'Session creation cancelled') {
+        setIsCreatingSession(false);
+        return;
+      }
       console.error('Failed to create session:', error);
       setIsCreatingSession(false);
     }
@@ -106,6 +151,12 @@ export default function Hub({
 
   return (
     <div className="flex flex-col h-full min-h-0 items-center justify-center px-6 relative">
+      <ExternalFileStrategyPrompt
+        open={strategyPromptOpen}
+        onChoose={handleChoose}
+        onCancel={handleCancel}
+      />
+
       <div className="w-full max-w-2xl">
         <div className="flex items-baseline gap-2 mb-1">
           <span className="text-6xl font-light text-text-primary tracking-tight tabular-nums">
@@ -126,12 +177,12 @@ export default function Hub({
             totalTokens={0}
             accumulatedInputTokens={0}
             accumulatedOutputTokens={0}
-            droppedFiles={[]}
-            onFilesProcessed={() => {}}
+            droppedFiles={pendingDroppedFiles}
+            onFilesProcessed={() => setPendingDroppedFiles([])}
             messages={[]}
             disableAnimation={false}
             toolCount={0}
-            onWorkingDirChange={setWorkingDir}
+            onWorkingDirChange={handleWorkingDirChange}
             inputRef={inputRef}
           />
         </ChatInputCard>

--- a/ui/desktop/src/components/Hub.tsx
+++ b/ui/desktop/src/components/Hub.tsx
@@ -120,7 +120,6 @@ export default function Hub({
   const handleWorkingDirChange = (newDir: string) => {
     setWorkingDir(newDir);
     setDirectoryExplicitlyChosen(true);
-    setSessionWorkspaceProfile('direct');
   };
 
   const handleSubmit = async (input: UserInput) => {

--- a/ui/desktop/src/components/Hub.tsx
+++ b/ui/desktop/src/components/Hub.tsx
@@ -69,8 +69,7 @@ export default function Hub({
   const intl = useIntl();
   const { extensionsList } = useConfig();
   const [workingDir, setWorkingDir] = useState(getInitialWorkingDir());
-  const requestDir = window.appConfig?.get('REQUEST_DIR') as string | undefined;
-  const [directoryExplicitlyChosen, setDirectoryExplicitlyChosen] = useState(Boolean(requestDir));
+  const [directoryExplicitlyChosen, setDirectoryExplicitlyChosen] = useState(false);
   const [isCreatingSession, setIsCreatingSession] = useState(false);
   const [pendingDroppedFiles, setPendingDroppedFiles] = useState<DroppedFile[]>([]);
   const [sessionWorkspaceProfile, setSessionWorkspaceProfile] = useState<WorkspaceProfile>('auto');

--- a/ui/desktop/src/components/MessageQueue.tsx
+++ b/ui/desktop/src/components/MessageQueue.tsx
@@ -92,6 +92,7 @@ export interface QueuedMessage {
   content: string;
   timestamp: number;
   images: ImageData[];
+  filePaths?: string[];
 }
 
 interface MessageQueueProps {

--- a/ui/desktop/src/components/SessionActionsHeader.tsx
+++ b/ui/desktop/src/components/SessionActionsHeader.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { ChevronDown, ChevronRight, FileJson, LoaderCircle } from 'lucide-react';
+import { ChevronDown, ChevronRight, FileJson, LoaderCircle, PanelRightClose, PanelRightOpen } from 'lucide-react';
 import { toast } from 'react-toastify';
 import { defineMessages, useIntl } from '../i18n';
 import { acpExportSession } from '../acp/sessions';
@@ -51,6 +51,18 @@ const i18n = defineMessages({
     id: 'sessionActionsHeader.copiedText',
     defaultMessage: 'Text copied',
   },
+  toggleArtifactsOpen: {
+    id: 'sessionArtifacts.toggleOpen',
+    defaultMessage: 'Show artifacts panel',
+  },
+  toggleArtifactsClose: {
+    id: 'sessionArtifacts.toggleClose',
+    defaultMessage: 'Hide artifacts panel',
+  },
+  fileCount: {
+    id: 'sessionArtifacts.fileCount',
+    defaultMessage: '{count, plural, one {# file} other {# files}}',
+  },
 });
 
 const LONG_STRING_THRESHOLD = 180;
@@ -60,6 +72,9 @@ const STRING_PREVIEW_END = 56;
 interface SessionActionsHeaderProps {
   session?: Session;
   className?: string;
+  artifactsOpen?: boolean;
+  artifactsFileCount?: number;
+  onArtifactsToggle?: () => void;
 }
 
 interface ParsedSessionJson {
@@ -253,7 +268,13 @@ function JsonTree({
   );
 }
 
-export default function SessionActionsHeader({ session, className }: SessionActionsHeaderProps) {
+export default function SessionActionsHeader({
+  session,
+  className,
+  artifactsOpen = false,
+  artifactsFileCount = 0,
+  onArtifactsToggle,
+}: SessionActionsHeaderProps) {
   const intl = useIntl();
   const [isJsonOpen, setIsJsonOpen] = useState(false);
   const [jsonValue, setJsonValue] = useState<unknown>(null);
@@ -312,6 +333,33 @@ export default function SessionActionsHeader({ session, className }: SessionActi
 
   return (
     <>
+      {onArtifactsToggle && (
+        <div className="no-drag absolute top-[14px] right-28 z-[60]">
+          <button
+            type="button"
+            className="relative flex h-7 items-center gap-1 rounded-md px-2 text-text-secondary transition-colors hover:bg-background-secondary hover:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border-active"
+            aria-label={intl.formatMessage(
+              artifactsOpen ? i18n.toggleArtifactsClose : i18n.toggleArtifactsOpen
+            )}
+            title={intl.formatMessage(
+              artifactsOpen ? i18n.toggleArtifactsClose : i18n.toggleArtifactsOpen
+            )}
+            onClick={onArtifactsToggle}
+          >
+            {artifactsOpen ? (
+              <PanelRightClose className="size-4" />
+            ) : (
+              <PanelRightOpen className="size-4" />
+            )}
+            {artifactsFileCount > 0 && (
+              <span className="rounded-full bg-background-accent px-1.5 py-0.5 text-[10px] font-medium text-text-primary">
+                {artifactsFileCount}
+              </span>
+            )}
+          </button>
+        </div>
+      )}
+
       <div
         className={cn(
           'no-drag absolute top-[14px] left-1/2 z-30 max-w-[min(36rem,calc(100vw-13rem))] -translate-x-1/2',

--- a/ui/desktop/src/components/bottom_menu/DirSwitcher.tsx
+++ b/ui/desktop/src/components/bottom_menu/DirSwitcher.tsx
@@ -12,6 +12,7 @@ import {
 import { updateWorkingDir } from '../../api';
 import { toast } from 'react-toastify';
 import { defineMessages, useIntl } from '../../i18n';
+import type { ResolvedWorkspaceProfile } from '../../workspace/types';
 
 const i18n = defineMessages({
   failedToUpdateWorkingDir: {
@@ -42,6 +43,26 @@ const i18n = defineMessages({
     id: 'dirSwitcher.noWorktreesFound',
     defaultMessage: 'No worktrees found',
   },
+  sandboxBadge: {
+    id: 'dirSwitcher.sandboxBadge',
+    defaultMessage: 'Sandbox',
+  },
+  worktreeBadge: {
+    id: 'dirSwitcher.worktreeBadge',
+    defaultMessage: 'Worktree',
+  },
+  projectBadge: {
+    id: 'dirSwitcher.projectBadge',
+    defaultMessage: 'Project',
+  },
+  openWorkspaceFolder: {
+    id: 'dirSwitcher.openWorkspaceFolder',
+    defaultMessage: 'Open workspace folder',
+  },
+  originalFiles: {
+    id: 'dirSwitcher.originalFiles',
+    defaultMessage: 'Original files',
+  },
 });
 
 interface DirSwitcherProps {
@@ -67,7 +88,31 @@ export const DirSwitcher: React.FC<DirSwitcherProps> = ({
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [recentDirs, setRecentDirs] = useState<string[]>([]);
   const [worktreeDirs, setWorktreeDirs] = useState<string[]>([]);
+  const [workspaceProfile, setWorkspaceProfile] = useState<ResolvedWorkspaceProfile | null>(null);
+  const [workspaceRootPath, setWorkspaceRootPath] = useState<string | null>(null);
+  const [stagedOriginalPaths, setStagedOriginalPaths] = useState<string[]>([]);
   const refreshVersionRef = useRef(0);
+
+  useEffect(() => {
+    if (!sessionId) {
+      setWorkspaceProfile(null);
+      setWorkspaceRootPath(null);
+      setStagedOriginalPaths([]);
+      return;
+    }
+
+    void window.electron.getWorkspaceInfo(sessionId).then((info) => {
+      if (!info) {
+        setWorkspaceProfile(null);
+        setWorkspaceRootPath(null);
+        setStagedOriginalPaths([]);
+        return;
+      }
+      setWorkspaceProfile(info.profile);
+      setWorkspaceRootPath(info.rootPath);
+      setStagedOriginalPaths(info.stagedFiles.map((file) => file.original));
+    });
+  }, [sessionId, workingDir]);
 
   const refreshMenuData = useCallback(async () => {
     const version = ++refreshVersionRef.current;
@@ -171,6 +216,18 @@ export const DirSwitcher: React.FC<DirSwitcherProps> = ({
     [recentDirs, workingDir]
   );
 
+  const workspaceBadgeLabel = useMemo(() => {
+    if (!workspaceProfile || workspaceProfile === 'direct') {
+      return intl.formatMessage(i18n.projectBadge);
+    }
+    if (workspaceProfile === 'worktree') {
+      return intl.formatMessage(i18n.worktreeBadge);
+    }
+    return intl.formatMessage(i18n.sandboxBadge);
+  }, [intl, workspaceProfile]);
+
+  const explorerPath = workspaceRootPath ?? workingDir;
+
   return (
     <TooltipProvider>
       <Tooltip
@@ -188,6 +245,11 @@ export const DirSwitcher: React.FC<DirSwitcherProps> = ({
                 disabled={isDirectoryChooserOpen}
               >
                 <FolderDot className="mr-1" size={16} />
+                {workspaceProfile && workspaceProfile !== 'direct' && (
+                  <span className="mr-1 rounded bg-background-accent px-1 py-0.5 text-[10px] uppercase tracking-wide">
+                    {workspaceBadgeLabel}
+                  </span>
+                )}
                 <div className="max-w-[200px] truncate">
                   {workingDir.replace(/\/+$/, '').split('/').pop() || workingDir}
                 </div>
@@ -197,12 +259,40 @@ export const DirSwitcher: React.FC<DirSwitcherProps> = ({
           <DropdownMenuContent className="w-80" side="top" align="start">
             <DropdownMenuLabel>{intl.formatMessage(i18n.currentDirectory)}</DropdownMenuLabel>
             <DropdownMenuItem
-              onSelect={() => void window.electron.openDirectoryInExplorer(workingDir)}
+              onSelect={() => void window.electron.openDirectoryInExplorer(explorerPath)}
             >
               <FolderOpen className="mr-2 h-4 w-4" />
               <span className="truncate">{workingDir}</span>
               <Check className="ml-auto h-4 w-4" />
             </DropdownMenuItem>
+
+            {workspaceRootPath && workspaceRootPath !== workingDir && (
+              <DropdownMenuItem
+                onSelect={() => void window.electron.openDirectoryInExplorer(workspaceRootPath)}
+              >
+                <FolderOpen className="mr-2 h-4 w-4" />
+                <span>{intl.formatMessage(i18n.openWorkspaceFolder)}</span>
+              </DropdownMenuItem>
+            )}
+
+            {stagedOriginalPaths.length > 0 && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel>{intl.formatMessage(i18n.originalFiles)}</DropdownMenuLabel>
+                {stagedOriginalPaths.map((originalPath) => (
+                  <DropdownMenuItem
+                    key={`original-${originalPath}`}
+                    onSelect={() => {
+                      const parentDir = originalPath.replace(/[/\\][^/\\]+$/, '') || originalPath;
+                      void window.electron.openDirectoryInExplorer(parentDir);
+                    }}
+                  >
+                    <FolderDot className="mr-2 h-4 w-4" />
+                    <span className="truncate">{originalPath}</span>
+                  </DropdownMenuItem>
+                ))}
+              </>
+            )}
 
             <DropdownMenuSeparator />
             <DropdownMenuLabel>{intl.formatMessage(i18n.gitWorktrees)}</DropdownMenuLabel>

--- a/ui/desktop/src/components/session/SessionArtifactsPanel.tsx
+++ b/ui/desktop/src/components/session/SessionArtifactsPanel.tsx
@@ -38,6 +38,10 @@ const i18n = defineMessages({
     id: 'sessionArtifacts.refresh',
     defaultMessage: 'Refresh',
   },
+  refreshing: {
+    id: 'sessionArtifacts.refreshing',
+    defaultMessage: 'Refreshing…',
+  },
   empty: {
     id: 'sessionArtifacts.empty',
     defaultMessage: 'No files yet',
@@ -61,6 +65,10 @@ const i18n = defineMessages({
   copiedPath: {
     id: 'sessionArtifacts.copiedPath',
     defaultMessage: 'Path copied',
+  },
+  openFailed: {
+    id: 'sessionArtifacts.openFailed',
+    defaultMessage: 'Could not open path in file manager',
   },
   externalBadge: {
     id: 'sessionArtifacts.externalBadge',
@@ -174,15 +182,15 @@ function FileRow({
       <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
         <button
           type="button"
-          className="rounded p-1 text-text-secondary hover:bg-background-primary hover:text-text-primary"
+          className="no-drag rounded p-1 text-text-secondary hover:bg-background-primary hover:text-text-primary"
           title={intl.formatMessage(i18n.openInFinder)}
-          onClick={() => onOpen(path)}
+          onClick={() => void onOpen(path)}
         >
           <ExternalLink className="size-3.5" />
         </button>
         <button
           type="button"
-          className="rounded p-1 text-text-secondary hover:bg-background-primary hover:text-text-primary"
+          className="no-drag rounded p-1 text-text-secondary hover:bg-background-primary hover:text-text-primary"
           title={intl.formatMessage(i18n.copyPath)}
           onClick={() => onCopy(path)}
         >
@@ -210,9 +218,15 @@ export default function SessionArtifactsPanel({
 }: SessionArtifactsPanelProps) {
   const intl = useIntl();
 
-  const handleOpen = useCallback((filePath: string) => {
-    void window.electron.openDirectoryInExplorer(filePath);
-  }, []);
+  const handleOpen = useCallback(
+    async (filePath: string) => {
+      const opened = await window.electron.openDirectoryInExplorer(filePath);
+      if (!opened) {
+        toast.error(intl.formatMessage(i18n.openFailed));
+      }
+    },
+    [intl]
+  );
 
   const handleCopy = useCallback(
     async (filePath: string) => {
@@ -235,7 +249,7 @@ export default function SessionArtifactsPanel({
         className
       )}
     >
-      <div className="flex items-center justify-between border-b border-border-primary px-3 py-2.5">
+      <div className="no-drag flex items-center justify-between border-b border-border-primary px-3 py-2.5">
         <div className="flex items-center gap-2">
           <Sparkles className="size-4 text-text-secondary" />
           <span className="text-sm font-medium text-text-primary">
@@ -247,9 +261,11 @@ export default function SessionArtifactsPanel({
             variant="ghost"
             size="xs"
             shape="round"
-            onClick={onRefresh}
+            className="no-drag active:scale-95"
+            onClick={() => void onRefresh()}
             disabled={isLoading}
             title={intl.formatMessage(i18n.refresh)}
+            aria-busy={isLoading}
           >
             {isLoading ? (
               <LoaderCircle className="size-3.5 animate-spin" />
@@ -265,7 +281,13 @@ export default function SessionArtifactsPanel({
         </div>
       </div>
 
-      <ScrollArea className="min-h-0 flex-1" paddingX={1} paddingY={2}>
+      <ScrollArea className="relative min-h-0 flex-1" paddingX={1} paddingY={2}>
+        {isLoading && (
+          <div className="flex items-center gap-2 border-b border-border-primary px-3 py-2 text-xs text-text-secondary">
+            <LoaderCircle className="size-3.5 shrink-0 animate-spin" />
+            <span>{intl.formatMessage(i18n.refreshing)}</span>
+          </div>
+        )}
         {!hasContent && !isLoading ? (
           <p className="px-3 py-6 text-center text-sm text-text-secondary">
             {intl.formatMessage(i18n.empty)}
@@ -394,15 +416,15 @@ function MetaRow({
         <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
           <button
             type="button"
-            className="rounded p-1 text-text-secondary hover:text-text-primary"
+            className="no-drag rounded p-1 text-text-secondary hover:text-text-primary"
             title={intl.formatMessage(i18n.openInFinder)}
-            onClick={() => onOpen(path)}
+            onClick={() => void onOpen(path)}
           >
             <FolderOpen className="size-3.5" />
           </button>
           <button
             type="button"
-            className="rounded p-1 text-text-secondary hover:text-text-primary"
+            className="no-drag rounded p-1 text-text-secondary hover:text-text-primary"
             title={intl.formatMessage(i18n.copyPath)}
             onClick={() => onCopy(path)}
           >

--- a/ui/desktop/src/components/session/SessionArtifactsPanel.tsx
+++ b/ui/desktop/src/components/session/SessionArtifactsPanel.tsx
@@ -42,6 +42,14 @@ const i18n = defineMessages({
     id: 'sessionArtifacts.empty',
     defaultMessage: 'No files yet',
   },
+  emptyDirect: {
+    id: 'sessionArtifacts.emptyDirect',
+    defaultMessage: 'Project files are not listed in direct mode — open the folder in your file manager',
+  },
+  emptyWorktree: {
+    id: 'sessionArtifacts.emptyWorktree',
+    defaultMessage: 'Only files changed in this session are shown',
+  },
   openInFinder: {
     id: 'sessionArtifacts.openInFinder',
     defaultMessage: 'Open in file manager',
@@ -98,6 +106,20 @@ interface SessionArtifactsPanelProps {
   onRefresh: () => void;
   onClose?: () => void;
   className?: string;
+}
+
+function workspaceEmptyMessage(
+  intl: ReturnType<typeof useIntl>,
+  profile: ResolvedWorkspaceProfile
+): string {
+  switch (profile) {
+    case 'direct':
+      return intl.formatMessage(i18n.emptyDirect);
+    case 'worktree':
+      return intl.formatMessage(i18n.emptyWorktree);
+    case 'sandbox':
+      return intl.formatMessage(i18n.empty);
+  }
 }
 
 function profileLabel(intl: ReturnType<typeof useIntl>, profile: ResolvedWorkspaceProfile): string {
@@ -277,7 +299,7 @@ export default function SessionArtifactsPanel({
                 <SectionTitle>{intl.formatMessage(i18n.workspace)}</SectionTitle>
                 {artifacts.workspace.length === 0 ? (
                   <p className="px-3 text-xs text-text-secondary">
-                    {intl.formatMessage(i18n.empty)}
+                    {workspaceEmptyMessage(intl, artifacts.meta.profile)}
                   </p>
                 ) : (
                   <div className="space-y-0.5">

--- a/ui/desktop/src/components/session/SessionArtifactsPanel.tsx
+++ b/ui/desktop/src/components/session/SessionArtifactsPanel.tsx
@@ -1,0 +1,393 @@
+import { useCallback } from 'react';
+import {
+  Copy,
+  ExternalLink,
+  FolderOpen,
+  FolderDot,
+  GitBranch,
+  LoaderCircle,
+  RefreshCw,
+  Sparkles,
+} from 'lucide-react';
+import { toast } from 'react-toastify';
+import { defineMessages, useIntl } from '../../i18n';
+import type { SessionArtifactsResult } from '../../workspace/artifactScanner';
+import type { ResolvedWorkspaceProfile } from '../../workspace/types';
+import { cn } from '../../utils';
+import { Button } from '../ui/button';
+import { ScrollArea } from '../ui/scroll-area';
+
+const i18n = defineMessages({
+  title: {
+    id: 'sessionArtifacts.title',
+    defaultMessage: 'Artifacts',
+  },
+  inputs: {
+    id: 'sessionArtifacts.inputs',
+    defaultMessage: 'Inputs',
+  },
+  workspace: {
+    id: 'sessionArtifacts.workspace',
+    defaultMessage: 'Workspace',
+  },
+  meta: {
+    id: 'sessionArtifacts.meta',
+    defaultMessage: 'Meta',
+  },
+  refresh: {
+    id: 'sessionArtifacts.refresh',
+    defaultMessage: 'Refresh',
+  },
+  empty: {
+    id: 'sessionArtifacts.empty',
+    defaultMessage: 'No files yet',
+  },
+  openInFinder: {
+    id: 'sessionArtifacts.openInFinder',
+    defaultMessage: 'Open in file manager',
+  },
+  copyPath: {
+    id: 'sessionArtifacts.copyPath',
+    defaultMessage: 'Copy path',
+  },
+  copiedPath: {
+    id: 'sessionArtifacts.copiedPath',
+    defaultMessage: 'Path copied',
+  },
+  externalBadge: {
+    id: 'sessionArtifacts.externalBadge',
+    defaultMessage: 'External',
+  },
+  truncated: {
+    id: 'sessionArtifacts.truncated',
+    defaultMessage: 'Showing first {count} files',
+  },
+  profileSandbox: {
+    id: 'sessionArtifacts.profileSandbox',
+    defaultMessage: 'Sandbox',
+  },
+  profileWorktree: {
+    id: 'sessionArtifacts.profileWorktree',
+    defaultMessage: 'Worktree',
+  },
+  profileDirect: {
+    id: 'sessionArtifacts.profileDirect',
+    defaultMessage: 'Direct',
+  },
+  workingDir: {
+    id: 'sessionArtifacts.workingDir',
+    defaultMessage: 'Working directory',
+  },
+  rootPath: {
+    id: 'sessionArtifacts.rootPath',
+    defaultMessage: 'Workspace root',
+  },
+  branchName: {
+    id: 'sessionArtifacts.branchName',
+    defaultMessage: 'Branch',
+  },
+  repoRoot: {
+    id: 'sessionArtifacts.repoRoot',
+    defaultMessage: 'Repository',
+  },
+});
+
+interface SessionArtifactsPanelProps {
+  artifacts: SessionArtifactsResult | null;
+  isLoading: boolean;
+  onRefresh: () => void;
+  onClose?: () => void;
+  className?: string;
+}
+
+function profileLabel(intl: ReturnType<typeof useIntl>, profile: ResolvedWorkspaceProfile): string {
+  switch (profile) {
+    case 'sandbox':
+      return intl.formatMessage(i18n.profileSandbox);
+    case 'worktree':
+      return intl.formatMessage(i18n.profileWorktree);
+    case 'direct':
+      return intl.formatMessage(i18n.profileDirect);
+  }
+}
+
+function ProfileIcon({ profile }: { profile: ResolvedWorkspaceProfile }) {
+  switch (profile) {
+    case 'sandbox':
+      return <FolderDot className="size-3.5" />;
+    case 'worktree':
+      return <GitBranch className="size-3.5" />;
+    case 'direct':
+      return <FolderOpen className="size-3.5" />;
+  }
+}
+
+function FileRow({
+  path,
+  label,
+  badge,
+  onOpen,
+  onCopy,
+}: {
+  path: string;
+  label: string;
+  badge?: string;
+  onOpen: (path: string) => void;
+  onCopy: (path: string) => void;
+}) {
+  const intl = useIntl();
+
+  return (
+    <div className="group flex min-w-0 items-start gap-1 rounded-md px-2 py-1.5 hover:bg-background-secondary">
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-xs text-text-primary" title={path}>
+          {label}
+        </div>
+        {badge && (
+          <span className="mt-0.5 inline-block rounded bg-background-accent px-1 py-0.5 text-[10px] uppercase tracking-wide text-text-secondary">
+            {badge}
+          </span>
+        )}
+      </div>
+      <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+        <button
+          type="button"
+          className="rounded p-1 text-text-secondary hover:bg-background-primary hover:text-text-primary"
+          title={intl.formatMessage(i18n.openInFinder)}
+          onClick={() => onOpen(path)}
+        >
+          <ExternalLink className="size-3.5" />
+        </button>
+        <button
+          type="button"
+          className="rounded p-1 text-text-secondary hover:bg-background-primary hover:text-text-primary"
+          title={intl.formatMessage(i18n.copyPath)}
+          onClick={() => onCopy(path)}
+        >
+          <Copy className="size-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="px-2 py-1 text-[11px] font-medium uppercase tracking-wide text-text-secondary">
+      {children}
+    </h3>
+  );
+}
+
+export default function SessionArtifactsPanel({
+  artifacts,
+  isLoading,
+  onRefresh,
+  onClose,
+  className,
+}: SessionArtifactsPanelProps) {
+  const intl = useIntl();
+
+  const handleOpen = useCallback((filePath: string) => {
+    void window.electron.openDirectoryInExplorer(filePath);
+  }, []);
+
+  const handleCopy = useCallback(
+    async (filePath: string) => {
+      await navigator.clipboard.writeText(filePath);
+      toast.success(intl.formatMessage(i18n.copiedPath));
+    },
+    [intl]
+  );
+
+  const hasContent =
+    artifacts &&
+    (artifacts.inputs.length > 0 ||
+      artifacts.workspace.length > 0 ||
+      artifacts.meta.workingDir.length > 0);
+
+  return (
+    <aside
+      className={cn(
+        'flex h-full min-h-0 w-[min(360px,35vw)] shrink-0 flex-col border-l border-border-primary bg-background-primary',
+        className
+      )}
+    >
+      <div className="flex items-center justify-between border-b border-border-primary px-3 py-2.5">
+        <div className="flex items-center gap-2">
+          <Sparkles className="size-4 text-text-secondary" />
+          <span className="text-sm font-medium text-text-primary">
+            {intl.formatMessage(i18n.title)}
+          </span>
+        </div>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="xs"
+            shape="round"
+            onClick={onRefresh}
+            disabled={isLoading}
+            title={intl.formatMessage(i18n.refresh)}
+          >
+            {isLoading ? (
+              <LoaderCircle className="size-3.5 animate-spin" />
+            ) : (
+              <RefreshCw className="size-3.5" />
+            )}
+          </Button>
+          {onClose && (
+            <Button variant="ghost" size="xs" shape="round" onClick={onClose}>
+              ×
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <ScrollArea className="min-h-0 flex-1" paddingX={1} paddingY={2}>
+        {!hasContent && !isLoading ? (
+          <p className="px-3 py-6 text-center text-sm text-text-secondary">
+            {intl.formatMessage(i18n.empty)}
+          </p>
+        ) : (
+          <div className="space-y-4">
+            {artifacts && artifacts.inputs.length > 0 && (
+              <section>
+                <SectionTitle>{intl.formatMessage(i18n.inputs)}</SectionTitle>
+                <div className="space-y-0.5">
+                  {artifacts.inputs.map((input) => (
+                    <FileRow
+                      key={`${input.original}-${input.staged}`}
+                      path={input.staged}
+                      label={input.original.split('/').pop() || input.original}
+                      badge={
+                        input.original !== input.staged
+                          ? intl.formatMessage(i18n.externalBadge)
+                          : undefined
+                      }
+                      onOpen={handleOpen}
+                      onCopy={handleCopy}
+                    />
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {artifacts && (
+              <section>
+                <SectionTitle>{intl.formatMessage(i18n.workspace)}</SectionTitle>
+                {artifacts.workspace.length === 0 ? (
+                  <p className="px-3 text-xs text-text-secondary">
+                    {intl.formatMessage(i18n.empty)}
+                  </p>
+                ) : (
+                  <div className="space-y-0.5">
+                    {artifacts.workspace.map((file) => (
+                      <FileRow
+                        key={file.path}
+                        path={file.path}
+                        label={file.relativePath}
+                        onOpen={handleOpen}
+                        onCopy={handleCopy}
+                      />
+                    ))}
+                  </div>
+                )}
+                {artifacts.truncated && (
+                  <p className="px-3 pt-2 text-xs text-text-secondary">
+                    {intl.formatMessage(i18n.truncated, { count: artifacts.workspace.length })}
+                  </p>
+                )}
+              </section>
+            )}
+
+            {artifacts && (
+              <section>
+                <SectionTitle>{intl.formatMessage(i18n.meta)}</SectionTitle>
+                <div className="space-y-2 px-2">
+                  <div className="flex items-center gap-2 text-xs text-text-primary">
+                    <ProfileIcon profile={artifacts.meta.profile} />
+                    <span>{profileLabel(intl, artifacts.meta.profile)}</span>
+                  </div>
+
+                  <MetaRow
+                    label={intl.formatMessage(i18n.workingDir)}
+                    path={artifacts.meta.workingDir}
+                    onOpen={handleOpen}
+                    onCopy={handleCopy}
+                  />
+
+                  {artifacts.meta.rootPath !== artifacts.meta.workingDir && (
+                    <MetaRow
+                      label={intl.formatMessage(i18n.rootPath)}
+                      path={artifacts.meta.rootPath}
+                      onOpen={handleOpen}
+                      onCopy={handleCopy}
+                    />
+                  )}
+
+                  {artifacts.meta.repoRoot && (
+                    <MetaRow
+                      label={intl.formatMessage(i18n.repoRoot)}
+                      path={artifacts.meta.repoRoot}
+                      onOpen={handleOpen}
+                      onCopy={handleCopy}
+                    />
+                  )}
+
+                  {artifacts.meta.branchName && (
+                    <div className="text-xs text-text-secondary">
+                      {intl.formatMessage(i18n.branchName)}: {artifacts.meta.branchName}
+                    </div>
+                  )}
+                </div>
+              </section>
+            )}
+          </div>
+        )}
+      </ScrollArea>
+    </aside>
+  );
+}
+
+function MetaRow({
+  label,
+  path,
+  onOpen,
+  onCopy,
+}: {
+  label: string;
+  path: string;
+  onOpen: (path: string) => void;
+  onCopy: (path: string) => void;
+}) {
+  const intl = useIntl();
+
+  return (
+    <div className="group rounded-md bg-background-secondary px-2 py-1.5">
+      <div className="text-[10px] uppercase tracking-wide text-text-secondary">{label}</div>
+      <div className="mt-0.5 flex min-w-0 items-start gap-1">
+        <div className="min-w-0 flex-1 truncate text-xs text-text-primary" title={path}>
+          {path}
+        </div>
+        <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+          <button
+            type="button"
+            className="rounded p-1 text-text-secondary hover:text-text-primary"
+            title={intl.formatMessage(i18n.openInFinder)}
+            onClick={() => onOpen(path)}
+          >
+            <FolderOpen className="size-3.5" />
+          </button>
+          <button
+            type="button"
+            className="rounded p-1 text-text-secondary hover:text-text-primary"
+            title={intl.formatMessage(i18n.copyPath)}
+            onClick={() => onCopy(path)}
+          >
+            <Copy className="size-3.5" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -507,6 +507,7 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
 
       try {
         await acpDeleteSession(sessionToDeleteId);
+        void window.electron.cleanupSessionWorkspace(sessionToDeleteId);
         toast.success(intl.formatMessage(i18n.deleteSuccess));
         window.dispatchEvent(
           new CustomEvent(AppEvents.SESSION_DELETED, { detail: { sessionId: sessionToDeleteId } })

--- a/ui/desktop/src/components/settings/chat/ChatSettingsSection.tsx
+++ b/ui/desktop/src/components/settings/chat/ChatSettingsSection.tsx
@@ -4,6 +4,7 @@ import { SecurityToggle } from '../security/SecurityToggle';
 import { ResponseStylesSection } from '../response_styles/ResponseStylesSection';
 import { GoosehintsSection } from './GoosehintsSection';
 import { SpellcheckToggle } from './SpellcheckToggle';
+import { WorkspaceSettingsSection } from './WorkspaceSettingsSection';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../ui/card';
 import { defineMessages, useIntl } from '../../../i18n';
 
@@ -44,6 +45,12 @@ export default function ChatSettingsSection({ sessionId }: { sessionId?: string 
       <Card className="pb-2 rounded-lg">
         <CardContent className="px-2">
           <GoosehintsSection />
+        </CardContent>
+      </Card>
+
+      <Card className="pb-2 rounded-lg">
+        <CardContent className="px-2">
+          <WorkspaceSettingsSection />
         </CardContent>
       </Card>
 

--- a/ui/desktop/src/components/settings/chat/WorkspaceSettingsSection.tsx
+++ b/ui/desktop/src/components/settings/chat/WorkspaceSettingsSection.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from 'react';
+import { defineMessages, useIntl } from '../../../i18n';
+import type { ExternalFileStrategy, WorkspaceProfile } from '../../../utils/settings';
+
+const i18n = defineMessages({
+  title: {
+    id: 'workspaceSettings.title',
+    defaultMessage: 'Session workspace',
+  },
+  description: {
+    id: 'workspaceSettings.description',
+    defaultMessage: 'Control how goose isolates each session from your files and projects.',
+  },
+  profileLabel: {
+    id: 'workspaceSettings.profileLabel',
+    defaultMessage: 'Isolation mode',
+  },
+  profileAuto: {
+    id: 'workspaceSettings.profileAuto',
+    defaultMessage: 'Auto (worktree in git repos, otherwise sandbox)',
+  },
+  profileSandbox: {
+    id: 'workspaceSettings.profileSandbox',
+    defaultMessage: 'Always sandbox',
+  },
+  profileWorktree: {
+    id: 'workspaceSettings.profileWorktree',
+    defaultMessage: 'Prefer git worktree',
+  },
+  profileDirect: {
+    id: 'workspaceSettings.profileDirect',
+    defaultMessage: 'Direct (no isolation)',
+  },
+  strategyLabel: {
+    id: 'workspaceSettings.strategyLabel',
+    defaultMessage: 'External files default',
+  },
+  strategyCopy: {
+    id: 'workspaceSettings.strategyCopy',
+    defaultMessage: 'Copy into workspace',
+  },
+  strategyReference: {
+    id: 'workspaceSettings.strategyReference',
+    defaultMessage: 'Read-only reference',
+  },
+  strategySymlink: {
+    id: 'workspaceSettings.strategySymlink',
+    defaultMessage: 'Symlink into workspace',
+  },
+  rememberLabel: {
+    id: 'workspaceSettings.rememberLabel',
+    defaultMessage: 'Remember external file choice',
+  },
+});
+
+export function WorkspaceSettingsSection() {
+  const intl = useIntl();
+  const [workspaceProfile, setWorkspaceProfile] = useState<WorkspaceProfile>('auto');
+  const [externalFileStrategy, setExternalFileStrategy] = useState<ExternalFileStrategy>('copy');
+  const [rememberExternalFileChoice, setRememberExternalFileChoice] = useState(false);
+
+  useEffect(() => {
+    void (async () => {
+      setWorkspaceProfile(await window.electron.getSetting('workspaceProfile'));
+      setExternalFileStrategy(await window.electron.getSetting('externalFileStrategy'));
+      setRememberExternalFileChoice(await window.electron.getSetting('rememberExternalFileChoice'));
+    })();
+  }, []);
+
+  const updateProfile = async (value: WorkspaceProfile) => {
+    setWorkspaceProfile(value);
+    await window.electron.setSetting('workspaceProfile', value);
+  };
+
+  const updateStrategy = async (value: ExternalFileStrategy) => {
+    setExternalFileStrategy(value);
+    await window.electron.setSetting('externalFileStrategy', value);
+  };
+
+  const updateRemember = async (value: boolean) => {
+    setRememberExternalFileChoice(value);
+    await window.electron.setSetting('rememberExternalFileChoice', value);
+  };
+
+  return (
+    <section className="space-y-4">
+      <div>
+        <h3 className="text-sm font-medium text-text-primary">{intl.formatMessage(i18n.title)}</h3>
+        <p className="text-xs text-text-secondary mt-1">{intl.formatMessage(i18n.description)}</p>
+      </div>
+
+      <label className="block space-y-1">
+        <span className="text-xs text-text-secondary">{intl.formatMessage(i18n.profileLabel)}</span>
+        <select
+          className="w-full rounded-md border border-border-default bg-background-primary px-2 py-1.5 text-sm"
+          value={workspaceProfile}
+          onChange={(e) => void updateProfile(e.target.value as WorkspaceProfile)}
+        >
+          <option value="auto">{intl.formatMessage(i18n.profileAuto)}</option>
+          <option value="sandbox">{intl.formatMessage(i18n.profileSandbox)}</option>
+          <option value="worktree">{intl.formatMessage(i18n.profileWorktree)}</option>
+          <option value="direct">{intl.formatMessage(i18n.profileDirect)}</option>
+        </select>
+      </label>
+
+      <label className="block space-y-1">
+        <span className="text-xs text-text-secondary">{intl.formatMessage(i18n.strategyLabel)}</span>
+        <select
+          className="w-full rounded-md border border-border-default bg-background-primary px-2 py-1.5 text-sm"
+          value={externalFileStrategy}
+          onChange={(e) => void updateStrategy(e.target.value as ExternalFileStrategy)}
+        >
+          <option value="copy">{intl.formatMessage(i18n.strategyCopy)}</option>
+          <option value="reference">{intl.formatMessage(i18n.strategyReference)}</option>
+          <option value="symlink">{intl.formatMessage(i18n.strategySymlink)}</option>
+        </select>
+      </label>
+
+      <label className="flex items-center gap-2 text-sm text-text-secondary cursor-pointer">
+        <input
+          type="checkbox"
+          checked={rememberExternalFileChoice}
+          onChange={(e) => void updateRemember(e.target.checked)}
+          className="rounded"
+        />
+        {intl.formatMessage(i18n.rememberLabel)}
+      </label>
+    </section>
+  );
+}

--- a/ui/desktop/src/components/workspace/ExternalFileStrategyPrompt.tsx
+++ b/ui/desktop/src/components/workspace/ExternalFileStrategyPrompt.tsx
@@ -1,0 +1,159 @@
+import { useCallback, useRef, useState } from 'react';
+import { defineMessages, useIntl } from '../../i18n';
+import type { ExternalFileStrategy } from '../../utils/settings';
+import { Button } from '../ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
+
+const i18n = defineMessages({
+  title: {
+    id: 'externalFileStrategy.title',
+    defaultMessage: 'How should attached files be handled?',
+  },
+  description: {
+    id: 'externalFileStrategy.description',
+    defaultMessage:
+      'These files are outside the session workspace. Choose how goose should access them.',
+  },
+  copy: {
+    id: 'externalFileStrategy.copy',
+    defaultMessage: 'Copy into workspace (recommended)',
+  },
+  copyDetail: {
+    id: 'externalFileStrategy.copyDetail',
+    defaultMessage: 'Safe — originals stay untouched.',
+  },
+  reference: {
+    id: 'externalFileStrategy.reference',
+    defaultMessage: 'Read-only reference',
+  },
+  referenceDetail: {
+    id: 'externalFileStrategy.referenceDetail',
+    defaultMessage: 'Use original paths; goose writes only in workspace.',
+  },
+  symlink: {
+    id: 'externalFileStrategy.symlink',
+    defaultMessage: 'Link into workspace',
+  },
+  symlinkDetail: {
+    id: 'externalFileStrategy.symlinkDetail',
+    defaultMessage: 'Saves space; changes may affect originals.',
+  },
+  remember: {
+    id: 'externalFileStrategy.remember',
+    defaultMessage: 'Remember my choice',
+  },
+});
+
+interface ExternalFileStrategyPromptProps {
+  open: boolean;
+  onChoose: (strategy: ExternalFileStrategy, remember: boolean) => void;
+  onCancel: () => void;
+}
+
+export function ExternalFileStrategyPrompt({
+  open,
+  onChoose,
+  onCancel,
+}: ExternalFileStrategyPromptProps) {
+  const intl = useIntl();
+  const [remember, setRemember] = useState(false);
+
+  const choose = useCallback(
+    (strategy: ExternalFileStrategy) => {
+      onChoose(strategy, remember);
+    },
+    [onChoose, remember]
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onCancel()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{intl.formatMessage(i18n.title)}</DialogTitle>
+          <DialogDescription>{intl.formatMessage(i18n.description)}</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-2">
+          <Button variant="outline" className="h-auto flex-col items-start p-3" onClick={() => choose('copy')}>
+            <span className="font-medium">{intl.formatMessage(i18n.copy)}</span>
+            <span className="text-xs text-text-secondary">{intl.formatMessage(i18n.copyDetail)}</span>
+          </Button>
+          <Button
+            variant="outline"
+            className="h-auto flex-col items-start p-3"
+            onClick={() => choose('reference')}
+          >
+            <span className="font-medium">{intl.formatMessage(i18n.reference)}</span>
+            <span className="text-xs text-text-secondary">{intl.formatMessage(i18n.referenceDetail)}</span>
+          </Button>
+          <Button
+            variant="outline"
+            className="h-auto flex-col items-start p-3"
+            onClick={() => choose('symlink')}
+          >
+            <span className="font-medium">{intl.formatMessage(i18n.symlink)}</span>
+            <span className="text-xs text-text-secondary">{intl.formatMessage(i18n.symlinkDetail)}</span>
+          </Button>
+        </div>
+
+        <label className="flex items-center gap-2 text-sm text-text-secondary cursor-pointer">
+          <input
+            type="checkbox"
+            checked={remember}
+            onChange={(e) => setRemember(e.target.checked)}
+            className="rounded"
+          />
+          {intl.formatMessage(i18n.remember)}
+        </label>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onCancel}>
+            Cancel
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function useExternalFileStrategyPrompt() {
+  const strategyPromptResolverRef = useRef<((value: ExternalFileStrategy | null) => void) | null>(
+    null
+  );
+  const [open, setOpen] = useState(false);
+
+  const prompt = useCallback((): Promise<ExternalFileStrategy | null> => {
+    setOpen(true);
+    return new Promise((resolve) => {
+      strategyPromptResolverRef.current = (strategy) => {
+        setOpen(false);
+        resolve(strategy);
+      };
+    });
+  }, []);
+
+  const handleChoose = useCallback((strategy: ExternalFileStrategy, remember: boolean) => {
+    if (remember) {
+      void window.electron.setSetting('rememberExternalFileChoice', true);
+      void window.electron.setSetting('externalFileStrategy', strategy);
+    }
+    strategyPromptResolverRef.current?.(strategy);
+    strategyPromptResolverRef.current = null;
+    setOpen(false);
+  }, []);
+
+  const handleCancel = useCallback(() => {
+    strategyPromptResolverRef.current?.(null);
+    strategyPromptResolverRef.current = null;
+    setOpen(false);
+  }, []);
+
+  return { open, prompt, handleChoose, handleCancel };
+}

--- a/ui/desktop/src/components/workspace/WorkspaceProfilePicker.tsx
+++ b/ui/desktop/src/components/workspace/WorkspaceProfilePicker.tsx
@@ -1,0 +1,121 @@
+import { FolderDot, FolderOpen, GitBranch, Sparkles } from 'lucide-react';
+import { defineMessages, useIntl } from '../../i18n';
+import type { WorkspaceProfile } from '../../workspace/types';
+import { cn } from '../../utils';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/Tooltip';
+
+const i18n = defineMessages({
+  auto: {
+    id: 'hub.workspaceProfile.auto',
+    defaultMessage: 'Auto',
+  },
+  sandbox: {
+    id: 'hub.workspaceProfile.sandbox',
+    defaultMessage: 'Sandbox',
+  },
+  worktree: {
+    id: 'hub.workspaceProfile.worktree',
+    defaultMessage: 'Worktree',
+  },
+  direct: {
+    id: 'hub.workspaceProfile.direct',
+    defaultMessage: 'Direct',
+  },
+  autoTooltip: {
+    id: 'hub.workspaceProfile.autoTooltip',
+    defaultMessage: 'Auto (worktree in git repos, otherwise sandbox). Default from Settings.',
+  },
+  sandboxTooltip: {
+    id: 'hub.workspaceProfile.sandboxTooltip',
+    defaultMessage: 'Always sandbox. Default from Settings.',
+  },
+  worktreeTooltip: {
+    id: 'hub.workspaceProfile.worktreeTooltip',
+    defaultMessage: 'Prefer git worktree. Default from Settings.',
+  },
+  directTooltip: {
+    id: 'hub.workspaceProfile.directTooltip',
+    defaultMessage: 'Direct (no isolation). Default from Settings.',
+  },
+  recommended: {
+    id: 'hub.workspaceProfile.recommended',
+    defaultMessage: 'Recommended',
+  },
+});
+
+const PROFILES: Array<{
+  value: WorkspaceProfile;
+  icon: typeof Sparkles;
+  label: typeof i18n.auto;
+  tooltip: typeof i18n.autoTooltip;
+}> = [
+  { value: 'auto', icon: Sparkles, label: i18n.auto, tooltip: i18n.autoTooltip },
+  { value: 'sandbox', icon: FolderDot, label: i18n.sandbox, tooltip: i18n.sandboxTooltip },
+  { value: 'worktree', icon: GitBranch, label: i18n.worktree, tooltip: i18n.worktreeTooltip },
+  { value: 'direct', icon: FolderOpen, label: i18n.direct, tooltip: i18n.directTooltip },
+];
+
+interface WorkspaceProfilePickerProps {
+  value: WorkspaceProfile;
+  onChange: (value: WorkspaceProfile) => void;
+  disabled?: boolean;
+  compact?: boolean;
+  recommended?: WorkspaceProfile | null;
+}
+
+export function WorkspaceProfilePicker({
+  value,
+  onChange,
+  disabled = false,
+  compact = false,
+  recommended = null,
+}: WorkspaceProfilePickerProps) {
+  const intl = useIntl();
+
+  return (
+    <TooltipProvider>
+      <div
+        className={cn(
+          'inline-flex items-center gap-0.5 rounded-lg border border-border-primary bg-background-secondary p-0.5',
+          compact && 'scale-95',
+          disabled && 'opacity-50 pointer-events-none'
+        )}
+        role="group"
+        aria-label={intl.formatMessage(i18n.autoTooltip)}
+      >
+        {PROFILES.map(({ value: profileValue, icon: Icon, label, tooltip }) => {
+          const isActive = value === profileValue;
+          const isRecommended = recommended === profileValue && !isActive;
+
+          return (
+            <Tooltip key={profileValue}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  disabled={disabled}
+                  onClick={() => onChange(profileValue)}
+                  className={cn(
+                    'relative flex items-center gap-1 rounded-md px-2 py-1 text-xs transition-colors',
+                    isActive
+                      ? 'bg-background-primary text-text-primary shadow-xs'
+                      : 'text-text-secondary hover:bg-background-primary/60 hover:text-text-primary'
+                  )}
+                  aria-pressed={isActive}
+                >
+                  <Icon className="size-3.5 shrink-0" />
+                  {!compact && <span>{intl.formatMessage(label)}</span>}
+                  {isRecommended && (
+                    <span className="absolute -right-1 -top-1 rounded-full bg-background-accent px-1 text-[8px] uppercase tracking-wide text-text-secondary">
+                      {intl.formatMessage(i18n.recommended)}
+                    </span>
+                  )}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top">{intl.formatMessage(tooltip)}</TooltipContent>
+            </Tooltip>
+          );
+        })}
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/ui/desktop/src/hooks/useAcpChatSession.ts
+++ b/ui/desktop/src/hooks/useAcpChatSession.ts
@@ -18,6 +18,7 @@ import {
 import { createUserMessage, NotificationEvent, UserInput } from '../types/message';
 import { errorMessage } from '../utils/conversionUtils';
 import { showExtensionLoadResults } from '../utils/extensionErrorUtils';
+import { stageUserInputFiles } from '../workspace/resolveSessionWorkspace';
 import type { UseChatSessionParams, UseChatSessionResult } from './useChatSessionTypes';
 import { cancelAcpPermissionRequestsForSession } from '../acp/permissionRequests';
 import {
@@ -378,7 +379,8 @@ export function useAcpChatSession({
 
   const handleSubmit = useCallback(
     async (input: UserInput) => {
-      const { msg: userMessage, images } = input;
+      const stagedInput = await stageUserInputFiles(sessionId, input);
+      const { msg: userMessage, images } = stagedInput;
       const currentState = stateRef.current;
 
       if (

--- a/ui/desktop/src/hooks/useAcpChatSession.ts
+++ b/ui/desktop/src/hooks/useAcpChatSession.ts
@@ -19,6 +19,7 @@ import { createUserMessage, NotificationEvent, UserInput } from '../types/messag
 import { errorMessage } from '../utils/conversionUtils';
 import { showExtensionLoadResults } from '../utils/extensionErrorUtils';
 import { stageUserInputFiles } from '../workspace/resolveSessionWorkspace';
+import { toastError } from '../toasts';
 import type { UseChatSessionParams, UseChatSessionResult } from './useChatSessionTypes';
 import { cancelAcpPermissionRequestsForSession } from '../acp/permissionRequests';
 import {
@@ -379,7 +380,13 @@ export function useAcpChatSession({
 
   const handleSubmit = useCallback(
     async (input: UserInput) => {
-      const stagedInput = await stageUserInputFiles(sessionId, input);
+      let stagedInput: UserInput;
+      try {
+        stagedInput = await stageUserInputFiles(sessionId, input);
+      } catch (error) {
+        toastError(errorMessage(error));
+        return;
+      }
       const { msg: userMessage, images } = stagedInput;
       const currentState = stateRef.current;
 

--- a/ui/desktop/src/hooks/useArtifactsPanel.ts
+++ b/ui/desktop/src/hooks/useArtifactsPanel.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { SessionArtifactsResult } from '../workspace/artifactScanner';
+
+const ARTIFACTS_PANEL_OPEN_KEY = 'artifacts_panel_open';
+const NARROW_WINDOW_THRESHOLD = 900;
+
+export function useArtifactsPanel(sessionId: string | null, workingDir?: string) {
+  const [isOpen, setIsOpenState] = useState<boolean>(() => {
+    return localStorage.getItem(ARTIFACTS_PANEL_OPEN_KEY) === 'true';
+  });
+  const [artifacts, setArtifacts] = useState<SessionArtifactsResult | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const isOpenRef = useRef(isOpen);
+
+  useEffect(() => {
+    isOpenRef.current = isOpen;
+  }, [isOpen]);
+
+  const setIsOpen = useCallback((open: boolean) => {
+    setIsOpenState(open);
+    localStorage.setItem(ARTIFACTS_PANEL_OPEN_KEY, String(open));
+  }, []);
+
+  const toggle = useCallback(() => {
+    setIsOpen(!isOpenRef.current);
+  }, [setIsOpen]);
+
+  const refresh = useCallback(async () => {
+    if (!sessionId) {
+      setArtifacts(null);
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const result = await window.electron.listSessionArtifacts(sessionId, workingDir);
+      setArtifacts(result);
+    } catch {
+      setArtifacts(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [sessionId, workingDir]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    if (isOpen) {
+      void refresh();
+    }
+  }, [isOpen, refresh]);
+
+  useEffect(() => {
+    let lastWidth = window.innerWidth;
+    if (lastWidth < NARROW_WINDOW_THRESHOLD && isOpenRef.current) {
+      setIsOpen(false);
+    }
+
+    const onResize = () => {
+      const width = window.innerWidth;
+      if (
+        width < NARROW_WINDOW_THRESHOLD &&
+        lastWidth >= NARROW_WINDOW_THRESHOLD &&
+        isOpenRef.current
+      ) {
+        setIsOpen(false);
+      }
+      lastWidth = width;
+    };
+
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, [setIsOpen]);
+
+  const fileCount = artifacts?.totalCount ?? 0;
+
+  return {
+    isOpen,
+    setIsOpen,
+    toggle,
+    artifacts,
+    isLoading,
+    refresh,
+    fileCount,
+  };
+}

--- a/ui/desktop/src/hooks/useArtifactsPanel.ts
+++ b/ui/desktop/src/hooks/useArtifactsPanel.ts
@@ -3,6 +3,14 @@ import type { SessionArtifactsResult } from '../workspace/artifactScanner';
 
 const ARTIFACTS_PANEL_OPEN_KEY = 'artifacts_panel_open';
 const NARROW_WINDOW_THRESHOLD = 900;
+const MIN_REFRESH_SPINNER_MS = 400;
+
+async function ensureMinDuration(startedAt: number, minMs: number): Promise<void> {
+  const elapsed = Date.now() - startedAt;
+  if (elapsed < minMs) {
+    await new Promise((resolve) => setTimeout(resolve, minMs - elapsed));
+  }
+}
 
 export function useArtifactsPanel(sessionId: string | null, workingDir?: string) {
   const [isOpen, setIsOpenState] = useState<boolean>(() => {
@@ -31,6 +39,7 @@ export function useArtifactsPanel(sessionId: string | null, workingDir?: string)
       return;
     }
 
+    const startedAt = Date.now();
     setIsLoading(true);
     try {
       const result = await window.electron.listSessionArtifacts(sessionId, workingDir);
@@ -38,6 +47,7 @@ export function useArtifactsPanel(sessionId: string | null, workingDir?: string)
     } catch {
       setArtifacts(null);
     } finally {
+      await ensureMinDuration(startedAt, MIN_REFRESH_SPINNER_MS);
       setIsLoading(false);
     }
   }, [sessionId, workingDir]);

--- a/ui/desktop/src/hooks/useChatStream.ts
+++ b/ui/desktop/src/hooks/useChatStream.ts
@@ -27,6 +27,7 @@ import {
 } from '../types/message';
 import { errorMessage } from '../utils/conversionUtils';
 import { showExtensionLoadResults } from '../utils/extensionErrorUtils';
+import { stageUserInputFiles } from '../workspace/resolveSessionWorkspace';
 import { maybeHandlePlatformEvent } from '../utils/platform_events';
 import { useSessionEvents, type SessionEvent } from './useSessionEvents';
 import type { UseChatSessionParams, UseChatSessionResult } from './useChatSessionTypes';
@@ -839,7 +840,8 @@ export function useChatStream({
 
   const handleSubmit = useCallback(
     async (input: UserInput) => {
-      const { msg: userMessage, images } = input;
+      const stagedInput = await stageUserInputFiles(sessionId, input);
+      const { msg: userMessage, images } = stagedInput;
       const currentState = stateRef.current;
 
       if (

--- a/ui/desktop/src/hooks/useChatStream.ts
+++ b/ui/desktop/src/hooks/useChatStream.ts
@@ -28,6 +28,7 @@ import {
 import { errorMessage } from '../utils/conversionUtils';
 import { showExtensionLoadResults } from '../utils/extensionErrorUtils';
 import { stageUserInputFiles } from '../workspace/resolveSessionWorkspace';
+import { toastError } from '../toasts';
 import { maybeHandlePlatformEvent } from '../utils/platform_events';
 import { useSessionEvents, type SessionEvent } from './useSessionEvents';
 import type { UseChatSessionParams, UseChatSessionResult } from './useChatSessionTypes';
@@ -840,7 +841,13 @@ export function useChatStream({
 
   const handleSubmit = useCallback(
     async (input: UserInput) => {
-      const stagedInput = await stageUserInputFiles(sessionId, input);
+      let stagedInput: UserInput;
+      try {
+        stagedInput = await stageUserInputFiles(sessionId, input);
+      } catch (error) {
+        toastError(errorMessage(error));
+        return;
+      }
       const { msg: userMessage, images } = stagedInput;
       const currentState = stateRef.current;
 

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -4906,5 +4906,95 @@
   },
   "workspaceSettings.title": {
     "defaultMessage": "Session workspace"
+  },
+  "sessionArtifacts.title": {
+    "defaultMessage": "Artifacts"
+  },
+  "sessionArtifacts.toggleOpen": {
+    "defaultMessage": "Show artifacts panel"
+  },
+  "sessionArtifacts.toggleClose": {
+    "defaultMessage": "Hide artifacts panel"
+  },
+  "sessionArtifacts.inputs": {
+    "defaultMessage": "Inputs"
+  },
+  "sessionArtifacts.workspace": {
+    "defaultMessage": "Workspace"
+  },
+  "sessionArtifacts.meta": {
+    "defaultMessage": "Meta"
+  },
+  "sessionArtifacts.refresh": {
+    "defaultMessage": "Refresh"
+  },
+  "sessionArtifacts.empty": {
+    "defaultMessage": "No files yet"
+  },
+  "sessionArtifacts.openInFinder": {
+    "defaultMessage": "Open in file manager"
+  },
+  "sessionArtifacts.copyPath": {
+    "defaultMessage": "Copy path"
+  },
+  "sessionArtifacts.copiedPath": {
+    "defaultMessage": "Path copied"
+  },
+  "sessionArtifacts.externalBadge": {
+    "defaultMessage": "External"
+  },
+  "sessionArtifacts.fileCount": {
+    "defaultMessage": "{count, plural, one {# file} other {# files}}"
+  },
+  "sessionArtifacts.truncated": {
+    "defaultMessage": "Showing first {count} files"
+  },
+  "sessionArtifacts.profileSandbox": {
+    "defaultMessage": "Sandbox"
+  },
+  "sessionArtifacts.profileWorktree": {
+    "defaultMessage": "Worktree"
+  },
+  "sessionArtifacts.profileDirect": {
+    "defaultMessage": "Direct"
+  },
+  "sessionArtifacts.workingDir": {
+    "defaultMessage": "Working directory"
+  },
+  "sessionArtifacts.rootPath": {
+    "defaultMessage": "Workspace root"
+  },
+  "sessionArtifacts.branchName": {
+    "defaultMessage": "Branch"
+  },
+  "sessionArtifacts.repoRoot": {
+    "defaultMessage": "Repository"
+  },
+  "hub.workspaceProfile.auto": {
+    "defaultMessage": "Auto"
+  },
+  "hub.workspaceProfile.sandbox": {
+    "defaultMessage": "Sandbox"
+  },
+  "hub.workspaceProfile.worktree": {
+    "defaultMessage": "Worktree"
+  },
+  "hub.workspaceProfile.direct": {
+    "defaultMessage": "Direct"
+  },
+  "hub.workspaceProfile.autoTooltip": {
+    "defaultMessage": "Auto (worktree in git repos, otherwise sandbox). Default from Settings."
+  },
+  "hub.workspaceProfile.sandboxTooltip": {
+    "defaultMessage": "Always sandbox. Default from Settings."
+  },
+  "hub.workspaceProfile.worktreeTooltip": {
+    "defaultMessage": "Prefer git worktree. Default from Settings."
+  },
+  "hub.workspaceProfile.directTooltip": {
+    "defaultMessage": "Direct (no isolation). Default from Settings."
+  },
+  "hub.workspaceProfile.recommended": {
+    "defaultMessage": "Recommended"
   }
 }

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -974,8 +974,23 @@
   "dirSwitcher.openInFinder": {
     "defaultMessage": "Open in file manager"
   },
+  "dirSwitcher.openWorkspaceFolder": {
+    "defaultMessage": "Open workspace folder"
+  },
+  "dirSwitcher.originalFiles": {
+    "defaultMessage": "Original files"
+  },
+  "dirSwitcher.projectBadge": {
+    "defaultMessage": "Project"
+  },
   "dirSwitcher.recentDirectories": {
     "defaultMessage": "Recent directories"
+  },
+  "dirSwitcher.sandboxBadge": {
+    "defaultMessage": "Sandbox"
+  },
+  "dirSwitcher.worktreeBadge": {
+    "defaultMessage": "Worktree"
   },
   "elicitationRequest.accept": {
     "defaultMessage": "Accept"
@@ -1264,6 +1279,33 @@
   },
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "Connect to a goose server running elsewhere (requires app restart)"
+  },
+  "externalFileStrategy.copy": {
+    "defaultMessage": "Copy into workspace (recommended)"
+  },
+  "externalFileStrategy.copyDetail": {
+    "defaultMessage": "Safe — originals stay untouched."
+  },
+  "externalFileStrategy.description": {
+    "defaultMessage": "These files are outside the session workspace. Choose how goose should access them."
+  },
+  "externalFileStrategy.reference": {
+    "defaultMessage": "Read-only reference"
+  },
+  "externalFileStrategy.referenceDetail": {
+    "defaultMessage": "Use original paths; goose writes only in workspace."
+  },
+  "externalFileStrategy.remember": {
+    "defaultMessage": "Remember my choice"
+  },
+  "externalFileStrategy.symlink": {
+    "defaultMessage": "Link into workspace"
+  },
+  "externalFileStrategy.symlinkDetail": {
+    "defaultMessage": "Saves space; changes may affect originals."
+  },
+  "externalFileStrategy.title": {
+    "defaultMessage": "How should attached files be handled?"
   },
   "freeOptionCards.chooseOption": {
     "defaultMessage": "Choose an option to get started."
@@ -4828,5 +4870,41 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Create a new session with the edited message"
+  },
+  "workspaceSettings.description": {
+    "defaultMessage": "Control how goose isolates each session from your files and projects."
+  },
+  "workspaceSettings.profileAuto": {
+    "defaultMessage": "Auto (worktree in git repos, otherwise sandbox)"
+  },
+  "workspaceSettings.profileDirect": {
+    "defaultMessage": "Direct (no isolation)"
+  },
+  "workspaceSettings.profileLabel": {
+    "defaultMessage": "Isolation mode"
+  },
+  "workspaceSettings.profileSandbox": {
+    "defaultMessage": "Always sandbox"
+  },
+  "workspaceSettings.profileWorktree": {
+    "defaultMessage": "Prefer git worktree"
+  },
+  "workspaceSettings.rememberLabel": {
+    "defaultMessage": "Remember external file choice"
+  },
+  "workspaceSettings.strategyCopy": {
+    "defaultMessage": "Copy into workspace"
+  },
+  "workspaceSettings.strategyLabel": {
+    "defaultMessage": "External files default"
+  },
+  "workspaceSettings.strategyReference": {
+    "defaultMessage": "Read-only reference"
+  },
+  "workspaceSettings.strategySymlink": {
+    "defaultMessage": "Symlink into workspace"
+  },
+  "workspaceSettings.title": {
+    "defaultMessage": "Session workspace"
   }
 }

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -4928,6 +4928,9 @@
   "sessionArtifacts.refresh": {
     "defaultMessage": "Refresh"
   },
+  "sessionArtifacts.refreshing": {
+    "defaultMessage": "Refreshing…"
+  },
   "sessionArtifacts.empty": {
     "defaultMessage": "No files yet"
   },
@@ -4945,6 +4948,9 @@
   },
   "sessionArtifacts.copiedPath": {
     "defaultMessage": "Path copied"
+  },
+  "sessionArtifacts.openFailed": {
+    "defaultMessage": "Could not open path in file manager"
   },
   "sessionArtifacts.externalBadge": {
     "defaultMessage": "External"

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -1526,6 +1526,33 @@
   "hub.goodMorning": {
     "defaultMessage": "Good morning"
   },
+  "hub.workspaceProfile.auto": {
+    "defaultMessage": "Auto"
+  },
+  "hub.workspaceProfile.autoTooltip": {
+    "defaultMessage": "Auto (worktree in git repos, otherwise sandbox). Default from Settings."
+  },
+  "hub.workspaceProfile.direct": {
+    "defaultMessage": "Direct"
+  },
+  "hub.workspaceProfile.directTooltip": {
+    "defaultMessage": "Direct (no isolation). Default from Settings."
+  },
+  "hub.workspaceProfile.recommended": {
+    "defaultMessage": "Recommended"
+  },
+  "hub.workspaceProfile.sandbox": {
+    "defaultMessage": "Sandbox"
+  },
+  "hub.workspaceProfile.sandboxTooltip": {
+    "defaultMessage": "Always sandbox. Default from Settings."
+  },
+  "hub.workspaceProfile.worktree": {
+    "defaultMessage": "Worktree"
+  },
+  "hub.workspaceProfile.worktreeTooltip": {
+    "defaultMessage": "Prefer git worktree. Default from Settings."
+  },
   "huggingFaceModelSearch.download": {
     "defaultMessage": "Download"
   },
@@ -3830,6 +3857,81 @@
   "sessionActionsHeader.viewJson": {
     "defaultMessage": "View session JSON"
   },
+  "sessionArtifacts.branchName": {
+    "defaultMessage": "Branch"
+  },
+  "sessionArtifacts.copiedPath": {
+    "defaultMessage": "Path copied"
+  },
+  "sessionArtifacts.copyPath": {
+    "defaultMessage": "Copy path"
+  },
+  "sessionArtifacts.empty": {
+    "defaultMessage": "No files yet"
+  },
+  "sessionArtifacts.emptyDirect": {
+    "defaultMessage": "Project files are not listed in direct mode — open the folder in your file manager"
+  },
+  "sessionArtifacts.emptyWorktree": {
+    "defaultMessage": "Only files changed in this session are shown"
+  },
+  "sessionArtifacts.externalBadge": {
+    "defaultMessage": "External"
+  },
+  "sessionArtifacts.fileCount": {
+    "defaultMessage": "{count,plural,one{# file} other{# files}}"
+  },
+  "sessionArtifacts.inputs": {
+    "defaultMessage": "Inputs"
+  },
+  "sessionArtifacts.meta": {
+    "defaultMessage": "Meta"
+  },
+  "sessionArtifacts.openFailed": {
+    "defaultMessage": "Could not open path in file manager"
+  },
+  "sessionArtifacts.openInFinder": {
+    "defaultMessage": "Open in file manager"
+  },
+  "sessionArtifacts.profileDirect": {
+    "defaultMessage": "Direct"
+  },
+  "sessionArtifacts.profileSandbox": {
+    "defaultMessage": "Sandbox"
+  },
+  "sessionArtifacts.profileWorktree": {
+    "defaultMessage": "Worktree"
+  },
+  "sessionArtifacts.refresh": {
+    "defaultMessage": "Refresh"
+  },
+  "sessionArtifacts.refreshing": {
+    "defaultMessage": "Refreshing…"
+  },
+  "sessionArtifacts.repoRoot": {
+    "defaultMessage": "Repository"
+  },
+  "sessionArtifacts.rootPath": {
+    "defaultMessage": "Workspace root"
+  },
+  "sessionArtifacts.title": {
+    "defaultMessage": "Artifacts"
+  },
+  "sessionArtifacts.toggleClose": {
+    "defaultMessage": "Hide artifacts panel"
+  },
+  "sessionArtifacts.toggleOpen": {
+    "defaultMessage": "Show artifacts panel"
+  },
+  "sessionArtifacts.truncated": {
+    "defaultMessage": "Showing first {count} files"
+  },
+  "sessionArtifacts.workingDir": {
+    "defaultMessage": "Working directory"
+  },
+  "sessionArtifacts.workspace": {
+    "defaultMessage": "Workspace"
+  },
   "sessionHistory.cancel": {
     "defaultMessage": "Cancel"
   },
@@ -4906,107 +5008,5 @@
   },
   "workspaceSettings.title": {
     "defaultMessage": "Session workspace"
-  },
-  "sessionArtifacts.title": {
-    "defaultMessage": "Artifacts"
-  },
-  "sessionArtifacts.toggleOpen": {
-    "defaultMessage": "Show artifacts panel"
-  },
-  "sessionArtifacts.toggleClose": {
-    "defaultMessage": "Hide artifacts panel"
-  },
-  "sessionArtifacts.inputs": {
-    "defaultMessage": "Inputs"
-  },
-  "sessionArtifacts.workspace": {
-    "defaultMessage": "Workspace"
-  },
-  "sessionArtifacts.meta": {
-    "defaultMessage": "Meta"
-  },
-  "sessionArtifacts.refresh": {
-    "defaultMessage": "Refresh"
-  },
-  "sessionArtifacts.refreshing": {
-    "defaultMessage": "Refreshing…"
-  },
-  "sessionArtifacts.empty": {
-    "defaultMessage": "No files yet"
-  },
-  "sessionArtifacts.emptyDirect": {
-    "defaultMessage": "Project files are not listed in direct mode — open the folder in your file manager"
-  },
-  "sessionArtifacts.emptyWorktree": {
-    "defaultMessage": "Only files changed in this session are shown"
-  },
-  "sessionArtifacts.openInFinder": {
-    "defaultMessage": "Open in file manager"
-  },
-  "sessionArtifacts.copyPath": {
-    "defaultMessage": "Copy path"
-  },
-  "sessionArtifacts.copiedPath": {
-    "defaultMessage": "Path copied"
-  },
-  "sessionArtifacts.openFailed": {
-    "defaultMessage": "Could not open path in file manager"
-  },
-  "sessionArtifacts.externalBadge": {
-    "defaultMessage": "External"
-  },
-  "sessionArtifacts.fileCount": {
-    "defaultMessage": "{count, plural, one {# file} other {# files}}"
-  },
-  "sessionArtifacts.truncated": {
-    "defaultMessage": "Showing first {count} files"
-  },
-  "sessionArtifacts.profileSandbox": {
-    "defaultMessage": "Sandbox"
-  },
-  "sessionArtifacts.profileWorktree": {
-    "defaultMessage": "Worktree"
-  },
-  "sessionArtifacts.profileDirect": {
-    "defaultMessage": "Direct"
-  },
-  "sessionArtifacts.workingDir": {
-    "defaultMessage": "Working directory"
-  },
-  "sessionArtifacts.rootPath": {
-    "defaultMessage": "Workspace root"
-  },
-  "sessionArtifacts.branchName": {
-    "defaultMessage": "Branch"
-  },
-  "sessionArtifacts.repoRoot": {
-    "defaultMessage": "Repository"
-  },
-  "hub.workspaceProfile.auto": {
-    "defaultMessage": "Auto"
-  },
-  "hub.workspaceProfile.sandbox": {
-    "defaultMessage": "Sandbox"
-  },
-  "hub.workspaceProfile.worktree": {
-    "defaultMessage": "Worktree"
-  },
-  "hub.workspaceProfile.direct": {
-    "defaultMessage": "Direct"
-  },
-  "hub.workspaceProfile.autoTooltip": {
-    "defaultMessage": "Auto (worktree in git repos, otherwise sandbox). Default from Settings."
-  },
-  "hub.workspaceProfile.sandboxTooltip": {
-    "defaultMessage": "Always sandbox. Default from Settings."
-  },
-  "hub.workspaceProfile.worktreeTooltip": {
-    "defaultMessage": "Prefer git worktree. Default from Settings."
-  },
-  "hub.workspaceProfile.directTooltip": {
-    "defaultMessage": "Direct (no isolation). Default from Settings."
-  },
-  "hub.workspaceProfile.recommended": {
-    "defaultMessage": "Recommended"
   }
 }

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -4931,6 +4931,12 @@
   "sessionArtifacts.empty": {
     "defaultMessage": "No files yet"
   },
+  "sessionArtifacts.emptyDirect": {
+    "defaultMessage": "Project files are not listed in direct mode — open the folder in your file manager"
+  },
+  "sessionArtifacts.emptyWorktree": {
+    "defaultMessage": "Only files changed in this session are shown"
+  },
   "sessionArtifacts.openInFinder": {
     "defaultMessage": "Open in file manager"
   },

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -4928,6 +4928,9 @@
   "sessionArtifacts.refresh": {
     "defaultMessage": "Actualizar"
   },
+  "sessionArtifacts.refreshing": {
+    "defaultMessage": "Actualizando…"
+  },
   "sessionArtifacts.empty": {
     "defaultMessage": "Aún no hay archivos"
   },
@@ -4945,6 +4948,9 @@
   },
   "sessionArtifacts.copiedPath": {
     "defaultMessage": "Ruta copiada"
+  },
+  "sessionArtifacts.openFailed": {
+    "defaultMessage": "No se pudo abrir la ruta en el administrador de archivos"
   },
   "sessionArtifacts.externalBadge": {
     "defaultMessage": "Externo"

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -4906,5 +4906,95 @@
   },
   "workspaceSettings.title": {
     "defaultMessage": "Workspace de sesión"
+  },
+  "sessionArtifacts.title": {
+    "defaultMessage": "Artefactos"
+  },
+  "sessionArtifacts.toggleOpen": {
+    "defaultMessage": "Mostrar panel de artefactos"
+  },
+  "sessionArtifacts.toggleClose": {
+    "defaultMessage": "Ocultar panel de artefactos"
+  },
+  "sessionArtifacts.inputs": {
+    "defaultMessage": "Entradas"
+  },
+  "sessionArtifacts.workspace": {
+    "defaultMessage": "Workspace"
+  },
+  "sessionArtifacts.meta": {
+    "defaultMessage": "Meta"
+  },
+  "sessionArtifacts.refresh": {
+    "defaultMessage": "Actualizar"
+  },
+  "sessionArtifacts.empty": {
+    "defaultMessage": "Aún no hay archivos"
+  },
+  "sessionArtifacts.openInFinder": {
+    "defaultMessage": "Abrir en el administrador de archivos"
+  },
+  "sessionArtifacts.copyPath": {
+    "defaultMessage": "Copiar ruta"
+  },
+  "sessionArtifacts.copiedPath": {
+    "defaultMessage": "Ruta copiada"
+  },
+  "sessionArtifacts.externalBadge": {
+    "defaultMessage": "Externo"
+  },
+  "sessionArtifacts.fileCount": {
+    "defaultMessage": "{count, plural, one {# archivo} other {# archivos}}"
+  },
+  "sessionArtifacts.truncated": {
+    "defaultMessage": "Mostrando los primeros {count} archivos"
+  },
+  "sessionArtifacts.profileSandbox": {
+    "defaultMessage": "Sandbox"
+  },
+  "sessionArtifacts.profileWorktree": {
+    "defaultMessage": "Worktree"
+  },
+  "sessionArtifacts.profileDirect": {
+    "defaultMessage": "Direct"
+  },
+  "sessionArtifacts.workingDir": {
+    "defaultMessage": "Directorio de trabajo"
+  },
+  "sessionArtifacts.rootPath": {
+    "defaultMessage": "Raíz del workspace"
+  },
+  "sessionArtifacts.branchName": {
+    "defaultMessage": "Rama"
+  },
+  "sessionArtifacts.repoRoot": {
+    "defaultMessage": "Repositorio"
+  },
+  "hub.workspaceProfile.auto": {
+    "defaultMessage": "Auto"
+  },
+  "hub.workspaceProfile.sandbox": {
+    "defaultMessage": "Sandbox"
+  },
+  "hub.workspaceProfile.worktree": {
+    "defaultMessage": "Worktree"
+  },
+  "hub.workspaceProfile.direct": {
+    "defaultMessage": "Direct"
+  },
+  "hub.workspaceProfile.autoTooltip": {
+    "defaultMessage": "Auto (worktree en repos git, si no sandbox). Predeterminado de Ajustes."
+  },
+  "hub.workspaceProfile.sandboxTooltip": {
+    "defaultMessage": "Siempre sandbox. Predeterminado de Ajustes."
+  },
+  "hub.workspaceProfile.worktreeTooltip": {
+    "defaultMessage": "Preferir git worktree. Predeterminado de Ajustes."
+  },
+  "hub.workspaceProfile.directTooltip": {
+    "defaultMessage": "Direct (sin aislamiento). Predeterminado de Ajustes."
+  },
+  "hub.workspaceProfile.recommended": {
+    "defaultMessage": "Recomendado"
   }
 }

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -4931,6 +4931,12 @@
   "sessionArtifacts.empty": {
     "defaultMessage": "Aún no hay archivos"
   },
+  "sessionArtifacts.emptyDirect": {
+    "defaultMessage": "Los archivos del proyecto no se listan en modo directo — abra la carpeta en el administrador de archivos"
+  },
+  "sessionArtifacts.emptyWorktree": {
+    "defaultMessage": "Solo se muestran los archivos modificados en esta sesión"
+  },
   "sessionArtifacts.openInFinder": {
     "defaultMessage": "Abrir en el administrador de archivos"
   },

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -974,8 +974,23 @@
   "dirSwitcher.openInFinder": {
     "defaultMessage": "Abrir en el gestor de archivos"
   },
+  "dirSwitcher.openWorkspaceFolder": {
+    "defaultMessage": "Abrir carpeta del workspace"
+  },
+  "dirSwitcher.originalFiles": {
+    "defaultMessage": "Archivos originales"
+  },
+  "dirSwitcher.projectBadge": {
+    "defaultMessage": "Proyecto"
+  },
   "dirSwitcher.recentDirectories": {
     "defaultMessage": "Directorios recientes"
+  },
+  "dirSwitcher.sandboxBadge": {
+    "defaultMessage": "Sandbox"
+  },
+  "dirSwitcher.worktreeBadge": {
+    "defaultMessage": "Worktree"
   },
   "elicitationRequest.accept": {
     "defaultMessage": "Aceptar"
@@ -1264,6 +1279,33 @@
   },
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "Conéctate a un servidor goose que se ejecuta en otro lugar (requiere reiniciar la app)"
+  },
+  "externalFileStrategy.copy": {
+    "defaultMessage": "Copiar al workspace (recomendado)"
+  },
+  "externalFileStrategy.copyDetail": {
+    "defaultMessage": "Seguro: los originales no se modifican."
+  },
+  "externalFileStrategy.description": {
+    "defaultMessage": "Estos archivos están fuera del workspace de la sesión. Elige cómo debe acceder goose a ellos."
+  },
+  "externalFileStrategy.reference": {
+    "defaultMessage": "Referencia de solo lectura"
+  },
+  "externalFileStrategy.referenceDetail": {
+    "defaultMessage": "Usar rutas originales; goose escribe solo en el workspace."
+  },
+  "externalFileStrategy.remember": {
+    "defaultMessage": "Recordar mi elección"
+  },
+  "externalFileStrategy.symlink": {
+    "defaultMessage": "Enlace al workspace"
+  },
+  "externalFileStrategy.symlinkDetail": {
+    "defaultMessage": "Ahorra espacio; los cambios pueden afectar a los originales."
+  },
+  "externalFileStrategy.title": {
+    "defaultMessage": "¿Cómo deben gestionarse los archivos adjuntos?"
   },
   "freeOptionCards.chooseOption": {
     "defaultMessage": "Elige una opción para empezar."
@@ -4828,5 +4870,41 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Crear una nueva sesión con el mensaje editado"
+  },
+  "workspaceSettings.description": {
+    "defaultMessage": "Controla cómo goose aísla cada sesión de tus archivos y proyectos."
+  },
+  "workspaceSettings.profileAuto": {
+    "defaultMessage": "Automático (worktree en repos git, si no sandbox)"
+  },
+  "workspaceSettings.profileDirect": {
+    "defaultMessage": "Directo (sin aislamiento)"
+  },
+  "workspaceSettings.profileLabel": {
+    "defaultMessage": "Modo de aislamiento"
+  },
+  "workspaceSettings.profileSandbox": {
+    "defaultMessage": "Siempre sandbox"
+  },
+  "workspaceSettings.profileWorktree": {
+    "defaultMessage": "Preferir git worktree"
+  },
+  "workspaceSettings.rememberLabel": {
+    "defaultMessage": "Recordar elección para archivos externos"
+  },
+  "workspaceSettings.strategyCopy": {
+    "defaultMessage": "Copiar al workspace"
+  },
+  "workspaceSettings.strategyLabel": {
+    "defaultMessage": "Archivos externos por defecto"
+  },
+  "workspaceSettings.strategyReference": {
+    "defaultMessage": "Solo lectura"
+  },
+  "workspaceSettings.strategySymlink": {
+    "defaultMessage": "Symlink al workspace"
+  },
+  "workspaceSettings.title": {
+    "defaultMessage": "Workspace de sesión"
   }
 }

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -4931,6 +4931,12 @@
   "sessionArtifacts.empty": {
     "defaultMessage": "अभी कोई फ़ाइल नहीं"
   },
+  "sessionArtifacts.emptyDirect": {
+    "defaultMessage": "डायरेक्ट मोड में प्रोजेक्ट फ़ाइलें सूचीबद्ध नहीं होतीं — फ़ाइल मैनेजर में फ़ोल्डर खोलें"
+  },
+  "sessionArtifacts.emptyWorktree": {
+    "defaultMessage": "केवल इस सत्र में बदली गई फ़ाइलें दिखाई जाती हैं"
+  },
   "sessionArtifacts.openInFinder": {
     "defaultMessage": "फ़ाइल मैनेजर में खोलें"
   },

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -4928,6 +4928,9 @@
   "sessionArtifacts.refresh": {
     "defaultMessage": "रीफ़्रेश"
   },
+  "sessionArtifacts.refreshing": {
+    "defaultMessage": "रीफ़्रेश हो रहा है…"
+  },
   "sessionArtifacts.empty": {
     "defaultMessage": "अभी कोई फ़ाइल नहीं"
   },
@@ -4945,6 +4948,9 @@
   },
   "sessionArtifacts.copiedPath": {
     "defaultMessage": "पथ कॉपी हो गया"
+  },
+  "sessionArtifacts.openFailed": {
+    "defaultMessage": "फ़ाइल मैनेजर में पथ नहीं खोला जा सका"
   },
   "sessionArtifacts.externalBadge": {
     "defaultMessage": "बाहरी"

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -4906,5 +4906,95 @@
   },
   "workspaceSettings.title": {
     "defaultMessage": "सत्र वर्कस्पेस"
+  },
+  "sessionArtifacts.title": {
+    "defaultMessage": "आर्टिफैक्ट"
+  },
+  "sessionArtifacts.toggleOpen": {
+    "defaultMessage": "आर्टिफैक्ट पैनल दिखाएँ"
+  },
+  "sessionArtifacts.toggleClose": {
+    "defaultMessage": "आर्टिफैक्ट पैनल छिपाएँ"
+  },
+  "sessionArtifacts.inputs": {
+    "defaultMessage": "इनपुट"
+  },
+  "sessionArtifacts.workspace": {
+    "defaultMessage": "वर्कस्पेस"
+  },
+  "sessionArtifacts.meta": {
+    "defaultMessage": "मेटा"
+  },
+  "sessionArtifacts.refresh": {
+    "defaultMessage": "रीफ़्रेश"
+  },
+  "sessionArtifacts.empty": {
+    "defaultMessage": "अभी कोई फ़ाइल नहीं"
+  },
+  "sessionArtifacts.openInFinder": {
+    "defaultMessage": "फ़ाइल मैनेजर में खोलें"
+  },
+  "sessionArtifacts.copyPath": {
+    "defaultMessage": "पथ कॉपी करें"
+  },
+  "sessionArtifacts.copiedPath": {
+    "defaultMessage": "पथ कॉपी हो गया"
+  },
+  "sessionArtifacts.externalBadge": {
+    "defaultMessage": "बाहरी"
+  },
+  "sessionArtifacts.fileCount": {
+    "defaultMessage": "{count, plural, one {# फ़ाइल} other {# फ़ाइलें}}"
+  },
+  "sessionArtifacts.truncated": {
+    "defaultMessage": "पहली {count} फ़ाइलें दिखाई जा रही हैं"
+  },
+  "sessionArtifacts.profileSandbox": {
+    "defaultMessage": "Sandbox"
+  },
+  "sessionArtifacts.profileWorktree": {
+    "defaultMessage": "Worktree"
+  },
+  "sessionArtifacts.profileDirect": {
+    "defaultMessage": "Direct"
+  },
+  "sessionArtifacts.workingDir": {
+    "defaultMessage": "कार्य निर्देशिका"
+  },
+  "sessionArtifacts.rootPath": {
+    "defaultMessage": "वर्कस्पेस रूट"
+  },
+  "sessionArtifacts.branchName": {
+    "defaultMessage": "शाखा"
+  },
+  "sessionArtifacts.repoRoot": {
+    "defaultMessage": "रिपॉज़िटरी"
+  },
+  "hub.workspaceProfile.auto": {
+    "defaultMessage": "Auto"
+  },
+  "hub.workspaceProfile.sandbox": {
+    "defaultMessage": "Sandbox"
+  },
+  "hub.workspaceProfile.worktree": {
+    "defaultMessage": "Worktree"
+  },
+  "hub.workspaceProfile.direct": {
+    "defaultMessage": "Direct"
+  },
+  "hub.workspaceProfile.autoTooltip": {
+    "defaultMessage": "Auto (git repos में worktree, अन्यथा sandbox)। सेटिंग्स से डिफ़ॉल्ट।"
+  },
+  "hub.workspaceProfile.sandboxTooltip": {
+    "defaultMessage": "हमेशा sandbox। सेटिंग्स से डिफ़ॉल्ट।"
+  },
+  "hub.workspaceProfile.worktreeTooltip": {
+    "defaultMessage": "git worktree प्राथमिकता। सेटिंग्स से डिफ़ॉल्ट।"
+  },
+  "hub.workspaceProfile.directTooltip": {
+    "defaultMessage": "Direct (कोई अलगाव नहीं)। सेटिंग्स से डिफ़ॉल्ट।"
+  },
+  "hub.workspaceProfile.recommended": {
+    "defaultMessage": "अनुशंसित"
   }
 }

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -974,8 +974,23 @@
   "dirSwitcher.openInFinder": {
     "defaultMessage": "फ़ाइल प्रबंधक में खोलें"
   },
+  "dirSwitcher.openWorkspaceFolder": {
+    "defaultMessage": "वर्कस्पेस फ़ोल्डर खोलें"
+  },
+  "dirSwitcher.originalFiles": {
+    "defaultMessage": "मूल फ़ाइलें"
+  },
+  "dirSwitcher.projectBadge": {
+    "defaultMessage": "प्रोजेक्ट"
+  },
   "dirSwitcher.recentDirectories": {
     "defaultMessage": "हाल की निर्देशिकाएँ"
+  },
+  "dirSwitcher.sandboxBadge": {
+    "defaultMessage": "सैंडबॉक्स"
+  },
+  "dirSwitcher.worktreeBadge": {
+    "defaultMessage": "वर्कट्री"
   },
   "elicitationRequest.accept": {
     "defaultMessage": "स्वीकार करो"
@@ -1264,6 +1279,33 @@
   },
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "कहीं और चल रहे goose सर्वर से कनेक्ट करें (ऐप पुनरारंभ की आवश्यकता है)"
+  },
+  "externalFileStrategy.copy": {
+    "defaultMessage": "वर्कस्पेस में कॉपी करें (अनुशंसित)"
+  },
+  "externalFileStrategy.copyDetail": {
+    "defaultMessage": "सुरक्षित — मूल फ़ाइलें अप्रभावित रहती हैं।"
+  },
+  "externalFileStrategy.description": {
+    "defaultMessage": "ये फ़ाइलें सत्र वर्कस्पेस के बाहर हैं। चुनें कि goose उन्हें कैसे एक्सेस करे।"
+  },
+  "externalFileStrategy.reference": {
+    "defaultMessage": "केवल-पढ़ने योग्य संदर्भ"
+  },
+  "externalFileStrategy.referenceDetail": {
+    "defaultMessage": "मूल पथ उपयोग करें; goose केवल वर्कस्पेस में लिखता है।"
+  },
+  "externalFileStrategy.remember": {
+    "defaultMessage": "मेरी पसंद याद रखें"
+  },
+  "externalFileStrategy.symlink": {
+    "defaultMessage": "वर्कस्पेस में लिंक करें"
+  },
+  "externalFileStrategy.symlinkDetail": {
+    "defaultMessage": "स्थान बचाता है; बदलाव मूल फ़ाइलों को प्रभावित कर सकते हैं।"
+  },
+  "externalFileStrategy.title": {
+    "defaultMessage": "संलग्न फ़ाइलों को कैसे संभाला जाए?"
   },
   "freeOptionCards.chooseOption": {
     "defaultMessage": "आरंभ करने के लिए एक विकल्प चुनें."
@@ -4828,5 +4870,41 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "संपादित संदेश के साथ एक नया सत्र बनाएं"
+  },
+  "workspaceSettings.description": {
+    "defaultMessage": "नियंत्रित करें कि goose प्रत्येक सत्र को आपकी फ़ाइलों और प्रोजेक्ट्स से कैसे अलग करता है।"
+  },
+  "workspaceSettings.profileAuto": {
+    "defaultMessage": "ऑटो (git रिपो में worktree, अन्यथा सैंडबॉक्स)"
+  },
+  "workspaceSettings.profileDirect": {
+    "defaultMessage": "प्रत्यक्ष (कोई अलगाव नहीं)"
+  },
+  "workspaceSettings.profileLabel": {
+    "defaultMessage": "अलगाव मोड"
+  },
+  "workspaceSettings.profileSandbox": {
+    "defaultMessage": "हमेशा सैंडबॉक्स"
+  },
+  "workspaceSettings.profileWorktree": {
+    "defaultMessage": "git worktree प्राथमिकता"
+  },
+  "workspaceSettings.rememberLabel": {
+    "defaultMessage": "बाहरी फ़ाइल विकल्प याद रखें"
+  },
+  "workspaceSettings.strategyCopy": {
+    "defaultMessage": "वर्कस्पेस में कॉपी करें"
+  },
+  "workspaceSettings.strategyLabel": {
+    "defaultMessage": "बाहरी फ़ाइलों का डिफ़ॉल्ट"
+  },
+  "workspaceSettings.strategyReference": {
+    "defaultMessage": "केवल-पढ़ने योग्य संदर्भ"
+  },
+  "workspaceSettings.strategySymlink": {
+    "defaultMessage": "वर्कस्पेस में सिमलिंक"
+  },
+  "workspaceSettings.title": {
+    "defaultMessage": "सत्र वर्कस्पेस"
   }
 }

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -974,8 +974,23 @@
   "dirSwitcher.openInFinder": {
     "defaultMessage": "ファイルマネージャーで開く"
   },
+  "dirSwitcher.openWorkspaceFolder": {
+    "defaultMessage": "ワークスペースフォルダを開く"
+  },
+  "dirSwitcher.originalFiles": {
+    "defaultMessage": "元のファイル"
+  },
+  "dirSwitcher.projectBadge": {
+    "defaultMessage": "プロジェクト"
+  },
   "dirSwitcher.recentDirectories": {
     "defaultMessage": "最近のディレクトリ"
+  },
+  "dirSwitcher.sandboxBadge": {
+    "defaultMessage": "サンドボックス"
+  },
+  "dirSwitcher.worktreeBadge": {
+    "defaultMessage": "ワークツリー"
   },
   "elicitationRequest.accept": {
     "defaultMessage": "承諾"
@@ -1264,6 +1279,33 @@
   },
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "別の場所で実行中の goose サーバーに接続します（アプリの再起動が必要）"
+  },
+  "externalFileStrategy.copy": {
+    "defaultMessage": "ワークスペースにコピー（推奨）"
+  },
+  "externalFileStrategy.copyDetail": {
+    "defaultMessage": "安全 — 元のファイルは変更されません。"
+  },
+  "externalFileStrategy.description": {
+    "defaultMessage": "これらのファイルはセッションワークスペースの外にあります。goose のアクセス方法を選択してください。"
+  },
+  "externalFileStrategy.reference": {
+    "defaultMessage": "読み取り専用参照"
+  },
+  "externalFileStrategy.referenceDetail": {
+    "defaultMessage": "元のパスを使用；goose はワークスペース内にのみ書き込みます。"
+  },
+  "externalFileStrategy.remember": {
+    "defaultMessage": "選択を記憶する"
+  },
+  "externalFileStrategy.symlink": {
+    "defaultMessage": "ワークスペースにリンク"
+  },
+  "externalFileStrategy.symlinkDetail": {
+    "defaultMessage": "容量を節約；変更が元のファイルに影響する場合があります。"
+  },
+  "externalFileStrategy.title": {
+    "defaultMessage": "添付ファイルをどのように扱いますか？"
   },
   "freeOptionCards.chooseOption": {
     "defaultMessage": "開始するオプションを選択してください。"
@@ -4828,5 +4870,41 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "編集したメッセージで新しいセッションを作成"
+  },
+  "workspaceSettings.description": {
+    "defaultMessage": "goose が各セッションをファイルやプロジェクトからどのように分離するかを制御します。"
+  },
+  "workspaceSettings.profileAuto": {
+    "defaultMessage": "自動（git リポジトリでは worktree、それ以外はサンドボックス）"
+  },
+  "workspaceSettings.profileDirect": {
+    "defaultMessage": "直接（分離なし）"
+  },
+  "workspaceSettings.profileLabel": {
+    "defaultMessage": "分離モード"
+  },
+  "workspaceSettings.profileSandbox": {
+    "defaultMessage": "常にサンドボックス"
+  },
+  "workspaceSettings.profileWorktree": {
+    "defaultMessage": "git worktree を優先"
+  },
+  "workspaceSettings.rememberLabel": {
+    "defaultMessage": "外部ファイルの選択を記憶"
+  },
+  "workspaceSettings.strategyCopy": {
+    "defaultMessage": "ワークスペースにコピー"
+  },
+  "workspaceSettings.strategyLabel": {
+    "defaultMessage": "外部ファイルのデフォルト"
+  },
+  "workspaceSettings.strategyReference": {
+    "defaultMessage": "読み取り専用参照"
+  },
+  "workspaceSettings.strategySymlink": {
+    "defaultMessage": "ワークスペースにシンボリックリンク"
+  },
+  "workspaceSettings.title": {
+    "defaultMessage": "セッションワークスペース"
   }
 }

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -4928,6 +4928,9 @@
   "sessionArtifacts.refresh": {
     "defaultMessage": "更新"
   },
+  "sessionArtifacts.refreshing": {
+    "defaultMessage": "更新中…"
+  },
   "sessionArtifacts.empty": {
     "defaultMessage": "ファイルはまだありません"
   },
@@ -4945,6 +4948,9 @@
   },
   "sessionArtifacts.copiedPath": {
     "defaultMessage": "パスをコピーしました"
+  },
+  "sessionArtifacts.openFailed": {
+    "defaultMessage": "ファイルマネージャーでパスを開けませんでした"
   },
   "sessionArtifacts.externalBadge": {
     "defaultMessage": "外部"

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -4906,5 +4906,95 @@
   },
   "workspaceSettings.title": {
     "defaultMessage": "セッションワークスペース"
+  },
+  "sessionArtifacts.title": {
+    "defaultMessage": "アーティファクト"
+  },
+  "sessionArtifacts.toggleOpen": {
+    "defaultMessage": "アーティファクトパネルを表示"
+  },
+  "sessionArtifacts.toggleClose": {
+    "defaultMessage": "アーティファクトパネルを非表示"
+  },
+  "sessionArtifacts.inputs": {
+    "defaultMessage": "入力"
+  },
+  "sessionArtifacts.workspace": {
+    "defaultMessage": "ワークスペース"
+  },
+  "sessionArtifacts.meta": {
+    "defaultMessage": "メタ"
+  },
+  "sessionArtifacts.refresh": {
+    "defaultMessage": "更新"
+  },
+  "sessionArtifacts.empty": {
+    "defaultMessage": "ファイルはまだありません"
+  },
+  "sessionArtifacts.openInFinder": {
+    "defaultMessage": "ファイルマネージャーで開く"
+  },
+  "sessionArtifacts.copyPath": {
+    "defaultMessage": "パスをコピー"
+  },
+  "sessionArtifacts.copiedPath": {
+    "defaultMessage": "パスをコピーしました"
+  },
+  "sessionArtifacts.externalBadge": {
+    "defaultMessage": "外部"
+  },
+  "sessionArtifacts.fileCount": {
+    "defaultMessage": "{count, plural, other {# 件のファイル}}"
+  },
+  "sessionArtifacts.truncated": {
+    "defaultMessage": "最初の {count} 件を表示"
+  },
+  "sessionArtifacts.profileSandbox": {
+    "defaultMessage": "Sandbox"
+  },
+  "sessionArtifacts.profileWorktree": {
+    "defaultMessage": "Worktree"
+  },
+  "sessionArtifacts.profileDirect": {
+    "defaultMessage": "Direct"
+  },
+  "sessionArtifacts.workingDir": {
+    "defaultMessage": "作業ディレクトリ"
+  },
+  "sessionArtifacts.rootPath": {
+    "defaultMessage": "ワークスペースルート"
+  },
+  "sessionArtifacts.branchName": {
+    "defaultMessage": "ブランチ"
+  },
+  "sessionArtifacts.repoRoot": {
+    "defaultMessage": "リポジトリ"
+  },
+  "hub.workspaceProfile.auto": {
+    "defaultMessage": "Auto"
+  },
+  "hub.workspaceProfile.sandbox": {
+    "defaultMessage": "Sandbox"
+  },
+  "hub.workspaceProfile.worktree": {
+    "defaultMessage": "Worktree"
+  },
+  "hub.workspaceProfile.direct": {
+    "defaultMessage": "Direct"
+  },
+  "hub.workspaceProfile.autoTooltip": {
+    "defaultMessage": "Auto（git リポジトリでは worktree、それ以外は sandbox）。設定のデフォルト。"
+  },
+  "hub.workspaceProfile.sandboxTooltip": {
+    "defaultMessage": "常に sandbox。設定のデフォルト。"
+  },
+  "hub.workspaceProfile.worktreeTooltip": {
+    "defaultMessage": "git worktree を優先。設定のデフォルト。"
+  },
+  "hub.workspaceProfile.directTooltip": {
+    "defaultMessage": "Direct（隔離なし）。設定のデフォルト。"
+  },
+  "hub.workspaceProfile.recommended": {
+    "defaultMessage": "おすすめ"
   }
 }

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -4931,6 +4931,12 @@
   "sessionArtifacts.empty": {
     "defaultMessage": "ファイルはまだありません"
   },
+  "sessionArtifacts.emptyDirect": {
+    "defaultMessage": "ダイレクトモードではプロジェクトファイルは一覧表示されません — ファイルマネージャーでフォルダを開いてください"
+  },
+  "sessionArtifacts.emptyWorktree": {
+    "defaultMessage": "このセッションで変更されたファイルのみ表示されます"
+  },
   "sessionArtifacts.openInFinder": {
     "defaultMessage": "ファイルマネージャーで開く"
   },

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -4928,6 +4928,9 @@
   "sessionArtifacts.refresh": {
     "defaultMessage": "Обновить"
   },
+  "sessionArtifacts.refreshing": {
+    "defaultMessage": "Обновление…"
+  },
   "sessionArtifacts.empty": {
     "defaultMessage": "Файлов пока нет"
   },
@@ -4945,6 +4948,9 @@
   },
   "sessionArtifacts.copiedPath": {
     "defaultMessage": "Путь скопирован"
+  },
+  "sessionArtifacts.openFailed": {
+    "defaultMessage": "Не удалось открыть путь в файловом менеджере"
   },
   "sessionArtifacts.externalBadge": {
     "defaultMessage": "Внешний"

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -4931,6 +4931,12 @@
   "sessionArtifacts.empty": {
     "defaultMessage": "Файлов пока нет"
   },
+  "sessionArtifacts.emptyDirect": {
+    "defaultMessage": "Файлы проекта не перечисляются в direct mode — откройте папку в файловом менеджере"
+  },
+  "sessionArtifacts.emptyWorktree": {
+    "defaultMessage": "Показаны только файлы, изменённые в этой сессии"
+  },
   "sessionArtifacts.openInFinder": {
     "defaultMessage": "Открыть в файловом менеджере"
   },

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -974,8 +974,23 @@
   "dirSwitcher.openInFinder": {
     "defaultMessage": "Открыть в файловом менеджере"
   },
+  "dirSwitcher.openWorkspaceFolder": {
+    "defaultMessage": "Открыть папку workspace"
+  },
+  "dirSwitcher.originalFiles": {
+    "defaultMessage": "Исходные файлы"
+  },
+  "dirSwitcher.projectBadge": {
+    "defaultMessage": "Проект"
+  },
   "dirSwitcher.recentDirectories": {
     "defaultMessage": "Недавние каталоги"
+  },
+  "dirSwitcher.sandboxBadge": {
+    "defaultMessage": "Sandbox"
+  },
+  "dirSwitcher.worktreeBadge": {
+    "defaultMessage": "Worktree"
   },
   "elicitationRequest.accept": {
     "defaultMessage": "Принять"
@@ -1264,6 +1279,33 @@
   },
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "Подключиться к серверу goose, запущенному в другом месте (требуется перезапуск приложения)"
+  },
+  "externalFileStrategy.copy": {
+    "defaultMessage": "Копировать в workspace (рекомендуется)"
+  },
+  "externalFileStrategy.copyDetail": {
+    "defaultMessage": "Безопасно — оригиналы не затрагиваются."
+  },
+  "externalFileStrategy.description": {
+    "defaultMessage": "Эти файлы находятся вне workspace сессии. Выберите, как goose должен с ними работать."
+  },
+  "externalFileStrategy.reference": {
+    "defaultMessage": "Только чтение"
+  },
+  "externalFileStrategy.referenceDetail": {
+    "defaultMessage": "Использовать исходные пути; goose пишет только в workspace."
+  },
+  "externalFileStrategy.remember": {
+    "defaultMessage": "Запомнить мой выбор"
+  },
+  "externalFileStrategy.symlink": {
+    "defaultMessage": "Ссылка в workspace"
+  },
+  "externalFileStrategy.symlinkDetail": {
+    "defaultMessage": "Экономит место; изменения могут затронуть оригиналы."
+  },
+  "externalFileStrategy.title": {
+    "defaultMessage": "Как обрабатывать прикреплённые файлы?"
   },
   "freeOptionCards.chooseOption": {
     "defaultMessage": "Выберите вариант, чтобы начать."
@@ -4828,5 +4870,41 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Создать новый сеанс с измененным сообщением"
+  },
+  "workspaceSettings.description": {
+    "defaultMessage": "Управляйте тем, как goose изолирует каждую сессию от ваших файлов и проектов."
+  },
+  "workspaceSettings.profileAuto": {
+    "defaultMessage": "Авто (worktree в git-репозиториях, иначе sandbox)"
+  },
+  "workspaceSettings.profileDirect": {
+    "defaultMessage": "Прямой (без изоляции)"
+  },
+  "workspaceSettings.profileLabel": {
+    "defaultMessage": "Режим изоляции"
+  },
+  "workspaceSettings.profileSandbox": {
+    "defaultMessage": "Всегда sandbox"
+  },
+  "workspaceSettings.profileWorktree": {
+    "defaultMessage": "Предпочитать git worktree"
+  },
+  "workspaceSettings.rememberLabel": {
+    "defaultMessage": "Запомнить выбор для внешних файлов"
+  },
+  "workspaceSettings.strategyCopy": {
+    "defaultMessage": "Копировать в workspace"
+  },
+  "workspaceSettings.strategyLabel": {
+    "defaultMessage": "Внешние файлы по умолчанию"
+  },
+  "workspaceSettings.strategyReference": {
+    "defaultMessage": "Только чтение"
+  },
+  "workspaceSettings.strategySymlink": {
+    "defaultMessage": "Симлинк в workspace"
+  },
+  "workspaceSettings.title": {
+    "defaultMessage": "Workspace сессии"
   }
 }

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -4906,5 +4906,95 @@
   },
   "workspaceSettings.title": {
     "defaultMessage": "Workspace сессии"
+  },
+  "sessionArtifacts.title": {
+    "defaultMessage": "Артефакты"
+  },
+  "sessionArtifacts.toggleOpen": {
+    "defaultMessage": "Показать панель артефактов"
+  },
+  "sessionArtifacts.toggleClose": {
+    "defaultMessage": "Скрыть панель артефактов"
+  },
+  "sessionArtifacts.inputs": {
+    "defaultMessage": "Входные файлы"
+  },
+  "sessionArtifacts.workspace": {
+    "defaultMessage": "Workspace"
+  },
+  "sessionArtifacts.meta": {
+    "defaultMessage": "Мета"
+  },
+  "sessionArtifacts.refresh": {
+    "defaultMessage": "Обновить"
+  },
+  "sessionArtifacts.empty": {
+    "defaultMessage": "Файлов пока нет"
+  },
+  "sessionArtifacts.openInFinder": {
+    "defaultMessage": "Открыть в файловом менеджере"
+  },
+  "sessionArtifacts.copyPath": {
+    "defaultMessage": "Копировать путь"
+  },
+  "sessionArtifacts.copiedPath": {
+    "defaultMessage": "Путь скопирован"
+  },
+  "sessionArtifacts.externalBadge": {
+    "defaultMessage": "Внешний"
+  },
+  "sessionArtifacts.fileCount": {
+    "defaultMessage": "{count, plural, one {# файл} few {# файла} many {# файлов} other {# файла}}"
+  },
+  "sessionArtifacts.truncated": {
+    "defaultMessage": "Показаны первые {count} файлов"
+  },
+  "sessionArtifacts.profileSandbox": {
+    "defaultMessage": "Sandbox"
+  },
+  "sessionArtifacts.profileWorktree": {
+    "defaultMessage": "Worktree"
+  },
+  "sessionArtifacts.profileDirect": {
+    "defaultMessage": "Direct"
+  },
+  "sessionArtifacts.workingDir": {
+    "defaultMessage": "Рабочая директория"
+  },
+  "sessionArtifacts.rootPath": {
+    "defaultMessage": "Корень workspace"
+  },
+  "sessionArtifacts.branchName": {
+    "defaultMessage": "Ветка"
+  },
+  "sessionArtifacts.repoRoot": {
+    "defaultMessage": "Репозиторий"
+  },
+  "hub.workspaceProfile.auto": {
+    "defaultMessage": "Auto"
+  },
+  "hub.workspaceProfile.sandbox": {
+    "defaultMessage": "Sandbox"
+  },
+  "hub.workspaceProfile.worktree": {
+    "defaultMessage": "Worktree"
+  },
+  "hub.workspaceProfile.direct": {
+    "defaultMessage": "Direct"
+  },
+  "hub.workspaceProfile.autoTooltip": {
+    "defaultMessage": "Auto (worktree в git-репозиториях, иначе sandbox). По умолчанию из настроек."
+  },
+  "hub.workspaceProfile.sandboxTooltip": {
+    "defaultMessage": "Всегда sandbox. По умолчанию из настроек."
+  },
+  "hub.workspaceProfile.worktreeTooltip": {
+    "defaultMessage": "Предпочитать git worktree. По умолчанию из настроек."
+  },
+  "hub.workspaceProfile.directTooltip": {
+    "defaultMessage": "Direct (без изоляции). По умолчанию из настроек."
+  },
+  "hub.workspaceProfile.recommended": {
+    "defaultMessage": "Рекомендуется"
   }
 }

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -4928,6 +4928,9 @@
   "sessionArtifacts.refresh": {
     "defaultMessage": "Yenile"
   },
+  "sessionArtifacts.refreshing": {
+    "defaultMessage": "Yenileniyor…"
+  },
   "sessionArtifacts.empty": {
     "defaultMessage": "Henüz dosya yok"
   },
@@ -4945,6 +4948,9 @@
   },
   "sessionArtifacts.copiedPath": {
     "defaultMessage": "Yol kopyalandı"
+  },
+  "sessionArtifacts.openFailed": {
+    "defaultMessage": "Yol dosya yöneticisinde açılamadı"
   },
   "sessionArtifacts.externalBadge": {
     "defaultMessage": "Harici"

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -974,8 +974,23 @@
   "dirSwitcher.openInFinder": {
     "defaultMessage": "Dosya yöneticisinde aç"
   },
+  "dirSwitcher.openWorkspaceFolder": {
+    "defaultMessage": "Workspace klasörünü aç"
+  },
+  "dirSwitcher.originalFiles": {
+    "defaultMessage": "Orijinal dosyalar"
+  },
+  "dirSwitcher.projectBadge": {
+    "defaultMessage": "Proje"
+  },
   "dirSwitcher.recentDirectories": {
     "defaultMessage": "Son dizinler"
+  },
+  "dirSwitcher.sandboxBadge": {
+    "defaultMessage": "Sandbox"
+  },
+  "dirSwitcher.worktreeBadge": {
+    "defaultMessage": "Worktree"
   },
   "elicitationRequest.accept": {
     "defaultMessage": "Kabul et"
@@ -1264,6 +1279,33 @@
   },
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "Başka bir yerde çalışan bir goose sunucusuna bağlanın (uygulamanın yeniden başlatılmasını gerektirir)"
+  },
+  "externalFileStrategy.copy": {
+    "defaultMessage": "Workspace'e kopyala (önerilen)"
+  },
+  "externalFileStrategy.copyDetail": {
+    "defaultMessage": "Güvenli — orijinaller değiştirilmez."
+  },
+  "externalFileStrategy.description": {
+    "defaultMessage": "Bu dosyalar oturum workspace'inin dışında. goose'un bunlara nasıl erişeceğini seçin."
+  },
+  "externalFileStrategy.reference": {
+    "defaultMessage": "Salt okunur referans"
+  },
+  "externalFileStrategy.referenceDetail": {
+    "defaultMessage": "Orijinal yolları kullan; goose yalnızca workspace'e yazar."
+  },
+  "externalFileStrategy.remember": {
+    "defaultMessage": "Seçimimi hatırla"
+  },
+  "externalFileStrategy.symlink": {
+    "defaultMessage": "Workspace'e bağla"
+  },
+  "externalFileStrategy.symlinkDetail": {
+    "defaultMessage": "Yer tasarrufu sağlar; değişiklikler orijinalleri etkileyebilir."
+  },
+  "externalFileStrategy.title": {
+    "defaultMessage": "Ekli dosyalar nasıl işlensin?"
   },
   "freeOptionCards.chooseOption": {
     "defaultMessage": "Başlamak için bir seçenek seçin."
@@ -4828,5 +4870,41 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Düzenlenen mesajla yeni bir oturum oluşturun"
+  },
+  "workspaceSettings.description": {
+    "defaultMessage": "goose'un her oturumu dosyalarınızdan ve projelerinizden nasıl izole ettiğini kontrol edin."
+  },
+  "workspaceSettings.profileAuto": {
+    "defaultMessage": "Otomatik (git depolarında worktree, aksi halde sandbox)"
+  },
+  "workspaceSettings.profileDirect": {
+    "defaultMessage": "Doğrudan (izolasyon yok)"
+  },
+  "workspaceSettings.profileLabel": {
+    "defaultMessage": "İzolasyon modu"
+  },
+  "workspaceSettings.profileSandbox": {
+    "defaultMessage": "Her zaman sandbox"
+  },
+  "workspaceSettings.profileWorktree": {
+    "defaultMessage": "Git worktree tercih et"
+  },
+  "workspaceSettings.rememberLabel": {
+    "defaultMessage": "Harici dosya seçimini hatırla"
+  },
+  "workspaceSettings.strategyCopy": {
+    "defaultMessage": "Workspace'e kopyala"
+  },
+  "workspaceSettings.strategyLabel": {
+    "defaultMessage": "Varsayılan harici dosyalar"
+  },
+  "workspaceSettings.strategyReference": {
+    "defaultMessage": "Salt okunur referans"
+  },
+  "workspaceSettings.strategySymlink": {
+    "defaultMessage": "Workspace'e symlink"
+  },
+  "workspaceSettings.title": {
+    "defaultMessage": "Oturum workspace'i"
   }
 }

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -4931,6 +4931,12 @@
   "sessionArtifacts.empty": {
     "defaultMessage": "Henüz dosya yok"
   },
+  "sessionArtifacts.emptyDirect": {
+    "defaultMessage": "Doğrudan modda proje dosyaları listelenmez — klasörü dosya yöneticisinde açın"
+  },
+  "sessionArtifacts.emptyWorktree": {
+    "defaultMessage": "Yalnızca bu oturumda değiştirilen dosyalar gösterilir"
+  },
   "sessionArtifacts.openInFinder": {
     "defaultMessage": "Dosya yöneticisinde aç"
   },

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -4906,5 +4906,95 @@
   },
   "workspaceSettings.title": {
     "defaultMessage": "Oturum workspace'i"
+  },
+  "sessionArtifacts.title": {
+    "defaultMessage": "Artefaktlar"
+  },
+  "sessionArtifacts.toggleOpen": {
+    "defaultMessage": "Artefakt panelini göster"
+  },
+  "sessionArtifacts.toggleClose": {
+    "defaultMessage": "Artefakt panelini gizle"
+  },
+  "sessionArtifacts.inputs": {
+    "defaultMessage": "Girdiler"
+  },
+  "sessionArtifacts.workspace": {
+    "defaultMessage": "Workspace"
+  },
+  "sessionArtifacts.meta": {
+    "defaultMessage": "Meta"
+  },
+  "sessionArtifacts.refresh": {
+    "defaultMessage": "Yenile"
+  },
+  "sessionArtifacts.empty": {
+    "defaultMessage": "Henüz dosya yok"
+  },
+  "sessionArtifacts.openInFinder": {
+    "defaultMessage": "Dosya yöneticisinde aç"
+  },
+  "sessionArtifacts.copyPath": {
+    "defaultMessage": "Yolu kopyala"
+  },
+  "sessionArtifacts.copiedPath": {
+    "defaultMessage": "Yol kopyalandı"
+  },
+  "sessionArtifacts.externalBadge": {
+    "defaultMessage": "Harici"
+  },
+  "sessionArtifacts.fileCount": {
+    "defaultMessage": "{count, plural, one {# dosya} other {# dosya}}"
+  },
+  "sessionArtifacts.truncated": {
+    "defaultMessage": "İlk {count} dosya gösteriliyor"
+  },
+  "sessionArtifacts.profileSandbox": {
+    "defaultMessage": "Sandbox"
+  },
+  "sessionArtifacts.profileWorktree": {
+    "defaultMessage": "Worktree"
+  },
+  "sessionArtifacts.profileDirect": {
+    "defaultMessage": "Direct"
+  },
+  "sessionArtifacts.workingDir": {
+    "defaultMessage": "Çalışma dizini"
+  },
+  "sessionArtifacts.rootPath": {
+    "defaultMessage": "Workspace kökü"
+  },
+  "sessionArtifacts.branchName": {
+    "defaultMessage": "Dal"
+  },
+  "sessionArtifacts.repoRoot": {
+    "defaultMessage": "Depo"
+  },
+  "hub.workspaceProfile.auto": {
+    "defaultMessage": "Auto"
+  },
+  "hub.workspaceProfile.sandbox": {
+    "defaultMessage": "Sandbox"
+  },
+  "hub.workspaceProfile.worktree": {
+    "defaultMessage": "Worktree"
+  },
+  "hub.workspaceProfile.direct": {
+    "defaultMessage": "Direct"
+  },
+  "hub.workspaceProfile.autoTooltip": {
+    "defaultMessage": "Auto (git repolarında worktree, aksi halde sandbox). Ayarlardan varsayılan."
+  },
+  "hub.workspaceProfile.sandboxTooltip": {
+    "defaultMessage": "Her zaman sandbox. Ayarlardan varsayılan."
+  },
+  "hub.workspaceProfile.worktreeTooltip": {
+    "defaultMessage": "Git worktree tercih et. Ayarlardan varsayılan."
+  },
+  "hub.workspaceProfile.directTooltip": {
+    "defaultMessage": "Direct (izolasyon yok). Ayarlardan varsayılan."
+  },
+  "hub.workspaceProfile.recommended": {
+    "defaultMessage": "Önerilen"
   }
 }

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -4931,6 +4931,12 @@
   "sessionArtifacts.empty": {
     "defaultMessage": "暂无文件"
   },
+  "sessionArtifacts.emptyDirect": {
+    "defaultMessage": "直接模式下不会列出项目文件 — 请在文件管理器中打开文件夹"
+  },
+  "sessionArtifacts.emptyWorktree": {
+    "defaultMessage": "仅显示此会话中更改的文件"
+  },
   "sessionArtifacts.openInFinder": {
     "defaultMessage": "在文件管理器中打开"
   },

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -4928,6 +4928,9 @@
   "sessionArtifacts.refresh": {
     "defaultMessage": "刷新"
   },
+  "sessionArtifacts.refreshing": {
+    "defaultMessage": "刷新中…"
+  },
   "sessionArtifacts.empty": {
     "defaultMessage": "暂无文件"
   },
@@ -4945,6 +4948,9 @@
   },
   "sessionArtifacts.copiedPath": {
     "defaultMessage": "路径已复制"
+  },
+  "sessionArtifacts.openFailed": {
+    "defaultMessage": "无法在文件管理器中打开路径"
   },
   "sessionArtifacts.externalBadge": {
     "defaultMessage": "外部"

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -4906,5 +4906,95 @@
   },
   "workspaceSettings.title": {
     "defaultMessage": "会话工作区"
+  },
+  "sessionArtifacts.title": {
+    "defaultMessage": "产物"
+  },
+  "sessionArtifacts.toggleOpen": {
+    "defaultMessage": "显示产物面板"
+  },
+  "sessionArtifacts.toggleClose": {
+    "defaultMessage": "隐藏产物面板"
+  },
+  "sessionArtifacts.inputs": {
+    "defaultMessage": "输入"
+  },
+  "sessionArtifacts.workspace": {
+    "defaultMessage": "工作区"
+  },
+  "sessionArtifacts.meta": {
+    "defaultMessage": "元信息"
+  },
+  "sessionArtifacts.refresh": {
+    "defaultMessage": "刷新"
+  },
+  "sessionArtifacts.empty": {
+    "defaultMessage": "暂无文件"
+  },
+  "sessionArtifacts.openInFinder": {
+    "defaultMessage": "在文件管理器中打开"
+  },
+  "sessionArtifacts.copyPath": {
+    "defaultMessage": "复制路径"
+  },
+  "sessionArtifacts.copiedPath": {
+    "defaultMessage": "路径已复制"
+  },
+  "sessionArtifacts.externalBadge": {
+    "defaultMessage": "外部"
+  },
+  "sessionArtifacts.fileCount": {
+    "defaultMessage": "{count, plural, other {# 个文件}}"
+  },
+  "sessionArtifacts.truncated": {
+    "defaultMessage": "显示前 {count} 个文件"
+  },
+  "sessionArtifacts.profileSandbox": {
+    "defaultMessage": "Sandbox"
+  },
+  "sessionArtifacts.profileWorktree": {
+    "defaultMessage": "Worktree"
+  },
+  "sessionArtifacts.profileDirect": {
+    "defaultMessage": "Direct"
+  },
+  "sessionArtifacts.workingDir": {
+    "defaultMessage": "工作目录"
+  },
+  "sessionArtifacts.rootPath": {
+    "defaultMessage": "工作区根目录"
+  },
+  "sessionArtifacts.branchName": {
+    "defaultMessage": "分支"
+  },
+  "sessionArtifacts.repoRoot": {
+    "defaultMessage": "仓库"
+  },
+  "hub.workspaceProfile.auto": {
+    "defaultMessage": "Auto"
+  },
+  "hub.workspaceProfile.sandbox": {
+    "defaultMessage": "Sandbox"
+  },
+  "hub.workspaceProfile.worktree": {
+    "defaultMessage": "Worktree"
+  },
+  "hub.workspaceProfile.direct": {
+    "defaultMessage": "Direct"
+  },
+  "hub.workspaceProfile.autoTooltip": {
+    "defaultMessage": "Auto（Git 仓库使用 worktree，否则 sandbox）。默认来自设置。"
+  },
+  "hub.workspaceProfile.sandboxTooltip": {
+    "defaultMessage": "始终 sandbox。默认来自设置。"
+  },
+  "hub.workspaceProfile.worktreeTooltip": {
+    "defaultMessage": "优先 git worktree。默认来自设置。"
+  },
+  "hub.workspaceProfile.directTooltip": {
+    "defaultMessage": "Direct（无隔离）。默认来自设置。"
+  },
+  "hub.workspaceProfile.recommended": {
+    "defaultMessage": "推荐"
   }
 }

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -974,8 +974,23 @@
   "dirSwitcher.openInFinder": {
     "defaultMessage": "在文件管理器中打开"
   },
+  "dirSwitcher.openWorkspaceFolder": {
+    "defaultMessage": "打开工作区文件夹"
+  },
+  "dirSwitcher.originalFiles": {
+    "defaultMessage": "原始文件"
+  },
+  "dirSwitcher.projectBadge": {
+    "defaultMessage": "项目"
+  },
   "dirSwitcher.recentDirectories": {
     "defaultMessage": "最近的目录"
+  },
+  "dirSwitcher.sandboxBadge": {
+    "defaultMessage": "沙箱"
+  },
+  "dirSwitcher.worktreeBadge": {
+    "defaultMessage": "工作树"
   },
   "elicitationRequest.accept": {
     "defaultMessage": "接受"
@@ -1264,6 +1279,33 @@
   },
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "连接到运行在其他位置的 goose 服务器（需要重启应用）"
+  },
+  "externalFileStrategy.copy": {
+    "defaultMessage": "复制到工作区（推荐）"
+  },
+  "externalFileStrategy.copyDetail": {
+    "defaultMessage": "安全 — 不会修改原始文件。"
+  },
+  "externalFileStrategy.description": {
+    "defaultMessage": "这些文件位于会话工作区之外。请选择 goose 的访问方式。"
+  },
+  "externalFileStrategy.reference": {
+    "defaultMessage": "只读引用"
+  },
+  "externalFileStrategy.referenceDetail": {
+    "defaultMessage": "使用原始路径；goose 仅在工作区中写入。"
+  },
+  "externalFileStrategy.remember": {
+    "defaultMessage": "记住我的选择"
+  },
+  "externalFileStrategy.symlink": {
+    "defaultMessage": "链接到工作区"
+  },
+  "externalFileStrategy.symlinkDetail": {
+    "defaultMessage": "节省空间；更改可能影响原始文件。"
+  },
+  "externalFileStrategy.title": {
+    "defaultMessage": "如何处理附加文件？"
   },
   "freeOptionCards.chooseOption": {
     "defaultMessage": "选择一个选项以开始。"
@@ -4828,5 +4870,41 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "用编辑过的消息创建新会话"
+  },
+  "workspaceSettings.description": {
+    "defaultMessage": "控制 goose 如何将每个会话与你的文件和项目隔离。"
+  },
+  "workspaceSettings.profileAuto": {
+    "defaultMessage": "自动（git 仓库使用 worktree，否则使用沙箱）"
+  },
+  "workspaceSettings.profileDirect": {
+    "defaultMessage": "直接模式（不隔离）"
+  },
+  "workspaceSettings.profileLabel": {
+    "defaultMessage": "隔离模式"
+  },
+  "workspaceSettings.profileSandbox": {
+    "defaultMessage": "始终使用沙箱"
+  },
+  "workspaceSettings.profileWorktree": {
+    "defaultMessage": "优先使用 git worktree"
+  },
+  "workspaceSettings.rememberLabel": {
+    "defaultMessage": "记住外部文件选择"
+  },
+  "workspaceSettings.strategyCopy": {
+    "defaultMessage": "复制到工作区"
+  },
+  "workspaceSettings.strategyLabel": {
+    "defaultMessage": "外部文件默认策略"
+  },
+  "workspaceSettings.strategyReference": {
+    "defaultMessage": "只读引用"
+  },
+  "workspaceSettings.strategySymlink": {
+    "defaultMessage": "符号链接到工作区"
+  },
+  "workspaceSettings.title": {
+    "defaultMessage": "会话工作区"
   }
 }

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -61,6 +61,7 @@ import {
   getWorkspaceInfo,
   hasExternalWorkspaceFiles,
   resolveWorkspace,
+  stageSessionFiles,
 } from './workspace/workspaceManager';
 
 function shouldSetupUpdater(): boolean {
@@ -1744,6 +1745,16 @@ ipcMain.handle('resolve-session-workspace', async (_event, request) => {
 ipcMain.handle('finalize-session-workspace', async (_event, request) => {
   await finalizeWorkspace({
     ...request,
+    goosePathRoot: appConfig.GOOSE_PATH_ROOT as string | undefined,
+  });
+});
+
+ipcMain.handle('stage-session-files', async (_event, request) => {
+  const settings = getSettings();
+  return stageSessionFiles({
+    ...request,
+    externalFileStrategy:
+      request.externalFileStrategy ?? settings.externalFileStrategy ?? 'copy',
     goosePathRoot: appConfig.GOOSE_PATH_ROOT as string | undefined,
   });
 });

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -53,6 +53,14 @@ import * as mesh from './mesh';
 import installExtension, { REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer';
 import { BLOCKED_PROTOCOLS, WEB_PROTOCOLS } from './utils/urlSecurity';
 import { buildCSP } from './utils/csp';
+import {
+  cleanupOrphanedWorkspaces,
+  cleanupWorkspace,
+  finalizeWorkspace,
+  getWorkspaceInfo,
+  hasExternalWorkspaceFiles,
+  resolveWorkspace,
+} from './workspace/workspaceManager';
 
 function shouldSetupUpdater(): boolean {
   // Setup updater if either the flag is enabled OR dev updates are enabled
@@ -687,20 +695,10 @@ async function handleFileOpen(filePath: string) {
     }
 
     const stats = fsSync.lstatSync(filePath);
-    let targetDir = filePath;
+    const pendingFiles = stats.isFile() ? [filePath] : [];
 
-    // If it's a file, use its parent directory
-    if (stats.isFile()) {
-      targetDir = path.dirname(filePath);
-    }
+    const newWindow = await createChat(app, { pendingFiles });
 
-    // Add to recent directories
-    addRecentDir(targetDir);
-
-    // Create new window for the directory
-    const newWindow = await createChat(app, { dir: targetDir });
-
-    // Focus the new window
     if (newWindow) {
       newWindow.show();
       newWindow.focus();
@@ -871,11 +869,13 @@ const windowPowerSaveBlockers = new Map<number, number>(); // windowId -> blocke
 // Track pending initial messages per window
 const pendingInitialMessages = new Map<number, string>(); // windowId -> initialMessage
 const pendingInitialMessageNoAutoSubmit = new Set<number>(); // windowIds whose initialMessage should NOT auto-submit
+const pendingDroppedFiles = new Map<number, string[]>(); // windowId -> file paths from dock drop
 
 interface CreateChatOptions {
   initialMessage?: string;
   initialMessageNoAutoSubmit?: boolean;
   dir?: string;
+  pendingFiles?: string[];
   resumeSessionId?: string;
   viewType?: string;
   recipeDeeplink?: string;
@@ -895,6 +895,7 @@ const createChat = async (app: App, options: CreateChatOptions = {}) => {
     recipeId,
     scheduledJobId,
     recipeParameters,
+    pendingFiles,
   } = options;
   const settings = getSettings();
   const serverSecret = getServerSecret(settings);
@@ -1249,6 +1250,10 @@ const createChat = async (app: App, options: CreateChatOptions = {}) => {
     }
   }
 
+  if (pendingFiles && pendingFiles.length > 0) {
+    pendingDroppedFiles.set(mainWindow.id, pendingFiles);
+  }
+
   // Set up local keyboard shortcuts that only work when the window is focused
   mainWindow.webContents.on('before-input-event', (event, input) => {
     if (input.key === 'r' && input.meta) {
@@ -1294,6 +1299,7 @@ const createChat = async (app: App, options: CreateChatOptions = {}) => {
     windowMap.delete(windowId);
 
     pendingInitialMessages.delete(windowId);
+    pendingDroppedFiles.delete(windowId);
     pendingDeepLinks.delete(windowId);
 
     if (windowPowerSaveBlockers.has(windowId)) {
@@ -1664,6 +1670,12 @@ ipcMain.on('react-ready', (event) => {
     pendingInitialMessageNoAutoSubmit.delete(windowId);
   }
 
+  if (windowId && pendingDroppedFiles.has(windowId)) {
+    const files = pendingDroppedFiles.get(windowId)!;
+    window.webContents.send('set-pending-dropped-files', files);
+    pendingDroppedFiles.delete(windowId);
+  }
+
   if (windowId && pendingDeepLinks.has(windowId) && window) {
     const deepLinkUrl = pendingDeepLinks.get(windowId)!;
     pendingDeepLinks.delete(windowId);
@@ -1713,6 +1725,32 @@ ipcMain.handle('list-git-worktree-dirs', async (_event, dir: string) => {
   return await listGitWorktreeDirs(dir);
 });
 
+ipcMain.handle('resolve-session-workspace', async (_event, request) => {
+  return resolveWorkspace({
+    ...request,
+    goosePathRoot: appConfig.GOOSE_PATH_ROOT as string | undefined,
+  });
+});
+
+ipcMain.handle('finalize-session-workspace', async (_event, request) => {
+  await finalizeWorkspace({
+    ...request,
+    goosePathRoot: appConfig.GOOSE_PATH_ROOT as string | undefined,
+  });
+});
+
+ipcMain.handle('has-external-workspace-files', async (_event, { workingDir, filePaths }) => {
+  return hasExternalWorkspaceFiles(workingDir, filePaths);
+});
+
+ipcMain.handle('get-workspace-info', async (_event, sessionId: string) => {
+  return getWorkspaceInfo(sessionId, appConfig.GOOSE_PATH_ROOT as string | undefined);
+});
+
+ipcMain.handle('cleanup-session-workspace', async (_event, sessionId: string) => {
+  await cleanupWorkspace(sessionId, appConfig.GOOSE_PATH_ROOT as string | undefined);
+});
+
 ipcMain.handle('get-setting', (_event, key: SettingKey) => {
   const settings = getSettings();
   return settings[key];
@@ -1735,6 +1773,9 @@ const validSettingKeys: Set<string> = new Set([
   'showPricing',
   'sessionSharing',
   'seenAnnouncementIds',
+  'workspaceProfile',
+  'externalFileStrategy',
+  'rememberExternalFileChoice',
 ]);
 
 ipcMain.handle('set-setting', (_event, key: SettingKey, value: unknown) => {
@@ -2232,6 +2273,10 @@ const registerGlobalShortcuts = () => {
 
 async function appMain() {
   await configureProxy();
+
+  void cleanupOrphanedWorkspaces(appConfig.GOOSE_PATH_ROOT as string | undefined).catch((error) => {
+    log.warn('Failed to cleanup orphaned workspaces:', error);
+  });
 
   // Ensure Windows shims are available before any MCP processes are spawned
   await ensureWinShims();

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -696,9 +696,17 @@ async function handleFileOpen(filePath: string) {
     }
 
     const stats = fsSync.lstatSync(filePath);
-    const pendingFiles = stats.isFile() ? [filePath] : [];
+    let targetDir = filePath;
+    if (stats.isFile()) {
+      targetDir = path.dirname(filePath);
+    }
 
-    const newWindow = await createChat(app, { pendingFiles });
+    addRecentDir(targetDir);
+
+    const newWindow = await createChat(app, {
+      dir: targetDir,
+      ...(stats.isFile() ? { pendingFiles: [filePath] } : {}),
+    });
 
     if (newWindow) {
       newWindow.show();

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -53,6 +53,7 @@ import * as mesh from './mesh';
 import installExtension, { REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer';
 import { BLOCKED_PROTOCOLS, WEB_PROTOCOLS } from './utils/urlSecurity';
 import { buildCSP } from './utils/csp';
+import { listSessionArtifacts } from './workspace/artifactScanner';
 import {
   cleanupOrphanedWorkspaces,
   cleanupWorkspace,
@@ -1747,6 +1748,17 @@ ipcMain.handle('get-workspace-info', async (_event, sessionId: string) => {
   return getWorkspaceInfo(sessionId, appConfig.GOOSE_PATH_ROOT as string | undefined);
 });
 
+ipcMain.handle(
+  'list-session-artifacts',
+  async (_event, { sessionId, workingDir }: { sessionId: string; workingDir?: string }) => {
+    return listSessionArtifacts(
+      sessionId,
+      workingDir,
+      appConfig.GOOSE_PATH_ROOT as string | undefined
+    );
+  }
+);
+
 ipcMain.handle('cleanup-session-workspace', async (_event, sessionId: string) => {
   await cleanupWorkspace(sessionId, appConfig.GOOSE_PATH_ROOT as string | undefined);
 });
@@ -2815,9 +2827,13 @@ async function appMain() {
     event.returnValue = getConfiguredGooseLocale();
   });
 
-  ipcMain.handle('open-directory-in-explorer', async (_event, path: string) => {
+  ipcMain.handle('open-directory-in-explorer', async (_event, targetPath: string) => {
     try {
-      return !!(await shell.openPath(path));
+      if (fsSync.existsSync(targetPath) && fsSync.statSync(targetPath).isFile()) {
+        shell.showItemInFolder(targetPath);
+        return true;
+      }
+      return !!(await shell.openPath(targetPath));
     } catch (error) {
       console.error('Error opening directory in explorer:', error);
       return false;

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -2829,13 +2829,37 @@ async function appMain() {
 
   ipcMain.handle('open-directory-in-explorer', async (_event, targetPath: string) => {
     try {
-      if (fsSync.existsSync(targetPath) && fsSync.statSync(targetPath).isFile()) {
-        shell.showItemInFolder(targetPath);
+      const trimmed = targetPath?.trim();
+      if (!trimmed) {
+        return false;
+      }
+
+      let resolved = path.resolve(trimmed);
+      if (!fsSync.existsSync(resolved)) {
+        const parent = path.dirname(resolved);
+        if (!fsSync.existsSync(parent)) {
+          log.warn(`Path does not exist: ${trimmed}`);
+          return false;
+        }
+        resolved = parent;
+      }
+
+      if (fsSync.statSync(resolved).isFile()) {
+        shell.showItemInFolder(resolved);
         return true;
       }
-      return !!(await shell.openPath(targetPath));
+
+      if (process.platform === 'darwin') {
+        await new Promise<void>((resolve, reject) => {
+          execFile('open', [resolved], (error) => (error ? reject(error) : resolve()));
+        });
+        return true;
+      }
+
+      const error = await shell.openPath(resolved);
+      return error === '';
     } catch (error) {
-      console.error('Error opening directory in explorer:', error);
+      log.error('Error opening path in explorer:', error);
       return false;
     }
   });

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -201,6 +201,10 @@ type ElectronAPI = {
   ) => Promise<import('./workspace/types').ResolveWorkspaceResult>;
   finalizeSessionWorkspace: (request: Record<string, unknown>) => Promise<void>;
   getWorkspaceInfo: (sessionId: string) => Promise<import('./workspace/types').WorkspaceInfo | null>;
+  listSessionArtifacts: (
+    sessionId: string,
+    workingDir?: string
+  ) => Promise<import('./workspace/artifactScanner').SessionArtifactsResult | null>;
   cleanupSessionWorkspace: (sessionId: string) => Promise<void>;
 };
 
@@ -253,6 +257,8 @@ const electronAPI: ElectronAPI = {
   finalizeSessionWorkspace: (request: Record<string, unknown>) =>
     ipcRenderer.invoke('finalize-session-workspace', request),
   getWorkspaceInfo: (sessionId: string) => ipcRenderer.invoke('get-workspace-info', sessionId),
+  listSessionArtifacts: (sessionId: string, workingDir?: string) =>
+    ipcRenderer.invoke('list-session-artifacts', { sessionId, workingDir }),
   cleanupSessionWorkspace: (sessionId: string) =>
     ipcRenderer.invoke('cleanup-session-workspace', sessionId),
   getPathForFile: (file: File) => webUtils.getPathForFile(file),

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -200,6 +200,11 @@ type ElectronAPI = {
     request: Record<string, unknown>
   ) => Promise<import('./workspace/types').ResolveWorkspaceResult>;
   finalizeSessionWorkspace: (request: Record<string, unknown>) => Promise<void>;
+  stageSessionFiles: (request: {
+    sessionId: string;
+    filePaths: string[];
+    externalFileStrategy?: import('./utils/settings').ExternalFileStrategy;
+  }) => Promise<import('./workspace/types').StageSessionFilesResult>;
   getWorkspaceInfo: (sessionId: string) => Promise<import('./workspace/types').WorkspaceInfo | null>;
   listSessionArtifacts: (
     sessionId: string,
@@ -256,6 +261,11 @@ const electronAPI: ElectronAPI = {
     ipcRenderer.invoke('resolve-session-workspace', request),
   finalizeSessionWorkspace: (request: Record<string, unknown>) =>
     ipcRenderer.invoke('finalize-session-workspace', request),
+  stageSessionFiles: (request: {
+    sessionId: string;
+    filePaths: string[];
+    externalFileStrategy?: import('./utils/settings').ExternalFileStrategy;
+  }) => ipcRenderer.invoke('stage-session-files', request),
   getWorkspaceInfo: (sessionId: string) => ipcRenderer.invoke('get-workspace-info', sessionId),
   listSessionArtifacts: (sessionId: string, workingDir?: string) =>
     ipcRenderer.invoke('list-session-artifacts', { sessionId, workingDir }),

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -192,6 +192,16 @@ type ElectronAPI = {
   addRecentDir: (dir: string) => Promise<boolean>;
   listRecentDirs: () => Promise<string[]>;
   listGitWorktreeDirs: (dir: string) => Promise<string[]>;
+  hasExternalWorkspaceFiles: (options: {
+    workingDir: string;
+    filePaths: string[];
+  }) => Promise<boolean>;
+  resolveSessionWorkspace: (
+    request: Record<string, unknown>
+  ) => Promise<import('./workspace/types').ResolveWorkspaceResult>;
+  finalizeSessionWorkspace: (request: Record<string, unknown>) => Promise<void>;
+  getWorkspaceInfo: (sessionId: string) => Promise<import('./workspace/types').WorkspaceInfo | null>;
+  cleanupSessionWorkspace: (sessionId: string) => Promise<void>;
 };
 
 type AppConfigAPI = {
@@ -236,6 +246,15 @@ const electronAPI: ElectronAPI = {
   ensureDirectory: (dirPath: string) => ipcRenderer.invoke('ensure-directory', dirPath),
   listFiles: (dirPath: string, extension?: string) =>
     ipcRenderer.invoke('list-files', dirPath, extension),
+  hasExternalWorkspaceFiles: (options: { workingDir: string; filePaths: string[] }) =>
+    ipcRenderer.invoke('has-external-workspace-files', options),
+  resolveSessionWorkspace: (request: Record<string, unknown>) =>
+    ipcRenderer.invoke('resolve-session-workspace', request),
+  finalizeSessionWorkspace: (request: Record<string, unknown>) =>
+    ipcRenderer.invoke('finalize-session-workspace', request),
+  getWorkspaceInfo: (sessionId: string) => ipcRenderer.invoke('get-workspace-info', sessionId),
+  cleanupSessionWorkspace: (sessionId: string) =>
+    ipcRenderer.invoke('cleanup-session-workspace', sessionId),
   getPathForFile: (file: File) => webUtils.getPathForFile(file),
   getAllowedExtensions: () => ipcRenderer.invoke('get-allowed-extensions'),
   setMenuBarIcon: (show: boolean) => ipcRenderer.invoke('set-menu-bar-icon', show),

--- a/ui/desktop/src/sessions.ts
+++ b/ui/desktop/src/sessions.ts
@@ -9,6 +9,33 @@ import {
 import type { FixedExtensionEntry } from './components/ConfigContext';
 import { AppEvents } from './constants/events';
 import { decodeRecipe, Recipe } from './recipe';
+import type { ExternalFileStrategy, WorkspaceProfile } from './utils/settings';
+import {
+  applyWorkspaceToUserInput,
+  extractExternalFilePaths,
+  finalizeSessionWorkspace,
+  needsExternalFileStrategyChoice,
+  prepareSessionWorkspace,
+} from './workspace/resolveSessionWorkspace';
+import type { UserInput } from './types/message';
+
+export interface CreateSessionWithWorkspaceOptions {
+  workingDir: string;
+  directoryExplicitlyChosen?: boolean;
+  userInput?: UserInput;
+  workspaceProfile?: WorkspaceProfile;
+  externalFileStrategy?: ExternalFileStrategy;
+  resolveExternalFileStrategy?: () => Promise<ExternalFileStrategy | null>;
+  recipeDeeplink?: string;
+  recipeId?: string;
+  extensionConfigs?: ExtensionConfig[];
+  allExtensions?: FixedExtensionEntry[];
+}
+
+export interface CreateSessionWithWorkspaceResult {
+  session: Session;
+  userInput?: UserInput;
+}
 
 export function getSessionDisplayName(session: Session): string {
   return session.name || DEFAULT_CHAT_TITLE;
@@ -73,6 +100,61 @@ export async function createSession(
     throwOnError: true,
   });
   return newAgent.data;
+}
+
+export async function createSessionWithWorkspace(
+  options: CreateSessionWithWorkspaceOptions
+): Promise<CreateSessionWithWorkspaceResult> {
+  const directoryExplicitlyChosen = options.directoryExplicitlyChosen ?? false;
+  const externalFilePaths = options.userInput ? extractExternalFilePaths(options.userInput) : [];
+
+  let workspaceProfile =
+    options.workspaceProfile ??
+    ((await window.electron.getSetting('workspaceProfile')) as WorkspaceProfile);
+  let externalFileStrategy =
+    options.externalFileStrategy ??
+    ((await window.electron.getSetting('externalFileStrategy')) as ExternalFileStrategy);
+
+  const rememberChoice = await window.electron.getSetting('rememberExternalFileChoice');
+  const needsChoice = await needsExternalFileStrategyChoice(
+    options.workingDir,
+    externalFilePaths,
+    directoryExplicitlyChosen,
+    workspaceProfile
+  );
+
+  if (needsChoice && !rememberChoice && !options.externalFileStrategy) {
+    const chosen = options.resolveExternalFileStrategy
+      ? await options.resolveExternalFileStrategy()
+      : null;
+    if (!chosen) {
+      throw new Error('Session creation cancelled');
+    }
+    externalFileStrategy = chosen;
+  }
+
+  const workspace = await prepareSessionWorkspace({
+    workingDir: options.workingDir,
+    directoryExplicitlyChosen,
+    externalFilePaths,
+    workspaceProfile,
+    externalFileStrategy,
+  });
+
+  const session = await createSession(workspace.workingDir, {
+    recipeDeeplink: options.recipeDeeplink,
+    recipeId: options.recipeId,
+    extensionConfigs: options.extensionConfigs,
+    allExtensions: options.allExtensions,
+  });
+
+  await finalizeSessionWorkspace(workspace.pendingWorkspaceId, session.id);
+
+  const userInput = options.userInput
+    ? applyWorkspaceToUserInput(options.userInput, workspace)
+    : undefined;
+
+  return { session, userInput };
 }
 
 export async function startNewSession(

--- a/ui/desktop/src/sessions.ts
+++ b/ui/desktop/src/sessions.ts
@@ -1,4 +1,4 @@
-import { Session, startAgent, ExtensionConfig } from './api';
+import { Session, startAgent, ExtensionConfig, updateWorkingDir } from './api';
 import { DEFAULT_CHAT_TITLE } from './contexts/ChatContext';
 import type { setViewType } from './hooks/useNavigation';
 import {
@@ -141,7 +141,7 @@ export async function createSessionWithWorkspace(
     externalFileStrategy,
   });
 
-  const session = await createSession(workspace.workingDir, {
+  let session = await createSession(workspace.workingDir, {
     recipeDeeplink: options.recipeDeeplink,
     recipeId: options.recipeId,
     extensionConfigs: options.extensionConfigs,
@@ -149,6 +149,17 @@ export async function createSessionWithWorkspace(
   });
 
   await finalizeSessionWorkspace(workspace.pendingWorkspaceId, session.id);
+
+  if (workspace.profile !== 'direct') {
+    const info = await window.electron.getWorkspaceInfo(session.id);
+    const finalWorkingDir = info?.workingDir;
+    if (finalWorkingDir && finalWorkingDir !== session.working_dir) {
+      await updateWorkingDir({
+        body: { session_id: session.id, working_dir: finalWorkingDir },
+      });
+      session = { ...session, working_dir: finalWorkingDir };
+    }
+  }
 
   const userInput = options.userInput
     ? applyWorkspaceToUserInput(options.userInput, workspace)

--- a/ui/desktop/src/sessions.ts
+++ b/ui/desktop/src/sessions.ts
@@ -17,6 +17,7 @@ import {
   needsExternalFileStrategyChoice,
   prepareSessionWorkspace,
 } from './workspace/resolveSessionWorkspace';
+import { pathMappingFromStagedFiles } from './workspace/workspaceHint';
 import type { UserInput } from './types/message';
 
 export interface CreateSessionWithWorkspaceOptions {
@@ -133,7 +134,7 @@ export async function createSessionWithWorkspace(
     externalFileStrategy = chosen;
   }
 
-  const workspace = await prepareSessionWorkspace({
+  let workspace = await prepareSessionWorkspace({
     workingDir: options.workingDir,
     directoryExplicitlyChosen,
     externalFilePaths,
@@ -159,6 +160,10 @@ export async function createSessionWithWorkspace(
       });
       session = { ...session, working_dir: finalWorkingDir };
     }
+    workspace = {
+      ...workspace,
+      pathMapping: pathMappingFromStagedFiles(info?.stagedFiles ?? []),
+    };
   }
 
   const userInput = options.userInput

--- a/ui/desktop/src/sessions.ts
+++ b/ui/desktop/src/sessions.ts
@@ -167,19 +167,21 @@ export async function startNewSession(
     allExtensions?: FixedExtensionEntry[];
   }
 ): Promise<Session> {
-  const session = await createSession(workingDir, options);
+  const { session, userInput } = await createSessionWithWorkspace({
+    workingDir,
+    userInput: initialText ? { msg: initialText, images: [] } : undefined,
+    recipeDeeplink: options?.recipeDeeplink,
+    recipeId: options?.recipeId,
+    allExtensions: options?.allExtensions,
+  });
+
   window.dispatchEvent(new CustomEvent(AppEvents.SESSION_CREATED, { detail: { session } }));
 
-  const initialMessage = initialText ? { msg: initialText, images: [] } : undefined;
-
-  const eventDetail = {
-    sessionId: session.id,
-    initialMessage,
-  };
+  const initialMessage = userInput ?? (initialText ? { msg: initialText, images: [] } : undefined);
 
   window.dispatchEvent(
     new CustomEvent(AppEvents.ADD_ACTIVE_SESSION, {
-      detail: eventDetail,
+      detail: { sessionId: session.id, initialMessage },
     })
   );
 

--- a/ui/desktop/src/types/message.ts
+++ b/ui/desktop/src/types/message.ts
@@ -25,6 +25,7 @@ export interface ImageData {
 export interface UserInput {
   msg: string;
   images: ImageData[];
+  filePaths?: string[];
 }
 
 export function createUserMessage(text: string, images?: ImageData[]): Message {

--- a/ui/desktop/src/utils/settings.ts
+++ b/ui/desktop/src/utils/settings.ts
@@ -30,6 +30,9 @@ export interface SessionSharingConfig {
 
 export type LanguageSetting = 'system' | 'en' | 'es' | 'hi' | 'ja' | 'ru' | 'tr' | 'zh-CN';
 
+export type WorkspaceProfile = 'auto' | 'sandbox' | 'worktree' | 'direct';
+export type ExternalFileStrategy = 'copy' | 'reference' | 'symlink';
+
 export interface Settings {
   // Desktop app settings
   showMenuBarIcon: boolean;
@@ -49,6 +52,9 @@ export interface Settings {
   showPricing: boolean;
   sessionSharing: SessionSharingConfig;
   seenAnnouncementIds: string[];
+  workspaceProfile: WorkspaceProfile;
+  externalFileStrategy: ExternalFileStrategy;
+  rememberExternalFileChoice: boolean;
 }
 
 export type SettingKey = keyof Settings;
@@ -92,6 +98,9 @@ export const defaultSettings: Settings = {
     baseUrl: '',
   },
   seenAnnouncementIds: [],
+  workspaceProfile: 'auto',
+  externalFileStrategy: 'copy',
+  rememberExternalFileChoice: false,
 };
 
 export function getKeyboardShortcuts(settings: Settings): KeyboardShortcuts {

--- a/ui/desktop/src/workspace/artifactScanner.test.ts
+++ b/ui/desktop/src/workspace/artifactScanner.test.ts
@@ -1,0 +1,63 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  MAX_ARTIFACT_FILES,
+  shouldExcludeDir,
+  shouldExcludeFile,
+  walkWorkspaceFiles,
+} from './artifactScanner';
+
+describe('artifactScanner', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  });
+
+  async function makeTempDir(): Promise<string> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'goose-artifacts-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  it('excludes dotfiles, node_modules, target, and .git', () => {
+    expect(shouldExcludeDir('.git')).toBe(true);
+    expect(shouldExcludeDir('node_modules')).toBe(true);
+    expect(shouldExcludeDir('target')).toBe(true);
+    expect(shouldExcludeDir('.hidden')).toBe(true);
+    expect(shouldExcludeDir('src')).toBe(false);
+
+    expect(shouldExcludeFile('.env')).toBe(true);
+    expect(shouldExcludeFile('script.py')).toBe(false);
+  });
+
+  it('walks workspace files with excludes applied', async () => {
+    const root = await makeTempDir();
+    await fs.mkdir(path.join(root, 'src'));
+    await fs.mkdir(path.join(root, 'node_modules', 'pkg'), { recursive: true });
+    await fs.mkdir(path.join(root, '.git'));
+    await fs.writeFile(path.join(root, 'src', 'main.py'), 'print("hi")');
+    await fs.writeFile(path.join(root, 'node_modules', 'pkg', 'index.js'), 'x');
+    await fs.writeFile(path.join(root, '.env'), 'SECRET=1');
+    await fs.writeFile(path.join(root, 'README.md'), '# hi');
+
+    const { files, truncated } = await walkWorkspaceFiles(root);
+
+    expect(truncated).toBe(false);
+    expect(files.map((f) => f.relativePath).sort()).toEqual(['README.md', 'src/main.py']);
+  });
+
+  it('limits the number of returned files', async () => {
+    const root = await makeTempDir();
+    for (let i = 0; i < MAX_ARTIFACT_FILES + 5; i++) {
+      await fs.writeFile(path.join(root, `file-${i}.txt`), 'x');
+    }
+
+    const { files, truncated } = await walkWorkspaceFiles(root, 10);
+
+    expect(files).toHaveLength(10);
+    expect(truncated).toBe(true);
+  });
+});

--- a/ui/desktop/src/workspace/artifactScanner.test.ts
+++ b/ui/desktop/src/workspace/artifactScanner.test.ts
@@ -69,6 +69,24 @@ describe('artifactScanner', () => {
     expect(truncated).toBe(true);
   });
 
+  it('lists untracked files inside new directories for worktree profile', async () => {
+    const root = await makeTempDir();
+    await execFileAsync('git', ['init'], { cwd: root });
+    await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+    await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: root });
+    await fs.writeFile(path.join(root, 'tracked.txt'), 'initial');
+    await execFileAsync('git', ['add', 'tracked.txt'], { cwd: root });
+    await execFileAsync('git', ['commit', '-m', 'init'], { cwd: root });
+
+    await fs.mkdir(path.join(root, 'reports'), { recursive: true });
+    await fs.writeFile(path.join(root, 'reports', 'index.html'), '<html></html>');
+
+    const { files, truncated } = await listWorktreeChangedFiles(root);
+
+    expect(truncated).toBe(false);
+    expect(files.map((f) => f.relativePath).sort()).toEqual(['reports/index.html']);
+  });
+
   it('lists only changed files for worktree profile', async () => {
     const root = await makeTempDir();
     await execFileAsync('git', ['init'], { cwd: root });

--- a/ui/desktop/src/workspace/artifactScanner.test.ts
+++ b/ui/desktop/src/workspace/artifactScanner.test.ts
@@ -1,13 +1,21 @@
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   MAX_ARTIFACT_FILES,
+  buildSessionArtifactsFromManifest,
+  listSessionArtifacts,
+  listWorktreeChangedFiles,
   shouldExcludeDir,
   shouldExcludeFile,
   walkWorkspaceFiles,
 } from './artifactScanner';
+import type { WorkspaceManifest } from './types';
+
+const execFileAsync = promisify(execFile);
 
 describe('artifactScanner', () => {
   const tempDirs: string[] = [];
@@ -59,5 +67,54 @@ describe('artifactScanner', () => {
 
     expect(files).toHaveLength(10);
     expect(truncated).toBe(true);
+  });
+
+  it('lists only changed files for worktree profile', async () => {
+    const root = await makeTempDir();
+    await execFileAsync('git', ['init'], { cwd: root });
+    await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+    await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: root });
+    await fs.writeFile(path.join(root, 'tracked.txt'), 'initial');
+    await execFileAsync('git', ['add', 'tracked.txt'], { cwd: root });
+    await execFileAsync('git', ['commit', '-m', 'init'], { cwd: root });
+
+    await fs.writeFile(path.join(root, 'tracked.txt'), 'modified');
+    await fs.writeFile(path.join(root, 'new-file.txt'), 'new');
+
+    const { files, truncated } = await listWorktreeChangedFiles(root);
+
+    expect(truncated).toBe(false);
+    expect(files.map((f) => f.relativePath).sort()).toEqual(['new-file.txt', 'tracked.txt']);
+  });
+
+  it('returns empty workspace for direct profile manifest', async () => {
+    const root = await makeTempDir();
+    await fs.writeFile(path.join(root, 'script.py'), 'print("hi")');
+
+    const manifest: WorkspaceManifest = {
+      sessionId: 'session-1',
+      profile: 'direct',
+      rootPath: root,
+      workingDir: root,
+      stagedFiles: [],
+      createdAt: new Date().toISOString(),
+    };
+
+    const result = await buildSessionArtifactsFromManifest(manifest);
+
+    expect(result.workspace).toEqual([]);
+    expect(result.totalCount).toBe(0);
+    expect(result.meta.profile).toBe('direct');
+  });
+
+  it('returns empty workspace without walking when manifest is missing', async () => {
+    const root = await makeTempDir();
+    await fs.writeFile(path.join(root, 'should-not-appear.txt'), 'secret');
+
+    const result = await listSessionArtifacts('missing-session', root);
+
+    expect(result.workspace).toEqual([]);
+    expect(result.totalCount).toBe(0);
+    expect(result.meta.workingDir).toBe(root);
   });
 });

--- a/ui/desktop/src/workspace/artifactScanner.ts
+++ b/ui/desktop/src/workspace/artifactScanner.ts
@@ -128,7 +128,7 @@ export async function listWorktreeChangedFiles(
   try {
     const { stdout } = await execFileAsync(
       'git',
-      ['-C', workingDir, 'status', '--porcelain'],
+      ['-C', workingDir, 'status', '--porcelain', '-uall'],
       { timeout: 10_000 }
     );
 

--- a/ui/desktop/src/workspace/artifactScanner.ts
+++ b/ui/desktop/src/workspace/artifactScanner.ts
@@ -1,8 +1,12 @@
 import fs from 'node:fs/promises';
 import fsSync from 'node:fs';
 import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { readManifestForSession } from './workspaceManager';
-import type { ResolvedWorkspaceProfile, StagedFile } from './types';
+import type { ResolvedWorkspaceProfile, StagedFile, WorkspaceManifest } from './types';
+
+const execFileAsync = promisify(execFile);
 
 export const MAX_ARTIFACT_FILES = 500;
 
@@ -91,10 +95,94 @@ export async function walkWorkspaceFiles(
   return { files, truncated };
 }
 
+function parseGitStatusPath(line: string): string | null {
+  if (line.length < 4) {
+    return null;
+  }
+
+  let filePath = line.slice(3).trim();
+  const renameArrow = ' -> ';
+  const renameIndex = filePath.indexOf(renameArrow);
+  if (renameIndex !== -1) {
+    filePath = filePath.slice(renameIndex + renameArrow.length).trim();
+  }
+
+  if (filePath.startsWith('"') && filePath.endsWith('"')) {
+    try {
+      filePath = JSON.parse(filePath) as string;
+    } catch {
+      filePath = filePath.slice(1, -1);
+    }
+  }
+
+  return filePath || null;
+}
+
+export async function listWorktreeChangedFiles(
+  workingDir: string,
+  maxFiles = MAX_ARTIFACT_FILES
+): Promise<{ files: WorkspaceFileEntry[]; truncated: boolean }> {
+  const files: WorkspaceFileEntry[] = [];
+  let truncated = false;
+
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['-C', workingDir, 'status', '--porcelain'],
+      { timeout: 10_000 }
+    );
+
+    const seen = new Set<string>();
+    for (const line of stdout.split('\n')) {
+      if (truncated || !line.trim()) {
+        continue;
+      }
+
+      const relativePath = parseGitStatusPath(line);
+      if (!relativePath || seen.has(relativePath)) {
+        continue;
+      }
+      seen.add(relativePath);
+
+      const fullPath = path.join(workingDir, relativePath);
+      if (!fsSync.existsSync(fullPath) || !fsSync.statSync(fullPath).isFile()) {
+        continue;
+      }
+
+      files.push({ path: fullPath, relativePath });
+      if (files.length >= maxFiles) {
+        truncated = true;
+      }
+    }
+  } catch {
+    return { files: [], truncated: false };
+  }
+
+  return { files, truncated };
+}
+
 export async function buildSessionArtifactsFromManifest(
-  manifest: import('./types').WorkspaceManifest
+  manifest: WorkspaceManifest
 ): Promise<SessionArtifactsResult> {
-  const { files, truncated } = await walkWorkspaceFiles(manifest.workingDir);
+  let files: WorkspaceFileEntry[] = [];
+  let truncated = false;
+
+  switch (manifest.profile) {
+    case 'sandbox': {
+      const result = await walkWorkspaceFiles(manifest.workingDir);
+      files = result.files;
+      truncated = result.truncated;
+      break;
+    }
+    case 'worktree': {
+      const result = await listWorktreeChangedFiles(manifest.workingDir);
+      files = result.files;
+      truncated = result.truncated;
+      break;
+    }
+    case 'direct':
+      break;
+  }
 
   return {
     inputs: manifest.stagedFiles,
@@ -115,28 +203,23 @@ export async function listSessionArtifacts(
   sessionId: string,
   workingDirFallback?: string,
   goosePathRoot?: string
-): Promise<SessionArtifactsResult | null> {
+): Promise<SessionArtifactsResult> {
   const manifest = await readManifestForSession(sessionId, goosePathRoot);
   if (manifest) {
     return buildSessionArtifactsFromManifest(manifest);
   }
 
-  if (!workingDirFallback?.trim()) {
-    return null;
-  }
-
-  const workingDir = workingDirFallback.trim();
-  const { files, truncated } = await walkWorkspaceFiles(workingDir);
+  const workingDir = workingDirFallback?.trim() ?? '';
 
   return {
     inputs: [],
-    workspace: files,
+    workspace: [],
     meta: {
       profile: 'direct',
       rootPath: workingDir,
       workingDir,
     },
-    totalCount: files.length,
-    truncated,
+    totalCount: 0,
+    truncated: false,
   };
 }

--- a/ui/desktop/src/workspace/artifactScanner.ts
+++ b/ui/desktop/src/workspace/artifactScanner.ts
@@ -1,0 +1,142 @@
+import fs from 'node:fs/promises';
+import fsSync from 'node:fs';
+import path from 'node:path';
+import { readManifestForSession } from './workspaceManager';
+import type { ResolvedWorkspaceProfile, StagedFile } from './types';
+
+export const MAX_ARTIFACT_FILES = 500;
+
+const EXCLUDED_DIRS = new Set(['.git', 'node_modules', 'target']);
+
+export interface WorkspaceFileEntry {
+  path: string;
+  relativePath: string;
+}
+
+export interface SessionArtifactsMeta {
+  profile: ResolvedWorkspaceProfile;
+  rootPath: string;
+  workingDir: string;
+  repoRoot?: string;
+  branchName?: string;
+}
+
+export interface SessionArtifactsResult {
+  inputs: StagedFile[];
+  workspace: WorkspaceFileEntry[];
+  meta: SessionArtifactsMeta;
+  totalCount: number;
+  truncated: boolean;
+}
+
+export function shouldExcludeDir(name: string): boolean {
+  return name.startsWith('.') || EXCLUDED_DIRS.has(name);
+}
+
+export function shouldExcludeFile(name: string): boolean {
+  return name.startsWith('.');
+}
+
+export async function walkWorkspaceFiles(
+  workingDir: string,
+  maxFiles = MAX_ARTIFACT_FILES
+): Promise<{ files: WorkspaceFileEntry[]; truncated: boolean }> {
+  const files: WorkspaceFileEntry[] = [];
+  let truncated = false;
+
+  async function walk(dir: string): Promise<void> {
+    if (truncated) {
+      return;
+    }
+
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (truncated) {
+        return;
+      }
+
+      const fullPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        if (shouldExcludeDir(entry.name)) {
+          continue;
+        }
+        await walk(fullPath);
+      } else if (entry.isFile()) {
+        if (shouldExcludeFile(entry.name)) {
+          continue;
+        }
+        files.push({
+          path: fullPath,
+          relativePath: path.relative(workingDir, fullPath),
+        });
+        if (files.length >= maxFiles) {
+          truncated = true;
+          return;
+        }
+      }
+    }
+  }
+
+  if (fsSync.existsSync(workingDir)) {
+    await walk(workingDir);
+  }
+
+  return { files, truncated };
+}
+
+export async function buildSessionArtifactsFromManifest(
+  manifest: import('./types').WorkspaceManifest
+): Promise<SessionArtifactsResult> {
+  const { files, truncated } = await walkWorkspaceFiles(manifest.workingDir);
+
+  return {
+    inputs: manifest.stagedFiles,
+    workspace: files,
+    meta: {
+      profile: manifest.profile,
+      rootPath: manifest.rootPath,
+      workingDir: manifest.workingDir,
+      repoRoot: manifest.repoRoot,
+      branchName: manifest.branchName,
+    },
+    totalCount: manifest.stagedFiles.length + files.length,
+    truncated,
+  };
+}
+
+export async function listSessionArtifacts(
+  sessionId: string,
+  workingDirFallback?: string,
+  goosePathRoot?: string
+): Promise<SessionArtifactsResult | null> {
+  const manifest = await readManifestForSession(sessionId, goosePathRoot);
+  if (manifest) {
+    return buildSessionArtifactsFromManifest(manifest);
+  }
+
+  if (!workingDirFallback?.trim()) {
+    return null;
+  }
+
+  const workingDir = workingDirFallback.trim();
+  const { files, truncated } = await walkWorkspaceFiles(workingDir);
+
+  return {
+    inputs: [],
+    workspace: files,
+    meta: {
+      profile: 'direct',
+      rootPath: workingDir,
+      workingDir,
+    },
+    totalCount: files.length,
+    truncated,
+  };
+}

--- a/ui/desktop/src/workspace/resolveSessionWorkspace.test.ts
+++ b/ui/desktop/src/workspace/resolveSessionWorkspace.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { applyWorkspaceToUserInput } from './resolveSessionWorkspace';
+import type { PreparedSessionWorkspace } from './resolveSessionWorkspace';
+
+describe('resolveSessionWorkspace', () => {
+  it('does not prepend workspace hint to user message', () => {
+    const workspace: PreparedSessionWorkspace = {
+      workingDir: '/tmp/workspace',
+      pendingWorkspaceId: 'pending-id',
+      workspaceHint: '[Workspace isolation]\nWrite files only inside: /tmp/workspace',
+      pathMapping: { '/tmp/file.txt': '/tmp/workspace/inputs/file.txt' },
+      profile: 'sandbox',
+    };
+
+    const result = applyWorkspaceToUserInput(
+      { msg: 'please read /tmp/file.txt', images: [] },
+      workspace
+    );
+
+    expect(result.msg).toBe('please read /tmp/workspace/inputs/file.txt');
+    expect(result.msg).not.toContain('[Workspace isolation]');
+  });
+});

--- a/ui/desktop/src/workspace/resolveSessionWorkspace.test.ts
+++ b/ui/desktop/src/workspace/resolveSessionWorkspace.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { applyWorkspaceToUserInput } from './resolveSessionWorkspace';
 import type { PreparedSessionWorkspace } from './resolveSessionWorkspace';
+import { pathMappingFromStagedFiles } from './workspaceHint';
 
 describe('resolveSessionWorkspace', () => {
   it('does not prepend workspace hint to user message', () => {
@@ -19,5 +20,16 @@ describe('resolveSessionWorkspace', () => {
 
     expect(result.msg).toBe('please read /tmp/workspace/inputs/file.txt');
     expect(result.msg).not.toContain('[Workspace isolation]');
+  });
+
+  it('builds path mapping from staged files after finalize', () => {
+    const mapping = pathMappingFromStagedFiles([
+      { original: '/tmp/file.txt', staged: '/project/.goose/sessions/id/inputs/file.txt', strategy: 'copy' },
+      { original: '/tmp/ref.txt', staged: '/tmp/ref.txt', strategy: 'reference' },
+    ]);
+
+    expect(mapping).toEqual({
+      '/tmp/file.txt': '/project/.goose/sessions/id/inputs/file.txt',
+    });
   });
 });

--- a/ui/desktop/src/workspace/resolveSessionWorkspace.ts
+++ b/ui/desktop/src/workspace/resolveSessionWorkspace.ts
@@ -57,6 +57,40 @@ export function applyWorkspaceToUserInput(
   return { ...input, msg };
 }
 
+export async function stageUserInputFiles(sessionId: string, input: UserInput): Promise<UserInput> {
+  const filePaths = extractExternalFilePaths(input);
+  if (filePaths.length === 0) {
+    return input;
+  }
+
+  const info = await window.electron.getWorkspaceInfo(sessionId);
+  if (!info || info.profile === 'direct') {
+    return input;
+  }
+
+  const externalFileStrategy = (await window.electron.getSetting(
+    'externalFileStrategy'
+  )) as ExternalFileStrategy;
+
+  const { pathMapping } = await window.electron.stageSessionFiles({
+    sessionId,
+    filePaths,
+    externalFileStrategy,
+  });
+
+  if (Object.keys(pathMapping).length === 0) {
+    return input;
+  }
+
+  return applyWorkspaceToUserInput(input, {
+    workingDir: info.workingDir,
+    pendingWorkspaceId: sessionId,
+    workspaceHint: '',
+    pathMapping,
+    profile: info.profile,
+  });
+}
+
 export function extractExternalFilePaths(input: UserInput): string[] {
   return input.filePaths ?? [];
 }

--- a/ui/desktop/src/workspace/resolveSessionWorkspace.ts
+++ b/ui/desktop/src/workspace/resolveSessionWorkspace.ts
@@ -1,6 +1,6 @@
 import type { ExternalFileStrategy, WorkspaceProfile } from '../utils/settings';
 import type { ResolveWorkspaceResult } from './types';
-import { applyPathMapping, prependWorkspaceHint } from './workspaceHint';
+import { applyPathMapping } from './workspaceHint';
 import type { UserInput } from '../types/message';
 
 export interface PrepareSessionWorkspaceOptions {
@@ -52,8 +52,7 @@ export function applyWorkspaceToUserInput(
   input: UserInput,
   workspace: PreparedSessionWorkspace
 ): UserInput {
-  const mappedMsg = applyPathMapping(input.msg, workspace.pathMapping);
-  const msg = prependWorkspaceHint(mappedMsg, workspace.workspaceHint);
+  const msg = applyPathMapping(input.msg, workspace.pathMapping);
   return { ...input, msg };
 }
 

--- a/ui/desktop/src/workspace/resolveSessionWorkspace.ts
+++ b/ui/desktop/src/workspace/resolveSessionWorkspace.ts
@@ -1,0 +1,74 @@
+import type { ExternalFileStrategy, WorkspaceProfile } from '../utils/settings';
+import type { ResolveWorkspaceResult } from './types';
+import { applyPathMapping, prependWorkspaceHint } from './workspaceHint';
+import type { UserInput } from '../types/message';
+
+export interface PrepareSessionWorkspaceOptions {
+  workingDir: string;
+  directoryExplicitlyChosen: boolean;
+  externalFilePaths: string[];
+  workspaceProfile: WorkspaceProfile;
+  externalFileStrategy: ExternalFileStrategy;
+}
+
+export interface PreparedSessionWorkspace {
+  workingDir: string;
+  pendingWorkspaceId: string;
+  workspaceHint: string;
+  pathMapping: Record<string, string>;
+  profile: ResolveWorkspaceResult['profile'];
+}
+
+export async function prepareSessionWorkspace(
+  options: PrepareSessionWorkspaceOptions
+): Promise<PreparedSessionWorkspace> {
+  const pendingId = crypto.randomUUID();
+  const result = await window.electron.resolveSessionWorkspace({
+    pendingId,
+    profile: options.workspaceProfile,
+    externalFileStrategy: options.externalFileStrategy,
+    explicitWorkingDir: options.workingDir,
+    externalFilePaths: options.externalFilePaths,
+    directoryExplicitlyChosen: options.directoryExplicitlyChosen,
+  });
+
+  return {
+    workingDir: result.workingDir,
+    pendingWorkspaceId: result.pendingWorkspaceId,
+    workspaceHint: result.workspaceHint,
+    pathMapping: result.pathMapping,
+    profile: result.profile,
+  };
+}
+
+export async function finalizeSessionWorkspace(
+  pendingWorkspaceId: string,
+  sessionId: string
+): Promise<void> {
+  await window.electron.finalizeSessionWorkspace({ pendingWorkspaceId, sessionId });
+}
+
+export function applyWorkspaceToUserInput(
+  input: UserInput,
+  workspace: PreparedSessionWorkspace
+): UserInput {
+  const mappedMsg = applyPathMapping(input.msg, workspace.pathMapping);
+  const msg = prependWorkspaceHint(mappedMsg, workspace.workspaceHint);
+  return { ...input, msg };
+}
+
+export function extractExternalFilePaths(input: UserInput): string[] {
+  return input.filePaths ?? [];
+}
+
+export async function needsExternalFileStrategyChoice(
+  workingDir: string,
+  filePaths: string[],
+  directoryExplicitlyChosen: boolean,
+  workspaceProfile: WorkspaceProfile
+): Promise<boolean> {
+  if (filePaths.length === 0 || directoryExplicitlyChosen || workspaceProfile === 'direct') {
+    return false;
+  }
+  return window.electron.hasExternalWorkspaceFiles({ workingDir, filePaths });
+}

--- a/ui/desktop/src/workspace/resolveSessionWorkspace.ts
+++ b/ui/desktop/src/workspace/resolveSessionWorkspace.ts
@@ -1,3 +1,4 @@
+import { v7 as uuidv7 } from 'uuid';
 import type { ExternalFileStrategy, WorkspaceProfile } from '../utils/settings';
 import type { ResolveWorkspaceResult } from './types';
 import { applyPathMapping } from './workspaceHint';
@@ -22,7 +23,7 @@ export interface PreparedSessionWorkspace {
 export async function prepareSessionWorkspace(
   options: PrepareSessionWorkspaceOptions
 ): Promise<PreparedSessionWorkspace> {
-  const pendingId = crypto.randomUUID();
+  const pendingId = uuidv7();
   const result = await window.electron.resolveSessionWorkspace({
     pendingId,
     profile: options.workspaceProfile,

--- a/ui/desktop/src/workspace/types.ts
+++ b/ui/desktop/src/workspace/types.ts
@@ -1,0 +1,53 @@
+export type WorkspaceProfile = 'auto' | 'sandbox' | 'worktree' | 'direct';
+
+export type ResolvedWorkspaceProfile = 'sandbox' | 'worktree' | 'direct';
+
+export type ExternalFileStrategy = 'copy' | 'reference' | 'symlink';
+
+export interface StagedFile {
+  original: string;
+  staged: string;
+  strategy: ExternalFileStrategy;
+}
+
+export interface WorkspaceManifest {
+  sessionId: string;
+  profile: ResolvedWorkspaceProfile;
+  rootPath: string;
+  workingDir: string;
+  repoRoot?: string;
+  branchName?: string;
+  stagedFiles: StagedFile[];
+  createdAt: string;
+}
+
+export interface ResolveWorkspaceRequest {
+  pendingId: string;
+  profile: WorkspaceProfile;
+  externalFileStrategy: ExternalFileStrategy;
+  explicitWorkingDir?: string;
+  externalFilePaths?: string[];
+  directoryExplicitlyChosen?: boolean;
+  goosePathRoot?: string;
+}
+
+export interface ResolveWorkspaceResult {
+  workingDir: string;
+  pendingWorkspaceId: string;
+  profile: ResolvedWorkspaceProfile;
+  manifest: WorkspaceManifest;
+  pathMapping: Record<string, string>;
+  workspaceHint: string;
+}
+
+export interface FinalizeWorkspaceRequest {
+  pendingWorkspaceId: string;
+  sessionId: string;
+  goosePathRoot?: string;
+}
+
+export interface WorkspaceInfo {
+  profile: ResolvedWorkspaceProfile;
+  rootPath: string;
+  stagedFiles: StagedFile[];
+}

--- a/ui/desktop/src/workspace/types.ts
+++ b/ui/desktop/src/workspace/types.ts
@@ -19,6 +19,7 @@ export interface WorkspaceManifest {
   branchName?: string;
   stagedFiles: StagedFile[];
   createdAt: string;
+  status?: 'pending' | 'active';
 }
 
 export interface ResolveWorkspaceRequest {

--- a/ui/desktop/src/workspace/types.ts
+++ b/ui/desktop/src/workspace/types.ts
@@ -49,5 +49,6 @@ export interface FinalizeWorkspaceRequest {
 export interface WorkspaceInfo {
   profile: ResolvedWorkspaceProfile;
   rootPath: string;
+  workingDir: string;
   stagedFiles: StagedFile[];
 }

--- a/ui/desktop/src/workspace/types.ts
+++ b/ui/desktop/src/workspace/types.ts
@@ -52,3 +52,14 @@ export interface WorkspaceInfo {
   workingDir: string;
   stagedFiles: StagedFile[];
 }
+
+export interface StageSessionFilesRequest {
+  sessionId: string;
+  filePaths: string[];
+  externalFileStrategy: ExternalFileStrategy;
+  goosePathRoot?: string;
+}
+
+export interface StageSessionFilesResult {
+  pathMapping: Record<string, string>;
+}

--- a/ui/desktop/src/workspace/types.ts
+++ b/ui/desktop/src/workspace/types.ts
@@ -64,3 +64,13 @@ export interface StageSessionFilesRequest {
 export interface StageSessionFilesResult {
   pathMapping: Record<string, string>;
 }
+
+export class UnstageablePathsError extends Error {
+  readonly paths: string[];
+
+  constructor(paths: string[]) {
+    super(`Could not stage external paths for isolation: ${paths.join(', ')}`);
+    this.name = 'UnstageablePathsError';
+    this.paths = paths;
+  }
+}

--- a/ui/desktop/src/workspace/workspaceHint.test.ts
+++ b/ui/desktop/src/workspace/workspaceHint.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { applyPathMapping, buildWorkspaceHint, prependWorkspaceHint } from './workspaceHint';
+import type { WorkspaceManifest } from './types';
+
+describe('workspaceHint', () => {
+  it('builds sandbox hint with staged files', () => {
+    const manifest: WorkspaceManifest = {
+      sessionId: 'abc',
+      profile: 'sandbox',
+      rootPath: '/data/workspaces/abc',
+      workingDir: '/data/workspaces/abc/workspace',
+      stagedFiles: [
+        {
+          original: '/tmp/report.pdf',
+          staged: '/data/workspaces/abc/inputs/report.pdf',
+          strategy: 'copy',
+        },
+      ],
+      createdAt: new Date().toISOString(),
+    };
+
+    const hint = buildWorkspaceHint(manifest);
+    expect(hint).toContain('Write files only inside');
+    expect(hint).toContain('/data/workspaces/abc/inputs/report.pdf');
+    expect(hint).toContain('/tmp/report.pdf');
+  });
+
+  it('maps original paths in message text', () => {
+    const mapped = applyPathMapping('please read /tmp/a.txt', {
+      '/tmp/a.txt': '/sandbox/inputs/a.txt',
+    });
+    expect(mapped).toBe('please read /sandbox/inputs/a.txt');
+  });
+
+  it('prepends hint before user message', () => {
+    const result = prependWorkspaceHint('hello', '[Workspace isolation]\nwrite here');
+    expect(result).toContain('[Workspace isolation]');
+    expect(result).toContain('hello');
+  });
+});

--- a/ui/desktop/src/workspace/workspaceHint.ts
+++ b/ui/desktop/src/workspace/workspaceHint.ts
@@ -1,0 +1,48 @@
+import type { WorkspaceManifest } from './types';
+
+export function buildWorkspaceHint(manifest: WorkspaceManifest): string {
+  if (manifest.profile === 'direct') {
+    return '';
+  }
+
+  const lines = [
+    '[Workspace isolation]',
+    `Write files only inside: ${manifest.workingDir}`,
+  ];
+
+  if (manifest.profile === 'worktree' && manifest.branchName) {
+    lines.push(`Git worktree branch: ${manifest.branchName}`);
+    if (manifest.repoRoot) {
+      lines.push(`Repository root: ${manifest.repoRoot}`);
+    }
+  }
+
+  if (manifest.stagedFiles.length > 0) {
+    lines.push('Attached files:');
+    for (const file of manifest.stagedFiles) {
+      if (file.strategy === 'copy' || file.strategy === 'symlink') {
+        lines.push(`- ${file.staged} (from ${file.original})`);
+      } else {
+        lines.push(`- ${file.original} (read-only reference; write only in workspace)`);
+      }
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export function applyPathMapping(message: string, mapping: Record<string, string>): string {
+  let result = message;
+  const entries = Object.entries(mapping).sort((a, b) => b[0].length - a[0].length);
+  for (const [original, staged] of entries) {
+    result = result.split(original).join(staged);
+  }
+  return result;
+}
+
+export function prependWorkspaceHint(message: string, hint: string): string {
+  if (!hint.trim()) {
+    return message;
+  }
+  return message.trim() ? `${hint}\n\n${message}` : hint;
+}

--- a/ui/desktop/src/workspace/workspaceHint.ts
+++ b/ui/desktop/src/workspace/workspaceHint.ts
@@ -1,4 +1,4 @@
-import type { WorkspaceManifest } from './types';
+import type { StagedFile, WorkspaceManifest } from './types';
 
 export function buildWorkspaceHint(manifest: WorkspaceManifest): string {
   if (manifest.profile === 'direct') {
@@ -29,6 +29,16 @@ export function buildWorkspaceHint(manifest: WorkspaceManifest): string {
   }
 
   return lines.join('\n');
+}
+
+export function pathMappingFromStagedFiles(stagedFiles: StagedFile[]): Record<string, string> {
+  const mapping: Record<string, string> = {};
+  for (const file of stagedFiles) {
+    if (file.original !== file.staged) {
+      mapping[file.original] = file.staged;
+    }
+  }
+  return mapping;
 }
 
 export function applyPathMapping(message: string, mapping: Record<string, string>): string {

--- a/ui/desktop/src/workspace/workspaceManager.test.ts
+++ b/ui/desktop/src/workspace/workspaceManager.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { sandboxSessionRoot } from './workspaceManager';
+
+describe('workspaceManager', () => {
+  it('places sandbox session root under context directory', () => {
+    expect(sandboxSessionRoot('/Users/me/GooseDoc', 'session-abc')).toBe(
+      '/Users/me/GooseDoc/.goose/sessions/session-abc'
+    );
+  });
+});

--- a/ui/desktop/src/workspace/workspaceManager.test.ts
+++ b/ui/desktop/src/workspace/workspaceManager.test.ts
@@ -4,11 +4,13 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  cleanupOrphanedWorkspaces,
   cleanupWorkspace,
   finalizeWorkspace,
   getWorkspaceInfo,
   readManifestForSession,
   sandboxSessionRoot,
+  stageSessionFiles,
 } from './workspaceManager';
 import type { WorkspaceManifest } from './types';
 
@@ -100,14 +102,19 @@ describe('workspaceManager', () => {
     const sessionId = 'final-session-id';
     const pendingRoot = sandboxSessionRoot(contextDir, pendingId);
     const pendingWorkingDir = path.join(pendingRoot, 'workspace');
+    const pendingStaged = path.join(pendingRoot, 'inputs', 'file.txt');
+    await fs.mkdir(path.dirname(pendingStaged), { recursive: true });
     await fs.mkdir(pendingWorkingDir, { recursive: true });
+    await fs.writeFile(pendingStaged, 'data');
 
     const manifest: WorkspaceManifest = {
       sessionId: pendingId,
       profile: 'sandbox',
       rootPath: pendingRoot,
       workingDir: pendingWorkingDir,
-      stagedFiles: [],
+      stagedFiles: [
+        { original: '/tmp/file.txt', staged: pendingStaged, strategy: 'copy' },
+      ],
       createdAt: new Date().toISOString(),
     };
     await writeManifestAtIndex(gooseRoot, pendingId, manifest);
@@ -120,14 +127,79 @@ describe('workspaceManager', () => {
 
     const finalRoot = sandboxSessionRoot(contextDir, sessionId);
     const finalWorkingDir = path.join(finalRoot, 'workspace');
+    const finalStaged = path.join(finalRoot, 'inputs', 'file.txt');
     expect(fsSync.existsSync(finalWorkingDir)).toBe(true);
     expect(fsSync.existsSync(pendingWorkingDir)).toBe(false);
 
     const updated = await readManifestForSession(sessionId, gooseRoot);
     expect(updated?.workingDir).toBe(finalWorkingDir);
     expect(updated?.rootPath).toBe(finalRoot);
+    expect(updated?.stagedFiles[0]?.staged).toBe(finalStaged);
 
     const info = await getWorkspaceInfo(sessionId, gooseRoot);
     expect(info?.workingDir).toBe(finalWorkingDir);
+  });
+
+  it('stages follow-up files into an existing sandbox session', async () => {
+    const gooseRoot = await makeTempDir('goose-data-');
+    const contextDir = await makeTempDir('context-');
+    const sessionId = 'existing-session';
+    const sessionRoot = sandboxSessionRoot(contextDir, sessionId);
+    const workingDir = path.join(sessionRoot, 'workspace');
+    await fs.mkdir(workingDir, { recursive: true });
+
+    const externalFile = path.join(await makeTempDir('external-'), 'note.txt');
+    await fs.writeFile(externalFile, 'hello');
+
+    const manifest: WorkspaceManifest = {
+      sessionId,
+      profile: 'sandbox',
+      rootPath: sessionRoot,
+      workingDir,
+      stagedFiles: [],
+      createdAt: new Date().toISOString(),
+    };
+    await writeManifestAtIndex(gooseRoot, sessionId, manifest);
+
+    const { pathMapping } = await stageSessionFiles({
+      sessionId,
+      filePaths: [externalFile],
+      externalFileStrategy: 'copy',
+      goosePathRoot: gooseRoot,
+    });
+
+    expect(Object.keys(pathMapping)).toEqual([externalFile]);
+    const stagedPath = pathMapping[externalFile];
+    expect(stagedPath.startsWith(path.join(sessionRoot, 'inputs'))).toBe(true);
+    expect(fsSync.existsSync(stagedPath)).toBe(true);
+
+    const updated = await readManifestForSession(sessionId, gooseRoot);
+    expect(updated?.stagedFiles).toHaveLength(1);
+  });
+
+  it('removes orphaned sandbox workspace roots after TTL', async () => {
+    const gooseRoot = await makeTempDir('goose-data-');
+    const contextDir = await makeTempDir('context-');
+    const pendingId = 'orphan-pending';
+    const sessionRoot = sandboxSessionRoot(contextDir, pendingId);
+    const workingDir = path.join(sessionRoot, 'workspace');
+    await fs.mkdir(workingDir, { recursive: true });
+    await fs.writeFile(path.join(workingDir, 'leftover.txt'), 'data');
+
+    const staleDate = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+    const manifest: WorkspaceManifest = {
+      sessionId: pendingId,
+      profile: 'sandbox',
+      rootPath: sessionRoot,
+      workingDir,
+      stagedFiles: [],
+      createdAt: staleDate,
+    };
+    await writeManifestAtIndex(gooseRoot, pendingId, manifest);
+
+    await cleanupOrphanedWorkspaces(gooseRoot);
+
+    expect(fsSync.existsSync(sessionRoot)).toBe(false);
+    expect(fsSync.existsSync(workspaceIndexPath(gooseRoot, pendingId))).toBe(false);
   });
 });

--- a/ui/desktop/src/workspace/workspaceManager.test.ts
+++ b/ui/desktop/src/workspace/workspaceManager.test.ts
@@ -140,6 +140,7 @@ describe('workspaceManager', () => {
     expect(updated?.workingDir).toBe(finalWorkingDir);
     expect(updated?.rootPath).toBe(finalRoot);
     expect(updated?.stagedFiles[0]?.staged).toBe(finalStaged);
+    expect(updated?.status).toBe('active');
 
     const info = await getWorkspaceInfo(sessionId, gooseRoot);
     expect(info?.workingDir).toBe(finalWorkingDir);
@@ -199,6 +200,7 @@ describe('workspaceManager', () => {
       workingDir,
       stagedFiles: [],
       createdAt: staleDate,
+      status: 'pending',
     };
     await writeManifestAtIndex(gooseRoot, pendingId, manifest);
 
@@ -206,6 +208,78 @@ describe('workspaceManager', () => {
 
     expect(fsSync.existsSync(sessionRoot)).toBe(false);
     expect(fsSync.existsSync(workspaceIndexPath(gooseRoot, pendingId))).toBe(false);
+  });
+
+  it('does not delete active finalized workspaces after TTL', async () => {
+    const gooseRoot = await makeTempDir('goose-data-');
+    const contextDir = await makeTempDir('context-');
+    const sessionId = 'active-session';
+    const sessionRoot = sandboxSessionRoot(contextDir, sessionId);
+    const workingDir = path.join(sessionRoot, 'workspace');
+    await fs.mkdir(workingDir, { recursive: true });
+    await fs.writeFile(path.join(workingDir, 'keep.txt'), 'data');
+
+    const staleDate = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+    const manifest: WorkspaceManifest = {
+      sessionId,
+      profile: 'sandbox',
+      rootPath: sessionRoot,
+      workingDir,
+      stagedFiles: [],
+      createdAt: staleDate,
+      status: 'active',
+    };
+    await writeManifestAtIndex(gooseRoot, sessionId, manifest);
+
+    await cleanupOrphanedWorkspaces(gooseRoot);
+
+    expect(fsSync.existsSync(sessionRoot)).toBe(true);
+    expect(fsSync.existsSync(workspaceIndexPath(gooseRoot, sessionId))).toBe(true);
+  });
+
+  it('maps repo files to the worktree path instead of copying into inputs', async () => {
+    const gooseRoot = await makeTempDir('goose-data-');
+    const repoRoot = await makeTempDir('git-repo-');
+    await execFileAsync('git', ['init'], { cwd: repoRoot });
+    await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: repoRoot });
+    await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: repoRoot });
+    await fs.mkdir(path.join(repoRoot, 'src'), { recursive: true });
+    const repoFile = path.join(repoRoot, 'src', 'foo.ts');
+    await fs.writeFile(repoFile, 'export const foo = 1;');
+    await execFileAsync('git', ['add', 'src/foo.ts'], { cwd: repoRoot });
+    await execFileAsync('git', ['commit', '-m', 'init'], { cwd: repoRoot });
+
+    const sessionId = 'worktree-session';
+    const { workingDir, branchName } = await createGitWorktree(repoRoot, sessionId);
+    const worktreeFile = path.join(workingDir, 'src', 'foo.ts');
+    expect(fsSync.existsSync(worktreeFile)).toBe(true);
+
+    const manifest: WorkspaceManifest = {
+      sessionId,
+      profile: 'worktree',
+      rootPath: workingDir,
+      workingDir,
+      repoRoot,
+      branchName,
+      stagedFiles: [],
+      createdAt: new Date().toISOString(),
+      status: 'active',
+    };
+    await writeManifestAtIndex(gooseRoot, sessionId, manifest);
+
+    const { pathMapping } = await stageSessionFiles({
+      sessionId,
+      filePaths: [repoFile],
+      externalFileStrategy: 'copy',
+      goosePathRoot: gooseRoot,
+    });
+
+    expect(pathMapping[repoFile]).toBe(worktreeFile);
+
+    const updated = await readManifestForSession(sessionId, gooseRoot);
+    expect(updated?.stagedFiles).toHaveLength(1);
+    expect(updated?.stagedFiles[0]?.staged).toBe(worktreeFile);
+    expect(updated?.stagedFiles[0]?.strategy).toBe('reference');
   });
 
   it('uses a unique branch name when the default worktree branch already exists', async () => {

--- a/ui/desktop/src/workspace/workspaceManager.test.ts
+++ b/ui/desktop/src/workspace/workspaceManager.test.ts
@@ -326,6 +326,77 @@ describe('workspaceManager', () => {
     expect(updated?.stagedFiles[0]?.strategy).toBe('copy');
   });
 
+  it('stages dropped directories into sandbox inputs', async () => {
+    const gooseRoot = await makeTempDir('goose-data-');
+    const contextDir = await makeTempDir('context-');
+    const sessionId = 'dir-session';
+    const sessionRoot = sandboxSessionRoot(contextDir, sessionId);
+    const workingDir = path.join(sessionRoot, 'workspace');
+    await fs.mkdir(workingDir, { recursive: true });
+
+    const externalDir = await makeTempDir('external-dir-');
+    await fs.writeFile(path.join(externalDir, 'note.txt'), 'hello');
+
+    const manifest: WorkspaceManifest = {
+      sessionId,
+      profile: 'sandbox',
+      rootPath: sessionRoot,
+      workingDir,
+      stagedFiles: [],
+      createdAt: new Date().toISOString(),
+      status: 'active',
+    };
+    await writeManifestAtIndex(gooseRoot, sessionId, manifest);
+
+    const { pathMapping } = await stageSessionFiles({
+      sessionId,
+      filePaths: [externalDir],
+      externalFileStrategy: 'copy',
+      goosePathRoot: gooseRoot,
+    });
+
+    const stagedDir = pathMapping[externalDir];
+    expect(stagedDir).toBeDefined();
+    expect(fsSync.existsSync(path.join(stagedDir, 'note.txt'))).toBe(true);
+  });
+
+  it('symlinks oversized files into inputs when copy strategy is requested', async () => {
+    const gooseRoot = await makeTempDir('goose-data-');
+    const contextDir = await makeTempDir('context-');
+    const sessionId = 'large-file-session';
+    const sessionRoot = sandboxSessionRoot(contextDir, sessionId);
+    const workingDir = path.join(sessionRoot, 'workspace');
+    await fs.mkdir(workingDir, { recursive: true });
+
+    const largeFile = path.join(await makeTempDir('large-file-'), 'big.bin');
+    const largeFileBytes = 50 * 1024 * 1024 + 1;
+    await fs.writeFile(largeFile, Buffer.alloc(largeFileBytes));
+
+    const manifest: WorkspaceManifest = {
+      sessionId,
+      profile: 'sandbox',
+      rootPath: sessionRoot,
+      workingDir,
+      stagedFiles: [],
+      createdAt: new Date().toISOString(),
+      status: 'active',
+    };
+    await writeManifestAtIndex(gooseRoot, sessionId, manifest);
+
+    const { pathMapping } = await stageSessionFiles({
+      sessionId,
+      filePaths: [largeFile],
+      externalFileStrategy: 'copy',
+      goosePathRoot: gooseRoot,
+    });
+
+    expect(pathMapping[largeFile]).toMatch(/inputs[/\\]big\.bin$/);
+
+    const updated = await readManifestForSession(sessionId, gooseRoot);
+    expect(updated?.stagedFiles[0]?.strategy).toBe('symlink');
+    expect(fsSync.lstatSync(pathMapping[largeFile]).isSymbolicLink()).toBe(true);
+  });
+
   it('uses a unique branch name when the default worktree branch already exists', async () => {
     const repoRoot = await makeTempDir('git-repo-');
     await execFileAsync('git', ['init'], { cwd: repoRoot });

--- a/ui/desktop/src/workspace/workspaceManager.test.ts
+++ b/ui/desktop/src/workspace/workspaceManager.test.ts
@@ -282,6 +282,50 @@ describe('workspaceManager', () => {
     expect(updated?.stagedFiles[0]?.strategy).toBe('reference');
   });
 
+  it('copies dirty repo file contents into the worktree before staging', async () => {
+    const gooseRoot = await makeTempDir('goose-data-');
+    const repoRoot = await makeTempDir('git-repo-');
+    await execFileAsync('git', ['init'], { cwd: repoRoot });
+    await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: repoRoot });
+    await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: repoRoot });
+    await fs.mkdir(path.join(repoRoot, 'src'), { recursive: true });
+    const repoFile = path.join(repoRoot, 'src', 'foo.ts');
+    await fs.writeFile(repoFile, 'export const foo = 1;');
+    await execFileAsync('git', ['add', 'src/foo.ts'], { cwd: repoRoot });
+    await execFileAsync('git', ['commit', '-m', 'init'], { cwd: repoRoot });
+
+    const sessionId = 'dirty-worktree-session';
+    const { workingDir, branchName } = await createGitWorktree(repoRoot, sessionId);
+    const worktreeFile = path.join(workingDir, 'src', 'foo.ts');
+    await fs.writeFile(repoFile, 'export const foo = 2; // dirty edit');
+
+    const manifest: WorkspaceManifest = {
+      sessionId,
+      profile: 'worktree',
+      rootPath: workingDir,
+      workingDir,
+      repoRoot,
+      branchName,
+      stagedFiles: [],
+      createdAt: new Date().toISOString(),
+      status: 'active',
+    };
+    await writeManifestAtIndex(gooseRoot, sessionId, manifest);
+
+    const { pathMapping } = await stageSessionFiles({
+      sessionId,
+      filePaths: [repoFile],
+      externalFileStrategy: 'copy',
+      goosePathRoot: gooseRoot,
+    });
+
+    expect(pathMapping[repoFile]).toBe(worktreeFile);
+    expect(fsSync.readFileSync(worktreeFile, 'utf8')).toBe('export const foo = 2; // dirty edit');
+
+    const updated = await readManifestForSession(sessionId, gooseRoot);
+    expect(updated?.stagedFiles[0]?.strategy).toBe('copy');
+  });
+
   it('uses a unique branch name when the default worktree branch already exists', async () => {
     const repoRoot = await makeTempDir('git-repo-');
     await execFileAsync('git', ['init'], { cwd: repoRoot });

--- a/ui/desktop/src/workspace/workspaceManager.test.ts
+++ b/ui/desktop/src/workspace/workspaceManager.test.ts
@@ -1,10 +1,133 @@
-import { describe, expect, it } from 'vitest';
-import { sandboxSessionRoot } from './workspaceManager';
+import fs from 'node:fs/promises';
+import fsSync from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  cleanupWorkspace,
+  finalizeWorkspace,
+  getWorkspaceInfo,
+  readManifestForSession,
+  sandboxSessionRoot,
+} from './workspaceManager';
+import type { WorkspaceManifest } from './types';
 
 describe('workspaceManager', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  });
+
+  async function makeTempDir(prefix: string): Promise<string> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  function workspaceIndexPath(gooseRoot: string, id: string): string {
+    return path.join(gooseRoot, 'data', 'workspaces', id);
+  }
+
+  async function writeManifestAtIndex(
+    gooseRoot: string,
+    id: string,
+    manifest: WorkspaceManifest
+  ): Promise<void> {
+    const indexPath = workspaceIndexPath(gooseRoot, id);
+    await fs.mkdir(indexPath, { recursive: true });
+    await fs.writeFile(path.join(indexPath, 'manifest.json'), JSON.stringify(manifest, null, 2));
+  }
+
   it('places sandbox session root under context directory', () => {
     expect(sandboxSessionRoot('/Users/me/GooseDoc', 'session-abc')).toBe(
       '/Users/me/GooseDoc/.goose/sessions/session-abc'
     );
+  });
+
+  it('does not delete direct-mode user directory on cleanup', async () => {
+    const gooseRoot = await makeTempDir('goose-data-');
+    const userProject = await makeTempDir('user-project-');
+    const marker = path.join(userProject, 'keep-me.txt');
+    await fs.writeFile(marker, 'important');
+
+    const sessionId = 'direct-session';
+    const manifest: WorkspaceManifest = {
+      sessionId,
+      profile: 'direct',
+      rootPath: userProject,
+      workingDir: userProject,
+      stagedFiles: [],
+      createdAt: new Date().toISOString(),
+    };
+    await writeManifestAtIndex(gooseRoot, sessionId, manifest);
+
+    await cleanupWorkspace(sessionId, gooseRoot);
+
+    expect(fsSync.existsSync(marker)).toBe(true);
+    expect(fsSync.existsSync(workspaceIndexPath(gooseRoot, sessionId))).toBe(false);
+  });
+
+  it('deletes sandbox session root on cleanup', async () => {
+    const gooseRoot = await makeTempDir('goose-data-');
+    const contextDir = await makeTempDir('context-');
+    const sessionId = 'sandbox-session';
+    const sessionRoot = sandboxSessionRoot(contextDir, sessionId);
+    const workingDir = path.join(sessionRoot, 'workspace');
+    await fs.mkdir(workingDir, { recursive: true });
+    await fs.writeFile(path.join(workingDir, 'output.txt'), 'artifact');
+
+    const manifest: WorkspaceManifest = {
+      sessionId,
+      profile: 'sandbox',
+      rootPath: sessionRoot,
+      workingDir,
+      stagedFiles: [],
+      createdAt: new Date().toISOString(),
+    };
+    await writeManifestAtIndex(gooseRoot, sessionId, manifest);
+
+    await cleanupWorkspace(sessionId, gooseRoot);
+
+    expect(fsSync.existsSync(sessionRoot)).toBe(false);
+    expect(fsSync.existsSync(workspaceIndexPath(gooseRoot, sessionId))).toBe(false);
+  });
+
+  it('renames sandbox paths and updates workingDir on finalize', async () => {
+    const gooseRoot = await makeTempDir('goose-data-');
+    const contextDir = await makeTempDir('context-');
+    const pendingId = 'pending-uuid';
+    const sessionId = 'final-session-id';
+    const pendingRoot = sandboxSessionRoot(contextDir, pendingId);
+    const pendingWorkingDir = path.join(pendingRoot, 'workspace');
+    await fs.mkdir(pendingWorkingDir, { recursive: true });
+
+    const manifest: WorkspaceManifest = {
+      sessionId: pendingId,
+      profile: 'sandbox',
+      rootPath: pendingRoot,
+      workingDir: pendingWorkingDir,
+      stagedFiles: [],
+      createdAt: new Date().toISOString(),
+    };
+    await writeManifestAtIndex(gooseRoot, pendingId, manifest);
+
+    await finalizeWorkspace({
+      pendingWorkspaceId: pendingId,
+      sessionId,
+      goosePathRoot: gooseRoot,
+    });
+
+    const finalRoot = sandboxSessionRoot(contextDir, sessionId);
+    const finalWorkingDir = path.join(finalRoot, 'workspace');
+    expect(fsSync.existsSync(finalWorkingDir)).toBe(true);
+    expect(fsSync.existsSync(pendingWorkingDir)).toBe(false);
+
+    const updated = await readManifestForSession(sessionId, gooseRoot);
+    expect(updated?.workingDir).toBe(finalWorkingDir);
+    expect(updated?.rootPath).toBe(finalRoot);
+
+    const info = await getWorkspaceInfo(sessionId, gooseRoot);
+    expect(info?.workingDir).toBe(finalWorkingDir);
   });
 });

--- a/ui/desktop/src/workspace/workspaceManager.test.ts
+++ b/ui/desktop/src/workspace/workspaceManager.test.ts
@@ -2,10 +2,13 @@ import fs from 'node:fs/promises';
 import fsSync from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   cleanupOrphanedWorkspaces,
   cleanupWorkspace,
+  createGitWorktree,
   finalizeWorkspace,
   getWorkspaceInfo,
   readManifestForSession,
@@ -13,6 +16,8 @@ import {
   stageSessionFiles,
 } from './workspaceManager';
 import type { WorkspaceManifest } from './types';
+
+const execFileAsync = promisify(execFile);
 
 describe('workspaceManager', () => {
   const tempDirs: string[] = [];
@@ -201,5 +206,34 @@ describe('workspaceManager', () => {
 
     expect(fsSync.existsSync(sessionRoot)).toBe(false);
     expect(fsSync.existsSync(workspaceIndexPath(gooseRoot, pendingId))).toBe(false);
+  });
+
+  it('uses a unique branch name when the default worktree branch already exists', async () => {
+    const repoRoot = await makeTempDir('git-repo-');
+    await execFileAsync('git', ['init'], { cwd: repoRoot });
+    await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: repoRoot });
+    await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: repoRoot });
+    await fs.writeFile(path.join(repoRoot, 'README.md'), '# test');
+    await execFileAsync('git', ['add', 'README.md'], { cwd: repoRoot });
+    await execFileAsync('git', ['commit', '-m', 'init'], { cwd: repoRoot });
+
+    const sessionId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const existingBranch = 'goose/session-aaaaaaaa';
+    await execFileAsync('git', ['branch', existingBranch], { cwd: repoRoot });
+
+    const { branchName, workingDir } = await createGitWorktree(repoRoot, sessionId);
+
+    expect(branchName).toBe(`${existingBranch}-1`);
+    expect(fsSync.existsSync(workingDir)).toBe(true);
+
+    const originalRef = (
+      await execFileAsync('git', ['-C', repoRoot, 'rev-parse', existingBranch], {
+        timeout: 10_000,
+      })
+    ).stdout.trim();
+    const collisionRef = (
+      await execFileAsync('git', ['-C', repoRoot, 'rev-parse', branchName], { timeout: 10_000 })
+    ).stdout.trim();
+    expect(collisionRef).toBe(originalRef);
   });
 });

--- a/ui/desktop/src/workspace/workspaceManager.ts
+++ b/ui/desktop/src/workspace/workspaceManager.ts
@@ -225,6 +225,15 @@ function worktreePathForRepoFile(
   return path.join(workingDir, relativePath);
 }
 
+function filesHaveSameContent(pathA: string, pathB: string): boolean {
+  const statA = fsSync.statSync(pathA);
+  const statB = fsSync.statSync(pathB);
+  if (statA.size !== statB.size) {
+    return false;
+  }
+  return fsSync.readFileSync(pathA).equals(fsSync.readFileSync(pathB));
+}
+
 async function copyFileToWorktreeLocation(
   original: string,
   worktreePath: string,
@@ -301,20 +310,25 @@ async function stageExternalFiles(
     if (repoRoot) {
       const worktreePath = worktreePathForRepoFile(repoRoot, workingDir, original);
       if (worktreePath) {
-        if (fsSync.existsSync(worktreePath) && fsSync.statSync(worktreePath).isFile()) {
+        const worktreeExists =
+          fsSync.existsSync(worktreePath) && fsSync.statSync(worktreePath).isFile();
+        const sameContent = worktreeExists && filesHaveSameContent(original, worktreePath);
+
+        if (worktreeExists && sameContent) {
           stagedFiles.push({ original, staged: worktreePath, strategy: 'reference' });
           pathMapping[original] = worktreePath;
           continue;
         }
 
-        if (strategy === 'reference') {
+        if (!worktreeExists && strategy === 'reference') {
           stagedFiles.push({ original, staged: worktreePath, strategy: 'reference' });
           pathMapping[original] = worktreePath;
           continue;
         }
 
-        await copyFileToWorktreeLocation(original, worktreePath, strategy);
-        stagedFiles.push({ original, staged: worktreePath, strategy });
+        const syncStrategy = sameContent ? strategy : 'copy';
+        await copyFileToWorktreeLocation(original, worktreePath, syncStrategy);
+        stagedFiles.push({ original, staged: worktreePath, strategy: syncStrategy });
         pathMapping[original] = worktreePath;
         continue;
       }

--- a/ui/desktop/src/workspace/workspaceManager.ts
+++ b/ui/desktop/src/workspace/workspaceManager.ts
@@ -172,10 +172,9 @@ async function stageExternalFiles(
 
 function resolveProfile(
   profile: WorkspaceProfile,
-  directoryExplicitlyChosen: boolean,
   hasGitContext: boolean
 ): ResolvedWorkspaceProfile {
-  if (directoryExplicitlyChosen || profile === 'direct') {
+  if (profile === 'direct') {
     return 'direct';
   }
   if (profile === 'sandbox') {
@@ -239,7 +238,6 @@ export async function resolveWorkspace(
 ): Promise<ResolveWorkspaceResult> {
   const pendingId = request.pendingId || randomUUID();
   const externalFilePaths = [...new Set((request.externalFilePaths ?? []).filter(Boolean))];
-  const directoryExplicitlyChosen = request.directoryExplicitlyChosen ?? false;
 
   let gitRepoRoot: string | null = null;
   if (externalFilePaths.length > 0) {
@@ -248,14 +246,13 @@ export async function resolveWorkspace(
     gitRepoRoot = await findGitRepoRoot(request.explicitWorkingDir);
   }
 
-  const resolvedProfile = resolveProfile(
-    request.profile,
-    directoryExplicitlyChosen,
-    gitRepoRoot !== null
-  );
+  const resolvedProfile = resolveProfile(request.profile, gitRepoRoot !== null);
 
   if (resolvedProfile === 'direct') {
     const workingDir = request.explicitWorkingDir?.trim() || app.getPath('home');
+    const rootPath = workspaceRootForId(pendingId, request.goosePathRoot);
+    await fs.mkdir(rootPath, { recursive: true });
+
     const manifest: WorkspaceManifest = {
       sessionId: pendingId,
       profile: 'direct',
@@ -264,6 +261,8 @@ export async function resolveWorkspace(
       stagedFiles: [],
       createdAt: new Date().toISOString(),
     };
+
+    await writeManifest(rootPath, manifest);
 
     return {
       workingDir,

--- a/ui/desktop/src/workspace/workspaceManager.ts
+++ b/ui/desktop/src/workspace/workspaceManager.ts
@@ -229,6 +229,7 @@ export async function getWorkspaceInfo(
   return {
     profile: manifest.profile,
     rootPath: manifest.rootPath,
+    workingDir: manifest.workingDir,
     stagedFiles: manifest.stagedFiles,
   };
 }
@@ -379,7 +380,15 @@ export async function finalizeWorkspace(request: FinalizeWorkspaceRequest): Prom
     const newRootPath = manifest.rootPath.split(pendingWorkspaceId).join(sessionId);
     if (newRootPath !== manifest.rootPath && fsSync.existsSync(manifest.rootPath)) {
       if (!fsSync.existsSync(newRootPath)) {
-        await fs.rename(manifest.rootPath, newRootPath);
+        if (manifest.profile === 'worktree' && manifest.repoRoot) {
+          await execFileAsync(
+            'git',
+            ['-C', manifest.repoRoot, 'worktree', 'move', manifest.rootPath, newRootPath],
+            { timeout: 30_000 }
+          );
+        } else {
+          await fs.rename(manifest.rootPath, newRootPath);
+        }
       }
       manifest.rootPath = newRootPath;
       if (manifest.workingDir.includes(pendingWorkspaceId)) {
@@ -431,7 +440,11 @@ export async function cleanupWorkspace(
   const resolvedIndexPath = path.resolve(indexPath);
   const resolvedSessionRoot = path.resolve(manifest.rootPath);
 
-  if (resolvedSessionRoot !== resolvedIndexPath && fsSync.existsSync(manifest.rootPath)) {
+  if (
+    manifest.profile !== 'direct' &&
+    resolvedSessionRoot !== resolvedIndexPath &&
+    fsSync.existsSync(manifest.rootPath)
+  ) {
     await fs.rm(manifest.rootPath, { recursive: true, force: true });
   }
 

--- a/ui/desktop/src/workspace/workspaceManager.ts
+++ b/ui/desktop/src/workspace/workspaceManager.ts
@@ -208,6 +208,42 @@ async function removePhysicalWorkspace(
   }
 }
 
+function worktreePathForRepoFile(
+  repoRoot: string,
+  workingDir: string,
+  filePath: string
+): string | null {
+  if (!isPathInside(filePath, repoRoot)) {
+    return null;
+  }
+
+  const relativePath = path.relative(repoRoot, filePath);
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    return null;
+  }
+
+  return path.join(workingDir, relativePath);
+}
+
+async function copyFileToWorktreeLocation(
+  original: string,
+  worktreePath: string,
+  strategy: ExternalFileStrategy
+): Promise<void> {
+  await fs.mkdir(path.dirname(worktreePath), { recursive: true });
+
+  if (strategy === 'copy') {
+    await fs.copyFile(original, worktreePath);
+    return;
+  }
+
+  try {
+    await fs.symlink(original, worktreePath);
+  } catch {
+    await fs.copyFile(original, worktreePath);
+  }
+}
+
 export async function stageSessionFiles(
   request: StageSessionFilesRequest
 ): Promise<StageSessionFilesResult> {
@@ -220,7 +256,8 @@ export async function stageSessionFiles(
     manifest.rootPath,
     manifest.workingDir,
     request.filePaths,
-    request.externalFileStrategy
+    request.externalFileStrategy,
+    manifest.repoRoot
   );
 
   if (stagedFiles.length === 0) {
@@ -238,7 +275,8 @@ async function stageExternalFiles(
   workspaceRoot: string,
   workingDir: string,
   filePaths: string[],
-  strategy: ExternalFileStrategy
+  strategy: ExternalFileStrategy,
+  repoRoot?: string
 ): Promise<{ stagedFiles: StagedFile[]; pathMapping: Record<string, string> }> {
   const inputsDir = path.join(workspaceRoot, 'inputs');
   await fs.mkdir(inputsDir, { recursive: true });
@@ -258,6 +296,28 @@ async function stageExternalFiles(
     const stat = fsSync.statSync(original);
     if (!stat.isFile()) {
       continue;
+    }
+
+    if (repoRoot) {
+      const worktreePath = worktreePathForRepoFile(repoRoot, workingDir, original);
+      if (worktreePath) {
+        if (fsSync.existsSync(worktreePath) && fsSync.statSync(worktreePath).isFile()) {
+          stagedFiles.push({ original, staged: worktreePath, strategy: 'reference' });
+          pathMapping[original] = worktreePath;
+          continue;
+        }
+
+        if (strategy === 'reference') {
+          stagedFiles.push({ original, staged: worktreePath, strategy: 'reference' });
+          pathMapping[original] = worktreePath;
+          continue;
+        }
+
+        await copyFileToWorktreeLocation(original, worktreePath, strategy);
+        stagedFiles.push({ original, staged: worktreePath, strategy });
+        pathMapping[original] = worktreePath;
+        continue;
+      }
     }
 
     if (strategy === 'reference') {
@@ -379,6 +439,7 @@ export async function resolveWorkspace(
       workingDir,
       stagedFiles: [],
       createdAt: new Date().toISOString(),
+      status: 'pending',
     };
 
     await writeManifest(rootPath, manifest);
@@ -422,7 +483,8 @@ export async function resolveWorkspace(
     sessionRoot,
     workingDir,
     externalFilePaths,
-    request.externalFileStrategy
+    request.externalFileStrategy,
+    repoRoot
   );
 
   const manifest: WorkspaceManifest = {
@@ -434,6 +496,7 @@ export async function resolveWorkspace(
     branchName,
     stagedFiles,
     createdAt: new Date().toISOString(),
+    status: 'pending',
   };
 
   await fs.mkdir(indexRoot, { recursive: true });
@@ -506,6 +569,7 @@ export async function finalizeWorkspace(request: FinalizeWorkspaceRequest): Prom
   }));
 
   manifest.sessionId = sessionId;
+  manifest.status = 'active';
   const manifestWritePath = fsSync.existsSync(finalIndexPath) ? finalIndexPath : pendingIndexPath;
   await fs.writeFile(
     manifestPathForRoot(manifestWritePath),
@@ -559,6 +623,11 @@ export async function cleanupOrphanedWorkspaces(goosePathRoot?: string): Promise
         if (manifest.sessionId && manifest.sessionId !== entry.name) {
           continue;
         }
+        if (manifest.status !== 'pending') {
+          continue;
+        }
+      } else {
+        continue;
       }
 
       if (now - createdAt > ORPHAN_TTL_MS) {

--- a/ui/desktop/src/workspace/workspaceManager.ts
+++ b/ui/desktop/src/workspace/workspaceManager.ts
@@ -1,0 +1,436 @@
+import fs from 'node:fs/promises';
+import fsSync from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { randomUUID } from 'node:crypto';
+import { app } from 'electron';
+import { buildWorkspaceHint } from './workspaceHint';
+import type {
+  ExternalFileStrategy,
+  FinalizeWorkspaceRequest,
+  ResolveWorkspaceRequest,
+  ResolveWorkspaceResult,
+  ResolvedWorkspaceProfile,
+  StagedFile,
+  WorkspaceInfo,
+  WorkspaceManifest,
+  WorkspaceProfile,
+} from './types';
+
+const execFileAsync = promisify(execFile);
+
+const WORKSPACES_DIR = 'workspaces';
+const LARGE_FILE_BYTES = 50 * 1024 * 1024;
+const ORPHAN_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function getGooseDataDir(goosePathRoot?: string): string {
+  if (goosePathRoot?.trim()) {
+    return path.join(goosePathRoot.trim(), 'data');
+  }
+
+  const home = os.homedir();
+  if (process.platform === 'darwin') {
+    return path.join(home, 'Library', 'Application Support', 'Block', 'goose', 'data');
+  }
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA || path.join(home, 'AppData', 'Roaming');
+    return path.join(appData, 'Block', 'goose', 'data');
+  }
+  return path.join(home, '.local', 'share', 'Block', 'goose', 'data');
+}
+
+function workspacesRoot(goosePathRoot?: string): string {
+  return path.join(getGooseDataDir(goosePathRoot), WORKSPACES_DIR);
+}
+
+function workspaceRootForId(id: string, goosePathRoot?: string): string {
+  return path.join(workspacesRoot(goosePathRoot), id);
+}
+
+function manifestPathForRoot(rootPath: string): string {
+  return path.join(rootPath, 'manifest.json');
+}
+
+async function runGit(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', ['-C', cwd, ...args], { timeout: 10_000 });
+  return stdout.trim();
+}
+
+export async function findGitRepoRoot(startPath: string): Promise<string | null> {
+  try {
+    const dir = fsSync.statSync(startPath).isFile() ? path.dirname(startPath) : startPath;
+    return await runGit(dir, ['rev-parse', '--show-toplevel']);
+  } catch {
+    return null;
+  }
+}
+
+function shortId(id: string): string {
+  return id.replace(/-/g, '').slice(0, 8);
+}
+
+export async function createGitWorktree(
+  repoRoot: string,
+  sessionId: string
+): Promise<{ workingDir: string; branchName: string }> {
+  const branchName = `goose/session-${shortId(sessionId)}`;
+  const worktreePath = path.join(repoRoot, '.goose', 'sessions', sessionId);
+  await fs.mkdir(path.dirname(worktreePath), { recursive: true });
+
+  try {
+    await execFileAsync(
+      'git',
+      ['-C', repoRoot, 'worktree', 'add', '-B', branchName, worktreePath],
+      { timeout: 30_000 }
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to create git worktree: ${message}`);
+  }
+
+  return { workingDir: worktreePath, branchName };
+}
+
+function isPathInside(child: string, parent: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+async function uniqueInputPath(inputsDir: string, filePath: string): Promise<string> {
+  const baseName = path.basename(filePath);
+  let candidate = path.join(inputsDir, baseName);
+  if (!fsSync.existsSync(candidate)) {
+    return candidate;
+  }
+
+  const ext = path.extname(baseName);
+  const stem = path.basename(baseName, ext);
+  for (let i = 1; i < 1000; i++) {
+    candidate = path.join(inputsDir, `${stem}-${i}${ext}`);
+    if (!fsSync.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return path.join(inputsDir, `${stem}-${Date.now()}${ext}`);
+}
+
+async function stageExternalFiles(
+  workspaceRoot: string,
+  workingDir: string,
+  filePaths: string[],
+  strategy: ExternalFileStrategy
+): Promise<{ stagedFiles: StagedFile[]; pathMapping: Record<string, string> }> {
+  const inputsDir = path.join(workspaceRoot, 'inputs');
+  await fs.mkdir(inputsDir, { recursive: true });
+
+  const stagedFiles: StagedFile[] = [];
+  const pathMapping: Record<string, string> = {};
+
+  for (const original of filePaths) {
+    if (!original?.trim() || !fsSync.existsSync(original)) {
+      continue;
+    }
+
+    if (isPathInside(original, workingDir)) {
+      continue;
+    }
+
+    const stat = fsSync.statSync(original);
+    if (!stat.isFile()) {
+      continue;
+    }
+
+    if (strategy === 'reference') {
+      stagedFiles.push({ original, staged: original, strategy });
+      continue;
+    }
+
+    const staged = await uniqueInputPath(inputsDir, original);
+
+    if (strategy === 'copy') {
+      if (stat.size > LARGE_FILE_BYTES) {
+        stagedFiles.push({ original, staged: original, strategy: 'reference' });
+        continue;
+      }
+      await fs.copyFile(original, staged);
+    } else {
+      try {
+        await fs.symlink(original, staged);
+      } catch {
+        await fs.copyFile(original, staged);
+      }
+    }
+
+    stagedFiles.push({ original, staged, strategy });
+    pathMapping[original] = staged;
+  }
+
+  return { stagedFiles, pathMapping };
+}
+
+function resolveProfile(
+  profile: WorkspaceProfile,
+  directoryExplicitlyChosen: boolean,
+  hasGitContext: boolean
+): ResolvedWorkspaceProfile {
+  if (directoryExplicitlyChosen || profile === 'direct') {
+    return 'direct';
+  }
+  if (profile === 'sandbox') {
+    return 'sandbox';
+  }
+  if (profile === 'worktree') {
+    return hasGitContext ? 'worktree' : 'sandbox';
+  }
+  return hasGitContext ? 'worktree' : 'sandbox';
+}
+
+async function writeManifest(rootPath: string, manifest: WorkspaceManifest): Promise<void> {
+  await fs.writeFile(manifestPathForRoot(rootPath), JSON.stringify(manifest, null, 2), 'utf8');
+}
+
+export async function readManifestForSession(
+  sessionId: string,
+  goosePathRoot?: string
+): Promise<WorkspaceManifest | null> {
+  const manifestPath = manifestPathForRoot(workspaceRootForId(sessionId, goosePathRoot));
+  try {
+    const raw = await fs.readFile(manifestPath, 'utf8');
+    return JSON.parse(raw) as WorkspaceManifest;
+  } catch {
+    return null;
+  }
+}
+
+export async function getWorkspaceInfo(
+  sessionId: string,
+  goosePathRoot?: string
+): Promise<WorkspaceInfo | null> {
+  const manifest = await readManifestForSession(sessionId, goosePathRoot);
+  if (!manifest) {
+    return null;
+  }
+  return {
+    profile: manifest.profile,
+    rootPath: manifest.rootPath,
+    stagedFiles: manifest.stagedFiles,
+  };
+}
+
+export async function hasExternalWorkspaceFiles(
+  workingDir: string,
+  filePaths: string[]
+): Promise<boolean> {
+  for (const filePath of filePaths) {
+    if (!filePath?.trim() || !fsSync.existsSync(filePath)) {
+      continue;
+    }
+    if (!isPathInside(filePath, workingDir)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export async function resolveWorkspace(
+  request: ResolveWorkspaceRequest
+): Promise<ResolveWorkspaceResult> {
+  const pendingId = request.pendingId || randomUUID();
+  const externalFilePaths = [...new Set((request.externalFilePaths ?? []).filter(Boolean))];
+  const directoryExplicitlyChosen = request.directoryExplicitlyChosen ?? false;
+
+  let gitRepoRoot: string | null = null;
+  if (externalFilePaths.length > 0) {
+    gitRepoRoot = await findGitRepoRoot(externalFilePaths[0]);
+  } else if (request.explicitWorkingDir) {
+    gitRepoRoot = await findGitRepoRoot(request.explicitWorkingDir);
+  }
+
+  const resolvedProfile = resolveProfile(
+    request.profile,
+    directoryExplicitlyChosen,
+    gitRepoRoot !== null
+  );
+
+  if (resolvedProfile === 'direct') {
+    const workingDir = request.explicitWorkingDir?.trim() || app.getPath('home');
+    const manifest: WorkspaceManifest = {
+      sessionId: pendingId,
+      profile: 'direct',
+      rootPath: workingDir,
+      workingDir,
+      stagedFiles: [],
+      createdAt: new Date().toISOString(),
+    };
+
+    return {
+      workingDir,
+      pendingWorkspaceId: pendingId,
+      profile: 'direct',
+      manifest,
+      pathMapping: {},
+      workspaceHint: '',
+    };
+  }
+
+  const rootPath = workspaceRootForId(pendingId, request.goosePathRoot);
+  await fs.mkdir(path.join(rootPath, 'inputs'), { recursive: true });
+  let workingDir = path.join(rootPath, 'workspace');
+  let branchName: string | undefined;
+  let repoRoot: string | undefined;
+  let profile: ResolvedWorkspaceProfile = resolvedProfile;
+
+  if (resolvedProfile === 'worktree' && gitRepoRoot) {
+    try {
+      const worktree = await createGitWorktree(gitRepoRoot, pendingId);
+      workingDir = worktree.workingDir;
+      branchName = worktree.branchName;
+      repoRoot = gitRepoRoot;
+      profile = 'worktree';
+    } catch {
+      profile = 'sandbox';
+      await fs.mkdir(workingDir, { recursive: true });
+    }
+  } else {
+    profile = 'sandbox';
+    await fs.mkdir(workingDir, { recursive: true });
+  }
+
+  const { stagedFiles, pathMapping } = await stageExternalFiles(
+    rootPath,
+    workingDir,
+    externalFilePaths,
+    request.externalFileStrategy
+  );
+
+  const manifest: WorkspaceManifest = {
+    sessionId: pendingId,
+    profile,
+    rootPath,
+    workingDir,
+    repoRoot,
+    branchName,
+    stagedFiles,
+    createdAt: new Date().toISOString(),
+  };
+
+  await writeManifest(rootPath, manifest);
+
+  const workspaceHint = buildWorkspaceHint(manifest);
+
+  return {
+    workingDir,
+    pendingWorkspaceId: pendingId,
+    profile,
+    manifest,
+    pathMapping,
+    workspaceHint,
+  };
+}
+
+export async function finalizeWorkspace(request: FinalizeWorkspaceRequest): Promise<void> {
+  const { pendingWorkspaceId, sessionId } = request;
+  if (!pendingWorkspaceId || pendingWorkspaceId === sessionId) {
+    return;
+  }
+
+  const root = workspacesRoot(request.goosePathRoot);
+  const pendingPath = path.join(root, pendingWorkspaceId);
+  const finalPath = path.join(root, sessionId);
+
+  if (!fsSync.existsSync(pendingPath)) {
+    return;
+  }
+  if (fsSync.existsSync(finalPath)) {
+    return;
+  }
+
+  await fs.rename(pendingPath, finalPath);
+
+  const manifestPath = manifestPathForRoot(finalPath);
+  try {
+    const raw = await fs.readFile(manifestPath, 'utf8');
+    const manifest = JSON.parse(raw) as WorkspaceManifest;
+    manifest.sessionId = sessionId;
+    await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
+  } catch {
+    // ignore
+  }
+}
+
+export async function cleanupWorkspace(
+  sessionId: string,
+  goosePathRoot?: string
+): Promise<void> {
+  const manifest = await readManifestForSession(sessionId, goosePathRoot);
+  if (!manifest) {
+    return;
+  }
+
+  if (manifest.profile === 'worktree' && manifest.repoRoot && manifest.branchName) {
+    try {
+      await execFileAsync(
+        'git',
+        ['-C', manifest.repoRoot, 'worktree', 'remove', '--force', manifest.workingDir],
+        { timeout: 30_000 }
+      );
+    } catch {
+      // ignore
+    }
+    try {
+      await execFileAsync(
+        'git',
+        ['-C', manifest.repoRoot, 'branch', '-D', manifest.branchName],
+        { timeout: 10_000 }
+      );
+    } catch {
+      // ignore
+    }
+  }
+
+  const rootPath = workspaceRootForId(sessionId, goosePathRoot);
+
+  if (fsSync.existsSync(rootPath)) {
+    await fs.rm(rootPath, { recursive: true, force: true });
+  }
+}
+
+export async function cleanupOrphanedWorkspaces(goosePathRoot?: string): Promise<void> {
+  const root = workspacesRoot(goosePathRoot);
+  if (!fsSync.existsSync(root)) {
+    return;
+  }
+
+  const entries = await fs.readdir(root, { withFileTypes: true });
+  const now = Date.now();
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const dirPath = path.join(root, entry.name);
+    const manifestPath = manifestPathForRoot(dirPath);
+
+    try {
+      const stat = await fs.stat(dirPath);
+      let createdAt = stat.mtimeMs;
+
+      if (fsSync.existsSync(manifestPath)) {
+        const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8')) as WorkspaceManifest;
+        createdAt = Date.parse(manifest.createdAt) || createdAt;
+        if (manifest.sessionId && manifest.sessionId !== entry.name) {
+          continue;
+        }
+      }
+
+      if (now - createdAt > ORPHAN_TTL_MS) {
+        await fs.rm(dirPath, { recursive: true, force: true });
+      }
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/ui/desktop/src/workspace/workspaceManager.ts
+++ b/ui/desktop/src/workspace/workspaceManager.ts
@@ -16,6 +16,7 @@ import type {
   StagedFile,
   StageSessionFilesRequest,
   StageSessionFilesResult,
+  UnstageablePathsError,
   WorkspaceInfo,
   WorkspaceManifest,
   WorkspaceProfile,
@@ -142,6 +143,164 @@ export async function createGitWorktree(
 function isPathInside(child: string, parent: string): boolean {
   const relative = path.relative(parent, child);
   return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+export { UnstageablePathsError } from './types';
+
+async function uniqueInputDir(inputsDir: string, dirPath: string): Promise<string> {
+  const baseName = path.basename(dirPath);
+  let candidate = path.join(inputsDir, baseName);
+  if (!fsSync.existsSync(candidate)) {
+    return candidate;
+  }
+
+  for (let i = 1; i < 1000; i++) {
+    candidate = path.join(inputsDir, `${baseName}-${i}`);
+    if (!fsSync.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return path.join(inputsDir, `${baseName}-${Date.now()}`);
+}
+
+async function copyDirectoryRecursive(source: string, destination: string): Promise<void> {
+  await fs.mkdir(destination, { recursive: true });
+  const entries = await fs.readdir(source, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const sourcePath = path.join(source, entry.name);
+    const destinationPath = path.join(destination, entry.name);
+
+    if (entry.isDirectory()) {
+      await copyDirectoryRecursive(sourcePath, destinationPath);
+    } else if (entry.isFile()) {
+      await fs.copyFile(sourcePath, destinationPath);
+    }
+  }
+}
+
+async function symlinkPath(original: string, staged: string, isDirectory: boolean): Promise<void> {
+  const type = isDirectory ? 'dir' : 'file';
+  await fs.symlink(original, staged, type);
+}
+
+function assertIsolatedStaging(
+  filePaths: string[],
+  workingDir: string,
+  pathMapping: Record<string, string>,
+  strategy: ExternalFileStrategy
+): void {
+  if (strategy === 'reference') {
+    return;
+  }
+
+  const unstaged = filePaths.filter((filePath) => {
+    if (!filePath?.trim() || !fsSync.existsSync(filePath)) {
+      return false;
+    }
+    if (isPathInside(filePath, workingDir)) {
+      return false;
+    }
+    return !(filePath in pathMapping);
+  });
+
+  if (unstaged.length > 0) {
+    throw new UnstageablePathsError(unstaged);
+  }
+}
+
+async function stageExternalDirectory(
+  original: string,
+  inputsDir: string,
+  strategy: ExternalFileStrategy
+): Promise<{ staged: string; effectiveStrategy: ExternalFileStrategy }> {
+  if (strategy === 'reference') {
+    return { staged: original, effectiveStrategy: 'reference' };
+  }
+
+  const staged = await uniqueInputDir(inputsDir, original);
+
+  if (strategy === 'copy') {
+    await copyDirectoryRecursive(original, staged);
+    return { staged, effectiveStrategy: 'copy' };
+  }
+
+  try {
+    await symlinkPath(original, staged, true);
+    return { staged, effectiveStrategy: 'symlink' };
+  } catch {
+    await copyDirectoryRecursive(original, staged);
+    return { staged, effectiveStrategy: 'copy' };
+  }
+}
+
+async function stageExternalFileToInputs(
+  original: string,
+  inputsDir: string,
+  strategy: ExternalFileStrategy,
+  sizeBytes: number
+): Promise<{ staged: string; effectiveStrategy: ExternalFileStrategy }> {
+  if (strategy === 'reference') {
+    return { staged: original, effectiveStrategy: 'reference' };
+  }
+
+  const staged = await uniqueInputPath(inputsDir, original);
+
+  if (strategy === 'copy') {
+    if (sizeBytes > LARGE_FILE_BYTES) {
+      try {
+        await symlinkPath(original, staged, false);
+        return { staged, effectiveStrategy: 'symlink' };
+      } catch {
+        throw new UnstageablePathsError([original]);
+      }
+    }
+    await fs.copyFile(original, staged);
+    return { staged, effectiveStrategy: 'copy' };
+  }
+
+  try {
+    await symlinkPath(original, staged, false);
+    return { staged, effectiveStrategy: 'symlink' };
+  } catch {
+    await fs.copyFile(original, staged);
+    return { staged, effectiveStrategy: 'copy' };
+  }
+}
+
+async function stageRepoFileInWorktree(
+  original: string,
+  worktreePath: string,
+  strategy: ExternalFileStrategy,
+  isDirectory: boolean
+): Promise<{ staged: string; effectiveStrategy: ExternalFileStrategy }> {
+  const worktreeExists = fsSync.existsSync(worktreePath);
+  const sameContent =
+    !isDirectory &&
+    worktreeExists &&
+    fsSync.statSync(worktreePath).isFile() &&
+    filesHaveSameContent(original, worktreePath);
+
+  if (worktreeExists && sameContent) {
+    return { staged: worktreePath, effectiveStrategy: 'reference' };
+  }
+
+  if (!worktreeExists && strategy === 'reference') {
+    return { staged: worktreePath, effectiveStrategy: 'reference' };
+  }
+
+  const syncStrategy = sameContent ? strategy : 'copy';
+
+  if (isDirectory) {
+    if (fsSync.existsSync(worktreePath)) {
+      await fs.rm(worktreePath, { recursive: true, force: true });
+    }
+    await copyDirectoryRecursive(original, worktreePath);
+    return { staged: worktreePath, effectiveStrategy: 'copy' };
+  }
+
+  await copyFileToWorktreeLocation(original, worktreePath, syncStrategy);
+  return { staged: worktreePath, effectiveStrategy: syncStrategy };
 }
 
 async function uniqueInputPath(inputsDir: string, filePath: string): Promise<string> {
@@ -303,61 +462,54 @@ async function stageExternalFiles(
     }
 
     const stat = fsSync.statSync(original);
-    if (!stat.isFile()) {
-      continue;
+    const isDirectory = stat.isDirectory();
+    if (!stat.isFile() && !isDirectory) {
+      throw new UnstageablePathsError([original]);
     }
 
     if (repoRoot) {
       const worktreePath = worktreePathForRepoFile(repoRoot, workingDir, original);
       if (worktreePath) {
-        const worktreeExists =
-          fsSync.existsSync(worktreePath) && fsSync.statSync(worktreePath).isFile();
-        const sameContent = worktreeExists && filesHaveSameContent(original, worktreePath);
-
-        if (worktreeExists && sameContent) {
-          stagedFiles.push({ original, staged: worktreePath, strategy: 'reference' });
-          pathMapping[original] = worktreePath;
-          continue;
+        const { staged, effectiveStrategy } = await stageRepoFileInWorktree(
+          original,
+          worktreePath,
+          strategy,
+          isDirectory
+        );
+        stagedFiles.push({ original, staged, strategy: effectiveStrategy });
+        if (staged !== original) {
+          pathMapping[original] = staged;
         }
-
-        if (!worktreeExists && strategy === 'reference') {
-          stagedFiles.push({ original, staged: worktreePath, strategy: 'reference' });
-          pathMapping[original] = worktreePath;
-          continue;
-        }
-
-        const syncStrategy = sameContent ? strategy : 'copy';
-        await copyFileToWorktreeLocation(original, worktreePath, syncStrategy);
-        stagedFiles.push({ original, staged: worktreePath, strategy: syncStrategy });
-        pathMapping[original] = worktreePath;
         continue;
       }
     }
 
-    if (strategy === 'reference') {
-      stagedFiles.push({ original, staged: original, strategy });
+    if (isDirectory) {
+      const { staged, effectiveStrategy } = await stageExternalDirectory(
+        original,
+        inputsDir,
+        strategy
+      );
+      stagedFiles.push({ original, staged, strategy: effectiveStrategy });
+      if (staged !== original) {
+        pathMapping[original] = staged;
+      }
       continue;
     }
 
-    const staged = await uniqueInputPath(inputsDir, original);
-
-    if (strategy === 'copy') {
-      if (stat.size > LARGE_FILE_BYTES) {
-        stagedFiles.push({ original, staged: original, strategy: 'reference' });
-        continue;
-      }
-      await fs.copyFile(original, staged);
-    } else {
-      try {
-        await fs.symlink(original, staged);
-      } catch {
-        await fs.copyFile(original, staged);
-      }
+    const { staged, effectiveStrategy } = await stageExternalFileToInputs(
+      original,
+      inputsDir,
+      strategy,
+      stat.size
+    );
+    stagedFiles.push({ original, staged, strategy: effectiveStrategy });
+    if (staged !== original) {
+      pathMapping[original] = staged;
     }
-
-    stagedFiles.push({ original, staged, strategy });
-    pathMapping[original] = staged;
   }
+
+  assertIsolatedStaging(filePaths, workingDir, pathMapping, strategy);
 
   return { stagedFiles, pathMapping };
 }

--- a/ui/desktop/src/workspace/workspaceManager.ts
+++ b/ui/desktop/src/workspace/workspaceManager.ts
@@ -53,6 +53,21 @@ function manifestPathForRoot(rootPath: string): string {
   return path.join(rootPath, 'manifest.json');
 }
 
+export function sandboxSessionRoot(contextDir: string, sessionId: string): string {
+  return path.join(contextDir, '.goose', 'sessions', sessionId);
+}
+
+async function createSandboxWorkspace(
+  contextDir: string,
+  pendingId: string
+): Promise<{ sessionRoot: string; workingDir: string }> {
+  const sessionRoot = sandboxSessionRoot(contextDir, pendingId);
+  const workingDir = path.join(sessionRoot, 'workspace');
+  await fs.mkdir(path.join(sessionRoot, 'inputs'), { recursive: true });
+  await fs.mkdir(workingDir, { recursive: true });
+  return { sessionRoot, workingDir };
+}
+
 async function runGit(cwd: string, args: string[]): Promise<string> {
   const { stdout } = await execFileAsync('git', ['-C', cwd, ...args], { timeout: 10_000 });
   return stdout.trim();
@@ -274,9 +289,10 @@ export async function resolveWorkspace(
     };
   }
 
-  const rootPath = workspaceRootForId(pendingId, request.goosePathRoot);
-  await fs.mkdir(path.join(rootPath, 'inputs'), { recursive: true });
-  let workingDir = path.join(rootPath, 'workspace');
+  const contextDir = request.explicitWorkingDir?.trim() || app.getPath('home');
+  const indexRoot = workspaceRootForId(pendingId, request.goosePathRoot);
+  let sessionRoot: string;
+  let workingDir: string;
   let branchName: string | undefined;
   let repoRoot: string | undefined;
   let profile: ResolvedWorkspaceProfile = resolvedProfile;
@@ -285,20 +301,21 @@ export async function resolveWorkspace(
     try {
       const worktree = await createGitWorktree(gitRepoRoot, pendingId);
       workingDir = worktree.workingDir;
+      sessionRoot = worktree.workingDir;
       branchName = worktree.branchName;
       repoRoot = gitRepoRoot;
       profile = 'worktree';
     } catch {
       profile = 'sandbox';
-      await fs.mkdir(workingDir, { recursive: true });
+      ({ sessionRoot, workingDir } = await createSandboxWorkspace(contextDir, pendingId));
     }
   } else {
     profile = 'sandbox';
-    await fs.mkdir(workingDir, { recursive: true });
+    ({ sessionRoot, workingDir } = await createSandboxWorkspace(contextDir, pendingId));
   }
 
   const { stagedFiles, pathMapping } = await stageExternalFiles(
-    rootPath,
+    sessionRoot,
     workingDir,
     externalFilePaths,
     request.externalFileStrategy
@@ -307,7 +324,7 @@ export async function resolveWorkspace(
   const manifest: WorkspaceManifest = {
     sessionId: pendingId,
     profile,
-    rootPath,
+    rootPath: sessionRoot,
     workingDir,
     repoRoot,
     branchName,
@@ -315,7 +332,8 @@ export async function resolveWorkspace(
     createdAt: new Date().toISOString(),
   };
 
-  await writeManifest(rootPath, manifest);
+  await fs.mkdir(indexRoot, { recursive: true });
+  await writeManifest(indexRoot, manifest);
 
   const workspaceHint = buildWorkspaceHint(manifest);
 
@@ -336,27 +354,47 @@ export async function finalizeWorkspace(request: FinalizeWorkspaceRequest): Prom
   }
 
   const root = workspacesRoot(request.goosePathRoot);
-  const pendingPath = path.join(root, pendingWorkspaceId);
-  const finalPath = path.join(root, sessionId);
+  const pendingIndexPath = path.join(root, pendingWorkspaceId);
+  const finalIndexPath = path.join(root, sessionId);
 
-  if (!fsSync.existsSync(pendingPath)) {
+  let manifest: WorkspaceManifest | null = null;
+  const pendingManifestPath = manifestPathForRoot(pendingIndexPath);
+  if (fsSync.existsSync(pendingManifestPath)) {
+    try {
+      manifest = JSON.parse(await fs.readFile(pendingManifestPath, 'utf8')) as WorkspaceManifest;
+    } catch {
+      manifest = null;
+    }
+  }
+
+  if (fsSync.existsSync(pendingIndexPath) && !fsSync.existsSync(finalIndexPath)) {
+    await fs.rename(pendingIndexPath, finalIndexPath);
+  }
+
+  if (!manifest) {
     return;
   }
-  if (fsSync.existsSync(finalPath)) {
-    return;
+
+  if (manifest.rootPath.includes(pendingWorkspaceId)) {
+    const newRootPath = manifest.rootPath.split(pendingWorkspaceId).join(sessionId);
+    if (newRootPath !== manifest.rootPath && fsSync.existsSync(manifest.rootPath)) {
+      if (!fsSync.existsSync(newRootPath)) {
+        await fs.rename(manifest.rootPath, newRootPath);
+      }
+      manifest.rootPath = newRootPath;
+      if (manifest.workingDir.includes(pendingWorkspaceId)) {
+        manifest.workingDir = manifest.workingDir.split(pendingWorkspaceId).join(sessionId);
+      }
+    }
   }
 
-  await fs.rename(pendingPath, finalPath);
-
-  const manifestPath = manifestPathForRoot(finalPath);
-  try {
-    const raw = await fs.readFile(manifestPath, 'utf8');
-    const manifest = JSON.parse(raw) as WorkspaceManifest;
-    manifest.sessionId = sessionId;
-    await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
-  } catch {
-    // ignore
-  }
+  manifest.sessionId = sessionId;
+  const manifestWritePath = fsSync.existsSync(finalIndexPath) ? finalIndexPath : pendingIndexPath;
+  await fs.writeFile(
+    manifestPathForRoot(manifestWritePath),
+    JSON.stringify(manifest, null, 2),
+    'utf8'
+  );
 }
 
 export async function cleanupWorkspace(
@@ -389,10 +427,16 @@ export async function cleanupWorkspace(
     }
   }
 
-  const rootPath = workspaceRootForId(sessionId, goosePathRoot);
+  const indexPath = workspaceRootForId(sessionId, goosePathRoot);
+  const resolvedIndexPath = path.resolve(indexPath);
+  const resolvedSessionRoot = path.resolve(manifest.rootPath);
 
-  if (fsSync.existsSync(rootPath)) {
-    await fs.rm(rootPath, { recursive: true, force: true });
+  if (resolvedSessionRoot !== resolvedIndexPath && fsSync.existsSync(manifest.rootPath)) {
+    await fs.rm(manifest.rootPath, { recursive: true, force: true });
+  }
+
+  if (fsSync.existsSync(indexPath)) {
+    await fs.rm(indexPath, { recursive: true, force: true });
   }
 }
 

--- a/ui/desktop/src/workspace/workspaceManager.ts
+++ b/ui/desktop/src/workspace/workspaceManager.ts
@@ -14,6 +14,8 @@ import type {
   ResolveWorkspaceResult,
   ResolvedWorkspaceProfile,
   StagedFile,
+  StageSessionFilesRequest,
+  StageSessionFilesResult,
   WorkspaceInfo,
   WorkspaceManifest,
   WorkspaceProfile,
@@ -129,6 +131,78 @@ async function uniqueInputPath(inputsDir: string, filePath: string): Promise<str
     }
   }
   return path.join(inputsDir, `${stem}-${Date.now()}${ext}`);
+}
+
+function replaceSessionIdInPath(pathStr: string, pendingId: string, sessionId: string): string {
+  if (!pathStr.includes(pendingId)) {
+    return pathStr;
+  }
+  return pathStr.split(pendingId).join(sessionId);
+}
+
+async function removePhysicalWorkspace(
+  manifest: WorkspaceManifest,
+  indexSessionId: string,
+  goosePathRoot?: string
+): Promise<void> {
+  if (manifest.profile === 'worktree' && manifest.repoRoot && manifest.branchName) {
+    try {
+      await execFileAsync(
+        'git',
+        ['-C', manifest.repoRoot, 'worktree', 'remove', '--force', manifest.workingDir],
+        { timeout: 30_000 }
+      );
+    } catch {
+      // ignore
+    }
+    try {
+      await execFileAsync(
+        'git',
+        ['-C', manifest.repoRoot, 'branch', '-D', manifest.branchName],
+        { timeout: 10_000 }
+      );
+    } catch {
+      // ignore
+    }
+  }
+
+  const indexPath = workspaceRootForId(indexSessionId, goosePathRoot);
+  const resolvedIndexPath = path.resolve(indexPath);
+  const resolvedSessionRoot = path.resolve(manifest.rootPath);
+
+  if (
+    manifest.profile !== 'direct' &&
+    resolvedSessionRoot !== resolvedIndexPath &&
+    fsSync.existsSync(manifest.rootPath)
+  ) {
+    await fs.rm(manifest.rootPath, { recursive: true, force: true });
+  }
+}
+
+export async function stageSessionFiles(
+  request: StageSessionFilesRequest
+): Promise<StageSessionFilesResult> {
+  const manifest = await readManifestForSession(request.sessionId, request.goosePathRoot);
+  if (!manifest || manifest.profile === 'direct') {
+    return { pathMapping: {} };
+  }
+
+  const { stagedFiles, pathMapping } = await stageExternalFiles(
+    manifest.rootPath,
+    manifest.workingDir,
+    request.filePaths,
+    request.externalFileStrategy
+  );
+
+  if (stagedFiles.length === 0) {
+    return { pathMapping: {} };
+  }
+
+  manifest.stagedFiles = [...manifest.stagedFiles, ...stagedFiles];
+  const indexPath = workspaceRootForId(request.sessionId, request.goosePathRoot);
+  await writeManifest(indexPath, manifest);
+
+  return { pathMapping };
 }
 
 async function stageExternalFiles(
@@ -256,10 +330,10 @@ export async function resolveWorkspace(
   const externalFilePaths = [...new Set((request.externalFilePaths ?? []).filter(Boolean))];
 
   let gitRepoRoot: string | null = null;
-  if (externalFilePaths.length > 0) {
-    gitRepoRoot = await findGitRepoRoot(externalFilePaths[0]);
-  } else if (request.explicitWorkingDir) {
+  if (request.explicitWorkingDir) {
     gitRepoRoot = await findGitRepoRoot(request.explicitWorkingDir);
+  } else if (externalFilePaths.length > 0) {
+    gitRepoRoot = await findGitRepoRoot(externalFilePaths[0]);
   }
 
   const resolvedProfile = resolveProfile(request.profile, gitRepoRoot !== null);
@@ -397,6 +471,11 @@ export async function finalizeWorkspace(request: FinalizeWorkspaceRequest): Prom
     }
   }
 
+  manifest.stagedFiles = manifest.stagedFiles.map((file) => ({
+    ...file,
+    staged: replaceSessionIdInPath(file.staged, pendingWorkspaceId, sessionId),
+  }));
+
   manifest.sessionId = sessionId;
   const manifestWritePath = fsSync.existsSync(finalIndexPath) ? finalIndexPath : pendingIndexPath;
   await fs.writeFile(
@@ -415,39 +494,9 @@ export async function cleanupWorkspace(
     return;
   }
 
-  if (manifest.profile === 'worktree' && manifest.repoRoot && manifest.branchName) {
-    try {
-      await execFileAsync(
-        'git',
-        ['-C', manifest.repoRoot, 'worktree', 'remove', '--force', manifest.workingDir],
-        { timeout: 30_000 }
-      );
-    } catch {
-      // ignore
-    }
-    try {
-      await execFileAsync(
-        'git',
-        ['-C', manifest.repoRoot, 'branch', '-D', manifest.branchName],
-        { timeout: 10_000 }
-      );
-    } catch {
-      // ignore
-    }
-  }
+  await removePhysicalWorkspace(manifest, sessionId, goosePathRoot);
 
   const indexPath = workspaceRootForId(sessionId, goosePathRoot);
-  const resolvedIndexPath = path.resolve(indexPath);
-  const resolvedSessionRoot = path.resolve(manifest.rootPath);
-
-  if (
-    manifest.profile !== 'direct' &&
-    resolvedSessionRoot !== resolvedIndexPath &&
-    fsSync.existsSync(manifest.rootPath)
-  ) {
-    await fs.rm(manifest.rootPath, { recursive: true, force: true });
-  }
-
   if (fsSync.existsSync(indexPath)) {
     await fs.rm(indexPath, { recursive: true, force: true });
   }
@@ -473,9 +522,10 @@ export async function cleanupOrphanedWorkspaces(goosePathRoot?: string): Promise
     try {
       const stat = await fs.stat(dirPath);
       let createdAt = stat.mtimeMs;
+      let manifest: WorkspaceManifest | null = null;
 
       if (fsSync.existsSync(manifestPath)) {
-        const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8')) as WorkspaceManifest;
+        manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8')) as WorkspaceManifest;
         createdAt = Date.parse(manifest.createdAt) || createdAt;
         if (manifest.sessionId && manifest.sessionId !== entry.name) {
           continue;
@@ -483,6 +533,9 @@ export async function cleanupOrphanedWorkspaces(goosePathRoot?: string): Promise
       }
 
       if (now - createdAt > ORPHAN_TTL_MS) {
+        if (manifest) {
+          await removePhysicalWorkspace(manifest, entry.name, goosePathRoot);
+        }
         await fs.rm(dirPath, { recursive: true, force: true });
       }
     } catch {

--- a/ui/desktop/src/workspace/workspaceManager.ts
+++ b/ui/desktop/src/workspace/workspaceManager.ts
@@ -88,18 +88,47 @@ function shortId(id: string): string {
   return id.replace(/-/g, '').slice(0, 8);
 }
 
+async function branchExists(repoRoot: string, branchName: string): Promise<boolean> {
+  try {
+    await execFileAsync(
+      'git',
+      ['-C', repoRoot, 'show-ref', '--verify', '--quiet', `refs/heads/${branchName}`],
+      { timeout: 10_000 }
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function uniqueWorktreeBranchName(repoRoot: string, sessionId: string): Promise<string> {
+  const base = `goose/session-${shortId(sessionId)}`;
+  if (!(await branchExists(repoRoot, base))) {
+    return base;
+  }
+
+  for (let i = 1; i < 1000; i++) {
+    const candidate = `${base}-${i}`;
+    if (!(await branchExists(repoRoot, candidate))) {
+      return candidate;
+    }
+  }
+
+  return `${base}-${Date.now()}`;
+}
+
 export async function createGitWorktree(
   repoRoot: string,
   sessionId: string
 ): Promise<{ workingDir: string; branchName: string }> {
-  const branchName = `goose/session-${shortId(sessionId)}`;
+  const branchName = await uniqueWorktreeBranchName(repoRoot, sessionId);
   const worktreePath = path.join(repoRoot, '.goose', 'sessions', sessionId);
   await fs.mkdir(path.dirname(worktreePath), { recursive: true });
 
   try {
     await execFileAsync(
       'git',
-      ['-C', repoRoot, 'worktree', 'add', '-B', branchName, worktreePath],
+      ['-C', repoRoot, 'worktree', 'add', '-b', branchName, worktreePath],
       { timeout: 30_000 }
     );
   } catch (error) {


### PR DESCRIPTION
## Summary
Adds session workspace isolation to the desktop app so agents do not write directly into the user's chosen directory unless Direct mode is explicitly selected.

Workspace profiles (Hub picker + default in Settings):

Sandbox — session files under {contextDir}/.goose/sessions/{session-id}/workspace/; manifest index in GOOSE_DATA
Worktree — git worktree when context is a git repo; falls back to sandbox
Direct — existing behavior: agent works in the selected folder
Auto — worktree in a git repo, otherwise sandbox
Artifacts panel — shows staged inputs and workspace files; auto-refreshes when the agent stream finishes and on transition to Idle.

External files — copy / reference / symlink strategies with path mapping in the user message. Workspace isolation is enforced via session.working_dir; the [Workspace isolation] hint is not shown in chat.

Includes i18n strings and workspace unit tests.

### Testing
Automated:

cd ui/desktop && pnpm exec tsc --noEmit
cd ui/desktop && pnpm exec vitest run src/workspace/
Manual:

Hub → Sandbox with context folder → first message has no [Workspace isolation] text
Artifacts Meta shows {contextDir}/.goose/sessions/{id}/workspace
Agent creates a file → appears in WORKSPACE without manual refresh
Manual refresh matches auto-refresh
Open in Finder opens the sandbox session directory
Dropped file → staged under inputs/, path remapped in message
Git repo + Worktree → separate worktree, artifacts visible
Direct profile → working dir equals selected folder
Session delete → removes sandbox dir and GOOSE_DATA manifest index
Legacy session (Application Support paths) → artifacts still readable
### Related Issues
N/A

### Screenshots/Demos (for UX changes)
Before:
Agent could write into the user folder; artifacts panel stayed empty after writes; [Workspace isolation] appeared in the first chat message; Meta pointed to ~/Library/Application Support/....

After:
Sandbox lives under {contextDir}/.goose/sessions/...; artifacts auto-update after agent response; chat message stays clean; Meta shows the context-directory path.
<img width="364" height="64" alt="image" src="https://github.com/user-attachments/assets/bab7f787-a588-46b1-88d0-a834be4a843c" />
Settings:
<img width="460" height="270" alt="image" src="https://github.com/user-attachments/assets/a524acd7-4ba9-46b5-b539-7e227508ff33" />

