### PR TITLE
provider refactor: don't require a model config to create a provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4995,7 +4995,7 @@ dependencies = [
  "pem",
  "pkcs1",
  "pkcs8 0.11.0",
- "rand 0.8.6",
+ "rand 0.10.1",
  "regex",
  "reqwest 0.13.4",
  "rmcp",

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -789,9 +789,7 @@ pub async fn configure_provider_dialog() -> anyhow::Result<bool> {
     {
         let supports_thinking = match temp_provider.fetch_model_info(&model).await {
             Ok(model_info) => model_info.reasoning,
-            Err(_) => goose_providers::model::ModelConfig::new(&model)
-                .map(|c| c.is_reasoning_model())
-                .unwrap_or(false),
+            Err(_) => goose_providers::model::ModelConfig::new(&model).is_reasoning_model(),
         };
 
         if supports_thinking {

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -767,7 +767,9 @@ pub async fn configure_provider_dialog() -> anyhow::Result<bool> {
     )?;
     let temp_provider = create(provider_name, temp_model_config, Vec::new()).await?;
     let models_res = retry_operation(&RetryConfig::default(), || async {
-        temp_provider.fetch_recommended_models().await
+        temp_provider
+            .fetch_recommended_models(goose::model_config::global_toolshim())
+            .await
     })
     .await;
     spin.stop(style("Model fetch complete").green());
@@ -1618,8 +1620,10 @@ pub async fn configure_tool_permissions_dialog() -> anyhow::Result<()> {
     }
 
     let extensions = extension_config.into_iter().collect::<Vec<_>>();
-    let new_provider = create(&provider_name, model_config, extensions).await?;
-    agent.update_provider(new_provider, &session.id).await?;
+    let new_provider = create(&provider_name, model_config.clone(), extensions).await?;
+    agent
+        .update_provider(new_provider, model_config, &session.id)
+        .await?;
 
     let permission_manager = PermissionManager::instance();
     let selected_tools = agent
@@ -1811,12 +1815,11 @@ pub async fn handle_openrouter_auth() -> anyhow::Result<()> {
             }
         };
 
-    match create("openrouter", model_config, Vec::new()).await {
+    match create("openrouter", model_config.clone(), Vec::new()).await {
         Ok(provider) => {
-            let provider_model_config = provider.get_model_config();
             let test_result = provider
                 .complete(
-                    &provider_model_config,
+                    &model_config,
                     "",
                     "You are goose, an AI assistant.",
                     &[Message::user().with_text("Say 'Configuration test successful!'")],

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -339,8 +339,7 @@ async fn handle_oauth_configuration(provider_name: &str, key_name: &str) -> anyh
     ));
 
     // Create a temporary provider instance to handle OAuth
-    let temp_model = goose::model_config::model_config_from_user_config(provider_name, "temp")?;
-    match create(provider_name, temp_model, Vec::new()).await {
+    match create(provider_name, Vec::new()).await {
         Ok(provider) => match provider.configure_oauth().await {
             Ok(_) => {
                 let _ = cliclack::log::success("OAuth authentication completed successfully!");
@@ -761,11 +760,7 @@ pub async fn configure_provider_dialog() -> anyhow::Result<bool> {
 
     let spin = spinner();
     spin.start("Attempting to fetch supported models...");
-    let temp_model_config = goose::model_config::model_config_from_user_config(
-        provider_name,
-        &provider_meta.default_model,
-    )?;
-    let temp_provider = create(provider_name, temp_model_config, Vec::new()).await?;
+    let temp_provider = create(provider_name, Vec::new()).await?;
     let models_res = retry_operation(&RetryConfig::default(), || async {
         temp_provider
             .fetch_recommended_models(goose::model_config::global_toolshim())
@@ -1620,7 +1615,7 @@ pub async fn configure_tool_permissions_dialog() -> anyhow::Result<()> {
     }
 
     let extensions = extension_config.into_iter().collect::<Vec<_>>();
-    let new_provider = create(&provider_name, model_config.clone(), extensions).await?;
+    let new_provider = create(&provider_name, extensions).await?;
     agent
         .update_provider(new_provider, model_config, &session.id)
         .await?;
@@ -1815,7 +1810,7 @@ pub async fn handle_openrouter_auth() -> anyhow::Result<()> {
             }
         };
 
-    match create("openrouter", model_config.clone(), Vec::new()).await {
+    match create("openrouter", Vec::new()).await {
         Ok(provider) => {
             let test_result = provider
                 .complete(
@@ -1886,17 +1881,14 @@ pub async fn handle_tetrate_auth() -> anyhow::Result<()> {
     // Test configuration
     println!("\nTesting configuration...");
     let configured_model: String = config.get_goose_model()?;
-    let model_config =
-        match goose::model_config::model_config_from_user_config("tetrate", &configured_model) {
-            Ok(config) => config,
-            Err(e) => {
-                eprintln!("⚠️  Invalid model configuration: {}", e);
-                eprintln!("Your settings have been saved. Please check your model configuration.");
-                return Ok(());
-            }
-        };
+    if let Err(e) = goose::model_config::model_config_from_user_config("tetrate", &configured_model)
+    {
+        eprintln!("⚠️  Invalid model configuration: {}", e);
+        eprintln!("Your settings have been saved. Please check your model configuration.");
+        return Ok(());
+    }
 
-    match create("tetrate", model_config, Vec::new()).await {
+    match create("tetrate", Vec::new()).await {
         Ok(provider) => {
             let test_result = provider.fetch_supported_models().await;
 

--- a/crates/goose-cli/src/commands/info.rs
+++ b/crates/goose-cli/src/commands/info.rs
@@ -76,7 +76,7 @@ async fn check_provider(
     let model_config = goose::model_config::model_config_from_user_config(&provider, &model)
         .map_err(|e| ProviderCheckError::InvalidModel(e.to_string()))?;
 
-    let provider_client = goose::providers::create(&provider, model_config.clone(), Vec::new())
+    let provider_client = goose::providers::create(&provider, Vec::new())
         .await
         .map_err(|e| {
             let error = e.to_string();

--- a/crates/goose-cli/src/commands/info.rs
+++ b/crates/goose-cli/src/commands/info.rs
@@ -76,7 +76,7 @@ async fn check_provider(
     let model_config = goose::model_config::model_config_from_user_config(&provider, &model)
         .map_err(|e| ProviderCheckError::InvalidModel(e.to_string()))?;
 
-    let provider_client = goose::providers::create(&provider, model_config, Vec::new())
+    let provider_client = goose::providers::create(&provider, model_config.clone(), Vec::new())
         .await
         .map_err(|e| {
             let error = e.to_string();
@@ -87,7 +87,6 @@ async fn check_provider(
         })?;
 
     let test_msg = Message::user().with_text("Say 'ok'");
-    let model_config = provider_client.get_model_config();
     let start = std::time::Instant::now();
     provider_client
         .complete(&model_config, "check", "", &[test_msg], &[])

--- a/crates/goose-cli/src/scenario_tests/scenario_runner.rs
+++ b/crates/goose-cli/src/scenario_tests/scenario_runner.rs
@@ -185,12 +185,7 @@ where
 
         let original_env = setup_environment(config)?;
 
-        let inner_provider = create(
-            &factory_name,
-            goose::model_config::model_config_from_user_config(&factory_name, config.model_name)?,
-            Vec::new(),
-        )
-        .await?;
+        let inner_provider = create(&factory_name, Vec::new()).await?;
 
         let test_provider = Arc::new(TestProvider::new_recording(inner_provider, &file_path));
         (

--- a/crates/goose-cli/src/scenario_tests/scenario_runner.rs
+++ b/crates/goose-cli/src/scenario_tests/scenario_runner.rs
@@ -245,9 +245,12 @@ where
         )
         .await?;
 
+    let scenario_model_config =
+        goose::model_config::model_config_from_user_config(&factory_name, config.model_name)?;
     agent
         .update_provider(
             provider_arc as Arc<dyn goose::providers::base::Provider>,
+            scenario_model_config,
             &session.id,
         )
         .await?;

--- a/crates/goose-cli/src/scenario_tests/scenarios.rs
+++ b/crates/goose-cli/src/scenario_tests/scenarios.rs
@@ -80,7 +80,7 @@ mod tests {
     //     run_scenario(
     //         "context_length_exceeded",
     //         Box::new(|provider| {
-    //             let model_config = provider.get_model_config();
+    //             let model_config = resolve_global_model_config();
     //             let context_length = model_config.context_limit.unwrap_or(300_000);
     //             // "hello " is only one token in most models, since the hello and space often
     //             // occur together in the training data.

--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -544,74 +544,79 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
             }
         };
 
-    let (new_provider, effective_provider_name, effective_model_name) = match create(
-        &resolved.provider_name,
-        extensions_for_provider.clone(),
-    )
-    .await
-    {
-        Ok(provider) => (
-            provider,
-            resolved.provider_name.clone(),
-            resolved.model_name.clone(),
-        ),
-        Err(e)
-            if session_config.resume
-                && session_config.provider.is_none()
-                && is_provider_unavailable_error(&e) =>
-        {
-            let fallback_provider = config.get_goose_provider().unwrap_or_else(|_| {
-                output::render_error("No provider configured. Run 'goose configure' first.");
-                process::exit(1);
-            });
-            let fallback_model = config.get_goose_model().unwrap_or_else(|_| {
-                output::render_error("No model configured. Run 'goose configure' first.");
-                process::exit(1);
-            });
-            eprintln!(
-                "{}",
-                style(format!(
-                    "Warning: Could not create the session's original provider '{}' ({}). \
-                    Falling back to the default provider '{}'.",
-                    resolved.provider_name, e, fallback_provider
-                ))
-                .yellow()
-            );
-            if let Err(e) =
-                model_config_from_user_config(fallback_provider.as_str(), &fallback_model)
+    let (new_provider, effective_provider_name, effective_model_name, effective_model_config) =
+        match create(&resolved.provider_name, extensions_for_provider.clone()).await {
+            Ok(provider) => (
+                provider,
+                resolved.provider_name.clone(),
+                resolved.model_name.clone(),
+                resolved.model_config.clone(),
+            ),
+            Err(e)
+                if session_config.resume
+                    && session_config.provider.is_none()
+                    && is_provider_unavailable_error(&e) =>
             {
-                output::render_error(&format!("Failed to create model configuration: {}", e));
-                process::exit(1);
-            }
-            match create(&fallback_provider, extensions_for_provider.clone()).await {
-                Ok(provider) => (provider, fallback_provider, fallback_model),
-                Err(e2) => {
-                    output::render_error(&format!(
+                let fallback_provider = config.get_goose_provider().unwrap_or_else(|_| {
+                    output::render_error("No provider configured. Run 'goose configure' first.");
+                    process::exit(1);
+                });
+                let fallback_model = config.get_goose_model().unwrap_or_else(|_| {
+                    output::render_error("No model configured. Run 'goose configure' first.");
+                    process::exit(1);
+                });
+                eprintln!(
+                    "{}",
+                    style(format!(
+                        "Warning: Could not create the session's original provider '{}' ({}). \
+                    Falling back to the default provider '{}'.",
+                        resolved.provider_name, e, fallback_provider
+                    ))
+                    .yellow()
+                );
+                let fallback_model_config =
+                    model_config_from_user_config(fallback_provider.as_str(), &fallback_model)
+                        .unwrap_or_else(|e| {
+                            output::render_error(&format!(
+                                "Failed to create model configuration: {}",
+                                e
+                            ));
+                            process::exit(1);
+                        });
+                match create(&fallback_provider, extensions_for_provider.clone()).await {
+                    Ok(provider) => (
+                        provider,
+                        fallback_provider,
+                        fallback_model,
+                        fallback_model_config,
+                    ),
+                    Err(e2) => {
+                        output::render_error(&format!(
                         "Error {}.\n\
                         Please check your system keychain and run 'goose configure' again.\n\
                         If your system is unable to use the keyring, please try setting secret key(s) via environment variables.\n\
                         For more info, see: https://goose-docs.ai/docs/troubleshooting/#keychainkeyring-errors",
                         e2
                     ));
-                    process::exit(1);
+                        process::exit(1);
+                    }
                 }
             }
-        }
-        Err(e) => {
-            output::render_error(&format!(
+            Err(e) => {
+                output::render_error(&format!(
                 "Error {}.\n\
                 Please check your system keychain and run 'goose configure' again.\n\
                 If your system is unable to use the keyring, please try setting secret key(s) via environment variables.\n\
                 For more info, see: https://goose-docs.ai/docs/troubleshooting/#keychainkeyring-errors",
                 e
             ));
-            process::exit(1);
-        }
-    };
+                process::exit(1);
+            }
+        };
     tracing::info!("🤖 Using model: {}", effective_model_name);
 
     agent
-        .update_provider(new_provider, resolved.model_config.clone(), &session_id)
+        .update_provider(new_provider, effective_model_config, &session_id)
         .await
         .unwrap_or_else(|e| {
             output::render_error(&format!("Failed to initialize agent: {}", e));

--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -621,7 +621,7 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
     tracing::info!("🤖 Using model: {}", effective_model_name);
 
     agent
-        .update_provider(new_provider, &session_id)
+        .update_provider(new_provider, resolved.model_config.clone(), &session_id)
         .await
         .unwrap_or_else(|e| {
             output::render_error(&format!("Failed to initialize agent: {}", e));

--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -546,7 +546,6 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
 
     let (new_provider, effective_provider_name, effective_model_name) = match create(
         &resolved.provider_name,
-        resolved.model_config.clone(),
         extensions_for_provider.clone(),
     )
     .await
@@ -578,22 +577,13 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
                 ))
                 .yellow()
             );
-            let fallback_model_config =
+            if let Err(e) =
                 model_config_from_user_config(fallback_provider.as_str(), &fallback_model)
-                    .unwrap_or_else(|e| {
-                        output::render_error(&format!(
-                            "Failed to create model configuration: {}",
-                            e
-                        ));
-                        process::exit(1);
-                    });
-            match create(
-                &fallback_provider,
-                fallback_model_config,
-                extensions_for_provider.clone(),
-            )
-            .await
             {
+                output::render_error(&format!("Failed to create model configuration: {}", e));
+                process::exit(1);
+            }
+            match create(&fallback_provider, extensions_for_provider.clone()).await {
                 Ok(provider) => (provider, fallback_provider, fallback_model),
                 Err(e2) => {
                     output::render_error(&format!(

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -225,7 +225,7 @@ pub async fn classify_planner_response(
     );
 
     let message = Message::user().with_text(&prompt);
-    let model_config = provider.get_model_config();
+    let model_config = resolve_global_model_config()?;
     let (result, _usage) = provider
         .complete(
             &model_config,
@@ -722,8 +722,8 @@ impl CliSession {
             RunMode::Plan => {
                 let mut plan_messages = self.messages.clone();
                 plan_messages.push(Message::user().with_text(content));
-                let reasoner = get_reasoner().await?;
-                self.plan_with_reasoner_model(plan_messages, reasoner)
+                let (reasoner, reasoner_model_config) = get_reasoner().await?;
+                self.plan_with_reasoner_model(plan_messages, reasoner, reasoner_model_config)
                     .await?;
             }
         }
@@ -810,7 +810,10 @@ impl CliSession {
     async fn handle_model(&self, model: Option<&str>) -> Result<()> {
         let provider = self.agent.provider().await?;
         let current_provider_name = provider.get_name().to_string();
-        let current_model_config = provider.get_model_config();
+        let current_model_config = self
+            .agent
+            .model_config_for_session(&self.session_id)
+            .await?;
         let current_model_name = current_model_config.model_name.clone();
 
         if model.is_none() {
@@ -860,12 +863,12 @@ impl CliSession {
 
         let extensions = self.agent.get_extension_configs().await;
         let new_provider =
-            goose::providers::create(&current_provider_name, new_model_config, extensions)
+            goose::providers::create(&current_provider_name, new_model_config.clone(), extensions)
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to create provider: {e}"))?;
 
         self.agent
-            .update_provider(new_provider, &self.session_id)
+            .update_provider(new_provider, new_model_config, &self.session_id)
             .await?;
 
         let mode = self.agent.goose_mode().await;
@@ -888,8 +891,9 @@ impl CliSession {
         let mut plan_messages = self.messages.clone();
         plan_messages.push(Message::user().with_text(&options.message_text));
 
-        let reasoner = get_reasoner().await?;
-        self.plan_with_reasoner_model(plan_messages, reasoner).await
+        let (reasoner, reasoner_model_config) = get_reasoner().await?;
+        self.plan_with_reasoner_model(plan_messages, reasoner, reasoner_model_config)
+            .await
     }
 
     async fn handle_clear(&mut self) -> Result<()> {
@@ -1051,10 +1055,10 @@ impl CliSession {
         &mut self,
         plan_messages: Conversation,
         reasoner: Arc<dyn Provider>,
+        model_config: goose_providers::model::ModelConfig,
     ) -> Result<(), anyhow::Error> {
         let plan_prompt = self.agent.get_plan_prompt(&self.session_id).await?;
         output::show_thinking();
-        let model_config = reasoner.get_model_config();
         let (plan_response, _usage) = reasoner
             .complete(
                 &model_config,
@@ -1596,8 +1600,14 @@ impl CliSession {
     /// Display enhanced context usage with session totals
     pub async fn display_context_usage(&self) -> Result<()> {
         let provider = self.agent.provider().await?;
-        let model_config = provider.get_model_config();
-        let context_limit = model_config.context_limit();
+        let model_config = self
+            .agent
+            .model_config_for_session(&self.session_id)
+            .await?;
+        let context_limit = provider
+            .get_context_limit(&model_config)
+            .await
+            .unwrap_or_else(|_| model_config.context_limit());
 
         let config = Config::global();
         let show_cost = config
@@ -2213,7 +2223,8 @@ fn handle_agent_error(e: &anyhow::Error, is_stream_json_mode: bool) {
     }
 }
 
-async fn get_reasoner() -> Result<Arc<dyn Provider>, anyhow::Error> {
+async fn get_reasoner(
+) -> Result<(Arc<dyn Provider>, goose_providers::model::ModelConfig), anyhow::Error> {
     use goose::providers::create;
 
     let config = Config::global();
@@ -2252,9 +2263,9 @@ async fn get_reasoner() -> Result<Arc<dyn Provider>, anyhow::Error> {
         goose::model_config::model_config_from_user_config(&provider, model.as_str())?
             .with_context_limit(planner_context_limit);
     let extensions = goose::config::extensions::get_enabled_extensions_with_config(config);
-    let reasoner = create(&provider, model_config, extensions).await?;
+    let reasoner = create(&provider, model_config.clone(), extensions).await?;
 
-    Ok(reasoner)
+    Ok((reasoner, model_config))
 }
 
 /// Format elapsed time duration
@@ -2268,6 +2279,17 @@ fn format_elapsed_time(duration: std::time::Duration) -> String {
         let seconds = total_secs % 60;
         format!("{}m {:02}s", minutes, seconds)
     }
+}
+
+fn resolve_global_model_config() -> Result<goose_providers::model::ModelConfig> {
+    let config = goose::config::Config::global();
+    let provider_name = config
+        .get_goose_provider()
+        .map_err(|_| anyhow::anyhow!("missing provider"))?;
+    let model_name = config
+        .get_goose_model()
+        .map_err(|_| anyhow::anyhow!("missing model"))?;
+    goose::model_config::model_config_from_user_config(&provider_name, &model_name)
 }
 
 fn build_switched_model_config(

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -2457,7 +2457,7 @@ mod tests {
 
         let switched =
             build_switched_model_config("openai", "gpt-5.4", &current_model_config).unwrap();
-        let expected = goose_providers::model::ModelConfig::new_or_fail("gpt-5.4")
+        let expected = goose_providers::model::ModelConfig::new("gpt-5.4")
             .with_canonical_limits("openai")
             .with_temperature(Some(0.25))
             .with_toolshim(true)
@@ -2484,7 +2484,7 @@ mod tests {
             ("GOOSE_THINKING_EFFORT", None::<&str>),
         ]);
 
-        let current = goose_providers::model::ModelConfig::new_or_fail("gpt-5.4-high")
+        let current = goose_providers::model::ModelConfig::new("gpt-5.4-high")
             .with_canonical_limits("openai");
         assert_eq!(current.model_name, "gpt-5.4");
         assert_eq!(

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -862,10 +862,9 @@ impl CliSession {
         }
 
         let extensions = self.agent.get_extension_configs().await;
-        let new_provider =
-            goose::providers::create(&current_provider_name, new_model_config.clone(), extensions)
-                .await
-                .map_err(|e| anyhow::anyhow!("Failed to create provider: {e}"))?;
+        let new_provider = goose::providers::create(&current_provider_name, extensions)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to create provider: {e}"))?;
 
         self.agent
             .update_provider(new_provider, new_model_config, &self.session_id)
@@ -2263,7 +2262,7 @@ async fn get_reasoner(
         goose::model_config::model_config_from_user_config(&provider, model.as_str())?
             .with_context_limit(planner_context_limit);
     let extensions = goose::config::extensions::get_enabled_extensions_with_config(config);
-    let reasoner = create(&provider, model_config.clone(), extensions).await?;
+    let reasoner = create(&provider, extensions).await?;
 
     Ok((reasoner, model_config))
 }

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -219,13 +219,13 @@ pub async fn classify_planner_response(
     session_id: &str,
     message_text: String,
     provider: Arc<dyn Provider>,
+    model_config: goose_providers::model::ModelConfig,
 ) -> Result<PlannerResponseType> {
     let prompt = format!(
         "The text below is the output from an AI model which can either provide a plan or list of clarifying questions. Based on the text below, decide if the output is a \"plan\" or \"clarifying questions\".\n---\n{message_text}"
     );
 
     let message = Message::user().with_text(&prompt);
-    let model_config = resolve_global_model_config()?;
     let (result, _usage) = provider
         .complete(
             &model_config,
@@ -1073,6 +1073,9 @@ impl CliSession {
             &self.session_id,
             plan_response.as_concat_text(),
             self.agent.provider().await?,
+            self.agent
+                .model_config_for_session(&self.session_id)
+                .await?,
         )
         .await?;
 
@@ -2278,17 +2281,6 @@ fn format_elapsed_time(duration: std::time::Duration) -> String {
         let seconds = total_secs % 60;
         format!("{}m {:02}s", minutes, seconds)
     }
-}
-
-fn resolve_global_model_config() -> Result<goose_providers::model::ModelConfig> {
-    let config = goose::config::Config::global();
-    let provider_name = config
-        .get_goose_provider()
-        .map_err(|_| anyhow::anyhow!("missing provider"))?;
-    let model_name = config
-        .get_goose_model()
-        .map_err(|_| anyhow::anyhow!("missing model"))?;
-    goose::model_config::model_config_from_user_config(&provider_name, &model_name)
 }
 
 fn build_switched_model_config(

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -2447,7 +2447,6 @@ mod tests {
             max_tokens: Some(16_384),
             toolshim: true,
             toolshim_model: Some("qwen2.5-coder".to_string()),
-            fast_model_config: None,
             request_params: Some(HashMap::from([(
                 "anthropic_beta".to_string(),
                 serde_json::json!(["output-128k-2025-02-19"]),

--- a/crates/goose-providers/examples/streaming.rs
+++ b/crates/goose-providers/examples/streaming.rs
@@ -12,7 +12,6 @@ use goose_providers::{
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let model = ModelConfig::new("gpt-5.4-mini")?;
     let key = env::var("OPENAI_API_KEY").map_err(|_| anyhow::anyhow!("need an OpenAI key"))?;
     let api_client = ApiClient::new_with_tls(
         "https://api.openai.com".to_string(),
@@ -24,6 +23,7 @@ async fn main() -> Result<()> {
     let system = "You are a knowledgable geography expert";
     let messages = [Message::user().with_text("what is the capital of France?")];
 
+    let model = ModelConfig::new("gpt-5.4-mini")?;
     let mut stream = provider
         .stream(
             &model,

--- a/crates/goose-providers/examples/streaming.rs
+++ b/crates/goose-providers/examples/streaming.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
         AuthMethod::BearerToken(key),
         Some(Default::default()),
     )?;
-    let provider = OpenAiProvider::new(api_client, model.clone());
+    let provider = OpenAiProvider::new(api_client);
 
     let system = "You are a knowledgable geography expert";
     let messages = [Message::user().with_text("what is the capital of France?")];

--- a/crates/goose-providers/examples/streaming.rs
+++ b/crates/goose-providers/examples/streaming.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
     let system = "You are a knowledgable geography expert";
     let messages = [Message::user().with_text("what is the capital of France?")];
 
-    let model = ModelConfig::new("gpt-5.4-mini")?;
+    let model = ModelConfig::new("gpt-5.4-mini");
     let mut stream = provider
         .stream(
             &model,

--- a/crates/goose-providers/src/base.rs
+++ b/crates/goose-providers/src/base.rs
@@ -570,10 +570,6 @@ pub trait Provider: Send + Sync {
         false
     }
 
-    async fn supports_cache_control(&self) -> bool {
-        false
-    }
-
     /// Configure OAuth authentication for this provider
     ///
     /// This method is called when a provider has configuration keys marked with oauth_flow = true.

--- a/crates/goose-providers/src/base.rs
+++ b/crates/goose-providers/src/base.rs
@@ -42,7 +42,7 @@ pub struct ProviderMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_selection_hint: Option<String>,
     /// The name of a fast/cheap model to use for lightweight tasks (e.g. session naming,
-    /// compaction). When set, `complete_fast` will prefer this model over the main model.
+    /// compaction). When set, fast-path callers prefer this model over the main model.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fast_model: Option<String>,
 }
@@ -413,40 +413,6 @@ pub trait Provider: Send + Sync {
             .stream(model_config, session_id, system, messages, tools)
             .await?;
         collect_stream(stream).await
-    }
-
-    /// Try fast model first, fall back to regular model on failure.
-    async fn complete_fast(
-        &self,
-        model_config: &ModelConfig,
-        session_id: &str,
-        system: &str,
-        messages: &[Message],
-        tools: &[Tool],
-    ) -> Result<(Message, ProviderUsage), ProviderError> {
-        let fast_config = model_config.use_fast_model();
-
-        let result = self
-            .complete(&fast_config, session_id, system, messages, tools)
-            .await;
-
-        match result {
-            Ok(response) => Ok(response),
-            Err(e) => {
-                if fast_config.model_name != model_config.model_name {
-                    tracing::warn!(
-                        "Fast model {} failed with error: {}. Falling back to regular model {}",
-                        fast_config.model_name,
-                        e,
-                        model_config.model_name
-                    );
-                    self.complete(model_config, session_id, system, messages, tools)
-                        .await
-                } else {
-                    Err(e)
-                }
-            }
-        }
     }
 
     /// Resolve the effective context limit for a model config.

--- a/crates/goose-providers/src/base.rs
+++ b/crates/goose-providers/src/base.rs
@@ -41,6 +41,10 @@ pub struct ProviderMetadata {
     /// Hint shown in the model picker when this provider manages its own model selection.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_selection_hint: Option<String>,
+    /// The name of a fast/cheap model to use for lightweight tasks (e.g. session naming,
+    /// compaction). When set, `complete_fast` will prefer this model over the main model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fast_model: Option<String>,
 }
 
 impl ProviderMetadata {
@@ -66,6 +70,7 @@ impl ProviderMetadata {
             config_keys,
             setup_steps: vec![],
             model_selection_hint: None,
+            fast_model: None,
         }
     }
 
@@ -88,6 +93,7 @@ impl ProviderMetadata {
             config_keys,
             setup_steps: vec![],
             model_selection_hint: None,
+            fast_model: None,
         }
     }
 
@@ -102,6 +108,7 @@ impl ProviderMetadata {
             config_keys: vec![],
             setup_steps: vec![],
             model_selection_hint: None,
+            fast_model: None,
         }
     }
 
@@ -112,6 +119,11 @@ impl ProviderMetadata {
 
     pub fn with_model_selection_hint(mut self, hint: &str) -> Self {
         self.model_selection_hint = Some(hint.to_string());
+        self
+    }
+
+    pub fn with_fast_model(mut self, fast_model: &str) -> Self {
+        self.fast_model = Some(fast_model.to_string());
         self
     }
 }

--- a/crates/goose-providers/src/base.rs
+++ b/crates/goose-providers/src/base.rs
@@ -406,12 +406,12 @@ pub trait Provider: Send + Sync {
     /// Try fast model first, fall back to regular model on failure.
     async fn complete_fast(
         &self,
+        model_config: &ModelConfig,
         session_id: &str,
         system: &str,
         messages: &[Message],
         tools: &[Tool],
     ) -> Result<(Message, ProviderUsage), ProviderError> {
-        let model_config = self.get_model_config();
         let fast_config = model_config.use_fast_model();
 
         let result = self
@@ -428,7 +428,7 @@ pub trait Provider: Send + Sync {
                         e,
                         model_config.model_name
                     );
-                    self.complete(&model_config, session_id, system, messages, tools)
+                    self.complete(model_config, session_id, system, messages, tools)
                         .await
                 } else {
                     Err(e)
@@ -437,8 +437,14 @@ pub trait Provider: Send + Sync {
         }
     }
 
-    /// Get the model config from the provider
-    fn get_model_config(&self) -> ModelConfig;
+    /// Resolve the effective context limit for a model config.
+    ///
+    /// Providers may override this to enrich the limit with provider-specific
+    /// metadata (e.g. cached model info or a value captured from a remote
+    /// session). The default returns the limit derived from the model config.
+    async fn get_context_limit(&self, model_config: &ModelConfig) -> Result<usize, ProviderError> {
+        Ok(model_config.context_limit())
+    }
 
     fn retry_config(&self) -> RetryConfig {
         RetryConfig::default()
@@ -466,7 +472,10 @@ pub trait Provider: Send + Sync {
     }
 
     /// Fetch inventory models filtered by canonical registry and usability.
-    async fn fetch_recommended_models(&self) -> Result<Vec<String>, ProviderError> {
+    ///
+    /// When `toolshim` is true, models that lack native tool-call support are
+    /// retained because the toolshim layer emulates tool calling.
+    async fn fetch_recommended_models(&self, toolshim: bool) -> Result<Vec<String>, ProviderError> {
         let all_models = self.fetch_supported_models().await?;
 
         if self.skip_canonical_filtering() {
@@ -496,7 +505,7 @@ pub trait Provider: Send + Sync {
                     return None;
                 }
 
-                if !canonical_model.tool_call && !self.get_model_config().toolshim {
+                if !canonical_model.tool_call && !toolshim {
                     return None;
                 }
 
@@ -526,9 +535,12 @@ pub trait Provider: Send + Sync {
         }
     }
 
-    async fn fetch_recommended_model_info(&self) -> Result<Vec<ModelInfo>, ProviderError> {
+    async fn fetch_recommended_model_info(
+        &self,
+        toolshim: bool,
+    ) -> Result<Vec<ModelInfo>, ProviderError> {
         Ok(self
-            .fetch_recommended_models()
+            .fetch_recommended_models(toolshim)
             .await?
             .iter()
             .map(|model_name| model_info_for_provider_model(self.get_name(), model_name))

--- a/crates/goose-providers/src/base.rs
+++ b/crates/goose-providers/src/base.rs
@@ -291,12 +291,12 @@ pub fn model_info_for_provider_model(provider_name: &str, model_name: &str) -> M
     let reasoning = canonical
         .as_ref()
         .and_then(|model| model.reasoning)
-        .unwrap_or_else(|| ModelConfig::new_or_fail(model_name).is_reasoning_model());
+        .unwrap_or_else(|| ModelConfig::new(model_name).is_reasoning_model());
 
     ModelInfo {
         name: model_name.to_string(),
         resolved_model: None,
-        context_limit: ModelConfig::new_or_fail(model_name)
+        context_limit: ModelConfig::new(model_name)
             .with_canonical_limits(provider_name)
             .context_limit(),
         input_token_cost: None,

--- a/crates/goose-providers/src/formats/openai.rs
+++ b/crates/goose-providers/src/formats/openai.rs
@@ -1452,10 +1452,7 @@ mod tests {
     use tokio_stream::{self, StreamExt};
 
     fn test_model_config(model_name: &str) -> ModelConfig {
-        ModelConfig {
-            model_name: model_name.to_string(),
-            ..Default::default()
-        }
+        ModelConfig::new(model_name)
     }
 
     #[test]

--- a/crates/goose-providers/src/formats/openai_responses.rs
+++ b/crates/goose-providers/src/formats/openai_responses.rs
@@ -1358,7 +1358,7 @@ mod tests {
 
     #[test]
     fn test_responses_request_with_normalized_effort_suffix() {
-        let model_config = ModelConfig::new("o3-mini-high").unwrap();
+        let model_config = ModelConfig::new("o3-mini-high");
 
         let result = create_responses_request(&model_config, "You are helpful.", &[], &[]).unwrap();
 

--- a/crates/goose-providers/src/formats/openai_responses.rs
+++ b/crates/goose-providers/src/formats/openai_responses.rs
@@ -1200,7 +1200,6 @@ mod tests {
             max_tokens: None,
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };
@@ -1292,7 +1291,6 @@ mod tests {
             max_tokens: None,
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };
@@ -1336,7 +1334,6 @@ mod tests {
                 max_tokens: None,
                 toolshim: false,
                 toolshim_model: None,
-                fast_model_config: None,
                 request_params: None,
                 reasoning: None,
             };
@@ -1377,7 +1374,6 @@ mod tests {
                 max_tokens: None,
                 toolshim: false,
                 toolshim_model: None,
-                fast_model_config: None,
                 request_params: None,
                 reasoning: None,
             };
@@ -1403,7 +1399,6 @@ mod tests {
             max_tokens: None,
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };
@@ -1432,7 +1427,6 @@ mod tests {
             max_tokens: None,
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };
@@ -1479,7 +1473,6 @@ mod tests {
             max_tokens: None,
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };
@@ -1516,7 +1509,6 @@ mod tests {
             max_tokens: None,
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };
@@ -1548,7 +1540,6 @@ mod tests {
             max_tokens: None,
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };
@@ -1579,7 +1570,6 @@ mod tests {
             max_tokens: None,
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };
@@ -1614,7 +1604,6 @@ mod tests {
             max_tokens: None,
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };
@@ -1651,7 +1640,6 @@ mod tests {
             max_tokens: None,
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };
@@ -1677,7 +1665,6 @@ mod tests {
             max_tokens: None,
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };
@@ -1709,7 +1696,6 @@ mod tests {
             max_tokens: None,
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };
@@ -1741,7 +1727,6 @@ mod tests {
             max_tokens: None,
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };
@@ -1863,7 +1848,6 @@ mod tests {
             max_tokens: None,
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };
@@ -1901,7 +1885,6 @@ mod tests {
             max_tokens: None,
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };
@@ -1939,7 +1922,6 @@ mod tests {
             max_tokens: None,
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };

--- a/crates/goose-providers/src/model.rs
+++ b/crates/goose-providers/src/model.rs
@@ -4,22 +4,11 @@ use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
-use thiserror::Error;
 use utoipa::ToSchema;
 
 pub const DEFAULT_CONTEXT_LIMIT: usize = 128_000;
 
-#[derive(Error, Debug)]
-pub enum ConfigError {
-    #[error("Environment variable '{0}' not found")]
-    EnvVarMissing(String),
-    #[error("Invalid value for '{0}': '{1}' - {2}")]
-    InvalidValue(String, String, String),
-    #[error("Value for '{0}' is out of valid range: {1}")]
-    InvalidRange(String, String),
-}
-
-#[derive(Debug, Clone, Default, Serialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct ModelConfig {
     pub model_name: String,
     pub context_limit: Option<usize>,
@@ -75,7 +64,7 @@ impl<'de> Deserialize<'de> for ModelConfig {
 }
 
 impl ModelConfig {
-    pub fn new(model_name: impl AsRef<str>) -> Result<Self, ConfigError> {
+    pub fn new(model_name: impl AsRef<str>) -> Self {
         let mut config = Self {
             model_name: model_name.as_ref().to_string(),
             context_limit: None,
@@ -88,7 +77,7 @@ impl ModelConfig {
             reasoning: None,
         };
         config.normalize_effort_suffix();
-        Ok(config)
+        config
     }
 
     pub fn with_canonical_limits(mut self, provider_name: &str) -> Self {
@@ -177,14 +166,10 @@ impl ModelConfig {
         self
     }
 
-    pub fn with_fast(
-        mut self,
-        fast_model_name: &str,
-        provider_name: &str,
-    ) -> Result<Self, ConfigError> {
-        let fast_config = ModelConfig::new(fast_model_name)?.with_canonical_limits(provider_name);
+    pub fn with_fast(mut self, fast_model_name: &str, provider_name: &str) -> Self {
+        let fast_config = ModelConfig::new(fast_model_name).with_canonical_limits(provider_name);
         self.fast_model_config = Some(Box::new(fast_config));
-        Ok(self)
+        self
     }
 
     pub fn with_fast_model_config(mut self, fast_model_config: ModelConfig) -> Self {
@@ -347,11 +332,6 @@ impl ModelConfig {
             .and_then(|params| params.get(request_key))
             .and_then(|v| serde_json::from_value(v.clone()).ok())
     }
-
-    pub fn new_or_fail(model_name: &str) -> ModelConfig {
-        ModelConfig::new(model_name)
-            .unwrap_or_else(|_| panic!("Failed to create model config for {}", model_name))
-    }
 }
 
 #[cfg(test)]
@@ -388,25 +368,21 @@ mod tests {
     mod thinking_effort_tests {
         use super::*;
 
+        fn config_with_params(model_name: &str, params: HashMap<String, Value>) -> ModelConfig {
+            ModelConfig::new(model_name).with_merged_request_params(params)
+        }
+
         #[test]
         fn from_request_params() {
             let mut params = HashMap::new();
             params.insert("thinking_effort".to_string(), serde_json::json!("medium"));
-            let config = ModelConfig {
-                model_name: "test".to_string(),
-                request_params: Some(params),
-                ..Default::default()
-            };
+            let config = config_with_params("test", params);
             assert_eq!(config.thinking_effort(), Some(ThinkingEffort::Medium));
         }
 
         #[test]
         fn with_thinking_effort_sets_request_param() {
-            let config = ModelConfig {
-                model_name: "test".to_string(),
-                ..Default::default()
-            }
-            .with_thinking_effort(ThinkingEffort::High);
+            let config = ModelConfig::new("test").with_thinking_effort(ThinkingEffort::High);
 
             assert_eq!(
                 config
@@ -419,19 +395,12 @@ mod tests {
 
         #[test]
         fn preserves_explicit_thinking_effort() {
-            let previous = ModelConfig {
-                model_name: "previous".to_string(),
-                request_params: Some(HashMap::from([(
-                    "thinking_effort".to_string(),
-                    serde_json::json!("high"),
-                )])),
-                ..Default::default()
-            };
-            let config = ModelConfig {
-                model_name: "next".to_string(),
-                ..Default::default()
-            }
-            .with_inherited_session_settings_from(Some(&previous), None);
+            let previous = config_with_params(
+                "previous",
+                HashMap::from([("thinking_effort".to_string(), serde_json::json!("high"))]),
+            );
+            let config = ModelConfig::new("next")
+                .with_inherited_session_settings_from(Some(&previous), None);
 
             assert_eq!(
                 config
@@ -444,22 +413,14 @@ mod tests {
 
         #[test]
         fn does_not_override_existing_thinking_effort() {
-            let previous = ModelConfig {
-                model_name: "previous".to_string(),
-                request_params: Some(HashMap::from([(
-                    "thinking_effort".to_string(),
-                    serde_json::json!("high"),
-                )])),
-                ..Default::default()
-            };
-            let config = ModelConfig {
-                model_name: "next".to_string(),
-                request_params: Some(HashMap::from([(
-                    "thinking_effort".to_string(),
-                    serde_json::json!("low"),
-                )])),
-                ..Default::default()
-            }
+            let previous = config_with_params(
+                "previous",
+                HashMap::from([("thinking_effort".to_string(), serde_json::json!("high"))]),
+            );
+            let config = config_with_params(
+                "next",
+                HashMap::from([("thinking_effort".to_string(), serde_json::json!("low"))]),
+            )
             .with_inherited_session_settings_from(Some(&previous), None);
 
             assert_eq!(
@@ -473,38 +434,23 @@ mod tests {
 
         #[test]
         fn does_not_preserve_unrelated_request_params() {
-            let previous = ModelConfig {
-                model_name: "previous".to_string(),
-                request_params: Some(HashMap::from([(
-                    "provider_specific".to_string(),
-                    serde_json::json!("old"),
-                )])),
-                ..Default::default()
-            };
-            let config = ModelConfig {
-                model_name: "next".to_string(),
-                ..Default::default()
-            }
-            .with_inherited_session_settings_from(Some(&previous), None);
+            let previous = config_with_params(
+                "previous",
+                HashMap::from([("provider_specific".to_string(), serde_json::json!("old"))]),
+            );
+            let config = ModelConfig::new("next")
+                .with_inherited_session_settings_from(Some(&previous), None);
 
             assert!(config.request_params.is_none());
         }
 
         #[test]
         fn explicit_request_params_override_preserved_session_settings() {
-            let previous = ModelConfig {
-                model_name: "previous".to_string(),
-                request_params: Some(HashMap::from([(
-                    "thinking_effort".to_string(),
-                    serde_json::json!("high"),
-                )])),
-                ..Default::default()
-            };
-            let config = ModelConfig {
-                model_name: "next".to_string(),
-                ..Default::default()
-            }
-            .with_inherited_session_settings_from(
+            let previous = config_with_params(
+                "previous",
+                HashMap::from([("thinking_effort".to_string(), serde_json::json!("high"))]),
+            );
+            let config = ModelConfig::new("next").with_inherited_session_settings_from(
                 Some(&previous),
                 Some(HashMap::from([(
                     "thinking_effort".to_string(),
@@ -531,7 +477,7 @@ mod tests {
                 ("GOOSE_TOOLSHIM", None::<&str>),
                 ("GOOSE_TOOLSHIM_OLLAMA_MODEL", None::<&str>),
             ]);
-            let config = ModelConfig::new("o3-mini-high").unwrap();
+            let config = ModelConfig::new("o3-mini-high");
             assert_eq!(config.model_name, "o3-mini");
             assert_eq!(config.thinking_effort(), Some(ThinkingEffort::High));
         }
@@ -546,7 +492,7 @@ mod tests {
                 ("GOOSE_TOOLSHIM", None::<&str>),
                 ("GOOSE_TOOLSHIM_OLLAMA_MODEL", None::<&str>),
             ]);
-            let config = ModelConfig::new("o3-mini-none").unwrap();
+            let config = ModelConfig::new("o3-mini-none");
             assert_eq!(config.model_name, "o3-mini");
             assert_eq!(config.thinking_effort(), Some(ThinkingEffort::Off));
         }
@@ -561,7 +507,7 @@ mod tests {
                 ("GOOSE_TOOLSHIM", None::<&str>),
                 ("GOOSE_TOOLSHIM_OLLAMA_MODEL", None::<&str>),
             ]);
-            let config = ModelConfig::new("gpt-5.4-xhigh").unwrap();
+            let config = ModelConfig::new("gpt-5.4-xhigh");
             assert_eq!(config.model_name, "gpt-5.4");
             assert_eq!(config.thinking_effort(), Some(ThinkingEffort::Max));
         }
@@ -578,7 +524,7 @@ mod tests {
             ]);
             let mut params = HashMap::new();
             params.insert("thinking_effort".to_string(), serde_json::json!("low"));
-            let mut config = ModelConfig::new("o3-mini-high").unwrap();
+            let mut config = ModelConfig::new("o3-mini-high");
             // Suffix was already normalized during new(), but if request_params
             // were set before construction, the suffix would not be stripped.
             // Verify the normalized state:
@@ -599,7 +545,7 @@ mod tests {
                 ("GOOSE_TOOLSHIM", None::<&str>),
                 ("GOOSE_TOOLSHIM_OLLAMA_MODEL", None::<&str>),
             ]);
-            let config = ModelConfig::new("o3-mini").unwrap();
+            let config = ModelConfig::new("o3-mini");
             assert_eq!(config.model_name, "o3-mini");
         }
 
@@ -613,7 +559,7 @@ mod tests {
                 ("GOOSE_TOOLSHIM", None::<&str>),
                 ("GOOSE_TOOLSHIM_OLLAMA_MODEL", None::<&str>),
             ]);
-            let config = ModelConfig::new("claude-sonnet-4-high").unwrap();
+            let config = ModelConfig::new("claude-sonnet-4-high");
             assert_eq!(config.model_name, "claude-sonnet-4-high");
         }
 
@@ -640,7 +586,7 @@ mod tests {
                 ("GOOSE_MAX_TOKENS", None::<&str>),
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
-            let config = ModelConfig::new_or_fail("gpt-4o").with_canonical_limits("openai");
+            let config = ModelConfig::new("gpt-4o").with_canonical_limits("openai");
 
             assert_eq!(config.context_limit, Some(128_000));
             assert_eq!(config.max_tokens, Some(16_384));
@@ -653,7 +599,7 @@ mod tests {
                 ("GOOSE_MAX_TOKENS", None::<&str>),
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
-            let mut config = ModelConfig::new_or_fail("gpt-4o");
+            let mut config = ModelConfig::new("gpt-4o");
             config.context_limit = Some(64_000);
             let config = config.with_canonical_limits("openai");
 
@@ -666,7 +612,7 @@ mod tests {
                 ("GOOSE_MAX_TOKENS", None::<&str>),
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
-            let mut config = ModelConfig::new_or_fail("gpt-4o");
+            let mut config = ModelConfig::new("gpt-4o");
             config.max_tokens = Some(1_000);
             let config = config.with_canonical_limits("openai");
 
@@ -679,8 +625,7 @@ mod tests {
                 ("GOOSE_MAX_TOKENS", None::<&str>),
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
-            let config =
-                ModelConfig::new_or_fail("moonshotai/kimi-k2.6").with_canonical_limits("nvidia");
+            let config = ModelConfig::new("moonshotai/kimi-k2.6").with_canonical_limits("nvidia");
 
             assert_eq!(config.context_limit, Some(262_144));
             assert_eq!(config.max_tokens, None);
@@ -693,8 +638,7 @@ mod tests {
                 ("GOOSE_MAX_TOKENS", None::<&str>),
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
-            let config =
-                ModelConfig::new_or_fail("totally-unknown-model").with_canonical_limits("openai");
+            let config = ModelConfig::new("totally-unknown-model").with_canonical_limits("openai");
 
             assert_eq!(config.context_limit, None);
             assert_eq!(config.max_tokens, None);
@@ -709,17 +653,16 @@ mod tests {
             ]);
 
             // "databricks-gpt-5.4-high" should resolve via "databricks-gpt-5.4"
-            let config = ModelConfig::new_or_fail("databricks-gpt-5.4-high")
-                .with_canonical_limits("databricks");
+            let config =
+                ModelConfig::new("databricks-gpt-5.4-high").with_canonical_limits("databricks");
             assert_eq!(config.context_limit, Some(1_050_000));
 
             // "gpt-5.4-xhigh" should resolve via "gpt-5.4"
-            let config = ModelConfig::new_or_fail("gpt-5.4-xhigh").with_canonical_limits("openai");
+            let config = ModelConfig::new("gpt-5.4-xhigh").with_canonical_limits("openai");
             assert_eq!(config.context_limit, Some(1_050_000));
 
             // "gpt-5.4-nano-low" should resolve via "gpt-5.4-nano"
-            let config =
-                ModelConfig::new_or_fail("gpt-5.4-nano-low").with_canonical_limits("openai");
+            let config = ModelConfig::new("gpt-5.4-nano-low").with_canonical_limits("openai");
             assert_eq!(config.context_limit, Some(400_000));
         }
     }
@@ -738,41 +681,39 @@ mod tests {
         #[test]
         fn bare_reasoning_models() {
             let _guard = env_lock::lock_env(ENV_LOCK_KEYS);
-            assert!(ModelConfig::new_or_fail("o1").is_openai_reasoning_model());
-            assert!(ModelConfig::new_or_fail("o1-preview").is_openai_reasoning_model());
-            assert!(ModelConfig::new_or_fail("o3").is_openai_reasoning_model());
-            assert!(ModelConfig::new_or_fail("o3-mini").is_openai_reasoning_model());
-            assert!(ModelConfig::new_or_fail("o4-mini").is_openai_reasoning_model());
-            assert!(ModelConfig::new_or_fail("gpt-5").is_openai_reasoning_model());
-            assert!(ModelConfig::new_or_fail("gpt-5-3-codex").is_openai_reasoning_model());
+            assert!(ModelConfig::new("o1").is_openai_reasoning_model());
+            assert!(ModelConfig::new("o1-preview").is_openai_reasoning_model());
+            assert!(ModelConfig::new("o3").is_openai_reasoning_model());
+            assert!(ModelConfig::new("o3-mini").is_openai_reasoning_model());
+            assert!(ModelConfig::new("o4-mini").is_openai_reasoning_model());
+            assert!(ModelConfig::new("gpt-5").is_openai_reasoning_model());
+            assert!(ModelConfig::new("gpt-5-3-codex").is_openai_reasoning_model());
         }
 
         #[test]
         fn goose_prefixed_reasoning_models() {
             let _guard = env_lock::lock_env(ENV_LOCK_KEYS);
-            assert!(ModelConfig::new_or_fail("goose-o3-mini").is_openai_reasoning_model());
-            assert!(ModelConfig::new_or_fail("goose-o4-mini").is_openai_reasoning_model());
-            assert!(ModelConfig::new_or_fail("goose-gpt-5").is_openai_reasoning_model());
+            assert!(ModelConfig::new("goose-o3-mini").is_openai_reasoning_model());
+            assert!(ModelConfig::new("goose-o4-mini").is_openai_reasoning_model());
+            assert!(ModelConfig::new("goose-gpt-5").is_openai_reasoning_model());
         }
 
         #[test]
         fn databricks_prefixed_reasoning_models() {
             let _guard = env_lock::lock_env(ENV_LOCK_KEYS);
-            assert!(ModelConfig::new_or_fail("databricks-o3-mini").is_openai_reasoning_model());
-            assert!(ModelConfig::new_or_fail("databricks-o4-mini").is_openai_reasoning_model());
-            assert!(ModelConfig::new_or_fail("databricks-gpt-5").is_openai_reasoning_model());
+            assert!(ModelConfig::new("databricks-o3-mini").is_openai_reasoning_model());
+            assert!(ModelConfig::new("databricks-o4-mini").is_openai_reasoning_model());
+            assert!(ModelConfig::new("databricks-gpt-5").is_openai_reasoning_model());
         }
 
         #[test]
         fn non_reasoning_models() {
             let _guard = env_lock::lock_env(ENV_LOCK_KEYS);
-            assert!(!ModelConfig::new_or_fail("claude-sonnet-4").is_openai_reasoning_model());
-            assert!(!ModelConfig::new_or_fail("gpt-4o").is_openai_reasoning_model());
-            assert!(
-                !ModelConfig::new_or_fail("databricks-claude-sonnet-4").is_openai_reasoning_model()
-            );
-            assert!(!ModelConfig::new_or_fail("goose-claude-sonnet-4").is_openai_reasoning_model());
-            assert!(!ModelConfig::new_or_fail("llama-3-70b").is_openai_reasoning_model());
+            assert!(!ModelConfig::new("claude-sonnet-4").is_openai_reasoning_model());
+            assert!(!ModelConfig::new("gpt-4o").is_openai_reasoning_model());
+            assert!(!ModelConfig::new("databricks-claude-sonnet-4").is_openai_reasoning_model());
+            assert!(!ModelConfig::new("goose-claude-sonnet-4").is_openai_reasoning_model());
+            assert!(!ModelConfig::new("llama-3-70b").is_openai_reasoning_model());
         }
     }
 
@@ -790,19 +731,19 @@ mod tests {
         #[test]
         fn includes_reasoning_model_families() {
             let _guard = env_lock::lock_env(ENV_LOCK_KEYS);
-            assert!(ModelConfig::new_or_fail("o3-mini").is_reasoning_model());
-            assert!(ModelConfig::new_or_fail("claude-sonnet-4").is_reasoning_model());
-            assert!(ModelConfig::new_or_fail("gemini-3-pro").is_reasoning_model());
+            assert!(ModelConfig::new("o3-mini").is_reasoning_model());
+            assert!(ModelConfig::new("claude-sonnet-4").is_reasoning_model());
+            assert!(ModelConfig::new("gemini-3-pro").is_reasoning_model());
         }
 
         #[test]
         fn uses_explicit_metadata_first() {
             let _guard = env_lock::lock_env(ENV_LOCK_KEYS);
-            let mut config = ModelConfig::new_or_fail("provider-alias");
+            let mut config = ModelConfig::new("provider-alias");
             config.reasoning = Some(true);
             assert!(config.is_reasoning_model());
 
-            let mut config = ModelConfig::new_or_fail("claude-sonnet-4");
+            let mut config = ModelConfig::new("claude-sonnet-4");
             config.reasoning = Some(false);
             assert!(!config.is_reasoning_model());
         }

--- a/crates/goose-providers/src/model.rs
+++ b/crates/goose-providers/src/model.rs
@@ -16,8 +16,6 @@ pub struct ModelConfig {
     pub max_tokens: Option<i32>,
     pub toolshim: bool,
     pub toolshim_model: Option<String>,
-    #[serde(skip)]
-    pub fast_model_config: Option<Box<ModelConfig>>,
     /// Provider-specific request parameters (e.g., anthropic_beta headers)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub request_params: Option<HashMap<String, Value>>,
@@ -38,8 +36,6 @@ impl<'de> Deserialize<'de> for ModelConfig {
             max_tokens: Option<i32>,
             toolshim: bool,
             toolshim_model: Option<String>,
-            #[serde(default)]
-            fast_model_config: Option<Box<ModelConfig>>,
             #[serde(default, skip_serializing_if = "Option::is_none")]
             request_params: Option<HashMap<String, Value>>,
             #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -54,7 +50,6 @@ impl<'de> Deserialize<'de> for ModelConfig {
             max_tokens: raw.max_tokens,
             toolshim: raw.toolshim,
             toolshim_model: raw.toolshim_model,
-            fast_model_config: raw.fast_model_config,
             request_params: raw.request_params,
             reasoning: raw.reasoning,
         };
@@ -72,7 +67,6 @@ impl ModelConfig {
             max_tokens: None,
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };
@@ -136,11 +130,6 @@ impl ModelConfig {
         if self.context_limit.is_none() {
             self.context_limit = limit;
         }
-
-        if let Some(fast_config) = self.fast_model_config.take() {
-            self.fast_model_config = Some(Box::new(fast_config.with_default_context_limit(limit)));
-        }
-
         self
     }
 
@@ -148,11 +137,6 @@ impl ModelConfig {
         if self.max_tokens.is_none() {
             self.max_tokens = tokens;
         }
-
-        if let Some(fast_config) = self.fast_model_config.take() {
-            self.fast_model_config = Some(Box::new(fast_config.with_default_max_tokens(tokens)));
-        }
-
         self
     }
 
@@ -163,17 +147,6 @@ impl ModelConfig {
 
     pub fn with_toolshim_model(mut self, model: Option<String>) -> Self {
         self.toolshim_model = model;
-        self
-    }
-
-    pub fn with_fast(mut self, fast_model_name: &str, provider_name: &str) -> Self {
-        let fast_config = ModelConfig::new(fast_model_name).with_canonical_limits(provider_name);
-        self.fast_model_config = Some(Box::new(fast_config));
-        self
-    }
-
-    pub fn with_fast_model_config(mut self, fast_model_config: ModelConfig) -> Self {
-        self.fast_model_config = Some(Box::new(fast_model_config));
         self
     }
 
@@ -206,12 +179,6 @@ impl ModelConfig {
                 self = self.with_thinking_effort(effort);
             }
         }
-
-        if let Some(fast_config) = self.fast_model_config.take() {
-            self.fast_model_config =
-                Some(Box::new(fast_config.with_default_thinking_effort(effort)));
-        }
-
         self
     }
 
@@ -245,14 +212,6 @@ impl ModelConfig {
         }
 
         self
-    }
-
-    pub fn use_fast_model(&self) -> Self {
-        if let Some(fast_config) = &self.fast_model_config {
-            *fast_config.clone()
-        } else {
-            self.clone()
-        }
     }
 
     pub fn context_limit(&self) -> usize {
@@ -337,33 +296,6 @@ impl ModelConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_deserialize_preserves_fast_model_config() {
-        let config: ModelConfig = serde_json::from_value(serde_json::json!({
-            "model_name": "primary-model",
-            "context_limit": null,
-            "temperature": null,
-            "max_tokens": null,
-            "toolshim": false,
-            "toolshim_model": null,
-            "fast_model_config": {
-                "model_name": "fast-model",
-                "context_limit": 4096,
-                "temperature": null,
-                "max_tokens": 1024,
-                "toolshim": false,
-                "toolshim_model": null
-            }
-        }))
-        .unwrap();
-
-        let fast_config = config.fast_model_config.as_ref().unwrap();
-        assert_eq!(fast_config.model_name, "fast-model");
-        assert_eq!(fast_config.context_limit, Some(4096));
-        assert_eq!(fast_config.max_tokens, Some(1024));
-        assert_eq!(config.use_fast_model().model_name, "fast-model");
-    }
 
     mod thinking_effort_tests {
         use super::*;

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -20,6 +20,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use reqwest::StatusCode;
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 use crate::base::{MessageStream, ProviderDescriptor};
 use crate::model::ModelConfig;
@@ -132,6 +133,8 @@ pub struct OpenAiProvider {
     dynamic_models: Option<bool>,
     skip_canonical_filtering: bool,
     preserve_thinking_context: bool,
+    #[serde(skip)]
+    n_ctx_cache: Arc<Mutex<HashMap<String, Option<usize>>>>,
 }
 
 /// Builder for [`OpenAiProvider`].
@@ -238,6 +241,7 @@ impl OpenAiProviderBuilder {
             dynamic_models: self.dynamic_models,
             skip_canonical_filtering: self.skip_canonical_filtering,
             preserve_thinking_context: self.preserve_thinking_context,
+            n_ctx_cache: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
@@ -257,6 +261,7 @@ impl OpenAiProvider {
             dynamic_models: None,
             skip_canonical_filtering: false,
             preserve_thinking_context: false,
+            n_ctx_cache: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -525,16 +530,30 @@ impl Provider for OpenAiProvider {
         if let Some(limit) = model_config.context_limit {
             return Ok(limit);
         }
+
+        if let Some(cached) = self
+            .n_ctx_cache
+            .lock()
+            .ok()
+            .and_then(|cache| cache.get(&model_config.model_name).copied())
+        {
+            return Ok(cached.unwrap_or_else(|| model_config.context_limit()));
+        }
+
         const N_CTX_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
-        if let Ok(Some(n_ctx)) = tokio::time::timeout(
+        let probed = tokio::time::timeout(
             N_CTX_PROBE_TIMEOUT,
             self.fetch_n_ctx_from_api(&model_config.model_name),
         )
         .await
-        {
-            return Ok(n_ctx);
+        .ok()
+        .flatten();
+
+        if let Ok(mut cache) = self.n_ctx_cache.lock() {
+            cache.insert(model_config.model_name.clone(), probed);
         }
-        Ok(model_config.context_limit())
+
+        Ok(probed.unwrap_or_else(|| model_config.context_limit()))
     }
 
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
@@ -709,6 +728,7 @@ mod tests {
             dynamic_models: None,
             skip_canonical_filtering: false,
             preserve_thinking_context: false,
+            n_ctx_cache: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -546,10 +546,6 @@ impl Provider for OpenAiProvider {
         self.skip_canonical_filtering
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.model.clone()
-    }
-
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         if let Some(custom_models) = &self.custom_models {
             if self.dynamic_models == Some(false) {

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -380,29 +380,6 @@ impl OpenAiProvider {
         }
     }
 
-    /// TODO(jack): replace this
-    /// Fill the model's context limit from the API when it isn't already set.
-    ///
-    /// An existing value may be an explicit GOOSE_CONTEXT_LIMIT, an ACP/server
-    /// per-session override, or a GOOSE_PREDEFINED_MODELS entry, none of which we
-    /// should overwrite. llama.cpp and Ollama report the real allocated window via
-    /// the non-standard meta.n_ctx field; reading it fixes auto-compaction for local
-    /// servers that would otherwise fall back to DEFAULT_CONTEXT_LIMIT. The probe is
-    /// bounded by a short timeout so a hung /v1/models can't stall provider
-    /// construction (the shared ApiClient uses OPENAI_TIMEOUT, up to 600s).
-    // pub async fn probe_context_limit_if_unset(&self, model: &mut ModelConfig) {
-    //     if model.context_limit.is_some() {
-    //         return;
-    //     }
-    //     const N_CTX_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
-    //     let model_name = model.model_name.clone();
-    //     if let Ok(Some(n_ctx)) =
-    //         tokio::time::timeout(N_CTX_PROBE_TIMEOUT, self.fetch_n_ctx_from_api(&model_name)).await
-    //     {
-    //         model.context_limit = Some(n_ctx);
-    //     }
-    // }
-
     async fn fetch_models_from_api(&self) -> Result<Vec<String>, ProviderError> {
         let models_path =
             Self::map_base_path(&self.base_path, "models", OPEN_AI_DEFAULT_MODELS_PATH);
@@ -535,6 +512,29 @@ impl Provider for OpenAiProvider {
 
     fn skip_canonical_filtering(&self) -> bool {
         self.skip_canonical_filtering
+    }
+
+    /// Resolve the effective context limit. When the config carries an explicit
+    /// limit (GOOSE_CONTEXT_LIMIT, a session override, or a known/canonical
+    /// value) it is used as-is. Otherwise probe `/v1/models`: llama.cpp and
+    /// Ollama report the real allocated window via the non-standard
+    /// `meta.n_ctx` field, which fixes auto-compaction for local servers that
+    /// would otherwise fall back to DEFAULT_CONTEXT_LIMIT. The probe is bounded
+    /// by a short timeout so a hung endpoint can't stall the caller.
+    async fn get_context_limit(&self, model_config: &ModelConfig) -> Result<usize, ProviderError> {
+        if let Some(limit) = model_config.context_limit {
+            return Ok(limit);
+        }
+        const N_CTX_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+        if let Ok(Some(n_ctx)) = tokio::time::timeout(
+            N_CTX_PROBE_TIMEOUT,
+            self.fetch_n_ctx_from_api(&model_config.model_name),
+        )
+        .await
+        {
+            return Ok(n_ctx);
+        }
+        Ok(model_config.context_limit())
     }
 
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -125,7 +125,6 @@ pub struct OpenAiProvider {
     base_path: String,
     organization: Option<String>,
     project: Option<String>,
-    model: ModelConfig,
     custom_headers: Option<HashMap<String, String>>,
     supports_streaming: bool,
     name: String,
@@ -145,7 +144,6 @@ pub struct OpenAiProviderBuilder {
     base_path: String,
     organization: Option<String>,
     project: Option<String>,
-    model: ModelConfig,
     custom_headers: Option<HashMap<String, String>>,
     supports_streaming: bool,
     name: String,
@@ -156,13 +154,12 @@ pub struct OpenAiProviderBuilder {
 }
 
 impl OpenAiProviderBuilder {
-    pub fn new(api_client: ApiClient, model: ModelConfig) -> Self {
+    pub fn new(api_client: ApiClient) -> Self {
         Self {
             api_client,
             base_path: OPEN_AI_DEFAULT_BASE_PATH.to_string(),
             organization: None,
             project: None,
-            model,
             custom_headers: None,
             supports_streaming: true,
             name: OPEN_AI_PROVIDER_NAME.to_string(),
@@ -190,11 +187,6 @@ impl OpenAiProviderBuilder {
 
     pub fn project(mut self, project: Option<String>) -> Self {
         self.project = project;
-        self
-    }
-
-    pub fn model(mut self, model: ModelConfig) -> Self {
-        self.model = model;
         self
     }
 
@@ -239,7 +231,6 @@ impl OpenAiProviderBuilder {
             base_path: self.base_path,
             organization: self.organization,
             project: self.project,
-            model: self.model,
             custom_headers: self.custom_headers,
             supports_streaming: self.supports_streaming,
             name: self.name,
@@ -253,13 +244,12 @@ impl OpenAiProviderBuilder {
 
 impl OpenAiProvider {
     #[doc(hidden)]
-    pub fn new(api_client: ApiClient, model: ModelConfig) -> Self {
+    pub fn new(api_client: ApiClient) -> Self {
         Self {
             api_client,
             base_path: OPEN_AI_DEFAULT_BASE_PATH.to_string(),
             organization: None,
             project: None,
-            model,
             custom_headers: None,
             supports_streaming: true,
             name: OPEN_AI_PROVIDER_NAME.to_string(),
@@ -390,6 +380,7 @@ impl OpenAiProvider {
         }
     }
 
+    /// TODO(jack): replace this
     /// Fill the model's context limit from the API when it isn't already set.
     ///
     /// An existing value may be an explicit GOOSE_CONTEXT_LIMIT, an ACP/server
@@ -399,18 +390,18 @@ impl OpenAiProvider {
     /// servers that would otherwise fall back to DEFAULT_CONTEXT_LIMIT. The probe is
     /// bounded by a short timeout so a hung /v1/models can't stall provider
     /// construction (the shared ApiClient uses OPENAI_TIMEOUT, up to 600s).
-    pub async fn probe_context_limit_if_unset(&mut self) {
-        if self.model.context_limit.is_some() {
-            return;
-        }
-        const N_CTX_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
-        let model_name = self.model.model_name.clone();
-        if let Ok(Some(n_ctx)) =
-            tokio::time::timeout(N_CTX_PROBE_TIMEOUT, self.fetch_n_ctx_from_api(&model_name)).await
-        {
-            self.model.context_limit = Some(n_ctx);
-        }
-    }
+    // pub async fn probe_context_limit_if_unset(&self, model: &mut ModelConfig) {
+    //     if model.context_limit.is_some() {
+    //         return;
+    //     }
+    //     const N_CTX_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+    //     let model_name = model.model_name.clone();
+    //     if let Ok(Some(n_ctx)) =
+    //         tokio::time::timeout(N_CTX_PROBE_TIMEOUT, self.fetch_n_ctx_from_api(&model_name)).await
+    //     {
+    //         model.context_limit = Some(n_ctx);
+    //     }
+    // }
 
     async fn fetch_models_from_api(&self) -> Result<Vec<String>, ProviderError> {
         let models_path =
@@ -711,7 +702,6 @@ mod tests {
             base_path: "v1/chat/completions".to_string(),
             organization: None,
             project: None,
-            model: ModelConfig::new_or_fail("test-model"),
             custom_headers: None,
             supports_streaming: true,
             name: name.to_string(),

--- a/crates/goose-providers/src/openai_compatible.rs
+++ b/crates/goose-providers/src/openai_compatible.rs
@@ -29,6 +29,7 @@ pub struct OpenAiCompatibleProvider {
     name: String,
     /// Client targeted at the base URL (e.g. `https://api.x.ai/v1`)
     api_client: ApiClient,
+    #[allow(dead_code)]
     model: ModelConfig,
     /// Path prefix prepended to `chat/completions` (e.g. `"deployments/{name}/"` for Azure).
     completions_prefix: String,
@@ -80,10 +81,6 @@ impl OpenAiCompatibleProvider {
 impl Provider for OpenAiCompatibleProvider {
     fn get_name(&self) -> &str {
         &self.name
-    }
-
-    fn get_model_config(&self) -> ModelConfig {
-        self.model.clone()
     }
 
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {

--- a/crates/goose-providers/src/openai_compatible.rs
+++ b/crates/goose-providers/src/openai_compatible.rs
@@ -29,24 +29,16 @@ pub struct OpenAiCompatibleProvider {
     name: String,
     /// Client targeted at the base URL (e.g. `https://api.x.ai/v1`)
     api_client: ApiClient,
-    #[allow(dead_code)]
-    model: ModelConfig,
     /// Path prefix prepended to `chat/completions` (e.g. `"deployments/{name}/"` for Azure).
     completions_prefix: String,
     supports_streaming: bool,
 }
 
 impl OpenAiCompatibleProvider {
-    pub fn new(
-        name: String,
-        api_client: ApiClient,
-        model: ModelConfig,
-        completions_prefix: String,
-    ) -> Self {
+    pub fn new(name: String, api_client: ApiClient, completions_prefix: String) -> Self {
         Self {
             name,
             api_client,
-            model,
             completions_prefix,
             supports_streaming: true,
         }
@@ -309,13 +301,13 @@ mod tests {
                 None,
             )
             .unwrap(),
-            ModelConfig::new_or_fail("test-model"),
             String::new(),
         )
         .with_supports_streaming(false);
 
+        let model = ModelConfig::new_or_fail("test-model");
         let payload = provider
-            .build_request(&provider.model, "", &[], &[], provider.supports_streaming)
+            .build_request(&model, "", &[], &[], provider.supports_streaming)
             .unwrap();
 
         assert_eq!(payload.get("stream"), None);

--- a/crates/goose-providers/src/openai_compatible.rs
+++ b/crates/goose-providers/src/openai_compatible.rs
@@ -305,7 +305,7 @@ mod tests {
         )
         .with_supports_streaming(false);
 
-        let model = ModelConfig::new_or_fail("test-model");
+        let model = ModelConfig::new("test-model");
         let payload = provider
             .build_request(&model, "", &[], &[], provider.supports_streaming)
             .unwrap();

--- a/crates/goose-server/src/routes/agent.rs
+++ b/crates/goose-server/src/routes/agent.rs
@@ -660,14 +660,12 @@ async fn update_agent_provider(
         EnabledExtensionsState::for_session(state.session_manager(), &payload.session_id, config)
             .await;
 
-    let new_provider = create(&payload.provider, model_config.clone(), extensions)
-        .await
-        .map_err(|e| {
-            (
-                StatusCode::BAD_REQUEST,
-                format!("Failed to create {} provider: {}", &payload.provider, e),
-            )
-        })?;
+    let new_provider = create(&payload.provider, extensions).await.map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Failed to create {} provider: {}", &payload.provider, e),
+        )
+    })?;
 
     agent
         .update_provider(new_provider, model_config, &payload.session_id)

--- a/crates/goose-server/src/routes/agent.rs
+++ b/crates/goose-server/src/routes/agent.rs
@@ -660,7 +660,7 @@ async fn update_agent_provider(
         EnabledExtensionsState::for_session(state.session_manager(), &payload.session_id, config)
             .await;
 
-    let new_provider = create(&payload.provider, model_config, extensions)
+    let new_provider = create(&payload.provider, model_config.clone(), extensions)
         .await
         .map_err(|e| {
             (
@@ -670,7 +670,7 @@ async fn update_agent_provider(
         })?;
 
     agent
-        .update_provider(new_provider, &payload.session_id)
+        .update_provider(new_provider, model_config, &payload.session_id)
         .await
         .map_err(|e| {
             (

--- a/crates/goose-server/src/routes/config_management.rs
+++ b/crates/goose-server/src/routes/config_management.rs
@@ -1124,7 +1124,7 @@ pub async fn get_canonical_model_info(
         max_output_tokens: canonical_model.limit.output,
         reasoning: canonical_model
             .reasoning
-            .unwrap_or_else(|| ModelConfig::new_or_fail(&query.model).is_reasoning_model()),
+            .unwrap_or_else(|| ModelConfig::new(&query.model).is_reasoning_model()),
         // Costs are per million tokens - client handles division for display
         input_token_cost: canonical_model.cost.input,
         output_token_cost: canonical_model.cost.output,

--- a/crates/goose-server/src/routes/config_management.rs
+++ b/crates/goose-server/src/routes/config_management.rs
@@ -937,9 +937,7 @@ pub async fn get_provider_models(
         )));
     }
 
-    let model_config =
-        goose::model_config::model_config_from_user_config(&name, &metadata.default_model)?;
-    let provider = goose::providers::create(&name, model_config, Vec::new()).await?;
+    let provider = goose::providers::create(&name, Vec::new()).await?;
 
     let models_result = provider
         .fetch_recommended_model_info(goose::model_config::global_toolshim())
@@ -975,7 +973,7 @@ pub async fn resolve_provider_model_info(
     }
 
     let model_config = goose::model_config::model_config_from_user_config(name, model)?;
-    let provider = goose::providers::create(name, model_config.clone(), Vec::new()).await?;
+    let provider = goose::providers::create(name, Vec::new()).await?;
     match provider.fetch_model_info(model).await {
         Ok(info) => Ok(info),
         Err(error) => {
@@ -1442,20 +1440,13 @@ pub async fn configure_provider_oauth(
         return Ok(Json("OAuth configuration completed".to_string()));
     }
 
-    let temp_model = goose::model_config::model_config_from_user_config(&provider_name, "temp")
-        .map_err(|e| {
-            ErrorResponse::bad_request(format!("Failed to create temporary model config: {}", e))
-        })?;
-
     // OAuth configuration does not use extensions.
-    let provider = create(&provider_name, temp_model, Vec::new())
-        .await
-        .map_err(|e| {
-            ErrorResponse::bad_request(format!(
-                "Failed to create provider '{}': {}",
-                provider_name, e
-            ))
-        })?;
+    let provider = create(&provider_name, Vec::new()).await.map_err(|e| {
+        ErrorResponse::bad_request(format!(
+            "Failed to create provider '{}': {}",
+            provider_name, e
+        ))
+    })?;
 
     provider.configure_oauth().await.map_err(|e| {
         ErrorResponse::bad_request(format!(

--- a/crates/goose-server/src/routes/config_management.rs
+++ b/crates/goose-server/src/routes/config_management.rs
@@ -941,7 +941,9 @@ pub async fn get_provider_models(
         goose::model_config::model_config_from_user_config(&name, &metadata.default_model)?;
     let provider = goose::providers::create(&name, model_config, Vec::new()).await?;
 
-    let models_result = provider.fetch_recommended_model_info().await;
+    let models_result = provider
+        .fetch_recommended_model_info(goose::model_config::global_toolshim())
+        .await;
 
     match models_result {
         Ok(models) => Ok(Json(models)),

--- a/crates/goose-server/src/routes/errors.rs
+++ b/crates/goose-server/src/routes/errors.rs
@@ -5,7 +5,6 @@ use axum::{
 };
 use goose::config::ConfigError;
 use goose_providers::errors::ProviderError;
-use goose_providers::model::ConfigError as ModelConfigError;
 use serde::Serialize;
 use utoipa::ToSchema;
 
@@ -74,12 +73,6 @@ impl From<ConfigError> for ErrorResponse {
             ConfigError::NotFound(key) => Self::not_found(format!("Config key not found: {}", key)),
             _ => Self::internal(err.to_string()),
         }
-    }
-}
-
-impl From<ModelConfigError> for ErrorResponse {
-    fn from(err: ModelConfigError) -> Self {
-        Self::internal(format!("Model configuration error: {}", err))
     }
 }
 

--- a/crates/goose-server/src/routes/sampling.rs
+++ b/crates/goose-server/src/routes/sampling.rs
@@ -51,7 +51,13 @@ async fn create_message(
         .as_deref()
         .unwrap_or("You are a helpful AI assistant.");
 
-    let model_config = provider.get_model_config();
+    let model_config = agent
+        .model_config_for_session(&session_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to resolve model config: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
     let (response, usage) = provider
         .complete(&model_config, &session_id, system, &messages, &[])
         .await

--- a/crates/goose/examples/agent.rs
+++ b/crates/goose/examples/agent.rs
@@ -14,6 +14,8 @@ async fn main() -> anyhow::Result<()> {
 
     let provider =
         create_with_named_model("databricks", DATABRICKS_DEFAULT_MODEL, Vec::new()).await?;
+    let model_config =
+        goose::model_config::model_config_from_user_config("databricks", DATABRICKS_DEFAULT_MODEL)?;
 
     let agent = Agent::new();
 
@@ -28,7 +30,9 @@ async fn main() -> anyhow::Result<()> {
         )
         .await?;
 
-    agent.update_provider(provider, &session.id).await?;
+    agent
+        .update_provider(provider, model_config, &session.id)
+        .await?;
 
     let config = ExtensionConfig::stdio(
         "developer",

--- a/crates/goose/examples/agent.rs
+++ b/crates/goose/examples/agent.rs
@@ -12,8 +12,7 @@ use std::path::PathBuf;
 async fn main() -> anyhow::Result<()> {
     let _ = dotenv();
 
-    let provider =
-        create_with_named_model("databricks", DATABRICKS_DEFAULT_MODEL, Vec::new()).await?;
+    let provider = create_with_named_model("databricks", Vec::new()).await?;
     let model_config =
         goose::model_config::model_config_from_user_config("databricks", DATABRICKS_DEFAULT_MODEL)?;
 

--- a/crates/goose/examples/databricks_oauth.rs
+++ b/crates/goose/examples/databricks_oauth.rs
@@ -10,8 +10,7 @@ async fn main() -> Result<()> {
 
     std::env::remove_var("DATABRICKS_TOKEN");
 
-    let provider =
-        create_with_named_model("databricks", DATABRICKS_DEFAULT_MODEL, Vec::new()).await?;
+    let provider = create_with_named_model("databricks", Vec::new()).await?;
 
     let message = Message::user().with_text("Tell me a short joke about programming.");
 

--- a/crates/goose/examples/databricks_oauth.rs
+++ b/crates/goose/examples/databricks_oauth.rs
@@ -15,7 +15,8 @@ async fn main() -> Result<()> {
 
     let message = Message::user().with_text("Tell me a short joke about programming.");
 
-    let model_config = provider.get_model_config();
+    let model_config =
+        goose::model_config::model_config_from_user_config("databricks", DATABRICKS_DEFAULT_MODEL)?;
     let (response, usage) = provider
         .complete(
             &model_config,

--- a/crates/goose/examples/image_tool.rs
+++ b/crates/goose/examples/image_tool.rs
@@ -22,18 +22,18 @@ async fn main() -> Result<()> {
         goose_providers::model::ModelConfig,
     )> = vec![
         (
-            create_with_named_model("databricks", DATABRICKS_DEFAULT_MODEL, Vec::new()).await?,
+            create_with_named_model("databricks", Vec::new()).await?,
             goose::model_config::model_config_from_user_config(
                 "databricks",
                 DATABRICKS_DEFAULT_MODEL,
             )?,
         ),
         (
-            create_with_named_model("openai", OPEN_AI_DEFAULT_MODEL, Vec::new()).await?,
+            create_with_named_model("openai", Vec::new()).await?,
             goose::model_config::model_config_from_user_config("openai", OPEN_AI_DEFAULT_MODEL)?,
         ),
         (
-            create_with_named_model("anthropic", ANTHROPIC_DEFAULT_MODEL, Vec::new()).await?,
+            create_with_named_model("anthropic", Vec::new()).await?,
             goose::model_config::model_config_from_user_config(
                 "anthropic",
                 ANTHROPIC_DEFAULT_MODEL,

--- a/crates/goose/examples/image_tool.rs
+++ b/crates/goose/examples/image_tool.rs
@@ -17,12 +17,30 @@ async fn main() -> Result<()> {
     dotenv().ok();
 
     // Create providers
-    let providers: Vec<Arc<dyn goose::providers::base::Provider>> = vec![
-        create_with_named_model("databricks", DATABRICKS_DEFAULT_MODEL, Vec::new()).await?,
-        create_with_named_model("openai", OPEN_AI_DEFAULT_MODEL, Vec::new()).await?,
-        create_with_named_model("anthropic", ANTHROPIC_DEFAULT_MODEL, Vec::new()).await?,
+    let providers: Vec<(
+        Arc<dyn goose::providers::base::Provider>,
+        goose_providers::model::ModelConfig,
+    )> = vec![
+        (
+            create_with_named_model("databricks", DATABRICKS_DEFAULT_MODEL, Vec::new()).await?,
+            goose::model_config::model_config_from_user_config(
+                "databricks",
+                DATABRICKS_DEFAULT_MODEL,
+            )?,
+        ),
+        (
+            create_with_named_model("openai", OPEN_AI_DEFAULT_MODEL, Vec::new()).await?,
+            goose::model_config::model_config_from_user_config("openai", OPEN_AI_DEFAULT_MODEL)?,
+        ),
+        (
+            create_with_named_model("anthropic", ANTHROPIC_DEFAULT_MODEL, Vec::new()).await?,
+            goose::model_config::model_config_from_user_config(
+                "anthropic",
+                ANTHROPIC_DEFAULT_MODEL,
+            )?,
+        ),
     ];
-    for provider in providers {
+    for (provider, model_config) in providers {
         // Read and encode test image
         let image_data = fs::read("crates/goose/examples/test_assets/test_image.png")?;
         let base64_image = BASE64.encode(image_data);
@@ -56,7 +74,6 @@ async fn main() -> Result<()> {
                 },
             }
         });
-        let model_config = provider.get_model_config();
         let (response, usage) = provider
             .complete(
                 &model_config,

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -135,7 +135,6 @@ struct HandoffContextClaim {
 
 pub struct AcpProvider {
     name: String,
-    model: ModelConfig,
     goose_mode: Arc<Mutex<GooseMode>>,
     mode_mapping: HashMap<GooseMode, String>,
 
@@ -159,7 +158,6 @@ impl std::fmt::Debug for AcpProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AcpProvider")
             .field("name", &self.name)
-            .field("model", &self.model)
             .finish()
     }
 }
@@ -177,13 +175,11 @@ fn spawn_client_loop(fut: impl Future<Output = ()> + Send + 'static) -> JoinHand
 impl AcpProvider {
     pub async fn connect(
         name: String,
-        model: ModelConfig,
         goose_mode: GooseMode,
         config: AcpProviderConfig,
     ) -> Result<Self> {
         Self::start(
             name,
-            model,
             goose_mode,
             config,
             Box::new(|cl, rx, init_tx| Box::pin(cl.spawn(rx, init_tx))),
@@ -194,14 +190,12 @@ impl AcpProvider {
     #[doc(hidden)]
     pub async fn connect_with_transport(
         name: String,
-        model: ModelConfig,
         goose_mode: GooseMode,
         config: AcpProviderConfig,
         transport: impl agent_client_protocol::ConnectTo<Client> + 'static,
     ) -> Result<Self> {
         Self::start(
             name,
-            model,
             goose_mode,
             config,
             Box::new(move |cl, mut rx, init_tx| {
@@ -217,7 +211,6 @@ impl AcpProvider {
 
     async fn start(
         name: String,
-        model: ModelConfig,
         goose_mode: GooseMode,
         config: AcpProviderConfig,
         run: ClientLoopFn,
@@ -252,21 +245,6 @@ impl AcpProvider {
             .await
             .context("ACP session creation cancelled")??;
 
-        // Resolve model from the session response.
-        let resolved_model = if model.model_name == ACP_CURRENT_MODEL {
-            if let Ok((resolved, _)) = resolve_model_info(&name, &response) {
-                tracing::info!(from = ACP_CURRENT_MODEL, to = %resolved, "resolved ACP model");
-                ModelConfig {
-                    model_name: resolved,
-                    ..model
-                }
-            } else {
-                model
-            }
-        } else {
-            model
-        };
-
         let session = AcpSession {
             id: response.session_id.clone(),
             response,
@@ -274,7 +252,6 @@ impl AcpProvider {
 
         Ok(Self {
             name,
-            model: resolved_model,
             goose_mode: goose_mode_shared,
             mode_mapping,
             session,
@@ -1530,30 +1507,34 @@ mod tests {
         }
     }
 
-    fn test_provider() -> AcpProvider {
+    fn test_provider() -> (AcpProvider, ModelConfig) {
         test_provider_with_tx(None)
     }
 
-    fn test_provider_with_tx(tx: Option<mpsc::Sender<ClientRequest>>) -> AcpProvider {
-        AcpProvider {
-            name: "acp-test".to_string(),
-            model: ModelConfig {
+    fn test_provider_with_tx(
+        tx: Option<mpsc::Sender<ClientRequest>>,
+    ) -> (AcpProvider, ModelConfig) {
+        (
+            AcpProvider {
+                name: "acp-test".to_string(),
+                goose_mode: Arc::new(Mutex::new(GooseMode::Auto)),
+                mode_mapping: HashMap::new(),
+                session: AcpSession {
+                    id: SessionId::new("test-session"),
+                    response: NewSessionResponse::new("test-session"),
+                },
+                pending_confirmations: Arc::new(TokioMutex::new(HashMap::new())),
+                pending_tool_updates: Arc::new(Mutex::new(HashMap::new())),
+                handoff_context_sent: AtomicBool::new(false),
+                context_size: Arc::new(AtomicU64::new(0)),
+                tx,
+                loop_thread: None,
+            },
+            ModelConfig {
                 model_name: "test-model".to_string(),
                 ..Default::default()
             },
-            goose_mode: Arc::new(Mutex::new(GooseMode::Auto)),
-            mode_mapping: HashMap::new(),
-            session: AcpSession {
-                id: SessionId::new("test-session"),
-                response: NewSessionResponse::new("test-session"),
-            },
-            pending_confirmations: Arc::new(TokioMutex::new(HashMap::new())),
-            pending_tool_updates: Arc::new(Mutex::new(HashMap::new())),
-            handoff_context_sent: AtomicBool::new(false),
-            context_size: Arc::new(AtomicU64::new(0)),
-            tx,
-            loop_thread: None,
-        }
+        )
     }
 
     #[test]
@@ -1622,7 +1603,7 @@ mod tests {
 
     #[test]
     fn handoff_context_is_sent_only_on_first_provider_prompt() {
-        let provider = test_provider();
+        let (provider, _) = test_provider();
         let messages = vec![
             Message::assistant().with_text("prior answer"),
             Message::user().with_text("current request"),
@@ -1639,7 +1620,7 @@ mod tests {
 
     #[test]
     fn first_prompt_without_history_still_marks_handoff_context_sent() {
-        let provider = test_provider();
+        let (provider, _) = test_provider();
         let first_prompt = vec![Message::user().with_text("new conversation")];
         let later_prompt_with_history = vec![
             Message::assistant().with_text("prior answer"),
@@ -1657,31 +1638,28 @@ mod tests {
 
     #[tokio::test]
     async fn get_context_limit_surfaces_captured_context_size() {
-        let provider = test_provider();
+        let (provider, model) = test_provider();
         assert_eq!(
-            provider.get_context_limit(&provider.model).await.unwrap(),
+            provider.get_context_limit(&model).await.unwrap(),
             goose_providers::model::DEFAULT_CONTEXT_LIMIT
         );
 
         provider.context_size.store(200_000, Ordering::Relaxed);
-        assert_eq!(
-            provider.get_context_limit(&provider.model).await.unwrap(),
-            200_000
-        );
+        assert_eq!(provider.get_context_limit(&model).await.unwrap(), 200_000);
     }
 
     #[tokio::test]
     async fn failed_first_prompt_send_rolls_back_handoff_context_claim() {
         let (tx, rx) = mpsc::channel(1);
         drop(rx);
-        let provider = test_provider_with_tx(Some(tx));
+        let (provider, model) = test_provider_with_tx(Some(tx));
         let messages = vec![
             Message::assistant().with_text("prior answer"),
             Message::user().with_text("current request"),
         ];
 
         let result = provider
-            .stream(&provider.model, "goose-session", "", &messages, &[])
+            .stream(&model, "goose-session", "", &messages, &[])
             .await;
 
         assert!(matches!(result, Err(ProviderError::RequestFailed(_))));

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -147,7 +147,7 @@ pub struct AcpProvider {
     handoff_context_sent: AtomicBool,
     /// Latest `size` reported by the ACP server in a `session/update` →
     /// `usage_update` notification. 0 means no real update has arrived yet,
-    /// in which case `get_model_config()` falls back to the static model
+    /// in which case `get_context_limit()` falls back to the supplied model
     /// configuration's context limit.
     context_size: Arc<AtomicU64>,
 
@@ -378,13 +378,12 @@ impl Provider for AcpProvider {
         &self.name
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        let mut model = self.model.clone();
+    async fn get_context_limit(&self, model_config: &ModelConfig) -> Result<usize, ProviderError> {
         let size = self.context_size.load(Ordering::Relaxed);
         if size > 0 {
-            model.context_limit = Some(size as usize);
+            return Ok(size as usize);
         }
-        model
+        Ok(model_config.context_limit())
     }
 
     async fn update_mode(&self, session_id: &str, mode: GooseMode) -> Result<(), ProviderError> {
@@ -1656,16 +1655,19 @@ mod tests {
         assert!(!later_claim.include_context);
     }
 
-    #[test]
-    fn get_model_config_surfaces_captured_context_size() {
+    #[tokio::test]
+    async fn get_context_limit_surfaces_captured_context_size() {
         let provider = test_provider();
         assert_eq!(
-            provider.get_model_config().context_limit(),
+            provider.get_context_limit(&provider.model).await.unwrap(),
             goose_providers::model::DEFAULT_CONTEXT_LIMIT
         );
 
         provider.context_size.store(200_000, Ordering::Relaxed);
-        assert_eq!(provider.get_model_config().context_limit(), 200_000);
+        assert_eq!(
+            provider.get_context_limit(&provider.model).await.unwrap(),
+            200_000
+        );
     }
 
     #[tokio::test]

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -52,6 +52,7 @@ pub struct AcpProviderConfig {
     pub work_dir: PathBuf,
     pub mcp_servers: Vec<McpServer>,
     pub session_mode_id: Option<String>,
+    pub session_config_options: Vec<(String, String)>,
     pub mode_mapping: HashMap<GooseMode, String>,
     pub notification_callback: Option<Arc<dyn Fn(SessionNotification) + Send + Sync>>,
 }
@@ -1025,6 +1026,8 @@ async fn handle_requests(
                 let result = match session {
                     Ok(session) => {
                         session_ids.push(session.session_id.clone());
+                        apply_session_config_options(&config, &cx, session.session_id.clone())
+                            .await?;
                         apply_session_mode(&config, &goose_mode, &cx, session).await
                     }
                     Err(err) => Err(anyhow::anyhow!(
@@ -1113,6 +1116,31 @@ async fn handle_requests(
         }
     }
 
+    Ok(())
+}
+
+async fn apply_session_config_options(
+    config: &AcpProviderConfig,
+    cx: &ConnectionTo<Agent>,
+    session_id: SessionId,
+) -> Result<()> {
+    for (config_id, value) in &config.session_config_options {
+        let value_id = agent_client_protocol::schema::SessionConfigValueId::new(value.clone());
+        cx.send_request(SetSessionConfigOptionRequest::new(
+            session_id.clone(),
+            config_id.clone(),
+            value_id,
+        ))
+        .block_task()
+        .await
+        .map_err(|err| {
+            anyhow::anyhow!(
+                "ACP agent rejected {} for '{}': {err}",
+                AGENT_METHOD_NAMES.session_set_config_option,
+                config_id
+            )
+        })?;
+    }
     Ok(())
 }
 

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -1530,10 +1530,7 @@ mod tests {
                 tx,
                 loop_thread: None,
             },
-            ModelConfig {
-                model_name: "test-model".to_string(),
-                ..Default::default()
-            },
+            ModelConfig::new("test-model"),
         )
     }
 

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -53,6 +53,10 @@ pub struct AcpProviderConfig {
     pub mcp_servers: Vec<McpServer>,
     pub session_mode_id: Option<String>,
     pub session_config_options: Vec<(String, String)>,
+    /// Config option id used to select the model (e.g. `"model"`). When set, the
+    /// provider re-applies this option from the per-completion `ModelConfig`
+    /// whenever the active session model changes.
+    pub model_config_option_id: Option<String>,
     pub mode_mapping: HashMap<GooseMode, String>,
     pub notification_callback: Option<Arc<dyn Fn(SessionNotification) + Send + Sync>>,
 }
@@ -151,6 +155,12 @@ pub struct AcpProvider {
     /// configuration's context limit.
     context_size: Arc<AtomicU64>,
 
+    /// Config option id used to select the model, if this agent supports it.
+    model_config_option_id: Option<String>,
+    /// Model currently applied via `model_config_option_id`, used to avoid
+    /// redundant `SetConfigOption` calls.
+    applied_model: Arc<Mutex<Option<String>>>,
+
     tx: Option<mpsc::Sender<ClientRequest>>,
     loop_thread: Option<JoinHandle<()>>,
 }
@@ -219,6 +229,14 @@ impl AcpProvider {
         let (tx, rx) = mpsc::channel(32);
         let (init_tx, init_rx) = oneshot::channel();
         let mode_mapping = config.mode_mapping.clone();
+        let model_config_option_id = config.model_config_option_id.clone();
+        let applied_model = config.model_config_option_id.as_ref().and_then(|id| {
+            config
+                .session_config_options
+                .iter()
+                .find(|(opt_id, _)| opt_id == id)
+                .map(|(_, value)| value.clone())
+        });
         let goose_mode_shared = Arc::new(Mutex::new(goose_mode));
         let pending_tool_updates: Arc<Mutex<HashMap<String, AccumulatedToolCall>>> =
             Arc::new(Mutex::new(HashMap::new()));
@@ -260,6 +278,8 @@ impl AcpProvider {
             pending_tool_updates,
             handoff_context_sent: AtomicBool::new(false),
             context_size,
+            model_config_option_id,
+            applied_model: Arc::new(Mutex::new(applied_model)),
             tx: Some(tx),
             loop_thread: Some(loop_thread),
         })
@@ -305,6 +325,39 @@ impl AcpProvider {
             .await
             .context("ACP client is unavailable")?;
         response_rx.await.context("ACP request cancelled")?
+    }
+
+    /// Re-apply the model selection config option when the active session model
+    /// differs from what was last applied. ACP agents that select their model
+    /// via a config option (e.g. Copilot) need this so resumed or switched
+    /// sessions actually use the requested model instead of the agent default.
+    async fn apply_model_if_changed(&self, model_name: &str) -> Result<()> {
+        let Some(config_id) = self.model_config_option_id.clone() else {
+            return Ok(());
+        };
+        if model_name == ACP_CURRENT_MODEL {
+            return Ok(());
+        }
+
+        {
+            let applied = self
+                .applied_model
+                .lock()
+                .map_err(|_| anyhow::anyhow!("applied_model lock poisoned"))?;
+            if applied.as_deref() == Some(model_name) {
+                return Ok(());
+            }
+        }
+
+        self.send_set_config_option("", config_id, model_name.to_string())
+            .await?;
+
+        let mut applied = self
+            .applied_model
+            .lock()
+            .map_err(|_| anyhow::anyhow!("applied_model lock poisoned"))?;
+        *applied = Some(model_name.to_string());
+        Ok(())
     }
 
     async fn prompt(
@@ -417,6 +470,12 @@ impl Provider for AcpProvider {
         _tools: &[Tool],
     ) -> Result<MessageStream, ProviderError> {
         let session_id = self.acp_session_id();
+
+        self.apply_model_if_changed(&model_config.model_name)
+            .await
+            .map_err(|e| {
+                ProviderError::RequestFailed(format!("Failed to set ACP model option: {e}"))
+            })?;
 
         let claim = self.claim_handoff_context(messages);
         let prompt_blocks = messages_to_prompt(messages, claim.include_context);
@@ -1555,6 +1614,8 @@ mod tests {
                 pending_tool_updates: Arc::new(Mutex::new(HashMap::new())),
                 handoff_context_sent: AtomicBool::new(false),
                 context_size: Arc::new(AtomicU64::new(0)),
+                model_config_option_id: None,
+                applied_model: Arc::new(Mutex::new(None)),
                 tx,
                 loop_thread: None,
             },
@@ -1691,6 +1752,74 @@ mod tests {
         let next_claim = provider.claim_handoff_context(&messages);
         assert!(next_claim.first_prompt);
         assert!(next_claim.include_context);
+    }
+
+    fn test_provider_with_model_option(
+        tx: mpsc::Sender<ClientRequest>,
+        applied_model: Option<String>,
+    ) -> AcpProvider {
+        let (mut provider, _) = test_provider_with_tx(Some(tx));
+        provider.model_config_option_id = Some("model".to_string());
+        provider.applied_model = Arc::new(Mutex::new(applied_model));
+        provider
+    }
+
+    #[tokio::test]
+    async fn apply_model_if_changed_sends_set_config_option_on_change() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let provider = test_provider_with_model_option(tx, Some("old-model".to_string()));
+
+        let handle =
+            tokio::spawn(async move { provider.apply_model_if_changed("new-model").await });
+
+        match rx.recv().await.expect("expected a SetConfigOption request") {
+            ClientRequest::SetConfigOption {
+                config_id,
+                value,
+                response_tx,
+                ..
+            } => {
+                assert_eq!(config_id, "model");
+                assert_eq!(value, "new-model");
+                let _ = response_tx.send(Ok(()));
+            }
+            _ => panic!("unexpected request kind"),
+        }
+
+        handle.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn apply_model_if_changed_skips_when_model_unchanged() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let provider = test_provider_with_model_option(tx, Some("same-model".to_string()));
+
+        provider.apply_model_if_changed("same-model").await.unwrap();
+
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn apply_model_if_changed_noop_without_option_id() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let (provider, _) = test_provider_with_tx(Some(tx));
+
+        provider.apply_model_if_changed("any-model").await.unwrap();
+
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn apply_model_if_changed_skips_sentinel_model() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let provider = test_provider_with_model_option(tx, None);
+
+        provider
+            .apply_model_if_changed(ACP_CURRENT_MODEL)
+            .await
+            .unwrap();
+
+        assert!(rx.try_recv().is_err());
     }
 
     #[test]

--- a/crates/goose/src/acp/response_builder.rs
+++ b/crates/goose/src/acp/response_builder.rs
@@ -524,14 +524,11 @@ mod tests {
         provider_options: Vec<SessionConfigSelectOption>,
         model_state: SessionModelState,
     ) -> Vec<SessionConfigOption> {
-        let model_config = ModelConfig {
-            model_name: model_state.current_model_id.0.to_string(),
-            request_params: Some(std::collections::HashMap::from([(
+        let model_config = ModelConfig::new(model_state.current_model_id.0.as_ref())
+            .with_merged_request_params(std::collections::HashMap::from([(
                 "thinking_effort".to_string(),
                 serde_json::json!("off"),
-            )])),
-            ..Default::default()
-        };
+            )]));
         build_config_options(
             &mode_state,
             &model_state,
@@ -551,14 +548,12 @@ mod tests {
                 "claude-sonnet-4",
             )],
         );
-        let model_config = ModelConfig {
-            model_name: "claude-sonnet-4".to_string(),
-            request_params: Some(std::collections::HashMap::from([(
+        let model_config = ModelConfig::new("claude-sonnet-4").with_merged_request_params(
+            std::collections::HashMap::from([(
                 "thinking_effort".to_string(),
                 serde_json::json!("high"),
-            )])),
-            ..Default::default()
-        };
+            )]),
+        );
 
         let options = build_config_options(
             &mode_state,
@@ -586,15 +581,11 @@ mod tests {
             ModelId::new("gpt-4"),
             vec![ModelInfo::new(ModelId::new("gpt-4"), "gpt-4")],
         );
-        let model_config = ModelConfig {
-            model_name: "gpt-4".to_string(),
-            request_params: Some(std::collections::HashMap::from([(
-                "thinking_effort".to_string(),
-                serde_json::json!("high"),
-            )])),
-            reasoning: Some(false),
-            ..Default::default()
-        };
+        let mut model_config =
+            ModelConfig::new("gpt-4").with_merged_request_params(std::collections::HashMap::from(
+                [("thinking_effort".to_string(), serde_json::json!("high"))],
+            ));
+        model_config.reasoning = Some(false);
 
         let options = build_config_options(
             &mode_state,

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -3733,7 +3733,6 @@ print(\"hello, world\")
         );
         session.model_config = Some(
             goose_providers::model::ModelConfig::new("test-model")
-                .unwrap()
                 .with_context_limit(Some(258_000)),
         );
         let updates = build_usage_updates(&session).expect("usage updates should be present");

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1429,6 +1429,15 @@ impl GooseAcpAgent {
                             Ok(config) => config,
                             Err(_) => return,
                         };
+                        let fast_model_config = match crate::model_config::get_fast_model(
+                            provider.get_name(),
+                            &model_config,
+                        )
+                        .await
+                        {
+                            Ok(config) => config,
+                            Err(_) => return,
+                        };
                         // The fast model occasionally returns an empty response
                         // under load (rate limiting, transient network). One
                         // retry with a short backoff is enough to recover the
@@ -1436,8 +1445,8 @@ impl GooseAcpAgent {
                         let mut llm_outcome: Option<String> = None;
                         for attempt in 0..2 {
                             match provider
-                                .complete_fast(
-                                    &model_config,
+                                .complete(
+                                    &fast_model_config,
                                     &sid.0,
                                     system,
                                     std::slice::from_ref(&message),
@@ -1713,6 +1722,12 @@ impl GooseAcpAgent {
                 Ok(config) => config,
                 Err(_) => return,
             };
+            let fast_model_config =
+                match crate::model_config::get_fast_model(provider.get_name(), &model_config).await
+                {
+                    Ok(config) => config,
+                    Err(_) => return,
+                };
 
             // Match the per-tool retry policy: one retry on empty/error keeps
             // the chain header reliable when the fast model is rate-limited or
@@ -1720,8 +1735,8 @@ impl GooseAcpAgent {
             let mut summary: Option<String> = None;
             for attempt in 0..2 {
                 match provider
-                    .complete_fast(
-                        &model_config,
+                    .complete(
+                        &fast_model_config,
                         &sid.0,
                         system,
                         std::slice::from_ref(&message),

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -100,7 +100,6 @@ mod tools;
 pub type AcpProviderFactory = Arc<
     dyn Fn(
             String,
-            goose_providers::model::ModelConfig,
             Vec<ExtensionConfig>,
             Option<PathBuf>,
         ) -> BoxFuture<'static, Result<Arc<dyn Provider>>>
@@ -914,17 +913,10 @@ impl GooseAcpAgent {
     async fn create_provider(
         &self,
         provider_name: &str,
-        model_config: goose_providers::model::ModelConfig,
         extensions: Vec<ExtensionConfig>,
         working_dir: Option<PathBuf>,
     ) -> Result<Arc<dyn Provider>> {
-        (self.provider_factory)(
-            provider_name.to_string(),
-            model_config,
-            extensions,
-            working_dir,
-        )
-        .await
+        (self.provider_factory)(provider_name.to_string(), extensions, working_dir).await
     }
 
     async fn maybe_refresh_provider_inventory_with_agent(

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1433,6 +1433,10 @@ impl GooseAcpAgent {
                              checking network connectivity, listing files in src directory";
                         let user_text = format!("Tool: {name}\nArguments: {args_json}");
                         let message = Message::user().with_text(&user_text);
+                        let model_config = match agent.model_config_for_session(&sid.0).await {
+                            Ok(config) => config,
+                            Err(_) => return,
+                        };
                         // The fast model occasionally returns an empty response
                         // under load (rate limiting, transient network). One
                         // retry with a short backoff is enough to recover the
@@ -1440,7 +1444,13 @@ impl GooseAcpAgent {
                         let mut llm_outcome: Option<String> = None;
                         for attempt in 0..2 {
                             match provider
-                                .complete_fast(&sid.0, system, std::slice::from_ref(&message), &[])
+                                .complete_fast(
+                                    &model_config,
+                                    &sid.0,
+                                    system,
+                                    std::slice::from_ref(&message),
+                                    &[],
+                                )
                                 .await
                             {
                                 Ok((response, _)) => {
@@ -1707,6 +1717,10 @@ impl GooseAcpAgent {
                 user_text.push_str(&format!("Step {}: {} {}\n", i + 1, name, args));
             }
             let message = Message::user().with_text(&user_text);
+            let model_config = match agent.model_config_for_session(&sid.0).await {
+                Ok(config) => config,
+                Err(_) => return,
+            };
 
             // Match the per-tool retry policy: one retry on empty/error keeps
             // the chain header reliable when the fast model is rate-limited or
@@ -1714,7 +1728,13 @@ impl GooseAcpAgent {
             let mut summary: Option<String> = None;
             for attempt in 0..2 {
                 match provider
-                    .complete_fast(&sid.0, system, std::slice::from_ref(&message), &[])
+                    .complete_fast(
+                        &model_config,
+                        &sid.0,
+                        system,
+                        std::slice::from_ref(&message),
+                        &[],
+                    )
                     .await
                 {
                     Ok((response, _)) => {
@@ -2664,7 +2684,10 @@ impl GooseAcpAgent {
             .await
             .internal_err_ctx("Failed to get provider")?;
         let provider_name = current_provider.get_name().to_string();
-        let current_model_config = current_provider.get_model_config();
+        let current_model_config = agent
+            .model_config_for_session(session_id)
+            .await
+            .internal_err_ctx("Failed to resolve model config")?;
         let model_config =
             crate::model_config::model_config_from_user_config_with_session_settings(
                 &provider_name,
@@ -2697,7 +2720,10 @@ impl GooseAcpAgent {
             .await
             .internal_err_ctx("Failed to get provider")?;
         let provider_name = provider.get_name().to_string();
-        let current_model_config = provider.get_model_config();
+        let current_model_config = agent
+            .model_config_for_session(&session_id.0)
+            .await
+            .internal_err_ctx("Failed to resolve model config")?;
         let current_model = current_model_config.model_name.clone();
         let goose_mode = agent.goose_mode().await;
         let inventory = self
@@ -2782,7 +2808,10 @@ impl GooseAcpAgent {
             .await
             .internal_err_ctx("Failed to get provider")?;
         let current_provider_name = current_provider.get_name();
-        let current_model_config = current_provider.get_model_config();
+        let current_model_config = agent
+            .model_config_for_session(session_id)
+            .await
+            .internal_err_ctx("Failed to resolve model config")?;
         let current_model = current_model_config.model_name.clone();
         let use_default_provider = provider_name == DEFAULT_PROVIDER_ID;
         let resolved_provider_name = if use_default_provider {

--- a/crates/goose/src/acp/server/dispatch.rs
+++ b/crates/goose/src/acp/server/dispatch.rs
@@ -204,7 +204,9 @@ impl HandleDispatchFrom<Client> for GooseAcpHandler {
                                         .await
                                         {
                                             Ok(()) => match AssertUnwindSafe(
-                                                provider.fetch_recommended_models(),
+                                                provider.fetch_recommended_models(
+                                                    crate::model_config::global_toolshim(),
+                                                ),
                                             )
                                             .catch_unwind()
                                             .await

--- a/crates/goose/src/acp/server/providers.rs
+++ b/crates/goose/src/acp/server/providers.rs
@@ -732,25 +732,28 @@ impl GooseAcpAgent {
                 .catch_unwind()
                 .await;
 
-                let fetch_result: Result<Vec<String>> = match provider_result {
-                    Ok(Ok(provider)) => {
-                        match ensure_refresh_identity_current(&provider_id, &identity).await {
-                            Ok(()) => match AssertUnwindSafe(provider.fetch_recommended_models())
+                let fetch_result: Result<Vec<String>> =
+                    match provider_result {
+                        Ok(Ok(provider)) => {
+                            match ensure_refresh_identity_current(&provider_id, &identity).await {
+                                Ok(()) => match AssertUnwindSafe(provider.fetch_recommended_models(
+                                    crate::model_config::global_toolshim(),
+                                ))
                                 .catch_unwind()
                                 .await
-                            {
-                                Ok(Ok(models)) => Ok(models),
-                                Ok(Err(error)) => Err(anyhow::anyhow!(error.to_string())),
-                                Err(_) => {
-                                    Err(anyhow::anyhow!("provider inventory refresh task panicked"))
-                                }
-                            },
-                            Err(error) => Err(error),
+                                {
+                                    Ok(Ok(models)) => Ok(models),
+                                    Ok(Err(error)) => Err(anyhow::anyhow!(error.to_string())),
+                                    Err(_) => Err(anyhow::anyhow!(
+                                        "provider inventory refresh task panicked"
+                                    )),
+                                },
+                                Err(error) => Err(error),
+                            }
                         }
-                    }
-                    Ok(Err(error)) => Err(error),
-                    Err(_) => Err(anyhow::anyhow!("provider inventory refresh task panicked")),
-                };
+                        Ok(Err(error)) => Err(error),
+                        Err(_) => Err(anyhow::anyhow!("provider inventory refresh task panicked")),
+                    };
 
                 match fetch_result {
                     Ok(models) => match provider_inventory

--- a/crates/goose/src/acp/server/providers.rs
+++ b/crates/goose/src/acp/server/providers.rs
@@ -443,16 +443,8 @@ impl GooseAcpAgent {
         &self,
         req: ProviderSupportedModelsListRequest,
     ) -> Result<ProviderSupportedModelsListResponse, agent_client_protocol::Error> {
-        let entry = crate::providers::get_from_registry(&req.provider_id)
-            .await
-            .invalid_params_err_ctx("Unknown provider")?;
-        let model_config = crate::model_config::model_config_from_user_config(
-            &req.provider_id,
-            &entry.metadata().default_model,
-        )
-        .invalid_params_err_ctx("Invalid default model")?;
         let provider = self
-            .create_provider(&req.provider_id, model_config, Vec::new(), None)
+            .create_provider(&req.provider_id, Vec::new(), None)
             .await
             .internal_err_ctx("Failed to initialize provider")?;
         let models = provider
@@ -722,12 +714,7 @@ impl GooseAcpAgent {
             tokio::spawn(async move {
                 let mut refresh_guard = provider_inventory.refresh_guard(&identity);
                 let provider_result = AssertUnwindSafe(async {
-                    let metadata = crate::providers::get_from_registry(&provider_id).await?;
-                    let model_config = crate::model_config::model_config_from_user_config(
-                        &provider_id,
-                        &metadata.metadata().default_model,
-                    )?;
-                    provider_factory(provider_id.clone(), model_config, Vec::new(), None).await
+                    provider_factory(provider_id.clone(), Vec::new(), None).await
                 })
                 .catch_unwind()
                 .await;

--- a/crates/goose/src/acp/server_factory.rs
+++ b/crates/goose/src/acp/server_factory.rs
@@ -26,26 +26,22 @@ impl AcpServer {
         let config = crate::config::Config::global();
         let disable_session_naming = config.get_goose_disable_session_naming().unwrap_or(false);
 
-        let provider_factory: AcpProviderFactory = Arc::new(
-            move |provider_name, model_config, extensions, working_dir| {
+        let provider_factory: AcpProviderFactory =
+            Arc::new(move |provider_name, extensions, working_dir| {
                 Box::pin(async move {
                     match working_dir {
                         Some(working_dir) => {
                             crate::providers::create_with_working_dir(
                                 &provider_name,
-                                model_config,
                                 extensions,
                                 working_dir,
                             )
                             .await
                         }
-                        None => {
-                            crate::providers::create(&provider_name, model_config, extensions).await
-                        }
+                        None => crate::providers::create(&provider_name, extensions).await,
                     }
                 })
-            },
-        );
+            });
 
         let agent = GooseAcpAgent::new(GooseAcpAgentOptions {
             provider_factory,

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2710,7 +2710,6 @@ impl Agent {
 
         let provider = crate::providers::create_with_working_dir(
             provider_name,
-            model_config.clone(),
             extensions,
             session.working_dir.clone(),
         )
@@ -2774,7 +2773,6 @@ impl Agent {
             {
                 let p = crate::providers::create_with_working_dir(
                     &provider_name,
-                    model_config.clone(),
                     extensions,
                     session.working_dir.clone(),
                 )
@@ -2812,7 +2810,6 @@ impl Agent {
 
                 let fallback_provider = crate::providers::create_with_working_dir(
                     &fallback_provider_name,
-                    fallback_model_config.clone(),
                     extensions,
                     session.working_dir.clone(),
                 )

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -3530,7 +3530,7 @@ exit 0
         agent
             .update_provider(
                 provider,
-                goose_providers::model::ModelConfig::new("mock-model").unwrap(),
+                goose_providers::model::ModelConfig::new("mock-model"),
                 &session.id,
             )
             .await?;

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -345,6 +345,7 @@ impl Agent {
             .and_then(|host_info| host_info.client_name.clone())
             .unwrap_or_else(|| goose_platform.to_string());
         let session_manager = Arc::clone(&config.session_manager);
+        let inspection_session_manager = Arc::clone(&config.session_manager);
         let permission_manager = Arc::clone(&config.permission_manager);
         let use_login_shell_path = config.resolve_use_login_shell_path();
         Self {
@@ -370,6 +371,7 @@ impl Agent {
             tool_inspection_manager: Self::create_tool_inspection_manager(
                 permission_manager,
                 provider.clone(),
+                inspection_session_manager,
             ),
             hook_manager: crate::hooks::HookManager::load(
                 std::env::current_dir().ok().as_deref(),
@@ -578,6 +580,7 @@ impl Agent {
     fn create_tool_inspection_manager(
         permission_manager: Arc<PermissionManager>,
         provider: SharedProvider,
+        session_manager: Arc<SessionManager>,
     ) -> ToolInspectionManager {
         let mut tool_inspection_manager = ToolInspectionManager::new();
 
@@ -586,7 +589,10 @@ impl Agent {
         tool_inspection_manager.add_inspector(Box::new(EgressInspector::new()));
 
         // Add adversary inspector (LLM-based review, enabled by ~/.config/goose/adversary.md)
-        tool_inspection_manager.add_inspector(Box::new(AdversaryInspector::new(provider.clone())));
+        tool_inspection_manager.add_inspector(Box::new(AdversaryInspector::new(
+            provider.clone(),
+            session_manager,
+        )));
 
         // Add permission inspector (medium-high priority)
         tool_inspection_manager.add_inspector(Box::new(PermissionInspector::new(

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -138,6 +138,7 @@ pub struct ReplyContext {
     pub goose_mode: GooseMode,
     pub tool_call_cut_off: usize,
     pub initial_messages: Vec<Message>,
+    pub model_config: goose_providers::model::ModelConfig,
 }
 
 pub struct ToolCategorizeResult {
@@ -689,7 +690,7 @@ impl Agent {
         }
         let initial_messages = conversation.messages().clone();
 
-        let (tools, toolshim_tools, system_prompt) = self
+        let (tools, toolshim_tools, system_prompt, model_config) = self
             .prepare_tools_and_prompt(session_id, working_dir)
             .await?;
 
@@ -703,11 +704,13 @@ impl Agent {
         {
             Ok(v) => v,
             Err(_) => {
-                let context_limit = self
-                    .provider()
-                    .await
-                    .map(|p| p.get_model_config().context_limit())
-                    .unwrap_or(goose_providers::model::DEFAULT_CONTEXT_LIMIT);
+                let context_limit = match self.provider().await {
+                    Ok(provider) => provider
+                        .get_context_limit(&model_config)
+                        .await
+                        .unwrap_or_else(|_| model_config.context_limit()),
+                    Err(_) => goose_providers::model::DEFAULT_CONTEXT_LIMIT,
+                };
                 let compaction_threshold = Config::global()
                     .get_param::<f64>("GOOSE_AUTO_COMPACT_THRESHOLD")
                     .unwrap_or(crate::context_mgmt::DEFAULT_COMPACTION_THRESHOLD);
@@ -723,6 +726,7 @@ impl Agent {
             goose_mode,
             tool_call_cut_off,
             initial_messages,
+            model_config,
         })
     }
 
@@ -809,6 +813,38 @@ impl Agent {
             Some(provider) => Ok(Arc::clone(provider)),
             None => Err(anyhow!("Provider not set")),
         }
+    }
+
+    /// Resolve the active model config for a session.
+    ///
+    /// The session is the source of truth for the selected model and its
+    /// settings. When the session has no stored config (e.g. before the
+    /// provider has been persisted), fall back to the configured provider
+    /// defaults.
+    pub async fn model_config_for_session(
+        &self,
+        session_id: &str,
+    ) -> Result<goose_providers::model::ModelConfig> {
+        if let Ok(session) = self
+            .config
+            .session_manager
+            .get_session(session_id, false)
+            .await
+        {
+            if let Some(model_config) = session.model_config {
+                return Ok(model_config);
+            }
+        }
+
+        let config = Config::global();
+        let provider_name = config
+            .get_goose_provider()
+            .map_err(|_| anyhow!("Could not resolve model config: missing provider"))?;
+        let model_name = config
+            .get_goose_model()
+            .map_err(|_| anyhow!("Could not resolve model config: missing model"))?;
+        crate::model_config::model_config_from_user_config(&provider_name, &model_name)
+            .map_err(|e| anyhow!("Could not resolve model config: {e}"))
     }
 
     /// When set, all stdio extensions will be started via `docker exec` in the specified container.
@@ -1671,8 +1707,10 @@ impl Agent {
                     )
                 );
 
+                let compact_model_config = self.model_config_for_session(&session_config.id).await?;
                 match compact_messages(
                     self.provider().await?.as_ref(),
+                    &compact_model_config,
                     &session_config.id,
                     &conversation_to_compact,
                     false,
@@ -1730,6 +1768,7 @@ impl Agent {
             tool_call_cut_off,
             goose_mode,
             initial_messages,
+            model_config,
         } = context;
 
         if let Some(project_addendum) = self.load_project_instructions(&session).await {
@@ -1740,7 +1779,7 @@ impl Agent {
 
         let provider = self.provider().await?;
         let provider_name = provider.get_name().to_string();
-        let requested_model = provider.get_model_config().model_name;
+        let requested_model = model_config.model_name.clone();
         let inference = provider
             .fetch_model_info(&requested_model)
             .await
@@ -1904,6 +1943,7 @@ impl Agent {
 
                 let mut stream = Self::stream_response_from_provider(
                     self.provider().await?,
+                    model_config.clone(),
                     &session_config.id,
                     &system_prompt,
                     conversation_with_moim.messages(),
@@ -1922,6 +1962,7 @@ impl Agent {
                 } else {
                     crate::context_mgmt::maybe_summarize_tool_pairs(
                         self.provider().await?,
+                        model_config.clone(),
                         session_config.id.clone(),
                         conversation.clone(),
                         tool_call_cut_off,
@@ -2273,6 +2314,7 @@ impl Agent {
 
                             match compact_messages(
                                 self.provider().await?.as_ref(),
+                                &model_config,
                                 &session_config.id,
                                 &conversation,
                                 false,
@@ -2366,7 +2408,7 @@ impl Agent {
                 can_drain_pending_steers = true;
 
                 if tools_updated {
-                    (tools, toolshim_tools, system_prompt) =
+                    (tools, toolshim_tools, system_prompt, _) =
                         self.prepare_tools_and_prompt(&session_config.id, &session.working_dir).await?;
                 }
 
@@ -2377,7 +2419,7 @@ impl Agent {
                         .await
                         .load_subdirectory_hints(&working_dir);
                     if has_new_hints && !tools_updated {
-                        (tools, toolshim_tools, system_prompt) =
+                        (tools, toolshim_tools, system_prompt, _) =
                             self.prepare_tools_and_prompt(&session_config.id, &session.working_dir).await?;
                     }
                 }
@@ -2607,10 +2649,10 @@ impl Agent {
     pub async fn update_provider(
         &self,
         provider: Arc<dyn Provider>,
+        model_config: goose_providers::model::ModelConfig,
         session_id: &str,
     ) -> Result<()> {
         let provider_name = provider.get_name().to_string();
-        let model_config = provider.get_model_config();
 
         let mut current_provider = self.provider.lock().await;
         *current_provider = Some(provider);
@@ -2668,14 +2710,15 @@ impl Agent {
 
         let provider = crate::providers::create_with_working_dir(
             provider_name,
-            model_config,
+            model_config.clone(),
             extensions,
             session.working_dir.clone(),
         )
         .await
         .map_err(|e| anyhow!("Could not create provider: {}", e))?;
 
-        self.update_provider(provider, session_id).await?;
+        self.update_provider(provider, model_config, session_id)
+            .await?;
 
         let mode = self.goose_mode().await;
         self.update_goose_mode(mode, session_id).await
@@ -2688,8 +2731,9 @@ impl Agent {
     ) -> Result<()> {
         let current_provider = self.provider().await?;
         let provider_name = current_provider.get_name().to_string();
-        let model_config = current_provider
-            .get_model_config()
+        let model_config = self
+            .model_config_for_session(session_id)
+            .await?
             .with_thinking_effort(effort);
 
         self.recreate_provider_for_session(session_id, &provider_name, model_config)
@@ -2723,79 +2767,82 @@ impl Agent {
         let extensions =
             EnabledExtensionsState::extensions_or_default(Some(&session.extension_data), config);
 
-        let (provider, provider_changed) = if crate::providers::get_from_registry(&provider_name)
-            .await
-            .is_ok()
-        {
-            let p = crate::providers::create_with_working_dir(
-                &provider_name,
-                model_config,
-                extensions,
-                session.working_dir.clone(),
-            )
-            .await
-            .map_err(|e| anyhow!("Could not create provider: {}", e))?;
-            (p, false)
-        } else {
-            let fallback_provider_name = config
-                .get_goose_provider()
-                .ok()
-                .filter(|name| name != &provider_name)
-                .ok_or_else(|| {
+        let (provider, active_model_config, provider_changed) =
+            if crate::providers::get_from_registry(&provider_name)
+                .await
+                .is_ok()
+            {
+                let p = crate::providers::create_with_working_dir(
+                    &provider_name,
+                    model_config.clone(),
+                    extensions,
+                    session.working_dir.clone(),
+                )
+                .await
+                .map_err(|e| anyhow!("Could not create provider: {}", e))?;
+                (p, model_config, false)
+            } else {
+                let fallback_provider_name = config
+                    .get_goose_provider()
+                    .ok()
+                    .filter(|name| name != &provider_name)
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "Could not create provider: provider '{}' not found",
+                            provider_name
+                        )
+                    })?;
+
+                tracing::warn!(
+                    "Session provider '{}' unavailable, falling back to '{}'",
+                    provider_name,
+                    fallback_provider_name
+                );
+
+                let fallback_model_name = config.get_goose_model().ok().ok_or_else(|| {
+                    anyhow!("Could not configure fallback provider: missing model")
+                })?;
+                let fallback_model_config = crate::model_config::model_config_from_user_config(
+                    &fallback_provider_name,
+                    &fallback_model_name,
+                )
+                .map_err(|e| {
+                    anyhow!("Could not configure fallback provider: invalid model {}", e)
+                })?;
+
+                let fallback_provider = crate::providers::create_with_working_dir(
+                    &fallback_provider_name,
+                    fallback_model_config.clone(),
+                    extensions,
+                    session.working_dir.clone(),
+                )
+                .await
+                .map_err(|e| {
                     anyhow!(
-                        "Could not create provider: provider '{}' not found",
-                        provider_name
+                        "Could not create provider '{}' or fallback '{}': {}",
+                        provider_name,
+                        fallback_provider_name,
+                        e
                     )
                 })?;
 
-            tracing::warn!(
-                "Session provider '{}' unavailable, falling back to '{}'",
-                provider_name,
-                fallback_provider_name
-            );
+                if let Err(e) = self
+                    .config
+                    .session_manager
+                    .update(&session.id)
+                    .provider_name(&fallback_provider_name)
+                    .model_config(fallback_model_config.clone())
+                    .apply()
+                    .await
+                {
+                    tracing::warn!("Failed to update session provider: {}", e);
+                }
 
-            let fallback_model_name = config
-                .get_goose_model()
-                .ok()
-                .ok_or_else(|| anyhow!("Could not configure fallback provider: missing model"))?;
-            let fallback_model_config = crate::model_config::model_config_from_user_config(
-                &fallback_provider_name,
-                &fallback_model_name,
-            )
-            .map_err(|e| anyhow!("Could not configure fallback provider: invalid model {}", e))?;
+                (fallback_provider, fallback_model_config, true)
+            };
 
-            let fallback_provider = crate::providers::create_with_working_dir(
-                &fallback_provider_name,
-                fallback_model_config.clone(),
-                extensions,
-                session.working_dir.clone(),
-            )
-            .await
-            .map_err(|e| {
-                anyhow!(
-                    "Could not create provider '{}' or fallback '{}': {}",
-                    provider_name,
-                    fallback_provider_name,
-                    e
-                )
-            })?;
-
-            if let Err(e) = self
-                .config
-                .session_manager
-                .update(&session.id)
-                .provider_name(&fallback_provider_name)
-                .model_config(fallback_model_config)
-                .apply()
-                .await
-            {
-                tracing::warn!("Failed to update session provider: {}", e);
-            }
-
-            (fallback_provider, true)
-        };
-
-        self.update_provider(provider, &session.id).await?;
+        self.update_provider(provider, active_model_config, &session.id)
+            .await?;
         // Propagate session mode to the new provider
         if let Some(provider) = self.provider.lock().await.as_ref() {
             provider
@@ -2909,12 +2956,7 @@ impl Agent {
         tracing::debug!("Retrieved {} extensions info", extensions_info.len());
         let (extension_count, tool_count) = self.total_extension_and_tool_counts(session_id).await;
 
-        // Get model name from provider
-        let provider = self.provider().await.map_err(|e| {
-            tracing::error!("Failed to get provider for recipe creation: {}", e);
-            e
-        })?;
-        let model_config = provider.get_model_config();
+        let model_config = self.model_config_for_session(session_id).await?;
         let model_name = &model_config.model_name;
         tracing::debug!("Using model: {}", model_name);
 
@@ -2956,15 +2998,6 @@ impl Agent {
         );
 
         tracing::info!("Calling provider to generate recipe content");
-        let model_config = {
-            let provider_guard = self.provider.lock().await;
-            let provider = provider_guard.as_ref().ok_or_else(|| {
-                let error = anyhow!("Provider not available during recipe creation");
-                tracing::error!("{}", error);
-                error
-            })?;
-            provider.get_model_config()
-        };
         let (result, _usage) = self
             .provider
             .lock()
@@ -3191,9 +3224,6 @@ mod tests {
         fn get_name(&self) -> &str {
             "test-action-required"
         }
-        fn get_model_config(&self) -> goose_providers::model::ModelConfig {
-            goose_providers::model::ModelConfig::new("test").unwrap()
-        }
         async fn stream(
             &self,
             _: &goose_providers::model::ModelConfig,
@@ -3390,10 +3420,6 @@ exit 0
             Ok(stream_from_single_message(message, usage))
         }
 
-        fn get_model_config(&self) -> goose_providers::model::ModelConfig {
-            goose_providers::model::ModelConfig::new("mock-model").unwrap()
-        }
-
         fn get_name(&self) -> &str {
             "counting-text"
         }
@@ -3420,10 +3446,6 @@ exit 0
                     category: Some("cyber".to_string()),
                 })
             })))
-        }
-
-        fn get_model_config(&self) -> goose_providers::model::ModelConfig {
-            goose_providers::model::ModelConfig::new("mock-model").unwrap()
         }
 
         fn get_name(&self) -> &str {
@@ -3497,7 +3519,13 @@ exit 0
                 GooseMode::Auto,
             )
             .await?;
-        agent.update_provider(provider, &session.id).await?;
+        agent
+            .update_provider(
+                provider,
+                goose_providers::model::ModelConfig::new("mock-model").unwrap(),
+                &session.id,
+            )
+            .await?;
         Ok((agent, session.id))
     }
 

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2654,6 +2654,17 @@ impl Agent {
     ) -> Result<()> {
         let provider_name = provider.get_name().to_string();
 
+        // Normalize against the provider entry so custom/declarative providers
+        // backfill `context_limit` from their known models before the config is
+        // persisted as the session source of truth; otherwise auto-compaction
+        // would fall back to DEFAULT_CONTEXT_LIMIT.
+        let model_config = match crate::providers::get_from_registry(&provider_name).await {
+            Ok(entry) => entry
+                .normalize_model_config(model_config.clone())
+                .unwrap_or(model_config),
+            Err(_) => model_config,
+        };
+
         let mut current_provider = self.provider.lock().await;
         *current_provider = Some(provider);
 

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -591,13 +591,14 @@ impl Agent {
         // Add adversary inspector (LLM-based review, enabled by ~/.config/goose/adversary.md)
         tool_inspection_manager.add_inspector(Box::new(AdversaryInspector::new(
             provider.clone(),
-            session_manager,
+            session_manager.clone(),
         )));
 
         // Add permission inspector (medium-high priority)
         tool_inspection_manager.add_inspector(Box::new(PermissionInspector::new(
             permission_manager,
             provider,
+            session_manager,
         )));
 
         // Add repetition inspector (lower priority - basic repetition checking)

--- a/crates/goose/src/agents/execute_commands.rs
+++ b/crates/goose/src/agents/execute_commands.rs
@@ -156,8 +156,10 @@ impl Agent {
             .conversation
             .ok_or_else(|| anyhow!("Session has no conversation"))?;
 
+        let model_config = self.model_config_for_session(session_id).await?;
         let (compacted_conversation, usage) = compact_messages(
             self.provider().await?.as_ref(),
+            &model_config,
             session_id,
             &conversation,
             true, // is_manual_compact
@@ -209,8 +211,11 @@ impl Agent {
 
     async fn handle_status_command(&self, session_id: &str) -> Result<Option<Message>> {
         let provider = self.provider().await?;
-        let model_config = provider.get_model_config();
-        let context_limit = model_config.context_limit();
+        let model_config = self.model_config_for_session(session_id).await?;
+        let context_limit = provider
+            .get_context_limit(&model_config)
+            .await
+            .unwrap_or_else(|_| model_config.context_limit());
 
         let goose_mode = self.goose_mode().await;
 

--- a/crates/goose/src/agents/mcp_client.rs
+++ b/crates/goose/src/agents/mcp_client.rs
@@ -40,28 +40,19 @@ pub type Error = rmcp::ServiceError;
 const MCP_APPS_UI_EXTENSION_ID: &str = "io.modelcontextprotocol/ui";
 const MCP_APPS_UI_MIME_TYPE: &str = "text/html;profile=mcp-app";
 
-async fn resolve_sampling_model_config(
-    session_id: Option<&str>,
-) -> anyhow::Result<goose_providers::model::ModelConfig> {
-    if let Some(session_id) = session_id {
-        if let Ok(session) = crate::session::SessionManager::instance()
-            .get_session(session_id, false)
-            .await
+fn resolve_sampling_model_config() -> goose_providers::model::ModelConfig {
+    let config = crate::config::Config::global();
+    if let (Ok(provider_name), Ok(model_name)) =
+        (config.get_goose_provider(), config.get_goose_model())
+    {
+        if let Ok(model_config) =
+            crate::model_config::model_config_from_user_config(&provider_name, &model_name)
         {
-            if let Some(model_config) = session.model_config {
-                return Ok(model_config);
-            }
+            return model_config;
         }
     }
 
-    let config = crate::config::Config::global();
-    let provider_name = config
-        .get_goose_provider()
-        .map_err(|_| anyhow::anyhow!("missing provider"))?;
-    let model_name = config
-        .get_goose_model()
-        .map_err(|_| anyhow::anyhow!("missing model"))?;
-    crate::model_config::model_config_from_user_config(&provider_name, &model_name)
+    goose_providers::model::ModelConfig::default()
 }
 
 fn default_mcp_apps_ui_extensions() -> ExtensionCapabilities {
@@ -348,15 +339,7 @@ impl ClientHandler for GooseClient {
             .as_deref()
             .unwrap_or("You are a general-purpose AI agent called goose");
 
-        let model_config = resolve_sampling_model_config(session_id.as_deref())
-            .await
-            .map_err(|e| {
-                ErrorData::new(
-                    ErrorCode::INTERNAL_ERROR,
-                    "Could not resolve model config",
-                    Some(Value::from(e.to_string())),
-                )
-            })?;
+        let model_config = resolve_sampling_model_config();
         let (response, usage) = provider
             .complete(
                 &model_config,

--- a/crates/goose/src/agents/mcp_client.rs
+++ b/crates/goose/src/agents/mcp_client.rs
@@ -40,19 +40,11 @@ pub type Error = rmcp::ServiceError;
 const MCP_APPS_UI_EXTENSION_ID: &str = "io.modelcontextprotocol/ui";
 const MCP_APPS_UI_MIME_TYPE: &str = "text/html;profile=mcp-app";
 
-fn resolve_sampling_model_config() -> goose_providers::model::ModelConfig {
+fn resolve_sampling_model_config() -> anyhow::Result<goose_providers::model::ModelConfig> {
     let config = crate::config::Config::global();
-    if let (Ok(provider_name), Ok(model_name)) =
-        (config.get_goose_provider(), config.get_goose_model())
-    {
-        if let Ok(model_config) =
-            crate::model_config::model_config_from_user_config(&provider_name, &model_name)
-        {
-            return model_config;
-        }
-    }
-
-    goose_providers::model::ModelConfig::default()
+    let provider_name = config.get_goose_provider()?;
+    let model_name = config.get_goose_model()?;
+    crate::model_config::model_config_from_user_config(&provider_name, &model_name)
 }
 
 fn default_mcp_apps_ui_extensions() -> ExtensionCapabilities {
@@ -339,7 +331,13 @@ impl ClientHandler for GooseClient {
             .as_deref()
             .unwrap_or("You are a general-purpose AI agent called goose");
 
-        let model_config = resolve_sampling_model_config();
+        let model_config = resolve_sampling_model_config().map_err(|e| {
+            ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                "Could not resolve model config",
+                Some(Value::from(e.to_string())),
+            )
+        })?;
         let (response, usage) = provider
             .complete(
                 &model_config,

--- a/crates/goose/src/agents/mcp_client.rs
+++ b/crates/goose/src/agents/mcp_client.rs
@@ -40,7 +40,20 @@ pub type Error = rmcp::ServiceError;
 const MCP_APPS_UI_EXTENSION_ID: &str = "io.modelcontextprotocol/ui";
 const MCP_APPS_UI_MIME_TYPE: &str = "text/html;profile=mcp-app";
 
-fn resolve_sampling_model_config() -> anyhow::Result<goose_providers::model::ModelConfig> {
+async fn resolve_sampling_model_config(
+    session_id: Option<&str>,
+) -> anyhow::Result<goose_providers::model::ModelConfig> {
+    if let Some(session_id) = session_id {
+        if let Ok(session) = crate::session::SessionManager::instance()
+            .get_session(session_id, false)
+            .await
+        {
+            if let Some(model_config) = session.model_config {
+                return Ok(model_config);
+            }
+        }
+    }
+
     let config = crate::config::Config::global();
     let provider_name = config
         .get_goose_provider()
@@ -335,13 +348,15 @@ impl ClientHandler for GooseClient {
             .as_deref()
             .unwrap_or("You are a general-purpose AI agent called goose");
 
-        let model_config = resolve_sampling_model_config().map_err(|e| {
-            ErrorData::new(
-                ErrorCode::INTERNAL_ERROR,
-                "Could not resolve model config",
-                Some(Value::from(e.to_string())),
-            )
-        })?;
+        let model_config = resolve_sampling_model_config(session_id.as_deref())
+            .await
+            .map_err(|e| {
+                ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    "Could not resolve model config",
+                    Some(Value::from(e.to_string())),
+                )
+            })?;
         let (response, usage) = provider
             .complete(
                 &model_config,

--- a/crates/goose/src/agents/mcp_client.rs
+++ b/crates/goose/src/agents/mcp_client.rs
@@ -40,6 +40,17 @@ pub type Error = rmcp::ServiceError;
 const MCP_APPS_UI_EXTENSION_ID: &str = "io.modelcontextprotocol/ui";
 const MCP_APPS_UI_MIME_TYPE: &str = "text/html;profile=mcp-app";
 
+fn resolve_sampling_model_config() -> anyhow::Result<goose_providers::model::ModelConfig> {
+    let config = crate::config::Config::global();
+    let provider_name = config
+        .get_goose_provider()
+        .map_err(|_| anyhow::anyhow!("missing provider"))?;
+    let model_name = config
+        .get_goose_model()
+        .map_err(|_| anyhow::anyhow!("missing model"))?;
+    crate::model_config::model_config_from_user_config(&provider_name, &model_name)
+}
+
 fn default_mcp_apps_ui_extensions() -> ExtensionCapabilities {
     let mut extensions = ExtensionCapabilities::new();
     let mut ui_extension_settings = JsonObject::new();
@@ -324,7 +335,13 @@ impl ClientHandler for GooseClient {
             .as_deref()
             .unwrap_or("You are a general-purpose AI agent called goose");
 
-        let model_config = provider.get_model_config();
+        let model_config = resolve_sampling_model_config().map_err(|e| {
+            ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                "Could not resolve model config",
+                Some(Value::from(e.to_string())),
+            )
+        })?;
         let (response, usage) = provider
             .complete(
                 &model_config,

--- a/crates/goose/src/agents/moim.rs
+++ b/crates/goose/src/agents/moim.rs
@@ -51,23 +51,22 @@ pub async fn inject_moim(
         .get_session(session_id, false)
         .await
         .ok();
-    let provider_context_limit =
-        extension_manager
-            .get_provider()
-            .try_lock()
-            .ok()
-            .and_then(|provider| {
-                provider
-                    .as_ref()
-                    .map(|provider| provider.get_model_config().context_limit())
-            });
-    let session_context_limit = session.as_ref().and_then(|session| {
-        session
-            .model_config
-            .as_ref()
-            .map(|config| config.context_limit())
-    });
-    let context_limit = provider_context_limit.or(session_context_limit);
+    let session_model_config = session
+        .as_ref()
+        .and_then(|session| session.model_config.clone());
+    let context_limit = if let Some(model_config) = session_model_config.as_ref() {
+        let provider = extension_manager.get_provider().lock().await.clone();
+        match provider {
+            Some(provider) => provider
+                .get_context_limit(model_config)
+                .await
+                .ok()
+                .or_else(|| Some(model_config.context_limit())),
+            None => Some(model_config.context_limit()),
+        }
+    } else {
+        None
+    };
     if should_skip_moim(context_limit) {
         return conversation;
     }

--- a/crates/goose/src/agents/platform_extensions/apps.rs
+++ b/crates/goose/src/agents/platform_extensions/apps.rs
@@ -272,7 +272,7 @@ impl AppsManagerClient {
         let messages = vec![Message::user().with_text(&user_prompt)];
         let tools = vec![Self::create_app_content_tool()];
 
-        let model_config = provider.get_model_config();
+        let model_config = self.context.model_config_for_session(session_id).await?;
 
         let (response, usage) = provider
             .complete(&model_config, session_id, &system_prompt, &messages, &tools)
@@ -315,7 +315,7 @@ impl AppsManagerClient {
         let messages = vec![Message::user().with_text(&user_prompt)];
         let tools = vec![Self::update_app_content_tool()];
 
-        let model_config = provider.get_model_config();
+        let model_config = self.context.model_config_for_session(session_id).await?;
 
         let (response, usage) = provider
             .complete(&model_config, session_id, &system_prompt, &messages, &tools)

--- a/crates/goose/src/agents/platform_extensions/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/mod.rs
@@ -216,6 +216,27 @@ pub struct PlatformExtensionContext {
 }
 
 impl PlatformExtensionContext {
+    pub async fn model_config_for_session(
+        &self,
+        session_id: &str,
+    ) -> Result<goose_providers::model::ModelConfig, String> {
+        if let Ok(session) = self.session_manager.get_session(session_id, false).await {
+            if let Some(model_config) = session.model_config {
+                return Ok(model_config);
+            }
+        }
+
+        let config = crate::config::Config::global();
+        let provider_name = config
+            .get_goose_provider()
+            .map_err(|_| "Could not resolve model config: missing provider".to_string())?;
+        let model_name = config
+            .get_goose_model()
+            .map_err(|_| "Could not resolve model config: missing model".to_string())?;
+        crate::model_config::model_config_from_user_config(&provider_name, &model_name)
+            .map_err(|e| format!("Could not resolve model config: {e}"))
+    }
+
     pub fn result_with_platform_notification(
         &self,
         mut result: rmcp::model::CallToolResult,

--- a/crates/goose/src/agents/platform_extensions/orchestrator.rs
+++ b/crates/goose/src/agents/platform_extensions/orchestrator.rs
@@ -141,14 +141,12 @@ impl OrchestratorClient {
             .ok_or_else(|| "Provider not available".to_string())
     }
 
-    fn parent_model_config(
+    async fn parent_model_config(
         &self,
         provider_name: &str,
     ) -> Result<goose_providers::model::ModelConfig, String> {
         if let Some(session) = self.context.session.as_ref() {
-            if let Some(model_config) = session.model_config.clone() {
-                return Ok(model_config);
-            }
+            return self.context.model_config_for_session(&session.id).await;
         }
 
         let model_name = Config::global()
@@ -354,7 +352,7 @@ impl OrchestratorClient {
             conversation_text
         ));
 
-        let model_config = self.parent_model_config(provider.get_name())?;
+        let model_config = self.parent_model_config(provider.get_name()).await?;
         let (response, _usage) = provider
             .complete_fast(&model_config, session_id, system, &[user_message], &[])
             .await
@@ -424,7 +422,7 @@ impl OrchestratorClient {
 
         let parent_provider = self.get_provider().await?;
         let extensions = self.parent_extensions();
-        let model_config = self.parent_model_config(parent_provider.get_name())?;
+        let model_config = self.parent_model_config(parent_provider.get_name()).await?;
         let provider = providers::create(parent_provider.get_name(), extensions)
             .await
             .map_err(|e| format!("Failed to create provider for new agent: {}", e))?;
@@ -463,7 +461,7 @@ impl OrchestratorClient {
         if agent.provider().await.is_err() {
             if let Ok(parent_provider) = self.get_provider().await {
                 let extensions = self.parent_extensions();
-                let model_config = self.parent_model_config(parent_provider.get_name())?;
+                let model_config = self.parent_model_config(parent_provider.get_name()).await?;
                 if let Ok(provider) =
                     providers::create(parent_provider.get_name(), extensions).await
                 {

--- a/crates/goose/src/agents/platform_extensions/orchestrator.rs
+++ b/crates/goose/src/agents/platform_extensions/orchestrator.rs
@@ -425,10 +425,9 @@ impl OrchestratorClient {
         let parent_provider = self.get_provider().await?;
         let extensions = self.parent_extensions();
         let model_config = self.parent_model_config(parent_provider.get_name())?;
-        let provider =
-            providers::create(parent_provider.get_name(), model_config.clone(), extensions)
-                .await
-                .map_err(|e| format!("Failed to create provider for new agent: {}", e))?;
+        let provider = providers::create(parent_provider.get_name(), extensions)
+            .await
+            .map_err(|e| format!("Failed to create provider for new agent: {}", e))?;
         agent
             .update_provider(provider, model_config, &session.id)
             .await
@@ -466,8 +465,7 @@ impl OrchestratorClient {
                 let extensions = self.parent_extensions();
                 let model_config = self.parent_model_config(parent_provider.get_name())?;
                 if let Ok(provider) =
-                    providers::create(parent_provider.get_name(), model_config.clone(), extensions)
-                        .await
+                    providers::create(parent_provider.get_name(), extensions).await
                 {
                     agent
                         .update_provider(provider, model_config, &session_id)

--- a/crates/goose/src/agents/platform_extensions/orchestrator.rs
+++ b/crates/goose/src/agents/platform_extensions/orchestrator.rs
@@ -141,6 +141,23 @@ impl OrchestratorClient {
             .ok_or_else(|| "Provider not available".to_string())
     }
 
+    fn parent_model_config(
+        &self,
+        provider_name: &str,
+    ) -> Result<goose_providers::model::ModelConfig, String> {
+        if let Some(session) = self.context.session.as_ref() {
+            if let Some(model_config) = session.model_config.clone() {
+                return Ok(model_config);
+            }
+        }
+
+        let model_name = Config::global()
+            .get_goose_model()
+            .map_err(|_| "Could not resolve model config: missing model".to_string())?;
+        crate::model_config::model_config_from_user_config(provider_name, &model_name)
+            .map_err(|e| format!("Could not resolve model config: {e}"))
+    }
+
     fn parent_extensions(&self) -> Vec<ExtensionConfig> {
         let extension_data = self.context.session.as_ref().map(|s| &s.extension_data);
         EnabledExtensionsState::extensions_or_default(extension_data, Config::global())
@@ -337,8 +354,9 @@ impl OrchestratorClient {
             conversation_text
         ));
 
+        let model_config = self.parent_model_config(provider.get_name())?;
         let (response, _usage) = provider
-            .complete_fast(session_id, system, &[user_message], &[])
+            .complete_fast(&model_config, session_id, system, &[user_message], &[])
             .await
             .map_err(|e| format!("LLM summarization failed: {}", e))?;
 
@@ -406,15 +424,13 @@ impl OrchestratorClient {
 
         let parent_provider = self.get_provider().await?;
         let extensions = self.parent_extensions();
-        let provider = providers::create(
-            parent_provider.get_name(),
-            parent_provider.get_model_config(),
-            extensions,
-        )
-        .await
-        .map_err(|e| format!("Failed to create provider for new agent: {}", e))?;
+        let model_config = self.parent_model_config(parent_provider.get_name())?;
+        let provider =
+            providers::create(parent_provider.get_name(), model_config.clone(), extensions)
+                .await
+                .map_err(|e| format!("Failed to create provider for new agent: {}", e))?;
         agent
-            .update_provider(provider, &session.id)
+            .update_provider(provider, model_config, &session.id)
             .await
             .map_err(|e| format!("Failed to set provider on new agent: {}", e))?;
 
@@ -448,15 +464,13 @@ impl OrchestratorClient {
         if agent.provider().await.is_err() {
             if let Ok(parent_provider) = self.get_provider().await {
                 let extensions = self.parent_extensions();
-                if let Ok(provider) = providers::create(
-                    parent_provider.get_name(),
-                    parent_provider.get_model_config(),
-                    extensions,
-                )
-                .await
+                let model_config = self.parent_model_config(parent_provider.get_name())?;
+                if let Ok(provider) =
+                    providers::create(parent_provider.get_name(), model_config.clone(), extensions)
+                        .await
                 {
                     agent
-                        .update_provider(provider, &session_id)
+                        .update_provider(provider, model_config, &session_id)
                         .await
                         .map_err(|e| format!("Failed to set provider: {}", e))?;
                 }

--- a/crates/goose/src/agents/platform_extensions/orchestrator.rs
+++ b/crates/goose/src/agents/platform_extensions/orchestrator.rs
@@ -353,8 +353,12 @@ impl OrchestratorClient {
         ));
 
         let model_config = self.parent_model_config(provider.get_name()).await?;
+        let fast_model_config =
+            crate::model_config::get_fast_model(provider.get_name(), &model_config)
+                .await
+                .map_err(|e| format!("Failed to resolve fast model: {}", e))?;
         let (response, _usage) = provider
-            .complete_fast(&model_config, session_id, system, &[user_message], &[])
+            .complete(&fast_model_config, session_id, system, &[user_message], &[])
             .await
             .map_err(|e| format!("LLM summarization failed: {}", e))?;
 

--- a/crates/goose/src/agents/platform_extensions/orchestrator.rs
+++ b/crates/goose/src/agents/platform_extensions/orchestrator.rs
@@ -353,14 +353,16 @@ impl OrchestratorClient {
         ));
 
         let model_config = self.parent_model_config(provider.get_name()).await?;
-        let fast_model_config =
-            crate::model_config::get_fast_model(provider.get_name(), &model_config)
-                .await
-                .map_err(|e| format!("Failed to resolve fast model: {}", e))?;
-        let (response, _usage) = provider
-            .complete(&fast_model_config, session_id, system, &[user_message], &[])
-            .await
-            .map_err(|e| format!("LLM summarization failed: {}", e))?;
+        let (response, _usage) = crate::model_config::complete_fast(
+            provider.as_ref(),
+            &model_config,
+            session_id,
+            system,
+            &[user_message],
+            &[],
+        )
+        .await
+        .map_err(|e| format!("LLM summarization failed: {}", e))?;
 
         Ok(response
             .content

--- a/crates/goose/src/agents/platform_extensions/summarize.rs
+++ b/crates/goose/src/agents/platform_extensions/summarize.rs
@@ -149,7 +149,16 @@ impl McpClientTrait for SummarizeClient {
         };
 
         let session_id = &ctx.session_id;
-        match execute_summarize(provider, session_id, params, &working_dir).await {
+        let model_config = match self.context.model_config_for_session(session_id).await {
+            Ok(config) => config,
+            Err(e) => {
+                return Ok(CallToolResult::error(vec![Content::text(format!(
+                    "Error: {}",
+                    e
+                ))]));
+            }
+        };
+        match execute_summarize(provider, model_config, session_id, params, &working_dir).await {
             Ok(result) => Ok(result),
             Err(msg) => Ok(CallToolResult::error(vec![Content::text(format!(
                 "Error: {}",
@@ -165,6 +174,7 @@ impl McpClientTrait for SummarizeClient {
 
 async fn execute_summarize(
     provider: Arc<dyn Provider>,
+    model_config: goose_providers::model::ModelConfig,
     session_id: &str,
     params: SummarizeParams,
     working_dir: &Path,
@@ -186,8 +196,6 @@ async fn execute_summarize(
          Be specific and reference relevant parts of the content when helpful.";
 
     let user_message = Message::user().with_text(&prompt);
-
-    let model_config = provider.get_model_config();
 
     let (response, _usage) = provider
         .complete(&model_config, session_id, system, &[user_message], &[])

--- a/crates/goose/src/agents/platform_extensions/summon.rs
+++ b/crates/goose/src/agents/platform_extensions/summon.rs
@@ -1528,7 +1528,7 @@ impl SummonClient {
         recipe: &Recipe,
         session: &crate::session::Session,
     ) -> Result<TaskConfig, anyhow::Error> {
-        let provider = self.resolve_provider(params, recipe, session).await?;
+        let (provider, model_config) = self.resolve_provider(params, recipe, session).await?;
 
         let mut extensions = EnabledExtensionsState::extensions_or_default(
             Some(&session.extension_data),
@@ -1574,9 +1574,14 @@ impl SummonClient {
             None => session.working_dir.clone(),
         };
 
-        let task_config =
-            TaskConfig::new(provider, &session.id, &effective_working_dir, extensions)
-                .with_max_turns(Some(max_turns));
+        let task_config = TaskConfig::new(
+            provider,
+            model_config,
+            &session.id,
+            &effective_working_dir,
+            extensions,
+        )
+        .with_max_turns(Some(max_turns));
 
         Ok(task_config)
     }
@@ -1640,7 +1645,13 @@ impl SummonClient {
         params: &DelegateParams,
         recipe: &Recipe,
         session: &crate::session::Session,
-    ) -> Result<Arc<dyn crate::providers::base::Provider>, anyhow::Error> {
+    ) -> Result<
+        (
+            Arc<dyn crate::providers::base::Provider>,
+            goose_providers::model::ModelConfig,
+        ),
+        anyhow::Error,
+    > {
         let provider_name = params
             .provider
             .clone()
@@ -1659,7 +1670,8 @@ impl SummonClient {
             .ok_or_else(|| anyhow::anyhow!("No provider configured"))?;
 
         let model_config = self.resolve_model_config(params, recipe, session, &provider_name)?;
-        providers::create(&provider_name, model_config, Vec::new()).await
+        let provider = providers::create(&provider_name, model_config.clone(), Vec::new()).await?;
+        Ok((provider, model_config))
     }
 
     fn resolve_max_turns(&self, session: &crate::session::Session) -> usize {

--- a/crates/goose/src/agents/platform_extensions/summon.rs
+++ b/crates/goose/src/agents/platform_extensions/summon.rs
@@ -2589,9 +2589,7 @@ You review code."#;
     }
 
     fn parent_config() -> goose_providers::model::ModelConfig {
-        goose_providers::model::ModelConfig::new(PARENT_MODEL)
-            .unwrap()
-            .with_canonical_limits(PROVIDER)
+        goose_providers::model::ModelConfig::new(PARENT_MODEL).with_canonical_limits(PROVIDER)
     }
 
     #[tokio::test]
@@ -2605,7 +2603,6 @@ You review code."#;
 
         let parent = parent_config();
         let overridden = goose_providers::model::ModelConfig::new(OVERRIDE_MODEL)
-            .unwrap()
             .with_canonical_limits(PROVIDER);
         assert_ne!(parent.context_limit, overridden.context_limit);
         assert_ne!(parent.reasoning, overridden.reasoning);

--- a/crates/goose/src/agents/platform_extensions/summon.rs
+++ b/crates/goose/src/agents/platform_extensions/summon.rs
@@ -1670,7 +1670,7 @@ impl SummonClient {
             .ok_or_else(|| anyhow::anyhow!("No provider configured"))?;
 
         let model_config = self.resolve_model_config(params, recipe, session, &provider_name)?;
-        let provider = providers::create(&provider_name, model_config.clone(), Vec::new()).await?;
+        let provider = providers::create(&provider_name, Vec::new()).await?;
         Ok((provider, model_config))
     }
 

--- a/crates/goose/src/agents/platform_extensions/summon.rs
+++ b/crates/goose/src/agents/platform_extensions/summon.rs
@@ -1619,7 +1619,6 @@ impl SummonClient {
                     crate::model_config::model_config_from_user_config(provider_name, &model)?;
                 cfg.toolshim = parent.toolshim;
                 cfg.toolshim_model = parent.toolshim_model;
-                cfg.fast_model_config = parent.fast_model_config;
                 cfg.temperature = cfg.temperature.or(parent.temperature);
                 if let Some(parent_params) = parent.request_params {
                     let merged = cfg.request_params.get_or_insert_with(Default::default);

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -22,10 +22,15 @@ use crate::providers::toolshim::{
     modify_system_prompt_for_tool_json, sanitize_residual_markers,
 };
 use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
+use goose_providers::model::ModelConfig;
 use rmcp::model::Tool;
 use tracing::warn;
 
-async fn enhance_model_error(error: ProviderError, provider: &Arc<dyn Provider>) -> ProviderError {
+async fn enhance_model_error(
+    error: ProviderError,
+    provider: &Arc<dyn Provider>,
+    toolshim: bool,
+) -> ProviderError {
     let ProviderError::RequestFailed(ref msg) = error else {
         return error;
     };
@@ -35,7 +40,7 @@ async fn enhance_model_error(error: ProviderError, provider: &Arc<dyn Provider>)
         return error;
     }
 
-    let Ok(models) = provider.fetch_recommended_models().await else {
+    let Ok(models) = provider.fetch_recommended_models(toolshim).await else {
         return error;
     };
     if models.is_empty() {
@@ -143,7 +148,7 @@ impl Agent {
         &self,
         session_id: &str,
         working_dir: &std::path::Path,
-    ) -> Result<(Vec<Tool>, Vec<Tool>, String)> {
+    ) -> Result<(Vec<Tool>, Vec<Tool>, String, ModelConfig)> {
         let mut tools = self.list_tools(session_id, None).await;
 
         #[cfg(feature = "code-mode")]
@@ -215,9 +220,7 @@ impl Agent {
             .await;
         let (extension_count, tool_count) = self.total_extension_and_tool_counts(session_id).await;
 
-        // Get model name from provider
-        let provider = self.provider().await?;
-        let model_config = provider.get_model_config();
+        let model_config = self.model_config_for_session(session_id).await?;
 
         let goose_mode = *self.current_goose_mode.lock().await;
 
@@ -243,22 +246,23 @@ impl Agent {
             tools = vec![];
         }
 
-        Ok((tools, toolshim_tools, system_prompt))
+        Ok((tools, toolshim_tools, system_prompt, model_config))
     }
 
     #[tracing::instrument(
-        skip(provider, session_id, system_prompt, messages, tools, toolshim_tools),
+        skip(provider, model_config, session_id, system_prompt, messages, tools, toolshim_tools),
         fields(session.id = %session_id)
     )]
     pub(crate) async fn stream_response_from_provider(
         provider: Arc<dyn Provider>,
+        model_config: ModelConfig,
         session_id: &str,
         system_prompt: &str,
         messages: &[Message],
         tools: &[Tool],
         toolshim_tools: &[Tool],
     ) -> Result<MessageStream, ProviderError> {
-        let config = provider.get_model_config();
+        let config = model_config.clone();
 
         let filtered_messages: Vec<Message> = messages
             .iter()
@@ -281,9 +285,8 @@ impl Agent {
 
         // Capture errors during stream creation and return them as part of the stream
         // so they can be handled by the existing error handling logic in the agent
-        let model_config = provider
-            .get_model_config()
-            .with_default_thinking_effort(Config::global().get_goose_thinking_effort());
+        let model_config =
+            model_config.with_default_thinking_effort(Config::global().get_goose_thinking_effort());
         debug!("WAITING_LLM_STREAM_START");
         let stream_result = provider
             .stream(
@@ -300,7 +303,7 @@ impl Agent {
         let mut stream = match stream_result {
             Ok(s) => s,
             Err(e) => {
-                let enhanced_error = enhance_model_error(e, &provider).await;
+                let enhanced_error = enhance_model_error(e, &provider, config.toolshim).await;
                 // Return a stream that immediately yields the error
                 // This allows the error to be caught by existing error handling in agent.rs
                 return Ok(Box::pin(try_stream! {
@@ -621,18 +624,12 @@ mod tests {
     use rmcp::object;
 
     #[derive(Clone)]
-    struct MockProvider {
-        model_config: ModelConfig,
-    }
+    struct MockProvider;
 
     #[async_trait]
     impl Provider for MockProvider {
         fn get_name(&self) -> &str {
             "mock"
-        }
-
-        fn get_model_config(&self) -> ModelConfig {
-            self.model_config.clone()
         }
 
         async fn stream(
@@ -665,8 +662,10 @@ mod tests {
             .await?;
 
         let model_config = ModelConfig::new("test-model").unwrap();
-        let provider = std::sync::Arc::new(MockProvider { model_config });
-        agent.update_provider(provider, &session.id).await?;
+        let provider = std::sync::Arc::new(MockProvider);
+        agent
+            .update_provider(provider, model_config, &session.id)
+            .await?;
 
         // Add unsorted frontend tools
         let frontend_tools = vec![
@@ -697,7 +696,7 @@ mod tests {
             .await
             .unwrap();
 
-        let (tools, _toolshim_tools, _system_prompt) = agent
+        let (tools, _toolshim_tools, _system_prompt, _model_config) = agent
             .prepare_tools_and_prompt(&session.id, session.working_dir.as_path())
             .await?;
 

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -661,7 +661,7 @@ mod tests {
             )
             .await?;
 
-        let model_config = ModelConfig::new("test-model").unwrap();
+        let model_config = ModelConfig::new("test-model");
         let provider = std::sync::Arc::new(MockProvider);
         agent
             .update_provider(provider, model_config, &session.id)

--- a/crates/goose/src/agents/subagent_handler.rs
+++ b/crates/goose/src/agents/subagent_handler.rs
@@ -141,7 +141,11 @@ fn get_agent_messages(params: SubagentRunParams) -> AgentMessagesFuture {
         let agent = Arc::new(Agent::with_config(config));
 
         agent
-            .update_provider(task_config.provider.clone(), &session_id)
+            .update_provider(
+                task_config.provider.clone(),
+                task_config.model_config.clone(),
+                &session_id,
+            )
             .await
             .map_err(|e| anyhow!("Failed to set provider on sub agent: {}", e))?;
 

--- a/crates/goose/src/agents/subagent_task_config.rs
+++ b/crates/goose/src/agents/subagent_task_config.rs
@@ -12,6 +12,7 @@ pub const DEFAULT_SUBAGENT_MAX_TURNS: usize = 25;
 #[derive(Clone)]
 pub struct TaskConfig {
     pub provider: Arc<dyn Provider>,
+    pub model_config: goose_providers::model::ModelConfig,
     pub parent_session_id: String,
     pub parent_working_dir: PathBuf,
     pub extensions: Vec<ExtensionConfig>,
@@ -33,12 +34,14 @@ impl fmt::Debug for TaskConfig {
 impl TaskConfig {
     pub fn new(
         provider: Arc<dyn Provider>,
+        model_config: goose_providers::model::ModelConfig,
         parent_session_id: &str,
         parent_working_dir: &Path,
         extensions: Vec<ExtensionConfig>,
     ) -> Self {
         Self {
             provider,
+            model_config,
             parent_session_id: parent_session_id.to_owned(),
             parent_working_dir: parent_working_dir.to_owned(),
             extensions,

--- a/crates/goose/src/bin/build_canonical_models.rs
+++ b/crates/goose/src/bin/build_canonical_models.rs
@@ -644,7 +644,7 @@ async fn check_provider(
         }
     };
 
-    let recommended_models = match provider.fetch_recommended_models().await {
+    let recommended_models = match provider.fetch_recommended_models(false).await {
         Ok(models) => {
             println!("  ✓ Found {} recommended models", models.len());
             models

--- a/crates/goose/src/bin/build_canonical_models.rs
+++ b/crates/goose/src/bin/build_canonical_models.rs
@@ -619,11 +619,11 @@ async fn build_canonical_models() -> Result<()> {
 
 async fn check_provider(
     provider_name: &str,
-    model_for_init: &str,
+    _model_for_init: &str,
 ) -> Result<(Vec<String>, Vec<ModelMapping>, Vec<String>)> {
     println!("Checking provider: {}", provider_name);
 
-    let provider = match create_with_named_model(provider_name, model_for_init, Vec::new()).await {
+    let provider = match create_with_named_model(provider_name, Vec::new()).await {
         Ok(p) => p,
         Err(e) => {
             println!("  ⚠ Failed to create provider: {}", e);

--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -585,10 +585,10 @@ pub fn register_declarative_provider(
                         &config,
                         provider_type,
                         config.dynamic_models.unwrap_or(false),
-                        move |model, tls_config| {
+                        move |tls_config| {
                             let mut cfg = captured.clone();
                             resolve_config(&mut cfg)?;
-                            HuggingFaceProvider::from_custom_config(model, cfg, tls_config)
+                            HuggingFaceProvider::from_custom_config(cfg, tls_config)
                         },
                         move || {
                             let mut cfg = identity_config.clone();
@@ -608,10 +608,10 @@ pub fn register_declarative_provider(
                     &config,
                     provider_type,
                     config.dynamic_models.unwrap_or(false),
-                    move |model, tls_config| {
+                    move |tls_config| {
                         let mut cfg = captured.clone();
                         resolve_config(&mut cfg)?;
-                        crate::providers::openai_def::from_custom_config(model, cfg, tls_config)
+                        crate::providers::openai_def::from_custom_config(cfg, tls_config)
                     },
                     move || {
                         let mut cfg = identity_config.clone();
@@ -628,10 +628,10 @@ pub fn register_declarative_provider(
                 &config,
                 provider_type,
                 config.dynamic_models.unwrap_or(false),
-                move |model, tls_config| {
+                move |tls_config| {
                     let mut cfg = captured.clone();
                     resolve_config(&mut cfg)?;
-                    OllamaProvider::from_custom_config(model, cfg, tls_config)
+                    OllamaProvider::from_custom_config(cfg, tls_config)
                 },
                 move || {
                     let mut cfg = identity_config.clone();
@@ -647,10 +647,10 @@ pub fn register_declarative_provider(
                 &config,
                 provider_type,
                 config.dynamic_models.unwrap_or(false),
-                move |model, tls_config| {
+                move |tls_config| {
                     let mut cfg = captured.clone();
                     resolve_config(&mut cfg)?;
-                    AnthropicProvider::from_custom_config(model, cfg, tls_config)
+                    AnthropicProvider::from_custom_config(cfg, tls_config)
                 },
                 move || {
                     let mut cfg = identity_config.clone();

--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -301,9 +301,6 @@ async fn do_compact(
         .map(|msg| msg.agent_visible_content())
         .collect();
 
-    let fast_model_config =
-        crate::model_config::get_fast_model(provider.get_name(), model_config).await?;
-
     // Try progressively removing more tool response messages from the middle to reduce context length
     let removal_percentages = [0, 10, 20, 50, 100];
 
@@ -326,15 +323,15 @@ async fn do_compact(
             .with_text("Please summarize the conversation history provided in the system prompt.");
         let summarization_request = vec![user_message];
 
-        match provider
-            .complete(
-                &fast_model_config,
-                session_id,
-                &system_prompt,
-                &summarization_request,
-                &[],
-            )
-            .await
+        match crate::model_config::complete_fast(
+            provider,
+            model_config,
+            session_id,
+            &system_prompt,
+            &summarization_request,
+            &[],
+        )
+        .await
         {
             Ok((mut response, mut provider_usage)) => {
                 response.role = Role::User;
@@ -542,17 +539,15 @@ pub async fn summarize_tool_call(
                 if that is what it was.
             "#};
 
-    let fast_model_config =
-        crate::model_config::get_fast_model(provider.get_name(), model_config).await?;
-    let (mut response, _) = provider
-        .complete(
-            &fast_model_config,
-            session_id,
-            system_prompt,
-            &summarization_request,
-            &[],
-        )
-        .await?;
+    let (mut response, _) = crate::model_config::complete_fast(
+        provider,
+        model_config,
+        session_id,
+        system_prompt,
+        &summarization_request,
+        &[],
+    )
+    .await?;
 
     response.role = Role::User;
     response.created = matching_messages.last().unwrap().created;

--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -206,7 +206,7 @@ pub async fn check_if_compaction_needed(
     let model_config = session
         .model_config
         .clone()
-        .unwrap_or_else(|| ModelConfig::new_or_fail("unknown"));
+        .unwrap_or_else(|| ModelConfig::new("unknown"));
     let context_limit = provider
         .get_context_limit(&model_config)
         .await

--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -9,6 +9,7 @@ use crate::{config::Config, token_counter::create_token_counter};
 use anyhow::Result;
 use goose_providers::conversation::token_usage::ProviderUsage;
 use goose_providers::errors::ProviderError;
+use goose_providers::model::ModelConfig;
 use indoc::indoc;
 use rmcp::model::Role;
 use serde::Serialize;
@@ -65,6 +66,7 @@ struct SummarizeContext {
 ///   - `ProviderUsage`: Provider usage from summarization
 pub async fn compact_messages(
     provider: &dyn Provider,
+    model_config: &ModelConfig,
     session_id: &str,
     conversation: &Conversation,
     manual_compact: bool,
@@ -128,7 +130,7 @@ pub async fn compact_messages(
     let messages_to_compact = messages.as_slice();
 
     let (summary_message, summarization_usage) =
-        do_compact(provider, session_id, messages_to_compact).await?;
+        do_compact(provider, model_config, session_id, messages_to_compact).await?;
 
     // Create the final message list with updated visibility metadata:
     // 1. Original messages become user_visible but not agent_visible
@@ -201,7 +203,14 @@ pub async fn check_if_compaction_needed(
             .unwrap_or(DEFAULT_COMPACTION_THRESHOLD)
     });
 
-    let context_limit = provider.get_model_config().context_limit();
+    let model_config = session
+        .model_config
+        .clone()
+        .unwrap_or_else(|| ModelConfig::new_or_fail("unknown"));
+    let context_limit = provider
+        .get_context_limit(&model_config)
+        .await
+        .unwrap_or_else(|_| model_config.context_limit());
 
     let (current_tokens, _token_source) = match session.usage.total_tokens {
         Some(tokens) => (tokens as usize, "session metadata"),
@@ -282,6 +291,7 @@ fn filter_tool_responses(messages: &[Message], remove_percent: u32) -> Vec<&Mess
 
 async fn do_compact(
     provider: &dyn Provider,
+    model_config: &ModelConfig,
     session_id: &str,
     messages: &[Message],
 ) -> Result<(Message, ProviderUsage), anyhow::Error> {
@@ -314,7 +324,13 @@ async fn do_compact(
         let summarization_request = vec![user_message];
 
         match provider
-            .complete_fast(session_id, &system_prompt, &summarization_request, &[])
+            .complete_fast(
+                model_config,
+                session_id,
+                &system_prompt,
+                &summarization_request,
+                &[],
+            )
             .await
         {
             Ok((mut response, mut provider_usage)) => {
@@ -476,6 +492,7 @@ pub fn tool_ids_to_summarize(
 
 pub async fn summarize_tool_call(
     provider: &dyn Provider,
+    model_config: &ModelConfig,
     session_id: &str,
     conversation: &Conversation,
     tool_id: &str,
@@ -523,7 +540,13 @@ pub async fn summarize_tool_call(
             "#};
 
     let (mut response, _) = provider
-        .complete_fast(session_id, system_prompt, &summarization_request, &[])
+        .complete_fast(
+            model_config,
+            session_id,
+            system_prompt,
+            &summarization_request,
+            &[],
+        )
         .await?;
 
     response.role = Role::User;
@@ -535,6 +558,7 @@ pub async fn summarize_tool_call(
 
 pub fn maybe_summarize_tool_pairs(
     provider: Arc<dyn Provider>,
+    model_config: ModelConfig,
     session_id: String,
     conversation: Conversation,
     cutoff: usize,
@@ -552,7 +576,14 @@ pub fn maybe_summarize_tool_pairs(
     Some(tokio::spawn(async move {
         let mut results = Vec::new();
         for tool_id in tool_ids {
-            match summarize_tool_call(provider.as_ref(), &session_id, &conversation, &tool_id).await
+            match summarize_tool_call(
+                provider.as_ref(),
+                &model_config,
+                &session_id,
+                &conversation,
+                &tool_id,
+            )
+            .await
             {
                 Ok(summary) => results.push((summary, tool_id)),
                 Err(e) => {
@@ -569,8 +600,6 @@ mod tests {
     use super::*;
     use async_trait::async_trait;
     use goose_providers::conversation::token_usage::Usage;
-    use goose_providers::errors::ProviderError;
-    use goose_providers::model::ModelConfig;
     use rmcp::model::{AnnotateAble, CallToolRequestParams, RawContent, Tool};
 
     fn create_tool_pair(
@@ -666,8 +695,11 @@ mod tests {
             Ok(stream_from_single_message(message, usage))
         }
 
-        fn get_model_config(&self) -> ModelConfig {
-            self.config.clone()
+        async fn get_context_limit(
+            &self,
+            _model_config: &ModelConfig,
+        ) -> Result<usize, ProviderError> {
+            Ok(self.config.context_limit())
         }
     }
 
@@ -688,10 +720,16 @@ mod tests {
         ];
 
         let conversation = Conversation::new_unvalidated(basic_conversation);
-        let (compacted_conversation, _usage) =
-            compact_messages(&provider, "test-session-id", &conversation, false)
-                .await
-                .unwrap();
+        let model_config = provider.config.clone();
+        let (compacted_conversation, _usage) = compact_messages(
+            &provider,
+            &model_config,
+            "test-session-id",
+            &conversation,
+            false,
+        )
+        .await
+        .unwrap();
 
         let agent_conversation = compacted_conversation.agent_visible_messages();
 
@@ -721,7 +759,15 @@ mod tests {
         }
 
         let conversation = Conversation::new_unvalidated(messages);
-        let result = compact_messages(&provider, "test-session-id", &conversation, false).await;
+        let model_config = provider.config.clone();
+        let result = compact_messages(
+            &provider,
+            &model_config,
+            "test-session-id",
+            &conversation,
+            false,
+        )
+        .await;
 
         assert!(
             result.is_ok(),

--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -301,6 +301,9 @@ async fn do_compact(
         .map(|msg| msg.agent_visible_content())
         .collect();
 
+    let fast_model_config =
+        crate::model_config::get_fast_model(provider.get_name(), model_config).await?;
+
     // Try progressively removing more tool response messages from the middle to reduce context length
     let removal_percentages = [0, 10, 20, 50, 100];
 
@@ -324,8 +327,8 @@ async fn do_compact(
         let summarization_request = vec![user_message];
 
         match provider
-            .complete_fast(
-                model_config,
+            .complete(
+                &fast_model_config,
                 session_id,
                 &system_prompt,
                 &summarization_request,
@@ -539,9 +542,11 @@ pub async fn summarize_tool_call(
                 if that is what it was.
             "#};
 
+    let fast_model_config =
+        crate::model_config::get_fast_model(provider.get_name(), model_config).await?;
     let (mut response, _) = provider
-        .complete_fast(
-            model_config,
+        .complete(
+            &fast_model_config,
             session_id,
             system_prompt,
             &summarization_request,
@@ -643,7 +648,6 @@ mod tests {
                     max_tokens: None,
                     toolshim: false,
                     toolshim_model: None,
-                    fast_model_config: None,
                     request_params: None,
                     reasoning: None,
                 },

--- a/crates/goose/src/doctor.rs
+++ b/crates/goose/src/doctor.rs
@@ -78,9 +78,9 @@ async fn ensure_working_provider(
         }
 
         log.push(format!("Looking for alternative models on {} ...", pname));
-        if let Some(working) = try_other_models(pname, mname, &mut log).await {
-            let new_model = working.get_model_config().model_name.clone();
-            save_and_set(agent, session_id, working).await?;
+        if let Some((working, model_config)) = try_other_models(pname, mname, &mut log).await {
+            let new_model = model_config.model_name.clone();
+            save_and_set(agent, session_id, working, model_config).await?;
             let preamble = log.join("\n");
             return Ok(Some(Message::assistant().with_text(format!(
                 "**Goose Doctor**\n\n{}\n\n\
@@ -95,10 +95,10 @@ async fn ensure_working_provider(
 
     log.push("Looking for other configured providers ...".to_string());
     let skip = provider_name.as_deref().unwrap_or("");
-    if let Some(working) = try_other_providers(skip, &mut log).await {
+    if let Some((working, model_config)) = try_other_providers(skip, &mut log).await {
         let name = working.get_name().to_string();
-        let model = working.get_model_config().model_name.clone();
-        save_and_set(agent, session_id, working).await?;
+        let model = model_config.model_name.clone();
+        save_and_set(agent, session_id, working, model_config).await?;
         let preamble = log.join("\n");
         return Ok(Some(Message::assistant().with_text(format!(
             "**Goose Doctor**\n\n{}\n\n\
@@ -139,21 +139,23 @@ async fn save_and_set(
     agent: &crate::agents::Agent,
     session_id: &str,
     provider: Arc<dyn Provider>,
+    model_config: goose_providers::model::ModelConfig,
 ) -> anyhow::Result<()> {
     let config = Config::global();
-    crate::config::set_active_provider(
-        config,
-        provider.get_name(),
-        &provider.get_model_config().model_name,
-    )?;
-    agent.update_provider(provider, session_id).await
+    crate::config::set_active_provider(config, provider.get_name(), &model_config.model_name)?;
+    agent
+        .update_provider(provider, model_config, session_id)
+        .await
 }
 
-async fn test_provider(provider: &dyn Provider) -> Result<(), ProviderError> {
+async fn test_provider(
+    provider: &dyn Provider,
+    model_config: &goose_providers::model::ModelConfig,
+) -> Result<(), ProviderError> {
     let messages = vec![Message::user().with_text("Say 'hello' and nothing else.")];
     provider
         .complete(
-            &provider.get_model_config(),
+            model_config,
             "doctor-check",
             "Respond as briefly as possible.",
             &messages,
@@ -166,27 +168,30 @@ async fn test_provider(provider: &dyn Provider) -> Result<(), ProviderError> {
 async fn try_create_and_test(
     provider_name: &str,
     model_name: &str,
-) -> Result<Arc<dyn Provider>, ProviderError> {
+) -> Result<(Arc<dyn Provider>, goose_providers::model::ModelConfig), ProviderError> {
     let model_config =
         crate::model_config::model_config_from_user_config(provider_name, model_name)
             .map_err(|e| ProviderError::ExecutionError(e.to_string()))?;
 
-    let provider = providers::create(provider_name, model_config, vec![])
+    let provider = providers::create(provider_name, model_config.clone(), vec![])
         .await
         .map_err(|e| ProviderError::ExecutionError(e.to_string()))?;
 
-    test_provider(provider.as_ref()).await?;
-    Ok(provider)
+    test_provider(provider.as_ref(), &model_config).await?;
+    Ok((provider, model_config))
 }
 
 async fn try_other_models(
     provider_name: &str,
     skip_model: &str,
     log: &mut Vec<String>,
-) -> Option<Arc<dyn Provider>> {
+) -> Option<(Arc<dyn Provider>, goose_providers::model::ModelConfig)> {
     let entry = providers::get_from_registry(provider_name).await.ok()?;
     let temp = entry.create_with_default_model(vec![]).await.ok()?;
-    let models = temp.fetch_recommended_models().await.ok()?;
+    let toolshim = Config::global()
+        .get_param::<bool>("GOOSE_TOOLSHIM")
+        .unwrap_or(false);
+    let models = temp.fetch_recommended_models(toolshim).await.ok()?;
 
     for model in models.iter().filter(|m| m.as_str() != skip_model).take(3) {
         log.push(format!("  Trying {} / {} ...", provider_name, model));
@@ -201,7 +206,10 @@ async fn try_other_models(
     None
 }
 
-async fn try_other_providers(skip: &str, log: &mut Vec<String>) -> Option<Arc<dyn Provider>> {
+async fn try_other_providers(
+    skip: &str,
+    log: &mut Vec<String>,
+) -> Option<(Arc<dyn Provider>, goose_providers::model::ModelConfig)> {
     for (meta, _) in providers::providers().await {
         if meta.name == skip {
             continue;
@@ -210,16 +218,21 @@ async fn try_other_providers(skip: &str, log: &mut Vec<String>) -> Option<Arc<dy
             Ok(e) => e,
             Err(_) => continue,
         };
+        let model_name = entry.metadata().default_model.clone();
+        let model_config =
+            match crate::model_config::model_config_from_user_config(&meta.name, &model_name) {
+                Ok(config) => config,
+                Err(_) => continue,
+            };
         let provider = match entry.create_with_default_model(vec![]).await {
             Ok(p) => p,
             Err(_) => continue,
         };
-        let model_name = provider.get_model_config().model_name.clone();
         log.push(format!("  Trying {} / {} ...", meta.name, model_name));
-        match test_provider(provider.as_ref()).await {
+        match test_provider(provider.as_ref(), &model_config).await {
             Ok(()) => {
                 log.push(format!("  ✓ {} / {} works", meta.name, model_name));
-                return Some(provider);
+                return Some((provider, model_config));
             }
             Err(e) => log.push(format!("  ✗ {}", describe_error(&e))),
         }

--- a/crates/goose/src/doctor.rs
+++ b/crates/goose/src/doctor.rs
@@ -173,7 +173,7 @@ async fn try_create_and_test(
         crate::model_config::model_config_from_user_config(provider_name, model_name)
             .map_err(|e| ProviderError::ExecutionError(e.to_string()))?;
 
-    let provider = providers::create(provider_name, model_config.clone(), vec![])
+    let provider = providers::create(provider_name, vec![])
         .await
         .map_err(|e| ProviderError::ExecutionError(e.to_string()))?;
 

--- a/crates/goose/src/execution/manager.rs
+++ b/crates/goose/src/execution/manager.rs
@@ -250,7 +250,7 @@ impl AgentManager {
                         )
                         .ok()
                     })
-                    .unwrap_or_else(|| goose_providers::model::ModelConfig::new_or_fail("unknown"));
+                    .unwrap_or_else(|| goose_providers::model::ModelConfig::new("unknown"));
                 agent
                     .update_provider(Arc::clone(provider), model_config, session_id)
                     .await?;

--- a/crates/goose/src/execution/manager.rs
+++ b/crates/goose/src/execution/manager.rs
@@ -238,8 +238,21 @@ impl AgentManager {
 
         if agent.provider().await.is_err() {
             if let Some(provider) = &*self.default_provider.read().await {
+                let config = crate::config::Config::global();
+                let model_config = config
+                    .get_goose_provider()
+                    .ok()
+                    .zip(config.get_goose_model().ok())
+                    .and_then(|(provider_name, model_name)| {
+                        crate::model_config::model_config_from_user_config(
+                            &provider_name,
+                            &model_name,
+                        )
+                        .ok()
+                    })
+                    .unwrap_or_else(|| goose_providers::model::ModelConfig::new_or_fail("unknown"));
                 agent
-                    .update_provider(Arc::clone(provider), session_id)
+                    .update_provider(Arc::clone(provider), model_config, session_id)
                     .await?;
                 provider
                     .update_mode(session_id, mode)
@@ -620,10 +633,6 @@ mod tests {
         impl Provider for FailingProvider {
             fn get_name(&self) -> &str {
                 "failing-test-provider"
-            }
-
-            fn get_model_config(&self) -> ModelConfig {
-                ModelConfig::new_or_fail("test-model")
             }
 
             async fn stream(

--- a/crates/goose/src/model_config.rs
+++ b/crates/goose/src/model_config.rs
@@ -59,23 +59,40 @@ fn materialize_model_config_inner(
     Ok(model)
 }
 
-pub fn configured_fast_model_name(default_model: &str) -> String {
+fn configured_fast_model_name() -> Option<String> {
     Config::global()
         .get_param::<String>("GOOSE_FAST_MODEL")
         .ok()
         .map(|v| v.trim().to_string())
         .filter(|v| !v.is_empty())
-        .unwrap_or_else(|| default_model.to_string())
 }
 
-pub fn with_configured_fast_model(
-    model: ModelConfig,
+/// Resolve the model config to use for lightweight "fast" tasks (session
+/// naming, compaction, summarization). Resolution order:
+///   1. `GOOSE_FAST_MODEL` (user override)
+///   2. the provider's declared default fast model
+///   3. the supplied `model_config` (i.e. the main model)
+///
+/// The resulting config is materialized against the same provider so it picks
+/// up context limits, temperature, and other provider defaults.
+pub async fn get_fast_model(
     provider_name: &str,
-    default_fast_model_name: &str,
+    model_config: &ModelConfig,
 ) -> Result<ModelConfig> {
-    let fast_model_name = configured_fast_model_name(default_fast_model_name);
-    let fast_model_config = model_config_from_user_config(provider_name, fast_model_name)?;
-    Ok(model.with_fast_model_config(fast_model_config))
+    let fast_model_name = match configured_fast_model_name() {
+        Some(name) => Some(name),
+        None => crate::providers::get_from_registry(provider_name)
+            .await
+            .ok()
+            .and_then(|entry| entry.metadata().fast_model.clone()),
+    };
+
+    match fast_model_name {
+        Some(name) if name != model_config.model_name => {
+            model_config_from_user_config(provider_name, name)
+        }
+        _ => Ok(model_config.clone()),
+    }
 }
 
 fn base_model_config_from_user_config(model_name: &str) -> Result<ModelConfig> {
@@ -87,7 +104,6 @@ fn base_model_config_from_user_config(model_name: &str) -> Result<ModelConfig> {
         max_tokens: None,
         toolshim: get_goose_toolshim(config)?.unwrap_or(false),
         toolshim_model: get_goose_toolshim_model(config)?,
-        fast_model_config: None,
         request_params: None,
         reasoning: None,
     };

--- a/crates/goose/src/model_config.rs
+++ b/crates/goose/src/model_config.rs
@@ -1,6 +1,11 @@
 use crate::config::{Config, ConfigError};
+use crate::conversation::message::Message;
+use crate::providers::base::Provider;
 use anyhow::{anyhow, Result};
+use goose_providers::conversation::token_usage::ProviderUsage;
+use goose_providers::errors::ProviderError;
 use goose_providers::model::ModelConfig;
+use rmcp::model::Tool;
 use serde_json::Value;
 use std::collections::HashMap;
 
@@ -92,6 +97,41 @@ pub async fn get_fast_model(
             model_config_from_user_config(provider_name, name)
         }
         _ => Ok(model_config.clone()),
+    }
+}
+
+/// Run a completion for a lightweight "fast" task (session naming, compaction,
+/// summarization) using the provider's fast model, falling back to the supplied
+/// main `model_config` if the fast model errors.
+pub async fn complete_fast(
+    provider: &dyn Provider,
+    model_config: &ModelConfig,
+    session_id: &str,
+    system: &str,
+    messages: &[Message],
+    tools: &[Tool],
+) -> Result<(Message, ProviderUsage), ProviderError> {
+    let fast_model_config = get_fast_model(provider.get_name(), model_config)
+        .await
+        .map_err(|e| ProviderError::ExecutionError(e.to_string()))?;
+
+    match provider
+        .complete(&fast_model_config, session_id, system, messages, tools)
+        .await
+    {
+        Ok(response) => Ok(response),
+        Err(e) if fast_model_config.model_name != model_config.model_name => {
+            tracing::warn!(
+                "Fast model {} failed with error: {}. Falling back to main model {}",
+                fast_model_config.model_name,
+                e,
+                model_config.model_name
+            );
+            provider
+                .complete(model_config, session_id, system, messages, tools)
+                .await
+        }
+        Err(e) => Err(e),
     }
 }
 

--- a/crates/goose/src/model_config.rs
+++ b/crates/goose/src/model_config.rs
@@ -86,10 +86,7 @@ pub async fn get_fast_model(
 ) -> Result<ModelConfig> {
     let fast_model_name = match configured_fast_model_name() {
         Some(name) => Some(name),
-        None => crate::providers::get_from_registry(provider_name)
-            .await
-            .ok()
-            .and_then(|entry| entry.metadata().fast_model.clone()),
+        None => provider_default_fast_model(provider_name).await,
     };
 
     match fast_model_name {
@@ -133,6 +130,17 @@ pub async fn complete_fast(
         }
         Err(e) => Err(e),
     }
+}
+
+async fn provider_default_fast_model(provider_name: &str) -> Option<String> {
+    if provider_name == goose_providers::openai::OPEN_AI_PROVIDER_NAME {
+        return crate::providers::openai_def::live_fast_model();
+    }
+
+    crate::providers::get_from_registry(provider_name)
+        .await
+        .ok()
+        .and_then(|entry| entry.metadata().fast_model.clone())
 }
 
 fn base_model_config_from_user_config(model_name: &str) -> Result<ModelConfig> {

--- a/crates/goose/src/model_config.rs
+++ b/crates/goose/src/model_config.rs
@@ -114,6 +114,14 @@ fn get_goose_toolshim(config: &Config) -> Result<Option<bool>> {
     }
 }
 
+/// Resolve the global toolshim setting, defaulting to false when unset.
+pub fn global_toolshim() -> bool {
+    get_goose_toolshim(Config::global())
+        .ok()
+        .flatten()
+        .unwrap_or(false)
+}
+
 fn get_goose_toolshim_model(config: &Config) -> Result<Option<String>> {
     match config.get_param::<String>("GOOSE_TOOLSHIM_OLLAMA_MODEL") {
         Ok(value) if value.trim().is_empty() => Err(anyhow!(

--- a/crates/goose/src/permission/permission_inspector.rs
+++ b/crates/goose/src/permission/permission_inspector.rs
@@ -15,14 +15,20 @@ use std::sync::{Arc, RwLock};
 pub struct PermissionInspector {
     pub permission_manager: Arc<PermissionManager>,
     provider: SharedProvider,
+    session_manager: Arc<crate::session::SessionManager>,
     readonly_tools: RwLock<HashSet<String>>,
 }
 
 impl PermissionInspector {
-    pub fn new(permission_manager: Arc<PermissionManager>, provider: SharedProvider) -> Self {
+    pub fn new(
+        permission_manager: Arc<PermissionManager>,
+        provider: SharedProvider,
+        session_manager: Arc<crate::session::SessionManager>,
+    ) -> Self {
         Self {
             permission_manager,
             provider,
+            session_manager,
             readonly_tools: RwLock::new(HashSet::new()),
         }
     }
@@ -212,12 +218,15 @@ impl ToolInspector for PermissionInspector {
         // LLM-based read-only detection for deferred SmartApprove candidates
         if !llm_detect_candidates.is_empty() {
             let detected: HashSet<String> = match self.provider.lock().await.clone() {
-                Some(provider) => {
-                    detect_read_only_tools(provider, session_id, llm_detect_candidates.to_vec())
-                        .await
-                        .into_iter()
-                        .collect()
-                }
+                Some(provider) => detect_read_only_tools(
+                    provider,
+                    &self.session_manager,
+                    session_id,
+                    llm_detect_candidates.to_vec(),
+                )
+                .await
+                .into_iter()
+                .collect(),
                 None => Default::default(),
             };
 
@@ -288,7 +297,10 @@ mod tests {
         if let Some(level) = cache {
             pm.update_smart_approve_permission("tool", level);
         }
-        let inspector = PermissionInspector::new(pm, Arc::new(Mutex::new(None)));
+        let session_manager = Arc::new(crate::session::SessionManager::new(
+            tempfile::tempdir().unwrap().keep(),
+        ));
+        let inspector = PermissionInspector::new(pm, Arc::new(Mutex::new(None)), session_manager);
         if smart_approved {
             *inspector.readonly_tools.write().unwrap() = ["tool".to_string()].into_iter().collect();
         }

--- a/crates/goose/src/permission/permission_judge.rs
+++ b/crates/goose/src/permission/permission_judge.rs
@@ -11,13 +11,11 @@ use serde_json::Value;
 use std::sync::Arc;
 
 async fn resolve_model_config(
+    session_manager: &crate::session::SessionManager,
     session_id: &str,
 ) -> anyhow::Result<goose_providers::model::ModelConfig> {
     if !session_id.is_empty() {
-        if let Ok(session) = crate::session::SessionManager::instance()
-            .get_session(session_id, false)
-            .await
-        {
+        if let Ok(session) = session_manager.get_session(session_id, false).await {
             if let Some(model_config) = session.model_config {
                 return Ok(model_config);
             }
@@ -145,6 +143,7 @@ fn extract_read_only_tools(response: &Message) -> Option<Vec<String>> {
 /// Executes the read-only tools detection and returns the list of tools with read-only operations.
 pub async fn detect_read_only_tools(
     provider: Arc<dyn Provider>,
+    session_manager: &crate::session::SessionManager,
     session_id: &str,
     tool_requests: Vec<&ToolRequest>,
 ) -> Vec<String> {
@@ -158,7 +157,7 @@ pub async fn detect_read_only_tools(
     let system_prompt = render_template("permission_judge.md", &context)
         .unwrap_or_else(|_| "You are a good analyst and can detect operations whether they have read-only operations.".to_string());
 
-    let model_config = match resolve_model_config(session_id).await {
+    let model_config = match resolve_model_config(session_manager, session_id).await {
         Ok(config) => config,
         Err(e) => {
             tracing::warn!("Could not resolve model config for permission judge: {e}");

--- a/crates/goose/src/permission/permission_judge.rs
+++ b/crates/goose/src/permission/permission_judge.rs
@@ -10,7 +10,20 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::sync::Arc;
 
-fn resolve_model_config() -> anyhow::Result<goose_providers::model::ModelConfig> {
+async fn resolve_model_config(
+    session_id: &str,
+) -> anyhow::Result<goose_providers::model::ModelConfig> {
+    if !session_id.is_empty() {
+        if let Ok(session) = crate::session::SessionManager::instance()
+            .get_session(session_id, false)
+            .await
+        {
+            if let Some(model_config) = session.model_config {
+                return Ok(model_config);
+            }
+        }
+    }
+
     let config = crate::config::Config::global();
     let provider_name = config
         .get_goose_provider()
@@ -145,7 +158,7 @@ pub async fn detect_read_only_tools(
     let system_prompt = render_template("permission_judge.md", &context)
         .unwrap_or_else(|_| "You are a good analyst and can detect operations whether they have read-only operations.".to_string());
 
-    let model_config = match resolve_model_config() {
+    let model_config = match resolve_model_config(session_id).await {
         Ok(config) => config,
         Err(e) => {
             tracing::warn!("Could not resolve model config for permission judge: {e}");

--- a/crates/goose/src/permission/permission_judge.rs
+++ b/crates/goose/src/permission/permission_judge.rs
@@ -10,6 +10,17 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::sync::Arc;
 
+fn resolve_model_config() -> anyhow::Result<goose_providers::model::ModelConfig> {
+    let config = crate::config::Config::global();
+    let provider_name = config
+        .get_goose_provider()
+        .map_err(|_| anyhow::anyhow!("missing provider"))?;
+    let model_name = config
+        .get_goose_model()
+        .map_err(|_| anyhow::anyhow!("missing model"))?;
+    crate::model_config::model_config_from_user_config(&provider_name, &model_name)
+}
+
 #[derive(Serialize)]
 struct PermissionJudgeContext {
     // Empty struct for now since the current template doesn't need variables
@@ -134,7 +145,13 @@ pub async fn detect_read_only_tools(
     let system_prompt = render_template("permission_judge.md", &context)
         .unwrap_or_else(|_| "You are a good analyst and can detect operations whether they have read-only operations.".to_string());
 
-    let model_config = provider.get_model_config();
+    let model_config = match resolve_model_config() {
+        Ok(config) => config,
+        Err(e) => {
+            tracing::warn!("Could not resolve model config for permission judge: {e}");
+            return vec![];
+        }
+    };
     let res = provider
         .complete(
             &model_config,

--- a/crates/goose/src/providers/amp_acp.rs
+++ b/crates/goose/src/providers/amp_acp.rs
@@ -11,7 +11,6 @@ use crate::config::{Config, GooseMode};
 use crate::providers::base::{
     current_working_dir, ProviderDef, ProviderDescriptor, ProviderMetadata,
 };
-use goose_providers::model::ModelConfig;
 
 pub(crate) const AMP_ACP_PROVIDER_NAME: &str = "amp-acp";
 const AMP_ACP_DOC_URL: &str = "https://ampcode.com";
@@ -45,15 +44,13 @@ impl ProviderDef for AmpAcpProvider {
     type Provider = AcpProvider;
 
     fn from_env(
-        model: ModelConfig,
         extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<AcpProvider>> {
-        Self::from_env_with_working_dir(model, extensions, current_working_dir(), tls_config)
+        Self::from_env_with_working_dir(extensions, current_working_dir(), tls_config)
     }
 
     fn from_env_with_working_dir(
-        model: ModelConfig,
         extensions: Vec<crate::config::ExtensionConfig>,
         working_dir: PathBuf,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
@@ -85,7 +82,7 @@ impl ProviderDef for AmpAcpProvider {
             };
 
             let metadata = Self::metadata();
-            AcpProvider::connect(metadata.name, model, goose_mode, provider_config).await
+            AcpProvider::connect(metadata.name, goose_mode, provider_config).await
         })
     }
 }

--- a/crates/goose/src/providers/amp_acp.rs
+++ b/crates/goose/src/providers/amp_acp.rs
@@ -78,6 +78,7 @@ impl ProviderDef for AmpAcpProvider {
                 mcp_servers: extension_configs_to_mcp_servers(&extensions),
                 session_mode_id: Some(mode_mapping[&goose_mode].clone()),
                 session_config_options: vec![],
+                model_config_option_id: None,
                 mode_mapping,
                 notification_callback: None,
             };

--- a/crates/goose/src/providers/amp_acp.rs
+++ b/crates/goose/src/providers/amp_acp.rs
@@ -77,6 +77,7 @@ impl ProviderDef for AmpAcpProvider {
                 work_dir: working_dir,
                 mcp_servers: extension_configs_to_mcp_servers(&extensions),
                 session_mode_id: Some(mode_mapping[&goose_mode].clone()),
+                session_config_options: vec![],
                 mode_mapping,
                 notification_callback: None,
             };

--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -290,10 +290,6 @@ impl Provider for AnthropicProvider {
         self.skip_canonical_filtering
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.model.clone()
-    }
-
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         if let Some(custom_models) = &self.custom_models {
             if self.dynamic_models == Some(false) {

--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -63,7 +63,6 @@ pub struct AnthropicProvider {
 
 impl AnthropicProvider {
     pub async fn from_env(
-        _model: ModelConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -92,7 +91,6 @@ impl AnthropicProvider {
     }
 
     pub fn from_custom_config(
-        _model: ModelConfig,
         config: DeclarativeProviderConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
@@ -243,11 +241,10 @@ impl ProviderDef for AnthropicProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
-        Box::pin(Self::from_env(model, tls_config))
+        Box::pin(Self::from_env(tls_config))
     }
 }
 
@@ -414,13 +411,9 @@ mod tests {
     #[test]
     fn from_custom_config_rejects_static_only_without_models() {
         let config = base_declarative_config(vec![], Some(false));
-        let err = AnthropicProvider::from_custom_config(
-            ModelConfig::new_or_fail("claude-test"),
-            config,
-            None,
-        )
-        .err()
-        .expect("expected construction error for dynamic_models: false with empty models");
+        let err = AnthropicProvider::from_custom_config(config, None)
+            .err()
+            .expect("expected construction error for dynamic_models: false with empty models");
         let msg = err.to_string();
         assert!(
             msg.contains("dynamic_models: false"),

--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -53,7 +53,6 @@ const ANTHROPIC_API_VERSION: &str = "2023-06-01";
 pub struct AnthropicProvider {
     #[serde(skip)]
     api_client: ApiClient,
-    model: ModelConfig,
     supports_streaming: bool,
     name: String,
     custom_models: Option<Vec<String>>,
@@ -90,7 +89,6 @@ impl AnthropicProvider {
 
         Ok(Self {
             api_client,
-            model,
             supports_streaming: true,
             name: ANTHROPIC_PROVIDER_NAME.to_string(),
             custom_models: None,
@@ -167,7 +165,6 @@ impl AnthropicProvider {
 
         Ok(Self {
             api_client,
-            model,
             supports_streaming,
             name: config.name.clone(),
             custom_models,
@@ -182,19 +179,6 @@ impl AnthropicProvider {
             preserve_unsigned_thinking: preserves_thinking,
             preserve_thinking_context: preserves_thinking,
         }
-    }
-
-    fn get_conditional_headers(&self) -> Vec<(&str, &str)> {
-        let mut headers = Vec::new();
-
-        if self.model.model_name.starts_with("claude-3-7-sonnet-") {
-            if thinking_type(&self.model) == ThinkingType::Enabled {
-                headers.push(("anthropic-beta", "output-128k-2025-02-19"));
-            }
-            headers.push(("anthropic-beta", "token-efficient-tools-2025-02-19"));
-        }
-
-        headers
     }
 
     async fn fetch_models_from_api(&self) -> Result<Vec<String>, ProviderError> {
@@ -333,15 +317,11 @@ impl Provider for AnthropicProvider {
             .unwrap()
             .insert("stream".to_string(), Value::Bool(true));
 
-        let conditional_headers = self.get_conditional_headers();
         let mut log = start_log(model_config, &payload)?;
 
         let response = self
             .with_retry(|| async {
-                let mut request = self.api_client.request(Some(session_id), "v1/messages");
-                for (key, value) in &conditional_headers {
-                    request = request.header(key, value)?;
-                }
+                let request = self.api_client.request(Some(session_id), "v1/messages");
                 let resp = request.response_post(&payload).await?;
                 handle_status(resp).await
             })
@@ -389,7 +369,6 @@ mod tests {
             .unwrap();
         AnthropicProvider {
             api_client,
-            model: ModelConfig::new_or_fail("claude-test"),
             supports_streaming: true,
             name: "custom_anthropic".to_string(),
             custom_models,

--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -47,6 +47,7 @@ const ANTHROPIC_KNOWN_MODELS: &[&str] = &[
 
 const ANTHROPIC_DOC_URL: &str = "https://docs.anthropic.com/en/docs/about-claude/models";
 const ANTHROPIC_API_VERSION: &str = "2023-06-01";
+const ANTHROPIC_DEFAULT_FAST_MODEL: &str = "claude-haiku-4-5";
 
 #[derive(serde::Serialize)]
 pub struct AnthropicProvider {
@@ -234,6 +235,7 @@ impl ProviderDescriptor for AnthropicProvider {
             "Click 'Create Key'",
             "Copy the key and paste it above",
         ])
+        .with_fast_model(ANTHROPIC_DEFAULT_FAST_MODEL)
     }
 }
 

--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -14,8 +14,8 @@ use tokio_util::io::StreamReader;
 use super::api_client::{ApiClient, AuthMethod};
 use super::base::{ConfigKey, MessageStream, ModelInfo, Provider, ProviderDef, ProviderMetadata};
 use super::formats::anthropic::{
-    create_request_with_options_for_provider, response_to_streaming_message, thinking_type,
-    AnthropicFormatOptions, ThinkingType, ANTHROPIC_PROVIDER_NAME,
+    create_request_with_options_for_provider, response_to_streaming_message,
+    AnthropicFormatOptions, ANTHROPIC_PROVIDER_NAME,
 };
 use super::openai_compatible::handle_status;
 use super::openai_compatible::map_http_error_to_provider_error;
@@ -27,7 +27,6 @@ use goose_providers::model::ModelConfig;
 use rmcp::model::Tool;
 
 pub const ANTHROPIC_DEFAULT_MODEL: &str = "claude-sonnet-4-5";
-const ANTHROPIC_DEFAULT_FAST_MODEL: &str = "claude-haiku-4-5";
 const ANTHROPIC_KNOWN_MODELS: &[&str] = &[
     // Claude 4.6 models
     "claude-opus-4-6",
@@ -64,15 +63,9 @@ pub struct AnthropicProvider {
 
 impl AnthropicProvider {
     pub async fn from_env(
-        model: ModelConfig,
+        _model: ModelConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
-        let model = crate::model_config::with_configured_fast_model(
-            model,
-            ANTHROPIC_PROVIDER_NAME,
-            ANTHROPIC_DEFAULT_FAST_MODEL,
-        )?;
-
         let config = crate::config::Config::global();
         let api_key: String = config.get_secret("ANTHROPIC_API_KEY")?;
         let host: String = config
@@ -99,7 +92,7 @@ impl AnthropicProvider {
     }
 
     pub fn from_custom_config(
-        model: ModelConfig,
+        _model: ModelConfig,
         config: DeclarativeProviderConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
@@ -156,12 +149,6 @@ impl AnthropicProvider {
                 Please remove 'supports_streaming: false' from your provider configuration."
             ));
         }
-
-        let model = if let Some(ref fast_model_name) = config.fast_model {
-            crate::model_config::with_configured_fast_model(model, &config.name, fast_model_name)?
-        } else {
-            model
-        };
 
         Ok(Self {
             api_client,

--- a/crates/goose/src/providers/avian.rs
+++ b/crates/goose/src/providers/avian.rs
@@ -3,7 +3,6 @@ use super::base::{ConfigKey, ProviderDef, ProviderMetadata};
 use super::openai_compatible::OpenAiCompatibleProvider;
 use anyhow::Result;
 use futures::future::BoxFuture;
-use goose_providers::model::ModelConfig;
 
 const AVIAN_PROVIDER_NAME: &str = "avian";
 pub const AVIAN_API_HOST: &str = "https://api.avian.io/v1";
@@ -39,7 +38,6 @@ impl ProviderDef for AvianProvider {
     type Provider = OpenAiCompatibleProvider;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<OpenAiCompatibleProvider>> {
@@ -56,7 +54,6 @@ impl ProviderDef for AvianProvider {
             Ok(OpenAiCompatibleProvider::new(
                 AVIAN_PROVIDER_NAME.to_string(),
                 api_client,
-                model,
                 String::new(),
             ))
         })

--- a/crates/goose/src/providers/azure.rs
+++ b/crates/goose/src/providers/azure.rs
@@ -6,7 +6,6 @@ use super::azureauth::{AuthError, AzureAuth};
 use super::base::{ConfigKey, ProviderDef, ProviderMetadata};
 use super::openai_compatible::OpenAiCompatibleProvider;
 use futures::future::BoxFuture;
-use goose_providers::model::ModelConfig;
 
 const AZURE_PROVIDER_NAME: &str = "azure_openai";
 pub const AZURE_DEFAULT_MODEL: &str = "gpt-4o";
@@ -74,7 +73,6 @@ impl ProviderDef for AzureProvider {
     type Provider = OpenAiCompatibleProvider;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
@@ -120,7 +118,6 @@ impl ProviderDef for AzureProvider {
             Ok(OpenAiCompatibleProvider::new(
                 AZURE_PROVIDER_NAME.to_string(),
                 api_client,
-                model,
                 format!("deployments/{}/", deployment_name),
             ))
         })

--- a/crates/goose/src/providers/base.rs
+++ b/crates/goose/src/providers/base.rs
@@ -9,7 +9,6 @@ use serde::{Deserialize, Serialize};
 pub const DEFAULT_PROVIDER_TIMEOUT_SECS: u64 = 600;
 
 use crate::config::ExtensionConfig;
-use goose_providers::model::ModelConfig;
 use utoipa::ToSchema;
 
 use std::path::PathBuf;
@@ -32,7 +31,6 @@ pub trait ProviderDef: ProviderDescriptor + Send + Sync {
     type Provider: Provider + 'static;
 
     fn from_env(
-        model: ModelConfig,
         extensions: Vec<ExtensionConfig>,
         tls_config: Option<TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>>
@@ -40,7 +38,6 @@ pub trait ProviderDef: ProviderDescriptor + Send + Sync {
         Self: Sized;
 
     fn from_env_with_working_dir(
-        model: ModelConfig,
         extensions: Vec<ExtensionConfig>,
         _working_dir: PathBuf,
         tls_config: Option<TlsConfig>,
@@ -48,6 +45,6 @@ pub trait ProviderDef: ProviderDescriptor + Send + Sync {
     where
         Self: Sized,
     {
-        Self::from_env(model, extensions, tls_config)
+        Self::from_env(extensions, tls_config)
     }
 }

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -934,7 +934,6 @@ mod tests {
                 max_tokens: None,
                 toolshim: false,
                 toolshim_model: None,
-                fast_model_config: None,
                 request_params: None,
                 reasoning: None,
             },

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -731,10 +731,6 @@ impl Provider for BedrockProvider {
         self.retry_config.clone()
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.model.clone()
-    }
-
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         Ok(BEDROCK_KNOWN_MODELS.iter().map(|s| s.to_string()).collect())
     }

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -55,7 +55,6 @@ pub const BEDROCK_DEFAULT_MAX_RETRY_INTERVAL_MS: u64 = 120_000;
 pub struct BedrockProvider {
     #[serde(skip)]
     client: Client,
-    model: ModelConfig,
     #[serde(skip)]
     retry_config: RetryConfig,
     #[serde(skip)]
@@ -80,7 +79,7 @@ struct ConverseRequestParts {
 
 impl BedrockProvider {
     pub async fn from_env(
-        model: ModelConfig,
+        _model: ModelConfig,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -173,7 +172,6 @@ impl BedrockProvider {
 
         Ok(Self {
             client,
-            model,
             retry_config,
             name: BEDROCK_PROVIDER_NAME.to_string(),
             region: resolved_region,
@@ -224,13 +222,13 @@ impl BedrockProvider {
         )
     }
 
-    fn should_enable_caching(&self) -> bool {
+    fn should_enable_caching(&self, model: &ModelConfig) -> bool {
         let config = crate::config::Config::global();
 
         let enabled = config
             .get_param::<bool>("BEDROCK_ENABLE_CACHING")
             .unwrap_or(false);
-        enabled && self.model.model_name.contains("anthropic.claude")
+        enabled && model.model_name.contains("anthropic.claude")
     }
 
     async fn post_mantle_streaming(
@@ -285,11 +283,12 @@ impl BedrockProvider {
     /// the tool configuration.
     fn build_request_parts(
         &self,
+        model: &ModelConfig,
         system: &str,
         messages: &[Message],
         tools: &[Tool],
     ) -> Result<ConverseRequestParts, ProviderError> {
-        let enable_caching = self.should_enable_caching();
+        let enable_caching = self.should_enable_caching(model);
 
         let system_blocks = if enable_caching {
             vec![
@@ -332,26 +331,25 @@ impl BedrockProvider {
             system_blocks,
             messages: bedrock_messages,
             tool_config,
-            thinking_fields: bedrock_anthropic_thinking_fields(&self.model),
+            thinking_fields: bedrock_anthropic_thinking_fields(model),
         })
     }
 
     async fn converse(
         &self,
+        model: &ModelConfig,
         session_id: Option<&str>,
         system: &str,
         messages: &[Message],
         tools: &[Tool],
     ) -> Result<(bedrock::Message, Option<bedrock::TokenUsage>), ProviderError> {
-        let model_name = &self.model.model_name;
-
-        let parts = self.build_request_parts(system, messages, tools)?;
+        let parts = self.build_request_parts(model, system, messages, tools)?;
 
         let mut request = self
             .client
             .converse()
             .set_system(Some(parts.system_blocks))
-            .model_id(model_name.to_string())
+            .model_id(&model.model_name)
             .set_messages(Some(parts.messages));
 
         if let Some(fields) = parts.thinking_fields {
@@ -431,6 +429,7 @@ impl BedrockProvider {
     /// receiver so [`Provider::stream`] can forward deltas incrementally.
     async fn converse_stream(
         &self,
+        model: &ModelConfig,
         session_id: Option<&str>,
         system: &str,
         messages: &[Message],
@@ -439,15 +438,13 @@ impl BedrockProvider {
         aws_sdk_bedrockruntime::operation::converse_stream::ConverseStreamOutput,
         ProviderError,
     > {
-        let model_name = &self.model.model_name;
-
-        let parts = self.build_request_parts(system, messages, tools)?;
+        let parts = self.build_request_parts(model, system, messages, tools)?;
 
         let mut request = self
             .client
             .converse_stream()
             .set_system(Some(parts.system_blocks))
-            .model_id(model_name.to_string())
+            .model_id(&model.model_name)
             .set_messages(Some(parts.messages));
 
         if let Some(fields) = parts.thinking_fields {
@@ -506,6 +503,7 @@ impl BedrockProvider {
     /// escape hatch.
     async fn stream_via_converse(
         &self,
+        model: &ModelConfig,
         session_id: Option<&str>,
         system: &str,
         messages: &[Message],
@@ -513,7 +511,7 @@ impl BedrockProvider {
         model_name: &str,
     ) -> Result<MessageStream, ProviderError> {
         let (bedrock_message, bedrock_usage) = self
-            .with_retry(|| self.converse(session_id, system, messages, tools))
+            .with_retry(|| self.converse(model, session_id, system, messages, tools))
             .await?;
 
         let usage = bedrock_usage
@@ -529,7 +527,7 @@ impl BedrockProvider {
             "messages": messages,
             "tools": tools
         });
-        let mut log = start_log(&self.model, &debug_payload)?;
+        let mut log = start_log(model, &debug_payload)?;
         log.write(
             &serde_json::to_value(&message).unwrap_or_default(),
             Some(&usage),
@@ -794,7 +792,14 @@ impl Provider for BedrockProvider {
         // Escape hatch: restore the previous blocking-Converse behaviour.
         if self.streaming_disabled() {
             return self
-                .stream_via_converse(session_id_opt, system, messages, tools, &model_name)
+                .stream_via_converse(
+                    model_config,
+                    session_id_opt,
+                    system,
+                    messages,
+                    tools,
+                    &model_name,
+                )
                 .await;
         }
 
@@ -802,7 +807,9 @@ impl Provider for BedrockProvider {
         // setup only — mid-stream errors are surfaced, not retried (matching
         // the Anthropic provider's behaviour).
         let response = self
-            .with_retry(|| self.converse_stream(session_id_opt, system, messages, tools))
+            .with_retry(|| {
+                self.converse_stream(model_config, session_id_opt, system, messages, tools)
+            })
             .await?;
 
         // Debug trace with input context; the streamed text is written once
@@ -812,7 +819,7 @@ impl Provider for BedrockProvider {
             "messages": messages,
             "tools": tools
         });
-        let mut log = start_log(&self.model, &debug_payload)?;
+        let mut log = start_log(&model_config, &debug_payload)?;
 
         let mut event_stream = response.stream;
 
@@ -905,16 +912,24 @@ mod tests {
     use goose_providers::base::ProviderDescriptor as _;
     use serial_test::serial;
 
-    fn create_mock_provider(model_name: &str) -> BedrockProvider {
+    fn create_mock_provider_and_model(model_name: &str) -> (BedrockProvider, ModelConfig) {
         let sdk_config = aws_config::SdkConfig::builder()
             .behavior_version(aws_config::BehaviorVersion::latest())
             .region(aws_config::Region::new("us-east-1"))
             .build();
         let client = Client::new(&sdk_config);
 
-        BedrockProvider {
-            client,
-            model: ModelConfig {
+        (
+            BedrockProvider {
+                client,
+                retry_config: RetryConfig::default(),
+                name: "aws_bedrock".to_string(),
+                region: None,
+                bearer_token: None,
+                http_client: reqwest::Client::new(),
+                mantle_base_url: None,
+            },
+            ModelConfig {
                 model_name: model_name.to_string(),
                 context_limit: None,
                 temperature: None,
@@ -925,13 +940,7 @@ mod tests {
                 request_params: None,
                 reasoning: None,
             },
-            retry_config: RetryConfig::default(),
-            name: "aws_bedrock".to_string(),
-            region: None,
-            bearer_token: None,
-            http_client: reqwest::Client::new(),
-            mantle_base_url: None,
-        }
+        )
     }
 
     #[test]
@@ -997,23 +1006,10 @@ mod tests {
     }
 
     #[test]
-    #[serial]
-    fn test_caching_disabled_by_default() {
-        // Ensure clean environment
-        std::env::remove_var("BEDROCK_ENABLE_CACHING");
-
-        let provider = create_mock_provider("us.anthropic.claude-sonnet-4-5-20250929-v1:0");
-        assert!(
-            !provider.should_enable_caching(),
-            "Caching should be disabled by default"
-        );
-    }
-
-    #[test]
     fn test_caching_disabled_for_non_claude_models() {
-        let provider = create_mock_provider("amazon.titan-text-express-v1");
+        let (provider, model) = create_mock_provider_and_model("amazon.titan-text-express-v1");
         assert!(
-            !provider.should_enable_caching(),
+            !provider.should_enable_caching(&model),
             "Caching should be disabled for non-Claude models"
         );
     }
@@ -1023,9 +1019,10 @@ mod tests {
     fn test_caching_enabled_for_claude_model() {
         std::env::set_var("BEDROCK_ENABLE_CACHING", "true");
 
-        let provider = create_mock_provider("us.anthropic.claude-sonnet-4-5-20250929-v1:0");
+        let (provider, model) =
+            create_mock_provider_and_model("us.anthropic.claude-sonnet-4-5-20250929-v1:0");
         assert!(
-            provider.should_enable_caching(),
+            provider.should_enable_caching(&model),
             "Caching should be enabled for Claude models when BEDROCK_ENABLE_CACHING=true"
         );
 
@@ -1034,7 +1031,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_post_mantle_streaming_missing_region() {
-        let provider = create_mock_provider("openai.gpt-5.5");
+        let (provider, _) = create_mock_provider_and_model("openai.gpt-5.5");
         let payload = serde_json::json!({"model": "openai.gpt-5.5"});
         let result = provider.post_mantle_streaming(None, &payload).await;
         assert!(result.is_err());
@@ -1051,7 +1048,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_post_mantle_streaming_missing_bearer_token() {
-        let mut provider = create_mock_provider("openai.gpt-5.5");
+        let (mut provider, _) = create_mock_provider_and_model("openai.gpt-5.5");
         provider.region = Some("us-east-1".to_string());
 
         let payload = serde_json::json!({"model": "openai.gpt-5.5"});
@@ -1095,9 +1092,9 @@ mod tests {
             .region(aws_config::Region::new("us-east-1"))
             .build();
 
+        let model = ModelConfig::new("openai.gpt-5.5").unwrap();
         let provider = BedrockProvider {
             client: Client::new(&sdk_config),
-            model: ModelConfig::new("openai.gpt-5.5").unwrap(),
             retry_config: RetryConfig::default(),
             name: "aws_bedrock".to_string(),
             region: Some("us-east-1".to_string()),
@@ -1108,7 +1105,7 @@ mod tests {
 
         let messages = vec![crate::conversation::message::Message::user().with_text("hi")];
         let mut stream = provider
-            .stream(&provider.model.clone(), "", "", &messages, &[])
+            .stream(&model.clone(), "", "", &messages, &[])
             .await
             .unwrap();
 

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -1090,7 +1090,7 @@ mod tests {
             .region(aws_config::Region::new("us-east-1"))
             .build();
 
-        let model = ModelConfig::new("openai.gpt-5.5").unwrap();
+        let model = ModelConfig::new("openai.gpt-5.5");
         let provider = BedrockProvider {
             client: Client::new(&sdk_config),
             retry_config: RetryConfig::default(),

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -79,7 +79,6 @@ struct ConverseRequestParts {
 
 impl BedrockProvider {
     pub async fn from_env(
-        _model: ModelConfig,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -711,11 +710,10 @@ impl ProviderDef for BedrockProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
-        Box::pin(Self::from_env(model, tls_config))
+        Box::pin(Self::from_env(tls_config))
     }
 }
 
@@ -819,7 +817,7 @@ impl Provider for BedrockProvider {
             "messages": messages,
             "tools": tools
         });
-        let mut log = start_log(&model_config, &debug_payload)?;
+        let mut log = start_log(model_config, &debug_payload)?;
 
         let mut event_stream = response.stream;
 

--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -1206,7 +1206,7 @@ mod tests {
     fn test_create_codex_request_reasoning_effort_from_unified_thinking() {
         let mut params = std::collections::HashMap::new();
         params.insert("thinking_effort".to_string(), json!("max"));
-        let mut config = ModelConfig::new("gpt-5.3-codex").unwrap();
+        let mut config = ModelConfig::new("gpt-5.3-codex");
         config.request_params = Some(params);
 
         let payload = create_codex_request(&config, "sys", &[], &[]).unwrap();
@@ -1218,7 +1218,7 @@ mod tests {
     fn test_create_codex_request_caps_unified_thinking_to_supported_level() {
         let mut params = std::collections::HashMap::new();
         params.insert("thinking_effort".to_string(), json!("max"));
-        let mut config = ModelConfig::new("unknown-model").unwrap();
+        let mut config = ModelConfig::new("unknown-model");
         config.request_params = Some(params);
 
         let payload = create_codex_request(&config, "sys", &[], &[]).unwrap();
@@ -1230,7 +1230,7 @@ mod tests {
     fn test_create_codex_request_off_omits_reasoning_for_codex_models() {
         let mut params = std::collections::HashMap::new();
         params.insert("thinking_effort".to_string(), json!("off"));
-        let mut config = ModelConfig::new("gpt-5.2-codex").unwrap();
+        let mut config = ModelConfig::new("gpt-5.2-codex");
         config.request_params = Some(params);
 
         let payload = create_codex_request(&config, "sys", &[], &[]).unwrap();
@@ -1241,9 +1241,7 @@ mod tests {
     // ChatGPT Codex does not support temperature and will return an error
     #[test]
     fn test_create_codex_request_omits_temperature() {
-        let config = ModelConfig::new("gpt-5.5")
-            .unwrap()
-            .with_temperature(Some(0.2));
+        let config = ModelConfig::new("gpt-5.5").with_temperature(Some(0.2));
 
         let payload = create_codex_request(&config, "sys", &[], &[]).unwrap();
         assert!(payload.get("temperature").is_none());
@@ -1409,7 +1407,7 @@ mod tests {
 
     #[test]
     fn test_gpt53_preamble_injected() {
-        let model = ModelConfig::new("gpt-5.3-codex").unwrap();
+        let model = ModelConfig::new("gpt-5.3-codex");
         let payload = create_codex_request(&model, "system prompt", &[], &[]).unwrap();
         let instructions = payload["instructions"].as_str().unwrap();
         assert!(instructions.contains(GPT_53_CODEX_TOOL_PREAMBLE));
@@ -1418,7 +1416,7 @@ mod tests {
 
     #[test]
     fn test_other_models_no_preamble() {
-        let model = ModelConfig::new("gpt-5.4").unwrap();
+        let model = ModelConfig::new("gpt-5.4");
         let payload = create_codex_request(&model, "system prompt", &[], &[]).unwrap();
         let instructions = payload["instructions"].as_str().unwrap();
         assert_eq!(instructions, "system prompt");

--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -879,7 +879,6 @@ impl AuthProvider for ChatGptCodexAuthProvider {
 pub struct ChatGptCodexProvider {
     #[serde(skip)]
     auth_provider: Arc<ChatGptCodexAuthProvider>,
-    model: ModelConfig,
     #[serde(skip)]
     name: String,
 }
@@ -891,7 +890,6 @@ impl ChatGptCodexProvider {
     }
 
     pub async fn from_env(
-        model: ModelConfig,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let auth_provider = Arc::new(ChatGptCodexAuthProvider::new(
@@ -900,7 +898,6 @@ impl ChatGptCodexProvider {
 
         Ok(Self {
             auth_provider,
-            model,
             name: CHATGPT_CODEX_PROVIDER_NAME.to_string(),
         })
     }
@@ -975,11 +972,10 @@ impl ProviderDef for ChatGptCodexProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
-        Box::pin(Self::from_env(model, tls_config))
+        Box::pin(Self::from_env(tls_config))
     }
 }
 

--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -989,10 +989,6 @@ impl Provider for ChatGptCodexProvider {
         &self.name
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.model.clone()
-    }
-
     async fn stream(
         &self,
         model_config: &ModelConfig,

--- a/crates/goose/src/providers/claude_acp.rs
+++ b/crates/goose/src/providers/claude_acp.rs
@@ -81,6 +81,7 @@ impl ProviderDef for ClaudeAcpProvider {
                 work_dir: working_dir,
                 mcp_servers: extension_configs_to_mcp_servers(&extensions),
                 session_mode_id: Some(mode_mapping[&goose_mode].clone()),
+                session_config_options: vec![],
                 mode_mapping,
                 notification_callback: None,
             };

--- a/crates/goose/src/providers/claude_acp.rs
+++ b/crates/goose/src/providers/claude_acp.rs
@@ -11,7 +11,6 @@ use crate::config::{Config, GooseMode};
 use crate::providers::base::{
     current_working_dir, ProviderDef, ProviderDescriptor, ProviderMetadata,
 };
-use goose_providers::model::ModelConfig;
 
 pub(crate) const CLAUDE_ACP_PROVIDER_NAME: &str = "claude-acp";
 const CLAUDE_ACP_DOC_URL: &str = "https://github.com/agentclientprotocol/claude-agent-acp";
@@ -43,15 +42,13 @@ impl ProviderDef for ClaudeAcpProvider {
     type Provider = AcpProvider;
 
     fn from_env(
-        model: ModelConfig,
         extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<AcpProvider>> {
-        Self::from_env_with_working_dir(model, extensions, current_working_dir(), tls_config)
+        Self::from_env_with_working_dir(extensions, current_working_dir(), tls_config)
     }
 
     fn from_env_with_working_dir(
-        model: ModelConfig,
         extensions: Vec<crate::config::ExtensionConfig>,
         working_dir: PathBuf,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
@@ -89,7 +86,7 @@ impl ProviderDef for ClaudeAcpProvider {
             };
 
             let metadata = Self::metadata();
-            AcpProvider::connect(metadata.name, model, goose_mode, provider_config).await
+            AcpProvider::connect(metadata.name, goose_mode, provider_config).await
         })
     }
 }

--- a/crates/goose/src/providers/claude_acp.rs
+++ b/crates/goose/src/providers/claude_acp.rs
@@ -82,6 +82,7 @@ impl ProviderDef for ClaudeAcpProvider {
                 mcp_servers: extension_configs_to_mcp_servers(&extensions),
                 session_mode_id: Some(mode_mapping[&goose_mode].clone()),
                 session_config_options: vec![],
+                model_config_option_id: None,
                 mode_mapping,
                 notification_callback: None,
             };

--- a/crates/goose/src/providers/claude_code.rs
+++ b/crates/goose/src/providers/claude_code.rs
@@ -1314,7 +1314,7 @@ mod tests {
         provider.cli_process.set(process_arc).unwrap();
 
         let messages = vec![Message::user().with_text("test")];
-        let model = ModelConfig::new_or_fail(CLAUDE_CODE_DEFAULT_MODEL)
+        let model = ModelConfig::new(CLAUDE_CODE_DEFAULT_MODEL)
             .with_canonical_limits(CLAUDE_CODE_PROVIDER_NAME);
         let stream = provider
             .stream(&model, "test-session", "", &messages, &[])
@@ -1524,7 +1524,7 @@ mod tests {
             .insert("stale_1".to_string(), tx);
 
         let messages = vec![Message::user().with_text("test")];
-        let model = ModelConfig::new_or_fail(CLAUDE_CODE_DEFAULT_MODEL)
+        let model = ModelConfig::new(CLAUDE_CODE_DEFAULT_MODEL)
             .with_canonical_limits(CLAUDE_CODE_PROVIDER_NAME);
         let mut stream = provider
             .stream(&model, "test-session", "", &messages, &[])

--- a/crates/goose/src/providers/claude_code.rs
+++ b/crates/goose/src/providers/claude_code.rs
@@ -611,7 +611,6 @@ impl ProviderDef for ClaudeCodeProvider {
     type Provider = Self;
 
     fn from_env(
-        _model: ModelConfig,
         extensions: Vec<ExtensionConfig>,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {

--- a/crates/goose/src/providers/claude_code.rs
+++ b/crates/goose/src/providers/claude_code.rs
@@ -648,10 +648,6 @@ impl Provider for ClaudeCodeProvider {
         true
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.model.clone()
-    }
-
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         // Uses a separate short-lived process because --system-prompt is a CLI-only
         // flag with no NDJSON equivalent. The persistent process needs it at spawn,

--- a/crates/goose/src/providers/claude_code.rs
+++ b/crates/goose/src/providers/claude_code.rs
@@ -259,7 +259,6 @@ impl Drop for CliProcess {
 #[derive(Debug, serde::Serialize)]
 pub struct ClaudeCodeProvider {
     command: PathBuf,
-    model: ModelConfig,
     #[serde(skip)]
     name: String,
     /// Temp file holding MCP config JSON (auto-deleted on drop).
@@ -364,7 +363,11 @@ impl ClaudeCodeProvider {
         }
     }
 
-    async fn spawn_process(&self, filtered_system: &str) -> Result<CliProcess, ProviderError> {
+    async fn spawn_process(
+        &self,
+        model: &ModelConfig,
+        filtered_system: &str,
+    ) -> Result<CliProcess, ProviderError> {
         let mut cmd = self.build_stream_json_command();
 
         if let Some(f) = &self.mcp_config_file {
@@ -376,7 +379,7 @@ impl ClaudeCodeProvider {
             .arg("--system-prompt")
             .arg(filtered_system)
             .arg("--model")
-            .arg(&self.model.model_name);
+            .arg(&model.model_name);
 
         let control_protocol_enabled = Self::apply_permission_flags(&mut cmd)?;
 
@@ -411,7 +414,7 @@ impl ClaudeCodeProvider {
             stdin: Box::new(stdin),
             reader: BufReader::new(Box::new(stdout)),
             stderr_handle,
-            current_model: self.model.model_name.clone(),
+            current_model: model.model_name.clone(),
             log_model_update: false,
             next_request_id: 0,
             needs_drain: false,
@@ -428,12 +431,13 @@ impl ClaudeCodeProvider {
 
     async fn get_or_init_process(
         &self,
+        model_config: &ModelConfig,
         filtered_system: &str,
     ) -> Result<&Arc<tokio::sync::Mutex<CliProcess>>, ProviderError> {
         self.cli_process
             .get_or_try_init(|| async {
                 Ok(Arc::new(tokio::sync::Mutex::new(
-                    self.spawn_process(filtered_system).await?,
+                    self.spawn_process(model_config, filtered_system).await?,
                 )))
             })
             .await
@@ -607,7 +611,7 @@ impl ProviderDef for ClaudeCodeProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
+        _model: ModelConfig,
         extensions: Vec<ExtensionConfig>,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
@@ -627,7 +631,6 @@ impl ProviderDef for ClaudeCodeProvider {
 
             Ok(Self {
                 command: resolved_command,
-                model,
                 name: CLAUDE_CODE_PROVIDER_NAME.to_string(),
                 mcp_config_file,
                 cli_process: tokio::sync::OnceCell::new(),
@@ -726,7 +729,10 @@ impl Provider for ClaudeCodeProvider {
         }
 
         let filtered_system = filter_extensions_from_system_prompt(system);
-        let process_arc = Arc::clone(self.get_or_init_process(&filtered_system).await?);
+        let process_arc = Arc::clone(
+            self.get_or_init_process(model_config, &filtered_system)
+                .await?,
+        );
 
         // Prepare the payload outside the lock — these don't need the process.
         let blocks = self.last_user_content_blocks(messages);
@@ -1271,9 +1277,6 @@ mod tests {
     fn make_provider() -> ClaudeCodeProvider {
         ClaudeCodeProvider {
             command: PathBuf::from("claude"),
-            model: ModelConfig::new(CLAUDE_CODE_DEFAULT_MODEL)
-                .unwrap()
-                .with_canonical_limits(CLAUDE_CODE_PROVIDER_NAME),
             name: "claude-code".to_string(),
             mcp_config_file: None,
             cli_process: tokio::sync::OnceCell::new(),
@@ -1312,8 +1315,10 @@ mod tests {
         provider.cli_process.set(process_arc).unwrap();
 
         let messages = vec![Message::user().with_text("test")];
+        let model = ModelConfig::new_or_fail(CLAUDE_CODE_DEFAULT_MODEL)
+            .with_canonical_limits(CLAUDE_CODE_PROVIDER_NAME);
         let stream = provider
-            .stream(&provider.model, "test-session", "", &messages, &[])
+            .stream(&model, "test-session", "", &messages, &[])
             .await
             .unwrap();
         (provider, stream, stdin_reader)
@@ -1520,8 +1525,10 @@ mod tests {
             .insert("stale_1".to_string(), tx);
 
         let messages = vec![Message::user().with_text("test")];
+        let model = ModelConfig::new_or_fail(CLAUDE_CODE_DEFAULT_MODEL)
+            .with_canonical_limits(CLAUDE_CODE_PROVIDER_NAME);
         let mut stream = provider
-            .stream(&provider.model, "test-session", "", &messages, &[])
+            .stream(&model, "test-session", "", &messages, &[])
             .await
             .unwrap();
 

--- a/crates/goose/src/providers/codex.rs
+++ b/crates/goose/src/providers/codex.rs
@@ -48,8 +48,6 @@ pub struct CodexProvider {
     command: PathBuf,
     #[serde(skip)]
     name: String,
-    /// Reasoning effort level (none, low, medium, high, xhigh)
-    reasoning_effort: Option<String>,
     /// Whether to skip git repo check
     skip_git_check: bool,
     /// CLI config overrides for MCP servers
@@ -137,10 +135,12 @@ impl CodexProvider {
         let (prompt, temp_files) = prepare_input(system, messages, &image_dir)?;
 
         if std::env::var("GOOSE_CODEX_DEBUG").is_ok() {
+            let reasoning_effort =
+                Self::map_thinking_effort(&model.model_name, model.thinking_effort());
             println!("=== CODEX PROVIDER DEBUG ===");
             println!("Command: {:?}", self.command);
             println!("Model: {}", model.model_name);
-            println!("Reasoning effort: {:?}", self.reasoning_effort);
+            println!("Reasoning effort: {:?}", reasoning_effort);
             println!("Skip git check: {}", self.skip_git_check);
             println!("Prompt length: {} chars", prompt.len());
             println!("Prompt: {}", prompt);
@@ -167,7 +167,9 @@ impl CodexProvider {
             cmd.arg("-m").arg(&model.model_name);
         }
 
-        if let Some(reasoning_effort) = &self.reasoning_effort {
+        if let Some(reasoning_effort) =
+            Self::map_thinking_effort(&model.model_name, model.thinking_effort())
+        {
             cmd.arg("-c")
                 .arg(format!("model_reasoning_effort=\"{}\"", reasoning_effort));
         }
@@ -650,13 +652,6 @@ impl ProviderDef for CodexProvider {
             let command: String = config.get_codex_command().unwrap_or_default().into();
             let resolved_command = SearchPaths::builder().with_npm().resolve(command)?;
 
-            let model = crate::model_config::model_config_from_user_config(
-                CODEX_PROVIDER_NAME,
-                config.get_goose_model().unwrap_or_default(),
-            )?;
-            let reasoning_effort =
-                Self::map_thinking_effort(&model.model_name, model.thinking_effort());
-
             // Get skip_git_check from config, default to false
             let skip_git_check = config
                 .get_codex_skip_git_check()
@@ -671,7 +666,6 @@ impl ProviderDef for CodexProvider {
             Ok(Self {
                 command: resolved_command,
                 name: CODEX_PROVIDER_NAME.to_string(),
-                reasoning_effort,
                 skip_git_check,
                 mcp_config_overrides: codex_mcp_config_overrides(&resolved),
                 mode_by_session: tokio::sync::RwLock::new(HashMap::new()),
@@ -719,7 +713,7 @@ impl Provider for CodexProvider {
         let payload = json!({
             "command": self.command,
             "model": model_config.model_name,
-            "reasoning_effort": self.reasoning_effort,
+            "reasoning_effort": Self::map_thinking_effort(&model_config.model_name, model_config.thinking_effort()),
             "system_length": system.len(),
             "messages_count": messages.len()
         });
@@ -939,7 +933,6 @@ mod tests {
         let provider = CodexProvider {
             command: PathBuf::from("codex"),
             name: "codex".to_string(),
-            reasoning_effort: Some("high".to_string()),
             skip_git_check: false,
             mcp_config_overrides: Vec::new(),
             mode_by_session: tokio::sync::RwLock::new(HashMap::new()),
@@ -959,7 +952,6 @@ mod tests {
         let provider = CodexProvider {
             command: PathBuf::from("codex"),
             name: "codex".to_string(),
-            reasoning_effort: Some("high".to_string()),
             skip_git_check: false,
             mcp_config_overrides: Vec::new(),
             mode_by_session: tokio::sync::RwLock::new(HashMap::new()),
@@ -993,7 +985,6 @@ mod tests {
         let provider = CodexProvider {
             command: PathBuf::from("codex"),
             name: "codex".to_string(),
-            reasoning_effort: Some("high".to_string()),
             skip_git_check: false,
             mcp_config_overrides: Vec::new(),
             mode_by_session: tokio::sync::RwLock::new(HashMap::new()),
@@ -1041,7 +1032,6 @@ mod tests {
         let provider = CodexProvider {
             command: PathBuf::from("codex"),
             name: "codex".to_string(),
-            reasoning_effort: Some("high".to_string()),
             skip_git_check: false,
             mcp_config_overrides: Vec::new(),
             mode_by_session: tokio::sync::RwLock::new(HashMap::new()),
@@ -1066,7 +1056,6 @@ mod tests {
         let provider = CodexProvider {
             command: PathBuf::from("codex"),
             name: "codex".to_string(),
-            reasoning_effort: Some("high".to_string()),
             skip_git_check: false,
             mcp_config_overrides: Vec::new(),
             mode_by_session: tokio::sync::RwLock::new(HashMap::new()),
@@ -1139,7 +1128,6 @@ mod tests {
         let provider = CodexProvider {
             command: PathBuf::from("codex"),
             name: "codex".to_string(),
-            reasoning_effort: Some("high".to_string()),
             skip_git_check: false,
             mcp_config_overrides: Vec::new(),
             mode_by_session: tokio::sync::RwLock::new(HashMap::new()),
@@ -1155,7 +1143,6 @@ mod tests {
         let provider = CodexProvider {
             command: PathBuf::from("codex"),
             name: "codex".to_string(),
-            reasoning_effort: Some("high".to_string()),
             skip_git_check: false,
             mcp_config_overrides: Vec::new(),
             mode_by_session: tokio::sync::RwLock::new(HashMap::new()),
@@ -1281,7 +1268,6 @@ mod tests {
         let provider = CodexProvider {
             command: PathBuf::from("codex"),
             name: "codex".to_string(),
-            reasoning_effort: Some("high".to_string()),
             skip_git_check: false,
             mcp_config_overrides: Vec::new(),
             mode_by_session: tokio::sync::RwLock::new(HashMap::new()),

--- a/crates/goose/src/providers/codex.rs
+++ b/crates/goose/src/providers/codex.rs
@@ -684,10 +684,6 @@ impl Provider for CodexProvider {
         &self.name
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.model.clone()
-    }
-
     async fn stream(
         &self,
         model_config: &ModelConfig,

--- a/crates/goose/src/providers/codex.rs
+++ b/crates/goose/src/providers/codex.rs
@@ -642,7 +642,6 @@ impl ProviderDef for CodexProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         extensions: Vec<ExtensionConfig>,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
@@ -651,6 +650,10 @@ impl ProviderDef for CodexProvider {
             let command: String = config.get_codex_command().unwrap_or_default().into();
             let resolved_command = SearchPaths::builder().with_npm().resolve(command)?;
 
+            let model = crate::model_config::model_config_from_user_config(
+                CODEX_PROVIDER_NAME,
+                config.get_goose_model().unwrap_or_default(),
+            )?;
             let reasoning_effort =
                 Self::map_thinking_effort(&model.model_name, model.thinking_effort());
 

--- a/crates/goose/src/providers/codex.rs
+++ b/crates/goose/src/providers/codex.rs
@@ -46,7 +46,6 @@ pub const CODEX_REASONING_LEVELS: &[&str] = &["none", "low", "medium", "high", "
 #[derive(Debug, serde::Serialize)]
 pub struct CodexProvider {
     command: PathBuf,
-    model: ModelConfig,
     #[serde(skip)]
     name: String,
     /// Reasoning effort level (none, low, medium, high, xhigh)
@@ -126,6 +125,7 @@ impl CodexProvider {
     /// Execute codex CLI command
     async fn execute_command(
         &self,
+        model: &ModelConfig,
         system: &str,
         messages: &[Message],
         _tools: &[Tool],
@@ -139,7 +139,7 @@ impl CodexProvider {
         if std::env::var("GOOSE_CODEX_DEBUG").is_ok() {
             println!("=== CODEX PROVIDER DEBUG ===");
             println!("Command: {:?}", self.command);
-            println!("Model: {}", self.model.model_name);
+            println!("Model: {}", model.model_name);
             println!("Reasoning effort: {:?}", self.reasoning_effort);
             println!("Skip git check: {}", self.skip_git_check);
             println!("Prompt length: {} chars", prompt.len());
@@ -163,8 +163,8 @@ impl CodexProvider {
 
         // Only pass model parameter if it's in the known models list
         // This allows users to set GOOSE_PROVIDER=codex without needing to specify a model
-        if CODEX_KNOWN_MODELS.contains(&self.model.model_name.as_str()) {
-            cmd.arg("-m").arg(&self.model.model_name);
+        if CODEX_KNOWN_MODELS.contains(&model.model_name.as_str()) {
+            cmd.arg("-m").arg(&model.model_name);
         }
 
         if let Some(reasoning_effort) = &self.reasoning_effort {
@@ -667,7 +667,6 @@ impl ProviderDef for CodexProvider {
 
             Ok(Self {
                 command: resolved_command,
-                model,
                 name: CODEX_PROVIDER_NAME.to_string(),
                 reasoning_effort,
                 skip_git_check,
@@ -708,7 +707,7 @@ impl Provider for CodexProvider {
             map.get(session_id).copied().unwrap_or_default()
         };
         let lines = self
-            .execute_command(system, messages, tools, goose_mode)
+            .execute_command(model_config, system, messages, tools, goose_mode)
             .await?;
 
         let (message, usage) = self.parse_response(&lines)?;
@@ -936,7 +935,6 @@ mod tests {
     fn test_parse_response_plain_text() {
         let provider = CodexProvider {
             command: PathBuf::from("codex"),
-            model: ModelConfig::new("gpt-5.2-codex").unwrap(),
             name: "codex".to_string(),
             reasoning_effort: Some("high".to_string()),
             skip_git_check: false,
@@ -957,7 +955,6 @@ mod tests {
     fn test_parse_response_json_events() {
         let provider = CodexProvider {
             command: PathBuf::from("codex"),
-            model: ModelConfig::new("gpt-5.2-codex").unwrap(),
             name: "codex".to_string(),
             reasoning_effort: Some("high".to_string()),
             skip_git_check: false,
@@ -992,7 +989,6 @@ mod tests {
     fn test_parse_response_empty() {
         let provider = CodexProvider {
             command: PathBuf::from("codex"),
-            model: ModelConfig::new("gpt-5.2-codex").unwrap(),
             name: "codex".to_string(),
             reasoning_effort: Some("high".to_string()),
             skip_git_check: false,
@@ -1041,7 +1037,6 @@ mod tests {
     fn test_parse_response_item_completed() {
         let provider = CodexProvider {
             command: PathBuf::from("codex"),
-            model: ModelConfig::new("gpt-5.2-codex").unwrap(),
             name: "codex".to_string(),
             reasoning_effort: Some("high".to_string()),
             skip_git_check: false,
@@ -1067,7 +1062,6 @@ mod tests {
     fn test_parse_response_turn_completed_usage() {
         let provider = CodexProvider {
             command: PathBuf::from("codex"),
-            model: ModelConfig::new("gpt-5.2-codex").unwrap(),
             name: "codex".to_string(),
             reasoning_effort: Some("high".to_string()),
             skip_git_check: false,
@@ -1141,7 +1135,6 @@ mod tests {
     fn test_parse_response_error_event(lines: &[&str], expected: ProviderError) {
         let provider = CodexProvider {
             command: PathBuf::from("codex"),
-            model: ModelConfig::new("gpt-5.2-codex").unwrap(),
             name: "codex".to_string(),
             reasoning_effort: Some("high".to_string()),
             skip_git_check: false,
@@ -1158,7 +1151,6 @@ mod tests {
     fn test_parse_response_skips_reasoning() {
         let provider = CodexProvider {
             command: PathBuf::from("codex"),
-            model: ModelConfig::new("gpt-5.2-codex").unwrap(),
             name: "codex".to_string(),
             reasoning_effort: Some("high".to_string()),
             skip_git_check: false,
@@ -1285,7 +1277,6 @@ mod tests {
     fn test_parse_response_multiple_agent_messages() {
         let provider = CodexProvider {
             command: PathBuf::from("codex"),
-            model: ModelConfig::new("gpt-5.2-codex").unwrap(),
             name: "codex".to_string(),
             reasoning_effort: Some("high".to_string()),
             skip_git_check: false,

--- a/crates/goose/src/providers/codex_acp.rs
+++ b/crates/goose/src/providers/codex_acp.rs
@@ -100,6 +100,7 @@ impl ProviderDef for CodexAcpProvider {
                 mcp_servers,
                 // Disabled until https://github.com/zed-industries/codex-acp/issues/179 is fixed.
                 session_mode_id: None,
+                session_config_options: vec![],
                 mode_mapping,
                 notification_callback: None,
             };

--- a/crates/goose/src/providers/codex_acp.rs
+++ b/crates/goose/src/providers/codex_acp.rs
@@ -11,7 +11,6 @@ use crate::config::{Config, GooseMode};
 use crate::providers::base::{
     current_working_dir, ProviderDef, ProviderDescriptor, ProviderMetadata,
 };
-use goose_providers::model::ModelConfig;
 
 pub(crate) const CODEX_ACP_PROVIDER_NAME: &str = "codex-acp";
 const CODEX_ACP_DOC_URL: &str = "https://github.com/zed-industries/codex-acp";
@@ -42,15 +41,13 @@ impl ProviderDef for CodexAcpProvider {
     type Provider = AcpProvider;
 
     fn from_env(
-        model: ModelConfig,
         extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<AcpProvider>> {
-        Self::from_env_with_working_dir(model, extensions, current_working_dir(), tls_config)
+        Self::from_env_with_working_dir(extensions, current_working_dir(), tls_config)
     }
 
     fn from_env_with_working_dir(
-        model: ModelConfig,
         extensions: Vec<crate::config::ExtensionConfig>,
         working_dir: PathBuf,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
@@ -108,7 +105,7 @@ impl ProviderDef for CodexAcpProvider {
             };
 
             let metadata = Self::metadata();
-            AcpProvider::connect(metadata.name, model, goose_mode, provider_config).await
+            AcpProvider::connect(metadata.name, goose_mode, provider_config).await
         })
     }
 }

--- a/crates/goose/src/providers/codex_acp.rs
+++ b/crates/goose/src/providers/codex_acp.rs
@@ -101,6 +101,7 @@ impl ProviderDef for CodexAcpProvider {
                 // Disabled until https://github.com/zed-industries/codex-acp/issues/179 is fixed.
                 session_mode_id: None,
                 session_config_options: vec![],
+                model_config_option_id: None,
                 mode_mapping,
                 notification_callback: None,
             };

--- a/crates/goose/src/providers/copilot_acp.rs
+++ b/crates/goose/src/providers/copilot_acp.rs
@@ -92,6 +92,7 @@ impl ProviderDef for CopilotAcpProvider {
                 mcp_servers: extension_configs_to_mcp_servers(&extensions),
                 session_mode_id: Some(mode_mapping[&goose_mode].clone()),
                 session_config_options,
+                model_config_option_id: Some("model".to_string()),
                 mode_mapping,
                 notification_callback: None,
             };

--- a/crates/goose/src/providers/copilot_acp.rs
+++ b/crates/goose/src/providers/copilot_acp.rs
@@ -63,8 +63,16 @@ impl ProviderDef for CopilotAcpProvider {
                 .with_npm()
                 .resolve(COPILOT_ACP_BINARY)?;
             let goose_mode = config.get_goose_mode().unwrap_or(GooseMode::Auto);
+            let model = config
+                .get_goose_model()
+                .unwrap_or_else(|_| ACP_CURRENT_MODEL.to_string());
 
             let args = vec!["--acp".to_string()];
+            let session_config_options = if model == ACP_CURRENT_MODEL {
+                vec![]
+            } else {
+                vec![("model".to_string(), model)]
+            };
 
             // Copilot modes are full protocol URIs.
             // No approve-specific mode; permissions are handled separately.
@@ -83,6 +91,7 @@ impl ProviderDef for CopilotAcpProvider {
                 work_dir: working_dir,
                 mcp_servers: extension_configs_to_mcp_servers(&extensions),
                 session_mode_id: Some(mode_mapping[&goose_mode].clone()),
+                session_config_options,
                 mode_mapping,
                 notification_callback: None,
             };

--- a/crates/goose/src/providers/copilot_acp.rs
+++ b/crates/goose/src/providers/copilot_acp.rs
@@ -11,7 +11,6 @@ use crate::config::{Config, GooseMode};
 use crate::providers::base::{
     current_working_dir, ProviderDef, ProviderDescriptor, ProviderMetadata,
 };
-use goose_providers::model::ModelConfig;
 
 pub(crate) const COPILOT_ACP_PROVIDER_NAME: &str = "copilot-acp";
 const COPILOT_ACP_DOC_URL: &str = "https://github.com/github/copilot-cli";
@@ -46,15 +45,13 @@ impl ProviderDef for CopilotAcpProvider {
     type Provider = AcpProvider;
 
     fn from_env(
-        model: ModelConfig,
         extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<AcpProvider>> {
-        Self::from_env_with_working_dir(model, extensions, current_working_dir(), tls_config)
+        Self::from_env_with_working_dir(extensions, current_working_dir(), tls_config)
     }
 
     fn from_env_with_working_dir(
-        model: ModelConfig,
         extensions: Vec<crate::config::ExtensionConfig>,
         working_dir: PathBuf,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
@@ -67,11 +64,7 @@ impl ProviderDef for CopilotAcpProvider {
                 .resolve(COPILOT_ACP_BINARY)?;
             let goose_mode = config.get_goose_mode().unwrap_or(GooseMode::Auto);
 
-            let mut args = vec!["--acp".to_string()];
-            if model.model_name != ACP_CURRENT_MODEL {
-                args.push("--model".to_string());
-                args.push(model.model_name.clone());
-            }
+            let args = vec!["--acp".to_string()];
 
             // Copilot modes are full protocol URIs.
             // No approve-specific mode; permissions are handled separately.
@@ -95,7 +88,7 @@ impl ProviderDef for CopilotAcpProvider {
             };
 
             let metadata = Self::metadata();
-            AcpProvider::connect(metadata.name, model, goose_mode, provider_config).await
+            AcpProvider::connect(metadata.name, goose_mode, provider_config).await
         })
     }
 }

--- a/crates/goose/src/providers/cursor_agent.rs
+++ b/crates/goose/src/providers/cursor_agent.rs
@@ -317,11 +317,6 @@ impl Provider for CursorAgentProvider {
         &self.name
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        // Return the model config with appropriate context limit for Cursor models
-        self.model.clone()
-    }
-
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         Ok(CURSOR_AGENT_KNOWN_MODELS
             .iter()

--- a/crates/goose/src/providers/cursor_agent.rs
+++ b/crates/goose/src/providers/cursor_agent.rs
@@ -36,7 +36,6 @@ pub struct CursorAgentProvider {
 
 impl CursorAgentProvider {
     pub async fn from_env(
-        _model: ModelConfig,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -302,11 +301,10 @@ impl ProviderDef for CursorAgentProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
-        Box::pin(Self::from_env(model, tls_config))
+        Box::pin(Self::from_env(tls_config))
     }
 }
 
@@ -358,7 +356,7 @@ impl Provider for CursorAgentProvider {
             "usage": usage
         });
 
-        let mut log = start_log(&model_config, &payload)?;
+        let mut log = start_log(model_config, &payload)?;
         log.write(&response, Some(&usage))?;
 
         let provider_usage = ProviderUsage::new(model_config.model_name.clone(), usage);

--- a/crates/goose/src/providers/cursor_agent.rs
+++ b/crates/goose/src/providers/cursor_agent.rs
@@ -30,14 +30,13 @@ pub const CURSOR_AGENT_DOC_URL: &str = "https://docs.cursor.com/en/cli/overview"
 #[derive(Debug, serde::Serialize)]
 pub struct CursorAgentProvider {
     command: PathBuf,
-    model: ModelConfig,
     #[serde(skip)]
     name: String,
 }
 
 impl CursorAgentProvider {
     pub async fn from_env(
-        model: ModelConfig,
+        _model: ModelConfig,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -46,7 +45,6 @@ impl CursorAgentProvider {
 
         Ok(Self {
             command: resolved_command,
-            model,
             name: CURSOR_AGENT_PROVIDER_NAME.to_string(),
         })
     }
@@ -182,6 +180,7 @@ impl CursorAgentProvider {
 
     async fn execute_command(
         &self,
+        model: &ModelConfig,
         system: &str,
         messages: &[Message],
         _tools: &[Tool],
@@ -197,7 +196,7 @@ impl CursorAgentProvider {
                 filter_extensions_from_system_prompt(system).len()
             );
             println!("Full prompt: {}", prompt);
-            println!("Model: {}", self.model.model_name);
+            println!("Model: {}", model.model_name);
             println!("================================");
         }
 
@@ -208,7 +207,7 @@ impl CursorAgentProvider {
             cmd.env("PATH", path);
         }
 
-        cmd.arg("--model").arg(&self.model.model_name);
+        cmd.arg("--model").arg(&model.model_name);
 
         cmd.arg("-p")
             .arg(&prompt)
@@ -340,7 +339,9 @@ impl Provider for CursorAgentProvider {
             return Ok(stream_from_single_message(message, provider_usage));
         }
 
-        let lines = self.execute_command(system, messages, tools).await?;
+        let lines = self
+            .execute_command(model_config, system, messages, tools)
+            .await?;
 
         let (message, usage) = self.parse_cursor_agent_response(&lines)?;
 
@@ -357,7 +358,7 @@ impl Provider for CursorAgentProvider {
             "usage": usage
         });
 
-        let mut log = start_log(&self.model, &payload)?;
+        let mut log = start_log(&model_config, &payload)?;
         log.write(&response, Some(&usage))?;
 
         let provider_usage = ProviderUsage::new(model_config.model_name.clone(), usage);

--- a/crates/goose/src/providers/databricks.rs
+++ b/crates/goose/src/providers/databricks.rs
@@ -63,7 +63,6 @@ static DATABRICKS_ENDPOINT_INFO_CACHE: LazyLock<
     Mutex<std::collections::HashMap<String, CachedDatabricksEndpointInfo>>,
 > = LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
 pub const DATABRICKS_DEFAULT_MODEL: &str = "databricks-claude-sonnet-4";
-const DATABRICKS_DEFAULT_FAST_MODEL: &str = "databricks-claude-haiku-4-5";
 pub const DATABRICKS_KNOWN_MODELS: &[&str] = &[
     "databricks-claude-sonnet-4-5",
     "databricks-meta-llama-3-3-70b-instruct",
@@ -80,7 +79,6 @@ pub struct DatabricksProvider {
     #[serde(skip)]
     host: String,
     auth: DatabricksAuth,
-    model: ModelConfig,
     image_format: ImageFormat,
     #[serde(skip)]
     retry_config: RetryConfig,
@@ -98,7 +96,7 @@ impl DatabricksProvider {
     }
 
     pub async fn from_env(
-        model: ModelConfig,
+        _model: ModelConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -141,23 +139,16 @@ impl DatabricksProvider {
             tls_config.clone(),
         )?;
 
-        let mut provider = Self {
+        Ok(Self {
             api_client,
             host,
             auth,
-            model: model.clone(),
             image_format: ImageFormat::OpenAi,
             retry_config,
             name: DATABRICKS_PROVIDER_NAME.to_string(),
             token_cache,
             instance_id: Self::resolve_instance_id(),
-        };
-        provider.model = crate::model_config::with_configured_fast_model(
-            model,
-            DATABRICKS_PROVIDER_NAME,
-            DATABRICKS_DEFAULT_FAST_MODEL,
-        )?;
-        Ok(provider)
+        })
     }
 
     fn load_retry_config(config: &crate::config::Config) -> RetryConfig {

--- a/crates/goose/src/providers/databricks.rs
+++ b/crates/goose/src/providers/databricks.rs
@@ -63,6 +63,7 @@ static DATABRICKS_ENDPOINT_INFO_CACHE: LazyLock<
     Mutex<std::collections::HashMap<String, CachedDatabricksEndpointInfo>>,
 > = LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
 pub const DATABRICKS_DEFAULT_MODEL: &str = "databricks-claude-sonnet-4";
+pub const DATABRICKS_DEFAULT_FAST_MODEL: &str = "databricks-claude-haiku-4-5";
 pub const DATABRICKS_KNOWN_MODELS: &[&str] = &[
     "databricks-claude-sonnet-4-5",
     "databricks-meta-llama-3-3-70b-instruct",
@@ -529,6 +530,7 @@ impl goose_providers::base::ProviderDescriptor for DatabricksProvider {
                 ConfigKey::new("DATABRICKS_TOKEN", false, true, None, true),
             ],
         )
+        .with_fast_model(DATABRICKS_DEFAULT_FAST_MODEL)
     }
 }
 

--- a/crates/goose/src/providers/databricks.rs
+++ b/crates/goose/src/providers/databricks.rs
@@ -477,12 +477,12 @@ impl DatabricksProvider {
 
     fn model_info_from_endpoint(info: DatabricksEndpointInfo) -> ModelInfo {
         let context_model = info.upstream_model_name.as_deref().unwrap_or(&info.name);
-        let context_limit = ModelConfig::new_or_fail(context_model)
+        let context_limit = ModelConfig::new(context_model)
             .with_canonical_limits(DATABRICKS_PROVIDER_NAME)
             .context_limit();
         let reasoning = info
             .reasoning
-            .unwrap_or_else(|| ModelConfig::new_or_fail(context_model).is_reasoning_model());
+            .unwrap_or_else(|| ModelConfig::new(context_model).is_reasoning_model());
 
         ModelInfo {
             name: info.name,

--- a/crates/goose/src/providers/databricks.rs
+++ b/crates/goose/src/providers/databricks.rs
@@ -96,7 +96,6 @@ impl DatabricksProvider {
     }
 
     pub async fn from_env(
-        _model: ModelConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -537,11 +536,10 @@ impl ProviderDef for DatabricksProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
-        Box::pin(Self::from_env(model, tls_config))
+        Box::pin(Self::from_env(tls_config))
     }
 }
 

--- a/crates/goose/src/providers/databricks.rs
+++ b/crates/goose/src/providers/databricks.rs
@@ -571,10 +571,6 @@ impl Provider for DatabricksProvider {
         Ok(())
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.model.clone()
-    }
-
     async fn stream(
         &self,
         model_config: &ModelConfig,
@@ -812,7 +808,10 @@ impl Provider for DatabricksProvider {
         Ok(Self::model_info_from_endpoint(endpoint_info))
     }
 
-    async fn fetch_recommended_model_info(&self) -> Result<Vec<ModelInfo>, ProviderError> {
+    async fn fetch_recommended_model_info(
+        &self,
+        _toolshim: bool,
+    ) -> Result<Vec<ModelInfo>, ProviderError> {
         self.fetch_supported_model_info().await
     }
 }

--- a/crates/goose/src/providers/databricks_v2.rs
+++ b/crates/goose/src/providers/databricks_v2.rs
@@ -68,7 +68,6 @@ impl DatabricksV2Provider {
     }
 
     pub async fn from_env(
-        _model: ModelConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -352,11 +351,10 @@ impl ProviderDef for DatabricksV2Provider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
-        Box::pin(Self::from_env(model, tls_config))
+        Box::pin(Self::from_env(tls_config))
     }
 }
 

--- a/crates/goose/src/providers/databricks_v2.rs
+++ b/crates/goose/src/providers/databricks_v2.rs
@@ -379,10 +379,6 @@ impl Provider for DatabricksV2Provider {
         Ok(())
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.model.clone()
-    }
-
     async fn stream(
         &self,
         model_config: &ModelConfig,

--- a/crates/goose/src/providers/databricks_v2.rs
+++ b/crates/goose/src/providers/databricks_v2.rs
@@ -54,7 +54,6 @@ enum DatabricksV2Route {
 pub struct DatabricksV2Provider {
     #[serde(skip)]
     api_client: ApiClient,
-    model: ModelConfig,
     #[serde(skip)]
     retry_config: RetryConfig,
     #[serde(skip)]
@@ -69,7 +68,7 @@ impl DatabricksV2Provider {
     }
 
     pub async fn from_env(
-        model: ModelConfig,
+        _model: ModelConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -95,13 +94,12 @@ impl DatabricksV2Provider {
             DatabricksAuth::oauth(host.clone())
         };
 
-        Self::new(host, auth, model, retry_config, tls_config)
+        Self::new(host, auth, retry_config, tls_config)
     }
 
     fn new(
         host: String,
         auth: DatabricksAuth,
-        model: ModelConfig,
         retry_config: RetryConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
@@ -124,7 +122,6 @@ impl DatabricksV2Provider {
 
         Ok(Self {
             api_client,
-            model,
             retry_config,
             name: DATABRICKS_V2_PROVIDER_NAME.to_string(),
             token_cache,

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -1595,20 +1595,13 @@ mod tests {
     }
 
     fn cfg(name: &str) -> ModelConfig {
-        ModelConfig {
-            model_name: name.to_string(),
-            ..Default::default()
-        }
+        ModelConfig::new(name)
     }
 
     fn cfg_with_effort(name: &str, effort: &str) -> ModelConfig {
         let mut params = std::collections::HashMap::new();
         params.insert("thinking_effort".to_string(), json!(effort));
-        ModelConfig {
-            model_name: name.to_string(),
-            request_params: Some(params),
-            ..Default::default()
-        }
+        ModelConfig::new(name).with_merged_request_params(params)
     }
 
     #[test]

--- a/crates/goose/src/providers/formats/bedrock.rs
+++ b/crates/goose/src/providers/formats/bedrock.rs
@@ -535,7 +535,7 @@ mod tests {
     fn test_bedrock_anthropic_thinking_fields_enabled() {
         let mut params = HashMap::new();
         params.insert("thinking_effort".to_string(), json!("low"));
-        let mut config = ModelConfig::new_or_fail("us.anthropic.claude-3-7-sonnet-20250219-v1:0");
+        let mut config = ModelConfig::new("us.anthropic.claude-3-7-sonnet-20250219-v1:0");
         config.request_params = Some(params);
         config.reasoning = Some(true);
 
@@ -553,7 +553,7 @@ mod tests {
 
     #[test]
     fn test_bedrock_anthropic_thinking_fields_disabled() {
-        let mut config = ModelConfig::new_or_fail("us.anthropic.claude-3-7-sonnet-20250219-v1:0");
+        let mut config = ModelConfig::new("us.anthropic.claude-3-7-sonnet-20250219-v1:0");
         config.reasoning = Some(true);
         config.request_params = Some(HashMap::from([(
             "thinking_effort".to_string(),
@@ -565,7 +565,7 @@ mod tests {
 
     #[test]
     fn test_bedrock_anthropic_thinking_fields_always_on_adaptive() {
-        let mut config = ModelConfig::new_or_fail("global.anthropic.claude-fable-5");
+        let mut config = ModelConfig::new("global.anthropic.claude-fable-5");
         config.reasoning = Some(true);
         config.request_params = Some(HashMap::from([(
             "thinking_effort".to_string(),
@@ -584,7 +584,7 @@ mod tests {
 
     #[test]
     fn test_bedrock_anthropic_thinking_fields_adaptive_with_effort() {
-        let mut config = ModelConfig::new_or_fail("us.anthropic.claude-opus-4.7");
+        let mut config = ModelConfig::new("us.anthropic.claude-opus-4.7");
         config.reasoning = Some(true);
         config.request_params = Some(HashMap::from([(
             "thinking_effort".to_string(),
@@ -603,7 +603,7 @@ mod tests {
 
     #[test]
     fn test_bedrock_anthropic_thinking_fields_adaptive_with_version_suffix() {
-        let mut config = ModelConfig::new_or_fail("us.anthropic.claude-opus-4-7-20251101-v1:0");
+        let mut config = ModelConfig::new("us.anthropic.claude-opus-4-7-20251101-v1:0");
         config.reasoning = Some(true);
         config.request_params = Some(HashMap::from([(
             "thinking_effort".to_string(),
@@ -622,7 +622,7 @@ mod tests {
 
     #[test]
     fn test_bedrock_thinking_fields_skipped_for_non_anthropic() {
-        let mut config = ModelConfig::new_or_fail("us.deepseek.r1-v1:0");
+        let mut config = ModelConfig::new("us.deepseek.r1-v1:0");
         config.reasoning = Some(true);
         config.request_params = Some(HashMap::from([(
             "thinking_effort".to_string(),

--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -1210,7 +1210,7 @@ mod tests {
 
     #[test]
     fn test_create_request_adaptive_thinking_for_46_models() -> anyhow::Result<()> {
-        let mut model_config = ModelConfig::new_or_fail("databricks-claude-opus-4-6");
+        let mut model_config = ModelConfig::new("databricks-claude-opus-4-6");
         model_config.max_tokens = Some(4096);
         let mut params = std::collections::HashMap::new();
         params.insert("thinking_effort".to_string(), serde_json::json!("low"));
@@ -1237,7 +1237,7 @@ mod tests {
             "databricks-claude-fable-5",
             "global.anthropic.claude-fable-5",
         ] {
-            let mut model_config = ModelConfig::new_or_fail(name);
+            let mut model_config = ModelConfig::new(name);
             model_config.max_tokens = Some(4096);
             let mut params = std::collections::HashMap::new();
             params.insert("thinking_effort".to_string(), serde_json::json!("high"));
@@ -1258,7 +1258,7 @@ mod tests {
     fn test_create_request_always_on_adaptive_off_effort_falls_back_to_high() -> anyhow::Result<()>
     {
         let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", None::<&str>)]);
-        let mut model_config = ModelConfig::new_or_fail("databricks-claude-fable-5");
+        let mut model_config = ModelConfig::new("databricks-claude-fable-5");
         model_config.max_tokens = Some(4096);
         let mut params = std::collections::HashMap::new();
         params.insert("thinking_effort".to_string(), serde_json::json!("off"));
@@ -1274,7 +1274,7 @@ mod tests {
 
     #[test]
     fn test_create_request_enabled_thinking_with_budget() -> anyhow::Result<()> {
-        let mut model_config = ModelConfig::new_or_fail("databricks-claude-3-7-sonnet");
+        let mut model_config = ModelConfig::new("databricks-claude-3-7-sonnet");
         model_config.max_tokens = Some(4096);
         let mut params = std::collections::HashMap::new();
         params.insert("thinking_effort".to_string(), serde_json::json!("high"));
@@ -1299,7 +1299,7 @@ mod tests {
             ("high", 16000),
             ("max", 32000),
         ] {
-            let mut model_config = ModelConfig::new_or_fail("databricks-claude-3-7-sonnet");
+            let mut model_config = ModelConfig::new("databricks-claude-3-7-sonnet");
             model_config.max_tokens = Some(4096);
             let mut params = std::collections::HashMap::new();
             params.insert("thinking_effort".to_string(), serde_json::json!(effort));

--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -1065,7 +1065,6 @@ mod tests {
             max_tokens: Some(1024),
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };
@@ -1100,7 +1099,6 @@ mod tests {
             max_tokens: Some(1024),
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: Some(params),
             reasoning: None,
         };
@@ -1120,7 +1118,6 @@ mod tests {
             max_tokens: Some(1024),
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: Some(params),
             reasoning: None,
         };
@@ -1141,7 +1138,6 @@ mod tests {
             max_tokens: Some(1024),
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: Some(params),
             reasoning: None,
         };
@@ -1160,7 +1156,6 @@ mod tests {
             max_tokens: Some(1024),
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };
@@ -1179,7 +1174,6 @@ mod tests {
             max_tokens: Some(1024),
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };
@@ -1198,7 +1192,6 @@ mod tests {
             max_tokens: Some(1024),
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };
@@ -1643,7 +1636,6 @@ mod tests {
             max_tokens: Some(8192),
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };
@@ -1696,7 +1688,6 @@ mod tests {
             max_tokens: Some(4096),
             toolshim: false,
             toolshim_model: None,
-            fast_model_config: None,
             request_params: None,
             reasoning: None,
         };

--- a/crates/goose/src/providers/formats/google.rs
+++ b/crates/goose/src/providers/formats/google.rs
@@ -1404,7 +1404,7 @@ data: [DONE]"#;
         // Test 1: Gemini 3 model with low thinking effort
         let mut params = std::collections::HashMap::new();
         params.insert("thinking_effort".to_string(), serde_json::json!("low"));
-        let mut config = ModelConfig::new("gemini-3-pro").unwrap();
+        let mut config = ModelConfig::new("gemini-3-pro");
         config.request_params = Some(params);
         let result = get_thinking_config(&config);
         assert!(result.is_some());
@@ -1416,7 +1416,7 @@ data: [DONE]"#;
         // Test 2: Gemini 3 model with high thinking effort
         let mut params = std::collections::HashMap::new();
         params.insert("thinking_effort".to_string(), serde_json::json!("high"));
-        let mut config = ModelConfig::new("Gemini-3-Flash").unwrap();
+        let mut config = ModelConfig::new("Gemini-3-Flash");
         config.request_params = Some(params);
         let result = get_thinking_config(&config);
         assert!(result.is_some());
@@ -1426,7 +1426,7 @@ data: [DONE]"#;
             Some(ThinkingLevel::High)
         ));
 
-        let config = ModelConfig::new("gemini-2.5-flash").unwrap();
+        let config = ModelConfig::new("gemini-2.5-flash");
         let result = get_thinking_config(&config);
         assert!(result.is_some());
         let thinking_config = result.unwrap();
@@ -1439,9 +1439,7 @@ data: [DONE]"#;
 
         let mut params = HashMap::new();
         params.insert("thinking_budget".to_string(), json!(4096));
-        let config = ModelConfig::new("gemini-2.5-flash")
-            .unwrap()
-            .with_merged_request_params(params);
+        let config = ModelConfig::new("gemini-2.5-flash").with_merged_request_params(params);
         let result = get_thinking_config(&config);
         assert!(result.is_some());
         let thinking_config = result.unwrap();
@@ -1449,9 +1447,7 @@ data: [DONE]"#;
 
         let mut params = HashMap::new();
         params.insert("thinking_budget".to_string(), json!(-1));
-        let config = ModelConfig::new("gemini-2.5-flash")
-            .unwrap()
-            .with_merged_request_params(params);
+        let config = ModelConfig::new("gemini-2.5-flash").with_merged_request_params(params);
         let result = get_thinking_config(&config);
         assert!(result.is_some());
         let thinking_config = result.unwrap();
@@ -1460,11 +1456,11 @@ data: [DONE]"#;
             Some(GEMINI25_DEFAULT_THINKING_BUDGET)
         );
 
-        let config = ModelConfig::new("gemini-2.0-flash").unwrap();
+        let config = ModelConfig::new("gemini-2.0-flash");
         let result = get_thinking_config(&config);
         assert!(result.is_none());
 
-        let config = ModelConfig::new("gpt-4o").unwrap();
+        let config = ModelConfig::new("gpt-4o");
         let result = get_thinking_config(&config);
         assert!(result.is_none());
     }

--- a/crates/goose/src/providers/formats/openrouter.rs
+++ b/crates/goose/src/providers/formats/openrouter.rs
@@ -190,7 +190,7 @@ mod tests {
             "messages": [],
             "reasoning_effort": "high"
         });
-        let mut model_config = ModelConfig::new_or_fail("openai/gpt-5");
+        let mut model_config = ModelConfig::new("openai/gpt-5");
         let mut params = HashMap::new();
         params.insert("thinking_effort".to_string(), json!("max"));
         model_config.request_params = Some(params);
@@ -207,7 +207,7 @@ mod tests {
             "model": "x-ai/grok-4",
             "messages": []
         });
-        let mut model_config = ModelConfig::new_or_fail("x-ai/grok-4");
+        let mut model_config = ModelConfig::new("x-ai/grok-4");
         let mut params = HashMap::new();
         params.insert("thinking_effort".to_string(), json!("high"));
         model_config.request_params = Some(params);
@@ -224,7 +224,7 @@ mod tests {
             "model": "anthropic/claude-sonnet-4",
             "messages": []
         });
-        let mut model_config = ModelConfig::new_or_fail("anthropic/claude-sonnet-4");
+        let mut model_config = ModelConfig::new("anthropic/claude-sonnet-4");
         let mut params = HashMap::new();
         params.insert("thinking_effort".to_string(), json!("high"));
         model_config.request_params = Some(params);
@@ -240,7 +240,7 @@ mod tests {
             "model": "openai/gpt-4o",
             "messages": []
         });
-        let mut model_config = ModelConfig::new_or_fail("openai/gpt-4o");
+        let mut model_config = ModelConfig::new("openai/gpt-4o");
         let mut params = HashMap::new();
         params.insert("thinking_effort".to_string(), json!("high"));
         model_config.request_params = Some(params);
@@ -257,7 +257,7 @@ mod tests {
             "model": "x-ai/grok-4",
             "messages": []
         });
-        let mut model_config = ModelConfig::new_or_fail("x-ai/grok-4");
+        let mut model_config = ModelConfig::new("x-ai/grok-4");
         let mut params = HashMap::new();
         params.insert("thinking_effort".to_string(), json!("off"));
         model_config.request_params = Some(params);

--- a/crates/goose/src/providers/formats/snowflake.rs
+++ b/crates/goose/src/providers/formats/snowflake.rs
@@ -562,8 +562,7 @@ data: {"id":"a9537c2c-2017-4906-9817-2456168d89fa","model":"claude-sonnet-4-2025
         use crate::conversation::message::Message;
         use goose_providers::model::ModelConfig;
 
-        let model_config =
-            ModelConfig::new_or_fail("claude-4-sonnet").with_canonical_limits("snowflake");
+        let model_config = ModelConfig::new("claude-4-sonnet").with_canonical_limits("snowflake");
 
         let system = "You are a helpful assistant that can use tools to get information.";
         let messages = vec![Message::user().with_text("What is the stock price of Nvidia?")];
@@ -672,8 +671,7 @@ data: {"id":"a9537c2c-2017-4906-9817-2456168d89fa","model":"claude-sonnet-4-2025
         use crate::conversation::message::Message;
         use goose_providers::model::ModelConfig;
 
-        let model_config =
-            ModelConfig::new_or_fail("claude-4-sonnet").with_canonical_limits("snowflake");
+        let model_config = ModelConfig::new("claude-4-sonnet").with_canonical_limits("snowflake");
         let system = "Reply with only a description in four words or less";
         let messages = vec![Message::user().with_text("Test message")];
         let tools = vec![Tool::new(

--- a/crates/goose/src/providers/gcpvertexai.rs
+++ b/crates/goose/src/providers/gcpvertexai.rs
@@ -164,7 +164,6 @@ impl GcpVertexAIProvider {
     /// # Arguments
     /// * `model` - Configuration for the model to be used
     pub async fn from_env(
-        _model: ModelConfig,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -583,11 +582,10 @@ impl ProviderDef for GcpVertexAIProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
-        Box::pin(Self::from_env(model, tls_config))
+        Box::pin(Self::from_env(tls_config))
     }
 }
 

--- a/crates/goose/src/providers/gcpvertexai.rs
+++ b/crates/goose/src/providers/gcpvertexai.rs
@@ -603,11 +603,6 @@ impl Provider for GcpVertexAIProvider {
     /// * `system` - System prompt or context
     /// * `messages` - Array of previous messages in the conversation
     /// * `tools` - Array of available tools for the model
-    /// Returns the current model configuration.
-    fn get_model_config(&self) -> ModelConfig {
-        self.model.clone()
-    }
-
     async fn stream(
         &self,
         model_config: &ModelConfig,

--- a/crates/goose/src/providers/gcpvertexai.rs
+++ b/crates/goose/src/providers/gcpvertexai.rs
@@ -148,8 +148,6 @@ pub struct GcpVertexAIProvider {
     project_id: String,
     /// GCP region for model deployment
     location: String,
-    /// Configuration for the specific model being used
-    model: ModelConfig,
     /// Retry configuration for handling rate limit errors
     #[serde(skip)]
     retry_config: RetryConfig,
@@ -166,7 +164,7 @@ impl GcpVertexAIProvider {
     /// # Arguments
     /// * `model` - Configuration for the model to be used
     pub async fn from_env(
-        model: ModelConfig,
+        _model: ModelConfig,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -189,7 +187,6 @@ impl GcpVertexAIProvider {
             host,
             project_id,
             location,
-            model,
             retry_config,
             name: GCP_VERTEX_AI_PROVIDER_NAME.to_string(),
         })
@@ -262,6 +259,7 @@ impl GcpVertexAIProvider {
 
     fn build_request_url(
         &self,
+        model: &ModelConfig,
         provider: ModelProvider,
         location: &str,
         streaming: bool,
@@ -270,7 +268,7 @@ impl GcpVertexAIProvider {
             &self.host,
             &self.location,
             &self.project_id,
-            &self.model.model_name,
+            &model.model_name,
             provider,
             location,
             streaming,
@@ -395,13 +393,14 @@ impl GcpVertexAIProvider {
 
     async fn post_stream_with_location(
         &self,
+        model: &ModelConfig,
         session_id: Option<&str>,
         payload: &Value,
         context: &RequestContext,
         location: &str,
     ) -> Result<reqwest::Response, ProviderError> {
         let url = self
-            .build_request_url(context.provider(), location, true)
+            .build_request_url(model, context.provider(), location, true)
             .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
 
         self.send_request_with_retry(session_id, url, payload).await
@@ -409,12 +408,13 @@ impl GcpVertexAIProvider {
 
     async fn post_stream(
         &self,
+        model: &ModelConfig,
         session_id: Option<&str>,
         payload: &Value,
         context: &RequestContext,
     ) -> Result<reqwest::Response, ProviderError> {
         let result = self
-            .post_stream_with_location(session_id, payload, context, &self.location)
+            .post_stream_with_location(model, session_id, payload, context, &self.location)
             .await;
 
         if self.location == context.model.known_location().to_string() || result.is_ok() {
@@ -431,7 +431,7 @@ impl GcpVertexAIProvider {
                     "Trying known location {known_location} for {model_name} instead of {configured_location}: {msg}"
                 );
 
-                self.post_stream_with_location(session_id, payload, context, &known_location)
+                self.post_stream_with_location(model, session_id, payload, context, &known_location)
                     .await
             }
             _ => result,
@@ -622,7 +622,7 @@ impl Provider for GcpVertexAIProvider {
         let mut log = start_log(model_config, &request)?;
 
         let response = self
-            .post_stream(Some(session_id), &request, &context)
+            .post_stream(model_config, Some(session_id), &request, &context)
             .await
             .inspect_err(|e| {
                 let _ = log.error(e);

--- a/crates/goose/src/providers/gemini_cli.rs
+++ b/crates/goose/src/providers/gemini_cli.rs
@@ -198,10 +198,6 @@ impl Provider for GeminiCliProvider {
         true
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.model.clone()
-    }
-
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         Ok(GEMINI_CLI_KNOWN_MODELS
             .iter()

--- a/crates/goose/src/providers/gemini_cli.rs
+++ b/crates/goose/src/providers/gemini_cli.rs
@@ -46,7 +46,6 @@ pub struct GeminiCliProvider {
 
 impl GeminiCliProvider {
     pub async fn from_env(
-        _model: ModelConfig,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = Config::global();
@@ -178,11 +177,10 @@ impl ProviderDef for GeminiCliProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
-        Box::pin(Self::from_env(model, tls_config))
+        Box::pin(Self::from_env(tls_config))
     }
 }
 

--- a/crates/goose/src/providers/gemini_cli.rs
+++ b/crates/goose/src/providers/gemini_cli.rs
@@ -38,7 +38,6 @@ pub const GEMINI_CLI_DOC_URL: &str = "https://ai.google.dev/gemini-api/docs";
 #[derive(Debug, serde::Serialize)]
 pub struct GeminiCliProvider {
     command: PathBuf,
-    model: ModelConfig,
     #[serde(skip)]
     name: String,
     #[serde(skip)]
@@ -47,7 +46,7 @@ pub struct GeminiCliProvider {
 
 impl GeminiCliProvider {
     pub async fn from_env(
-        model: ModelConfig,
+        _model: ModelConfig,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = Config::global();
@@ -56,7 +55,6 @@ impl GeminiCliProvider {
 
         Ok(Self {
             command: resolved_command,
-            model,
             name: GEMINI_CLI_PROVIDER_NAME.to_string(),
             cli_session_id: Arc::new(OnceLock::new()),
         })
@@ -332,7 +330,6 @@ mod tests {
     fn make_provider() -> GeminiCliProvider {
         GeminiCliProvider {
             command: PathBuf::from("gemini"),
-            model: ModelConfig::new("gemini-2.5-pro").unwrap(),
             name: "gemini-cli".to_string(),
             cli_session_id: Arc::new(OnceLock::new()),
         }

--- a/crates/goose/src/providers/gemini_oauth.rs
+++ b/crates/goose/src/providers/gemini_oauth.rs
@@ -11,6 +11,7 @@ use goose_providers::model::ModelConfig;
 use goose_providers::request_log::{start_log, LoggerHandleExt};
 
 const GEMINI_OAUTH_DEFAULT_MODEL: &str = "gemini-3-flash-preview";
+const GEMINI_OAUTH_DEFAULT_FAST_MODEL: &str = "gemini-2.5-flash-lite";
 use crate::providers::retry::ProviderRetry;
 use crate::session_context::SESSION_ID_HEADER;
 use anyhow::{anyhow, Result};
@@ -942,6 +943,7 @@ impl goose_providers::base::ProviderDescriptor for GeminiOAuthProvider {
                 false,
             )],
         )
+        .with_fast_model(GEMINI_OAUTH_DEFAULT_FAST_MODEL)
     }
 }
 

--- a/crates/goose/src/providers/gemini_oauth.rs
+++ b/crates/goose/src/providers/gemini_oauth.rs
@@ -836,7 +836,6 @@ pub struct GeminiOAuthProvider {
 
 impl GeminiOAuthProvider {
     pub async fn from_env(
-        _model: ModelConfig,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let token_provider = Arc::new(GeminiOAuthTokenProvider::new(
@@ -950,11 +949,10 @@ impl ProviderDef for GeminiOAuthProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
-        Box::pin(Self::from_env(model, tls_config))
+        Box::pin(Self::from_env(tls_config))
     }
 }
 

--- a/crates/goose/src/providers/gemini_oauth.rs
+++ b/crates/goose/src/providers/gemini_oauth.rs
@@ -973,10 +973,6 @@ impl Provider for GeminiOAuthProvider {
         &self.name
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.model.clone()
-    }
-
     async fn configure_oauth(&self) -> Result<(), ProviderError> {
         self.token_provider
             .get_valid_setup()

--- a/crates/goose/src/providers/gemini_oauth.rs
+++ b/crates/goose/src/providers/gemini_oauth.rs
@@ -11,7 +11,6 @@ use goose_providers::model::ModelConfig;
 use goose_providers::request_log::{start_log, LoggerHandleExt};
 
 const GEMINI_OAUTH_DEFAULT_MODEL: &str = "gemini-3-flash-preview";
-const GEMINI_OAUTH_DEFAULT_FAST_MODEL: &str = "gemini-2.5-flash-lite";
 use crate::providers::retry::ProviderRetry;
 use crate::session_context::SESSION_ID_HEADER;
 use anyhow::{anyhow, Result};
@@ -831,29 +830,21 @@ fn parse_retry_delay(body: &str) -> Option<Duration> {
 pub struct GeminiOAuthProvider {
     #[serde(skip)]
     token_provider: Arc<GeminiOAuthTokenProvider>,
-    model: ModelConfig,
     #[serde(skip)]
     name: String,
 }
 
 impl GeminiOAuthProvider {
     pub async fn from_env(
-        model: ModelConfig,
+        _model: ModelConfig,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
-        let model = crate::model_config::with_configured_fast_model(
-            model,
-            GEMINI_OAUTH_PROVIDER_NAME,
-            GEMINI_OAUTH_DEFAULT_FAST_MODEL,
-        )?;
-
         let token_provider = Arc::new(GeminiOAuthTokenProvider::new(
             GeminiOAuthAuthState::instance(),
         ));
 
         Ok(Self {
             token_provider,
-            model,
             name: GEMINI_OAUTH_PROVIDER_NAME.to_string(),
         })
     }

--- a/crates/goose/src/providers/githubcopilot.rs
+++ b/crates/goose/src/providers/githubcopilot.rs
@@ -231,7 +231,6 @@ impl GithubCopilotProvider {
     }
 
     pub async fn from_env(
-        _model: ModelConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = Config::global();
@@ -551,11 +550,10 @@ impl ProviderDef for GithubCopilotProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
-        Box::pin(Self::from_env(model, tls_config))
+        Box::pin(Self::from_env(tls_config))
     }
 }
 

--- a/crates/goose/src/providers/githubcopilot.rs
+++ b/crates/goose/src/providers/githubcopilot.rs
@@ -195,7 +195,6 @@ pub struct GithubCopilotProvider {
     cache: DiskCache,
     #[serde(skip)]
     mu: tokio::sync::Mutex<RefCell<Option<CopilotState>>>,
-    model: ModelConfig,
     #[serde(skip)]
     urls: GithubCopilotUrls,
     #[serde(skip)]
@@ -232,7 +231,7 @@ impl GithubCopilotProvider {
     }
 
     pub async fn from_env(
-        model: ModelConfig,
+        _model: ModelConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = Config::global();
@@ -255,7 +254,6 @@ impl GithubCopilotProvider {
             client,
             cache,
             mu,
-            model,
             urls,
             client_id,
             name: GITHUB_COPILOT_PROVIDER_NAME.to_string(),

--- a/crates/goose/src/providers/githubcopilot.rs
+++ b/crates/goose/src/providers/githubcopilot.rs
@@ -567,10 +567,6 @@ impl Provider for GithubCopilotProvider {
         &self.name
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.model.clone()
-    }
-
     #[tracing::instrument(
         skip(self, model_config, session_id, system, messages, tools),
         fields(session.id = %session_id, gen_ai.request.model = %model_config.model_name)

--- a/crates/goose/src/providers/google.rs
+++ b/crates/goose/src/providers/google.rs
@@ -25,7 +25,6 @@ use tokio_util::io::StreamReader;
 pub(crate) const GOOGLE_PROVIDER_NAME: &str = "google";
 pub const GOOGLE_API_HOST: &str = "https://generativelanguage.googleapis.com";
 pub const GOOGLE_DEFAULT_MODEL: &str = "gemini-2.5-pro";
-pub const GOOGLE_DEFAULT_FAST_MODEL: &str = "gemini-2.5-flash";
 pub const GOOGLE_KNOWN_MODELS: &[&str] = &[
     // Gemini 3 models
     "gemini-3-pro-preview",
@@ -60,22 +59,15 @@ pub const GOOGLE_DOC_URL: &str = "https://ai.google.dev/gemini-api/docs/models";
 pub struct GoogleProvider {
     #[serde(skip)]
     api_client: ApiClient,
-    model: ModelConfig,
     #[serde(skip)]
     name: String,
 }
 
 impl GoogleProvider {
     pub async fn from_env(
-        model: ModelConfig,
+        _model: ModelConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
-        let model = crate::model_config::with_configured_fast_model(
-            model,
-            GOOGLE_PROVIDER_NAME,
-            GOOGLE_DEFAULT_FAST_MODEL,
-        )?;
-
         let config = crate::config::Config::global();
         let api_key: String = config.get_secret("GOOGLE_API_KEY")?;
         let host: String = config
@@ -92,7 +84,6 @@ impl GoogleProvider {
 
         Ok(Self {
             api_client,
-            model,
             name: GOOGLE_PROVIDER_NAME.to_string(),
         })
     }

--- a/crates/goose/src/providers/google.rs
+++ b/crates/goose/src/providers/google.rs
@@ -65,7 +65,6 @@ pub struct GoogleProvider {
 
 impl GoogleProvider {
     pub async fn from_env(
-        _model: ModelConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -130,11 +129,10 @@ impl ProviderDef for GoogleProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
-        Box::pin(Self::from_env(model, tls_config))
+        Box::pin(Self::from_env(tls_config))
     }
 }
 

--- a/crates/goose/src/providers/google.rs
+++ b/crates/goose/src/providers/google.rs
@@ -153,10 +153,6 @@ impl Provider for GoogleProvider {
         &self.name
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.model.clone()
-    }
-
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         let response = self
             .api_client

--- a/crates/goose/src/providers/google.rs
+++ b/crates/goose/src/providers/google.rs
@@ -25,6 +25,7 @@ use tokio_util::io::StreamReader;
 pub(crate) const GOOGLE_PROVIDER_NAME: &str = "google";
 pub const GOOGLE_API_HOST: &str = "https://generativelanguage.googleapis.com";
 pub const GOOGLE_DEFAULT_MODEL: &str = "gemini-2.5-pro";
+pub const GOOGLE_DEFAULT_FAST_MODEL: &str = "gemini-2.5-flash";
 pub const GOOGLE_KNOWN_MODELS: &[&str] = &[
     // Gemini 3 models
     "gemini-3-pro-preview",
@@ -116,6 +117,7 @@ impl goose_providers::base::ProviderDescriptor for GoogleProvider {
                 ConfigKey::new("GOOGLE_HOST", false, false, Some(GOOGLE_API_HOST), false),
             ],
         )
+        .with_fast_model(GOOGLE_DEFAULT_FAST_MODEL)
         .with_setup_steps(vec![
             "Go to https://aistudio.google.com and sign in with your Google account",
             "Click 'Get API key' on the left sidebar",

--- a/crates/goose/src/providers/huggingface.rs
+++ b/crates/goose/src/providers/huggingface.rs
@@ -72,7 +72,6 @@ impl HuggingFaceProvider {
     }
 
     pub fn from_custom_config(
-        model: ModelConfig,
         config: DeclarativeProviderConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
@@ -110,17 +109,10 @@ impl HuggingFaceProvider {
             api_client = api_client.with_headers(header_map)?;
         }
 
-        let model = if let Some(ref fast_model_name) = config.fast_model {
-            crate::model_config::with_configured_fast_model(model, &config.name, fast_model_name)?
-        } else {
-            model
-        };
-
         Ok(Self {
             inner: OpenAiCompatibleProvider::new(
                 config.name.clone(),
                 api_client,
-                model,
                 completions_prefix,
             )
             .with_supports_streaming(config.supports_streaming.unwrap_or(true)),
@@ -204,7 +196,6 @@ impl ProviderDef for HuggingFaceProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
@@ -221,7 +212,6 @@ impl ProviderDef for HuggingFaceProvider {
                 inner: OpenAiCompatibleProvider::new(
                     huggingface_auth::HUGGINGFACE_PROVIDER_NAME.to_string(),
                     api_client,
-                    model,
                     String::new(),
                 ),
                 custom_models: None,
@@ -445,12 +435,7 @@ mod tests {
             ModelInfo::new("static-b".to_string(), 128000),
         ];
 
-        let provider = HuggingFaceProvider::from_custom_config(
-            ModelConfig::new("static-a").unwrap(),
-            config,
-            None,
-        )
-        .unwrap();
+        let provider = HuggingFaceProvider::from_custom_config(config, None).unwrap();
 
         assert_eq!(
             provider.fetch_supported_models().await.unwrap(),
@@ -464,11 +449,7 @@ mod tests {
         config.requires_auth = false;
         config.dynamic_models = Some(false);
 
-        let error = match HuggingFaceProvider::from_custom_config(
-            ModelConfig::new("model").unwrap(),
-            config,
-            None,
-        ) {
+        let error = match HuggingFaceProvider::from_custom_config(config, None) {
             Ok(_) => panic!("expected dynamic_models: false without static models to fail"),
             Err(error) => error,
         };

--- a/crates/goose/src/providers/huggingface.rs
+++ b/crates/goose/src/providers/huggingface.rs
@@ -140,10 +140,6 @@ impl Provider for HuggingFaceProvider {
         self.inner.get_name()
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.inner.get_model_config()
-    }
-
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         if let Some(custom_models) = &self.custom_models {
             if self.dynamic_models == Some(false) {

--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -48,7 +48,6 @@ use crate::{
     providers::provider_registry::ProviderEntry,
 };
 use anyhow::Result;
-use goose_providers::model::ModelConfig;
 use tokio::sync::OnceCell;
 
 static REGISTRY: OnceCell<RwLock<ProviderRegistry>> = OnceCell::const_new();
@@ -221,25 +220,18 @@ pub async fn inventory_identity(name: &str) -> Result<super::inventory::Inventor
     get_from_registry(name).await?.inventory_identity()
 }
 
-pub async fn create(
-    name: &str,
-    model: ModelConfig,
-    extensions: Vec<ExtensionConfig>,
-) -> Result<Arc<dyn Provider>> {
+pub async fn create(name: &str, extensions: Vec<ExtensionConfig>) -> Result<Arc<dyn Provider>> {
     let entry = get_from_registry(name).await?;
-    entry.create(model, extensions).await
+    entry.create(extensions).await
 }
 
 pub async fn create_with_working_dir(
     name: &str,
-    model: ModelConfig,
     extensions: Vec<ExtensionConfig>,
     working_dir: PathBuf,
 ) -> Result<Arc<dyn Provider>> {
     let entry = get_from_registry(name).await?;
-    entry
-        .create_with_working_dir(model, extensions, working_dir)
-        .await
+    entry.create_with_working_dir(extensions, working_dir).await
 }
 
 pub async fn create_with_default_model(
@@ -268,11 +260,9 @@ pub async fn cleanup_provider(name: &str) -> Result<()> {
 
 pub async fn create_with_named_model(
     provider_name: &str,
-    model_name: &str,
     extensions: Vec<ExtensionConfig>,
 ) -> Result<Arc<dyn Provider>> {
-    let config = crate::model_config::model_config_from_user_config(provider_name, model_name)?;
-    create(provider_name, config, extensions).await
+    create(provider_name, extensions).await
 }
 
 #[cfg(test)]
@@ -520,7 +510,7 @@ mod tests {
             .await
             .expect("custom_inf entry should exist");
         let inf_config = inf_entry
-            .normalize_model_config_for_test(
+            .normalize_model_config(
                 crate::model_config::model_config_from_user_config("custom_inf", "kimi-k2.5")
                     .expect("custom_inf model config should resolve"),
             )
@@ -531,7 +521,7 @@ mod tests {
             .await
             .expect("custom_zero entry should exist");
         let zero_config = zero_entry
-            .normalize_model_config_for_test(
+            .normalize_model_config(
                 crate::model_config::model_config_from_user_config("custom_zero", "zero-model")
                     .expect("custom_zero model config should resolve"),
             )

--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -516,15 +516,27 @@ mod tests {
             .await
             .expect("custom providers should refresh");
 
-        let provider = create_with_named_model("custom_inf", "kimi-k2.5", Vec::new())
+        let inf_entry = get_from_registry("custom_inf")
             .await
-            .expect("custom_inf provider should be creatable");
-        assert_eq!(provider.get_model_config().context_limit, Some(256_000));
+            .expect("custom_inf entry should exist");
+        let inf_config = inf_entry
+            .normalize_model_config_for_test(
+                crate::model_config::model_config_from_user_config("custom_inf", "kimi-k2.5")
+                    .expect("custom_inf model config should resolve"),
+            )
+            .expect("custom_inf model config should normalize");
+        assert_eq!(inf_config.context_limit, Some(256_000));
 
-        let zero_provider = create_with_named_model("custom_zero", "zero-model", Vec::new())
+        let zero_entry = get_from_registry("custom_zero")
             .await
-            .expect("custom_zero provider should be creatable");
-        assert_eq!(zero_provider.get_model_config().context_limit, None);
+            .expect("custom_zero entry should exist");
+        let zero_config = zero_entry
+            .normalize_model_config_for_test(
+                crate::model_config::model_config_from_user_config("custom_zero", "zero-model")
+                    .expect("custom_zero model config should resolve"),
+            )
+            .expect("custom_zero model config should normalize");
+        assert_eq!(zero_config.context_limit, None);
 
         std::env::remove_var("GOOSE_PATH_ROOT");
     }

--- a/crates/goose/src/providers/inventory/mod.rs
+++ b/crates/goose/src/providers/inventory/mod.rs
@@ -617,9 +617,11 @@ impl ProviderInventoryService {
                             .await
                         {
                             Ok(()) => {
-                                match AssertUnwindSafe(provider.fetch_recommended_models())
-                                    .catch_unwind()
-                                    .await
+                                match AssertUnwindSafe(provider.fetch_recommended_models(
+                                    crate::model_config::global_toolshim(),
+                                ))
+                                .catch_unwind()
+                                .await
                                 {
                                     Ok(Ok(models)) => Ok(models),
                                     Ok(Err(error)) => Err(anyhow::anyhow!(error.to_string())),

--- a/crates/goose/src/providers/kimicode.rs
+++ b/crates/goose/src/providers/kimicode.rs
@@ -35,7 +35,6 @@ use rmcp::model::Tool;
 
 const KIMI_CODE_PROVIDER_NAME: &str = "kimi_code";
 pub const KIMI_CODE_DEFAULT_MODEL: &str = "kimi-for-coding";
-pub const KIMI_CODE_DEFAULT_FAST_MODEL: &str = "kimi-for-coding";
 /// Known models for the provider metadata registration. The live catalogue is
 /// fetched from `/v1/models` at request time; this constant is only used for
 /// `ProviderMetadata`. As of 2025-10 Kimi Code exposes a single model,
@@ -152,7 +151,6 @@ pub struct KimiCodeProvider {
     auth_host: String,
     #[serde(skip)]
     api_base: String,
-    model: ModelConfig,
     #[serde(skip)]
     name: String,
 }
@@ -163,14 +161,9 @@ impl KimiCodeProvider {
     }
 
     pub async fn from_env(
-        model: ModelConfig,
+        _model: ModelConfig,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
-        let model = crate::model_config::with_configured_fast_model(
-            model,
-            KIMI_CODE_PROVIDER_NAME,
-            KIMI_CODE_DEFAULT_FAST_MODEL,
-        )?;
         let client = Client::builder()
             .timeout(StdDuration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS))
             .build()?;
@@ -182,7 +175,6 @@ impl KimiCodeProvider {
             device_id,
             auth_host: KIMI_AUTH_HOST.to_string(),
             api_base: KIMI_API_BASE.to_string(),
-            model,
             name: KIMI_CODE_PROVIDER_NAME.to_string(),
         })
     }
@@ -509,7 +501,6 @@ mod tests {
             device_id: device_id.to_string(),
             auth_host: server_uri.to_string(),
             api_base: server_uri.to_string(),
-            model: ModelConfig::new(KIMI_CODE_DEFAULT_MODEL).unwrap(),
             name: KIMI_CODE_PROVIDER_NAME.to_string(),
         }
     }

--- a/crates/goose/src/providers/kimicode.rs
+++ b/crates/goose/src/providers/kimicode.rs
@@ -161,7 +161,6 @@ impl KimiCodeProvider {
     }
 
     pub async fn from_env(
-        _model: ModelConfig,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let client = Client::builder()
@@ -367,11 +366,10 @@ impl ProviderDef for KimiCodeProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
-        Box::pin(Self::from_env(model, tls_config))
+        Box::pin(Self::from_env(tls_config))
     }
 }
 

--- a/crates/goose/src/providers/kimicode.rs
+++ b/crates/goose/src/providers/kimicode.rs
@@ -391,10 +391,6 @@ impl Provider for KimiCodeProvider {
         &self.name
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.model.clone()
-    }
-
     async fn stream(
         &self,
         model_config: &ModelConfig,

--- a/crates/goose/src/providers/litellm.rs
+++ b/crates/goose/src/providers/litellm.rs
@@ -37,7 +37,6 @@ pub struct LiteLLMProvider {
 
 impl LiteLLMProvider {
     pub async fn from_env(
-        _model: ModelConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -199,11 +198,10 @@ impl ProviderDef for LiteLLMProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
-        Box::pin(Self::from_env(model, tls_config))
+        Box::pin(Self::from_env(tls_config))
     }
 }
 

--- a/crates/goose/src/providers/litellm.rs
+++ b/crates/goose/src/providers/litellm.rs
@@ -29,7 +29,6 @@ pub struct LiteLLMProvider {
     #[serde(skip)]
     api_client: ApiClient,
     base_path: String,
-    model: ModelConfig,
     #[serde(skip)]
     name: String,
     #[serde(skip)]
@@ -38,7 +37,7 @@ pub struct LiteLLMProvider {
 
 impl LiteLLMProvider {
     pub async fn from_env(
-        model: ModelConfig,
+        _model: ModelConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -86,7 +85,6 @@ impl LiteLLMProvider {
         Ok(Self {
             api_client,
             base_path,
-            model,
             name: LITELLM_PROVIDER_NAME.to_string(),
             cached_model_info: tokio::sync::OnceCell::new(),
         })
@@ -152,6 +150,16 @@ impl LiteLLMProvider {
             .response_post(session_id, &self.base_path, payload)
             .await?;
         handle_response_openai_compat(response).await
+    }
+
+    async fn supports_cache_control(&self, model: &ModelConfig) -> bool {
+        if let Ok(models) = self.get_or_fetch_models().await {
+            if let Some(model_info) = models.iter().find(|m| m.name == model.model_name) {
+                return model_info.supports_cache_control.unwrap_or(false);
+            }
+        }
+
+        model.model_name.to_lowercase().contains("claude")
     }
 }
 
@@ -248,7 +256,7 @@ impl Provider for LiteLLMProvider {
             false,
         )?;
 
-        if self.supports_cache_control().await {
+        if self.supports_cache_control(model_config).await {
             payload = update_request_for_cache_control(&payload);
         }
 
@@ -269,16 +277,6 @@ impl Provider for LiteLLMProvider {
             message,
             provider_usage,
         ))
-    }
-
-    async fn supports_cache_control(&self) -> bool {
-        if let Ok(models) = self.get_or_fetch_models().await {
-            if let Some(model_info) = models.iter().find(|m| m.name == self.model.model_name) {
-                return model_info.supports_cache_control.unwrap_or(false);
-            }
-        }
-
-        self.model.model_name.to_lowercase().contains("claude")
     }
 
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {

--- a/crates/goose/src/providers/litellm.rs
+++ b/crates/goose/src/providers/litellm.rs
@@ -205,23 +205,25 @@ impl Provider for LiteLLMProvider {
         &self.name
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        let mut config = self.model.clone();
+    async fn get_context_limit(&self, model_config: &ModelConfig) -> Result<usize, ProviderError> {
+        if let Some(limit) = model_config.context_limit {
+            return Ok(limit);
+        }
+
         // The cache is populated lazily by the first stream() call (via
         // supports_cache_control). On turn 1 this will be None and we fall
         // back to DEFAULT_CONTEXT_LIMIT, which is fine — the conversation is
         // too small to trigger compaction. From turn 2 onward the real limit
         // from /model/info is used.
-        if config.context_limit.is_none() {
-            if let Some(models) = self.cached_model_info.get() {
-                if let Some(info) = models.iter().find(|m| m.name == config.model_name) {
-                    if info.context_limit > 0 {
-                        config.context_limit = Some(info.context_limit);
-                    }
+        if let Some(models) = self.cached_model_info.get() {
+            if let Some(info) = models.iter().find(|m| m.name == model_config.model_name) {
+                if info.context_limit > 0 {
+                    return Ok(info.context_limit);
                 }
             }
         }
-        config
+
+        Ok(model_config.context_limit())
     }
 
     async fn stream(

--- a/crates/goose/src/providers/local_inference.rs
+++ b/crates/goose/src/providers/local_inference.rs
@@ -549,10 +549,6 @@ impl Provider for LocalInferenceProvider {
         &self.name
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.model_config.clone()
-    }
-
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         use crate::providers::local_inference::local_model_registry::get_registry;
 

--- a/crates/goose/src/providers/local_inference.rs
+++ b/crates/goose/src/providers/local_inference.rs
@@ -482,7 +482,7 @@ pub struct LocalInferenceProvider {
 }
 
 impl LocalInferenceProvider {
-    pub async fn from_env(_model: ModelConfig, _extensions: Vec<ExtensionConfig>) -> Result<Self> {
+    pub async fn from_env(_extensions: Vec<ExtensionConfig>) -> Result<Self> {
         let runtime = InferenceRuntime::get_or_init()?;
         Ok(Self {
             runtime,
@@ -530,14 +530,13 @@ impl ProviderDef for LocalInferenceProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         extensions: Vec<ExtensionConfig>,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>>
     where
         Self: Sized,
     {
-        Box::pin(Self::from_env(model, extensions))
+        Box::pin(Self::from_env(extensions))
     }
 }
 

--- a/crates/goose/src/providers/local_inference.rs
+++ b/crates/goose/src/providers/local_inference.rs
@@ -478,16 +478,14 @@ type StreamSender =
 
 pub struct LocalInferenceProvider {
     runtime: Arc<InferenceRuntime>,
-    model_config: ModelConfig,
     name: String,
 }
 
 impl LocalInferenceProvider {
-    pub async fn from_env(model: ModelConfig, _extensions: Vec<ExtensionConfig>) -> Result<Self> {
+    pub async fn from_env(_model: ModelConfig, _extensions: Vec<ExtensionConfig>) -> Result<Self> {
         let runtime = InferenceRuntime::get_or_init()?;
         Ok(Self {
             runtime,
-            model_config: model,
             name: PROVIDER_NAME.to_string(),
         })
     }
@@ -650,7 +648,7 @@ impl Provider for LocalInferenceProvider {
             },
         });
 
-        let mut log = start_log(&self.model_config, &log_payload)?;
+        let mut log = start_log(model_config, &log_payload)?;
 
         let (tx, mut rx) = tokio::sync::mpsc::channel::<
             Result<(Option<Message>, Option<ProviderUsage>), ProviderError>,

--- a/crates/goose/src/providers/nanogpt.rs
+++ b/crates/goose/src/providers/nanogpt.rs
@@ -121,10 +121,6 @@ impl Provider for NanoGptProvider {
         &self.name
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.model.clone()
-    }
-
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         let response = self
             .api_client

--- a/crates/goose/src/providers/nanogpt.rs
+++ b/crates/goose/src/providers/nanogpt.rs
@@ -24,7 +24,6 @@ const NANOGPT_API_KEY: &str = "NANOGPT_API_KEY";
 pub struct NanoGptProvider {
     #[serde(skip)]
     api_client: ApiClient,
-    model: ModelConfig,
     #[serde(skip)]
     name: String,
 }
@@ -64,7 +63,7 @@ impl NanoGptProvider {
     }
 
     pub async fn from_env(
-        model: ModelConfig,
+        _model: ModelConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -83,7 +82,6 @@ impl NanoGptProvider {
 
         Ok(Self {
             api_client,
-            model,
             name: NANOGPT_PROVIDER_NAME.to_string(),
         })
     }

--- a/crates/goose/src/providers/nanogpt.rs
+++ b/crates/goose/src/providers/nanogpt.rs
@@ -63,7 +63,6 @@ impl NanoGptProvider {
     }
 
     pub async fn from_env(
-        _model: ModelConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -105,11 +104,10 @@ impl ProviderDef for NanoGptProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
-        Box::pin(Self::from_env(model, tls_config))
+        Box::pin(Self::from_env(tls_config))
     }
 }
 

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -506,9 +506,7 @@ mod tests {
     #[test]
     fn test_apply_ollama_options_uses_input_limit() {
         let _guard = env_lock::lock_env([("GOOSE_INPUT_LIMIT", Some("8192"))]);
-        let model_config = ModelConfig::new("qwen3")
-            .unwrap()
-            .with_context_limit(Some(16_000));
+        let model_config = ModelConfig::new("qwen3").with_context_limit(Some(16_000));
         let mut payload = json!({});
         apply_ollama_options(&mut payload, &model_config);
         assert_eq!(payload["options"]["num_ctx"], 8192);
@@ -517,9 +515,7 @@ mod tests {
     #[test]
     fn test_apply_ollama_options_falls_back_to_context_limit() {
         let _guard = env_lock::lock_env([("GOOSE_INPUT_LIMIT", None::<&str>)]);
-        let model_config = ModelConfig::new("qwen3")
-            .unwrap()
-            .with_context_limit(Some(12_000));
+        let model_config = ModelConfig::new("qwen3").with_context_limit(Some(12_000));
         let mut payload = json!({});
         apply_ollama_options(&mut payload, &model_config);
         assert_eq!(payload["options"]["num_ctx"], 12_000);
@@ -528,7 +524,7 @@ mod tests {
     #[test]
     fn test_apply_ollama_options_skips_when_no_limit() {
         let _guard = env_lock::lock_env([("GOOSE_INPUT_LIMIT", None::<&str>)]);
-        let mut model_config = ModelConfig::new("qwen3").unwrap();
+        let mut model_config = ModelConfig::new("qwen3");
         model_config.context_limit = None;
         let mut payload = json!({});
         apply_ollama_options(&mut payload, &model_config);
@@ -539,9 +535,7 @@ mod tests {
     fn test_raw_create_request_contains_unsupported_ollama_fields() {
         use crate::providers::formats::ollama::create_request;
 
-        let model_config = ModelConfig::new("llama3.1")
-            .unwrap()
-            .with_max_tokens(Some(4096));
+        let model_config = ModelConfig::new("llama3.1").with_max_tokens(Some(4096));
         let messages = vec![crate::conversation::message::Message::user().with_text("hi")];
 
         let payload = create_request(
@@ -572,9 +566,7 @@ mod tests {
             ("GOOSE_INPUT_LIMIT", None::<&str>),
             ("OLLAMA_STREAM_USAGE", None::<&str>),
         ]);
-        let model_config = ModelConfig::new("llama3.1")
-            .unwrap()
-            .with_max_tokens(Some(4096));
+        let model_config = ModelConfig::new("llama3.1").with_max_tokens(Some(4096));
         let messages = vec![crate::conversation::message::Message::user().with_text("hi")];
 
         let mut payload = create_request(
@@ -616,9 +608,7 @@ mod tests {
             ("GOOSE_INPUT_LIMIT", None::<&str>),
             ("OLLAMA_STREAM_USAGE", Some("false")),
         ]);
-        let model_config = ModelConfig::new("llama3.1")
-            .unwrap()
-            .with_max_tokens(Some(4096));
+        let model_config = ModelConfig::new("llama3.1").with_max_tokens(Some(4096));
         let messages = vec![crate::conversation::message::Message::user().with_text("hi")];
 
         let mut payload = create_request(

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -291,10 +291,6 @@ impl Provider for OllamaProvider {
         self.skip_canonical_filtering
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.model.clone()
-    }
-
     fn retry_config(&self) -> RetryConfig {
         RetryConfig::new(
             OLLAMA_MAX_RETRIES,

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -130,7 +130,6 @@ pub(crate) fn ollama_host_configured(config: &crate::config::Config) -> bool {
 
 impl OllamaProvider {
     pub async fn from_env(
-        _model: ModelConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -176,7 +175,6 @@ impl OllamaProvider {
     }
 
     pub fn from_custom_config(
-        _model: ModelConfig,
         config: DeclarativeProviderConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
@@ -264,11 +262,10 @@ impl ProviderDef for OllamaProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
-        Box::pin(Self::from_env(model, tls_config))
+        Box::pin(Self::from_env(tls_config))
     }
 }
 

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -52,7 +52,6 @@ const OLLAMA_MAX_RETRY_INTERVAL_MS: u64 = 15_000;
 pub struct OllamaProvider {
     #[serde(skip)]
     api_client: ApiClient,
-    model: ModelConfig,
     supports_streaming: bool,
     name: String,
     skip_canonical_filtering: bool,
@@ -131,7 +130,7 @@ pub(crate) fn ollama_host_configured(config: &crate::config::Config) -> bool {
 
 impl OllamaProvider {
     pub async fn from_env(
-        model: ModelConfig,
+        _model: ModelConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -170,7 +169,6 @@ impl OllamaProvider {
 
         Ok(Self {
             api_client,
-            model,
             supports_streaming: true,
             name: OLLAMA_PROVIDER_NAME.to_string(),
             skip_canonical_filtering: false,
@@ -178,7 +176,7 @@ impl OllamaProvider {
     }
 
     pub fn from_custom_config(
-        model: ModelConfig,
+        _model: ModelConfig,
         config: DeclarativeProviderConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
@@ -230,15 +228,8 @@ impl OllamaProvider {
             ));
         }
 
-        let model = if let Some(ref fast_model_name) = config.fast_model {
-            crate::model_config::with_configured_fast_model(model, &config.name, fast_model_name)?
-        } else {
-            model
-        };
-
         Ok(Self {
             api_client,
-            model,
             supports_streaming,
             name: config.name.clone(),
             skip_canonical_filtering: config.skip_canonical_filtering,

--- a/crates/goose/src/providers/openai_def.rs
+++ b/crates/goose/src/providers/openai_def.rs
@@ -9,8 +9,7 @@ use goose_providers::api_client::{ApiClient, AuthMethod};
 use goose_providers::model::ModelConfig;
 use goose_providers::openai::{
     ensure_url_scheme, parse_custom_headers, parse_openai_base_url, OpenAiProvider,
-    OpenAiProviderBuilder, OPEN_AI_DEFAULT_BASE_PATH, OPEN_AI_DEFAULT_FAST_MODEL,
-    OPEN_AI_PROVIDER_NAME, OPEN_AI_VERSIONLESS_BASE_PATH,
+    OpenAiProviderBuilder, OPEN_AI_DEFAULT_BASE_PATH, OPEN_AI_VERSIONLESS_BASE_PATH,
 };
 
 pub struct OpenAiProviderDef;
@@ -34,7 +33,7 @@ impl ProviderDef for OpenAiProviderDef {
 }
 
 pub async fn from_env(
-    model: ModelConfig,
+    _model: ModelConfig,
     tls_config: Option<goose_providers::api_client::TlsConfig>,
 ) -> Result<OpenAiProvider> {
     let config = crate::config::Config::global();
@@ -116,16 +115,6 @@ pub async fn from_env(
         .and_then(|u| u.host_str().map(|h| h.to_ascii_lowercase()))
         .map(|h| h == "api.openai.com" || h.ends_with(".api.openai.com"))
         .unwrap_or(false);
-    let model = if is_openai {
-        crate::model_config::with_configured_fast_model(
-            model,
-            OPEN_AI_PROVIDER_NAME,
-            OPEN_AI_DEFAULT_FAST_MODEL,
-        )?
-    } else {
-        model
-    };
-
     let secrets = config
         .get_secrets("OPENAI_API_KEY", &["OPENAI_CUSTOM_HEADERS"])
         .unwrap_or_default();
@@ -174,7 +163,7 @@ pub async fn from_env(
         api_client = api_client.with_headers(header_map)?;
     }
 
-    let mut provider = OpenAiProviderBuilder::new(api_client, model)
+    let provider = OpenAiProviderBuilder::new(api_client)
         .base_path(base_path)
         .organization(organization)
         .project(project)
@@ -182,7 +171,8 @@ pub async fn from_env(
         .preserve_thinking_context(!is_openai)
         .build();
 
-    provider.probe_context_limit_if_unset().await;
+    // TODO(jack): replace this
+    // provider.probe_context_limit_if_unset(&mut model).await;
 
     Ok(provider)
 }
@@ -235,7 +225,7 @@ pub fn resolve_api_key(
 }
 
 pub fn from_custom_config(
-    model: ModelConfig,
+    _model: ModelConfig,
     config: DeclarativeProviderConfig,
     tls_config: Option<goose_providers::api_client::TlsConfig>,
 ) -> Result<OpenAiProvider> {
@@ -307,13 +297,7 @@ pub fn from_custom_config(
         api_client = api_client.with_headers(header_map)?;
     }
 
-    let model = if let Some(ref fast_model_name) = config.fast_model {
-        crate::model_config::with_configured_fast_model(model, &config.name, fast_model_name)?
-    } else {
-        model
-    };
-
-    Ok(OpenAiProviderBuilder::new(api_client, model)
+    Ok(OpenAiProviderBuilder::new(api_client)
         .base_path(base_path)
         .custom_headers(config.headers)
         .supports_streaming(config.supports_streaming.unwrap_or(true))

--- a/crates/goose/src/providers/openai_def.rs
+++ b/crates/goose/src/providers/openai_def.rs
@@ -8,14 +8,25 @@ use crate::providers::base::{ProviderDef, DEFAULT_PROVIDER_TIMEOUT_SECS};
 use goose_providers::api_client::{ApiClient, AuthMethod};
 use goose_providers::openai::{
     ensure_url_scheme, parse_custom_headers, parse_openai_base_url, OpenAiProvider,
-    OpenAiProviderBuilder, OPEN_AI_DEFAULT_BASE_PATH, OPEN_AI_VERSIONLESS_BASE_PATH,
+    OpenAiProviderBuilder, OPEN_AI_DEFAULT_BASE_PATH, OPEN_AI_DEFAULT_FAST_MODEL,
+    OPEN_AI_VERSIONLESS_BASE_PATH,
 };
 
 pub struct OpenAiProviderDef;
 
 impl ProviderDescriptor for OpenAiProviderDef {
     fn metadata() -> goose_providers::base::ProviderMetadata {
-        OpenAiProvider::metadata()
+        // Only advertise the default fast model when talking to OpenAI
+        // directly. Custom/compatible endpoints likely don't serve
+        // gpt-4o-mini, so leave it unset (complete_fast falls back to the
+        // main model).
+        let metadata = OpenAiProvider::metadata();
+        match resolve_base_url(crate::config::Config::global()) {
+            Ok(parsed) if is_direct_openai_host(&parsed.host) => {
+                metadata.with_fast_model(OPEN_AI_DEFAULT_FAST_MODEL)
+            }
+            _ => metadata,
+        }
     }
 }
 
@@ -50,34 +61,7 @@ pub async fn from_env(
     // otherwise "chat/completions" to match the OpenAI SDK convention.
     //
     // OPENAI_BASE_PATH always wins when set explicitly.
-    let parsed = if let Ok(h) = std::env::var("OPENAI_HOST") {
-        // OPENAI_HOST env var takes priority as a session override so
-        // that existing scripts like `OPENAI_HOST=… goose` still work
-        // even after OPENAI_BASE_URL is persisted in config.
-        ParsedBaseUrl {
-            host: h,
-            query_params: vec![],
-            has_v1: true,
-            from_base_url: false,
-        }
-    } else if let Some(raw_url) = config
-        .get_param::<String>("OPENAI_BASE_URL")
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-    {
-        parse_base_url(&raw_url)?
-    } else {
-        let h: String = config
-            .get_param("OPENAI_HOST")
-            .unwrap_or_else(|_| "https://api.openai.com".to_string());
-        ParsedBaseUrl {
-            host: h,
-            query_params: vec![],
-            has_v1: true,
-            from_base_url: false,
-        }
-    };
+    let parsed = resolve_base_url(config)?;
 
     // When the host was derived from OPENAI_BASE_URL, read
     // OPENAI_BASE_PATH from env only so that the desktop UI's persisted
@@ -100,18 +84,7 @@ pub async fn from_env(
             .unwrap_or_else(|_| default_bp())
     };
 
-    // Only apply the default fast model when talking to OpenAI directly.
-    // Custom/compatible endpoints likely don't serve gpt-4o-mini, so
-    // leave fast_model unset (complete_fast will fall back to the main model).
-    // Parse the URL and compare the hostname exactly to avoid false positives
-    // (e.g. https://api.openai.com.local:8000 or proxy paths containing api.openai.com).
-    let host = parsed.host.clone();
-
-    let is_openai = url::Url::parse(&host)
-        .ok()
-        .and_then(|u| u.host_str().map(|h| h.to_ascii_lowercase()))
-        .map(|h| h == "api.openai.com" || h.ends_with(".api.openai.com"))
-        .unwrap_or(false);
+    let is_openai = is_direct_openai_host(&parsed.host);
     let secrets = config
         .get_secrets("OPENAI_API_KEY", &["OPENAI_CUSTOM_HEADERS"])
         .unwrap_or_default();
@@ -330,6 +303,56 @@ fn parse_base_url(raw_url: &str) -> Result<ParsedBaseUrl> {
     })
 }
 
+/// Resolve the effective host from environment and config.
+///
+/// Priority (highest first):
+///   1. OPENAI_HOST env var — session override (deprecated but still honoured)
+///   2. OPENAI_BASE_URL (env or config) — ecosystem-standard
+///   3. OPENAI_HOST from config file — persisted by `goose configure`
+///   4. Default "https://api.openai.com"
+fn resolve_base_url(config: &crate::config::Config) -> Result<ParsedBaseUrl> {
+    if let Ok(h) = std::env::var("OPENAI_HOST") {
+        return Ok(ParsedBaseUrl {
+            host: h,
+            query_params: vec![],
+            has_v1: true,
+            from_base_url: false,
+        });
+    }
+
+    if let Some(raw_url) = config
+        .get_param::<String>("OPENAI_BASE_URL")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+    {
+        return parse_base_url(&raw_url);
+    }
+
+    let h: String = config
+        .get_param("OPENAI_HOST")
+        .unwrap_or_else(|_| "https://api.openai.com".to_string());
+    Ok(ParsedBaseUrl {
+        host: h,
+        query_params: vec![],
+        has_v1: true,
+        from_base_url: false,
+    })
+}
+
+/// Whether `host` points at OpenAI directly.
+///
+/// Compares the hostname exactly to avoid false positives (e.g.
+/// `https://api.openai.com.local:8000` or proxy paths containing
+/// `api.openai.com`).
+fn is_direct_openai_host(host: &str) -> bool {
+    url::Url::parse(host)
+        .ok()
+        .and_then(|u| u.host_str().map(|h| h.to_ascii_lowercase()))
+        .map(|h| h == "api.openai.com" || h.ends_with(".api.openai.com"))
+        .unwrap_or(false)
+}
+
 fn derive_base_path(url_path: &str) -> String {
     let stripped = url_path.trim_start_matches('/');
     let normalized = stripped.trim_end_matches('/');
@@ -401,6 +424,16 @@ mod tests {
     fn derive_base_path_not_removing_api_path() {
         let r = derive_base_path("https://opencode.ai/zen/go");
         assert_eq!(r, "https://opencode.ai/zen/go/v1/chat/completions");
+    }
+
+    #[test]
+    fn is_direct_openai_host_matches_only_openai() {
+        assert!(is_direct_openai_host("https://api.openai.com"));
+        assert!(is_direct_openai_host("https://api.openai.com/v1"));
+        assert!(is_direct_openai_host("https://eu.api.openai.com"));
+        assert!(!is_direct_openai_host("https://api.openai.com.local:8000"));
+        assert!(!is_direct_openai_host("https://localhost:1234"));
+        assert!(!is_direct_openai_host("https://router.huggingface.co/v1"));
     }
 
     #[test]

--- a/crates/goose/src/providers/openai_def.rs
+++ b/crates/goose/src/providers/openai_def.rs
@@ -16,17 +16,21 @@ pub struct OpenAiProviderDef;
 
 impl ProviderDescriptor for OpenAiProviderDef {
     fn metadata() -> goose_providers::base::ProviderMetadata {
-        // Only advertise the default fast model when talking to OpenAI
-        // directly. Custom/compatible endpoints likely don't serve
-        // gpt-4o-mini, so leave it unset (complete_fast falls back to the
-        // main model).
-        let metadata = OpenAiProvider::metadata();
-        match resolve_base_url(crate::config::Config::global()) {
-            Ok(parsed) if is_direct_openai_host(&parsed.host) => {
-                metadata.with_fast_model(OPEN_AI_DEFAULT_FAST_MODEL)
-            }
-            _ => metadata,
+        // The default fast model is resolved live in `live_fast_model` rather
+        // than baked into metadata here: registry metadata is snapshotted at
+        // init time, but the OpenAI base URL can change at runtime (e.g.
+        // switching to an OpenAI-compatible endpoint), which would otherwise
+        // leave the cached fast model stale.
+        OpenAiProvider::metadata()
+    }
+}
+
+pub fn live_fast_model() -> Option<String> {
+    match resolve_base_url(crate::config::Config::global()) {
+        Ok(parsed) if is_direct_openai_host(&parsed.host) => {
+            Some(OPEN_AI_DEFAULT_FAST_MODEL.to_string())
         }
+        _ => None,
     }
 }
 

--- a/crates/goose/src/providers/openai_def.rs
+++ b/crates/goose/src/providers/openai_def.rs
@@ -6,7 +6,6 @@ use std::collections::HashMap;
 use crate::config::declarative_providers::DeclarativeProviderConfig;
 use crate::providers::base::{ProviderDef, DEFAULT_PROVIDER_TIMEOUT_SECS};
 use goose_providers::api_client::{ApiClient, AuthMethod};
-use goose_providers::model::ModelConfig;
 use goose_providers::openai::{
     ensure_url_scheme, parse_custom_headers, parse_openai_base_url, OpenAiProvider,
     OpenAiProviderBuilder, OPEN_AI_DEFAULT_BASE_PATH, OPEN_AI_VERSIONLESS_BASE_PATH,
@@ -24,16 +23,14 @@ impl ProviderDef for OpenAiProviderDef {
     type Provider = OpenAiProvider;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
-        Box::pin(from_env(model, tls_config))
+        Box::pin(from_env(tls_config))
     }
 }
 
 pub async fn from_env(
-    _model: ModelConfig,
     tls_config: Option<goose_providers::api_client::TlsConfig>,
 ) -> Result<OpenAiProvider> {
     let config = crate::config::Config::global();
@@ -225,7 +222,6 @@ pub fn resolve_api_key(
 }
 
 pub fn from_custom_config(
-    _model: ModelConfig,
     config: DeclarativeProviderConfig,
     tls_config: Option<goose_providers::api_client::TlsConfig>,
 ) -> Result<OpenAiProvider> {

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -170,6 +170,7 @@ impl goose_providers::base::ProviderDescriptor for OpenRouterProvider {
             "Click 'Create' or use an existing API key",
             "Copy the key and paste it above",
         ])
+        .with_fast_model(OPENROUTER_DEFAULT_FAST_MODEL)
     }
 }
 

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -40,7 +40,6 @@ pub const OPENROUTER_DOC_URL: &str = "https://openrouter.ai/models";
 pub struct OpenRouterProvider {
     #[serde(skip)]
     api_client: ApiClient,
-    model: ModelConfig,
     supports_streaming: bool,
     #[serde(skip)]
     name: String,
@@ -48,15 +47,9 @@ pub struct OpenRouterProvider {
 
 impl OpenRouterProvider {
     pub async fn from_env(
-        model: ModelConfig,
+        _model: ModelConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
-        let model = crate::model_config::with_configured_fast_model(
-            model,
-            OPENROUTER_PROVIDER_NAME,
-            OPENROUTER_DEFAULT_FAST_MODEL,
-        )?;
-
         let config = crate::config::Config::global();
         let api_key: String = config.get_secret("OPENROUTER_API_KEY")?;
         let host: String = config
@@ -70,7 +63,6 @@ impl OpenRouterProvider {
 
         Ok(Self {
             api_client,
-            model,
             supports_streaming: true,
             name: OPENROUTER_PROVIDER_NAME.to_string(),
         })
@@ -248,12 +240,6 @@ impl Provider for OpenRouterProvider {
         Ok(models)
     }
 
-    async fn supports_cache_control(&self) -> bool {
-        self.model
-            .model_name
-            .starts_with(OPENROUTER_MODEL_PREFIX_ANTHROPIC)
-    }
-
     async fn stream(
         &self,
         model_config: &ModelConfig,
@@ -278,7 +264,7 @@ impl Provider for OpenRouterProvider {
             }
         }
 
-        if self.supports_cache_control().await {
+        if supports_cache_control(model_config) {
             payload = update_request_for_anthropic(&payload);
         }
 
@@ -308,4 +294,10 @@ impl Provider for OpenRouterProvider {
 
         stream_openai_compat(response, log)
     }
+}
+
+fn supports_cache_control(model: &ModelConfig) -> bool {
+    model
+        .model_name
+        .starts_with(OPENROUTER_MODEL_PREFIX_ANTHROPIC)
 }

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -47,7 +47,6 @@ pub struct OpenRouterProvider {
 
 impl OpenRouterProvider {
     pub async fn from_env(
-        _model: ModelConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -178,11 +177,10 @@ impl ProviderDef for OpenRouterProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
-        Box::pin(Self::from_env(model, tls_config))
+        Box::pin(Self::from_env(tls_config))
     }
 }
 

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -200,10 +200,6 @@ impl Provider for OpenRouterProvider {
         &self.name
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.model.clone()
-    }
-
     /// Fetch supported models from OpenRouter API (only models with tool support)
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         let response = self

--- a/crates/goose/src/providers/pi_acp.rs
+++ b/crates/goose/src/providers/pi_acp.rs
@@ -75,6 +75,7 @@ impl ProviderDef for PiAcpProvider {
                 mcp_servers: extension_configs_to_mcp_servers(&extensions),
                 session_mode_id: Some(mode_mapping[&goose_mode].clone()),
                 session_config_options: vec![],
+                model_config_option_id: None,
                 mode_mapping,
                 notification_callback: None,
             };

--- a/crates/goose/src/providers/pi_acp.rs
+++ b/crates/goose/src/providers/pi_acp.rs
@@ -74,6 +74,7 @@ impl ProviderDef for PiAcpProvider {
                 work_dir: working_dir,
                 mcp_servers: extension_configs_to_mcp_servers(&extensions),
                 session_mode_id: Some(mode_mapping[&goose_mode].clone()),
+                session_config_options: vec![],
                 mode_mapping,
                 notification_callback: None,
             };

--- a/crates/goose/src/providers/pi_acp.rs
+++ b/crates/goose/src/providers/pi_acp.rs
@@ -11,7 +11,6 @@ use crate::config::{Config, GooseMode};
 use crate::providers::base::{
     current_working_dir, ProviderDef, ProviderDescriptor, ProviderMetadata,
 };
-use goose_providers::model::ModelConfig;
 
 pub(crate) const PI_ACP_PROVIDER_NAME: &str = "pi-acp";
 const PI_ACP_DOC_URL: &str = "https://github.com/anthropics/pi";
@@ -44,15 +43,13 @@ impl ProviderDef for PiAcpProvider {
     type Provider = AcpProvider;
 
     fn from_env(
-        model: ModelConfig,
         extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<AcpProvider>> {
-        Self::from_env_with_working_dir(model, extensions, current_working_dir(), tls_config)
+        Self::from_env_with_working_dir(extensions, current_working_dir(), tls_config)
     }
 
     fn from_env_with_working_dir(
-        model: ModelConfig,
         extensions: Vec<crate::config::ExtensionConfig>,
         working_dir: PathBuf,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
@@ -82,7 +79,7 @@ impl ProviderDef for PiAcpProvider {
             };
 
             let metadata = Self::metadata();
-            AcpProvider::connect(metadata.name, model, goose_mode, provider_config).await
+            AcpProvider::connect(metadata.name, goose_mode, provider_config).await
         })
     }
 }

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -55,6 +55,14 @@ impl ProviderEntry {
         (self.inventory_configured)()
     }
 
+    #[cfg(test)]
+    pub(crate) fn normalize_model_config_for_test(
+        &self,
+        model: ModelConfig,
+    ) -> Result<ModelConfig> {
+        self.normalize_model_config(model)
+    }
+
     fn normalize_model_config(&self, mut model: ModelConfig) -> Result<ModelConfig> {
         model = crate::model_config::materialize_model_config(&self.metadata.name, model)?;
 

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -56,9 +56,11 @@ impl ProviderEntry {
 
     /// Apply provider-specific normalization to a model config: materialize
     /// global defaults and backfill `context_limit` from the provider's known
-    /// models when the canonical registry didn't already resolve one. Used by
-    /// the agent/session layer to resolve effective limits (e.g. for custom
-    /// providers that declare explicit context limits in their config).
+    /// models when the canonical registry didn't already resolve one. Also
+    /// attaches `fast_model_config` when the provider declares a fast model and
+    /// the config doesn't already have one. Used by the agent/session layer to
+    /// resolve effective limits (e.g. for custom providers that declare explicit
+    /// context limits in their config).
     pub fn normalize_model_config(&self, mut model: ModelConfig) -> Result<ModelConfig> {
         model = crate::model_config::materialize_model_config(&self.metadata.name, model)?;
 
@@ -70,6 +72,16 @@ impl ProviderEntry {
                 .find(|m| m.name.eq_ignore_ascii_case(&model.model_name) && m.context_limit > 0)
             {
                 model.context_limit = Some(info.context_limit);
+            }
+        }
+
+        if model.fast_model_config.is_none() {
+            if let Some(ref fast_model_name) = self.metadata.fast_model {
+                model = crate::model_config::with_configured_fast_model(
+                    model,
+                    &self.metadata.name,
+                    fast_model_name,
+                )?;
             }
         }
 
@@ -297,6 +309,7 @@ impl ProviderRegistry {
             config_keys,
             setup_steps: config.setup_steps.clone(),
             model_selection_hint: None,
+            fast_model: config.fast_model.clone(),
         };
         let inventory_config_keys = custom_metadata.config_keys.clone();
         let default_inventory_configured = Arc::new(move || {

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -11,7 +11,6 @@ use std::sync::Arc;
 
 pub type ProviderConstructor = Arc<
     dyn Fn(
-            ModelConfig,
             Vec<ExtensionConfig>,
             Option<PathBuf>,
             Option<TlsConfig>,
@@ -55,15 +54,12 @@ impl ProviderEntry {
         (self.inventory_configured)()
     }
 
-    #[cfg(test)]
-    pub(crate) fn normalize_model_config_for_test(
-        &self,
-        model: ModelConfig,
-    ) -> Result<ModelConfig> {
-        self.normalize_model_config(model)
-    }
-
-    fn normalize_model_config(&self, mut model: ModelConfig) -> Result<ModelConfig> {
+    /// Apply provider-specific normalization to a model config: materialize
+    /// global defaults and backfill `context_limit` from the provider's known
+    /// models when the canonical registry didn't already resolve one. Used by
+    /// the agent/session layer to resolve effective limits (e.g. for custom
+    /// providers that declare explicit context limits in their config).
+    pub fn normalize_model_config(&self, mut model: ModelConfig) -> Result<ModelConfig> {
         model = crate::model_config::materialize_model_config(&self.metadata.name, model)?;
 
         if model.context_limit.is_none() {
@@ -84,37 +80,19 @@ impl ProviderEntry {
         &self,
         extensions: Vec<ExtensionConfig>,
     ) -> Result<Arc<dyn Provider>> {
-        let model_config = crate::model_config::model_config_from_user_config(
-            &self.metadata.name,
-            &self.metadata.default_model,
-        )?;
-        let model_config = self.normalize_model_config(model_config)?;
-        (self.constructor)(model_config, extensions, None, self.tls_config.clone()).await
+        self.create(extensions).await
     }
 
-    pub async fn create(
-        &self,
-        model: ModelConfig,
-        extensions: Vec<ExtensionConfig>,
-    ) -> Result<Arc<dyn Provider>> {
-        let model = self.normalize_model_config(model)?;
-        (self.constructor)(model, extensions, None, self.tls_config.clone()).await
+    pub async fn create(&self, extensions: Vec<ExtensionConfig>) -> Result<Arc<dyn Provider>> {
+        (self.constructor)(extensions, None, self.tls_config.clone()).await
     }
 
     pub async fn create_with_working_dir(
         &self,
-        model: ModelConfig,
         extensions: Vec<ExtensionConfig>,
         working_dir: PathBuf,
     ) -> Result<Arc<dyn Provider>> {
-        let model = self.normalize_model_config(model)?;
-        (self.constructor)(
-            model,
-            extensions,
-            Some(working_dir),
-            self.tls_config.clone(),
-        )
-        .await
+        (self.constructor)(extensions, Some(working_dir), self.tls_config.clone()).await
     }
 }
 
@@ -155,19 +133,14 @@ impl ProviderRegistry {
             name,
             ProviderEntry {
                 metadata,
-                constructor: Arc::new(|model, extensions, working_dir, tls_config| {
+                constructor: Arc::new(|extensions, working_dir, tls_config| {
                     Box::pin(async move {
                         let provider = match working_dir {
                             Some(working_dir) => {
-                                F::from_env_with_working_dir(
-                                    model,
-                                    extensions,
-                                    working_dir,
-                                    tls_config,
-                                )
-                                .await?
+                                F::from_env_with_working_dir(extensions, working_dir, tls_config)
+                                    .await?
                             }
-                            None => F::from_env(model, extensions, tls_config).await?,
+                            None => F::from_env(extensions, tls_config).await?,
                         };
                         Ok(Arc::new(provider) as Arc<dyn Provider>)
                     })
@@ -195,7 +168,7 @@ impl ProviderRegistry {
         inventory_identity: G,
     ) where
         P: ProviderDef + 'static,
-        F: Fn(ModelConfig, Option<TlsConfig>) -> Result<P::Provider> + Send + Sync + 'static,
+        F: Fn(Option<TlsConfig>) -> Result<P::Provider> + Send + Sync + 'static,
         G: Fn() -> Result<InventoryIdentityInput> + Send + Sync + 'static,
     {
         self.register_with_name_impl::<P, F, G>(
@@ -218,7 +191,7 @@ impl ProviderRegistry {
         inventory_configured: H,
     ) where
         P: ProviderDef + 'static,
-        F: Fn(ModelConfig, Option<TlsConfig>) -> Result<P::Provider> + Send + Sync + 'static,
+        F: Fn(Option<TlsConfig>) -> Result<P::Provider> + Send + Sync + 'static,
         G: Fn() -> Result<InventoryIdentityInput> + Send + Sync + 'static,
         H: Fn() -> bool + Send + Sync + 'static,
     {
@@ -242,7 +215,7 @@ impl ProviderRegistry {
         inventory_configured: Option<super::inventory::InventoryConfiguredResolver>,
     ) where
         P: ProviderDef + 'static,
-        F: Fn(ModelConfig, Option<TlsConfig>) -> Result<P::Provider> + Send + Sync + 'static,
+        F: Fn(Option<TlsConfig>) -> Result<P::Provider> + Send + Sync + 'static,
         G: Fn() -> Result<InventoryIdentityInput> + Send + Sync + 'static,
     {
         let base_metadata = P::metadata();
@@ -337,8 +310,8 @@ impl ProviderRegistry {
             config.name.clone(),
             ProviderEntry {
                 metadata: custom_metadata,
-                constructor: Arc::new(move |model, _extensions, _working_dir, tls_config| {
-                    let result = constructor(model, tls_config);
+                constructor: Arc::new(move |_extensions, _working_dir, tls_config| {
+                    let result = constructor(tls_config);
                     Box::pin(async move {
                         let provider = result?;
                         Ok(Arc::new(provider) as Arc<dyn Provider>)
@@ -371,7 +344,6 @@ impl ProviderRegistry {
     pub async fn create(
         &self,
         name: &str,
-        model: ModelConfig,
         extensions: Vec<ExtensionConfig>,
     ) -> Result<Arc<dyn Provider>> {
         let entry = self
@@ -379,7 +351,7 @@ impl ProviderRegistry {
             .get(name)
             .ok_or_else(|| anyhow::anyhow!("Unknown provider: {}", name))?;
 
-        entry.create(model, extensions).await
+        entry.create(extensions).await
     }
 
     pub fn all_metadata_with_types(&self) -> Vec<(ProviderMetadata, ProviderType)> {
@@ -432,7 +404,7 @@ mod tests {
             &test_config(),
             ProviderType::Declarative,
             false,
-            |_, _| unreachable!("constructor is not used by this test"),
+            |_| unreachable!("constructor is not used by this test"),
             || Ok(InventoryIdentityInput::new("custom_hf", "huggingface")),
             || false,
         );

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -56,11 +56,9 @@ impl ProviderEntry {
 
     /// Apply provider-specific normalization to a model config: materialize
     /// global defaults and backfill `context_limit` from the provider's known
-    /// models when the canonical registry didn't already resolve one. Also
-    /// attaches `fast_model_config` when the provider declares a fast model and
-    /// the config doesn't already have one. Used by the agent/session layer to
-    /// resolve effective limits (e.g. for custom providers that declare explicit
-    /// context limits in their config).
+    /// models when the canonical registry didn't already resolve one. Used by
+    /// the agent/session layer to resolve effective limits (e.g. for custom
+    /// providers that declare explicit context limits in their config).
     pub fn normalize_model_config(&self, mut model: ModelConfig) -> Result<ModelConfig> {
         model = crate::model_config::materialize_model_config(&self.metadata.name, model)?;
 
@@ -72,16 +70,6 @@ impl ProviderEntry {
                 .find(|m| m.name.eq_ignore_ascii_case(&model.model_name) && m.context_limit > 0)
             {
                 model.context_limit = Some(info.context_limit);
-            }
-        }
-
-        if model.fast_model_config.is_none() {
-            if let Some(ref fast_model_name) = self.metadata.fast_model {
-                model = crate::model_config::with_configured_fast_model(
-                    model,
-                    &self.metadata.name,
-                    fast_model_name,
-                )?;
             }
         }
 

--- a/crates/goose/src/providers/provider_test.rs
+++ b/crates/goose/src/providers/provider_test.rs
@@ -15,7 +15,7 @@ pub async fn test_provider_configuration(
         .with_toolshim(toolshim_enabled)
         .with_toolshim_model(toolshim_model);
 
-    let provider = create(provider_name, model_config, Vec::new()).await?;
+    let provider = create(provider_name, model_config.clone(), Vec::new()).await?;
 
     let messages =
         vec![Message::user().with_text("What is the weather like in San Francisco today?")];
@@ -26,10 +26,9 @@ pub async fn test_provider_configuration(
         vec![]
     };
 
-    let provider_model_config = provider.get_model_config();
     let mut stream = provider
         .stream(
-            &provider_model_config,
+            &model_config,
             "test-session-id",
             "You are an AI agent called goose. You use tools of connected extensions to solve problems.",
             &messages,

--- a/crates/goose/src/providers/provider_test.rs
+++ b/crates/goose/src/providers/provider_test.rs
@@ -15,7 +15,7 @@ pub async fn test_provider_configuration(
         .with_toolshim(toolshim_enabled)
         .with_toolshim_model(toolshim_model);
 
-    let provider = create(provider_name, model_config.clone(), Vec::new()).await?;
+    let provider = create(provider_name, Vec::new()).await?;
 
     let messages =
         vec![Message::user().with_text("What is the weather like in San Francisco today?")];

--- a/crates/goose/src/providers/sagemaker_tgi.rs
+++ b/crates/goose/src/providers/sagemaker_tgi.rs
@@ -34,14 +34,13 @@ pub struct SageMakerTgiProvider {
     #[serde(skip)]
     sagemaker_client: SageMakerClient,
     endpoint_name: String,
-    model: ModelConfig,
     #[serde(skip)]
     name: String,
 }
 
 impl SageMakerTgiProvider {
     pub async fn from_env(
-        model: ModelConfig,
+        _model: ModelConfig,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -91,12 +90,16 @@ impl SageMakerTgiProvider {
         Ok(Self {
             sagemaker_client,
             endpoint_name,
-            model,
             name: SAGEMAKER_TGI_PROVIDER_NAME.to_string(),
         })
     }
 
-    fn create_tgi_request(&self, system: &str, messages: &[Message]) -> Result<Value> {
+    fn create_tgi_request(
+        &self,
+        model: &ModelConfig,
+        system: &str,
+        messages: &[Message],
+    ) -> Result<Value> {
         // Create a simplified prompt for TGI models using recent user and assistant messages.
         // Uses a minimal system prompt and avoids HTML or tool-related formatting.
         let mut prompt = String::new();
@@ -155,8 +158,8 @@ impl SageMakerTgiProvider {
         let request = json!({
             "inputs": prompt,
             "parameters": {
-                "max_new_tokens": self.model.max_output_tokens(),
-                "temperature": self.model.temperature.unwrap_or(0.7),
+                "max_new_tokens": model.max_output_tokens(),
+                "temperature": model.temperature.unwrap_or(0.7),
                 "do_sample": true,
                 "return_full_text": false
             }
@@ -329,9 +332,11 @@ impl Provider for SageMakerTgiProvider {
         };
         let model_name = &model_config.model_name;
 
-        let request_payload = self.create_tgi_request(system, messages).map_err(|e| {
-            ProviderError::RequestFailed(format!("Failed to create request: {}", e))
-        })?;
+        let request_payload = self
+            .create_tgi_request(model_config, system, messages)
+            .map_err(|e| {
+                ProviderError::RequestFailed(format!("Failed to create request: {}", e))
+            })?;
 
         let response = self
             .with_retry(|| self.invoke_endpoint(session_id, request_payload.clone()))
@@ -352,7 +357,7 @@ impl Provider for SageMakerTgiProvider {
             "messages": messages,
             "tools": tools
         });
-        let mut log = start_log(&self.model, &debug_payload)?;
+        let mut log = start_log(model_config, &debug_payload)?;
         log.write(
             &serde_json::to_value(&message).unwrap_or_default(),
             Some(&usage),

--- a/crates/goose/src/providers/sagemaker_tgi.rs
+++ b/crates/goose/src/providers/sagemaker_tgi.rs
@@ -40,7 +40,6 @@ pub struct SageMakerTgiProvider {
 
 impl SageMakerTgiProvider {
     pub async fn from_env(
-        _model: ModelConfig,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -303,11 +302,10 @@ impl ProviderDef for SageMakerTgiProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
-        Box::pin(Self::from_env(model, tls_config))
+        Box::pin(Self::from_env(tls_config))
     }
 }
 

--- a/crates/goose/src/providers/sagemaker_tgi.rs
+++ b/crates/goose/src/providers/sagemaker_tgi.rs
@@ -314,10 +314,6 @@ impl Provider for SageMakerTgiProvider {
         &self.name
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.model.clone()
-    }
-
     async fn stream(
         &self,
         model_config: &ModelConfig,

--- a/crates/goose/src/providers/snowflake.rs
+++ b/crates/goose/src/providers/snowflake.rs
@@ -59,7 +59,6 @@ pub struct SnowflakeProvider {
 
 impl SnowflakeProvider {
     pub async fn from_env(
-        _model: ModelConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -322,11 +321,10 @@ impl ProviderDef for SnowflakeProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
-        Box::pin(Self::from_env(model, tls_config))
+        Box::pin(Self::from_env(tls_config))
     }
 }
 

--- a/crates/goose/src/providers/snowflake.rs
+++ b/crates/goose/src/providers/snowflake.rs
@@ -338,10 +338,6 @@ impl Provider for SnowflakeProvider {
         &self.name
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.model.clone()
-    }
-
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         Ok(SNOWFLAKE_KNOWN_MODELS
             .iter()

--- a/crates/goose/src/providers/snowflake.rs
+++ b/crates/goose/src/providers/snowflake.rs
@@ -52,7 +52,6 @@ impl SnowflakeAuth {
 pub struct SnowflakeProvider {
     #[serde(skip)]
     api_client: ApiClient,
-    model: ModelConfig,
     image_format: ImageFormat,
     #[serde(skip)]
     name: String,
@@ -60,7 +59,7 @@ pub struct SnowflakeProvider {
 
 impl SnowflakeProvider {
     pub async fn from_env(
-        model: ModelConfig,
+        _model: ModelConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -111,7 +110,6 @@ impl SnowflakeProvider {
 
         Ok(Self {
             api_client,
-            model,
             image_format: ImageFormat::OpenAi,
             name: SNOWFLAKE_PROVIDER_NAME.to_string(),
         })
@@ -360,7 +358,7 @@ impl Provider for SnowflakeProvider {
         };
         let payload = create_request(model_config, system, messages, tools)?;
 
-        let mut log = start_log(&self.model, &payload)?;
+        let mut log = start_log(model_config, &payload)?;
 
         let response = self
             .with_retry(|| async {

--- a/crates/goose/src/providers/testprovider.rs
+++ b/crates/goose/src/providers/testprovider.rs
@@ -219,10 +219,6 @@ impl Provider for TestProvider {
             }
         }
     }
-
-    fn get_model_config(&self) -> ModelConfig {
-        ModelConfig::new_or_fail("test-model")
-    }
 }
 
 #[cfg(test)]
@@ -236,7 +232,6 @@ mod tests {
 
     #[derive(Clone)]
     struct MockProvider {
-        model_config: ModelConfig,
         response: String,
     }
 
@@ -268,10 +263,6 @@ mod tests {
             let usage = ProviderUsage::new("mock-model".to_string(), Usage::default());
             Ok(stream_from_single_message(message, usage))
         }
-
-        fn get_model_config(&self) -> ModelConfig {
-            self.model_config.clone()
-        }
     }
 
     #[tokio::test]
@@ -283,13 +274,12 @@ mod tests {
         );
 
         let mock = Arc::new(MockProvider {
-            model_config: ModelConfig::new_or_fail("mock-model"),
             response: "Hello, world!".to_string(),
         });
 
         {
             let test_provider = TestProvider::new_recording(mock, &temp_file);
-            let model_config = test_provider.get_model_config();
+            let model_config = ModelConfig::new_or_fail("test-model");
 
             let result = test_provider
                 .complete(
@@ -314,7 +304,7 @@ mod tests {
 
         {
             let replay_provider = TestProvider::new_replaying(&temp_file).unwrap();
-            let model_config = replay_provider.get_model_config();
+            let model_config = ModelConfig::new_or_fail("test-model");
 
             let result = replay_provider
                 .complete(
@@ -346,7 +336,7 @@ mod tests {
         );
 
         let replay_provider = TestProvider::new_replaying(&temp_file).unwrap();
-        let model_config = replay_provider.get_model_config();
+        let model_config = ModelConfig::new_or_fail("test-model");
 
         let result = replay_provider
             .complete(

--- a/crates/goose/src/providers/testprovider.rs
+++ b/crates/goose/src/providers/testprovider.rs
@@ -278,7 +278,7 @@ mod tests {
 
         {
             let test_provider = TestProvider::new_recording(mock, &temp_file);
-            let model_config = ModelConfig::new_or_fail("test-model");
+            let model_config = ModelConfig::new("test-model");
 
             let result = test_provider
                 .complete(
@@ -303,7 +303,7 @@ mod tests {
 
         {
             let replay_provider = TestProvider::new_replaying(&temp_file).unwrap();
-            let model_config = ModelConfig::new_or_fail("test-model");
+            let model_config = ModelConfig::new("test-model");
 
             let result = replay_provider
                 .complete(
@@ -335,7 +335,7 @@ mod tests {
         );
 
         let replay_provider = TestProvider::new_replaying(&temp_file).unwrap();
-        let model_config = ModelConfig::new_or_fail("test-model");
+        let model_config = ModelConfig::new("test-model");
 
         let result = replay_provider
             .complete(

--- a/crates/goose/src/providers/testprovider.rs
+++ b/crates/goose/src/providers/testprovider.rs
@@ -156,7 +156,6 @@ impl ProviderDef for TestProvider {
     type Provider = Self;
 
     fn from_env(
-        _model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {

--- a/crates/goose/src/providers/tetrate.rs
+++ b/crates/goose/src/providers/tetrate.rs
@@ -47,7 +47,6 @@ pub struct TetrateProvider {
 
 impl TetrateProvider {
     pub async fn from_env(
-        _model: ModelConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -117,11 +116,10 @@ impl ProviderDef for TetrateProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
-        Box::pin(Self::from_env(model, tls_config))
+        Box::pin(Self::from_env(tls_config))
     }
 }
 

--- a/crates/goose/src/providers/tetrate.rs
+++ b/crates/goose/src/providers/tetrate.rs
@@ -133,10 +133,6 @@ impl Provider for TetrateProvider {
         &self.name
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.model.clone()
-    }
-
     async fn stream(
         &self,
         model_config: &ModelConfig,

--- a/crates/goose/src/providers/tetrate.rs
+++ b/crates/goose/src/providers/tetrate.rs
@@ -40,7 +40,6 @@ pub const TETRATE_KNOWN_MODELS: &[&str] = &[
 pub struct TetrateProvider {
     #[serde(skip)]
     api_client: ApiClient,
-    model: ModelConfig,
     supports_streaming: bool,
     #[serde(skip)]
     name: String,
@@ -48,7 +47,7 @@ pub struct TetrateProvider {
 
 impl TetrateProvider {
     pub async fn from_env(
-        model: ModelConfig,
+        _model: ModelConfig,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let config = crate::config::Config::global();
@@ -64,7 +63,6 @@ impl TetrateProvider {
 
         Ok(Self {
             api_client,
-            model,
             supports_streaming: true,
             name: TETRATE_PROVIDER_NAME.to_string(),
         })

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -571,7 +571,7 @@ impl LocalInterpreter {
             .with_toolshim(false)
             .with_toolshim_model(None);
 
-        let provider = crate::providers::init::create("local", model_config, vec![])
+        let provider = crate::providers::init::create("local", model_config.clone(), vec![])
             .await
             .map_err(|e| {
                 ProviderError::RequestFailed(format!(
@@ -581,13 +581,7 @@ impl LocalInterpreter {
 
         let request_messages = vec![Message::user().with_text(format_instruction)];
         let mut stream = provider
-            .stream(
-                &provider.get_model_config(),
-                "toolshim-local",
-                "",
-                &request_messages,
-                &[],
-            )
+            .stream(&model_config, "toolshim-local", "", &request_messages, &[])
             .await?;
 
         let mut content = String::new();

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -571,7 +571,7 @@ impl LocalInterpreter {
             .with_toolshim(false)
             .with_toolshim_model(None);
 
-        let provider = crate::providers::init::create("local", model_config.clone(), vec![])
+        let provider = crate::providers::init::create("local", vec![])
             .await
             .map_err(|e| {
                 ProviderError::RequestFailed(format!(

--- a/crates/goose/src/providers/xai.rs
+++ b/crates/goose/src/providers/xai.rs
@@ -3,7 +3,6 @@ use super::base::{ConfigKey, ProviderDef, ProviderMetadata};
 use super::openai_compatible::OpenAiCompatibleProvider;
 use anyhow::Result;
 use futures::future::BoxFuture;
-use goose_providers::model::ModelConfig;
 
 const XAI_PROVIDER_NAME: &str = "xai";
 pub const XAI_API_HOST: &str = "https://api.x.ai/v1";
@@ -54,7 +53,6 @@ impl ProviderDef for XaiProvider {
     type Provider = OpenAiCompatibleProvider;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<OpenAiCompatibleProvider>> {
@@ -71,7 +69,6 @@ impl ProviderDef for XaiProvider {
             Ok(OpenAiCompatibleProvider::new(
                 XAI_PROVIDER_NAME.to_string(),
                 api_client,
-                model,
                 String::new(),
             ))
         })

--- a/crates/goose/src/providers/xai_oauth.rs
+++ b/crates/goose/src/providers/xai_oauth.rs
@@ -703,10 +703,6 @@ impl Provider for XaiOAuthProvider {
         self.inner.get_name()
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.inner.get_model_config()
-    }
-
     async fn stream(
         &self,
         model_config: &ModelConfig,

--- a/crates/goose/src/providers/xai_oauth.rs
+++ b/crates/goose/src/providers/xai_oauth.rs
@@ -777,7 +777,6 @@ impl ProviderDef for XaiOAuthProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<crate::config::ExtensionConfig>,
         tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<Self::Provider>> {
@@ -798,7 +797,6 @@ impl ProviderDef for XaiOAuthProvider {
             let inner = OpenAiCompatibleProvider::new(
                 XAI_OAUTH_PROVIDER_NAME.to_string(),
                 api_client,
-                model,
                 String::new(),
             );
 

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -858,8 +858,10 @@ async fn execute_job(
         agent.add_extension(ext.clone(), &session.id).await?;
     }
 
-    let agent_provider = create(&provider_name, model_config, extensions).await?;
-    agent.update_provider(agent_provider, &session.id).await?;
+    let agent_provider = create(&provider_name, model_config.clone(), extensions).await?;
+    agent
+        .update_provider(agent_provider, model_config, &session.id)
+        .await?;
 
     let mut jobs_guard = jobs.lock().await;
     if let Some((_, job_def)) = jobs_guard.get_mut(job_id.as_str()) {

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -858,7 +858,7 @@ async fn execute_job(
         agent.add_extension(ext.clone(), &session.id).await?;
     }
 
-    let agent_provider = create(&provider_name, model_config.clone(), extensions).await?;
+    let agent_provider = create(&provider_name, extensions).await?;
     agent
         .update_provider(agent_provider, model_config, &session.id)
         .await?;

--- a/crates/goose/src/security/adversary_inspector.rs
+++ b/crates/goose/src/security/adversary_inspector.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use chrono::Utc;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 use crate::agents::types::SharedProvider;
 use crate::config::paths::Paths;
@@ -13,12 +13,12 @@ use crate::utils::safe_truncate;
 
 const DEFAULT_TOOLS: &[&str] = &["shell", "computercontroller__automation_script"];
 
-async fn resolve_model_config(session_id: &str) -> Result<goose_providers::model::ModelConfig> {
+async fn resolve_model_config(
+    session_manager: &crate::session::SessionManager,
+    session_id: &str,
+) -> Result<goose_providers::model::ModelConfig> {
     if !session_id.is_empty() {
-        if let Ok(session) = crate::session::SessionManager::instance()
-            .get_session(session_id, false)
-            .await
-        {
+        if let Ok(session) = session_manager.get_session(session_id, false).await {
             if let Some(model_config) = session.model_config {
                 return Ok(model_config);
             }
@@ -72,22 +72,32 @@ struct AdversaryConfig {
 /// If the review fails, the inspector fails open (allows the tool call).
 pub struct AdversaryInspector {
     provider: SharedProvider,
+    session_manager: Arc<crate::session::SessionManager>,
     config: OnceLock<Option<AdversaryConfig>>,
     config_path: Option<std::path::PathBuf>,
 }
 
 impl AdversaryInspector {
-    pub fn new(provider: SharedProvider) -> Self {
+    pub fn new(
+        provider: SharedProvider,
+        session_manager: Arc<crate::session::SessionManager>,
+    ) -> Self {
         Self {
             provider,
+            session_manager,
             config: OnceLock::new(),
             config_path: None,
         }
     }
 
-    pub fn with_config_dir(provider: SharedProvider, config_dir: std::path::PathBuf) -> Self {
+    pub fn with_config_dir(
+        provider: SharedProvider,
+        session_manager: Arc<crate::session::SessionManager>,
+        config_dir: std::path::PathBuf,
+    ) -> Self {
         Self {
             provider,
+            session_manager,
             config: OnceLock::new(),
             config_path: Some(config_dir.join("adversary.md")),
         }
@@ -313,7 +323,7 @@ impl AdversaryInspector {
         )];
         let conversation = Conversation::new_unvalidated(check_messages);
 
-        let model_config = resolve_model_config(session_id)
+        let model_config = resolve_model_config(&self.session_manager, session_id)
             .await
             .map_err(|e| anyhow::anyhow!("Could not resolve model config: {}", e))?;
         let (response, _usage) = provider
@@ -651,7 +661,14 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
 
         let provider: SharedProvider = Arc::new(Mutex::new(None));
-        let inspector = AdversaryInspector::with_config_dir(provider, tmp.path().to_path_buf());
+        let session_manager = Arc::new(crate::session::SessionManager::new(
+            tmp.path().to_path_buf(),
+        ));
+        let inspector = AdversaryInspector::with_config_dir(
+            provider,
+            session_manager,
+            tmp.path().to_path_buf(),
+        );
         assert!(!inspector.is_enabled());
 
         let request = ToolRequest {

--- a/crates/goose/src/security/adversary_inspector.rs
+++ b/crates/goose/src/security/adversary_inspector.rs
@@ -13,7 +13,18 @@ use crate::utils::safe_truncate;
 
 const DEFAULT_TOOLS: &[&str] = &["shell", "computercontroller__automation_script"];
 
-fn resolve_model_config() -> Result<goose_providers::model::ModelConfig> {
+async fn resolve_model_config(session_id: &str) -> Result<goose_providers::model::ModelConfig> {
+    if !session_id.is_empty() {
+        if let Ok(session) = crate::session::SessionManager::instance()
+            .get_session(session_id, false)
+            .await
+        {
+            if let Some(model_config) = session.model_config {
+                return Ok(model_config);
+            }
+        }
+    }
+
     let config = crate::config::Config::global();
     let provider_name = config
         .get_goose_provider()
@@ -251,6 +262,7 @@ impl AdversaryInspector {
 
     async fn consult_llm(
         &self,
+        session_id: &str,
         tool_description: &str,
         original_task: &str,
         recent_messages: &[String],
@@ -301,12 +313,13 @@ impl AdversaryInspector {
         )];
         let conversation = Conversation::new_unvalidated(check_messages);
 
-        let model_config = resolve_model_config()
+        let model_config = resolve_model_config(session_id)
+            .await
             .map_err(|e| anyhow::anyhow!("Could not resolve model config: {}", e))?;
         let (response, _usage) = provider
             .complete(
                 &model_config,
-                "",
+                session_id,
                 system_prompt,
                 conversation.messages(),
                 &[],
@@ -370,7 +383,7 @@ impl ToolInspector for AdversaryInspector {
 
     async fn inspect(
         &self,
-        _session_id: &str,
+        session_id: &str,
         tool_requests: &[ToolRequest],
         messages: &[Message],
         _goose_mode: GooseMode,
@@ -404,6 +417,7 @@ impl ToolInspector for AdversaryInspector {
 
             match self
                 .consult_llm(
+                    session_id,
                     &tool_description,
                     &original_task,
                     &recent_messages,

--- a/crates/goose/src/security/adversary_inspector.rs
+++ b/crates/goose/src/security/adversary_inspector.rs
@@ -13,6 +13,17 @@ use crate::utils::safe_truncate;
 
 const DEFAULT_TOOLS: &[&str] = &["shell", "computercontroller__automation_script"];
 
+fn resolve_model_config() -> Result<goose_providers::model::ModelConfig> {
+    let config = crate::config::Config::global();
+    let provider_name = config
+        .get_goose_provider()
+        .map_err(|_| anyhow::anyhow!("missing provider"))?;
+    let model_name = config
+        .get_goose_model()
+        .map_err(|_| anyhow::anyhow!("missing model"))?;
+    crate::model_config::model_config_from_user_config(&provider_name, &model_name)
+}
+
 const DEFAULT_RULES: &str = r#"BLOCK if the command:
 - Exfiltrates data (curl/wget posting to unknown URLs, piping secrets out)
 - Is destructive beyond the project scope (rm -rf /, modifying system files)
@@ -290,7 +301,8 @@ impl AdversaryInspector {
         )];
         let conversation = Conversation::new_unvalidated(check_messages);
 
-        let model_config = provider.get_model_config();
+        let model_config = resolve_model_config()
+            .map_err(|e| anyhow::anyhow!("Could not resolve model config: {}", e))?;
         let (response, _usage) = provider
             .complete(
                 &model_config,

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -495,6 +495,10 @@ impl SessionManager {
             return Ok(Some(self.system_generated_name_update(id, name).await?));
         }
 
+        let model_config = session
+            .model_config
+            .clone()
+            .unwrap_or_else(|| goose_providers::model::ModelConfig::new_or_fail("unknown"));
         let conversation = session
             .conversation
             .ok_or_else(|| anyhow::anyhow!("No messages found"))?;
@@ -506,7 +510,8 @@ impl SessionManager {
             .count();
 
         if user_message_count <= MSG_COUNT_FOR_SESSION_NAME_GENERATION {
-            let name = generate_session_name(provider.as_ref(), id, &conversation).await?;
+            let name =
+                generate_session_name(provider.as_ref(), &model_config, id, &conversation).await?;
             return Ok(Some(self.system_generated_name_update(id, name).await?));
         }
         Ok(None)
@@ -2089,9 +2094,7 @@ mod tests {
     const NUM_CONCURRENT_SESSIONS: i32 = 10;
     const GENERATED_SESSION_NAME: &str = "Generated session name";
 
-    struct NamingTestProvider {
-        model_config: ModelConfig,
-    }
+    struct NamingTestProvider;
 
     #[async_trait::async_trait]
     impl Provider for NamingTestProvider {
@@ -2110,12 +2113,9 @@ mod tests {
             unimplemented!("session naming calls complete_fast")
         }
 
-        fn get_model_config(&self) -> ModelConfig {
-            self.model_config.clone()
-        }
-
         async fn complete_fast(
             &self,
+            _model_config: &ModelConfig,
             _session_id: &str,
             _system: &str,
             _messages: &[Message],
@@ -2129,9 +2129,7 @@ mod tests {
     }
 
     fn naming_test_provider() -> Arc<dyn Provider> {
-        Arc::new(NamingTestProvider {
-            model_config: ModelConfig::new("test-model").unwrap(),
-        })
+        Arc::new(NamingTestProvider)
     }
 
     fn test_recipe(title: &str) -> Recipe {

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -495,10 +495,21 @@ impl SessionManager {
             return Ok(Some(self.system_generated_name_update(id, name).await?));
         }
 
-        let model_config = session
-            .model_config
-            .clone()
-            .unwrap_or_else(|| goose_providers::model::ModelConfig::new("unknown"));
+        let model_config = match session.model_config.clone() {
+            Some(model_config) => model_config,
+            None => {
+                let model_name =
+                    crate::config::Config::global()
+                        .get_goose_model()
+                        .map_err(|_| {
+                            anyhow::anyhow!("Could not resolve model config: missing model")
+                        })?;
+                crate::model_config::model_config_from_user_config(
+                    provider.get_name(),
+                    &model_name,
+                )?
+            }
+        };
         let conversation = session
             .conversation
             .ok_or_else(|| anyhow::anyhow!("No messages found"))?;
@@ -2110,10 +2121,10 @@ mod tests {
             _messages: &[Message],
             _tools: &[rmcp::model::Tool],
         ) -> std::result::Result<MessageStream, goose_providers::errors::ProviderError> {
-            unimplemented!("session naming calls complete_fast")
+            unimplemented!("session naming calls complete")
         }
 
-        async fn complete_fast(
+        async fn complete(
             &self,
             _model_config: &ModelConfig,
             _session_id: &str,

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -498,7 +498,7 @@ impl SessionManager {
         let model_config = session
             .model_config
             .clone()
-            .unwrap_or_else(|| goose_providers::model::ModelConfig::new_or_fail("unknown"));
+            .unwrap_or_else(|| goose_providers::model::ModelConfig::new("unknown"));
         let conversation = session
             .conversation
             .ok_or_else(|| anyhow::anyhow!("No messages found"))?;

--- a/crates/goose/src/session/session_naming.rs
+++ b/crates/goose/src/session/session_naming.rs
@@ -145,11 +145,15 @@ pub(crate) async fn generate_session_name(
         SESSION_NAME_SUFFIX,
     );
     let message = Message::user().with_text(&user_text);
-    let fast_model_config =
-        crate::model_config::get_fast_model(provider.get_name(), model_config).await?;
-    let result = provider
-        .complete(&fast_model_config, session_id, &system, &[message], &[])
-        .await?;
+    let result = crate::model_config::complete_fast(
+        provider,
+        model_config,
+        session_id,
+        &system,
+        &[message],
+        &[],
+    )
+    .await?;
 
     let raw: String = result
         .0

--- a/crates/goose/src/session/session_naming.rs
+++ b/crates/goose/src/session/session_naming.rs
@@ -112,6 +112,7 @@ fn get_preprompt_context(messages: &Conversation) -> String {
 /// Creates a prompt asking for a concise description in 4 words or less.
 pub(crate) async fn generate_session_name(
     provider: &dyn Provider,
+    model_config: &goose_providers::model::ModelConfig,
     session_id: &str,
     messages: &Conversation,
 ) -> Result<String> {
@@ -145,7 +146,7 @@ pub(crate) async fn generate_session_name(
     );
     let message = Message::user().with_text(&user_text);
     let result = provider
-        .complete_fast(session_id, &system, &[message], &[])
+        .complete_fast(model_config, session_id, &system, &[message], &[])
         .await?;
 
     let raw: String = result

--- a/crates/goose/src/session/session_naming.rs
+++ b/crates/goose/src/session/session_naming.rs
@@ -145,8 +145,10 @@ pub(crate) async fn generate_session_name(
         SESSION_NAME_SUFFIX,
     );
     let message = Message::user().with_text(&user_text);
+    let fast_model_config =
+        crate::model_config::get_fast_model(provider.get_name(), model_config).await?;
     let result = provider
-        .complete_fast(model_config, session_id, &system, &[message], &[])
+        .complete(&fast_model_config, session_id, &system, &[message], &[])
         .await?;
 
     let raw: String = result

--- a/crates/goose/tests/acp_common_tests/mod.rs
+++ b/crates/goose/tests/acp_common_tests/mod.rs
@@ -429,7 +429,7 @@ pub async fn run_fs_write_text_file_true<C: Connection>() {
 
 pub async fn run_initialize_doesnt_hit_provider<C: Connection>() {
     let provider_factory: AcpProviderFactory =
-        Arc::new(|_, _, _, _| Box::pin(async { Err(anyhow::anyhow!("no provider configured")) }));
+        Arc::new(|_, _, _| Box::pin(async { Err(anyhow::anyhow!("no provider configured")) }));
 
     let openai = OpenAiFixture::new(vec![], C::expected_session_id()).await;
     let config = TestConnectionConfig {

--- a/crates/goose/tests/acp_custom_requests_test.rs
+++ b/crates/goose/tests/acp_custom_requests_test.rs
@@ -47,8 +47,6 @@ fn write_acp_global_config(contents: &str) -> PathBuf {
 
 struct MockProvider {
     name: String,
-    #[allow(dead_code)]
-    model_config: ModelConfig,
     recommended_models: Vec<String>,
     supported_models: Vec<String>,
 }
@@ -1040,11 +1038,10 @@ fn test_custom_provider_supported_models_lists_raw_provider_models() {
     run_test(async move {
         let openai = OpenAiFixture::new(vec![], Arc::new(EnforceSessionId::default())).await;
         let provider_factory: AcpProviderFactory =
-            Arc::new(|provider_name, model_config, _extensions, _working_dir| {
+            Arc::new(|provider_name, _extensions, _working_dir| {
                 Box::pin(async move {
                     Ok(Arc::new(MockProvider {
                         name: provider_name,
-                        model_config,
                         recommended_models: vec!["canonical-filtered-model".to_string()],
                         supported_models: vec![
                             "goose-claude-opus-4-8".to_string(),

--- a/crates/goose/tests/acp_custom_requests_test.rs
+++ b/crates/goose/tests/acp_custom_requests_test.rs
@@ -47,6 +47,7 @@ fn write_acp_global_config(contents: &str) -> PathBuf {
 
 struct MockProvider {
     name: String,
+    #[allow(dead_code)]
     model_config: ModelConfig,
     recommended_models: Vec<String>,
     supported_models: Vec<String>,
@@ -69,11 +70,10 @@ impl Provider for MockProvider {
         unimplemented!()
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.model_config.clone()
-    }
-
-    async fn fetch_recommended_models(&self) -> Result<Vec<String>, ProviderError> {
+    async fn fetch_recommended_models(
+        &self,
+        _toolshim: bool,
+    ) -> Result<Vec<String>, ProviderError> {
         Ok(self.recommended_models.clone())
     }
 

--- a/crates/goose/tests/acp_fixtures/mod.rs
+++ b/crates/goose/tests/acp_fixtures/mod.rs
@@ -196,7 +196,7 @@ pub async fn spawn_acp_server_in_process(
     let provider_factory = provider_factory.unwrap_or_else(|| {
         let base_url = openai_base_url.to_string();
         Arc::new(
-            move |_provider_name, model_config, _extensions, _working_dir| {
+            move |_provider_name, _model_config, _extensions, _working_dir| {
                 let base_url = base_url.clone();
                 Box::pin(async move {
                     let api_client = ApiClient::new_with_tls(
@@ -205,8 +205,7 @@ pub async fn spawn_acp_server_in_process(
                         None,
                     )
                     .unwrap();
-                    let provider: Arc<dyn Provider> =
-                        Arc::new(OpenAiProvider::new(api_client, model_config));
+                    let provider: Arc<dyn Provider> = Arc::new(OpenAiProvider::new(api_client));
                     Ok(provider)
                 })
             },

--- a/crates/goose/tests/acp_fixtures/mod.rs
+++ b/crates/goose/tests/acp_fixtures/mod.rs
@@ -195,21 +195,19 @@ pub async fn spawn_acp_server_in_process(
     write_global_test_config(&config_path, openai_base_url);
     let provider_factory = provider_factory.unwrap_or_else(|| {
         let base_url = openai_base_url.to_string();
-        Arc::new(
-            move |_provider_name, _model_config, _extensions, _working_dir| {
-                let base_url = base_url.clone();
-                Box::pin(async move {
-                    let api_client = ApiClient::new_with_tls(
-                        base_url,
-                        ApiAuthMethod::BearerToken("test-key".to_string()),
-                        None,
-                    )
-                    .unwrap();
-                    let provider: Arc<dyn Provider> = Arc::new(OpenAiProvider::new(api_client));
-                    Ok(provider)
-                })
-            },
-        )
+        Arc::new(move |_provider_name, _extensions, _working_dir| {
+            let base_url = base_url.clone();
+            Box::pin(async move {
+                let api_client = ApiClient::new_with_tls(
+                    base_url,
+                    ApiAuthMethod::BearerToken("test-key".to_string()),
+                    None,
+                )
+                .unwrap();
+                let provider: Arc<dyn Provider> = Arc::new(OpenAiProvider::new(api_client));
+                Ok(provider)
+            })
+        })
     });
 
     let agent = GooseAcpAgent::new(GooseAcpAgentOptions {

--- a/crates/goose/tests/acp_fixtures/provider.rs
+++ b/crates/goose/tests/acp_fixtures/provider.rs
@@ -76,7 +76,7 @@ impl AcpProviderSession {
             .unwrap()
             .get(session_id.as_ref())
             .cloned()
-            .unwrap_or_else(|| ModelConfig::new(TEST_MODEL).unwrap());
+            .unwrap_or_else(|| ModelConfig::new(TEST_MODEL));
         let mut stream = provider
             .stream(&model_config, &session_id, "", &[message], &[])
             .await?;

--- a/crates/goose/tests/acp_fixtures/provider.rs
+++ b/crates/goose/tests/acp_fixtures/provider.rs
@@ -76,7 +76,7 @@ impl AcpProviderSession {
             .unwrap()
             .get(session_id.as_ref())
             .cloned()
-            .unwrap_or_else(|| provider.get_model_config());
+            .unwrap_or_else(|| ModelConfig::new(TEST_MODEL).unwrap());
         let mut stream = provider
             .stream(&model_config, &session_id, "", &[message], &[])
             .await?;
@@ -237,7 +237,7 @@ impl Connection for AcpProviderConnection {
             let provider = provider.as_ref().unwrap();
             let available_models = provider.fetch_supported_models().await?;
             Some(SessionModelState::new(
-                ModelId::new(provider.get_model_config().model_name.clone()),
+                ModelId::new(TEST_MODEL.to_string()),
                 available_models
                     .into_iter()
                     .map(|model_id| ModelInfo::new(ModelId::new(model_id.clone()), model_id))

--- a/crates/goose/tests/acp_fixtures/provider.rs
+++ b/crates/goose/tests/acp_fixtures/provider.rs
@@ -183,6 +183,7 @@ impl Connection for AcpProviderConnection {
             work_dir: cwd_path.clone(),
             mcp_servers,
             session_mode_id: None,
+            session_config_options: vec![],
             mode_mapping: GooseMode::VARIANTS
                 .iter()
                 .map(|v| {

--- a/crates/goose/tests/acp_fixtures/provider.rs
+++ b/crates/goose/tests/acp_fixtures/provider.rs
@@ -184,6 +184,7 @@ impl Connection for AcpProviderConnection {
             mcp_servers,
             session_mode_id: None,
             session_config_options: vec![],
+            model_config_option_id: None,
             mode_mapping: GooseMode::VARIANTS
                 .iter()
                 .map(|v| {

--- a/crates/goose/tests/acp_fixtures/provider.rs
+++ b/crates/goose/tests/acp_fixtures/provider.rs
@@ -203,7 +203,6 @@ impl Connection for AcpProviderConnection {
         };
         let provider = AcpProvider::connect_with_transport(
             "acp-test".to_string(),
-            ModelConfig::new(TEST_MODEL).unwrap(),
             goose_mode,
             provider_config,
             transport,

--- a/crates/goose/tests/acp_secret_cache_invalidation_test.rs
+++ b/crates/goose/tests/acp_secret_cache_invalidation_test.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 struct MockProvider {
     name: String,
+    #[allow(dead_code)]
     model_config: ModelConfig,
 }
 
@@ -37,11 +38,10 @@ impl Provider for MockProvider {
         unimplemented!()
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        self.model_config.clone()
-    }
-
-    async fn fetch_recommended_models(&self) -> Result<Vec<String>, ProviderError> {
+    async fn fetch_recommended_models(
+        &self,
+        _toolshim: bool,
+    ) -> Result<Vec<String>, ProviderError> {
         Ok(vec!["claude-3-5-haiku-latest".to_string()])
     }
 }

--- a/crates/goose/tests/acp_secret_cache_invalidation_test.rs
+++ b/crates/goose/tests/acp_secret_cache_invalidation_test.rs
@@ -17,8 +17,6 @@ use std::sync::Arc;
 
 struct MockProvider {
     name: String,
-    #[allow(dead_code)]
-    model_config: ModelConfig,
 }
 
 #[async_trait::async_trait]
@@ -47,11 +45,10 @@ impl Provider for MockProvider {
 }
 
 fn mock_provider_factory() -> goose::acp::server::AcpProviderFactory {
-    Arc::new(|provider_name, model_config, _extensions, _working_dir| {
+    Arc::new(|provider_name, _extensions, _working_dir| {
         Box::pin(async move {
             Ok(Arc::new(MockProvider {
                 name: provider_name,
-                model_config,
             }) as Arc<dyn Provider>)
         })
     })

--- a/crates/goose/tests/adversary_inspector_tests.rs
+++ b/crates/goose/tests/adversary_inspector_tests.rs
@@ -30,7 +30,13 @@ async fn test_adversary_disabled_without_config_file() {
     let tmp = tempfile::tempdir().unwrap();
 
     let provider = Arc::new(Mutex::new(None));
-    let inspector = AdversaryInspector::with_config_dir(provider, tmp.path().to_path_buf());
+    let inspector = AdversaryInspector::with_config_dir(
+        provider,
+        Arc::new(goose::session::SessionManager::new(
+            tmp.path().to_path_buf(),
+        )),
+        tmp.path().to_path_buf(),
+    );
 
     assert_eq!(inspector.name(), "adversary");
     assert!(!inspector.is_enabled());
@@ -58,7 +64,13 @@ async fn test_adversary_enabled_default_tools() {
     write_adversary_md(tmp.path(), "BLOCK everything for testing");
 
     let provider = Arc::new(Mutex::new(None));
-    let inspector = AdversaryInspector::with_config_dir(provider, tmp.path().to_path_buf());
+    let inspector = AdversaryInspector::with_config_dir(
+        provider,
+        Arc::new(goose::session::SessionManager::new(
+            tmp.path().to_path_buf(),
+        )),
+        tmp.path().to_path_buf(),
+    );
 
     assert!(inspector.is_enabled());
 
@@ -116,7 +128,13 @@ async fn test_adversary_custom_tool_filter() {
     );
 
     let provider = Arc::new(Mutex::new(None));
-    let inspector = AdversaryInspector::with_config_dir(provider, tmp.path().to_path_buf());
+    let inspector = AdversaryInspector::with_config_dir(
+        provider,
+        Arc::new(goose::session::SessionManager::new(
+            tmp.path().to_path_buf(),
+        )),
+        tmp.path().to_path_buf(),
+    );
 
     assert!(inspector.is_enabled());
 

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -433,11 +433,7 @@ mod tests {
                 .await?;
 
             agent
-                .update_provider(
-                    provider,
-                    ModelConfig::new("mock-model").unwrap(),
-                    &session.id,
-                )
+                .update_provider(provider, ModelConfig::new("mock-model"), &session.id)
                 .await?;
 
             let session_config = SessionConfig {
@@ -621,11 +617,7 @@ mod tests {
                 .await?;
 
             agent
-                .update_provider(
-                    provider,
-                    ModelConfig::new("mock-model").unwrap(),
-                    &session.id,
-                )
+                .update_provider(provider, ModelConfig::new("mock-model"), &session.id)
                 .await?;
 
             // Pre-populate 13 tool pairs (need > cutoff + batch_size = 12 to trigger).
@@ -1011,11 +1003,7 @@ mod tests {
 
             let session_id = session.id.clone();
             agent
-                .update_provider(
-                    provider,
-                    ModelConfig::new("mock-model").unwrap(),
-                    &session_id,
-                )
+                .update_provider(provider, ModelConfig::new("mock-model"), &session_id)
                 .await?;
 
             // ── Single reply: tool call (call 0) → text stream (call 1) → cancelled text (call 2)
@@ -1250,7 +1238,7 @@ mod tests {
             agent
                 .update_provider(
                     provider.clone(),
-                    ModelConfig::new("mock-model").unwrap(),
+                    ModelConfig::new("mock-model"),
                     &session.id,
                 )
                 .await?;
@@ -1332,7 +1320,7 @@ mod tests {
             agent
                 .update_provider(
                     provider.clone(),
-                    ModelConfig::new("mock-model").unwrap(),
+                    ModelConfig::new("mock-model"),
                     &session.id,
                 )
                 .await?;
@@ -1428,7 +1416,7 @@ mod tests {
             agent
                 .update_provider(
                     provider.clone(),
-                    ModelConfig::new("mock-model").unwrap(),
+                    ModelConfig::new("mock-model"),
                     &session.id,
                 )
                 .await?;
@@ -1492,7 +1480,7 @@ mod tests {
             agent
                 .update_provider(
                     provider.clone(),
-                    ModelConfig::new("mock-model").unwrap(),
+                    ModelConfig::new("mock-model"),
                     &session.id,
                 )
                 .await?;
@@ -1620,7 +1608,7 @@ mod tests {
             agent
                 .update_provider(
                     provider.clone(),
-                    ModelConfig::new("mock-model").unwrap(),
+                    ModelConfig::new("mock-model"),
                     &session_id,
                 )
                 .await?;

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -373,6 +373,7 @@ mod tests {
                     config_keys: vec![],
                     setup_steps: vec![],
                     model_selection_hint: None,
+                    fast_model: None,
                 }
             }
         }
@@ -543,6 +544,7 @@ mod tests {
                     config_keys: vec![],
                     setup_steps: vec![],
                     model_selection_hint: None,
+                    fast_model: None,
                 }
             }
         }
@@ -895,6 +897,7 @@ mod tests {
                     config_keys: vec![],
                     setup_steps: vec![],
                     model_selection_hint: None,
+                    fast_model: None,
                 }
             }
         }
@@ -1165,6 +1168,7 @@ mod tests {
                     config_keys: vec![],
                     setup_steps: vec![],
                     model_selection_hint: None,
+                    fast_model: None,
                 }
             }
         }

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -381,7 +381,6 @@ mod tests {
             type Provider = Self;
 
             fn from_env(
-                _model: ModelConfig,
                 _extensions: Vec<goose::config::ExtensionConfig>,
                 _tls_config: Option<goose::providers::api_client::TlsConfig>,
             ) -> futures::future::BoxFuture<'static, anyhow::Result<Self>> {
@@ -556,7 +555,6 @@ mod tests {
             type Provider = Self;
 
             fn from_env(
-                _model: ModelConfig,
                 _extensions: Vec<goose::config::ExtensionConfig>,
                 _tls_config: Option<goose::providers::api_client::TlsConfig>,
             ) -> futures::future::BoxFuture<'static, anyhow::Result<Self>> {
@@ -913,7 +911,6 @@ mod tests {
             type Provider = Self;
 
             fn from_env(
-                _model: ModelConfig,
                 _extensions: Vec<goose::config::ExtensionConfig>,
                 _tls_config: Option<goose::providers::api_client::TlsConfig>,
             ) -> futures::future::BoxFuture<'static, anyhow::Result<Self>> {
@@ -1188,7 +1185,6 @@ mod tests {
             type Provider = Self;
 
             fn from_env(
-                _model: ModelConfig,
                 _extensions: Vec<goose::config::ExtensionConfig>,
                 _tls_config: Option<goose::providers::api_client::TlsConfig>,
             ) -> futures::future::BoxFuture<'static, anyhow::Result<Self>> {

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -411,10 +411,6 @@ mod tests {
                 Ok(stream_from_single_message(message, usage))
             }
 
-            fn get_model_config(&self) -> ModelConfig {
-                ModelConfig::new("mock-model").unwrap()
-            }
-
             fn get_name(&self) -> &str {
                 "mock-test"
             }
@@ -437,7 +433,13 @@ mod tests {
                 )
                 .await?;
 
-            agent.update_provider(provider, &session.id).await?;
+            agent
+                .update_provider(
+                    provider,
+                    ModelConfig::new("mock-model").unwrap(),
+                    &session.id,
+                )
+                .await?;
 
             let session_config = SessionConfig {
                 id: session.id,
@@ -588,10 +590,6 @@ mod tests {
                 Ok(stream_from_single_message(message, usage))
             }
 
-            fn get_model_config(&self) -> ModelConfig {
-                ModelConfig::new("mock-model").unwrap()
-            }
-
             fn get_name(&self) -> &str {
                 "mock-summarization"
             }
@@ -624,7 +622,13 @@ mod tests {
                 )
                 .await?;
 
-            agent.update_provider(provider, &session.id).await?;
+            agent
+                .update_provider(
+                    provider,
+                    ModelConfig::new("mock-model").unwrap(),
+                    &session.id,
+                )
+                .await?;
 
             // Pre-populate 13 tool pairs (need > cutoff + batch_size = 12 to trigger).
             // Timestamps in the past so DB ordering places summaries before current turn.
@@ -978,10 +982,6 @@ mod tests {
                 }
             }
 
-            fn get_model_config(&self) -> ModelConfig {
-                ModelConfig::new("mock-model").unwrap()
-            }
-
             fn get_name(&self) -> &str {
                 "multi-step-mock"
             }
@@ -1013,7 +1013,13 @@ mod tests {
                 .await?;
 
             let session_id = session.id.clone();
-            agent.update_provider(provider, &session_id).await?;
+            agent
+                .update_provider(
+                    provider,
+                    ModelConfig::new("mock-model").unwrap(),
+                    &session_id,
+                )
+                .await?;
 
             // ── Single reply: tool call (call 0) → text stream (call 1) → cancelled text (call 2)
             // max_turns=3 allows all three provider calls within one reply().
@@ -1210,10 +1216,6 @@ mod tests {
                 Ok(stream_from_single_message(message, usage))
             }
 
-            fn get_model_config(&self) -> ModelConfig {
-                ModelConfig::new("mock-model").unwrap()
-            }
-
             fn get_name(&self) -> &str {
                 "goal-mock"
             }
@@ -1249,7 +1251,13 @@ mod tests {
                 )
                 .await?;
 
-            agent.update_provider(provider.clone(), &session.id).await?;
+            agent
+                .update_provider(
+                    provider.clone(),
+                    ModelConfig::new("mock-model").unwrap(),
+                    &session.id,
+                )
+                .await?;
             agent
                 .set_goal(Some("Ensure the sky is blue".to_string()))
                 .await;
@@ -1325,7 +1333,13 @@ mod tests {
                 )
                 .await?;
 
-            agent.update_provider(provider.clone(), &session.id).await?;
+            agent
+                .update_provider(
+                    provider.clone(),
+                    ModelConfig::new("mock-model").unwrap(),
+                    &session.id,
+                )
+                .await?;
 
             let session_config = SessionConfig {
                 id: session.id.clone(),
@@ -1415,7 +1429,13 @@ mod tests {
                     GooseMode::default(),
                 )
                 .await?;
-            agent.update_provider(provider.clone(), &session.id).await?;
+            agent
+                .update_provider(
+                    provider.clone(),
+                    ModelConfig::new("mock-model").unwrap(),
+                    &session.id,
+                )
+                .await?;
 
             let session_config = SessionConfig {
                 id: session.id.clone(),
@@ -1473,7 +1493,13 @@ mod tests {
                     GooseMode::default(),
                 )
                 .await?;
-            agent.update_provider(provider.clone(), &session.id).await?;
+            agent
+                .update_provider(
+                    provider.clone(),
+                    ModelConfig::new("mock-model").unwrap(),
+                    &session.id,
+                )
+                .await?;
 
             let session_config = SessionConfig {
                 id: session.id.clone(),
@@ -1545,10 +1571,6 @@ mod tests {
                 Ok(stream_from_single_message(message, usage))
             }
 
-            fn get_model_config(&self) -> ModelConfig {
-                ModelConfig::new("mock-model").unwrap()
-            }
-
             fn get_name(&self) -> &str {
                 "fixed-usage-mock"
             }
@@ -1599,7 +1621,13 @@ mod tests {
                 .await?;
 
             let session_id = session.id.clone();
-            agent.update_provider(provider.clone(), &session_id).await?;
+            agent
+                .update_provider(
+                    provider.clone(),
+                    ModelConfig::new("mock-model").unwrap(),
+                    &session_id,
+                )
+                .await?;
 
             run_turn(&agent, &session_id, "Turn 1").await?;
             let after_1 = session_manager.get_session(&session_id, false).await?;

--- a/crates/goose/tests/compaction.rs
+++ b/crates/goose/tests/compaction.rs
@@ -344,11 +344,7 @@ async fn test_manual_compaction_updates_token_counts_and_conversation() -> Resul
     // Setup mock provider
     let provider = Arc::new(MockCompactionProvider::new());
     agent
-        .update_provider(
-            provider,
-            ModelConfig::new("mock-model").unwrap(),
-            &session.id,
-        )
+        .update_provider(provider, ModelConfig::new("mock-model"), &session.id)
         .await?;
 
     // Execute manual compaction
@@ -446,11 +442,7 @@ async fn test_auto_compaction_during_reply() -> Result<()> {
     // Setup mock provider (no context limit enforcement)
     let provider = Arc::new(MockCompactionProvider::new());
     agent
-        .update_provider(
-            provider,
-            ModelConfig::new("mock-model").unwrap(),
-            &session.id,
-        )
+        .update_provider(provider, ModelConfig::new("mock-model"), &session.id)
         .await?;
 
     // Trigger a reply
@@ -608,11 +600,7 @@ async fn test_context_limit_recovery_compaction() -> Result<()> {
     // Initial context (6000 system + 15400 messages = 21400) exceeds this limit
     let provider = Arc::new(MockCompactionProvider::new());
     agent
-        .update_provider(
-            provider,
-            ModelConfig::new("mock-model").unwrap(),
-            &session.id,
-        )
+        .update_provider(provider, ModelConfig::new("mock-model"), &session.id)
         .await?;
 
     // Try to send a message - should trigger context limit, then recover via compaction

--- a/crates/goose/tests/compaction.rs
+++ b/crates/goose/tests/compaction.rs
@@ -170,10 +170,6 @@ impl Provider for MockCompactionProvider {
         Ok(stream_from_single_message(message, usage))
     }
 
-    fn get_model_config(&self) -> ModelConfig {
-        ModelConfig::new("mock-model").unwrap()
-    }
-
     fn get_name(&self) -> &str {
         "mock-compaction"
     }
@@ -348,7 +344,13 @@ async fn test_manual_compaction_updates_token_counts_and_conversation() -> Resul
 
     // Setup mock provider
     let provider = Arc::new(MockCompactionProvider::new());
-    agent.update_provider(provider, &session.id).await?;
+    agent
+        .update_provider(
+            provider,
+            ModelConfig::new("mock-model").unwrap(),
+            &session.id,
+        )
+        .await?;
 
     // Execute manual compaction
     let result = agent.execute_command("/compact", &session.id).await?;
@@ -444,7 +446,13 @@ async fn test_auto_compaction_during_reply() -> Result<()> {
 
     // Setup mock provider (no context limit enforcement)
     let provider = Arc::new(MockCompactionProvider::new());
-    agent.update_provider(provider, &session.id).await?;
+    agent
+        .update_provider(
+            provider,
+            ModelConfig::new("mock-model").unwrap(),
+            &session.id,
+        )
+        .await?;
 
     // Trigger a reply
     // Expected tokens for reply:
@@ -600,7 +608,13 @@ async fn test_context_limit_recovery_compaction() -> Result<()> {
     // Setup mock provider with context limit of 20000 tokens
     // Initial context (6000 system + 15400 messages = 21400) exceeds this limit
     let provider = Arc::new(MockCompactionProvider::new());
-    agent.update_provider(provider, &session.id).await?;
+    agent
+        .update_provider(
+            provider,
+            ModelConfig::new("mock-model").unwrap(),
+            &session.id,
+        )
+        .await?;
 
     // Try to send a message - should trigger context limit, then recover via compaction
     let session_config = SessionConfig {

--- a/crates/goose/tests/compaction.rs
+++ b/crates/goose/tests/compaction.rs
@@ -187,6 +187,7 @@ impl goose::providers::base::ProviderDescriptor for MockCompactionProvider {
             config_keys: vec![],
             setup_steps: vec![],
             model_selection_hint: None,
+            fast_model: None,
         }
     }
 }

--- a/crates/goose/tests/compaction.rs
+++ b/crates/goose/tests/compaction.rs
@@ -195,7 +195,6 @@ impl ProviderDef for MockCompactionProvider {
     type Provider = Self;
 
     fn from_env(
-        _model: ModelConfig,
         _extensions: Vec<goose::config::ExtensionConfig>,
         _tls_config: Option<goose::providers::api_client::TlsConfig>,
     ) -> futures::future::BoxFuture<'static, anyhow::Result<Self>> {

--- a/crates/goose/tests/local_inference_integration.rs
+++ b/crates/goose/tests/local_inference_integration.rs
@@ -28,7 +28,7 @@ fn test_model() -> String {
 #[tokio::test]
 #[ignore]
 async fn test_local_inference_stream_produces_output() {
-    let model_config = ModelConfig::new(test_model()).expect("valid model config");
+    let model_config = ModelConfig::new(test_model());
     let provider = create("local", Vec::new())
         .await
         .expect("provider creation should succeed");
@@ -70,9 +70,7 @@ async fn test_local_inference_stream_produces_output() {
 #[tokio::test]
 #[ignore]
 async fn test_local_inference_large_prompt() {
-    let model_config = ModelConfig::new(test_model())
-        .expect("valid model config")
-        .with_max_tokens(Some(20));
+    let model_config = ModelConfig::new(test_model()).with_max_tokens(Some(20));
     let provider = create("local", Vec::new())
         .await
         .expect("provider creation should succeed");
@@ -137,7 +135,7 @@ async fn test_local_inference_vision_produces_output() {
         }
     };
 
-    let model_config = ModelConfig::new(&model_id).expect("valid model config");
+    let model_config = ModelConfig::new(&model_id);
     let provider = create("local", Vec::new())
         .await
         .expect("provider creation should succeed");
@@ -182,7 +180,7 @@ async fn test_local_inference_vision_produces_output() {
 #[tokio::test]
 #[ignore]
 async fn test_local_inference_vision_text_only_model_graceful() {
-    let model_config = ModelConfig::new(test_model()).expect("valid model config");
+    let model_config = ModelConfig::new(test_model());
     let provider = create("local", Vec::new())
         .await
         .expect("provider creation should succeed");

--- a/crates/goose/tests/local_inference_integration.rs
+++ b/crates/goose/tests/local_inference_integration.rs
@@ -29,7 +29,7 @@ fn test_model() -> String {
 #[ignore]
 async fn test_local_inference_stream_produces_output() {
     let model_config = ModelConfig::new(test_model()).expect("valid model config");
-    let provider = create("local", model_config.clone(), Vec::new())
+    let provider = create("local", Vec::new())
         .await
         .expect("provider creation should succeed");
 
@@ -73,7 +73,7 @@ async fn test_local_inference_large_prompt() {
     let model_config = ModelConfig::new(test_model())
         .expect("valid model config")
         .with_max_tokens(Some(20));
-    let provider = create("local", model_config.clone(), Vec::new())
+    let provider = create("local", Vec::new())
         .await
         .expect("provider creation should succeed");
 
@@ -138,7 +138,7 @@ async fn test_local_inference_vision_produces_output() {
     };
 
     let model_config = ModelConfig::new(&model_id).expect("valid model config");
-    let provider = create("local", model_config.clone(), Vec::new())
+    let provider = create("local", Vec::new())
         .await
         .expect("provider creation should succeed");
 
@@ -183,7 +183,7 @@ async fn test_local_inference_vision_produces_output() {
 #[ignore]
 async fn test_local_inference_vision_text_only_model_graceful() {
     let model_config = ModelConfig::new(test_model()).expect("valid model config");
-    let provider = create("local", model_config.clone(), Vec::new())
+    let provider = create("local", Vec::new())
         .await
         .expect("provider creation should succeed");
 

--- a/crates/goose/tests/local_inference_perf.rs
+++ b/crates/goose/tests/local_inference_perf.rs
@@ -27,7 +27,7 @@ async fn test_local_inference_cold_vs_warm() {
     let model_config = ModelConfig::new(test_model())
         .expect("valid model config")
         .with_max_tokens(Some(20));
-    let provider = create("local", model_config.clone(), Vec::new())
+    let provider = create("local", Vec::new())
         .await
         .expect("provider creation should succeed");
 

--- a/crates/goose/tests/local_inference_perf.rs
+++ b/crates/goose/tests/local_inference_perf.rs
@@ -24,9 +24,7 @@ fn test_model() -> String {
 #[tokio::test]
 #[ignore]
 async fn test_local_inference_cold_vs_warm() {
-    let model_config = ModelConfig::new(test_model())
-        .expect("valid model config")
-        .with_max_tokens(Some(20));
+    let model_config = ModelConfig::new(test_model()).with_max_tokens(Some(20));
     let provider = create("local", Vec::new())
         .await
         .expect("provider creation should succeed");

--- a/crates/goose/tests/mcp_integration_test.rs
+++ b/crates/goose/tests/mcp_integration_test.rs
@@ -177,7 +177,11 @@ async fn test_replayed_session(
     tool_calls: Vec<CallToolRequestParams>,
     required_envs: Vec<&str>,
 ) {
-    std::env::set_var("GOOSE_MCP_CLIENT_VERSION", "0.0.0");
+    let _env = env_lock::lock_env([
+        ("GOOSE_MCP_CLIENT_VERSION", Some("0.0.0")),
+        ("GOOSE_PROVIDER", Some("openai")),
+        ("GOOSE_MODEL", Some("gpt-4o")),
+    ]);
 
     // Setup test file for developer extension tests
     let test_file_path = "/tmp/goose_test/goose.txt";

--- a/crates/goose/tests/mcp_integration_test.rs
+++ b/crates/goose/tests/mcp_integration_test.rs
@@ -40,15 +40,12 @@ struct Target {
     kind: Vec<String>,
 }
 
-#[derive(Clone)]
-pub struct MockProvider {
-    #[allow(dead_code)]
-    pub model_config: ModelConfig,
-}
+#[derive(Clone, Default)]
+pub struct MockProvider;
 
 impl MockProvider {
-    pub fn new(model_config: ModelConfig) -> Self {
-        Self { model_config }
+    pub fn new() -> Self {
+        Self
     }
 }
 
@@ -62,11 +59,10 @@ impl ProviderDef for MockProvider {
     type Provider = Self;
 
     fn from_env(
-        model: ModelConfig,
         _extensions: Vec<goose::config::ExtensionConfig>,
         _tls_config: Option<goose::providers::api_client::TlsConfig>,
     ) -> futures::future::BoxFuture<'static, anyhow::Result<Self>> {
-        Box::pin(async move { Ok(Self::new(model)) })
+        Box::pin(async move { Ok(Self::new()) })
     }
 }
 
@@ -251,9 +247,9 @@ async fn test_replayed_session(
         available_tools: vec![],
     };
 
-    let provider = Arc::new(tokio::sync::Mutex::new(Some(Arc::new(MockProvider {
-        model_config: ModelConfig::new("test-model").unwrap(),
-    }) as Arc<dyn Provider>)));
+    let provider = Arc::new(tokio::sync::Mutex::new(Some(
+        Arc::new(MockProvider::new()) as Arc<dyn Provider>
+    )));
     let temp_dir = tempfile::tempdir().unwrap();
     let session_manager = Arc::new(goose::session::SessionManager::new(
         temp_dir.path().to_path_buf(),

--- a/crates/goose/tests/mcp_integration_test.rs
+++ b/crates/goose/tests/mcp_integration_test.rs
@@ -42,6 +42,7 @@ struct Target {
 
 #[derive(Clone)]
 pub struct MockProvider {
+    #[allow(dead_code)]
     pub model_config: ModelConfig,
 }
 
@@ -86,10 +87,6 @@ impl Provider for MockProvider {
         let message = Message::assistant().with_text("\"So we beat on, boats against the current, borne back ceaselessly into the past.\" — F. Scott Fitzgerald, The Great Gatsby (1925)");
         let usage = ProviderUsage::new("mock".to_string(), Usage::default());
         Ok(stream_from_single_message(message, usage))
-    }
-
-    fn get_model_config(&self) -> ModelConfig {
-        self.model_config.clone()
     }
 }
 

--- a/crates/goose/tests/providers.rs
+++ b/crates/goose/tests/providers.rs
@@ -235,7 +235,6 @@ impl ProviderFixture {
 
         let provider = create_with_named_model(
             &config.name.to_lowercase(),
-            config.model_name,
             vec![mcp_extension.clone(), developer_extension.clone()],
         )
         .await

--- a/crates/goose/tests/providers.rs
+++ b/crates/goose/tests/providers.rs
@@ -101,6 +101,7 @@ struct ProviderFixture {
     expect_context_length_exceeded: bool,
     context_length_exceeded: usize,
     provider: Arc<dyn Provider>,
+    model_config: goose_providers::model::ModelConfig,
     agent: Agent,
     session_id: String,
     _mcp: McpFixture,
@@ -239,6 +240,10 @@ impl ProviderFixture {
         )
         .await
         .map_err(|e| anyhow::anyhow!("{}", e))?;
+        let model_config = goose::model_config::model_config_from_user_config(
+            &config.name.to_lowercase(),
+            config.model_name,
+        )?;
 
         let temp_dir = tempfile::tempdir()?;
         let session_manager = Arc::new(SessionManager::new(temp_dir.path().to_path_buf()));
@@ -262,7 +267,9 @@ impl ProviderFixture {
             .await?;
         let session_id = session.id;
         expected_session_id.set(&session_id);
-        agent.update_provider(provider.clone(), &session_id).await?;
+        agent
+            .update_provider(provider.clone(), model_config.clone(), &session_id)
+            .await?;
         agent
             .add_extension(mcp_extension, &session_id)
             .await
@@ -279,6 +286,7 @@ impl ProviderFixture {
             expect_context_length_exceeded: config.expect_context_length_exceeded,
             context_length_exceeded: config.context_length_exceeded,
             provider,
+            model_config,
             agent,
             session_id,
             _mcp: mcp,
@@ -310,7 +318,7 @@ impl ProviderFixture {
             .build();
 
         let message = Message::user().with_text(prompt);
-        let model_config = model_config.unwrap_or_else(|| self.provider.get_model_config());
+        let model_config = model_config.unwrap_or_else(|| self.model_config.clone());
         let (response1, _) = self
             .provider
             .complete(
@@ -372,7 +380,7 @@ impl ProviderFixture {
 
     async fn test_basic_response(&self) -> Result<()> {
         let message = Message::user().with_text("Just say hello!");
-        let model_config = self.provider.get_model_config();
+        let model_config = self.model_config.clone();
 
         let (response, _) = self
             .provider
@@ -413,7 +421,7 @@ impl ProviderFixture {
         // "hello " ≈ 2 tokens across common tokenizers
         let large_message_content = "hello ".repeat(self.context_length_exceeded / 2);
         let messages = vec![Message::user().with_text(&large_message_content)];
-        let model_config = self.provider.get_model_config();
+        let model_config = self.model_config.clone();
 
         let result = self
             .provider
@@ -466,7 +474,7 @@ impl ProviderFixture {
     }
 
     async fn test_model_switch(&self) -> Result<()> {
-        let default = &self.provider.get_model_config().model_name;
+        let default = &self.model_config.model_name;
         let alt = self.model_switch_name.as_deref().unwrap();
         let alt_config =
             goose_providers::model::ModelConfig::new(alt)?.with_canonical_limits(&self.name);
@@ -505,7 +513,7 @@ impl ProviderFixture {
         println!("===================");
 
         assert!(!models.is_empty());
-        let resolved = &self.provider.get_model_config().model_name;
+        let resolved = &self.model_config.model_name;
         assert_ne!(resolved.as_str(), ACP_CURRENT_MODEL);
         assert!(models
             .iter()

--- a/crates/goose/tests/providers.rs
+++ b/crates/goose/tests/providers.rs
@@ -451,12 +451,9 @@ impl ProviderFixture {
     }
 
     async fn test_image_content_support(&self) -> Result<()> {
-        let image_config = match &self.image_model {
-            Some(model) => Some(
-                goose_providers::model::ModelConfig::new(model)?.with_canonical_limits(&self.name),
-            ),
-            None => None,
-        };
+        let image_config = self.image_model.as_ref().map(|model| {
+            goose_providers::model::ModelConfig::new(model).with_canonical_limits(&self.name)
+        });
         let response = self
             .tool_roundtrip(
                 "Use the get_image tool and describe what you see in its result.",
@@ -476,7 +473,7 @@ impl ProviderFixture {
         let default = &self.model_config.model_name;
         let alt = self.model_switch_name.as_deref().unwrap();
         let alt_config =
-            goose_providers::model::ModelConfig::new(alt)?.with_canonical_limits(&self.name);
+            goose_providers::model::ModelConfig::new(alt).with_canonical_limits(&self.name);
 
         let message = Message::user().with_text("Just say hello!");
         let (response, _) = self

--- a/crates/goose/tests/session_id_propagation_test.rs
+++ b/crates/goose/tests/session_id_propagation_test.rs
@@ -143,7 +143,7 @@ async fn setup_mock_server() -> (MockServer, HeaderCapture, Box<dyn Provider>) {
 
 async fn make_request(provider: &dyn Provider, session_id: &str) {
     let message = Message::user().with_text("test message");
-    let model_config = ModelConfig::new_or_fail("gpt-5-nano");
+    let model_config = ModelConfig::new("gpt-5-nano");
     let _ = provider
         .complete(
             &model_config,

--- a/crates/goose/tests/session_id_propagation_test.rs
+++ b/crates/goose/tests/session_id_propagation_test.rs
@@ -144,7 +144,7 @@ async fn setup_mock_server() -> (MockServer, HeaderCapture, Box<dyn Provider>) {
 
 async fn make_request(provider: &dyn Provider, session_id: &str) {
     let message = Message::user().with_text("test message");
-    let model_config = provider.get_model_config();
+    let model_config = ModelConfig::new_or_fail("gpt-5-nano");
     let _ = provider
         .complete(
             &model_config,

--- a/crates/goose/tests/session_id_propagation_test.rs
+++ b/crates/goose/tests/session_id_propagation_test.rs
@@ -42,8 +42,7 @@ fn create_test_provider(mock_server_url: &str) -> Box<dyn Provider> {
         None,
     )
     .unwrap();
-    let model = ModelConfig::new_or_fail("gpt-5-nano");
-    Box::new(OpenAiProvider::new(api_client, model))
+    Box::new(OpenAiProvider::new(api_client))
 }
 
 async fn setup_mock_server() -> (MockServer, HeaderCapture, Box<dyn Provider>) {

--- a/crates/goose/tests/tetrate_streaming.rs
+++ b/crates/goose/tests/tetrate_streaming.rs
@@ -25,7 +25,7 @@ mod tetrate_streaming_tests {
 
         let messages = vec![Message::user().with_text("Count from 1 to 5, one number at a time.")];
         let model_config =
-            ModelConfig::new("claude-3-5-sonnet-latest")?.with_canonical_limits("tetrate");
+            ModelConfig::new("claude-3-5-sonnet-latest").with_canonical_limits("tetrate");
 
         let mut stream = provider
             .stream(
@@ -100,7 +100,7 @@ mod tetrate_streaming_tests {
 
         let messages = vec![Message::user().with_text("What's the weather in San Francisco?")];
         let model_config =
-            ModelConfig::new("claude-3-5-sonnet-latest")?.with_canonical_limits("tetrate");
+            ModelConfig::new("claude-3-5-sonnet-latest").with_canonical_limits("tetrate");
 
         let mut stream = provider
             .stream(
@@ -151,7 +151,7 @@ mod tetrate_streaming_tests {
         // This might result in a very short or empty response
         let messages = vec![Message::user().with_text("")];
         let model_config =
-            ModelConfig::new("claude-3-5-sonnet-latest")?.with_canonical_limits("tetrate");
+            ModelConfig::new("claude-3-5-sonnet-latest").with_canonical_limits("tetrate");
 
         let mut stream = provider
             .stream(
@@ -189,7 +189,7 @@ mod tetrate_streaming_tests {
             "Write a detailed 3-paragraph essay about the importance of streaming in modern APIs.",
         )];
         let model_config =
-            ModelConfig::new("claude-3-5-sonnet-latest")?.with_canonical_limits("tetrate");
+            ModelConfig::new("claude-3-5-sonnet-latest").with_canonical_limits("tetrate");
 
         let mut stream = provider
             .stream(
@@ -251,7 +251,7 @@ mod tetrate_streaming_tests {
 
         let messages = vec![Message::user().with_text("Hello")];
         let model_config =
-            ModelConfig::new("claude-3-5-sonnet-latest")?.with_canonical_limits("tetrate");
+            ModelConfig::new("claude-3-5-sonnet-latest").with_canonical_limits("tetrate");
 
         let result = provider
             .stream(
@@ -282,7 +282,7 @@ mod tetrate_streaming_tests {
         let messages1 = vec![Message::user().with_text("Say 'Stream 1'")];
         let messages2 = vec![Message::user().with_text("Say 'Stream 2'")];
         let model_config =
-            ModelConfig::new("claude-3-5-sonnet-latest")?.with_canonical_limits("tetrate");
+            ModelConfig::new("claude-3-5-sonnet-latest").with_canonical_limits("tetrate");
 
         let stream1 = provider
             .stream(

--- a/crates/goose/tests/tetrate_streaming.rs
+++ b/crates/goose/tests/tetrate_streaming.rs
@@ -14,10 +14,7 @@ mod tetrate_streaming_tests {
     use super::*;
 
     async fn create_test_provider() -> Result<TetrateProvider> {
-        // Create a test provider with the default model
-        let model_config =
-            ModelConfig::new("claude-3-5-sonnet-latest")?.with_canonical_limits("tetrate");
-        TetrateProvider::from_env(model_config, None).await
+        TetrateProvider::from_env(None).await
     }
 
     #[tokio::test]
@@ -250,9 +247,7 @@ mod tetrate_streaming_tests {
         // Test with invalid API key to ensure error handling works
         std::env::set_var("TETRATE_API_KEY", "invalid-key-for-testing");
 
-        let model_config =
-            ModelConfig::new("claude-3-5-sonnet-latest")?.with_canonical_limits("tetrate");
-        let provider = TetrateProvider::from_env(model_config, None).await?;
+        let provider = TetrateProvider::from_env(None).await?;
 
         let messages = vec![Message::user().with_text("Hello")];
         let model_config =

--- a/crates/goose/tests/tetrate_streaming.rs
+++ b/crates/goose/tests/tetrate_streaming.rs
@@ -27,7 +27,8 @@ mod tetrate_streaming_tests {
         let provider = create_test_provider().await?;
 
         let messages = vec![Message::user().with_text("Count from 1 to 5, one number at a time.")];
-        let model_config = provider.get_model_config();
+        let model_config =
+            ModelConfig::new("claude-3-5-sonnet-latest")?.with_canonical_limits("tetrate");
 
         let mut stream = provider
             .stream(
@@ -101,7 +102,8 @@ mod tetrate_streaming_tests {
         );
 
         let messages = vec![Message::user().with_text("What's the weather in San Francisco?")];
-        let model_config = provider.get_model_config();
+        let model_config =
+            ModelConfig::new("claude-3-5-sonnet-latest")?.with_canonical_limits("tetrate");
 
         let mut stream = provider
             .stream(
@@ -151,7 +153,8 @@ mod tetrate_streaming_tests {
 
         // This might result in a very short or empty response
         let messages = vec![Message::user().with_text("")];
-        let model_config = provider.get_model_config();
+        let model_config =
+            ModelConfig::new("claude-3-5-sonnet-latest")?.with_canonical_limits("tetrate");
 
         let mut stream = provider
             .stream(
@@ -188,7 +191,8 @@ mod tetrate_streaming_tests {
         let messages = vec![Message::user().with_text(
             "Write a detailed 3-paragraph essay about the importance of streaming in modern APIs.",
         )];
-        let model_config = provider.get_model_config();
+        let model_config =
+            ModelConfig::new("claude-3-5-sonnet-latest")?.with_canonical_limits("tetrate");
 
         let mut stream = provider
             .stream(
@@ -251,7 +255,8 @@ mod tetrate_streaming_tests {
         let provider = TetrateProvider::from_env(model_config, None).await?;
 
         let messages = vec![Message::user().with_text("Hello")];
-        let model_config = provider.get_model_config();
+        let model_config =
+            ModelConfig::new("claude-3-5-sonnet-latest")?.with_canonical_limits("tetrate");
 
         let result = provider
             .stream(
@@ -281,7 +286,8 @@ mod tetrate_streaming_tests {
         // Create multiple concurrent streams
         let messages1 = vec![Message::user().with_text("Say 'Stream 1'")];
         let messages2 = vec![Message::user().with_text("Say 'Stream 2'")];
-        let model_config = provider.get_model_config();
+        let model_config =
+            ModelConfig::new("claude-3-5-sonnet-latest")?.with_canonical_limits("tetrate");
 
         let stream1 = provider
             .stream(

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -6912,7 +6912,7 @@
           },
           "fast_model": {
             "type": "string",
-            "description": "The name of a fast/cheap model to use for lightweight tasks (e.g. session naming,\ncompaction). When set, `complete_fast` will prefer this model over the main model.",
+            "description": "The name of a fast/cheap model to use for lightweight tasks (e.g. session naming,\ncompaction). When set, fast-path callers prefer this model over the main model.",
             "nullable": true
           },
           "known_models": {

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -6910,6 +6910,11 @@
             "type": "string",
             "description": "Display name for the provider in UIs"
           },
+          "fast_model": {
+            "type": "string",
+            "description": "The name of a fast/cheap model to use for lightweight tasks (e.g. session naming,\ncompaction). When set, `complete_fast` will prefer this model over the main model.",
+            "nullable": true
+          },
           "known_models": {
             "type": "array",
             "items": {

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -1026,7 +1026,7 @@ export type ProviderMetadata = {
     display_name: string;
     /**
      * The name of a fast/cheap model to use for lightweight tasks (e.g. session naming,
-     * compaction). When set, `complete_fast` will prefer this model over the main model.
+     * compaction). When set, fast-path callers prefer this model over the main model.
      */
     fast_model?: string | null;
     /**

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -1025,6 +1025,11 @@ export type ProviderMetadata = {
      */
     display_name: string;
     /**
+     * The name of a fast/cheap model to use for lightweight tasks (e.g. session naming,
+     * compaction). When set, `complete_fast` will prefer this model over the main model.
+     */
+    fast_model?: string | null;
+    /**
      * A list of currently known models with their capabilities
      */
     known_models: Array<ModelInfo>;


### PR DESCRIPTION
The motivating change here is removing the owned `ModelConfig` from the providers:

- constructing a Provider no longer needs a ModelConfig
- complete_fast() is removed, and callers now construct a separate model config if they need to
- agents/sessions now own the model, and pass it into completion calls
- provider registry (a goose app construct, not from provider crate) can set fast models per provider
- providers may apply their own context limit logic on top of the model configs limits

for #9803