### PR TITLE
fix(prompt): add an overeager scope-discipline rule to the system prompt

### DIFF
--- a/crates/goose/src/prompts/system.md
+++ b/crates/goose/src/prompts/system.md
@@ -46,3 +46,7 @@ Consider asking if they'd like to disable some extensions to improve tool select
 # Response Guidelines
 
 Use Markdown formatting for all responses.
+
+# Scope
+
+Guard against overeager actions: pay careful attention to the scope of the user's request. Do what they ask, but no more. Do not improve, comment, fix, or modify unrelated parts of the code in any way.


### PR DESCRIPTION
Adds a general overeager scope-discipline rule to the system prompt, in the spirit of the `overeager_prompt` line aider ships: the agent stays within the scope of the request -- does what's asked and no more, and does not modify unrelated parts of the code.

Prompt-only change; one line added to `crates/goose/src/prompts/system.md`. No new behavior beyond the scope guidance.