### PR TITLE
Add Agentage Memory (remote MCP server)

### DIFF
--- a/documentation/docs/mcp/agentage-memory-mcp.md
+++ b/documentation/docs/mcp/agentage-memory-mcp.md
@@ -1,0 +1,83 @@
+---
+title: Agentage Memory Extension
+description: Add Agentage Memory MCP Server as a goose Extension
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+
+This tutorial covers how to add [Agentage Memory](https://agentage.io) as a goose extension - a remote MCP server that gives every AI tool one shared markdown memory you own.
+
+Agentage Memory is a **remote MCP server** (Streamable HTTP) hosted at `https://memory.agentage.io/mcp`. It authenticates with OAuth 2.1 + PKCE and Dynamic Client Registration, so there is no API key to manage - you sign in to your agentage account in the browser.
+
+:::info Documentation
+See the [Agentage Memory documentation](https://agentage.io/blog/mcp-endpoint-is-live) for details.
+:::
+
+## Configuration
+
+:::tip Quick Install
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Fmemory.agentage.io%2Fmcp&id=agentage-memory&name=Agentage%20Memory&description=One%20shared%20markdown%20memory%20for%20every%20AI)
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+  Use `goose configure` to add a `Remote Extension (Streaming HTTP)` extension type with:
+
+  **Endpoint URL**
+  ```
+  https://memory.agentage.io/mcp
+  ```
+  </TabItem>
+</Tabs>
+:::
+
+:::info OAUTH FLOW
+An OAuth window will open in your browser. Follow the prompts to authorize access to your agentage account.
+:::
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+    <GooseDesktopInstaller
+      extensionId="agentage-memory"
+      extensionName="Agentage Memory"
+      description="One shared markdown memory for every AI"
+      type="http"
+      url="https://memory.agentage.io/mcp"
+    />
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    <CLIExtensionInstructions
+      name="agentage-memory"
+      description="One shared markdown memory for every AI"
+      type="http"
+      url="https://memory.agentage.io/mcp"
+      timeout={300}
+    />
+  </TabItem>
+</Tabs>
+
+For all setup and configuration options, see the [Agentage Memory documentation](https://agentage.io/blog/mcp-endpoint-is-live).
+
+## Example Usage
+
+Agentage Memory exposes six tools - `memory__search`, `memory__read`, `memory__write`, `memory__edit`, `memory__list`, and `memory__delete` - so any goose session reads and writes the same markdown memory you use from Claude, Cursor, and ChatGPT.
+
+### goose Prompt
+
+```
+Remember that I prefer TypeScript with strict mode for all new projects.
+```
+
+### goose Output
+
+```
+I'll save that to your memory using the memory__write tool.
+
+Saved to preferences/coding-style.md:
+- Language: TypeScript (strict mode) for all new projects
+
+This is now available to every AI tool connected to your Agentage Memory.
+```

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -882,12 +882,12 @@
   },
   {
     "id": "agentage-memory",
-    "name": "agentage Memory",
+    "name": "Agentage Memory",
     "description": "One memory. Every AI. Owned by you. A shared markdown memory layer that Claude, Cursor, and ChatGPT all read and write through MCP, mirrored locally as plain .md you own.",
     "type": "streamable-http",
     "url": "https://memory.agentage.io/mcp",
     "link": "https://memory.agentage.io",
-    "installation_notes": "Streamable HTTP extension with OAuth 2.1 browser authentication (PKCE + Dynamic Client Registration) to your agentage Memory account. No API key or environment variables required.",
+    "installation_notes": "Streamable HTTP extension with OAuth 2.1 browser authentication (PKCE + Dynamic Client Registration) to your Agentage Memory account. No API key or environment variables required.",
     "is_builtin": false,
     "endorsed": false,
     "environmentVariables": []

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -879,6 +879,18 @@
       "required": false
     }
   ]
-}
+  },
+  {
+    "id": "agentage-memory",
+    "name": "agentage Memory",
+    "description": "One memory. Every AI. Owned by you. A shared markdown memory layer that Claude, Cursor, and ChatGPT all read and write through MCP, mirrored locally as plain .md you own.",
+    "type": "streamable-http",
+    "url": "https://memory.agentage.io/mcp",
+    "link": "https://memory.agentage.io",
+    "installation_notes": "Streamable HTTP extension with OAuth 2.1 browser authentication (PKCE + Dynamic Client Registration) to your agentage Memory account. No API key or environment variables required.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": []
+  }
 
 ]


### PR DESCRIPTION
Adds **Agentage Memory**, a remote MCP server (Streamable HTTP) that gives every AI tool one shared markdown memory you own.

- **Endpoint:** `https://memory.agentage.io/mcp`
- **Auth:** OAuth 2.1 + PKCE + Dynamic Client Registration (no API key)
- **Website:** https://agentage.io
- **Documentation:** https://agentage.io/blog/mcp-endpoint-is-live
- **Official MCP registry:** `io.agentage/memory`

**Tools (6):** `memory__search`, `memory__read`, `memory__write`, `memory__edit`, `memory__list`, `memory__delete` — one markdown memory that Claude, Cursor, and ChatGPT all read and write, mirrored locally as plain `.md` you can export anytime.

Happy to adjust placement/format to match this list's conventions.
