### PR TITLE
fix: Improve screen reader accessibility of initial onboarding screen

### DIFF
--- a/ui/desktop/src/components/onboarding/FreeOptionCards.tsx
+++ b/ui/desktop/src/components/onboarding/FreeOptionCards.tsx
@@ -6,6 +6,7 @@ import LocalModelPicker from './LocalModelPicker';
 import { HardDrive } from 'lucide-react';
 import { useFeatures } from '../../contexts/FeaturesContext';
 import { defineMessages, useIntl } from '../../i18n';
+import { activateOnKey } from '../../utils/a11y';
 
 const i18n = defineMessages({
   chooseOption: {
@@ -18,7 +19,8 @@ const i18n = defineMessages({
   },
   tetrateDescription: {
     id: 'freeOptionCards.tetrateDescription',
-    defaultMessage: 'Access multiple AI models with automatic setup. Sign up to receive $10 credit.',
+    defaultMessage:
+      'Access multiple AI models with automatic setup. Sign up to receive $10 credit.',
   },
   nanogptTitle: {
     id: 'freeOptionCards.nanogptTitle',
@@ -122,7 +124,14 @@ export default function FreeOptionCards({ onConfigured }: FreeOptionCardsProps) 
         <p className="text-sm text-text-muted mb-4">{intl.formatMessage(i18n.chooseOption)}</p>
 
         <div className="flex flex-col gap-3">
-          <div onClick={handleTetrateSetup} className={cardClass(selectedProvider === TETRATE)}>
+          <div
+            role="button"
+            tabIndex={0}
+            onClick={handleTetrateSetup}
+            onKeyDown={activateOnKey(handleTetrateSetup)}
+            aria-pressed={selectedProvider === TETRATE}
+            className={cardClass(selectedProvider === TETRATE)}
+          >
             <div className="flex items-start justify-between mb-1">
               <div className="flex items-center gap-2">
                 <Tetrate className="w-5 h-5 text-text-default" />
@@ -134,34 +143,47 @@ export default function FreeOptionCards({ onConfigured }: FreeOptionCardsProps) 
                 <ChevronRight />
               </div>
             </div>
-            <p className="text-text-muted text-sm">
-              {intl.formatMessage(i18n.tetrateDescription)}
-            </p>
+            <p className="text-text-muted text-sm">{intl.formatMessage(i18n.tetrateDescription)}</p>
           </div>
 
-          <div onClick={handleNanogptSetup} className={cardClass(selectedProvider === NANOGPT)}>
+          <div
+            role="button"
+            tabIndex={0}
+            onClick={handleNanogptSetup}
+            onKeyDown={activateOnKey(handleNanogptSetup)}
+            aria-pressed={selectedProvider === NANOGPT}
+            className={cardClass(selectedProvider === NANOGPT)}
+          >
             <div className="flex items-start justify-between mb-1">
               <div className="flex items-center gap-2">
                 <span className="w-5 h-5 flex items-center justify-center text-text-default text-xs font-bold">
                   N
                 </span>
-                <span className="font-medium text-text-default text-base">{intl.formatMessage(i18n.nanogptTitle)}</span>
+                <span className="font-medium text-text-default text-base">
+                  {intl.formatMessage(i18n.nanogptTitle)}
+                </span>
               </div>
               <div className="text-text-muted group-hover:text-text-default transition-colors">
                 <ChevronRight />
               </div>
             </div>
-            <p className="text-text-muted text-sm">
-              {intl.formatMessage(i18n.nanogptDescription)}
-            </p>
+            <p className="text-text-muted text-sm">{intl.formatMessage(i18n.nanogptDescription)}</p>
           </div>
 
           {localInference && (
-            <div onClick={handleRunLocallyClick} className={cardClass(false)}>
+            <div
+              role="button"
+              tabIndex={0}
+              onClick={handleRunLocallyClick}
+              onKeyDown={activateOnKey(handleRunLocallyClick)}
+              className={cardClass(false)}
+            >
               <div className="flex items-start justify-between mb-1">
                 <div className="flex items-center gap-2">
                   <HardDrive className="w-5 h-5 text-text-default" />
-                  <span className="font-medium text-text-default text-base">{intl.formatMessage(i18n.localModelTitle)}</span>
+                  <span className="font-medium text-text-default text-base">
+                    {intl.formatMessage(i18n.localModelTitle)}
+                  </span>
                   <span className="inline-block px-1.5 py-0.5 text-[10px] font-medium bg-green-600 text-white rounded-full">
                     {intl.formatMessage(i18n.freeAndPrivate)}
                   </span>

--- a/ui/desktop/src/components/onboarding/LocalModelPicker.tsx
+++ b/ui/desktop/src/components/onboarding/LocalModelPicker.tsx
@@ -66,7 +66,8 @@ const i18n = defineMessages({
   },
   localModelsNote: {
     id: 'localModelPicker.localModelsNote',
-    defaultMessage: 'Local models keep everything on your machine for full privacy. Performance and context window size may vary compared to cloud providers depending on your hardware and model size.',
+    defaultMessage:
+      'Local models keep everything on your machine for full privacy. Performance and context window size may vary compared to cloud providers depending on your hardware and model size.',
   },
   failedToLoad: {
     id: 'localModelPicker.failedToLoad',
@@ -285,13 +286,18 @@ export default function LocalModelPicker({ onConfigured, onBack }: LocalModelPic
                 <div className="flex items-start gap-3">
                   <input
                     type="radio"
+                    name="local-model"
                     checked={selectedModelId === recommended.id}
                     onChange={() => setSelectedModelId(recommended.id)}
+                    aria-labelledby={`local-model-${recommended.id}-label`}
                     className="cursor-pointer flex-shrink-0 mt-1"
                   />
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 flex-wrap">
-                      <span className="font-medium text-text-default text-sm">
+                      <span
+                        id={`local-model-${recommended.id}-label`}
+                        className="font-medium text-text-default text-sm"
+                      >
                         {recommended.id}
                       </span>
                       {recommended.status.state === 'Downloaded' && (
@@ -314,7 +320,9 @@ export default function LocalModelPicker({ onConfigured, onBack }: LocalModelPic
                   onClick={() => setShowAllModels(!showAllModels)}
                   className="text-sm text-blue-500 hover:text-blue-400 transition-colors flex items-center gap-1"
                 >
-                  {showAllModels ? intl.formatMessage(i18n.hideOtherSizes) : intl.formatMessage(i18n.showOtherSizes, { count: otherModels.length })}
+                  {showAllModels
+                    ? intl.formatMessage(i18n.hideOtherSizes)
+                    : intl.formatMessage(i18n.showOtherSizes, { count: otherModels.length })}
                   <svg
                     className={`w-3.5 h-3.5 transition-transform ${showAllModels ? 'rotate-180' : ''}`}
                     fill="none"
@@ -345,13 +353,18 @@ export default function LocalModelPicker({ onConfigured, onBack }: LocalModelPic
                         <div className="flex items-start gap-3">
                           <input
                             type="radio"
+                            name="local-model"
                             checked={selectedModelId === model.id}
                             onChange={() => setSelectedModelId(model.id)}
+                            aria-labelledby={`local-model-${model.id}-label`}
                             className="cursor-pointer flex-shrink-0 mt-0.5"
                           />
                           <div className="flex-1 min-w-0">
                             <div className="flex items-center gap-2 flex-wrap">
-                              <span className="font-medium text-text-default text-sm">
+                              <span
+                                id={`local-model-${model.id}-label`}
+                                className="font-medium text-text-default text-sm"
+                              >
                                 {model.id}
                               </span>
                               <span className="text-xs text-text-muted">
@@ -380,7 +393,10 @@ export default function LocalModelPicker({ onConfigured, onBack }: LocalModelPic
               {selectedModel?.status.state === 'Downloaded'
                 ? intl.formatMessage(i18n.useModel, { modelId: selectedModel.id })
                 : selectedModel
-                  ? intl.formatMessage(i18n.downloadModel, { modelId: selectedModel.id, size: formatSize(selectedModel.size_bytes) })
+                  ? intl.formatMessage(i18n.downloadModel, {
+                      modelId: selectedModel.id,
+                      size: formatSize(selectedModel.size_bytes),
+                    })
                   : intl.formatMessage(i18n.selectModel)}
             </button>
 
@@ -398,13 +414,26 @@ export default function LocalModelPicker({ onConfigured, onBack }: LocalModelPic
         {phase === 'downloading' && selectedModel && (
           <div className="space-y-3">
             <div className="border border-border-subtle rounded-lg p-4 bg-background-default">
-              <p className="font-medium text-text-default text-sm mb-3">
+              <p
+                id="local-model-download-label"
+                className="font-medium text-text-default text-sm mb-3"
+              >
                 {intl.formatMessage(i18n.downloading, { modelId: selectedModel.id })}
               </p>
 
               {downloadProgress ? (
                 <div className="space-y-2">
-                  <div className="w-full bg-background-subtle rounded-full h-2 overflow-hidden">
+                  <div
+                    role="progressbar"
+                    aria-labelledby="local-model-download-label"
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-valuenow={Math.round(downloadProgress.progress_percent)}
+                    aria-valuetext={`${downloadProgress.progress_percent.toFixed(0)}%, ${formatBytes(
+                      downloadProgress.bytes_downloaded
+                    )} of ${formatBytes(downloadProgress.total_bytes)}`}
+                    className="w-full bg-background-subtle rounded-full h-2 overflow-hidden"
+                  >
                     <div
                       className="bg-blue-500 h-2 rounded-full transition-all duration-500 ease-out"
                       style={{ width: `${downloadProgress.progress_percent}%` }}
@@ -439,7 +468,9 @@ export default function LocalModelPicker({ onConfigured, onBack }: LocalModelPic
               ) : (
                 <div className="flex items-center gap-3">
                   <div className="animate-spin rounded-full h-4 w-4 border-t-2 border-b-2 border-text-muted"></div>
-                  <span className="text-sm text-text-muted">{intl.formatMessage(i18n.startingDownload)}</span>
+                  <span className="text-sm text-text-muted">
+                    {intl.formatMessage(i18n.startingDownload)}
+                  </span>
                 </div>
               )}
             </div>

--- a/ui/desktop/src/components/onboarding/ProviderSelector.tsx
+++ b/ui/desktop/src/components/onboarding/ProviderSelector.tsx
@@ -12,6 +12,7 @@ import CustomProviderForm from '../settings/providers/modal/subcomponents/forms/
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../ui/dialog';
 import { Gift, Key, Plus } from 'lucide-react';
 import { defineMessages, useIntl } from '../../i18n';
+import { activateOnKey } from '../../utils/a11y';
 
 const i18n = defineMessages({
   useFreeLocal: {
@@ -33,6 +34,10 @@ const i18n = defineMessages({
   selectProvider: {
     id: 'providerSelector.selectProvider',
     defaultMessage: 'Select a provider',
+  },
+  providerLabel: {
+    id: 'providerSelector.providerLabel',
+    defaultMessage: 'Provider',
   },
   addCustomProvider: {
     id: 'providerSelector.addCustomProvider',
@@ -140,7 +145,11 @@ export default function ProviderSelector({
     <div>
       <div className="grid grid-cols-2 gap-3 mb-6">
         <div
+          role="button"
+          tabIndex={0}
           onClick={handleFreeCreditClick}
+          onKeyDown={activateOnKey(handleFreeCreditClick)}
+          aria-pressed={selectedPath === FREE_OPTIONS}
           className={`p-4 border rounded-xl transition-all duration-200 cursor-pointer group ${
             selectedPath === FREE_OPTIONS
               ? 'border-blue-400 bg-background-muted'
@@ -157,7 +166,11 @@ export default function ProviderSelector({
         </div>
 
         <div
+          role="button"
+          tabIndex={0}
           onClick={handleOwnProviderClick}
+          onKeyDown={activateOnKey(handleOwnProviderClick)}
+          aria-pressed={selectedPath === OWN_PROVIDER}
           className={`p-4 border rounded-xl transition-all duration-200 cursor-pointer group ${
             selectedPath === OWN_PROVIDER
               ? 'border-blue-400 bg-background-muted'
@@ -168,7 +181,9 @@ export default function ProviderSelector({
           <span className="font-medium text-text-default text-base block">
             {intl.formatMessage(i18n.connectProvider)}
           </span>
-          <p className="text-text-muted text-sm mt-1">{intl.formatMessage(i18n.connectProviderDescription)}</p>
+          <p className="text-text-muted text-sm mt-1">
+            {intl.formatMessage(i18n.connectProviderDescription)}
+          </p>
         </div>
       </div>
 
@@ -186,6 +201,7 @@ export default function ProviderSelector({
               value={selectedOption}
               onChange={(option) => handleProviderSelect(option as ProviderOption | null)}
               placeholder={intl.formatMessage(i18n.selectProvider)}
+              aria-label={intl.formatMessage(i18n.providerLabel)}
               isClearable
               isSearchable
               autoFocus

--- a/ui/desktop/src/components/settings/providers/modal/subcomponents/forms/CustomProviderForm.tsx
+++ b/ui/desktop/src/components/settings/providers/modal/subcomponents/forms/CustomProviderForm.tsx
@@ -92,7 +92,8 @@ const i18n = defineMessages({
   },
   apiBasePathHint: {
     id: 'customProviderForm.apiBasePathHint',
-    defaultMessage: "Override the default API path. Leave blank to use the provider's default path.",
+    defaultMessage:
+      "Override the default API path. Leave blank to use the provider's default path.",
   },
   authentication: {
     id: 'customProviderForm.authentication',
@@ -411,7 +412,8 @@ export default function CustomProviderForm({
     if (!displayName) errors.displayName = intl.formatMessage(i18n.displayNameRequired);
     if (!apiUrl) errors.apiUrl = intl.formatMessage(i18n.apiUrlRequired);
     const existingHadAuth = initialData && (initialData.requires_auth ?? true);
-    if (requiresAuth && !apiKey && !existingHadAuth) errors.apiKey = intl.formatMessage(i18n.apiKeyRequired);
+    if (requiresAuth && !apiKey && !existingHadAuth)
+      errors.apiKey = intl.formatMessage(i18n.apiKeyRequired);
     if (!models) errors.models = intl.formatMessage(i18n.modelsRequired);
 
     if (Object.keys(errors).length > 0) {
@@ -491,7 +493,9 @@ export default function CustomProviderForm({
           <div className="flex items-center gap-3">
             <Search className="w-5 h-5 text-primary flex-shrink-0" />
             <div>
-              <div className="font-medium text-textStandard">{intl.formatMessage(i18n.startFromTemplate)}</div>
+              <div className="font-medium text-textStandard">
+                {intl.formatMessage(i18n.startFromTemplate)}
+              </div>
               <div className="text-sm text-textSubtle mt-0.5">
                 {intl.formatMessage(i18n.startFromTemplateDesc)}
               </div>
@@ -506,7 +510,9 @@ export default function CustomProviderForm({
           <div className="flex items-center gap-3">
             <Settings className="w-5 h-5 text-textSubtle flex-shrink-0" />
             <div>
-              <div className="font-medium text-textStandard">{intl.formatMessage(i18n.configureManually)}</div>
+              <div className="font-medium text-textStandard">
+                {intl.formatMessage(i18n.configureManually)}
+              </div>
               <div className="text-sm text-textSubtle mt-0.5">
                 {intl.formatMessage(i18n.configureManuallyDesc)}
               </div>
@@ -595,12 +601,15 @@ export default function CustomProviderForm({
             <span className="text-red-500 ml-1">*</span>
           </label>
           <Select
-            id="provider-select"
+            inputId="provider-select"
             aria-invalid={!!validationErrors.providerType}
             aria-describedby={validationErrors.providerType ? 'provider-select-error' : undefined}
             options={[
               { value: 'openai_compatible', label: intl.formatMessage(i18n.openaiCompatible) },
-              { value: 'anthropic_compatible', label: intl.formatMessage(i18n.anthropicCompatible) },
+              {
+                value: 'anthropic_compatible',
+                label: intl.formatMessage(i18n.anthropicCompatible),
+              },
               { value: 'ollama_compatible', label: intl.formatMessage(i18n.ollamaCompatible) },
             ]}
             value={{
@@ -695,18 +704,16 @@ export default function CustomProviderForm({
             onChange={(e) => setBasePath(e.target.value)}
             placeholder={intl.formatMessage(i18n.apiBasePathPlaceholder)}
           />
-          <p className="text-xs text-textSubtle mt-1">
-            {intl.formatMessage(i18n.apiBasePathHint)}
-          </p>
+          <p className="text-xs text-textSubtle mt-1">{intl.formatMessage(i18n.apiBasePathHint)}</p>
         </div>
       )}
 
       {/* Authentication */}
       <div>
-        <label className="block text-sm font-medium text-text-primary mb-2">{intl.formatMessage(i18n.authentication)}</label>
-        <p className="text-sm text-text-secondary mb-3">
-          {intl.formatMessage(i18n.authHint)}
-        </p>
+        <label className="block text-sm font-medium text-text-primary mb-2">
+          {intl.formatMessage(i18n.authentication)}
+        </label>
+        <p className="text-sm text-text-secondary mb-3">{intl.formatMessage(i18n.authHint)}</p>
         <div className="flex items-center space-x-2">
           <input
             type="checkbox"
@@ -739,7 +746,11 @@ export default function CustomProviderForm({
               type="password"
               value={apiKey}
               onChange={(e) => setApiKey(e.target.value)}
-              placeholder={initialData ? intl.formatMessage(i18n.apiKeyPlaceholderExisting) : intl.formatMessage(i18n.apiKeyPlaceholderNew)}
+              placeholder={
+                initialData
+                  ? intl.formatMessage(i18n.apiKeyPlaceholderExisting)
+                  : intl.formatMessage(i18n.apiKeyPlaceholderNew)
+              }
               aria-invalid={!!validationErrors.apiKey}
               aria-describedby={validationErrors.apiKey ? 'api-key-error' : undefined}
               className={validationErrors.apiKey ? 'border-red-500' : ''}
@@ -819,7 +830,9 @@ export default function CustomProviderForm({
       {/* Custom headers */}
       {isEditable && (
         <div>
-          <label className="text-sm font-medium text-textStandard mb-2 block">{intl.formatMessage(i18n.customHeaders)}</label>
+          <label className="text-sm font-medium text-textStandard mb-2 block">
+            {intl.formatMessage(i18n.customHeaders)}
+          </label>
           <p className="text-xs text-textSubtle mb-4">
             {intl.formatMessage(i18n.customHeadersHint)}
           </p>
@@ -900,16 +913,12 @@ export default function CustomProviderForm({
             <div className="px-4 py-3 bg-yellow-600/20 border border-yellow-500/30 rounded">
               <p className="text-yellow-500 text-sm flex items-start">
                 <AlertTriangle className="h-4 w-4 mr-2 mt-0.5 flex-shrink-0" />
-                <span>
-                  {intl.formatMessage(i18n.cannotDeleteActive)}
-                </span>
+                <span>{intl.formatMessage(i18n.cannotDeleteActive)}</span>
               </p>
             </div>
           ) : (
             <div className="px-4 py-3 bg-red-900/20 border border-red-500/30 rounded">
-              <p className="text-red-400 text-sm">
-                {intl.formatMessage(i18n.deleteConfirmation)}
-              </p>
+              <p className="text-red-400 text-sm">{intl.formatMessage(i18n.deleteConfirmation)}</p>
             </div>
           )}
           <div className="flex justify-end space-x-2">
@@ -944,7 +953,11 @@ export default function CustomProviderForm({
           <Button type="button" variant="outline" onClick={onCancel}>
             {intl.formatMessage(i18n.cancel)}
           </Button>
-          <Button type="submit">{initialData ? intl.formatMessage(i18n.updateProvider) : intl.formatMessage(i18n.createProvider)}</Button>
+          <Button type="submit">
+            {initialData
+              ? intl.formatMessage(i18n.updateProvider)
+              : intl.formatMessage(i18n.createProvider)}
+          </Button>
         </div>
       )}
     </form>

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -2813,6 +2813,9 @@
   "providerSelector.freeLocalDescription": {
     "defaultMessage": "Use a local model or a provider with free credits"
   },
+  "providerSelector.providerLabel": {
+    "defaultMessage": "Provider"
+  },
   "providerSelector.selectProvider": {
     "defaultMessage": "Select a provider"
   },

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -2813,6 +2813,9 @@
   "providerSelector.freeLocalDescription": {
     "defaultMessage": "Usa un modelo local o un proveedor con créditos gratis"
   },
+  "providerSelector.providerLabel": {
+    "defaultMessage": "Proveedor"
+  },
   "providerSelector.selectProvider": {
     "defaultMessage": "Selecciona un proveedor"
   },

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -2813,6 +2813,9 @@
   "providerSelector.freeLocalDescription": {
     "defaultMessage": "स्थानीय मॉडल या मुफ़्त क्रेडिट वाले प्रदाता का उपयोग करें"
   },
+  "providerSelector.providerLabel": {
+    "defaultMessage": "प्रदाता"
+  },
   "providerSelector.selectProvider": {
     "defaultMessage": "एक प्रदाता चुनें"
   },

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -2813,6 +2813,9 @@
   "providerSelector.freeLocalDescription": {
     "defaultMessage": "ローカルモデルまたは無料クレジット付きのプロバイダーを使用"
   },
+  "providerSelector.providerLabel": {
+    "defaultMessage": "プロバイダー"
+  },
   "providerSelector.selectProvider": {
     "defaultMessage": "プロバイダーを選択"
   },

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -2813,6 +2813,9 @@
   "providerSelector.freeLocalDescription": {
     "defaultMessage": "무료 크레딧이 있는 로컬 모델이나 제공업체를 사용하세요."
   },
+  "providerSelector.providerLabel": {
+    "defaultMessage": "제공업체"
+  },
   "providerSelector.selectProvider": {
     "defaultMessage": "제공업체 선택"
   },

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -2813,6 +2813,9 @@
   "providerSelector.freeLocalDescription": {
     "defaultMessage": "Используйте локальную модель или провайдера с бесплатными кредитами"
   },
+  "providerSelector.providerLabel": {
+    "defaultMessage": "Провайдер"
+  },
   "providerSelector.selectProvider": {
     "defaultMessage": "Выберите провайдера"
   },

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -2813,6 +2813,9 @@
   "providerSelector.freeLocalDescription": {
     "defaultMessage": "Yerel bir model veya ücretsiz kredili bir sağlayıcı kullanın"
   },
+  "providerSelector.providerLabel": {
+    "defaultMessage": "Sağlayıcı"
+  },
   "providerSelector.selectProvider": {
     "defaultMessage": "Bir sağlayıcı seçin"
   },

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -2813,6 +2813,9 @@
   "providerSelector.freeLocalDescription": {
     "defaultMessage": "使用本地模型或带有免费额度的提供商"
   },
+  "providerSelector.providerLabel": {
+    "defaultMessage": "提供商"
+  },
   "providerSelector.selectProvider": {
     "defaultMessage": "选择提供商"
   },

--- a/ui/desktop/src/utils/a11y.test.ts
+++ b/ui/desktop/src/utils/a11y.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { KeyboardEvent } from 'react';
+import { activateOnKey } from './a11y';
+
+const keyEvent = (key: string): KeyboardEvent => {
+  return { key, preventDefault: vi.fn() } as unknown as KeyboardEvent;
+};
+
+describe('activateOnKey', () => {
+  it('activates on Enter and prevents default', () => {
+    const handler = vi.fn();
+    const event = keyEvent('Enter');
+
+    activateOnKey(handler)(event);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it('activates on Space and prevents default', () => {
+    const handler = vi.fn();
+    const event = keyEvent(' ');
+
+    activateOnKey(handler)(event);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['Tab', 'ArrowDown', 'Escape', 'a'])(
+    'ignores "%s" without activating or preventing default',
+    (key) => {
+      const handler = vi.fn();
+      const event = keyEvent(key);
+
+      activateOnKey(handler)(event);
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/ui/desktop/src/utils/a11y.ts
+++ b/ui/desktop/src/utils/a11y.ts
@@ -1,0 +1,12 @@
+import type { KeyboardEvent } from 'react';
+
+/**
+ * onKeyDown handler that activates a control on Enter or Space, matching native
+ * button behavior. For elements given `role="button"` that aren't native buttons.
+ */
+export const activateOnKey = (handler: () => void) => (e: KeyboardEvent) => {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault();
+    handler();
+  }
+};


### PR DESCRIPTION
## Summary
I'm a blind screen reader user wanting to use the desktop app, and hit several issues which made onboarding difficult:
* The initial provider selection buttons were not keyboard-activatable. Now they're tabbable with correct ARIA expandable semantics, and can be clicked via space/enter.
* The provider type `<select>` and custom provider type `<select>` are now associated with their labels.
* The local model download percentage display now uses correct ARIA progress semantics. This makes it present as an updating progress bar to screen readers. On Orca/NVDA, this means automatic, configurable announcements/beeps on change.
* The local model radio buttons were not labelled. They are now.

This isn't perfect, but with these changes in place it's a lot easier to navigate through the onboarding screens and to reach the main chat area, which I'll be working on next.

### Testing
I myself am a blind screen reader user so I'm putting this through its paces. There's also one manual test verifying the keyboard handler semantics for some of the buttons--please let me know if you'd like more added. I've verified each of these screens under Orca and they behave much better than they did before.