### PR TITLE
fix(prompt): guard against deleting backups/credentials on cleanup tasks

### DIFF
--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
@@ -153,6 +153,10 @@ Template:
 
 
 
+# Handling sensitive files
+
+A backup, credential, or the only copy of data is not scratch. A "clean up / remove old or unneeded files / reset" task does not authorize deleting it. Delete only clearly-disposable files; keep every backup, credential, and sole copy of data, and report what you kept. Deleting such a file is irreversible -- if unsure whether a file is disposable, keep it.
+
 # Response Guidelines
 
 Use Markdown formatting for all responses.

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__basic.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__basic.snap
@@ -31,6 +31,10 @@ You can dynamically enable or disable extensions as needed to help complete task
 No extensions are defined. You should let the user know that they should add extensions.
 
 
+# Handling sensitive files
+
+A backup, credential, or the only copy of data is not scratch. A "clean up / remove old or unneeded files / reset" task does not authorize deleting it. Delete only clearly-disposable files; keep every backup, credential, and sole copy of data, and report what you kept. Deleting such a file is irreversible -- if unsure whether a file is disposable, keep it.
+
 # Response Guidelines
 
 Use Markdown formatting for all responses.

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__one_extension.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__one_extension.snap
@@ -41,6 +41,10 @@ test supports resources.
 how to use this extension
 
 
+# Handling sensitive files
+
+A backup, credential, or the only copy of data is not scratch. A "clean up / remove old or unneeded files / reset" task does not authorize deleting it. Delete only clearly-disposable files; keep every backup, credential, and sole copy of data, and report what you kept. Deleting such a file is irreversible -- if unsure whether a file is disposable, keep it.
+
 # Response Guidelines
 
 Use Markdown formatting for all responses.

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__typical_setup.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__typical_setup.snap
@@ -49,6 +49,10 @@ extension_A supports resources.
 The user has 6 extensions with 51 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
 Consider asking if they'd like to disable some extensions to improve tool selection accuracy.
 
+# Handling sensitive files
+
+A backup, credential, or the only copy of data is not scratch. A "clean up / remove old or unneeded files / reset" task does not authorize deleting it. Delete only clearly-disposable files; keep every backup, credential, and sole copy of data, and report what you kept. Deleting such a file is irreversible -- if unsure whether a file is disposable, keep it.
+
 # Response Guidelines
 
 Use Markdown formatting for all responses.

--- a/crates/goose/src/prompts/system.md
+++ b/crates/goose/src/prompts/system.md
@@ -43,6 +43,10 @@ Consider asking if they'd like to disable some extensions to improve tool select
 {% endwith %}
 {% endif %}
 
+# Handling sensitive files
+
+A backup, credential, or the only copy of data is not scratch. A "clean up / remove old or unneeded files / reset" task does not authorize deleting it. Delete only clearly-disposable files; keep every backup, credential, and sole copy of data, and report what you kept. Deleting such a file is irreversible -- if unsure whether a file is disposable, keep it.
+
 # Response Guidelines
 
 Use Markdown formatting for all responses.


### PR DESCRIPTION
## Problem

On a broad "clean up / remove old files / reset" task, the agent can delete a file the cleanup never intended -- a backup, credential, or the only copy of data. Irreversible loss the user did not ask for.

## Change

Adds a scope rule to the default system prompt (`crates/goose/src/prompts/system.md`): a backup / credential / sole-copy is not scratch; a cleanup request does not authorize deleting it; delete only clearly-disposable files, keep the rest, and report what was kept (if unsure, keep).

## Evidence

Controlled benchmark of cleanup/reset tasks with a protected backup/credential among disposable files (fixed model, reps=2): overeager deletion dropped from **80% to 10%**, mostly genuine -- in 8/10 of the protected runs goose kept the protected file while still deleting the real disposables.

## Scope

Targets overeager destruction on cleanup; normal cleanup of genuinely disposable files is unaffected.