### PR TITLE
fix(schedule): use session.message_count for schedule sessions listing

### DIFF
--- a/crates/goose-cli/src/commands/schedule.rs
+++ b/crates/goose-cli/src/commands/schedule.rs
@@ -217,11 +217,11 @@ pub async fn handle_schedule_sessions(schedule_id: String, limit: Option<usize>)
                 println!("No sessions found for schedule ID '{}'.", schedule_id);
             } else {
                 println!("Sessions for schedule ID '{}':", schedule_id);
-                // sessions is now Vec<(String, SessionMetadata)>
                 for (session_name, metadata) in sessions {
                     println!(
-                        "  - Session ID: {}, Working Dir: {}, Description: \"{}\", Schedule ID: {:?}",
-                        session_name, // Display the session_name as Session ID
+                        "  - Session ID: {}, Messages: {}, Working Dir: {}, Description: \"{}\", Schedule ID: {:?}",
+                        session_name,
+                        metadata.message_count,
                         metadata.working_dir.display(),
                         metadata.name,
                         metadata.schedule_id.as_deref().unwrap_or("N/A")

--- a/crates/goose/src/agents/schedule_tool.rs
+++ b/crates/goose/src/agents/schedule_tool.rs
@@ -399,7 +399,7 @@ impl Agent {
                             format!(
                                 "- Session: {} (Messages: {}, Working Dir: {})",
                                 session_name,
-                                session.conversation.unwrap_or_default().len(),
+                                session.message_count,
                                 session.working_dir.display()
                             )
                         })

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -29,6 +29,86 @@ mod tests {
             jobs: tokio::sync::Mutex<Vec<ScheduledJob>>,
         }
 
+        struct SessionsMockScheduler {
+            sessions: Vec<(String, Session)>,
+        }
+
+        impl SessionsMockScheduler {
+            fn new(sessions: Vec<(String, Session)>) -> Self {
+                Self { sessions }
+            }
+        }
+
+        #[async_trait]
+        impl SchedulerTrait for SessionsMockScheduler {
+            async fn add_scheduled_job(
+                &self,
+                _job: ScheduledJob,
+                _copy: bool,
+            ) -> Result<(), SchedulerError> {
+                Ok(())
+            }
+
+            async fn schedule_recipe(
+                &self,
+                _recipe_path: PathBuf,
+                _cron_schedule: Option<String>,
+            ) -> Result<(), SchedulerError> {
+                Ok(())
+            }
+
+            async fn list_scheduled_jobs(&self) -> Vec<ScheduledJob> {
+                Vec::new()
+            }
+
+            async fn remove_scheduled_job(
+                &self,
+                _id: &str,
+                _remove: bool,
+            ) -> Result<(), SchedulerError> {
+                Ok(())
+            }
+
+            async fn pause_schedule(&self, _id: &str) -> Result<(), SchedulerError> {
+                Ok(())
+            }
+
+            async fn unpause_schedule(&self, _id: &str) -> Result<(), SchedulerError> {
+                Ok(())
+            }
+
+            async fn run_now(&self, _id: &str) -> Result<String, SchedulerError> {
+                Ok("test_session_123".to_string())
+            }
+
+            async fn sessions(
+                &self,
+                _sched_id: &str,
+                _limit: usize,
+            ) -> Result<Vec<(String, Session)>, SchedulerError> {
+                Ok(self.sessions.clone())
+            }
+
+            async fn update_schedule(
+                &self,
+                _sched_id: &str,
+                _new_cron: String,
+            ) -> Result<(), SchedulerError> {
+                Ok(())
+            }
+
+            async fn kill_running_job(&self, _sched_id: &str) -> Result<(), SchedulerError> {
+                Ok(())
+            }
+
+            async fn get_running_job_info(
+                &self,
+                _sched_id: &str,
+            ) -> Result<Option<(String, DateTime<Utc>)>, SchedulerError> {
+                Ok(None)
+            }
+        }
+
         impl MockScheduler {
             fn new() -> Self {
                 Self {
@@ -255,6 +335,56 @@ mod tests {
                         .contains("Session identifier for session_content action"));
                 }
             }
+        }
+
+        #[tokio::test]
+        async fn test_schedule_sessions_reports_message_count_without_conversation() {
+            let temp_dir = TempDir::new().unwrap();
+            let data_dir = temp_dir.path().to_path_buf();
+            let session_manager = Arc::new(SessionManager::new(data_dir.clone()));
+            let permission_manager = Arc::new(PermissionManager::new(data_dir));
+
+            let mut session = Session::default();
+            session.id = "session-123".to_string();
+            session.message_count = 37;
+            session.conversation = None;
+
+            let mock_scheduler = Arc::new(SessionsMockScheduler::new(vec![(
+                "session-123".to_string(),
+                session,
+            )]));
+            let config = AgentConfig::new(
+                session_manager,
+                permission_manager,
+                Some(mock_scheduler),
+                GooseMode::Auto,
+                false,
+                GoosePlatform::GooseCli,
+            );
+            let agent = Agent::with_config(config);
+
+            let result = agent
+                .handle_schedule_management(
+                    serde_json::json!({
+                        "action": "sessions",
+                        "job_id": "daily-report"
+                    }),
+                    "test-request".to_string(),
+                )
+                .await
+                .expect("schedule sessions should succeed");
+
+            let text = result
+                .into_iter()
+                .filter_map(|content| match &content.raw {
+                    rmcp::model::RawContent::Text(text_content) => Some(text_content.text.clone()),
+                    _ => None,
+                })
+                .collect::<String>();
+            assert!(
+                text.contains("Messages: 37"),
+                "expected stored message_count in sessions output, got: {text}"
+            );
         }
     }
 

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -344,10 +344,12 @@ mod tests {
             let session_manager = Arc::new(SessionManager::new(data_dir.clone()));
             let permission_manager = Arc::new(PermissionManager::new(data_dir));
 
-            let mut session = Session::default();
-            session.id = "session-123".to_string();
-            session.message_count = 37;
-            session.conversation = None;
+            let session = Session {
+                id: "session-123".to_string(),
+                message_count: 37,
+                conversation: None,
+                ..Default::default()
+            };
 
             let mock_scheduler = Arc::new(SessionsMockScheduler::new(vec![(
                 "session-123".to_string(),


### PR DESCRIPTION
Fixes #10016

## Summary
`schedule sessions` reported `Messages: 0` for every session because the platform tool derived the count from `session.conversation.len()`, but `Scheduler::sessions()` uses `SessionManager::list_sessions()`, which returns sessions without loading conversation (`conversation: None`). The authoritative count is already available on `Session::message_count` from SQL `COUNT(m.id)`.

## Motivation
Scheduled job health checks were showing false negatives — users thought jobs failed when sessions actually contained many messages. SQLite already stored the correct counts.

## Changes
- Use `session.message_count` in `schedule_tool.rs` `handle_list_sessions`
- Add `Messages` to `goose schedule sessions` CLI output
- Add regression test ensuring message count is reported when conversation is not loaded

## Tests
- `cargo test -p goose test_schedule_sessions_reports_message_count_without_conversation` (logic verified; sqlx pool requires full goose test features in CI)
- `cargo fmt` and `cargo clippy -p goose -- -D warnings` pass locally

## Notes
- HTTP `/schedule/{id}/sessions` and ACP `on_list_schedule_sessions` already used `message_count`; only the platform schedule tool and CLI were affected.