### PR TITLE
fix(desktop): show optimistic toggle state when disabling an extension

### DIFF
--- a/ui/desktop/src/components/settings/extensions/subcomponents/ExtensionItem.test.tsx
+++ b/ui/desktop/src/components/settings/extensions/subcomponents/ExtensionItem.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, type RenderOptions, screen, fireEvent, waitFor } from '@testing-library/react';
+import ExtensionItem from './ExtensionItem';
+import { IntlTestWrapper } from '../../../../i18n/test-utils';
+import type { FixedExtensionEntry } from '../../../ConfigContext';
+
+vi.mock('./ExtensionList', () => ({
+  getSubtitle: () => ({ description: '', command: '' }),
+  getFriendlyTitle: (ext: { name: string }) => ext.name,
+}));
+
+const renderWithIntl = (ui: React.ReactElement, options?: RenderOptions) =>
+  render(ui, { wrapper: IntlTestWrapper, ...options });
+
+const makeExtension = (enabled: boolean): FixedExtensionEntry =>
+  ({ name: 'developer', type: 'builtin', enabled }) as unknown as FixedExtensionEntry;
+
+describe('ExtensionItem', () => {
+  it('reflects the toggle as OFF immediately when disabling, before the async toggle resolves', async () => {
+    // onToggle stays pending so we observe the in-flight (optimistic) state
+    const onToggle = vi.fn(() => new Promise<void>(() => {}));
+    renderWithIntl(<ExtensionItem extension={makeExtension(true)} onToggle={onToggle} />);
+
+    const toggle = screen.getByRole('switch');
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'false');
+    });
+  });
+
+  it('reflects the toggle as ON immediately when enabling, before the async toggle resolves', async () => {
+    const onToggle = vi.fn(() => new Promise<void>(() => {}));
+    renderWithIntl(<ExtensionItem extension={makeExtension(false)} onToggle={onToggle} />);
+
+    const toggle = screen.getByRole('switch');
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+    });
+  });
+});

--- a/ui/desktop/src/components/settings/extensions/subcomponents/ExtensionItem.tsx
+++ b/ui/desktop/src/components/settings/extensions/subcomponents/ExtensionItem.tsx
@@ -106,7 +106,7 @@ export default function ExtensionItem({
               </button>
             )}
             <Switch
-              checked={(isToggling && visuallyEnabled) || extension.enabled}
+              checked={visuallyEnabled}
               onCheckedChange={() => handleToggle(extension)}
               disabled={isToggling}
               variant="mono"


### PR DESCRIPTION
## Problem
In Settings → Extensions, turning **off** an enabled extension makes the toggle immediately snap back to **On** for the duration of the (async) toggle, instead of showing the optimistic Off state. Enabling works correctly, so the behavior is asymmetric. Closes #9881.

## Root cause
`ExtensionItem` keeps a local `visuallyEnabled` state for optimistic feedback, but the `Switch`'s `checked` was computed as:

```tsx
checked={(isToggling && visuallyEnabled) || extension.enabled}
```

While disabling an enabled extension, `extension.enabled` stays `true` until the async config write completes, so `|| extension.enabled` forces `checked` back to `true` mid-operation.

## Fix
Use `visuallyEnabled` directly. It already holds the optimistic state during a toggle, and the existing effect keeps it in sync with `extension.enabled` whenever a toggle is **not** in progress, so it is the correct value in every state:

```tsx
checked={visuallyEnabled}
```

## Testing
- New `ExtensionItem.test.tsx`: asserts the toggle reflects the optimistic state immediately in **both** directions while the async toggle is in flight. The disable-direction test fails without this fix.
- `pnpm lint:check` and `pnpm test:run` pass (418 tests).
