### PR TITLE
suppress telemetry event on ui

### DIFF
--- a/ui/desktop/src/utils/analytics.ts
+++ b/ui/desktop/src/utils/analytics.ts
@@ -1,51 +1,19 @@
 /**
  * Frontend Analytics Module
  *
- * Provides privacy-respecting analytics by routing events through the backend.
- * The backend uses posthog-rs which handles the PostHog API correctly.
- *
- * What we track:
- * - Feature usage (which features users interact with)
- * - Screen/view navigation
- * - Onboarding funnel completion
- * - Error types (without sensitive details)
- *
- * What we never track:
- * - Conversation content
- * - Code or file contents
- * - API keys or credentials
- * - Tool arguments or outputs
- * - Personal identifiable information
+ * Compatibility layer for existing UI tracking call sites. Frontend telemetry is
+ * disabled during the ACP migration, so events are intentionally not sent.
  */
 
-import { sendTelemetryEvent } from '../api';
-
-let telemetryEnabled: boolean | null = null;
-
-export function setTelemetryEnabled(enabled: boolean): void {
-  telemetryEnabled = enabled;
+export function setTelemetryEnabled(_enabled: boolean): void {
+  // Frontend telemetry is disabled.
 }
 
-function canTrack(): boolean {
-  return telemetryEnabled === true;
-}
-
-async function sendEvent(
-  eventName: string,
-  properties: Record<string, unknown> = {}
-): Promise<void> {
-  if (!canTrack()) return;
-
-  try {
-    await sendTelemetryEvent({
-      body: {
-        event_name: eventName,
-        properties: properties as Record<string, unknown>,
-      },
-    });
-  } catch (error) {
-    console.debug('[Analytics] Failed to send event:', error);
-  }
+function sendEvent(
+  _eventName: string,
+  _properties: Record<string, unknown> = {}
+): void {
+  // Frontend telemetry is disabled.
 }
 
 // ============================================================================
@@ -338,8 +306,6 @@ export function trackTelemetryPreference(
   enabled: boolean,
   location: 'settings' | 'onboarding' | 'modal'
 ): void {
-  // Always send this event, even if telemetry is disabled
-  // This is the one exception - we need to know opt-out rates
   sendEvent('telemetry_preference_set', { enabled, location });
 }
 


### PR DESCRIPTION
## Summary
Suppress sending telemetry events from UI to remove the dependency on rest api `POST /telemetry/event`.  Currently we only track the onboarding events which measured new onboarding flow.  Now we can remove it.  

Since there are many places using the send event, this PR only opt out the call to rest api first.  We will clean up the UI code after the migration. 

On the server side, we still track the start_session (in goose core) which will track all the acp client start_session, which is not ideal but I think the event is still worthwhile being tracked for goose app/cli.  I will revisit the goose telemetry as soon as we migrate ui to ACP

### Testing
CI
 

