### PR TITLE
fix(desktop): honor GOOSE_CONTEXT_LIMIT for custom model context display

### DIFF
--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -35,6 +35,8 @@ import { getNavigationShortcutText } from '../utils/keyboardShortcuts';
 import { UserInput, ImageData } from '../types/message';
 import { compressImageDataUrl } from '../utils/conversionUtils';
 import { fetchCanonicalModelInfo } from '../utils/canonical';
+import { DEFAULT_CONTEXT_LIMIT, resolveDisplayContextLimit } from '../utils/modelContextLimit';
+import { useConfig } from './ConfigContext';
 import { defineMessages, useIntl } from '../i18n';
 import TurndownService from 'turndown';
 import type { NextChatExtensionDraft } from '../utils/nextChatExtensions';
@@ -79,8 +81,6 @@ const removeQueuedMessage = (messages: QueuedMessage[], messageId: string): Queu
   messages.filter((msg) => msg.id !== messageId);
 
 const MAX_IMAGES_PER_MESSAGE = 10;
-
-const TOKEN_LIMIT_DEFAULT = 128000; // fallback for custom models that the backend doesn't know about
 
 const getContextAlertType = (totalTokens: number, tokenLimit: number): AlertType => {
   const percentage = tokenLimit ? (totalTokens / tokenLimit) * 100 : 0;
@@ -288,6 +288,8 @@ export default function ChatInput({
     currentModel: configModel,
     currentProvider: configProvider,
   } = useModelAndProvider();
+  const { config } = useConfig();
+  const configuredContextLimit = config.GOOSE_CONTEXT_LIMIT as number | undefined;
 
   // Local override for when the user changes the model in the modal,
   // before the session object is re-fetched from the backend.
@@ -311,7 +313,7 @@ export default function ChatInput({
       setModelOverride(null);
     }
   }, [sessionModel, sessionProvider, configModel, configProvider, sessionId, modelOverride]);
-  const [tokenLimit, setTokenLimit] = useState<number>(TOKEN_LIMIT_DEFAULT);
+  const [tokenLimit, setTokenLimit] = useState<number>(DEFAULT_CONTEXT_LIMIT);
   const [isTokenLimitLoaded, setIsTokenLimitLoaded] = useState(false);
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
   const [workingDirOverride, setWorkingDirOverride] = useState<string | null>(null);
@@ -623,23 +625,22 @@ export default function ChatInput({
         }
       }
 
-      // Priority 4: Use default if nothing else found
-      setTokenLimit(TOKEN_LIMIT_DEFAULT);
+      // Priority 4: Resolve via goosed (honors GOOSE_CONTEXT_LIMIT and provider defaults)
+      const resolvedLimit = await resolveDisplayContextLimit(provider, model);
+      setTokenLimit(resolvedLimit);
       setIsTokenLimitLoaded(true);
     } catch (err) {
       console.error('Error loading providers or token limit:', err);
-      // Set default limit on error
-      setTokenLimit(TOKEN_LIMIT_DEFAULT);
+      setTokenLimit(configuredContextLimit ?? DEFAULT_CONTEXT_LIMIT);
       setIsTokenLimitLoaded(true);
     }
   };
 
-  // Initial load and refresh when model changes (effective model includes overrides,
-  // config model is the fallback for Hub/no-session contexts)
+  // Initial load and refresh when model or context limit override changes
   useEffect(() => {
     loadProviderDetails();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [effectiveModel, effectiveProvider, configModel, configProvider]);
+  }, [effectiveModel, effectiveProvider, configModel, configProvider, configuredContextLimit]);
 
   // Handle token usage alerts
   useEffect(() => {

--- a/ui/desktop/src/components/settings/mode/ConversationLimitsDropdown.tsx
+++ b/ui/desktop/src/components/settings/mode/ConversationLimitsDropdown.tsx
@@ -16,16 +16,33 @@ const i18n = defineMessages({
     id: 'conversationLimitsDropdown.maxTurnsDescription',
     defaultMessage: 'Maximum agent turns before Goose asks for user input',
   },
+  contextLimit: {
+    id: 'conversationLimitsDropdown.contextLimit',
+    defaultMessage: 'Context limit override',
+  },
+  contextLimitDescription: {
+    id: 'conversationLimitsDropdown.contextLimitDescription',
+    defaultMessage:
+      'Default context window for models without a known limit (also used for auto-compaction). Leave empty to use 128,000.',
+  },
+  contextLimitPlaceholder: {
+    id: 'conversationLimitsDropdown.contextLimitPlaceholder',
+    defaultMessage: '128000',
+  },
 });
 
 interface ConversationLimitsDropdownProps {
   maxTurns: number;
   onMaxTurnsChange: (value: number) => void;
+  contextLimit: number | null;
+  onContextLimitChange: (value: number | null) => void;
 }
 
 export const ConversationLimitsDropdown = ({
   maxTurns,
   onMaxTurnsChange,
+  contextLimit,
+  onContextLimitChange,
 }: ConversationLimitsDropdownProps) => {
   const intl = useIntl();
   const [isExpanded, setIsExpanded] = useState(false);
@@ -69,6 +86,32 @@ export const ConversationLimitsDropdown = ({
               value={maxTurns}
               onChange={(e) => onMaxTurnsChange(Number(e.target.value))}
               className="w-20"
+            />
+          </div>
+          <div className="flex items-center justify-between py-2 px-2 bg-background-secondary rounded-lg transform transition-all duration-200 ease-in-out">
+            <div>
+              <h4 className="text-text-primary text-sm">{intl.formatMessage(i18n.contextLimit)}</h4>
+              <p className="text-xs text-text-secondary mt-[2px]">
+                {intl.formatMessage(i18n.contextLimitDescription)}
+              </p>
+            </div>
+            <Input
+              type="number"
+              min="1"
+              placeholder={intl.formatMessage(i18n.contextLimitPlaceholder)}
+              value={contextLimit ?? ''}
+              onChange={(e) => {
+                const raw = e.target.value.trim();
+                if (!raw) {
+                  onContextLimitChange(null);
+                  return;
+                }
+                const parsed = Number(raw);
+                if (Number.isFinite(parsed) && parsed > 0) {
+                  onContextLimitChange(parsed);
+                }
+              }}
+              className="w-28"
             />
           </div>
         </div>

--- a/ui/desktop/src/components/settings/mode/ModeSection.tsx
+++ b/ui/desktop/src/components/settings/mode/ModeSection.tsx
@@ -6,7 +6,8 @@ import { ConversationLimitsDropdown } from './ConversationLimitsDropdown';
 export const ModeSection = () => {
   const [currentMode, setCurrentMode] = useState('auto');
   const [maxTurns, setMaxTurns] = useState<number>(1000);
-  const { config, read, upsert } = useConfig();
+  const [contextLimit, setContextLimit] = useState<number | null>(null);
+  const { config, read, upsert, remove } = useConfig();
 
   const handleModeChange = async (newMode: string) => {
     try {
@@ -36,6 +37,19 @@ export const ModeSection = () => {
     }
   }, [read]);
 
+  const fetchContextLimit = useCallback(async () => {
+    try {
+      const limit = (await read('GOOSE_CONTEXT_LIMIT', false)) as number;
+      if (typeof limit === 'number' && limit > 0) {
+        setContextLimit(limit);
+      } else {
+        setContextLimit(null);
+      }
+    } catch (error) {
+      console.error('Error fetching context limit:', error);
+    }
+  }, [read]);
+
   const handleMaxTurnsChange = async (value: number) => {
     try {
       await upsert('GOOSE_MAX_TURNS', value, false);
@@ -45,9 +59,33 @@ export const ModeSection = () => {
     }
   };
 
+  const handleContextLimitChange = async (value: number | null) => {
+    try {
+      if (value === null) {
+        await remove('GOOSE_CONTEXT_LIMIT', false);
+        setContextLimit(null);
+        return;
+      }
+      await upsert('GOOSE_CONTEXT_LIMIT', value, false);
+      setContextLimit(value);
+    } catch (error) {
+      console.error('Error updating context limit:', error);
+    }
+  };
+
   useEffect(() => {
     fetchMaxTurns();
-  }, [fetchMaxTurns]);
+    fetchContextLimit();
+  }, [fetchMaxTurns, fetchContextLimit]);
+
+  useEffect(() => {
+    const limit = config.GOOSE_CONTEXT_LIMIT as number | undefined;
+    if (typeof limit === 'number' && limit > 0) {
+      setContextLimit(limit);
+    } else if (limit === undefined) {
+      setContextLimit(null);
+    }
+  }, [config.GOOSE_CONTEXT_LIMIT]);
 
   return (
     <div className="space-y-1">
@@ -64,7 +102,12 @@ export const ModeSection = () => {
       ))}
 
       {/* Conversation Limits Dropdown */}
-      <ConversationLimitsDropdown maxTurns={maxTurns} onMaxTurnsChange={handleMaxTurnsChange} />
+      <ConversationLimitsDropdown
+        maxTurns={maxTurns}
+        onMaxTurnsChange={handleMaxTurnsChange}
+        contextLimit={contextLimit}
+        onContextLimitChange={handleContextLimitChange}
+      />
     </div>
   );
 };

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -299,6 +299,15 @@
   "confirmationModal.processing": {
     "defaultMessage": "Processing..."
   },
+  "conversationLimitsDropdown.contextLimit": {
+    "defaultMessage": "Context limit override"
+  },
+  "conversationLimitsDropdown.contextLimitDescription": {
+    "defaultMessage": "Default context window for models without a known limit (also used for auto-compaction). Leave empty to use 128,000."
+  },
+  "conversationLimitsDropdown.contextLimitPlaceholder": {
+    "defaultMessage": "128000"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "Conversation Limits"
   },

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -299,6 +299,15 @@
   "confirmationModal.processing": {
     "defaultMessage": "Procesando..."
   },
+  "conversationLimitsDropdown.contextLimit": {
+    "defaultMessage": "Anulación del límite de contexto"
+  },
+  "conversationLimitsDropdown.contextLimitDescription": {
+    "defaultMessage": "Ventana de contexto predeterminada para modelos sin un límite conocido (también se usa para la compactación automática). Déjalo vacío para usar 128.000."
+  },
+  "conversationLimitsDropdown.contextLimitPlaceholder": {
+    "defaultMessage": "128000"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "Límites de conversación"
   },

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -299,6 +299,15 @@
   "confirmationModal.processing": {
     "defaultMessage": "प्रसंस्करण..."
   },
+  "conversationLimitsDropdown.contextLimit": {
+    "defaultMessage": "संदर्भ सीमा ओवरराइड"
+  },
+  "conversationLimitsDropdown.contextLimitDescription": {
+    "defaultMessage": "अज्ञात सीमा वाले मॉडल के लिए डिफ़ॉल्ट संदर्भ विंडो (ऑटो-कम्पैक्शन के लिए भी उपयोग होता है)। 128,000 उपयोग करने के लिए खाली छोड़ें।"
+  },
+  "conversationLimitsDropdown.contextLimitPlaceholder": {
+    "defaultMessage": "128000"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "बातचीत की सीमाएँ"
   },

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -299,6 +299,15 @@
   "confirmationModal.processing": {
     "defaultMessage": "処理中..."
   },
+  "conversationLimitsDropdown.contextLimit": {
+    "defaultMessage": "コンテキスト上限の上書き"
+  },
+  "conversationLimitsDropdown.contextLimitDescription": {
+    "defaultMessage": "既知の上限がないモデルのデフォルトコンテキストウィンドウ（自動コンパクションにも使用）。空のままにすると 128,000 が使われます。"
+  },
+  "conversationLimitsDropdown.contextLimitPlaceholder": {
+    "defaultMessage": "128000"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "会話制限"
   },

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -299,6 +299,15 @@
   "confirmationModal.processing": {
     "defaultMessage": "처리 중..."
   },
+  "conversationLimitsDropdown.contextLimit": {
+    "defaultMessage": "컨텍스트 한도 재정의"
+  },
+  "conversationLimitsDropdown.contextLimitDescription": {
+    "defaultMessage": "알려진 한도가 없는 모델의 기본 컨텍스트 창(자동 압축에도 사용됨). 비워 두면 128,000을 사용합니다."
+  },
+  "conversationLimitsDropdown.contextLimitPlaceholder": {
+    "defaultMessage": "128000"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "대화 제한"
   },

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -299,6 +299,15 @@
   "confirmationModal.processing": {
     "defaultMessage": "Обработка..."
   },
+  "conversationLimitsDropdown.contextLimit": {
+    "defaultMessage": "Переопределение лимита контекста"
+  },
+  "conversationLimitsDropdown.contextLimitDescription": {
+    "defaultMessage": "Контекстное окно по умолчанию для моделей без известного лимита (также используется для авто-сжатия). Оставьте пустым, чтобы использовать 128 000."
+  },
+  "conversationLimitsDropdown.contextLimitPlaceholder": {
+    "defaultMessage": "128000"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "Ограничения разговора"
   },

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -299,6 +299,15 @@
   "confirmationModal.processing": {
     "defaultMessage": "İşleniyor..."
   },
+  "conversationLimitsDropdown.contextLimit": {
+    "defaultMessage": "Bağlam limiti geçersiz kılma"
+  },
+  "conversationLimitsDropdown.contextLimitDescription": {
+    "defaultMessage": "Bilinen limiti olmayan modeller için varsayılan bağlam penceresi (otomatik sıkıştırma için de kullanılır). 128.000 kullanmak için boş bırakın."
+  },
+  "conversationLimitsDropdown.contextLimitPlaceholder": {
+    "defaultMessage": "128000"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "Konuşma Sınırları"
   },

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -299,6 +299,15 @@
   "confirmationModal.processing": {
     "defaultMessage": "处理中…"
   },
+  "conversationLimitsDropdown.contextLimit": {
+    "defaultMessage": "上下文限制覆盖"
+  },
+  "conversationLimitsDropdown.contextLimitDescription": {
+    "defaultMessage": "没有已知限制的模型的默认上下文窗口（也用于自动压缩）。留空则使用 128,000。"
+  },
+  "conversationLimitsDropdown.contextLimitPlaceholder": {
+    "defaultMessage": "128000"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "对话限制"
   },

--- a/ui/desktop/src/utils/configUtils.ts
+++ b/ui/desktop/src/utils/configUtils.ts
@@ -10,6 +10,7 @@ export const configLabels: Record<string, string> = {
   GOOSE_TOOLSHIM_OLLAMA_MODEL: 'Tool Shim Ollama Model',
   GOOSE_CLI_MIN_PRIORITY: 'CLI Min Priority',
   GOOSE_ALLOWLIST: 'Allow List',
+  GOOSE_CONTEXT_LIMIT: 'Context Limit',
   GOOSE_RECIPE_GITHUB_REPO: 'Recipe GitHub Repo',
 
   // security settings

--- a/ui/desktop/src/utils/modelContextLimit.test.ts
+++ b/ui/desktop/src/utils/modelContextLimit.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import {
+  DEFAULT_CONTEXT_LIMIT,
+  fetchResolvedModelContextLimit,
+  readConfiguredContextLimit,
+  resolveDisplayContextLimit,
+} from './modelContextLimit';
+import { getProviderModelInfo } from '../api';
+import { acpReadConfig } from '../acp/config';
+
+vi.mock('../api', () => ({
+  getProviderModelInfo: vi.fn(),
+}));
+
+vi.mock('../acp/config', () => ({
+  acpReadConfig: vi.fn(),
+}));
+
+describe('modelContextLimit', () => {
+  beforeEach(() => {
+    vi.mocked(getProviderModelInfo).mockReset();
+    vi.mocked(acpReadConfig).mockReset();
+  });
+
+  it('returns provider-resolved limit from model-info', async () => {
+    vi.mocked(getProviderModelInfo).mockResolvedValue({
+      data: { context_limit: 1_000_000, name: 'glm-5.2' },
+    } as Awaited<ReturnType<typeof getProviderModelInfo>>);
+
+    await expect(fetchResolvedModelContextLimit('opencode_go', 'glm-5.2')).resolves.toBe(
+      1_000_000
+    );
+  });
+
+  it('falls back to GOOSE_CONTEXT_LIMIT when model-info is unavailable', async () => {
+    vi.mocked(getProviderModelInfo).mockRejectedValue(new Error('not configured'));
+    vi.mocked(acpReadConfig).mockResolvedValue(500_000);
+
+    await expect(resolveDisplayContextLimit('custom', 'MiniMax-M3')).resolves.toBe(500_000);
+  });
+
+  it('uses default when nothing is configured', async () => {
+    vi.mocked(getProviderModelInfo).mockRejectedValue(new Error('not configured'));
+    vi.mocked(acpReadConfig).mockResolvedValue(null);
+
+    await expect(resolveDisplayContextLimit('custom', 'unknown-model')).resolves.toBe(
+      DEFAULT_CONTEXT_LIMIT
+    );
+  });
+
+  it('readConfiguredContextLimit ignores invalid values', async () => {
+    vi.mocked(acpReadConfig).mockResolvedValue(0);
+    await expect(readConfiguredContextLimit()).resolves.toBeNull();
+  });
+});

--- a/ui/desktop/src/utils/modelContextLimit.ts
+++ b/ui/desktop/src/utils/modelContextLimit.ts
@@ -1,0 +1,58 @@
+/**
+ * Resolve the effective context window for a provider/model pair.
+ * Uses the goosed model-info endpoint so GOOSE_CONTEXT_LIMIT and provider
+ * defaults match what the backend uses for compaction.
+ */
+
+import { getProviderModelInfo } from '../api';
+import { acpReadConfig } from '../acp/config';
+
+export const DEFAULT_CONTEXT_LIMIT = 128_000;
+
+export async function fetchResolvedModelContextLimit(
+  provider: string,
+  model: string
+): Promise<number | null> {
+  try {
+    const response = await getProviderModelInfo({
+      path: { name: provider },
+      body: { model },
+    });
+    const limit = response.data?.context_limit;
+    if (typeof limit === 'number' && limit > 0) {
+      return limit;
+    }
+  } catch {
+    // Provider may be unconfigured during onboarding.
+  }
+  return null;
+}
+
+export async function readConfiguredContextLimit(): Promise<number | null> {
+  try {
+    const value = await acpReadConfig('GOOSE_CONTEXT_LIMIT', false);
+    if (typeof value === 'number' && value > 0) {
+      return value;
+    }
+  } catch {
+    // Key not set.
+  }
+  return null;
+}
+
+export async function resolveDisplayContextLimit(
+  provider: string,
+  model: string
+): Promise<number> {
+  const resolved = await fetchResolvedModelContextLimit(provider, model);
+  if (resolved !== null) {
+    return resolved;
+  }
+
+  const configured = await readConfiguredContextLimit();
+  if (configured !== null) {
+    return configured;
+  }
+
+  return DEFAULT_CONTEXT_LIMIT;
+}


### PR DESCRIPTION
## Summary

Desktop showed a hard-coded 128k context window for custom models even when `GOOSE_CONTEXT_LIMIT` was set in config. The chat UI now resolves the effective limit through goosed's model-info endpoint (same path the backend uses for compaction) and exposes a **Context limit override** field under Settings → Chat → Conversation Limits.

## Problem

Fixes #10058 (also #10045, #8780).

Custom OpenAI-compatible models (e.g. GLM-5.2, MiniMax-M3) without a canonical registry entry fell back to `128000` in `ChatInput.tsx`. `GOOSE_CONTEXT_LIMIT` worked for CLI sessions but was not reflected in the Desktop token indicator or auto-compaction threshold display.

## Approach

- Add `resolveDisplayContextLimit()` that calls `GET /config/providers/{name}/model-info` so the UI honors `GOOSE_CONTEXT_LIMIT` and provider defaults.
- Wire `ChatInput` to refresh when the override changes.
- Add a Settings control to read/write `GOOSE_CONTEXT_LIMIT` (clearing the field removes the override).

## Test plan

- [x] `vitest run src/utils/modelContextLimit.test.ts` (4 passed)
- [x] ESLint on changed files
- [ ] Manual: set `GOOSE_CONTEXT_LIMIT` to `1000000` in Settings → Chat, confirm token indicator shows `… / 1000k` for a custom model
- [ ] Manual: clear override and confirm fallback returns to 128k for unknown models
