### PR TITLE
fix: honor env-var override when stored setting is also true

### DIFF
--- a/ui/desktop/src/components/settings/app/UpdateSection.tsx
+++ b/ui/desktop/src/components/settings/app/UpdateSection.tsx
@@ -168,11 +168,8 @@ export default function UpdateSection() {
     window.electron.getSetting('disableAutoDownload').then((stored) => {
       setDisableAutoDownload(!!stored);
     });
-    window.electron.getAutoDownloadDisabled().then((effective) => {
-      window.electron.getSetting('disableAutoDownload').then((stored) => {
-        // If effective is true but user setting is false, env var is forcing it
-        setAutoDownloadForcedByEnv(effective && !stored);
-      });
+    window.electron.isAutoDownloadEnvOverride().then((forcedByEnv) => {
+      setAutoDownloadForcedByEnv(forcedByEnv);
     });
 
     // Listen for updater events

--- a/ui/desktop/src/components/settings/app/UpdateSection.tsx
+++ b/ui/desktop/src/components/settings/app/UpdateSection.tsx
@@ -5,6 +5,28 @@ import { errorMessage } from '../../../utils/conversionUtils';
 import { defineMessages, useIntl } from '../../../i18n';
 
 const i18n = defineMessages({
+  disableAutoDownload: {
+    id: 'updateSection.disableAutoDownload',
+    defaultMessage: 'Disable automatic update downloads',
+  },
+  disableAutoDownloadDesc: {
+    id: 'updateSection.disableAutoDownloadDesc',
+    defaultMessage:
+      'When enabled, Goose will notify you of new versions but will not download them automatically.',
+  },
+  autoDownloadDisabledByEnv: {
+    id: 'updateSection.autoDownloadDisabledByEnv',
+    defaultMessage:
+      'Automatic downloads are disabled via the GOOSE_DISABLE_AUTO_DOWNLOAD environment variable.',
+  },
+  downloadNow: {
+    id: 'updateSection.downloadNow',
+    defaultMessage: 'Download Now',
+  },
+  autoDownloadDisabledNote: {
+    id: 'updateSection.autoDownloadDisabledNote',
+    defaultMessage: 'Automatic download is disabled. Click "Download Now" to download manually.',
+  },
   loading: {
     id: 'updateSection.loading',
     defaultMessage: 'Loading...',
@@ -116,6 +138,8 @@ export default function UpdateSection() {
   });
   const [progress, setProgress] = useState<number>(0);
   const [isUsingGitHubFallback, setIsUsingGitHubFallback] = useState<boolean>(false);
+  const [disableAutoDownload, setDisableAutoDownload] = useState<boolean>(false);
+  const [autoDownloadForcedByEnv, setAutoDownloadForcedByEnv] = useState<boolean>(false);
   const progressTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastProgressRef = React.useRef<number>(0); // Track last progress to prevent backward jumps
 
@@ -138,6 +162,17 @@ export default function UpdateSection() {
     // Check if using GitHub fallback
     window.electron.isUsingGitHubFallback().then((isGitHub) => {
       setIsUsingGitHubFallback(isGitHub);
+    });
+
+    // Load auto-download preference and detect env-var override
+    window.electron.getSetting('disableAutoDownload').then((stored) => {
+      setDisableAutoDownload(!!stored);
+    });
+    window.electron.getAutoDownloadDisabled().then((effective) => {
+      window.electron.getSetting('disableAutoDownload').then((stored) => {
+        // If effective is true but user setting is false, env var is forcing it
+        setAutoDownloadForcedByEnv(effective && !stored);
+      });
     });
 
     // Listen for updater events
@@ -249,6 +284,30 @@ export default function UpdateSection() {
     window.electron.installUpdate();
   };
 
+  const downloadUpdate = async () => {
+    setUpdateStatus('downloading');
+    setProgress(0);
+    lastProgressRef.current = 0;
+    try {
+      const result = await window.electron.downloadUpdate();
+      if (result.error) {
+        throw new Error(result.error);
+      }
+    } catch (error) {
+      setUpdateInfo((prev) => ({
+        ...prev,
+        error: errorMessage(error, 'Failed to download update'),
+      }));
+      setUpdateStatus('error');
+      setTimeout(() => setUpdateStatus('idle'), 5000);
+    }
+  };
+
+  const toggleAutoDownload = async (disabled: boolean) => {
+    setDisableAutoDownload(disabled);
+    await window.electron.setSetting('disableAutoDownload', disabled);
+  };
+
   const getStatusMessage = () => {
     switch (updateStatus) {
       case 'checking':
@@ -287,6 +346,8 @@ export default function UpdateSection() {
     }
   };
 
+  const autoDownloadEffectivelyDisabled = disableAutoDownload || autoDownloadForcedByEnv;
+
   return (
     <div>
       <div className="text-sm text-text-secondary mb-4 flex items-center gap-2">
@@ -314,6 +375,12 @@ export default function UpdateSection() {
           >
             {intl.formatMessage(i18n.checkForUpdates)}
           </Button>
+
+          {updateInfo.isUpdateAvailable && updateStatus === 'idle' && autoDownloadEffectivelyDisabled && (
+            <Button onClick={downloadUpdate} variant="secondary" size="sm">
+              {intl.formatMessage(i18n.downloadNow)}
+            </Button>
+          )}
 
           {updateStatus === 'ready' && (
             <Button onClick={installUpdate} variant="default" size="sm">
@@ -347,15 +414,23 @@ export default function UpdateSection() {
         {/* Update information */}
         {updateInfo.isUpdateAvailable && updateStatus === 'idle' && (
           <div className="text-xs text-text-secondary mt-4 space-y-1">
-            <p>{intl.formatMessage(i18n.autoDownload)}</p>
-            {isUsingGitHubFallback ? (
+            {autoDownloadEffectivelyDisabled ? (
               <p className="text-xs text-amber-600">
-                {intl.formatMessage(i18n.manualInstallNote)}
+                {intl.formatMessage(i18n.autoDownloadDisabledNote)}
               </p>
             ) : (
-              <p className="text-xs text-green-600">
-                {intl.formatMessage(i18n.autoInstallNote)}
-              </p>
+              <>
+                <p>{intl.formatMessage(i18n.autoDownload)}</p>
+                {isUsingGitHubFallback ? (
+                  <p className="text-xs text-amber-600">
+                    {intl.formatMessage(i18n.manualInstallNote)}
+                  </p>
+                ) : (
+                  <p className="text-xs text-green-600">
+                    {intl.formatMessage(i18n.autoInstallNote)}
+                  </p>
+                )}
+              </>
             )}
           </div>
         )}
@@ -382,6 +457,32 @@ export default function UpdateSection() {
               </>
             )}
           </div>
+        )}
+      </div>
+
+      {/* Auto-download toggle */}
+      <div className="mt-6 pt-4 border-t border-borderSubtle">
+        {autoDownloadForcedByEnv ? (
+          <p className="text-xs text-amber-600">
+            {intl.formatMessage(i18n.autoDownloadDisabledByEnv)}
+          </p>
+        ) : (
+          <label className="flex items-start gap-3 cursor-pointer group">
+            <input
+              type="checkbox"
+              className="mt-0.5 cursor-pointer accent-bgApp"
+              checked={disableAutoDownload}
+              onChange={(e) => toggleAutoDownload(e.target.checked)}
+            />
+            <div>
+              <p className="text-sm text-text-primary group-hover:text-text-primary">
+                {intl.formatMessage(i18n.disableAutoDownload)}
+              </p>
+              <p className="text-xs text-text-secondary mt-0.5">
+                {intl.formatMessage(i18n.disableAutoDownloadDesc)}
+              </p>
+            </div>
+          </label>
         )}
       </div>
     </div>

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -41,6 +41,7 @@ import windowStateKeeper from 'electron-window-state';
 import {
   getUpdateAvailable,
   registerUpdateIpcHandlers,
+  setAutoDownloadDisabled,
   setTrayRef,
   setupAutoUpdater,
   updateTrayMenu,
@@ -1736,6 +1737,7 @@ const validSettingKeys: Set<string> = new Set([
   'showPricing',
   'sessionSharing',
   'seenAnnouncementIds',
+  'disableAutoDownload',
 ]);
 
 ipcMain.handle('set-setting', (_event, key: SettingKey, value: unknown) => {
@@ -1762,6 +1764,11 @@ ipcMain.handle('set-setting', (_event, key: SettingKey, value: unknown) => {
   // Re-register shortcuts if keyboard shortcuts changed
   if (key === 'keyboardShortcuts') {
     registerGlobalShortcuts();
+  }
+
+  // Apply auto-download preference immediately (env var still takes precedence at startup)
+  if (key === 'disableAutoDownload') {
+    setAutoDownloadDisabled(value as boolean);
   }
 });
 
@@ -2301,6 +2308,11 @@ async function appMain() {
     if (shouldSetupUpdater()) {
       log.info('Setting up auto-updater after window creation...');
       try {
+        // Initialize auto-download preference from persisted settings before setup
+        const settings = getSettings();
+        if (settings.disableAutoDownload) {
+          setAutoDownloadDisabled(true);
+        }
         setupAutoUpdater();
       } catch (error) {
         log.error('Error setting up auto-updater:', error);

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -181,6 +181,7 @@ type ElectronAPI = {
   onUpdaterEvent: (callback: (event: UpdaterEvent) => void) => void;
   getUpdateState: () => Promise<{ updateAvailable: boolean; latestVersion?: string } | null>;
   isUsingGitHubFallback: () => Promise<boolean>;
+  getAutoDownloadDisabled: () => Promise<boolean>;
   // Recipe warning functions
   closeWindow: () => void;
   hasAcceptedRecipeBefore: (recipe: Recipe) => Promise<boolean>;
@@ -337,6 +338,9 @@ const electronAPI: ElectronAPI = {
   },
   isUsingGitHubFallback: (): Promise<boolean> => {
     return ipcRenderer.invoke('is-using-github-fallback');
+  },
+  getAutoDownloadDisabled: (): Promise<boolean> => {
+    return ipcRenderer.invoke('get-auto-download-disabled');
   },
   closeWindow: () => ipcRenderer.send('close-window'),
   hasAcceptedRecipeBefore: (recipe: Recipe) =>

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -182,6 +182,7 @@ type ElectronAPI = {
   getUpdateState: () => Promise<{ updateAvailable: boolean; latestVersion?: string } | null>;
   isUsingGitHubFallback: () => Promise<boolean>;
   getAutoDownloadDisabled: () => Promise<boolean>;
+  isAutoDownloadEnvOverride: () => Promise<boolean>;
   // Recipe warning functions
   closeWindow: () => void;
   hasAcceptedRecipeBefore: (recipe: Recipe) => Promise<boolean>;
@@ -341,6 +342,9 @@ const electronAPI: ElectronAPI = {
   },
   getAutoDownloadDisabled: (): Promise<boolean> => {
     return ipcRenderer.invoke('get-auto-download-disabled');
+  },
+  isAutoDownloadEnvOverride: (): Promise<boolean> => {
+    return ipcRenderer.invoke('is-auto-download-env-override');
   },
   closeWindow: () => ipcRenderer.send('close-window'),
   hasAcceptedRecipeBefore: (recipe: Recipe) =>

--- a/ui/desktop/src/utils/autoUpdater.ts
+++ b/ui/desktop/src/utils/autoUpdater.ts
@@ -46,6 +46,19 @@ let lastReportedProgress = 0;
 // Track if IPC handlers have been registered
 let ipcUpdateHandlersRegistered = false;
 
+// Whether automatic background downloading is disabled (env var or user setting)
+let autoDownloadDisabled = false;
+
+export function setAutoDownloadDisabled(disabled: boolean) {
+  autoDownloadDisabled = disabled;
+  autoUpdater.autoDownload = !disabled;
+  log.info(`Auto-download ${disabled ? 'disabled' : 'enabled'}`);
+}
+
+export function getAutoDownloadDisabled(): boolean {
+  return autoDownloadDisabled;
+}
+
 // Register IPC handlers (only once)
 export function registerUpdateIpcHandlers() {
   if (ipcUpdateHandlersRegistered) {
@@ -154,9 +167,12 @@ export function registerUpdateIpcHandlers() {
             updateTrayIcon(true);
             sendStatusToWindow('update-available', { version: result.latestVersion });
 
-            // Auto-download for GitHub fallback (matching autoDownload behavior)
-            log.info('Auto-downloading update via GitHub fallback...');
-            await githubAutoDownload(result.downloadUrl!, result.latestVersion!, 'manual check');
+            if (!autoDownloadDisabled) {
+              log.info('Auto-downloading update via GitHub fallback...');
+              await githubAutoDownload(result.downloadUrl!, result.latestVersion!, 'manual check');
+            } else {
+              log.info('Auto-download disabled — skipping GitHub fallback download');
+            }
           } else {
             trackUpdateCheckCompleted('not_available', currentVersion, {
               latestVersion: result.latestVersion,
@@ -333,6 +349,10 @@ export function registerUpdateIpcHandlers() {
   ipcMain.handle('is-using-github-fallback', () => {
     return isUsingGitHubFallback;
   });
+
+  ipcMain.handle('get-auto-download-disabled', () => {
+    return autoDownloadDisabled;
+  });
 }
 
 // Configure auto-updater
@@ -368,8 +388,17 @@ export function setupAutoUpdater(tray?: Tray) {
     log.error('Error getting feed URL:', e);
   }
 
+  // Respect GOOSE_DISABLE_AUTO_DOWNLOAD env var (takes precedence over user setting)
+  const envDisabled =
+    process.env.GOOSE_DISABLE_AUTO_DOWNLOAD === '1' ||
+    process.env.GOOSE_DISABLE_AUTO_DOWNLOAD === 'true';
+  if (envDisabled) {
+    autoDownloadDisabled = true;
+    log.info('Auto-download disabled via GOOSE_DISABLE_AUTO_DOWNLOAD environment variable');
+  }
+
   // Configure auto-updater settings
-  autoUpdater.autoDownload = true; // Automatically download updates when available
+  autoUpdater.autoDownload = !autoDownloadDisabled;
   autoUpdater.autoInstallOnAppQuit = true;
 
   // Enable updates in development mode for testing
@@ -485,9 +514,12 @@ export function setupAutoUpdater(tray?: Tray) {
                 updateTrayIcon(true);
                 sendStatusToWindow('update-available', { version: result.latestVersion });
 
-                // Auto-download for GitHub fallback (matching autoDownload behavior)
-                log.info('Auto-downloading update via GitHub fallback on startup...');
-                await githubAutoDownload(result.downloadUrl!, result.latestVersion!, 'on startup');
+                if (!autoDownloadDisabled) {
+                  log.info('Auto-downloading update via GitHub fallback on startup...');
+                  await githubAutoDownload(result.downloadUrl!, result.latestVersion!, 'on startup');
+                } else {
+                  log.info('Auto-download disabled — skipping GitHub fallback download on startup');
+                }
               } else {
                 trackUpdateCheckCompleted('not_available', currentVersion, {
                   latestVersion: result.latestVersion,
@@ -533,7 +565,9 @@ export function setupAutoUpdater(tray?: Tray) {
       latestVersion: info.version,
       usingFallback: false,
     });
-    trackUpdateDownloadStarted(info.version, 'electron-updater');
+    if (!autoDownloadDisabled) {
+      trackUpdateDownloadStarted(info.version, 'electron-updater');
+    }
     updateAvailable = true;
     lastUpdateState = { updateAvailable: true, latestVersion: info.version };
     updateTrayIcon(true);
@@ -591,9 +625,12 @@ export function setupAutoUpdater(tray?: Tray) {
           updateTrayIcon(true);
           sendStatusToWindow('update-available', { version: result.latestVersion });
 
-          // Auto-download for GitHub fallback (matching autoDownload behavior)
-          log.info('Auto-downloading update via GitHub fallback after error...');
-          await githubAutoDownload(result.downloadUrl!, result.latestVersion!, 'after error');
+          if (!autoDownloadDisabled) {
+            log.info('Auto-downloading update via GitHub fallback after error...');
+            await githubAutoDownload(result.downloadUrl!, result.latestVersion!, 'after error');
+          } else {
+            log.info('Auto-download disabled — skipping GitHub fallback download after error');
+          }
         } else {
           updateAvailable = false;
           updateTrayIcon(false);

--- a/ui/desktop/src/utils/autoUpdater.ts
+++ b/ui/desktop/src/utils/autoUpdater.ts
@@ -48,6 +48,8 @@ let ipcUpdateHandlersRegistered = false;
 
 // Whether automatic background downloading is disabled (env var or user setting)
 let autoDownloadDisabled = false;
+// Set only when GOOSE_DISABLE_AUTO_DOWNLOAD env var is present; never cleared at runtime
+let autoDownloadForcedByEnv = false;
 
 export function setAutoDownloadDisabled(disabled: boolean) {
   autoDownloadDisabled = disabled;
@@ -57,6 +59,10 @@ export function setAutoDownloadDisabled(disabled: boolean) {
 
 export function getAutoDownloadDisabled(): boolean {
   return autoDownloadDisabled;
+}
+
+export function isAutoDownloadEnvOverride(): boolean {
+  return autoDownloadForcedByEnv;
 }
 
 // Register IPC handlers (only once)
@@ -353,6 +359,10 @@ export function registerUpdateIpcHandlers() {
   ipcMain.handle('get-auto-download-disabled', () => {
     return autoDownloadDisabled;
   });
+
+  ipcMain.handle('is-auto-download-env-override', () => {
+    return autoDownloadForcedByEnv;
+  });
 }
 
 // Configure auto-updater
@@ -393,6 +403,7 @@ export function setupAutoUpdater(tray?: Tray) {
     process.env.GOOSE_DISABLE_AUTO_DOWNLOAD === '1' ||
     process.env.GOOSE_DISABLE_AUTO_DOWNLOAD === 'true';
   if (envDisabled) {
+    autoDownloadForcedByEnv = true;
     autoDownloadDisabled = true;
     log.info('Auto-download disabled via GOOSE_DISABLE_AUTO_DOWNLOAD environment variable');
   }

--- a/ui/desktop/src/utils/settings.ts
+++ b/ui/desktop/src/utils/settings.ts
@@ -33,6 +33,7 @@ export type LanguageSetting = 'system' | 'en' | 'es' | 'hi' | 'ja' | 'ko' | 'ru'
 export interface Settings {
   // Desktop app settings
   showMenuBarIcon: boolean;
+  disableAutoDownload: boolean;
   showDockIcon: boolean;
   enableWakelock: boolean;
   enableNotifications: boolean;
@@ -70,6 +71,7 @@ export const defaultKeyboardShortcuts: DefaultKeyboardShortcuts = {
 export const defaultSettings: Settings = {
   // Desktop app settings
   showMenuBarIcon: true,
+  disableAutoDownload: false,
   showDockIcon: true,
   enableWakelock: false,
   enableNotifications: true,


### PR DESCRIPTION
## What

Fixes the P2 bug flagged by the code-review bot on #9872.

## The bug

When `GOOSE_DISABLE_AUTO_DOWNLOAD=1` is set **and** `disableAutoDownload: true` is already persisted in settings, the expression `effective && !stored` evaluates to `false` — so the UI renders an editable toggle instead of the read-only env-var notice. The user can untoggle it mid-session, breaking the advertised env-var precedence.

## The fix

Track env-var presence with a dedicated `autoDownloadForcedByEnv` flag (set only in `setupAutoUpdater()`, never cleared by `setAutoDownloadDisabled()`). Expose it via a new `isAutoDownloadEnvOverride()` / `is-auto-download-env-override` IPC. The renderer calls this directly instead of inferring env presence from two booleans.

**3 files changed:**
- `autoUpdater.ts` — `autoDownloadForcedByEnv` flag + `isAutoDownloadEnvOverride()` export + IPC handler
- `preload.ts` — type + implementation for `isAutoDownloadEnvOverride()`
- `UpdateSection.tsx` — replace nested `.then()` dance with single `isAutoDownloadEnvOverride()` call

This branch (`Crazyop757:feat/disable-auto-update-download`) contains the original feature commits plus this fix on top — safe to merge into `download-skip`.