### PR TITLE
docs(installation): correct whitespace in fenced code block

### DIFF
--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -35,7 +35,7 @@ import { PanelLeft } from 'lucide-react';
         <h3>Option 2: Install via Homebrew</h3>
         Homebrew downloads the [same app](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/b/block-goose.rb) but can take care of updates too.
         ```bash
-          brew install --cask block-goose
+        brew install --cask block-goose
         ```
         ---
         <div style={{ marginTop: '1rem' }}>


### PR DESCRIPTION
## Summary

When copying the brew install code block via the copy button, it includes some leading whitespace.

This removes the leading whitespace so it matches the other fenced code blocks on the page.

The page in question: https://goose-docs.ai/docs/getting-started/installation