### PR TITLE
Add PipRail to the extensions directory

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -879,6 +879,22 @@
       "required": false
     }
   ]
-}
-
+},
+  {
+    "id": "piprail",
+    "name": "PipRail",
+    "description": "Autonomously pay any x402 (HTTP 402) endpoint across 29 chains - budget-capped and self-custody, with no facilitator, backend, or fee.",
+    "command": "npx -y @piprail/mcp",
+    "link": "https://github.com/piprail/piprail",
+    "installation_notes": "Install using npx. Optionally set PIPRAIL_PRIVATE_KEY to enable payments; without it the server runs read-only (discover/quote/plan).",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [
+      {
+        "name": "PIPRAIL_PRIVATE_KEY",
+        "description": "Optional. Wallet private key used to pay x402 endpoints. Without it, the server boots read-only.",
+        "required": false
+      }
+    ]
+  }
 ]


### PR DESCRIPTION
Adds **PipRail** to the extensions directory (`documentation/static/servers.json`).

[PipRail](https://github.com/piprail/piprail) (`@piprail/mcp`) is an open-source MCP server that lets a Goose agent **autonomously pay any x402 (HTTP 402 "Payment Required") endpoint** — across 29 chains, **self-custody**, budget-capped by a spend policy the model can't exceed, with no facilitator, backend, or fee. It runs over stdio via `npx -y @piprail/mcp` (boots read-only without a key; set `PIPRAIL_PRIVATE_KEY` to enable payments), mirroring the existing payment extensions (Alby, Square, Cash App).

- Repo: https://github.com/piprail/piprail
- npm: https://www.npmjs.com/package/@piprail/mcp
- Official MCP Registry: `io.github.piprail/mcp`

Happy to add a tutorial page under `documentation/docs/mcp/` if you'd like one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)