### PR TITLE
fix: do not pass temperature to ChatGPT Codex provider

### DIFF
--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -295,7 +295,6 @@ fn create_codex_request(
         payload_obj.insert("parallel_tool_calls".to_string(), json!(true));
     }
 
-    // ChatGPT Codex does not support temperature and will return an error
     if let Some(reasoning_effort) = reasoning_effort {
         payload_obj.insert(
             "reasoning".to_string(),
@@ -1245,6 +1244,7 @@ mod tests {
         assert!(payload.get("reasoning_effort").is_none());
     }
 
+    // ChatGPT Codex does not support temperature and will return an error
     #[test]
     fn test_create_codex_request_omits_temperature() {
         let config = ModelConfig::new("gpt-5.5")

--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -295,10 +295,7 @@ fn create_codex_request(
         payload_obj.insert("parallel_tool_calls".to_string(), json!(true));
     }
 
-    if let Some(temp) = model_config.temperature {
-        payload_obj.insert("temperature".to_string(), json!(temp));
-    }
-
+    // ChatGPT Codex does not support temperature and will return an error
     if let Some(reasoning_effort) = reasoning_effort {
         payload_obj.insert(
             "reasoning".to_string(),
@@ -1246,6 +1243,16 @@ mod tests {
         let payload = create_codex_request(&config, "sys", &[], &[]).unwrap();
         assert!(payload.get("reasoning").is_none());
         assert!(payload.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn test_create_codex_request_omits_temperature() {
+        let config = ModelConfig::new("gpt-5.5")
+            .unwrap()
+            .with_temperature(Some(0.2));
+
+        let payload = create_codex_request(&config, "sys", &[], &[]).unwrap();
+        assert!(payload.get("temperature").is_none());
     }
 
     #[test_case(


### PR DESCRIPTION
## Summary
When a recipe has `temperature` setting defined, ChatGPT Codex provider errors out when trying to run that recipe

> Unsupported parameter: temperature

This fix removes the code that inserts temperature into the payload.

### Testing
Added new test
