### PR TITLE
docs: add text2sql MCP server

### DIFF
--- a/documentation/docs/mcp/text2sql-mcp.md
+++ b/documentation/docs/mcp/text2sql-mcp.md
@@ -8,9 +8,11 @@ import TabItem from '@theme/TabItem';
 import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
 import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 
-This tutorial covers how to add the [text2sql MCP Server](https://github.com/cpenniman12/text2sql-mcp) as a goose extension to ask any SQL database questions in natural language. The agent explores the schema, writes SQL, executes it against the real database, and self-corrects on errors — no RAG layer, no schema descriptions, no embeddings required. Just a connection string and a frontier model.
+This tutorial covers how to add the [text2sql MCP Server](https://github.com/cpenniman12/text2sql-mcp) as a goose extension to ask SQL databases questions in natural language. The agent explores the schema, writes SQL, executes it against the real database, and self-corrects on errors — no RAG layer, no schema descriptions, no embeddings required. Just a connection string and a frontier model.
 
-:::tip Quick Install
+The base install supports **SQLite + Anthropic** out of the box. For other databases or LLM providers, swap the command for the matching install extra — see [Other databases & providers](#other-databases--providers) below.
+
+:::tip Quick Install (SQLite + Anthropic)
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=uvx&arg=text2sql-mcp&id=text2sql&name=text2sql&description=Ask%20your%20SQL%20database%20questions%20in%20natural%20language&env=TEXT2SQL_DATABASE_URL%3DSQLAlchemy%20connection%20string&env=ANTHROPIC_API_KEY%3DAnthropic%20API%20key)
@@ -24,7 +26,7 @@ This tutorial covers how to add the [text2sql MCP Server](https://github.com/cpe
 </Tabs>
   **Environment Variables**
   ```
-  TEXT2SQL_DATABASE_URL: <SQLALCHEMY_CONNECTION_STRING>
+  TEXT2SQL_DATABASE_URL: sqlite:///path/to/mydb.db
   ANTHROPIC_API_KEY: <YOUR_ANTHROPIC_API_KEY>
   ```
 :::
@@ -69,7 +71,7 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
       ]}
       infoNote={
         <>
-          <code>TEXT2SQL_DATABASE_URL</code> is any SQLAlchemy URL — SQLite, Postgres, MySQL, Snowflake, BigQuery, etc. Get your Anthropic API key from{" "}
+          For SQLite use a <code>sqlite:///path/to/mydb.db</code> URL. For other databases, see <a href="#other-databases--providers">Other databases &amp; providers</a> below. Get your Anthropic API key from{" "}
           <a href="https://console.anthropic.com/settings/keys" target="_blank" rel="noopener noreferrer">
             console.anthropic.com
           </a>.
@@ -80,9 +82,19 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
   </TabItem>
 </Tabs>
 
-:::info
-text2sql defaults to `anthropic:claude-sonnet-4-6`. To use OpenAI instead, set `TEXT2SQL_MODEL=openai:gpt-4.1` and provide `OPENAI_API_KEY`. See the [text2sql-framework README](https://github.com/cpenniman12/text2sql-framework) for the full list of supported options, including custom business-rule instructions and example libraries.
-:::
+## Other databases & providers
+
+The base `text2sql-mcp` package ships only the SQLite driver (via SQLAlchemy core) and Anthropic support. For Postgres, MySQL, Snowflake, BigQuery, or OpenAI, swap the command in the Configuration above for the matching install extra:
+
+| Database / provider | Command | Notes |
+| --- | --- | --- |
+| Postgres | `uvx 'text2sql-mcp[postgres]'` | Installs `psycopg2-binary`. Use `postgresql://...` URLs. |
+| MySQL | `uvx 'text2sql-mcp[mysql]'` | Installs `pymysql`. Use `mysql+pymysql://...` URLs. |
+| Snowflake | `uvx 'text2sql-mcp[snowflake]'` | Installs `snowflake-sqlalchemy`. |
+| BigQuery | `uvx 'text2sql-mcp[bigquery]'` | Installs `sqlalchemy-bigquery`. |
+| OpenAI models | add `openai` to any extra, e.g. `uvx 'text2sql-mcp[postgres,openai]'` | Then set `TEXT2SQL_MODEL=openai:gpt-4.1` and `OPENAI_API_KEY` instead of `ANTHROPIC_API_KEY`. |
+
+Combine extras with commas (e.g. `uvx 'text2sql-mcp[postgres,openai]'`). See the [text2sql-framework README](https://github.com/cpenniman12/text2sql-framework) for the full list of supported options, including custom business-rule instructions and example libraries.
 
 ## Tools
 

--- a/documentation/docs/mcp/text2sql-mcp.md
+++ b/documentation/docs/mcp/text2sql-mcp.md
@@ -109,24 +109,23 @@ Point text2sql at any SQL database — here we use a SQLite copy of the [Chinook
 ### goose Prompt
 
 ```
-What were the top 5 customers by total invoice amount last year?
+Who are the top 5 customers by total invoice amount, all time?
 ```
 
 ### goose Output
 
 ```
 I'll ask the text2sql agent to figure this out. Behind the scenes it explored
-the schema, found the `customers` and `invoices` tables, joined them, and
-filtered by the previous calendar year.
+the schema, found the `Customer` and `Invoice` tables, joined them, and
+aggregated invoice totals per customer.
 
 SQL:
 
   SELECT
     c.FirstName || ' ' || c.LastName AS customer,
     ROUND(SUM(i.Total), 2)            AS total_spent
-  FROM invoices i
-  JOIN customers c ON c.CustomerId = i.CustomerId
-  WHERE strftime('%Y', i.InvoiceDate) = strftime('%Y', date('now', '-1 year'))
+  FROM Invoice i
+  JOIN Customer c ON c.CustomerId = i.CustomerId
   GROUP BY c.CustomerId
   ORDER BY total_spent DESC
   LIMIT 5;
@@ -135,11 +134,11 @@ Top 5 customers:
 
   Helena Holý           49.62
   Richard Cunningham    47.62
-  Luis Rojas            46.62
+  Luís Gonçalves        46.62
   Ladislav Kovács       45.62
   Hugh O'Reilly         45.62
 
-The agent made 6 exploratory SQL calls before writing the final query —
-listing tables, inspecting the `customers` and `invoices` schemas,
-checking the date format, and verifying the join works.
+The agent made 5 exploratory SQL calls before writing the final query —
+listing tables, inspecting the `Customer` and `Invoice` schemas, and
+checking the join columns.
 ```

--- a/documentation/docs/mcp/text2sql-mcp.md
+++ b/documentation/docs/mcp/text2sql-mcp.md
@@ -1,0 +1,133 @@
+---
+title: text2sql Extension
+description: Add text2sql MCP Server as a goose Extension
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+
+This tutorial covers how to add the [text2sql MCP Server](https://github.com/cpenniman12/text2sql-mcp) as a goose extension to ask any SQL database questions in natural language. The agent explores the schema, writes SQL, executes it against the real database, and self-corrects on errors — no RAG layer, no schema descriptions, no embeddings required. Just a connection string and a frontier model.
+
+:::tip Quick Install
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  [Launch the installer](goose://extension?cmd=uvx&arg=text2sql-mcp&id=text2sql&name=text2sql&description=Ask%20your%20SQL%20database%20questions%20in%20natural%20language&env=TEXT2SQL_DATABASE_URL%3DSQLAlchemy%20connection%20string&env=ANTHROPIC_API_KEY%3DAnthropic%20API%20key)
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+  **Command**
+  ```sh
+  uvx text2sql-mcp
+  ```
+  </TabItem>
+</Tabs>
+  **Environment Variables**
+  ```
+  TEXT2SQL_DATABASE_URL: <SQLALCHEMY_CONNECTION_STRING>
+  ANTHROPIC_API_KEY: <YOUR_ANTHROPIC_API_KEY>
+  ```
+:::
+
+## Configuration
+
+:::info
+Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on your system to run this command, as it uses `uvx`.
+:::
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+
+    <GooseDesktopInstaller
+      extensionId="text2sql"
+      extensionName="text2sql"
+      description="Ask your SQL database questions in natural language"
+      type="stdio"
+      command="uvx"
+      args={["text2sql-mcp"]}
+      timeout={300}
+      envVars={[
+        { name: "TEXT2SQL_DATABASE_URL", label: "SQLAlchemy connection string (e.g. sqlite:///mydb.db)" },
+        { name: "ANTHROPIC_API_KEY", label: "Anthropic API key" }
+      ]}
+      apiKeyLink="https://console.anthropic.com/settings/keys"
+      apiKeyLinkText="Anthropic API Key"
+    />
+
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+
+    <CLIExtensionInstructions
+      name="text2sql"
+      description="Ask your SQL database questions in natural language"
+      type="stdio"
+      command="uvx text2sql-mcp"
+      timeout={300}
+      envVars={[
+        { key: "TEXT2SQL_DATABASE_URL", value: "sqlite:///mydb.db" },
+        { key: "ANTHROPIC_API_KEY", value: "▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪" }
+      ]}
+      infoNote={
+        <>
+          <code>TEXT2SQL_DATABASE_URL</code> is any SQLAlchemy URL — SQLite, Postgres, MySQL, Snowflake, BigQuery, etc. Get your Anthropic API key from{" "}
+          <a href="https://console.anthropic.com/settings/keys" target="_blank" rel="noopener noreferrer">
+            console.anthropic.com
+          </a>.
+        </>
+      }
+    />
+
+  </TabItem>
+</Tabs>
+
+:::info
+text2sql defaults to `anthropic:claude-sonnet-4-6`. To use OpenAI instead, set `TEXT2SQL_MODEL=openai:gpt-4.1` and provide `OPENAI_API_KEY`. See the [text2sql-framework README](https://github.com/cpenniman12/text2sql-framework) for the full list of supported options, including custom business-rule instructions and example libraries.
+:::
+
+## Tools
+
+text2sql exposes a single tool:
+
+- **`query`** — ask the database a natural-language question. Returns the SQL the agent ran, the resulting rows, the row count, and the number of exploratory SQL calls the agent made along the way.
+
+## Example Usage
+
+Point text2sql at any SQL database — here we use a SQLite copy of the [Chinook](https://github.com/lerocha/chinook-database) sample database — and ask a question that requires the agent to figure out the schema on its own.
+
+### goose Prompt
+
+```
+What were the top 5 customers by total invoice amount last year?
+```
+
+### goose Output
+
+```
+I'll ask the text2sql agent to figure this out. Behind the scenes it explored
+the schema, found the `customers` and `invoices` tables, joined them, and
+filtered by the previous calendar year.
+
+SQL:
+
+  SELECT
+    c.FirstName || ' ' || c.LastName AS customer,
+    ROUND(SUM(i.Total), 2)            AS total_spent
+  FROM invoices i
+  JOIN customers c ON c.CustomerId = i.CustomerId
+  WHERE strftime('%Y', i.InvoiceDate) = strftime('%Y', date('now', '-1 year'))
+  GROUP BY c.CustomerId
+  ORDER BY total_spent DESC
+  LIMIT 5;
+
+Top 5 customers:
+
+  Helena Holý           49.62
+  Richard Cunningham    47.62
+  Luis Rojas            46.62
+  Ladislav Kovács       45.62
+  Hugh O'Reilly         45.62
+
+The agent made 6 exploratory SQL calls before writing the final query —
+listing tables, inspecting the `customers` and `invoices` schemas,
+checking the date format, and verifying the join works.
+```


### PR DESCRIPTION
## Summary

Adds documentation for the [text2sql MCP server](https://github.com/cpenniman12/text2sql-mcp) — a natural-language-to-SQL agent built on top of [text2sql-framework](https://github.com/cpenniman12/text2sql-framework).

The agent explores the schema, writes SQL, executes it against the real database, and self-corrects on errors. No RAG layer, no schema descriptions, no embeddings — just a connection string and a frontier model. Works with any SQLAlchemy-compatible database (SQLite, Postgres, MySQL, Snowflake, BigQuery, etc.).

- **Source:** https://github.com/cpenniman12/text2sql-mcp
- **PyPI:** https://pypi.org/project/text2sql-mcp/
- **Install in Goose:** `uvx text2sql-mcp`
- **Benchmarks (underlying framework):** 19/20 zero-shot on Spider across 80 tables / 20 databases

One new file added: `documentation/docs/mcp/text2sql-mcp.md`. Structure mirrors existing community MCP docs (`cognee-mcp.md`, `agentql-mcp.md`, `beads-mcp.md`).

### Testing

- Installed the package locally (`uvx text2sql-mcp`) and confirmed the MCP server starts in stdio mode and registers the `query` tool.
- Verified the `goose://extension?...` quick-install URL format matches the pattern used by other docs (e.g. `apify-mcp.md`).
- Doc renders under `documentation/docs/mcp/` and is auto-discovered by the `generated-index` in `_category_.json` — no sidebar changes required.

### Related Issues

n/a — new doc page only.