### PR TITLE
Add Ophis MCP server to the extensions registry

### DIFF
--- a/documentation/docs/mcp/ophis-mcp.md
+++ b/documentation/docs/mcp/ophis-mcp.md
@@ -1,0 +1,83 @@
+---
+title: Ophis Extension
+description: Add Ophis as a goose Extension to swap tokens with natural-language intents
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+
+This tutorial covers how to add [Ophis](https://ophis.fi) as a goose extension so goose can turn natural-language swap requests into executable orders across supported chains.
+
+:::tip Quick Install
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+    [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Fmcp.ophis.fi%2Fmcp&id=ophis&name=Ophis&description=Natural-language%20intent%20DEX%20aggregator%20with%20a%20keyless%20MCP%20server%20for%20AI%20agents)
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    Use `goose configure` to add a `Remote Extension (Streamable HTTP)` extension type with:
+
+    **Endpoint URL**
+    ```
+    https://mcp.ophis.fi/mcp
+    ```
+  </TabItem>
+</Tabs>
+:::
+
+## What is Ophis?
+
+Ophis is an intent-based DEX aggregator with a natural-language layer and a keyless MCP server for AI agents. It is non-custodial, gasless, and MEV-protected, and returns swap surplus to the trader. Ophis is a fork of CoW Protocol. It deploys its own settlement contract on Optimism and routes through CoW Protocol on the other supported chains: Ethereum, Base, Arbitrum, Polygon, BNB Chain, Gnosis, Avalanche, Linea, Plasma, and Ink.
+
+The MCP server is keyless and requires no API key or environment variables. It exposes six tools: `parse_intent`, `get_quote`, `build_order`, `submit_order`, `lookup_tier`, and `list_chains`. Trades are signed by the user's own wallet, so the server never holds keys or funds.
+
+## Configuration
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+    <GooseDesktopInstaller
+      extensionId="ophis"
+      extensionName="Ophis"
+      description="Natural-language intent DEX aggregator with a keyless MCP server for AI agents"
+      type="http"
+      url="https://mcp.ophis.fi/mcp"
+    />
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    <CLIExtensionInstructions
+      name="Ophis"
+      description="Natural-language intent DEX aggregator with a keyless MCP server for AI agents"
+      type="http"
+      url="https://mcp.ophis.fi/mcp"
+    />
+  </TabItem>
+</Tabs>
+
+## Example Usage
+
+Once Ophis is configured, you can describe a swap in plain language and ask goose to prepare an order. Here are some examples:
+
+**Parse an intent**
+```
+Parse this swap intent: "swap 100 USDC for ETH on Base".
+```
+
+**Get a quote**
+```
+Get a quote to swap 0.5 WETH for USDC on Arbitrum.
+```
+
+**List supported chains**
+```
+Which chains does Ophis support?
+```
+
+The server returns a quote and an unsigned order. The actual trade is signed by your own wallet, so no keys or funds are ever shared with the extension.
+
+## Resources
+
+- Website: [ophis.fi](https://ophis.fi)
+- App: [swap.ophis.fi](https://swap.ophis.fi)
+- Docs: [docs.ophis.fi](https://docs.ophis.fi)
+- Source: [github.com/ophis-fi/ophis](https://github.com/ophis-fi/ophis)

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -568,6 +568,18 @@
     ]
   },
   {
+    "id": "ophis",
+    "name": "Ophis",
+    "description": "Natural-language intent DEX aggregator with a keyless MCP server for AI agents",
+    "type": "streamable-http",
+    "url": "https://mcp.ophis.fi/mcp",
+    "link": "https://github.com/ophis-fi/ophis",
+    "installation_notes": "Streamable HTTP extension. No API key or environment variables required.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": []
+  },
+  {
     "id": "pdf_read",
     "name": "PDF Reader",
     "description": "Read large and complex PDF documents",


### PR DESCRIPTION
## Summary

This adds [Ophis](https://ophis.fi) to the extensions registry (`documentation/static/servers.json`) and a tutorial page at `documentation/docs/mcp/ophis-mcp.md`.

Ophis is an intent-based DEX aggregator with a natural-language layer and a keyless Streamable HTTP MCP server for AI agents at `https://mcp.ophis.fi/mcp`. The server requires no API key or environment variables, so the entry has an empty `environmentVariables` array and no headers. Source: https://github.com/ophis-fi/ophis

### Testing
Validated that `servers.json` remains valid JSON and that the new streamable-http entry matches the format of the existing remote entries.