### PR TITLE
chore: clean up ui as we don't have session based permission setting on ui

### DIFF
--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -183,7 +183,7 @@ const PairRouteWrapper = ({
   return null;
 };
 
-const SettingsRoute = ({ activeSessionId }: { activeSessionId?: string }) => {
+const SettingsRoute = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -199,13 +199,7 @@ const SettingsRoute = ({ activeSessionId }: { activeSessionId?: string }) => {
     viewOptions.section = sectionFromUrl;
   }
 
-  return (
-    <SettingsView
-      onClose={() => navigate('/')}
-      setView={setView}
-      viewOptions={{ ...viewOptions, sessionId: activeSessionId }}
-    />
-  );
+  return <SettingsView onClose={() => navigate('/')} setView={setView} viewOptions={viewOptions} />;
 };
 
 const SessionsRoute = () => {
@@ -701,14 +695,7 @@ export function AppInner() {
                   />
                 }
               />
-              <Route
-                path="settings"
-                element={
-                  <SettingsRoute
-                    activeSessionId={activeSessions[activeSessions.length - 1]?.sessionId}
-                  />
-                }
-              />
+              <Route path="settings" element={<SettingsRoute />} />
               <Route
                 path="extensions"
                 element={

--- a/ui/desktop/src/components/settings/SettingsView.tsx
+++ b/ui/desktop/src/components/settings/SettingsView.tsx
@@ -77,7 +77,6 @@ export type SettingsViewOptions = {
   deepLinkConfig?: ExtensionConfig;
   showEnvVars?: boolean;
   section?: string;
-  sessionId?: string;
 };
 
 export default function SettingsView({
@@ -290,7 +289,7 @@ export default function SettingsView({
                   value="chat"
                   className="mt-0 focus-visible:outline-none focus-visible:ring-0"
                 >
-                  <ChatSettingsSection sessionId={viewOptions.sessionId} />
+                  <ChatSettingsSection />
                 </TabsContent>
 
                 <TabsContent

--- a/ui/desktop/src/components/settings/chat/ChatSettingsSection.tsx
+++ b/ui/desktop/src/components/settings/chat/ChatSettingsSection.tsx
@@ -10,11 +10,12 @@ import { defineMessages, useIntl } from '../../../i18n';
 const i18n = defineMessages({
   modeTitle: {
     id: 'chatSettings.modeTitle',
-    defaultMessage: 'Mode',
+    defaultMessage: 'Default Mode',
   },
   modeDescription: {
     id: 'chatSettings.modeDescription',
-    defaultMessage: 'Configure how Goose interacts with tools and extensions',
+    defaultMessage:
+      'Choose the default mode Goose uses for new sessions. Existing sessions keep their current mode.',
   },
   responseStylesTitle: {
     id: 'chatSettings.responseStylesTitle',
@@ -26,7 +27,7 @@ const i18n = defineMessages({
   },
 });
 
-export default function ChatSettingsSection({ sessionId }: { sessionId?: string }) {
+export default function ChatSettingsSection() {
   const intl = useIntl();
 
   return (
@@ -37,7 +38,7 @@ export default function ChatSettingsSection({ sessionId }: { sessionId?: string 
           <CardDescription>{intl.formatMessage(i18n.modeDescription)}</CardDescription>
         </CardHeader>
         <CardContent className="px-2">
-          <ModeSection sessionId={sessionId} />
+          <ModeSection />
         </CardContent>
       </Card>
 

--- a/ui/desktop/src/components/settings/mode/ModeSection.tsx
+++ b/ui/desktop/src/components/settings/mode/ModeSection.tsx
@@ -2,18 +2,14 @@ import { useEffect, useState, useCallback } from 'react';
 import { all_goose_modes, ModeSelectionItem } from './ModeSelectionItem';
 import { useConfig } from '../../ConfigContext';
 import { ConversationLimitsDropdown } from './ConversationLimitsDropdown';
-import { updateSession } from '../../../api';
 
-export const ModeSection = ({ sessionId }: { sessionId?: string }) => {
+export const ModeSection = () => {
   const [currentMode, setCurrentMode] = useState('auto');
   const [maxTurns, setMaxTurns] = useState<number>(1000);
   const { config, read, upsert } = useConfig();
 
   const handleModeChange = async (newMode: string) => {
     try {
-      if (sessionId) {
-        await updateSession({ body: { session_id: sessionId, goose_mode: newMode } });
-      }
       await upsert('GOOSE_MODE', newMode, false);
       setCurrentMode(newMode);
     } catch (error) {

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -207,10 +207,10 @@
     "defaultMessage": "Waiting for images to save..."
   },
   "chatSettings.modeDescription": {
-    "defaultMessage": "Configure how Goose interacts with tools and extensions"
+    "defaultMessage": "Choose the default mode Goose uses for new sessions. Existing sessions keep their current mode."
   },
   "chatSettings.modeTitle": {
-    "defaultMessage": "Mode"
+    "defaultMessage": "Default Mode"
   },
   "chatSettings.responseStylesDescription": {
     "defaultMessage": "Choose how Goose should format and style its responses"


### PR DESCRIPTION
## Summary

Clean up ui as we don't have session based permission setting on ui and this will remove the dependency on rest api updateSession


For ACP server, we already have set session config implemented to set session mode

### Testing
CI


