### PR TITLE
removed unnecessary call setRecipeParams for acp enabled path

### DIFF
--- a/ui/desktop/src/acp/__tests__/sessions.test.ts
+++ b/ui/desktop/src/acp/__tests__/sessions.test.ts
@@ -1,7 +1,7 @@
 import type { SessionInfo } from '@agentclientprotocol/sdk';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getAcpClient } from '../acpConnection';
-import { acpLoadSession, sessionInfoToSession } from '../sessions';
+import { acpGetSessionListItem, acpLoadSession, sessionInfoToSession } from '../sessions';
 
 vi.mock('../acpConnection', () => ({
   getAcpClient: vi.fn(),
@@ -68,5 +68,41 @@ describe('ACP sessions', () => {
     expect(sessionInfoToSession(result.sessionInfo).model_config?.model_name).toBe(
       'claude-sonnet-4-5'
     );
+  });
+
+  it('returns a list item from ACP session info', async () => {
+    const client = {
+      goose: {
+        sessionInfo_unstable: vi.fn().mockResolvedValue({
+          session: sessionInfo({
+            title: 'Subagent session',
+            _meta: {
+              createdAt: '2026-01-01T00:00:00Z',
+              lastMessageAt: '2026-01-01T00:01:00Z',
+              messageCount: 3,
+              sessionType: 'sub_agent',
+              providerId: 'anthropic',
+              modelId: 'claude-sonnet-4-5',
+            },
+          }),
+        }),
+      },
+    };
+    vi.mocked(getAcpClient).mockResolvedValue(
+      client as unknown as Awaited<ReturnType<typeof getAcpClient>>
+    );
+
+    const item = await acpGetSessionListItem('session-1');
+
+    expect(client.goose.sessionInfo_unstable).toHaveBeenCalledWith({ sessionId: 'session-1' });
+    expect(item).toMatchObject({
+      id: 'session-1',
+      name: 'Subagent session',
+      workingDir: '/tmp',
+      messageCount: 3,
+      lastMessageAt: '2026-01-01T00:01:00Z',
+      providerId: 'anthropic',
+      modelId: 'claude-sonnet-4-5',
+    });
   });
 });

--- a/ui/desktop/src/acp/chatSessionController.ts
+++ b/ui/desktop/src/acp/chatSessionController.ts
@@ -1,5 +1,5 @@
 import { v7 as uuidv7 } from 'uuid';
-import { updateSessionUserRecipeValues, type Message, type Session } from '../api';
+import type { Message, Session } from '../api';
 import type { GooseExtension } from '@aaif/goose-sdk';
 import { AppEvents } from '../constants/events';
 import { ChatState } from '../types/chatState';
@@ -56,11 +56,6 @@ export interface AcpChatSessionController {
     newContent: string,
     editType: 'fork' | 'edit' | undefined,
     options: AcpSubmitMessageOptions
-  ): Promise<void>;
-  setRecipeUserParams(
-    sessionId: string,
-    userRecipeValues: Record<string, string>,
-    options: AcpSnapshotOptions
   ): Promise<void>;
 }
 
@@ -271,42 +266,10 @@ async function updateMessage(
   }
 }
 
-async function setRecipeUserParams(
-  sessionId: string,
-  userRecipeValues: Record<string, string>,
-  options: AcpSnapshotOptions
-): Promise<void> {
-  const currentSession =
-    options.getCurrentSnapshot()?.session ?? acpChatSessionStore.getSnapshot(sessionId)?.session;
-
-  if (currentSession) {
-    await updateSessionUserRecipeValues({
-      path: {
-        session_id: sessionId,
-      },
-      body: {
-        userRecipeValues,
-      },
-      throwOnError: true,
-    });
-    const updatedSession = {
-      ...currentSession,
-      user_recipe_values: userRecipeValues,
-    };
-    acpChatSessionActions.setSessionMetadata(sessionId, updatedSession);
-  } else {
-    acpChatSessionActions.setSessionLoadError(
-      sessionId,
-      "can't call setRecipeParams without a session"
-    );
-  }
-}
-
 export const acpChatSessionController: AcpChatSessionController = {
   createSession,
   loadSession,
   submitMessage,
   stop,
   updateMessage,
-  setRecipeUserParams,
 };

--- a/ui/desktop/src/acp/sessions.ts
+++ b/ui/desktop/src/acp/sessions.ts
@@ -168,6 +168,12 @@ export async function acpListRecentSessions(maxSessions: number): Promise<Sessio
   return response.sessions.slice(0, maxSessions).map(sessionInfoToListItem);
 }
 
+export async function acpGetSessionListItem(sessionId: string): Promise<SessionListItem> {
+  const client = await getAcpClient();
+  const response = await client.goose.sessionInfo_unstable({ sessionId });
+  return sessionInfoToListItem(response.session);
+}
+
 export async function acpLoadSession(sessionId: string): Promise<AcpLoadSessionResult> {
   const pendingLoad = inFlightSessionLoads.get(sessionId);
   if (pendingLoad) {

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -554,7 +554,8 @@ export default function BaseChat({
         />
       )}
 
-      {recipe?.parameters &&
+      {!USE_ACP_CHAT &&
+        recipe?.parameters &&
         recipe.parameters.length > 0 &&
         !session?.user_recipe_values &&
         session?.session_type !== 'scheduled' && (

--- a/ui/desktop/src/hooks/useAcpChatSession.ts
+++ b/ui/desktop/src/hooks/useAcpChatSession.ts
@@ -263,14 +263,9 @@ export function useAcpChatSession({
     [getCurrentSnapshot, sessionId]
   );
 
-  const setRecipeUserParams = useCallback(
-    async (user_recipe_values: Record<string, string>) => {
-      await acpChatSessionController.setRecipeUserParams(sessionId, user_recipe_values, {
-        getCurrentSnapshot,
-      });
-    },
-    [getCurrentSnapshot, sessionId]
-  );
+  const setRecipeUserParams = useCallback((_userRecipeValues: Record<string, string>) => {
+    return Promise.reject(new Error('ACP recipe parameters are handled during session creation'));
+  }, []);
 
   useEffect(() => {
     if (session) {

--- a/ui/desktop/src/hooks/useNavigationSessions.ts
+++ b/ui/desktop/src/hooks/useNavigationSessions.ts
@@ -1,15 +1,21 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate, useLocation, useSearchParams } from 'react-router-dom';
-import { getSession } from '../api';
 import { useChatContext } from '../contexts/ChatContext';
 import { getSessionDisplayName } from '../sessions';
 import { AppEvents } from '../constants/events';
 import type { Session } from '../api';
-import { acpListRecentSessions, type SessionListItem } from '../acp/sessions';
+import {
+  acpGetSessionListItem,
+  acpListRecentSessions,
+  type SessionListItem,
+} from '../acp/sessions';
 
 const MAX_RECENT_SESSIONS = 25;
 
-export function prependUnique(prev: SessionListItem[], session: SessionListItem): SessionListItem[] {
+export function prependUnique(
+  prev: SessionListItem[],
+  session: SessionListItem
+): SessionListItem[] {
   if (prev.some((s) => s.id === session.id)) return prev;
   return [session, ...prev].slice(0, MAX_RECENT_SESSIONS);
 }
@@ -74,11 +80,13 @@ export function useNavigationSessions() {
     if (!activeSessionId) return;
     if (recentSessions.some((s) => s.id === activeSessionId)) return;
 
-    getSession({ path: { session_id: activeSessionId }, throwOnError: false }).then((response) => {
-      if (!response.data) return;
-      const item = sessionToListItem(response.data as Session);
-      setRecentSessions((prev) => prependUnique(prev, item));
-    });
+    acpGetSessionListItem(activeSessionId)
+      .then((item) => {
+        setRecentSessions((prev) => prependUnique(prev, item));
+      })
+      .catch((error) => {
+        console.error('Failed to fetch active session:', error);
+      });
   }, [activeSessionId, recentSessions]);
 
   useEffect(() => {


### PR DESCRIPTION
Removed: 
 
- removed unnecessary call setRecipeParams for acp enabled path
- replaced getSession (restful) to use ACP getSessionInfo method