### PR TITLE
fix(developer/read_image): send a User-Agent on URL image fetches

### DIFF
--- a/crates/goose/src/agents/platform_extensions/developer/image.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/image.rs
@@ -180,6 +180,11 @@ async fn load_image_bytes(source: &str, working_dir: Option<&Path>) -> Result<Ve
 
 async fn load_url_bytes(url: url::Url) -> Result<Vec<u8>, String> {
     let client = reqwest::Client::builder()
+        .user_agent(concat!(
+            "goose/",
+            env!("CARGO_PKG_VERSION"),
+            " (+https://github.com/aaif-goose/goose)"
+        ))
         .timeout(Duration::from_secs(30))
         .build()
         .map_err(|error| format!("failed to create HTTP client: {error}"))?;


### PR DESCRIPTION
## Summary

`read_image`'s URL fetch path (`load_url_bytes` in `crates/goose/src/agents/platform_extensions/developer/image.rs`) builds its reqwest client with only a timeout and **no `User-Agent` header**. reqwest with no UA sends no `User-Agent` at all, and many image hosts (Wikimedia, Unsplash, etc.) return **403 Forbidden** to blank-UA requests. As a result, `read_image <https url>` fails for a large fraction of real-world image URLs, and the agent falls back to clumsy workarounds (curl with a spoofed UA, or giving up).

This sets a descriptive product User-Agent on the client builder:

```rust
.user_agent(concat!(
    "goose/",
    env!("CARGO_PKG_VERSION"),
    " (+https://github.com/aaif-goose/goose)"
))
```

- No new dependency or feature flag — `ClientBuilder::user_agent` is in reqwest's default API.
- `env!("CARGO_PKG_VERSION")` avoids hardcoding a version.
- A product-token UA with a contact URL is what [Wikimedia's User-Agent policy](https://meta.wikimedia.org/wiki/User-Agent_policy) asks for, and is preferable to a `Mozilla/5.0` browser spoof.

### Testing

`cargo check -p goose` passes. Verified the behavior change directly against a real host that UA-gates:

Same URL `https://upload.wikimedia.org/wikipedia/commons/4/43/Cute_dog.jpg`:

| Request | Result |
|---|---|
| No User-Agent (current behavior) | HTTP **403 Forbidden** |
| With `goose/<ver> (+https://github.com/aaif-goose/goose)` | HTTP **200** |

End-to-end through a locally-built `read_image` with this patch:

```
read_image source=https://upload.wikimedia.org/wikipedia/commons/4/43/Cute_dog.jpg
-> Loaded image from <url> (5175843 bytes, image/jpeg, 3176x2117)
```

Before the patch the same call returns `failed to download image: ... 403 Forbidden`.

### Related Issues

No existing issue found; this is a small, self-contained bug fix. Happy to open one first if preferred.
