### PR TITLE
feat(acp): incorporate client systemPrompt into new sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,7 +1613,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -7221,7 +7221,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.2",

--- a/crates/goose/src/acp/server/new_session.rs
+++ b/crates/goose/src/acp/server/new_session.rs
@@ -67,6 +67,10 @@ impl GooseAcpAgent {
         recipe: Option<(Recipe, PathBuf)>,
         project_id: Option<String>,
     ) -> Result<NewSessionResponse, agent_client_protocol::Error> {
+        // Read the ACP `systemPrompt` before `args` is moved into
+        // `configure_new_session`; the agent it applies to doesn't exist yet.
+        let system_prompt = client_system_prompt(&args)?;
+
         let rendered_recipe = self
             .configure_new_session(cx, config, session, args, recipe, project_id)
             .await?;
@@ -77,6 +81,22 @@ impl GooseAcpAgent {
             .await?;
         if let Some(recipe) = &rendered_recipe {
             self.apply_recipe(&agent, recipe).await;
+        }
+        // Incorporate the client's `systemPrompt` additively under a distinct
+        // key from the recipe's, never replacing goose's own instructions. The
+        // RFD requires an error (and no session) if incorporation fails; a
+        // literal-string insert is infallible, so that clause holds vacuously
+        // and no error path is added.
+        if let Some(text) = system_prompt {
+            agent
+                .extend_system_prompt("system_prompt".into(), text.clone())
+                .await;
+            let _ = self
+                .session_manager
+                .update(&session.id)
+                .system_prompt(Some(text))
+                .apply()
+                .await;
         }
 
         let reloaded_session = self.reload_session(&session.id).await?;
@@ -257,4 +277,53 @@ fn meta_goose_extensions(
         .map_err(|e| {
             agent_client_protocol::Error::invalid_params().data(format!("enabledExtensions: {e}"))
         })
+}
+
+fn client_system_prompt(
+    args: &NewSessionRequest,
+) -> Result<Option<String>, agent_client_protocol::Error> {
+    let text = meta_string(args.meta.as_ref(), "systemPrompt")?;
+    Ok(text.filter(|t| !t.trim().is_empty()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request_with_system_prompt(system_prompt: Option<&str>) -> NewSessionRequest {
+        let mut request = NewSessionRequest::new(PathBuf::from("/tmp"));
+        if let Some(text) = system_prompt {
+            let mut meta = serde_json::Map::new();
+            meta.insert("systemPrompt".into(), serde_json::Value::String(text.to_string()));
+            request.meta = Some(meta);
+        }
+        request
+    }
+
+    #[test]
+    fn test_client_system_prompt_present_returns_text() {
+        let request = request_with_system_prompt(Some("Be concise."));
+        assert_eq!(
+            client_system_prompt(&request).unwrap(),
+            Some("Be concise.".to_string())
+        );
+    }
+
+    #[test]
+    fn test_client_system_prompt_absent_returns_none() {
+        let request = request_with_system_prompt(None);
+        assert_eq!(client_system_prompt(&request).unwrap(), None);
+    }
+
+    #[test]
+    fn test_client_system_prompt_whitespace_only_returns_none() {
+        let request = request_with_system_prompt(Some("   \n\t "));
+        assert_eq!(client_system_prompt(&request).unwrap(), None);
+    }
+
+    #[test]
+    fn test_client_system_prompt_empty_string_returns_none() {
+        let request = request_with_system_prompt(Some(""));
+        assert_eq!(client_system_prompt(&request).unwrap(), None);
+    }
 }

--- a/crates/goose/src/acp/server/new_session.rs
+++ b/crates/goose/src/acp/server/new_session.rs
@@ -294,7 +294,10 @@ mod tests {
         let mut request = NewSessionRequest::new(PathBuf::from("/tmp"));
         if let Some(text) = system_prompt {
             let mut meta = serde_json::Map::new();
-            meta.insert("systemPrompt".into(), serde_json::Value::String(text.to_string()));
+            meta.insert(
+                "systemPrompt".into(),
+                serde_json::Value::String(text.to_string()),
+            );
             request.meta = Some(meta);
         }
         request

--- a/crates/goose/src/execution/manager.rs
+++ b/crates/goose/src/execution/manager.rs
@@ -235,7 +235,9 @@ impl AgentManager {
             }
             extension_results = agent.load_extensions_from_session(&session).await;
             if let Some(ref text) = session.system_prompt {
-                agent.extend_system_prompt("system_prompt".into(), text.clone()).await;
+                agent
+                    .extend_system_prompt("system_prompt".into(), text.clone())
+                    .await;
             }
         }
 

--- a/crates/goose/src/execution/manager.rs
+++ b/crates/goose/src/execution/manager.rs
@@ -234,6 +234,9 @@ impl AgentManager {
                 }
             }
             extension_results = agent.load_extensions_from_session(&session).await;
+            if let Some(ref text) = session.system_prompt {
+                agent.extend_system_prompt("system_prompt".into(), text.clone()).await;
+            }
         }
 
         if agent.provider().await.is_err() {

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -1339,9 +1339,17 @@ impl SessionStorage {
                 }
             }
             15 => {
-                sqlx::query("ALTER TABLE sessions ADD COLUMN system_prompt TEXT")
-                    .execute(&mut **tx)
-                    .await?;
+                let has_column: bool = sqlx::query_scalar::<_, i64>(
+                    "SELECT COUNT(*) FROM pragma_table_info('sessions') WHERE name = 'system_prompt'",
+                )
+                .fetch_one(&mut **tx)
+                .await?
+                    > 0;
+                if !has_column {
+                    sqlx::query("ALTER TABLE sessions ADD COLUMN system_prompt TEXT")
+                        .execute(&mut **tx)
+                        .await?;
+                }
             }
             _ => {
                 anyhow::bail!("Unknown migration version: {}", version);

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -23,7 +23,7 @@ use std::sync::{Arc, LazyLock};
 use tracing::{info, warn};
 use utoipa::ToSchema;
 
-pub const CURRENT_SCHEMA_VERSION: i32 = 14;
+pub const CURRENT_SCHEMA_VERSION: i32 = 15;
 pub const SESSIONS_FOLDER: &str = "sessions";
 pub const DB_NAME: &str = "sessions.db";
 const MILLISECOND_TIMESTAMP_THRESHOLD: i64 = 10_000_000_000;
@@ -92,6 +92,8 @@ pub struct Session {
     #[serde(default)]
     pub project_id: Option<String>,
     #[serde(default)]
+    pub system_prompt: Option<String>,
+    #[serde(default)]
     pub last_message_snippet: Option<String>,
 }
 
@@ -139,6 +141,7 @@ pub struct SessionUpdateBuilder<'a> {
     archived_at: Option<Option<DateTime<Utc>>>,
 
     project_id: Option<Option<String>>,
+    system_prompt: Option<Option<String>>,
 }
 
 #[derive(Serialize, ToSchema, Debug)]
@@ -169,6 +172,7 @@ impl<'a> SessionUpdateBuilder<'a> {
             goose_mode: None,
             archived_at: None,
             project_id: None,
+            system_prompt: None,
         }
     }
 
@@ -269,6 +273,11 @@ impl<'a> SessionUpdateBuilder<'a> {
 
     pub fn project_id(mut self, project_id: Option<String>) -> Self {
         self.project_id = Some(project_id);
+        self
+    }
+
+    pub fn system_prompt(mut self, system_prompt: Option<String>) -> Self {
+        self.system_prompt = Some(system_prompt);
         self
     }
 }
@@ -648,6 +657,7 @@ impl Default for Session {
             goose_mode: GooseMode::default(),
             archived_at: None,
             project_id: None,
+            system_prompt: None,
             last_message_snippet: None,
         }
     }
@@ -742,6 +752,7 @@ impl sqlx::FromRow<'_, sqlx::sqlite::SqliteRow> for Session {
                 .unwrap_or_default(),
             archived_at: row.try_get("archived_at").ok(),
             project_id: row.try_get("project_id").ok().flatten(),
+            system_prompt: row.try_get("system_prompt").ok().flatten(),
             last_message_snippet: None,
         })
     }
@@ -864,7 +875,8 @@ impl SessionStorage {
                 model_config_json TEXT,
                 goose_mode TEXT NOT NULL DEFAULT 'auto',
                 archived_at TIMESTAMP,
-                project_id TEXT
+                project_id TEXT,
+                system_prompt TEXT
             )
         "#,
         )
@@ -1326,6 +1338,11 @@ impl SessionStorage {
                     }
                 }
             }
+            15 => {
+                sqlx::query("ALTER TABLE sessions ADD COLUMN system_prompt TEXT")
+                    .execute(&mut **tx)
+                    .await?;
+            }
             _ => {
                 anyhow::bail!("Unknown migration version: {}", version);
             }
@@ -1470,6 +1487,7 @@ impl SessionStorage {
         add_update!(builder.archived_at, "archived_at");
 
         add_update!(builder.project_id, "project_id");
+        add_update!(builder.system_prompt, "system_prompt");
 
         if updates.is_empty() {
             return Ok(());
@@ -1545,6 +1563,9 @@ impl SessionStorage {
 
         if let Some(ref project_id) = builder.project_id {
             q = q.bind(project_id.as_ref());
+        }
+        if let Some(ref system_prompt) = builder.system_prompt {
+            q = q.bind(system_prompt.as_ref());
         }
 
         let pool = self.pool().await?;

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -7756,6 +7756,10 @@
           "session_type": {
             "$ref": "#/components/schemas/SessionType"
           },
+          "system_prompt": {
+            "type": "string",
+            "nullable": true
+          },
           "updated_at": {
             "type": "string",
             "format": "date-time"

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -1379,6 +1379,7 @@ export type Session = {
     recipe?: Recipe | null;
     schedule_id?: string | null;
     session_type?: SessionType;
+    system_prompt?: string | null;
     updated_at: string;
     usage?: Usage;
     user_recipe_values?: {


### PR DESCRIPTION
> **Reference implementation of [RFD #1237](https://github.com/agentclientprotocol/agent-client-protocol/pull/1237), which is not yet merged.** The RFD proposes `systemPrompt` as a first-class `session/new` field in ACP. Until it lands, this PR implements the same capability via `_meta["systemPrompt"]` — the ACP extensibility mechanism — so no fork or schema change is required and the PR is mergeable today.

Incorporates the client-provided system prompt into new sessions. When a client sends `systemPrompt` via `_meta` on `session/new`, goose adds it to the session's system prompt additively, alongside its own built-in instructions, rather than replacing them. The value is persisted to SQLite and re-applied when an evicted agent is recreated, so the prompt survives the full session lifecycle.

The field is read from `_meta["systemPrompt"]` before `args` is moved into session configuration, then applied via `extend_system_prompt` after the agent exists (past recipe application) under a key distinct from the recipe's, so neither overwrites the other. Empty and whitespace-only values are treated as absent, leaving the default system prompt unchanged.

Using `_meta` keeps the implementation self-contained: no typed schema field, no fork, no `[patch.crates-io]` entry. When RFD #1237 merges and `systemPrompt` becomes a first-class ACP field, this PR can be updated to read it directly from `args` instead of `_meta`.

## Changes

- `crates/goose/src/acp/server/new_session.rs` — `client_system_prompt` reads `_meta["systemPrompt"]` via `meta_string` (returns `Result` — propagates invalid-params error if the value is not a string); `None`, empty, and whitespace-only values yield `None` so the default prompt is unchanged. Applied after the agent is built and persisted to the session; unit tests for present, absent, whitespace-only, and empty-string inputs.
- `crates/goose/src/session/session_manager.rs` — `system_prompt: Option<String>` on `Session`, `SessionUpdateBuilder`, `FromRow`, `create_schema`, and `apply_update`. Schema version bumped 14→15 with idempotent `ALTER TABLE sessions ADD COLUMN system_prompt TEXT` migration.
- `crates/goose/src/execution/manager.rs` — re-applies `session.system_prompt` via `extend_system_prompt` in `create_agent_locked` so the prompt is restored after LRU eviction or restart.
- `ui/desktop/openapi.json`, `ui/desktop/src/api/types.gen.ts` — `system_prompt` field on the Session type.

## Related

- [agentclientprotocol/agent-client-protocol#1237](https://github.com/agentclientprotocol/agent-client-protocol/pull/1237) — RFD proposing `systemPrompt` as a first-class ACP field (not yet merged)
- [block/buzz#1290](https://github.com/block/buzz/pull/1290) — buzz-side companion: routes `systemPrompt` into `_meta` when the target agent is goose