### PR TITLE
Fix Windows build and desktop dependency resolution

### DIFF
--- a/crates/goose/src/windows_job.rs
+++ b/crates/goose/src/windows_job.rs
@@ -16,9 +16,8 @@ mod windows_impl {
 
     use winapi::shared::minwindef::FALSE;
     use winapi::um::handleapi::CloseHandle;
-    use winapi::um::jobapi2::{AssignProcessToJobObject, CreateJobObjectW};
+    use winapi::um::jobapi2::{AssignProcessToJobObject, CreateJobObjectW, SetInformationJobObject};
     use winapi::um::processthreadsapi::OpenProcess;
-    use winapi::um::winbase::SetInformationJobObject;
     use winapi::um::winnt::{
         JobObjectExtendedLimitInformation, HANDLE, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
         JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, PROCESS_SET_QUOTA, PROCESS_TERMINATE,

--- a/ui/desktop/vite.renderer.config.mts
+++ b/ui/desktop/vite.renderer.config.mts
@@ -3,6 +3,9 @@ import tailwindcss from '@tailwindcss/vite';
 
 // https://vitejs.dev/config
 export default defineConfig({
+  resolve: {
+    dedupe: ['react', 'react-dom'],
+  },
   define: {
     'process.env.GOOSE_TUNNEL': JSON.stringify(process.env.GOOSE_TUNNEL !== 'no' && process.env.GOOSE_TUNNEL !== 'none'),
   },

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -815,7 +815,7 @@ packages:
     engines: {node: '>=14'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -3140,6 +3140,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react@5.2.0':
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
@@ -3241,6 +3242,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -3,3 +3,23 @@ packages:
   - 'text'
   - 'desktop'
   - 'goose-binary/*'
+
+onlyBuiltDependencies:
+  - '@modelcontextprotocol/ext-apps'
+  - electron
+  - electron-winstaller
+  - esbuild
+
+overrides:
+  react: ^19.2.4
+  react-dom: ^19.2.4
+
+blockExoticSubdeps: false
+
+nodeLinker: hoisted
+
+allowBuilds:
+  '@modelcontextprotocol/ext-apps': true
+  electron: true
+  electron-winstaller: true
+  esbuild: true


### PR DESCRIPTION
## Summary
Fixes the desktop React `useRef` runtime error by deduping React/React DOM and updating pnpm workspace dependency resolution for hoisted/native builds. Also corrects a Windows job object import.

- Fixes null `useRef` runtime error by deduping React/React DOM
- Aligns workspace React versions and hoists pnpm dependencies
- Allows required Electron/native dependency builds
- Corrects Windows `SetInformationJobObject` import


### Testing
I have tested it locally, and it builds and runs without any issues after the fixes.

