### PR TITLE
fix(desktop): allow settings recovery after bad Goose Server config

### DIFF
--- a/ui/desktop/src/components/onboarding/OnboardingGuard.test.tsx
+++ b/ui/desktop/src/components/onboarding/OnboardingGuard.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, type RenderOptions } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import OnboardingGuard from './OnboardingGuard';
+import { IntlTestWrapper } from '../../i18n/test-utils';
+
+const mockNavigate = vi.fn();
+const mockRead = vi.fn();
+const mockGetFallbackModelAndProvider = vi.fn();
+const mockRefreshCurrentModelAndProvider = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('../ConfigContext', () => ({
+  useConfig: () => ({
+    read: mockRead,
+    upsert: vi.fn(),
+    getProviders: vi.fn(),
+  }),
+}));
+
+vi.mock('./ProviderSelector', () => ({
+  default: () => null,
+}));
+
+vi.mock('./OnboardingSuccess', () => ({
+  default: () => null,
+}));
+
+vi.mock('../ModelAndProviderContext', () => ({
+  useModelAndProvider: () => ({
+    getFallbackModelAndProvider: mockGetFallbackModelAndProvider,
+    refreshCurrentModelAndProvider: mockRefreshCurrentModelAndProvider,
+  }),
+}));
+
+vi.mock('../../utils/analytics', () => ({
+  trackOnboardingStarted: vi.fn(),
+  trackOnboardingCompleted: vi.fn(),
+  trackOnboardingProviderSelected: vi.fn(),
+  trackTelemetryPreference: vi.fn(),
+  setTelemetryEnabled: vi.fn(),
+}));
+
+const renderWithProviders = (
+  ui: React.ReactElement,
+  { route = '/' }: { route?: string } = {},
+  options?: RenderOptions
+) =>
+  render(
+    <IntlTestWrapper>
+      <MemoryRouter initialEntries={[route]}>
+        <Routes>
+          <Route path="*" element={ui} />
+        </Routes>
+      </MemoryRouter>
+    </IntlTestWrapper>,
+    options
+  );
+
+describe('OnboardingGuard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRead.mockRejectedValue(new Error('backend unavailable'));
+    mockGetFallbackModelAndProvider.mockResolvedValue({ provider: '', model: '' });
+    mockRefreshCurrentModelAndProvider.mockResolvedValue(undefined);
+  });
+
+  it(
+    'shows recovery actions when the backend check fails',
+    async () => {
+      renderWithProviders(
+        <OnboardingGuard>
+          <div>child content</div>
+        </OnboardingGuard>
+      );
+
+      expect(await screen.findByText('Unable to connect to Goose server', {}, { timeout: 8000 })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Open Settings' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    },
+    10000
+  );
+
+  it(
+    'navigates to Goose Server settings when Open Settings is clicked',
+    async () => {
+      const user = userEvent.setup();
+      renderWithProviders(
+        <OnboardingGuard>
+          <div>child content</div>
+        </OnboardingGuard>
+      );
+
+      await screen.findByText('Unable to connect to Goose server', {}, { timeout: 8000 });
+      await user.click(screen.getByRole('button', { name: 'Open Settings' }));
+
+      expect(mockNavigate).toHaveBeenCalledWith('/settings?section=sharing');
+    },
+    10000
+  );
+
+  it(
+    'renders settings route children even when the backend check fails',
+    async () => {
+      renderWithProviders(
+        <OnboardingGuard>
+          <div>settings content</div>
+        </OnboardingGuard>,
+        { route: '/settings' }
+      );
+
+      await waitFor(
+        () => {
+          expect(screen.getByText('settings content')).toBeInTheDocument();
+        },
+        { timeout: 8000 }
+      );
+      expect(screen.queryByText('Unable to connect to Goose server')).not.toBeInTheDocument();
+    },
+    10000
+  );
+});

--- a/ui/desktop/src/components/onboarding/OnboardingGuard.tsx
+++ b/ui/desktop/src/components/onboarding/OnboardingGuard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useConfig } from '../ConfigContext';
 import { useModelAndProvider } from '../ModelAndProviderContext';
 import { Goose } from '../icons';
@@ -36,6 +36,10 @@ const i18n = defineMessages({
     id: 'onboardingGuard.retry',
     defaultMessage: 'Retry',
   },
+  openSettings: {
+    id: 'onboardingGuard.openSettings',
+    defaultMessage: 'Open Settings',
+  },
 });
 
 const TELEMETRY_CONFIG_KEY = 'GOOSE_TELEMETRY_ENABLED';
@@ -47,6 +51,7 @@ interface OnboardingGuardProps {
 export default function OnboardingGuard({ children }: OnboardingGuardProps) {
   const intl = useIntl();
   const navigate = useNavigate();
+  const location = useLocation();
   const { read, upsert, getProviders } = useConfig();
   const { getFallbackModelAndProvider, refreshCurrentModelAndProvider } = useModelAndProvider();
 
@@ -150,6 +155,10 @@ export default function OnboardingGuard({ children }: OnboardingGuardProps) {
   }
 
   if (checkProviderError) {
+    if (location.pathname === '/settings') {
+      return <>{children}</>;
+    }
+
     return (
       <div className="h-screen w-full bg-background-default flex flex-col items-center justify-center">
         <div className="text-center max-w-md">
@@ -158,9 +167,14 @@ export default function OnboardingGuard({ children }: OnboardingGuardProps) {
           </div>
           <h1 className="text-xl font-light mb-3">{intl.formatMessage(i18n.checkProviderErrorTitle)}</h1>
           <p className="text-text-muted mb-6">{intl.formatMessage(i18n.checkProviderErrorDescription)}</p>
-          <Button onClick={() => checkProvider()}>
-            {intl.formatMessage(i18n.retry)}
-          </Button>
+          <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+            <Button onClick={() => navigate('/settings?section=sharing')}>
+              {intl.formatMessage(i18n.openSettings)}
+            </Button>
+            <Button variant="outline" onClick={() => checkProvider()}>
+              {intl.formatMessage(i18n.retry)}
+            </Button>
+          </div>
         </div>
       </div>
     );

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -2351,6 +2351,9 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "Unable to connect to Goose server"
   },
+  "onboardingGuard.openSettings": {
+    "defaultMessage": "Open Settings"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "Retry"
   },

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -2351,6 +2351,9 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "No se pudo conectar con el servidor de Goose"
   },
+  "onboardingGuard.openSettings": {
+    "defaultMessage": "Abrir configuración"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "Reintentar"
   },

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -2351,6 +2351,9 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "Goose सर्वर से कनेक्ट करने में असमर्थ"
   },
+  "onboardingGuard.openSettings": {
+    "defaultMessage": "Settings खोलें"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "पुनः प्रयास करें"
   },

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -2351,6 +2351,9 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "gooseサーバーに接続できません"
   },
+  "onboardingGuard.openSettings": {
+    "defaultMessage": "設定を開く"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "再試行"
   },

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -2351,6 +2351,9 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "Goose 서버에 접속할 수 없습니다"
   },
+  "onboardingGuard.openSettings": {
+    "defaultMessage": "설정 열기"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "다시 시도"
   },

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -2351,6 +2351,9 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "Не удалось подключиться к серверу Goose"
   },
+  "onboardingGuard.openSettings": {
+    "defaultMessage": "Откройте «Параметры»"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "Повторить"
   },

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -2351,6 +2351,9 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "Goose sunucusuna bağlanılamıyor"
   },
+  "onboardingGuard.openSettings": {
+    "defaultMessage": "Ayarları Aç"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "Yeniden dene"
   },

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -2351,6 +2351,9 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "无法连接到 Goose 服务器"
   },
+  "onboardingGuard.openSettings": {
+    "defaultMessage": "打开设置"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "重试"
   },

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -872,6 +872,7 @@ interface CreateChatOptions {
   dir?: string;
   resumeSessionId?: string;
   viewType?: string;
+  settingsSection?: string;
   recipeDeeplink?: string;
   recipeId?: string;
   scheduledJobId?: string;
@@ -885,6 +886,7 @@ const createChat = async (app: App, options: CreateChatOptions = {}) => {
     dir,
     resumeSessionId,
     viewType,
+    settingsSection,
     recipeDeeplink,
     recipeId,
     scheduledJobId,
@@ -1052,19 +1054,27 @@ const createChat = async (app: App, options: CreateChatOptions = {}) => {
         type: 'error',
         title: 'External Backend Unreachable',
         message: `Could not connect to external backend at ${settings.externalGoosed?.url}`,
-        detail: 'The external goosed server may not be running.',
-        buttons: ['Disable External Backend & Retry', 'Quit'],
+        detail:
+          'The external goosed server may not be running. Open Settings to fix the Goose Server configuration.',
+        buttons: ['Open Settings', 'Disable External Backend & Retry', 'Quit'],
         defaultId: 0,
-        cancelId: 1,
+        cancelId: 2,
       });
 
-      if (response === 0) {
+      if (response === 0 || response === 1) {
         updateSettings((s) => {
           if (s.externalGoosed) {
             s.externalGoosed.enabled = false;
           }
         });
         mainWindow.destroy();
+        if (response === 0) {
+          return createChat(app, {
+            viewType: 'settings',
+            settingsSection: 'sharing',
+            dir,
+          });
+        }
         return createChat(app, { initialMessage, dir });
       }
     } else {
@@ -1212,6 +1222,9 @@ const createChat = async (app: App, options: CreateChatOptions = {}) => {
     if (appPath === '/') {
       appPath = '/pair';
     }
+  }
+  if (settingsSection) {
+    searchParams.set('section', settingsSection);
   }
 
   // Goose's react app uses HashRouter, so the path + search params follow a #/


### PR DESCRIPTION
## Summary

When Goose Desktop is configured to use an external Goose Server with invalid connection details, restart leaves the app in a dead-end: the error screen blocks navigation and File → Settings cannot be opened to fix the configuration.

This PR adds recovery paths so users can reach the Goose Server settings tab and correct or disable the external backend.

## Motivation

Fixes #9977.

After enabling Goose Server with a bad URL/secret and restarting, users could not open Settings or capture diagnostics. The only workaround was manually editing `settings.json`.

## Changes

- **Startup dialog (`main.ts`)**: when an external backend is unreachable at launch, add an **Open Settings** action (default). It temporarily disables the external backend for launch and opens `/settings?section=sharing` (Goose Server tab). Existing **Disable External Backend & Retry** and **Quit** options are preserved.
- **Onboarding guard**: when the backend health check fails, show **Open Settings** alongside **Retry**, and allow the `/settings` route to render even if the provider check failed (Goose Server settings use Electron IPC, not the live backend).
- **Tests**: add `OnboardingGuard` unit tests for the recovery UI and settings-route bypass.

## Tests

```bash
cd ui/desktop
pnpm run test:run src/components/onboarding/OnboardingGuard.test.tsx
```

Result: **3 passed**

Also ran ESLint on changed files (clean).

## Notes

- The startup recovery path disables `externalGoosed.enabled` before reopening Settings so local `goosed` can start and the user is not stuck in a dialog loop.
- Users who only hit the in-app error screen can open Settings without that automatic disable; they can fix or disable the external backend from the Goose Server tab.