### PR TITLE
fix(cli): restore terminal cursor on configure Ctrl+C

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2725,6 +2725,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3556,6 +3567,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.1",
+ "block2",
+ "libc",
  "objc2",
 ]
 
@@ -4915,6 +4928,7 @@ dependencies = [
  "cliclack",
  "comfy-table",
  "console 0.16.3",
+ "ctrlc",
  "dotenvy",
  "env-lock",
  "etcetera 0.11.0",

--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -28,6 +28,7 @@ rmcp = { workspace = true }
 clap = { workspace = true }
 cliclack = { version = "0.5", default-features = false }
 console = { version = "0.16", default-features = false, features = ["std"] }
+ctrlc = { version = "3.5", default-features = false }
 dotenvy = { workspace = true }
 bat = { version = "0.26", default-features = false, features = ["regex-onig"] }
 anyhow = { workspace = true }

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -28,11 +28,49 @@ use goose::session::SessionType;
 use goose_providers::thinking::ThinkingEffort;
 use serde_json::Value;
 use std::collections::HashMap;
-use std::io::IsTerminal;
+use std::io::{self, IsTerminal};
 
 // useful for light themes where there is no discernible colour contrast between
 // cursor-selected and cursor-unselected items.
 const MULTISELECT_VISIBILITY_HINT: &str = "<";
+
+/// Ensures cliclack restores the terminal cursor when configure exits, including Ctrl+C.
+struct RestoreTerminalCursor;
+
+impl Drop for RestoreTerminalCursor {
+    fn drop(&mut self) {
+        restore_terminal_cursor();
+    }
+}
+
+fn prepare_configure_terminal() -> anyhow::Result<()> {
+    // cliclack expects a no-op Ctrl-C handler so SIGINT surfaces as Interrupted from
+    // read_key() instead of terminating the process while the cursor is hidden.
+    match ctrlc::set_handler(|| {}) {
+        Ok(()) => {}
+        Err(ctrlc::Error::MultipleHandlers) => {}
+        Err(e) => return Err(anyhow::anyhow!("failed to install Ctrl+C handler: {e}")),
+    }
+    Ok(())
+}
+
+fn restore_terminal_cursor() {
+    let _ = console::Term::stderr().show_cursor();
+    let _ = console::Term::stdout().show_cursor();
+}
+
+fn exit_on_configure_interrupt() -> ! {
+    restore_terminal_cursor();
+    std::process::exit(130);
+}
+
+fn is_interrupted(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<io::Error>()
+            .is_some_and(|e| e.kind() == io::ErrorKind::Interrupted)
+    })
+}
 
 pub async fn handle_configure() -> anyhow::Result<()> {
     if !std::io::stdin().is_terminal() {
@@ -42,13 +80,24 @@ pub async fn handle_configure() -> anyhow::Result<()> {
         );
     }
 
+    prepare_configure_terminal()?;
+    let _cursor_guard = RestoreTerminalCursor;
+
     let config = Config::global();
 
-    if !config.exists() {
+    let result = if !config.exists() {
         handle_first_time_setup(config).await
     } else {
         handle_existing_config().await
+    };
+
+    if let Err(err) = &result {
+        if is_interrupted(err) {
+            exit_on_configure_interrupt();
+        }
     }
+
+    result
 }
 
 #[cfg(feature = "telemetry")]
@@ -2162,4 +2211,32 @@ fn print_config_file_saved() -> anyhow::Result<()> {
         config.path()
     ))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod terminal_restore_tests {
+    use super::{is_interrupted, RestoreTerminalCursor};
+    use std::io::{self, ErrorKind};
+
+    #[test]
+    fn restore_terminal_cursor_shows_cursor_on_drop() {
+        let _ = console::Term::stderr().hide_cursor();
+        drop(RestoreTerminalCursor);
+        // If show_cursor failed this would leave the terminal unusable; the drop
+        // path must not panic.
+    }
+
+    #[test]
+    fn is_interrupted_detects_cliclack_cancel() {
+        let err = anyhow::anyhow!(io::Error::new(ErrorKind::Interrupted, "cancelled"));
+        assert!(is_interrupted(&err));
+        assert!(!is_interrupted(&anyhow::anyhow!("other error")));
+    }
+
+    #[test]
+    fn is_interrupted_detects_wrapped_cliclack_cancel() {
+        let err = anyhow::anyhow!(io::Error::new(ErrorKind::Interrupted, "cancelled"))
+            .context("prompt cancelled");
+        assert!(is_interrupted(&err));
+    }
 }


### PR DESCRIPTION
## Summary

Restore terminal cursor visibility when `goose configure` is cancelled with Ctrl+C during cliclack prompts.

## Motivation

Fixes #10018

cliclack hides the terminal cursor while prompting. Without a Ctrl-C handler, SIGINT terminates the process before cliclack can call `show_cursor()`, leaving the terminal cursor hidden until the user runs `tput cnorm` manually.

## Changes

- Install cliclack's recommended no-op `ctrlc` handler at the start of `handle_configure()`
- Add a `RestoreTerminalCursor` guard and explicit cursor restore before exit code 130 on prompt cancellation
- Tolerate `ctrlc::Error::MultipleHandlers` if configure is re-entered in the same process
- Add unit tests for interrupt detection and cursor guard drop path

## Tests

```bash
cargo test -p goose-cli --no-default-features \
  --features "tui,telemetry,rustls-tls,aws-providers,otel,code-mode" \
  terminal_restore_tests
```

Result: 3/3 passed

`cargo fmt --all -- --check` passed.

## Notes

This follows cliclack's documented Ctrl-C setup pattern. Ctrl+C during non-prompt work (spinners/OAuth) is deferred until the next prompt read, matching cliclack's intended behavior.

Fixes #10018