### PR TITLE
fix(config): apply GOOSE_CONTEXT_LIMIT after canonical limits, not before

### DIFF
--- a/crates/goose/src/model_config.rs
+++ b/crates/goose/src/model_config.rs
@@ -233,3 +233,41 @@ fn parse_yaml_bool_config(key: &str, value: serde_yaml::Value) -> Result<bool> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use goose_providers::model::ModelConfig;
+
+    #[test]
+    fn canonical_limit_wins_over_global_context_limit() {
+        let _guard = env_lock::lock_env([("GOOSE_CONTEXT_LIMIT", Some("1000"))]);
+
+        // A model with a known canonical context window keeps it instead of being
+        // capped to the much smaller global default.
+        let canonical = ModelConfig::new("claude-3-5-sonnet-20241022")
+            .with_canonical_limits("anthropic")
+            .context_limit();
+        assert!(
+            canonical > 1000,
+            "expected a canonical context limit for the test model"
+        );
+
+        let materialized =
+            materialize_model_config("anthropic", ModelConfig::new("claude-3-5-sonnet-20241022"))
+                .expect("materialize");
+        assert_eq!(materialized.context_limit(), canonical);
+    }
+
+    #[test]
+    fn global_context_limit_is_last_resort_for_unknown_models() {
+        let _guard = env_lock::lock_env([("GOOSE_CONTEXT_LIMIT", Some("1000"))]);
+
+        let materialized = materialize_model_config(
+            "anthropic",
+            ModelConfig::new("a-model-not-in-the-canonical-registry-xyz"),
+        )
+        .expect("materialize");
+        assert_eq!(materialized.context_limit(), 1000);
+    }
+}

--- a/crates/goose/src/model_config.rs
+++ b/crates/goose/src/model_config.rs
@@ -32,12 +32,20 @@ pub fn model_config_from_user_config_with_session_settings(
         .with_inherited_session_settings_from(previous, request_params)
         .with_default_thinking_effort(config.get_goose_thinking_effort());
 
-    Ok(model.with_canonical_limits(provider_name))
+    // Canonical first, then GOOSE_CONTEXT_LIMIT only as a last-resort default.
+    Ok(model
+        .with_canonical_limits(provider_name)
+        .with_default_context_limit(config.get_goose_context_limit()?))
 }
 
 pub fn materialize_model_config(provider_name: &str, model: ModelConfig) -> Result<ModelConfig> {
+    let config = Config::global();
     let model = materialize_model_config_inner(model, true)?;
-    Ok(model.with_canonical_limits(provider_name))
+    // Canonical (model-specific) limits win; GOOSE_CONTEXT_LIMIT is only a
+    // last-resort default for models with no known limit, never a cap over them.
+    Ok(model
+        .with_canonical_limits(provider_name)
+        .with_default_context_limit(config.get_goose_context_limit()?))
 }
 
 fn materialize_model_config_inner(
@@ -54,9 +62,9 @@ fn materialize_model_config_inner(
         model = model.with_toolshim_model(get_goose_toolshim_model(config)?);
     }
 
-    model = model
-        .with_default_context_limit(config.get_goose_context_limit()?)
-        .with_default_max_tokens(config.get_goose_max_tokens()?);
+    // GOOSE_CONTEXT_LIMIT is applied later, after canonical limits, so a model's
+    // known context window is never overridden by the global default.
+    model = model.with_default_max_tokens(config.get_goose_max_tokens()?);
 
     if include_default_thinking_effort {
         model = model.with_default_thinking_effort(config.get_goose_thinking_effort());


### PR DESCRIPTION
### What

`GOOSE_CONTEXT_LIMIT` is now applied as a last-resort default, after canonical (model-specific) limits, instead of before them.

### Why

`materialize_model_config` applied the global default before `with_canonical_limits`, and both only set the context limit when it is `None`. So the global value overrode every model's known window: setting `GOOSE_CONTEXT_LIMIT` to protect a small local model capped large hosted models too, forcing proactive auto-compaction at `0.8 x` the wrong (small) limit. A model with a 262k window would report 28k. See #10032.

### How

- `materialize_model_config` and `model_config_from_user_config_with_session_settings` apply `with_canonical_limits(...)` first, then `with_default_context_limit(GOOSE_CONTEXT_LIMIT)` as a fallback only for models with no known limit.
- Moved the global default out of `materialize_model_config_inner` so it cannot run ahead of canonical resolution.

### Testing

- New unit tests: a canonical model keeps its real limit even with `GOOSE_CONTEXT_LIMIT` set small; an unknown model falls back to the global value.
- `cargo fmt`, `cargo clippy -p goose -- -D warnings`, and `cargo test -p goose --lib model_config` are clean. (Two pre-existing `summon::tests::test_resolve_model_config_*` failures reproduce on unmodified `main` in this environment; they panic in the sqlx pool / lazy_lock setup and are unrelated to this change.)

Fixes #10032. Every commit is DCO signed-off.
