### PR TITLE
fix: remove unused SubagentStart/SubagentStop hook events

### DIFF
--- a/crates/goose/src/hooks/mod.rs
+++ b/crates/goose/src/hooks/mod.rs
@@ -58,8 +58,6 @@ pub enum HookEvent {
     BeforeShellExecution,
     AfterShellExecution,
     Stop,
-    SubagentStart,
-    SubagentStop,
 }
 
 impl HookEvent {
@@ -76,8 +74,6 @@ impl HookEvent {
             HookEvent::BeforeShellExecution => "BeforeShellExecution",
             HookEvent::AfterShellExecution => "AfterShellExecution",
             HookEvent::Stop => "Stop",
-            HookEvent::SubagentStart => "SubagentStart",
-            HookEvent::SubagentStop => "SubagentStop",
         }
     }
 
@@ -94,8 +90,6 @@ impl HookEvent {
             "BeforeShellExecution" => HookEvent::BeforeShellExecution,
             "AfterShellExecution" => HookEvent::AfterShellExecution,
             "Stop" => HookEvent::Stop,
-            "SubagentStart" => HookEvent::SubagentStart,
-            "SubagentStop" => HookEvent::SubagentStop,
             _ => return None,
         })
     }

--- a/documentation/docs/guides/context-engineering/hooks.md
+++ b/documentation/docs/guides/context-engineering/hooks.md
@@ -318,6 +318,7 @@ Check the following:
 - The command path is correct. Use `${PLUGIN_ROOT}` for scripts inside the plugin.
 - The script is executable if you call it directly.
 - The plugin is not listed in `disabledPlugins`.
+- The event is not a subagent lifecycle event. `SubagentStart` and `SubagentStop` are not currently emitted by goose, so hooks registered for them will never run.
 
 ### My Hook Timed Out or Failed
 


### PR DESCRIPTION
## Summary
`HookEvent::SubagentStart` and `HookEvent::SubagentStop` were defined in `crates/goose/src/hooks/mod.rs` and accepted by `HookEvent::from_name()`, but nothing in the codebase ever emits them. A hook registered for either name in `hooks.json` would load successfully with no warning, yet silently never fire — which is worse than the documented "unknown event names are ignored" behavior, since it bypasses that path entirely. These two names were also absent from the "Supported Events" table in the hooks documentation.

This PR removes the two dead enum variants and their corresponding match arms in `name()` and `from_name()`, so the names now fall through to the existing unknown-event handling. It also adds a note to the Troubleshooting section of the hooks doc clarifying that subagent lifecycle hooks are not currently emitted, so anyone who guesses those names understands why nothing fires.

Wiring up real emit call-sites for subagent spawn/teardown is a larger, separate follow-up and is intentionally out of scope here.

### Testing
- Reviewed all references to `SubagentStart`/`SubagentStop` repo-wide (`rg "SubagentStart|SubagentStop"`) — confirmed no other code or tests referenced these variants.
- Manually reviewed the diff; the change is a mechanical removal of two enum variants and their match arms with no behavioral impact beyond making the two event names fall through to the existing "unknown event is ignored" code path.

### Related Issues
Closes #9907

### Screenshots/Demos (for UX changes)
N/A — backend/docs only change