### PR TITLE
Sanitize extension environment maps

### DIFF
--- a/crates/goose/src/agents/extension.rs
+++ b/crates/goose/src/agents/extension.rs
@@ -58,12 +58,22 @@ pub enum ExtensionError {
 
 pub type ExtensionResult<T> = Result<T, ExtensionError>;
 
-#[derive(Debug, Clone, Deserialize, Serialize, Default, ToSchema, PartialEq)]
+#[derive(Debug, Clone, Serialize, Default, ToSchema, PartialEq)]
 pub struct Envs {
     /// A map of environment variables to set, e.g. API_KEY -> some_secret, HOST -> host
     #[serde(default)]
     #[serde(flatten)]
     map: HashMap<String, String>,
+}
+
+impl<'de> Deserialize<'de> for Envs {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let map = HashMap::<String, String>::deserialize(deserializer)?;
+        Ok(Self::new(map))
+    }
 }
 
 impl Envs {
@@ -663,6 +673,16 @@ available_tools: []
         } else {
             panic!("unexpected result of deserialization: {}", config)
         }
+    }
+
+    #[test]
+    fn envs_deserialization_filters_disallowed_keys() {
+        let envs: extension::Envs =
+            serde_yaml::from_str("LD_PRELOAD: /tmp/injected.so\nSAFE_VAR: ok\n").unwrap();
+        let map = envs.get_env();
+
+        assert!(!map.contains_key("LD_PRELOAD"));
+        assert_eq!(map.get("SAFE_VAR"), Some(&"ok".to_string()));
     }
 
     #[test_case(

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -498,7 +498,7 @@ pub(crate) async fn merge_environments(
         }
     }
 
-    Ok(all_envs)
+    Ok(Envs::new(all_envs).get_env())
 }
 
 /// Substitute environment variables in a string. Supports both ${VAR} and $VAR syntax.

--- a/crates/goose/src/recipe/recipe_extension_adapter.rs
+++ b/crates/goose/src/recipe/recipe_extension_adapter.rs
@@ -260,4 +260,33 @@ mod tests {
             other => panic!("unexpected extension variant: {:?}", other),
         }
     }
+
+    #[test]
+    fn recipe_stdio_envs_deserialization_filters_disallowed_keys() {
+        let wrapper: Wrapper = serde_json::from_value(json!({
+            "extensions": [{
+                "type": "stdio",
+                "name": "test-stdio",
+                "cmd": "echo",
+                "args": [],
+                "envs": {
+                    "LD_PRELOAD": "/tmp/injected.so",
+                    "SAFE_VAR": "ok"
+                }
+            }]
+        }))
+        .expect("failed to deserialize extensions");
+
+        let extensions = wrapper.extensions.expect("expected extensions");
+        assert_eq!(extensions.len(), 1);
+
+        match &extensions[0] {
+            ExtensionConfig::Stdio { envs, .. } => {
+                let map = envs.get_env();
+                assert!(!map.contains_key("LD_PRELOAD"));
+                assert_eq!(map.get("SAFE_VAR"), Some(&"ok".to_string()));
+            }
+            other => panic!("unexpected extension variant: {:?}", other),
+        }
+    }
 }


### PR DESCRIPTION
Filter disallowed extension environment variables when Envs is deserialized, and apply the same filtering after merging configured environment keys. Add regression coverage for direct Envs deserialization and recipe-provided stdio extension env maps.

This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe).