### PR TITLE
fix: sync the sesion store after session provider and model update and also update thinking effort

### DIFF
--- a/ui/desktop/src/acp/__tests__/providers.test.ts
+++ b/ui/desktop/src/acp/__tests__/providers.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getAcpClient } from '../acpConnection';
+import { acpSetSessionProviderModel } from '../providers';
+
+vi.mock('../acpConnection', () => ({
+  getAcpClient: vi.fn(),
+}));
+
+function selectConfigOption(id: string, currentValue: string) {
+  return {
+    id,
+    name: id,
+    kind: {
+      type: 'select',
+      currentValue,
+      options: [],
+    },
+  };
+}
+
+describe('ACP providers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns provider and model from the final model config response', async () => {
+    const client = {
+      setSessionConfigOption: vi
+        .fn()
+        .mockResolvedValueOnce({
+          configOptions: [
+            selectConfigOption('provider', 'anthropic'),
+            selectConfigOption('model', 'provider-default-model'),
+          ],
+        })
+        .mockResolvedValueOnce({
+          configOptions: [
+            selectConfigOption('provider', 'anthropic'),
+            selectConfigOption('model', 'claude-sonnet-4-5'),
+          ],
+        }),
+    };
+    vi.mocked(getAcpClient).mockResolvedValue(
+      client as unknown as Awaited<ReturnType<typeof getAcpClient>>
+    );
+
+    const applied = await acpSetSessionProviderModel(
+      'session-1',
+      'anthropic',
+      'claude-sonnet-4-5'
+    );
+
+    expect(client.setSessionConfigOption).toHaveBeenCalledTimes(2);
+    expect(client.setSessionConfigOption).toHaveBeenNthCalledWith(1, {
+      sessionId: 'session-1',
+      configId: 'provider',
+      value: 'anthropic',
+    });
+    expect(client.setSessionConfigOption).toHaveBeenNthCalledWith(2, {
+      sessionId: 'session-1',
+      configId: 'model',
+      value: 'claude-sonnet-4-5',
+    });
+    expect(applied).toEqual({
+      providerId: 'anthropic',
+      modelId: 'claude-sonnet-4-5',
+    });
+  });
+});

--- a/ui/desktop/src/acp/__tests__/providers.test.ts
+++ b/ui/desktop/src/acp/__tests__/providers.test.ts
@@ -23,7 +23,7 @@ describe('ACP providers', () => {
     vi.clearAllMocks();
   });
 
-  it('returns provider and model from the final model config response', async () => {
+  it('sets thinking effort after provider and model, then returns the final config response', async () => {
     const client = {
       setSessionConfigOption: vi
         .fn()
@@ -38,6 +38,13 @@ describe('ACP providers', () => {
             selectConfigOption('provider', 'anthropic'),
             selectConfigOption('model', 'claude-sonnet-4-5'),
           ],
+        })
+        .mockResolvedValueOnce({
+          configOptions: [
+            selectConfigOption('provider', 'anthropic'),
+            selectConfigOption('model', 'claude-sonnet-4-5'),
+            selectConfigOption('thinking_effort', 'high'),
+          ],
         }),
     };
     vi.mocked(getAcpClient).mockResolvedValue(
@@ -47,10 +54,11 @@ describe('ACP providers', () => {
     const applied = await acpSetSessionProviderModel(
       'session-1',
       'anthropic',
-      'claude-sonnet-4-5'
+      'claude-sonnet-4-5',
+      'high'
     );
 
-    expect(client.setSessionConfigOption).toHaveBeenCalledTimes(2);
+    expect(client.setSessionConfigOption).toHaveBeenCalledTimes(3);
     expect(client.setSessionConfigOption).toHaveBeenNthCalledWith(1, {
       sessionId: 'session-1',
       configId: 'provider',
@@ -60,6 +68,11 @@ describe('ACP providers', () => {
       sessionId: 'session-1',
       configId: 'model',
       value: 'claude-sonnet-4-5',
+    });
+    expect(client.setSessionConfigOption).toHaveBeenNthCalledWith(3, {
+      sessionId: 'session-1',
+      configId: 'thinking_effort',
+      value: 'high',
     });
     expect(applied).toEqual({
       providerId: 'anthropic',

--- a/ui/desktop/src/acp/__tests__/providers.test.ts
+++ b/ui/desktop/src/acp/__tests__/providers.test.ts
@@ -10,11 +10,9 @@ function selectConfigOption(id: string, currentValue: string) {
   return {
     id,
     name: id,
-    kind: {
-      type: 'select',
-      currentValue,
-      options: [],
-    },
+    type: 'select',
+    currentValue,
+    options: [],
   };
 }
 

--- a/ui/desktop/src/acp/providers.ts
+++ b/ui/desktop/src/acp/providers.ts
@@ -265,7 +265,8 @@ function selectCurrentValue(kind: unknown): unknown {
 export async function acpSetSessionProviderModel(
   sessionId: string,
   providerId: string,
-  modelId?: string | null
+  modelId?: string | null,
+  thinkingEffort?: ThinkingEffort | null
 ): Promise<AppliedSessionProviderModel> {
   const client = await getAcpClient();
   let response = await client.setSessionConfigOption({
@@ -278,6 +279,13 @@ export async function acpSetSessionProviderModel(
       sessionId,
       configId: 'model',
       value: modelId,
+    });
+  }
+  if (thinkingEffort != null) {
+    response = await client.setSessionConfigOption({
+      sessionId,
+      configId: 'thinking_effort',
+      value: thinkingEffort,
     });
   }
 

--- a/ui/desktop/src/acp/providers.ts
+++ b/ui/desktop/src/acp/providers.ts
@@ -198,6 +198,64 @@ export async function acpSaveThinkingEffort(effort: ThinkingEffort): Promise<voi
   });
 }
 
+export type AppliedSessionProviderModel = {
+  providerId?: string;
+  modelId?: string;
+};
+
+function extractAppliedSessionProviderModel(configOptions: unknown): AppliedSessionProviderModel {
+  if (!Array.isArray(configOptions)) {
+    return {};
+  }
+
+  const applied: AppliedSessionProviderModel = {};
+
+  for (const option of configOptions) {
+    if (!option || typeof option !== 'object') {
+      continue;
+    }
+
+    const id = 'id' in option ? option.id : undefined;
+    if (id !== 'provider' && id !== 'model') {
+      continue;
+    }
+
+    const currentValue = selectCurrentValue('kind' in option ? option.kind : undefined);
+    if (typeof currentValue !== 'string') {
+      continue;
+    }
+
+    if (id === 'provider') {
+      applied.providerId = currentValue;
+    } else {
+      applied.modelId = currentValue;
+    }
+  }
+
+  return applied;
+}
+
+function selectCurrentValue(kind: unknown): unknown {
+  if (!kind || typeof kind !== 'object') {
+    return undefined;
+  }
+
+  if ('type' in kind && kind.type === 'select' && 'currentValue' in kind) {
+    return kind.currentValue;
+  }
+
+  if (!('select' in kind)) {
+    return undefined;
+  }
+
+  const select = kind.select;
+  if (!select || typeof select !== 'object' || !('currentValue' in select)) {
+    return undefined;
+  }
+
+  return select.currentValue;
+}
+
 /**
  * Switch the provider (and model) for an active session via ACP config options.
  *
@@ -208,10 +266,20 @@ export async function acpSetSessionProviderModel(
   sessionId: string,
   providerId: string,
   modelId?: string | null
-): Promise<void> {
+): Promise<AppliedSessionProviderModel> {
   const client = await getAcpClient();
-  await client.setSessionConfigOption({ sessionId, configId: 'provider', value: providerId });
+  let response = await client.setSessionConfigOption({
+    sessionId,
+    configId: 'provider',
+    value: providerId,
+  });
   if (modelId) {
-    await client.setSessionConfigOption({ sessionId, configId: 'model', value: modelId });
+    response = await client.setSessionConfigOption({
+      sessionId,
+      configId: 'model',
+      value: modelId,
+    });
   }
+
+  return extractAppliedSessionProviderModel(response.configOptions);
 }

--- a/ui/desktop/src/acp/providers.ts
+++ b/ui/desktop/src/acp/providers.ts
@@ -220,7 +220,7 @@ function extractAppliedSessionProviderModel(configOptions: unknown): AppliedSess
       continue;
     }
 
-    const currentValue = selectCurrentValue('kind' in option ? option.kind : undefined);
+    const currentValue = selectCurrentValue(option);
     if (typeof currentValue !== 'string') {
       continue;
     }
@@ -244,16 +244,7 @@ function selectCurrentValue(kind: unknown): unknown {
     return kind.currentValue;
   }
 
-  if (!('select' in kind)) {
-    return undefined;
-  }
-
-  const select = kind.select;
-  if (!select || typeof select !== 'object' || !('currentValue' in select)) {
-    return undefined;
-  }
-
-  return select.currentValue;
+  return undefined;
 }
 
 /**

--- a/ui/desktop/src/components/ModelAndProviderContext.tsx
+++ b/ui/desktop/src/components/ModelAndProviderContext.tsx
@@ -2,7 +2,13 @@ import React, { createContext, useContext, useState, useEffect, useMemo, useCall
 import { toastError, toastSuccess } from '../toasts';
 import Model, { getProviderMetadata } from './settings/models/modelInterface';
 import { ProviderMetadata } from '../api';
-import { acpReadDefaults, acpSaveDefaults, acpSetSessionProviderModel } from '../acp/providers';
+import { acpChatSessionActions, acpChatSessionStore } from '../acp/chatSessionStore';
+import {
+  acpReadDefaults,
+  acpSaveDefaults,
+  acpSetSessionProviderModel,
+  type AppliedSessionProviderModel,
+} from '../acp/providers';
 import { errorMessage } from '../utils/conversionUtils';
 import {
   getModelDisplayName,
@@ -57,6 +63,27 @@ const ModelAndProviderContext = createContext<ModelAndProviderContextType | unde
 
 export { i18n as modelAndProviderMessages };
 
+function patchAcpSessionProviderModel(
+  sessionId: string,
+  { providerId, modelId }: AppliedSessionProviderModel
+) {
+  if (!providerId && !modelId) return;
+
+  const currentSession = acpChatSessionStore.getSnapshot(sessionId)?.session;
+  if (!currentSession) return;
+
+  acpChatSessionActions.setSessionMetadata(sessionId, {
+    ...currentSession,
+    provider_name: providerId ?? currentSession.provider_name,
+    model_config: modelId
+      ? {
+          ...(currentSession.model_config ?? { toolshim: false }),
+          model_name: modelId,
+        }
+      : currentSession.model_config,
+  });
+}
+
 export const ModelAndProviderProvider: React.FC<ModelAndProviderProviderProps> = ({ children }) => {
   const [currentModel, setCurrentModel] = useState<string | null>(null);
   const [currentProvider, setCurrentProvider] = useState<string | null>(null);
@@ -70,7 +97,8 @@ export const ModelAndProviderProvider: React.FC<ModelAndProviderProviderProps> =
 
       try {
         if (sessionId) {
-          await acpSetSessionProviderModel(sessionId, providerName, modelName);
+          const applied = await acpSetSessionProviderModel(sessionId, providerName, modelName);
+          patchAcpSessionProviderModel(sessionId, applied);
         }
 
         // Only update the global config default when there's no session

--- a/ui/desktop/src/components/ModelAndProviderContext.tsx
+++ b/ui/desktop/src/components/ModelAndProviderContext.tsx
@@ -97,7 +97,12 @@ export const ModelAndProviderProvider: React.FC<ModelAndProviderProviderProps> =
 
       try {
         if (sessionId) {
-          const applied = await acpSetSessionProviderModel(sessionId, providerName, modelName);
+          const applied = await acpSetSessionProviderModel(
+            sessionId,
+            providerName,
+            modelName,
+            model.request_params?.thinking_effort ?? null
+          );
           patchAcpSessionProviderModel(sessionId, applied);
         }
 


### PR DESCRIPTION
## Summary

### Why

- With ACP chat enabled, changing provider/model updates the active ACP agent and persisted session server-side, but the UI’s local ACP chat session store could keep stale `provider_name` / `model_config.model_name` until reload. The bottom bar had a local visual override, but the underlying session metadata did not catch up.

- The thinking effort is not updated when the form is submitted


### Changes

- fixes the stale UI session metadata by syncing the local ACP chat session store from the ACP server’s final applied config response, without adding `config_option_update` notification handling or reloading the session.
-  send requests to update thinking efforts to acp server


### Testing
Unit and Manual

