### PR TITLE
fix(providers): use catalog_provider_id for canonical model resolution

### DIFF
--- a/crates/goose-providers/src/base.rs
+++ b/crates/goose-providers/src/base.rs
@@ -449,7 +449,9 @@ pub trait Provider: Send + Sync {
             .fetch_supported_models()
             .await?
             .iter()
-            .map(|model_name| model_info_for_provider_model(self.canonical_provider_id(), model_name))
+            .map(|model_name| {
+                model_info_for_provider_model(self.canonical_provider_id(), model_name)
+            })
             .collect())
     }
 
@@ -536,7 +538,9 @@ pub trait Provider: Send + Sync {
             .fetch_recommended_models(toolshim)
             .await?
             .iter()
-            .map(|model_name| model_info_for_provider_model(self.canonical_provider_id(), model_name))
+            .map(|model_name| {
+                model_info_for_provider_model(self.canonical_provider_id(), model_name)
+            })
             .collect())
     }
 

--- a/crates/goose-providers/src/base.rs
+++ b/crates/goose-providers/src/base.rs
@@ -382,6 +382,18 @@ pub trait Provider: Send + Sync {
     /// Get the name of this provider instance
     fn get_name(&self) -> &str;
 
+    /// Provider identity used for canonical model-catalog lookups.
+    ///
+    /// Defaults to [`get_name`](Self::get_name). Providers backed by a shared
+    /// upstream catalog override this so canonical metadata and filtering
+    /// resolve against the catalog id rather than the user-facing provider name
+    /// — e.g. a custom OpenAI-compatible provider configured with
+    /// `catalog_provider_id` (the user-chosen name is prefixed with `custom_`
+    /// and would otherwise never match a catalog entry).
+    fn canonical_provider_id(&self) -> &str {
+        self.get_name()
+    }
+
     /// Primary streaming method that all providers must implement.
     ///
     /// Note: Do not add `#[instrument]` here — the call sites (`complete` and
@@ -437,12 +449,15 @@ pub trait Provider: Send + Sync {
             .fetch_supported_models()
             .await?
             .iter()
-            .map(|model_name| model_info_for_provider_model(self.get_name(), model_name))
+            .map(|model_name| model_info_for_provider_model(self.canonical_provider_id(), model_name))
             .collect())
     }
 
     async fn fetch_model_info(&self, model_name: &str) -> Result<ModelInfo, ProviderError> {
-        Ok(model_info_for_provider_model(self.get_name(), model_name))
+        Ok(model_info_for_provider_model(
+            self.canonical_provider_id(),
+            model_name,
+        ))
     }
 
     fn skip_canonical_filtering(&self) -> bool {
@@ -464,7 +479,7 @@ pub trait Provider: Send + Sync {
             ProviderError::ExecutionError(format!("Failed to load canonical registry: {}", e))
         })?;
 
-        let provider_name = self.get_name();
+        let provider_name = self.canonical_provider_id();
 
         // Get all text-capable models with their release dates
         let mut models_with_dates: Vec<(String, Option<String>)> = all_models
@@ -521,7 +536,7 @@ pub trait Provider: Send + Sync {
             .fetch_recommended_models(toolshim)
             .await?
             .iter()
-            .map(|model_name| model_info_for_provider_model(self.get_name(), model_name))
+            .map(|model_name| model_info_for_provider_model(self.canonical_provider_id(), model_name))
             .collect())
     }
 
@@ -534,7 +549,7 @@ pub trait Provider: Send + Sync {
         })?;
 
         Ok(map_to_canonical_model(
-            self.get_name(),
+            self.canonical_provider_id(),
             provider_model,
             registry,
         ))

--- a/crates/goose-providers/src/model.rs
+++ b/crates/goose-providers/src/model.rs
@@ -109,6 +109,46 @@ impl ModelConfig {
         self
     }
 
+    /// Replace canonical limit fields that were materialized under
+    /// `inferred_provider` with the entry under `canonical_provider`.
+    ///
+    /// `with_canonical_limits` only fills `None` fields, so a config that was
+    /// first materialized under a custom provider name (where an inferable model
+    /// like `codestral` resolves to a first-party entry, e.g. Mistral's output
+    /// cap) keeps those inferred values even after a later catalog-id pass. This
+    /// overrides each field, but only when it still equals the value the inferred
+    /// entry would have produced — so explicit user overrides are preserved. A
+    /// no-op when both providers resolve to the same canonical entry (e.g.
+    /// built-in declarative providers whose name aliases to their catalog id).
+    pub fn reconcile_canonical_limits(
+        mut self,
+        inferred_provider: &str,
+        canonical_provider: &str,
+    ) -> Self {
+        let inferred =
+            crate::canonical::maybe_get_canonical_model(inferred_provider, &self.model_name);
+        let canonical =
+            crate::canonical::maybe_get_canonical_model(canonical_provider, &self.model_name);
+        if let (Some(inferred), Some(canonical)) = (inferred, canonical) {
+            let derive_output = |limit: &crate::canonical::Limit| {
+                limit
+                    .output
+                    .filter(|&output| output < limit.context)
+                    .map(|output| output as i32)
+            };
+            if self.context_limit == Some(inferred.limit.context) {
+                self.context_limit = Some(canonical.limit.context);
+            }
+            if self.max_tokens == derive_output(&inferred.limit) {
+                self.max_tokens = derive_output(&canonical.limit);
+            }
+            if self.reasoning == inferred.reasoning {
+                self.reasoning = canonical.reasoning;
+            }
+        }
+        self
+    }
+
     pub fn with_context_limit(mut self, limit: Option<usize>) -> Self {
         if limit.is_some() {
             self.context_limit = limit;
@@ -296,6 +336,36 @@ impl ModelConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    mod reconcile_canonical_limits_tests {
+        use super::*;
+
+        #[test]
+        fn preserves_user_override_that_does_not_match_inferred() {
+            // A context limit that matches no canonical entry must survive
+            // reconciliation untouched, regardless of catalog values.
+            let model = ModelConfig::new("codestral").with_context_limit(Some(999_999));
+            let reconciled = model.reconcile_canonical_limits("mistralai", "cortecs");
+            assert_eq!(reconciled.context_limit, Some(999_999));
+        }
+
+        #[test]
+        fn overrides_inferred_limit_with_catalog_value() {
+            // Derive expectations from the bundled registry so the test isn't
+            // tied to specific catalog numbers; only meaningful when the model
+            // exists under both providers with differing context windows.
+            let inferred = crate::canonical::maybe_get_canonical_model("mistralai", "codestral");
+            let canonical = crate::canonical::maybe_get_canonical_model("cortecs", "codestral");
+            if let (Some(inferred), Some(canonical)) = (inferred, canonical) {
+                if inferred.limit.context != canonical.limit.context {
+                    let model = ModelConfig::new("codestral")
+                        .with_context_limit(Some(inferred.limit.context));
+                    let reconciled = model.reconcile_canonical_limits("mistralai", "cortecs");
+                    assert_eq!(reconciled.context_limit, Some(canonical.limit.context));
+                }
+            }
+        }
+    }
 
     mod thinking_effort_tests {
         use super::*;

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -129,6 +129,10 @@ pub struct OpenAiProvider {
     custom_headers: Option<HashMap<String, String>>,
     supports_streaming: bool,
     name: String,
+    /// Canonical catalog id for model-metadata/filtering lookups when it differs
+    /// from `name` (e.g. a custom provider's `catalog_provider_id`). Falls back
+    /// to `name` when None.
+    canonical_provider_id: Option<String>,
     custom_models: Option<Vec<String>>,
     dynamic_models: Option<bool>,
     skip_canonical_filtering: bool,
@@ -150,6 +154,7 @@ pub struct OpenAiProviderBuilder {
     custom_headers: Option<HashMap<String, String>>,
     supports_streaming: bool,
     name: String,
+    canonical_provider_id: Option<String>,
     custom_models: Option<Vec<String>>,
     dynamic_models: Option<bool>,
     skip_canonical_filtering: bool,
@@ -166,6 +171,7 @@ impl OpenAiProviderBuilder {
             custom_headers: None,
             supports_streaming: true,
             name: OPEN_AI_PROVIDER_NAME.to_string(),
+            canonical_provider_id: None,
             custom_models: None,
             dynamic_models: None,
             skip_canonical_filtering: false,
@@ -208,6 +214,11 @@ impl OpenAiProviderBuilder {
         self
     }
 
+    pub fn canonical_provider_id(mut self, canonical_provider_id: Option<String>) -> Self {
+        self.canonical_provider_id = canonical_provider_id;
+        self
+    }
+
     pub fn custom_models(mut self, custom_models: Option<Vec<String>>) -> Self {
         self.custom_models = custom_models;
         self
@@ -237,6 +248,7 @@ impl OpenAiProviderBuilder {
             custom_headers: self.custom_headers,
             supports_streaming: self.supports_streaming,
             name: self.name,
+            canonical_provider_id: self.canonical_provider_id,
             custom_models: self.custom_models,
             dynamic_models: self.dynamic_models,
             skip_canonical_filtering: self.skip_canonical_filtering,
@@ -257,6 +269,7 @@ impl OpenAiProvider {
             custom_headers: None,
             supports_streaming: true,
             name: OPEN_AI_PROVIDER_NAME.to_string(),
+            canonical_provider_id: None,
             custom_models: None,
             dynamic_models: None,
             skip_canonical_filtering: false,
@@ -515,6 +528,10 @@ impl Provider for OpenAiProvider {
         &self.name
     }
 
+    fn canonical_provider_id(&self) -> &str {
+        self.canonical_provider_id.as_deref().unwrap_or(&self.name)
+    }
+
     fn skip_canonical_filtering(&self) -> bool {
         self.skip_canonical_filtering
     }
@@ -724,12 +741,35 @@ mod tests {
             custom_headers: None,
             supports_streaming: true,
             name: name.to_string(),
+            canonical_provider_id: None,
             custom_models: None,
             dynamic_models: None,
             skip_canonical_filtering: false,
             preserve_thinking_context: false,
             n_ctx_cache: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    #[test]
+    fn canonical_provider_id_prefers_catalog_id_over_name() {
+        // A custom OpenAI-compatible provider keeps its prefixed name for
+        // identity but resolves canonical metadata against catalog_provider_id.
+        let provider = OpenAiProviderBuilder::new(
+            ApiClient::new_with_tls("http://localhost".to_string(), AuthMethod::NoAuth, None)
+                .unwrap(),
+        )
+        .name("custom_cortecs")
+        .canonical_provider_id(Some("cortecs".to_string()))
+        .build();
+
+        assert_eq!(provider.get_name(), "custom_cortecs");
+        assert_eq!(provider.canonical_provider_id(), "cortecs");
+    }
+
+    #[test]
+    fn canonical_provider_id_falls_back_to_name() {
+        let provider = make_provider("custom_thing");
+        assert_eq!(provider.canonical_provider_id(), "custom_thing");
     }
 
     #[test]

--- a/crates/goose/src/providers/openai_def.rs
+++ b/crates/goose/src/providers/openai_def.rs
@@ -275,6 +275,9 @@ pub fn from_custom_config(
         .custom_headers(config.headers)
         .supports_streaming(config.supports_streaming.unwrap_or(true))
         .name(config.name.clone())
+        // Resolve canonical model metadata/filtering against the shared catalog
+        // id (e.g. "cortecs") rather than the prefixed custom name ("custom_cortecs").
+        .canonical_provider_id(config.catalog_provider_id.clone())
         .custom_models(custom_models)
         .dynamic_models(config.dynamic_models)
         .skip_canonical_filtering(config.skip_canonical_filtering)

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -74,6 +74,18 @@ impl ProviderEntry {
             .unwrap_or(&self.metadata.name);
         model = crate::model_config::materialize_model_config(canonical_name, model)?;
 
+        // The incoming config may have been materialized earlier under the
+        // provider name, where an inferable model (e.g. `codestral`) resolves to
+        // a first-party catalog entry and `with_canonical_limits` only fills
+        // `None` fields — so the catalog id above can't replace those inferred
+        // limits. Reconcile them to the catalog entry's values where they still
+        // match the inferred ones (preserving explicit user overrides).
+        if let Some(catalog_id) = self.canonical_provider_id.as_deref() {
+            if catalog_id != self.metadata.name {
+                model = model.reconcile_canonical_limits(&self.metadata.name, catalog_id);
+            }
+        }
+
         if model.context_limit.is_none() {
             if let Some(info) = self
                 .metadata

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -24,6 +24,10 @@ pub type ProviderCleanup = Arc<dyn Fn() -> BoxFuture<'static, Result<()>> + Send
 #[derive(Clone)]
 pub struct ProviderEntry {
     metadata: ProviderMetadata,
+    /// Catalog id for canonical model-limit resolution when it differs from
+    /// `metadata.name` (e.g. a custom provider's `catalog_provider_id`). Falls
+    /// back to `metadata.name` when None.
+    canonical_provider_id: Option<String>,
     pub(crate) constructor: ProviderConstructor,
     pub(crate) inventory_identity: super::inventory::InventoryIdentityResolver,
     pub(crate) inventory_configured: super::inventory::InventoryConfiguredResolver,
@@ -60,7 +64,15 @@ impl ProviderEntry {
     /// the agent/session layer to resolve effective limits (e.g. for custom
     /// providers that declare explicit context limits in their config).
     pub fn normalize_model_config(&self, mut model: ModelConfig) -> Result<ModelConfig> {
-        model = crate::model_config::materialize_model_config(&self.metadata.name, model)?;
+        // Resolve canonical limits against the catalog id (e.g. "cortecs") rather
+        // than the user-facing provider name ("custom_cortecs"), so provider-native
+        // models that don't infer back through the canonical mapper still pick up
+        // their catalog limits instead of falling back to defaults.
+        let canonical_name = self
+            .canonical_provider_id
+            .as_deref()
+            .unwrap_or(&self.metadata.name);
+        model = crate::model_config::materialize_model_config(canonical_name, model)?;
 
         if model.context_limit.is_none() {
             if let Some(info) = self
@@ -133,6 +145,7 @@ impl ProviderRegistry {
             name,
             ProviderEntry {
                 metadata,
+                canonical_provider_id: None,
                 constructor: Arc::new(|extensions, working_dir, tls_config| {
                     Box::pin(async move {
                         let provider = match working_dir {
@@ -311,6 +324,7 @@ impl ProviderRegistry {
             config.name.clone(),
             ProviderEntry {
                 metadata: custom_metadata,
+                canonical_provider_id: config.catalog_provider_id.clone(),
                 constructor: Arc::new(move |_extensions, _working_dir, tls_config| {
                     let result = constructor(tls_config);
                     Box::pin(async move {


### PR DESCRIPTION
## Problem

A custom OpenAI-compatible provider configured with `catalog_provider_id` does not actually use it for canonical model resolution. `from_custom_config` passes only `config.name` to the provider, and the canonical lookups in `Provider` (`fetch_recommended_models`, `fetch_model_info`, …) key off `get_name()`.

Because user-created custom providers get a `custom_` prefix (`generate_id` → `custom_<slug>`), the effective lookup key is e.g. `custom_cortecs`, which matches no entry in `canonical_models.json` (entries are keyed `cortecs/…`). The canonical filter in `fetch_recommended_models` then drops every model that doesn't *infer* back to a built-in provider, so a provider exposing 106 models surfaces only the subset whose names look like `claude-*`, `gpt-*`, `gemini-*`, `mistral-*`, etc. — the provider-native models (GLM, Kimi, MiniMax, Nova, …) silently disappear, even though the user explicitly set `catalog_provider_id` to point at the right catalog.

## Change

Introduce a dedicated provider identity for catalog lookups:

- `Provider::canonical_provider_id()` — new trait method, defaults to `get_name()`.
- All canonical-resolution call sites in `base.rs` (`fetch_supported_model_info`, `fetch_model_info`, `fetch_recommended_models`, `fetch_recommended_model_info`, `map_to_canonical_model`) now use `canonical_provider_id()` instead of `get_name()`.
- `OpenAiProvider` gains a `canonical_provider_id: Option<String>` field and overrides the trait method to return it, falling back to `name`.
- `openai_def::from_custom_config` wires `config.catalog_provider_id` into the builder.

Identity (`get_name`) is unchanged, so config storage, telemetry, and routing keep using the prefixed name; only catalog metadata/filtering resolves against the catalog id.

## Effect

A custom provider with `catalog_provider_id: "cortecs"` now resolves canonical metadata and filtering under `cortecs`, so the catalog entries apply and provider-native models are no longer dropped. Built-in declarative providers are unaffected: their `catalog_provider_id` already matches the catalog (previously reached via the `map_provider_name` alias, now used directly), and providers without one fall back to `name`.

## Tests

- `canonical_provider_id_prefers_catalog_id_over_name` — `get_name()` stays `custom_cortecs`, `canonical_provider_id()` returns `cortecs`.
- `canonical_provider_id_falls_back_to_name` — no catalog id → falls back to name.
- Full `goose-providers` suite passes.

## Related

- Complements the Cortecs catalog completion (the canonical-data PR): this fix makes that catalog actually reachable for custom Cortecs providers; together they raise the Cortecs picker from a filtered subset to the full tool-capable set.
- Background for #10035.
