### PR TITLE
feat(providers): add PleumRouter declarative provider

### DIFF
--- a/crates/goose/src/providers/declarative/pleumrouter.json
+++ b/crates/goose/src/providers/declarative/pleumrouter.json
@@ -1,0 +1,27 @@
+{
+  "name": "pleumrouter",
+  "engine": "openai",
+  "display_name": "PleumRouter",
+  "description": "Korea-region OpenAI-compatible multi-provider LLM gateway — one key for OpenAI, Anthropic, Google, and more.",
+  "api_key_env": "PLEUMROUTER_API_KEY",
+  "base_url": "https://router.pleum.ai/v1",
+  "headers": {
+    "http-referer": "https://goose-docs.ai",
+    "x-title": "goose"
+  },
+  "models": [
+    { "name": "claude-sonnet-4-6", "context_limit": 1000000 },
+    { "name": "claude-opus-4-8", "context_limit": 1000000 },
+    { "name": "gpt-5.5", "context_limit": 1050000 },
+    { "name": "gemini-2.5-pro", "context_limit": 1000000 }
+  ],
+  "dynamic_models": true,
+  "supports_streaming": true,
+  "preserves_thinking": true,
+  "model_doc_link": "https://router.pleum.ai/docs",
+  "setup_steps": [
+    "Sign up at https://router.pleum.ai",
+    "Create an API key (starts with plm_)",
+    "Paste the key above as PLEUMROUTER_API_KEY"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds **PleumRouter** (https://router.pleum.ai) as a declarative provider. PleumRouter is a Korea-region, OpenAI-compatible multi-provider LLM gateway (one key → many providers). It follows the existing declarative-provider pattern in `crates/goose/src/providers/declarative/`, mirroring the **orcarouter** / **together** gateway entries: `engine: "openai"`, `base_url: https://router.pleum.ai/v1`, `api_key_env: PLEUMROUTER_API_KEY`, and `dynamic_models: true` (the live model list is fetched from PleumRouter's public `GET /v1/models`).

One file added: `crates/goose/src/providers/declarative/pleumrouter.json` — auto-included via the existing `include_dir!` scan, no code changes needed.

### Testing

- Schema: fields match `DeclarativeProviderConfig` (`catalog_provider_id` is optional / omitted since models are discovered dynamically). Mirrors the merged `orcarouter.json` router entry.
- Manual: set `PLEUMROUTER_API_KEY`, select **PleumRouter** in the provider list, confirm models populate from `/v1/models` and a chat + tool call round-trips.
- Did not run the full Rust workspace build/tests locally; relying on CI. The change is a single declarative JSON matching existing entries.

### Related Issues

Relates to # (none — new provider, declarative JSON pattern)
Discussion: (none)

### Screenshots/Demos (for UX changes)

N/A — provider registration; the picker simply lists a new "PleumRouter" entry.