### PR TITLE
fix(cli): restore terminal cursor after configure Ctrl+C

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2725,6 +2725,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3556,6 +3567,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.1",
+ "block2",
+ "libc",
  "objc2",
 ]
 
@@ -4915,6 +4928,7 @@ dependencies = [
  "cliclack",
  "comfy-table",
  "console 0.16.3",
+ "ctrlc",
  "dotenvy",
  "env-lock",
  "etcetera 0.11.0",

--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -28,6 +28,7 @@ rmcp = { workspace = true }
 clap = { workspace = true }
 cliclack = { version = "0.5", default-features = false }
 console = { version = "0.16", default-features = false, features = ["std"] }
+ctrlc = { version = "3.4", default-features = false }
 dotenvy = { workspace = true }
 bat = { version = "0.26", default-features = false, features = ["regex-onig"] }
 anyhow = { workspace = true }

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -42,6 +42,8 @@ pub async fn handle_configure() -> anyhow::Result<()> {
         );
     }
 
+    let _terminal_guard = crate::terminal::InteractiveTerminalGuard::new();
+
     let config = Config::global();
 
     if !config.exists() {

--- a/crates/goose-cli/src/lib.rs
+++ b/crates/goose-cli/src/lib.rs
@@ -12,6 +12,7 @@ pub mod recipes;
 pub mod scenario_tests;
 pub mod session;
 pub mod signal;
+pub mod terminal;
 
 // Re-export commonly used types
 pub use cli::Cli;

--- a/crates/goose-cli/src/terminal.rs
+++ b/crates/goose-cli/src/terminal.rs
@@ -1,0 +1,53 @@
+use console::Term;
+use std::sync::Once;
+
+static SIGINT_HANDLER: Once = Once::new();
+
+/// Restores cursor visibility after cliclack/dialoguer TUI prompts.
+pub fn restore_interactive_terminal() {
+    let _ = Term::stdout().show_cursor();
+}
+
+/// RAII guard for interactive TUI flows such as `goose configure`.
+///
+/// cliclack hides the cursor during prompts; if the user presses Ctrl+C the
+/// process can exit before the library restores it. This guard shows the cursor
+/// on normal return and registers a SIGINT handler for interrupt exits.
+pub struct InteractiveTerminalGuard {
+    _private: (),
+}
+
+impl InteractiveTerminalGuard {
+    pub fn new() -> Self {
+        SIGINT_HANDLER.call_once(|| {
+            ctrlc::set_handler(|| {
+                restore_interactive_terminal();
+                std::process::exit(130);
+            })
+            .expect("failed to set Ctrl+C handler");
+        });
+        Self { _private: () }
+    }
+}
+
+impl Default for InteractiveTerminalGuard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for InteractiveTerminalGuard {
+    fn drop(&mut self) {
+        restore_interactive_terminal();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn restore_interactive_terminal_does_not_panic() {
+        restore_interactive_terminal();
+    }
+}


### PR DESCRIPTION
## Summary

Restore terminal cursor visibility when exiting `goose configure` via Ctrl+C or normal completion.

## Motivation

Fixes #10018. cliclack hides the cursor during configure prompts (`\e[?25l`). On SIGINT the process can exit before the TUI sends the matching show-cursor sequence, leaving the terminal cursor invisible until the user manually runs `tput cnorm` or `printf '\e[?25h'`.

## Changes

- Add `InteractiveTerminalGuard` in `goose-cli/src/terminal.rs` that:
  - calls `console::Term::stdout().show_cursor()` on drop (normal/error exit)
  - registers a SIGINT handler via `ctrlc` to restore the cursor and exit 130
- Activate the guard at the start of `handle_configure()` (after the TTY check)
- Add `ctrlc` dependency (SIGINT only, no `termination` feature)

## Tests

```bash
cargo test -p goose-cli --no-default-features --features rustls-tls terminal::
cargo clippy -p goose-cli --no-default-features --features rustls-tls -- -D warnings
```

Results: 1 passed; clippy clean.

Manual verification recommended: run `goose configure`, navigate to a text input prompt, press Ctrl+C, confirm cursor is visible.

## Notes

- Scope is intentionally limited to `goose configure`; other cliclack entry points (e.g. telemetry consent dialog) can be handled in a follow-up if needed.
- Pre-PR review by automated reviewer: APPROVE after removing `termination` feature from `ctrlc`.

Fixes #10018