### PR TITLE
fix(canonical): add 35 missing Cortecs models and fix 21 provider mislabels

### DIFF
--- a/crates/goose-providers/src/canonical/data/canonical_models.json
+++ b/crates/goose-providers/src/canonical/data/canonical_models.json
@@ -153125,8 +153125,7 @@
     },
     "limit": {
       "context": 256000
-    },
-    "release_date": "2026-06-02"
+    }
   },
   {
     "id": "cortecs/deepseek-chat-v3.1",
@@ -153149,8 +153148,7 @@
     },
     "limit": {
       "context": 164000
-    },
-    "release_date": "2026-03-26"
+    }
   },
   {
     "id": "cortecs/gemma-3-27b-it",
@@ -153174,8 +153172,7 @@
     },
     "limit": {
       "context": 131000
-    },
-    "release_date": "2025-03-12"
+    }
   },
   {
     "id": "cortecs/glm-4.6",
@@ -153198,8 +153195,7 @@
     },
     "limit": {
       "context": 203000
-    },
-    "release_date": "2026-03-26"
+    }
   },
   {
     "id": "cortecs/gpt-oss-20b",
@@ -153222,8 +153218,7 @@
     },
     "limit": {
       "context": 131000
-    },
-    "release_date": "2025-07-18"
+    }
   },
   {
     "id": "cortecs/gpt-oss-safeguard-120b",
@@ -153246,8 +153241,7 @@
     },
     "limit": {
       "context": 128000
-    },
-    "release_date": "2025-12-04"
+    }
   },
   {
     "id": "cortecs/hermes-4-405b",
@@ -153270,8 +153264,7 @@
     },
     "limit": {
       "context": 128000
-    },
-    "release_date": "2024-08-13"
+    }
   },
   {
     "id": "cortecs/holo2-30b-a3b",
@@ -153295,8 +153288,7 @@
     },
     "limit": {
       "context": 22000
-    },
-    "release_date": "2025-12-10"
+    }
   },
   {
     "id": "cortecs/llama-3.1-8b-instruct",
@@ -153319,8 +153311,7 @@
     },
     "limit": {
       "context": 131000
-    },
-    "release_date": "2024-04-09"
+    }
   },
   {
     "id": "cortecs/llama-3.1-nemotron-ultra-253b-v1",
@@ -153343,8 +153334,7 @@
     },
     "limit": {
       "context": 128000
-    },
-    "release_date": "2025-04-07"
+    }
   },
   {
     "id": "cortecs/magistral-medium",
@@ -153417,8 +153407,7 @@
     },
     "limit": {
       "context": 32000
-    },
-    "release_date": "2026-06-02"
+    }
   },
   {
     "id": "cortecs/ministral-14b",
@@ -153466,8 +153455,7 @@
     },
     "limit": {
       "context": 32000
-    },
-    "release_date": "2025-05-26"
+    }
   },
   {
     "id": "cortecs/mistral-7b-instruct-v0.3",
@@ -153490,8 +153478,7 @@
     },
     "limit": {
       "context": 127000
-    },
-    "release_date": "2025-05-26"
+    }
   },
   {
     "id": "cortecs/mistral-medium-3.5",
@@ -153515,8 +153502,7 @@
     },
     "limit": {
       "context": 256000
-    },
-    "release_date": "2026-04-30"
+    }
   },
   {
     "id": "cortecs/mistral-nemo-instruct",
@@ -153589,8 +153575,7 @@
     },
     "limit": {
       "context": 128000
-    },
-    "release_date": "2025-10-31"
+    }
   },
   {
     "id": "cortecs/nova-2-lite",
@@ -153614,8 +153599,7 @@
     },
     "limit": {
       "context": 1000000
-    },
-    "release_date": "2025-12-04"
+    }
   },
   {
     "id": "cortecs/nova-lite-v1",
@@ -153639,8 +153623,7 @@
     },
     "limit": {
       "context": 300000
-    },
-    "release_date": "2025-04-14"
+    }
   },
   {
     "id": "cortecs/nova-micro-v1",
@@ -153664,8 +153647,7 @@
     },
     "limit": {
       "context": 128000
-    },
-    "release_date": "2025-04-14"
+    }
   },
   {
     "id": "cortecs/nvidia-nemotron-3-nano-30b-a3b",
@@ -153688,8 +153670,7 @@
     },
     "limit": {
       "context": 128000
-    },
-    "release_date": "2026-01-12"
+    }
   },
   {
     "id": "cortecs/nvidia-nemotron-3-nano-omni",
@@ -153712,8 +153693,7 @@
     },
     "limit": {
       "context": 300000
-    },
-    "release_date": "2026-04-29"
+    }
   },
   {
     "id": "cortecs/qwen2.5-vl-72b-instruct",
@@ -153737,8 +153717,7 @@
     },
     "limit": {
       "context": 32000
-    },
-    "release_date": "2025-01-27"
+    }
   },
   {
     "id": "cortecs/qwen3-30b-a3b-instruct",
@@ -153786,8 +153765,7 @@
     },
     "limit": {
       "context": 131000
-    },
-    "release_date": "2026-01-13"
+    }
   },
   {
     "id": "cortecs/qwen3.5-9b",
@@ -153810,8 +153788,7 @@
     },
     "limit": {
       "context": 262000
-    },
-    "release_date": "2026-04-09"
+    }
   },
   {
     "id": "cortecs/qwen3.6-27b",
@@ -153835,8 +153812,7 @@
     },
     "limit": {
       "context": 262000
-    },
-    "release_date": "2026-06-02"
+    }
   },
   {
     "id": "cortecs/qwen3.6-35b-a3b",
@@ -153860,8 +153836,7 @@
     },
     "limit": {
       "context": 262000
-    },
-    "release_date": "2026-05-14"
+    }
   },
   {
     "id": "cortecs/qwen3guard-gen-0.6b",
@@ -153884,8 +153859,7 @@
     },
     "limit": {
       "context": 32000
-    },
-    "release_date": "2026-02-04"
+    }
   },
   {
     "id": "cortecs/qwen3guard-gen-8b",
@@ -153908,8 +153882,7 @@
     },
     "limit": {
       "context": 32000
-    },
-    "release_date": "2026-02-04"
+    }
   },
   {
     "id": "cortecs/voxtral-small",

--- a/crates/goose-providers/src/canonical/data/canonical_models.json
+++ b/crates/goose-providers/src/canonical/data/canonical_models.json
@@ -153103,5 +153103,837 @@
       "context": 200000,
       "output": 131072
     }
+  },
+  {
+    "id": "cortecs/cosmos3-super-reasoner",
+    "name": "Cosmos3 Super Reasoner",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.089,
+      "output": 0.266
+    },
+    "limit": {
+      "context": 256000
+    },
+    "release_date": "2026-06-02"
+  },
+  {
+    "id": "cortecs/deepseek-chat-v3.1",
+    "name": "Deepseek Chat v3.1",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.177,
+      "output": 0.71
+    },
+    "limit": {
+      "context": 164000
+    },
+    "release_date": "2026-03-26"
+  },
+  {
+    "id": "cortecs/gemma-3-27b-it",
+    "name": "Gemma 3 27B IT",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.089,
+      "output": 0.268
+    },
+    "limit": {
+      "context": 131000
+    },
+    "release_date": "2025-03-12"
+  },
+  {
+    "id": "cortecs/glm-4.6",
+    "name": "GLM 4.6",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.355,
+      "output": 1.553
+    },
+    "limit": {
+      "context": 203000
+    },
+    "release_date": "2026-03-26"
+  },
+  {
+    "id": "cortecs/gpt-oss-20b",
+    "name": "GPT OSS 20B",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.027,
+      "output": 0.124
+    },
+    "limit": {
+      "context": 131000
+    },
+    "release_date": "2025-07-18"
+  },
+  {
+    "id": "cortecs/gpt-oss-safeguard-120b",
+    "name": "GPT OSS Safeguard 120B",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.161,
+      "output": 0.626
+    },
+    "limit": {
+      "context": 128000
+    },
+    "release_date": "2025-12-04"
+  },
+  {
+    "id": "cortecs/hermes-4-405b",
+    "name": "Hermes 4 405B",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.894,
+      "output": 2.683
+    },
+    "limit": {
+      "context": 128000
+    },
+    "release_date": "2024-08-13"
+  },
+  {
+    "id": "cortecs/holo2-30b-a3b",
+    "name": "Holo2 30B A3B",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.3,
+      "output": 0.7
+    },
+    "limit": {
+      "context": 22000
+    },
+    "release_date": "2025-12-10"
+  },
+  {
+    "id": "cortecs/llama-3.1-8b-instruct",
+    "name": "Llama 3.1 8B Instruct",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.1,
+      "output": 0.1
+    },
+    "limit": {
+      "context": 131000
+    },
+    "release_date": "2024-04-09"
+  },
+  {
+    "id": "cortecs/llama-3.1-nemotron-ultra-253b-v1",
+    "name": "Llama 3.1 Nemotron Ultra 253B v1",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.537,
+      "output": 1.61
+    },
+    "limit": {
+      "context": 128000
+    },
+    "release_date": "2025-04-07"
+  },
+  {
+    "id": "cortecs/magistral-medium",
+    "name": "Magistral Medium",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 2.0,
+      "output": 5.0
+    },
+    "limit": {
+      "context": 128000
+    },
+    "release_date": "2025-09-18"
+  },
+  {
+    "id": "cortecs/magistral-small",
+    "name": "Magistral Small",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.5,
+      "output": 1.5
+    },
+    "limit": {
+      "context": 128000
+    },
+    "release_date": "2025-09-18"
+  },
+  {
+    "id": "cortecs/minicpm-v-4.5",
+    "name": "MiniCPM V 4.5",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.584,
+      "output": 0.985
+    },
+    "limit": {
+      "context": 32000
+    },
+    "release_date": "2026-06-02"
+  },
+  {
+    "id": "cortecs/ministral-14b",
+    "name": "Ministral 14B",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.2,
+      "output": 0.2
+    },
+    "limit": {
+      "context": 256000
+    },
+    "release_date": "2025-12-03"
+  },
+  {
+    "id": "cortecs/mistral-7b-instruct-v0.2",
+    "name": "Mistral 7B Instruct v0.2",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.143,
+      "output": 0.197
+    },
+    "limit": {
+      "context": 32000
+    },
+    "release_date": "2025-05-26"
+  },
+  {
+    "id": "cortecs/mistral-7b-instruct-v0.3",
+    "name": "Mistral 7B Instruct v0.3",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.1,
+      "output": 0.1
+    },
+    "limit": {
+      "context": 127000
+    },
+    "release_date": "2025-05-26"
+  },
+  {
+    "id": "cortecs/mistral-medium-3.5",
+    "name": "Mistral Medium 3.5",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.25,
+      "output": 6.4
+    },
+    "limit": {
+      "context": 256000
+    },
+    "release_date": "2026-04-30"
+  },
+  {
+    "id": "cortecs/mistral-nemo-instruct",
+    "name": "Mistral Nemo Instruct",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.13,
+      "output": 0.13
+    },
+    "limit": {
+      "context": 131072
+    },
+    "release_date": "2024-08-07"
+  },
+  {
+    "id": "cortecs/mistral-small-3.2-24b-instruct",
+    "name": "Mistral Small 3.2 24B Instruct",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.09,
+      "output": 0.28
+    },
+    "limit": {
+      "context": 128000
+    },
+    "release_date": "2025-05-26"
+  },
+  {
+    "id": "cortecs/nemotron-nano-v2-12b",
+    "name": "Nemotron Nano v2 12B",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.215,
+      "output": 0.635
+    },
+    "limit": {
+      "context": 128000
+    },
+    "release_date": "2025-10-31"
+  },
+  {
+    "id": "cortecs/nova-2-lite",
+    "name": "Nova 2 Lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.335,
+      "output": 2.822
+    },
+    "limit": {
+      "context": 1000000
+    },
+    "release_date": "2025-12-04"
+  },
+  {
+    "id": "cortecs/nova-lite-v1",
+    "name": "Nova Lite v1",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.062,
+      "output": 0.247
+    },
+    "limit": {
+      "context": 300000
+    },
+    "release_date": "2025-04-14"
+  },
+  {
+    "id": "cortecs/nova-micro-v1",
+    "name": "Nova Micro v1",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.036,
+      "output": 0.143
+    },
+    "limit": {
+      "context": 128000
+    },
+    "release_date": "2025-04-14"
+  },
+  {
+    "id": "cortecs/nvidia-nemotron-3-nano-30b-a3b",
+    "name": "NVIDIA Nemotron 3 Nano 30B A3B",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.054,
+      "output": 0.215
+    },
+    "limit": {
+      "context": 128000
+    },
+    "release_date": "2026-01-12"
+  },
+  {
+    "id": "cortecs/nvidia-nemotron-3-nano-omni",
+    "name": "NVIDIA Nemotron 3 Nano Omni",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.053,
+      "output": 0.213
+    },
+    "limit": {
+      "context": 300000
+    },
+    "release_date": "2026-04-29"
+  },
+  {
+    "id": "cortecs/qwen2.5-vl-72b-instruct",
+    "name": "Qwen2.5 VL 72B Instruct",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.224,
+      "output": 0.671
+    },
+    "limit": {
+      "context": 32000
+    },
+    "release_date": "2025-01-27"
+  },
+  {
+    "id": "cortecs/qwen3-30b-a3b-instruct",
+    "name": "Qwen3 30B A3B Instruct",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.089,
+      "output": 0.268
+    },
+    "limit": {
+      "context": 262000
+    },
+    "release_date": "2025-07-28"
+  },
+  {
+    "id": "cortecs/qwen3-vl-235b-a22b",
+    "name": "Qwen3 VL 235B A22B",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.186,
+      "output": 1.686
+    },
+    "limit": {
+      "context": 131000
+    },
+    "release_date": "2026-01-13"
+  },
+  {
+    "id": "cortecs/qwen3.5-9b",
+    "name": "Qwen3.5 9B",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.1,
+      "output": 0.15
+    },
+    "limit": {
+      "context": 262000
+    },
+    "release_date": "2026-04-09"
+  },
+  {
+    "id": "cortecs/qwen3.6-27b",
+    "name": "Qwen3.6 27B",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.4,
+      "output": 2.7
+    },
+    "limit": {
+      "context": 262000
+    },
+    "release_date": "2026-06-02"
+  },
+  {
+    "id": "cortecs/qwen3.6-35b-a3b",
+    "name": "Qwen3.6 35B A3B",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.25,
+      "output": 1.5
+    },
+    "limit": {
+      "context": 262000
+    },
+    "release_date": "2026-05-14"
+  },
+  {
+    "id": "cortecs/qwen3guard-gen-0.6b",
+    "name": "Qwen3guard Gen 0.6B",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 32000
+    },
+    "release_date": "2026-02-04"
+  },
+  {
+    "id": "cortecs/qwen3guard-gen-8b",
+    "name": "Qwen3guard Gen 8B",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 32000
+    },
+    "release_date": "2026-02-04"
+  },
+  {
+    "id": "cortecs/voxtral-small",
+    "name": "Voxtral Small",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.1,
+      "output": 0.3
+    },
+    "limit": {
+      "context": 32000
+    },
+    "release_date": "2026-02-02"
   }
 ]

--- a/crates/goose-providers/src/canonical/data/canonical_models.json
+++ b/crates/goose-providers/src/canonical/data/canonical_models.json
@@ -153935,5 +153935,458 @@
       "context": 32000
     },
     "release_date": "2026-02-02"
+  },
+  {
+    "id": "cortecs/gemini-2.5-flash",
+    "name": "Gemini 2.5 Flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.268,
+      "output": 2.236
+    },
+    "limit": {
+      "context": 1048576
+    },
+    "release_date": "2025-03-16"
+  },
+  {
+    "id": "cortecs/gemini-3.1-flash-lite",
+    "name": "Gemini 3.1 Flash Lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.244,
+      "output": 1.464
+    },
+    "limit": {
+      "context": 1048576
+    },
+    "release_date": "2026-05-18"
+  },
+  {
+    "id": "cortecs/gemini-3.5-flash",
+    "name": "Gemini 3.5 Flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.331,
+      "output": 7.987
+    },
+    "limit": {
+      "context": 1048576
+    },
+    "release_date": "2026-05-20"
+  },
+  {
+    "id": "cortecs/gemma-4-26b-a4b-it",
+    "name": "Gemma 4 26B A4B IT",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.25,
+      "output": 0.5
+    },
+    "limit": {
+      "context": 262000
+    },
+    "release_date": "2026-05-07"
+  },
+  {
+    "id": "cortecs/gemma-4-31b-it",
+    "name": "Gemma 4 31B IT",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.2,
+      "output": 0.35
+    },
+    "limit": {
+      "context": 128000
+    },
+    "release_date": "2026-06-19"
+  },
+  {
+    "id": "cortecs/gpt-4.1-mini",
+    "name": "GPT 4.1 Mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.39,
+      "output": 1.53
+    },
+    "limit": {
+      "context": 1047576
+    },
+    "release_date": "2025-04-14"
+  },
+  {
+    "id": "cortecs/gpt-4.1-nano",
+    "name": "GPT 4.1 Nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.1,
+      "output": 0.39
+    },
+    "limit": {
+      "context": 1047576
+    },
+    "release_date": "2025-04-14"
+  },
+  {
+    "id": "cortecs/gpt-4o",
+    "name": "GPT 4o",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 2.387,
+      "output": 9.547
+    },
+    "limit": {
+      "context": 128000
+    },
+    "release_date": "2024-11-20"
+  },
+  {
+    "id": "cortecs/gpt-4o-mini",
+    "name": "GPT 4o Mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.143,
+      "output": 0.573
+    },
+    "limit": {
+      "context": 128000
+    },
+    "release_date": "2024-07-18"
+  },
+  {
+    "id": "cortecs/gpt-5",
+    "name": "GPT 5",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.234,
+      "output": 9.838
+    },
+    "limit": {
+      "context": 400000
+    },
+    "release_date": "2025-08-07"
+  },
+  {
+    "id": "cortecs/gpt-5-mini",
+    "name": "GPT 5 Mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.25,
+      "output": 1.968
+    },
+    "limit": {
+      "context": 400000
+    },
+    "release_date": "2024-11-20"
+  },
+  {
+    "id": "cortecs/gpt-5-nano",
+    "name": "GPT 5 Nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.054,
+      "output": 0.394
+    },
+    "limit": {
+      "context": 400000
+    },
+    "release_date": "2024-11-20"
+  },
+  {
+    "id": "cortecs/gpt-5.1",
+    "name": "GPT 5.1",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.234,
+      "output": 9.838
+    },
+    "limit": {
+      "context": 400000
+    },
+    "release_date": "2025-11-15"
+  },
+  {
+    "id": "cortecs/ministral-3b",
+    "name": "Ministral 3B",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.1,
+      "output": 0.1
+    },
+    "limit": {
+      "context": 256000
+    },
+    "release_date": "2025-12-03"
+  },
+  {
+    "id": "cortecs/ministral-8b",
+    "name": "Ministral 8B",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.15,
+      "output": 0.15
+    },
+    "limit": {
+      "context": 256000
+    },
+    "release_date": "2025-12-03"
+  },
+  {
+    "id": "cortecs/mistral-medium",
+    "name": "Mistral Medium",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.4,
+      "output": 2.0
+    },
+    "limit": {
+      "context": 128000
+    },
+    "release_date": "2024-08-07"
+  },
+  {
+    "id": "cortecs/mistral-small",
+    "name": "Mistral Small",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.128,
+      "output": 0.51
+    },
+    "limit": {
+      "context": 256000
+    },
+    "release_date": "2026-03-17"
+  },
+  {
+    "id": "cortecs/pixtral-large",
+    "name": "Pixtral Large",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.789,
+      "output": 5.366
+    },
+    "limit": {
+      "context": 128000
+    },
+    "release_date": "2025-05-26"
   }
 ]

--- a/crates/goose-providers/src/canonical/data/canonical_models.json
+++ b/crates/goose-providers/src/canonical/data/canonical_models.json
@@ -153369,7 +153369,7 @@
     "limit": {
       "context": 128000
     },
-    "release_date": "2025-09-18"
+    "release_date": "2025-09-01"
   },
   {
     "id": "cortecs/magistral-small",
@@ -153394,7 +153394,7 @@
     "limit": {
       "context": 128000
     },
-    "release_date": "2025-09-18"
+    "release_date": "2025-09-01"
   },
   {
     "id": "cortecs/minicpm-v-4.5",
@@ -153443,7 +153443,7 @@
     "limit": {
       "context": 256000
     },
-    "release_date": "2025-12-03"
+    "release_date": "2025-12-01"
   },
   {
     "id": "cortecs/mistral-7b-instruct-v0.2",
@@ -153540,7 +153540,7 @@
     "limit": {
       "context": 131072
     },
-    "release_date": "2024-08-07"
+    "release_date": "2024-07-01"
   },
   {
     "id": "cortecs/mistral-small-3.2-24b-instruct",
@@ -153565,7 +153565,7 @@
     "limit": {
       "context": 128000
     },
-    "release_date": "2025-05-26"
+    "release_date": "2025-06-01"
   },
   {
     "id": "cortecs/nemotron-nano-v2-12b",
@@ -153762,7 +153762,7 @@
     "limit": {
       "context": 262000
     },
-    "release_date": "2025-07-28"
+    "release_date": "2025-07-01"
   },
   {
     "id": "cortecs/qwen3-vl-235b-a22b",
@@ -153934,7 +153934,7 @@
     "limit": {
       "context": 32000
     },
-    "release_date": "2026-02-02"
+    "release_date": "2025-07-01"
   },
   {
     "id": "cortecs/gemini-2.5-flash",
@@ -153960,7 +153960,7 @@
     "limit": {
       "context": 1048576
     },
-    "release_date": "2025-03-16"
+    "release_date": "2025-06-17"
   },
   {
     "id": "cortecs/gemini-3.1-flash-lite",
@@ -153986,7 +153986,7 @@
     "limit": {
       "context": 1048576
     },
-    "release_date": "2026-05-18"
+    "release_date": "2026-05-07"
   },
   {
     "id": "cortecs/gemini-3.5-flash",
@@ -154012,7 +154012,7 @@
     "limit": {
       "context": 1048576
     },
-    "release_date": "2026-05-20"
+    "release_date": "2026-05-19"
   },
   {
     "id": "cortecs/gemma-4-26b-a4b-it",
@@ -154037,7 +154037,7 @@
     "limit": {
       "context": 262000
     },
-    "release_date": "2026-05-07"
+    "release_date": "2026-04-02"
   },
   {
     "id": "cortecs/gemma-4-31b-it",
@@ -154062,7 +154062,7 @@
     "limit": {
       "context": 128000
     },
-    "release_date": "2026-06-19"
+    "release_date": "2026-04-02"
   },
   {
     "id": "cortecs/gpt-4.1-mini",
@@ -154137,7 +154137,7 @@
     "limit": {
       "context": 128000
     },
-    "release_date": "2024-11-20"
+    "release_date": "2024-05-13"
   },
   {
     "id": "cortecs/gpt-4o-mini",
@@ -154262,7 +154262,7 @@
     "limit": {
       "context": 400000
     },
-    "release_date": "2025-11-15"
+    "release_date": "2025-11-13"
   },
   {
     "id": "cortecs/ministral-3b",
@@ -154287,7 +154287,7 @@
     "limit": {
       "context": 256000
     },
-    "release_date": "2025-12-03"
+    "release_date": "2025-12-01"
   },
   {
     "id": "cortecs/ministral-8b",
@@ -154312,7 +154312,7 @@
     "limit": {
       "context": 256000
     },
-    "release_date": "2025-12-03"
+    "release_date": "2025-12-01"
   },
   {
     "id": "cortecs/mistral-medium",
@@ -154337,7 +154337,7 @@
     "limit": {
       "context": 128000
     },
-    "release_date": "2024-08-07"
+    "release_date": "2025-08-01"
   },
   {
     "id": "cortecs/mistral-small",
@@ -154362,7 +154362,7 @@
     "limit": {
       "context": 256000
     },
-    "release_date": "2026-03-17"
+    "release_date": "2026-03-01"
   },
   {
     "id": "cortecs/pixtral-large",
@@ -154387,6 +154387,6 @@
     "limit": {
       "context": 128000
     },
-    "release_date": "2025-05-26"
+    "release_date": "2025-02-01"
   }
 ]

--- a/crates/goose-providers/src/canonical/data/canonical_models.json
+++ b/crates/goose-providers/src/canonical/data/canonical_models.json
@@ -154068,7 +154068,7 @@
     "id": "cortecs/gpt-4.1-mini",
     "name": "GPT 4.1 Mini",
     "attachment": true,
-    "reasoning": true,
+    "reasoning": false,
     "tool_call": true,
     "temperature": true,
     "modalities": {
@@ -154093,7 +154093,7 @@
     "id": "cortecs/gpt-4.1-nano",
     "name": "GPT 4.1 Nano",
     "attachment": true,
-    "reasoning": true,
+    "reasoning": false,
     "tool_call": true,
     "temperature": true,
     "modalities": {
@@ -154118,7 +154118,7 @@
     "id": "cortecs/gpt-4o",
     "name": "GPT 4o",
     "attachment": true,
-    "reasoning": true,
+    "reasoning": false,
     "tool_call": true,
     "temperature": true,
     "modalities": {
@@ -154143,7 +154143,7 @@
     "id": "cortecs/gpt-4o-mini",
     "name": "GPT 4o Mini",
     "attachment": true,
-    "reasoning": true,
+    "reasoning": false,
     "tool_call": true,
     "temperature": true,
     "modalities": {
@@ -154212,7 +154212,7 @@
     "limit": {
       "context": 400000
     },
-    "release_date": "2024-11-20"
+    "release_date": "2025-08-07"
   },
   {
     "id": "cortecs/gpt-5-nano",
@@ -154237,7 +154237,7 @@
     "limit": {
       "context": 400000
     },
-    "release_date": "2024-11-20"
+    "release_date": "2025-08-07"
   },
   {
     "id": "cortecs/gpt-5.1",

--- a/crates/goose-providers/src/canonical/data/provider_metadata.json
+++ b/crates/goose-providers/src/canonical/data/provider_metadata.json
@@ -240,7 +240,7 @@
     "env": [
       "CORTECS_API_KEY"
     ],
-    "model_count": 90
+    "model_count": 108
   },
   {
     "id": "crof",

--- a/crates/goose-providers/src/canonical/data/provider_metadata.json
+++ b/crates/goose-providers/src/canonical/data/provider_metadata.json
@@ -240,7 +240,7 @@
     "env": [
       "CORTECS_API_KEY"
     ],
-    "model_count": 56
+    "model_count": 90
   },
   {
     "id": "crof",


### PR DESCRIPTION
Fixes #10035

## Problem

Cortecs exposes **106** models via `/v1/models`, but Goose's model picker surfaces only **71**, and a further **21** of those show up under the wrong provider's metadata (wrong pricing/context).

`get_provider_models` → `Provider::fetch_recommended_models()` (`crates/goose-providers/src/base.rs`) filters the live model list against the bundled canonical registry (`crates/goose-providers/src/canonical/data/canonical_models.json`). Live IDs with no canonical mapping are dropped; IDs that only resolve via provider *inference* (`map_to_canonical_model`) survive but carry another provider's entry (e.g. `gpt-4o` → `openai/gpt-4o`). The registry mirrors [models.dev](https://models.dev/api.json), which lists only 56 Cortecs models, so 35 live models had no entry.

## Change

Stopgap entirely within the canonical data files:

- **+34** entries for the Cortecs models that had no canonical mapping (`cosmos3-super-reasoner`, `glm-4.6`, `gpt-oss-20b`, the Nova/Qwen3.x/Magistral/Ministral/Nemotron families, …).
- **+18** explicit `cortecs/` entries for models that previously inference-mapped to `openai/google/mistralai`, so they now carry correct Cortecs metadata. The direct cortecs lookup precedes inference, so these take over. `mistral-small-2503/2506/2603` collapse to a single de-versioned `cortecs/mistral-small`.
- `provider_metadata.json` `model_count` for cortecs: 56 → 108.

All fields are sourced from the live Cortecs API: capabilities (`tool_call`/`reasoning`/`attachment` from the API tags), context windows, EUR pricing, and de-versioned canonical IDs consistent with the existing catalog convention (e.g. `magistral-medium-2509` → `cortecs/magistral-medium`).

## Result

Verified by replicating `map_to_canonical_model()` + the `fetch_recommended_models()` filter against the live 106-model response:

| | before | after |
|---|---|---|
| visible | 71 | **99** / 106 |
| dropped | 35 | 7 |
| mislabeled to a foreign provider | 21 | 1 |

The remaining **7** dropped models advertise **no tool-calling** on the Cortecs API (`minicpm-v-4.5`, `mistral-7b-instruct-v0.2`, `mixtral-8x7B-instruct-v0.1`, `qwen2.5-vl-72b-instruct`, `qwen3guard-gen-0.6b/8b`, `voxtral-small-2507`) and stay hidden by the existing non-tool-model policy — `tool_call` is recorded truthfully rather than forced. `pixtral-12b-2409` is likewise left on its `mistralai/pixtral-12b` inferred mapping: it has no tool-calling on Cortecs, so a truthful `cortecs/` entry would hide it.

## Notes

- `canonical_models.json` is generated from models.dev, so this hand-edit is a **stopgap** until the missing Cortecs models land upstream. A durable fix would complete the Cortecs data at models.dev and/or treat canonical as enrichment rather than a gate for custom OpenAI-compatible providers.
- No code changes; data-only. Both JSON files validate and use only existing schema fields.
