### PR TITLE
feat(desktop): graceful window close (tray / quit) with busy-session warning

### DIFF
--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -12,6 +12,7 @@ import { importNostrSessionFromDeepLink } from './sessionLinks';
 import { ErrorUI } from './components/ErrorBoundary';
 import { ExtensionInstallModal } from './components/ExtensionInstallModal';
 import RecipeParamsModalContainer from './components/RecipeParamsModalContainer';
+import CloseConfirmationModal from './components/CloseConfirmationModal';
 import { isRecipeParamsCancelled } from './acp/errors';
 import { toast, ToastContainer } from 'react-toastify';
 import AnnouncementModal from './components/AnnouncementModal';
@@ -605,6 +606,7 @@ export function AppInner() {
       />
       <ExtensionInstallModal addExtension={addExtension} setView={setView} />
       <RecipeParamsModalContainer />
+      <CloseConfirmationModal />
       <div className="relative w-screen h-screen overflow-hidden bg-background-secondary flex flex-col">
         <div className="titlebar-drag-region" />
         <div style={{ position: 'relative', width: '100%', height: '100%' }}>

--- a/ui/desktop/src/acp/chatSessionStore.ts
+++ b/ui/desktop/src/acp/chatSessionStore.ts
@@ -50,7 +50,19 @@ const initialTokenState: TokenState = {
 
 export interface AcpChatSessionStore {
   getSnapshot(sessionId: string): AcpChatSessionSnapshot | undefined;
+  // True if any session has work in flight (a turn that would be lost if the window closed now).
+  hasAnyBusySession(): boolean;
 }
+
+// Chat states that represent in-flight work whose result would be lost on a hard close.
+// `Idle` and `LoadingConversation` are not "pending return".
+const BUSY_CHAT_STATES: ReadonlySet<ChatState> = new Set([
+  ChatState.Thinking,
+  ChatState.Streaming,
+  ChatState.WaitingForUserInput,
+  ChatState.Compacting,
+  ChatState.RestartingAgent,
+]);
 
 export interface AcpChatSessionActions {
   deleteSnapshot(sessionId: string): void;
@@ -114,6 +126,15 @@ function createAcpChatSessionStoreInternal(): AcpChatSessionStoreInternal {
   const getSnapshot: AcpChatSessionStore['getSnapshot'] = (sessionId) => {
     const entry = sessionsById.get(sessionId);
     return entry ? snapshotFromEntry(entry) : undefined;
+  };
+
+  const hasAnyBusySession: AcpChatSessionStore['hasAnyBusySession'] = () => {
+    for (const entry of sessionsById.values()) {
+      if (BUSY_CHAT_STATES.has(entry.chatState)) {
+        return true;
+      }
+    }
+    return false;
   };
 
   const subscribe: AcpChatSessionStoreInternal['subscribe'] = (sessionId, listener) => {
@@ -470,6 +491,7 @@ function createAcpChatSessionStoreInternal(): AcpChatSessionStoreInternal {
 
   return {
     getSnapshot,
+    hasAnyBusySession,
     subscribe,
     deleteSnapshot,
     setSessionMetadata,
@@ -539,6 +561,7 @@ export function useAcpChatSessionSnapshot(sessionId: string): AcpChatSessionSnap
 function storeFromInternal(store: AcpChatSessionStoreInternal): AcpChatSessionStore {
   return {
     getSnapshot: store.getSnapshot,
+    hasAnyBusySession: store.hasAnyBusySession,
   };
 }
 

--- a/ui/desktop/src/components/CloseConfirmationModal.tsx
+++ b/ui/desktop/src/components/CloseConfirmationModal.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './ui/dialog';
+import { Button } from './ui/button';
+import { Switch } from './ui/switch';
+import { defineMessages, useIntl } from '../i18n';
+import { acpChatSessionStore } from '../acp/chatSessionStore';
+import { decideInitialStep, resolveCloseOutcome } from '../utils/closeDecision';
+import type { CloseAction } from '../utils/settings';
+
+const i18n = defineMessages({
+  title: { id: 'closeDialog.title', defaultMessage: 'Close Goose' },
+  prompt: { id: 'closeDialog.prompt', defaultMessage: 'Do you want to:' },
+  tray: { id: 'closeDialog.tray', defaultMessage: 'Close to system tray' },
+  quit: { id: 'closeDialog.quit', defaultMessage: 'Close immediately' },
+  cancel: { id: 'closeDialog.cancel', defaultMessage: 'Cancel' },
+  remember: { id: 'closeDialog.remember', defaultMessage: 'Remember my selection' },
+  busyTitle: { id: 'closeDialog.busy.title', defaultMessage: 'Sessions still running' },
+  busyMessage: {
+    id: 'closeDialog.busy.message',
+    defaultMessage:
+      'A session is still running. If you close now, its in-progress response will be lost. Do you want to close now?',
+  },
+  busyConfirm: { id: 'closeDialog.busy.confirm', defaultMessage: 'Yes, close now' },
+  busyWait: { id: 'closeDialog.busy.wait', defaultMessage: "No, I'll wait" },
+});
+
+type Step = 'closed' | 'choice' | 'busy';
+
+/**
+ * Renderer side of the window-close flow. The main process intercepts the window close and asks
+ * via the 'request-window-close' IPC; this component decides what to do — minimize to tray, quit,
+ * or (when a session is busy) confirm first — and reports the verdict back with `resolveWindowClose`.
+ * Mount once per window, inside the IntlProvider.
+ */
+export default function CloseConfirmationModal() {
+  const intl = useIntl();
+  const [step, setStep] = useState<Step>('closed');
+  const [remember, setRemember] = useState(false);
+  const isBusyRef = useRef(false);
+  // Guards against double-resolving: closing the Dialog (button click or Esc) both fire, and
+  // a stale Esc must not send a second verdict after a button already settled the decision.
+  const settledRef = useRef(false);
+
+  const resolve = (action: 'tray' | 'quit' | 'abort') => {
+    if (settledRef.current) {
+      return;
+    }
+    settledRef.current = true;
+    setStep('closed');
+    setRemember(false);
+    window.electron.resolveWindowClose(action);
+  };
+
+  const handleChoice = (action: 'tray' | 'quit') => {
+    if (remember) {
+      void window.electron.setSetting('closeAction', action);
+    }
+    const outcome = resolveCloseOutcome(action, isBusyRef.current);
+    if (outcome === 'confirm-busy') {
+      setStep('busy');
+      return;
+    }
+    resolve(outcome === 'hide-to-tray' ? 'tray' : 'quit');
+  };
+
+  useEffect(() => {
+    const handleRequest = async () => {
+      // Tell main a live modal is handling this close, so it cancels its no-answer force-close
+      // fallback and waits for the user's decision however long it takes.
+      window.electron.ackWindowClose();
+      settledRef.current = false;
+      setRemember(false);
+      isBusyRef.current = acpChatSessionStore.hasAnyBusySession();
+
+      let closeAction: CloseAction = 'ask';
+      try {
+        closeAction = (await window.electron.getSetting('closeAction')) ?? 'ask';
+      } catch {
+        closeAction = 'ask';
+      }
+
+      switch (decideInitialStep(closeAction, isBusyRef.current)) {
+        case 'show-choice':
+          setStep('choice');
+          break;
+        case 'confirm-busy':
+          setStep('busy');
+          break;
+        case 'hide-to-tray':
+          resolve('tray');
+          break;
+        case 'quit':
+          resolve('quit');
+          break;
+      }
+    };
+
+    window.electron.on('request-window-close', handleRequest);
+    return () => window.electron.off('request-window-close', handleRequest);
+  }, []);
+
+  return (
+    <Dialog open={step !== 'closed'} onOpenChange={(open) => !open && resolve('abort')}>
+      <DialogContent className="sm:max-w-[440px]">
+        {step === 'busy' ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>{intl.formatMessage(i18n.busyTitle)}</DialogTitle>
+              <DialogDescription>{intl.formatMessage(i18n.busyMessage)}</DialogDescription>
+            </DialogHeader>
+            <DialogFooter className="pt-2">
+              <Button variant="outline" onClick={() => resolve('abort')}>
+                {intl.formatMessage(i18n.busyWait)}
+              </Button>
+              <Button variant="destructive" onClick={() => resolve('quit')}>
+                {intl.formatMessage(i18n.busyConfirm)}
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>{intl.formatMessage(i18n.title)}</DialogTitle>
+              <DialogDescription>{intl.formatMessage(i18n.prompt)}</DialogDescription>
+            </DialogHeader>
+            <label className="flex items-center gap-2 text-sm text-text-secondary cursor-pointer">
+              <Switch checked={remember} onCheckedChange={setRemember} variant="mono" />
+              <span>{intl.formatMessage(i18n.remember)}</span>
+            </label>
+            <DialogFooter className="pt-2">
+              <Button variant="ghost" onClick={() => resolve('abort')}>
+                {intl.formatMessage(i18n.cancel)}
+              </Button>
+              <Button variant="outline" onClick={() => handleChoice('quit')}>
+                {intl.formatMessage(i18n.quit)}
+              </Button>
+              <Button variant="default" onClick={() => handleChoice('tray')}>
+                {intl.formatMessage(i18n.tray)}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/desktop/src/components/settings/app/AppSettingsSection.tsx
+++ b/ui/desktop/src/components/settings/app/AppSettingsSection.tsx
@@ -20,7 +20,7 @@ import BlockLogoBlack from './icons/block-lockup_black.png';
 import BlockLogoWhite from './icons/block-lockup_white.png';
 import TelemetrySettings from './TelemetrySettings';
 import { trackSettingToggled } from '../../../utils/analytics';
-import type { LanguageSetting } from '../../../utils/settings';
+import type { LanguageSetting, CloseAction } from '../../../utils/settings';
 
 const i18n = defineMessages({
   appearanceTitle: { id: 'settings.appearance.title', defaultMessage: 'Appearance' },
@@ -71,6 +71,17 @@ const i18n = defineMessages({
     id: 'settings.language.description',
     defaultMessage: 'Choose the display language for goose',
   },
+  closeBehaviorTitle: {
+    id: 'settings.closeBehavior.title',
+    defaultMessage: 'When closing the window',
+  },
+  closeBehaviorDesc: {
+    id: 'settings.closeBehavior.description',
+    defaultMessage: 'Choose what happens when you close the Goose window',
+  },
+  closeBehaviorAsk: { id: 'settings.closeBehavior.ask', defaultMessage: 'Always ask' },
+  closeBehaviorTray: { id: 'settings.closeBehavior.tray', defaultMessage: 'Close to system tray' },
+  closeBehaviorQuit: { id: 'settings.closeBehavior.quit', defaultMessage: 'Close immediately' },
   languageSystem: { id: 'settings.language.systemDefault', defaultMessage: 'System Default' },
   languageEnglish: { id: 'settings.language.english', defaultMessage: 'English' },
   languageChineseSimplified: {
@@ -174,6 +185,12 @@ const LANGUAGE_OPTIONS: Array<{ value: LanguageSetting; message: keyof typeof i1
   { value: 'zh-TW', message: 'languageChineseTraditional' },
 ];
 
+const CLOSE_ACTION_OPTIONS: Array<{ value: CloseAction; message: keyof typeof i18n }> = [
+  { value: 'ask', message: 'closeBehaviorAsk' },
+  { value: 'tray', message: 'closeBehaviorTray' },
+  { value: 'quit', message: 'closeBehaviorQuit' },
+];
+
 interface AppSettingsSectionProps {
   scrollToSection?: string;
 }
@@ -188,6 +205,7 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
   const [showNotificationModal, setShowNotificationModal] = useState(false);
   const [showPricing, setShowPricing] = useState(true);
   const [language, setLanguage] = useState<LanguageSetting>('system');
+  const [closeAction, setCloseAction] = useState<CloseAction>('ask');
   const [isDarkMode, setIsDarkMode] = useState(false);
   const updateSectionRef = useRef<HTMLDivElement>(null);
   const shouldShowUpdates = !window.appConfig.get('GOOSE_VERSION');
@@ -215,6 +233,7 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
   useEffect(() => {
     window.electron.getSetting('showPricing').then(setShowPricing);
     window.electron.getSetting('language').then((value) => setLanguage(value ?? 'system'));
+    window.electron.getSetting('closeAction').then((value) => setCloseAction(value ?? 'ask'));
   }, []);
 
   useEffect(() => {
@@ -326,9 +345,27 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
     }
   };
 
+  const handleCloseActionChange = async (value: string) => {
+    const next = CLOSE_ACTION_OPTIONS.find((option) => option.value === value)?.value;
+    if (!next || next === closeAction) {
+      return;
+    }
+
+    const previous = closeAction;
+    setCloseAction(next);
+    try {
+      await window.electron.setSetting('closeAction', next);
+    } catch (error) {
+      console.error('Failed to update close behavior setting:', error);
+      setCloseAction(previous);
+    }
+  };
+
   const intl = useIntl();
   const selectedLanguage =
     LANGUAGE_OPTIONS.find((option) => option.value === language) ?? LANGUAGE_OPTIONS[0];
+  const selectedCloseAction =
+    CLOSE_ACTION_OPTIONS.find((option) => option.value === closeAction) ?? CLOSE_ACTION_OPTIONS[0];
 
   return (
     <div className="space-y-4 pr-4 pb-8 mt-1">
@@ -490,6 +527,32 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
             <DropdownMenuContent align="start" className="w-[260px]">
               <DropdownMenuRadioGroup value={language} onValueChange={handleLanguageChange}>
                 {LANGUAGE_OPTIONS.map((option) => (
+                  <DropdownMenuRadioItem key={option.value} value={option.value}>
+                    {intl.formatMessage(i18n[option.message])}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </CardContent>
+      </Card>
+
+      <Card className="rounded-lg">
+        <CardHeader className="pb-0">
+          <CardTitle className="mb-1">{intl.formatMessage(i18n.closeBehaviorTitle)}</CardTitle>
+          <CardDescription>{intl.formatMessage(i18n.closeBehaviorDesc)}</CardDescription>
+        </CardHeader>
+        <CardContent className="pt-4 px-4">
+          <DropdownMenu>
+            <DropdownMenuTrigger className="flex w-full max-w-[260px] items-center justify-between gap-2 rounded-md border border-border-primary bg-background-primary px-3 py-2 text-sm text-text-primary transition-colors hover:border-border-primary">
+              <span className="truncate">
+                {intl.formatMessage(i18n[selectedCloseAction.message])}
+              </span>
+              <ChevronDown className="h-4 w-4 shrink-0" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="w-[260px]">
+              <DropdownMenuRadioGroup value={closeAction} onValueChange={handleCloseActionChange}>
+                {CLOSE_ACTION_OPTIONS.map((option) => (
                   <DropdownMenuRadioItem key={option.value} value={option.value}>
                     {intl.formatMessage(i18n[option.message])}
                   </DropdownMenuRadioItem>

--- a/ui/desktop/src/i18n/messages/de.json
+++ b/ui/desktop/src/i18n/messages/de.json
@@ -41,14 +41,14 @@
   "appsView.noAppsTitle": {
     "defaultMessage": "Keine Apps verfügbar"
   },
-  "appsView.retry": {
-    "defaultMessage": "Erneut versuchen"
-  },
   "appsView.retiredChatApp": {
     "defaultMessage": "Chat app retired"
   },
   "appsView.retiredChatAppDetail": {
     "defaultMessage": "We removed this feature because MCP sampling is no longer supported."
+  },
+  "appsView.retry": {
+    "defaultMessage": "Erneut versuchen"
   },
   "appsView.title": {
     "defaultMessage": "Apps"
@@ -220,6 +220,36 @@
   },
   "chatSettings.responseStylesTitle": {
     "defaultMessage": "Antwortstile"
+  },
+  "closeDialog.busy.confirm": {
+    "defaultMessage": "Ja, jetzt schließen"
+  },
+  "closeDialog.busy.message": {
+    "defaultMessage": "Es wurden ausstehende Sitzungen erkannt. Wenn Sie jetzt schließen, gehen die Rückgaben verloren. Möchten Sie jetzt schließen?"
+  },
+  "closeDialog.busy.title": {
+    "defaultMessage": "Sitzungen laufen noch"
+  },
+  "closeDialog.busy.wait": {
+    "defaultMessage": "Nein, ich warte"
+  },
+  "closeDialog.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "closeDialog.prompt": {
+    "defaultMessage": "Möchten Sie:"
+  },
+  "closeDialog.quit": {
+    "defaultMessage": "Sofort schließen"
+  },
+  "closeDialog.remember": {
+    "defaultMessage": "Meine Auswahl merken"
+  },
+  "closeDialog.title": {
+    "defaultMessage": "Goose schließen"
+  },
+  "closeDialog.tray": {
+    "defaultMessage": "In den Systembereich schließen"
   },
   "configSettings.configReset": {
     "defaultMessage": "Konfiguration zurückgesetzt"
@@ -3814,6 +3844,21 @@
   },
   "settings.close": {
     "defaultMessage": "Schließen"
+  },
+  "settings.closeBehavior.ask": {
+    "defaultMessage": "Immer fragen"
+  },
+  "settings.closeBehavior.description": {
+    "defaultMessage": "Wählen Sie, was passiert, wenn Sie das Goose-Fenster schließen"
+  },
+  "settings.closeBehavior.quit": {
+    "defaultMessage": "Sofort schließen"
+  },
+  "settings.closeBehavior.title": {
+    "defaultMessage": "Beim Schließen des Fensters"
+  },
+  "settings.closeBehavior.tray": {
+    "defaultMessage": "In den Infobereich schließen"
   },
   "settings.costTracking.description": {
     "defaultMessage": "Modellpreise und Nutzungskosten anzeigen"

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -221,6 +221,36 @@
   "chatSettings.responseStylesTitle": {
     "defaultMessage": "Response Styles"
   },
+  "closeDialog.busy.confirm": {
+    "defaultMessage": "Yes, close now"
+  },
+  "closeDialog.busy.message": {
+    "defaultMessage": "A session is still running. If you close now, its in-progress response will be lost. Do you want to close now?"
+  },
+  "closeDialog.busy.title": {
+    "defaultMessage": "Sessions still running"
+  },
+  "closeDialog.busy.wait": {
+    "defaultMessage": "No, I'll wait"
+  },
+  "closeDialog.cancel": {
+    "defaultMessage": "Cancel"
+  },
+  "closeDialog.prompt": {
+    "defaultMessage": "Do you want to:"
+  },
+  "closeDialog.quit": {
+    "defaultMessage": "Close immediately"
+  },
+  "closeDialog.remember": {
+    "defaultMessage": "Remember my selection"
+  },
+  "closeDialog.title": {
+    "defaultMessage": "Close Goose"
+  },
+  "closeDialog.tray": {
+    "defaultMessage": "Close to system tray"
+  },
   "configSettings.configReset": {
     "defaultMessage": "Configuration Reset"
   },
@@ -3814,6 +3844,21 @@
   },
   "settings.close": {
     "defaultMessage": "Close"
+  },
+  "settings.closeBehavior.ask": {
+    "defaultMessage": "Always ask"
+  },
+  "settings.closeBehavior.description": {
+    "defaultMessage": "Choose what happens when you close the Goose window"
+  },
+  "settings.closeBehavior.quit": {
+    "defaultMessage": "Close immediately"
+  },
+  "settings.closeBehavior.title": {
+    "defaultMessage": "When closing the window"
+  },
+  "settings.closeBehavior.tray": {
+    "defaultMessage": "Close to system tray"
   },
   "settings.costTracking.description": {
     "defaultMessage": "Show model pricing and usage costs"

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -221,6 +221,36 @@
   "chatSettings.responseStylesTitle": {
     "defaultMessage": "Estilos de respuesta"
   },
+  "closeDialog.busy.confirm": {
+    "defaultMessage": "Sí, cerrar ahora"
+  },
+  "closeDialog.busy.message": {
+    "defaultMessage": "Se detectaron sesiones con devolución pendiente. Si cierras ahora, se perderá la devolución. ¿Quieres cerrar ahora?"
+  },
+  "closeDialog.busy.title": {
+    "defaultMessage": "Aún hay sesiones en ejecución"
+  },
+  "closeDialog.busy.wait": {
+    "defaultMessage": "No, esperaré"
+  },
+  "closeDialog.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "closeDialog.prompt": {
+    "defaultMessage": "¿Qué quieres hacer?"
+  },
+  "closeDialog.quit": {
+    "defaultMessage": "Cerrar inmediatamente"
+  },
+  "closeDialog.remember": {
+    "defaultMessage": "Recordar mi selección"
+  },
+  "closeDialog.title": {
+    "defaultMessage": "Cerrar Goose"
+  },
+  "closeDialog.tray": {
+    "defaultMessage": "Minimizar a la bandeja del sistema"
+  },
   "configSettings.configReset": {
     "defaultMessage": "Configuración restablecida"
   },
@@ -3814,6 +3844,21 @@
   },
   "settings.close": {
     "defaultMessage": "Cerrar"
+  },
+  "settings.closeBehavior.ask": {
+    "defaultMessage": "Preguntar siempre"
+  },
+  "settings.closeBehavior.description": {
+    "defaultMessage": "Elige qué ocurre cuando cierras la ventana de Goose"
+  },
+  "settings.closeBehavior.quit": {
+    "defaultMessage": "Cerrar inmediatamente"
+  },
+  "settings.closeBehavior.title": {
+    "defaultMessage": "Al cerrar la ventana"
+  },
+  "settings.closeBehavior.tray": {
+    "defaultMessage": "Minimizar a la bandeja del sistema"
   },
   "settings.costTracking.description": {
     "defaultMessage": "Muestra los precios del modelo y los costos de uso"

--- a/ui/desktop/src/i18n/messages/fr.json
+++ b/ui/desktop/src/i18n/messages/fr.json
@@ -41,14 +41,14 @@
   "appsView.noAppsTitle": {
     "defaultMessage": "Aucune application disponible"
   },
-  "appsView.retry": {
-    "defaultMessage": "Réessayer"
-  },
   "appsView.retiredChatApp": {
     "defaultMessage": "Chat app retired"
   },
   "appsView.retiredChatAppDetail": {
     "defaultMessage": "We removed this feature because MCP sampling is no longer supported."
+  },
+  "appsView.retry": {
+    "defaultMessage": "Réessayer"
   },
   "appsView.title": {
     "defaultMessage": "Applications"
@@ -220,6 +220,36 @@
   },
   "chatSettings.responseStylesTitle": {
     "defaultMessage": "Styles de réponse"
+  },
+  "closeDialog.busy.confirm": {
+    "defaultMessage": "Oui, fermer maintenant"
+  },
+  "closeDialog.busy.message": {
+    "defaultMessage": "Des sessions en attente de retour ont été détectées. Si vous fermez maintenant, le retour sera perdu. Voulez-vous fermer maintenant ?"
+  },
+  "closeDialog.busy.title": {
+    "defaultMessage": "Des sessions sont toujours en cours"
+  },
+  "closeDialog.busy.wait": {
+    "defaultMessage": "Non, je vais attendre"
+  },
+  "closeDialog.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "closeDialog.prompt": {
+    "defaultMessage": "Que voulez-vous faire :"
+  },
+  "closeDialog.quit": {
+    "defaultMessage": "Fermer immédiatement"
+  },
+  "closeDialog.remember": {
+    "defaultMessage": "Mémoriser mon choix"
+  },
+  "closeDialog.title": {
+    "defaultMessage": "Fermer Goose"
+  },
+  "closeDialog.tray": {
+    "defaultMessage": "Réduire dans la barre d'état système"
   },
   "configSettings.configReset": {
     "defaultMessage": "Configuration réinitialisée"
@@ -3814,6 +3844,21 @@
   },
   "settings.close": {
     "defaultMessage": "Fermer"
+  },
+  "settings.closeBehavior.ask": {
+    "defaultMessage": "Toujours demander"
+  },
+  "settings.closeBehavior.description": {
+    "defaultMessage": "Choisissez ce qui se passe lorsque vous fermez la fenêtre de Goose"
+  },
+  "settings.closeBehavior.quit": {
+    "defaultMessage": "Fermer immédiatement"
+  },
+  "settings.closeBehavior.title": {
+    "defaultMessage": "À la fermeture de la fenêtre"
+  },
+  "settings.closeBehavior.tray": {
+    "defaultMessage": "Réduire dans la zone de notification"
   },
   "settings.costTracking.description": {
     "defaultMessage": "Afficher la tarification des modèles et les coûts d'utilisation"

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -221,6 +221,36 @@
   "chatSettings.responseStylesTitle": {
     "defaultMessage": "प्रतिक्रिया शैलियाँ"
   },
+  "closeDialog.busy.confirm": {
+    "defaultMessage": "हाँ, अभी बंद करें"
+  },
+  "closeDialog.busy.message": {
+    "defaultMessage": "ऐसे सत्र मिले जिनकी वापसी लंबित है। यदि आप अभी बंद करते हैं, तो वापसी खो जाएगी। क्या आप अभी बंद करना चाहते हैं?"
+  },
+  "closeDialog.busy.title": {
+    "defaultMessage": "सत्र अभी भी चल रहे हैं"
+  },
+  "closeDialog.busy.wait": {
+    "defaultMessage": "नहीं, मैं प्रतीक्षा करूँगा"
+  },
+  "closeDialog.cancel": {
+    "defaultMessage": "रद्द करें"
+  },
+  "closeDialog.prompt": {
+    "defaultMessage": "आप क्या करना चाहते हैं:"
+  },
+  "closeDialog.quit": {
+    "defaultMessage": "तुरंत बंद करें"
+  },
+  "closeDialog.remember": {
+    "defaultMessage": "मेरा चयन याद रखें"
+  },
+  "closeDialog.title": {
+    "defaultMessage": "Goose बंद करें"
+  },
+  "closeDialog.tray": {
+    "defaultMessage": "सिस्टम ट्रे में बंद करें"
+  },
   "configSettings.configReset": {
     "defaultMessage": "कॉन्फ़िगरेशन रीसेट"
   },
@@ -3814,6 +3844,21 @@
   },
   "settings.close": {
     "defaultMessage": "बंद करें"
+  },
+  "settings.closeBehavior.ask": {
+    "defaultMessage": "हमेशा पूछें"
+  },
+  "settings.closeBehavior.description": {
+    "defaultMessage": "चुनें कि जब आप Goose विंडो बंद करें तो क्या हो"
+  },
+  "settings.closeBehavior.quit": {
+    "defaultMessage": "तुरंत बंद करें"
+  },
+  "settings.closeBehavior.title": {
+    "defaultMessage": "विंडो बंद करते समय"
+  },
+  "settings.closeBehavior.tray": {
+    "defaultMessage": "सिस्टम ट्रे में बंद करें"
   },
   "settings.costTracking.description": {
     "defaultMessage": "मॉडल मूल्य निर्धारण और उपयोग लागत दिखाएं"

--- a/ui/desktop/src/i18n/messages/id.json
+++ b/ui/desktop/src/i18n/messages/id.json
@@ -41,14 +41,14 @@
   "appsView.noAppsTitle": {
     "defaultMessage": "Tidak ada aplikasi yang tersedia"
   },
-  "appsView.retry": {
-    "defaultMessage": "Coba lagi"
-  },
   "appsView.retiredChatApp": {
     "defaultMessage": "Chat app retired"
   },
   "appsView.retiredChatAppDetail": {
     "defaultMessage": "We removed this feature because MCP sampling is no longer supported."
+  },
+  "appsView.retry": {
+    "defaultMessage": "Coba lagi"
   },
   "appsView.title": {
     "defaultMessage": "Aplikasi"
@@ -220,6 +220,36 @@
   },
   "chatSettings.responseStylesTitle": {
     "defaultMessage": "Gaya Respons"
+  },
+  "closeDialog.busy.confirm": {
+    "defaultMessage": "Ya, tutup sekarang"
+  },
+  "closeDialog.busy.message": {
+    "defaultMessage": "Terdeteksi sesi yang menunggu untuk kembali. Jika Anda menutup sekarang, proses kembali akan hilang. Apakah Anda ingin menutup sekarang?"
+  },
+  "closeDialog.busy.title": {
+    "defaultMessage": "Sesi masih berjalan"
+  },
+  "closeDialog.busy.wait": {
+    "defaultMessage": "Tidak, saya akan menunggu"
+  },
+  "closeDialog.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "closeDialog.prompt": {
+    "defaultMessage": "Apakah Anda ingin:"
+  },
+  "closeDialog.quit": {
+    "defaultMessage": "Tutup segera"
+  },
+  "closeDialog.remember": {
+    "defaultMessage": "Ingat pilihan saya"
+  },
+  "closeDialog.title": {
+    "defaultMessage": "Tutup Goose"
+  },
+  "closeDialog.tray": {
+    "defaultMessage": "Tutup ke baki sistem"
   },
   "configSettings.configReset": {
     "defaultMessage": "Konfigurasi Disetel Ulang"
@@ -3814,6 +3844,21 @@
   },
   "settings.close": {
     "defaultMessage": "Tutup"
+  },
+  "settings.closeBehavior.ask": {
+    "defaultMessage": "Selalu tanya"
+  },
+  "settings.closeBehavior.description": {
+    "defaultMessage": "Pilih apa yang terjadi saat Anda menutup jendela Goose"
+  },
+  "settings.closeBehavior.quit": {
+    "defaultMessage": "Tutup segera"
+  },
+  "settings.closeBehavior.title": {
+    "defaultMessage": "Saat menutup jendela"
+  },
+  "settings.closeBehavior.tray": {
+    "defaultMessage": "Tutup ke baki sistem"
   },
   "settings.costTracking.description": {
     "defaultMessage": "Tampilkan harga model dan biaya penggunaan"

--- a/ui/desktop/src/i18n/messages/it.json
+++ b/ui/desktop/src/i18n/messages/it.json
@@ -41,14 +41,14 @@
   "appsView.noAppsTitle": {
     "defaultMessage": "Nessuna app disponibile"
   },
-  "appsView.retry": {
-    "defaultMessage": "Riprova"
-  },
   "appsView.retiredChatApp": {
     "defaultMessage": "Chat app retired"
   },
   "appsView.retiredChatAppDetail": {
     "defaultMessage": "We removed this feature because MCP sampling is no longer supported."
+  },
+  "appsView.retry": {
+    "defaultMessage": "Riprova"
   },
   "appsView.title": {
     "defaultMessage": "App"
@@ -220,6 +220,36 @@
   },
   "chatSettings.responseStylesTitle": {
     "defaultMessage": "Stili di risposta"
+  },
+  "closeDialog.busy.confirm": {
+    "defaultMessage": "Sì, chiudi ora"
+  },
+  "closeDialog.busy.message": {
+    "defaultMessage": "Rilevate sessioni con restituzione in sospeso. Se chiudi ora, la restituzione andrà persa. Vuoi chiudere ora?"
+  },
+  "closeDialog.busy.title": {
+    "defaultMessage": "Sessioni ancora in esecuzione"
+  },
+  "closeDialog.busy.wait": {
+    "defaultMessage": "No, aspetto"
+  },
+  "closeDialog.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "closeDialog.prompt": {
+    "defaultMessage": "Cosa vuoi fare:"
+  },
+  "closeDialog.quit": {
+    "defaultMessage": "Chiudi immediatamente"
+  },
+  "closeDialog.remember": {
+    "defaultMessage": "Ricorda la mia scelta"
+  },
+  "closeDialog.title": {
+    "defaultMessage": "Chiudi Goose"
+  },
+  "closeDialog.tray": {
+    "defaultMessage": "Riduci nella barra delle applicazioni"
   },
   "configSettings.configReset": {
     "defaultMessage": "Configurazione reimpostata"
@@ -3814,6 +3844,21 @@
   },
   "settings.close": {
     "defaultMessage": "Chiudi"
+  },
+  "settings.closeBehavior.ask": {
+    "defaultMessage": "Chiedi sempre"
+  },
+  "settings.closeBehavior.description": {
+    "defaultMessage": "Scegli cosa accade quando chiudi la finestra di Goose"
+  },
+  "settings.closeBehavior.quit": {
+    "defaultMessage": "Chiudi immediatamente"
+  },
+  "settings.closeBehavior.title": {
+    "defaultMessage": "Alla chiusura della finestra"
+  },
+  "settings.closeBehavior.tray": {
+    "defaultMessage": "Riduci nell'area di notifica"
   },
   "settings.costTracking.description": {
     "defaultMessage": "Mostra i prezzi dei modelli e i costi di utilizzo"

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -221,6 +221,36 @@
   "chatSettings.responseStylesTitle": {
     "defaultMessage": "回答スタイル"
   },
+  "closeDialog.busy.confirm": {
+    "defaultMessage": "はい、今すぐ閉じる"
+  },
+  "closeDialog.busy.message": {
+    "defaultMessage": "返却待ちのセッションが検出されました。今すぐ閉じると、返却内容が失われます。今すぐ閉じますか?"
+  },
+  "closeDialog.busy.title": {
+    "defaultMessage": "セッションがまだ実行中です"
+  },
+  "closeDialog.busy.wait": {
+    "defaultMessage": "いいえ、待ちます"
+  },
+  "closeDialog.cancel": {
+    "defaultMessage": "キャンセル"
+  },
+  "closeDialog.prompt": {
+    "defaultMessage": "次の操作を選択してください:"
+  },
+  "closeDialog.quit": {
+    "defaultMessage": "すぐに閉じる"
+  },
+  "closeDialog.remember": {
+    "defaultMessage": "選択内容を記憶する"
+  },
+  "closeDialog.title": {
+    "defaultMessage": "Goose を閉じる"
+  },
+  "closeDialog.tray": {
+    "defaultMessage": "システムトレイに収納する"
+  },
   "configSettings.configReset": {
     "defaultMessage": "設定をリセットしました"
   },
@@ -3814,6 +3844,21 @@
   },
   "settings.close": {
     "defaultMessage": "閉じる"
+  },
+  "settings.closeBehavior.ask": {
+    "defaultMessage": "常に確認する"
+  },
+  "settings.closeBehavior.description": {
+    "defaultMessage": "Goose ウィンドウを閉じたときの動作を選択します"
+  },
+  "settings.closeBehavior.quit": {
+    "defaultMessage": "すぐに閉じる"
+  },
+  "settings.closeBehavior.title": {
+    "defaultMessage": "ウィンドウを閉じるとき"
+  },
+  "settings.closeBehavior.tray": {
+    "defaultMessage": "システムトレイに収納する"
   },
   "settings.costTracking.description": {
     "defaultMessage": "モデル料金と使用コストを表示します"

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -221,6 +221,36 @@
   "chatSettings.responseStylesTitle": {
     "defaultMessage": "응답 스타일"
   },
+  "closeDialog.busy.confirm": {
+    "defaultMessage": "예, 지금 닫기"
+  },
+  "closeDialog.busy.message": {
+    "defaultMessage": "반환 대기 중인 세션이 감지되었습니다. 지금 닫으면 반환이 손실됩니다. 지금 닫으시겠습니까?"
+  },
+  "closeDialog.busy.title": {
+    "defaultMessage": "세션이 아직 실행 중입니다"
+  },
+  "closeDialog.busy.wait": {
+    "defaultMessage": "아니요, 기다리겠습니다"
+  },
+  "closeDialog.cancel": {
+    "defaultMessage": "취소"
+  },
+  "closeDialog.prompt": {
+    "defaultMessage": "다음 중 무엇을 하시겠습니까:"
+  },
+  "closeDialog.quit": {
+    "defaultMessage": "즉시 닫기"
+  },
+  "closeDialog.remember": {
+    "defaultMessage": "내 선택 기억하기"
+  },
+  "closeDialog.title": {
+    "defaultMessage": "Goose 닫기"
+  },
+  "closeDialog.tray": {
+    "defaultMessage": "시스템 트레이로 닫기"
+  },
   "configSettings.configReset": {
     "defaultMessage": "구성 재설정"
   },
@@ -3814,6 +3844,21 @@
   },
   "settings.close": {
     "defaultMessage": "닫기"
+  },
+  "settings.closeBehavior.ask": {
+    "defaultMessage": "항상 묻기"
+  },
+  "settings.closeBehavior.description": {
+    "defaultMessage": "Goose 창을 닫을 때 수행할 동작을 선택하세요"
+  },
+  "settings.closeBehavior.quit": {
+    "defaultMessage": "즉시 닫기"
+  },
+  "settings.closeBehavior.title": {
+    "defaultMessage": "창을 닫을 때"
+  },
+  "settings.closeBehavior.tray": {
+    "defaultMessage": "시스템 트레이로 닫기"
   },
   "settings.costTracking.description": {
     "defaultMessage": "모델 가격 및 사용 비용을 표시합니다."

--- a/ui/desktop/src/i18n/messages/ms.json
+++ b/ui/desktop/src/i18n/messages/ms.json
@@ -41,14 +41,14 @@
   "appsView.noAppsTitle": {
     "defaultMessage": "Tiada apl tersedia"
   },
-  "appsView.retry": {
-    "defaultMessage": "Cuba semula"
-  },
   "appsView.retiredChatApp": {
     "defaultMessage": "Chat app retired"
   },
   "appsView.retiredChatAppDetail": {
     "defaultMessage": "We removed this feature because MCP sampling is no longer supported."
+  },
+  "appsView.retry": {
+    "defaultMessage": "Cuba semula"
   },
   "appsView.title": {
     "defaultMessage": "Apl"
@@ -220,6 +220,36 @@
   },
   "chatSettings.responseStylesTitle": {
     "defaultMessage": "Gaya Respons"
+  },
+  "closeDialog.busy.confirm": {
+    "defaultMessage": "Ya, tutup sekarang"
+  },
+  "closeDialog.busy.message": {
+    "defaultMessage": "Sesi yang menunggu pemulangan dikesan. Jika anda tutup sekarang, pemulangan akan hilang. Adakah anda mahu menutup sekarang?"
+  },
+  "closeDialog.busy.title": {
+    "defaultMessage": "Sesi masih berjalan"
+  },
+  "closeDialog.busy.wait": {
+    "defaultMessage": "Tidak, saya akan tunggu"
+  },
+  "closeDialog.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "closeDialog.prompt": {
+    "defaultMessage": "Adakah anda mahu:"
+  },
+  "closeDialog.quit": {
+    "defaultMessage": "Tutup serta-merta"
+  },
+  "closeDialog.remember": {
+    "defaultMessage": "Ingat pilihan saya"
+  },
+  "closeDialog.title": {
+    "defaultMessage": "Tutup Goose"
+  },
+  "closeDialog.tray": {
+    "defaultMessage": "Tutup ke dulang sistem"
   },
   "configSettings.configReset": {
     "defaultMessage": "Konfigurasi Ditetapkan Semula"
@@ -3814,6 +3844,21 @@
   },
   "settings.close": {
     "defaultMessage": "Tutup"
+  },
+  "settings.closeBehavior.ask": {
+    "defaultMessage": "Sentiasa tanya"
+  },
+  "settings.closeBehavior.description": {
+    "defaultMessage": "Pilih apa yang berlaku apabila anda menutup tetingkap Goose"
+  },
+  "settings.closeBehavior.quit": {
+    "defaultMessage": "Tutup serta-merta"
+  },
+  "settings.closeBehavior.title": {
+    "defaultMessage": "Apabila menutup tetingkap"
+  },
+  "settings.closeBehavior.tray": {
+    "defaultMessage": "Tutup ke dulang sistem"
   },
   "settings.costTracking.description": {
     "defaultMessage": "Tunjukkan harga model dan kos penggunaan"

--- a/ui/desktop/src/i18n/messages/pt.json
+++ b/ui/desktop/src/i18n/messages/pt.json
@@ -41,14 +41,14 @@
   "appsView.noAppsTitle": {
     "defaultMessage": "Nenhuma aplicação disponível"
   },
-  "appsView.retry": {
-    "defaultMessage": "Tentar novamente"
-  },
   "appsView.retiredChatApp": {
     "defaultMessage": "Chat app retired"
   },
   "appsView.retiredChatAppDetail": {
     "defaultMessage": "We removed this feature because MCP sampling is no longer supported."
+  },
+  "appsView.retry": {
+    "defaultMessage": "Tentar novamente"
   },
   "appsView.title": {
     "defaultMessage": "Aplicações"
@@ -220,6 +220,36 @@
   },
   "chatSettings.responseStylesTitle": {
     "defaultMessage": "Estilos de resposta"
+  },
+  "closeDialog.busy.confirm": {
+    "defaultMessage": "Sim, fechar agora"
+  },
+  "closeDialog.busy.message": {
+    "defaultMessage": "Foram detetadas sessões com retorno pendente. Se fechar agora, o retorno será perdido. Pretende fechar agora?"
+  },
+  "closeDialog.busy.title": {
+    "defaultMessage": "Sessões ainda em execução"
+  },
+  "closeDialog.busy.wait": {
+    "defaultMessage": "Não, vou aguardar"
+  },
+  "closeDialog.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "closeDialog.prompt": {
+    "defaultMessage": "Pretende:"
+  },
+  "closeDialog.quit": {
+    "defaultMessage": "Fechar imediatamente"
+  },
+  "closeDialog.remember": {
+    "defaultMessage": "Lembrar a minha seleção"
+  },
+  "closeDialog.title": {
+    "defaultMessage": "Fechar o Goose"
+  },
+  "closeDialog.tray": {
+    "defaultMessage": "Fechar para a bandeja do sistema"
   },
   "configSettings.configReset": {
     "defaultMessage": "Configuração reposta"
@@ -3814,6 +3844,21 @@
   },
   "settings.close": {
     "defaultMessage": "Fechar"
+  },
+  "settings.closeBehavior.ask": {
+    "defaultMessage": "Perguntar sempre"
+  },
+  "settings.closeBehavior.description": {
+    "defaultMessage": "Escolha o que acontece quando fecha a janela do Goose"
+  },
+  "settings.closeBehavior.quit": {
+    "defaultMessage": "Fechar imediatamente"
+  },
+  "settings.closeBehavior.title": {
+    "defaultMessage": "Ao fechar a janela"
+  },
+  "settings.closeBehavior.tray": {
+    "defaultMessage": "Fechar para a bandeja do sistema"
   },
   "settings.costTracking.description": {
     "defaultMessage": "Mostrar os preços do modelo e os custos de utilização"

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -221,6 +221,36 @@
   "chatSettings.responseStylesTitle": {
     "defaultMessage": "Стили ответов"
   },
+  "closeDialog.busy.confirm": {
+    "defaultMessage": "Да, закрыть сейчас"
+  },
+  "closeDialog.busy.message": {
+    "defaultMessage": "Обнаружены сеансы, ожидающие возврата. Если закрыть сейчас, возврат будет потерян. Закрыть сейчас?"
+  },
+  "closeDialog.busy.title": {
+    "defaultMessage": "Сеансы всё ещё выполняются"
+  },
+  "closeDialog.busy.wait": {
+    "defaultMessage": "Нет, я подожду"
+  },
+  "closeDialog.cancel": {
+    "defaultMessage": "Отмена"
+  },
+  "closeDialog.prompt": {
+    "defaultMessage": "Выберите действие:"
+  },
+  "closeDialog.quit": {
+    "defaultMessage": "Закрыть немедленно"
+  },
+  "closeDialog.remember": {
+    "defaultMessage": "Запомнить мой выбор"
+  },
+  "closeDialog.title": {
+    "defaultMessage": "Закрыть Goose"
+  },
+  "closeDialog.tray": {
+    "defaultMessage": "Свернуть в системный трей"
+  },
   "configSettings.configReset": {
     "defaultMessage": "Конфигурация сброшена"
   },
@@ -3814,6 +3844,21 @@
   },
   "settings.close": {
     "defaultMessage": "Закрыть"
+  },
+  "settings.closeBehavior.ask": {
+    "defaultMessage": "Всегда спрашивать"
+  },
+  "settings.closeBehavior.description": {
+    "defaultMessage": "Выберите, что происходит при закрытии окна Goose"
+  },
+  "settings.closeBehavior.quit": {
+    "defaultMessage": "Закрыть немедленно"
+  },
+  "settings.closeBehavior.title": {
+    "defaultMessage": "При закрытии окна"
+  },
+  "settings.closeBehavior.tray": {
+    "defaultMessage": "Свернуть в системный трей"
   },
   "settings.costTracking.description": {
     "defaultMessage": "Показывать цены моделей и стоимость использования"

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -221,6 +221,36 @@
   "chatSettings.responseStylesTitle": {
     "defaultMessage": "Yanıt Stilleri"
   },
+  "closeDialog.busy.confirm": {
+    "defaultMessage": "Evet, şimdi kapat"
+  },
+  "closeDialog.busy.message": {
+    "defaultMessage": "Dönüşü bekleyen oturum(lar) algılandı. Şimdi kapatırsanız dönüş kaybolur. Şimdi kapatmak istiyor musunuz?"
+  },
+  "closeDialog.busy.title": {
+    "defaultMessage": "Oturumlar hâlâ çalışıyor"
+  },
+  "closeDialog.busy.wait": {
+    "defaultMessage": "Hayır, bekleyeceğim"
+  },
+  "closeDialog.cancel": {
+    "defaultMessage": "İptal"
+  },
+  "closeDialog.prompt": {
+    "defaultMessage": "Ne yapmak istiyorsunuz:"
+  },
+  "closeDialog.quit": {
+    "defaultMessage": "Hemen kapat"
+  },
+  "closeDialog.remember": {
+    "defaultMessage": "Seçimimi hatırla"
+  },
+  "closeDialog.title": {
+    "defaultMessage": "Goose'u kapat"
+  },
+  "closeDialog.tray": {
+    "defaultMessage": "Sistem tepsisine küçült"
+  },
   "configSettings.configReset": {
     "defaultMessage": "Yapılandırma Sıfırlama"
   },
@@ -3814,6 +3844,21 @@
   },
   "settings.close": {
     "defaultMessage": "Kapat"
+  },
+  "settings.closeBehavior.ask": {
+    "defaultMessage": "Her zaman sor"
+  },
+  "settings.closeBehavior.description": {
+    "defaultMessage": "Goose penceresini kapattığınızda ne olacağını seçin"
+  },
+  "settings.closeBehavior.quit": {
+    "defaultMessage": "Hemen kapat"
+  },
+  "settings.closeBehavior.title": {
+    "defaultMessage": "Pencere kapatılırken"
+  },
+  "settings.closeBehavior.tray": {
+    "defaultMessage": "Sistem tepsisine küçült"
   },
   "settings.costTracking.description": {
     "defaultMessage": "Model fiyatlandırmasını ve kullanım maliyetlerini göster"

--- a/ui/desktop/src/i18n/messages/vi.json
+++ b/ui/desktop/src/i18n/messages/vi.json
@@ -41,14 +41,14 @@
   "appsView.noAppsTitle": {
     "defaultMessage": "Không có ứng dụng nào"
   },
-  "appsView.retry": {
-    "defaultMessage": "Thử lại"
-  },
   "appsView.retiredChatApp": {
     "defaultMessage": "Chat app retired"
   },
   "appsView.retiredChatAppDetail": {
     "defaultMessage": "We removed this feature because MCP sampling is no longer supported."
+  },
+  "appsView.retry": {
+    "defaultMessage": "Thử lại"
   },
   "appsView.title": {
     "defaultMessage": "Ứng dụng"
@@ -220,6 +220,36 @@
   },
   "chatSettings.responseStylesTitle": {
     "defaultMessage": "Phong cách phản hồi"
+  },
+  "closeDialog.busy.confirm": {
+    "defaultMessage": "Có, đóng ngay"
+  },
+  "closeDialog.busy.message": {
+    "defaultMessage": "Đã phát hiện (các) phiên đang chờ trả kết quả. Nếu bạn đóng ngay, kết quả trả về sẽ bị mất. Bạn có muốn đóng ngay không?"
+  },
+  "closeDialog.busy.title": {
+    "defaultMessage": "Các phiên vẫn đang chạy"
+  },
+  "closeDialog.busy.wait": {
+    "defaultMessage": "Không, tôi sẽ chờ"
+  },
+  "closeDialog.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "closeDialog.prompt": {
+    "defaultMessage": "Bạn muốn:"
+  },
+  "closeDialog.quit": {
+    "defaultMessage": "Đóng ngay lập tức"
+  },
+  "closeDialog.remember": {
+    "defaultMessage": "Ghi nhớ lựa chọn của tôi"
+  },
+  "closeDialog.title": {
+    "defaultMessage": "Đóng Goose"
+  },
+  "closeDialog.tray": {
+    "defaultMessage": "Thu nhỏ xuống khay hệ thống"
   },
   "configSettings.configReset": {
     "defaultMessage": "Đặt lại cấu hình"
@@ -3814,6 +3844,21 @@
   },
   "settings.close": {
     "defaultMessage": "Đóng"
+  },
+  "settings.closeBehavior.ask": {
+    "defaultMessage": "Luôn hỏi"
+  },
+  "settings.closeBehavior.description": {
+    "defaultMessage": "Chọn điều xảy ra khi bạn đóng cửa sổ Goose"
+  },
+  "settings.closeBehavior.quit": {
+    "defaultMessage": "Đóng ngay lập tức"
+  },
+  "settings.closeBehavior.title": {
+    "defaultMessage": "Khi đóng cửa sổ"
+  },
+  "settings.closeBehavior.tray": {
+    "defaultMessage": "Thu nhỏ xuống khay hệ thống"
   },
   "settings.costTracking.description": {
     "defaultMessage": "Hiển thị giá mô hình và chi phí sử dụng"

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -221,6 +221,36 @@
   "chatSettings.responseStylesTitle": {
     "defaultMessage": "回复风格"
   },
+  "closeDialog.busy.confirm": {
+    "defaultMessage": "是的，立即关闭"
+  },
+  "closeDialog.busy.message": {
+    "defaultMessage": "检测到有会话尚未返回。如果现在关闭，返回结果将会丢失。是否要立即关闭？"
+  },
+  "closeDialog.busy.title": {
+    "defaultMessage": "会话仍在运行"
+  },
+  "closeDialog.busy.wait": {
+    "defaultMessage": "不，我再等等"
+  },
+  "closeDialog.cancel": {
+    "defaultMessage": "取消"
+  },
+  "closeDialog.prompt": {
+    "defaultMessage": "你想要："
+  },
+  "closeDialog.quit": {
+    "defaultMessage": "立即关闭"
+  },
+  "closeDialog.remember": {
+    "defaultMessage": "记住我的选择"
+  },
+  "closeDialog.title": {
+    "defaultMessage": "关闭 Goose"
+  },
+  "closeDialog.tray": {
+    "defaultMessage": "关闭到系统托盘"
+  },
   "configSettings.configReset": {
     "defaultMessage": "配置已重置"
   },
@@ -3814,6 +3844,21 @@
   },
   "settings.close": {
     "defaultMessage": "关闭"
+  },
+  "settings.closeBehavior.ask": {
+    "defaultMessage": "每次询问"
+  },
+  "settings.closeBehavior.description": {
+    "defaultMessage": "选择关闭 Goose 窗口时执行的操作"
+  },
+  "settings.closeBehavior.quit": {
+    "defaultMessage": "立即关闭"
+  },
+  "settings.closeBehavior.title": {
+    "defaultMessage": "关闭窗口时"
+  },
+  "settings.closeBehavior.tray": {
+    "defaultMessage": "关闭到系统托盘"
   },
   "settings.costTracking.description": {
     "defaultMessage": "显示模型定价和使用费用"

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -41,14 +41,14 @@
   "appsView.noAppsTitle": {
     "defaultMessage": "沒有可用的應用程式"
   },
-  "appsView.retry": {
-    "defaultMessage": "重試"
-  },
   "appsView.retiredChatApp": {
     "defaultMessage": "Chat app retired"
   },
   "appsView.retiredChatAppDetail": {
     "defaultMessage": "We removed this feature because MCP sampling is no longer supported."
+  },
+  "appsView.retry": {
+    "defaultMessage": "重試"
   },
   "appsView.title": {
     "defaultMessage": "應用程式"
@@ -220,6 +220,36 @@
   },
   "chatSettings.responseStylesTitle": {
     "defaultMessage": "回應樣式"
+  },
+  "closeDialog.busy.confirm": {
+    "defaultMessage": "是，立即關閉"
+  },
+  "closeDialog.busy.message": {
+    "defaultMessage": "偵測到尚待返回的工作階段。如果您現在關閉，返回的內容將會遺失。您要立即關閉嗎？"
+  },
+  "closeDialog.busy.title": {
+    "defaultMessage": "工作階段仍在執行中"
+  },
+  "closeDialog.busy.wait": {
+    "defaultMessage": "否，我要等待"
+  },
+  "closeDialog.cancel": {
+    "defaultMessage": "取消"
+  },
+  "closeDialog.prompt": {
+    "defaultMessage": "您想要："
+  },
+  "closeDialog.quit": {
+    "defaultMessage": "立即關閉"
+  },
+  "closeDialog.remember": {
+    "defaultMessage": "記住我的選擇"
+  },
+  "closeDialog.title": {
+    "defaultMessage": "關閉 Goose"
+  },
+  "closeDialog.tray": {
+    "defaultMessage": "關閉至系統匣"
   },
   "configSettings.configReset": {
     "defaultMessage": "設定已重設"
@@ -3814,6 +3844,21 @@
   },
   "settings.close": {
     "defaultMessage": "關閉"
+  },
+  "settings.closeBehavior.ask": {
+    "defaultMessage": "每次都詢問"
+  },
+  "settings.closeBehavior.description": {
+    "defaultMessage": "選擇關閉 Goose 視窗時的行為"
+  },
+  "settings.closeBehavior.quit": {
+    "defaultMessage": "立即關閉"
+  },
+  "settings.closeBehavior.title": {
+    "defaultMessage": "關閉視窗時"
+  },
+  "settings.closeBehavior.tray": {
+    "defaultMessage": "縮小至系統匣"
   },
   "settings.costTracking.description": {
     "defaultMessage": "顯示模型定價與使用費用"

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -964,6 +964,16 @@ let appConfig = {
 };
 
 const windowMap = new Map<number, BrowserWindow>();
+
+// Window-close (X) handling. The close is intercepted so the renderer can offer "close to tray"
+// or warn about an in-flight session. `isQuitting` is set on a real quit (before-quit / restart)
+// so those paths bypass the interceptor. A window is only intercepted once its renderer is ready
+// (see `reactReadyWindows`); `windowsAwaitingCloseDecision` de-dupes pending asks and
+// `windowCloseTimeouts` force-closes if the renderer never answers.
+let isQuitting = false;
+const windowsAwaitingCloseDecision = new Set<number>();
+const windowCloseTimeouts = new Map<number, ReturnType<typeof setTimeout>>();
+
 const appWindows = new Map<string, BrowserWindow>();
 
 const gooseServeLeases = new GooseServeLeaseRegistry(log);
@@ -1476,9 +1486,50 @@ const createChat = async (
 
   windowMap.set(windowId, mainWindow);
 
+  // Intercept the close (X) so the renderer can offer "close to tray" / warn about an in-flight
+  // session. A real quit (Cmd+Q, tray Quit, restart) sets isQuitting and is let through. If the
+  // renderer isn't ready, is reloading, or is gone, the window closes normally so it can't get stuck.
+  mainWindow.on('close', (event) => {
+    if (isQuitting || mainWindow.isDestroyed()) {
+      return;
+    }
+    // Only intercept when a live renderer can actually answer. isLoadingMainFrame() covers a
+    // reload in progress; the destroyed/crashed checks cover a dead renderer.
+    if (!reactReadyWindows.has(windowId) || mainWindow.webContents.isLoadingMainFrame()) {
+      return;
+    }
+    if (mainWindow.webContents.isDestroyed() || mainWindow.webContents.isCrashed()) {
+      return;
+    }
+    event.preventDefault();
+    if (windowsAwaitingCloseDecision.has(windowId)) {
+      return;
+    }
+    windowsAwaitingCloseDecision.add(windowId);
+    mainWindow.webContents.send('request-window-close');
+    // Safety net for a renderer that can't answer (fatal-error UI without the modal, a hang, or an
+    // unmounted listener). A live modal acks receipt ('window-close-ack'), which cancels this timer,
+    // so it NEVER fires while the user is deciding — only when nothing handled the request, in which
+    // case we force the close so the window can't get stuck.
+    const closeTimeout = setTimeout(() => {
+      windowsAwaitingCloseDecision.delete(windowId);
+      windowCloseTimeouts.delete(windowId);
+      if (!mainWindow.isDestroyed()) {
+        mainWindow.destroy();
+      }
+    }, 3000);
+    windowCloseTimeouts.set(windowId, closeTimeout);
+  });
+
   // Handle window closure
   mainWindow.on('closed', () => {
     windowMap.delete(windowId);
+    windowsAwaitingCloseDecision.delete(windowId);
+    const pendingCloseTimeout = windowCloseTimeouts.get(windowId);
+    if (pendingCloseTimeout) {
+      clearTimeout(pendingCloseTimeout);
+      windowCloseTimeouts.delete(windowId);
+    }
 
     pendingInitialMessages.delete(windowId);
     pendingDeepLinks.delete(windowId);
@@ -1655,6 +1706,10 @@ const showWindow = async () => {
       height: currentBounds.height,
     });
 
+    if (process.platform === 'win32') {
+      // Undo the skipTaskbar we set when hiding to tray, so the taskbar button returns.
+      win.setSkipTaskbar(false);
+    }
     if (!win.isVisible()) {
       win.show();
     }
@@ -1918,6 +1973,7 @@ const validSettingKeys: Set<string> = new Set([
   'enableWakelock',
   'enableNotifications',
   'spellcheckEnabled',
+  'closeAction',
   'externalGoosed',
   'globalShortcut',
   'keyboardShortcuts',
@@ -1939,6 +1995,11 @@ ipcMain.handle('set-setting', (_event, key: SettingKey, value: unknown) => {
 
   if (key === 'language' && !isValidLanguageSetting(value)) {
     console.error(`Invalid language setting rejected: ${String(value)}`);
+    return;
+  }
+
+  if (key === 'closeAction' && value !== 'ask' && value !== 'tray' && value !== 'quit') {
+    console.error(`Invalid closeAction setting rejected: ${String(value)}`);
     return;
   }
 
@@ -2819,6 +2880,64 @@ async function appMain() {
     }
   });
 
+  // A live CloseConfirmationModal acks that it received 'request-window-close'. Cancel the force-close
+  // safety timer so the user has as long as they need to decide (the verdict arrives separately).
+  ipcMain.on('window-close-ack', (_event) => {
+    const window = BrowserWindow.fromWebContents(_event.sender);
+    if (!window) {
+      return;
+    }
+    const pendingCloseTimeout = windowCloseTimeouts.get(window.id);
+    if (pendingCloseTimeout) {
+      clearTimeout(pendingCloseTimeout);
+      windowCloseTimeouts.delete(window.id);
+    }
+  });
+
+  // The renderer's verdict for an intercepted close (see the 'close' handler in createChat).
+  ipcMain.on('resolve-window-close', (_event, action: 'tray' | 'quit' | 'abort') => {
+    const window = BrowserWindow.fromWebContents(_event.sender);
+    if (!window) {
+      return;
+    }
+    windowsAwaitingCloseDecision.delete(window.id);
+    const pendingCloseTimeout = windowCloseTimeouts.get(window.id);
+    if (pendingCloseTimeout) {
+      clearTimeout(pendingCloseTimeout);
+      windowCloseTimeouts.delete(window.id);
+    }
+    if (window.isDestroyed()) {
+      return;
+    }
+
+    if (action === 'tray') {
+      // Keep goosed alive: hide/minimize rather than close, so the in-flight turn keeps running.
+      // On Linux the system tray is unreliable and has no click-to-restore, so always minimize
+      // (the window stays reachable from the taskbar).
+      if (process.platform !== 'linux' && !tray) {
+        createTray();
+      }
+      if (process.platform === 'linux' || !tray) {
+        // No reliable tray to restore from — minimize so the window can't be lost.
+        window.minimize();
+        return;
+      }
+      if (process.platform === 'win32') {
+        // Otherwise a hidden window still leaves a taskbar button — not really "closed to tray".
+        window.setSkipTaskbar(true);
+      }
+      window.hide();
+      return;
+    }
+
+    if (action === 'quit') {
+      // destroy() (not close()) so we don't re-enter the 'close' interceptor; 'closed' still
+      // fires and releases this window's goosed lease.
+      window.destroy();
+    }
+    // 'abort' → do nothing; the window stays open.
+  });
+
   ipcMain.on('notify', (event, data) => {
     try {
       // Validate notification data
@@ -2938,6 +3057,8 @@ async function appMain() {
 
   // Handle app restart
   ipcMain.on('restart-app', () => {
+    // app.exit() skips 'before-quit', so set the flag here to bypass the close interceptor.
+    isQuitting = true;
     app.relaunch();
     app.exit(0);
   });
@@ -3106,6 +3227,12 @@ async function getAllowList(): Promise<string[]> {
     return [];
   }
 }
+
+// A real quit (app.quit(), Cmd+Q, tray "Quit", auto-update install) must bypass the per-window
+// close interceptor so windows don't trap the quit.
+app.on('before-quit', () => {
+  isQuitting = true;
+});
 
 app.on('will-quit', async () => {
   const gooseServeLeaseCount = gooseServeLeases.activeLeaseCount();

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -150,6 +150,8 @@ type ElectronAPI = {
     callback: (event: Electron.IpcRendererEvent, ...args: unknown[]) => void
   ) => void;
   emit: (channel: string, ...args: unknown[]) => void;
+  resolveWindowClose: (action: 'tray' | 'quit' | 'abort') => void;
+  ackWindowClose: () => void;
   broadcastThemeChange: (themeData: {
     mode: string;
     useSystemTheme: boolean;
@@ -284,6 +286,12 @@ const electronAPI: ElectronAPI = {
   },
   emit: (channel: string, ...args: unknown[]) => {
     ipcRenderer.emit(channel, ...args);
+  },
+  resolveWindowClose: (action: 'tray' | 'quit' | 'abort') => {
+    ipcRenderer.send('resolve-window-close', action);
+  },
+  ackWindowClose: () => {
+    ipcRenderer.send('window-close-ack');
   },
   broadcastThemeChange: (themeData: {
     mode: string;

--- a/ui/desktop/src/utils/__tests__/closeDecision.test.ts
+++ b/ui/desktop/src/utils/__tests__/closeDecision.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { decideInitialStep, resolveCloseOutcome } from '../closeDecision';
+
+describe('decideInitialStep', () => {
+  it('asks the user when the remembered action is "ask"', () => {
+    expect(decideInitialStep('ask', false)).toBe('show-choice');
+    expect(decideInitialStep('ask', true)).toBe('show-choice');
+  });
+
+  it('hides to tray for a remembered "tray" action regardless of busy state', () => {
+    expect(decideInitialStep('tray', false)).toBe('hide-to-tray');
+    expect(decideInitialStep('tray', true)).toBe('hide-to-tray');
+  });
+
+  it('quits immediately for a remembered "quit" action when idle', () => {
+    expect(decideInitialStep('quit', false)).toBe('quit');
+  });
+
+  it('still confirms when a remembered "quit" action would discard an in-flight turn', () => {
+    // Regression guard: a remembered quit must never silently kill a busy session.
+    expect(decideInitialStep('quit', true)).toBe('confirm-busy');
+  });
+});
+
+describe('resolveCloseOutcome', () => {
+  it('maps tray to hide-to-tray (busy is irrelevant)', () => {
+    expect(resolveCloseOutcome('tray', false)).toBe('hide-to-tray');
+    expect(resolveCloseOutcome('tray', true)).toBe('hide-to-tray');
+  });
+
+  it('quits directly when not busy', () => {
+    expect(resolveCloseOutcome('quit', false)).toBe('quit');
+  });
+
+  it('routes to a busy confirmation when busy', () => {
+    expect(resolveCloseOutcome('quit', true)).toBe('confirm-busy');
+  });
+});

--- a/ui/desktop/src/utils/closeDecision.ts
+++ b/ui/desktop/src/utils/closeDecision.ts
@@ -1,0 +1,35 @@
+import type { CloseAction } from './settings';
+
+/**
+ * The next step the renderer should take when the main window is asked to close.
+ *
+ * - `show-choice`   — ask the user (tray vs quit) before doing anything.
+ * - `confirm-busy`  — about to quit while a session is busy; confirm first.
+ * - `hide-to-tray`  — resolved: minimize the window to the system tray.
+ * - `quit`          — resolved: close the window.
+ * - `abort`         — do nothing; keep the window open.
+ */
+export type CloseOutcome = 'show-choice' | 'confirm-busy' | 'hide-to-tray' | 'quit' | 'abort';
+
+/**
+ * Resolve a concrete close action (chosen explicitly or remembered) against the current
+ * busy state. Quitting while busy always routes through a confirmation so an in-flight
+ * turn is never discarded silently — independent of whether the user was asked.
+ */
+export function resolveCloseOutcome(action: 'tray' | 'quit', isBusy: boolean): CloseOutcome {
+  if (action === 'tray') {
+    return 'hide-to-tray';
+  }
+  return isBusy ? 'confirm-busy' : 'quit';
+}
+
+/**
+ * Decide the first step from the remembered `closeAction` setting. `ask` shows the choice
+ * modal; a remembered `tray`/`quit` skips it but still honors the busy confirmation.
+ */
+export function decideInitialStep(closeAction: CloseAction, isBusy: boolean): CloseOutcome {
+  if (closeAction === 'ask') {
+    return 'show-choice';
+  }
+  return resolveCloseOutcome(closeAction, isBusy);
+}

--- a/ui/desktop/src/utils/settings.ts
+++ b/ui/desktop/src/utils/settings.ts
@@ -28,6 +28,9 @@ export type LanguageSetting =
   | 'system' | 'en' | 'es' | 'fr' | 'de' | 'it' | 'pt' | 'id' | 'ms' | 'vi'
   | 'hi' | 'ja' | 'ko' | 'ru' | 'tr' | 'zh-CN' | 'zh-TW';
 
+/** What happens when the user closes the main window (clicks the X). */
+export type CloseAction = 'ask' | 'tray' | 'quit';
+
 export interface Settings {
   // Desktop app settings
   showMenuBarIcon: boolean;
@@ -36,6 +39,7 @@ export interface Settings {
   enableWakelock: boolean;
   enableNotifications: boolean;
   spellcheckEnabled: boolean;
+  closeAction: CloseAction;
   externalGoosed: ExternalGoosedConfig;
   globalShortcut?: string | null;
   keyboardShortcuts: KeyboardShortcuts;
@@ -73,6 +77,7 @@ export const defaultSettings: Settings = {
   enableWakelock: false,
   enableNotifications: true,
   spellcheckEnabled: true,
+  closeAction: 'ask',
   keyboardShortcuts: defaultKeyboardShortcuts,
   externalGoosed: {
     enabled: false,


### PR DESCRIPTION
## What

Intercepts the desktop window close (X) and lets the user choose what happens, instead of force-killing the backend mid-session.

Addresses #9391 (close to system tray). Also relevant to #10063 (`goosed` lingering after the last window closes).

## Behaviour

Clicking the window **X** now opens a small dialog:

- **Close to system tray** — hides the window and keeps `goosed` running, so an in-flight turn keeps going. Restore from the tray.
- **Close immediately** — closes the window (the existing lease cleanup runs).
- **Cancel** — keep the window open.
- **Remember my selection** — persists the choice (a `closeAction` setting); change or reset it under **Settings → App → "When closing the window"**.

If a session is still working when you choose **Close immediately** (or have a remembered "quit"), a confirmation warns first, so an in-progress response is never discarded silently.

Real quits — **Cmd/Ctrl+Q**, the tray **Quit**, app relaunch / auto-update install — bypass the dialog (an `isQuitting` flag set on `before-quit` / restart).

## Why

Today closing the window force-kills the backend: `taskkill /pid <pid> /f /t` on Windows (`ui/desktop/src/goosed.ts`), `SIGKILL` elsewhere, via `cleanupGoosedLease`. There is no `close` interceptor, so an accidental X aborts any running turn or tool call — only messages already persisted to the session store survive.

## How

- **main.ts**: a `mainWindow.on('close')` interceptor (engages only once the renderer has signalled `react-ready`, and never when it's destroyed/crashed); a `resolve-window-close` IPC that hides-to-tray or `destroy()`s the window per the renderer's verdict; `isQuitting` set on `before-quit` and `restart-app`; `closeAction` added to the settings allow-list + validation.
- **renderer**: `CloseConfirmationModal` (mounted once at the app root) decides tray / quit / confirm-busy from the remembered setting plus live busy state, and reports back via `resolveWindowClose` (new preload bridge). The decision logic is a pure, unit-tested module (`utils/closeDecision.ts`).
- **busy detection**: `acpChatSessionStore.hasAnyBusySession()` — true if any session is in Thinking / Streaming / WaitingForUserInput / Compacting / RestartingAgent.
- **settings**: `closeAction: 'ask' | 'tray' | 'quit'` (default `ask`) + a Settings dropdown to change it.
- **i18n**: new `closeDialog.*` / `settings.closeBehavior.*` strings, translated across all shipped locales (es, hi, ja, ko, ru, tr, zh-CN).

## Tests / checks

- New unit tests for the decision logic (`closeDecision.test.ts`).
- `typecheck`, `eslint`, `i18n:check`, and the full `vitest` suite pass locally.

## Test plan (manual)

- Idle window → X → **Close to tray** → window hides, tray icon present, `goosed` still running; restore from the tray.
- Start a long turn → X → **Close immediately** → busy warning → "No, I'll wait" keeps it; "Yes, close now" closes.
- Tick **Remember my selection** → tray; the next X hides without asking. Reset via **Settings → App**.
- **Cmd/Ctrl+Q** / tray **Quit** mid-turn → quits with no dialog.
