### PR TITLE
feat(providers): add Fireworks AI declarative provider

### DIFF
--- a/crates/goose/src/providers/declarative/fireworks.json
+++ b/crates/goose/src/providers/declarative/fireworks.json
@@ -1,0 +1,55 @@
+{
+  "name": "fireworks-ai",
+  "engine": "openai",
+  "display_name": "Fireworks AI",
+  "description": "Fast serverless inference for open models with an OpenAI-compatible API",
+  "api_key_env": "FIREWORKS_API_KEY",
+  "base_url": "https://api.fireworks.ai/inference/v1/chat/completions",
+  "catalog_provider_id": "fireworks-ai",
+  "dynamic_models": false,
+  "models": [
+    {
+      "name": "accounts/fireworks/models/kimi-k2p7-code",
+      "context_limit": 262000
+    },
+    {
+      "name": "accounts/fireworks/models/kimi-k2p6",
+      "context_limit": 262000
+    },
+    {
+      "name": "accounts/fireworks/models/glm-5p2",
+      "context_limit": 1048576
+    },
+    {
+      "name": "accounts/fireworks/models/deepseek-v4-pro",
+      "context_limit": 1000000
+    },
+    {
+      "name": "accounts/fireworks/models/deepseek-v4-flash",
+      "context_limit": 1000000
+    },
+    {
+      "name": "accounts/fireworks/models/minimax-m3",
+      "context_limit": 512000
+    },
+    {
+      "name": "accounts/fireworks/models/qwen3p7-plus",
+      "context_limit": 262144
+    },
+    {
+      "name": "accounts/fireworks/models/glm-5p1",
+      "context_limit": 202800
+    },
+    {
+      "name": "accounts/fireworks/models/gpt-oss-120b",
+      "context_limit": 131072
+    },
+    {
+      "name": "accounts/fireworks/models/gpt-oss-20b",
+      "context_limit": 131072
+    }
+  ],
+  "preserves_thinking": true,
+  "supports_streaming": true,
+  "model_doc_link": "https://fireworks.ai/models"
+}

--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -411,6 +411,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_fireworks_declarative_provider_registry_wiring() {
+        let fireworks = get_from_registry("fireworks-ai")
+            .await
+            .expect("fireworks-ai provider should be registered");
+        let meta = fireworks.metadata();
+
+        assert_eq!(fireworks.provider_type(), ProviderType::Declarative);
+        assert_eq!(meta.display_name, "Fireworks AI");
+        assert_eq!(
+            meta.default_model,
+            "accounts/fireworks/models/kimi-k2p7-code"
+        );
+        assert_eq!(meta.model_doc_link, "https://fireworks.ai/models");
+
+        let api_key = meta
+            .config_keys
+            .iter()
+            .find(|k| k.name == "FIREWORKS_API_KEY")
+            .expect("FIREWORKS_API_KEY config key should exist");
+        assert!(api_key.required, "FIREWORKS_API_KEY should be required");
+        assert!(api_key.secret, "FIREWORKS_API_KEY should be secret");
+    }
+
+    #[tokio::test]
     async fn test_openai_compatible_providers_config_keys() {
         let providers_list = providers().await;
         let required_api_key_cases = vec![


### PR DESCRIPTION
## Summary

Adds **Fireworks AI** as a declarative, OpenAI-compatible provider with 10 serverless models (Kimi, GLM, DeepSeek, MiniMax, Qwen, GPT-OSS).

Two changes make it work end-to-end:

1. **`crates/goose/src/providers/declarative/fireworks.json`** — the provider definition. Uses `"dynamic_models": false` because Fireworks' `/v1/models` endpoint returns **500** for serverless accounts, and goose only falls back to the static list on a **404** (`openai.rs::fetch_supported_models`). The curated static catalog is the reliable source; context limits match the bundled canonical registry.

2. **`crates/goose-providers/src/canonical/name_builder.rs`** — maps the `fireworks` provider name to the canonical `fireworks-ai` id, mirroring the existing `"novita" => "novita-ai"` entry. Without this, only models whose names *infer* to a first-party vendor resolved, so the model picker (`fetch_recommended_models`) silently dropped glm/qwen/minimax/gpt-oss and lost their reasoning-capability flags.

### Testing

- `cargo test -p goose-providers --lib` — new test asserts all 10 Fireworks models resolve to a canonical entry and are text-input + tool-call capable.
- `cargo test -p goose --lib` — new test asserts the provider registers with the expected metadata/config key.
- `cargo fmt` + `cargo clippy` clean on both crates.
- **Manual, end-to-end:** built `goosed` from this branch and ran the desktop app. Verified Fireworks appears in the provider list, all 10 models show in the picker, and a real chat completion succeeds. Also confirmed each model returns HTTP 200 against the live `/chat/completions` endpoint.

### Related Issues

N/A

### Screenshots/Demos

Model picker shows all 10 Fireworks models after the canonical-mapping fix.