### PR TITLE
Apply ACP recipe state during session load and fork

### DIFF
--- a/crates/goose-server/src/routes/session.rs
+++ b/crates/goose-server/src/routes/session.rs
@@ -211,7 +211,7 @@ async fn update_session_user_recipe_values(
                     message: format!("Failed to get agent: {}", status),
                     status,
                 })?;
-            if let Some(prompt) = apply_recipe_to_agent(&agent, &recipe, false).await {
+            if let Some(prompt) = apply_recipe_to_agent(&agent, &recipe, true).await {
                 agent
                     .extend_system_prompt("recipe".to_string(), prompt)
                     .await;

--- a/crates/goose/src/acp/server/fork_session.rs
+++ b/crates/goose/src/acp/server/fork_session.rs
@@ -51,9 +51,10 @@ impl GooseAcpAgent {
             )
             .await?;
 
-        let (_agent, extension_results) = self
+        let (agent, extension_results) = self
             .activate_acp_session(cx, &goose_session, HashMap::new())
             .await?;
+        self.apply_session_recipe(&agent, &goose_session).await?;
 
         let acp_session_id = SessionId::new(new_session_id.clone());
         let mut meta = session_meta(&new_session);

--- a/crates/goose/src/acp/server/fork_session.rs
+++ b/crates/goose/src/acp/server/fork_session.rs
@@ -51,10 +51,10 @@ impl GooseAcpAgent {
             )
             .await?;
 
-        let (agent, extension_results) = self
-            .activate_acp_session(cx, &goose_session, HashMap::new())
-            .await?;
+        let (agent, extension_results) = self.prepare_acp_session_agent(cx, &goose_session).await?;
         self.apply_session_recipe(&agent, &goose_session).await?;
+        self.register_acp_session(new_session_id.clone(), agent, HashMap::new())
+            .await;
 
         let acp_session_id = SessionId::new(new_session_id.clone());
         let mut meta = session_meta(&new_session);

--- a/crates/goose/src/acp/server/fork_session.rs
+++ b/crates/goose/src/acp/server/fork_session.rs
@@ -53,11 +53,11 @@ impl GooseAcpAgent {
 
         let (agent, extension_results) = self.prepare_acp_session_agent(cx, &goose_session).await?;
         self.apply_session_recipe(&agent, &goose_session).await?;
-        self.register_acp_session(new_session_id.clone(), agent, HashMap::new())
+        self.register_acp_session(goose_session.id.clone(), agent, HashMap::new())
             .await;
 
         let acp_session_id = SessionId::new(new_session_id.clone());
-        let mut meta = session_meta(&new_session);
+        let mut meta = session_meta(&goose_session);
         if let Ok(v) = serde_json::to_value(&extension_results) {
             meta.insert("extensionResults".to_string(), v);
         }

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -191,6 +191,7 @@ impl GooseAcpAgent {
 
         let replay_tool_requests = replay_conversation_to_client(cx, &session)?;
         let (agent, extension_results) = self.prepare_acp_session_agent(cx, &session).await?;
+        self.apply_session_recipe(&agent, &session).await?;
         self.register_acp_session(session_id_str.clone(), agent.clone(), replay_tool_requests)
             .await;
 

--- a/crates/goose/src/acp/server/recipe/mod.rs
+++ b/crates/goose/src/acp/server/recipe/mod.rs
@@ -29,6 +29,7 @@ use crate::recipe::manifest::{
 use crate::recipe::validate_recipe::validate_recipe_template_from_content;
 use crate::recipe::{strip_error_location, Recipe, RecipeParameter};
 use crate::recipe_deeplink;
+use crate::session::{Session, SessionType};
 use crate::slash_commands::recipe_slash_command;
 
 use self::conversions::recipe_manifest_to_list_entry_dto;
@@ -319,6 +320,32 @@ impl GooseAcpAgent {
                 .extend_system_prompt("recipe".to_string(), instructions)
                 .await;
         }
+    }
+
+    pub(super) async fn apply_session_recipe(
+        &self,
+        agent: &Arc<Agent>,
+        session: &Session,
+    ) -> Result<(), agent_client_protocol::Error> {
+        let Some(recipe) = session.recipe.as_ref() else {
+            return Ok(());
+        };
+
+        if session.session_type == SessionType::Scheduled {
+            self.apply_recipe(agent, recipe).await;
+            return Ok(());
+        }
+
+        let recipe_dir = get_recipe_library_dir(true);
+        if let Some(rendered) = self.render_recipe(
+            recipe,
+            &recipe_dir,
+            session.user_recipe_values.clone().unwrap_or_default(),
+        )? {
+            self.apply_recipe(agent, &rendered).await;
+        }
+
+        Ok(())
     }
 
     pub(super) async fn render_recipe_for_session(

--- a/ui/desktop/src/hooks/useAcpChatSession.ts
+++ b/ui/desktop/src/hooks/useAcpChatSession.ts
@@ -3,7 +3,7 @@ import { defineMessages, useIntl } from '../i18n';
 import { AppEvents } from '../constants/events';
 import { ChatState } from '../types/chatState';
 
-import { Message, Session, TokenState, updateFromSession } from '../api';
+import { Message, Session, TokenState } from '../api';
 
 import { createUserMessage, NotificationEvent, UserInput } from '../types/message';
 import { errorMessage } from '../utils/conversionUtils';
@@ -271,17 +271,6 @@ export function useAcpChatSession({
     },
     [getCurrentSnapshot, sessionId]
   );
-
-  useEffect(() => {
-    if (session) {
-      updateFromSession({
-        body: {
-          session_id: session.id,
-        },
-        throwOnError: true,
-      });
-    }
-  }, [session]);
 
   const stopStreaming = useCallback(() => {
     acpChatSessionController.stop(sessionId);


### PR DESCRIPTION
## Summary
- apply saved recipe state during ACP session load and fork activation
- remove the ACP desktop hook dependency on `/agent/update_from_session`

### Testing
Manual