### PR TITLE
ignore unused on windows

### DIFF
--- a/crates/goose/src/agents/platform_extensions/developer/shell.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/shell.rs
@@ -320,6 +320,8 @@ pub struct ShellTool {
 
 impl ShellTool {
     pub fn new(use_login_shell_path: bool) -> std::io::Result<Self> {
+        #[cfg(windows)]
+        let _unused = use_login_shell_path;
         Ok(Self {
             output_dir: tempfile::tempdir()?,
             call_index: AtomicUsize::new(0),


### PR DESCRIPTION
This generates a warning on windows builds otherwise.