### PR TITLE
fix: honor env-var override when stored setting is also true

### DIFF
--- a/ui/desktop/src/components/settings/app/UpdateSection.tsx
+++ b/ui/desktop/src/components/settings/app/UpdateSection.tsx
@@ -168,11 +168,8 @@ export default function UpdateSection() {
     window.electron.getSetting('disableAutoDownload').then((stored) => {
       setDisableAutoDownload(!!stored);
     });
-    window.electron.getAutoDownloadDisabled().then((effective) => {
-      window.electron.getSetting('disableAutoDownload').then((stored) => {
-        // If effective is true but user setting is false, env var is forcing it
-        setAutoDownloadForcedByEnv(effective && !stored);
-      });
+    window.electron.isAutoDownloadEnvOverride().then((forcedByEnv) => {
+      setAutoDownloadForcedByEnv(forcedByEnv);
     });
 
     // Listen for updater events

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -182,6 +182,7 @@ type ElectronAPI = {
   getUpdateState: () => Promise<{ updateAvailable: boolean; latestVersion?: string } | null>;
   isUsingGitHubFallback: () => Promise<boolean>;
   getAutoDownloadDisabled: () => Promise<boolean>;
+  isAutoDownloadEnvOverride: () => Promise<boolean>;
   // Recipe warning functions
   closeWindow: () => void;
   hasAcceptedRecipeBefore: (recipe: Recipe) => Promise<boolean>;
@@ -341,6 +342,9 @@ const electronAPI: ElectronAPI = {
   },
   getAutoDownloadDisabled: (): Promise<boolean> => {
     return ipcRenderer.invoke('get-auto-download-disabled');
+  },
+  isAutoDownloadEnvOverride: (): Promise<boolean> => {
+    return ipcRenderer.invoke('is-auto-download-env-override');
   },
   closeWindow: () => ipcRenderer.send('close-window'),
   hasAcceptedRecipeBefore: (recipe: Recipe) =>

--- a/ui/desktop/src/utils/autoUpdater.ts
+++ b/ui/desktop/src/utils/autoUpdater.ts
@@ -48,6 +48,8 @@ let ipcUpdateHandlersRegistered = false;
 
 // Whether automatic background downloading is disabled (env var or user setting)
 let autoDownloadDisabled = false;
+// Set only when GOOSE_DISABLE_AUTO_DOWNLOAD env var is present; never cleared at runtime
+let autoDownloadForcedByEnv = false;
 
 export function setAutoDownloadDisabled(disabled: boolean) {
   autoDownloadDisabled = disabled;
@@ -57,6 +59,10 @@ export function setAutoDownloadDisabled(disabled: boolean) {
 
 export function getAutoDownloadDisabled(): boolean {
   return autoDownloadDisabled;
+}
+
+export function isAutoDownloadEnvOverride(): boolean {
+  return autoDownloadForcedByEnv;
 }
 
 // Register IPC handlers (only once)
@@ -353,6 +359,10 @@ export function registerUpdateIpcHandlers() {
   ipcMain.handle('get-auto-download-disabled', () => {
     return autoDownloadDisabled;
   });
+
+  ipcMain.handle('is-auto-download-env-override', () => {
+    return autoDownloadForcedByEnv;
+  });
 }
 
 // Configure auto-updater
@@ -393,6 +403,7 @@ export function setupAutoUpdater(tray?: Tray) {
     process.env.GOOSE_DISABLE_AUTO_DOWNLOAD === '1' ||
     process.env.GOOSE_DISABLE_AUTO_DOWNLOAD === 'true';
   if (envDisabled) {
+    autoDownloadForcedByEnv = true;
     autoDownloadDisabled = true;
     log.info('Auto-download disabled via GOOSE_DISABLE_AUTO_DOWNLOAD environment variable');
   }


### PR DESCRIPTION
Fixes the P2 bug flagged on #9872.

**The bug:** When `GOOSE_DISABLE_AUTO_DOWNLOAD=1` is set and `disableAutoDownload: true` is already in settings, `effective && !stored` evaluates to `false` — UI shows an editable toggle instead of the read-only env-var notice. User can untoggle it, breaking env-var precedence.

**The fix:** Dedicated `autoDownloadForcedByEnv` flag set only by the env var (never by `setAutoDownloadDisabled`). Exposed via `isAutoDownloadEnvOverride()` / `is-auto-download-env-override` IPC. Renderer calls this directly.

3 files: `autoUpdater.ts`, `preload.ts`, `UpdateSection.tsx`