### PR TITLE
feat(i18n): add fr, de, it, pt, id, ms, vi, zh-TW desktop locales

### DIFF
--- a/ui/desktop/src/components/settings/app/AppSettingsSection.tsx
+++ b/ui/desktop/src/components/settings/app/AppSettingsSection.tsx
@@ -83,6 +83,17 @@ const i18n = defineMessages({
   languageJapanese: { id: 'settings.language.japanese', defaultMessage: 'Japanese' },
   languageSpanish: { id: 'settings.language.spanish', defaultMessage: 'Spanish' },
   languageKorean: { id: 'settings.language.korean', defaultMessage: 'Korean' },
+  languageFrench: { id: 'settings.language.french', defaultMessage: 'French' },
+  languageGerman: { id: 'settings.language.german', defaultMessage: 'German' },
+  languageItalian: { id: 'settings.language.italian', defaultMessage: 'Italian' },
+  languagePortuguese: { id: 'settings.language.portuguese', defaultMessage: 'Portuguese' },
+  languageIndonesian: { id: 'settings.language.indonesian', defaultMessage: 'Indonesian' },
+  languageMalay: { id: 'settings.language.malay', defaultMessage: 'Malay' },
+  languageVietnamese: { id: 'settings.language.vietnamese', defaultMessage: 'Vietnamese' },
+  languageChineseTraditional: {
+    id: 'settings.language.zhTW',
+    defaultMessage: 'Chinese (Traditional)',
+  },
   helpTitle: { id: 'settings.help.title', defaultMessage: 'Help & feedback' },
   helpDesc: {
     id: 'settings.help.description',
@@ -147,12 +158,20 @@ const LANGUAGE_OPTIONS: Array<{ value: LanguageSetting; message: keyof typeof i1
   { value: 'system', message: 'languageSystem' },
   { value: 'en', message: 'languageEnglish' },
   { value: 'es', message: 'languageSpanish' },
+  { value: 'fr', message: 'languageFrench' },
+  { value: 'de', message: 'languageGerman' },
+  { value: 'it', message: 'languageItalian' },
+  { value: 'pt', message: 'languagePortuguese' },
+  { value: 'id', message: 'languageIndonesian' },
+  { value: 'ms', message: 'languageMalay' },
+  { value: 'vi', message: 'languageVietnamese' },
   { value: 'hi', message: 'languageHindi' },
   { value: 'ja', message: 'languageJapanese' },
   { value: 'ko', message: 'languageKorean' },
   { value: 'ru', message: 'languageRussian' },
   { value: 'tr', message: 'languageTurkish' },
   { value: 'zh-CN', message: 'languageChineseSimplified' },
+  { value: 'zh-TW', message: 'languageChineseTraditional' },
 ];
 
 interface AppSettingsSectionProps {

--- a/ui/desktop/src/i18n/index.ts
+++ b/ui/desktop/src/i18n/index.ts
@@ -7,25 +7,30 @@
  *   3. "en" (fallback)
  *
  * For Chinese: any Simplified Chinese tag (zh, zh-CN, zh-Hans, zh-Hans-CN, zh-SG, zh-MY)
- * maps to the "zh-CN" catalog. Traditional variants (zh-TW, zh-HK, zh-Hant) are not yet
- * translated and fall through to English.
+ * maps to the "zh-CN" catalog; Traditional variants (zh-TW, zh-HK, zh-MO, zh-Hant) map to
+ * the "zh-TW" catalog.
  */
 
 // Re-export react-intl utilities that components use directly
 export { defineMessages, useIntl } from 'react-intl';
 
 /** The set of locales that have translation catalogs. */
-export const SUPPORTED_LOCALES = ['en', 'es', 'hi', 'ja', 'ko', 'ru', 'tr', 'zh-CN'] as const;
+// prettier-ignore
+export const SUPPORTED_LOCALES = [
+  'en', 'es', 'fr', 'de', 'it', 'pt', 'id', 'ms', 'vi', 'hi', 'ja', 'ko', 'ru', 'tr', 'zh-CN', 'zh-TW',
+] as const;
 export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
 const SUPPORTED_LOCALE_SET = new Set<string>(SUPPORTED_LOCALES);
 
 /**
- * Map Simplified Chinese aliases (zh, zh-Hans*, zh-SG, zh-MY) to "zh-CN".
- * Traditional variants (zh-Hant*, zh-TW, zh-HK, zh-MO) and non-Chinese tags pass through unchanged.
+ * Map Simplified Chinese aliases (zh, zh-Hans*, zh-SG, zh-MY) to "zh-CN" and Traditional
+ * variants (zh-Hant*, zh-TW, zh-HK, zh-MO) to "zh-TW". Non-Chinese tags pass through unchanged.
  */
 function resolveChineseAlias(tag: string): string {
   const lower = tag.toLowerCase();
-  if (/^zh-(hant|tw|hk|mo)(-|$)/.test(lower)) return tag;
+  // Traditional Chinese variants (zh-Hant*, zh-TW, zh-HK, zh-MO) → "zh-TW".
+  if (/^zh-(hant|tw|hk|mo)(-|$)/.test(lower)) return 'zh-TW';
+  // Remaining Chinese tags (zh, zh-CN, zh-Hans*, zh-SG, zh-MY) → "zh-CN".
   if (lower === 'zh' || lower.startsWith('zh-')) return 'zh-CN';
   return tag;
 }

--- a/ui/desktop/src/i18n/messages/de.json
+++ b/ui/desktop/src/i18n/messages/de.json
@@ -1,0 +1,4574 @@
+{
+  "alertBox.autoCompactAt": {
+    "defaultMessage": "Automatisch verdichten bei"
+  },
+  "alertBox.compactNow": {
+    "defaultMessage": "Jetzt verdichten"
+  },
+  "alertBox.failedToSaveThreshold": {
+    "defaultMessage": "Schwellenwert konnte nicht gespeichert werden: {error}"
+  },
+  "announcementModal.gotIt": {
+    "defaultMessage": "Verstanden!"
+  },
+  "appLayout.collapseNavigation": {
+    "defaultMessage": "Navigation einklappen"
+  },
+  "appLayout.openNavigation": {
+    "defaultMessage": "Navigation öffnen"
+  },
+  "appsView.customApp": {
+    "defaultMessage": "Benutzerdefinierte App"
+  },
+  "appsView.description": {
+    "defaultMessage": "Anwendungen von Ihren MCP-Servern und Apps, die goose selbst erstellt hat. Sie können über die Chat-Oberfläche neue Apps anfordern, die dann hier erscheinen."
+  },
+  "appsView.errorLoading": {
+    "defaultMessage": "Fehler beim Laden der Apps: {error}"
+  },
+  "appsView.importApp": {
+    "defaultMessage": "App importieren"
+  },
+  "appsView.launch": {
+    "defaultMessage": "Starten"
+  },
+  "appsView.loading": {
+    "defaultMessage": "Apps werden geladen..."
+  },
+  "appsView.noAppsDescription": {
+    "defaultMessage": "Öffnen Sie einen Chat und bitten Sie goose um die gewünschte App. goose kann eine für Sie erstellen, die dann hier erscheint. Oder wenn jemand eine App geteilt hat, können Sie sie über die Schaltfläche oben importieren."
+  },
+  "appsView.noAppsTitle": {
+    "defaultMessage": "Keine Apps verfügbar"
+  },
+  "appsView.retry": {
+    "defaultMessage": "Erneut versuchen"
+  },
+  "appsView.title": {
+    "defaultMessage": "Apps"
+  },
+  "authSettings.activeProviderWarning": {
+    "defaultMessage": "Dies ist der aktive Anbieter. Neue Anfragen können fehlschlagen, bis Sie eine andere Anmeldeinformation konfigurieren."
+  },
+  "authSettings.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "authSettings.delete": {
+    "defaultMessage": "Löschen"
+  },
+  "authSettings.deleteCredential": {
+    "defaultMessage": "Anmeldeinformation löschen"
+  },
+  "authSettings.deleteMessage": {
+    "defaultMessage": "Die Anmeldeinformation {name} für {provider} löschen?"
+  },
+  "authSettings.deleteTitle": {
+    "defaultMessage": "Anmeldeinformation löschen"
+  },
+  "authSettings.deleted": {
+    "defaultMessage": "Anmeldeinformation gelöscht"
+  },
+  "authSettings.description": {
+    "defaultMessage": "Verwalten Sie die lokal von goose gespeicherten Anbieter-Anmeldeinformationen."
+  },
+  "authSettings.empty": {
+    "defaultMessage": "Es wurden keine lokal gespeicherten Anbieter-Anmeldeinformationen gefunden."
+  },
+  "authSettings.expiresAt": {
+    "defaultMessage": "Läuft ab am {date}"
+  },
+  "authSettings.failedToConfigure": {
+    "defaultMessage": "Anmeldeinformation konnte nicht konfiguriert werden: {error}"
+  },
+  "authSettings.failedToDelete": {
+    "defaultMessage": "Anmeldeinformation konnte nicht gelöscht werden: {error}"
+  },
+  "authSettings.failedToLoad": {
+    "defaultMessage": "Anbieter-Anmeldeinformationen konnten nicht geladen werden"
+  },
+  "authSettings.loading": {
+    "defaultMessage": "Anmeldeinformationen werden geladen..."
+  },
+  "authSettings.reauthorize": {
+    "defaultMessage": "Erneut autorisieren"
+  },
+  "authSettings.signIn": {
+    "defaultMessage": "Anmelden"
+  },
+  "authSettings.signedIn": {
+    "defaultMessage": "Anmeldeinformation konfiguriert"
+  },
+  "authSettings.storageProviderCache": {
+    "defaultMessage": "Anbieter-Cache"
+  },
+  "authSettings.storageSecretStore": {
+    "defaultMessage": "Geheimnisspeicher"
+  },
+  "authSettings.title": {
+    "defaultMessage": "Anbieter-Anmeldeinformationen"
+  },
+  "backButton.back": {
+    "defaultMessage": "Zurück"
+  },
+  "baseChat.failedToLoadSession": {
+    "defaultMessage": "Sitzung konnte nicht geladen werden"
+  },
+  "baseChat.goHome": {
+    "defaultMessage": "Zur Startseite"
+  },
+  "bottomMenuExtensionSelection.extensionUpdated": {
+    "defaultMessage": "Erweiterung aktualisiert"
+  },
+  "bottomMenuExtensionSelection.extensionWillBeDisabled": {
+    "defaultMessage": "{name} wird in neuen Chats deaktiviert"
+  },
+  "bottomMenuExtensionSelection.extensionWillBeEnabled": {
+    "defaultMessage": "{name} wird in neuen Chats aktiviert"
+  },
+  "bottomMenuExtensionSelection.extensionsForNewChats": {
+    "defaultMessage": "Erweiterungen für neue Chats"
+  },
+  "bottomMenuExtensionSelection.extensionsForThisSession": {
+    "defaultMessage": "Erweiterungen für diese Chat-Sitzung"
+  },
+  "bottomMenuExtensionSelection.manageExtensions": {
+    "defaultMessage": "Erweiterungen verwalten"
+  },
+  "bottomMenuExtensionSelection.noExtensionsAvailable": {
+    "defaultMessage": "keine Erweiterungen verfügbar"
+  },
+  "bottomMenuExtensionSelection.noExtensionsFound": {
+    "defaultMessage": "keine Erweiterungen gefunden"
+  },
+  "bottomMenuExtensionSelection.searchExtensions": {
+    "defaultMessage": "Erweiterungen suchen..."
+  },
+  "cardButtons.configure": {
+    "defaultMessage": "Konfigurieren"
+  },
+  "cardButtons.launch": {
+    "defaultMessage": "Starten"
+  },
+  "chat.notification.taskComplete.body": {
+    "defaultMessage": "Klicken Sie hier, um Goose wieder in den Vordergrund zu holen."
+  },
+  "chat.notification.taskComplete.title": {
+    "defaultMessage": "Goose hat die Aufgabe abgeschlossen."
+  },
+  "chatInput.contextWindow": {
+    "defaultMessage": "Kontextfenster"
+  },
+  "chatInput.dictationError": {
+    "defaultMessage": "Diktierfehler"
+  },
+  "chatInput.failedToReadImage": {
+    "defaultMessage": "Bilddatei konnte nicht gelesen werden"
+  },
+  "chatInput.navigationShortcut": {
+    "defaultMessage": "{prefix}↑/{prefix}↓ zum Navigieren der Nachrichten"
+  },
+  "chatInput.processingDroppedFiles": {
+    "defaultMessage": "Abgelegte Dateien werden verarbeitet..."
+  },
+  "chatInput.recording": {
+    "defaultMessage": "Aufnahme läuft..."
+  },
+  "chatInput.removeFile": {
+    "defaultMessage": "Datei entfernen"
+  },
+  "chatInput.removeImage": {
+    "defaultMessage": "Bild entfernen"
+  },
+  "chatInput.restartingSession": {
+    "defaultMessage": "Sitzung wird neu gestartet..."
+  },
+  "chatInput.send": {
+    "defaultMessage": "Senden"
+  },
+  "chatInput.transcribing": {
+    "defaultMessage": "Transkription läuft..."
+  },
+  "chatInput.typeMessage": {
+    "defaultMessage": "Geben Sie eine Nachricht zum Senden ein"
+  },
+  "chatInput.unknownType": {
+    "defaultMessage": "Unbekannter Typ"
+  },
+  "chatInput.viewEditRecipe": {
+    "defaultMessage": "Rezept anzeigen/bearbeiten"
+  },
+  "chatInput.waitingForCancellation": {
+    "defaultMessage": "Warten auf Abschluss des Abbruchs"
+  },
+  "chatInput.waitingForImages": {
+    "defaultMessage": "Warten auf das Speichern der Bilder..."
+  },
+  "chatSettings.modeDescription": {
+    "defaultMessage": "Wählen Sie den Standardmodus, den Goose für neue Sitzungen verwendet. Bestehende Sitzungen behalten ihren aktuellen Modus bei."
+  },
+  "chatSettings.modeTitle": {
+    "defaultMessage": "Standardmodus"
+  },
+  "chatSettings.responseStylesDescription": {
+    "defaultMessage": "Wählen Sie, wie Goose seine Antworten formatieren und gestalten soll"
+  },
+  "chatSettings.responseStylesTitle": {
+    "defaultMessage": "Antwortstile"
+  },
+  "configSettings.configReset": {
+    "defaultMessage": "Konfiguration zurückgesetzt"
+  },
+  "configSettings.configResetMsg": {
+    "defaultMessage": "Alle Änderungen wurden rückgängig gemacht"
+  },
+  "configSettings.configUpdated": {
+    "defaultMessage": "Konfiguration aktualisiert"
+  },
+  "configSettings.configUpdatedMsg": {
+    "defaultMessage": "\"{name}\" erfolgreich gespeichert"
+  },
+  "configSettings.configurationEditor": {
+    "defaultMessage": "Konfigurationseditor"
+  },
+  "configSettings.description": {
+    "defaultMessage": "Bearbeiten Sie Ihre goose-Konfigurationseinstellungen"
+  },
+  "configSettings.descriptionWithProvider": {
+    "defaultMessage": "Bearbeiten Sie Ihre goose-Konfigurationseinstellungen (aktuelle Einstellungen für {provider})"
+  },
+  "configSettings.done": {
+    "defaultMessage": "Fertig"
+  },
+  "configSettings.editConfiguration": {
+    "defaultMessage": "Konfiguration bearbeiten"
+  },
+  "configSettings.enterValue": {
+    "defaultMessage": "{name} eingeben"
+  },
+  "configSettings.noSettings": {
+    "defaultMessage": "Keine Konfigurationseinstellungen gefunden."
+  },
+  "configSettings.resetChanges": {
+    "defaultMessage": "Änderungen zurücksetzen"
+  },
+  "configSettings.saveFailed": {
+    "defaultMessage": "Speichern fehlgeschlagen"
+  },
+  "configSettings.saveFailedMsg": {
+    "defaultMessage": "\"{name}\" konnte nicht gespeichert werden"
+  },
+  "configSettings.saving": {
+    "defaultMessage": "Wird gespeichert..."
+  },
+  "configSettings.title": {
+    "defaultMessage": "Konfiguration"
+  },
+  "configureApproveMode.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "configureApproveMode.description": {
+    "defaultMessage": "Genehmigungsanfragen können entweder für alle Tool-Anfragen gelten oder bestimmen, welche Aktionen eine Integration erfordern können"
+  },
+  "configureApproveMode.manualApproval": {
+    "defaultMessage": "Manuelle Genehmigung"
+  },
+  "configureApproveMode.manualApprovalDescription": {
+    "defaultMessage": "Alle Tools, Erweiterungen und Dateiänderungen erfordern eine menschliche Genehmigung"
+  },
+  "configureApproveMode.save": {
+    "defaultMessage": "Speichern"
+  },
+  "configureApproveMode.saving": {
+    "defaultMessage": "Wird gespeichert..."
+  },
+  "configureApproveMode.smartApproval": {
+    "defaultMessage": "Intelligente Genehmigung"
+  },
+  "configureApproveMode.smartApprovalDescription": {
+    "defaultMessage": "Intelligent bestimmen, welche Aktionen basierend auf dem Risikoniveau eine Genehmigung erfordern"
+  },
+  "configureApproveMode.title": {
+    "defaultMessage": "Genehmigungsmodus konfigurieren"
+  },
+  "confirmationModal.defaultCancel": {
+    "defaultMessage": "Nein"
+  },
+  "confirmationModal.defaultConfirm": {
+    "defaultMessage": "Ja"
+  },
+  "confirmationModal.processing": {
+    "defaultMessage": "Wird verarbeitet..."
+  },
+  "conversationLimitsDropdown.conversationLimits": {
+    "defaultMessage": "Konversationslimits"
+  },
+  "conversationLimitsDropdown.maxTurns": {
+    "defaultMessage": "Max. Durchgänge"
+  },
+  "conversationLimitsDropdown.maxTurnsDescription": {
+    "defaultMessage": "Maximale Anzahl an Agentendurchgängen, bevor Goose eine Benutzereingabe anfordert"
+  },
+  "costTracker.costUnavailable": {
+    "defaultMessage": "Kostendaten für {model} nicht verfügbar ({inputTokens} Eingabe, {outputTokens} Ausgabe-Token)"
+  },
+  "costTracker.inputOutputTooltip": {
+    "defaultMessage": "Eingabe: {inputTokens} Token ({inputCost}) | Ausgabe: {outputTokens} Token ({outputCost})"
+  },
+  "costTracker.pricingUnavailable": {
+    "defaultMessage": "Preisdaten für {model} nicht verfügbar"
+  },
+  "costTracker.totalSessionCost": {
+    "defaultMessage": "Gesamtkosten der Sitzung: {cost}"
+  },
+  "createEditRecipe.clickToGenerateDeeplink": {
+    "defaultMessage": "Klicken, um Deeplink zu generieren"
+  },
+  "createEditRecipe.close": {
+    "defaultMessage": "Schließen"
+  },
+  "createEditRecipe.copied": {
+    "defaultMessage": "Kopiert!"
+  },
+  "createEditRecipe.copy": {
+    "defaultMessage": "Kopieren"
+  },
+  "createEditRecipe.copyLinkDescription": {
+    "defaultMessage": "Kopieren Sie diesen Link, um ihn mit Freunden zu teilen, oder fügen Sie ihn direkt in Chrome ein, um ihn zu öffnen"
+  },
+  "createEditRecipe.createRecipeTitle": {
+    "defaultMessage": "Rezept erstellen"
+  },
+  "createEditRecipe.createSubtitle": {
+    "defaultMessage": "Erstellen Sie ein neues Rezept, um das Verhalten und die Fähigkeiten des Agenten für wiederverwendbare Chat-Sitzungen festzulegen."
+  },
+  "createEditRecipe.editSubtitle": {
+    "defaultMessage": "Sie können das Rezept unten bearbeiten, um das Verhalten des Agenten in einer neuen Sitzung zu ändern."
+  },
+  "createEditRecipe.generatingDeeplink": {
+    "defaultMessage": "Deeplink wird generiert..."
+  },
+  "createEditRecipe.learnMore": {
+    "defaultMessage": "Mehr erfahren"
+  },
+  "createEditRecipe.recipeSavedAndLaunchedMsg": {
+    "defaultMessage": "Rezept erfolgreich gespeichert und gestartet"
+  },
+  "createEditRecipe.recipeSavedMsg": {
+    "defaultMessage": "Rezept erfolgreich gespeichert"
+  },
+  "createEditRecipe.saveAndRunFailed": {
+    "defaultMessage": "Speichern und Ausführen fehlgeschlagen"
+  },
+  "createEditRecipe.saveAndRunFailedMsg": {
+    "defaultMessage": "Rezept konnte nicht gespeichert und ausgeführt werden: {error}"
+  },
+  "createEditRecipe.saveAndRunRecipe": {
+    "defaultMessage": "Rezept speichern & ausführen"
+  },
+  "createEditRecipe.saveFailed": {
+    "defaultMessage": "Speichern fehlgeschlagen"
+  },
+  "createEditRecipe.saveFailedMsg": {
+    "defaultMessage": "Rezept konnte nicht gespeichert werden: {error}"
+  },
+  "createEditRecipe.saveRecipe": {
+    "defaultMessage": "Rezept speichern"
+  },
+  "createEditRecipe.saving": {
+    "defaultMessage": "Wird gespeichert..."
+  },
+  "createEditRecipe.validationFailed": {
+    "defaultMessage": "Validierung fehlgeschlagen"
+  },
+  "createEditRecipe.validationMsg": {
+    "defaultMessage": "Bitte füllen Sie alle erforderlichen Felder aus und stellen Sie sicher, dass das JSON-Schema gültig ist."
+  },
+  "createEditRecipe.viewEditRecipeTitle": {
+    "defaultMessage": "Rezept anzeigen/bearbeiten"
+  },
+  "createSubRecipeInline.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "createSubRecipeInline.closeModal": {
+    "defaultMessage": "Dialog zum Erstellen von Unterrezepten schließen"
+  },
+  "createSubRecipeInline.createAndAdd": {
+    "defaultMessage": "Unterrezept erstellen & hinzufügen"
+  },
+  "createSubRecipeInline.createdSuccess": {
+    "defaultMessage": "Unterrezept erfolgreich erstellt"
+  },
+  "createSubRecipeInline.creating": {
+    "defaultMessage": "Wird erstellt..."
+  },
+  "createSubRecipeInline.duplicateName": {
+    "defaultMessage": "Doppelter Name"
+  },
+  "createSubRecipeInline.duplicateNameMsg": {
+    "defaultMessage": "Ein Unterrezept mit dem Namen \"{name}\" existiert bereits. Bitte verwenden Sie einen eindeutigen Namen."
+  },
+  "createSubRecipeInline.instructionsLabel": {
+    "defaultMessage": "Anweisungen"
+  },
+  "createSubRecipeInline.instructionsPlaceholder": {
+    "defaultMessage": "Anweisungen für die KI, wenn dieses Unterrezept aufgerufen wird..."
+  },
+  "createSubRecipeInline.nameHint": {
+    "defaultMessage": "Eindeutige Kennung, die zur Generierung des Tool-Namens verwendet wird"
+  },
+  "createSubRecipeInline.nameLabel": {
+    "defaultMessage": "Name"
+  },
+  "createSubRecipeInline.namePlaceholder": {
+    "defaultMessage": "z. B. security_scan"
+  },
+  "createSubRecipeInline.preconfiguredValues": {
+    "defaultMessage": "Vorkonfigurierte Werte"
+  },
+  "createSubRecipeInline.preconfiguredValuesHint": {
+    "defaultMessage": "Optionale Parameterwerte, die immer an das Unterrezept übergeben werden"
+  },
+  "createSubRecipeInline.recipeDescriptionLabel": {
+    "defaultMessage": "Rezeptbeschreibung"
+  },
+  "createSubRecipeInline.recipeDescriptionPlaceholder": {
+    "defaultMessage": "Was dieses Rezept bei der Ausführung tut"
+  },
+  "createSubRecipeInline.recipeTitleLabel": {
+    "defaultMessage": "Rezepttitel"
+  },
+  "createSubRecipeInline.recipeTitlePlaceholder": {
+    "defaultMessage": "z. B. Sicherheitsanalyse-Tool"
+  },
+  "createSubRecipeInline.saveFailed": {
+    "defaultMessage": "Speichern fehlgeschlagen"
+  },
+  "createSubRecipeInline.saveFailedMsg": {
+    "defaultMessage": "Unterrezept konnte nicht gespeichert werden: {error}"
+  },
+  "createSubRecipeInline.sequentialHint": {
+    "defaultMessage": "(Erzwingt die sequenzielle Ausführung mehrerer Instanzen)"
+  },
+  "createSubRecipeInline.sequentialLabel": {
+    "defaultMessage": "Sequenziell bei Wiederholung"
+  },
+  "createSubRecipeInline.subtitle": {
+    "defaultMessage": "Erstellen Sie ein einfaches Rezept zur Verwendung als aufrufbares Tool in Ihrem Hauptrezept"
+  },
+  "createSubRecipeInline.title": {
+    "defaultMessage": "Neues Unterrezept erstellen"
+  },
+  "createSubRecipeInline.toolDescriptionLabel": {
+    "defaultMessage": "Tool-Beschreibung"
+  },
+  "createSubRecipeInline.toolDescriptionPlaceholder": {
+    "defaultMessage": "Optionale Beschreibung, die angezeigt wird, wenn dies als Tool aufgerufen wird"
+  },
+  "createSubRecipeInline.validationFailed": {
+    "defaultMessage": "Validierung fehlgeschlagen"
+  },
+  "createSubRecipeInline.validationMsg": {
+    "defaultMessage": "Name, Titel, Rezeptbeschreibung und Anweisungen sind erforderlich."
+  },
+  "creditsExhaustedNotification.addCredits": {
+    "defaultMessage": "Guthaben hinzufügen"
+  },
+  "creditsExhaustedNotification.insufficientCredits": {
+    "defaultMessage": "Unzureichendes Guthaben"
+  },
+  "cronPicker.april": {
+    "defaultMessage": "April"
+  },
+  "cronPicker.at": {
+    "defaultMessage": "um"
+  },
+  "cronPicker.atMinute": {
+    "defaultMessage": "in Minute"
+  },
+  "cronPicker.atSecond": {
+    "defaultMessage": "in Sekunde"
+  },
+  "cronPicker.august": {
+    "defaultMessage": "August"
+  },
+  "cronPicker.cronExpression": {
+    "defaultMessage": "Cron-Ausdruck"
+  },
+  "cronPicker.custom": {
+    "defaultMessage": "Benutzerdefinierter Cron"
+  },
+  "cronPicker.day": {
+    "defaultMessage": "Tag"
+  },
+  "cronPicker.december": {
+    "defaultMessage": "Dezember"
+  },
+  "cronPicker.emptyCronError": {
+    "defaultMessage": "Der Cron-Ausdruck darf nicht leer sein"
+  },
+  "cronPicker.every": {
+    "defaultMessage": "Alle"
+  },
+  "cronPicker.february": {
+    "defaultMessage": "Februar"
+  },
+  "cronPicker.friday": {
+    "defaultMessage": "Freitag"
+  },
+  "cronPicker.hour": {
+    "defaultMessage": "Stunde"
+  },
+  "cronPicker.inMonth": {
+    "defaultMessage": "im"
+  },
+  "cronPicker.invalidDayOfMonth": {
+    "defaultMessage": "Der Tag muss zwischen 1 und {max} liegen"
+  },
+  "cronPicker.january": {
+    "defaultMessage": "Januar"
+  },
+  "cronPicker.july": {
+    "defaultMessage": "Juli"
+  },
+  "cronPicker.june": {
+    "defaultMessage": "Juni"
+  },
+  "cronPicker.march": {
+    "defaultMessage": "März"
+  },
+  "cronPicker.may": {
+    "defaultMessage": "Mai"
+  },
+  "cronPicker.minute": {
+    "defaultMessage": "Minute"
+  },
+  "cronPicker.mode": {
+    "defaultMessage": "Modus"
+  },
+  "cronPicker.monday": {
+    "defaultMessage": "Montag"
+  },
+  "cronPicker.month": {
+    "defaultMessage": "Monat"
+  },
+  "cronPicker.november": {
+    "defaultMessage": "November"
+  },
+  "cronPicker.october": {
+    "defaultMessage": "Oktober"
+  },
+  "cronPicker.on": {
+    "defaultMessage": "am"
+  },
+  "cronPicker.onDay": {
+    "defaultMessage": "am Tag"
+  },
+  "cronPicker.quarter": {
+    "defaultMessage": "Quartal"
+  },
+  "cronPicker.saturday": {
+    "defaultMessage": "Samstag"
+  },
+  "cronPicker.september": {
+    "defaultMessage": "September"
+  },
+  "cronPicker.startingMonth": {
+    "defaultMessage": "Startmonat"
+  },
+  "cronPicker.sunday": {
+    "defaultMessage": "Sonntag"
+  },
+  "cronPicker.thursday": {
+    "defaultMessage": "Donnerstag"
+  },
+  "cronPicker.tuesday": {
+    "defaultMessage": "Dienstag"
+  },
+  "cronPicker.wednesday": {
+    "defaultMessage": "Mittwoch"
+  },
+  "cronPicker.week": {
+    "defaultMessage": "Woche"
+  },
+  "cronPicker.year": {
+    "defaultMessage": "Jahr"
+  },
+  "customProviderForm.add": {
+    "defaultMessage": "Hinzufügen"
+  },
+  "customProviderForm.anthropicCompatible": {
+    "defaultMessage": "Anthropic-kompatibel"
+  },
+  "customProviderForm.apiBasePath": {
+    "defaultMessage": "API-Basispfad (optional)"
+  },
+  "customProviderForm.apiBasePathHint": {
+    "defaultMessage": "Überschreiben Sie den Standard-API-Pfad. Leer lassen, um den Standardpfad des Anbieters zu verwenden."
+  },
+  "customProviderForm.apiBasePathPlaceholder": {
+    "defaultMessage": "z. B. v1/chat/completions oder project_id/v1"
+  },
+  "customProviderForm.apiKey": {
+    "defaultMessage": "API-Schlüssel"
+  },
+  "customProviderForm.apiKeyPlaceholderExisting": {
+    "defaultMessage": "Leer lassen, um den vorhandenen Schlüssel beizubehalten"
+  },
+  "customProviderForm.apiKeyPlaceholderNew": {
+    "defaultMessage": "Ihr API-Schlüssel"
+  },
+  "customProviderForm.apiKeyRequired": {
+    "defaultMessage": "API-Schlüssel ist erforderlich"
+  },
+  "customProviderForm.apiUrl": {
+    "defaultMessage": "API-URL"
+  },
+  "customProviderForm.apiUrlPlaceholder": {
+    "defaultMessage": "https://api.example.com"
+  },
+  "customProviderForm.apiUrlRequired": {
+    "defaultMessage": "API-URL ist erforderlich"
+  },
+  "customProviderForm.attachments": {
+    "defaultMessage": "Anhänge"
+  },
+  "customProviderForm.authHint": {
+    "defaultMessage": "Lokale LLMs wie Ollama benötigen normalerweise keinen API-Schlüssel."
+  },
+  "customProviderForm.authentication": {
+    "defaultMessage": "Authentifizierung"
+  },
+  "customProviderForm.availableModels": {
+    "defaultMessage": "Verfügbare Modelle (durch Kommas getrennt)"
+  },
+  "customProviderForm.back": {
+    "defaultMessage": "← Zurück"
+  },
+  "customProviderForm.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "customProviderForm.cannotDeleteActive": {
+    "defaultMessage": "Sie können diesen Anbieter nicht löschen, während er gerade verwendet wird. Bitte wechseln Sie zuerst zu einem anderen Modell."
+  },
+  "customProviderForm.chooseSetup": {
+    "defaultMessage": "Wählen Sie, wie Sie Ihren Anbieter einrichten möchten."
+  },
+  "customProviderForm.clear": {
+    "defaultMessage": "Löschen"
+  },
+  "customProviderForm.configureManually": {
+    "defaultMessage": "Manuell konfigurieren"
+  },
+  "customProviderForm.configureManuallyDesc": {
+    "defaultMessage": "Geben Sie alle Anbieterdetails selbst ein"
+  },
+  "customProviderForm.confirmDelete": {
+    "defaultMessage": "Löschen bestätigen"
+  },
+  "customProviderForm.createProvider": {
+    "defaultMessage": "Anbieter erstellen"
+  },
+  "customProviderForm.customHeaders": {
+    "defaultMessage": "Benutzerdefinierte Header"
+  },
+  "customProviderForm.customHeadersHint": {
+    "defaultMessage": "Fügen Sie benutzerdefinierte HTTP-Header hinzu, die in Anfragen an den Anbieter aufgenommen werden. Klicken Sie auf die Schaltfläche \"+\", um sie hinzuzufügen, nachdem Sie beide Felder ausgefüllt haben."
+  },
+  "customProviderForm.deleteConfirmation": {
+    "defaultMessage": "Möchten Sie diesen benutzerdefinierten Anbieter wirklich löschen? Dadurch werden der Anbieter und sein gespeicherter API-Schlüssel dauerhaft entfernt. Diese Aktion kann nicht rückgängig gemacht werden."
+  },
+  "customProviderForm.deleteProvider": {
+    "defaultMessage": "Anbieter löschen"
+  },
+  "customProviderForm.displayName": {
+    "defaultMessage": "Anzeigename"
+  },
+  "customProviderForm.displayNamePlaceholder": {
+    "defaultMessage": "Ihr Anbietername"
+  },
+  "customProviderForm.displayNameRequired": {
+    "defaultMessage": "Anzeigename ist erforderlich"
+  },
+  "customProviderForm.docs": {
+    "defaultMessage": "Dokumentation"
+  },
+  "customProviderForm.headerBothRequired": {
+    "defaultMessage": "Sowohl Header-Name als auch -Wert müssen eingegeben werden"
+  },
+  "customProviderForm.headerDuplicate": {
+    "defaultMessage": "Ein Header mit diesem Namen existiert bereits"
+  },
+  "customProviderForm.headerNamePlaceholder": {
+    "defaultMessage": "Header-Name"
+  },
+  "customProviderForm.headerNoSpaces": {
+    "defaultMessage": "Der Header-Name darf keine Leerzeichen enthalten"
+  },
+  "customProviderForm.modelsPlaceholder": {
+    "defaultMessage": "modell-a, modell-b, modell-c"
+  },
+  "customProviderForm.modelsRequired": {
+    "defaultMessage": "Mindestens ein Modell ist erforderlich"
+  },
+  "customProviderForm.ollamaCompatible": {
+    "defaultMessage": "Ollama-kompatibel"
+  },
+  "customProviderForm.openaiCompatible": {
+    "defaultMessage": "OpenAI-kompatibel"
+  },
+  "customProviderForm.providerType": {
+    "defaultMessage": "Anbietertyp"
+  },
+  "customProviderForm.reasoning": {
+    "defaultMessage": "Schlussfolgern"
+  },
+  "customProviderForm.requiresApiKey": {
+    "defaultMessage": "Dieser Anbieter erfordert einen API-Schlüssel"
+  },
+  "customProviderForm.startFromTemplate": {
+    "defaultMessage": "Mit einer Anbietervorlage beginnen"
+  },
+  "customProviderForm.startFromTemplateDesc": {
+    "defaultMessage": "Wählen Sie einen bekannten Anbieter aus, und wir füllen die Konfiguration automatisch aus"
+  },
+  "customProviderForm.submitError": {
+    "defaultMessage": "Anbieter konnte nicht gespeichert werden. Bitte überprüfen Sie Ihre Konfiguration und versuchen Sie es erneut."
+  },
+  "customProviderForm.supportsStreaming": {
+    "defaultMessage": "Anbieter unterstützt Streaming-Antworten"
+  },
+  "customProviderForm.toolCalling": {
+    "defaultMessage": "Tool-Aufrufe"
+  },
+  "customProviderForm.updateProvider": {
+    "defaultMessage": "Anbieter aktualisieren"
+  },
+  "customProviderForm.usingTemplate": {
+    "defaultMessage": "Verwendete Vorlage: {name}"
+  },
+  "customProviderForm.valuePlaceholder": {
+    "defaultMessage": "Wert"
+  },
+  "defaultCardButtons.configureSettings": {
+    "defaultMessage": "{name}-Einstellungen konfigurieren"
+  },
+  "defaultCardButtons.deleteSettings": {
+    "defaultMessage": "{name}-Einstellungen löschen"
+  },
+  "defaultCardButtons.editSettings": {
+    "defaultMessage": "{name}-Einstellungen bearbeiten"
+  },
+  "defaultCardButtons.getStarted": {
+    "defaultMessage": "Loslegen mit goose!"
+  },
+  "defaultProviderSetupForm.apiHostLabel": {
+    "defaultMessage": "API-Host"
+  },
+  "defaultProviderSetupForm.apiHostPlaceholder": {
+    "defaultMessage": "https://api.example.com"
+  },
+  "defaultProviderSetupForm.apiKeyLabel": {
+    "defaultMessage": "API-Schlüssel"
+  },
+  "defaultProviderSetupForm.apiKeyPlaceholder": {
+    "defaultMessage": "Ihr API-Schlüssel"
+  },
+  "defaultProviderSetupForm.hideOptions": {
+    "defaultMessage": "{count} Optionen ausblenden"
+  },
+  "defaultProviderSetupForm.loadingConfig": {
+    "defaultMessage": "Konfigurationswerte werden geladen..."
+  },
+  "defaultProviderSetupForm.modelsLabel": {
+    "defaultMessage": "Modelle"
+  },
+  "defaultProviderSetupForm.modelsPlaceholder": {
+    "defaultMessage": "model-a, model-b"
+  },
+  "defaultProviderSetupForm.noConfigParameters": {
+    "defaultMessage": "Keine Konfigurationsparameter für diesen Anbieter."
+  },
+  "defaultProviderSetupForm.showOptions": {
+    "defaultMessage": "{count} Optionen anzeigen"
+  },
+  "diagnosticsModal.attachHint": {
+    "defaultMessage": "Wenn Sie einen Fehler melden, sollten Sie den Diagnosebericht anhängen."
+  },
+  "diagnosticsModal.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "diagnosticsModal.configSettings": {
+    "defaultMessage": "Konfigurationseinstellungen"
+  },
+  "diagnosticsModal.description": {
+    "defaultMessage": "Sie können einen Diagnosebericht im JSON-Format herunterladen, um ihn mit dem Team zu teilen, oder direkt auf GitHub einen Fehler melden, bei dem Ihre Systemdetails bereits ausgefüllt sind. Ein Diagnosebericht enthält Folgendes:"
+  },
+  "diagnosticsModal.diagnosticsErrorMsg": {
+    "defaultMessage": "Herunterladen des Diagnoseberichts fehlgeschlagen"
+  },
+  "diagnosticsModal.diagnosticsErrorTitle": {
+    "defaultMessage": "Diagnosefehler"
+  },
+  "diagnosticsModal.download": {
+    "defaultMessage": "Herunterladen"
+  },
+  "diagnosticsModal.downloading": {
+    "defaultMessage": "Wird heruntergeladen..."
+  },
+  "diagnosticsModal.fileBug": {
+    "defaultMessage": "Fehler auf GitHub melden"
+  },
+  "diagnosticsModal.logFiles": {
+    "defaultMessage": "Aktuelle Protokolldateien"
+  },
+  "diagnosticsModal.opening": {
+    "defaultMessage": "Wird geöffnet..."
+  },
+  "diagnosticsModal.reportProblem": {
+    "defaultMessage": "Problem melden"
+  },
+  "diagnosticsModal.sensitiveWarning": {
+    "defaultMessage": "Wenn Ihre Sitzung vertrauliche Informationen enthält, teilen Sie die Diagnosedatei nicht öffentlich."
+  },
+  "diagnosticsModal.sessionMessages": {
+    "defaultMessage": "Ihre aktuellen Sitzungsnachrichten"
+  },
+  "diagnosticsModal.systemInfo": {
+    "defaultMessage": "Grundlegende Systeminformationen"
+  },
+  "diagnosticsModal.systemInfoErrorMsg": {
+    "defaultMessage": "Abrufen der Systeminformationen fehlgeschlagen"
+  },
+  "diagnosticsModal.systemInfoErrorTitle": {
+    "defaultMessage": "Fehler"
+  },
+  "dialog.close": {
+    "defaultMessage": "Schließen"
+  },
+  "dictationSettings.addApiKey": {
+    "defaultMessage": "API-Schlüssel hinzufügen"
+  },
+  "dictationSettings.apiKey": {
+    "defaultMessage": "API-Schlüssel"
+  },
+  "dictationSettings.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "dictationSettings.chooseVoiceConversion": {
+    "defaultMessage": "Wählen Sie, wie Sprache in Text umgewandelt wird"
+  },
+  "dictationSettings.configureApiKey": {
+    "defaultMessage": "Konfigurieren Sie den API-Schlüssel in <b>{settingsPath}</b>"
+  },
+  "dictationSettings.configured": {
+    "defaultMessage": "(Konfiguriert)"
+  },
+  "dictationSettings.configuredIn": {
+    "defaultMessage": "✓ Konfiguriert in {settingsPath}"
+  },
+  "dictationSettings.disabled": {
+    "defaultMessage": "Deaktiviert"
+  },
+  "dictationSettings.enterApiKey": {
+    "defaultMessage": "Geben Sie Ihren API-Schlüssel ein"
+  },
+  "dictationSettings.notConfigured": {
+    "defaultMessage": "(nicht konfiguriert)"
+  },
+  "dictationSettings.removeApiKey": {
+    "defaultMessage": "API-Schlüssel entfernen"
+  },
+  "dictationSettings.requiredForTranscription": {
+    "defaultMessage": "Erforderlich für die Transkription"
+  },
+  "dictationSettings.save": {
+    "defaultMessage": "Speichern"
+  },
+  "dictationSettings.updateApiKey": {
+    "defaultMessage": "API-Schlüssel aktualisieren"
+  },
+  "dictationSettings.voiceDictationProvider": {
+    "defaultMessage": "Anbieter für Sprachdiktat"
+  },
+  "dirSwitcher.chooseDirectory": {
+    "defaultMessage": "Verzeichnis auswählen…"
+  },
+  "dirSwitcher.currentDirectory": {
+    "defaultMessage": "Aktuelles Verzeichnis"
+  },
+  "dirSwitcher.failedToUpdateWorkingDir": {
+    "defaultMessage": "Aktualisieren des Arbeitsverzeichnisses fehlgeschlagen"
+  },
+  "dirSwitcher.gitWorktrees": {
+    "defaultMessage": "Git-Worktrees"
+  },
+  "dirSwitcher.noWorktreesFound": {
+    "defaultMessage": "Keine Worktrees gefunden"
+  },
+  "dirSwitcher.openInFinder": {
+    "defaultMessage": "Im Dateimanager öffnen"
+  },
+  "dirSwitcher.recentDirectories": {
+    "defaultMessage": "Zuletzt verwendete Verzeichnisse"
+  },
+  "elicitationRequest.accept": {
+    "defaultMessage": "Akzeptieren"
+  },
+  "elicitationRequest.cancelled": {
+    "defaultMessage": "Die Informationsanfrage wurde abgebrochen."
+  },
+  "elicitationRequest.defaultMessage": {
+    "defaultMessage": "Goose benötigt einige Informationen von Ihnen."
+  },
+  "elicitationRequest.expired": {
+    "defaultMessage": "Diese Anfrage ist abgelaufen. Die Erweiterung muss erneut nachfragen."
+  },
+  "elicitationRequest.submit": {
+    "defaultMessage": "Absenden"
+  },
+  "elicitationRequest.submitError": {
+    "defaultMessage": "Diese Anfrage ist nicht mehr aktiv. Die Erweiterung muss erneut nachfragen."
+  },
+  "elicitationRequest.submitted": {
+    "defaultMessage": "Informationen übermittelt"
+  },
+  "elicitationRequest.waitingForResponse": {
+    "defaultMessage": "Warten auf Ihre Antwort ({timeRemaining} verbleibend)"
+  },
+  "envVarsSection.add": {
+    "defaultMessage": "Hinzufügen"
+  },
+  "envVarsSection.bothRequired": {
+    "defaultMessage": "Sowohl Variablenname als auch Wert müssen eingegeben werden"
+  },
+  "envVarsSection.envVarsDescription": {
+    "defaultMessage": "Fügen Sie Schlüssel-Wert-Paare für Umgebungsvariablen hinzu. Klicken Sie auf die Schaltfläche „+“, um sie hinzuzufügen, nachdem Sie beide Felder ausgefüllt haben. Klicken Sie bei vorhandenen geheimen Werten auf die Schaltfläche „Bearbeiten“, um sie zu ändern."
+  },
+  "envVarsSection.environmentVariables": {
+    "defaultMessage": "Umgebungsvariablen"
+  },
+  "envVarsSection.noSpaces": {
+    "defaultMessage": "Der Variablenname darf keine Leerzeichen enthalten"
+  },
+  "envVarsSection.value": {
+    "defaultMessage": "Wert"
+  },
+  "envVarsSection.variableName": {
+    "defaultMessage": "Variablenname"
+  },
+  "environmentBadge.dev": {
+    "defaultMessage": "Dev"
+  },
+  "errorBoundary.errorGeneric": {
+    "defaultMessage": "Ein Fehler ist aufgetreten."
+  },
+  "errorBoundary.errorWithVersion": {
+    "defaultMessage": "In Goose v{version} ist ein Fehler aufgetreten."
+  },
+  "errorBoundary.heading": {
+    "defaultMessage": "Honk!"
+  },
+  "errorBoundary.reload": {
+    "defaultMessage": "Neu laden"
+  },
+  "extensionConfigFields.commandLabel": {
+    "defaultMessage": "Befehl"
+  },
+  "extensionConfigFields.commandPlaceholder": {
+    "defaultMessage": "z. B. npx -y @modelcontextprotocol/my-extension [filepath]"
+  },
+  "extensionConfigFields.commandRequired": {
+    "defaultMessage": "Befehl ist erforderlich"
+  },
+  "extensionConfigFields.endpointLabel": {
+    "defaultMessage": "Endpunkt"
+  },
+  "extensionConfigFields.endpointPlaceholder": {
+    "defaultMessage": "Endpunkt-URL eingeben..."
+  },
+  "extensionConfigFields.endpointRequired": {
+    "defaultMessage": "Endpunkt-URL ist erforderlich"
+  },
+  "extensionInfoFields.descriptionLabel": {
+    "defaultMessage": "Beschreibung"
+  },
+  "extensionInfoFields.descriptionPlaceholder": {
+    "defaultMessage": "Optionale Beschreibung..."
+  },
+  "extensionInfoFields.extensionName": {
+    "defaultMessage": "Erweiterungsname"
+  },
+  "extensionInfoFields.extensionNamePlaceholder": {
+    "defaultMessage": "Erweiterungsname eingeben..."
+  },
+  "extensionInfoFields.nameRequired": {
+    "defaultMessage": "Name ist erforderlich"
+  },
+  "extensionInfoFields.typeHttp": {
+    "defaultMessage": "HTTP"
+  },
+  "extensionInfoFields.typeLabel": {
+    "defaultMessage": "Typ"
+  },
+  "extensionInfoFields.typeSseUnsupported": {
+    "defaultMessage": "SSE (nicht unterstützt)"
+  },
+  "extensionInfoFields.typeStandardIo": {
+    "defaultMessage": "Standard IO (STDIO)"
+  },
+  "extensionInfoFields.typeStdio": {
+    "defaultMessage": "STDIO"
+  },
+  "extensionInfoFields.typeStreamableHttp": {
+    "defaultMessage": "Streamable HTTP"
+  },
+  "extensionInstallModal.alreadyInstalledMessage": {
+    "defaultMessage": "Die Erweiterung „{name}“ wurde bereits erfolgreich installiert. Starten Sie eine neue Chat-Sitzung, um sie zu verwenden."
+  },
+  "extensionInstallModal.alreadyInstalledTitle": {
+    "defaultMessage": "Erweiterung „{name}“ bereits installiert"
+  },
+  "extensionInstallModal.blockedMessage": {
+    "defaultMessage": "Dieser Erweiterungsbefehl steht nicht auf der Liste der zulässigen Befehle und seine Installation ist blockiert. Erweiterung: {name} Befehl: {command} Wenden Sie sich an Ihren Administrator, um eine Freigabe für diese Erweiterung anzufordern."
+  },
+  "extensionInstallModal.blockedTitle": {
+    "defaultMessage": "Erweiterungsinstallation blockiert"
+  },
+  "extensionInstallModal.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "extensionInstallModal.installAnyway": {
+    "defaultMessage": "Trotzdem installieren"
+  },
+  "extensionInstallModal.installing": {
+    "defaultMessage": "Wird installiert..."
+  },
+  "extensionInstallModal.no": {
+    "defaultMessage": "Nein"
+  },
+  "extensionInstallModal.ok": {
+    "defaultMessage": "OK"
+  },
+  "extensionInstallModal.trustedMessage": {
+    "defaultMessage": "Möchten Sie die Erweiterung {name} wirklich installieren? Befehl: {command}"
+  },
+  "extensionInstallModal.trustedTitle": {
+    "defaultMessage": "Erweiterungsinstallation bestätigen"
+  },
+  "extensionInstallModal.unknownCommand": {
+    "defaultMessage": "Unbekannter Befehl"
+  },
+  "extensionInstallModal.untrustedMessageWithCommand": {
+    "defaultMessage": "{securityMessage} Erweiterung: {name} Befehl: {command} Wenden Sie sich an Ihren Administrator, wenn Sie unsicher sind."
+  },
+  "extensionInstallModal.untrustedMessageWithUrl": {
+    "defaultMessage": "{securityMessage} Erweiterung: {name} URL: {url} Wenden Sie sich an Ihren Administrator, wenn Sie unsicher sind."
+  },
+  "extensionInstallModal.untrustedSecurityMessage": {
+    "defaultMessage": "Dieser Erweiterungsbefehl steht nicht auf der Liste der zulässigen Befehle und kann auf Ihre Konversationen zugreifen sowie zusätzliche Funktionen bereitstellen. Das Installieren von Erweiterungen aus nicht vertrauenswürdigen Quellen kann Sicherheitsrisiken bergen."
+  },
+  "extensionInstallModal.untrustedTitle": {
+    "defaultMessage": "Nicht vertrauenswürdige Erweiterung installieren?"
+  },
+  "extensionInstallModal.yes": {
+    "defaultMessage": "Ja"
+  },
+  "extensionItem.configureExtension": {
+    "defaultMessage": "Erweiterung {name} konfigurieren"
+  },
+  "extensionItem.toggleExtension": {
+    "defaultMessage": "Erweiterung {name} ein- oder ausschalten"
+  },
+  "extensionList.availableExtensions": {
+    "defaultMessage": "Verfügbare Erweiterungen ({count})"
+  },
+  "extensionList.builtInExtension": {
+    "defaultMessage": "Integrierte Erweiterung"
+  },
+  "extensionList.defaultExtensions": {
+    "defaultMessage": "Standarderweiterungen ({count})"
+  },
+  "extensionList.noExtensions": {
+    "defaultMessage": "Keine Erweiterungen verfügbar"
+  },
+  "extensionModal.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "extensionModal.closeWithoutSaving": {
+    "defaultMessage": "Ohne Speichern schließen"
+  },
+  "extensionModal.confirmRemoval": {
+    "defaultMessage": "Entfernen bestätigen"
+  },
+  "extensionModal.deleteDescription": {
+    "defaultMessage": "Dadurch werden diese Erweiterung und alle ihre Einstellungen dauerhaft entfernt."
+  },
+  "extensionModal.deleteExtensionTitle": {
+    "defaultMessage": "Erweiterung „{name}“ löschen"
+  },
+  "extensionModal.installationNotes": {
+    "defaultMessage": "Installationshinweise"
+  },
+  "extensionModal.removeExtension": {
+    "defaultMessage": "Erweiterung entfernen"
+  },
+  "extensionModal.unsavedChangesMessage": {
+    "defaultMessage": "Sie haben nicht gespeicherte Änderungen an der Erweiterungskonfiguration. Möchten Sie wirklich schließen, ohne zu speichern?"
+  },
+  "extensionModal.unsavedChangesTitle": {
+    "defaultMessage": "Nicht gespeicherte Änderungen"
+  },
+  "extensionTimeoutField.timeoutLabel": {
+    "defaultMessage": "Zeitlimit"
+  },
+  "extensionsSection.addCustomExtension": {
+    "defaultMessage": "Benutzerdefinierte Erweiterung hinzufügen"
+  },
+  "extensionsSection.addExtension": {
+    "defaultMessage": "Erweiterung hinzufügen"
+  },
+  "extensionsSection.browseExtensions": {
+    "defaultMessage": "Erweiterungen durchsuchen"
+  },
+  "extensionsSection.saveChanges": {
+    "defaultMessage": "Änderungen speichern"
+  },
+  "extensionsSection.updateExtension": {
+    "defaultMessage": "Erweiterung aktualisieren"
+  },
+  "extensionsView.addCustomExtension": {
+    "defaultMessage": "Benutzerdefinierte Erweiterung hinzufügen"
+  },
+  "extensionsView.addExtension": {
+    "defaultMessage": "Erweiterung hinzufügen"
+  },
+  "extensionsView.browseExtensions": {
+    "defaultMessage": "Erweiterungen durchsuchen"
+  },
+  "extensionsView.defaultNote": {
+    "defaultMessage": "Hier aktivierte Erweiterungen werden als Standard für neue Chats verwendet. Sie können aktive Erweiterungen auch während eines Chats umschalten."
+  },
+  "extensionsView.description": {
+    "defaultMessage": "Diese Erweiterungen nutzen das Model Context Protocol (MCP). Sie können die Fähigkeiten von Goose mit drei Hauptkomponenten erweitern: Prompts, Ressourcen und Tools. {searchShortcut} zum Suchen."
+  },
+  "extensionsView.heading": {
+    "defaultMessage": "Erweiterungen"
+  },
+  "extensionsView.searchPlaceholder": {
+    "defaultMessage": "Erweiterungen suchen..."
+  },
+  "externalBackendSection.certFingerprint": {
+    "defaultMessage": "Zertifikat-Fingerabdruck (optional)"
+  },
+  "externalBackendSection.certFingerprintHelp": {
+    "defaultMessage": "Pinnen Sie einen bestimmten TLS-Zertifikat-Fingerabdruck. Wird er weggelassen, wird dem Zertifikat bei der ersten Verwendung vertraut (TOFU)."
+  },
+  "externalBackendSection.certFingerprintPlaceholder": {
+    "defaultMessage": "AA:BB:CC:... oder sha256/base64"
+  },
+  "externalBackendSection.description": {
+    "defaultMessage": "Standardmäßig startet goose einen Server für Sie. Verwenden Sie dies, um eine Verbindung zu einem externen goose-Server herzustellen"
+  },
+  "externalBackendSection.restartNote": {
+    "defaultMessage": "Änderungen werden erst nach einem Neustart von Goose wirksam. Neue Chat-Fenster verbinden sich mit dem externen Server."
+  },
+  "externalBackendSection.secretKey": {
+    "defaultMessage": "Geheimer Schlüssel"
+  },
+  "externalBackendSection.secretKeyHelp": {
+    "defaultMessage": "Der auf dem goosed-Server konfigurierte geheime Schlüssel (GOOSE_SERVER__SECRET_KEY)"
+  },
+  "externalBackendSection.secretKeyPlaceholder": {
+    "defaultMessage": "Geben Sie den geheimen Schlüssel des Servers ein"
+  },
+  "externalBackendSection.serverUrl": {
+    "defaultMessage": "Server-URL"
+  },
+  "externalBackendSection.title": {
+    "defaultMessage": "Goose-Server"
+  },
+  "externalBackendSection.urlFormatError": {
+    "defaultMessage": "Ungültiges URL-Format"
+  },
+  "externalBackendSection.urlProtocolError": {
+    "defaultMessage": "Die URL muss das Protokoll http oder https verwenden"
+  },
+  "externalBackendSection.useExternalServer": {
+    "defaultMessage": "Externen Server verwenden"
+  },
+  "externalBackendSection.useExternalServerDescription": {
+    "defaultMessage": "Verbindung zu einem anderswo laufenden goose-Server herstellen (erfordert Neustart der App)"
+  },
+  "freeOptionCards.chooseOption": {
+    "defaultMessage": "Wählen Sie eine Option, um loszulegen."
+  },
+  "freeOptionCards.freeAndPrivate": {
+    "defaultMessage": "Kostenlos & privat"
+  },
+  "freeOptionCards.localModelDescription": {
+    "defaultMessage": "Laden Sie ein Modell herunter und führen Sie es vollständig auf Ihrem Rechner aus. Keine API-Schlüssel, keine Konten."
+  },
+  "freeOptionCards.localModelTitle": {
+    "defaultMessage": "Ein lokales Modell verwenden"
+  },
+  "freeOptionCards.nanogptDescription": {
+    "defaultMessage": "Registrieren Sie sich, um 7 Tage lang 60 Mio. kostenlose Token zu erhalten."
+  },
+  "freeOptionCards.nanogptTitle": {
+    "defaultMessage": "NanoGPT"
+  },
+  "freeOptionCards.retry": {
+    "defaultMessage": "Erneut versuchen"
+  },
+  "freeOptionCards.tetrateDescription": {
+    "defaultMessage": "Greifen Sie mit automatischer Einrichtung auf mehrere KI-Modelle zu. Registrieren Sie sich, um ein Guthaben von 10 $ zu erhalten."
+  },
+  "freeOptionCards.tetrateTitle": {
+    "defaultMessage": "Agent Router von Tetrate"
+  },
+  "freeOptionCards.unexpectedError": {
+    "defaultMessage": "Bei der Einrichtung ist ein unerwarteter Fehler aufgetreten."
+  },
+  "goosehintsModal.close": {
+    "defaultMessage": "Schließen"
+  },
+  "goosehintsModal.developer": {
+    "defaultMessage": "Entwickler"
+  },
+  "goosehintsModal.dialogDescription": {
+    "defaultMessage": "Stellen Sie zusätzlichen Kontext zu Ihrem Projekt bereit, um die Kommunikation mit Goose zu verbessern"
+  },
+  "goosehintsModal.dialogTitle": {
+    "defaultMessage": "Projekt-Hinweise konfigurieren (.goosehints)"
+  },
+  "goosehintsModal.errorReading": {
+    "defaultMessage": "Fehler beim Lesen der .goosehints-Datei: {error}"
+  },
+  "goosehintsModal.failedToAccess": {
+    "defaultMessage": "Zugriff auf die .goosehints-Datei fehlgeschlagen"
+  },
+  "goosehintsModal.failedToSave": {
+    "defaultMessage": "Speichern der .goosehints-Datei fehlgeschlagen"
+  },
+  "goosehintsModal.fileCreating": {
+    "defaultMessage": "Neue .goosehints-Datei wird erstellt unter: {filePath}"
+  },
+  "goosehintsModal.fileFound": {
+    "defaultMessage": ".goosehints-Datei gefunden unter: {filePath}"
+  },
+  "goosehintsModal.helpText1": {
+    "defaultMessage": ".goosehints ist eine Textdatei, mit der zusätzlicher Kontext zu Ihrem Projekt bereitgestellt und die Kommunikation mit Goose verbessert wird."
+  },
+  "goosehintsModal.helpText2": {
+    "defaultMessage": "Bitte stellen Sie sicher, dass die Erweiterung {bold} auf der Erweiterungsseite aktiviert ist. Diese Erweiterung ist erforderlich, um .goosehints zu verwenden. Sie müssen Ihre Sitzung neu starten, damit Aktualisierungen an .goosehints wirksam werden."
+  },
+  "goosehintsModal.helpText3": {
+    "defaultMessage": "Weitere Informationen finden Sie unter {link}."
+  },
+  "goosehintsModal.helpTextLink": {
+    "defaultMessage": ".goosehints verwenden"
+  },
+  "goosehintsModal.placeholder": {
+    "defaultMessage": "Projekt-Hinweise hier eingeben..."
+  },
+  "goosehintsModal.save": {
+    "defaultMessage": "Speichern"
+  },
+  "goosehintsModal.savedSuccessfully": {
+    "defaultMessage": "Erfolgreich gespeichert"
+  },
+  "goosehintsModal.saving": {
+    "defaultMessage": "Wird gespeichert..."
+  },
+  "goosehintsSection.configure": {
+    "defaultMessage": "Konfigurieren"
+  },
+  "goosehintsSection.description": {
+    "defaultMessage": "Konfigurieren Sie die .goosehints-Datei Ihres Projekts, um Goose zusätzlichen Kontext bereitzustellen"
+  },
+  "goosehintsSection.title": {
+    "defaultMessage": "Projekt-Hinweise (.goosehints)"
+  },
+  "groupedExtensionLoadingToast.askGoose": {
+    "defaultMessage": "goose fragen"
+  },
+  "groupedExtensionLoadingToast.collapseDetails": {
+    "defaultMessage": "Details einklappen"
+  },
+  "groupedExtensionLoadingToast.copied": {
+    "defaultMessage": "Kopiert!"
+  },
+  "groupedExtensionLoadingToast.copyError": {
+    "defaultMessage": "Kopierfehler"
+  },
+  "groupedExtensionLoadingToast.expandDetails": {
+    "defaultMessage": "Details ausklappen"
+  },
+  "groupedExtensionLoadingToast.failedToAddExtension": {
+    "defaultMessage": "Hinzufügen der Erweiterung fehlgeschlagen"
+  },
+  "groupedExtensionLoadingToast.failedToLoad": {
+    "defaultMessage": "{count,plural,one{# Erweiterung konnte nicht geladen werden} other{# Erweiterungen konnten nicht geladen werden}}"
+  },
+  "groupedExtensionLoadingToast.loadingExtensions": {
+    "defaultMessage": "{count,plural,one{# Erweiterung wird geladen...} other{# Erweiterungen werden geladen...}}"
+  },
+  "groupedExtensionLoadingToast.partiallyLoaded": {
+    "defaultMessage": "{totalCount,plural,one{{successCount}/# Erweiterung geladen} other{{successCount}/# Erweiterungen geladen}}"
+  },
+  "groupedExtensionLoadingToast.showDetails": {
+    "defaultMessage": "Details anzeigen"
+  },
+  "groupedExtensionLoadingToast.showLess": {
+    "defaultMessage": "Weniger anzeigen"
+  },
+  "groupedExtensionLoadingToast.successfullyLoaded": {
+    "defaultMessage": "{count,plural,one{# Erweiterung erfolgreich geladen} other{# Erweiterungen erfolgreich geladen}}"
+  },
+  "headersSection.add": {
+    "defaultMessage": "Hinzufügen"
+  },
+  "headersSection.bothRequired": {
+    "defaultMessage": "Sowohl Header-Name als auch Wert müssen eingegeben werden"
+  },
+  "headersSection.duplicateHeader": {
+    "defaultMessage": "Ein Header mit diesem Namen existiert bereits"
+  },
+  "headersSection.headerName": {
+    "defaultMessage": "Header-Name"
+  },
+  "headersSection.headersDescription": {
+    "defaultMessage": "Fügen Sie benutzerdefinierte HTTP-Header hinzu, die in Anfragen an den MCP-Server aufgenommen werden. Klicken Sie auf die Schaltfläche „+“, um sie hinzuzufügen, nachdem Sie beide Felder ausgefüllt haben."
+  },
+  "headersSection.noSpaces": {
+    "defaultMessage": "Der Header-Name darf keine Leerzeichen enthalten"
+  },
+  "headersSection.requestHeaders": {
+    "defaultMessage": "Anfrage-Header"
+  },
+  "headersSection.value": {
+    "defaultMessage": "Wert"
+  },
+  "hub.goodAfternoon": {
+    "defaultMessage": "Guten Tag"
+  },
+  "hub.goodEvening": {
+    "defaultMessage": "Guten Abend"
+  },
+  "hub.goodMorning": {
+    "defaultMessage": "Guten Morgen"
+  },
+  "huggingFaceModelSearch.download": {
+    "defaultMessage": "Herunterladen"
+  },
+  "huggingFaceModelSearch.downloaded": {
+    "defaultMessage": "Heruntergeladen"
+  },
+  "huggingFaceModelSearch.downloading": {
+    "defaultMessage": "Wird heruntergeladen…"
+  },
+  "huggingFaceModelSearch.loadingVariants": {
+    "defaultMessage": "Varianten werden geladen..."
+  },
+  "huggingFaceModelSearch.noGgufModels": {
+    "defaultMessage": "Keine kompatiblen lokalen Modelle für diese Suchanfrage gefunden."
+  },
+  "huggingFaceModelSearch.recommended": {
+    "defaultMessage": "Empfohlen"
+  },
+  "huggingFaceModelSearch.searchError": {
+    "defaultMessage": "Suchfehler: {details}"
+  },
+  "huggingFaceModelSearch.searchFailed": {
+    "defaultMessage": "Suche fehlgeschlagen. Bitte versuchen Sie es erneut."
+  },
+  "huggingFaceModelSearch.searchHuggingFace": {
+    "defaultMessage": "HuggingFace durchsuchen"
+  },
+  "huggingFaceModelSearch.searchNoData": {
+    "defaultMessage": "Die Suche lieferte keine Daten."
+  },
+  "huggingFaceModelSearch.searchPlaceholder": {
+    "defaultMessage": "Nach lokalen Modellen suchen..."
+  },
+  "huggingFaceModelSearch.tooLarge": {
+    "defaultMessage": "Passt möglicherweise nicht in den Speicher ({size}-Modell, {available} verfügbar)"
+  },
+  "huggingFaceSignInPrompt.failedToConfigure": {
+    "defaultMessage": "Anmeldung bei Hugging Face fehlgeschlagen: {error}"
+  },
+  "huggingFaceSignInPrompt.signIn": {
+    "defaultMessage": "Anmelden"
+  },
+  "huggingFaceSignInPrompt.signedIn": {
+    "defaultMessage": "Bei Hugging Face angemeldet"
+  },
+  "huggingFaceSignInPrompt.signingIn": {
+    "defaultMessage": "Wird angemeldet..."
+  },
+  "huggingFaceSignInPrompt.title": {
+    "defaultMessage": "Hugging Face"
+  },
+  "imagePreview.altText": {
+    "defaultMessage": "goose-Bild"
+  },
+  "imagePreview.clickToCollapse": {
+    "defaultMessage": "Zum Einklappen klicken"
+  },
+  "imagePreview.clickToExpand": {
+    "defaultMessage": "Zum Ausklappen klicken"
+  },
+  "imagePreview.unableToLoad": {
+    "defaultMessage": "Bild kann nicht geladen werden"
+  },
+  "importRecipeForm.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "importRecipeForm.deeplinkHint": {
+    "defaultMessage": "Fügen Sie einen Recipe-Deeplink ein, der mit „goose://recipe?config=“ beginnt"
+  },
+  "importRecipeForm.deeplinkPlaceholder": {
+    "defaultMessage": "Fügen Sie hier Ihren goose://recipe?config=...-Deeplink ein"
+  },
+  "importRecipeForm.example": {
+    "defaultMessage": "Beispiel"
+  },
+  "importRecipeForm.expectedRecipeStructure": {
+    "defaultMessage": "Erwartete Recipe-Struktur"
+  },
+  "importRecipeForm.importRecipeButton": {
+    "defaultMessage": "Recipe importieren"
+  },
+  "importRecipeForm.importRecipeTitle": {
+    "defaultMessage": "Recipe importieren"
+  },
+  "importRecipeForm.importing": {
+    "defaultMessage": "Wird importiert..."
+  },
+  "importRecipeForm.or": {
+    "defaultMessage": "ODER"
+  },
+  "importRecipeForm.recipeDeeplinkLabel": {
+    "defaultMessage": "Recipe-Deeplink"
+  },
+  "importRecipeForm.recipeFileHint": {
+    "defaultMessage": "Laden Sie eine YAML- oder JSON-Datei hoch, die die Recipe-Struktur enthält"
+  },
+  "importRecipeForm.recipeFileLabel": {
+    "defaultMessage": "Recipe-Datei"
+  },
+  "importRecipeForm.reviewWarning": {
+    "defaultMessage": "Stellen Sie sicher, dass Sie den Inhalt von Recipe-Dateien überprüfen, bevor Sie sie zu Ihrer goose-Oberfläche hinzufügen."
+  },
+  "importRecipeForm.schemaDescription": {
+    "defaultMessage": "Ihre YAML- oder JSON-Datei sollte dieser Struktur folgen. Erforderliche Felder sind: title, description und entweder instructions oder prompt."
+  },
+  "inlineEditText.clickToEdit": {
+    "defaultMessage": "Zum Bearbeiten klicken"
+  },
+  "inlineEditText.doubleClickToEdit": {
+    "defaultMessage": "Zum Bearbeiten doppelklicken"
+  },
+  "inlineEditText.enterText": {
+    "defaultMessage": "Text eingeben"
+  },
+  "inlineEditText.failedToSave": {
+    "defaultMessage": "Speichern fehlgeschlagen"
+  },
+  "instructionsEditor.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "instructionsEditor.insertExample": {
+    "defaultMessage": "Beispiel einfügen"
+  },
+  "instructionsEditor.label": {
+    "defaultMessage": "Anweisungen"
+  },
+  "instructionsEditor.placeholder": {
+    "defaultMessage": "Detaillierte Anweisungen für die KI, vor dem Benutzer verborgen"
+  },
+  "instructionsEditor.save": {
+    "defaultMessage": "Anweisungen speichern"
+  },
+  "instructionsEditor.syntaxHelp": {
+    "defaultMessage": "Verwenden Sie die {code}-Syntax, um Parameter zu definieren, die Benutzer ausfüllen können"
+  },
+  "instructionsEditor.title": {
+    "defaultMessage": "Anweisungseditor"
+  },
+  "jsonSchemaEditor.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "jsonSchemaEditor.description": {
+    "defaultMessage": "Definieren Sie die erwartete Struktur der KI-Antwort im JSON-Schema-Format"
+  },
+  "jsonSchemaEditor.insertExample": {
+    "defaultMessage": "Beispiel einfügen"
+  },
+  "jsonSchemaEditor.invalidJson": {
+    "defaultMessage": "Ungültiges JSON-Format"
+  },
+  "jsonSchemaEditor.label": {
+    "defaultMessage": "Antwort-JSON-Schema"
+  },
+  "jsonSchemaEditor.save": {
+    "defaultMessage": "Schema speichern"
+  },
+  "jsonSchemaEditor.title": {
+    "defaultMessage": "JSON-Schema-Editor"
+  },
+  "jsonSchemaForm.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "jsonSchemaForm.fieldRequired": {
+    "defaultMessage": "Dieses Feld ist erforderlich"
+  },
+  "jsonSchemaForm.maxLength": {
+    "defaultMessage": "Maximale Länge ist {maxLength}"
+  },
+  "jsonSchemaForm.maxValue": {
+    "defaultMessage": "Maximalwert ist {maximum}"
+  },
+  "jsonSchemaForm.minLength": {
+    "defaultMessage": "Mindestlänge ist {minLength}"
+  },
+  "jsonSchemaForm.minValue": {
+    "defaultMessage": "Mindestwert ist {minimum}"
+  },
+  "jsonSchemaForm.noFields": {
+    "defaultMessage": "Keine Felder anzuzeigen"
+  },
+  "jsonSchemaForm.selectPlaceholder": {
+    "defaultMessage": "Auswählen..."
+  },
+  "jsonSchemaForm.submit": {
+    "defaultMessage": "Absenden"
+  },
+  "keyValueEditor.addValue": {
+    "defaultMessage": "Vorkonfigurierten Wert hinzufügen"
+  },
+  "keyValueEditor.defaultKeyPlaceholder": {
+    "defaultMessage": "Parametername..."
+  },
+  "keyValueEditor.defaultValuePlaceholder": {
+    "defaultMessage": "Parameterwert..."
+  },
+  "keyValueEditor.removeValue": {
+    "defaultMessage": "Vorkonfigurierten Wert {key} entfernen"
+  },
+  "keyboardShortcuts.alwaysOnTopDescription": {
+    "defaultMessage": "Fenster immer im Vordergrund umschalten"
+  },
+  "keyboardShortcuts.alwaysOnTopLabel": {
+    "defaultMessage": "Immer im Vordergrund"
+  },
+  "keyboardShortcuts.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "keyboardShortcuts.categoryApplication": {
+    "defaultMessage": "Anwendungstastenkürzel"
+  },
+  "keyboardShortcuts.categoryApplicationDescription": {
+    "defaultMessage": "Diese Tastenkürzel funktionieren, wenn Goose die aktive Anwendung ist"
+  },
+  "keyboardShortcuts.categoryGlobal": {
+    "defaultMessage": "Globale Tastenkürzel"
+  },
+  "keyboardShortcuts.categoryGlobalDescription": {
+    "defaultMessage": "Diese Tastenkürzel funktionieren systemweit, auch wenn Goose nicht im Fokus ist"
+  },
+  "keyboardShortcuts.categorySearch": {
+    "defaultMessage": "Such-Tastenkürzel"
+  },
+  "keyboardShortcuts.categorySearchDescription": {
+    "defaultMessage": "Diese Tastenkürzel funktionieren beim Suchen in einer Unterhaltung"
+  },
+  "keyboardShortcuts.categoryWindow": {
+    "defaultMessage": "Fenster-Tastenkürzel"
+  },
+  "keyboardShortcuts.categoryWindowDescription": {
+    "defaultMessage": "Diese Tastenkürzel steuern das Fensterverhalten"
+  },
+  "keyboardShortcuts.change": {
+    "defaultMessage": "Ändern"
+  },
+  "keyboardShortcuts.disabled": {
+    "defaultMessage": "Deaktiviert"
+  },
+  "keyboardShortcuts.dismiss": {
+    "defaultMessage": "Schließen"
+  },
+  "keyboardShortcuts.findDescription": {
+    "defaultMessage": "Suche in der Unterhaltung öffnen"
+  },
+  "keyboardShortcuts.findLabel": {
+    "defaultMessage": "Suchen"
+  },
+  "keyboardShortcuts.findNextDescription": {
+    "defaultMessage": "Zum nächsten Suchergebnis springen"
+  },
+  "keyboardShortcuts.findNextLabel": {
+    "defaultMessage": "Weitersuchen"
+  },
+  "keyboardShortcuts.findPreviousDescription": {
+    "defaultMessage": "Zum vorherigen Suchergebnis springen"
+  },
+  "keyboardShortcuts.findPreviousLabel": {
+    "defaultMessage": "Rückwärts suchen"
+  },
+  "keyboardShortcuts.focusWindowDescription": {
+    "defaultMessage": "Goose-Fenster von überall in den Vordergrund holen"
+  },
+  "keyboardShortcuts.focusWindowLabel": {
+    "defaultMessage": "Goose-Fenster fokussieren"
+  },
+  "keyboardShortcuts.loading": {
+    "defaultMessage": "Wird geladen..."
+  },
+  "keyboardShortcuts.newChatDescription": {
+    "defaultMessage": "Einen neuen Chat im aktuellen Fenster erstellen"
+  },
+  "keyboardShortcuts.newChatLabel": {
+    "defaultMessage": "Neuer Chat"
+  },
+  "keyboardShortcuts.newChatWindowDescription": {
+    "defaultMessage": "Ein neues Goose-Fenster öffnen"
+  },
+  "keyboardShortcuts.newChatWindowLabel": {
+    "defaultMessage": "Neues Chat-Fenster"
+  },
+  "keyboardShortcuts.openDirectoryDescription": {
+    "defaultMessage": "Dialog zur Verzeichnisauswahl öffnen"
+  },
+  "keyboardShortcuts.openDirectoryLabel": {
+    "defaultMessage": "Verzeichnis öffnen"
+  },
+  "keyboardShortcuts.quickLauncherDescription": {
+    "defaultMessage": "Das Schnellstart-Overlay öffnen"
+  },
+  "keyboardShortcuts.quickLauncherLabel": {
+    "defaultMessage": "Schnellstart"
+  },
+  "keyboardShortcuts.reassignShortcut": {
+    "defaultMessage": "Tastenkürzel neu zuweisen"
+  },
+  "keyboardShortcuts.resetAllShortcuts": {
+    "defaultMessage": "Alle Tastenkürzel zurücksetzen"
+  },
+  "keyboardShortcuts.resetShortcutsDetail": {
+    "defaultMessage": "Dadurch werden alle Tastenkürzel auf ihre ursprüngliche Konfiguration zurückgesetzt."
+  },
+  "keyboardShortcuts.resetShortcutsMessage": {
+    "defaultMessage": "Alle Tastenkürzel auf ihre Standardwerte zurücksetzen?"
+  },
+  "keyboardShortcuts.resetShortcutsTitle": {
+    "defaultMessage": "Tastenkürzel zurücksetzen"
+  },
+  "keyboardShortcuts.resetToDefaultsDescription": {
+    "defaultMessage": "Alle Tastenkürzel auf ihre ursprüngliche Konfiguration zurücksetzen"
+  },
+  "keyboardShortcuts.resetToDefaultsHeading": {
+    "defaultMessage": "Auf Standard zurücksetzen"
+  },
+  "keyboardShortcuts.restartDescription": {
+    "defaultMessage": "Änderungen an Anwendungstastenkürzeln (wie Neuer Chat, Einstellungen usw.) erfordern einen Neustart von Goose, um wirksam zu werden. Globale Tastenkürzel (Fenster fokussieren, Schnellstart) funktionieren sofort."
+  },
+  "keyboardShortcuts.restartRequired": {
+    "defaultMessage": "Neustart erforderlich"
+  },
+  "keyboardShortcuts.settingsDescription": {
+    "defaultMessage": "Einstellungsbereich öffnen"
+  },
+  "keyboardShortcuts.settingsLabel": {
+    "defaultMessage": "Einstellungen"
+  },
+  "keyboardShortcuts.shortcutConflictSaveDetail": {
+    "defaultMessage": "Beim Speichern wird das Tastenkürzel von \"{conflictLabel}\" entfernt und \"{targetLabel}\" zugewiesen. Möchten Sie fortfahren?"
+  },
+  "keyboardShortcuts.shortcutConflictTitle": {
+    "defaultMessage": "Tastenkürzel-Konflikt"
+  },
+  "keyboardShortcuts.shortcutConflictToggleDetail": {
+    "defaultMessage": "Durch das Aktivieren wird das Tastenkürzel von \"{conflictLabel}\" entfernt und \"{targetLabel}\" zugewiesen. Möchten Sie fortfahren?"
+  },
+  "keyboardShortcuts.shortcutConflictToggleMessage": {
+    "defaultMessage": "Das Tastenkürzel {shortcut} ist bereits \"{conflictLabel}\" zugewiesen."
+  },
+  "keyboardShortcuts.toggleNavigationDescription": {
+    "defaultMessage": "Navigationsmenü ein- oder ausblenden"
+  },
+  "keyboardShortcuts.toggleNavigationLabel": {
+    "defaultMessage": "Navigation umschalten"
+  },
+  "launcher.placeholder": {
+    "defaultMessage": "Frag goose irgendetwas..."
+  },
+  "loadingGoose.compacting": {
+    "defaultMessage": "goose komprimiert die Unterhaltung..."
+  },
+  "loadingGoose.idle": {
+    "defaultMessage": "goose arbeitet daran…"
+  },
+  "loadingGoose.loadingConversation": {
+    "defaultMessage": "Unterhaltung wird geladen..."
+  },
+  "loadingGoose.restartingAgent": {
+    "defaultMessage": "Sitzung wird neu gestartet..."
+  },
+  "loadingGoose.streaming": {
+    "defaultMessage": "goose arbeitet daran…"
+  },
+  "loadingGoose.thinking": {
+    "defaultMessage": "goose denkt nach…"
+  },
+  "loadingGoose.waiting": {
+    "defaultMessage": "goose wartet…"
+  },
+  "localInferenceSettings.deleteConfirm": {
+    "defaultMessage": "Dieses Modell löschen? Sie können es später erneut herunterladen."
+  },
+  "localInferenceSettings.description": {
+    "defaultMessage": "Lokale LLM-Modelle für die Inferenz ohne API-Schlüssel herunterladen und verwalten. Durchsuchen Sie HuggingFace nach GGUF- oder MLX-Modellen oder verwenden Sie die unten empfohlenen Modelle."
+  },
+  "localInferenceSettings.dismiss": {
+    "defaultMessage": "Schließen"
+  },
+  "localInferenceSettings.download": {
+    "defaultMessage": "Herunterladen"
+  },
+  "localInferenceSettings.downloadCancelled": {
+    "defaultMessage": "Download abgebrochen"
+  },
+  "localInferenceSettings.downloadFailed": {
+    "defaultMessage": "Download fehlgeschlagen"
+  },
+  "localInferenceSettings.downloadProgress": {
+    "defaultMessage": "{downloaded} / {total} ({percent}%)"
+  },
+  "localInferenceSettings.downloadedModels": {
+    "defaultMessage": "Heruntergeladene Modelle"
+  },
+  "localInferenceSettings.downloading": {
+    "defaultMessage": "Wird heruntergeladen"
+  },
+  "localInferenceSettings.featuredModels": {
+    "defaultMessage": "Empfohlene Modelle"
+  },
+  "localInferenceSettings.huggingFaceSignInNote": {
+    "defaultMessage": "Melden Sie sich an, um die Ratenbegrenzungen beim Suchen und Herunterladen von Modellen zu erhöhen und auf private oder zugriffsbeschränkte Hugging-Face-Repositories zuzugreifen."
+  },
+  "localInferenceSettings.modelSettings": {
+    "defaultMessage": "Modelleinstellungen"
+  },
+  "localInferenceSettings.modelSettingsTitle": {
+    "defaultMessage": "Modelleinstellungen"
+  },
+  "localInferenceSettings.noModels": {
+    "defaultMessage": "Keine Modelle verfügbar"
+  },
+  "localInferenceSettings.recommended": {
+    "defaultMessage": "Empfohlen"
+  },
+  "localInferenceSettings.remaining": {
+    "defaultMessage": "{time} verbleibend"
+  },
+  "localInferenceSettings.retry": {
+    "defaultMessage": "Erneut versuchen"
+  },
+  "localInferenceSettings.showAllFeatured": {
+    "defaultMessage": "Alle empfohlenen anzeigen ({count} weitere)"
+  },
+  "localInferenceSettings.showRecommendedOnly": {
+    "defaultMessage": "Nur empfohlene anzeigen"
+  },
+  "localInferenceSettings.title": {
+    "defaultMessage": "Lokale Inferenzmodelle"
+  },
+  "localInferenceSettings.vision": {
+    "defaultMessage": "Vision"
+  },
+  "localInferenceSettings.visionEncoderDownloading": {
+    "defaultMessage": "Vision-Encoder wird heruntergeladen…"
+  },
+  "localInferenceSettings.visionEncoderNotDownloaded": {
+    "defaultMessage": "Vision-Encoder nicht heruntergeladen"
+  },
+  "localModelManager.active": {
+    "defaultMessage": "Aktiv"
+  },
+  "localModelManager.deleteConfirm": {
+    "defaultMessage": "Dieses Modell löschen? Sie können es später erneut herunterladen."
+  },
+  "localModelManager.download": {
+    "defaultMessage": "Herunterladen"
+  },
+  "localModelManager.downloaded": {
+    "defaultMessage": "Heruntergeladen"
+  },
+  "localModelManager.gpuAcceleration": {
+    "defaultMessage": "Unterstützt GPU-Beschleunigung (CUDA für NVIDIA, Metal für Apple Silicon). GPU-Funktionen müssen zur Build-Zeit aktiviert werden, um Hardwarebeschleunigung zu ermöglichen."
+  },
+  "localModelManager.noModels": {
+    "defaultMessage": "Keine Modelle verfügbar"
+  },
+  "localModelManager.recommended": {
+    "defaultMessage": "Empfohlen"
+  },
+  "localModelManager.recommendedForHardware": {
+    "defaultMessage": "Für Ihre Hardware empfohlen"
+  },
+  "localModelManager.showAllModels": {
+    "defaultMessage": "Alle Modelle anzeigen ({count} weitere)"
+  },
+  "localModelManager.showRecommendedOnly": {
+    "defaultMessage": "Nur empfohlene anzeigen"
+  },
+  "localModelPicker.back": {
+    "defaultMessage": "Zurück"
+  },
+  "localModelPicker.bestForMachine": {
+    "defaultMessage": "Am besten für Ihren Computer"
+  },
+  "localModelPicker.cancelDownload": {
+    "defaultMessage": "Download abbrechen"
+  },
+  "localModelPicker.checkingModels": {
+    "defaultMessage": "Verfügbare Modelle werden geprüft..."
+  },
+  "localModelPicker.downloadModel": {
+    "defaultMessage": "{modelId} ({size}) herunterladen"
+  },
+  "localModelPicker.downloading": {
+    "defaultMessage": "{modelId} wird heruntergeladen"
+  },
+  "localModelPicker.failedToLoad": {
+    "defaultMessage": "Verfügbare Modelle konnten nicht geladen werden. Bitte versuchen Sie es erneut."
+  },
+  "localModelPicker.failedToStartDownload": {
+    "defaultMessage": "Download konnte nicht gestartet werden. Bitte versuchen Sie es erneut."
+  },
+  "localModelPicker.hideOtherSizes": {
+    "defaultMessage": "Andere Größen ausblenden"
+  },
+  "localModelPicker.localModelsNote": {
+    "defaultMessage": "Lokale Modelle behalten alles auf Ihrem Computer für vollständige Privatsphäre. Leistung und Kontextfenstergröße können je nach Hardware und Modellgröße im Vergleich zu Cloud-Anbietern variieren."
+  },
+  "localModelPicker.lostConnection": {
+    "defaultMessage": "Verbindung zum Download verloren. Bitte versuchen Sie es erneut."
+  },
+  "localModelPicker.modelNotFound": {
+    "defaultMessage": "Modell nicht gefunden"
+  },
+  "localModelPicker.ready": {
+    "defaultMessage": "Bereit"
+  },
+  "localModelPicker.selectModel": {
+    "defaultMessage": "Modell auswählen"
+  },
+  "localModelPicker.showOtherSizes": {
+    "defaultMessage": "{count} andere Größen anzeigen"
+  },
+  "localModelPicker.startingDownload": {
+    "defaultMessage": "Download wird gestartet..."
+  },
+  "localModelPicker.tryAgain": {
+    "defaultMessage": "Erneut versuchen"
+  },
+  "localModelPicker.useModel": {
+    "defaultMessage": "{modelId} verwenden"
+  },
+  "markdownContent.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "markdownContent.copyCode": {
+    "defaultMessage": "Code kopieren"
+  },
+  "markdownContent.failedToOpenLink": {
+    "defaultMessage": "Link konnte nicht geöffnet werden"
+  },
+  "markdownContent.noApplicationFound": {
+    "defaultMessage": "Keine Anwendung zum Öffnen dieses Links gefunden."
+  },
+  "markdownContent.open": {
+    "defaultMessage": "Öffnen"
+  },
+  "markdownContent.openExternalLink": {
+    "defaultMessage": "Externen Link öffnen"
+  },
+  "markdownContent.openProtocolLink": {
+    "defaultMessage": "{protocol}-Link öffnen?"
+  },
+  "markdownContent.thisWillOpen": {
+    "defaultMessage": "Dies öffnet: {href}"
+  },
+  "mcpAppRenderer.appFallbackTitle": {
+    "defaultMessage": "App"
+  },
+  "mcpAppRenderer.cancelButton": {
+    "defaultMessage": "Abbrechen"
+  },
+  "mcpAppRenderer.close": {
+    "defaultMessage": "Schließen"
+  },
+  "mcpAppRenderer.exitFullscreen": {
+    "defaultMessage": "Vollbild beenden"
+  },
+  "mcpAppRenderer.exitFullscreenTitle": {
+    "defaultMessage": "Vollbild beenden (Esc)"
+  },
+  "mcpAppRenderer.failedToInitSandbox": {
+    "defaultMessage": "Sandbox-Proxy konnte nicht initialisiert werden"
+  },
+  "mcpAppRenderer.failedToLoadResource": {
+    "defaultMessage": "Ressource konnte nicht geladen werden"
+  },
+  "mcpAppRenderer.fullscreen": {
+    "defaultMessage": "Vollbild"
+  },
+  "mcpAppRenderer.invalidUrl": {
+    "defaultMessage": "Ungültige URL"
+  },
+  "mcpAppRenderer.movePipWindow": {
+    "defaultMessage": "Bild-in-Bild-Fenster verschieben (Pfeiltasten verwenden)"
+  },
+  "mcpAppRenderer.openButton": {
+    "defaultMessage": "Öffnen"
+  },
+  "mcpAppRenderer.openExternalLinkTitle": {
+    "defaultMessage": "Externen Link öffnen"
+  },
+  "mcpAppRenderer.openLinkDetail": {
+    "defaultMessage": "Dies öffnet: {url}"
+  },
+  "mcpAppRenderer.openProtocolLink": {
+    "defaultMessage": "{protocol}-Link öffnen?"
+  },
+  "mcpAppRenderer.pictureInPicture": {
+    "defaultMessage": "Bild-in-Bild"
+  },
+  "mcpAppRenderer.playingInPip": {
+    "defaultMessage": "Wiedergabe im Bild-in-Bild-Modus"
+  },
+  "mcpUIResourceRenderer.cancelButton": {
+    "defaultMessage": "Abbrechen"
+  },
+  "mcpUIResourceRenderer.openButton": {
+    "defaultMessage": "Öffnen"
+  },
+  "mcpUIResourceRenderer.openExternalLinkTitle": {
+    "defaultMessage": "Externen Link öffnen"
+  },
+  "mcpUIResourceRenderer.openLinkDetail": {
+    "defaultMessage": "Dies öffnet: {url}"
+  },
+  "mcpUIResourceRenderer.openProtocolLink": {
+    "defaultMessage": "{protocol}-Link öffnen?"
+  },
+  "mcpUIResourceRenderer.toastMessageReceived": {
+    "defaultMessage": "Nachricht für {message} empfangen."
+  },
+  "mcpUIResourceRenderer.toastTitle": {
+    "defaultMessage": "MCP-UI-Nachricht {messageType}"
+  },
+  "mcpUIResourceRenderer.toastUnsupported": {
+    "defaultMessage": "Nachricht für {message} empfangen. Nachrichten vom Typ {messageType} werden noch nicht unterstützt, weitere Details finden Sie in der Konsole."
+  },
+  "mentionPopover.itemsFound": {
+    "defaultMessage": "{count,plural,one{# Element gefunden} other{# Elemente gefunden}}"
+  },
+  "mentionPopover.loadingCommands": {
+    "defaultMessage": "Befehle werden geladen..."
+  },
+  "mentionPopover.noCommandsFound": {
+    "defaultMessage": "Keine Befehle gefunden, die \"{query}\" entsprechen"
+  },
+  "mentionPopover.noItemsFound": {
+    "defaultMessage": "Keine Elemente gefunden, die \"{query}\" entsprechen"
+  },
+  "mentionPopover.scanningFiles": {
+    "defaultMessage": "Dateien werden durchsucht..."
+  },
+  "messageCopyLink.copied": {
+    "defaultMessage": "Kopiert!"
+  },
+  "messageCopyLink.copy": {
+    "defaultMessage": "Kopieren"
+  },
+  "messageQueue.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "messageQueue.cannotSendWhileEditing": {
+    "defaultMessage": "Senden während der Bearbeitung nicht möglich"
+  },
+  "messageQueue.clearAll": {
+    "defaultMessage": "Alle löschen"
+  },
+  "messageQueue.clickToEdit": {
+    "defaultMessage": "{content} (Zum Bearbeiten klicken)"
+  },
+  "messageQueue.collapseQueue": {
+    "defaultMessage": "Warteschlange einklappen"
+  },
+  "messageQueue.dragToReorder": {
+    "defaultMessage": "Nachrichten ziehen, um die Priorität neu zu ordnen"
+  },
+  "messageQueue.expandQueue": {
+    "defaultMessage": "Warteschlange ausklappen"
+  },
+  "messageQueue.messageCount": {
+    "defaultMessage": "{count,plural,one{# Nachricht {status}} other{# Nachrichten {status}}}"
+  },
+  "messageQueue.messageQueue": {
+    "defaultMessage": "Nachrichtenwarteschlange"
+  },
+  "messageQueue.next": {
+    "defaultMessage": "Weiter"
+  },
+  "messageQueue.paused": {
+    "defaultMessage": "Angehalten"
+  },
+  "messageQueue.queuePaused": {
+    "defaultMessage": "Warteschlange angehalten"
+  },
+  "messageQueue.queuePausedCompact": {
+    "defaultMessage": "Warteschlange angehalten – auf \"Senden\" klicken oder neue Nachricht hinzufügen, um fortzufahren"
+  },
+  "messageQueue.queuePausedExpanded": {
+    "defaultMessage": "Warteschlange durch Unterbrechung angehalten. Verwenden Sie \"Jetzt senden\" oder fügen Sie eine neue Nachricht hinzu, um fortzufahren."
+  },
+  "messageQueue.queued": {
+    "defaultMessage": "in der Warteschlange"
+  },
+  "messageQueue.removeFromQueue": {
+    "defaultMessage": "Diese Nachricht aus der Warteschlange entfernen"
+  },
+  "messageQueue.save": {
+    "defaultMessage": "Speichern"
+  },
+  "messageQueue.sendNow": {
+    "defaultMessage": "Diese Nachricht jetzt senden"
+  },
+  "messageQueue.stopAndSend": {
+    "defaultMessage": "Aktuelle Verarbeitung stoppen und diese Nachricht jetzt senden"
+  },
+  "messageQueue.waiting": {
+    "defaultMessage": "wartet"
+  },
+  "microphoneSelector.chooseDescription": {
+    "defaultMessage": "Wählen Sie aus, welches Mikrofon für das Diktat verwendet werden soll"
+  },
+  "microphoneSelector.grantAccess": {
+    "defaultMessage": "Zugriff gewähren"
+  },
+  "microphoneSelector.grantAccessDescription": {
+    "defaultMessage": "Zugriff gewähren, um verfügbare Mikrofone anzuzeigen"
+  },
+  "microphoneSelector.microphone": {
+    "defaultMessage": "Mikrofon"
+  },
+  "microphoneSelector.microphoneLabel": {
+    "defaultMessage": "Mikrofon {index}"
+  },
+  "microphoneSelector.selectedMicrophone": {
+    "defaultMessage": "Ausgewähltes Mikrofon"
+  },
+  "microphoneSelector.speakToTest": {
+    "defaultMessage": "Sprechen Sie, um Ihr Mikrofon zu testen ({seconds}s)"
+  },
+  "microphoneSelector.stop": {
+    "defaultMessage": "Stopp"
+  },
+  "microphoneSelector.systemDefault": {
+    "defaultMessage": "Systemstandard"
+  },
+  "microphoneSelector.test": {
+    "defaultMessage": "Testen"
+  },
+  "modeSelectionItem.autonomousDescription": {
+    "defaultMessage": "Vollständige Dateiänderungsfunktionen, Dateien frei bearbeiten, erstellen und löschen."
+  },
+  "modeSelectionItem.autonomousLabel": {
+    "defaultMessage": "Autonom"
+  },
+  "modeSelectionItem.chatOnlyDescription": {
+    "defaultMessage": "Mit dem ausgewählten Anbieter interagieren, ohne Tools oder Erweiterungen zu verwenden."
+  },
+  "modeSelectionItem.chatOnlyLabel": {
+    "defaultMessage": "Nur Chat"
+  },
+  "modeSelectionItem.manualDescription": {
+    "defaultMessage": "Alle Tools, Erweiterungen und Dateiänderungen erfordern eine manuelle Genehmigung"
+  },
+  "modeSelectionItem.manualLabel": {
+    "defaultMessage": "Manuell"
+  },
+  "modeSelectionItem.smartDescription": {
+    "defaultMessage": "Intelligent bestimmen, welche Aktionen basierend auf dem Risikoniveau eine Genehmigung erfordern"
+  },
+  "modeSelectionItem.smartLabel": {
+    "defaultMessage": "Intelligent"
+  },
+  "modelAndProviderContext.modelChangeFailed": {
+    "defaultMessage": "{provider}/{model} fehlgeschlagen"
+  },
+  "modelAndProviderContext.modelChangedTitle": {
+    "defaultMessage": "Modell geändert"
+  },
+  "modelAndProviderContext.selectModel": {
+    "defaultMessage": "Modell auswählen"
+  },
+  "modelAndProviderContext.switchModelSuccess": {
+    "defaultMessage": "Modelle erfolgreich gewechselt – {model} von {provider} wird verwendet"
+  },
+  "modelAndProviderContext.unknownProviderMsg": {
+    "defaultMessage": "Unbekannter Anbieter in der Konfiguration – bitte überprüfen Sie Ihre config.yaml"
+  },
+  "modelAndProviderContext.unknownProviderTitle": {
+    "defaultMessage": "Anbietername-Suche"
+  },
+  "modelSettingsButtons.configureProviders": {
+    "defaultMessage": "Anbieter konfigurieren"
+  },
+  "modelSettingsButtons.switchModels": {
+    "defaultMessage": "Modelle wechseln"
+  },
+  "modelSettingsPanel.batchSize": {
+    "defaultMessage": "Stapelgröße"
+  },
+  "modelSettingsPanel.batchSizeDescription": {
+    "defaultMessage": "Stapel für die Prompt-Verarbeitung"
+  },
+  "modelSettingsPanel.builtinChatTemplate": {
+    "defaultMessage": "Integrierte Vorlage"
+  },
+  "modelSettingsPanel.builtinChatTemplateDescription": {
+    "defaultMessage": "Wählen Sie den Namen einer in llama.cpp integrierten Vorlage aus"
+  },
+  "modelSettingsPanel.chatTemplate": {
+    "defaultMessage": "Chat-Vorlage"
+  },
+  "modelSettingsPanel.chatTemplateBuiltin": {
+    "defaultMessage": "Integriert"
+  },
+  "modelSettingsPanel.chatTemplateCustomInline": {
+    "defaultMessage": "Benutzerdefiniert inline"
+  },
+  "modelSettingsPanel.chatTemplateDescription": {
+    "defaultMessage": "Verwenden Sie eingebettete GGUF-Metadaten, eine in llama.cpp integrierte Vorlage oder Inline-Jinja"
+  },
+  "modelSettingsPanel.chatTemplateEmbedded": {
+    "defaultMessage": "Eingebettet"
+  },
+  "modelSettingsPanel.contextAndGeneration": {
+    "defaultMessage": "Kontext & Generierung"
+  },
+  "modelSettingsPanel.contextSize": {
+    "defaultMessage": "Kontextgröße"
+  },
+  "modelSettingsPanel.contextSizeDescription": {
+    "defaultMessage": "Max. Kontextfenster (0 = Modellstandard)"
+  },
+  "modelSettingsPanel.customChatTemplate": {
+    "defaultMessage": "Benutzerdefinierte Chat-Vorlage"
+  },
+  "modelSettingsPanel.customChatTemplateDescription": {
+    "defaultMessage": "Fügen Sie den vollständigen Jinja-Chat-Vorlagenquelltext ein"
+  },
+  "modelSettingsPanel.etaLearningRate": {
+    "defaultMessage": "Eta (Lernrate)"
+  },
+  "modelSettingsPanel.flashAttention": {
+    "defaultMessage": "Flash Attention"
+  },
+  "modelSettingsPanel.flashAttentionDescription": {
+    "defaultMessage": "Flash-Attention-Optimierung aktivieren"
+  },
+  "modelSettingsPanel.frequencyPenalty": {
+    "defaultMessage": "Häufigkeitsstrafe"
+  },
+  "modelSettingsPanel.frequencyPenaltyDescription": {
+    "defaultMessage": "0.0 = aus"
+  },
+  "modelSettingsPanel.gpuLayers": {
+    "defaultMessage": "GPU-Schichten"
+  },
+  "modelSettingsPanel.gpuLayersDescription": {
+    "defaultMessage": "Auf die GPU auszulagernde Schichten"
+  },
+  "modelSettingsPanel.loadingSettings": {
+    "defaultMessage": "Einstellungen werden geladen..."
+  },
+  "modelSettingsPanel.lockModelInRam": {
+    "defaultMessage": "Modell im RAM sperren (mlock)"
+  },
+  "modelSettingsPanel.lockModelInRamDescription": {
+    "defaultMessage": "Verhindern, dass das Modell auf die Festplatte ausgelagert wird"
+  },
+  "modelSettingsPanel.maxOutputTokens": {
+    "defaultMessage": "Max. Ausgabe-Tokens"
+  },
+  "modelSettingsPanel.maxOutputTokensDescription": {
+    "defaultMessage": "Obergrenze für generierte Tokens"
+  },
+  "modelSettingsPanel.minP": {
+    "defaultMessage": "Min P"
+  },
+  "modelSettingsPanel.performance": {
+    "defaultMessage": "Leistung"
+  },
+  "modelSettingsPanel.presencePenalty": {
+    "defaultMessage": "Präsenzstrafe"
+  },
+  "modelSettingsPanel.presencePenaltyDescription": {
+    "defaultMessage": "0.0 = aus"
+  },
+  "modelSettingsPanel.repeatPenalty": {
+    "defaultMessage": "Wiederholungsstrafe"
+  },
+  "modelSettingsPanel.repeatPenaltyDescription": {
+    "defaultMessage": "1.0 = aus"
+  },
+  "modelSettingsPanel.repeatWindow": {
+    "defaultMessage": "Wiederholungsfenster"
+  },
+  "modelSettingsPanel.repeatWindowDescription": {
+    "defaultMessage": "Zurückzublickende Tokens"
+  },
+  "modelSettingsPanel.repetitionPenalty": {
+    "defaultMessage": "Wiederholungsstrafe"
+  },
+  "modelSettingsPanel.reset": {
+    "defaultMessage": "Zurücksetzen"
+  },
+  "modelSettingsPanel.resetToDefaults": {
+    "defaultMessage": "Auf Standard zurücksetzen"
+  },
+  "modelSettingsPanel.samplingStrategy": {
+    "defaultMessage": "Sampling-Strategie"
+  },
+  "modelSettingsPanel.saving": {
+    "defaultMessage": "Wird gespeichert..."
+  },
+  "modelSettingsPanel.seed": {
+    "defaultMessage": "Seed"
+  },
+  "modelSettingsPanel.tauTargetEntropy": {
+    "defaultMessage": "Tau (Zielentropie)"
+  },
+  "modelSettingsPanel.temperature": {
+    "defaultMessage": "Temperatur"
+  },
+  "modelSettingsPanel.threads": {
+    "defaultMessage": "Threads"
+  },
+  "modelSettingsPanel.threadsDescription": {
+    "defaultMessage": "CPU-Threads für die Generierung"
+  },
+  "modelSettingsPanel.toolCalling": {
+    "defaultMessage": "Tool-Aufruf"
+  },
+  "modelSettingsPanel.toolCallingAuto": {
+    "defaultMessage": "Automatisch"
+  },
+  "modelSettingsPanel.toolCallingDescription": {
+    "defaultMessage": "Wählen Sie aus, wie lokale Modelle nativen oder emulierten Tool-Aufruf auswählen"
+  },
+  "modelSettingsPanel.toolCallingForceEmulated": {
+    "defaultMessage": "Emuliert erzwingen"
+  },
+  "modelSettingsPanel.toolCallingForceNative": {
+    "defaultMessage": "Nativ erzwingen"
+  },
+  "modelSettingsPanel.topK": {
+    "defaultMessage": "Top K"
+  },
+  "modelSettingsPanel.topP": {
+    "defaultMessage": "Top P"
+  },
+  "modelsBottomBar.changeModel": {
+    "defaultMessage": "Modell ändern"
+  },
+  "modelsBottomBar.currentModel": {
+    "defaultMessage": "Aktuelles Modell"
+  },
+  "modelsBottomBar.loadingModel": {
+    "defaultMessage": "Modell wird geladen..."
+  },
+  "modelsBottomBar.localModelSettings": {
+    "defaultMessage": "Lokale Modelleinstellungen"
+  },
+  "modelsBottomBar.localModelSettingsTitle": {
+    "defaultMessage": "Lokale Modelleinstellungen — {modelName}"
+  },
+  "modelsBottomBar.resolvedModel": {
+    "defaultMessage": "Aufgelöstes Modell"
+  },
+  "modelsBottomBar.selectModel": {
+    "defaultMessage": "Modell auswählen"
+  },
+  "modelsSection.resetDescription": {
+    "defaultMessage": "Löschen Sie Ihre ausgewählten Modell- und Anbietereinstellungen, um neu zu beginnen"
+  },
+  "modelsSection.resetTitle": {
+    "defaultMessage": "Anbieter und Modell zurücksetzen"
+  },
+  "navigation.itemApps": {
+    "defaultMessage": "Apps"
+  },
+  "navigation.itemExtensions": {
+    "defaultMessage": "Erweiterungen"
+  },
+  "navigation.itemHome": {
+    "defaultMessage": "Neuer Chat"
+  },
+  "navigation.itemRecipes": {
+    "defaultMessage": "Rezepte"
+  },
+  "navigation.itemScheduler": {
+    "defaultMessage": "Planer"
+  },
+  "navigation.itemSessions": {
+    "defaultMessage": "Sitzungsverlauf"
+  },
+  "navigation.itemSettings": {
+    "defaultMessage": "Einstellungen"
+  },
+  "navigation.itemSkills": {
+    "defaultMessage": "Skills"
+  },
+  "navigationPanel.chats": {
+    "defaultMessage": "Chats"
+  },
+  "navigationPanel.noChats": {
+    "defaultMessage": "Keine aktuellen Chats"
+  },
+  "navigationPanel.untitledSession": {
+    "defaultMessage": "Unbenannte Sitzung"
+  },
+  "onboardingGuard.checkProviderErrorDescription": {
+    "defaultMessage": "Der Server startet möglicherweise gerade oder ist vorübergehend nicht verfügbar."
+  },
+  "onboardingGuard.checkProviderErrorTitle": {
+    "defaultMessage": "Verbindung zum Goose-Server nicht möglich"
+  },
+  "onboardingGuard.retry": {
+    "defaultMessage": "Erneut versuchen"
+  },
+  "onboardingGuard.welcomeDescription": {
+    "defaultMessage": "Ihr lokaler KI-Agent. Verbinden Sie einen KI-Modellanbieter, um zu beginnen."
+  },
+  "onboardingGuard.welcomeTitle": {
+    "defaultMessage": "Willkommen bei goose"
+  },
+  "onboardingSuccess.allSet": {
+    "defaultMessage": "Sie können jetzt mit goose loslegen."
+  },
+  "onboardingSuccess.connectedTo": {
+    "defaultMessage": "Verbunden mit {providerName}"
+  },
+  "onboardingSuccess.getStarted": {
+    "defaultMessage": "Loslegen"
+  },
+  "onboardingSuccess.learnMore": {
+    "defaultMessage": "Mehr erfahren"
+  },
+  "onboardingSuccess.localModelReady": {
+    "defaultMessage": "Lokales Modell bereit"
+  },
+  "onboardingSuccess.privacyDescription": {
+    "defaultMessage": "Anonyme Nutzungsdaten helfen, goose zu verbessern. Wir erfassen niemals Ihre Konversationen, Ihren Code oder Ihre persönlichen Daten."
+  },
+  "onboardingSuccess.privacyTitle": {
+    "defaultMessage": "Datenschutz"
+  },
+  "onboardingSuccess.shareUsageData": {
+    "defaultMessage": "Anonyme Nutzungsdaten teilen"
+  },
+  "parameterInput.defaultValue": {
+    "defaultMessage": "Standardwert"
+  },
+  "parameterInput.defaultValuePlaceholder": {
+    "defaultMessage": "Standardwert eingeben"
+  },
+  "parameterInput.deleteParameter": {
+    "defaultMessage": "Parameter löschen: {key}"
+  },
+  "parameterInput.description": {
+    "defaultMessage": "Beschreibung"
+  },
+  "parameterInput.descriptionHelp": {
+    "defaultMessage": "Dies ist die Nachricht, die der Endbenutzer sieht."
+  },
+  "parameterInput.descriptionPlaceholder": {
+    "defaultMessage": "Z. B. \"Geben Sie den Namen für die neue Komponente ein\""
+  },
+  "parameterInput.inputType": {
+    "defaultMessage": "Eingabetyp"
+  },
+  "parameterInput.optional": {
+    "defaultMessage": "Optional"
+  },
+  "parameterInput.optionsHelp": {
+    "defaultMessage": "Geben Sie jede Option in einer neuen Zeile ein. Diese werden als Dropdown-Auswahlmöglichkeiten angezeigt."
+  },
+  "parameterInput.optionsLabel": {
+    "defaultMessage": "Optionen (eine pro Zeile)"
+  },
+  "parameterInput.optionsPlaceholder": {
+    "defaultMessage": "Option 1 Option 2 Option 3"
+  },
+  "parameterInput.required": {
+    "defaultMessage": "Erforderlich"
+  },
+  "parameterInput.requirement": {
+    "defaultMessage": "Anforderung"
+  },
+  "parameterInput.typeBoolean": {
+    "defaultMessage": "Boolescher Wert"
+  },
+  "parameterInput.typeNumber": {
+    "defaultMessage": "Zahl"
+  },
+  "parameterInput.typeSelect": {
+    "defaultMessage": "Auswahl"
+  },
+  "parameterInput.typeString": {
+    "defaultMessage": "Zeichenkette"
+  },
+  "parameterInput.unused": {
+    "defaultMessage": "Nicht verwendet"
+  },
+  "parameterInput.unusedWarningTitle": {
+    "defaultMessage": "Dieser Parameter wird in den Anweisungen oder im Prompt nicht verwendet. Er steht für die manuelle Eingabe zur Verfügung, wird aber möglicherweise nicht benötigt."
+  },
+  "parameterInputModal.backToForm": {
+    "defaultMessage": "Zurück zum Parameterformular"
+  },
+  "parameterInputModal.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "parameterInputModal.cancelRecipeSetup": {
+    "defaultMessage": "Rezepteinrichtung abbrechen"
+  },
+  "parameterInputModal.enterValue": {
+    "defaultMessage": "Wert für {key} eingeben..."
+  },
+  "parameterInputModal.false": {
+    "defaultMessage": "Falsch"
+  },
+  "parameterInputModal.recipeParameters": {
+    "defaultMessage": "Rezeptparameter"
+  },
+  "parameterInputModal.select": {
+    "defaultMessage": "Auswählen..."
+  },
+  "parameterInputModal.selectOption": {
+    "defaultMessage": "Eine Option auswählen..."
+  },
+  "parameterInputModal.startNewChat": {
+    "defaultMessage": "Neuen Chat starten (kein Rezept)"
+  },
+  "parameterInputModal.startRecipe": {
+    "defaultMessage": "Rezept starten"
+  },
+  "parameterInputModal.true": {
+    "defaultMessage": "Wahr"
+  },
+  "parameterInputModal.whatToDo": {
+    "defaultMessage": "Was möchten Sie tun?"
+  },
+  "permissionModal.alwaysAllow": {
+    "defaultMessage": "Immer zulassen"
+  },
+  "permissionModal.askBefore": {
+    "defaultMessage": "Vorher fragen"
+  },
+  "permissionModal.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "permissionModal.close": {
+    "defaultMessage": "Schließen"
+  },
+  "permissionModal.failedToLoadTools": {
+    "defaultMessage": "Tools konnten nicht geladen werden"
+  },
+  "permissionModal.failedToLoadToolsDescription": {
+    "defaultMessage": "Die Tools für diese Erweiterung konnten nicht geladen werden. Die Erweiterung ist möglicherweise in der aktuellen Sitzung nicht geladen."
+  },
+  "permissionModal.neverAllow": {
+    "defaultMessage": "Nie zulassen"
+  },
+  "permissionModal.noActiveSession": {
+    "defaultMessage": "Keine aktive Sitzung"
+  },
+  "permissionModal.noActiveSessionDescription": {
+    "defaultMessage": "Starten Sie zuerst eine Chat-Sitzung, um die Tool-Berechtigungen für diese Erweiterung zu konfigurieren. Tool-Berechtigungen werden aus den Erweiterungen der aktiven Sitzung geladen."
+  },
+  "permissionModal.noToolsAvailable": {
+    "defaultMessage": "Keine Tools für diese Erweiterung verfügbar."
+  },
+  "permissionModal.saveChanges": {
+    "defaultMessage": "Änderungen speichern"
+  },
+  "permissionRulesModal.description": {
+    "defaultMessage": "Konfigurieren Sie Tool-Berechtigungen für Erweiterungen, um zu steuern, wie diese mit Ihrem System interagieren."
+  },
+  "permissionRulesModal.extensionRules": {
+    "defaultMessage": "Erweiterungsregeln"
+  },
+  "permissionRulesModal.title": {
+    "defaultMessage": "Berechtigungsregeln"
+  },
+  "permissionSetting.extensionRules": {
+    "defaultMessage": "Erweiterungsregeln"
+  },
+  "permissionSetting.permissionRules": {
+    "defaultMessage": "Berechtigungsregeln"
+  },
+  "permissionSetting.permissionRulesDescription": {
+    "defaultMessage": "Versteckte Anweisungen, die an den Anbieter übergeben werden, um Ihre Antworten zu steuern und mit Kontext anzureichern."
+  },
+  "privacyInfoModal.collectErrors": {
+    "defaultMessage": "Fehlertypen (z. B. \"rate_limit\", \"auth\" – keine Details)"
+  },
+  "privacyInfoModal.collectExtensions": {
+    "defaultMessage": "Erweiterungen und Anzahl der Tool-Nutzungen (nur Namen)"
+  },
+  "privacyInfoModal.collectOs": {
+    "defaultMessage": "Betriebssystem, Version und Architektur"
+  },
+  "privacyInfoModal.collectProvider": {
+    "defaultMessage": "Verwendeter Anbieter und verwendetes Modell"
+  },
+  "privacyInfoModal.collectSession": {
+    "defaultMessage": "Sitzungsmetriken (Dauer, Anzahl der Interaktionen, Token-Nutzung)"
+  },
+  "privacyInfoModal.collectVersion": {
+    "defaultMessage": "goose-Version und Installationsmethode"
+  },
+  "privacyInfoModal.description": {
+    "defaultMessage": "Anonyme Nutzungsdaten helfen uns zu verstehen, wie goose genutzt wird, und Verbesserungsbereiche zu identifizieren."
+  },
+  "privacyInfoModal.neverCollect": {
+    "defaultMessage": "Wir erfassen niemals Ihre Konversationen, Ihren Code, Tool-Argumente, Fehlermeldungen oder persönliche Daten. Sie können diese Einstellung jederzeit in den Einstellungen ändern."
+  },
+  "privacyInfoModal.title": {
+    "defaultMessage": "Datenschutzdetails"
+  },
+  "privacyInfoModal.whatWeCollect": {
+    "defaultMessage": "Was wir erfassen:"
+  },
+  "progressiveMessageList.loadingMessages": {
+    "defaultMessage": "Nachrichten werden geladen... ({renderedCount}/{totalCount})"
+  },
+  "progressiveMessageList.modelChanged": {
+    "defaultMessage": "Modell geändert: {previousModel} → {currentModel}"
+  },
+  "progressiveMessageList.searchHint": {
+    "defaultMessage": "Drücken Sie Cmd/Ctrl+F, um alle Nachrichten sofort für die Suche zu laden"
+  },
+  "promptsSettings.allPromptsReset": {
+    "defaultMessage": "Alle Prompts auf die Standardwerte zurückgesetzt"
+  },
+  "promptsSettings.backToList": {
+    "defaultMessage": "Zurück zur Liste"
+  },
+  "promptsSettings.confirmReplaceWithDefault": {
+    "defaultMessage": "Aktuellen Inhalt durch den Standard ersetzen? Ihre Änderungen gehen verloren."
+  },
+  "promptsSettings.confirmResetAll": {
+    "defaultMessage": "Möchten Sie wirklich alle Prompts auf ihre Standardwerte zurücksetzen? Dies kann nicht rückgängig gemacht werden."
+  },
+  "promptsSettings.confirmResetOne": {
+    "defaultMessage": "Möchten Sie diesen Prompt wirklich auf seinen Standard zurücksetzen? Dies kann nicht rückgängig gemacht werden."
+  },
+  "promptsSettings.confirmUnsavedBack": {
+    "defaultMessage": "Sie haben nicht gespeicherte Änderungen. Möchten Sie wirklich zurückgehen?"
+  },
+  "promptsSettings.customized": {
+    "defaultMessage": "Angepasst"
+  },
+  "promptsSettings.edit": {
+    "defaultMessage": "Bearbeiten"
+  },
+  "promptsSettings.editPromptTitle": {
+    "defaultMessage": "Bearbeiten: {name}"
+  },
+  "promptsSettings.editingLabel": {
+    "defaultMessage": "Bearbeitung: {name}"
+  },
+  "promptsSettings.enterPromptContent": {
+    "defaultMessage": "Prompt-Inhalt eingeben..."
+  },
+  "promptsSettings.failedToLoadPrompt": {
+    "defaultMessage": "Prompt konnte nicht geladen werden"
+  },
+  "promptsSettings.failedToLoadPrompts": {
+    "defaultMessage": "Prompts konnten nicht geladen werden"
+  },
+  "promptsSettings.failedToResetPrompt": {
+    "defaultMessage": "Prompt konnte nicht zurückgesetzt werden"
+  },
+  "promptsSettings.failedToResetPrompts": {
+    "defaultMessage": "Prompts konnten nicht zurückgesetzt werden"
+  },
+  "promptsSettings.failedToSavePrompt": {
+    "defaultMessage": "Prompt konnte nicht gespeichert werden"
+  },
+  "promptsSettings.promptEditingDescription": {
+    "defaultMessage": "Passen Sie die Prompts an, die das Verhalten von goose in verschiedenen Kontexten definieren. Diese Prompts verwenden die Jinja2-Templating-Syntax. Seien Sie vorsichtig beim Ändern von Template-Variablen, da fehlerhafte Änderungen die Funktionalität beeinträchtigen können. Bitte teilen Sie etwaige Verbesserungen mit der Community."
+  },
+  "promptsSettings.promptEditingTitle": {
+    "defaultMessage": "Prompt-Bearbeitung"
+  },
+  "promptsSettings.promptResetToDefault": {
+    "defaultMessage": "Prompt auf den Standard zurückgesetzt"
+  },
+  "promptsSettings.promptSaved": {
+    "defaultMessage": "Prompt gespeichert"
+  },
+  "promptsSettings.resetAll": {
+    "defaultMessage": "Alle zurücksetzen"
+  },
+  "promptsSettings.resetToDefault": {
+    "defaultMessage": "Auf Standard zurücksetzen"
+  },
+  "promptsSettings.restoreDefault": {
+    "defaultMessage": "Standard wiederherstellen"
+  },
+  "promptsSettings.save": {
+    "defaultMessage": "Speichern"
+  },
+  "promptsSettings.templateTip": {
+    "defaultMessage": "Template-Variablen wie {extensionsExample} oder {forExample} werden zur Laufzeit durch tatsächliche Werte ersetzt. Achten Sie darauf, keine erforderlichen Variablen zu entfernen."
+  },
+  "promptsSettings.unsavedChanges": {
+    "defaultMessage": "Sie haben nicht gespeicherte Änderungen"
+  },
+  "providerCard.noMetadata": {
+    "defaultMessage": "ProviderCard-Fehler: Keine Metadaten bereitgestellt"
+  },
+  "providerCard.unknownProvider": {
+    "defaultMessage": "Unbekannter Anbieter"
+  },
+  "providerCatalogPicker.anthropicCompatible": {
+    "defaultMessage": "Anthropic-kompatibel"
+  },
+  "providerCatalogPicker.apiFormat": {
+    "defaultMessage": "API-Format"
+  },
+  "providerCatalogPicker.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "providerCatalogPicker.chooseProvider": {
+    "defaultMessage": "Anbieter auswählen"
+  },
+  "providerCatalogPicker.errorPrefix": {
+    "defaultMessage": "Fehler: {error}"
+  },
+  "providerCatalogPicker.loadingProviders": {
+    "defaultMessage": "Anbieter werden geladen..."
+  },
+  "providerCatalogPicker.modelsAvailable": {
+    "defaultMessage": "{count} Modelle verfügbar"
+  },
+  "providerCatalogPicker.noProvidersAvailable": {
+    "defaultMessage": "Keine Anbieter verfügbar"
+  },
+  "providerCatalogPicker.noProvidersFound": {
+    "defaultMessage": "Keine Anbieter gefunden für \"{query}\""
+  },
+  "providerCatalogPicker.openaiCompatible": {
+    "defaultMessage": "OpenAI-kompatibel"
+  },
+  "providerCatalogPicker.requiresEnvVar": {
+    "defaultMessage": "• Erfordert {envVar}"
+  },
+  "providerCatalogPicker.searchProviders": {
+    "defaultMessage": "Anbieter suchen..."
+  },
+  "providerCatalogPicker.selectFormatDescription": {
+    "defaultMessage": "Wählen Sie ein API-Format und einen Anbieter aus. Wir füllen die Konfiguration automatisch für Sie aus."
+  },
+  "providerConfigForm.browserWindowOpen": {
+    "defaultMessage": "Es öffnet sich ein Browserfenster, in dem Sie die Anmeldung abschließen können."
+  },
+  "providerConfigForm.configuring": {
+    "defaultMessage": "Wird konfiguriert..."
+  },
+  "providerConfigForm.continue": {
+    "defaultMessage": "Weiter"
+  },
+  "providerConfigForm.deviceCodeFlowHint": {
+    "defaultMessage": "Es öffnet sich ein Browserfenster und der Bestätigungscode wird in Ihre Zwischenablage kopiert. Fügen Sie ihn im Browser ein, um die Anmeldung abzuschließen."
+  },
+  "providerConfigForm.noApiKey": {
+    "defaultMessage": "Sie haben keinen API-Schlüssel?"
+  },
+  "providerConfigForm.signInWith": {
+    "defaultMessage": "Anmelden mit {providerName}"
+  },
+  "providerConfigForm.signingIn": {
+    "defaultMessage": "Anmeldung läuft..."
+  },
+  "providerConfigurationModal.addApiKeyDescription": {
+    "defaultMessage": "Fügen Sie Ihre API-Schlüssel für diesen Anbieter hinzu, um ihn in goose zu integrieren"
+  },
+  "providerConfigurationModal.browserWindowHint": {
+    "defaultMessage": "Es öffnet sich ein Browserfenster, in dem Sie die Anmeldung abschließen können."
+  },
+  "providerConfigurationModal.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "providerConfigurationModal.cannotDeleteActive": {
+    "defaultMessage": "Sie können diesen Anbieter nicht löschen, während er gerade verwendet wird. Bitte wechseln Sie zuerst zu einem anderen Modell."
+  },
+  "providerConfigurationModal.checkConfigAgain": {
+    "defaultMessage": "Überprüfen Sie Ihre Konfiguration erneut, um diesen Anbieter zu verwenden."
+  },
+  "providerConfigurationModal.close": {
+    "defaultMessage": "Schließen"
+  },
+  "providerConfigurationModal.configureHeader": {
+    "defaultMessage": "{providerName} konfigurieren"
+  },
+  "providerConfigurationModal.deleteConfigHeader": {
+    "defaultMessage": "Konfiguration für {providerName} löschen"
+  },
+  "providerConfigurationModal.deleteConfirmation": {
+    "defaultMessage": "Dadurch wird die aktuelle Anbieterkonfiguration dauerhaft gelöscht."
+  },
+  "providerConfigurationModal.deviceCodeFlowHint": {
+    "defaultMessage": "Es öffnet sich ein Browserfenster und der Bestätigungscode wird in Ihre Zwischenablage kopiert. Fügen Sie ihn im Browser ein, um die Anmeldung abzuschließen."
+  },
+  "providerConfigurationModal.errorCheckingConfig": {
+    "defaultMessage": "Beim Überprüfen dieser Anbieterkonfiguration ist ein Fehler aufgetreten."
+  },
+  "providerConfigurationModal.errorTitle": {
+    "defaultMessage": "Fehler"
+  },
+  "providerConfigurationModal.externalSetupIntro": {
+    "defaultMessage": "Dieser Anbieter wird außerhalb von goose konfiguriert. Befolgen Sie diese Schritte:"
+  },
+  "providerConfigurationModal.goBack": {
+    "defaultMessage": "Zurück"
+  },
+  "providerConfigurationModal.huggingFaceOAuthDescription": {
+    "defaultMessage": "Melden Sie sich an, um Hugging Face Inference Providers zu nutzen, ohne manuell einen API-Token einzugeben."
+  },
+  "providerConfigurationModal.oauthLoginFailed": {
+    "defaultMessage": "OAuth-Anmeldung fehlgeschlagen: {error}"
+  },
+  "providerConfigurationModal.oauthSignInDescription": {
+    "defaultMessage": "Melden Sie sich mit Ihrem {providerName}-Konto an, um diesen Anbieter zu verwenden"
+  },
+  "providerConfigurationModal.parameterRequired": {
+    "defaultMessage": "{paramName} ist erforderlich"
+  },
+  "providerConfigurationModal.removeConfiguration": {
+    "defaultMessage": "Konfiguration entfernen"
+  },
+  "providerConfigurationModal.seeDocumentation": {
+    "defaultMessage": "Weitere Details finden Sie in der <link>Dokumentation</link>."
+  },
+  "providerConfigurationModal.signInWith": {
+    "defaultMessage": "Anmelden mit {providerName}"
+  },
+  "providerConfigurationModal.signingIn": {
+    "defaultMessage": "Anmeldung läuft..."
+  },
+  "providerGrid.addProvider": {
+    "defaultMessage": "Anbieter hinzufügen"
+  },
+  "providerGrid.addProviderTitle": {
+    "defaultMessage": "Anbieter hinzufügen"
+  },
+  "providerGrid.chooseModel": {
+    "defaultMessage": "Modell auswählen"
+  },
+  "providerGrid.configureProvider": {
+    "defaultMessage": "Anbieter konfigurieren"
+  },
+  "providerGrid.editProvider": {
+    "defaultMessage": "Anbieter bearbeiten"
+  },
+  "providerGrid.fromTemplateOrManual": {
+    "defaultMessage": "Aus Vorlage oder manuelle Einrichtung"
+  },
+  "providerLogo.alt": {
+    "defaultMessage": "{providerName}-Logo"
+  },
+  "providerSelector.addCustomProvider": {
+    "defaultMessage": "Benutzerdefinierten Anbieter hinzufügen"
+  },
+  "providerSelector.addCustomProviderTitle": {
+    "defaultMessage": "Benutzerdefinierten Anbieter hinzufügen"
+  },
+  "providerSelector.connectProvider": {
+    "defaultMessage": "Mit einem Anbieter verbinden"
+  },
+  "providerSelector.connectProviderDescription": {
+    "defaultMessage": "Verbinden Sie OpenAI, Anthropic, Google usw."
+  },
+  "providerSelector.freeLocalDescription": {
+    "defaultMessage": "Verwenden Sie ein lokales Modell oder einen Anbieter mit kostenlosem Guthaben"
+  },
+  "providerSelector.selectProvider": {
+    "defaultMessage": "Einen Anbieter auswählen"
+  },
+  "providerSelector.useFreeLocal": {
+    "defaultMessage": "Kostenlose/lokale Anbieter verwenden"
+  },
+  "providerSettings.configurationSettings": {
+    "defaultMessage": "Einstellungen zur Anbieterkonfiguration"
+  },
+  "providerSettings.loadingProviders": {
+    "defaultMessage": "Anbieter werden geladen..."
+  },
+  "providerSettings.onboardingDescription": {
+    "defaultMessage": "Wählen Sie einen KI-Modellanbieter aus, um mit goose zu beginnen. Sie benötigen API-Schlüssel, die von jedem Anbieter generiert werden und die verschlüsselt und lokal gespeichert werden. Sie können Ihren Anbieter jederzeit in den Einstellungen ändern."
+  },
+  "providerSettings.otherProviders": {
+    "defaultMessage": "Andere Anbieter"
+  },
+  "providerSetupActions.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "providerSetupActions.cannotDeleteActive": {
+    "defaultMessage": "Sie können {providerName} nicht löschen, während er gerade verwendet wird. Bitte wechseln Sie zu einem anderen Modell, bevor Sie diesen Anbieter löschen."
+  },
+  "providerSetupActions.confirmDelete": {
+    "defaultMessage": "Löschen bestätigen"
+  },
+  "providerSetupActions.confirmDeleteMessage": {
+    "defaultMessage": "Möchten Sie die Konfigurationsparameter für {providerName} wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden."
+  },
+  "providerSetupActions.deleteProvider": {
+    "defaultMessage": "Anbieter löschen"
+  },
+  "providerSetupActions.enableProvider": {
+    "defaultMessage": "Anbieter aktivieren"
+  },
+  "providerSetupActions.ok": {
+    "defaultMessage": "Ok"
+  },
+  "providerSetupActions.submit": {
+    "defaultMessage": "Absenden"
+  },
+  "recipeActivityEditor.activitiesDescription": {
+    "defaultMessage": "Die einleitenden Prompts und Aktivitätsschaltflächen, die im Rezept-Chatfenster angezeigt werden."
+  },
+  "recipeActivityEditor.activitiesLabel": {
+    "defaultMessage": "Aktivitäten"
+  },
+  "recipeActivityEditor.activityButtonsDescription": {
+    "defaultMessage": "Anklickbare Schaltflächen, die unterhalb der Nachricht erscheinen, um Benutzern die Interaktion mit Ihrem Rezept zu erleichtern."
+  },
+  "recipeActivityEditor.activityButtonsLabel": {
+    "defaultMessage": "Aktivitätsschaltflächen"
+  },
+  "recipeActivityEditor.addActivity": {
+    "defaultMessage": "Aktivität hinzufügen"
+  },
+  "recipeActivityEditor.addNewActivityPlaceholder": {
+    "defaultMessage": "Neue Aktivität hinzufügen..."
+  },
+  "recipeActivityEditor.messageDescription": {
+    "defaultMessage": "Eine formatierte Nachricht, die oben im Rezept angezeigt wird. Unterstützt Markdown-Formatierung."
+  },
+  "recipeActivityEditor.messageLabel": {
+    "defaultMessage": "Nachricht"
+  },
+  "recipeActivityEditor.messagePlaceholder": {
+    "defaultMessage": "Geben Sie eine für Benutzer sichtbare Einleitungsnachricht für Ihr Rezept ein (unterstützt **fett**, *kursiv*, `Code` usw.)"
+  },
+  "recipeExtensionSelector.description": {
+    "defaultMessage": "Wählen Sie aus, welche Erweiterungen beim Ausführen dieses Rezepts verfügbar sein sollen. Leer lassen, um die Standarderweiterungen zu verwenden."
+  },
+  "recipeExtensionSelector.extensionsSelected": {
+    "defaultMessage": "{count,plural,one{# Erweiterung ausgewählt} other{# Erweiterungen ausgewählt}}"
+  },
+  "recipeExtensionSelector.label": {
+    "defaultMessage": "Erweiterungen (optional)"
+  },
+  "recipeExtensionSelector.noExtensionsAvailable": {
+    "defaultMessage": "Keine Erweiterungen verfügbar"
+  },
+  "recipeExtensionSelector.noExtensionsFound": {
+    "defaultMessage": "Keine Erweiterungen gefunden"
+  },
+  "recipeExtensionSelector.searchPlaceholder": {
+    "defaultMessage": "Erweiterungen suchen..."
+  },
+  "recipeFormFields.addParameter": {
+    "defaultMessage": "Parameter hinzufügen"
+  },
+  "recipeFormFields.advancedOptions": {
+    "defaultMessage": "Erweiterte Optionen"
+  },
+  "recipeFormFields.advancedOptionsHint": {
+    "defaultMessage": "Aktivitäten, Parameter, Modell, Erweiterungen, Antwortschema, Unterrezepte"
+  },
+  "recipeFormFields.descriptionLabel": {
+    "defaultMessage": "Beschreibung"
+  },
+  "recipeFormFields.descriptionPlaceholder": {
+    "defaultMessage": "Kurze Beschreibung dessen, was dieses Rezept tut"
+  },
+  "recipeFormFields.enterValueFor": {
+    "defaultMessage": "Wert für {key} eingeben"
+  },
+  "recipeFormFields.initialPrompt": {
+    "defaultMessage": "Erster Prompt"
+  },
+  "recipeFormFields.instructionsLabel": {
+    "defaultMessage": "Anweisungen"
+  },
+  "recipeFormFields.instructionsPlaceholder": {
+    "defaultMessage": "Detaillierte Anweisungen für die KI, vor dem Benutzer verborgen"
+  },
+  "recipeFormFields.openEditor": {
+    "defaultMessage": "Editor öffnen"
+  },
+  "recipeFormFields.parameterNamePlaceholder": {
+    "defaultMessage": "Parameternamen eingeben..."
+  },
+  "recipeFormFields.parametersDescription": {
+    "defaultMessage": "Parameter werden automatisch anhand der Syntax '{{parameter_name}}' in Anweisungen/Prompt/Aktivitäten erkannt, oder Sie können sie unten manuell hinzufügen."
+  },
+  "recipeFormFields.parametersLabel": {
+    "defaultMessage": "Parameter"
+  },
+  "recipeFormFields.promptOptionalHint": {
+    "defaultMessage": "(Optional – Anweisungen oder Prompt sind erforderlich)"
+  },
+  "recipeFormFields.promptPlaceholder": {
+    "defaultMessage": "Vorausgefüllter Prompt beim Start des Rezepts"
+  },
+  "recipeFormFields.responseJsonSchema": {
+    "defaultMessage": "JSON-Schema der Antwort"
+  },
+  "recipeFormFields.responseJsonSchemaDescription": {
+    "defaultMessage": "Definieren Sie die erwartete Struktur der KI-Antwort im JSON-Schema-Format"
+  },
+  "recipeFormFields.templateVarHint": {
+    "defaultMessage": "Verwenden Sie '{{parameter_name}}', um Parameter zu definieren, die beim Ausführen des Rezepts ausgefüllt werden können."
+  },
+  "recipeFormFields.titleLabel": {
+    "defaultMessage": "Titel"
+  },
+  "recipeFormFields.titlePlaceholder": {
+    "defaultMessage": "Rezepttitel"
+  },
+  "recipeHeader.recipeLabel": {
+    "defaultMessage": "Rezept"
+  },
+  "recipeModelSelector.backToModelList": {
+    "defaultMessage": "Zurück zur Modellliste"
+  },
+  "recipeModelSelector.enterCustomModel": {
+    "defaultMessage": "Benutzerdefinierten Modellnamen eingeben"
+  },
+  "recipeModelSelector.enterModelNotListed": {
+    "defaultMessage": "Ein nicht aufgeführtes Modell eingeben..."
+  },
+  "recipeModelSelector.fetchError": {
+    "defaultMessage": "Modelle konnten nicht abgerufen werden. Bitte versuchen Sie es später erneut."
+  },
+  "recipeModelSelector.loadingModels": {
+    "defaultMessage": "Modelle werden geladen…"
+  },
+  "recipeModelSelector.modelHint": {
+    "defaultMessage": "Leer lassen, um das Standardmodell für den ausgewählten Anbieter zu verwenden"
+  },
+  "recipeModelSelector.modelLabel": {
+    "defaultMessage": "Modell (optional)"
+  },
+  "recipeModelSelector.providerHint": {
+    "defaultMessage": "Leer lassen, um den in den Einstellungen konfigurierten Standardanbieter zu verwenden"
+  },
+  "recipeModelSelector.providerLabel": {
+    "defaultMessage": "Anbieter (optional)"
+  },
+  "recipeModelSelector.selectModel": {
+    "defaultMessage": "Ein Modell auswählen"
+  },
+  "recipeModelSelector.selectProvider": {
+    "defaultMessage": "Anbieter auswählen"
+  },
+  "recipeModelSelector.useDefaultProvider": {
+    "defaultMessage": "Standardanbieter verwenden"
+  },
+  "recipeNameField.defaultLabel": {
+    "defaultMessage": "Rezeptname"
+  },
+  "recipeNameField.formatHint": {
+    "defaultMessage": "Wird automatisch formatiert (Kleinbuchstaben, Bindestriche für Leerzeichen)"
+  },
+  "recipeWarningModal.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "recipeWarningModal.descriptionLabel": {
+    "defaultMessage": "Beschreibung:"
+  },
+  "recipeWarningModal.firstTimeDescription": {
+    "defaultMessage": "Sie sind dabei, ein Rezept auszuführen, das Sie zuvor noch nicht ausgeführt haben."
+  },
+  "recipeWarningModal.hiddenCharsWarning": {
+    "defaultMessage": "Dieses Rezept enthält versteckte Zeichen, die zu Ihrer Sicherheit ignoriert werden, da sie für böswillige Zwecke verwendet werden könnten."
+  },
+  "recipeWarningModal.instructionsLabel": {
+    "defaultMessage": "Anweisungen:"
+  },
+  "recipeWarningModal.newRecipeWarningTitle": {
+    "defaultMessage": "⚠️ Warnung zu neuem Rezept"
+  },
+  "recipeWarningModal.recipePreview": {
+    "defaultMessage": "Rezeptvorschau:"
+  },
+  "recipeWarningModal.securityWarningTitle": {
+    "defaultMessage": "⚠️ Sicherheitswarnung"
+  },
+  "recipeWarningModal.titleLabel": {
+    "defaultMessage": "Titel:"
+  },
+  "recipeWarningModal.trustAndExecute": {
+    "defaultMessage": "Vertrauen und ausführen"
+  },
+  "recipeWarningModal.trustSource": {
+    "defaultMessage": "Fahren Sie nur fort, wenn Sie der Quelle dieses Rezepts vertrauen."
+  },
+  "recipesView.addSchedule": {
+    "defaultMessage": "Zeitplan hinzufügen"
+  },
+  "recipesView.addSlashCommand": {
+    "defaultMessage": "Slash-Befehl hinzufügen"
+  },
+  "recipesView.adjustSearchTerms": {
+    "defaultMessage": "Versuchen Sie, Ihre Suchbegriffe anzupassen"
+  },
+  "recipesView.allFiles": {
+    "defaultMessage": "Alle Dateien"
+  },
+  "recipesView.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "recipesView.copyDeeplink": {
+    "defaultMessage": "Deeplink kopieren"
+  },
+  "recipesView.copyDeeplinkFailedMsg": {
+    "defaultMessage": "Deeplink konnte nicht in die Zwischenablage kopiert werden"
+  },
+  "recipesView.copyFailedTitle": {
+    "defaultMessage": "Kopieren fehlgeschlagen"
+  },
+  "recipesView.copyYaml": {
+    "defaultMessage": "YAML kopieren"
+  },
+  "recipesView.copyYamlFailedMsg": {
+    "defaultMessage": "Rezept-YAML konnte nicht in die Zwischenablage kopiert werden"
+  },
+  "recipesView.createRecipe": {
+    "defaultMessage": "Rezept erstellen"
+  },
+  "recipesView.deeplinkCopiedMsg": {
+    "defaultMessage": "Der Rezept-Deeplink wurde in die Zwischenablage kopiert"
+  },
+  "recipesView.deeplinkCopiedTitle": {
+    "defaultMessage": "Deeplink kopiert"
+  },
+  "recipesView.deleteRecipe": {
+    "defaultMessage": "Rezept löschen"
+  },
+  "recipesView.deleteRecipeConfirm": {
+    "defaultMessage": "Möchten Sie \"{title}\" wirklich löschen?"
+  },
+  "recipesView.deleteRecipeDetail": {
+    "defaultMessage": "Die Rezeptdatei wird gelöscht."
+  },
+  "recipesView.deleteRecipeTitle": {
+    "defaultMessage": "Rezept löschen"
+  },
+  "recipesView.editRecipe": {
+    "defaultMessage": "Rezept bearbeiten"
+  },
+  "recipesView.editSchedule": {
+    "defaultMessage": "Zeitplan bearbeiten"
+  },
+  "recipesView.editSlashCommand": {
+    "defaultMessage": "Slash-Befehl bearbeiten"
+  },
+  "recipesView.errorLoadingRecipes": {
+    "defaultMessage": "Fehler beim Laden der Rezepte"
+  },
+  "recipesView.exportFailedMsg": {
+    "defaultMessage": "Rezept konnte nicht in eine Datei exportiert werden"
+  },
+  "recipesView.exportFailedTitle": {
+    "defaultMessage": "Export fehlgeschlagen"
+  },
+  "recipesView.exportRecipeDialogTitle": {
+    "defaultMessage": "Rezept exportieren"
+  },
+  "recipesView.exportToFile": {
+    "defaultMessage": "In Datei exportieren"
+  },
+  "recipesView.noMatchingRecipes": {
+    "defaultMessage": "Keine passenden Rezepte gefunden"
+  },
+  "recipesView.noSavedRecipes": {
+    "defaultMessage": "Keine gespeicherten Rezepte"
+  },
+  "recipesView.noSavedRecipesDescription": {
+    "defaultMessage": "Aus Chats gespeicherte Rezepte werden hier angezeigt."
+  },
+  "recipesView.openInNewWindow": {
+    "defaultMessage": "In neuem Fenster öffnen"
+  },
+  "recipesView.recipeDeletedSuccess": {
+    "defaultMessage": "Rezept erfolgreich gelöscht"
+  },
+  "recipesView.recipeExportedMsg": {
+    "defaultMessage": "Rezept gespeichert unter {filePath}"
+  },
+  "recipesView.recipeExportedTitle": {
+    "defaultMessage": "Rezept exportiert"
+  },
+  "recipesView.recipesDescription": {
+    "defaultMessage": "Sehen und verwalten Sie Ihre gespeicherten Rezepte, um schnell neue Sitzungen mit vordefinierten Konfigurationen zu starten. {shortcut} zum Suchen."
+  },
+  "recipesView.recipesTitle": {
+    "defaultMessage": "Rezepte"
+  },
+  "recipesView.remove": {
+    "defaultMessage": "Entfernen"
+  },
+  "recipesView.removeSchedule": {
+    "defaultMessage": "Zeitplan entfernen"
+  },
+  "recipesView.runs": {
+    "defaultMessage": "Läuft {schedule}"
+  },
+  "recipesView.save": {
+    "defaultMessage": "Speichern"
+  },
+  "recipesView.scheduleDialogTitle": {
+    "defaultMessage": "Zeitplan {action}"
+  },
+  "recipesView.scheduleRemovedMsg": {
+    "defaultMessage": "Das Rezept wird nicht mehr automatisch ausgeführt"
+  },
+  "recipesView.scheduleRemovedTitle": {
+    "defaultMessage": "Zeitplan entfernt"
+  },
+  "recipesView.scheduleSavedMsg": {
+    "defaultMessage": "Das Rezept läuft {schedule}"
+  },
+  "recipesView.scheduleSavedTitle": {
+    "defaultMessage": "Zeitplan gespeichert"
+  },
+  "recipesView.searchRecipesPlaceholder": {
+    "defaultMessage": "Rezepte suchen..."
+  },
+  "recipesView.shareRecipe": {
+    "defaultMessage": "Rezept teilen"
+  },
+  "recipesView.slashCommandDescription": {
+    "defaultMessage": "Legen Sie einen Slash-Befehl fest, um dieses Rezept schnell aus jedem Chat auszuführen"
+  },
+  "recipesView.slashCommandPlaceholder": {
+    "defaultMessage": "befehlsname"
+  },
+  "recipesView.slashCommandRemovedMsg": {
+    "defaultMessage": "Der Slash-Befehl des Rezepts wurde entfernt"
+  },
+  "recipesView.slashCommandRemovedTitle": {
+    "defaultMessage": "Slash-Befehl entfernt"
+  },
+  "recipesView.slashCommandSavedMsg": {
+    "defaultMessage": "Verwenden Sie /{command}, um dieses Rezept auszuführen"
+  },
+  "recipesView.slashCommandSavedTitle": {
+    "defaultMessage": "Slash-Befehl gespeichert"
+  },
+  "recipesView.slashCommandTitle": {
+    "defaultMessage": "Slash-Befehl"
+  },
+  "recipesView.slashCommandUsageHint": {
+    "defaultMessage": "Verwenden Sie /{command} in jedem Chat, um dieses Rezept auszuführen"
+  },
+  "recipesView.tryAgain": {
+    "defaultMessage": "Erneut versuchen"
+  },
+  "recipesView.useRecipe": {
+    "defaultMessage": "Rezept verwenden"
+  },
+  "recipesView.yamlCopiedMsg": {
+    "defaultMessage": "Das Rezept-YAML wurde in die Zwischenablage kopiert"
+  },
+  "recipesView.yamlCopiedTitle": {
+    "defaultMessage": "YAML kopiert"
+  },
+  "recipesView.yamlFiles": {
+    "defaultMessage": "YAML-Dateien"
+  },
+  "resetProviderSection.resetButton": {
+    "defaultMessage": "Anbieter und Modell zurücksetzen"
+  },
+  "resetProviderSection.resetDescription": {
+    "defaultMessage": "Dadurch werden Ihre ausgewählten Modell- und Anbietereinstellungen gelöscht. Wenn keine Standardwerte verfügbar sind, werden Sie zum Willkommensbildschirm geleitet, um sie erneut einzurichten."
+  },
+  "responseStyle.conciseDescription": {
+    "defaultMessage": "Tool-Aufrufe sind standardmäßig geschlossen und zeigen nur das verwendete Tool an"
+  },
+  "responseStyle.conciseLabel": {
+    "defaultMessage": "Kompakt"
+  },
+  "responseStyle.detailedDescription": {
+    "defaultMessage": "Tool-Aufrufe werden standardmäßig geöffnet angezeigt, um Details offenzulegen"
+  },
+  "responseStyle.detailedLabel": {
+    "defaultMessage": "Ausführlich"
+  },
+  "scheduleDetailView.actions": {
+    "defaultMessage": "Aktionen"
+  },
+  "scheduleDetailView.cannotModifyRunning": {
+    "defaultMessage": "Ein Zeitplan kann nicht ausgelöst oder geändert werden, während er bereits läuft."
+  },
+  "scheduleDetailView.completedSession": {
+    "defaultMessage": "Sitzung: {sessionId}"
+  },
+  "scheduleDetailView.created": {
+    "defaultMessage": "Erstellt: {date}"
+  },
+  "scheduleDetailView.cronExpression": {
+    "defaultMessage": "Cron-Ausdruck:"
+  },
+  "scheduleDetailView.currentSession": {
+    "defaultMessage": "Aktuelle Sitzung:"
+  },
+  "scheduleDetailView.currentlyRunning": {
+    "defaultMessage": "Läuft gerade"
+  },
+  "scheduleDetailView.dir": {
+    "defaultMessage": "Verzeichnis: {path}"
+  },
+  "scheduleDetailView.editSchedule": {
+    "defaultMessage": "Zeitplan bearbeiten"
+  },
+  "scheduleDetailView.errorPrefix": {
+    "defaultMessage": "Fehler: {error}"
+  },
+  "scheduleDetailView.idLabel": {
+    "defaultMessage": "ID:"
+  },
+  "scheduleDetailView.inspectJobError": {
+    "defaultMessage": "Fehler beim Untersuchen des Auftrags"
+  },
+  "scheduleDetailView.inspectNoInfo": {
+    "defaultMessage": "Keine detaillierten Informationen verfügbar"
+  },
+  "scheduleDetailView.inspectRunningJob": {
+    "defaultMessage": "Laufenden Auftrag untersuchen"
+  },
+  "scheduleDetailView.jobCancelled": {
+    "defaultMessage": "Auftrag abgebrochen"
+  },
+  "scheduleDetailView.jobCancelledMsg": {
+    "defaultMessage": "Der Auftrag wurde beim Starten abgebrochen."
+  },
+  "scheduleDetailView.jobInspection": {
+    "defaultMessage": "Auftragsuntersuchung"
+  },
+  "scheduleDetailView.jobKilled": {
+    "defaultMessage": "Auftrag beendet"
+  },
+  "scheduleDetailView.killJobError": {
+    "defaultMessage": "Fehler beim Beenden des Auftrags"
+  },
+  "scheduleDetailView.killRunningJob": {
+    "defaultMessage": "Laufenden Auftrag beenden"
+  },
+  "scheduleDetailView.lastRun": {
+    "defaultMessage": "Letzte Ausführung:"
+  },
+  "scheduleDetailView.loadingSchedule": {
+    "defaultMessage": "Zeitplan wird geladen..."
+  },
+  "scheduleDetailView.loadingSessions": {
+    "defaultMessage": "Sitzungen werden geladen..."
+  },
+  "scheduleDetailView.messages": {
+    "defaultMessage": "Nachrichten: {count}"
+  },
+  "scheduleDetailView.noScheduleId": {
+    "defaultMessage": "Keine Zeitplan-ID angegeben. Kehren Sie zur Zeitplanliste zurück."
+  },
+  "scheduleDetailView.noSessions": {
+    "defaultMessage": "Keine Sitzungen für diesen Zeitplan gefunden."
+  },
+  "scheduleDetailView.pauseSchedule": {
+    "defaultMessage": "Zeitplan pausieren"
+  },
+  "scheduleDetailView.pauseUnpauseError": {
+    "defaultMessage": "Fehler beim Pausieren/Fortsetzen"
+  },
+  "scheduleDetailView.paused": {
+    "defaultMessage": "Pausiert"
+  },
+  "scheduleDetailView.pausedMsg": {
+    "defaultMessage": "\"{id}\" pausiert"
+  },
+  "scheduleDetailView.pausedWarning": {
+    "defaultMessage": "Dieser Zeitplan ist pausiert und wird nicht automatisch ausgeführt. Verwenden Sie \"Zeitplan jetzt ausführen\", um ihn manuell auszulösen, oder setzen Sie ihn fort, um die automatische Ausführung wieder aufzunehmen."
+  },
+  "scheduleDetailView.processStarted": {
+    "defaultMessage": "Prozess gestartet:"
+  },
+  "scheduleDetailView.recentSessions": {
+    "defaultMessage": "Letzte Sitzungen"
+  },
+  "scheduleDetailView.recipeSource": {
+    "defaultMessage": "Rezeptquelle:"
+  },
+  "scheduleDetailView.runScheduleError": {
+    "defaultMessage": "Fehler beim Ausführen des Zeitplans"
+  },
+  "scheduleDetailView.runScheduleNow": {
+    "defaultMessage": "Zeitplan jetzt ausführen"
+  },
+  "scheduleDetailView.scheduleCompleted": {
+    "defaultMessage": "Ausführung abgeschlossen"
+  },
+  "scheduleDetailView.scheduleDetails": {
+    "defaultMessage": "Zeitplandetails"
+  },
+  "scheduleDetailView.scheduleInformation": {
+    "defaultMessage": "Zeitplaninformationen"
+  },
+  "scheduleDetailView.scheduleLabel": {
+    "defaultMessage": "Zeitplan:"
+  },
+  "scheduleDetailView.scheduleNotFound": {
+    "defaultMessage": "Zeitplan nicht gefunden"
+  },
+  "scheduleDetailView.scheduleNotFoundError": {
+    "defaultMessage": "Zeitplan nicht gefunden"
+  },
+  "scheduleDetailView.schedulePaused": {
+    "defaultMessage": "Zeitplan pausiert"
+  },
+  "scheduleDetailView.scheduleUnpaused": {
+    "defaultMessage": "Zeitplan fortgesetzt"
+  },
+  "scheduleDetailView.scheduleUpdated": {
+    "defaultMessage": "Zeitplan aktualisiert"
+  },
+  "scheduleDetailView.sessionId": {
+    "defaultMessage": "Sitzungs-ID: {id}"
+  },
+  "scheduleDetailView.unpauseSchedule": {
+    "defaultMessage": "Zeitplan fortsetzen"
+  },
+  "scheduleDetailView.unpausedMsg": {
+    "defaultMessage": "\"{id}\" fortgesetzt"
+  },
+  "scheduleDetailView.updateScheduleError": {
+    "defaultMessage": "Fehler beim Aktualisieren des Zeitplans"
+  },
+  "scheduleDetailView.updatedMsg": {
+    "defaultMessage": "\"{id}\" aktualisiert"
+  },
+  "scheduleDetailView.viewingScheduleId": {
+    "defaultMessage": "Zeitplan-ID wird angezeigt: {id}"
+  },
+  "scheduleModal.browseYaml": {
+    "defaultMessage": "Nach YAML-Datei suchen..."
+  },
+  "scheduleModal.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "scheduleModal.createNewSchedule": {
+    "defaultMessage": "Neuen Zeitplan erstellen"
+  },
+  "scheduleModal.createSchedule": {
+    "defaultMessage": "Zeitplan erstellen"
+  },
+  "scheduleModal.creating": {
+    "defaultMessage": "Wird erstellt..."
+  },
+  "scheduleModal.deepLink": {
+    "defaultMessage": "Deep-Link"
+  },
+  "scheduleModal.deepLinkPlaceholder": {
+    "defaultMessage": "goose://recipe-Link hier einfügen..."
+  },
+  "scheduleModal.editSchedule": {
+    "defaultMessage": "Zeitplan bearbeiten"
+  },
+  "scheduleModal.failedParseRecipe": {
+    "defaultMessage": "Rezept konnte nicht aus der Datei gelesen werden."
+  },
+  "scheduleModal.failedReadFile": {
+    "defaultMessage": "Die ausgewählte Datei konnte nicht gelesen werden."
+  },
+  "scheduleModal.invalidDeepLink": {
+    "defaultMessage": "Ungültiger Deep-Link. Bitte verwenden Sie einen goose://recipe-Link."
+  },
+  "scheduleModal.invalidFileType": {
+    "defaultMessage": "Ungültiger Dateityp: Bitte wählen Sie eine YAML-Datei (.yaml oder .yml)"
+  },
+  "scheduleModal.nameLabel": {
+    "defaultMessage": "Name:"
+  },
+  "scheduleModal.namePlaceholder": {
+    "defaultMessage": "z. B. daily-summary-job"
+  },
+  "scheduleModal.provideValidRecipe": {
+    "defaultMessage": "Bitte geben Sie eine gültige Rezeptquelle an."
+  },
+  "scheduleModal.recipeDescription": {
+    "defaultMessage": "Beschreibung: {description}"
+  },
+  "scheduleModal.recipeParsed": {
+    "defaultMessage": "Rezept erfolgreich gelesen"
+  },
+  "scheduleModal.recipeTitle": {
+    "defaultMessage": "Titel: {title}"
+  },
+  "scheduleModal.scheduleIdRequired": {
+    "defaultMessage": "Zeitplan-ID ist erforderlich."
+  },
+  "scheduleModal.scheduleLabel": {
+    "defaultMessage": "Zeitplan:"
+  },
+  "scheduleModal.selected": {
+    "defaultMessage": "Ausgewählt: {path}"
+  },
+  "scheduleModal.sourceLabel": {
+    "defaultMessage": "Quelle:"
+  },
+  "scheduleModal.updateSchedule": {
+    "defaultMessage": "Zeitplan aktualisieren"
+  },
+  "scheduleModal.updating": {
+    "defaultMessage": "Wird aktualisiert..."
+  },
+  "scheduleModal.yaml": {
+    "defaultMessage": "YAML"
+  },
+  "schedulesView.confirmDelete": {
+    "defaultMessage": "Zeitplan \"{id}\" entfernen? Das Rezept bleibt erhalten."
+  },
+  "schedulesView.createSchedule": {
+    "defaultMessage": "Zeitplan erstellen"
+  },
+  "schedulesView.description": {
+    "defaultMessage": "Erstellen und verwalten Sie geplante Aufgaben, um Rezepte automatisch zu festgelegten Zeiten auszuführen."
+  },
+  "schedulesView.edit": {
+    "defaultMessage": "Bearbeiten"
+  },
+  "schedulesView.errorPrefix": {
+    "defaultMessage": "Fehler: {error}"
+  },
+  "schedulesView.inspect": {
+    "defaultMessage": "Untersuchen"
+  },
+  "schedulesView.inspectError": {
+    "defaultMessage": "Fehler beim Untersuchen des Auftrags"
+  },
+  "schedulesView.inspectNoInfo": {
+    "defaultMessage": "Keine detaillierten Informationen für diesen Auftrag verfügbar"
+  },
+  "schedulesView.jobInspection": {
+    "defaultMessage": "Auftragsuntersuchung"
+  },
+  "schedulesView.jobKilled": {
+    "defaultMessage": "Auftrag beendet"
+  },
+  "schedulesView.kill": {
+    "defaultMessage": "Beenden"
+  },
+  "schedulesView.killError": {
+    "defaultMessage": "Fehler beim Beenden des Auftrags"
+  },
+  "schedulesView.lastRun": {
+    "defaultMessage": "Letzte Ausführung: {date}"
+  },
+  "schedulesView.noSchedules": {
+    "defaultMessage": "Noch keine Zeitpläne"
+  },
+  "schedulesView.pause": {
+    "defaultMessage": "Pausieren"
+  },
+  "schedulesView.pauseError": {
+    "defaultMessage": "Fehler beim Pausieren des Zeitplans"
+  },
+  "schedulesView.paused": {
+    "defaultMessage": "Pausiert"
+  },
+  "schedulesView.refresh": {
+    "defaultMessage": "Aktualisieren"
+  },
+  "schedulesView.refreshing": {
+    "defaultMessage": "Wird aktualisiert..."
+  },
+  "schedulesView.resume": {
+    "defaultMessage": "Fortsetzen"
+  },
+  "schedulesView.running": {
+    "defaultMessage": "Läuft"
+  },
+  "schedulesView.schedulePaused": {
+    "defaultMessage": "Zeitplan pausiert"
+  },
+  "schedulesView.schedulePausedMsg": {
+    "defaultMessage": "Zeitplan \"{id}\" erfolgreich pausiert"
+  },
+  "schedulesView.scheduleUnpaused": {
+    "defaultMessage": "Zeitplan fortgesetzt"
+  },
+  "schedulesView.scheduleUnpausedMsg": {
+    "defaultMessage": "Zeitplan \"{id}\" erfolgreich fortgesetzt"
+  },
+  "schedulesView.scheduleUpdated": {
+    "defaultMessage": "Zeitplan aktualisiert"
+  },
+  "schedulesView.scheduleUpdatedMsg": {
+    "defaultMessage": "Zeitplan \"{id}\" erfolgreich aktualisiert"
+  },
+  "schedulesView.scheduler": {
+    "defaultMessage": "Planer"
+  },
+  "schedulesView.unpauseError": {
+    "defaultMessage": "Fehler beim Fortsetzen des Zeitplans"
+  },
+  "searchBar.caseSensitive": {
+    "defaultMessage": "Groß-/Kleinschreibung beachten"
+  },
+  "searchBar.close": {
+    "defaultMessage": "Schließen ({shortcut})"
+  },
+  "searchBar.next": {
+    "defaultMessage": "Weiter ({shortcut})"
+  },
+  "searchBar.placeholder": {
+    "defaultMessage": "Unterhaltung durchsuchen..."
+  },
+  "searchBar.previous": {
+    "defaultMessage": "Zurück ({shortcut})"
+  },
+  "secureStorageNotice.defaultMessage": {
+    "defaultMessage": "Schlüssel werden sicher im Schlüsselbund gespeichert"
+  },
+  "securityToggle.apiTokenDescription": {
+    "defaultMessage": "Authentifizierungstoken für den Klassifizierungsdienst"
+  },
+  "securityToggle.apiTokenOptional": {
+    "defaultMessage": "API-Token (optional)"
+  },
+  "securityToggle.classificationEndpoint": {
+    "defaultMessage": "Klassifizierungs-Endpunkt"
+  },
+  "securityToggle.classificationEndpointDescription": {
+    "defaultMessage": "Geben Sie die vollständige URL für Ihren Klassifizierungsdienst ein"
+  },
+  "securityToggle.commandClassifierActive": {
+    "defaultMessage": "Befehlsklassifizierer aktiv (automatisch aus der Umgebung konfiguriert)"
+  },
+  "securityToggle.commandEndpointDescription": {
+    "defaultMessage": "Geben Sie die vollständige URL für Ihren Dienst zur Klassifizierung von Befehlsinjektionen ein"
+  },
+  "securityToggle.commandInjectionDescription": {
+    "defaultMessage": "ML-Modelle verwenden, um schädliche Shell-Befehle zu erkennen"
+  },
+  "securityToggle.detectionModel": {
+    "defaultMessage": "Erkennungsmodell"
+  },
+  "securityToggle.detectionModelDescription": {
+    "defaultMessage": "Wählen Sie aus, welches ML-Modell für die Erkennung von Prompt-Injektionen verwendet werden soll"
+  },
+  "securityToggle.detectionThreshold": {
+    "defaultMessage": "Erkennungsschwellenwert"
+  },
+  "securityToggle.enableCommandInjection": {
+    "defaultMessage": "ML-Erkennung von Befehlsinjektionen aktivieren"
+  },
+  "securityToggle.enablePromptInjection": {
+    "defaultMessage": "Erkennung von Prompt-Injektionen aktivieren"
+  },
+  "securityToggle.enablePromptInjectionMl": {
+    "defaultMessage": "ML-Erkennung von Prompt-Injektionen aktivieren"
+  },
+  "securityToggle.mlEndpointDescription": {
+    "defaultMessage": "Geben Sie die vollständige URL für Ihren ML-Klassifizierungsdienst ein (einschließlich Modellkennung)"
+  },
+  "securityToggle.mlTokenDescription": {
+    "defaultMessage": "Authentifizierungstoken für den ML-Dienst (z. B. HuggingFace-Token)"
+  },
+  "securityToggle.overrideNotice": {
+    "defaultMessage": "Diese Einstellung wird von Ihrer Organisation verwaltet und kann nicht geändert werden."
+  },
+  "securityToggle.promptInjectionDescription": {
+    "defaultMessage": "Potenzielle Prompt-Injektionsangriffe erkennen und verhindern"
+  },
+  "securityToggle.promptInjectionMlDescription": {
+    "defaultMessage": "ML-Modelle verwenden, um potenzielle Prompt-Injektionen in Ihrem Chat zu erkennen"
+  },
+  "securityToggle.thresholdDescription": {
+    "defaultMessage": "Höhere Werte sind strenger (0,01 = sehr nachsichtig, 1,0 = maximal streng)"
+  },
+  "securityToggle.warpNotice": {
+    "defaultMessage": "Die Erkennung von Befehlsinjektionen funktioniert am besten, wenn eine Verbindung zu WARP besteht (erforderlich, um den Klassifizierungsdienst zu erreichen)."
+  },
+  "sessionActionsHeader.actionsLabel": {
+    "defaultMessage": "Sitzungsaktionen"
+  },
+  "sessionActionsHeader.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "sessionActionsHeader.close": {
+    "defaultMessage": "Schließen"
+  },
+  "sessionActionsHeader.copiedJson": {
+    "defaultMessage": "Sitzungs-JSON kopiert"
+  },
+  "sessionActionsHeader.copiedText": {
+    "defaultMessage": "Text kopiert"
+  },
+  "sessionActionsHeader.copyJson": {
+    "defaultMessage": "JSON kopieren"
+  },
+  "sessionActionsHeader.copyText": {
+    "defaultMessage": "Text kopieren"
+  },
+  "sessionActionsHeader.duplicateFailed": {
+    "defaultMessage": "Sitzung konnte nicht dupliziert werden: {error}"
+  },
+  "sessionActionsHeader.duplicateSession": {
+    "defaultMessage": "Sitzung duplizieren"
+  },
+  "sessionActionsHeader.duplicated": {
+    "defaultMessage": "Sitzung dupliziert"
+  },
+  "sessionActionsHeader.fullTextTitle": {
+    "defaultMessage": "Textwert"
+  },
+  "sessionActionsHeader.jsonFailed": {
+    "defaultMessage": "Sitzungs-JSON konnte nicht geladen werden: {error}"
+  },
+  "sessionActionsHeader.jsonTitle": {
+    "defaultMessage": "Sitzungs-JSON"
+  },
+  "sessionActionsHeader.loadingJson": {
+    "defaultMessage": "JSON wird geladen..."
+  },
+  "sessionActionsHeader.renameFailed": {
+    "defaultMessage": "Sitzung konnte nicht umbenannt werden: {error}"
+  },
+  "sessionActionsHeader.renamePlaceholder": {
+    "defaultMessage": "Sitzungsnamen eingeben"
+  },
+  "sessionActionsHeader.renameSession": {
+    "defaultMessage": "Sitzung umbenennen"
+  },
+  "sessionActionsHeader.renameTitle": {
+    "defaultMessage": "Sitzung umbenennen"
+  },
+  "sessionActionsHeader.renamed": {
+    "defaultMessage": "Sitzung umbenannt"
+  },
+  "sessionActionsHeader.save": {
+    "defaultMessage": "Speichern"
+  },
+  "sessionActionsHeader.saving": {
+    "defaultMessage": "Wird gespeichert..."
+  },
+  "sessionActionsHeader.viewJson": {
+    "defaultMessage": "Sitzungs-JSON anzeigen"
+  },
+  "sessionIndicators.error": {
+    "defaultMessage": "In der Sitzung ist ein Fehler aufgetreten"
+  },
+  "sessionIndicators.newActivity": {
+    "defaultMessage": "Hat neue Aktivität"
+  },
+  "sessionIndicators.streaming": {
+    "defaultMessage": "Streaming"
+  },
+  "sessionViewComponents.empty.description": {
+    "defaultMessage": "Diese Sitzung enthält keine Nachrichten"
+  },
+  "sessionViewComponents.empty.title": {
+    "defaultMessage": "Keine Nachrichten gefunden"
+  },
+  "sessionViewComponents.error.loading": {
+    "defaultMessage": "Fehler beim Laden der Sitzungsdetails"
+  },
+  "sessionViewComponents.error.tryAgain": {
+    "defaultMessage": "Erneut versuchen"
+  },
+  "sessionViewComponents.role.assistant": {
+    "defaultMessage": "Goose"
+  },
+  "sessionViewComponents.role.user": {
+    "defaultMessage": "Sie"
+  },
+  "sessions.action.delete": {
+    "defaultMessage": "Sitzung löschen"
+  },
+  "sessions.action.duplicate": {
+    "defaultMessage": "Sitzung duplizieren"
+  },
+  "sessions.action.editName": {
+    "defaultMessage": "Sitzungsnamen bearbeiten"
+  },
+  "sessions.action.export": {
+    "defaultMessage": "Sitzung exportieren"
+  },
+  "sessions.action.openNewWindow": {
+    "defaultMessage": "In neuem Fenster öffnen"
+  },
+  "sessions.action.shareNostr": {
+    "defaultMessage": "Verschlüsselten Nostr-Link teilen"
+  },
+  "sessions.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "sessions.chatHistory": {
+    "defaultMessage": "Chatverlauf"
+  },
+  "sessions.chatHistoryDesc": {
+    "defaultMessage": "Sehen und durchsuchen Sie Ihre vergangenen Unterhaltungen mit Goose. {shortcut} zum Suchen."
+  },
+  "sessions.close": {
+    "defaultMessage": "Schließen"
+  },
+  "sessions.delete.message": {
+    "defaultMessage": "Möchten Sie die Sitzung \"{name}\" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden."
+  },
+  "sessions.delete.title": {
+    "defaultMessage": "Sitzung löschen"
+  },
+  "sessions.edit.placeholder": {
+    "defaultMessage": "Sitzungsbeschreibung eingeben"
+  },
+  "sessions.edit.title": {
+    "defaultMessage": "Sitzungsbeschreibung bearbeiten"
+  },
+  "sessions.empty.description": {
+    "defaultMessage": "Ihr Chatverlauf wird hier angezeigt"
+  },
+  "sessions.empty.title": {
+    "defaultMessage": "Keine Chatsitzungen gefunden"
+  },
+  "sessions.error.loading": {
+    "defaultMessage": "Fehler beim Laden der Sitzungen"
+  },
+  "sessions.error.tryAgain": {
+    "defaultMessage": "Erneut versuchen"
+  },
+  "sessions.import": {
+    "defaultMessage": "Sitzung importieren"
+  },
+  "sessions.importNostr": {
+    "defaultMessage": "Link importieren"
+  },
+  "sessions.importNostr.description": {
+    "defaultMessage": "Fügen Sie einen Goose-Nostr-Freigabelink ein, um die Sitzung abzurufen, zu entschlüsseln und zu importieren."
+  },
+  "sessions.importNostr.placeholder": {
+    "defaultMessage": "goose://sessions/nostr?nevent=...&key=..."
+  },
+  "sessions.importNostr.title": {
+    "defaultMessage": "Nostr-Sitzung importieren"
+  },
+  "sessions.importing": {
+    "defaultMessage": "Wird importiert..."
+  },
+  "sessions.loadingMore": {
+    "defaultMessage": "Weitere Sitzungen werden geladen..."
+  },
+  "sessions.save": {
+    "defaultMessage": "Speichern"
+  },
+  "sessions.saving": {
+    "defaultMessage": "Wird gespeichert..."
+  },
+  "sessions.search.noResults": {
+    "defaultMessage": "Keine passenden Sitzungen gefunden"
+  },
+  "sessions.search.noResultsDesc": {
+    "defaultMessage": "Versuchen Sie, Ihre Suchbegriffe anzupassen"
+  },
+  "sessions.searchPlaceholder": {
+    "defaultMessage": "Verlauf durchsuchen..."
+  },
+  "sessions.shareNostr.description": {
+    "defaultMessage": "Jeder mit diesem Link kann die Sitzung abrufen und entschlüsseln. Behandeln Sie ihn wie ein Geheimnis."
+  },
+  "sessions.shareNostr.title": {
+    "defaultMessage": "Verschlüsselter Nostr-Freigabelink"
+  },
+  "sessions.toast.copied": {
+    "defaultMessage": "In die Zwischenablage kopiert"
+  },
+  "sessions.toast.deleteFailed": {
+    "defaultMessage": "Sitzung \"{name}\" konnte nicht gelöscht werden: {error}"
+  },
+  "sessions.toast.deleted": {
+    "defaultMessage": "Sitzung erfolgreich gelöscht"
+  },
+  "sessions.toast.duplicateFailed": {
+    "defaultMessage": "Sitzung konnte nicht dupliziert werden: {error}"
+  },
+  "sessions.toast.duplicated": {
+    "defaultMessage": "Sitzung \"{name}\" erfolgreich dupliziert"
+  },
+  "sessions.toast.exported": {
+    "defaultMessage": "Sitzung erfolgreich exportiert"
+  },
+  "sessions.toast.importFailed": {
+    "defaultMessage": "Sitzung konnte nicht importiert werden: {error}"
+  },
+  "sessions.toast.imported": {
+    "defaultMessage": "Sitzung erfolgreich importiert"
+  },
+  "sessions.toast.shareNostr": {
+    "defaultMessage": "Verschlüsselter Nostr-Freigabelink erstellt"
+  },
+  "sessions.toast.shareNostrFailed": {
+    "defaultMessage": "Nostr-Freigabelink konnte nicht erstellt werden: {error}"
+  },
+  "sessions.toast.updateFailed": {
+    "defaultMessage": "Sitzungsbeschreibung konnte nicht aktualisiert werden: {error}"
+  },
+  "sessions.toast.updated": {
+    "defaultMessage": "Sitzungsbeschreibung erfolgreich aktualisiert"
+  },
+  "settings.appearance.description": {
+    "defaultMessage": "Konfigurieren Sie, wie goose auf Ihrem System angezeigt wird"
+  },
+  "settings.appearance.title": {
+    "defaultMessage": "Darstellung"
+  },
+  "settings.close": {
+    "defaultMessage": "Schließen"
+  },
+  "settings.costTracking.description": {
+    "defaultMessage": "Modellpreise und Nutzungskosten anzeigen"
+  },
+  "settings.costTracking.title": {
+    "defaultMessage": "Kostenverfolgung"
+  },
+  "settings.dockIcon.description": {
+    "defaultMessage": "goose im Dock anzeigen"
+  },
+  "settings.dockIcon.title": {
+    "defaultMessage": "Dock-Symbol"
+  },
+  "settings.help.description": {
+    "defaultMessage": "Helfen Sie uns, goose zu verbessern, indem Sie Probleme melden oder neue Funktionen anfordern"
+  },
+  "settings.help.reportBug": {
+    "defaultMessage": "Fehler melden"
+  },
+  "settings.help.requestFeature": {
+    "defaultMessage": "Funktion anfordern"
+  },
+  "settings.help.title": {
+    "defaultMessage": "Hilfe & Feedback"
+  },
+  "settings.language.description": {
+    "defaultMessage": "Wählen Sie die Anzeigesprache für goose"
+  },
+  "settings.language.english": {
+    "defaultMessage": "English"
+  },
+  "settings.language.french": {
+    "defaultMessage": "Französisch"
+  },
+  "settings.language.german": {
+    "defaultMessage": "Deutsch"
+  },
+  "settings.language.hindi": {
+    "defaultMessage": "Hindi"
+  },
+  "settings.language.indonesian": {
+    "defaultMessage": "Indonesisch"
+  },
+  "settings.language.italian": {
+    "defaultMessage": "Italienisch"
+  },
+  "settings.language.japanese": {
+    "defaultMessage": "Japanisch"
+  },
+  "settings.language.korean": {
+    "defaultMessage": "Koreanisch"
+  },
+  "settings.language.malay": {
+    "defaultMessage": "Malaiisch"
+  },
+  "settings.language.portuguese": {
+    "defaultMessage": "Portugiesisch"
+  },
+  "settings.language.russian": {
+    "defaultMessage": "Russisch"
+  },
+  "settings.language.spanish": {
+    "defaultMessage": "Spanisch"
+  },
+  "settings.language.systemDefault": {
+    "defaultMessage": "Systemstandard"
+  },
+  "settings.language.title": {
+    "defaultMessage": "Sprache"
+  },
+  "settings.language.turkish": {
+    "defaultMessage": "Türkisch"
+  },
+  "settings.language.vietnamese": {
+    "defaultMessage": "Vietnamesisch"
+  },
+  "settings.language.zhCN": {
+    "defaultMessage": "Chinesisch (vereinfacht)"
+  },
+  "settings.language.zhTW": {
+    "defaultMessage": "Chinesisch (traditionell)"
+  },
+  "settings.menuBarIcon.description": {
+    "defaultMessage": "goose in der Menüleiste anzeigen"
+  },
+  "settings.menuBarIcon.title": {
+    "defaultMessage": "Menüleisten-Symbol"
+  },
+  "settings.notifications.configGuide": {
+    "defaultMessage": "Konfigurationsanleitung"
+  },
+  "settings.notifications.description": {
+    "defaultMessage": "Benachrichtigungen werden von Ihrem Betriebssystem verwaltet - {link}"
+  },
+  "settings.notifications.modal.macInstructions": {
+    "defaultMessage": "So aktivieren Sie Benachrichtigungen unter macOS:"
+  },
+  "settings.notifications.modal.macStep1": {
+    "defaultMessage": "Öffnen Sie die Systemeinstellungen"
+  },
+  "settings.notifications.modal.macStep2": {
+    "defaultMessage": "Klicken Sie auf Benachrichtigungen"
+  },
+  "settings.notifications.modal.macStep3": {
+    "defaultMessage": "Suchen und wählen Sie goose in der Anwendungsliste aus"
+  },
+  "settings.notifications.modal.macStep4": {
+    "defaultMessage": "Aktivieren Sie Benachrichtigungen und passen Sie die Einstellungen nach Wunsch an"
+  },
+  "settings.notifications.modal.title": {
+    "defaultMessage": "So aktivieren Sie Benachrichtigungen"
+  },
+  "settings.notifications.modal.winInstructions": {
+    "defaultMessage": "So aktivieren Sie Benachrichtigungen unter Windows:"
+  },
+  "settings.notifications.modal.winStep1": {
+    "defaultMessage": "Öffnen Sie die Einstellungen"
+  },
+  "settings.notifications.modal.winStep2": {
+    "defaultMessage": "Gehen Sie zu System > Benachrichtigungen"
+  },
+  "settings.notifications.modal.winStep3": {
+    "defaultMessage": "Suchen und wählen Sie goose in der Anwendungsliste aus"
+  },
+  "settings.notifications.modal.winStep4": {
+    "defaultMessage": "Schalten Sie Benachrichtigungen ein und passen Sie die Einstellungen nach Wunsch an"
+  },
+  "settings.notifications.openSettings": {
+    "defaultMessage": "Einstellungen öffnen"
+  },
+  "settings.notifications.task.description": {
+    "defaultMessage": "Benachrichtigen, wenn Goose eine Aufgabe abschließt, während sich das Fenster im Hintergrund befindet"
+  },
+  "settings.notifications.task.title": {
+    "defaultMessage": "Benachrichtigungen bei Aufgabenabschluss"
+  },
+  "settings.notifications.title": {
+    "defaultMessage": "Benachrichtigungen"
+  },
+  "settings.preventSleep.description": {
+    "defaultMessage": "Halten Sie Ihren Computer wach, während goose eine Aufgabe ausführt (der Bildschirm kann sich weiterhin sperren)"
+  },
+  "settings.preventSleep.title": {
+    "defaultMessage": "Energiesparmodus verhindern"
+  },
+  "settings.theme.description": {
+    "defaultMessage": "Passen Sie das Erscheinungsbild von goose an"
+  },
+  "settings.theme.title": {
+    "defaultMessage": "Design"
+  },
+  "settings.updates.description": {
+    "defaultMessage": "Suchen und installieren Sie Updates, damit goose stets optimal läuft"
+  },
+  "settings.updates.title": {
+    "defaultMessage": "Updates"
+  },
+  "settings.version.title": {
+    "defaultMessage": "Version"
+  },
+  "settingsView.tabApp": {
+    "defaultMessage": "App"
+  },
+  "settingsView.tabAuth": {
+    "defaultMessage": "Authentifizierung"
+  },
+  "settingsView.tabChat": {
+    "defaultMessage": "Chat"
+  },
+  "settingsView.tabKeyboard": {
+    "defaultMessage": "Tastatur"
+  },
+  "settingsView.tabLocalInference": {
+    "defaultMessage": "Lokale Inferenz"
+  },
+  "settingsView.tabModels": {
+    "defaultMessage": "Modelle"
+  },
+  "settingsView.tabPrompts": {
+    "defaultMessage": "Prompts"
+  },
+  "settingsView.tabSession": {
+    "defaultMessage": "Sitzung"
+  },
+  "settingsView.title": {
+    "defaultMessage": "Einstellungen"
+  },
+  "sheet.close": {
+    "defaultMessage": "Schließen"
+  },
+  "shortcutRecorder.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "shortcutRecorder.clickToRecord": {
+    "defaultMessage": "Klicken zum Aufzeichnen..."
+  },
+  "shortcutRecorder.conflictWarning": {
+    "defaultMessage": "Dieses Tastenkürzel wird bereits von {label} verwendet. Beim Speichern wird es dieser Aktion neu zugewiesen."
+  },
+  "shortcutRecorder.pressShortcut": {
+    "defaultMessage": "Tastenkürzel drücken..."
+  },
+  "shortcutRecorder.save": {
+    "defaultMessage": "Speichern"
+  },
+  "skillsView.addSkill": {
+    "defaultMessage": "Skill hinzufügen"
+  },
+  "skillsView.adjustSearchTerms": {
+    "defaultMessage": "Versuchen Sie, Ihre Suchbegriffe anzupassen"
+  },
+  "skillsView.comingSoon": {
+    "defaultMessage": "Demnächst verfügbar"
+  },
+  "skillsView.errorLoadingSkills": {
+    "defaultMessage": "Fehler beim Laden der Skills"
+  },
+  "skillsView.noMatchingSkills": {
+    "defaultMessage": "Keine passenden Skills gefunden"
+  },
+  "skillsView.noSkillsDescription": {
+    "defaultMessage": "Skills werden aus SKILL.md-Dateien in ~/.config/agents/skills/, .goose/skills/ oder anderen unterstützten Verzeichnissen geladen."
+  },
+  "skillsView.noSkillsInstalled": {
+    "defaultMessage": "Keine Skills installiert"
+  },
+  "skillsView.searchSkillsPlaceholder": {
+    "defaultMessage": "Skills durchsuchen..."
+  },
+  "skillsView.skillsDescription": {
+    "defaultMessage": "Zeigen Sie installierte Skills an, die die Fähigkeiten von Goose erweitern. {shortcut} zum Suchen."
+  },
+  "skillsView.skillsTitle": {
+    "defaultMessage": "Skills"
+  },
+  "skillsView.tryAgain": {
+    "defaultMessage": "Erneut versuchen"
+  },
+  "spellcheckToggle.description": {
+    "defaultMessage": "Rechtschreibung in der Chat-Eingabe prüfen. Erfordert einen Neustart, um wirksam zu werden."
+  },
+  "spellcheckToggle.title": {
+    "defaultMessage": "Rechtschreibprüfung aktivieren"
+  },
+  "standaloneAppView.failedToLoad": {
+    "defaultMessage": "App konnte nicht geladen werden"
+  },
+  "standaloneAppView.initializing": {
+    "defaultMessage": "App wird initialisiert..."
+  },
+  "standaloneAppView.missingParams": {
+    "defaultMessage": "Erforderliche Parameter fehlen"
+  },
+  "stringUtils.configuredProvider": {
+    "defaultMessage": "Anbieter {name} ist konfiguriert"
+  },
+  "stringUtils.ollamaApp": {
+    "defaultMessage": "Ollama-App"
+  },
+  "stringUtils.ollamaNotConfiguredPrefix": {
+    "defaultMessage": "Um dies zu nutzen, muss entweder die"
+  },
+  "stringUtils.ollamaNotConfiguredSuffix": {
+    "defaultMessage": "auf Ihrem Computer installiert und geöffnet sein, oder Sie müssen einen Wert für OLLAMA_HOST eingeben."
+  },
+  "subRecipeEditor.addExisting": {
+    "defaultMessage": "Vorhandenes hinzufügen"
+  },
+  "subRecipeEditor.createNew": {
+    "defaultMessage": "Neues Subrezept erstellen"
+  },
+  "subRecipeEditor.deleteSubrecipe": {
+    "defaultMessage": "Subrezept {name} löschen"
+  },
+  "subRecipeEditor.description": {
+    "defaultMessage": "Subrezepte sind Rezepte, die während der Ausführung als Tools aufgerufen werden können. Sie ermöglichen mehrstufige Workflows und wiederverwendbare Komponenten."
+  },
+  "subRecipeEditor.duplicateName": {
+    "defaultMessage": "Doppelter Name"
+  },
+  "subRecipeEditor.duplicateNameMsg": {
+    "defaultMessage": "Ein Subrezept namens \"{name}\" existiert bereits. Bitte verwenden Sie einen eindeutigen Namen."
+  },
+  "subRecipeEditor.editSubrecipe": {
+    "defaultMessage": "Subrezept {name} bearbeiten"
+  },
+  "subRecipeEditor.label": {
+    "defaultMessage": "Subrezepte"
+  },
+  "subRecipeEditor.preconfiguredValues": {
+    "defaultMessage": "Vorkonfigurierte Werte:"
+  },
+  "subRecipeEditor.sequential": {
+    "defaultMessage": "Sequenziell"
+  },
+  "subRecipeModal.addTitle": {
+    "defaultMessage": "Subrezept hinzufügen"
+  },
+  "subRecipeModal.apply": {
+    "defaultMessage": "Anwenden"
+  },
+  "subRecipeModal.browse": {
+    "defaultMessage": "Durchsuchen"
+  },
+  "subRecipeModal.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "subRecipeModal.closeModal": {
+    "defaultMessage": "Subrezept-Dialog schließen"
+  },
+  "subRecipeModal.configureTitle": {
+    "defaultMessage": "Subrezept konfigurieren"
+  },
+  "subRecipeModal.descriptionLabel": {
+    "defaultMessage": "Beschreibung"
+  },
+  "subRecipeModal.descriptionPlaceholder": {
+    "defaultMessage": "Optionale Beschreibung, was dieses Subrezept tut..."
+  },
+  "subRecipeModal.invalidFile": {
+    "defaultMessage": "Ungültige Datei"
+  },
+  "subRecipeModal.invalidFileMsg": {
+    "defaultMessage": "Bitte wählen Sie eine YAML-Datei (.yaml oder .yml)."
+  },
+  "subRecipeModal.nameHint": {
+    "defaultMessage": "Eindeutige Kennung, die zur Generierung des Tool-Namens verwendet wird"
+  },
+  "subRecipeModal.nameLabel": {
+    "defaultMessage": "Name"
+  },
+  "subRecipeModal.namePlaceholder": {
+    "defaultMessage": "z. B. security_scan"
+  },
+  "subRecipeModal.pathHint": {
+    "defaultMessage": "Nach einer vorhandenen Rezeptdatei suchen oder einen Pfad manuell eingeben"
+  },
+  "subRecipeModal.pathLabel": {
+    "defaultMessage": "Pfad"
+  },
+  "subRecipeModal.pathPlaceholder": {
+    "defaultMessage": "z. B. ./subrecipes/security-analysis.yaml"
+  },
+  "subRecipeModal.preconfiguredValues": {
+    "defaultMessage": "Vorkonfigurierte Werte"
+  },
+  "subRecipeModal.preconfiguredValuesHint": {
+    "defaultMessage": "Optionale Parameterwerte, die immer an das Subrezept übergeben werden"
+  },
+  "subRecipeModal.sequentialHint": {
+    "defaultMessage": "(Erzwingt die sequenzielle Ausführung mehrerer Subrezept-Instanzen)"
+  },
+  "subRecipeModal.sequentialLabel": {
+    "defaultMessage": "Sequenziell bei Wiederholung"
+  },
+  "subRecipeModal.subtitle": {
+    "defaultMessage": "Konfigurieren Sie ein Subrezept, das während der Rezeptausführung als Tool aufgerufen werden kann"
+  },
+  "switchModelModal.backToModelList": {
+    "defaultMessage": "Zurück zur Modellliste"
+  },
+  "switchModelModal.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "switchModelModal.checkProviderConfig": {
+    "defaultMessage": "Überprüfen Sie Ihre Anbieterkonfiguration unter Einstellungen → Anbieter"
+  },
+  "switchModelModal.chooseModel": {
+    "defaultMessage": "Wählen Sie ein Modell:"
+  },
+  "switchModelModal.claudeAdaptive": {
+    "defaultMessage": "Adaptiv - Claude entscheidet, wann und wie viel nachgedacht wird"
+  },
+  "switchModelModal.claudeDisabled": {
+    "defaultMessage": "Deaktiviert - Kein erweitertes Nachdenken"
+  },
+  "switchModelModal.claudeEffortHigh": {
+    "defaultMessage": "Hoch - Tiefes Nachdenken (Standard)"
+  },
+  "switchModelModal.claudeEffortLow": {
+    "defaultMessage": "Niedrig - Minimales Nachdenken, schnellste Antworten"
+  },
+  "switchModelModal.claudeEffortMax": {
+    "defaultMessage": "Max - Keine Beschränkungen für die Denktiefe"
+  },
+  "switchModelModal.claudeEffortMedium": {
+    "defaultMessage": "Mittel - Moderates Nachdenken"
+  },
+  "switchModelModal.claudeEnabled": {
+    "defaultMessage": "Aktiviert - Festes Token-Budget für das Nachdenken"
+  },
+  "switchModelModal.couldNotContactProvider": {
+    "defaultMessage": "Anbieter konnte nicht kontaktiert werden"
+  },
+  "switchModelModal.customModelName": {
+    "defaultMessage": "Benutzerdefinierter Modellname"
+  },
+  "switchModelModal.description": {
+    "defaultMessage": "Wählen Sie einen Anbieter und ein Modell für Ihre Unterhaltungen aus."
+  },
+  "switchModelModal.enterModelNotListed": {
+    "defaultMessage": "Ein nicht aufgeführtes Modell eingeben..."
+  },
+  "switchModelModal.extendedThinking": {
+    "defaultMessage": "Erweitertes Nachdenken"
+  },
+  "switchModelModal.geminiOnly": {
+    "defaultMessage": "(Nur Gemini-3-Modelle)"
+  },
+  "switchModelModal.goToSettings": {
+    "defaultMessage": "Zu den Einstellungen"
+  },
+  "switchModelModal.loadingModels": {
+    "defaultMessage": "Modelle werden geladen…"
+  },
+  "switchModelModal.localModelsDescription": {
+    "defaultMessage": "Um lokale Inferenz zu nutzen, müssen Sie zunächst ein Modell auf Ihren Computer herunterladen. Gehen Sie zu Einstellungen → Modelle, um lokale Modelle zu verwalten."
+  },
+  "switchModelModal.localModelsTitle": {
+    "defaultMessage": "Lokale Modelle müssen zuerst heruntergeladen werden"
+  },
+  "switchModelModal.providerPlaceholder": {
+    "defaultMessage": "Anbieter, zum Suchen tippen"
+  },
+  "switchModelModal.quickStartGuide": {
+    "defaultMessage": "Schnellstartanleitung"
+  },
+  "switchModelModal.recommended": {
+    "defaultMessage": "Empfohlen"
+  },
+  "switchModelModal.selectEffortLevel": {
+    "defaultMessage": "Aufwandsstufe auswählen"
+  },
+  "switchModelModal.selectModel": {
+    "defaultMessage": "Bitte wählen Sie ein Modell aus"
+  },
+  "switchModelModal.selectModelButton": {
+    "defaultMessage": "Modell auswählen"
+  },
+  "switchModelModal.selectModelPlaceholder": {
+    "defaultMessage": "Modell auswählen, zum Suchen tippen"
+  },
+  "switchModelModal.selectOrEnterModel": {
+    "defaultMessage": "Bitte wählen Sie ein Modell aus oder geben Sie eines ein"
+  },
+  "switchModelModal.selectProvider": {
+    "defaultMessage": "Bitte wählen Sie einen Anbieter aus"
+  },
+  "switchModelModal.selectThinkingLevel": {
+    "defaultMessage": "Denkstufe auswählen"
+  },
+  "switchModelModal.selectThinkingMode": {
+    "defaultMessage": "Denkmodus auswählen"
+  },
+  "switchModelModal.thinkingBudget": {
+    "defaultMessage": "Denkbudget (Tokens)"
+  },
+  "switchModelModal.thinkingEffort": {
+    "defaultMessage": "Denkaufwand"
+  },
+  "switchModelModal.thinkingEffortOff": {
+    "defaultMessage": "Aus - Kein erweitertes Nachdenken"
+  },
+  "switchModelModal.thinkingLevel": {
+    "defaultMessage": "Denkstufe"
+  },
+  "switchModelModal.thinkingLevelHigh": {
+    "defaultMessage": "Hoch - Tieferes Nachdenken, höhere Latenz"
+  },
+  "switchModelModal.thinkingLevelLow": {
+    "defaultMessage": "Niedrig - Bessere Latenz, leichteres Nachdenken"
+  },
+  "switchModelModal.title": {
+    "defaultMessage": "Modelle wechseln"
+  },
+  "switchModelModal.typeModelName": {
+    "defaultMessage": "Modellnamen hier eingeben"
+  },
+  "switchModelModal.useOtherProvider": {
+    "defaultMessage": "Anderen Anbieter verwenden"
+  },
+  "telemetryConsentPrompt.description": {
+    "defaultMessage": "Möchten Sie anonyme Nutzungsdaten teilen, um goose zu verbessern? Wir erfassen niemals Ihre Unterhaltungen, Ihren Code oder Ihre persönlichen Daten."
+  },
+  "telemetryConsentPrompt.heading": {
+    "defaultMessage": "Helfen Sie, goose zu verbessern"
+  },
+  "telemetryConsentPrompt.learnMore": {
+    "defaultMessage": "Mehr erfahren"
+  },
+  "telemetryConsentPrompt.optIn": {
+    "defaultMessage": "Ja, anonyme Nutzungsdaten teilen"
+  },
+  "telemetryConsentPrompt.optOut": {
+    "defaultMessage": "Nein danke"
+  },
+  "telemetrySettings.configErrorTitle": {
+    "defaultMessage": "Konfigurationsfehler"
+  },
+  "telemetrySettings.description": {
+    "defaultMessage": "Steuern Sie, wie Ihre Daten verwendet werden"
+  },
+  "telemetrySettings.learnMore": {
+    "defaultMessage": "Mehr erfahren"
+  },
+  "telemetrySettings.loadError": {
+    "defaultMessage": "Telemetrie-Einstellungen konnten nicht geladen werden."
+  },
+  "telemetrySettings.title": {
+    "defaultMessage": "Datenschutz"
+  },
+  "telemetrySettings.toggleDescription": {
+    "defaultMessage": "Helfen Sie, goose zu verbessern, indem Sie anonyme Nutzungsstatistiken teilen."
+  },
+  "telemetrySettings.toggleLabel": {
+    "defaultMessage": "Anonyme Nutzungsdaten"
+  },
+  "telemetrySettings.updateError": {
+    "defaultMessage": "Telemetrie-Einstellungen konnten nicht aktualisiert werden."
+  },
+  "themeSelector.dark": {
+    "defaultMessage": "Dunkel"
+  },
+  "themeSelector.light": {
+    "defaultMessage": "Hell"
+  },
+  "themeSelector.system": {
+    "defaultMessage": "System"
+  },
+  "themeSelector.theme": {
+    "defaultMessage": "Design"
+  },
+  "toolApprovalButtons.allowOnce": {
+    "defaultMessage": "Einmal erlauben"
+  },
+  "toolApprovalButtons.allowedOnce": {
+    "defaultMessage": "Einmal erlaubt"
+  },
+  "toolApprovalButtons.alwaysAllow": {
+    "defaultMessage": "Immer erlauben"
+  },
+  "toolApprovalButtons.alwaysAllowed": {
+    "defaultMessage": "Immer erlaubt"
+  },
+  "toolApprovalButtons.cancelled": {
+    "defaultMessage": "Abgebrochen"
+  },
+  "toolApprovalButtons.denied": {
+    "defaultMessage": "Verweigert"
+  },
+  "toolApprovalButtons.deniedOnce": {
+    "defaultMessage": "Einmal verweigert"
+  },
+  "toolApprovalButtons.deny": {
+    "defaultMessage": "Verweigern"
+  },
+  "toolApprovalButtons.staleApprovalRequest": {
+    "defaultMessage": "Diese Genehmigungsanfrage ist nicht mehr aktiv."
+  },
+  "toolCallStatusIndicator.toolStatus": {
+    "defaultMessage": "Tool-Status: {status}"
+  },
+  "toolCallWithResponse.activityCount": {
+    "defaultMessage": "Aktivität ({count})"
+  },
+  "toolCallWithResponse.code": {
+    "defaultMessage": "Code"
+  },
+  "toolCallWithResponse.loadingSpinner": {
+    "defaultMessage": "Ladeanimation"
+  },
+  "toolCallWithResponse.logs": {
+    "defaultMessage": "Protokolle"
+  },
+  "toolCallWithResponse.mcpUiExperimental": {
+    "defaultMessage": "MCP UI ist experimentell und kann sich jederzeit ändern."
+  },
+  "toolCallWithResponse.output": {
+    "defaultMessage": "Ausgabe"
+  },
+  "toolCallWithResponse.toolDetails": {
+    "defaultMessage": "Tool-Details"
+  },
+  "toolCallWithResponse.toolResultAlt": {
+    "defaultMessage": "Tool-Ergebnis"
+  },
+  "toolCallWithResponse.viewSubagentSession": {
+    "defaultMessage": "Subagent-Sitzung anzeigen"
+  },
+  "toolConfirmation.allowToolCallWithName": {
+    "defaultMessage": "{toolName} erlauben?"
+  },
+  "toolConfirmation.gooseWouldLikeToCallWithName": {
+    "defaultMessage": "Goose möchte {toolName} aufrufen. Erlauben?"
+  },
+  "updateSection.autoDownload": {
+    "defaultMessage": "Goose lädt das Update im Hintergrund herunter und installiert es beim nächsten Beenden oder Neustart."
+  },
+  "updateSection.autoDownloadDisabledByEnv": {
+    "defaultMessage": "Automatische Downloads sind über die Umgebungsvariable GOOSE_DISABLE_AUTO_DOWNLOAD deaktiviert."
+  },
+  "updateSection.autoDownloadDisabledNote": {
+    "defaultMessage": "Automatischer Download ist deaktiviert. Klicken Sie auf \"Jetzt herunterladen\", um manuell herunterzuladen."
+  },
+  "updateSection.autoInstallNote": {
+    "defaultMessage": "Keine manuelle Installation erforderlich."
+  },
+  "updateSection.checkForUpdates": {
+    "defaultMessage": "Nach Updates suchen"
+  },
+  "updateSection.checking": {
+    "defaultMessage": "Suche nach Updates..."
+  },
+  "updateSection.currentVersion": {
+    "defaultMessage": "Aktuelle Version"
+  },
+  "updateSection.disableAutoDownload": {
+    "defaultMessage": "Automatische Update-Downloads deaktivieren"
+  },
+  "updateSection.disableAutoDownloadDesc": {
+    "defaultMessage": "Wenn aktiviert, benachrichtigt Goose Sie über neue Versionen, lädt sie aber nicht automatisch herunter."
+  },
+  "updateSection.downloadNow": {
+    "defaultMessage": "Jetzt herunterladen"
+  },
+  "updateSection.downloadReady": {
+    "defaultMessage": "Update heruntergeladen und installationsbereit!"
+  },
+  "updateSection.downloadingProgress": {
+    "defaultMessage": "Update wird heruntergeladen... {percent}%"
+  },
+  "updateSection.downloadingUpdate": {
+    "defaultMessage": "Update wird heruntergeladen..."
+  },
+  "updateSection.installAndRestart": {
+    "defaultMessage": "Installieren & Neustarten"
+  },
+  "updateSection.installNowHint": {
+    "defaultMessage": "Klicken Sie auf \"Installieren & Neustarten\", um jetzt zu aktualisieren."
+  },
+  "updateSection.latestVersion": {
+    "defaultMessage": "Sie verwenden die neueste Version!"
+  },
+  "updateSection.loading": {
+    "defaultMessage": "Wird geladen..."
+  },
+  "updateSection.manualInstallNote": {
+    "defaultMessage": "Nach dem Download müssen Sie das Update manuell installieren."
+  },
+  "updateSection.manualInstallRequired": {
+    "defaultMessage": "Für diese Update-Methode ist eine manuelle Installation erforderlich."
+  },
+  "updateSection.readyInstallAuto": {
+    "defaultMessage": "✓ Update ist bereit. Starten Sie Goose neu, um die Installation abzuschließen, oder beenden Sie es, wenn Sie fertig sind."
+  },
+  "updateSection.readyInstallManual": {
+    "defaultMessage": "✓ Update ist bereit! Klicken Sie auf \"Installieren & Neustarten\", um die Installationsanweisungen zu erhalten."
+  },
+  "updateSection.upToDate": {
+    "defaultMessage": "(aktuell)"
+  },
+  "updateSection.updateAvailable": {
+    "defaultMessage": "Update verfügbar!"
+  },
+  "updateSection.versionAvailable": {
+    "defaultMessage": "→ {version} verfügbar"
+  },
+  "updateSection.versionIsAvailable": {
+    "defaultMessage": "Version {version} ist verfügbar"
+  },
+  "userMessage.cancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "userMessage.cancelAriaLabel": {
+    "defaultMessage": "Bearbeitung abbrechen"
+  },
+  "userMessage.editAriaLabel": {
+    "defaultMessage": "Nachrichteninhalt bearbeiten"
+  },
+  "userMessage.editButton": {
+    "defaultMessage": "Bearbeiten"
+  },
+  "userMessage.editInPlace": {
+    "defaultMessage": "An Ort und Stelle bearbeiten"
+  },
+  "userMessage.editInPlaceAriaLabel": {
+    "defaultMessage": "Nachricht an Ort und Stelle bearbeiten"
+  },
+  "userMessage.editInPlaceDescription": {
+    "defaultMessage": "<b>An Ort und Stelle bearbeiten</b> aktualisiert diese Sitzung • <b>Sitzung verzweigen</b> erstellt eine neue Sitzung"
+  },
+  "userMessage.editInPlaceTitle": {
+    "defaultMessage": "Die Nachricht in dieser Sitzung aktualisieren"
+  },
+  "userMessage.editMessageAriaLabel": {
+    "defaultMessage": "Nachricht bearbeiten: {preview}"
+  },
+  "userMessage.editMessageTitle": {
+    "defaultMessage": "Nachricht bearbeiten"
+  },
+  "userMessage.editPlaceholder": {
+    "defaultMessage": "Bearbeiten Sie Ihre Nachricht..."
+  },
+  "userMessage.emptyError": {
+    "defaultMessage": "Nachricht darf nicht leer sein"
+  },
+  "userMessage.forkSession": {
+    "defaultMessage": "Sitzung verzweigen"
+  },
+  "userMessage.forkSessionAriaLabel": {
+    "defaultMessage": "Sitzung mit bearbeiteter Nachricht verzweigen"
+  },
+  "userMessage.forkSessionTitle": {
+    "defaultMessage": "Eine neue Sitzung mit der bearbeiteten Nachricht erstellen"
+  }
+}

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -3887,14 +3887,32 @@
   "settings.language.english": {
     "defaultMessage": "English"
   },
+  "settings.language.french": {
+    "defaultMessage": "French"
+  },
+  "settings.language.german": {
+    "defaultMessage": "German"
+  },
   "settings.language.hindi": {
     "defaultMessage": "Hindi"
+  },
+  "settings.language.indonesian": {
+    "defaultMessage": "Indonesian"
+  },
+  "settings.language.italian": {
+    "defaultMessage": "Italian"
   },
   "settings.language.japanese": {
     "defaultMessage": "Japanese"
   },
   "settings.language.korean": {
     "defaultMessage": "Korean"
+  },
+  "settings.language.malay": {
+    "defaultMessage": "Malay"
+  },
+  "settings.language.portuguese": {
+    "defaultMessage": "Portuguese"
   },
   "settings.language.russian": {
     "defaultMessage": "Russian"
@@ -3911,8 +3929,14 @@
   "settings.language.turkish": {
     "defaultMessage": "Turkish"
   },
+  "settings.language.vietnamese": {
+    "defaultMessage": "Vietnamese"
+  },
   "settings.language.zhCN": {
     "defaultMessage": "Chinese (Simplified)"
+  },
+  "settings.language.zhTW": {
+    "defaultMessage": "Chinese (Traditional)"
   },
   "settings.menuBarIcon.description": {
     "defaultMessage": "Show goose in the menu bar"

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -3887,14 +3887,32 @@
   "settings.language.english": {
     "defaultMessage": "Inglés"
   },
+  "settings.language.french": {
+    "defaultMessage": "Francés"
+  },
+  "settings.language.german": {
+    "defaultMessage": "Alemán"
+  },
   "settings.language.hindi": {
     "defaultMessage": "Hindi"
+  },
+  "settings.language.indonesian": {
+    "defaultMessage": "Indonesio"
+  },
+  "settings.language.italian": {
+    "defaultMessage": "Italiano"
   },
   "settings.language.japanese": {
     "defaultMessage": "Japonés"
   },
   "settings.language.korean": {
     "defaultMessage": "Coreano"
+  },
+  "settings.language.malay": {
+    "defaultMessage": "Malayo"
+  },
+  "settings.language.portuguese": {
+    "defaultMessage": "Portugués"
   },
   "settings.language.russian": {
     "defaultMessage": "Ruso"
@@ -3911,8 +3929,14 @@
   "settings.language.turkish": {
     "defaultMessage": "Turco"
   },
+  "settings.language.vietnamese": {
+    "defaultMessage": "Vietnamita"
+  },
   "settings.language.zhCN": {
     "defaultMessage": "Chino (simplificado)"
+  },
+  "settings.language.zhTW": {
+    "defaultMessage": "Chino (tradicional)"
   },
   "settings.menuBarIcon.description": {
     "defaultMessage": "Muestra goose en la barra de menús"

--- a/ui/desktop/src/i18n/messages/fr.json
+++ b/ui/desktop/src/i18n/messages/fr.json
@@ -1,0 +1,4574 @@
+{
+  "alertBox.autoCompactAt": {
+    "defaultMessage": "Compactage automatique à"
+  },
+  "alertBox.compactNow": {
+    "defaultMessage": "Compacter maintenant"
+  },
+  "alertBox.failedToSaveThreshold": {
+    "defaultMessage": "Échec de l'enregistrement du seuil : {error}"
+  },
+  "announcementModal.gotIt": {
+    "defaultMessage": "Compris !"
+  },
+  "appLayout.collapseNavigation": {
+    "defaultMessage": "Réduire la navigation"
+  },
+  "appLayout.openNavigation": {
+    "defaultMessage": "Ouvrir la navigation"
+  },
+  "appsView.customApp": {
+    "defaultMessage": "Application personnalisée"
+  },
+  "appsView.description": {
+    "defaultMessage": "Applications provenant de vos serveurs MCP et applications créées par goose lui-même. Vous pouvez lui demander de créer de nouvelles applications via l'interface de chat et elles apparaîtront ici."
+  },
+  "appsView.errorLoading": {
+    "defaultMessage": "Erreur lors du chargement des applications : {error}"
+  },
+  "appsView.importApp": {
+    "defaultMessage": "Importer une application"
+  },
+  "appsView.launch": {
+    "defaultMessage": "Lancer"
+  },
+  "appsView.loading": {
+    "defaultMessage": "Chargement des applications..."
+  },
+  "appsView.noAppsDescription": {
+    "defaultMessage": "Ouvrez un chat et demandez à goose l'application que vous souhaitez. Il peut en créer une pour vous et elle apparaîtra ici. Ou si quelqu'un a partagé une application, vous pouvez l'importer à l'aide du bouton ci-dessus."
+  },
+  "appsView.noAppsTitle": {
+    "defaultMessage": "Aucune application disponible"
+  },
+  "appsView.retry": {
+    "defaultMessage": "Réessayer"
+  },
+  "appsView.title": {
+    "defaultMessage": "Applications"
+  },
+  "authSettings.activeProviderWarning": {
+    "defaultMessage": "Il s'agit du fournisseur actif. De nouvelles requêtes peuvent échouer tant que vous ne configurez pas d'autres identifiants."
+  },
+  "authSettings.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "authSettings.delete": {
+    "defaultMessage": "Supprimer"
+  },
+  "authSettings.deleteCredential": {
+    "defaultMessage": "Supprimer l'identifiant"
+  },
+  "authSettings.deleteMessage": {
+    "defaultMessage": "Supprimer l'identifiant {name} pour {provider} ?"
+  },
+  "authSettings.deleteTitle": {
+    "defaultMessage": "Supprimer l'identifiant"
+  },
+  "authSettings.deleted": {
+    "defaultMessage": "Identifiant supprimé"
+  },
+  "authSettings.description": {
+    "defaultMessage": "Gérez les identifiants de fournisseurs stockés localement par goose."
+  },
+  "authSettings.empty": {
+    "defaultMessage": "Aucun identifiant de fournisseur stocké localement n'a été trouvé."
+  },
+  "authSettings.expiresAt": {
+    "defaultMessage": "Expire le {date}"
+  },
+  "authSettings.failedToConfigure": {
+    "defaultMessage": "Échec de la configuration de l'identifiant : {error}"
+  },
+  "authSettings.failedToDelete": {
+    "defaultMessage": "Échec de la suppression de l'identifiant : {error}"
+  },
+  "authSettings.failedToLoad": {
+    "defaultMessage": "Échec du chargement des identifiants de fournisseurs"
+  },
+  "authSettings.loading": {
+    "defaultMessage": "Chargement des identifiants..."
+  },
+  "authSettings.reauthorize": {
+    "defaultMessage": "Réautoriser"
+  },
+  "authSettings.signIn": {
+    "defaultMessage": "Se connecter"
+  },
+  "authSettings.signedIn": {
+    "defaultMessage": "Identifiant configuré"
+  },
+  "authSettings.storageProviderCache": {
+    "defaultMessage": "Cache du fournisseur"
+  },
+  "authSettings.storageSecretStore": {
+    "defaultMessage": "Coffre de secrets"
+  },
+  "authSettings.title": {
+    "defaultMessage": "Identifiants de fournisseurs"
+  },
+  "backButton.back": {
+    "defaultMessage": "Retour"
+  },
+  "baseChat.failedToLoadSession": {
+    "defaultMessage": "Échec du chargement de la session"
+  },
+  "baseChat.goHome": {
+    "defaultMessage": "Aller à l'accueil"
+  },
+  "bottomMenuExtensionSelection.extensionUpdated": {
+    "defaultMessage": "Extension mise à jour"
+  },
+  "bottomMenuExtensionSelection.extensionWillBeDisabled": {
+    "defaultMessage": "{name} sera désactivée dans les nouveaux chats"
+  },
+  "bottomMenuExtensionSelection.extensionWillBeEnabled": {
+    "defaultMessage": "{name} sera activée dans les nouveaux chats"
+  },
+  "bottomMenuExtensionSelection.extensionsForNewChats": {
+    "defaultMessage": "Extensions pour les nouveaux chats"
+  },
+  "bottomMenuExtensionSelection.extensionsForThisSession": {
+    "defaultMessage": "Extensions pour cette session de chat"
+  },
+  "bottomMenuExtensionSelection.manageExtensions": {
+    "defaultMessage": "gérer les extensions"
+  },
+  "bottomMenuExtensionSelection.noExtensionsAvailable": {
+    "defaultMessage": "aucune extension disponible"
+  },
+  "bottomMenuExtensionSelection.noExtensionsFound": {
+    "defaultMessage": "aucune extension trouvée"
+  },
+  "bottomMenuExtensionSelection.searchExtensions": {
+    "defaultMessage": "rechercher des extensions..."
+  },
+  "cardButtons.configure": {
+    "defaultMessage": "Configurer"
+  },
+  "cardButtons.launch": {
+    "defaultMessage": "Lancer"
+  },
+  "chat.notification.taskComplete.body": {
+    "defaultMessage": "Cliquez ici pour remettre Goose au premier plan."
+  },
+  "chat.notification.taskComplete.title": {
+    "defaultMessage": "Goose a terminé la tâche."
+  },
+  "chatInput.contextWindow": {
+    "defaultMessage": "Fenêtre de contexte"
+  },
+  "chatInput.dictationError": {
+    "defaultMessage": "Erreur de dictée"
+  },
+  "chatInput.failedToReadImage": {
+    "defaultMessage": "Échec de la lecture du fichier image"
+  },
+  "chatInput.navigationShortcut": {
+    "defaultMessage": "{prefix}↑/{prefix}↓ pour naviguer entre les messages"
+  },
+  "chatInput.processingDroppedFiles": {
+    "defaultMessage": "Traitement des fichiers déposés..."
+  },
+  "chatInput.recording": {
+    "defaultMessage": "Enregistrement..."
+  },
+  "chatInput.removeFile": {
+    "defaultMessage": "Supprimer le fichier"
+  },
+  "chatInput.removeImage": {
+    "defaultMessage": "Supprimer l'image"
+  },
+  "chatInput.restartingSession": {
+    "defaultMessage": "Redémarrage de la session..."
+  },
+  "chatInput.send": {
+    "defaultMessage": "Envoyer"
+  },
+  "chatInput.transcribing": {
+    "defaultMessage": "Transcription..."
+  },
+  "chatInput.typeMessage": {
+    "defaultMessage": "Saisissez un message à envoyer"
+  },
+  "chatInput.unknownType": {
+    "defaultMessage": "Type inconnu"
+  },
+  "chatInput.viewEditRecipe": {
+    "defaultMessage": "Afficher/Modifier la recette"
+  },
+  "chatInput.waitingForCancellation": {
+    "defaultMessage": "En attente de la fin de l'annulation"
+  },
+  "chatInput.waitingForImages": {
+    "defaultMessage": "En attente de l'enregistrement des images..."
+  },
+  "chatSettings.modeDescription": {
+    "defaultMessage": "Choisissez le mode par défaut que Goose utilise pour les nouvelles sessions. Les sessions existantes conservent leur mode actuel."
+  },
+  "chatSettings.modeTitle": {
+    "defaultMessage": "Mode par défaut"
+  },
+  "chatSettings.responseStylesDescription": {
+    "defaultMessage": "Choisissez la façon dont Goose doit formater et styliser ses réponses"
+  },
+  "chatSettings.responseStylesTitle": {
+    "defaultMessage": "Styles de réponse"
+  },
+  "configSettings.configReset": {
+    "defaultMessage": "Configuration réinitialisée"
+  },
+  "configSettings.configResetMsg": {
+    "defaultMessage": "Toutes les modifications ont été annulées"
+  },
+  "configSettings.configUpdated": {
+    "defaultMessage": "Configuration mise à jour"
+  },
+  "configSettings.configUpdatedMsg": {
+    "defaultMessage": "« {name} » enregistré avec succès"
+  },
+  "configSettings.configurationEditor": {
+    "defaultMessage": "Éditeur de configuration"
+  },
+  "configSettings.description": {
+    "defaultMessage": "Modifiez les paramètres de configuration de goose"
+  },
+  "configSettings.descriptionWithProvider": {
+    "defaultMessage": "Modifiez les paramètres de configuration de goose (paramètres actuels pour {provider})"
+  },
+  "configSettings.done": {
+    "defaultMessage": "Terminé"
+  },
+  "configSettings.editConfiguration": {
+    "defaultMessage": "Modifier la configuration"
+  },
+  "configSettings.enterValue": {
+    "defaultMessage": "Saisissez {name}"
+  },
+  "configSettings.noSettings": {
+    "defaultMessage": "Aucun paramètre de configuration trouvé."
+  },
+  "configSettings.resetChanges": {
+    "defaultMessage": "Réinitialiser les modifications"
+  },
+  "configSettings.saveFailed": {
+    "defaultMessage": "Échec de l'enregistrement"
+  },
+  "configSettings.saveFailedMsg": {
+    "defaultMessage": "Échec de l'enregistrement de « {name} »"
+  },
+  "configSettings.saving": {
+    "defaultMessage": "Enregistrement..."
+  },
+  "configSettings.title": {
+    "defaultMessage": "Configuration"
+  },
+  "configureApproveMode.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "configureApproveMode.description": {
+    "defaultMessage": "Les demandes d'approbation peuvent s'appliquer à toutes les requêtes d'outils ou déterminer quelles actions nécessitent une intégration"
+  },
+  "configureApproveMode.manualApproval": {
+    "defaultMessage": "Approbation manuelle"
+  },
+  "configureApproveMode.manualApprovalDescription": {
+    "defaultMessage": "Tous les outils, extensions et modifications de fichiers nécessiteront une approbation humaine"
+  },
+  "configureApproveMode.save": {
+    "defaultMessage": "Enregistrer"
+  },
+  "configureApproveMode.saving": {
+    "defaultMessage": "Enregistrement..."
+  },
+  "configureApproveMode.smartApproval": {
+    "defaultMessage": "Approbation intelligente"
+  },
+  "configureApproveMode.smartApprovalDescription": {
+    "defaultMessage": "Déterminer intelligemment quelles actions nécessitent une approbation en fonction du niveau de risque"
+  },
+  "configureApproveMode.title": {
+    "defaultMessage": "Configurer le mode d'approbation"
+  },
+  "confirmationModal.defaultCancel": {
+    "defaultMessage": "Non"
+  },
+  "confirmationModal.defaultConfirm": {
+    "defaultMessage": "Oui"
+  },
+  "confirmationModal.processing": {
+    "defaultMessage": "Traitement en cours..."
+  },
+  "conversationLimitsDropdown.conversationLimits": {
+    "defaultMessage": "Limites de conversation"
+  },
+  "conversationLimitsDropdown.maxTurns": {
+    "defaultMessage": "Nombre maximal de tours"
+  },
+  "conversationLimitsDropdown.maxTurnsDescription": {
+    "defaultMessage": "Nombre maximal de tours de l'agent avant que Goose ne demande une intervention de l'utilisateur"
+  },
+  "costTracker.costUnavailable": {
+    "defaultMessage": "Données de coût non disponibles pour {model} ({inputTokens} jetons en entrée, {outputTokens} jetons en sortie)"
+  },
+  "costTracker.inputOutputTooltip": {
+    "defaultMessage": "Entrée : {inputTokens} jetons ({inputCost}) | Sortie : {outputTokens} jetons ({outputCost})"
+  },
+  "costTracker.pricingUnavailable": {
+    "defaultMessage": "Données tarifaires non disponibles pour {model}"
+  },
+  "costTracker.totalSessionCost": {
+    "defaultMessage": "Coût total de la session : {cost}"
+  },
+  "createEditRecipe.clickToGenerateDeeplink": {
+    "defaultMessage": "Cliquez pour générer un lien profond"
+  },
+  "createEditRecipe.close": {
+    "defaultMessage": "Fermer"
+  },
+  "createEditRecipe.copied": {
+    "defaultMessage": "Copié !"
+  },
+  "createEditRecipe.copy": {
+    "defaultMessage": "Copier"
+  },
+  "createEditRecipe.copyLinkDescription": {
+    "defaultMessage": "Copiez ce lien pour le partager avec des amis ou collez-le directement dans Chrome pour l'ouvrir"
+  },
+  "createEditRecipe.createRecipeTitle": {
+    "defaultMessage": "Créer une recette"
+  },
+  "createEditRecipe.createSubtitle": {
+    "defaultMessage": "Créez une nouvelle recette pour définir le comportement et les capacités de l'agent pour des sessions de chat réutilisables."
+  },
+  "createEditRecipe.editSubtitle": {
+    "defaultMessage": "Vous pouvez modifier la recette ci-dessous pour changer le comportement de l'agent dans une nouvelle session."
+  },
+  "createEditRecipe.generatingDeeplink": {
+    "defaultMessage": "Génération du lien profond..."
+  },
+  "createEditRecipe.learnMore": {
+    "defaultMessage": "En savoir plus"
+  },
+  "createEditRecipe.recipeSavedAndLaunchedMsg": {
+    "defaultMessage": "Recette enregistrée et lancée avec succès"
+  },
+  "createEditRecipe.recipeSavedMsg": {
+    "defaultMessage": "Recette enregistrée avec succès"
+  },
+  "createEditRecipe.saveAndRunFailed": {
+    "defaultMessage": "Échec de l'enregistrement et de l'exécution"
+  },
+  "createEditRecipe.saveAndRunFailedMsg": {
+    "defaultMessage": "Échec de l'enregistrement et de l'exécution de la recette : {error}"
+  },
+  "createEditRecipe.saveAndRunRecipe": {
+    "defaultMessage": "Enregistrer et exécuter la recette"
+  },
+  "createEditRecipe.saveFailed": {
+    "defaultMessage": "Échec de l'enregistrement"
+  },
+  "createEditRecipe.saveFailedMsg": {
+    "defaultMessage": "Échec de l'enregistrement de la recette : {error}"
+  },
+  "createEditRecipe.saveRecipe": {
+    "defaultMessage": "Enregistrer la recette"
+  },
+  "createEditRecipe.saving": {
+    "defaultMessage": "Enregistrement..."
+  },
+  "createEditRecipe.validationFailed": {
+    "defaultMessage": "Échec de la validation"
+  },
+  "createEditRecipe.validationMsg": {
+    "defaultMessage": "Veuillez remplir tous les champs obligatoires et vous assurer que le schéma JSON est valide."
+  },
+  "createEditRecipe.viewEditRecipeTitle": {
+    "defaultMessage": "Afficher/modifier la recette"
+  },
+  "createSubRecipeInline.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "createSubRecipeInline.closeModal": {
+    "defaultMessage": "Fermer la fenêtre de création de sous-recette"
+  },
+  "createSubRecipeInline.createAndAdd": {
+    "defaultMessage": "Créer et ajouter une sous-recette"
+  },
+  "createSubRecipeInline.createdSuccess": {
+    "defaultMessage": "Sous-recette créée avec succès"
+  },
+  "createSubRecipeInline.creating": {
+    "defaultMessage": "Création..."
+  },
+  "createSubRecipeInline.duplicateName": {
+    "defaultMessage": "Nom en double"
+  },
+  "createSubRecipeInline.duplicateNameMsg": {
+    "defaultMessage": "Une sous-recette nommée « {name} » existe déjà. Veuillez utiliser un nom unique."
+  },
+  "createSubRecipeInline.instructionsLabel": {
+    "defaultMessage": "Instructions"
+  },
+  "createSubRecipeInline.instructionsPlaceholder": {
+    "defaultMessage": "Instructions pour l'IA lorsque cette sous-recette est appelée..."
+  },
+  "createSubRecipeInline.nameHint": {
+    "defaultMessage": "Identifiant unique utilisé pour générer le nom de l'outil"
+  },
+  "createSubRecipeInline.nameLabel": {
+    "defaultMessage": "Nom"
+  },
+  "createSubRecipeInline.namePlaceholder": {
+    "defaultMessage": "p. ex., security_scan"
+  },
+  "createSubRecipeInline.preconfiguredValues": {
+    "defaultMessage": "Valeurs préconfigurées"
+  },
+  "createSubRecipeInline.preconfiguredValuesHint": {
+    "defaultMessage": "Valeurs de paramètres optionnelles qui sont toujours transmises à la sous-recette"
+  },
+  "createSubRecipeInline.recipeDescriptionLabel": {
+    "defaultMessage": "Description de la recette"
+  },
+  "createSubRecipeInline.recipeDescriptionPlaceholder": {
+    "defaultMessage": "Ce que fait cette recette lors de son exécution"
+  },
+  "createSubRecipeInline.recipeTitleLabel": {
+    "defaultMessage": "Titre de la recette"
+  },
+  "createSubRecipeInline.recipeTitlePlaceholder": {
+    "defaultMessage": "p. ex., Outil d'analyse de sécurité"
+  },
+  "createSubRecipeInline.saveFailed": {
+    "defaultMessage": "Échec de l'enregistrement"
+  },
+  "createSubRecipeInline.saveFailedMsg": {
+    "defaultMessage": "Échec de l'enregistrement de la sous-recette : {error}"
+  },
+  "createSubRecipeInline.sequentialHint": {
+    "defaultMessage": "(Force l'exécution séquentielle de plusieurs instances)"
+  },
+  "createSubRecipeInline.sequentialLabel": {
+    "defaultMessage": "Séquentiel en cas de répétition"
+  },
+  "createSubRecipeInline.subtitle": {
+    "defaultMessage": "Créez une recette simple à utiliser comme outil appelable dans votre recette principale"
+  },
+  "createSubRecipeInline.title": {
+    "defaultMessage": "Créer une nouvelle sous-recette"
+  },
+  "createSubRecipeInline.toolDescriptionLabel": {
+    "defaultMessage": "Description de l'outil"
+  },
+  "createSubRecipeInline.toolDescriptionPlaceholder": {
+    "defaultMessage": "Description optionnelle affichée lorsque ceci est appelé en tant qu'outil"
+  },
+  "createSubRecipeInline.validationFailed": {
+    "defaultMessage": "Échec de la validation"
+  },
+  "createSubRecipeInline.validationMsg": {
+    "defaultMessage": "Le nom, le titre, la description de la recette et les instructions sont obligatoires."
+  },
+  "creditsExhaustedNotification.addCredits": {
+    "defaultMessage": "Ajouter des crédits"
+  },
+  "creditsExhaustedNotification.insufficientCredits": {
+    "defaultMessage": "Crédits insuffisants"
+  },
+  "cronPicker.april": {
+    "defaultMessage": "Avril"
+  },
+  "cronPicker.at": {
+    "defaultMessage": "à"
+  },
+  "cronPicker.atMinute": {
+    "defaultMessage": "à la minute"
+  },
+  "cronPicker.atSecond": {
+    "defaultMessage": "à la seconde"
+  },
+  "cronPicker.august": {
+    "defaultMessage": "Août"
+  },
+  "cronPicker.cronExpression": {
+    "defaultMessage": "Expression cron"
+  },
+  "cronPicker.custom": {
+    "defaultMessage": "Cron personnalisé"
+  },
+  "cronPicker.day": {
+    "defaultMessage": "Jour"
+  },
+  "cronPicker.december": {
+    "defaultMessage": "Décembre"
+  },
+  "cronPicker.emptyCronError": {
+    "defaultMessage": "L'expression cron ne peut pas être vide"
+  },
+  "cronPicker.every": {
+    "defaultMessage": "Tous les"
+  },
+  "cronPicker.february": {
+    "defaultMessage": "Février"
+  },
+  "cronPicker.friday": {
+    "defaultMessage": "Vendredi"
+  },
+  "cronPicker.hour": {
+    "defaultMessage": "Heure"
+  },
+  "cronPicker.inMonth": {
+    "defaultMessage": "en"
+  },
+  "cronPicker.invalidDayOfMonth": {
+    "defaultMessage": "Le jour doit être compris entre 1 et {max}"
+  },
+  "cronPicker.january": {
+    "defaultMessage": "Janvier"
+  },
+  "cronPicker.july": {
+    "defaultMessage": "Juillet"
+  },
+  "cronPicker.june": {
+    "defaultMessage": "Juin"
+  },
+  "cronPicker.march": {
+    "defaultMessage": "Mars"
+  },
+  "cronPicker.may": {
+    "defaultMessage": "Mai"
+  },
+  "cronPicker.minute": {
+    "defaultMessage": "Minute"
+  },
+  "cronPicker.mode": {
+    "defaultMessage": "Mode"
+  },
+  "cronPicker.monday": {
+    "defaultMessage": "Lundi"
+  },
+  "cronPicker.month": {
+    "defaultMessage": "Mois"
+  },
+  "cronPicker.november": {
+    "defaultMessage": "Novembre"
+  },
+  "cronPicker.october": {
+    "defaultMessage": "Octobre"
+  },
+  "cronPicker.on": {
+    "defaultMessage": "le"
+  },
+  "cronPicker.onDay": {
+    "defaultMessage": "le jour"
+  },
+  "cronPicker.quarter": {
+    "defaultMessage": "Trimestre"
+  },
+  "cronPicker.saturday": {
+    "defaultMessage": "Samedi"
+  },
+  "cronPicker.september": {
+    "defaultMessage": "Septembre"
+  },
+  "cronPicker.startingMonth": {
+    "defaultMessage": "mois de début"
+  },
+  "cronPicker.sunday": {
+    "defaultMessage": "Dimanche"
+  },
+  "cronPicker.thursday": {
+    "defaultMessage": "Jeudi"
+  },
+  "cronPicker.tuesday": {
+    "defaultMessage": "Mardi"
+  },
+  "cronPicker.wednesday": {
+    "defaultMessage": "Mercredi"
+  },
+  "cronPicker.week": {
+    "defaultMessage": "Semaine"
+  },
+  "cronPicker.year": {
+    "defaultMessage": "Année"
+  },
+  "customProviderForm.add": {
+    "defaultMessage": "Ajouter"
+  },
+  "customProviderForm.anthropicCompatible": {
+    "defaultMessage": "Compatible Anthropic"
+  },
+  "customProviderForm.apiBasePath": {
+    "defaultMessage": "Chemin de base de l'API (optionnel)"
+  },
+  "customProviderForm.apiBasePathHint": {
+    "defaultMessage": "Remplace le chemin d'API par défaut. Laissez vide pour utiliser le chemin par défaut du fournisseur."
+  },
+  "customProviderForm.apiBasePathPlaceholder": {
+    "defaultMessage": "p. ex., v1/chat/completions ou project_id/v1"
+  },
+  "customProviderForm.apiKey": {
+    "defaultMessage": "Clé API"
+  },
+  "customProviderForm.apiKeyPlaceholderExisting": {
+    "defaultMessage": "Laissez vide pour conserver la clé existante"
+  },
+  "customProviderForm.apiKeyPlaceholderNew": {
+    "defaultMessage": "Votre clé API"
+  },
+  "customProviderForm.apiKeyRequired": {
+    "defaultMessage": "La clé API est obligatoire"
+  },
+  "customProviderForm.apiUrl": {
+    "defaultMessage": "URL de l'API"
+  },
+  "customProviderForm.apiUrlPlaceholder": {
+    "defaultMessage": "https://api.example.com"
+  },
+  "customProviderForm.apiUrlRequired": {
+    "defaultMessage": "L'URL de l'API est obligatoire"
+  },
+  "customProviderForm.attachments": {
+    "defaultMessage": "Pièces jointes"
+  },
+  "customProviderForm.authHint": {
+    "defaultMessage": "Les LLM locaux comme Ollama ne nécessitent généralement pas de clé API."
+  },
+  "customProviderForm.authentication": {
+    "defaultMessage": "Authentification"
+  },
+  "customProviderForm.availableModels": {
+    "defaultMessage": "Modèles disponibles (séparés par des virgules)"
+  },
+  "customProviderForm.back": {
+    "defaultMessage": "← Retour"
+  },
+  "customProviderForm.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "customProviderForm.cannotDeleteActive": {
+    "defaultMessage": "Vous ne pouvez pas supprimer ce fournisseur tant qu'il est en cours d'utilisation. Veuillez d'abord passer à un autre modèle."
+  },
+  "customProviderForm.chooseSetup": {
+    "defaultMessage": "Choisissez comment vous souhaitez configurer votre fournisseur."
+  },
+  "customProviderForm.clear": {
+    "defaultMessage": "Effacer"
+  },
+  "customProviderForm.configureManually": {
+    "defaultMessage": "Configurer manuellement"
+  },
+  "customProviderForm.configureManuallyDesc": {
+    "defaultMessage": "Saisissez vous-même tous les détails du fournisseur"
+  },
+  "customProviderForm.confirmDelete": {
+    "defaultMessage": "Confirmer la suppression"
+  },
+  "customProviderForm.createProvider": {
+    "defaultMessage": "Créer un fournisseur"
+  },
+  "customProviderForm.customHeaders": {
+    "defaultMessage": "En-têtes personnalisés"
+  },
+  "customProviderForm.customHeadersHint": {
+    "defaultMessage": "Ajoutez des en-têtes HTTP personnalisés à inclure dans les requêtes vers le fournisseur. Cliquez sur le bouton « + » pour les ajouter après avoir rempli les deux champs."
+  },
+  "customProviderForm.deleteConfirmation": {
+    "defaultMessage": "Êtes-vous sûr de vouloir supprimer ce fournisseur personnalisé ? Cela supprimera définitivement le fournisseur et sa clé API stockée. Cette action est irréversible."
+  },
+  "customProviderForm.deleteProvider": {
+    "defaultMessage": "Supprimer le fournisseur"
+  },
+  "customProviderForm.displayName": {
+    "defaultMessage": "Nom d'affichage"
+  },
+  "customProviderForm.displayNamePlaceholder": {
+    "defaultMessage": "Nom de votre fournisseur"
+  },
+  "customProviderForm.displayNameRequired": {
+    "defaultMessage": "Le nom d'affichage est obligatoire"
+  },
+  "customProviderForm.docs": {
+    "defaultMessage": "Documentation"
+  },
+  "customProviderForm.headerBothRequired": {
+    "defaultMessage": "Le nom et la valeur de l'en-tête doivent tous deux être saisis"
+  },
+  "customProviderForm.headerDuplicate": {
+    "defaultMessage": "Un en-tête portant ce nom existe déjà"
+  },
+  "customProviderForm.headerNamePlaceholder": {
+    "defaultMessage": "Nom de l'en-tête"
+  },
+  "customProviderForm.headerNoSpaces": {
+    "defaultMessage": "Le nom de l'en-tête ne peut pas contenir d'espaces"
+  },
+  "customProviderForm.modelsPlaceholder": {
+    "defaultMessage": "model-a, model-b, model-c"
+  },
+  "customProviderForm.modelsRequired": {
+    "defaultMessage": "Au moins un modèle est requis"
+  },
+  "customProviderForm.ollamaCompatible": {
+    "defaultMessage": "Compatible Ollama"
+  },
+  "customProviderForm.openaiCompatible": {
+    "defaultMessage": "Compatible OpenAI"
+  },
+  "customProviderForm.providerType": {
+    "defaultMessage": "Type de fournisseur"
+  },
+  "customProviderForm.reasoning": {
+    "defaultMessage": "Raisonnement"
+  },
+  "customProviderForm.requiresApiKey": {
+    "defaultMessage": "Ce fournisseur nécessite une clé API"
+  },
+  "customProviderForm.startFromTemplate": {
+    "defaultMessage": "Partir d'un modèle de fournisseur"
+  },
+  "customProviderForm.startFromTemplateDesc": {
+    "defaultMessage": "Choisissez un fournisseur connu et nous remplirons automatiquement la configuration"
+  },
+  "customProviderForm.submitError": {
+    "defaultMessage": "Échec de l'enregistrement du fournisseur. Veuillez vérifier votre configuration et réessayer."
+  },
+  "customProviderForm.supportsStreaming": {
+    "defaultMessage": "Le fournisseur prend en charge les réponses en streaming"
+  },
+  "customProviderForm.toolCalling": {
+    "defaultMessage": "Appel d'outils"
+  },
+  "customProviderForm.updateProvider": {
+    "defaultMessage": "Mettre à jour le fournisseur"
+  },
+  "customProviderForm.usingTemplate": {
+    "defaultMessage": "Modèle utilisé : {name}"
+  },
+  "customProviderForm.valuePlaceholder": {
+    "defaultMessage": "Valeur"
+  },
+  "defaultCardButtons.configureSettings": {
+    "defaultMessage": "Configurer les paramètres de {name}"
+  },
+  "defaultCardButtons.deleteSettings": {
+    "defaultMessage": "Supprimer les paramètres de {name}"
+  },
+  "defaultCardButtons.editSettings": {
+    "defaultMessage": "Modifier les paramètres de {name}"
+  },
+  "defaultCardButtons.getStarted": {
+    "defaultMessage": "Commencez avec goose !"
+  },
+  "defaultProviderSetupForm.apiHostLabel": {
+    "defaultMessage": "Hôte de l'API"
+  },
+  "defaultProviderSetupForm.apiHostPlaceholder": {
+    "defaultMessage": "https://api.example.com"
+  },
+  "defaultProviderSetupForm.apiKeyLabel": {
+    "defaultMessage": "Clé d'API"
+  },
+  "defaultProviderSetupForm.apiKeyPlaceholder": {
+    "defaultMessage": "Votre clé d'API"
+  },
+  "defaultProviderSetupForm.hideOptions": {
+    "defaultMessage": "Masquer {count} options"
+  },
+  "defaultProviderSetupForm.loadingConfig": {
+    "defaultMessage": "Chargement des valeurs de configuration..."
+  },
+  "defaultProviderSetupForm.modelsLabel": {
+    "defaultMessage": "Modèles"
+  },
+  "defaultProviderSetupForm.modelsPlaceholder": {
+    "defaultMessage": "modèle-a, modèle-b"
+  },
+  "defaultProviderSetupForm.noConfigParameters": {
+    "defaultMessage": "Aucun paramètre de configuration pour ce fournisseur."
+  },
+  "defaultProviderSetupForm.showOptions": {
+    "defaultMessage": "Afficher {count} options"
+  },
+  "diagnosticsModal.attachHint": {
+    "defaultMessage": "Si vous signalez un bogue, pensez à y joindre le rapport de diagnostic."
+  },
+  "diagnosticsModal.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "diagnosticsModal.configSettings": {
+    "defaultMessage": "Paramètres de configuration"
+  },
+  "diagnosticsModal.description": {
+    "defaultMessage": "Vous pouvez télécharger un rapport de diagnostic au format JSON à partager avec l'équipe, ou signaler un bogue directement sur GitHub avec vos informations système préremplies. Un rapport de diagnostic contient les éléments suivants :"
+  },
+  "diagnosticsModal.diagnosticsErrorMsg": {
+    "defaultMessage": "Échec du téléchargement du rapport de diagnostic"
+  },
+  "diagnosticsModal.diagnosticsErrorTitle": {
+    "defaultMessage": "Erreur de diagnostic"
+  },
+  "diagnosticsModal.download": {
+    "defaultMessage": "Télécharger"
+  },
+  "diagnosticsModal.downloading": {
+    "defaultMessage": "Téléchargement..."
+  },
+  "diagnosticsModal.fileBug": {
+    "defaultMessage": "Signaler un bogue sur GitHub"
+  },
+  "diagnosticsModal.logFiles": {
+    "defaultMessage": "Fichiers journaux récents"
+  },
+  "diagnosticsModal.opening": {
+    "defaultMessage": "Ouverture..."
+  },
+  "diagnosticsModal.reportProblem": {
+    "defaultMessage": "Signaler un problème"
+  },
+  "diagnosticsModal.sensitiveWarning": {
+    "defaultMessage": "Si votre session contient des informations sensibles, ne partagez pas le fichier de diagnostic publiquement."
+  },
+  "diagnosticsModal.sessionMessages": {
+    "defaultMessage": "Les messages de votre session actuelle"
+  },
+  "diagnosticsModal.systemInfo": {
+    "defaultMessage": "Informations système de base"
+  },
+  "diagnosticsModal.systemInfoErrorMsg": {
+    "defaultMessage": "Échec de la récupération des informations système"
+  },
+  "diagnosticsModal.systemInfoErrorTitle": {
+    "defaultMessage": "Erreur"
+  },
+  "dialog.close": {
+    "defaultMessage": "Fermer"
+  },
+  "dictationSettings.addApiKey": {
+    "defaultMessage": "Ajouter une clé d'API"
+  },
+  "dictationSettings.apiKey": {
+    "defaultMessage": "Clé d'API"
+  },
+  "dictationSettings.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "dictationSettings.chooseVoiceConversion": {
+    "defaultMessage": "Choisissez comment la voix est convertie en texte"
+  },
+  "dictationSettings.configureApiKey": {
+    "defaultMessage": "Configurez la clé d'API dans <b>{settingsPath}</b>"
+  },
+  "dictationSettings.configured": {
+    "defaultMessage": "(Configuré)"
+  },
+  "dictationSettings.configuredIn": {
+    "defaultMessage": "✓ Configuré dans {settingsPath}"
+  },
+  "dictationSettings.disabled": {
+    "defaultMessage": "Désactivé"
+  },
+  "dictationSettings.enterApiKey": {
+    "defaultMessage": "Saisissez votre clé d'API"
+  },
+  "dictationSettings.notConfigured": {
+    "defaultMessage": "(non configuré)"
+  },
+  "dictationSettings.removeApiKey": {
+    "defaultMessage": "Supprimer la clé d'API"
+  },
+  "dictationSettings.requiredForTranscription": {
+    "defaultMessage": "Requis pour la transcription"
+  },
+  "dictationSettings.save": {
+    "defaultMessage": "Enregistrer"
+  },
+  "dictationSettings.updateApiKey": {
+    "defaultMessage": "Mettre à jour la clé d'API"
+  },
+  "dictationSettings.voiceDictationProvider": {
+    "defaultMessage": "Fournisseur de dictée vocale"
+  },
+  "dirSwitcher.chooseDirectory": {
+    "defaultMessage": "Choisir un répertoire…"
+  },
+  "dirSwitcher.currentDirectory": {
+    "defaultMessage": "Répertoire actuel"
+  },
+  "dirSwitcher.failedToUpdateWorkingDir": {
+    "defaultMessage": "Échec de la mise à jour du répertoire de travail"
+  },
+  "dirSwitcher.gitWorktrees": {
+    "defaultMessage": "Arbres de travail Git"
+  },
+  "dirSwitcher.noWorktreesFound": {
+    "defaultMessage": "Aucun arbre de travail trouvé"
+  },
+  "dirSwitcher.openInFinder": {
+    "defaultMessage": "Ouvrir dans le gestionnaire de fichiers"
+  },
+  "dirSwitcher.recentDirectories": {
+    "defaultMessage": "Répertoires récents"
+  },
+  "elicitationRequest.accept": {
+    "defaultMessage": "Accepter"
+  },
+  "elicitationRequest.cancelled": {
+    "defaultMessage": "La demande d'informations a été annulée."
+  },
+  "elicitationRequest.defaultMessage": {
+    "defaultMessage": "Goose a besoin de certaines informations de votre part."
+  },
+  "elicitationRequest.expired": {
+    "defaultMessage": "Cette demande a expiré. L'extension devra la formuler à nouveau."
+  },
+  "elicitationRequest.submit": {
+    "defaultMessage": "Soumettre"
+  },
+  "elicitationRequest.submitError": {
+    "defaultMessage": "Cette demande n'est plus active. L'extension devra la formuler à nouveau."
+  },
+  "elicitationRequest.submitted": {
+    "defaultMessage": "Informations soumises"
+  },
+  "elicitationRequest.waitingForResponse": {
+    "defaultMessage": "En attente de votre réponse ({timeRemaining} restant)"
+  },
+  "envVarsSection.add": {
+    "defaultMessage": "Ajouter"
+  },
+  "envVarsSection.bothRequired": {
+    "defaultMessage": "Le nom et la valeur de la variable doivent tous deux être saisis"
+  },
+  "envVarsSection.envVarsDescription": {
+    "defaultMessage": "Ajoutez des paires clé-valeur pour les variables d'environnement. Cliquez sur le bouton « + » pour ajouter après avoir rempli les deux champs. Pour les valeurs secrètes existantes, cliquez sur le bouton de modification pour les modifier."
+  },
+  "envVarsSection.environmentVariables": {
+    "defaultMessage": "Variables d'environnement"
+  },
+  "envVarsSection.noSpaces": {
+    "defaultMessage": "Le nom de la variable ne peut pas contenir d'espaces"
+  },
+  "envVarsSection.value": {
+    "defaultMessage": "Valeur"
+  },
+  "envVarsSection.variableName": {
+    "defaultMessage": "Nom de la variable"
+  },
+  "environmentBadge.dev": {
+    "defaultMessage": "Dév"
+  },
+  "errorBoundary.errorGeneric": {
+    "defaultMessage": "Une erreur s'est produite."
+  },
+  "errorBoundary.errorWithVersion": {
+    "defaultMessage": "Une erreur s'est produite dans Goose v{version}."
+  },
+  "errorBoundary.heading": {
+    "defaultMessage": "Honk !"
+  },
+  "errorBoundary.reload": {
+    "defaultMessage": "Recharger"
+  },
+  "extensionConfigFields.commandLabel": {
+    "defaultMessage": "Commande"
+  },
+  "extensionConfigFields.commandPlaceholder": {
+    "defaultMessage": "p. ex. npx -y @modelcontextprotocol/my-extension [filepath]"
+  },
+  "extensionConfigFields.commandRequired": {
+    "defaultMessage": "La commande est requise"
+  },
+  "extensionConfigFields.endpointLabel": {
+    "defaultMessage": "Point de terminaison"
+  },
+  "extensionConfigFields.endpointPlaceholder": {
+    "defaultMessage": "Saisissez l'URL du point de terminaison..."
+  },
+  "extensionConfigFields.endpointRequired": {
+    "defaultMessage": "L'URL du point de terminaison est requise"
+  },
+  "extensionInfoFields.descriptionLabel": {
+    "defaultMessage": "Description"
+  },
+  "extensionInfoFields.descriptionPlaceholder": {
+    "defaultMessage": "Description facultative..."
+  },
+  "extensionInfoFields.extensionName": {
+    "defaultMessage": "Nom de l'extension"
+  },
+  "extensionInfoFields.extensionNamePlaceholder": {
+    "defaultMessage": "Saisissez le nom de l'extension..."
+  },
+  "extensionInfoFields.nameRequired": {
+    "defaultMessage": "Le nom est requis"
+  },
+  "extensionInfoFields.typeHttp": {
+    "defaultMessage": "HTTP"
+  },
+  "extensionInfoFields.typeLabel": {
+    "defaultMessage": "Type"
+  },
+  "extensionInfoFields.typeSseUnsupported": {
+    "defaultMessage": "SSE (non pris en charge)"
+  },
+  "extensionInfoFields.typeStandardIo": {
+    "defaultMessage": "Entrée/sortie standard (STDIO)"
+  },
+  "extensionInfoFields.typeStdio": {
+    "defaultMessage": "STDIO"
+  },
+  "extensionInfoFields.typeStreamableHttp": {
+    "defaultMessage": "HTTP en streaming"
+  },
+  "extensionInstallModal.alreadyInstalledMessage": {
+    "defaultMessage": "L'extension « {name} » a déjà été installée avec succès. Démarrez une nouvelle session de discussion pour l'utiliser."
+  },
+  "extensionInstallModal.alreadyInstalledTitle": {
+    "defaultMessage": "L'extension « {name} » est déjà installée"
+  },
+  "extensionInstallModal.blockedMessage": {
+    "defaultMessage": "Cette commande d'extension ne figure pas dans la liste autorisée et son installation est bloquée. Extension : {name} Commande : {command} Contactez votre administrateur pour demander l'approbation de cette extension."
+  },
+  "extensionInstallModal.blockedTitle": {
+    "defaultMessage": "Installation de l'extension bloquée"
+  },
+  "extensionInstallModal.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "extensionInstallModal.installAnyway": {
+    "defaultMessage": "Installer quand même"
+  },
+  "extensionInstallModal.installing": {
+    "defaultMessage": "Installation..."
+  },
+  "extensionInstallModal.no": {
+    "defaultMessage": "Non"
+  },
+  "extensionInstallModal.ok": {
+    "defaultMessage": "OK"
+  },
+  "extensionInstallModal.trustedMessage": {
+    "defaultMessage": "Voulez-vous vraiment installer l'extension {name} ? Commande : {command}"
+  },
+  "extensionInstallModal.trustedTitle": {
+    "defaultMessage": "Confirmer l'installation de l'extension"
+  },
+  "extensionInstallModal.unknownCommand": {
+    "defaultMessage": "Commande inconnue"
+  },
+  "extensionInstallModal.untrustedMessageWithCommand": {
+    "defaultMessage": "{securityMessage} Extension : {name} Commande : {command} Contactez votre administrateur en cas de doute."
+  },
+  "extensionInstallModal.untrustedMessageWithUrl": {
+    "defaultMessage": "{securityMessage} Extension : {name} URL : {url} Contactez votre administrateur en cas de doute."
+  },
+  "extensionInstallModal.untrustedSecurityMessage": {
+    "defaultMessage": "Cette commande d'extension ne figure pas dans la liste autorisée et pourra accéder à vos conversations et fournir des fonctionnalités supplémentaires. L'installation d'extensions provenant de sources non fiables peut présenter des risques de sécurité."
+  },
+  "extensionInstallModal.untrustedTitle": {
+    "defaultMessage": "Installer une extension non fiable ?"
+  },
+  "extensionInstallModal.yes": {
+    "defaultMessage": "Oui"
+  },
+  "extensionItem.configureExtension": {
+    "defaultMessage": "Configurer l'extension {name}"
+  },
+  "extensionItem.toggleExtension": {
+    "defaultMessage": "Activer ou désactiver l'extension {name}"
+  },
+  "extensionList.availableExtensions": {
+    "defaultMessage": "Extensions disponibles ({count})"
+  },
+  "extensionList.builtInExtension": {
+    "defaultMessage": "Extension intégrée"
+  },
+  "extensionList.defaultExtensions": {
+    "defaultMessage": "Extensions par défaut ({count})"
+  },
+  "extensionList.noExtensions": {
+    "defaultMessage": "Aucune extension disponible"
+  },
+  "extensionModal.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "extensionModal.closeWithoutSaving": {
+    "defaultMessage": "Fermer sans enregistrer"
+  },
+  "extensionModal.confirmRemoval": {
+    "defaultMessage": "Confirmer la suppression"
+  },
+  "extensionModal.deleteDescription": {
+    "defaultMessage": "Cela supprimera définitivement cette extension et tous ses paramètres."
+  },
+  "extensionModal.deleteExtensionTitle": {
+    "defaultMessage": "Supprimer l'extension « {name} »"
+  },
+  "extensionModal.installationNotes": {
+    "defaultMessage": "Notes d'installation"
+  },
+  "extensionModal.removeExtension": {
+    "defaultMessage": "Supprimer l'extension"
+  },
+  "extensionModal.unsavedChangesMessage": {
+    "defaultMessage": "Vous avez des modifications non enregistrées dans la configuration de l'extension. Voulez-vous vraiment fermer sans enregistrer ?"
+  },
+  "extensionModal.unsavedChangesTitle": {
+    "defaultMessage": "Modifications non enregistrées"
+  },
+  "extensionTimeoutField.timeoutLabel": {
+    "defaultMessage": "Délai d'expiration"
+  },
+  "extensionsSection.addCustomExtension": {
+    "defaultMessage": "Ajouter une extension personnalisée"
+  },
+  "extensionsSection.addExtension": {
+    "defaultMessage": "Ajouter une extension"
+  },
+  "extensionsSection.browseExtensions": {
+    "defaultMessage": "Parcourir les extensions"
+  },
+  "extensionsSection.saveChanges": {
+    "defaultMessage": "Enregistrer les modifications"
+  },
+  "extensionsSection.updateExtension": {
+    "defaultMessage": "Mettre à jour l'extension"
+  },
+  "extensionsView.addCustomExtension": {
+    "defaultMessage": "Ajouter une extension personnalisée"
+  },
+  "extensionsView.addExtension": {
+    "defaultMessage": "Ajouter une extension"
+  },
+  "extensionsView.browseExtensions": {
+    "defaultMessage": "Parcourir les extensions"
+  },
+  "extensionsView.defaultNote": {
+    "defaultMessage": "Les extensions activées ici sont utilisées par défaut pour les nouvelles discussions. Vous pouvez également activer ou désactiver les extensions actives pendant une discussion."
+  },
+  "extensionsView.description": {
+    "defaultMessage": "Ces extensions utilisent le protocole Model Context Protocol (MCP). Elles peuvent étendre les capacités de Goose à l'aide de trois composants principaux : Invites, Ressources et Outils. {searchShortcut} pour rechercher."
+  },
+  "extensionsView.heading": {
+    "defaultMessage": "Extensions"
+  },
+  "extensionsView.searchPlaceholder": {
+    "defaultMessage": "Rechercher des extensions..."
+  },
+  "externalBackendSection.certFingerprint": {
+    "defaultMessage": "Empreinte du certificat (facultatif)"
+  },
+  "externalBackendSection.certFingerprintHelp": {
+    "defaultMessage": "Épingler une empreinte de certificat TLS spécifique. Si elle est omise, le certificat est approuvé lors de la première utilisation (TOFU)."
+  },
+  "externalBackendSection.certFingerprintPlaceholder": {
+    "defaultMessage": "AA:BB:CC:... ou sha256/base64"
+  },
+  "externalBackendSection.description": {
+    "defaultMessage": "Par défaut, goose lance un serveur pour vous ; utilisez ceci pour vous connecter à un serveur goose externe"
+  },
+  "externalBackendSection.restartNote": {
+    "defaultMessage": "Les modifications nécessitent le redémarrage de Goose pour prendre effet. Les nouvelles fenêtres de discussion se connecteront au serveur externe."
+  },
+  "externalBackendSection.secretKey": {
+    "defaultMessage": "Clé secrète"
+  },
+  "externalBackendSection.secretKeyHelp": {
+    "defaultMessage": "La clé secrète configurée sur le serveur goosed (GOOSE_SERVER__SECRET_KEY)"
+  },
+  "externalBackendSection.secretKeyPlaceholder": {
+    "defaultMessage": "Saisissez la clé secrète du serveur"
+  },
+  "externalBackendSection.serverUrl": {
+    "defaultMessage": "URL du serveur"
+  },
+  "externalBackendSection.title": {
+    "defaultMessage": "Serveur Goose"
+  },
+  "externalBackendSection.urlFormatError": {
+    "defaultMessage": "Format d'URL non valide"
+  },
+  "externalBackendSection.urlProtocolError": {
+    "defaultMessage": "L'URL doit utiliser le protocole http ou https"
+  },
+  "externalBackendSection.useExternalServer": {
+    "defaultMessage": "Utiliser un serveur externe"
+  },
+  "externalBackendSection.useExternalServerDescription": {
+    "defaultMessage": "Se connecter à un serveur goose exécuté ailleurs (nécessite le redémarrage de l'application)"
+  },
+  "freeOptionCards.chooseOption": {
+    "defaultMessage": "Choisissez une option pour commencer."
+  },
+  "freeOptionCards.freeAndPrivate": {
+    "defaultMessage": "Gratuit et privé"
+  },
+  "freeOptionCards.localModelDescription": {
+    "defaultMessage": "Téléchargez un modèle et exécutez-le entièrement sur votre machine. Aucune clé d'API, aucun compte."
+  },
+  "freeOptionCards.localModelTitle": {
+    "defaultMessage": "Utiliser un modèle local"
+  },
+  "freeOptionCards.nanogptDescription": {
+    "defaultMessage": "Inscrivez-vous pour recevoir 60 M de jetons gratuits pendant 7 jours."
+  },
+  "freeOptionCards.nanogptTitle": {
+    "defaultMessage": "NanoGPT"
+  },
+  "freeOptionCards.retry": {
+    "defaultMessage": "Réessayer"
+  },
+  "freeOptionCards.tetrateDescription": {
+    "defaultMessage": "Accédez à plusieurs modèles d'IA avec une configuration automatique. Inscrivez-vous pour recevoir 10 $ de crédit."
+  },
+  "freeOptionCards.tetrateTitle": {
+    "defaultMessage": "Agent Router par Tetrate"
+  },
+  "freeOptionCards.unexpectedError": {
+    "defaultMessage": "Une erreur inattendue s'est produite lors de la configuration."
+  },
+  "goosehintsModal.close": {
+    "defaultMessage": "Fermer"
+  },
+  "goosehintsModal.developer": {
+    "defaultMessage": "Développeur"
+  },
+  "goosehintsModal.dialogDescription": {
+    "defaultMessage": "Fournissez un contexte supplémentaire sur votre projet pour améliorer la communication avec Goose"
+  },
+  "goosehintsModal.dialogTitle": {
+    "defaultMessage": "Configurer les indices du projet (.goosehints)"
+  },
+  "goosehintsModal.errorReading": {
+    "defaultMessage": "Erreur lors de la lecture du fichier .goosehints : {error}"
+  },
+  "goosehintsModal.failedToAccess": {
+    "defaultMessage": "Échec de l'accès au fichier .goosehints"
+  },
+  "goosehintsModal.failedToSave": {
+    "defaultMessage": "Échec de l'enregistrement du fichier .goosehints"
+  },
+  "goosehintsModal.fileCreating": {
+    "defaultMessage": "Création d'un nouveau fichier .goosehints à l'emplacement : {filePath}"
+  },
+  "goosehintsModal.fileFound": {
+    "defaultMessage": "Fichier .goosehints trouvé à l'emplacement : {filePath}"
+  },
+  "goosehintsModal.helpText1": {
+    "defaultMessage": ".goosehints est un fichier texte utilisé pour fournir un contexte supplémentaire sur votre projet et améliorer la communication avec Goose."
+  },
+  "goosehintsModal.helpText2": {
+    "defaultMessage": "Veuillez vous assurer que l'extension {bold} est activée sur la page des extensions. Cette extension est requise pour utiliser .goosehints. Vous devrez redémarrer votre session pour que les mises à jour de .goosehints prennent effet."
+  },
+  "goosehintsModal.helpText3": {
+    "defaultMessage": "Consultez {link} pour plus d'informations."
+  },
+  "goosehintsModal.helpTextLink": {
+    "defaultMessage": "utilisation de .goosehints"
+  },
+  "goosehintsModal.placeholder": {
+    "defaultMessage": "Saisissez les indices du projet ici..."
+  },
+  "goosehintsModal.save": {
+    "defaultMessage": "Enregistrer"
+  },
+  "goosehintsModal.savedSuccessfully": {
+    "defaultMessage": "Enregistré avec succès"
+  },
+  "goosehintsModal.saving": {
+    "defaultMessage": "Enregistrement..."
+  },
+  "goosehintsSection.configure": {
+    "defaultMessage": "Configurer"
+  },
+  "goosehintsSection.description": {
+    "defaultMessage": "Configurez le fichier .goosehints de votre projet pour fournir un contexte supplémentaire à Goose"
+  },
+  "goosehintsSection.title": {
+    "defaultMessage": "Indices du projet (.goosehints)"
+  },
+  "groupedExtensionLoadingToast.askGoose": {
+    "defaultMessage": "Demander à goose"
+  },
+  "groupedExtensionLoadingToast.collapseDetails": {
+    "defaultMessage": "Réduire les détails"
+  },
+  "groupedExtensionLoadingToast.copied": {
+    "defaultMessage": "Copié !"
+  },
+  "groupedExtensionLoadingToast.copyError": {
+    "defaultMessage": "Erreur de copie"
+  },
+  "groupedExtensionLoadingToast.expandDetails": {
+    "defaultMessage": "Développer les détails"
+  },
+  "groupedExtensionLoadingToast.failedToAddExtension": {
+    "defaultMessage": "Échec de l'ajout de l'extension"
+  },
+  "groupedExtensionLoadingToast.failedToLoad": {
+    "defaultMessage": "{count,plural,one{# extension n'a pas pu se charger} other{# extensions n'ont pas pu se charger}}"
+  },
+  "groupedExtensionLoadingToast.loadingExtensions": {
+    "defaultMessage": "{count,plural,one{Chargement de # extension...} other{Chargement de # extensions...}}"
+  },
+  "groupedExtensionLoadingToast.partiallyLoaded": {
+    "defaultMessage": "{totalCount,plural,one{{successCount}/# extension chargée} other{{successCount}/# extensions chargées}}"
+  },
+  "groupedExtensionLoadingToast.showDetails": {
+    "defaultMessage": "Afficher les détails"
+  },
+  "groupedExtensionLoadingToast.showLess": {
+    "defaultMessage": "Afficher moins"
+  },
+  "groupedExtensionLoadingToast.successfullyLoaded": {
+    "defaultMessage": "{count,plural,one{# extension chargée avec succès} other{# extensions chargées avec succès}}"
+  },
+  "headersSection.add": {
+    "defaultMessage": "Ajouter"
+  },
+  "headersSection.bothRequired": {
+    "defaultMessage": "Le nom et la valeur de l'en-tête doivent tous deux être saisis"
+  },
+  "headersSection.duplicateHeader": {
+    "defaultMessage": "Un en-tête portant ce nom existe déjà"
+  },
+  "headersSection.headerName": {
+    "defaultMessage": "Nom de l'en-tête"
+  },
+  "headersSection.headersDescription": {
+    "defaultMessage": "Ajoutez des en-têtes HTTP personnalisés à inclure dans les requêtes vers le serveur MCP. Cliquez sur le bouton « + » pour ajouter après avoir rempli les deux champs."
+  },
+  "headersSection.noSpaces": {
+    "defaultMessage": "Le nom de l'en-tête ne peut pas contenir d'espaces"
+  },
+  "headersSection.requestHeaders": {
+    "defaultMessage": "En-têtes de requête"
+  },
+  "headersSection.value": {
+    "defaultMessage": "Valeur"
+  },
+  "hub.goodAfternoon": {
+    "defaultMessage": "Bon après-midi"
+  },
+  "hub.goodEvening": {
+    "defaultMessage": "Bonsoir"
+  },
+  "hub.goodMorning": {
+    "defaultMessage": "Bonjour"
+  },
+  "huggingFaceModelSearch.download": {
+    "defaultMessage": "Télécharger"
+  },
+  "huggingFaceModelSearch.downloaded": {
+    "defaultMessage": "Téléchargé"
+  },
+  "huggingFaceModelSearch.downloading": {
+    "defaultMessage": "Téléchargement…"
+  },
+  "huggingFaceModelSearch.loadingVariants": {
+    "defaultMessage": "Chargement des variantes..."
+  },
+  "huggingFaceModelSearch.noGgufModels": {
+    "defaultMessage": "Aucun modèle local compatible trouvé pour cette requête."
+  },
+  "huggingFaceModelSearch.recommended": {
+    "defaultMessage": "Recommandé"
+  },
+  "huggingFaceModelSearch.searchError": {
+    "defaultMessage": "Erreur de recherche : {details}"
+  },
+  "huggingFaceModelSearch.searchFailed": {
+    "defaultMessage": "Échec de la recherche. Veuillez réessayer."
+  },
+  "huggingFaceModelSearch.searchHuggingFace": {
+    "defaultMessage": "Rechercher sur HuggingFace"
+  },
+  "huggingFaceModelSearch.searchNoData": {
+    "defaultMessage": "La recherche n'a renvoyé aucune donnée."
+  },
+  "huggingFaceModelSearch.searchPlaceholder": {
+    "defaultMessage": "Rechercher des modèles locaux..."
+  },
+  "huggingFaceModelSearch.tooLarge": {
+    "defaultMessage": "Peut ne pas tenir en mémoire (modèle de {size}, {available} disponibles)"
+  },
+  "huggingFaceSignInPrompt.failedToConfigure": {
+    "defaultMessage": "Échec de la connexion à Hugging Face : {error}"
+  },
+  "huggingFaceSignInPrompt.signIn": {
+    "defaultMessage": "Se connecter"
+  },
+  "huggingFaceSignInPrompt.signedIn": {
+    "defaultMessage": "Connecté à Hugging Face"
+  },
+  "huggingFaceSignInPrompt.signingIn": {
+    "defaultMessage": "Connexion..."
+  },
+  "huggingFaceSignInPrompt.title": {
+    "defaultMessage": "Hugging Face"
+  },
+  "imagePreview.altText": {
+    "defaultMessage": "image goose"
+  },
+  "imagePreview.clickToCollapse": {
+    "defaultMessage": "Cliquez pour réduire"
+  },
+  "imagePreview.clickToExpand": {
+    "defaultMessage": "Cliquez pour développer"
+  },
+  "imagePreview.unableToLoad": {
+    "defaultMessage": "Impossible de charger l'image"
+  },
+  "importRecipeForm.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "importRecipeForm.deeplinkHint": {
+    "defaultMessage": "Collez un lien profond de recette commençant par « goose://recipe?config= »"
+  },
+  "importRecipeForm.deeplinkPlaceholder": {
+    "defaultMessage": "Collez votre lien profond goose://recipe?config=... ici"
+  },
+  "importRecipeForm.example": {
+    "defaultMessage": "exemple"
+  },
+  "importRecipeForm.expectedRecipeStructure": {
+    "defaultMessage": "Structure de recette attendue"
+  },
+  "importRecipeForm.importRecipeButton": {
+    "defaultMessage": "Importer la recette"
+  },
+  "importRecipeForm.importRecipeTitle": {
+    "defaultMessage": "Importer une recette"
+  },
+  "importRecipeForm.importing": {
+    "defaultMessage": "Importation..."
+  },
+  "importRecipeForm.or": {
+    "defaultMessage": "OU"
+  },
+  "importRecipeForm.recipeDeeplinkLabel": {
+    "defaultMessage": "Lien profond de recette"
+  },
+  "importRecipeForm.recipeFileHint": {
+    "defaultMessage": "Téléversez un fichier YAML ou JSON contenant la structure de la recette"
+  },
+  "importRecipeForm.recipeFileLabel": {
+    "defaultMessage": "Fichier de recette"
+  },
+  "importRecipeForm.reviewWarning": {
+    "defaultMessage": "Assurez-vous de vérifier le contenu des fichiers de recette avant de les ajouter à votre interface goose."
+  },
+  "importRecipeForm.schemaDescription": {
+    "defaultMessage": "Votre fichier YAML ou JSON doit respecter cette structure. Les champs requis sont : title, description et soit instructions, soit prompt."
+  },
+  "inlineEditText.clickToEdit": {
+    "defaultMessage": "Cliquez pour modifier"
+  },
+  "inlineEditText.doubleClickToEdit": {
+    "defaultMessage": "Double-cliquez pour modifier"
+  },
+  "inlineEditText.enterText": {
+    "defaultMessage": "Saisissez du texte"
+  },
+  "inlineEditText.failedToSave": {
+    "defaultMessage": "Échec de l'enregistrement"
+  },
+  "instructionsEditor.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "instructionsEditor.insertExample": {
+    "defaultMessage": "Insérer un exemple"
+  },
+  "instructionsEditor.label": {
+    "defaultMessage": "Instructions"
+  },
+  "instructionsEditor.placeholder": {
+    "defaultMessage": "Instructions détaillées pour l'IA, masquées à l'utilisateur"
+  },
+  "instructionsEditor.save": {
+    "defaultMessage": "Enregistrer les instructions"
+  },
+  "instructionsEditor.syntaxHelp": {
+    "defaultMessage": "Utilisez la syntaxe {code} pour définir les paramètres que les utilisateurs peuvent renseigner"
+  },
+  "instructionsEditor.title": {
+    "defaultMessage": "Éditeur d'instructions"
+  },
+  "jsonSchemaEditor.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "jsonSchemaEditor.description": {
+    "defaultMessage": "Définissez la structure attendue de la réponse de l'IA à l'aide du format JSON Schema"
+  },
+  "jsonSchemaEditor.insertExample": {
+    "defaultMessage": "Insérer un exemple"
+  },
+  "jsonSchemaEditor.invalidJson": {
+    "defaultMessage": "Format JSON non valide"
+  },
+  "jsonSchemaEditor.label": {
+    "defaultMessage": "Schéma JSON de la réponse"
+  },
+  "jsonSchemaEditor.save": {
+    "defaultMessage": "Enregistrer le schéma"
+  },
+  "jsonSchemaEditor.title": {
+    "defaultMessage": "Éditeur de schéma JSON"
+  },
+  "jsonSchemaForm.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "jsonSchemaForm.fieldRequired": {
+    "defaultMessage": "Ce champ est requis"
+  },
+  "jsonSchemaForm.maxLength": {
+    "defaultMessage": "La longueur maximale est de {maxLength}"
+  },
+  "jsonSchemaForm.maxValue": {
+    "defaultMessage": "La valeur maximale est {maximum}"
+  },
+  "jsonSchemaForm.minLength": {
+    "defaultMessage": "La longueur minimale est {minLength}"
+  },
+  "jsonSchemaForm.minValue": {
+    "defaultMessage": "La valeur minimale est {minimum}"
+  },
+  "jsonSchemaForm.noFields": {
+    "defaultMessage": "Aucun champ à afficher"
+  },
+  "jsonSchemaForm.selectPlaceholder": {
+    "defaultMessage": "Sélectionner..."
+  },
+  "jsonSchemaForm.submit": {
+    "defaultMessage": "Envoyer"
+  },
+  "keyValueEditor.addValue": {
+    "defaultMessage": "Ajouter une valeur préconfigurée"
+  },
+  "keyValueEditor.defaultKeyPlaceholder": {
+    "defaultMessage": "Nom du paramètre..."
+  },
+  "keyValueEditor.defaultValuePlaceholder": {
+    "defaultMessage": "Valeur du paramètre..."
+  },
+  "keyValueEditor.removeValue": {
+    "defaultMessage": "Supprimer la valeur préconfigurée {key}"
+  },
+  "keyboardShortcuts.alwaysOnTopDescription": {
+    "defaultMessage": "Activer ou désactiver la fenêtre toujours au premier plan"
+  },
+  "keyboardShortcuts.alwaysOnTopLabel": {
+    "defaultMessage": "Toujours au premier plan"
+  },
+  "keyboardShortcuts.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "keyboardShortcuts.categoryApplication": {
+    "defaultMessage": "Raccourcis de l'application"
+  },
+  "keyboardShortcuts.categoryApplicationDescription": {
+    "defaultMessage": "Ces raccourcis fonctionnent lorsque Goose est l'application active"
+  },
+  "keyboardShortcuts.categoryGlobal": {
+    "defaultMessage": "Raccourcis globaux"
+  },
+  "keyboardShortcuts.categoryGlobalDescription": {
+    "defaultMessage": "Ces raccourcis fonctionnent à l'échelle du système, même lorsque Goose n'est pas au premier plan"
+  },
+  "keyboardShortcuts.categorySearch": {
+    "defaultMessage": "Raccourcis de recherche"
+  },
+  "keyboardShortcuts.categorySearchDescription": {
+    "defaultMessage": "Ces raccourcis fonctionnent lors d'une recherche dans une conversation"
+  },
+  "keyboardShortcuts.categoryWindow": {
+    "defaultMessage": "Raccourcis de fenêtre"
+  },
+  "keyboardShortcuts.categoryWindowDescription": {
+    "defaultMessage": "Ces raccourcis contrôlent le comportement des fenêtres"
+  },
+  "keyboardShortcuts.change": {
+    "defaultMessage": "Modifier"
+  },
+  "keyboardShortcuts.disabled": {
+    "defaultMessage": "Désactivé"
+  },
+  "keyboardShortcuts.dismiss": {
+    "defaultMessage": "Ignorer"
+  },
+  "keyboardShortcuts.findDescription": {
+    "defaultMessage": "Ouvrir la recherche dans la conversation"
+  },
+  "keyboardShortcuts.findLabel": {
+    "defaultMessage": "Rechercher"
+  },
+  "keyboardShortcuts.findNextDescription": {
+    "defaultMessage": "Passer au résultat de recherche suivant"
+  },
+  "keyboardShortcuts.findNextLabel": {
+    "defaultMessage": "Suivant"
+  },
+  "keyboardShortcuts.findPreviousDescription": {
+    "defaultMessage": "Passer au résultat de recherche précédent"
+  },
+  "keyboardShortcuts.findPreviousLabel": {
+    "defaultMessage": "Précédent"
+  },
+  "keyboardShortcuts.focusWindowDescription": {
+    "defaultMessage": "Mettre la fenêtre Goose au premier plan depuis n'importe où"
+  },
+  "keyboardShortcuts.focusWindowLabel": {
+    "defaultMessage": "Mettre la fenêtre Goose au premier plan"
+  },
+  "keyboardShortcuts.loading": {
+    "defaultMessage": "Chargement..."
+  },
+  "keyboardShortcuts.newChatDescription": {
+    "defaultMessage": "Créer une nouvelle discussion dans la fenêtre actuelle"
+  },
+  "keyboardShortcuts.newChatLabel": {
+    "defaultMessage": "Nouvelle discussion"
+  },
+  "keyboardShortcuts.newChatWindowDescription": {
+    "defaultMessage": "Ouvrir une nouvelle fenêtre Goose"
+  },
+  "keyboardShortcuts.newChatWindowLabel": {
+    "defaultMessage": "Nouvelle fenêtre de discussion"
+  },
+  "keyboardShortcuts.openDirectoryDescription": {
+    "defaultMessage": "Ouvrir la boîte de dialogue de sélection de répertoire"
+  },
+  "keyboardShortcuts.openDirectoryLabel": {
+    "defaultMessage": "Ouvrir un répertoire"
+  },
+  "keyboardShortcuts.quickLauncherDescription": {
+    "defaultMessage": "Ouvrir la superposition du lanceur rapide"
+  },
+  "keyboardShortcuts.quickLauncherLabel": {
+    "defaultMessage": "Lanceur rapide"
+  },
+  "keyboardShortcuts.reassignShortcut": {
+    "defaultMessage": "Réattribuer le raccourci"
+  },
+  "keyboardShortcuts.resetAllShortcuts": {
+    "defaultMessage": "Réinitialiser tous les raccourcis"
+  },
+  "keyboardShortcuts.resetShortcutsDetail": {
+    "defaultMessage": "Cette action rétablira tous les raccourcis à leur configuration d'origine."
+  },
+  "keyboardShortcuts.resetShortcutsMessage": {
+    "defaultMessage": "Réinitialiser tous les raccourcis clavier à leurs valeurs par défaut ?"
+  },
+  "keyboardShortcuts.resetShortcutsTitle": {
+    "defaultMessage": "Réinitialiser les raccourcis clavier"
+  },
+  "keyboardShortcuts.resetToDefaultsDescription": {
+    "defaultMessage": "Rétablir tous les raccourcis clavier à leur configuration d'origine"
+  },
+  "keyboardShortcuts.resetToDefaultsHeading": {
+    "defaultMessage": "Rétablir les valeurs par défaut"
+  },
+  "keyboardShortcuts.restartDescription": {
+    "defaultMessage": "Les modifications des raccourcis de l'application (comme Nouvelle discussion, Paramètres, etc.) nécessitent le redémarrage de Goose pour prendre effet. Les raccourcis globaux (Mettre la fenêtre au premier plan, Lanceur rapide) fonctionnent immédiatement."
+  },
+  "keyboardShortcuts.restartRequired": {
+    "defaultMessage": "Redémarrage requis"
+  },
+  "keyboardShortcuts.settingsDescription": {
+    "defaultMessage": "Ouvrir le panneau des paramètres"
+  },
+  "keyboardShortcuts.settingsLabel": {
+    "defaultMessage": "Paramètres"
+  },
+  "keyboardShortcuts.shortcutConflictSaveDetail": {
+    "defaultMessage": "Enregistrer cette action supprimera le raccourci de « {conflictLabel} » et l'attribuera à « {targetLabel} ». Voulez-vous continuer ?"
+  },
+  "keyboardShortcuts.shortcutConflictTitle": {
+    "defaultMessage": "Conflit de raccourci"
+  },
+  "keyboardShortcuts.shortcutConflictToggleDetail": {
+    "defaultMessage": "Activer cette option supprimera le raccourci de « {conflictLabel} » et l'attribuera à « {targetLabel} ». Voulez-vous continuer ?"
+  },
+  "keyboardShortcuts.shortcutConflictToggleMessage": {
+    "defaultMessage": "Le raccourci {shortcut} est déjà attribué à « {conflictLabel} »."
+  },
+  "keyboardShortcuts.toggleNavigationDescription": {
+    "defaultMessage": "Afficher ou masquer le menu de navigation"
+  },
+  "keyboardShortcuts.toggleNavigationLabel": {
+    "defaultMessage": "Afficher/masquer la navigation"
+  },
+  "launcher.placeholder": {
+    "defaultMessage": "Demandez n'importe quoi à goose..."
+  },
+  "loadingGoose.compacting": {
+    "defaultMessage": "goose compacte la conversation..."
+  },
+  "loadingGoose.idle": {
+    "defaultMessage": "goose y travaille…"
+  },
+  "loadingGoose.loadingConversation": {
+    "defaultMessage": "chargement de la conversation..."
+  },
+  "loadingGoose.restartingAgent": {
+    "defaultMessage": "redémarrage de la session..."
+  },
+  "loadingGoose.streaming": {
+    "defaultMessage": "goose y travaille…"
+  },
+  "loadingGoose.thinking": {
+    "defaultMessage": "goose réfléchit…"
+  },
+  "loadingGoose.waiting": {
+    "defaultMessage": "goose patiente…"
+  },
+  "localInferenceSettings.deleteConfirm": {
+    "defaultMessage": "Supprimer ce modèle ? Vous pourrez le retélécharger plus tard."
+  },
+  "localInferenceSettings.description": {
+    "defaultMessage": "Téléchargez et gérez des modèles LLM locaux pour l'inférence sans clés API. Recherchez des modèles GGUF ou MLX sur HuggingFace, ou utilisez les sélections présentées ci-dessous."
+  },
+  "localInferenceSettings.dismiss": {
+    "defaultMessage": "Ignorer"
+  },
+  "localInferenceSettings.download": {
+    "defaultMessage": "Télécharger"
+  },
+  "localInferenceSettings.downloadCancelled": {
+    "defaultMessage": "Téléchargement annulé"
+  },
+  "localInferenceSettings.downloadFailed": {
+    "defaultMessage": "Échec du téléchargement"
+  },
+  "localInferenceSettings.downloadProgress": {
+    "defaultMessage": "{downloaded} / {total} ({percent} %)"
+  },
+  "localInferenceSettings.downloadedModels": {
+    "defaultMessage": "Modèles téléchargés"
+  },
+  "localInferenceSettings.downloading": {
+    "defaultMessage": "Téléchargement en cours"
+  },
+  "localInferenceSettings.featuredModels": {
+    "defaultMessage": "Modèles en vedette"
+  },
+  "localInferenceSettings.huggingFaceSignInNote": {
+    "defaultMessage": "Connectez-vous pour augmenter les limites de débit lors de la recherche et du téléchargement de modèles, et pour accéder aux dépôts Hugging Face privés ou à accès restreint."
+  },
+  "localInferenceSettings.modelSettings": {
+    "defaultMessage": "Paramètres du modèle"
+  },
+  "localInferenceSettings.modelSettingsTitle": {
+    "defaultMessage": "Paramètres du modèle"
+  },
+  "localInferenceSettings.noModels": {
+    "defaultMessage": "Aucun modèle disponible"
+  },
+  "localInferenceSettings.recommended": {
+    "defaultMessage": "Recommandé"
+  },
+  "localInferenceSettings.remaining": {
+    "defaultMessage": "{time} restant"
+  },
+  "localInferenceSettings.retry": {
+    "defaultMessage": "Réessayer"
+  },
+  "localInferenceSettings.showAllFeatured": {
+    "defaultMessage": "Afficher tous les modèles en vedette ({count} de plus)"
+  },
+  "localInferenceSettings.showRecommendedOnly": {
+    "defaultMessage": "Afficher uniquement les modèles recommandés"
+  },
+  "localInferenceSettings.title": {
+    "defaultMessage": "Modèles d'inférence locale"
+  },
+  "localInferenceSettings.vision": {
+    "defaultMessage": "Vision"
+  },
+  "localInferenceSettings.visionEncoderDownloading": {
+    "defaultMessage": "Téléchargement de l'encodeur de vision…"
+  },
+  "localInferenceSettings.visionEncoderNotDownloaded": {
+    "defaultMessage": "Encodeur de vision non téléchargé"
+  },
+  "localModelManager.active": {
+    "defaultMessage": "Actif"
+  },
+  "localModelManager.deleteConfirm": {
+    "defaultMessage": "Supprimer ce modèle ? Vous pourrez le retélécharger plus tard."
+  },
+  "localModelManager.download": {
+    "defaultMessage": "Télécharger"
+  },
+  "localModelManager.downloaded": {
+    "defaultMessage": "Téléchargé"
+  },
+  "localModelManager.gpuAcceleration": {
+    "defaultMessage": "Prend en charge l'accélération GPU (CUDA pour NVIDIA, Metal pour Apple Silicon). Les fonctionnalités GPU doivent être activées au moment de la compilation pour l'accélération matérielle."
+  },
+  "localModelManager.noModels": {
+    "defaultMessage": "Aucun modèle disponible"
+  },
+  "localModelManager.recommended": {
+    "defaultMessage": "Recommandé"
+  },
+  "localModelManager.recommendedForHardware": {
+    "defaultMessage": "Recommandé pour votre matériel"
+  },
+  "localModelManager.showAllModels": {
+    "defaultMessage": "Afficher tous les modèles ({count} de plus)"
+  },
+  "localModelManager.showRecommendedOnly": {
+    "defaultMessage": "Afficher uniquement les modèles recommandés"
+  },
+  "localModelPicker.back": {
+    "defaultMessage": "Retour"
+  },
+  "localModelPicker.bestForMachine": {
+    "defaultMessage": "Idéal pour votre machine"
+  },
+  "localModelPicker.cancelDownload": {
+    "defaultMessage": "Annuler le téléchargement"
+  },
+  "localModelPicker.checkingModels": {
+    "defaultMessage": "Vérification des modèles disponibles..."
+  },
+  "localModelPicker.downloadModel": {
+    "defaultMessage": "Télécharger {modelId} ({size})"
+  },
+  "localModelPicker.downloading": {
+    "defaultMessage": "Téléchargement de {modelId}"
+  },
+  "localModelPicker.failedToLoad": {
+    "defaultMessage": "Échec du chargement des modèles disponibles. Veuillez réessayer."
+  },
+  "localModelPicker.failedToStartDownload": {
+    "defaultMessage": "Échec du démarrage du téléchargement. Veuillez réessayer."
+  },
+  "localModelPicker.hideOtherSizes": {
+    "defaultMessage": "Masquer les autres tailles"
+  },
+  "localModelPicker.localModelsNote": {
+    "defaultMessage": "Les modèles locaux conservent tout sur votre machine pour une confidentialité totale. Les performances et la taille de la fenêtre de contexte peuvent varier par rapport aux fournisseurs cloud selon votre matériel et la taille du modèle."
+  },
+  "localModelPicker.lostConnection": {
+    "defaultMessage": "Connexion au téléchargement perdue. Veuillez réessayer."
+  },
+  "localModelPicker.modelNotFound": {
+    "defaultMessage": "Modèle introuvable"
+  },
+  "localModelPicker.ready": {
+    "defaultMessage": "Prêt"
+  },
+  "localModelPicker.selectModel": {
+    "defaultMessage": "Sélectionner un modèle"
+  },
+  "localModelPicker.showOtherSizes": {
+    "defaultMessage": "Afficher {count} autres tailles"
+  },
+  "localModelPicker.startingDownload": {
+    "defaultMessage": "Démarrage du téléchargement..."
+  },
+  "localModelPicker.tryAgain": {
+    "defaultMessage": "Réessayer"
+  },
+  "localModelPicker.useModel": {
+    "defaultMessage": "Utiliser {modelId}"
+  },
+  "markdownContent.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "markdownContent.copyCode": {
+    "defaultMessage": "Copier le code"
+  },
+  "markdownContent.failedToOpenLink": {
+    "defaultMessage": "Échec de l'ouverture du lien"
+  },
+  "markdownContent.noApplicationFound": {
+    "defaultMessage": "Aucune application trouvée pour ouvrir ce lien."
+  },
+  "markdownContent.open": {
+    "defaultMessage": "Ouvrir"
+  },
+  "markdownContent.openExternalLink": {
+    "defaultMessage": "Ouvrir le lien externe"
+  },
+  "markdownContent.openProtocolLink": {
+    "defaultMessage": "Ouvrir le lien {protocol} ?"
+  },
+  "markdownContent.thisWillOpen": {
+    "defaultMessage": "Cela ouvrira : {href}"
+  },
+  "mcpAppRenderer.appFallbackTitle": {
+    "defaultMessage": "Application"
+  },
+  "mcpAppRenderer.cancelButton": {
+    "defaultMessage": "Annuler"
+  },
+  "mcpAppRenderer.close": {
+    "defaultMessage": "Fermer"
+  },
+  "mcpAppRenderer.exitFullscreen": {
+    "defaultMessage": "Quitter le plein écran"
+  },
+  "mcpAppRenderer.exitFullscreenTitle": {
+    "defaultMessage": "Quitter le plein écran (Échap)"
+  },
+  "mcpAppRenderer.failedToInitSandbox": {
+    "defaultMessage": "Échec de l'initialisation du proxy de bac à sable"
+  },
+  "mcpAppRenderer.failedToLoadResource": {
+    "defaultMessage": "Échec du chargement de la ressource"
+  },
+  "mcpAppRenderer.fullscreen": {
+    "defaultMessage": "Plein écran"
+  },
+  "mcpAppRenderer.invalidUrl": {
+    "defaultMessage": "URL non valide"
+  },
+  "mcpAppRenderer.movePipWindow": {
+    "defaultMessage": "Déplacer la fenêtre Picture-in-Picture (utilisez les touches fléchées)"
+  },
+  "mcpAppRenderer.openButton": {
+    "defaultMessage": "Ouvrir"
+  },
+  "mcpAppRenderer.openExternalLinkTitle": {
+    "defaultMessage": "Ouvrir le lien externe"
+  },
+  "mcpAppRenderer.openLinkDetail": {
+    "defaultMessage": "Cela ouvrira : {url}"
+  },
+  "mcpAppRenderer.openProtocolLink": {
+    "defaultMessage": "Ouvrir le lien {protocol} ?"
+  },
+  "mcpAppRenderer.pictureInPicture": {
+    "defaultMessage": "Picture-in-Picture"
+  },
+  "mcpAppRenderer.playingInPip": {
+    "defaultMessage": "Lecture en Picture-in-Picture"
+  },
+  "mcpUIResourceRenderer.cancelButton": {
+    "defaultMessage": "Annuler"
+  },
+  "mcpUIResourceRenderer.openButton": {
+    "defaultMessage": "Ouvrir"
+  },
+  "mcpUIResourceRenderer.openExternalLinkTitle": {
+    "defaultMessage": "Ouvrir le lien externe"
+  },
+  "mcpUIResourceRenderer.openLinkDetail": {
+    "defaultMessage": "Cela ouvrira : {url}"
+  },
+  "mcpUIResourceRenderer.openProtocolLink": {
+    "defaultMessage": "Ouvrir le lien {protocol} ?"
+  },
+  "mcpUIResourceRenderer.toastMessageReceived": {
+    "defaultMessage": "Message reçu pour {message}."
+  },
+  "mcpUIResourceRenderer.toastTitle": {
+    "defaultMessage": "Message MCP-UI {messageType}"
+  },
+  "mcpUIResourceRenderer.toastUnsupported": {
+    "defaultMessage": "Message reçu pour {message}. Les messages {messageType} ne sont pas encore pris en charge, consultez la console pour plus de détails."
+  },
+  "mentionPopover.itemsFound": {
+    "defaultMessage": "{count,plural,one{# élément trouvé} other{# éléments trouvés}}"
+  },
+  "mentionPopover.loadingCommands": {
+    "defaultMessage": "Chargement des commandes..."
+  },
+  "mentionPopover.noCommandsFound": {
+    "defaultMessage": "Aucune commande trouvée correspondant à « {query} »"
+  },
+  "mentionPopover.noItemsFound": {
+    "defaultMessage": "Aucun élément trouvé correspondant à « {query} »"
+  },
+  "mentionPopover.scanningFiles": {
+    "defaultMessage": "Analyse des fichiers..."
+  },
+  "messageCopyLink.copied": {
+    "defaultMessage": "Copié !"
+  },
+  "messageCopyLink.copy": {
+    "defaultMessage": "Copier"
+  },
+  "messageQueue.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "messageQueue.cannotSendWhileEditing": {
+    "defaultMessage": "Impossible d'envoyer pendant la modification"
+  },
+  "messageQueue.clearAll": {
+    "defaultMessage": "Tout effacer"
+  },
+  "messageQueue.clickToEdit": {
+    "defaultMessage": "{content} (Cliquer pour modifier)"
+  },
+  "messageQueue.collapseQueue": {
+    "defaultMessage": "Réduire la file d'attente"
+  },
+  "messageQueue.dragToReorder": {
+    "defaultMessage": "Faites glisser les messages pour réorganiser la priorité"
+  },
+  "messageQueue.expandQueue": {
+    "defaultMessage": "Développer la file d'attente"
+  },
+  "messageQueue.messageCount": {
+    "defaultMessage": "{count,plural,one{# message {status}} other{# messages {status}}}"
+  },
+  "messageQueue.messageQueue": {
+    "defaultMessage": "File d'attente des messages"
+  },
+  "messageQueue.next": {
+    "defaultMessage": "Suivant"
+  },
+  "messageQueue.paused": {
+    "defaultMessage": "En pause"
+  },
+  "messageQueue.queuePaused": {
+    "defaultMessage": "File d'attente en pause"
+  },
+  "messageQueue.queuePausedCompact": {
+    "defaultMessage": "File d'attente en pause - cliquez sur « Envoyer » ou ajoutez un nouveau message pour reprendre"
+  },
+  "messageQueue.queuePausedExpanded": {
+    "defaultMessage": "File d'attente mise en pause par une interruption. Utilisez « Envoyer maintenant » ou ajoutez un nouveau message pour reprendre."
+  },
+  "messageQueue.queued": {
+    "defaultMessage": "en file d'attente"
+  },
+  "messageQueue.removeFromQueue": {
+    "defaultMessage": "Retirer ce message de la file d'attente"
+  },
+  "messageQueue.save": {
+    "defaultMessage": "Enregistrer"
+  },
+  "messageQueue.sendNow": {
+    "defaultMessage": "Envoyer ce message maintenant"
+  },
+  "messageQueue.stopAndSend": {
+    "defaultMessage": "Arrêter le traitement en cours et envoyer ce message maintenant"
+  },
+  "messageQueue.waiting": {
+    "defaultMessage": "en attente"
+  },
+  "microphoneSelector.chooseDescription": {
+    "defaultMessage": "Choisissez le microphone à utiliser pour la dictée"
+  },
+  "microphoneSelector.grantAccess": {
+    "defaultMessage": "Autoriser l'accès"
+  },
+  "microphoneSelector.grantAccessDescription": {
+    "defaultMessage": "Autorisez l'accès pour voir les microphones disponibles"
+  },
+  "microphoneSelector.microphone": {
+    "defaultMessage": "Microphone"
+  },
+  "microphoneSelector.microphoneLabel": {
+    "defaultMessage": "Microphone {index}"
+  },
+  "microphoneSelector.selectedMicrophone": {
+    "defaultMessage": "Microphone sélectionné"
+  },
+  "microphoneSelector.speakToTest": {
+    "defaultMessage": "Parlez pour tester votre microphone ({seconds} s)"
+  },
+  "microphoneSelector.stop": {
+    "defaultMessage": "Arrêter"
+  },
+  "microphoneSelector.systemDefault": {
+    "defaultMessage": "Valeur par défaut du système"
+  },
+  "microphoneSelector.test": {
+    "defaultMessage": "Tester"
+  },
+  "modeSelectionItem.autonomousDescription": {
+    "defaultMessage": "Capacités complètes de modification de fichiers : modifier, créer et supprimer des fichiers librement."
+  },
+  "modeSelectionItem.autonomousLabel": {
+    "defaultMessage": "Autonome"
+  },
+  "modeSelectionItem.chatOnlyDescription": {
+    "defaultMessage": "Interagissez avec le fournisseur sélectionné sans utiliser d'outils ni d'extensions."
+  },
+  "modeSelectionItem.chatOnlyLabel": {
+    "defaultMessage": "Discussion uniquement"
+  },
+  "modeSelectionItem.manualDescription": {
+    "defaultMessage": "Tous les outils, extensions et modifications de fichiers nécessiteront une approbation humaine"
+  },
+  "modeSelectionItem.manualLabel": {
+    "defaultMessage": "Manuel"
+  },
+  "modeSelectionItem.smartDescription": {
+    "defaultMessage": "Déterminer intelligemment quelles actions nécessitent une approbation en fonction du niveau de risque"
+  },
+  "modeSelectionItem.smartLabel": {
+    "defaultMessage": "Intelligent"
+  },
+  "modelAndProviderContext.modelChangeFailed": {
+    "defaultMessage": "{provider}/{model} a échoué"
+  },
+  "modelAndProviderContext.modelChangedTitle": {
+    "defaultMessage": "Modèle modifié"
+  },
+  "modelAndProviderContext.selectModel": {
+    "defaultMessage": "Sélectionner un modèle"
+  },
+  "modelAndProviderContext.switchModelSuccess": {
+    "defaultMessage": "Modèles changés avec succès -- utilisation de {model} de {provider}"
+  },
+  "modelAndProviderContext.unknownProviderMsg": {
+    "defaultMessage": "Fournisseur inconnu dans la configuration -- veuillez vérifier votre config.yaml"
+  },
+  "modelAndProviderContext.unknownProviderTitle": {
+    "defaultMessage": "Recherche du nom du fournisseur"
+  },
+  "modelSettingsButtons.configureProviders": {
+    "defaultMessage": "Configurer les fournisseurs"
+  },
+  "modelSettingsButtons.switchModels": {
+    "defaultMessage": "Changer de modèle"
+  },
+  "modelSettingsPanel.batchSize": {
+    "defaultMessage": "Taille du lot"
+  },
+  "modelSettingsPanel.batchSizeDescription": {
+    "defaultMessage": "Lot de traitement des invites"
+  },
+  "modelSettingsPanel.builtinChatTemplate": {
+    "defaultMessage": "Modèle intégré"
+  },
+  "modelSettingsPanel.builtinChatTemplateDescription": {
+    "defaultMessage": "Sélectionnez le nom d'un modèle intégré de llama.cpp"
+  },
+  "modelSettingsPanel.chatTemplate": {
+    "defaultMessage": "Modèle de discussion"
+  },
+  "modelSettingsPanel.chatTemplateBuiltin": {
+    "defaultMessage": "Intégré"
+  },
+  "modelSettingsPanel.chatTemplateCustomInline": {
+    "defaultMessage": "Personnalisé en ligne"
+  },
+  "modelSettingsPanel.chatTemplateDescription": {
+    "defaultMessage": "Utilisez les métadonnées GGUF intégrées, un modèle intégré de llama.cpp ou du Jinja en ligne"
+  },
+  "modelSettingsPanel.chatTemplateEmbedded": {
+    "defaultMessage": "Intégré"
+  },
+  "modelSettingsPanel.contextAndGeneration": {
+    "defaultMessage": "Contexte et génération"
+  },
+  "modelSettingsPanel.contextSize": {
+    "defaultMessage": "Taille du contexte"
+  },
+  "modelSettingsPanel.contextSizeDescription": {
+    "defaultMessage": "Fenêtre de contexte maximale (0 = valeur par défaut du modèle)"
+  },
+  "modelSettingsPanel.customChatTemplate": {
+    "defaultMessage": "Modèle de discussion personnalisé"
+  },
+  "modelSettingsPanel.customChatTemplateDescription": {
+    "defaultMessage": "Collez la source complète du modèle de discussion Jinja"
+  },
+  "modelSettingsPanel.etaLearningRate": {
+    "defaultMessage": "Eta (taux d'apprentissage)"
+  },
+  "modelSettingsPanel.flashAttention": {
+    "defaultMessage": "Flash attention"
+  },
+  "modelSettingsPanel.flashAttentionDescription": {
+    "defaultMessage": "Activer l'optimisation flash attention"
+  },
+  "modelSettingsPanel.frequencyPenalty": {
+    "defaultMessage": "Pénalité de fréquence"
+  },
+  "modelSettingsPanel.frequencyPenaltyDescription": {
+    "defaultMessage": "0.0 = désactivé"
+  },
+  "modelSettingsPanel.gpuLayers": {
+    "defaultMessage": "Couches GPU"
+  },
+  "modelSettingsPanel.gpuLayersDescription": {
+    "defaultMessage": "Couches à décharger sur le GPU"
+  },
+  "modelSettingsPanel.loadingSettings": {
+    "defaultMessage": "Chargement des paramètres..."
+  },
+  "modelSettingsPanel.lockModelInRam": {
+    "defaultMessage": "Verrouiller le modèle en RAM (mlock)"
+  },
+  "modelSettingsPanel.lockModelInRamDescription": {
+    "defaultMessage": "Empêcher le modèle d'être déchargé sur le disque"
+  },
+  "modelSettingsPanel.maxOutputTokens": {
+    "defaultMessage": "Tokens de sortie maximum"
+  },
+  "modelSettingsPanel.maxOutputTokensDescription": {
+    "defaultMessage": "Limite sur les tokens générés"
+  },
+  "modelSettingsPanel.minP": {
+    "defaultMessage": "Min P"
+  },
+  "modelSettingsPanel.performance": {
+    "defaultMessage": "Performance"
+  },
+  "modelSettingsPanel.presencePenalty": {
+    "defaultMessage": "Pénalité de présence"
+  },
+  "modelSettingsPanel.presencePenaltyDescription": {
+    "defaultMessage": "0.0 = désactivé"
+  },
+  "modelSettingsPanel.repeatPenalty": {
+    "defaultMessage": "Pénalité de répétition"
+  },
+  "modelSettingsPanel.repeatPenaltyDescription": {
+    "defaultMessage": "1.0 = désactivé"
+  },
+  "modelSettingsPanel.repeatWindow": {
+    "defaultMessage": "Fenêtre de répétition"
+  },
+  "modelSettingsPanel.repeatWindowDescription": {
+    "defaultMessage": "Tokens à examiner en arrière"
+  },
+  "modelSettingsPanel.repetitionPenalty": {
+    "defaultMessage": "Pénalité de répétition"
+  },
+  "modelSettingsPanel.reset": {
+    "defaultMessage": "Réinitialiser"
+  },
+  "modelSettingsPanel.resetToDefaults": {
+    "defaultMessage": "Rétablir les valeurs par défaut"
+  },
+  "modelSettingsPanel.samplingStrategy": {
+    "defaultMessage": "Stratégie d'échantillonnage"
+  },
+  "modelSettingsPanel.saving": {
+    "defaultMessage": "Enregistrement..."
+  },
+  "modelSettingsPanel.seed": {
+    "defaultMessage": "Graine"
+  },
+  "modelSettingsPanel.tauTargetEntropy": {
+    "defaultMessage": "Tau (entropie cible)"
+  },
+  "modelSettingsPanel.temperature": {
+    "defaultMessage": "Température"
+  },
+  "modelSettingsPanel.threads": {
+    "defaultMessage": "Threads"
+  },
+  "modelSettingsPanel.threadsDescription": {
+    "defaultMessage": "Threads CPU pour la génération"
+  },
+  "modelSettingsPanel.toolCalling": {
+    "defaultMessage": "Appel d'outils"
+  },
+  "modelSettingsPanel.toolCallingAuto": {
+    "defaultMessage": "Auto"
+  },
+  "modelSettingsPanel.toolCallingDescription": {
+    "defaultMessage": "Choisissez comment les modèles locaux sélectionnent l'appel d'outils natif ou émulé"
+  },
+  "modelSettingsPanel.toolCallingForceEmulated": {
+    "defaultMessage": "Forcer l'émulé"
+  },
+  "modelSettingsPanel.toolCallingForceNative": {
+    "defaultMessage": "Forcer le natif"
+  },
+  "modelSettingsPanel.topK": {
+    "defaultMessage": "Top K"
+  },
+  "modelSettingsPanel.topP": {
+    "defaultMessage": "Top P"
+  },
+  "modelsBottomBar.changeModel": {
+    "defaultMessage": "Changer de modèle"
+  },
+  "modelsBottomBar.currentModel": {
+    "defaultMessage": "Modèle actuel"
+  },
+  "modelsBottomBar.loadingModel": {
+    "defaultMessage": "Chargement du modèle..."
+  },
+  "modelsBottomBar.localModelSettings": {
+    "defaultMessage": "Paramètres du modèle local"
+  },
+  "modelsBottomBar.localModelSettingsTitle": {
+    "defaultMessage": "Paramètres du modèle local — {modelName}"
+  },
+  "modelsBottomBar.resolvedModel": {
+    "defaultMessage": "Modèle résolu"
+  },
+  "modelsBottomBar.selectModel": {
+    "defaultMessage": "Sélectionner un modèle"
+  },
+  "modelsSection.resetDescription": {
+    "defaultMessage": "Effacez vos paramètres de modèle et de fournisseur sélectionnés pour repartir de zéro"
+  },
+  "modelsSection.resetTitle": {
+    "defaultMessage": "Réinitialiser le fournisseur et le modèle"
+  },
+  "navigation.itemApps": {
+    "defaultMessage": "Applications"
+  },
+  "navigation.itemExtensions": {
+    "defaultMessage": "Extensions"
+  },
+  "navigation.itemHome": {
+    "defaultMessage": "Nouvelle discussion"
+  },
+  "navigation.itemRecipes": {
+    "defaultMessage": "Recettes"
+  },
+  "navigation.itemScheduler": {
+    "defaultMessage": "Planificateur"
+  },
+  "navigation.itemSessions": {
+    "defaultMessage": "Historique des sessions"
+  },
+  "navigation.itemSettings": {
+    "defaultMessage": "Paramètres"
+  },
+  "navigation.itemSkills": {
+    "defaultMessage": "Compétences"
+  },
+  "navigationPanel.chats": {
+    "defaultMessage": "Discussions"
+  },
+  "navigationPanel.noChats": {
+    "defaultMessage": "Aucune discussion récente"
+  },
+  "navigationPanel.untitledSession": {
+    "defaultMessage": "Session sans titre"
+  },
+  "onboardingGuard.checkProviderErrorDescription": {
+    "defaultMessage": "Le serveur est peut-être en cours de démarrage ou temporairement indisponible."
+  },
+  "onboardingGuard.checkProviderErrorTitle": {
+    "defaultMessage": "Impossible de se connecter au serveur Goose"
+  },
+  "onboardingGuard.retry": {
+    "defaultMessage": "Réessayer"
+  },
+  "onboardingGuard.welcomeDescription": {
+    "defaultMessage": "Votre agent IA local. Connectez un fournisseur de modèle IA pour commencer."
+  },
+  "onboardingGuard.welcomeTitle": {
+    "defaultMessage": "Bienvenue dans goose"
+  },
+  "onboardingSuccess.allSet": {
+    "defaultMessage": "Vous êtes prêt à commencer à utiliser goose."
+  },
+  "onboardingSuccess.connectedTo": {
+    "defaultMessage": "Connecté à {providerName}"
+  },
+  "onboardingSuccess.getStarted": {
+    "defaultMessage": "Commencer"
+  },
+  "onboardingSuccess.learnMore": {
+    "defaultMessage": "En savoir plus"
+  },
+  "onboardingSuccess.localModelReady": {
+    "defaultMessage": "Modèle local prêt"
+  },
+  "onboardingSuccess.privacyDescription": {
+    "defaultMessage": "Les données d'utilisation anonymes contribuent à améliorer goose. Nous ne collectons jamais vos conversations, votre code ni vos données personnelles."
+  },
+  "onboardingSuccess.privacyTitle": {
+    "defaultMessage": "Confidentialité"
+  },
+  "onboardingSuccess.shareUsageData": {
+    "defaultMessage": "Partager des données d'utilisation anonymes"
+  },
+  "parameterInput.defaultValue": {
+    "defaultMessage": "Valeur par défaut"
+  },
+  "parameterInput.defaultValuePlaceholder": {
+    "defaultMessage": "Saisir une valeur par défaut"
+  },
+  "parameterInput.deleteParameter": {
+    "defaultMessage": "Supprimer le paramètre : {key}"
+  },
+  "parameterInput.description": {
+    "defaultMessage": "description"
+  },
+  "parameterInput.descriptionHelp": {
+    "defaultMessage": "Il s'agit du message que verra l'utilisateur final."
+  },
+  "parameterInput.descriptionPlaceholder": {
+    "defaultMessage": "Ex. : « Saisissez le nom du nouveau composant »"
+  },
+  "parameterInput.inputType": {
+    "defaultMessage": "Type de saisie"
+  },
+  "parameterInput.optional": {
+    "defaultMessage": "Facultatif"
+  },
+  "parameterInput.optionsHelp": {
+    "defaultMessage": "Saisissez chaque option sur une nouvelle ligne. Elles seront affichées sous forme de choix dans une liste déroulante."
+  },
+  "parameterInput.optionsLabel": {
+    "defaultMessage": "Options (une par ligne)"
+  },
+  "parameterInput.optionsPlaceholder": {
+    "defaultMessage": "Option 1 Option 2 Option 3"
+  },
+  "parameterInput.required": {
+    "defaultMessage": "Obligatoire"
+  },
+  "parameterInput.requirement": {
+    "defaultMessage": "Exigence"
+  },
+  "parameterInput.typeBoolean": {
+    "defaultMessage": "Booléen"
+  },
+  "parameterInput.typeNumber": {
+    "defaultMessage": "Nombre"
+  },
+  "parameterInput.typeSelect": {
+    "defaultMessage": "Sélection"
+  },
+  "parameterInput.typeString": {
+    "defaultMessage": "Chaîne"
+  },
+  "parameterInput.unused": {
+    "defaultMessage": "Inutilisé"
+  },
+  "parameterInput.unusedWarningTitle": {
+    "defaultMessage": "Ce paramètre n'est pas utilisé dans les instructions ni dans l'invite. Il sera disponible pour une saisie manuelle, mais n'est peut-être pas nécessaire."
+  },
+  "parameterInputModal.backToForm": {
+    "defaultMessage": "Retour au formulaire de paramètres"
+  },
+  "parameterInputModal.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "parameterInputModal.cancelRecipeSetup": {
+    "defaultMessage": "Annuler la configuration de la recette"
+  },
+  "parameterInputModal.enterValue": {
+    "defaultMessage": "Saisir une valeur pour {key}..."
+  },
+  "parameterInputModal.false": {
+    "defaultMessage": "Faux"
+  },
+  "parameterInputModal.recipeParameters": {
+    "defaultMessage": "Paramètres de la recette"
+  },
+  "parameterInputModal.select": {
+    "defaultMessage": "Sélectionner..."
+  },
+  "parameterInputModal.selectOption": {
+    "defaultMessage": "Sélectionner une option..."
+  },
+  "parameterInputModal.startNewChat": {
+    "defaultMessage": "Démarrer une nouvelle discussion (sans recette)"
+  },
+  "parameterInputModal.startRecipe": {
+    "defaultMessage": "Démarrer la recette"
+  },
+  "parameterInputModal.true": {
+    "defaultMessage": "Vrai"
+  },
+  "parameterInputModal.whatToDo": {
+    "defaultMessage": "Que souhaitez-vous faire ?"
+  },
+  "permissionModal.alwaysAllow": {
+    "defaultMessage": "Toujours autoriser"
+  },
+  "permissionModal.askBefore": {
+    "defaultMessage": "Demander avant"
+  },
+  "permissionModal.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "permissionModal.close": {
+    "defaultMessage": "Fermer"
+  },
+  "permissionModal.failedToLoadTools": {
+    "defaultMessage": "Échec du chargement des outils"
+  },
+  "permissionModal.failedToLoadToolsDescription": {
+    "defaultMessage": "Impossible de charger les outils de cette extension. L'extension n'est peut-être pas chargée dans la session actuelle."
+  },
+  "permissionModal.neverAllow": {
+    "defaultMessage": "Ne jamais autoriser"
+  },
+  "permissionModal.noActiveSession": {
+    "defaultMessage": "Aucune session active"
+  },
+  "permissionModal.noActiveSessionDescription": {
+    "defaultMessage": "Démarrez d'abord une session de discussion pour configurer les autorisations des outils de cette extension. Les autorisations des outils sont chargées à partir des extensions de la session active."
+  },
+  "permissionModal.noToolsAvailable": {
+    "defaultMessage": "Aucun outil disponible pour cette extension."
+  },
+  "permissionModal.saveChanges": {
+    "defaultMessage": "Enregistrer les modifications"
+  },
+  "permissionRulesModal.description": {
+    "defaultMessage": "Configurez les autorisations des outils pour les extensions afin de contrôler la façon dont elles interagissent avec votre système."
+  },
+  "permissionRulesModal.extensionRules": {
+    "defaultMessage": "Règles d'extension"
+  },
+  "permissionRulesModal.title": {
+    "defaultMessage": "Règles d'autorisation"
+  },
+  "permissionSetting.extensionRules": {
+    "defaultMessage": "Règles d'extension"
+  },
+  "permissionSetting.permissionRules": {
+    "defaultMessage": "Règles d'autorisation"
+  },
+  "permissionSetting.permissionRulesDescription": {
+    "defaultMessage": "Instructions masquées qui seront transmises au fournisseur pour aider à orienter et à contextualiser vos réponses."
+  },
+  "privacyInfoModal.collectErrors": {
+    "defaultMessage": "Types d'erreurs (par ex. « rate_limit », « auth » - sans détails)"
+  },
+  "privacyInfoModal.collectExtensions": {
+    "defaultMessage": "Nombre d'extensions et d'utilisations des outils (noms uniquement)"
+  },
+  "privacyInfoModal.collectOs": {
+    "defaultMessage": "Système d'exploitation, version et architecture"
+  },
+  "privacyInfoModal.collectProvider": {
+    "defaultMessage": "Fournisseur et modèle utilisés"
+  },
+  "privacyInfoModal.collectSession": {
+    "defaultMessage": "Indicateurs de session (durée, nombre d'interactions, utilisation des jetons)"
+  },
+  "privacyInfoModal.collectVersion": {
+    "defaultMessage": "Version de goose et méthode d'installation"
+  },
+  "privacyInfoModal.description": {
+    "defaultMessage": "Les données d'utilisation anonymes nous aident à comprendre comment goose est utilisé et à identifier les points à améliorer."
+  },
+  "privacyInfoModal.neverCollect": {
+    "defaultMessage": "Nous ne collectons jamais vos conversations, votre code, les arguments des outils, les messages d'erreur ni aucune donnée personnelle. Vous pouvez modifier ce paramètre à tout moment dans les Paramètres."
+  },
+  "privacyInfoModal.title": {
+    "defaultMessage": "Détails sur la confidentialité"
+  },
+  "privacyInfoModal.whatWeCollect": {
+    "defaultMessage": "Ce que nous collectons :"
+  },
+  "progressiveMessageList.loadingMessages": {
+    "defaultMessage": "Chargement des messages... ({renderedCount}/{totalCount})"
+  },
+  "progressiveMessageList.modelChanged": {
+    "defaultMessage": "Modèle modifié : {previousModel} → {currentModel}"
+  },
+  "progressiveMessageList.searchHint": {
+    "defaultMessage": "Appuyez sur Cmd/Ctrl+F pour charger immédiatement tous les messages et effectuer une recherche"
+  },
+  "promptsSettings.allPromptsReset": {
+    "defaultMessage": "Toutes les invites ont été réinitialisées aux valeurs par défaut"
+  },
+  "promptsSettings.backToList": {
+    "defaultMessage": "Retour à la liste"
+  },
+  "promptsSettings.confirmReplaceWithDefault": {
+    "defaultMessage": "Remplacer le contenu actuel par celui par défaut ? Vos modifications seront perdues."
+  },
+  "promptsSettings.confirmResetAll": {
+    "defaultMessage": "Voulez-vous vraiment réinitialiser toutes les invites à leurs valeurs par défaut ? Cette action est irréversible."
+  },
+  "promptsSettings.confirmResetOne": {
+    "defaultMessage": "Voulez-vous vraiment réinitialiser cette invite à sa valeur par défaut ? Cette action est irréversible."
+  },
+  "promptsSettings.confirmUnsavedBack": {
+    "defaultMessage": "Vous avez des modifications non enregistrées. Voulez-vous vraiment revenir en arrière ?"
+  },
+  "promptsSettings.customized": {
+    "defaultMessage": "Personnalisé"
+  },
+  "promptsSettings.edit": {
+    "defaultMessage": "Modifier"
+  },
+  "promptsSettings.editPromptTitle": {
+    "defaultMessage": "Modifier : {name}"
+  },
+  "promptsSettings.editingLabel": {
+    "defaultMessage": "Modification : {name}"
+  },
+  "promptsSettings.enterPromptContent": {
+    "defaultMessage": "Saisir le contenu de l'invite..."
+  },
+  "promptsSettings.failedToLoadPrompt": {
+    "defaultMessage": "Échec du chargement de l'invite"
+  },
+  "promptsSettings.failedToLoadPrompts": {
+    "defaultMessage": "Échec du chargement des invites"
+  },
+  "promptsSettings.failedToResetPrompt": {
+    "defaultMessage": "Échec de la réinitialisation de l'invite"
+  },
+  "promptsSettings.failedToResetPrompts": {
+    "defaultMessage": "Échec de la réinitialisation des invites"
+  },
+  "promptsSettings.failedToSavePrompt": {
+    "defaultMessage": "Échec de l'enregistrement de l'invite"
+  },
+  "promptsSettings.promptEditingDescription": {
+    "defaultMessage": "Personnalisez les invites qui définissent le comportement de goose dans différents contextes. Ces invites utilisent la syntaxe de gabarit Jinja2. Soyez prudent lorsque vous modifiez les variables de gabarit, car des modifications incorrectes peuvent altérer les fonctionnalités. N'hésitez pas à partager vos améliorations avec la communauté."
+  },
+  "promptsSettings.promptEditingTitle": {
+    "defaultMessage": "Modification des invites"
+  },
+  "promptsSettings.promptResetToDefault": {
+    "defaultMessage": "Invite réinitialisée à la valeur par défaut"
+  },
+  "promptsSettings.promptSaved": {
+    "defaultMessage": "Invite enregistrée"
+  },
+  "promptsSettings.resetAll": {
+    "defaultMessage": "Tout réinitialiser"
+  },
+  "promptsSettings.resetToDefault": {
+    "defaultMessage": "Réinitialiser à la valeur par défaut"
+  },
+  "promptsSettings.restoreDefault": {
+    "defaultMessage": "Restaurer la valeur par défaut"
+  },
+  "promptsSettings.save": {
+    "defaultMessage": "Enregistrer"
+  },
+  "promptsSettings.templateTip": {
+    "defaultMessage": "Les variables de gabarit telles que {extensionsExample} ou {forExample} sont remplacées par les valeurs réelles lors de l'exécution. Veillez à ne pas supprimer les variables obligatoires."
+  },
+  "promptsSettings.unsavedChanges": {
+    "defaultMessage": "Vous avez des modifications non enregistrées"
+  },
+  "providerCard.noMetadata": {
+    "defaultMessage": "Erreur ProviderCard : aucune métadonnée fournie"
+  },
+  "providerCard.unknownProvider": {
+    "defaultMessage": "Fournisseur inconnu"
+  },
+  "providerCatalogPicker.anthropicCompatible": {
+    "defaultMessage": "Compatible Anthropic"
+  },
+  "providerCatalogPicker.apiFormat": {
+    "defaultMessage": "Format d'API"
+  },
+  "providerCatalogPicker.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "providerCatalogPicker.chooseProvider": {
+    "defaultMessage": "Choisir un fournisseur"
+  },
+  "providerCatalogPicker.errorPrefix": {
+    "defaultMessage": "Erreur : {error}"
+  },
+  "providerCatalogPicker.loadingProviders": {
+    "defaultMessage": "Chargement des fournisseurs..."
+  },
+  "providerCatalogPicker.modelsAvailable": {
+    "defaultMessage": "{count} modèles disponibles"
+  },
+  "providerCatalogPicker.noProvidersAvailable": {
+    "defaultMessage": "Aucun fournisseur disponible"
+  },
+  "providerCatalogPicker.noProvidersFound": {
+    "defaultMessage": "Aucun fournisseur trouvé pour « {query} »"
+  },
+  "providerCatalogPicker.openaiCompatible": {
+    "defaultMessage": "Compatible OpenAI"
+  },
+  "providerCatalogPicker.requiresEnvVar": {
+    "defaultMessage": "• Nécessite {envVar}"
+  },
+  "providerCatalogPicker.searchProviders": {
+    "defaultMessage": "Rechercher des fournisseurs..."
+  },
+  "providerCatalogPicker.selectFormatDescription": {
+    "defaultMessage": "Sélectionnez un format d'API et un fournisseur. Nous remplirons automatiquement la configuration pour vous."
+  },
+  "providerConfigForm.browserWindowOpen": {
+    "defaultMessage": "Une fenêtre de navigateur s'ouvrira pour vous permettre de terminer la connexion."
+  },
+  "providerConfigForm.configuring": {
+    "defaultMessage": "Configuration en cours..."
+  },
+  "providerConfigForm.continue": {
+    "defaultMessage": "Continuer"
+  },
+  "providerConfigForm.deviceCodeFlowHint": {
+    "defaultMessage": "Une fenêtre de navigateur s'ouvrira et le code de vérification sera copié dans votre presse-papiers. Collez-le dans le navigateur pour terminer la connexion."
+  },
+  "providerConfigForm.noApiKey": {
+    "defaultMessage": "Vous n'avez pas de clé API ?"
+  },
+  "providerConfigForm.signInWith": {
+    "defaultMessage": "Se connecter avec {providerName}"
+  },
+  "providerConfigForm.signingIn": {
+    "defaultMessage": "Connexion en cours..."
+  },
+  "providerConfigurationModal.addApiKeyDescription": {
+    "defaultMessage": "Ajoutez votre ou vos clés API pour ce fournisseur afin de l'intégrer à goose"
+  },
+  "providerConfigurationModal.browserWindowHint": {
+    "defaultMessage": "Une fenêtre de navigateur s'ouvrira pour vous permettre de terminer la connexion."
+  },
+  "providerConfigurationModal.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "providerConfigurationModal.cannotDeleteActive": {
+    "defaultMessage": "Vous ne pouvez pas supprimer ce fournisseur tant qu'il est en cours d'utilisation. Veuillez d'abord passer à un autre modèle."
+  },
+  "providerConfigurationModal.checkConfigAgain": {
+    "defaultMessage": "Vérifiez à nouveau votre configuration pour utiliser ce fournisseur."
+  },
+  "providerConfigurationModal.close": {
+    "defaultMessage": "Fermer"
+  },
+  "providerConfigurationModal.configureHeader": {
+    "defaultMessage": "Configurer {providerName}"
+  },
+  "providerConfigurationModal.deleteConfigHeader": {
+    "defaultMessage": "Supprimer la configuration de {providerName}"
+  },
+  "providerConfigurationModal.deleteConfirmation": {
+    "defaultMessage": "Cette action supprimera définitivement la configuration actuelle du fournisseur."
+  },
+  "providerConfigurationModal.deviceCodeFlowHint": {
+    "defaultMessage": "Une fenêtre de navigateur s'ouvrira et le code de vérification sera copié dans votre presse-papiers. Collez-le dans le navigateur pour terminer la connexion."
+  },
+  "providerConfigurationModal.errorCheckingConfig": {
+    "defaultMessage": "Une erreur s'est produite lors de la vérification de la configuration de ce fournisseur."
+  },
+  "providerConfigurationModal.errorTitle": {
+    "defaultMessage": "Erreur"
+  },
+  "providerConfigurationModal.externalSetupIntro": {
+    "defaultMessage": "Ce fournisseur est configuré en dehors de goose. Suivez ces étapes :"
+  },
+  "providerConfigurationModal.goBack": {
+    "defaultMessage": "Retour"
+  },
+  "providerConfigurationModal.huggingFaceOAuthDescription": {
+    "defaultMessage": "Connectez-vous pour utiliser les fournisseurs d'inférence Hugging Face sans saisir manuellement de jeton API."
+  },
+  "providerConfigurationModal.oauthLoginFailed": {
+    "defaultMessage": "Échec de la connexion OAuth : {error}"
+  },
+  "providerConfigurationModal.oauthSignInDescription": {
+    "defaultMessage": "Connectez-vous avec votre compte {providerName} pour utiliser ce fournisseur"
+  },
+  "providerConfigurationModal.parameterRequired": {
+    "defaultMessage": "{paramName} est obligatoire"
+  },
+  "providerConfigurationModal.removeConfiguration": {
+    "defaultMessage": "Supprimer la configuration"
+  },
+  "providerConfigurationModal.seeDocumentation": {
+    "defaultMessage": "Consultez la <link>documentation</link> pour plus de détails."
+  },
+  "providerConfigurationModal.signInWith": {
+    "defaultMessage": "Se connecter avec {providerName}"
+  },
+  "providerConfigurationModal.signingIn": {
+    "defaultMessage": "Connexion en cours..."
+  },
+  "providerGrid.addProvider": {
+    "defaultMessage": "Ajouter un fournisseur"
+  },
+  "providerGrid.addProviderTitle": {
+    "defaultMessage": "Ajouter un fournisseur"
+  },
+  "providerGrid.chooseModel": {
+    "defaultMessage": "Choisir un modèle"
+  },
+  "providerGrid.configureProvider": {
+    "defaultMessage": "Configurer le fournisseur"
+  },
+  "providerGrid.editProvider": {
+    "defaultMessage": "Modifier le fournisseur"
+  },
+  "providerGrid.fromTemplateOrManual": {
+    "defaultMessage": "À partir d'un modèle ou d'une configuration manuelle"
+  },
+  "providerLogo.alt": {
+    "defaultMessage": "Logo {providerName}"
+  },
+  "providerSelector.addCustomProvider": {
+    "defaultMessage": "Ajouter un fournisseur personnalisé"
+  },
+  "providerSelector.addCustomProviderTitle": {
+    "defaultMessage": "Ajouter un fournisseur personnalisé"
+  },
+  "providerSelector.connectProvider": {
+    "defaultMessage": "Se connecter à un fournisseur"
+  },
+  "providerSelector.connectProviderDescription": {
+    "defaultMessage": "Connectez OpenAI, Anthropic, Google, etc."
+  },
+  "providerSelector.freeLocalDescription": {
+    "defaultMessage": "Utilisez un modèle local ou un fournisseur offrant des crédits gratuits"
+  },
+  "providerSelector.selectProvider": {
+    "defaultMessage": "Sélectionner un fournisseur"
+  },
+  "providerSelector.useFreeLocal": {
+    "defaultMessage": "Utiliser des fournisseurs gratuits/locaux"
+  },
+  "providerSettings.configurationSettings": {
+    "defaultMessage": "Paramètres de configuration du fournisseur"
+  },
+  "providerSettings.loadingProviders": {
+    "defaultMessage": "Chargement des fournisseurs..."
+  },
+  "providerSettings.onboardingDescription": {
+    "defaultMessage": "Sélectionnez un fournisseur de modèle IA pour commencer à utiliser goose. Vous devrez utiliser des clés API générées par chaque fournisseur ; elles seront chiffrées et stockées localement. Vous pouvez changer de fournisseur à tout moment dans les paramètres."
+  },
+  "providerSettings.otherProviders": {
+    "defaultMessage": "Autres fournisseurs"
+  },
+  "providerSetupActions.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "providerSetupActions.cannotDeleteActive": {
+    "defaultMessage": "Vous ne pouvez pas supprimer {providerName} tant qu'il est en cours d'utilisation. Veuillez passer à un autre modèle avant de supprimer ce fournisseur."
+  },
+  "providerSetupActions.confirmDelete": {
+    "defaultMessage": "Confirmer la suppression"
+  },
+  "providerSetupActions.confirmDeleteMessage": {
+    "defaultMessage": "Voulez-vous vraiment supprimer les paramètres de configuration de {providerName} ? Cette action est irréversible."
+  },
+  "providerSetupActions.deleteProvider": {
+    "defaultMessage": "Supprimer le fournisseur"
+  },
+  "providerSetupActions.enableProvider": {
+    "defaultMessage": "Activer le fournisseur"
+  },
+  "providerSetupActions.ok": {
+    "defaultMessage": "Ok"
+  },
+  "providerSetupActions.submit": {
+    "defaultMessage": "Envoyer"
+  },
+  "recipeActivityEditor.activitiesDescription": {
+    "defaultMessage": "Les invites principales et les boutons d'activité qui s'afficheront dans la fenêtre de discussion de la recette."
+  },
+  "recipeActivityEditor.activitiesLabel": {
+    "defaultMessage": "Activités"
+  },
+  "recipeActivityEditor.activityButtonsDescription": {
+    "defaultMessage": "Boutons cliquables qui apparaîtront sous le message pour aider les utilisateurs à interagir avec votre recette."
+  },
+  "recipeActivityEditor.activityButtonsLabel": {
+    "defaultMessage": "Boutons d'activité"
+  },
+  "recipeActivityEditor.addActivity": {
+    "defaultMessage": "Ajouter une activité"
+  },
+  "recipeActivityEditor.addNewActivityPlaceholder": {
+    "defaultMessage": "Ajouter une nouvelle activité..."
+  },
+  "recipeActivityEditor.messageDescription": {
+    "defaultMessage": "Un message mis en forme qui apparaîtra en haut de la recette. Prend en charge la mise en forme markdown."
+  },
+  "recipeActivityEditor.messageLabel": {
+    "defaultMessage": "Message"
+  },
+  "recipeActivityEditor.messagePlaceholder": {
+    "defaultMessage": "Saisissez un message d'introduction destiné à l'utilisateur pour votre recette (prend en charge **gras**, *italique*, `code`, etc.)"
+  },
+  "recipeExtensionSelector.description": {
+    "defaultMessage": "Sélectionnez les extensions qui doivent être disponibles lors de l'exécution de cette recette. Laissez vide pour utiliser les extensions par défaut."
+  },
+  "recipeExtensionSelector.extensionsSelected": {
+    "defaultMessage": "{count,plural,one{# extension sélectionnée} other{# extensions sélectionnées}}"
+  },
+  "recipeExtensionSelector.label": {
+    "defaultMessage": "Extensions (facultatif)"
+  },
+  "recipeExtensionSelector.noExtensionsAvailable": {
+    "defaultMessage": "Aucune extension disponible"
+  },
+  "recipeExtensionSelector.noExtensionsFound": {
+    "defaultMessage": "Aucune extension trouvée"
+  },
+  "recipeExtensionSelector.searchPlaceholder": {
+    "defaultMessage": "Rechercher des extensions..."
+  },
+  "recipeFormFields.addParameter": {
+    "defaultMessage": "Ajouter un paramètre"
+  },
+  "recipeFormFields.advancedOptions": {
+    "defaultMessage": "Options avancées"
+  },
+  "recipeFormFields.advancedOptionsHint": {
+    "defaultMessage": "Activités, paramètres, modèle, extensions, schéma de réponse, sous-recettes"
+  },
+  "recipeFormFields.descriptionLabel": {
+    "defaultMessage": "Description"
+  },
+  "recipeFormFields.descriptionPlaceholder": {
+    "defaultMessage": "Brève description de ce que fait cette recette"
+  },
+  "recipeFormFields.enterValueFor": {
+    "defaultMessage": "Saisir une valeur pour {key}"
+  },
+  "recipeFormFields.initialPrompt": {
+    "defaultMessage": "Invite initiale"
+  },
+  "recipeFormFields.instructionsLabel": {
+    "defaultMessage": "Instructions"
+  },
+  "recipeFormFields.instructionsPlaceholder": {
+    "defaultMessage": "Instructions détaillées pour l'IA, masquées à l'utilisateur"
+  },
+  "recipeFormFields.openEditor": {
+    "defaultMessage": "Ouvrir l'éditeur"
+  },
+  "recipeFormFields.parameterNamePlaceholder": {
+    "defaultMessage": "Saisir le nom du paramètre..."
+  },
+  "recipeFormFields.parametersDescription": {
+    "defaultMessage": "Les paramètres seront automatiquement détectés à partir de la syntaxe '{{parameter_name}}' dans les instructions, l'invite ou les activités, ou vous pouvez les ajouter manuellement ci-dessous."
+  },
+  "recipeFormFields.parametersLabel": {
+    "defaultMessage": "Paramètres"
+  },
+  "recipeFormFields.promptOptionalHint": {
+    "defaultMessage": "(Facultatif - Les instructions ou l'invite sont obligatoires)"
+  },
+  "recipeFormFields.promptPlaceholder": {
+    "defaultMessage": "Invite pré-remplie au démarrage de la recette"
+  },
+  "recipeFormFields.responseJsonSchema": {
+    "defaultMessage": "Schéma JSON de réponse"
+  },
+  "recipeFormFields.responseJsonSchemaDescription": {
+    "defaultMessage": "Définissez la structure attendue de la réponse de l'IA au format JSON Schema"
+  },
+  "recipeFormFields.templateVarHint": {
+    "defaultMessage": "Utilisez '{{parameter_name}}' pour définir des paramètres qui pourront être renseignés lors de l'exécution de la recette."
+  },
+  "recipeFormFields.titleLabel": {
+    "defaultMessage": "Titre"
+  },
+  "recipeFormFields.titlePlaceholder": {
+    "defaultMessage": "Titre de la recette"
+  },
+  "recipeHeader.recipeLabel": {
+    "defaultMessage": "Recette"
+  },
+  "recipeModelSelector.backToModelList": {
+    "defaultMessage": "Retour à la liste des modèles"
+  },
+  "recipeModelSelector.enterCustomModel": {
+    "defaultMessage": "Saisir un nom de modèle personnalisé"
+  },
+  "recipeModelSelector.enterModelNotListed": {
+    "defaultMessage": "Saisir un modèle non répertorié..."
+  },
+  "recipeModelSelector.fetchError": {
+    "defaultMessage": "Échec de la récupération des modèles. Veuillez réessayer plus tard."
+  },
+  "recipeModelSelector.loadingModels": {
+    "defaultMessage": "Chargement des modèles…"
+  },
+  "recipeModelSelector.modelHint": {
+    "defaultMessage": "Laissez vide pour utiliser le modèle par défaut du fournisseur sélectionné"
+  },
+  "recipeModelSelector.modelLabel": {
+    "defaultMessage": "Modèle (facultatif)"
+  },
+  "recipeModelSelector.providerHint": {
+    "defaultMessage": "Laissez vide pour utiliser le fournisseur par défaut configuré dans les paramètres"
+  },
+  "recipeModelSelector.providerLabel": {
+    "defaultMessage": "Fournisseur (facultatif)"
+  },
+  "recipeModelSelector.selectModel": {
+    "defaultMessage": "Sélectionner un modèle"
+  },
+  "recipeModelSelector.selectProvider": {
+    "defaultMessage": "Sélectionner un fournisseur"
+  },
+  "recipeModelSelector.useDefaultProvider": {
+    "defaultMessage": "Utiliser le fournisseur par défaut"
+  },
+  "recipeNameField.defaultLabel": {
+    "defaultMessage": "Nom de la recette"
+  },
+  "recipeNameField.formatHint": {
+    "defaultMessage": "Sera automatiquement mis en forme (minuscules, tirets à la place des espaces)"
+  },
+  "recipeWarningModal.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "recipeWarningModal.descriptionLabel": {
+    "defaultMessage": "Description :"
+  },
+  "recipeWarningModal.firstTimeDescription": {
+    "defaultMessage": "Vous êtes sur le point d'exécuter une recette que vous n'avez jamais lancée auparavant."
+  },
+  "recipeWarningModal.hiddenCharsWarning": {
+    "defaultMessage": "Cette recette contient des caractères masqués qui seront ignorés pour votre sécurité, car ils pourraient être utilisés à des fins malveillantes."
+  },
+  "recipeWarningModal.instructionsLabel": {
+    "defaultMessage": "Instructions :"
+  },
+  "recipeWarningModal.newRecipeWarningTitle": {
+    "defaultMessage": "⚠️ Avertissement : nouvelle recette"
+  },
+  "recipeWarningModal.recipePreview": {
+    "defaultMessage": "Aperçu de la recette :"
+  },
+  "recipeWarningModal.securityWarningTitle": {
+    "defaultMessage": "⚠️ Avertissement de sécurité"
+  },
+  "recipeWarningModal.titleLabel": {
+    "defaultMessage": "Titre :"
+  },
+  "recipeWarningModal.trustAndExecute": {
+    "defaultMessage": "Approuver et exécuter"
+  },
+  "recipeWarningModal.trustSource": {
+    "defaultMessage": "Ne continuez que si vous faites confiance à la source de cette recette."
+  },
+  "recipesView.addSchedule": {
+    "defaultMessage": "Ajouter une planification"
+  },
+  "recipesView.addSlashCommand": {
+    "defaultMessage": "Ajouter une commande slash"
+  },
+  "recipesView.adjustSearchTerms": {
+    "defaultMessage": "Essayez de modifier vos termes de recherche"
+  },
+  "recipesView.allFiles": {
+    "defaultMessage": "Tous les fichiers"
+  },
+  "recipesView.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "recipesView.copyDeeplink": {
+    "defaultMessage": "Copier le lien profond"
+  },
+  "recipesView.copyDeeplinkFailedMsg": {
+    "defaultMessage": "Échec de la copie du lien profond dans le presse-papiers"
+  },
+  "recipesView.copyFailedTitle": {
+    "defaultMessage": "Échec de la copie"
+  },
+  "recipesView.copyYaml": {
+    "defaultMessage": "Copier le YAML"
+  },
+  "recipesView.copyYamlFailedMsg": {
+    "defaultMessage": "Échec de la copie du YAML de la recette dans le presse-papiers"
+  },
+  "recipesView.createRecipe": {
+    "defaultMessage": "Créer une recette"
+  },
+  "recipesView.deeplinkCopiedMsg": {
+    "defaultMessage": "Le lien profond de la recette a été copié dans le presse-papiers"
+  },
+  "recipesView.deeplinkCopiedTitle": {
+    "defaultMessage": "Lien profond copié"
+  },
+  "recipesView.deleteRecipe": {
+    "defaultMessage": "Supprimer la recette"
+  },
+  "recipesView.deleteRecipeConfirm": {
+    "defaultMessage": "Voulez-vous vraiment supprimer « {title} » ?"
+  },
+  "recipesView.deleteRecipeDetail": {
+    "defaultMessage": "Le fichier de la recette sera supprimé."
+  },
+  "recipesView.deleteRecipeTitle": {
+    "defaultMessage": "Supprimer la recette"
+  },
+  "recipesView.editRecipe": {
+    "defaultMessage": "Modifier la recette"
+  },
+  "recipesView.editSchedule": {
+    "defaultMessage": "Modifier la planification"
+  },
+  "recipesView.editSlashCommand": {
+    "defaultMessage": "Modifier la commande slash"
+  },
+  "recipesView.errorLoadingRecipes": {
+    "defaultMessage": "Erreur lors du chargement des recettes"
+  },
+  "recipesView.exportFailedMsg": {
+    "defaultMessage": "Échec de l'exportation de la recette vers un fichier"
+  },
+  "recipesView.exportFailedTitle": {
+    "defaultMessage": "Échec de l'exportation"
+  },
+  "recipesView.exportRecipeDialogTitle": {
+    "defaultMessage": "Exporter la recette"
+  },
+  "recipesView.exportToFile": {
+    "defaultMessage": "Exporter vers un fichier"
+  },
+  "recipesView.noMatchingRecipes": {
+    "defaultMessage": "Aucune recette correspondante trouvée"
+  },
+  "recipesView.noSavedRecipes": {
+    "defaultMessage": "Aucune recette enregistrée"
+  },
+  "recipesView.noSavedRecipesDescription": {
+    "defaultMessage": "Les recettes enregistrées à partir des conversations apparaîtront ici."
+  },
+  "recipesView.openInNewWindow": {
+    "defaultMessage": "Ouvrir dans une nouvelle fenêtre"
+  },
+  "recipesView.recipeDeletedSuccess": {
+    "defaultMessage": "Recette supprimée avec succès"
+  },
+  "recipesView.recipeExportedMsg": {
+    "defaultMessage": "Recette enregistrée dans {filePath}"
+  },
+  "recipesView.recipeExportedTitle": {
+    "defaultMessage": "Recette exportée"
+  },
+  "recipesView.recipesDescription": {
+    "defaultMessage": "Affichez et gérez vos recettes enregistrées pour démarrer rapidement de nouvelles sessions avec des configurations prédéfinies. {shortcut} pour rechercher."
+  },
+  "recipesView.recipesTitle": {
+    "defaultMessage": "Recettes"
+  },
+  "recipesView.remove": {
+    "defaultMessage": "Supprimer"
+  },
+  "recipesView.removeSchedule": {
+    "defaultMessage": "Supprimer la planification"
+  },
+  "recipesView.runs": {
+    "defaultMessage": "Exécutions {schedule}"
+  },
+  "recipesView.save": {
+    "defaultMessage": "Enregistrer"
+  },
+  "recipesView.scheduleDialogTitle": {
+    "defaultMessage": "{action} la planification"
+  },
+  "recipesView.scheduleRemovedMsg": {
+    "defaultMessage": "La recette ne s'exécutera plus automatiquement"
+  },
+  "recipesView.scheduleRemovedTitle": {
+    "defaultMessage": "Planification supprimée"
+  },
+  "recipesView.scheduleSavedMsg": {
+    "defaultMessage": "La recette s'exécutera {schedule}"
+  },
+  "recipesView.scheduleSavedTitle": {
+    "defaultMessage": "Planification enregistrée"
+  },
+  "recipesView.searchRecipesPlaceholder": {
+    "defaultMessage": "Rechercher des recettes..."
+  },
+  "recipesView.shareRecipe": {
+    "defaultMessage": "Partager la recette"
+  },
+  "recipesView.slashCommandDescription": {
+    "defaultMessage": "Définissez une commande slash pour exécuter rapidement cette recette depuis n'importe quelle conversation"
+  },
+  "recipesView.slashCommandPlaceholder": {
+    "defaultMessage": "command-name"
+  },
+  "recipesView.slashCommandRemovedMsg": {
+    "defaultMessage": "La commande slash de la recette a été supprimée"
+  },
+  "recipesView.slashCommandRemovedTitle": {
+    "defaultMessage": "Commande slash supprimée"
+  },
+  "recipesView.slashCommandSavedMsg": {
+    "defaultMessage": "Utilisez /{command} pour exécuter cette recette"
+  },
+  "recipesView.slashCommandSavedTitle": {
+    "defaultMessage": "Commande slash enregistrée"
+  },
+  "recipesView.slashCommandTitle": {
+    "defaultMessage": "Commande slash"
+  },
+  "recipesView.slashCommandUsageHint": {
+    "defaultMessage": "Utilisez /{command} dans n'importe quelle conversation pour exécuter cette recette"
+  },
+  "recipesView.tryAgain": {
+    "defaultMessage": "Réessayer"
+  },
+  "recipesView.useRecipe": {
+    "defaultMessage": "Utiliser la recette"
+  },
+  "recipesView.yamlCopiedMsg": {
+    "defaultMessage": "Le YAML de la recette a été copié dans le presse-papiers"
+  },
+  "recipesView.yamlCopiedTitle": {
+    "defaultMessage": "YAML copié"
+  },
+  "recipesView.yamlFiles": {
+    "defaultMessage": "Fichiers YAML"
+  },
+  "resetProviderSection.resetButton": {
+    "defaultMessage": "Réinitialiser le fournisseur et le modèle"
+  },
+  "resetProviderSection.resetDescription": {
+    "defaultMessage": "Cela effacera votre modèle et vos paramètres de fournisseur sélectionnés. Si aucune valeur par défaut n'est disponible, vous serez redirigé vers l'écran d'accueil pour les reconfigurer."
+  },
+  "responseStyle.conciseDescription": {
+    "defaultMessage": "Les appels d'outils sont par défaut fermés et n'affichent que l'outil utilisé"
+  },
+  "responseStyle.conciseLabel": {
+    "defaultMessage": "Concis"
+  },
+  "responseStyle.detailedDescription": {
+    "defaultMessage": "Les appels d'outils sont par défaut affichés ouverts pour exposer les détails"
+  },
+  "responseStyle.detailedLabel": {
+    "defaultMessage": "Détaillé"
+  },
+  "scheduleDetailView.actions": {
+    "defaultMessage": "Actions"
+  },
+  "scheduleDetailView.cannotModifyRunning": {
+    "defaultMessage": "Impossible de déclencher ou de modifier une planification pendant qu'elle est déjà en cours d'exécution."
+  },
+  "scheduleDetailView.completedSession": {
+    "defaultMessage": "Session : {sessionId}"
+  },
+  "scheduleDetailView.created": {
+    "defaultMessage": "Créé le : {date}"
+  },
+  "scheduleDetailView.cronExpression": {
+    "defaultMessage": "Expression Cron :"
+  },
+  "scheduleDetailView.currentSession": {
+    "defaultMessage": "Session actuelle :"
+  },
+  "scheduleDetailView.currentlyRunning": {
+    "defaultMessage": "En cours d'exécution"
+  },
+  "scheduleDetailView.dir": {
+    "defaultMessage": "Rép. : {path}"
+  },
+  "scheduleDetailView.editSchedule": {
+    "defaultMessage": "Modifier la planification"
+  },
+  "scheduleDetailView.errorPrefix": {
+    "defaultMessage": "Erreur : {error}"
+  },
+  "scheduleDetailView.idLabel": {
+    "defaultMessage": "ID :"
+  },
+  "scheduleDetailView.inspectJobError": {
+    "defaultMessage": "Erreur d'inspection de la tâche"
+  },
+  "scheduleDetailView.inspectNoInfo": {
+    "defaultMessage": "Aucune information détaillée disponible"
+  },
+  "scheduleDetailView.inspectRunningJob": {
+    "defaultMessage": "Inspecter la tâche en cours"
+  },
+  "scheduleDetailView.jobCancelled": {
+    "defaultMessage": "Tâche annulée"
+  },
+  "scheduleDetailView.jobCancelledMsg": {
+    "defaultMessage": "La tâche a été annulée pendant son démarrage."
+  },
+  "scheduleDetailView.jobInspection": {
+    "defaultMessage": "Inspection de la tâche"
+  },
+  "scheduleDetailView.jobKilled": {
+    "defaultMessage": "Tâche arrêtée"
+  },
+  "scheduleDetailView.killJobError": {
+    "defaultMessage": "Erreur d'arrêt de la tâche"
+  },
+  "scheduleDetailView.killRunningJob": {
+    "defaultMessage": "Arrêter la tâche en cours"
+  },
+  "scheduleDetailView.lastRun": {
+    "defaultMessage": "Dernière exécution :"
+  },
+  "scheduleDetailView.loadingSchedule": {
+    "defaultMessage": "Chargement de la planification..."
+  },
+  "scheduleDetailView.loadingSessions": {
+    "defaultMessage": "Chargement des sessions..."
+  },
+  "scheduleDetailView.messages": {
+    "defaultMessage": "Messages : {count}"
+  },
+  "scheduleDetailView.noScheduleId": {
+    "defaultMessage": "Aucun ID de planification fourni. Retournez à la liste des planifications."
+  },
+  "scheduleDetailView.noSessions": {
+    "defaultMessage": "Aucune session trouvée pour cette planification."
+  },
+  "scheduleDetailView.pauseSchedule": {
+    "defaultMessage": "Mettre en pause la planification"
+  },
+  "scheduleDetailView.pauseUnpauseError": {
+    "defaultMessage": "Erreur de mise en pause/reprise"
+  },
+  "scheduleDetailView.paused": {
+    "defaultMessage": "En pause"
+  },
+  "scheduleDetailView.pausedMsg": {
+    "defaultMessage": "« {id} » mise en pause"
+  },
+  "scheduleDetailView.pausedWarning": {
+    "defaultMessage": "Cette planification est en pause et ne s'exécutera pas automatiquement. Utilisez « Exécuter la planification maintenant » pour la déclencher manuellement ou reprenez-la pour rétablir l'exécution automatique."
+  },
+  "scheduleDetailView.processStarted": {
+    "defaultMessage": "Processus démarré :"
+  },
+  "scheduleDetailView.recentSessions": {
+    "defaultMessage": "Sessions récentes"
+  },
+  "scheduleDetailView.recipeSource": {
+    "defaultMessage": "Source de la recette :"
+  },
+  "scheduleDetailView.runScheduleError": {
+    "defaultMessage": "Erreur d'exécution de la planification"
+  },
+  "scheduleDetailView.runScheduleNow": {
+    "defaultMessage": "Exécuter la planification maintenant"
+  },
+  "scheduleDetailView.scheduleCompleted": {
+    "defaultMessage": "Exécution terminée"
+  },
+  "scheduleDetailView.scheduleDetails": {
+    "defaultMessage": "Détails de la planification"
+  },
+  "scheduleDetailView.scheduleInformation": {
+    "defaultMessage": "Informations sur la planification"
+  },
+  "scheduleDetailView.scheduleLabel": {
+    "defaultMessage": "Planification :"
+  },
+  "scheduleDetailView.scheduleNotFound": {
+    "defaultMessage": "Planification introuvable"
+  },
+  "scheduleDetailView.scheduleNotFoundError": {
+    "defaultMessage": "Planification introuvable"
+  },
+  "scheduleDetailView.schedulePaused": {
+    "defaultMessage": "Planification mise en pause"
+  },
+  "scheduleDetailView.scheduleUnpaused": {
+    "defaultMessage": "Planification reprise"
+  },
+  "scheduleDetailView.scheduleUpdated": {
+    "defaultMessage": "Planification mise à jour"
+  },
+  "scheduleDetailView.sessionId": {
+    "defaultMessage": "ID de session : {id}"
+  },
+  "scheduleDetailView.unpauseSchedule": {
+    "defaultMessage": "Reprendre la planification"
+  },
+  "scheduleDetailView.unpausedMsg": {
+    "defaultMessage": "« {id} » reprise"
+  },
+  "scheduleDetailView.updateScheduleError": {
+    "defaultMessage": "Erreur de mise à jour de la planification"
+  },
+  "scheduleDetailView.updatedMsg": {
+    "defaultMessage": "« {id} » mise à jour"
+  },
+  "scheduleDetailView.viewingScheduleId": {
+    "defaultMessage": "Affichage de l'ID de planification : {id}"
+  },
+  "scheduleModal.browseYaml": {
+    "defaultMessage": "Parcourir pour un fichier YAML..."
+  },
+  "scheduleModal.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "scheduleModal.createNewSchedule": {
+    "defaultMessage": "Créer une nouvelle planification"
+  },
+  "scheduleModal.createSchedule": {
+    "defaultMessage": "Créer la planification"
+  },
+  "scheduleModal.creating": {
+    "defaultMessage": "Création..."
+  },
+  "scheduleModal.deepLink": {
+    "defaultMessage": "Lien profond"
+  },
+  "scheduleModal.deepLinkPlaceholder": {
+    "defaultMessage": "Collez le lien goose://recipe ici..."
+  },
+  "scheduleModal.editSchedule": {
+    "defaultMessage": "Modifier la planification"
+  },
+  "scheduleModal.failedParseRecipe": {
+    "defaultMessage": "Échec de l'analyse de la recette à partir du fichier."
+  },
+  "scheduleModal.failedReadFile": {
+    "defaultMessage": "Échec de la lecture du fichier sélectionné."
+  },
+  "scheduleModal.invalidDeepLink": {
+    "defaultMessage": "Lien profond invalide. Veuillez utiliser un lien goose://recipe."
+  },
+  "scheduleModal.invalidFileType": {
+    "defaultMessage": "Type de fichier invalide : veuillez sélectionner un fichier YAML (.yaml ou .yml)"
+  },
+  "scheduleModal.nameLabel": {
+    "defaultMessage": "Nom :"
+  },
+  "scheduleModal.namePlaceholder": {
+    "defaultMessage": "p. ex. daily-summary-job"
+  },
+  "scheduleModal.provideValidRecipe": {
+    "defaultMessage": "Veuillez fournir une source de recette valide."
+  },
+  "scheduleModal.recipeDescription": {
+    "defaultMessage": "Description : {description}"
+  },
+  "scheduleModal.recipeParsed": {
+    "defaultMessage": "Recette analysée avec succès"
+  },
+  "scheduleModal.recipeTitle": {
+    "defaultMessage": "Titre : {title}"
+  },
+  "scheduleModal.scheduleIdRequired": {
+    "defaultMessage": "L'ID de planification est requis."
+  },
+  "scheduleModal.scheduleLabel": {
+    "defaultMessage": "Planification :"
+  },
+  "scheduleModal.selected": {
+    "defaultMessage": "Sélectionné : {path}"
+  },
+  "scheduleModal.sourceLabel": {
+    "defaultMessage": "Source :"
+  },
+  "scheduleModal.updateSchedule": {
+    "defaultMessage": "Mettre à jour la planification"
+  },
+  "scheduleModal.updating": {
+    "defaultMessage": "Mise à jour..."
+  },
+  "scheduleModal.yaml": {
+    "defaultMessage": "YAML"
+  },
+  "schedulesView.confirmDelete": {
+    "defaultMessage": "Supprimer la planification « {id} » ? La recette sera conservée."
+  },
+  "schedulesView.createSchedule": {
+    "defaultMessage": "Créer une planification"
+  },
+  "schedulesView.description": {
+    "defaultMessage": "Créez et gérez des tâches planifiées pour exécuter automatiquement des recettes aux heures spécifiées."
+  },
+  "schedulesView.edit": {
+    "defaultMessage": "Modifier"
+  },
+  "schedulesView.errorPrefix": {
+    "defaultMessage": "Erreur : {error}"
+  },
+  "schedulesView.inspect": {
+    "defaultMessage": "Inspecter"
+  },
+  "schedulesView.inspectError": {
+    "defaultMessage": "Erreur d'inspection de la tâche"
+  },
+  "schedulesView.inspectNoInfo": {
+    "defaultMessage": "Aucune information détaillée disponible pour cette tâche"
+  },
+  "schedulesView.jobInspection": {
+    "defaultMessage": "Inspection de la tâche"
+  },
+  "schedulesView.jobKilled": {
+    "defaultMessage": "Tâche arrêtée"
+  },
+  "schedulesView.kill": {
+    "defaultMessage": "Arrêter"
+  },
+  "schedulesView.killError": {
+    "defaultMessage": "Erreur d'arrêt de la tâche"
+  },
+  "schedulesView.lastRun": {
+    "defaultMessage": "Dernière exécution : {date}"
+  },
+  "schedulesView.noSchedules": {
+    "defaultMessage": "Aucune planification pour le moment"
+  },
+  "schedulesView.pause": {
+    "defaultMessage": "Mettre en pause"
+  },
+  "schedulesView.pauseError": {
+    "defaultMessage": "Erreur de mise en pause de la planification"
+  },
+  "schedulesView.paused": {
+    "defaultMessage": "En pause"
+  },
+  "schedulesView.refresh": {
+    "defaultMessage": "Actualiser"
+  },
+  "schedulesView.refreshing": {
+    "defaultMessage": "Actualisation..."
+  },
+  "schedulesView.resume": {
+    "defaultMessage": "Reprendre"
+  },
+  "schedulesView.running": {
+    "defaultMessage": "En cours d'exécution"
+  },
+  "schedulesView.schedulePaused": {
+    "defaultMessage": "Planification mise en pause"
+  },
+  "schedulesView.schedulePausedMsg": {
+    "defaultMessage": "Planification « {id} » mise en pause avec succès"
+  },
+  "schedulesView.scheduleUnpaused": {
+    "defaultMessage": "Planification reprise"
+  },
+  "schedulesView.scheduleUnpausedMsg": {
+    "defaultMessage": "Planification « {id} » reprise avec succès"
+  },
+  "schedulesView.scheduleUpdated": {
+    "defaultMessage": "Planification mise à jour"
+  },
+  "schedulesView.scheduleUpdatedMsg": {
+    "defaultMessage": "Planification « {id} » mise à jour avec succès"
+  },
+  "schedulesView.scheduler": {
+    "defaultMessage": "Planificateur"
+  },
+  "schedulesView.unpauseError": {
+    "defaultMessage": "Erreur de reprise de la planification"
+  },
+  "searchBar.caseSensitive": {
+    "defaultMessage": "Sensible à la casse"
+  },
+  "searchBar.close": {
+    "defaultMessage": "Fermer ({shortcut})"
+  },
+  "searchBar.next": {
+    "defaultMessage": "Suivant ({shortcut})"
+  },
+  "searchBar.placeholder": {
+    "defaultMessage": "Rechercher dans la conversation..."
+  },
+  "searchBar.previous": {
+    "defaultMessage": "Précédent ({shortcut})"
+  },
+  "secureStorageNotice.defaultMessage": {
+    "defaultMessage": "Les clés sont stockées en toute sécurité dans le trousseau"
+  },
+  "securityToggle.apiTokenDescription": {
+    "defaultMessage": "Jeton d'authentification pour le service de classification"
+  },
+  "securityToggle.apiTokenOptional": {
+    "defaultMessage": "Jeton API (facultatif)"
+  },
+  "securityToggle.classificationEndpoint": {
+    "defaultMessage": "Point de terminaison de classification"
+  },
+  "securityToggle.classificationEndpointDescription": {
+    "defaultMessage": "Saisissez l'URL complète de votre service de classification"
+  },
+  "securityToggle.commandClassifierActive": {
+    "defaultMessage": "Classificateur de commandes actif (configuré automatiquement à partir de l'environnement)"
+  },
+  "securityToggle.commandEndpointDescription": {
+    "defaultMessage": "Saisissez l'URL complète de votre service de classification d'injection de commandes"
+  },
+  "securityToggle.commandInjectionDescription": {
+    "defaultMessage": "Utiliser des modèles ML pour détecter les commandes shell malveillantes"
+  },
+  "securityToggle.detectionModel": {
+    "defaultMessage": "Modèle de détection"
+  },
+  "securityToggle.detectionModelDescription": {
+    "defaultMessage": "Sélectionnez le modèle ML à utiliser pour la détection d'injection de prompt"
+  },
+  "securityToggle.detectionThreshold": {
+    "defaultMessage": "Seuil de détection"
+  },
+  "securityToggle.enableCommandInjection": {
+    "defaultMessage": "Activer la détection ML d'injection de commandes"
+  },
+  "securityToggle.enablePromptInjection": {
+    "defaultMessage": "Activer la détection d'injection de prompt"
+  },
+  "securityToggle.enablePromptInjectionMl": {
+    "defaultMessage": "Activer la détection ML d'injection de prompt"
+  },
+  "securityToggle.mlEndpointDescription": {
+    "defaultMessage": "Saisissez l'URL complète de votre service de classification ML (y compris l'identifiant du modèle)"
+  },
+  "securityToggle.mlTokenDescription": {
+    "defaultMessage": "Jeton d'authentification pour le service ML (p. ex. jeton HuggingFace)"
+  },
+  "securityToggle.overrideNotice": {
+    "defaultMessage": "Ce paramètre est géré par votre organisation et ne peut pas être modifié."
+  },
+  "securityToggle.promptInjectionDescription": {
+    "defaultMessage": "Détecter et prévenir les attaques potentielles d'injection de prompt"
+  },
+  "securityToggle.promptInjectionMlDescription": {
+    "defaultMessage": "Utiliser des modèles ML pour détecter une injection de prompt potentielle dans votre conversation"
+  },
+  "securityToggle.thresholdDescription": {
+    "defaultMessage": "Des valeurs plus élevées sont plus strictes (0,01 = très indulgent, 1,0 = strict maximum)"
+  },
+  "securityToggle.warpNotice": {
+    "defaultMessage": "La détection d'injection de commandes fonctionne mieux lorsqu'elle est connectée à WARP (requis pour atteindre le service de classification)."
+  },
+  "sessionActionsHeader.actionsLabel": {
+    "defaultMessage": "Actions de session"
+  },
+  "sessionActionsHeader.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "sessionActionsHeader.close": {
+    "defaultMessage": "Fermer"
+  },
+  "sessionActionsHeader.copiedJson": {
+    "defaultMessage": "JSON de la session copié"
+  },
+  "sessionActionsHeader.copiedText": {
+    "defaultMessage": "Texte copié"
+  },
+  "sessionActionsHeader.copyJson": {
+    "defaultMessage": "Copier le JSON"
+  },
+  "sessionActionsHeader.copyText": {
+    "defaultMessage": "Copier le texte"
+  },
+  "sessionActionsHeader.duplicateFailed": {
+    "defaultMessage": "Échec de la duplication de la session : {error}"
+  },
+  "sessionActionsHeader.duplicateSession": {
+    "defaultMessage": "Dupliquer la session"
+  },
+  "sessionActionsHeader.duplicated": {
+    "defaultMessage": "Session dupliquée"
+  },
+  "sessionActionsHeader.fullTextTitle": {
+    "defaultMessage": "Valeur du texte"
+  },
+  "sessionActionsHeader.jsonFailed": {
+    "defaultMessage": "Échec du chargement du JSON de la session : {error}"
+  },
+  "sessionActionsHeader.jsonTitle": {
+    "defaultMessage": "JSON de la session"
+  },
+  "sessionActionsHeader.loadingJson": {
+    "defaultMessage": "Chargement du JSON..."
+  },
+  "sessionActionsHeader.renameFailed": {
+    "defaultMessage": "Échec du renommage de la session : {error}"
+  },
+  "sessionActionsHeader.renamePlaceholder": {
+    "defaultMessage": "Saisissez le nom de la session"
+  },
+  "sessionActionsHeader.renameSession": {
+    "defaultMessage": "Renommer la session"
+  },
+  "sessionActionsHeader.renameTitle": {
+    "defaultMessage": "Renommer la session"
+  },
+  "sessionActionsHeader.renamed": {
+    "defaultMessage": "Session renommée"
+  },
+  "sessionActionsHeader.save": {
+    "defaultMessage": "Enregistrer"
+  },
+  "sessionActionsHeader.saving": {
+    "defaultMessage": "Enregistrement..."
+  },
+  "sessionActionsHeader.viewJson": {
+    "defaultMessage": "Afficher le JSON de la session"
+  },
+  "sessionIndicators.error": {
+    "defaultMessage": "La session a rencontré une erreur"
+  },
+  "sessionIndicators.newActivity": {
+    "defaultMessage": "A une nouvelle activité"
+  },
+  "sessionIndicators.streaming": {
+    "defaultMessage": "Diffusion en cours"
+  },
+  "sessionViewComponents.empty.description": {
+    "defaultMessage": "Cette session ne contient aucun message"
+  },
+  "sessionViewComponents.empty.title": {
+    "defaultMessage": "Aucun message trouvé"
+  },
+  "sessionViewComponents.error.loading": {
+    "defaultMessage": "Erreur lors du chargement des détails de la session"
+  },
+  "sessionViewComponents.error.tryAgain": {
+    "defaultMessage": "Réessayer"
+  },
+  "sessionViewComponents.role.assistant": {
+    "defaultMessage": "Goose"
+  },
+  "sessionViewComponents.role.user": {
+    "defaultMessage": "Vous"
+  },
+  "sessions.action.delete": {
+    "defaultMessage": "Supprimer la session"
+  },
+  "sessions.action.duplicate": {
+    "defaultMessage": "Dupliquer la session"
+  },
+  "sessions.action.editName": {
+    "defaultMessage": "Modifier le nom de la session"
+  },
+  "sessions.action.export": {
+    "defaultMessage": "Exporter la session"
+  },
+  "sessions.action.openNewWindow": {
+    "defaultMessage": "Ouvrir dans une nouvelle fenêtre"
+  },
+  "sessions.action.shareNostr": {
+    "defaultMessage": "Partager un lien Nostr chiffré"
+  },
+  "sessions.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "sessions.chatHistory": {
+    "defaultMessage": "Historique des conversations"
+  },
+  "sessions.chatHistoryDesc": {
+    "defaultMessage": "Affichez et recherchez vos conversations passées avec Goose. {shortcut} pour rechercher."
+  },
+  "sessions.close": {
+    "defaultMessage": "Fermer"
+  },
+  "sessions.delete.message": {
+    "defaultMessage": "Voulez-vous vraiment supprimer la session « {name} » ? Cette action est irréversible."
+  },
+  "sessions.delete.title": {
+    "defaultMessage": "Supprimer la session"
+  },
+  "sessions.edit.placeholder": {
+    "defaultMessage": "Saisissez la description de la session"
+  },
+  "sessions.edit.title": {
+    "defaultMessage": "Modifier la description de la session"
+  },
+  "sessions.empty.description": {
+    "defaultMessage": "Votre historique de conversations apparaîtra ici"
+  },
+  "sessions.empty.title": {
+    "defaultMessage": "Aucune session de conversation trouvée"
+  },
+  "sessions.error.loading": {
+    "defaultMessage": "Erreur lors du chargement des sessions"
+  },
+  "sessions.error.tryAgain": {
+    "defaultMessage": "Réessayer"
+  },
+  "sessions.import": {
+    "defaultMessage": "Importer une session"
+  },
+  "sessions.importNostr": {
+    "defaultMessage": "Importer un lien"
+  },
+  "sessions.importNostr.description": {
+    "defaultMessage": "Collez un lien de partage Goose Nostr pour récupérer, déchiffrer et importer la session."
+  },
+  "sessions.importNostr.placeholder": {
+    "defaultMessage": "goose://sessions/nostr?nevent=...&key=..."
+  },
+  "sessions.importNostr.title": {
+    "defaultMessage": "Importer une session Nostr"
+  },
+  "sessions.importing": {
+    "defaultMessage": "Importation..."
+  },
+  "sessions.loadingMore": {
+    "defaultMessage": "Chargement de sessions supplémentaires..."
+  },
+  "sessions.save": {
+    "defaultMessage": "Enregistrer"
+  },
+  "sessions.saving": {
+    "defaultMessage": "Enregistrement..."
+  },
+  "sessions.search.noResults": {
+    "defaultMessage": "Aucune session correspondante trouvée"
+  },
+  "sessions.search.noResultsDesc": {
+    "defaultMessage": "Essayez d'ajuster vos termes de recherche"
+  },
+  "sessions.searchPlaceholder": {
+    "defaultMessage": "Rechercher dans l'historique..."
+  },
+  "sessions.shareNostr.description": {
+    "defaultMessage": "Toute personne disposant de ce lien peut récupérer et déchiffrer la session. Traitez-le comme un secret."
+  },
+  "sessions.shareNostr.title": {
+    "defaultMessage": "Lien de partage Nostr chiffré"
+  },
+  "sessions.toast.copied": {
+    "defaultMessage": "Copié dans le presse-papiers"
+  },
+  "sessions.toast.deleteFailed": {
+    "defaultMessage": "Échec de la suppression de la session « {name} » : {error}"
+  },
+  "sessions.toast.deleted": {
+    "defaultMessage": "Session supprimée avec succès"
+  },
+  "sessions.toast.duplicateFailed": {
+    "defaultMessage": "Échec de la duplication de la session : {error}"
+  },
+  "sessions.toast.duplicated": {
+    "defaultMessage": "Session « {name} » dupliquée avec succès"
+  },
+  "sessions.toast.exported": {
+    "defaultMessage": "Session exportée avec succès"
+  },
+  "sessions.toast.importFailed": {
+    "defaultMessage": "Échec de l'importation de la session : {error}"
+  },
+  "sessions.toast.imported": {
+    "defaultMessage": "Session importée avec succès"
+  },
+  "sessions.toast.shareNostr": {
+    "defaultMessage": "Lien de partage Nostr chiffré créé"
+  },
+  "sessions.toast.shareNostrFailed": {
+    "defaultMessage": "Échec de la création du lien de partage Nostr : {error}"
+  },
+  "sessions.toast.updateFailed": {
+    "defaultMessage": "Échec de la mise à jour de la description de la session : {error}"
+  },
+  "sessions.toast.updated": {
+    "defaultMessage": "Description de la session mise à jour avec succès"
+  },
+  "settings.appearance.description": {
+    "defaultMessage": "Configurez l'apparence de goose sur votre système"
+  },
+  "settings.appearance.title": {
+    "defaultMessage": "Apparence"
+  },
+  "settings.close": {
+    "defaultMessage": "Fermer"
+  },
+  "settings.costTracking.description": {
+    "defaultMessage": "Afficher la tarification des modèles et les coûts d'utilisation"
+  },
+  "settings.costTracking.title": {
+    "defaultMessage": "Suivi des coûts"
+  },
+  "settings.dockIcon.description": {
+    "defaultMessage": "Afficher goose dans le Dock"
+  },
+  "settings.dockIcon.title": {
+    "defaultMessage": "Icône du Dock"
+  },
+  "settings.help.description": {
+    "defaultMessage": "Aidez-nous à améliorer goose en signalant des problèmes ou en demandant de nouvelles fonctionnalités"
+  },
+  "settings.help.reportBug": {
+    "defaultMessage": "Signaler un bogue"
+  },
+  "settings.help.requestFeature": {
+    "defaultMessage": "Demander une fonctionnalité"
+  },
+  "settings.help.title": {
+    "defaultMessage": "Aide et commentaires"
+  },
+  "settings.language.description": {
+    "defaultMessage": "Choisissez la langue d'affichage de goose"
+  },
+  "settings.language.english": {
+    "defaultMessage": "English"
+  },
+  "settings.language.french": {
+    "defaultMessage": "Français"
+  },
+  "settings.language.german": {
+    "defaultMessage": "Allemand"
+  },
+  "settings.language.hindi": {
+    "defaultMessage": "Hindi"
+  },
+  "settings.language.indonesian": {
+    "defaultMessage": "Indonésien"
+  },
+  "settings.language.italian": {
+    "defaultMessage": "Italien"
+  },
+  "settings.language.japanese": {
+    "defaultMessage": "Japonais"
+  },
+  "settings.language.korean": {
+    "defaultMessage": "Coréen"
+  },
+  "settings.language.malay": {
+    "defaultMessage": "Malais"
+  },
+  "settings.language.portuguese": {
+    "defaultMessage": "Portugais"
+  },
+  "settings.language.russian": {
+    "defaultMessage": "Russe"
+  },
+  "settings.language.spanish": {
+    "defaultMessage": "Espagnol"
+  },
+  "settings.language.systemDefault": {
+    "defaultMessage": "Paramètre par défaut du système"
+  },
+  "settings.language.title": {
+    "defaultMessage": "Langue"
+  },
+  "settings.language.turkish": {
+    "defaultMessage": "Turc"
+  },
+  "settings.language.vietnamese": {
+    "defaultMessage": "Vietnamien"
+  },
+  "settings.language.zhCN": {
+    "defaultMessage": "Chinois (simplifié)"
+  },
+  "settings.language.zhTW": {
+    "defaultMessage": "Chinois (traditionnel)"
+  },
+  "settings.menuBarIcon.description": {
+    "defaultMessage": "Afficher goose dans la barre de menus"
+  },
+  "settings.menuBarIcon.title": {
+    "defaultMessage": "Icône de la barre de menus"
+  },
+  "settings.notifications.configGuide": {
+    "defaultMessage": "Guide de configuration"
+  },
+  "settings.notifications.description": {
+    "defaultMessage": "Les notifications sont gérées par votre système d'exploitation - {link}"
+  },
+  "settings.notifications.modal.macInstructions": {
+    "defaultMessage": "Pour activer les notifications sous macOS :"
+  },
+  "settings.notifications.modal.macStep1": {
+    "defaultMessage": "Ouvrez les Préférences Système"
+  },
+  "settings.notifications.modal.macStep2": {
+    "defaultMessage": "Cliquez sur Notifications"
+  },
+  "settings.notifications.modal.macStep3": {
+    "defaultMessage": "Trouvez et sélectionnez goose dans la liste des applications"
+  },
+  "settings.notifications.modal.macStep4": {
+    "defaultMessage": "Activez les notifications et ajustez les paramètres selon vos préférences"
+  },
+  "settings.notifications.modal.title": {
+    "defaultMessage": "Comment activer les notifications"
+  },
+  "settings.notifications.modal.winInstructions": {
+    "defaultMessage": "Pour activer les notifications sous Windows :"
+  },
+  "settings.notifications.modal.winStep1": {
+    "defaultMessage": "Ouvrez les Paramètres"
+  },
+  "settings.notifications.modal.winStep2": {
+    "defaultMessage": "Allez dans Système > Notifications"
+  },
+  "settings.notifications.modal.winStep3": {
+    "defaultMessage": "Trouvez et sélectionnez goose dans la liste des applications"
+  },
+  "settings.notifications.modal.winStep4": {
+    "defaultMessage": "Activez les notifications et ajustez les paramètres selon vos préférences"
+  },
+  "settings.notifications.openSettings": {
+    "defaultMessage": "Ouvrir les Paramètres"
+  },
+  "settings.notifications.task.description": {
+    "defaultMessage": "Notifier lorsque Goose termine une tâche pendant que la fenêtre est en arrière-plan"
+  },
+  "settings.notifications.task.title": {
+    "defaultMessage": "Notifications de fin de tâche"
+  },
+  "settings.notifications.title": {
+    "defaultMessage": "Notifications"
+  },
+  "settings.preventSleep.description": {
+    "defaultMessage": "Maintenez votre ordinateur éveillé pendant que goose exécute une tâche (l'écran peut quand même se verrouiller)"
+  },
+  "settings.preventSleep.title": {
+    "defaultMessage": "Empêcher la mise en veille"
+  },
+  "settings.theme.description": {
+    "defaultMessage": "Personnalisez l'apparence et la convivialité de goose"
+  },
+  "settings.theme.title": {
+    "defaultMessage": "Thème"
+  },
+  "settings.updates.description": {
+    "defaultMessage": "Recherchez et installez les mises à jour pour que goose fonctionne de manière optimale"
+  },
+  "settings.updates.title": {
+    "defaultMessage": "Mises à jour"
+  },
+  "settings.version.title": {
+    "defaultMessage": "Version"
+  },
+  "settingsView.tabApp": {
+    "defaultMessage": "Application"
+  },
+  "settingsView.tabAuth": {
+    "defaultMessage": "Authentification"
+  },
+  "settingsView.tabChat": {
+    "defaultMessage": "Discussion"
+  },
+  "settingsView.tabKeyboard": {
+    "defaultMessage": "Clavier"
+  },
+  "settingsView.tabLocalInference": {
+    "defaultMessage": "Inférence locale"
+  },
+  "settingsView.tabModels": {
+    "defaultMessage": "Modèles"
+  },
+  "settingsView.tabPrompts": {
+    "defaultMessage": "Invites"
+  },
+  "settingsView.tabSession": {
+    "defaultMessage": "Session"
+  },
+  "settingsView.title": {
+    "defaultMessage": "Paramètres"
+  },
+  "sheet.close": {
+    "defaultMessage": "Fermer"
+  },
+  "shortcutRecorder.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "shortcutRecorder.clickToRecord": {
+    "defaultMessage": "Cliquez pour enregistrer..."
+  },
+  "shortcutRecorder.conflictWarning": {
+    "defaultMessage": "Ce raccourci est déjà utilisé par {label}. L'enregistrement le réaffectera à cette action."
+  },
+  "shortcutRecorder.pressShortcut": {
+    "defaultMessage": "Appuyez sur le raccourci..."
+  },
+  "shortcutRecorder.save": {
+    "defaultMessage": "Enregistrer"
+  },
+  "skillsView.addSkill": {
+    "defaultMessage": "Ajouter une compétence"
+  },
+  "skillsView.adjustSearchTerms": {
+    "defaultMessage": "Essayez d'ajuster vos termes de recherche"
+  },
+  "skillsView.comingSoon": {
+    "defaultMessage": "Bientôt disponible"
+  },
+  "skillsView.errorLoadingSkills": {
+    "defaultMessage": "Erreur lors du chargement des compétences"
+  },
+  "skillsView.noMatchingSkills": {
+    "defaultMessage": "Aucune compétence correspondante trouvée"
+  },
+  "skillsView.noSkillsDescription": {
+    "defaultMessage": "Les compétences sont chargées à partir des fichiers SKILL.md dans ~/.config/agents/skills/, .goose/skills/ ou d'autres répertoires pris en charge."
+  },
+  "skillsView.noSkillsInstalled": {
+    "defaultMessage": "Aucune compétence installée"
+  },
+  "skillsView.searchSkillsPlaceholder": {
+    "defaultMessage": "Rechercher des compétences..."
+  },
+  "skillsView.skillsDescription": {
+    "defaultMessage": "Affichez les compétences installées qui étendent les capacités de Goose. {shortcut} pour rechercher."
+  },
+  "skillsView.skillsTitle": {
+    "defaultMessage": "Compétences"
+  },
+  "skillsView.tryAgain": {
+    "defaultMessage": "Réessayer"
+  },
+  "spellcheckToggle.description": {
+    "defaultMessage": "Vérifier l'orthographe dans le champ de saisie de la discussion. Nécessite un redémarrage pour prendre effet."
+  },
+  "spellcheckToggle.title": {
+    "defaultMessage": "Activer la vérification orthographique"
+  },
+  "standaloneAppView.failedToLoad": {
+    "defaultMessage": "Échec du chargement de l'application"
+  },
+  "standaloneAppView.initializing": {
+    "defaultMessage": "Initialisation de l'application..."
+  },
+  "standaloneAppView.missingParams": {
+    "defaultMessage": "Paramètres requis manquants"
+  },
+  "stringUtils.configuredProvider": {
+    "defaultMessage": "Le fournisseur {name} est configuré"
+  },
+  "stringUtils.ollamaApp": {
+    "defaultMessage": "Application Ollama"
+  },
+  "stringUtils.ollamaNotConfiguredPrefix": {
+    "defaultMessage": "Pour l'utiliser, soit le"
+  },
+  "stringUtils.ollamaNotConfiguredSuffix": {
+    "defaultMessage": "doit être installé sur votre machine et ouvert, soit vous devez saisir une valeur pour OLLAMA_HOST."
+  },
+  "subRecipeEditor.addExisting": {
+    "defaultMessage": "Ajouter une existante"
+  },
+  "subRecipeEditor.createNew": {
+    "defaultMessage": "Créer une nouvelle sous-recette"
+  },
+  "subRecipeEditor.deleteSubrecipe": {
+    "defaultMessage": "Supprimer la sous-recette {name}"
+  },
+  "subRecipeEditor.description": {
+    "defaultMessage": "Les sous-recettes sont des recettes qui peuvent être appelées en tant qu'outils lors de l'exécution. Elles permettent des flux de travail en plusieurs étapes et des composants réutilisables."
+  },
+  "subRecipeEditor.duplicateName": {
+    "defaultMessage": "Nom en double"
+  },
+  "subRecipeEditor.duplicateNameMsg": {
+    "defaultMessage": "Une sous-recette nommée « {name} » existe déjà. Veuillez utiliser un nom unique."
+  },
+  "subRecipeEditor.editSubrecipe": {
+    "defaultMessage": "Modifier la sous-recette {name}"
+  },
+  "subRecipeEditor.label": {
+    "defaultMessage": "Sous-recettes"
+  },
+  "subRecipeEditor.preconfiguredValues": {
+    "defaultMessage": "Valeurs préconfigurées :"
+  },
+  "subRecipeEditor.sequential": {
+    "defaultMessage": "Séquentiel"
+  },
+  "subRecipeModal.addTitle": {
+    "defaultMessage": "Ajouter une sous-recette"
+  },
+  "subRecipeModal.apply": {
+    "defaultMessage": "Appliquer"
+  },
+  "subRecipeModal.browse": {
+    "defaultMessage": "Parcourir"
+  },
+  "subRecipeModal.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "subRecipeModal.closeModal": {
+    "defaultMessage": "Fermer la fenêtre de la sous-recette"
+  },
+  "subRecipeModal.configureTitle": {
+    "defaultMessage": "Configurer la sous-recette"
+  },
+  "subRecipeModal.descriptionLabel": {
+    "defaultMessage": "Description"
+  },
+  "subRecipeModal.descriptionPlaceholder": {
+    "defaultMessage": "Description facultative de ce que fait cette sous-recette..."
+  },
+  "subRecipeModal.invalidFile": {
+    "defaultMessage": "Fichier non valide"
+  },
+  "subRecipeModal.invalidFileMsg": {
+    "defaultMessage": "Veuillez sélectionner un fichier YAML (.yaml ou .yml)."
+  },
+  "subRecipeModal.nameHint": {
+    "defaultMessage": "Identifiant unique utilisé pour générer le nom de l'outil"
+  },
+  "subRecipeModal.nameLabel": {
+    "defaultMessage": "Nom"
+  },
+  "subRecipeModal.namePlaceholder": {
+    "defaultMessage": "p. ex., security_scan"
+  },
+  "subRecipeModal.pathHint": {
+    "defaultMessage": "Recherchez un fichier de recette existant ou saisissez un chemin manuellement"
+  },
+  "subRecipeModal.pathLabel": {
+    "defaultMessage": "Chemin"
+  },
+  "subRecipeModal.pathPlaceholder": {
+    "defaultMessage": "p. ex., ./subrecipes/security-analysis.yaml"
+  },
+  "subRecipeModal.preconfiguredValues": {
+    "defaultMessage": "Valeurs préconfigurées"
+  },
+  "subRecipeModal.preconfiguredValuesHint": {
+    "defaultMessage": "Valeurs de paramètres facultatives qui sont toujours transmises à la sous-recette"
+  },
+  "subRecipeModal.sequentialHint": {
+    "defaultMessage": "(Force l'exécution séquentielle de plusieurs instances de sous-recette)"
+  },
+  "subRecipeModal.sequentialLabel": {
+    "defaultMessage": "Séquentiel en cas de répétition"
+  },
+  "subRecipeModal.subtitle": {
+    "defaultMessage": "Configurez une sous-recette qui peut être appelée en tant qu'outil lors de l'exécution de la recette"
+  },
+  "switchModelModal.backToModelList": {
+    "defaultMessage": "Retour à la liste des modèles"
+  },
+  "switchModelModal.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "switchModelModal.checkProviderConfig": {
+    "defaultMessage": "Vérifiez la configuration de votre fournisseur dans Paramètres → Fournisseurs"
+  },
+  "switchModelModal.chooseModel": {
+    "defaultMessage": "Choisissez un modèle :"
+  },
+  "switchModelModal.claudeAdaptive": {
+    "defaultMessage": "Adaptatif - Claude décide quand et combien réfléchir"
+  },
+  "switchModelModal.claudeDisabled": {
+    "defaultMessage": "Désactivé - Pas de réflexion approfondie"
+  },
+  "switchModelModal.claudeEffortHigh": {
+    "defaultMessage": "Élevé - Raisonnement approfondi (par défaut)"
+  },
+  "switchModelModal.claudeEffortLow": {
+    "defaultMessage": "Faible - Réflexion minimale, réponses les plus rapides"
+  },
+  "switchModelModal.claudeEffortMax": {
+    "defaultMessage": "Max - Aucune contrainte sur la profondeur de réflexion"
+  },
+  "switchModelModal.claudeEffortMedium": {
+    "defaultMessage": "Moyen - Réflexion modérée"
+  },
+  "switchModelModal.claudeEnabled": {
+    "defaultMessage": "Activé - Budget de jetons fixe pour la réflexion"
+  },
+  "switchModelModal.couldNotContactProvider": {
+    "defaultMessage": "Impossible de contacter le fournisseur"
+  },
+  "switchModelModal.customModelName": {
+    "defaultMessage": "Nom de modèle personnalisé"
+  },
+  "switchModelModal.description": {
+    "defaultMessage": "Sélectionnez un fournisseur et un modèle à utiliser pour vos conversations."
+  },
+  "switchModelModal.enterModelNotListed": {
+    "defaultMessage": "Saisissez un modèle non répertorié..."
+  },
+  "switchModelModal.extendedThinking": {
+    "defaultMessage": "Réflexion approfondie"
+  },
+  "switchModelModal.geminiOnly": {
+    "defaultMessage": "(Modèles Gemini 3 uniquement)"
+  },
+  "switchModelModal.goToSettings": {
+    "defaultMessage": "Aller aux Paramètres"
+  },
+  "switchModelModal.loadingModels": {
+    "defaultMessage": "Chargement des modèles…"
+  },
+  "switchModelModal.localModelsDescription": {
+    "defaultMessage": "Pour utiliser l'inférence locale, vous devez d'abord télécharger un modèle sur votre ordinateur. Allez dans Paramètres → Modèles pour gérer les modèles locaux."
+  },
+  "switchModelModal.localModelsTitle": {
+    "defaultMessage": "Les modèles locaux doivent d'abord être téléchargés"
+  },
+  "switchModelModal.providerPlaceholder": {
+    "defaultMessage": "Fournisseur, saisissez pour rechercher"
+  },
+  "switchModelModal.quickStartGuide": {
+    "defaultMessage": "Guide de démarrage rapide"
+  },
+  "switchModelModal.recommended": {
+    "defaultMessage": "Recommandé"
+  },
+  "switchModelModal.selectEffortLevel": {
+    "defaultMessage": "Sélectionnez le niveau d'effort"
+  },
+  "switchModelModal.selectModel": {
+    "defaultMessage": "Veuillez sélectionner un modèle"
+  },
+  "switchModelModal.selectModelButton": {
+    "defaultMessage": "Sélectionner le modèle"
+  },
+  "switchModelModal.selectModelPlaceholder": {
+    "defaultMessage": "Sélectionnez un modèle, saisissez pour rechercher"
+  },
+  "switchModelModal.selectOrEnterModel": {
+    "defaultMessage": "Veuillez sélectionner ou saisir un modèle"
+  },
+  "switchModelModal.selectProvider": {
+    "defaultMessage": "Veuillez sélectionner un fournisseur"
+  },
+  "switchModelModal.selectThinkingLevel": {
+    "defaultMessage": "Sélectionnez le niveau de réflexion"
+  },
+  "switchModelModal.selectThinkingMode": {
+    "defaultMessage": "Sélectionnez le mode de réflexion"
+  },
+  "switchModelModal.thinkingBudget": {
+    "defaultMessage": "Budget de réflexion (jetons)"
+  },
+  "switchModelModal.thinkingEffort": {
+    "defaultMessage": "Effort de réflexion"
+  },
+  "switchModelModal.thinkingEffortOff": {
+    "defaultMessage": "Désactivé - Pas de réflexion approfondie"
+  },
+  "switchModelModal.thinkingLevel": {
+    "defaultMessage": "Niveau de réflexion"
+  },
+  "switchModelModal.thinkingLevelHigh": {
+    "defaultMessage": "Élevé - Raisonnement plus approfondi, latence plus élevée"
+  },
+  "switchModelModal.thinkingLevelLow": {
+    "defaultMessage": "Faible - Meilleure latence, raisonnement plus léger"
+  },
+  "switchModelModal.title": {
+    "defaultMessage": "Changer de modèle"
+  },
+  "switchModelModal.typeModelName": {
+    "defaultMessage": "Saisissez le nom du modèle ici"
+  },
+  "switchModelModal.useOtherProvider": {
+    "defaultMessage": "Utiliser un autre fournisseur"
+  },
+  "telemetryConsentPrompt.description": {
+    "defaultMessage": "Souhaitez-vous partager des données d'utilisation anonymes pour aider à améliorer goose ? Nous ne collectons jamais vos conversations, votre code ou vos données personnelles."
+  },
+  "telemetryConsentPrompt.heading": {
+    "defaultMessage": "Aidez à améliorer goose"
+  },
+  "telemetryConsentPrompt.learnMore": {
+    "defaultMessage": "En savoir plus"
+  },
+  "telemetryConsentPrompt.optIn": {
+    "defaultMessage": "Oui, partager des données d'utilisation anonymes"
+  },
+  "telemetryConsentPrompt.optOut": {
+    "defaultMessage": "Non merci"
+  },
+  "telemetrySettings.configErrorTitle": {
+    "defaultMessage": "Erreur de configuration"
+  },
+  "telemetrySettings.description": {
+    "defaultMessage": "Contrôlez la manière dont vos données sont utilisées"
+  },
+  "telemetrySettings.learnMore": {
+    "defaultMessage": "En savoir plus"
+  },
+  "telemetrySettings.loadError": {
+    "defaultMessage": "Échec du chargement des paramètres de télémétrie."
+  },
+  "telemetrySettings.title": {
+    "defaultMessage": "Confidentialité"
+  },
+  "telemetrySettings.toggleDescription": {
+    "defaultMessage": "Aidez à améliorer goose en partageant des statistiques d'utilisation anonymes."
+  },
+  "telemetrySettings.toggleLabel": {
+    "defaultMessage": "Données d'utilisation anonymes"
+  },
+  "telemetrySettings.updateError": {
+    "defaultMessage": "Échec de la mise à jour des paramètres de télémétrie."
+  },
+  "themeSelector.dark": {
+    "defaultMessage": "Sombre"
+  },
+  "themeSelector.light": {
+    "defaultMessage": "Clair"
+  },
+  "themeSelector.system": {
+    "defaultMessage": "Système"
+  },
+  "themeSelector.theme": {
+    "defaultMessage": "Thème"
+  },
+  "toolApprovalButtons.allowOnce": {
+    "defaultMessage": "Autoriser une fois"
+  },
+  "toolApprovalButtons.allowedOnce": {
+    "defaultMessage": "Autorisé une fois"
+  },
+  "toolApprovalButtons.alwaysAllow": {
+    "defaultMessage": "Toujours autoriser"
+  },
+  "toolApprovalButtons.alwaysAllowed": {
+    "defaultMessage": "Toujours autorisé"
+  },
+  "toolApprovalButtons.cancelled": {
+    "defaultMessage": "Annulé"
+  },
+  "toolApprovalButtons.denied": {
+    "defaultMessage": "Refusé"
+  },
+  "toolApprovalButtons.deniedOnce": {
+    "defaultMessage": "Refusé une fois"
+  },
+  "toolApprovalButtons.deny": {
+    "defaultMessage": "Refuser"
+  },
+  "toolApprovalButtons.staleApprovalRequest": {
+    "defaultMessage": "Cette demande d'approbation n'est plus active."
+  },
+  "toolCallStatusIndicator.toolStatus": {
+    "defaultMessage": "État de l'outil : {status}"
+  },
+  "toolCallWithResponse.activityCount": {
+    "defaultMessage": "Activité ({count})"
+  },
+  "toolCallWithResponse.code": {
+    "defaultMessage": "Code"
+  },
+  "toolCallWithResponse.loadingSpinner": {
+    "defaultMessage": "Indicateur de chargement"
+  },
+  "toolCallWithResponse.logs": {
+    "defaultMessage": "Journaux"
+  },
+  "toolCallWithResponse.mcpUiExperimental": {
+    "defaultMessage": "L'interface MCP est expérimentale et peut changer à tout moment."
+  },
+  "toolCallWithResponse.output": {
+    "defaultMessage": "Sortie"
+  },
+  "toolCallWithResponse.toolDetails": {
+    "defaultMessage": "Détails de l'outil"
+  },
+  "toolCallWithResponse.toolResultAlt": {
+    "defaultMessage": "Résultat de l'outil"
+  },
+  "toolCallWithResponse.viewSubagentSession": {
+    "defaultMessage": "Afficher la session du sous-agent"
+  },
+  "toolConfirmation.allowToolCallWithName": {
+    "defaultMessage": "Autoriser {toolName} ?"
+  },
+  "toolConfirmation.gooseWouldLikeToCallWithName": {
+    "defaultMessage": "Goose souhaite appeler {toolName}. Autoriser ?"
+  },
+  "updateSection.autoDownload": {
+    "defaultMessage": "Goose téléchargera la mise à jour en arrière-plan et l'installera lors de votre prochaine fermeture ou redémarrage."
+  },
+  "updateSection.autoDownloadDisabledByEnv": {
+    "defaultMessage": "Les téléchargements automatiques sont désactivés via la variable d'environnement GOOSE_DISABLE_AUTO_DOWNLOAD."
+  },
+  "updateSection.autoDownloadDisabledNote": {
+    "defaultMessage": "Le téléchargement automatique est désactivé. Cliquez sur « Télécharger maintenant » pour télécharger manuellement."
+  },
+  "updateSection.autoInstallNote": {
+    "defaultMessage": "Aucune installation manuelle n'est nécessaire."
+  },
+  "updateSection.checkForUpdates": {
+    "defaultMessage": "Rechercher des mises à jour"
+  },
+  "updateSection.checking": {
+    "defaultMessage": "Recherche de mises à jour..."
+  },
+  "updateSection.currentVersion": {
+    "defaultMessage": "Version actuelle"
+  },
+  "updateSection.disableAutoDownload": {
+    "defaultMessage": "Désactiver les téléchargements automatiques des mises à jour"
+  },
+  "updateSection.disableAutoDownloadDesc": {
+    "defaultMessage": "Lorsque cette option est activée, Goose vous informera des nouvelles versions mais ne les téléchargera pas automatiquement."
+  },
+  "updateSection.downloadNow": {
+    "defaultMessage": "Télécharger maintenant"
+  },
+  "updateSection.downloadReady": {
+    "defaultMessage": "Mise à jour téléchargée et prête à être installée !"
+  },
+  "updateSection.downloadingProgress": {
+    "defaultMessage": "Téléchargement de la mise à jour... {percent} %"
+  },
+  "updateSection.downloadingUpdate": {
+    "defaultMessage": "Téléchargement de la mise à jour..."
+  },
+  "updateSection.installAndRestart": {
+    "defaultMessage": "Installer et redémarrer"
+  },
+  "updateSection.installNowHint": {
+    "defaultMessage": "Cliquez sur « Installer et redémarrer » pour mettre à jour maintenant."
+  },
+  "updateSection.latestVersion": {
+    "defaultMessage": "Vous utilisez la dernière version !"
+  },
+  "updateSection.loading": {
+    "defaultMessage": "Chargement..."
+  },
+  "updateSection.manualInstallNote": {
+    "defaultMessage": "Après le téléchargement, vous devrez installer la mise à jour manuellement."
+  },
+  "updateSection.manualInstallRequired": {
+    "defaultMessage": "Installation manuelle requise pour cette méthode de mise à jour."
+  },
+  "updateSection.readyInstallAuto": {
+    "defaultMessage": "✓ La mise à jour est prête. Redémarrez Goose pour terminer son installation, ou quittez lorsque vous avez terminé."
+  },
+  "updateSection.readyInstallManual": {
+    "defaultMessage": "✓ La mise à jour est prête ! Cliquez sur « Installer et redémarrer » pour obtenir les instructions d'installation."
+  },
+  "updateSection.upToDate": {
+    "defaultMessage": "(à jour)"
+  },
+  "updateSection.updateAvailable": {
+    "defaultMessage": "Mise à jour disponible !"
+  },
+  "updateSection.versionAvailable": {
+    "defaultMessage": "→ {version} disponible"
+  },
+  "updateSection.versionIsAvailable": {
+    "defaultMessage": "La version {version} est disponible"
+  },
+  "userMessage.cancel": {
+    "defaultMessage": "Annuler"
+  },
+  "userMessage.cancelAriaLabel": {
+    "defaultMessage": "Annuler la modification"
+  },
+  "userMessage.editAriaLabel": {
+    "defaultMessage": "Modifier le contenu du message"
+  },
+  "userMessage.editButton": {
+    "defaultMessage": "Modifier"
+  },
+  "userMessage.editInPlace": {
+    "defaultMessage": "Modifier sur place"
+  },
+  "userMessage.editInPlaceAriaLabel": {
+    "defaultMessage": "Modifier le message sur place"
+  },
+  "userMessage.editInPlaceDescription": {
+    "defaultMessage": "<b>Modifier sur place</b> met à jour cette session • <b>Dériver la session</b> crée une nouvelle session"
+  },
+  "userMessage.editInPlaceTitle": {
+    "defaultMessage": "Mettre à jour le message dans cette session"
+  },
+  "userMessage.editMessageAriaLabel": {
+    "defaultMessage": "Modifier le message : {preview}"
+  },
+  "userMessage.editMessageTitle": {
+    "defaultMessage": "Modifier le message"
+  },
+  "userMessage.editPlaceholder": {
+    "defaultMessage": "Modifiez votre message..."
+  },
+  "userMessage.emptyError": {
+    "defaultMessage": "Le message ne peut pas être vide"
+  },
+  "userMessage.forkSession": {
+    "defaultMessage": "Dériver la session"
+  },
+  "userMessage.forkSessionAriaLabel": {
+    "defaultMessage": "Dériver la session avec le message modifié"
+  },
+  "userMessage.forkSessionTitle": {
+    "defaultMessage": "Créer une nouvelle session avec le message modifié"
+  }
+}

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -3887,14 +3887,32 @@
   "settings.language.english": {
     "defaultMessage": "अंग्रेज़ी"
   },
+  "settings.language.french": {
+    "defaultMessage": "फ़्रेंच"
+  },
+  "settings.language.german": {
+    "defaultMessage": "जर्मन"
+  },
   "settings.language.hindi": {
     "defaultMessage": "हिन्दी"
+  },
+  "settings.language.indonesian": {
+    "defaultMessage": "इंडोनेशियाई"
+  },
+  "settings.language.italian": {
+    "defaultMessage": "इतालवी"
   },
   "settings.language.japanese": {
     "defaultMessage": "जापानी"
   },
   "settings.language.korean": {
     "defaultMessage": "कोरियाई"
+  },
+  "settings.language.malay": {
+    "defaultMessage": "मलय"
+  },
+  "settings.language.portuguese": {
+    "defaultMessage": "पुर्तगाली"
   },
   "settings.language.russian": {
     "defaultMessage": "रूसी"
@@ -3911,8 +3929,14 @@
   "settings.language.turkish": {
     "defaultMessage": "तुर्की"
   },
+  "settings.language.vietnamese": {
+    "defaultMessage": "वियतनामी"
+  },
   "settings.language.zhCN": {
     "defaultMessage": "चीनी (सरलीकृत)"
+  },
+  "settings.language.zhTW": {
+    "defaultMessage": "चीनी (पारंपरिक)"
   },
   "settings.menuBarIcon.description": {
     "defaultMessage": "मेनू बार में goose दिखाएँ"

--- a/ui/desktop/src/i18n/messages/id.json
+++ b/ui/desktop/src/i18n/messages/id.json
@@ -1,0 +1,4574 @@
+{
+  "alertBox.autoCompactAt": {
+    "defaultMessage": "Padatkan otomatis pada"
+  },
+  "alertBox.compactNow": {
+    "defaultMessage": "Padatkan sekarang"
+  },
+  "alertBox.failedToSaveThreshold": {
+    "defaultMessage": "Gagal menyimpan ambang batas: {error}"
+  },
+  "announcementModal.gotIt": {
+    "defaultMessage": "Mengerti!"
+  },
+  "appLayout.collapseNavigation": {
+    "defaultMessage": "Ciutkan navigasi"
+  },
+  "appLayout.openNavigation": {
+    "defaultMessage": "Buka navigasi"
+  },
+  "appsView.customApp": {
+    "defaultMessage": "Aplikasi khusus"
+  },
+  "appsView.description": {
+    "defaultMessage": "Aplikasi dari server MCP Anda dan Aplikasi yang dibuat oleh goose sendiri. Anda dapat memintanya membuat aplikasi baru melalui antarmuka obrolan dan aplikasi tersebut akan muncul di sini."
+  },
+  "appsView.errorLoading": {
+    "defaultMessage": "Kesalahan saat memuat aplikasi: {error}"
+  },
+  "appsView.importApp": {
+    "defaultMessage": "Impor Aplikasi"
+  },
+  "appsView.launch": {
+    "defaultMessage": "Jalankan"
+  },
+  "appsView.loading": {
+    "defaultMessage": "Memuat aplikasi..."
+  },
+  "appsView.noAppsDescription": {
+    "defaultMessage": "Buka obrolan dan mintalah goose membuat aplikasi yang Anda inginkan. goose dapat membuatkannya untuk Anda dan aplikasi tersebut akan muncul di sini. Atau jika seseorang membagikan sebuah aplikasi, Anda dapat mengimpornya menggunakan tombol di atas."
+  },
+  "appsView.noAppsTitle": {
+    "defaultMessage": "Tidak ada aplikasi yang tersedia"
+  },
+  "appsView.retry": {
+    "defaultMessage": "Coba lagi"
+  },
+  "appsView.title": {
+    "defaultMessage": "Aplikasi"
+  },
+  "authSettings.activeProviderWarning": {
+    "defaultMessage": "Ini adalah penyedia aktif. Permintaan baru mungkin gagal hingga Anda mengonfigurasi kredensial lain."
+  },
+  "authSettings.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "authSettings.delete": {
+    "defaultMessage": "Hapus"
+  },
+  "authSettings.deleteCredential": {
+    "defaultMessage": "Hapus kredensial"
+  },
+  "authSettings.deleteMessage": {
+    "defaultMessage": "Hapus kredensial {name} untuk {provider}?"
+  },
+  "authSettings.deleteTitle": {
+    "defaultMessage": "Hapus kredensial"
+  },
+  "authSettings.deleted": {
+    "defaultMessage": "Kredensial dihapus"
+  },
+  "authSettings.description": {
+    "defaultMessage": "Kelola kredensial penyedia yang disimpan secara lokal oleh goose."
+  },
+  "authSettings.empty": {
+    "defaultMessage": "Tidak ditemukan kredensial penyedia yang tersimpan secara lokal."
+  },
+  "authSettings.expiresAt": {
+    "defaultMessage": "Kedaluwarsa {date}"
+  },
+  "authSettings.failedToConfigure": {
+    "defaultMessage": "Gagal mengonfigurasi kredensial: {error}"
+  },
+  "authSettings.failedToDelete": {
+    "defaultMessage": "Gagal menghapus kredensial: {error}"
+  },
+  "authSettings.failedToLoad": {
+    "defaultMessage": "Gagal memuat kredensial penyedia"
+  },
+  "authSettings.loading": {
+    "defaultMessage": "Memuat kredensial..."
+  },
+  "authSettings.reauthorize": {
+    "defaultMessage": "Otorisasi ulang"
+  },
+  "authSettings.signIn": {
+    "defaultMessage": "Masuk"
+  },
+  "authSettings.signedIn": {
+    "defaultMessage": "Kredensial dikonfigurasi"
+  },
+  "authSettings.storageProviderCache": {
+    "defaultMessage": "Cache penyedia"
+  },
+  "authSettings.storageSecretStore": {
+    "defaultMessage": "Penyimpanan rahasia"
+  },
+  "authSettings.title": {
+    "defaultMessage": "Kredensial Penyedia"
+  },
+  "backButton.back": {
+    "defaultMessage": "Kembali"
+  },
+  "baseChat.failedToLoadSession": {
+    "defaultMessage": "Gagal Memuat Sesi"
+  },
+  "baseChat.goHome": {
+    "defaultMessage": "Ke beranda"
+  },
+  "bottomMenuExtensionSelection.extensionUpdated": {
+    "defaultMessage": "Ekstensi Diperbarui"
+  },
+  "bottomMenuExtensionSelection.extensionWillBeDisabled": {
+    "defaultMessage": "{name} akan dinonaktifkan di obrolan baru"
+  },
+  "bottomMenuExtensionSelection.extensionWillBeEnabled": {
+    "defaultMessage": "{name} akan diaktifkan di obrolan baru"
+  },
+  "bottomMenuExtensionSelection.extensionsForNewChats": {
+    "defaultMessage": "Ekstensi untuk obrolan baru"
+  },
+  "bottomMenuExtensionSelection.extensionsForThisSession": {
+    "defaultMessage": "Ekstensi untuk sesi obrolan ini"
+  },
+  "bottomMenuExtensionSelection.manageExtensions": {
+    "defaultMessage": "kelola ekstensi"
+  },
+  "bottomMenuExtensionSelection.noExtensionsAvailable": {
+    "defaultMessage": "tidak ada ekstensi yang tersedia"
+  },
+  "bottomMenuExtensionSelection.noExtensionsFound": {
+    "defaultMessage": "tidak ada ekstensi yang ditemukan"
+  },
+  "bottomMenuExtensionSelection.searchExtensions": {
+    "defaultMessage": "cari ekstensi..."
+  },
+  "cardButtons.configure": {
+    "defaultMessage": "Konfigurasi"
+  },
+  "cardButtons.launch": {
+    "defaultMessage": "Jalankan"
+  },
+  "chat.notification.taskComplete.body": {
+    "defaultMessage": "Klik di sini untuk membawa Goose kembali ke fokus."
+  },
+  "chat.notification.taskComplete.title": {
+    "defaultMessage": "Goose telah menyelesaikan tugas."
+  },
+  "chatInput.contextWindow": {
+    "defaultMessage": "Jendela konteks"
+  },
+  "chatInput.dictationError": {
+    "defaultMessage": "Kesalahan Dikte"
+  },
+  "chatInput.failedToReadImage": {
+    "defaultMessage": "Gagal membaca berkas gambar"
+  },
+  "chatInput.navigationShortcut": {
+    "defaultMessage": "{prefix}↑/{prefix}↓ untuk menavigasi pesan"
+  },
+  "chatInput.processingDroppedFiles": {
+    "defaultMessage": "Memproses berkas yang dijatuhkan..."
+  },
+  "chatInput.recording": {
+    "defaultMessage": "Merekam..."
+  },
+  "chatInput.removeFile": {
+    "defaultMessage": "Hapus berkas"
+  },
+  "chatInput.removeImage": {
+    "defaultMessage": "Hapus gambar"
+  },
+  "chatInput.restartingSession": {
+    "defaultMessage": "Memulai ulang sesi..."
+  },
+  "chatInput.send": {
+    "defaultMessage": "Kirim"
+  },
+  "chatInput.transcribing": {
+    "defaultMessage": "Mentranskripsikan..."
+  },
+  "chatInput.typeMessage": {
+    "defaultMessage": "Ketik pesan untuk dikirim"
+  },
+  "chatInput.unknownType": {
+    "defaultMessage": "Tipe tidak diketahui"
+  },
+  "chatInput.viewEditRecipe": {
+    "defaultMessage": "Lihat/Edit Resep"
+  },
+  "chatInput.waitingForCancellation": {
+    "defaultMessage": "Menunggu pembatalan selesai"
+  },
+  "chatInput.waitingForImages": {
+    "defaultMessage": "Menunggu gambar disimpan..."
+  },
+  "chatSettings.modeDescription": {
+    "defaultMessage": "Pilih mode default yang digunakan Goose untuk sesi baru. Sesi yang sudah ada tetap menggunakan mode saat ini."
+  },
+  "chatSettings.modeTitle": {
+    "defaultMessage": "Mode Default"
+  },
+  "chatSettings.responseStylesDescription": {
+    "defaultMessage": "Pilih bagaimana Goose memformat dan menata respons-nya"
+  },
+  "chatSettings.responseStylesTitle": {
+    "defaultMessage": "Gaya Respons"
+  },
+  "configSettings.configReset": {
+    "defaultMessage": "Konfigurasi Disetel Ulang"
+  },
+  "configSettings.configResetMsg": {
+    "defaultMessage": "Semua perubahan telah dikembalikan"
+  },
+  "configSettings.configUpdated": {
+    "defaultMessage": "Konfigurasi Diperbarui"
+  },
+  "configSettings.configUpdatedMsg": {
+    "defaultMessage": "Berhasil menyimpan \"{name}\""
+  },
+  "configSettings.configurationEditor": {
+    "defaultMessage": "Editor Konfigurasi"
+  },
+  "configSettings.description": {
+    "defaultMessage": "Edit pengaturan konfigurasi goose Anda"
+  },
+  "configSettings.descriptionWithProvider": {
+    "defaultMessage": "Edit pengaturan konfigurasi goose Anda (pengaturan saat ini untuk {provider})"
+  },
+  "configSettings.done": {
+    "defaultMessage": "Selesai"
+  },
+  "configSettings.editConfiguration": {
+    "defaultMessage": "Edit Konfigurasi"
+  },
+  "configSettings.enterValue": {
+    "defaultMessage": "Masukkan {name}"
+  },
+  "configSettings.noSettings": {
+    "defaultMessage": "Tidak ada pengaturan konfigurasi yang ditemukan."
+  },
+  "configSettings.resetChanges": {
+    "defaultMessage": "Setel Ulang Perubahan"
+  },
+  "configSettings.saveFailed": {
+    "defaultMessage": "Gagal Menyimpan"
+  },
+  "configSettings.saveFailedMsg": {
+    "defaultMessage": "Gagal menyimpan \"{name}\""
+  },
+  "configSettings.saving": {
+    "defaultMessage": "Menyimpan..."
+  },
+  "configSettings.title": {
+    "defaultMessage": "Konfigurasi"
+  },
+  "configureApproveMode.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "configureApproveMode.description": {
+    "defaultMessage": "Persetujuan permintaan dapat diberikan ke semua permintaan alat atau menentukan tindakan mana yang mungkin memerlukan integrasi"
+  },
+  "configureApproveMode.manualApproval": {
+    "defaultMessage": "Persetujuan manual"
+  },
+  "configureApproveMode.manualApprovalDescription": {
+    "defaultMessage": "Semua alat, ekstensi, dan modifikasi berkas akan memerlukan persetujuan manusia"
+  },
+  "configureApproveMode.save": {
+    "defaultMessage": "Simpan"
+  },
+  "configureApproveMode.saving": {
+    "defaultMessage": "Menyimpan..."
+  },
+  "configureApproveMode.smartApproval": {
+    "defaultMessage": "Persetujuan cerdas"
+  },
+  "configureApproveMode.smartApprovalDescription": {
+    "defaultMessage": "Tentukan secara cerdas tindakan mana yang memerlukan persetujuan berdasarkan tingkat risiko"
+  },
+  "configureApproveMode.title": {
+    "defaultMessage": "Konfigurasi mode persetujuan"
+  },
+  "confirmationModal.defaultCancel": {
+    "defaultMessage": "Tidak"
+  },
+  "confirmationModal.defaultConfirm": {
+    "defaultMessage": "Ya"
+  },
+  "confirmationModal.processing": {
+    "defaultMessage": "Memproses..."
+  },
+  "conversationLimitsDropdown.conversationLimits": {
+    "defaultMessage": "Batas Percakapan"
+  },
+  "conversationLimitsDropdown.maxTurns": {
+    "defaultMessage": "Giliran Maksimum"
+  },
+  "conversationLimitsDropdown.maxTurnsDescription": {
+    "defaultMessage": "Giliran agen maksimum sebelum Goose meminta masukan pengguna"
+  },
+  "costTracker.costUnavailable": {
+    "defaultMessage": "Data biaya tidak tersedia untuk {model} ({inputTokens} token masukan, {outputTokens} token keluaran)"
+  },
+  "costTracker.inputOutputTooltip": {
+    "defaultMessage": "Masukan: {inputTokens} token ({inputCost}) | Keluaran: {outputTokens} token ({outputCost})"
+  },
+  "costTracker.pricingUnavailable": {
+    "defaultMessage": "Data harga tidak tersedia untuk {model}"
+  },
+  "costTracker.totalSessionCost": {
+    "defaultMessage": "Total biaya sesi: {cost}"
+  },
+  "createEditRecipe.clickToGenerateDeeplink": {
+    "defaultMessage": "Klik untuk membuat deeplink"
+  },
+  "createEditRecipe.close": {
+    "defaultMessage": "Tutup"
+  },
+  "createEditRecipe.copied": {
+    "defaultMessage": "Tersalin!"
+  },
+  "createEditRecipe.copy": {
+    "defaultMessage": "Salin"
+  },
+  "createEditRecipe.copyLinkDescription": {
+    "defaultMessage": "Salin tautan ini untuk dibagikan kepada teman atau tempel langsung di Chrome untuk membukanya"
+  },
+  "createEditRecipe.createRecipeTitle": {
+    "defaultMessage": "Buat Resep"
+  },
+  "createEditRecipe.createSubtitle": {
+    "defaultMessage": "Buat resep baru untuk mendefinisikan perilaku dan kemampuan agen bagi sesi obrolan yang dapat digunakan kembali."
+  },
+  "createEditRecipe.editSubtitle": {
+    "defaultMessage": "Anda dapat mengedit resep di bawah ini untuk mengubah perilaku agen dalam sesi baru."
+  },
+  "createEditRecipe.generatingDeeplink": {
+    "defaultMessage": "Membuat deeplink..."
+  },
+  "createEditRecipe.learnMore": {
+    "defaultMessage": "Pelajari selengkapnya"
+  },
+  "createEditRecipe.recipeSavedAndLaunchedMsg": {
+    "defaultMessage": "Resep berhasil disimpan dan dijalankan"
+  },
+  "createEditRecipe.recipeSavedMsg": {
+    "defaultMessage": "Resep berhasil disimpan"
+  },
+  "createEditRecipe.saveAndRunFailed": {
+    "defaultMessage": "Gagal Menyimpan dan Menjalankan"
+  },
+  "createEditRecipe.saveAndRunFailedMsg": {
+    "defaultMessage": "Gagal menyimpan dan menjalankan resep: {error}"
+  },
+  "createEditRecipe.saveAndRunRecipe": {
+    "defaultMessage": "Simpan & Jalankan Resep"
+  },
+  "createEditRecipe.saveFailed": {
+    "defaultMessage": "Gagal Menyimpan"
+  },
+  "createEditRecipe.saveFailedMsg": {
+    "defaultMessage": "Gagal menyimpan resep: {error}"
+  },
+  "createEditRecipe.saveRecipe": {
+    "defaultMessage": "Simpan Resep"
+  },
+  "createEditRecipe.saving": {
+    "defaultMessage": "Menyimpan..."
+  },
+  "createEditRecipe.validationFailed": {
+    "defaultMessage": "Validasi Gagal"
+  },
+  "createEditRecipe.validationMsg": {
+    "defaultMessage": "Harap isi semua bidang yang wajib diisi dan pastikan skema JSON valid."
+  },
+  "createEditRecipe.viewEditRecipeTitle": {
+    "defaultMessage": "Lihat/edit resep"
+  },
+  "createSubRecipeInline.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "createSubRecipeInline.closeModal": {
+    "defaultMessage": "Tutup modal buat subresep"
+  },
+  "createSubRecipeInline.createAndAdd": {
+    "defaultMessage": "Buat & Tambahkan Subresep"
+  },
+  "createSubRecipeInline.createdSuccess": {
+    "defaultMessage": "Subresep berhasil dibuat"
+  },
+  "createSubRecipeInline.creating": {
+    "defaultMessage": "Membuat..."
+  },
+  "createSubRecipeInline.duplicateName": {
+    "defaultMessage": "Nama Duplikat"
+  },
+  "createSubRecipeInline.duplicateNameMsg": {
+    "defaultMessage": "Subresep dengan nama \"{name}\" sudah ada. Harap gunakan nama yang unik."
+  },
+  "createSubRecipeInline.instructionsLabel": {
+    "defaultMessage": "Instruksi"
+  },
+  "createSubRecipeInline.instructionsPlaceholder": {
+    "defaultMessage": "Instruksi untuk AI saat subresep ini dipanggil..."
+  },
+  "createSubRecipeInline.nameHint": {
+    "defaultMessage": "Pengenal unik yang digunakan untuk membuat nama alat"
+  },
+  "createSubRecipeInline.nameLabel": {
+    "defaultMessage": "Nama"
+  },
+  "createSubRecipeInline.namePlaceholder": {
+    "defaultMessage": "mis., security_scan"
+  },
+  "createSubRecipeInline.preconfiguredValues": {
+    "defaultMessage": "Nilai yang Telah Dikonfigurasi"
+  },
+  "createSubRecipeInline.preconfiguredValuesHint": {
+    "defaultMessage": "Nilai parameter opsional yang selalu diteruskan ke subresep"
+  },
+  "createSubRecipeInline.recipeDescriptionLabel": {
+    "defaultMessage": "Deskripsi Resep"
+  },
+  "createSubRecipeInline.recipeDescriptionPlaceholder": {
+    "defaultMessage": "Apa yang dilakukan resep ini saat dijalankan"
+  },
+  "createSubRecipeInline.recipeTitleLabel": {
+    "defaultMessage": "Judul Resep"
+  },
+  "createSubRecipeInline.recipeTitlePlaceholder": {
+    "defaultMessage": "mis., Alat Analisis Keamanan"
+  },
+  "createSubRecipeInline.saveFailed": {
+    "defaultMessage": "Gagal Menyimpan"
+  },
+  "createSubRecipeInline.saveFailedMsg": {
+    "defaultMessage": "Gagal menyimpan subresep: {error}"
+  },
+  "createSubRecipeInline.sequentialHint": {
+    "defaultMessage": "(Memaksa eksekusi berurutan dari beberapa instans)"
+  },
+  "createSubRecipeInline.sequentialLabel": {
+    "defaultMessage": "Berurutan saat diulang"
+  },
+  "createSubRecipeInline.subtitle": {
+    "defaultMessage": "Buat resep sederhana untuk digunakan sebagai alat yang dapat dipanggil dalam resep utama Anda"
+  },
+  "createSubRecipeInline.title": {
+    "defaultMessage": "Buat Subresep Baru"
+  },
+  "createSubRecipeInline.toolDescriptionLabel": {
+    "defaultMessage": "Deskripsi Alat"
+  },
+  "createSubRecipeInline.toolDescriptionPlaceholder": {
+    "defaultMessage": "Deskripsi opsional yang ditampilkan saat ini dipanggil sebagai alat"
+  },
+  "createSubRecipeInline.validationFailed": {
+    "defaultMessage": "Validasi Gagal"
+  },
+  "createSubRecipeInline.validationMsg": {
+    "defaultMessage": "Nama, judul, deskripsi resep, dan instruksi wajib diisi."
+  },
+  "creditsExhaustedNotification.addCredits": {
+    "defaultMessage": "Tambah kredit"
+  },
+  "creditsExhaustedNotification.insufficientCredits": {
+    "defaultMessage": "Kredit Tidak Mencukupi"
+  },
+  "cronPicker.april": {
+    "defaultMessage": "April"
+  },
+  "cronPicker.at": {
+    "defaultMessage": "pada"
+  },
+  "cronPicker.atMinute": {
+    "defaultMessage": "pada menit"
+  },
+  "cronPicker.atSecond": {
+    "defaultMessage": "pada detik"
+  },
+  "cronPicker.august": {
+    "defaultMessage": "Agustus"
+  },
+  "cronPicker.cronExpression": {
+    "defaultMessage": "Ekspresi cron"
+  },
+  "cronPicker.custom": {
+    "defaultMessage": "Cron khusus"
+  },
+  "cronPicker.day": {
+    "defaultMessage": "Hari"
+  },
+  "cronPicker.december": {
+    "defaultMessage": "Desember"
+  },
+  "cronPicker.emptyCronError": {
+    "defaultMessage": "Ekspresi cron tidak boleh kosong"
+  },
+  "cronPicker.every": {
+    "defaultMessage": "Setiap"
+  },
+  "cronPicker.february": {
+    "defaultMessage": "Februari"
+  },
+  "cronPicker.friday": {
+    "defaultMessage": "Jumat"
+  },
+  "cronPicker.hour": {
+    "defaultMessage": "Jam"
+  },
+  "cronPicker.inMonth": {
+    "defaultMessage": "di"
+  },
+  "cronPicker.invalidDayOfMonth": {
+    "defaultMessage": "Hari harus antara 1 dan {max}"
+  },
+  "cronPicker.january": {
+    "defaultMessage": "Januari"
+  },
+  "cronPicker.july": {
+    "defaultMessage": "Juli"
+  },
+  "cronPicker.june": {
+    "defaultMessage": "Juni"
+  },
+  "cronPicker.march": {
+    "defaultMessage": "Maret"
+  },
+  "cronPicker.may": {
+    "defaultMessage": "Mei"
+  },
+  "cronPicker.minute": {
+    "defaultMessage": "Menit"
+  },
+  "cronPicker.mode": {
+    "defaultMessage": "Mode"
+  },
+  "cronPicker.monday": {
+    "defaultMessage": "Senin"
+  },
+  "cronPicker.month": {
+    "defaultMessage": "Bulan"
+  },
+  "cronPicker.november": {
+    "defaultMessage": "November"
+  },
+  "cronPicker.october": {
+    "defaultMessage": "Oktober"
+  },
+  "cronPicker.on": {
+    "defaultMessage": "pada"
+  },
+  "cronPicker.onDay": {
+    "defaultMessage": "pada hari"
+  },
+  "cronPicker.quarter": {
+    "defaultMessage": "Kuartal"
+  },
+  "cronPicker.saturday": {
+    "defaultMessage": "Sabtu"
+  },
+  "cronPicker.september": {
+    "defaultMessage": "September"
+  },
+  "cronPicker.startingMonth": {
+    "defaultMessage": "bulan mulai"
+  },
+  "cronPicker.sunday": {
+    "defaultMessage": "Minggu"
+  },
+  "cronPicker.thursday": {
+    "defaultMessage": "Kamis"
+  },
+  "cronPicker.tuesday": {
+    "defaultMessage": "Selasa"
+  },
+  "cronPicker.wednesday": {
+    "defaultMessage": "Rabu"
+  },
+  "cronPicker.week": {
+    "defaultMessage": "Minggu"
+  },
+  "cronPicker.year": {
+    "defaultMessage": "Tahun"
+  },
+  "customProviderForm.add": {
+    "defaultMessage": "Tambah"
+  },
+  "customProviderForm.anthropicCompatible": {
+    "defaultMessage": "Kompatibel dengan Anthropic"
+  },
+  "customProviderForm.apiBasePath": {
+    "defaultMessage": "Jalur Dasar API (opsional)"
+  },
+  "customProviderForm.apiBasePathHint": {
+    "defaultMessage": "Timpa jalur API default. Biarkan kosong untuk menggunakan jalur default penyedia."
+  },
+  "customProviderForm.apiBasePathPlaceholder": {
+    "defaultMessage": "mis., v1/chat/completions atau project_id/v1"
+  },
+  "customProviderForm.apiKey": {
+    "defaultMessage": "Kunci API"
+  },
+  "customProviderForm.apiKeyPlaceholderExisting": {
+    "defaultMessage": "Biarkan kosong untuk mempertahankan kunci yang ada"
+  },
+  "customProviderForm.apiKeyPlaceholderNew": {
+    "defaultMessage": "Kunci API Anda"
+  },
+  "customProviderForm.apiKeyRequired": {
+    "defaultMessage": "Kunci API wajib diisi"
+  },
+  "customProviderForm.apiUrl": {
+    "defaultMessage": "URL API"
+  },
+  "customProviderForm.apiUrlPlaceholder": {
+    "defaultMessage": "https://api.example.com"
+  },
+  "customProviderForm.apiUrlRequired": {
+    "defaultMessage": "URL API wajib diisi"
+  },
+  "customProviderForm.attachments": {
+    "defaultMessage": "Lampiran"
+  },
+  "customProviderForm.authHint": {
+    "defaultMessage": "LLM lokal seperti Ollama biasanya tidak memerlukan kunci API."
+  },
+  "customProviderForm.authentication": {
+    "defaultMessage": "Autentikasi"
+  },
+  "customProviderForm.availableModels": {
+    "defaultMessage": "Model yang Tersedia (dipisahkan koma)"
+  },
+  "customProviderForm.back": {
+    "defaultMessage": "← Kembali"
+  },
+  "customProviderForm.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "customProviderForm.cannotDeleteActive": {
+    "defaultMessage": "Anda tidak dapat menghapus penyedia ini selama sedang digunakan. Harap beralih ke model lain terlebih dahulu."
+  },
+  "customProviderForm.chooseSetup": {
+    "defaultMessage": "Pilih cara Anda ingin menyiapkan penyedia Anda."
+  },
+  "customProviderForm.clear": {
+    "defaultMessage": "Bersihkan"
+  },
+  "customProviderForm.configureManually": {
+    "defaultMessage": "Konfigurasikan secara manual"
+  },
+  "customProviderForm.configureManuallyDesc": {
+    "defaultMessage": "Masukkan sendiri semua detail penyedia"
+  },
+  "customProviderForm.confirmDelete": {
+    "defaultMessage": "Konfirmasi Hapus"
+  },
+  "customProviderForm.createProvider": {
+    "defaultMessage": "Buat Penyedia"
+  },
+  "customProviderForm.customHeaders": {
+    "defaultMessage": "Header Khusus"
+  },
+  "customProviderForm.customHeadersHint": {
+    "defaultMessage": "Tambahkan header HTTP khusus untuk disertakan dalam permintaan ke penyedia. Klik tombol \"+\" untuk menambahkan setelah mengisi kedua bidang."
+  },
+  "customProviderForm.deleteConfirmation": {
+    "defaultMessage": "Apakah Anda yakin ingin menghapus penyedia khusus ini? Tindakan ini akan menghapus penyedia secara permanen beserta kunci API yang tersimpan. Tindakan ini tidak dapat dibatalkan."
+  },
+  "customProviderForm.deleteProvider": {
+    "defaultMessage": "Hapus Penyedia"
+  },
+  "customProviderForm.displayName": {
+    "defaultMessage": "Nama Tampilan"
+  },
+  "customProviderForm.displayNamePlaceholder": {
+    "defaultMessage": "Nama Penyedia Anda"
+  },
+  "customProviderForm.displayNameRequired": {
+    "defaultMessage": "Nama tampilan wajib diisi"
+  },
+  "customProviderForm.docs": {
+    "defaultMessage": "Dokumentasi"
+  },
+  "customProviderForm.headerBothRequired": {
+    "defaultMessage": "Nama dan nilai header keduanya harus diisi"
+  },
+  "customProviderForm.headerDuplicate": {
+    "defaultMessage": "Header dengan nama ini sudah ada"
+  },
+  "customProviderForm.headerNamePlaceholder": {
+    "defaultMessage": "Nama header"
+  },
+  "customProviderForm.headerNoSpaces": {
+    "defaultMessage": "Nama header tidak boleh mengandung spasi"
+  },
+  "customProviderForm.modelsPlaceholder": {
+    "defaultMessage": "model-a, model-b, model-c"
+  },
+  "customProviderForm.modelsRequired": {
+    "defaultMessage": "Setidaknya satu model wajib diisi"
+  },
+  "customProviderForm.ollamaCompatible": {
+    "defaultMessage": "Kompatibel dengan Ollama"
+  },
+  "customProviderForm.openaiCompatible": {
+    "defaultMessage": "Kompatibel dengan OpenAI"
+  },
+  "customProviderForm.providerType": {
+    "defaultMessage": "Tipe Penyedia"
+  },
+  "customProviderForm.reasoning": {
+    "defaultMessage": "Penalaran"
+  },
+  "customProviderForm.requiresApiKey": {
+    "defaultMessage": "Penyedia ini memerlukan kunci API"
+  },
+  "customProviderForm.startFromTemplate": {
+    "defaultMessage": "Mulai dari templat penyedia"
+  },
+  "customProviderForm.startFromTemplateDesc": {
+    "defaultMessage": "Pilih penyedia yang dikenal dan kami akan mengisi konfigurasi secara otomatis"
+  },
+  "customProviderForm.submitError": {
+    "defaultMessage": "Gagal menyimpan penyedia. Harap periksa konfigurasi Anda dan coba lagi."
+  },
+  "customProviderForm.supportsStreaming": {
+    "defaultMessage": "Penyedia mendukung respons streaming"
+  },
+  "customProviderForm.toolCalling": {
+    "defaultMessage": "Pemanggilan alat"
+  },
+  "customProviderForm.updateProvider": {
+    "defaultMessage": "Perbarui Penyedia"
+  },
+  "customProviderForm.usingTemplate": {
+    "defaultMessage": "Menggunakan templat: {name}"
+  },
+  "customProviderForm.valuePlaceholder": {
+    "defaultMessage": "Nilai"
+  },
+  "defaultCardButtons.configureSettings": {
+    "defaultMessage": "Konfigurasikan pengaturan {name}"
+  },
+  "defaultCardButtons.deleteSettings": {
+    "defaultMessage": "Hapus pengaturan {name}"
+  },
+  "defaultCardButtons.editSettings": {
+    "defaultMessage": "Edit pengaturan {name}"
+  },
+  "defaultCardButtons.getStarted": {
+    "defaultMessage": "Mulai dengan goose!"
+  },
+  "defaultProviderSetupForm.apiHostLabel": {
+    "defaultMessage": "Host API"
+  },
+  "defaultProviderSetupForm.apiHostPlaceholder": {
+    "defaultMessage": "https://api.example.com"
+  },
+  "defaultProviderSetupForm.apiKeyLabel": {
+    "defaultMessage": "Kunci API"
+  },
+  "defaultProviderSetupForm.apiKeyPlaceholder": {
+    "defaultMessage": "Kunci API Anda"
+  },
+  "defaultProviderSetupForm.hideOptions": {
+    "defaultMessage": "Sembunyikan {count} opsi"
+  },
+  "defaultProviderSetupForm.loadingConfig": {
+    "defaultMessage": "Memuat nilai konfigurasi..."
+  },
+  "defaultProviderSetupForm.modelsLabel": {
+    "defaultMessage": "Model"
+  },
+  "defaultProviderSetupForm.modelsPlaceholder": {
+    "defaultMessage": "model-a, model-b"
+  },
+  "defaultProviderSetupForm.noConfigParameters": {
+    "defaultMessage": "Tidak ada parameter konfigurasi untuk penyedia ini."
+  },
+  "defaultProviderSetupForm.showOptions": {
+    "defaultMessage": "Tampilkan {count} opsi"
+  },
+  "diagnosticsModal.attachHint": {
+    "defaultMessage": "Jika Anda melaporkan bug, pertimbangkan untuk melampirkan laporan diagnostik ke dalamnya."
+  },
+  "diagnosticsModal.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "diagnosticsModal.configSettings": {
+    "defaultMessage": "Pengaturan konfigurasi"
+  },
+  "diagnosticsModal.description": {
+    "defaultMessage": "Anda dapat mengunduh laporan diagnostik JSON untuk dibagikan dengan tim, atau melaporkan bug langsung di GitHub dengan detail sistem Anda yang sudah terisi. Laporan diagnostik berisi hal berikut:"
+  },
+  "diagnosticsModal.diagnosticsErrorMsg": {
+    "defaultMessage": "Gagal mengunduh laporan diagnostik"
+  },
+  "diagnosticsModal.diagnosticsErrorTitle": {
+    "defaultMessage": "Kesalahan Diagnostik"
+  },
+  "diagnosticsModal.download": {
+    "defaultMessage": "Unduh"
+  },
+  "diagnosticsModal.downloading": {
+    "defaultMessage": "Mengunduh..."
+  },
+  "diagnosticsModal.fileBug": {
+    "defaultMessage": "Laporkan Bug di GitHub"
+  },
+  "diagnosticsModal.logFiles": {
+    "defaultMessage": "File log terbaru"
+  },
+  "diagnosticsModal.opening": {
+    "defaultMessage": "Membuka..."
+  },
+  "diagnosticsModal.reportProblem": {
+    "defaultMessage": "Laporkan Masalah"
+  },
+  "diagnosticsModal.sensitiveWarning": {
+    "defaultMessage": "Jika sesi Anda berisi informasi sensitif, jangan bagikan file diagnostik secara publik."
+  },
+  "diagnosticsModal.sessionMessages": {
+    "defaultMessage": "Pesan sesi Anda saat ini"
+  },
+  "diagnosticsModal.systemInfo": {
+    "defaultMessage": "Informasi sistem dasar"
+  },
+  "diagnosticsModal.systemInfoErrorMsg": {
+    "defaultMessage": "Gagal mendapatkan informasi sistem"
+  },
+  "diagnosticsModal.systemInfoErrorTitle": {
+    "defaultMessage": "Kesalahan"
+  },
+  "dialog.close": {
+    "defaultMessage": "Tutup"
+  },
+  "dictationSettings.addApiKey": {
+    "defaultMessage": "Tambah Kunci API"
+  },
+  "dictationSettings.apiKey": {
+    "defaultMessage": "Kunci API"
+  },
+  "dictationSettings.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "dictationSettings.chooseVoiceConversion": {
+    "defaultMessage": "Pilih cara suara dikonversi menjadi teks"
+  },
+  "dictationSettings.configureApiKey": {
+    "defaultMessage": "Konfigurasikan kunci API di <b>{settingsPath}</b>"
+  },
+  "dictationSettings.configured": {
+    "defaultMessage": "(Terkonfigurasi)"
+  },
+  "dictationSettings.configuredIn": {
+    "defaultMessage": "✓ Terkonfigurasi di {settingsPath}"
+  },
+  "dictationSettings.disabled": {
+    "defaultMessage": "Dinonaktifkan"
+  },
+  "dictationSettings.enterApiKey": {
+    "defaultMessage": "Masukkan kunci API Anda"
+  },
+  "dictationSettings.notConfigured": {
+    "defaultMessage": "(belum dikonfigurasi)"
+  },
+  "dictationSettings.removeApiKey": {
+    "defaultMessage": "Hapus Kunci API"
+  },
+  "dictationSettings.requiredForTranscription": {
+    "defaultMessage": "Diperlukan untuk transkripsi"
+  },
+  "dictationSettings.save": {
+    "defaultMessage": "Simpan"
+  },
+  "dictationSettings.updateApiKey": {
+    "defaultMessage": "Perbarui Kunci API"
+  },
+  "dictationSettings.voiceDictationProvider": {
+    "defaultMessage": "Penyedia Dikte Suara"
+  },
+  "dirSwitcher.chooseDirectory": {
+    "defaultMessage": "Pilih direktori…"
+  },
+  "dirSwitcher.currentDirectory": {
+    "defaultMessage": "Direktori saat ini"
+  },
+  "dirSwitcher.failedToUpdateWorkingDir": {
+    "defaultMessage": "Gagal memperbarui direktori kerja"
+  },
+  "dirSwitcher.gitWorktrees": {
+    "defaultMessage": "Git worktree"
+  },
+  "dirSwitcher.noWorktreesFound": {
+    "defaultMessage": "Tidak ada worktree yang ditemukan"
+  },
+  "dirSwitcher.openInFinder": {
+    "defaultMessage": "Buka di pengelola file"
+  },
+  "dirSwitcher.recentDirectories": {
+    "defaultMessage": "Direktori terbaru"
+  },
+  "elicitationRequest.accept": {
+    "defaultMessage": "Terima"
+  },
+  "elicitationRequest.cancelled": {
+    "defaultMessage": "Permintaan informasi dibatalkan."
+  },
+  "elicitationRequest.defaultMessage": {
+    "defaultMessage": "Goose memerlukan beberapa informasi dari Anda."
+  },
+  "elicitationRequest.expired": {
+    "defaultMessage": "Permintaan ini telah kedaluwarsa. Ekstensi perlu menanyakan lagi."
+  },
+  "elicitationRequest.submit": {
+    "defaultMessage": "Kirim"
+  },
+  "elicitationRequest.submitError": {
+    "defaultMessage": "Permintaan ini tidak lagi aktif. Ekstensi perlu menanyakan lagi."
+  },
+  "elicitationRequest.submitted": {
+    "defaultMessage": "Informasi terkirim"
+  },
+  "elicitationRequest.waitingForResponse": {
+    "defaultMessage": "Menunggu respons Anda ({timeRemaining} tersisa)"
+  },
+  "envVarsSection.add": {
+    "defaultMessage": "Tambah"
+  },
+  "envVarsSection.bothRequired": {
+    "defaultMessage": "Nama variabel dan nilai harus diisi"
+  },
+  "envVarsSection.envVarsDescription": {
+    "defaultMessage": "Tambahkan pasangan kunci-nilai untuk variabel lingkungan. Klik tombol \"+\" untuk menambahkan setelah mengisi kedua bidang. Untuk nilai rahasia yang sudah ada, klik tombol edit untuk mengubahnya."
+  },
+  "envVarsSection.environmentVariables": {
+    "defaultMessage": "Variabel Lingkungan"
+  },
+  "envVarsSection.noSpaces": {
+    "defaultMessage": "Nama variabel tidak boleh mengandung spasi"
+  },
+  "envVarsSection.value": {
+    "defaultMessage": "Nilai"
+  },
+  "envVarsSection.variableName": {
+    "defaultMessage": "Nama variabel"
+  },
+  "environmentBadge.dev": {
+    "defaultMessage": "Dev"
+  },
+  "errorBoundary.errorGeneric": {
+    "defaultMessage": "Terjadi kesalahan."
+  },
+  "errorBoundary.errorWithVersion": {
+    "defaultMessage": "Terjadi kesalahan di Goose v{version}."
+  },
+  "errorBoundary.heading": {
+    "defaultMessage": "Honk!"
+  },
+  "errorBoundary.reload": {
+    "defaultMessage": "Muat ulang"
+  },
+  "extensionConfigFields.commandLabel": {
+    "defaultMessage": "Perintah"
+  },
+  "extensionConfigFields.commandPlaceholder": {
+    "defaultMessage": "mis. npx -y @modelcontextprotocol/my-extension [filepath]"
+  },
+  "extensionConfigFields.commandRequired": {
+    "defaultMessage": "Perintah diperlukan"
+  },
+  "extensionConfigFields.endpointLabel": {
+    "defaultMessage": "Endpoint"
+  },
+  "extensionConfigFields.endpointPlaceholder": {
+    "defaultMessage": "Masukkan URL endpoint..."
+  },
+  "extensionConfigFields.endpointRequired": {
+    "defaultMessage": "URL endpoint diperlukan"
+  },
+  "extensionInfoFields.descriptionLabel": {
+    "defaultMessage": "Deskripsi"
+  },
+  "extensionInfoFields.descriptionPlaceholder": {
+    "defaultMessage": "Deskripsi opsional..."
+  },
+  "extensionInfoFields.extensionName": {
+    "defaultMessage": "Nama Ekstensi"
+  },
+  "extensionInfoFields.extensionNamePlaceholder": {
+    "defaultMessage": "Masukkan nama ekstensi..."
+  },
+  "extensionInfoFields.nameRequired": {
+    "defaultMessage": "Nama diperlukan"
+  },
+  "extensionInfoFields.typeHttp": {
+    "defaultMessage": "HTTP"
+  },
+  "extensionInfoFields.typeLabel": {
+    "defaultMessage": "Tipe"
+  },
+  "extensionInfoFields.typeSseUnsupported": {
+    "defaultMessage": "SSE (tidak didukung)"
+  },
+  "extensionInfoFields.typeStandardIo": {
+    "defaultMessage": "Standard IO (STDIO)"
+  },
+  "extensionInfoFields.typeStdio": {
+    "defaultMessage": "STDIO"
+  },
+  "extensionInfoFields.typeStreamableHttp": {
+    "defaultMessage": "Streamable HTTP"
+  },
+  "extensionInstallModal.alreadyInstalledMessage": {
+    "defaultMessage": "Ekstensi ''{name}'' telah berhasil dipasang. Mulai sesi obrolan baru untuk menggunakannya."
+  },
+  "extensionInstallModal.alreadyInstalledTitle": {
+    "defaultMessage": "Ekstensi ''{name}'' Sudah Terpasang"
+  },
+  "extensionInstallModal.blockedMessage": {
+    "defaultMessage": "Perintah ekstensi ini tidak ada dalam daftar yang diizinkan dan pemasangannya diblokir. Ekstensi: {name} Perintah: {command} Hubungi administrator Anda untuk meminta persetujuan ekstensi ini."
+  },
+  "extensionInstallModal.blockedTitle": {
+    "defaultMessage": "Pemasangan Ekstensi Diblokir"
+  },
+  "extensionInstallModal.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "extensionInstallModal.installAnyway": {
+    "defaultMessage": "Tetap Pasang"
+  },
+  "extensionInstallModal.installing": {
+    "defaultMessage": "Memasang..."
+  },
+  "extensionInstallModal.no": {
+    "defaultMessage": "Tidak"
+  },
+  "extensionInstallModal.ok": {
+    "defaultMessage": "OK"
+  },
+  "extensionInstallModal.trustedMessage": {
+    "defaultMessage": "Apakah Anda yakin ingin memasang ekstensi {name}? Perintah: {command}"
+  },
+  "extensionInstallModal.trustedTitle": {
+    "defaultMessage": "Konfirmasi Pemasangan Ekstensi"
+  },
+  "extensionInstallModal.unknownCommand": {
+    "defaultMessage": "Perintah Tidak Dikenal"
+  },
+  "extensionInstallModal.untrustedMessageWithCommand": {
+    "defaultMessage": "{securityMessage} Ekstensi: {name} Perintah: {command} Hubungi administrator Anda jika Anda tidak yakin tentang ini."
+  },
+  "extensionInstallModal.untrustedMessageWithUrl": {
+    "defaultMessage": "{securityMessage} Ekstensi: {name} URL: {url} Hubungi administrator Anda jika Anda tidak yakin tentang ini."
+  },
+  "extensionInstallModal.untrustedSecurityMessage": {
+    "defaultMessage": "Perintah ekstensi ini tidak ada dalam daftar yang diizinkan dan akan dapat mengakses percakapan Anda serta menyediakan fungsionalitas tambahan. Memasang ekstensi dari sumber yang tidak tepercaya dapat menimbulkan risiko keamanan."
+  },
+  "extensionInstallModal.untrustedTitle": {
+    "defaultMessage": "Pasang Ekstensi Tidak Tepercaya?"
+  },
+  "extensionInstallModal.yes": {
+    "defaultMessage": "Ya"
+  },
+  "extensionItem.configureExtension": {
+    "defaultMessage": "Konfigurasikan Ekstensi {name}"
+  },
+  "extensionItem.toggleExtension": {
+    "defaultMessage": "Aktifkan atau Nonaktifkan ekstensi {name}"
+  },
+  "extensionList.availableExtensions": {
+    "defaultMessage": "Ekstensi Tersedia ({count})"
+  },
+  "extensionList.builtInExtension": {
+    "defaultMessage": "Ekstensi bawaan"
+  },
+  "extensionList.defaultExtensions": {
+    "defaultMessage": "Ekstensi Bawaan ({count})"
+  },
+  "extensionList.noExtensions": {
+    "defaultMessage": "Tidak ada ekstensi yang tersedia"
+  },
+  "extensionModal.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "extensionModal.closeWithoutSaving": {
+    "defaultMessage": "Tutup Tanpa Menyimpan"
+  },
+  "extensionModal.confirmRemoval": {
+    "defaultMessage": "Konfirmasi penghapusan"
+  },
+  "extensionModal.deleteDescription": {
+    "defaultMessage": "Ini akan menghapus ekstensi ini secara permanen beserta semua pengaturannya."
+  },
+  "extensionModal.deleteExtensionTitle": {
+    "defaultMessage": "Hapus Ekstensi \"{name}\""
+  },
+  "extensionModal.installationNotes": {
+    "defaultMessage": "Catatan Pemasangan"
+  },
+  "extensionModal.removeExtension": {
+    "defaultMessage": "Hapus ekstensi"
+  },
+  "extensionModal.unsavedChangesMessage": {
+    "defaultMessage": "Anda memiliki perubahan yang belum disimpan pada konfigurasi ekstensi. Apakah Anda yakin ingin menutup tanpa menyimpan?"
+  },
+  "extensionModal.unsavedChangesTitle": {
+    "defaultMessage": "Perubahan Belum Disimpan"
+  },
+  "extensionTimeoutField.timeoutLabel": {
+    "defaultMessage": "Batas Waktu"
+  },
+  "extensionsSection.addCustomExtension": {
+    "defaultMessage": "Tambah ekstensi khusus"
+  },
+  "extensionsSection.addExtension": {
+    "defaultMessage": "Tambah Ekstensi"
+  },
+  "extensionsSection.browseExtensions": {
+    "defaultMessage": "Jelajahi ekstensi"
+  },
+  "extensionsSection.saveChanges": {
+    "defaultMessage": "Simpan Perubahan"
+  },
+  "extensionsSection.updateExtension": {
+    "defaultMessage": "Perbarui Ekstensi"
+  },
+  "extensionsView.addCustomExtension": {
+    "defaultMessage": "Tambah ekstensi khusus"
+  },
+  "extensionsView.addExtension": {
+    "defaultMessage": "Tambah Ekstensi"
+  },
+  "extensionsView.browseExtensions": {
+    "defaultMessage": "Jelajahi ekstensi"
+  },
+  "extensionsView.defaultNote": {
+    "defaultMessage": "Ekstensi yang diaktifkan di sini digunakan sebagai bawaan untuk obrolan baru. Anda juga dapat mengaktifkan ekstensi aktif selama obrolan."
+  },
+  "extensionsView.description": {
+    "defaultMessage": "Ekstensi ini menggunakan Model Context Protocol (MCP). Mereka dapat memperluas kemampuan Goose menggunakan tiga komponen utama: Prompt, Sumber Daya, dan Alat. {searchShortcut} untuk mencari."
+  },
+  "extensionsView.heading": {
+    "defaultMessage": "Ekstensi"
+  },
+  "extensionsView.searchPlaceholder": {
+    "defaultMessage": "Cari ekstensi..."
+  },
+  "externalBackendSection.certFingerprint": {
+    "defaultMessage": "Sidik Jari Sertifikat (opsional)"
+  },
+  "externalBackendSection.certFingerprintHelp": {
+    "defaultMessage": "Sematkan sidik jari sertifikat TLS tertentu. Jika dihilangkan, sertifikat dipercaya saat pertama kali digunakan (TOFU)."
+  },
+  "externalBackendSection.certFingerprintPlaceholder": {
+    "defaultMessage": "AA:BB:CC:... atau sha256/base64"
+  },
+  "externalBackendSection.description": {
+    "defaultMessage": "Secara bawaan goose menjalankan server untuk Anda, gunakan ini untuk terhubung ke server goose eksternal"
+  },
+  "externalBackendSection.restartNote": {
+    "defaultMessage": "Perubahan memerlukan mulai ulang Goose agar berlaku. Jendela obrolan baru akan terhubung ke server eksternal."
+  },
+  "externalBackendSection.secretKey": {
+    "defaultMessage": "Kunci Rahasia"
+  },
+  "externalBackendSection.secretKeyHelp": {
+    "defaultMessage": "Kunci rahasia yang dikonfigurasi pada server goosed (GOOSE_SERVER__SECRET_KEY)"
+  },
+  "externalBackendSection.secretKeyPlaceholder": {
+    "defaultMessage": "Masukkan kunci rahasia server"
+  },
+  "externalBackendSection.serverUrl": {
+    "defaultMessage": "URL Server"
+  },
+  "externalBackendSection.title": {
+    "defaultMessage": "Server Goose"
+  },
+  "externalBackendSection.urlFormatError": {
+    "defaultMessage": "Format URL tidak valid"
+  },
+  "externalBackendSection.urlProtocolError": {
+    "defaultMessage": "URL harus menggunakan protokol http atau https"
+  },
+  "externalBackendSection.useExternalServer": {
+    "defaultMessage": "Gunakan server eksternal"
+  },
+  "externalBackendSection.useExternalServerDescription": {
+    "defaultMessage": "Terhubung ke server goose yang berjalan di tempat lain (memerlukan mulai ulang aplikasi)"
+  },
+  "freeOptionCards.chooseOption": {
+    "defaultMessage": "Pilih opsi untuk memulai."
+  },
+  "freeOptionCards.freeAndPrivate": {
+    "defaultMessage": "Gratis & Pribadi"
+  },
+  "freeOptionCards.localModelDescription": {
+    "defaultMessage": "Unduh model dan jalankan sepenuhnya di mesin Anda. Tanpa kunci API, tanpa akun."
+  },
+  "freeOptionCards.localModelTitle": {
+    "defaultMessage": "Gunakan Model Lokal"
+  },
+  "freeOptionCards.nanogptDescription": {
+    "defaultMessage": "Daftar untuk menerima 60 juta token gratis selama 7 hari."
+  },
+  "freeOptionCards.nanogptTitle": {
+    "defaultMessage": "NanoGPT"
+  },
+  "freeOptionCards.retry": {
+    "defaultMessage": "Coba lagi"
+  },
+  "freeOptionCards.tetrateDescription": {
+    "defaultMessage": "Akses beberapa model AI dengan penyiapan otomatis. Daftar untuk menerima kredit $10."
+  },
+  "freeOptionCards.tetrateTitle": {
+    "defaultMessage": "Agent Router oleh Tetrate"
+  },
+  "freeOptionCards.unexpectedError": {
+    "defaultMessage": "Terjadi kesalahan tak terduga selama penyiapan."
+  },
+  "goosehintsModal.close": {
+    "defaultMessage": "Tutup"
+  },
+  "goosehintsModal.developer": {
+    "defaultMessage": "Pengembang"
+  },
+  "goosehintsModal.dialogDescription": {
+    "defaultMessage": "Berikan konteks tambahan tentang proyek Anda untuk meningkatkan komunikasi dengan Goose"
+  },
+  "goosehintsModal.dialogTitle": {
+    "defaultMessage": "Konfigurasikan Petunjuk Proyek (.goosehints)"
+  },
+  "goosehintsModal.errorReading": {
+    "defaultMessage": "Kesalahan membaca file .goosehints: {error}"
+  },
+  "goosehintsModal.failedToAccess": {
+    "defaultMessage": "Gagal mengakses file .goosehints"
+  },
+  "goosehintsModal.failedToSave": {
+    "defaultMessage": "Gagal menyimpan file .goosehints"
+  },
+  "goosehintsModal.fileCreating": {
+    "defaultMessage": "Membuat file .goosehints baru di: {filePath}"
+  },
+  "goosehintsModal.fileFound": {
+    "defaultMessage": "File .goosehints ditemukan di: {filePath}"
+  },
+  "goosehintsModal.helpText1": {
+    "defaultMessage": ".goosehints adalah file teks yang digunakan untuk memberikan konteks tambahan tentang proyek Anda dan meningkatkan komunikasi dengan Goose."
+  },
+  "goosehintsModal.helpText2": {
+    "defaultMessage": "Pastikan ekstensi {bold} diaktifkan di halaman ekstensi. Ekstensi ini diperlukan untuk menggunakan .goosehints. Anda perlu memulai ulang sesi agar pembaruan .goosehints berlaku."
+  },
+  "goosehintsModal.helpText3": {
+    "defaultMessage": "Lihat {link} untuk informasi lebih lanjut."
+  },
+  "goosehintsModal.helpTextLink": {
+    "defaultMessage": "menggunakan .goosehints"
+  },
+  "goosehintsModal.placeholder": {
+    "defaultMessage": "Masukkan petunjuk proyek di sini..."
+  },
+  "goosehintsModal.save": {
+    "defaultMessage": "Simpan"
+  },
+  "goosehintsModal.savedSuccessfully": {
+    "defaultMessage": "Berhasil disimpan"
+  },
+  "goosehintsModal.saving": {
+    "defaultMessage": "Menyimpan..."
+  },
+  "goosehintsSection.configure": {
+    "defaultMessage": "Konfigurasikan"
+  },
+  "goosehintsSection.description": {
+    "defaultMessage": "Konfigurasikan file .goosehints proyek Anda untuk memberikan konteks tambahan ke Goose"
+  },
+  "goosehintsSection.title": {
+    "defaultMessage": "Petunjuk Proyek (.goosehints)"
+  },
+  "groupedExtensionLoadingToast.askGoose": {
+    "defaultMessage": "Tanya goose"
+  },
+  "groupedExtensionLoadingToast.collapseDetails": {
+    "defaultMessage": "Ciutkan detail"
+  },
+  "groupedExtensionLoadingToast.copied": {
+    "defaultMessage": "Tersalin!"
+  },
+  "groupedExtensionLoadingToast.copyError": {
+    "defaultMessage": "Kesalahan penyalinan"
+  },
+  "groupedExtensionLoadingToast.expandDetails": {
+    "defaultMessage": "Perluas detail"
+  },
+  "groupedExtensionLoadingToast.failedToAddExtension": {
+    "defaultMessage": "Gagal menambahkan ekstensi"
+  },
+  "groupedExtensionLoadingToast.failedToLoad": {
+    "defaultMessage": "{count,plural,one{# ekstensi gagal dimuat} other{# ekstensi gagal dimuat}}"
+  },
+  "groupedExtensionLoadingToast.loadingExtensions": {
+    "defaultMessage": "{count,plural,one{Memuat # ekstensi...} other{Memuat # ekstensi...}}"
+  },
+  "groupedExtensionLoadingToast.partiallyLoaded": {
+    "defaultMessage": "{totalCount,plural,one{Memuat {successCount}/# ekstensi} other{Memuat {successCount}/# ekstensi}}"
+  },
+  "groupedExtensionLoadingToast.showDetails": {
+    "defaultMessage": "Tampilkan detail"
+  },
+  "groupedExtensionLoadingToast.showLess": {
+    "defaultMessage": "Tampilkan lebih sedikit"
+  },
+  "groupedExtensionLoadingToast.successfullyLoaded": {
+    "defaultMessage": "{count,plural,one{Berhasil memuat # ekstensi} other{Berhasil memuat # ekstensi}}"
+  },
+  "headersSection.add": {
+    "defaultMessage": "Tambah"
+  },
+  "headersSection.bothRequired": {
+    "defaultMessage": "Nama header dan nilai harus diisi"
+  },
+  "headersSection.duplicateHeader": {
+    "defaultMessage": "Header dengan nama ini sudah ada"
+  },
+  "headersSection.headerName": {
+    "defaultMessage": "Nama header"
+  },
+  "headersSection.headersDescription": {
+    "defaultMessage": "Tambahkan header HTTP khusus untuk disertakan dalam permintaan ke server MCP. Klik tombol \"+\" untuk menambahkan setelah mengisi kedua bidang."
+  },
+  "headersSection.noSpaces": {
+    "defaultMessage": "Nama header tidak boleh mengandung spasi"
+  },
+  "headersSection.requestHeaders": {
+    "defaultMessage": "Header Permintaan"
+  },
+  "headersSection.value": {
+    "defaultMessage": "Nilai"
+  },
+  "hub.goodAfternoon": {
+    "defaultMessage": "Selamat siang"
+  },
+  "hub.goodEvening": {
+    "defaultMessage": "Selamat malam"
+  },
+  "hub.goodMorning": {
+    "defaultMessage": "Selamat pagi"
+  },
+  "huggingFaceModelSearch.download": {
+    "defaultMessage": "Unduh"
+  },
+  "huggingFaceModelSearch.downloaded": {
+    "defaultMessage": "Terunduh"
+  },
+  "huggingFaceModelSearch.downloading": {
+    "defaultMessage": "Mengunduh…"
+  },
+  "huggingFaceModelSearch.loadingVariants": {
+    "defaultMessage": "Memuat varian..."
+  },
+  "huggingFaceModelSearch.noGgufModels": {
+    "defaultMessage": "Tidak ada model lokal yang kompatibel ditemukan untuk kueri ini."
+  },
+  "huggingFaceModelSearch.recommended": {
+    "defaultMessage": "Direkomendasikan"
+  },
+  "huggingFaceModelSearch.searchError": {
+    "defaultMessage": "Kesalahan pencarian: {details}"
+  },
+  "huggingFaceModelSearch.searchFailed": {
+    "defaultMessage": "Pencarian gagal. Silakan coba lagi."
+  },
+  "huggingFaceModelSearch.searchHuggingFace": {
+    "defaultMessage": "Cari HuggingFace"
+  },
+  "huggingFaceModelSearch.searchNoData": {
+    "defaultMessage": "Pencarian tidak mengembalikan data."
+  },
+  "huggingFaceModelSearch.searchPlaceholder": {
+    "defaultMessage": "Cari model lokal..."
+  },
+  "huggingFaceModelSearch.tooLarge": {
+    "defaultMessage": "Mungkin tidak muat dalam memori (model {size}, {available} tersedia)"
+  },
+  "huggingFaceSignInPrompt.failedToConfigure": {
+    "defaultMessage": "Gagal masuk ke Hugging Face: {error}"
+  },
+  "huggingFaceSignInPrompt.signIn": {
+    "defaultMessage": "Masuk"
+  },
+  "huggingFaceSignInPrompt.signedIn": {
+    "defaultMessage": "Hugging Face telah masuk"
+  },
+  "huggingFaceSignInPrompt.signingIn": {
+    "defaultMessage": "Sedang masuk..."
+  },
+  "huggingFaceSignInPrompt.title": {
+    "defaultMessage": "Hugging Face"
+  },
+  "imagePreview.altText": {
+    "defaultMessage": "gambar goose"
+  },
+  "imagePreview.clickToCollapse": {
+    "defaultMessage": "Klik untuk menciutkan"
+  },
+  "imagePreview.clickToExpand": {
+    "defaultMessage": "Klik untuk memperluas"
+  },
+  "imagePreview.unableToLoad": {
+    "defaultMessage": "Tidak dapat memuat gambar"
+  },
+  "importRecipeForm.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "importRecipeForm.deeplinkHint": {
+    "defaultMessage": "Tempelkan deeplink resep yang dimulai dengan \"goose://recipe?config=\""
+  },
+  "importRecipeForm.deeplinkPlaceholder": {
+    "defaultMessage": "Tempelkan deeplink goose://recipe?config=... Anda di sini"
+  },
+  "importRecipeForm.example": {
+    "defaultMessage": "contoh"
+  },
+  "importRecipeForm.expectedRecipeStructure": {
+    "defaultMessage": "Struktur Resep yang Diharapkan"
+  },
+  "importRecipeForm.importRecipeButton": {
+    "defaultMessage": "Impor Resep"
+  },
+  "importRecipeForm.importRecipeTitle": {
+    "defaultMessage": "Impor Resep"
+  },
+  "importRecipeForm.importing": {
+    "defaultMessage": "Mengimpor..."
+  },
+  "importRecipeForm.or": {
+    "defaultMessage": "ATAU"
+  },
+  "importRecipeForm.recipeDeeplinkLabel": {
+    "defaultMessage": "Deeplink Resep"
+  },
+  "importRecipeForm.recipeFileHint": {
+    "defaultMessage": "Unggah file YAML atau JSON yang berisi struktur resep"
+  },
+  "importRecipeForm.recipeFileLabel": {
+    "defaultMessage": "File Resep"
+  },
+  "importRecipeForm.reviewWarning": {
+    "defaultMessage": "Pastikan Anda meninjau konten file resep sebelum menambahkannya ke antarmuka goose Anda."
+  },
+  "importRecipeForm.schemaDescription": {
+    "defaultMessage": "File YAML atau JSON Anda harus mengikuti struktur ini. Bidang yang diperlukan adalah: title, description, dan salah satu dari instructions atau prompt."
+  },
+  "inlineEditText.clickToEdit": {
+    "defaultMessage": "Klik untuk mengedit"
+  },
+  "inlineEditText.doubleClickToEdit": {
+    "defaultMessage": "Klik dua kali untuk mengedit"
+  },
+  "inlineEditText.enterText": {
+    "defaultMessage": "Masukkan teks"
+  },
+  "inlineEditText.failedToSave": {
+    "defaultMessage": "Gagal menyimpan"
+  },
+  "instructionsEditor.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "instructionsEditor.insertExample": {
+    "defaultMessage": "Sisipkan Contoh"
+  },
+  "instructionsEditor.label": {
+    "defaultMessage": "Instruksi"
+  },
+  "instructionsEditor.placeholder": {
+    "defaultMessage": "Instruksi terperinci untuk AI, disembunyikan dari pengguna"
+  },
+  "instructionsEditor.save": {
+    "defaultMessage": "Simpan Instruksi"
+  },
+  "instructionsEditor.syntaxHelp": {
+    "defaultMessage": "Gunakan sintaks {code} untuk mendefinisikan parameter yang dapat diisi pengguna"
+  },
+  "instructionsEditor.title": {
+    "defaultMessage": "Editor Instruksi"
+  },
+  "jsonSchemaEditor.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "jsonSchemaEditor.description": {
+    "defaultMessage": "Definisikan struktur respons AI yang diharapkan menggunakan format JSON Schema"
+  },
+  "jsonSchemaEditor.insertExample": {
+    "defaultMessage": "Sisipkan Contoh"
+  },
+  "jsonSchemaEditor.invalidJson": {
+    "defaultMessage": "Format JSON tidak valid"
+  },
+  "jsonSchemaEditor.label": {
+    "defaultMessage": "JSON Schema Respons"
+  },
+  "jsonSchemaEditor.save": {
+    "defaultMessage": "Simpan Skema"
+  },
+  "jsonSchemaEditor.title": {
+    "defaultMessage": "Editor JSON Schema"
+  },
+  "jsonSchemaForm.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "jsonSchemaForm.fieldRequired": {
+    "defaultMessage": "Bidang ini diperlukan"
+  },
+  "jsonSchemaForm.maxLength": {
+    "defaultMessage": "Panjang maksimum adalah {maxLength}"
+  },
+  "jsonSchemaForm.maxValue": {
+    "defaultMessage": "Nilai maksimum adalah {maximum}"
+  },
+  "jsonSchemaForm.minLength": {
+    "defaultMessage": "Panjang minimum adalah {minLength}"
+  },
+  "jsonSchemaForm.minValue": {
+    "defaultMessage": "Nilai minimum adalah {minimum}"
+  },
+  "jsonSchemaForm.noFields": {
+    "defaultMessage": "Tidak ada bidang untuk ditampilkan"
+  },
+  "jsonSchemaForm.selectPlaceholder": {
+    "defaultMessage": "Pilih..."
+  },
+  "jsonSchemaForm.submit": {
+    "defaultMessage": "Kirim"
+  },
+  "keyValueEditor.addValue": {
+    "defaultMessage": "Tambahkan nilai prakonfigurasi"
+  },
+  "keyValueEditor.defaultKeyPlaceholder": {
+    "defaultMessage": "Nama parameter..."
+  },
+  "keyValueEditor.defaultValuePlaceholder": {
+    "defaultMessage": "Nilai parameter..."
+  },
+  "keyValueEditor.removeValue": {
+    "defaultMessage": "Hapus nilai prakonfigurasi {key}"
+  },
+  "keyboardShortcuts.alwaysOnTopDescription": {
+    "defaultMessage": "Aktifkan jendela selalu di atas"
+  },
+  "keyboardShortcuts.alwaysOnTopLabel": {
+    "defaultMessage": "Selalu di Atas"
+  },
+  "keyboardShortcuts.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "keyboardShortcuts.categoryApplication": {
+    "defaultMessage": "Pintasan Aplikasi"
+  },
+  "keyboardShortcuts.categoryApplicationDescription": {
+    "defaultMessage": "Pintasan ini berfungsi saat Goose menjadi aplikasi aktif"
+  },
+  "keyboardShortcuts.categoryGlobal": {
+    "defaultMessage": "Pintasan Global"
+  },
+  "keyboardShortcuts.categoryGlobalDescription": {
+    "defaultMessage": "Pintasan ini berfungsi di seluruh sistem, bahkan saat Goose tidak difokuskan"
+  },
+  "keyboardShortcuts.categorySearch": {
+    "defaultMessage": "Pintasan Pencarian"
+  },
+  "keyboardShortcuts.categorySearchDescription": {
+    "defaultMessage": "Pintasan ini berfungsi saat mencari dalam percakapan"
+  },
+  "keyboardShortcuts.categoryWindow": {
+    "defaultMessage": "Pintasan Jendela"
+  },
+  "keyboardShortcuts.categoryWindowDescription": {
+    "defaultMessage": "Pintasan ini mengontrol perilaku jendela"
+  },
+  "keyboardShortcuts.change": {
+    "defaultMessage": "Ubah"
+  },
+  "keyboardShortcuts.disabled": {
+    "defaultMessage": "Dinonaktifkan"
+  },
+  "keyboardShortcuts.dismiss": {
+    "defaultMessage": "Tutup"
+  },
+  "keyboardShortcuts.findDescription": {
+    "defaultMessage": "Buka pencarian dalam percakapan"
+  },
+  "keyboardShortcuts.findLabel": {
+    "defaultMessage": "Cari"
+  },
+  "keyboardShortcuts.findNextDescription": {
+    "defaultMessage": "Lompat ke hasil pencarian berikutnya"
+  },
+  "keyboardShortcuts.findNextLabel": {
+    "defaultMessage": "Cari Berikutnya"
+  },
+  "keyboardShortcuts.findPreviousDescription": {
+    "defaultMessage": "Lompat ke hasil pencarian sebelumnya"
+  },
+  "keyboardShortcuts.findPreviousLabel": {
+    "defaultMessage": "Cari Sebelumnya"
+  },
+  "keyboardShortcuts.focusWindowDescription": {
+    "defaultMessage": "Bawa jendela Goose ke depan dari mana saja"
+  },
+  "keyboardShortcuts.focusWindowLabel": {
+    "defaultMessage": "Fokuskan Jendela Goose"
+  },
+  "keyboardShortcuts.loading": {
+    "defaultMessage": "Memuat..."
+  },
+  "keyboardShortcuts.newChatDescription": {
+    "defaultMessage": "Buat obrolan baru di jendela saat ini"
+  },
+  "keyboardShortcuts.newChatLabel": {
+    "defaultMessage": "Obrolan Baru"
+  },
+  "keyboardShortcuts.newChatWindowDescription": {
+    "defaultMessage": "Buka jendela Goose baru"
+  },
+  "keyboardShortcuts.newChatWindowLabel": {
+    "defaultMessage": "Jendela Obrolan Baru"
+  },
+  "keyboardShortcuts.openDirectoryDescription": {
+    "defaultMessage": "Buka dialog pemilihan direktori"
+  },
+  "keyboardShortcuts.openDirectoryLabel": {
+    "defaultMessage": "Buka Direktori"
+  },
+  "keyboardShortcuts.quickLauncherDescription": {
+    "defaultMessage": "Buka lapisan peluncur cepat"
+  },
+  "keyboardShortcuts.quickLauncherLabel": {
+    "defaultMessage": "Peluncur Cepat"
+  },
+  "keyboardShortcuts.reassignShortcut": {
+    "defaultMessage": "Tetapkan Ulang Pintasan"
+  },
+  "keyboardShortcuts.resetAllShortcuts": {
+    "defaultMessage": "Atur Ulang Semua Pintasan"
+  },
+  "keyboardShortcuts.resetShortcutsDetail": {
+    "defaultMessage": "Ini akan mengembalikan semua pintasan ke konfigurasi aslinya."
+  },
+  "keyboardShortcuts.resetShortcutsMessage": {
+    "defaultMessage": "Atur ulang semua pintasan keyboard ke nilai default-nya?"
+  },
+  "keyboardShortcuts.resetShortcutsTitle": {
+    "defaultMessage": "Atur Ulang Pintasan Keyboard"
+  },
+  "keyboardShortcuts.resetToDefaultsDescription": {
+    "defaultMessage": "Kembalikan semua pintasan keyboard ke konfigurasi aslinya"
+  },
+  "keyboardShortcuts.resetToDefaultsHeading": {
+    "defaultMessage": "Atur Ulang ke Default"
+  },
+  "keyboardShortcuts.restartDescription": {
+    "defaultMessage": "Perubahan pada pintasan aplikasi (seperti Obrolan Baru, Pengaturan, dll.) memerlukan memulai ulang Goose agar berlaku. Pintasan global (Fokuskan Jendela, Peluncur Cepat) berfungsi segera."
+  },
+  "keyboardShortcuts.restartRequired": {
+    "defaultMessage": "Perlu Memulai Ulang"
+  },
+  "keyboardShortcuts.settingsDescription": {
+    "defaultMessage": "Buka panel pengaturan"
+  },
+  "keyboardShortcuts.settingsLabel": {
+    "defaultMessage": "Pengaturan"
+  },
+  "keyboardShortcuts.shortcutConflictSaveDetail": {
+    "defaultMessage": "Menyimpan ini akan menghapus pintasan dari \"{conflictLabel}\" dan menetapkannya ke \"{targetLabel}\". Apakah Anda ingin melanjutkan?"
+  },
+  "keyboardShortcuts.shortcutConflictTitle": {
+    "defaultMessage": "Konflik Pintasan"
+  },
+  "keyboardShortcuts.shortcutConflictToggleDetail": {
+    "defaultMessage": "Mengaktifkan ini akan menghapus pintasan dari \"{conflictLabel}\" dan menetapkannya ke \"{targetLabel}\". Apakah Anda ingin melanjutkan?"
+  },
+  "keyboardShortcuts.shortcutConflictToggleMessage": {
+    "defaultMessage": "Pintasan {shortcut} sudah ditetapkan ke \"{conflictLabel}\"."
+  },
+  "keyboardShortcuts.toggleNavigationDescription": {
+    "defaultMessage": "Tampilkan atau sembunyikan menu navigasi"
+  },
+  "keyboardShortcuts.toggleNavigationLabel": {
+    "defaultMessage": "Alihkan Navigasi"
+  },
+  "launcher.placeholder": {
+    "defaultMessage": "Tanyakan apa saja kepada goose..."
+  },
+  "loadingGoose.compacting": {
+    "defaultMessage": "goose sedang meringkas percakapan..."
+  },
+  "loadingGoose.idle": {
+    "defaultMessage": "goose sedang mengerjakannya…"
+  },
+  "loadingGoose.loadingConversation": {
+    "defaultMessage": "memuat percakapan..."
+  },
+  "loadingGoose.restartingAgent": {
+    "defaultMessage": "memulai ulang sesi..."
+  },
+  "loadingGoose.streaming": {
+    "defaultMessage": "goose sedang mengerjakannya…"
+  },
+  "loadingGoose.thinking": {
+    "defaultMessage": "goose sedang berpikir…"
+  },
+  "loadingGoose.waiting": {
+    "defaultMessage": "goose sedang menunggu…"
+  },
+  "localInferenceSettings.deleteConfirm": {
+    "defaultMessage": "Hapus model ini? Anda dapat mengunduhnya kembali nanti."
+  },
+  "localInferenceSettings.description": {
+    "defaultMessage": "Unduh dan kelola model LLM lokal untuk inferensi tanpa kunci API. Cari model GGUF atau MLX di HuggingFace, atau gunakan pilihan unggulan di bawah."
+  },
+  "localInferenceSettings.dismiss": {
+    "defaultMessage": "Tutup"
+  },
+  "localInferenceSettings.download": {
+    "defaultMessage": "Unduh"
+  },
+  "localInferenceSettings.downloadCancelled": {
+    "defaultMessage": "Unduhan dibatalkan"
+  },
+  "localInferenceSettings.downloadFailed": {
+    "defaultMessage": "Unduhan gagal"
+  },
+  "localInferenceSettings.downloadProgress": {
+    "defaultMessage": "{downloaded} / {total} ({percent}%)"
+  },
+  "localInferenceSettings.downloadedModels": {
+    "defaultMessage": "Model yang Diunduh"
+  },
+  "localInferenceSettings.downloading": {
+    "defaultMessage": "Mengunduh"
+  },
+  "localInferenceSettings.featuredModels": {
+    "defaultMessage": "Model Unggulan"
+  },
+  "localInferenceSettings.huggingFaceSignInNote": {
+    "defaultMessage": "Masuk untuk meningkatkan batas laju saat mencari dan mengunduh model, serta untuk mengakses repositori Hugging Face yang privat atau terbatas."
+  },
+  "localInferenceSettings.modelSettings": {
+    "defaultMessage": "Pengaturan Model"
+  },
+  "localInferenceSettings.modelSettingsTitle": {
+    "defaultMessage": "Pengaturan model"
+  },
+  "localInferenceSettings.noModels": {
+    "defaultMessage": "Tidak ada model yang tersedia"
+  },
+  "localInferenceSettings.recommended": {
+    "defaultMessage": "Direkomendasikan"
+  },
+  "localInferenceSettings.remaining": {
+    "defaultMessage": "{time} tersisa"
+  },
+  "localInferenceSettings.retry": {
+    "defaultMessage": "Coba Lagi"
+  },
+  "localInferenceSettings.showAllFeatured": {
+    "defaultMessage": "Tampilkan semua unggulan ({count} lainnya)"
+  },
+  "localInferenceSettings.showRecommendedOnly": {
+    "defaultMessage": "Tampilkan yang direkomendasikan saja"
+  },
+  "localInferenceSettings.title": {
+    "defaultMessage": "Model Inferensi Lokal"
+  },
+  "localInferenceSettings.vision": {
+    "defaultMessage": "Visi"
+  },
+  "localInferenceSettings.visionEncoderDownloading": {
+    "defaultMessage": "Mengunduh encoder visi…"
+  },
+  "localInferenceSettings.visionEncoderNotDownloaded": {
+    "defaultMessage": "Encoder visi belum diunduh"
+  },
+  "localModelManager.active": {
+    "defaultMessage": "Aktif"
+  },
+  "localModelManager.deleteConfirm": {
+    "defaultMessage": "Hapus model ini? Anda dapat mengunduhnya kembali nanti."
+  },
+  "localModelManager.download": {
+    "defaultMessage": "Unduh"
+  },
+  "localModelManager.downloaded": {
+    "defaultMessage": "Diunduh"
+  },
+  "localModelManager.gpuAcceleration": {
+    "defaultMessage": "Mendukung akselerasi GPU (CUDA untuk NVIDIA, Metal untuk Apple Silicon). Fitur GPU harus diaktifkan saat waktu build untuk akselerasi perangkat keras."
+  },
+  "localModelManager.noModels": {
+    "defaultMessage": "Tidak ada model yang tersedia"
+  },
+  "localModelManager.recommended": {
+    "defaultMessage": "Direkomendasikan"
+  },
+  "localModelManager.recommendedForHardware": {
+    "defaultMessage": "Direkomendasikan untuk perangkat keras Anda"
+  },
+  "localModelManager.showAllModels": {
+    "defaultMessage": "Tampilkan semua model ({count} lainnya)"
+  },
+  "localModelManager.showRecommendedOnly": {
+    "defaultMessage": "Tampilkan yang direkomendasikan saja"
+  },
+  "localModelPicker.back": {
+    "defaultMessage": "Kembali"
+  },
+  "localModelPicker.bestForMachine": {
+    "defaultMessage": "Terbaik untuk mesin Anda"
+  },
+  "localModelPicker.cancelDownload": {
+    "defaultMessage": "Batalkan Unduhan"
+  },
+  "localModelPicker.checkingModels": {
+    "defaultMessage": "Memeriksa model yang tersedia..."
+  },
+  "localModelPicker.downloadModel": {
+    "defaultMessage": "Unduh {modelId} ({size})"
+  },
+  "localModelPicker.downloading": {
+    "defaultMessage": "Mengunduh {modelId}"
+  },
+  "localModelPicker.failedToLoad": {
+    "defaultMessage": "Gagal memuat model yang tersedia. Silakan coba lagi."
+  },
+  "localModelPicker.failedToStartDownload": {
+    "defaultMessage": "Gagal memulai unduhan. Silakan coba lagi."
+  },
+  "localModelPicker.hideOtherSizes": {
+    "defaultMessage": "Sembunyikan ukuran lainnya"
+  },
+  "localModelPicker.localModelsNote": {
+    "defaultMessage": "Model lokal menyimpan semuanya di mesin Anda untuk privasi penuh. Kinerja dan ukuran jendela konteks dapat bervariasi dibandingkan penyedia cloud tergantung pada perangkat keras dan ukuran model Anda."
+  },
+  "localModelPicker.lostConnection": {
+    "defaultMessage": "Koneksi ke unduhan terputus. Silakan coba lagi."
+  },
+  "localModelPicker.modelNotFound": {
+    "defaultMessage": "Model tidak ditemukan"
+  },
+  "localModelPicker.ready": {
+    "defaultMessage": "Siap"
+  },
+  "localModelPicker.selectModel": {
+    "defaultMessage": "Pilih model"
+  },
+  "localModelPicker.showOtherSizes": {
+    "defaultMessage": "Tampilkan {count} ukuran lainnya"
+  },
+  "localModelPicker.startingDownload": {
+    "defaultMessage": "Memulai unduhan..."
+  },
+  "localModelPicker.tryAgain": {
+    "defaultMessage": "Coba Lagi"
+  },
+  "localModelPicker.useModel": {
+    "defaultMessage": "Gunakan {modelId}"
+  },
+  "markdownContent.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "markdownContent.copyCode": {
+    "defaultMessage": "Salin kode"
+  },
+  "markdownContent.failedToOpenLink": {
+    "defaultMessage": "Gagal Membuka Tautan"
+  },
+  "markdownContent.noApplicationFound": {
+    "defaultMessage": "Tidak ada aplikasi yang ditemukan untuk membuka tautan ini."
+  },
+  "markdownContent.open": {
+    "defaultMessage": "Buka"
+  },
+  "markdownContent.openExternalLink": {
+    "defaultMessage": "Buka Tautan Eksternal"
+  },
+  "markdownContent.openProtocolLink": {
+    "defaultMessage": "Buka tautan {protocol}?"
+  },
+  "markdownContent.thisWillOpen": {
+    "defaultMessage": "Ini akan membuka: {href}"
+  },
+  "mcpAppRenderer.appFallbackTitle": {
+    "defaultMessage": "Aplikasi"
+  },
+  "mcpAppRenderer.cancelButton": {
+    "defaultMessage": "Batal"
+  },
+  "mcpAppRenderer.close": {
+    "defaultMessage": "Tutup"
+  },
+  "mcpAppRenderer.exitFullscreen": {
+    "defaultMessage": "Keluar dari layar penuh"
+  },
+  "mcpAppRenderer.exitFullscreenTitle": {
+    "defaultMessage": "Keluar dari layar penuh (Esc)"
+  },
+  "mcpAppRenderer.failedToInitSandbox": {
+    "defaultMessage": "Gagal menginisialisasi proksi sandbox"
+  },
+  "mcpAppRenderer.failedToLoadResource": {
+    "defaultMessage": "Gagal memuat sumber daya"
+  },
+  "mcpAppRenderer.fullscreen": {
+    "defaultMessage": "Layar penuh"
+  },
+  "mcpAppRenderer.invalidUrl": {
+    "defaultMessage": "URL tidak valid"
+  },
+  "mcpAppRenderer.movePipWindow": {
+    "defaultMessage": "Pindahkan jendela Picture-in-Picture (gunakan tombol panah)"
+  },
+  "mcpAppRenderer.openButton": {
+    "defaultMessage": "Buka"
+  },
+  "mcpAppRenderer.openExternalLinkTitle": {
+    "defaultMessage": "Buka Tautan Eksternal"
+  },
+  "mcpAppRenderer.openLinkDetail": {
+    "defaultMessage": "Ini akan membuka: {url}"
+  },
+  "mcpAppRenderer.openProtocolLink": {
+    "defaultMessage": "Buka tautan {protocol}?"
+  },
+  "mcpAppRenderer.pictureInPicture": {
+    "defaultMessage": "Picture-in-Picture"
+  },
+  "mcpAppRenderer.playingInPip": {
+    "defaultMessage": "Memutar dalam Picture-in-Picture"
+  },
+  "mcpUIResourceRenderer.cancelButton": {
+    "defaultMessage": "Batal"
+  },
+  "mcpUIResourceRenderer.openButton": {
+    "defaultMessage": "Buka"
+  },
+  "mcpUIResourceRenderer.openExternalLinkTitle": {
+    "defaultMessage": "Buka Tautan Eksternal"
+  },
+  "mcpUIResourceRenderer.openLinkDetail": {
+    "defaultMessage": "Ini akan membuka: {url}"
+  },
+  "mcpUIResourceRenderer.openProtocolLink": {
+    "defaultMessage": "Buka tautan {protocol}?"
+  },
+  "mcpUIResourceRenderer.toastMessageReceived": {
+    "defaultMessage": "Pesan diterima untuk {message}."
+  },
+  "mcpUIResourceRenderer.toastTitle": {
+    "defaultMessage": "Pesan MCP-UI {messageType}"
+  },
+  "mcpUIResourceRenderer.toastUnsupported": {
+    "defaultMessage": "Pesan diterima untuk {message}. Pesan {messageType} belum didukung, lihat konsol untuk detail lebih lanjut."
+  },
+  "mentionPopover.itemsFound": {
+    "defaultMessage": "{count,plural,one{# item ditemukan} other{# item ditemukan}}"
+  },
+  "mentionPopover.loadingCommands": {
+    "defaultMessage": "Memuat perintah..."
+  },
+  "mentionPopover.noCommandsFound": {
+    "defaultMessage": "Tidak ada perintah yang cocok dengan \"{query}\""
+  },
+  "mentionPopover.noItemsFound": {
+    "defaultMessage": "Tidak ada item yang cocok dengan \"{query}\""
+  },
+  "mentionPopover.scanningFiles": {
+    "defaultMessage": "Memindai file..."
+  },
+  "messageCopyLink.copied": {
+    "defaultMessage": "Disalin!"
+  },
+  "messageCopyLink.copy": {
+    "defaultMessage": "Salin"
+  },
+  "messageQueue.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "messageQueue.cannotSendWhileEditing": {
+    "defaultMessage": "Tidak dapat mengirim saat mengedit"
+  },
+  "messageQueue.clearAll": {
+    "defaultMessage": "Hapus Semua"
+  },
+  "messageQueue.clickToEdit": {
+    "defaultMessage": "{content} (Klik untuk mengedit)"
+  },
+  "messageQueue.collapseQueue": {
+    "defaultMessage": "Ciutkan antrean"
+  },
+  "messageQueue.dragToReorder": {
+    "defaultMessage": "Seret pesan untuk mengatur ulang prioritas"
+  },
+  "messageQueue.expandQueue": {
+    "defaultMessage": "Perluas antrean"
+  },
+  "messageQueue.messageCount": {
+    "defaultMessage": "{count,plural,one{# pesan {status}} other{# pesan {status}}}"
+  },
+  "messageQueue.messageQueue": {
+    "defaultMessage": "Antrean Pesan"
+  },
+  "messageQueue.next": {
+    "defaultMessage": "Berikutnya"
+  },
+  "messageQueue.paused": {
+    "defaultMessage": "Dijeda"
+  },
+  "messageQueue.queuePaused": {
+    "defaultMessage": "Antrean Dijeda"
+  },
+  "messageQueue.queuePausedCompact": {
+    "defaultMessage": "Antrean dijeda - klik \"Kirim\" atau tambahkan pesan baru untuk melanjutkan"
+  },
+  "messageQueue.queuePausedExpanded": {
+    "defaultMessage": "Antrean dijeda karena interupsi. Gunakan \"Kirim Sekarang\" atau tambahkan pesan baru untuk melanjutkan."
+  },
+  "messageQueue.queued": {
+    "defaultMessage": "diantrekan"
+  },
+  "messageQueue.removeFromQueue": {
+    "defaultMessage": "Hapus pesan ini dari antrean"
+  },
+  "messageQueue.save": {
+    "defaultMessage": "Simpan"
+  },
+  "messageQueue.sendNow": {
+    "defaultMessage": "Kirim pesan ini sekarang"
+  },
+  "messageQueue.stopAndSend": {
+    "defaultMessage": "Hentikan pemrosesan saat ini dan kirim pesan ini sekarang"
+  },
+  "messageQueue.waiting": {
+    "defaultMessage": "menunggu"
+  },
+  "microphoneSelector.chooseDescription": {
+    "defaultMessage": "Pilih mikrofon mana yang akan digunakan untuk dikte"
+  },
+  "microphoneSelector.grantAccess": {
+    "defaultMessage": "Berikan Akses"
+  },
+  "microphoneSelector.grantAccessDescription": {
+    "defaultMessage": "Berikan akses untuk melihat mikrofon yang tersedia"
+  },
+  "microphoneSelector.microphone": {
+    "defaultMessage": "Mikrofon"
+  },
+  "microphoneSelector.microphoneLabel": {
+    "defaultMessage": "Mikrofon {index}"
+  },
+  "microphoneSelector.selectedMicrophone": {
+    "defaultMessage": "Mikrofon yang Dipilih"
+  },
+  "microphoneSelector.speakToTest": {
+    "defaultMessage": "Bicaralah untuk menguji mikrofon Anda ({seconds}d)"
+  },
+  "microphoneSelector.stop": {
+    "defaultMessage": "Hentikan"
+  },
+  "microphoneSelector.systemDefault": {
+    "defaultMessage": "Default Sistem"
+  },
+  "microphoneSelector.test": {
+    "defaultMessage": "Uji"
+  },
+  "modeSelectionItem.autonomousDescription": {
+    "defaultMessage": "Kemampuan modifikasi file penuh, edit, buat, dan hapus file dengan bebas."
+  },
+  "modeSelectionItem.autonomousLabel": {
+    "defaultMessage": "Otonom"
+  },
+  "modeSelectionItem.chatOnlyDescription": {
+    "defaultMessage": "Berinteraksi dengan penyedia yang dipilih tanpa menggunakan alat atau ekstensi."
+  },
+  "modeSelectionItem.chatOnlyLabel": {
+    "defaultMessage": "Obrolan saja"
+  },
+  "modeSelectionItem.manualDescription": {
+    "defaultMessage": "Semua alat, ekstensi, dan modifikasi file akan memerlukan persetujuan manusia"
+  },
+  "modeSelectionItem.manualLabel": {
+    "defaultMessage": "Manual"
+  },
+  "modeSelectionItem.smartDescription": {
+    "defaultMessage": "Tentukan secara cerdas tindakan mana yang memerlukan persetujuan berdasarkan tingkat risiko"
+  },
+  "modeSelectionItem.smartLabel": {
+    "defaultMessage": "Cerdas"
+  },
+  "modelAndProviderContext.modelChangeFailed": {
+    "defaultMessage": "{provider}/{model} gagal"
+  },
+  "modelAndProviderContext.modelChangedTitle": {
+    "defaultMessage": "Model diubah"
+  },
+  "modelAndProviderContext.selectModel": {
+    "defaultMessage": "Pilih Model"
+  },
+  "modelAndProviderContext.switchModelSuccess": {
+    "defaultMessage": "Berhasil mengganti model -- menggunakan {model} dari {provider}"
+  },
+  "modelAndProviderContext.unknownProviderMsg": {
+    "defaultMessage": "Penyedia tidak dikenal dalam konfigurasi -- silakan periksa config.yaml Anda"
+  },
+  "modelAndProviderContext.unknownProviderTitle": {
+    "defaultMessage": "Pencarian nama penyedia"
+  },
+  "modelSettingsButtons.configureProviders": {
+    "defaultMessage": "Konfigurasikan penyedia"
+  },
+  "modelSettingsButtons.switchModels": {
+    "defaultMessage": "Ganti model"
+  },
+  "modelSettingsPanel.batchSize": {
+    "defaultMessage": "Ukuran batch"
+  },
+  "modelSettingsPanel.batchSizeDescription": {
+    "defaultMessage": "Batch pemrosesan prompt"
+  },
+  "modelSettingsPanel.builtinChatTemplate": {
+    "defaultMessage": "Templat bawaan"
+  },
+  "modelSettingsPanel.builtinChatTemplateDescription": {
+    "defaultMessage": "Pilih nama templat bawaan llama.cpp"
+  },
+  "modelSettingsPanel.chatTemplate": {
+    "defaultMessage": "Templat obrolan"
+  },
+  "modelSettingsPanel.chatTemplateBuiltin": {
+    "defaultMessage": "Bawaan"
+  },
+  "modelSettingsPanel.chatTemplateCustomInline": {
+    "defaultMessage": "Inline kustom"
+  },
+  "modelSettingsPanel.chatTemplateDescription": {
+    "defaultMessage": "Gunakan metadata GGUF tersemat, templat bawaan llama.cpp, atau Jinja inline"
+  },
+  "modelSettingsPanel.chatTemplateEmbedded": {
+    "defaultMessage": "Tersemat"
+  },
+  "modelSettingsPanel.contextAndGeneration": {
+    "defaultMessage": "Konteks & Generasi"
+  },
+  "modelSettingsPanel.contextSize": {
+    "defaultMessage": "Ukuran konteks"
+  },
+  "modelSettingsPanel.contextSizeDescription": {
+    "defaultMessage": "Jendela konteks maks (0 = default model)"
+  },
+  "modelSettingsPanel.customChatTemplate": {
+    "defaultMessage": "Templat obrolan kustom"
+  },
+  "modelSettingsPanel.customChatTemplateDescription": {
+    "defaultMessage": "Tempel sumber templat obrolan Jinja lengkap"
+  },
+  "modelSettingsPanel.etaLearningRate": {
+    "defaultMessage": "Eta (laju pembelajaran)"
+  },
+  "modelSettingsPanel.flashAttention": {
+    "defaultMessage": "Flash attention"
+  },
+  "modelSettingsPanel.flashAttentionDescription": {
+    "defaultMessage": "Aktifkan optimasi flash attention"
+  },
+  "modelSettingsPanel.frequencyPenalty": {
+    "defaultMessage": "Penalti frekuensi"
+  },
+  "modelSettingsPanel.frequencyPenaltyDescription": {
+    "defaultMessage": "0.0 = nonaktif"
+  },
+  "modelSettingsPanel.gpuLayers": {
+    "defaultMessage": "Lapisan GPU"
+  },
+  "modelSettingsPanel.gpuLayersDescription": {
+    "defaultMessage": "Lapisan untuk dialihkan ke GPU"
+  },
+  "modelSettingsPanel.loadingSettings": {
+    "defaultMessage": "Memuat pengaturan..."
+  },
+  "modelSettingsPanel.lockModelInRam": {
+    "defaultMessage": "Kunci model di RAM (mlock)"
+  },
+  "modelSettingsPanel.lockModelInRamDescription": {
+    "defaultMessage": "Cegah model ditukar ke disk"
+  },
+  "modelSettingsPanel.maxOutputTokens": {
+    "defaultMessage": "Token output maks"
+  },
+  "modelSettingsPanel.maxOutputTokensDescription": {
+    "defaultMessage": "Batas pada token yang dihasilkan"
+  },
+  "modelSettingsPanel.minP": {
+    "defaultMessage": "Min P"
+  },
+  "modelSettingsPanel.performance": {
+    "defaultMessage": "Kinerja"
+  },
+  "modelSettingsPanel.presencePenalty": {
+    "defaultMessage": "Penalti kehadiran"
+  },
+  "modelSettingsPanel.presencePenaltyDescription": {
+    "defaultMessage": "0.0 = nonaktif"
+  },
+  "modelSettingsPanel.repeatPenalty": {
+    "defaultMessage": "Penalti pengulangan"
+  },
+  "modelSettingsPanel.repeatPenaltyDescription": {
+    "defaultMessage": "1.0 = nonaktif"
+  },
+  "modelSettingsPanel.repeatWindow": {
+    "defaultMessage": "Jendela pengulangan"
+  },
+  "modelSettingsPanel.repeatWindowDescription": {
+    "defaultMessage": "Token untuk ditinjau kembali"
+  },
+  "modelSettingsPanel.repetitionPenalty": {
+    "defaultMessage": "Penalti Repetisi"
+  },
+  "modelSettingsPanel.reset": {
+    "defaultMessage": "Atur Ulang"
+  },
+  "modelSettingsPanel.resetToDefaults": {
+    "defaultMessage": "Atur ulang ke default"
+  },
+  "modelSettingsPanel.samplingStrategy": {
+    "defaultMessage": "Strategi Sampling"
+  },
+  "modelSettingsPanel.saving": {
+    "defaultMessage": "Menyimpan..."
+  },
+  "modelSettingsPanel.seed": {
+    "defaultMessage": "Seed"
+  },
+  "modelSettingsPanel.tauTargetEntropy": {
+    "defaultMessage": "Tau (entropi target)"
+  },
+  "modelSettingsPanel.temperature": {
+    "defaultMessage": "Temperatur"
+  },
+  "modelSettingsPanel.threads": {
+    "defaultMessage": "Utas"
+  },
+  "modelSettingsPanel.threadsDescription": {
+    "defaultMessage": "Utas CPU untuk generasi"
+  },
+  "modelSettingsPanel.toolCalling": {
+    "defaultMessage": "Pemanggilan alat"
+  },
+  "modelSettingsPanel.toolCallingAuto": {
+    "defaultMessage": "Otomatis"
+  },
+  "modelSettingsPanel.toolCallingDescription": {
+    "defaultMessage": "Pilih cara model lokal memilih pemanggilan alat native atau emulasi"
+  },
+  "modelSettingsPanel.toolCallingForceEmulated": {
+    "defaultMessage": "Paksa emulasi"
+  },
+  "modelSettingsPanel.toolCallingForceNative": {
+    "defaultMessage": "Paksa native"
+  },
+  "modelSettingsPanel.topK": {
+    "defaultMessage": "Top K"
+  },
+  "modelSettingsPanel.topP": {
+    "defaultMessage": "Top P"
+  },
+  "modelsBottomBar.changeModel": {
+    "defaultMessage": "Ubah Model"
+  },
+  "modelsBottomBar.currentModel": {
+    "defaultMessage": "Model saat ini"
+  },
+  "modelsBottomBar.loadingModel": {
+    "defaultMessage": "Memuat model..."
+  },
+  "modelsBottomBar.localModelSettings": {
+    "defaultMessage": "Pengaturan Model Lokal"
+  },
+  "modelsBottomBar.localModelSettingsTitle": {
+    "defaultMessage": "Pengaturan Model Lokal — {modelName}"
+  },
+  "modelsBottomBar.resolvedModel": {
+    "defaultMessage": "Model yang diselesaikan"
+  },
+  "modelsBottomBar.selectModel": {
+    "defaultMessage": "Pilih Model"
+  },
+  "modelsSection.resetDescription": {
+    "defaultMessage": "Bersihkan pengaturan model dan penyedia yang dipilih untuk memulai dari awal"
+  },
+  "modelsSection.resetTitle": {
+    "defaultMessage": "Atur Ulang Penyedia dan Model"
+  },
+  "navigation.itemApps": {
+    "defaultMessage": "Aplikasi"
+  },
+  "navigation.itemExtensions": {
+    "defaultMessage": "Ekstensi"
+  },
+  "navigation.itemHome": {
+    "defaultMessage": "Obrolan Baru"
+  },
+  "navigation.itemRecipes": {
+    "defaultMessage": "Resep"
+  },
+  "navigation.itemScheduler": {
+    "defaultMessage": "Penjadwal"
+  },
+  "navigation.itemSessions": {
+    "defaultMessage": "Riwayat Sesi"
+  },
+  "navigation.itemSettings": {
+    "defaultMessage": "Pengaturan"
+  },
+  "navigation.itemSkills": {
+    "defaultMessage": "Keterampilan"
+  },
+  "navigationPanel.chats": {
+    "defaultMessage": "Obrolan"
+  },
+  "navigationPanel.noChats": {
+    "defaultMessage": "Tidak ada obrolan terbaru"
+  },
+  "navigationPanel.untitledSession": {
+    "defaultMessage": "Sesi tanpa judul"
+  },
+  "onboardingGuard.checkProviderErrorDescription": {
+    "defaultMessage": "Server mungkin sedang dimulai atau tidak tersedia untuk sementara."
+  },
+  "onboardingGuard.checkProviderErrorTitle": {
+    "defaultMessage": "Tidak dapat terhubung ke server Goose"
+  },
+  "onboardingGuard.retry": {
+    "defaultMessage": "Coba Lagi"
+  },
+  "onboardingGuard.welcomeDescription": {
+    "defaultMessage": "Agen AI lokal Anda. Hubungkan penyedia model AI untuk memulai."
+  },
+  "onboardingGuard.welcomeTitle": {
+    "defaultMessage": "Selamat datang di goose"
+  },
+  "onboardingSuccess.allSet": {
+    "defaultMessage": "Anda siap untuk mulai menggunakan goose."
+  },
+  "onboardingSuccess.connectedTo": {
+    "defaultMessage": "Terhubung ke {providerName}"
+  },
+  "onboardingSuccess.getStarted": {
+    "defaultMessage": "Mulai"
+  },
+  "onboardingSuccess.learnMore": {
+    "defaultMessage": "Pelajari selengkapnya"
+  },
+  "onboardingSuccess.localModelReady": {
+    "defaultMessage": "Model lokal siap"
+  },
+  "onboardingSuccess.privacyDescription": {
+    "defaultMessage": "Data penggunaan anonim membantu meningkatkan goose. Kami tidak pernah mengumpulkan percakapan, kode, atau data pribadi Anda."
+  },
+  "onboardingSuccess.privacyTitle": {
+    "defaultMessage": "Privasi"
+  },
+  "onboardingSuccess.shareUsageData": {
+    "defaultMessage": "Bagikan data penggunaan anonim"
+  },
+  "parameterInput.defaultValue": {
+    "defaultMessage": "Nilai Default"
+  },
+  "parameterInput.defaultValuePlaceholder": {
+    "defaultMessage": "Masukkan nilai default"
+  },
+  "parameterInput.deleteParameter": {
+    "defaultMessage": "Hapus parameter: {key}"
+  },
+  "parameterInput.description": {
+    "defaultMessage": "deskripsi"
+  },
+  "parameterInput.descriptionHelp": {
+    "defaultMessage": "Ini adalah pesan yang akan dilihat oleh pengguna akhir."
+  },
+  "parameterInput.descriptionPlaceholder": {
+    "defaultMessage": "Mis., \"Masukkan nama untuk komponen baru\""
+  },
+  "parameterInput.inputType": {
+    "defaultMessage": "Tipe Masukan"
+  },
+  "parameterInput.optional": {
+    "defaultMessage": "Opsional"
+  },
+  "parameterInput.optionsHelp": {
+    "defaultMessage": "Masukkan setiap opsi pada baris baru. Ini akan ditampilkan sebagai pilihan dropdown."
+  },
+  "parameterInput.optionsLabel": {
+    "defaultMessage": "Opsi (satu per baris)"
+  },
+  "parameterInput.optionsPlaceholder": {
+    "defaultMessage": "Opsi 1 Opsi 2 Opsi 3"
+  },
+  "parameterInput.required": {
+    "defaultMessage": "Wajib"
+  },
+  "parameterInput.requirement": {
+    "defaultMessage": "Persyaratan"
+  },
+  "parameterInput.typeBoolean": {
+    "defaultMessage": "Boolean"
+  },
+  "parameterInput.typeNumber": {
+    "defaultMessage": "Angka"
+  },
+  "parameterInput.typeSelect": {
+    "defaultMessage": "Pilih"
+  },
+  "parameterInput.typeString": {
+    "defaultMessage": "String"
+  },
+  "parameterInput.unused": {
+    "defaultMessage": "Tidak digunakan"
+  },
+  "parameterInput.unusedWarningTitle": {
+    "defaultMessage": "Parameter ini tidak digunakan dalam instruksi atau prompt. Parameter ini akan tersedia untuk masukan manual tetapi mungkin tidak diperlukan."
+  },
+  "parameterInputModal.backToForm": {
+    "defaultMessage": "Kembali ke Formulir Parameter"
+  },
+  "parameterInputModal.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "parameterInputModal.cancelRecipeSetup": {
+    "defaultMessage": "Batalkan Penyiapan Resep"
+  },
+  "parameterInputModal.enterValue": {
+    "defaultMessage": "Masukkan nilai untuk {key}..."
+  },
+  "parameterInputModal.false": {
+    "defaultMessage": "Salah"
+  },
+  "parameterInputModal.recipeParameters": {
+    "defaultMessage": "Parameter Resep"
+  },
+  "parameterInputModal.select": {
+    "defaultMessage": "Pilih..."
+  },
+  "parameterInputModal.selectOption": {
+    "defaultMessage": "Pilih opsi..."
+  },
+  "parameterInputModal.startNewChat": {
+    "defaultMessage": "Mulai Obrolan Baru (Tanpa Resep)"
+  },
+  "parameterInputModal.startRecipe": {
+    "defaultMessage": "Mulai Resep"
+  },
+  "parameterInputModal.true": {
+    "defaultMessage": "Benar"
+  },
+  "parameterInputModal.whatToDo": {
+    "defaultMessage": "Apa yang ingin Anda lakukan?"
+  },
+  "permissionModal.alwaysAllow": {
+    "defaultMessage": "Selalu izinkan"
+  },
+  "permissionModal.askBefore": {
+    "defaultMessage": "Tanyakan dulu"
+  },
+  "permissionModal.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "permissionModal.close": {
+    "defaultMessage": "Tutup"
+  },
+  "permissionModal.failedToLoadTools": {
+    "defaultMessage": "Gagal memuat alat"
+  },
+  "permissionModal.failedToLoadToolsDescription": {
+    "defaultMessage": "Tidak dapat memuat alat untuk ekstensi ini. Ekstensi mungkin tidak dimuat dalam sesi saat ini."
+  },
+  "permissionModal.neverAllow": {
+    "defaultMessage": "Jangan pernah izinkan"
+  },
+  "permissionModal.noActiveSession": {
+    "defaultMessage": "Tidak ada sesi aktif"
+  },
+  "permissionModal.noActiveSessionDescription": {
+    "defaultMessage": "Mulai sesi obrolan terlebih dahulu untuk mengonfigurasi izin alat untuk ekstensi ini. Izin alat dimuat dari ekstensi sesi aktif."
+  },
+  "permissionModal.noToolsAvailable": {
+    "defaultMessage": "Tidak ada alat yang tersedia untuk ekstensi ini."
+  },
+  "permissionModal.saveChanges": {
+    "defaultMessage": "Simpan Perubahan"
+  },
+  "permissionRulesModal.description": {
+    "defaultMessage": "Konfigurasikan izin alat untuk ekstensi guna mengontrol cara mereka berinteraksi dengan sistem Anda."
+  },
+  "permissionRulesModal.extensionRules": {
+    "defaultMessage": "Aturan ekstensi"
+  },
+  "permissionRulesModal.title": {
+    "defaultMessage": "Aturan Izin"
+  },
+  "permissionSetting.extensionRules": {
+    "defaultMessage": "Aturan ekstensi"
+  },
+  "permissionSetting.permissionRules": {
+    "defaultMessage": "Aturan Izin"
+  },
+  "permissionSetting.permissionRulesDescription": {
+    "defaultMessage": "Instruksi tersembunyi yang akan diteruskan ke penyedia untuk membantu mengarahkan dan menambahkan konteks ke respons Anda."
+  },
+  "privacyInfoModal.collectErrors": {
+    "defaultMessage": "Jenis kesalahan (mis., \"rate_limit\", \"auth\" - tanpa detail)"
+  },
+  "privacyInfoModal.collectExtensions": {
+    "defaultMessage": "Jumlah penggunaan ekstensi dan alat (hanya nama)"
+  },
+  "privacyInfoModal.collectOs": {
+    "defaultMessage": "Sistem operasi, versi, dan arsitektur"
+  },
+  "privacyInfoModal.collectProvider": {
+    "defaultMessage": "Penyedia dan model yang digunakan"
+  },
+  "privacyInfoModal.collectSession": {
+    "defaultMessage": "Metrik sesi (durasi, jumlah interaksi, penggunaan token)"
+  },
+  "privacyInfoModal.collectVersion": {
+    "defaultMessage": "Versi goose dan metode instalasi"
+  },
+  "privacyInfoModal.description": {
+    "defaultMessage": "Data penggunaan anonim membantu kami memahami cara goose digunakan dan mengidentifikasi area yang dapat ditingkatkan."
+  },
+  "privacyInfoModal.neverCollect": {
+    "defaultMessage": "Kami tidak pernah mengumpulkan percakapan, kode, argumen alat, pesan kesalahan, atau data pribadi Anda. Anda dapat mengubah pengaturan ini kapan saja di Pengaturan."
+  },
+  "privacyInfoModal.title": {
+    "defaultMessage": "Detail privasi"
+  },
+  "privacyInfoModal.whatWeCollect": {
+    "defaultMessage": "Apa yang kami kumpulkan:"
+  },
+  "progressiveMessageList.loadingMessages": {
+    "defaultMessage": "Memuat pesan... ({renderedCount}/{totalCount})"
+  },
+  "progressiveMessageList.modelChanged": {
+    "defaultMessage": "Model diubah: {previousModel} → {currentModel}"
+  },
+  "progressiveMessageList.searchHint": {
+    "defaultMessage": "Tekan Cmd/Ctrl+F untuk segera memuat semua pesan untuk pencarian"
+  },
+  "promptsSettings.allPromptsReset": {
+    "defaultMessage": "Semua prompt disetel ulang ke default"
+  },
+  "promptsSettings.backToList": {
+    "defaultMessage": "Kembali ke Daftar"
+  },
+  "promptsSettings.confirmReplaceWithDefault": {
+    "defaultMessage": "Ganti konten saat ini dengan default? Perubahan Anda akan hilang."
+  },
+  "promptsSettings.confirmResetAll": {
+    "defaultMessage": "Apakah Anda yakin ingin menyetel ulang semua prompt ke default? Tindakan ini tidak dapat dibatalkan."
+  },
+  "promptsSettings.confirmResetOne": {
+    "defaultMessage": "Apakah Anda yakin ingin menyetel ulang prompt ini ke default? Tindakan ini tidak dapat dibatalkan."
+  },
+  "promptsSettings.confirmUnsavedBack": {
+    "defaultMessage": "Anda memiliki perubahan yang belum disimpan. Apakah Anda yakin ingin kembali?"
+  },
+  "promptsSettings.customized": {
+    "defaultMessage": "Disesuaikan"
+  },
+  "promptsSettings.edit": {
+    "defaultMessage": "Edit"
+  },
+  "promptsSettings.editPromptTitle": {
+    "defaultMessage": "Edit: {name}"
+  },
+  "promptsSettings.editingLabel": {
+    "defaultMessage": "Mengedit: {name}"
+  },
+  "promptsSettings.enterPromptContent": {
+    "defaultMessage": "Masukkan konten prompt..."
+  },
+  "promptsSettings.failedToLoadPrompt": {
+    "defaultMessage": "Gagal memuat prompt"
+  },
+  "promptsSettings.failedToLoadPrompts": {
+    "defaultMessage": "Gagal memuat prompt"
+  },
+  "promptsSettings.failedToResetPrompt": {
+    "defaultMessage": "Gagal menyetel ulang prompt"
+  },
+  "promptsSettings.failedToResetPrompts": {
+    "defaultMessage": "Gagal menyetel ulang prompt"
+  },
+  "promptsSettings.failedToSavePrompt": {
+    "defaultMessage": "Gagal menyimpan prompt"
+  },
+  "promptsSettings.promptEditingDescription": {
+    "defaultMessage": "Sesuaikan prompt yang menentukan perilaku goose dalam berbagai konteks. Prompt ini menggunakan sintaks templat Jinja2. Berhati-hatilah saat memodifikasi variabel templat, karena perubahan yang salah dapat merusak fungsionalitas. Mohon bagikan setiap peningkatan dengan komunitas."
+  },
+  "promptsSettings.promptEditingTitle": {
+    "defaultMessage": "Pengeditan Prompt"
+  },
+  "promptsSettings.promptResetToDefault": {
+    "defaultMessage": "Prompt disetel ulang ke default"
+  },
+  "promptsSettings.promptSaved": {
+    "defaultMessage": "Prompt disimpan"
+  },
+  "promptsSettings.resetAll": {
+    "defaultMessage": "Setel Ulang Semua"
+  },
+  "promptsSettings.resetToDefault": {
+    "defaultMessage": "Setel Ulang ke Default"
+  },
+  "promptsSettings.restoreDefault": {
+    "defaultMessage": "Pulihkan Default"
+  },
+  "promptsSettings.save": {
+    "defaultMessage": "Simpan"
+  },
+  "promptsSettings.templateTip": {
+    "defaultMessage": "Variabel templat seperti {extensionsExample} atau {forExample} diganti dengan nilai sebenarnya saat runtime. Berhati-hatilah agar tidak menghapus variabel yang diperlukan."
+  },
+  "promptsSettings.unsavedChanges": {
+    "defaultMessage": "Anda memiliki perubahan yang belum disimpan"
+  },
+  "providerCard.noMetadata": {
+    "defaultMessage": "Kesalahan ProviderCard: Tidak ada metadata yang disediakan"
+  },
+  "providerCard.unknownProvider": {
+    "defaultMessage": "Penyedia Tidak Dikenal"
+  },
+  "providerCatalogPicker.anthropicCompatible": {
+    "defaultMessage": "Kompatibel dengan Anthropic"
+  },
+  "providerCatalogPicker.apiFormat": {
+    "defaultMessage": "Format API"
+  },
+  "providerCatalogPicker.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "providerCatalogPicker.chooseProvider": {
+    "defaultMessage": "Pilih Penyedia"
+  },
+  "providerCatalogPicker.errorPrefix": {
+    "defaultMessage": "Kesalahan: {error}"
+  },
+  "providerCatalogPicker.loadingProviders": {
+    "defaultMessage": "Memuat penyedia..."
+  },
+  "providerCatalogPicker.modelsAvailable": {
+    "defaultMessage": "{count} model tersedia"
+  },
+  "providerCatalogPicker.noProvidersAvailable": {
+    "defaultMessage": "Tidak ada penyedia yang tersedia"
+  },
+  "providerCatalogPicker.noProvidersFound": {
+    "defaultMessage": "Tidak ada penyedia yang ditemukan untuk \"{query}\""
+  },
+  "providerCatalogPicker.openaiCompatible": {
+    "defaultMessage": "Kompatibel dengan OpenAI"
+  },
+  "providerCatalogPicker.requiresEnvVar": {
+    "defaultMessage": "• Memerlukan {envVar}"
+  },
+  "providerCatalogPicker.searchProviders": {
+    "defaultMessage": "Cari penyedia..."
+  },
+  "providerCatalogPicker.selectFormatDescription": {
+    "defaultMessage": "Pilih format API dan penyedia. Kami akan mengisi konfigurasi secara otomatis untuk Anda."
+  },
+  "providerConfigForm.browserWindowOpen": {
+    "defaultMessage": "Jendela browser akan terbuka agar Anda dapat menyelesaikan proses masuk."
+  },
+  "providerConfigForm.configuring": {
+    "defaultMessage": "Mengonfigurasi..."
+  },
+  "providerConfigForm.continue": {
+    "defaultMessage": "Lanjutkan"
+  },
+  "providerConfigForm.deviceCodeFlowHint": {
+    "defaultMessage": "Jendela browser akan terbuka dan kode verifikasi akan disalin ke clipboard Anda. Tempelkan di browser untuk menyelesaikan proses masuk."
+  },
+  "providerConfigForm.noApiKey": {
+    "defaultMessage": "Tidak punya kunci API?"
+  },
+  "providerConfigForm.signInWith": {
+    "defaultMessage": "Masuk dengan {providerName}"
+  },
+  "providerConfigForm.signingIn": {
+    "defaultMessage": "Sedang masuk..."
+  },
+  "providerConfigurationModal.addApiKeyDescription": {
+    "defaultMessage": "Tambahkan kunci API Anda untuk penyedia ini agar terintegrasi ke dalam goose"
+  },
+  "providerConfigurationModal.browserWindowHint": {
+    "defaultMessage": "Jendela browser akan terbuka agar Anda dapat menyelesaikan proses masuk."
+  },
+  "providerConfigurationModal.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "providerConfigurationModal.cannotDeleteActive": {
+    "defaultMessage": "Anda tidak dapat menghapus penyedia ini selama sedang digunakan. Silakan beralih ke model lain terlebih dahulu."
+  },
+  "providerConfigurationModal.checkConfigAgain": {
+    "defaultMessage": "Periksa kembali konfigurasi Anda untuk menggunakan penyedia ini."
+  },
+  "providerConfigurationModal.close": {
+    "defaultMessage": "Tutup"
+  },
+  "providerConfigurationModal.configureHeader": {
+    "defaultMessage": "Konfigurasikan {providerName}"
+  },
+  "providerConfigurationModal.deleteConfigHeader": {
+    "defaultMessage": "Hapus konfigurasi untuk {providerName}"
+  },
+  "providerConfigurationModal.deleteConfirmation": {
+    "defaultMessage": "Tindakan ini akan menghapus konfigurasi penyedia saat ini secara permanen."
+  },
+  "providerConfigurationModal.deviceCodeFlowHint": {
+    "defaultMessage": "Jendela browser akan terbuka dan kode verifikasi akan disalin ke clipboard Anda. Tempelkan di browser untuk menyelesaikan proses masuk."
+  },
+  "providerConfigurationModal.errorCheckingConfig": {
+    "defaultMessage": "Terjadi kesalahan saat memeriksa konfigurasi penyedia ini."
+  },
+  "providerConfigurationModal.errorTitle": {
+    "defaultMessage": "Kesalahan"
+  },
+  "providerConfigurationModal.externalSetupIntro": {
+    "defaultMessage": "Penyedia ini dikonfigurasi di luar goose. Ikuti langkah-langkah berikut:"
+  },
+  "providerConfigurationModal.goBack": {
+    "defaultMessage": "Kembali"
+  },
+  "providerConfigurationModal.huggingFaceOAuthDescription": {
+    "defaultMessage": "Masuk untuk menggunakan Hugging Face Inference Providers tanpa memasukkan token API secara manual."
+  },
+  "providerConfigurationModal.oauthLoginFailed": {
+    "defaultMessage": "Login OAuth gagal: {error}"
+  },
+  "providerConfigurationModal.oauthSignInDescription": {
+    "defaultMessage": "Masuk dengan akun {providerName} Anda untuk menggunakan penyedia ini"
+  },
+  "providerConfigurationModal.parameterRequired": {
+    "defaultMessage": "{paramName} wajib diisi"
+  },
+  "providerConfigurationModal.removeConfiguration": {
+    "defaultMessage": "Hapus Konfigurasi"
+  },
+  "providerConfigurationModal.seeDocumentation": {
+    "defaultMessage": "Lihat <link>dokumentasi</link> untuk detail selengkapnya."
+  },
+  "providerConfigurationModal.signInWith": {
+    "defaultMessage": "Masuk dengan {providerName}"
+  },
+  "providerConfigurationModal.signingIn": {
+    "defaultMessage": "Sedang masuk..."
+  },
+  "providerGrid.addProvider": {
+    "defaultMessage": "Tambah Penyedia"
+  },
+  "providerGrid.addProviderTitle": {
+    "defaultMessage": "Tambah Penyedia"
+  },
+  "providerGrid.chooseModel": {
+    "defaultMessage": "Pilih Model"
+  },
+  "providerGrid.configureProvider": {
+    "defaultMessage": "Konfigurasikan Penyedia"
+  },
+  "providerGrid.editProvider": {
+    "defaultMessage": "Edit Penyedia"
+  },
+  "providerGrid.fromTemplateOrManual": {
+    "defaultMessage": "Dari templat atau penyiapan manual"
+  },
+  "providerLogo.alt": {
+    "defaultMessage": "Logo {providerName}"
+  },
+  "providerSelector.addCustomProvider": {
+    "defaultMessage": "Tambahkan penyedia khusus"
+  },
+  "providerSelector.addCustomProviderTitle": {
+    "defaultMessage": "Tambah Penyedia Khusus"
+  },
+  "providerSelector.connectProvider": {
+    "defaultMessage": "Hubungkan ke Penyedia"
+  },
+  "providerSelector.connectProviderDescription": {
+    "defaultMessage": "Hubungkan OpenAI, Anthropic, Google, dll"
+  },
+  "providerSelector.freeLocalDescription": {
+    "defaultMessage": "Gunakan model lokal atau penyedia dengan kredit gratis"
+  },
+  "providerSelector.selectProvider": {
+    "defaultMessage": "Pilih penyedia"
+  },
+  "providerSelector.useFreeLocal": {
+    "defaultMessage": "Gunakan Penyedia Gratis/Lokal"
+  },
+  "providerSettings.configurationSettings": {
+    "defaultMessage": "Pengaturan Konfigurasi Penyedia"
+  },
+  "providerSettings.loadingProviders": {
+    "defaultMessage": "Memuat penyedia..."
+  },
+  "providerSettings.onboardingDescription": {
+    "defaultMessage": "Pilih penyedia model AI untuk memulai dengan goose. Anda perlu menggunakan kunci API yang dihasilkan oleh setiap penyedia yang akan dienkripsi dan disimpan secara lokal. Anda dapat mengubah penyedia kapan saja di pengaturan."
+  },
+  "providerSettings.otherProviders": {
+    "defaultMessage": "Penyedia lain"
+  },
+  "providerSetupActions.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "providerSetupActions.cannotDeleteActive": {
+    "defaultMessage": "Anda tidak dapat menghapus {providerName} selama sedang digunakan. Silakan beralih ke model lain sebelum menghapus penyedia ini."
+  },
+  "providerSetupActions.confirmDelete": {
+    "defaultMessage": "Konfirmasi Hapus"
+  },
+  "providerSetupActions.confirmDeleteMessage": {
+    "defaultMessage": "Apakah Anda yakin ingin menghapus parameter konfigurasi untuk {providerName}? Tindakan ini tidak dapat dibatalkan."
+  },
+  "providerSetupActions.deleteProvider": {
+    "defaultMessage": "Hapus Penyedia"
+  },
+  "providerSetupActions.enableProvider": {
+    "defaultMessage": "Aktifkan Penyedia"
+  },
+  "providerSetupActions.ok": {
+    "defaultMessage": "Ok"
+  },
+  "providerSetupActions.submit": {
+    "defaultMessage": "Kirim"
+  },
+  "recipeActivityEditor.activitiesDescription": {
+    "defaultMessage": "Prompt utama dan tombol aktivitas yang akan ditampilkan di jendela obrolan resep."
+  },
+  "recipeActivityEditor.activitiesLabel": {
+    "defaultMessage": "Aktivitas"
+  },
+  "recipeActivityEditor.activityButtonsDescription": {
+    "defaultMessage": "Tombol yang dapat diklik yang akan muncul di bawah pesan untuk membantu pengguna berinteraksi dengan resep Anda."
+  },
+  "recipeActivityEditor.activityButtonsLabel": {
+    "defaultMessage": "Tombol Aktivitas"
+  },
+  "recipeActivityEditor.addActivity": {
+    "defaultMessage": "Tambah aktivitas"
+  },
+  "recipeActivityEditor.addNewActivityPlaceholder": {
+    "defaultMessage": "Tambah aktivitas baru..."
+  },
+  "recipeActivityEditor.messageDescription": {
+    "defaultMessage": "Pesan terformat yang akan muncul di bagian atas resep. Mendukung pemformatan markdown."
+  },
+  "recipeActivityEditor.messageLabel": {
+    "defaultMessage": "Pesan"
+  },
+  "recipeActivityEditor.messagePlaceholder": {
+    "defaultMessage": "Masukkan pesan pengantar yang menghadap pengguna untuk resep Anda (mendukung **tebal**, *miring*, `kode`, dll.)"
+  },
+  "recipeExtensionSelector.description": {
+    "defaultMessage": "Pilih ekstensi mana yang harus tersedia saat menjalankan resep ini. Biarkan kosong untuk menggunakan ekstensi default."
+  },
+  "recipeExtensionSelector.extensionsSelected": {
+    "defaultMessage": "{count,plural,one{# ekstensi dipilih} other{# ekstensi dipilih}}"
+  },
+  "recipeExtensionSelector.label": {
+    "defaultMessage": "Ekstensi (Opsional)"
+  },
+  "recipeExtensionSelector.noExtensionsAvailable": {
+    "defaultMessage": "Tidak ada ekstensi yang tersedia"
+  },
+  "recipeExtensionSelector.noExtensionsFound": {
+    "defaultMessage": "Tidak ada ekstensi yang ditemukan"
+  },
+  "recipeExtensionSelector.searchPlaceholder": {
+    "defaultMessage": "Cari ekstensi..."
+  },
+  "recipeFormFields.addParameter": {
+    "defaultMessage": "Tambah parameter"
+  },
+  "recipeFormFields.advancedOptions": {
+    "defaultMessage": "Opsi Lanjutan"
+  },
+  "recipeFormFields.advancedOptionsHint": {
+    "defaultMessage": "Aktivitas, parameter, model, ekstensi, skema respons, subresep"
+  },
+  "recipeFormFields.descriptionLabel": {
+    "defaultMessage": "Deskripsi"
+  },
+  "recipeFormFields.descriptionPlaceholder": {
+    "defaultMessage": "Deskripsi singkat tentang apa yang dilakukan resep ini"
+  },
+  "recipeFormFields.enterValueFor": {
+    "defaultMessage": "Masukkan nilai untuk {key}"
+  },
+  "recipeFormFields.initialPrompt": {
+    "defaultMessage": "Prompt Awal"
+  },
+  "recipeFormFields.instructionsLabel": {
+    "defaultMessage": "Instruksi"
+  },
+  "recipeFormFields.instructionsPlaceholder": {
+    "defaultMessage": "Instruksi terperinci untuk AI, disembunyikan dari pengguna"
+  },
+  "recipeFormFields.openEditor": {
+    "defaultMessage": "Buka Editor"
+  },
+  "recipeFormFields.parameterNamePlaceholder": {
+    "defaultMessage": "Masukkan nama parameter..."
+  },
+  "recipeFormFields.parametersDescription": {
+    "defaultMessage": "Parameter akan terdeteksi secara otomatis dari sintaks '{{parameter_name}}' di instruksi/prompt/aktivitas, atau Anda dapat menambahkannya secara manual di bawah ini."
+  },
+  "recipeFormFields.parametersLabel": {
+    "defaultMessage": "Parameter"
+  },
+  "recipeFormFields.promptOptionalHint": {
+    "defaultMessage": "(Opsional - Instruksi atau Prompt diperlukan)"
+  },
+  "recipeFormFields.promptPlaceholder": {
+    "defaultMessage": "Prompt yang sudah terisi saat resep dimulai"
+  },
+  "recipeFormFields.responseJsonSchema": {
+    "defaultMessage": "Skema JSON Respons"
+  },
+  "recipeFormFields.responseJsonSchemaDescription": {
+    "defaultMessage": "Tentukan struktur respons AI yang diharapkan menggunakan format JSON Schema"
+  },
+  "recipeFormFields.templateVarHint": {
+    "defaultMessage": "Gunakan '{{parameter_name}}' untuk mendefinisikan parameter yang dapat diisi saat menjalankan resep."
+  },
+  "recipeFormFields.titleLabel": {
+    "defaultMessage": "Judul"
+  },
+  "recipeFormFields.titlePlaceholder": {
+    "defaultMessage": "Judul resep"
+  },
+  "recipeHeader.recipeLabel": {
+    "defaultMessage": "Resep"
+  },
+  "recipeModelSelector.backToModelList": {
+    "defaultMessage": "Kembali ke daftar model"
+  },
+  "recipeModelSelector.enterCustomModel": {
+    "defaultMessage": "Masukkan nama model khusus"
+  },
+  "recipeModelSelector.enterModelNotListed": {
+    "defaultMessage": "Masukkan model yang tidak terdaftar..."
+  },
+  "recipeModelSelector.fetchError": {
+    "defaultMessage": "Gagal mengambil model. Silakan coba lagi nanti."
+  },
+  "recipeModelSelector.loadingModels": {
+    "defaultMessage": "Memuat model…"
+  },
+  "recipeModelSelector.modelHint": {
+    "defaultMessage": "Biarkan kosong untuk menggunakan model default bagi penyedia yang dipilih"
+  },
+  "recipeModelSelector.modelLabel": {
+    "defaultMessage": "Model (Opsional)"
+  },
+  "recipeModelSelector.providerHint": {
+    "defaultMessage": "Biarkan kosong untuk menggunakan penyedia default yang dikonfigurasi di pengaturan"
+  },
+  "recipeModelSelector.providerLabel": {
+    "defaultMessage": "Penyedia (Opsional)"
+  },
+  "recipeModelSelector.selectModel": {
+    "defaultMessage": "Pilih model"
+  },
+  "recipeModelSelector.selectProvider": {
+    "defaultMessage": "Pilih penyedia"
+  },
+  "recipeModelSelector.useDefaultProvider": {
+    "defaultMessage": "Gunakan penyedia default"
+  },
+  "recipeNameField.defaultLabel": {
+    "defaultMessage": "Nama Resep"
+  },
+  "recipeNameField.formatHint": {
+    "defaultMessage": "Akan diformat secara otomatis (huruf kecil, tanda hubung untuk spasi)"
+  },
+  "recipeWarningModal.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "recipeWarningModal.descriptionLabel": {
+    "defaultMessage": "Deskripsi:"
+  },
+  "recipeWarningModal.firstTimeDescription": {
+    "defaultMessage": "Anda akan menjalankan resep yang belum pernah Anda jalankan sebelumnya."
+  },
+  "recipeWarningModal.hiddenCharsWarning": {
+    "defaultMessage": "Resep ini berisi karakter tersembunyi yang akan diabaikan demi keamanan Anda, karena karakter tersebut dapat digunakan untuk tujuan jahat."
+  },
+  "recipeWarningModal.instructionsLabel": {
+    "defaultMessage": "Instruksi:"
+  },
+  "recipeWarningModal.newRecipeWarningTitle": {
+    "defaultMessage": "⚠️ Peringatan Resep Baru"
+  },
+  "recipeWarningModal.recipePreview": {
+    "defaultMessage": "Pratinjau Resep:"
+  },
+  "recipeWarningModal.securityWarningTitle": {
+    "defaultMessage": "⚠️ Peringatan Keamanan"
+  },
+  "recipeWarningModal.titleLabel": {
+    "defaultMessage": "Judul:"
+  },
+  "recipeWarningModal.trustAndExecute": {
+    "defaultMessage": "Percayai dan Jalankan"
+  },
+  "recipeWarningModal.trustSource": {
+    "defaultMessage": "Hanya lanjutkan jika Anda mempercayai sumber resep ini."
+  },
+  "recipesView.addSchedule": {
+    "defaultMessage": "Tambah jadwal"
+  },
+  "recipesView.addSlashCommand": {
+    "defaultMessage": "Tambah perintah garis miring"
+  },
+  "recipesView.adjustSearchTerms": {
+    "defaultMessage": "Coba sesuaikan istilah pencarian Anda"
+  },
+  "recipesView.allFiles": {
+    "defaultMessage": "Semua File"
+  },
+  "recipesView.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "recipesView.copyDeeplink": {
+    "defaultMessage": "Salin Deeplink"
+  },
+  "recipesView.copyDeeplinkFailedMsg": {
+    "defaultMessage": "Gagal menyalin deeplink ke clipboard"
+  },
+  "recipesView.copyFailedTitle": {
+    "defaultMessage": "Penyalinan gagal"
+  },
+  "recipesView.copyYaml": {
+    "defaultMessage": "Salin YAML"
+  },
+  "recipesView.copyYamlFailedMsg": {
+    "defaultMessage": "Gagal menyalin YAML resep ke clipboard"
+  },
+  "recipesView.createRecipe": {
+    "defaultMessage": "Buat Resep"
+  },
+  "recipesView.deeplinkCopiedMsg": {
+    "defaultMessage": "Deeplink resep telah disalin ke clipboard"
+  },
+  "recipesView.deeplinkCopiedTitle": {
+    "defaultMessage": "Deeplink disalin"
+  },
+  "recipesView.deleteRecipe": {
+    "defaultMessage": "Hapus resep"
+  },
+  "recipesView.deleteRecipeConfirm": {
+    "defaultMessage": "Apakah Anda yakin ingin menghapus \"{title}\"?"
+  },
+  "recipesView.deleteRecipeDetail": {
+    "defaultMessage": "File resep akan dihapus."
+  },
+  "recipesView.deleteRecipeTitle": {
+    "defaultMessage": "Hapus Resep"
+  },
+  "recipesView.editRecipe": {
+    "defaultMessage": "Edit resep"
+  },
+  "recipesView.editSchedule": {
+    "defaultMessage": "Edit jadwal"
+  },
+  "recipesView.editSlashCommand": {
+    "defaultMessage": "Edit perintah garis miring"
+  },
+  "recipesView.errorLoadingRecipes": {
+    "defaultMessage": "Kesalahan Memuat Resep"
+  },
+  "recipesView.exportFailedMsg": {
+    "defaultMessage": "Gagal mengekspor resep ke file"
+  },
+  "recipesView.exportFailedTitle": {
+    "defaultMessage": "Ekspor gagal"
+  },
+  "recipesView.exportRecipeDialogTitle": {
+    "defaultMessage": "Ekspor Resep"
+  },
+  "recipesView.exportToFile": {
+    "defaultMessage": "Ekspor ke File"
+  },
+  "recipesView.noMatchingRecipes": {
+    "defaultMessage": "Tidak ada resep yang cocok ditemukan"
+  },
+  "recipesView.noSavedRecipes": {
+    "defaultMessage": "Tidak ada resep tersimpan"
+  },
+  "recipesView.noSavedRecipesDescription": {
+    "defaultMessage": "Resep yang disimpan dari obrolan akan muncul di sini."
+  },
+  "recipesView.openInNewWindow": {
+    "defaultMessage": "Buka di jendela baru"
+  },
+  "recipesView.recipeDeletedSuccess": {
+    "defaultMessage": "Resep berhasil dihapus"
+  },
+  "recipesView.recipeExportedMsg": {
+    "defaultMessage": "Resep disimpan ke {filePath}"
+  },
+  "recipesView.recipeExportedTitle": {
+    "defaultMessage": "Resep diekspor"
+  },
+  "recipesView.recipesDescription": {
+    "defaultMessage": "Lihat dan kelola resep tersimpan Anda untuk memulai sesi baru dengan cepat menggunakan konfigurasi yang telah ditentukan. {shortcut} untuk mencari."
+  },
+  "recipesView.recipesTitle": {
+    "defaultMessage": "Resep"
+  },
+  "recipesView.remove": {
+    "defaultMessage": "Hapus"
+  },
+  "recipesView.removeSchedule": {
+    "defaultMessage": "Hapus Jadwal"
+  },
+  "recipesView.runs": {
+    "defaultMessage": "Berjalan {schedule}"
+  },
+  "recipesView.save": {
+    "defaultMessage": "Simpan"
+  },
+  "recipesView.scheduleDialogTitle": {
+    "defaultMessage": "{action} Jadwal"
+  },
+  "recipesView.scheduleRemovedMsg": {
+    "defaultMessage": "Resep tidak akan berjalan secara otomatis lagi"
+  },
+  "recipesView.scheduleRemovedTitle": {
+    "defaultMessage": "Jadwal dihapus"
+  },
+  "recipesView.scheduleSavedMsg": {
+    "defaultMessage": "Resep akan berjalan {schedule}"
+  },
+  "recipesView.scheduleSavedTitle": {
+    "defaultMessage": "Jadwal disimpan"
+  },
+  "recipesView.searchRecipesPlaceholder": {
+    "defaultMessage": "Cari resep..."
+  },
+  "recipesView.shareRecipe": {
+    "defaultMessage": "Bagikan resep"
+  },
+  "recipesView.slashCommandDescription": {
+    "defaultMessage": "Tetapkan perintah garis miring untuk menjalankan resep ini dengan cepat dari obrolan mana pun"
+  },
+  "recipesView.slashCommandPlaceholder": {
+    "defaultMessage": "command-name"
+  },
+  "recipesView.slashCommandRemovedMsg": {
+    "defaultMessage": "Perintah garis miring resep telah dihapus"
+  },
+  "recipesView.slashCommandRemovedTitle": {
+    "defaultMessage": "Perintah garis miring dihapus"
+  },
+  "recipesView.slashCommandSavedMsg": {
+    "defaultMessage": "Gunakan /{command} untuk menjalankan resep ini"
+  },
+  "recipesView.slashCommandSavedTitle": {
+    "defaultMessage": "Perintah garis miring disimpan"
+  },
+  "recipesView.slashCommandTitle": {
+    "defaultMessage": "Perintah Garis Miring"
+  },
+  "recipesView.slashCommandUsageHint": {
+    "defaultMessage": "Gunakan /{command} di obrolan mana pun untuk menjalankan resep ini"
+  },
+  "recipesView.tryAgain": {
+    "defaultMessage": "Coba Lagi"
+  },
+  "recipesView.useRecipe": {
+    "defaultMessage": "Gunakan resep"
+  },
+  "recipesView.yamlCopiedMsg": {
+    "defaultMessage": "YAML resep telah disalin ke papan klip"
+  },
+  "recipesView.yamlCopiedTitle": {
+    "defaultMessage": "YAML disalin"
+  },
+  "recipesView.yamlFiles": {
+    "defaultMessage": "Berkas YAML"
+  },
+  "resetProviderSection.resetButton": {
+    "defaultMessage": "Atur Ulang Penyedia dan Model"
+  },
+  "resetProviderSection.resetDescription": {
+    "defaultMessage": "Ini akan menghapus pengaturan model dan penyedia yang Anda pilih. Jika tidak ada default yang tersedia, Anda akan dibawa ke layar selamat datang untuk mengaturnya kembali."
+  },
+  "responseStyle.conciseDescription": {
+    "defaultMessage": "Panggilan alat secara default tertutup dan hanya menampilkan alat yang digunakan"
+  },
+  "responseStyle.conciseLabel": {
+    "defaultMessage": "Ringkas"
+  },
+  "responseStyle.detailedDescription": {
+    "defaultMessage": "Panggilan alat secara default ditampilkan terbuka untuk menampilkan detail"
+  },
+  "responseStyle.detailedLabel": {
+    "defaultMessage": "Terperinci"
+  },
+  "scheduleDetailView.actions": {
+    "defaultMessage": "Tindakan"
+  },
+  "scheduleDetailView.cannotModifyRunning": {
+    "defaultMessage": "Tidak dapat memicu atau mengubah jadwal saat sedang berjalan."
+  },
+  "scheduleDetailView.completedSession": {
+    "defaultMessage": "Sesi: {sessionId}"
+  },
+  "scheduleDetailView.created": {
+    "defaultMessage": "Dibuat: {date}"
+  },
+  "scheduleDetailView.cronExpression": {
+    "defaultMessage": "Ekspresi Cron:"
+  },
+  "scheduleDetailView.currentSession": {
+    "defaultMessage": "Sesi Saat Ini:"
+  },
+  "scheduleDetailView.currentlyRunning": {
+    "defaultMessage": "Sedang Berjalan"
+  },
+  "scheduleDetailView.dir": {
+    "defaultMessage": "Dir: {path}"
+  },
+  "scheduleDetailView.editSchedule": {
+    "defaultMessage": "Edit Jadwal"
+  },
+  "scheduleDetailView.errorPrefix": {
+    "defaultMessage": "Kesalahan: {error}"
+  },
+  "scheduleDetailView.idLabel": {
+    "defaultMessage": "ID:"
+  },
+  "scheduleDetailView.inspectJobError": {
+    "defaultMessage": "Periksa Kesalahan Pekerjaan"
+  },
+  "scheduleDetailView.inspectNoInfo": {
+    "defaultMessage": "Tidak ada informasi terperinci yang tersedia"
+  },
+  "scheduleDetailView.inspectRunningJob": {
+    "defaultMessage": "Periksa Pekerjaan yang Berjalan"
+  },
+  "scheduleDetailView.jobCancelled": {
+    "defaultMessage": "Pekerjaan Dibatalkan"
+  },
+  "scheduleDetailView.jobCancelledMsg": {
+    "defaultMessage": "Pekerjaan dibatalkan saat memulai."
+  },
+  "scheduleDetailView.jobInspection": {
+    "defaultMessage": "Pemeriksaan Pekerjaan"
+  },
+  "scheduleDetailView.jobKilled": {
+    "defaultMessage": "Pekerjaan Dihentikan"
+  },
+  "scheduleDetailView.killJobError": {
+    "defaultMessage": "Kesalahan Menghentikan Pekerjaan"
+  },
+  "scheduleDetailView.killRunningJob": {
+    "defaultMessage": "Hentikan Pekerjaan yang Berjalan"
+  },
+  "scheduleDetailView.lastRun": {
+    "defaultMessage": "Terakhir Berjalan:"
+  },
+  "scheduleDetailView.loadingSchedule": {
+    "defaultMessage": "Memuat jadwal..."
+  },
+  "scheduleDetailView.loadingSessions": {
+    "defaultMessage": "Memuat sesi..."
+  },
+  "scheduleDetailView.messages": {
+    "defaultMessage": "Pesan: {count}"
+  },
+  "scheduleDetailView.noScheduleId": {
+    "defaultMessage": "Tidak ada ID jadwal yang diberikan. Kembali ke daftar jadwal."
+  },
+  "scheduleDetailView.noSessions": {
+    "defaultMessage": "Tidak ada sesi yang ditemukan untuk jadwal ini."
+  },
+  "scheduleDetailView.pauseSchedule": {
+    "defaultMessage": "Jeda Jadwal"
+  },
+  "scheduleDetailView.pauseUnpauseError": {
+    "defaultMessage": "Kesalahan Jeda/Lanjutkan"
+  },
+  "scheduleDetailView.paused": {
+    "defaultMessage": "Dijeda"
+  },
+  "scheduleDetailView.pausedMsg": {
+    "defaultMessage": "Dijeda \"{id}\""
+  },
+  "scheduleDetailView.pausedWarning": {
+    "defaultMessage": "Jadwal ini dijeda dan tidak akan berjalan secara otomatis. Gunakan \"Jalankan Jadwal Sekarang\" untuk memicunya secara manual atau lanjutkan untuk melanjutkan eksekusi otomatis."
+  },
+  "scheduleDetailView.processStarted": {
+    "defaultMessage": "Proses Dimulai:"
+  },
+  "scheduleDetailView.recentSessions": {
+    "defaultMessage": "Sesi Terbaru"
+  },
+  "scheduleDetailView.recipeSource": {
+    "defaultMessage": "Sumber Resep:"
+  },
+  "scheduleDetailView.runScheduleError": {
+    "defaultMessage": "Kesalahan Menjalankan Jadwal"
+  },
+  "scheduleDetailView.runScheduleNow": {
+    "defaultMessage": "Jalankan Jadwal Sekarang"
+  },
+  "scheduleDetailView.scheduleCompleted": {
+    "defaultMessage": "Proses selesai"
+  },
+  "scheduleDetailView.scheduleDetails": {
+    "defaultMessage": "Detail Jadwal"
+  },
+  "scheduleDetailView.scheduleInformation": {
+    "defaultMessage": "Informasi Jadwal"
+  },
+  "scheduleDetailView.scheduleLabel": {
+    "defaultMessage": "Jadwal:"
+  },
+  "scheduleDetailView.scheduleNotFound": {
+    "defaultMessage": "Jadwal Tidak Ditemukan"
+  },
+  "scheduleDetailView.scheduleNotFoundError": {
+    "defaultMessage": "Jadwal tidak ditemukan"
+  },
+  "scheduleDetailView.schedulePaused": {
+    "defaultMessage": "Jadwal Dijeda"
+  },
+  "scheduleDetailView.scheduleUnpaused": {
+    "defaultMessage": "Jadwal Dilanjutkan"
+  },
+  "scheduleDetailView.scheduleUpdated": {
+    "defaultMessage": "Jadwal Diperbarui"
+  },
+  "scheduleDetailView.sessionId": {
+    "defaultMessage": "ID Sesi: {id}"
+  },
+  "scheduleDetailView.unpauseSchedule": {
+    "defaultMessage": "Lanjutkan Jadwal"
+  },
+  "scheduleDetailView.unpausedMsg": {
+    "defaultMessage": "Dilanjutkan \"{id}\""
+  },
+  "scheduleDetailView.updateScheduleError": {
+    "defaultMessage": "Kesalahan Memperbarui Jadwal"
+  },
+  "scheduleDetailView.updatedMsg": {
+    "defaultMessage": "Diperbarui \"{id}\""
+  },
+  "scheduleDetailView.viewingScheduleId": {
+    "defaultMessage": "Melihat ID Jadwal: {id}"
+  },
+  "scheduleModal.browseYaml": {
+    "defaultMessage": "Telusuri berkas YAML..."
+  },
+  "scheduleModal.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "scheduleModal.createNewSchedule": {
+    "defaultMessage": "Buat Jadwal Baru"
+  },
+  "scheduleModal.createSchedule": {
+    "defaultMessage": "Buat Jadwal"
+  },
+  "scheduleModal.creating": {
+    "defaultMessage": "Membuat..."
+  },
+  "scheduleModal.deepLink": {
+    "defaultMessage": "Tautan dalam"
+  },
+  "scheduleModal.deepLinkPlaceholder": {
+    "defaultMessage": "Tempel tautan goose://recipe di sini..."
+  },
+  "scheduleModal.editSchedule": {
+    "defaultMessage": "Edit Jadwal"
+  },
+  "scheduleModal.failedParseRecipe": {
+    "defaultMessage": "Gagal mengurai resep dari berkas."
+  },
+  "scheduleModal.failedReadFile": {
+    "defaultMessage": "Gagal membaca berkas yang dipilih."
+  },
+  "scheduleModal.invalidDeepLink": {
+    "defaultMessage": "Tautan dalam tidak valid. Harap gunakan tautan goose://recipe."
+  },
+  "scheduleModal.invalidFileType": {
+    "defaultMessage": "Jenis berkas tidak valid: Harap pilih berkas YAML (.yaml atau .yml)"
+  },
+  "scheduleModal.nameLabel": {
+    "defaultMessage": "Nama:"
+  },
+  "scheduleModal.namePlaceholder": {
+    "defaultMessage": "mis., daily-summary-job"
+  },
+  "scheduleModal.provideValidRecipe": {
+    "defaultMessage": "Harap berikan sumber resep yang valid."
+  },
+  "scheduleModal.recipeDescription": {
+    "defaultMessage": "Deskripsi: {description}"
+  },
+  "scheduleModal.recipeParsed": {
+    "defaultMessage": "Resep berhasil diurai"
+  },
+  "scheduleModal.recipeTitle": {
+    "defaultMessage": "Judul: {title}"
+  },
+  "scheduleModal.scheduleIdRequired": {
+    "defaultMessage": "ID jadwal diperlukan."
+  },
+  "scheduleModal.scheduleLabel": {
+    "defaultMessage": "Jadwal:"
+  },
+  "scheduleModal.selected": {
+    "defaultMessage": "Dipilih: {path}"
+  },
+  "scheduleModal.sourceLabel": {
+    "defaultMessage": "Sumber:"
+  },
+  "scheduleModal.updateSchedule": {
+    "defaultMessage": "Perbarui Jadwal"
+  },
+  "scheduleModal.updating": {
+    "defaultMessage": "Memperbarui..."
+  },
+  "scheduleModal.yaml": {
+    "defaultMessage": "YAML"
+  },
+  "schedulesView.confirmDelete": {
+    "defaultMessage": "Hapus jadwal \"{id}\"? Resep akan tetap disimpan."
+  },
+  "schedulesView.createSchedule": {
+    "defaultMessage": "Buat Jadwal"
+  },
+  "schedulesView.description": {
+    "defaultMessage": "Buat dan kelola tugas terjadwal untuk menjalankan resep secara otomatis pada waktu yang ditentukan."
+  },
+  "schedulesView.edit": {
+    "defaultMessage": "Edit"
+  },
+  "schedulesView.errorPrefix": {
+    "defaultMessage": "Kesalahan: {error}"
+  },
+  "schedulesView.inspect": {
+    "defaultMessage": "Periksa"
+  },
+  "schedulesView.inspectError": {
+    "defaultMessage": "Periksa Kesalahan Pekerjaan"
+  },
+  "schedulesView.inspectNoInfo": {
+    "defaultMessage": "Tidak ada informasi terperinci yang tersedia untuk pekerjaan ini"
+  },
+  "schedulesView.jobInspection": {
+    "defaultMessage": "Pemeriksaan Pekerjaan"
+  },
+  "schedulesView.jobKilled": {
+    "defaultMessage": "Pekerjaan Dihentikan"
+  },
+  "schedulesView.kill": {
+    "defaultMessage": "Hentikan"
+  },
+  "schedulesView.killError": {
+    "defaultMessage": "Kesalahan Menghentikan Pekerjaan"
+  },
+  "schedulesView.lastRun": {
+    "defaultMessage": "Terakhir berjalan: {date}"
+  },
+  "schedulesView.noSchedules": {
+    "defaultMessage": "Belum ada jadwal"
+  },
+  "schedulesView.pause": {
+    "defaultMessage": "Jeda"
+  },
+  "schedulesView.pauseError": {
+    "defaultMessage": "Kesalahan Menjeda Jadwal"
+  },
+  "schedulesView.paused": {
+    "defaultMessage": "Dijeda"
+  },
+  "schedulesView.refresh": {
+    "defaultMessage": "Segarkan"
+  },
+  "schedulesView.refreshing": {
+    "defaultMessage": "Menyegarkan..."
+  },
+  "schedulesView.resume": {
+    "defaultMessage": "Lanjutkan"
+  },
+  "schedulesView.running": {
+    "defaultMessage": "Berjalan"
+  },
+  "schedulesView.schedulePaused": {
+    "defaultMessage": "Jadwal Dijeda"
+  },
+  "schedulesView.schedulePausedMsg": {
+    "defaultMessage": "Berhasil menjeda jadwal \"{id}\""
+  },
+  "schedulesView.scheduleUnpaused": {
+    "defaultMessage": "Jadwal Dilanjutkan"
+  },
+  "schedulesView.scheduleUnpausedMsg": {
+    "defaultMessage": "Berhasil melanjutkan jadwal \"{id}\""
+  },
+  "schedulesView.scheduleUpdated": {
+    "defaultMessage": "Jadwal Diperbarui"
+  },
+  "schedulesView.scheduleUpdatedMsg": {
+    "defaultMessage": "Berhasil memperbarui jadwal \"{id}\""
+  },
+  "schedulesView.scheduler": {
+    "defaultMessage": "Penjadwal"
+  },
+  "schedulesView.unpauseError": {
+    "defaultMessage": "Kesalahan Melanjutkan Jadwal"
+  },
+  "searchBar.caseSensitive": {
+    "defaultMessage": "Peka Huruf Besar/Kecil"
+  },
+  "searchBar.close": {
+    "defaultMessage": "Tutup ({shortcut})"
+  },
+  "searchBar.next": {
+    "defaultMessage": "Berikutnya ({shortcut})"
+  },
+  "searchBar.placeholder": {
+    "defaultMessage": "Cari percakapan..."
+  },
+  "searchBar.previous": {
+    "defaultMessage": "Sebelumnya ({shortcut})"
+  },
+  "secureStorageNotice.defaultMessage": {
+    "defaultMessage": "Kunci disimpan dengan aman di keychain"
+  },
+  "securityToggle.apiTokenDescription": {
+    "defaultMessage": "Token autentikasi untuk layanan klasifikasi"
+  },
+  "securityToggle.apiTokenOptional": {
+    "defaultMessage": "Token API (Opsional)"
+  },
+  "securityToggle.classificationEndpoint": {
+    "defaultMessage": "Titik Akhir Klasifikasi"
+  },
+  "securityToggle.classificationEndpointDescription": {
+    "defaultMessage": "Masukkan URL lengkap untuk layanan klasifikasi Anda"
+  },
+  "securityToggle.commandClassifierActive": {
+    "defaultMessage": "Pengklasifikasi perintah aktif (dikonfigurasi otomatis dari lingkungan)"
+  },
+  "securityToggle.commandEndpointDescription": {
+    "defaultMessage": "Masukkan URL lengkap untuk layanan klasifikasi injeksi perintah Anda"
+  },
+  "securityToggle.commandInjectionDescription": {
+    "defaultMessage": "Gunakan model ML untuk mendeteksi perintah shell berbahaya"
+  },
+  "securityToggle.detectionModel": {
+    "defaultMessage": "Model Deteksi"
+  },
+  "securityToggle.detectionModelDescription": {
+    "defaultMessage": "Pilih model ML yang akan digunakan untuk deteksi injeksi prompt"
+  },
+  "securityToggle.detectionThreshold": {
+    "defaultMessage": "Ambang Deteksi"
+  },
+  "securityToggle.enableCommandInjection": {
+    "defaultMessage": "Aktifkan Deteksi ML Injeksi Perintah"
+  },
+  "securityToggle.enablePromptInjection": {
+    "defaultMessage": "Aktifkan Deteksi Injeksi Prompt"
+  },
+  "securityToggle.enablePromptInjectionMl": {
+    "defaultMessage": "Aktifkan Deteksi ML Injeksi Prompt"
+  },
+  "securityToggle.mlEndpointDescription": {
+    "defaultMessage": "Masukkan URL lengkap untuk layanan klasifikasi ML Anda (termasuk pengidentifikasi model)"
+  },
+  "securityToggle.mlTokenDescription": {
+    "defaultMessage": "Token autentikasi untuk layanan ML (mis., token HuggingFace)"
+  },
+  "securityToggle.overrideNotice": {
+    "defaultMessage": "Pengaturan ini dikelola oleh organisasi Anda dan tidak dapat diubah."
+  },
+  "securityToggle.promptInjectionDescription": {
+    "defaultMessage": "Deteksi dan cegah potensi serangan injeksi prompt"
+  },
+  "securityToggle.promptInjectionMlDescription": {
+    "defaultMessage": "Gunakan model ML untuk mendeteksi potensi injeksi prompt dalam obrolan Anda"
+  },
+  "securityToggle.thresholdDescription": {
+    "defaultMessage": "Nilai yang lebih tinggi lebih ketat (0,01 = sangat longgar, 1,0 = paling ketat)"
+  },
+  "securityToggle.warpNotice": {
+    "defaultMessage": "Deteksi injeksi perintah bekerja paling baik saat terhubung ke WARP (diperlukan untuk menjangkau layanan klasifikasi)."
+  },
+  "sessionActionsHeader.actionsLabel": {
+    "defaultMessage": "Tindakan sesi"
+  },
+  "sessionActionsHeader.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "sessionActionsHeader.close": {
+    "defaultMessage": "Tutup"
+  },
+  "sessionActionsHeader.copiedJson": {
+    "defaultMessage": "JSON sesi disalin"
+  },
+  "sessionActionsHeader.copiedText": {
+    "defaultMessage": "Teks disalin"
+  },
+  "sessionActionsHeader.copyJson": {
+    "defaultMessage": "Salin JSON"
+  },
+  "sessionActionsHeader.copyText": {
+    "defaultMessage": "Salin teks"
+  },
+  "sessionActionsHeader.duplicateFailed": {
+    "defaultMessage": "Gagal menggandakan sesi: {error}"
+  },
+  "sessionActionsHeader.duplicateSession": {
+    "defaultMessage": "Gandakan sesi"
+  },
+  "sessionActionsHeader.duplicated": {
+    "defaultMessage": "Sesi digandakan"
+  },
+  "sessionActionsHeader.fullTextTitle": {
+    "defaultMessage": "Nilai teks"
+  },
+  "sessionActionsHeader.jsonFailed": {
+    "defaultMessage": "Gagal memuat JSON sesi: {error}"
+  },
+  "sessionActionsHeader.jsonTitle": {
+    "defaultMessage": "JSON Sesi"
+  },
+  "sessionActionsHeader.loadingJson": {
+    "defaultMessage": "Memuat JSON..."
+  },
+  "sessionActionsHeader.renameFailed": {
+    "defaultMessage": "Gagal mengganti nama sesi: {error}"
+  },
+  "sessionActionsHeader.renamePlaceholder": {
+    "defaultMessage": "Masukkan nama sesi"
+  },
+  "sessionActionsHeader.renameSession": {
+    "defaultMessage": "Ganti nama sesi"
+  },
+  "sessionActionsHeader.renameTitle": {
+    "defaultMessage": "Ganti Nama Sesi"
+  },
+  "sessionActionsHeader.renamed": {
+    "defaultMessage": "Sesi diganti namanya"
+  },
+  "sessionActionsHeader.save": {
+    "defaultMessage": "Simpan"
+  },
+  "sessionActionsHeader.saving": {
+    "defaultMessage": "Menyimpan..."
+  },
+  "sessionActionsHeader.viewJson": {
+    "defaultMessage": "Lihat JSON sesi"
+  },
+  "sessionIndicators.error": {
+    "defaultMessage": "Sesi mengalami kesalahan"
+  },
+  "sessionIndicators.newActivity": {
+    "defaultMessage": "Memiliki aktivitas baru"
+  },
+  "sessionIndicators.streaming": {
+    "defaultMessage": "Streaming"
+  },
+  "sessionViewComponents.empty.description": {
+    "defaultMessage": "Sesi ini tidak berisi pesan apa pun"
+  },
+  "sessionViewComponents.empty.title": {
+    "defaultMessage": "Tidak ada pesan ditemukan"
+  },
+  "sessionViewComponents.error.loading": {
+    "defaultMessage": "Kesalahan Memuat Detail Sesi"
+  },
+  "sessionViewComponents.error.tryAgain": {
+    "defaultMessage": "Coba Lagi"
+  },
+  "sessionViewComponents.role.assistant": {
+    "defaultMessage": "Goose"
+  },
+  "sessionViewComponents.role.user": {
+    "defaultMessage": "Anda"
+  },
+  "sessions.action.delete": {
+    "defaultMessage": "Hapus sesi"
+  },
+  "sessions.action.duplicate": {
+    "defaultMessage": "Gandakan sesi"
+  },
+  "sessions.action.editName": {
+    "defaultMessage": "Edit nama sesi"
+  },
+  "sessions.action.export": {
+    "defaultMessage": "Ekspor sesi"
+  },
+  "sessions.action.openNewWindow": {
+    "defaultMessage": "Buka di jendela baru"
+  },
+  "sessions.action.shareNostr": {
+    "defaultMessage": "Bagikan tautan Nostr terenkripsi"
+  },
+  "sessions.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "sessions.chatHistory": {
+    "defaultMessage": "Riwayat obrolan"
+  },
+  "sessions.chatHistoryDesc": {
+    "defaultMessage": "Lihat dan cari percakapan Anda sebelumnya dengan Goose. {shortcut} untuk mencari."
+  },
+  "sessions.close": {
+    "defaultMessage": "Tutup"
+  },
+  "sessions.delete.message": {
+    "defaultMessage": "Apakah Anda yakin ingin menghapus sesi \"{name}\"? Tindakan ini tidak dapat dibatalkan."
+  },
+  "sessions.delete.title": {
+    "defaultMessage": "Hapus Sesi"
+  },
+  "sessions.edit.placeholder": {
+    "defaultMessage": "Masukkan deskripsi sesi"
+  },
+  "sessions.edit.title": {
+    "defaultMessage": "Edit Deskripsi Sesi"
+  },
+  "sessions.empty.description": {
+    "defaultMessage": "Riwayat obrolan Anda akan muncul di sini"
+  },
+  "sessions.empty.title": {
+    "defaultMessage": "Tidak ada sesi obrolan ditemukan"
+  },
+  "sessions.error.loading": {
+    "defaultMessage": "Kesalahan Memuat Sesi"
+  },
+  "sessions.error.tryAgain": {
+    "defaultMessage": "Coba Lagi"
+  },
+  "sessions.import": {
+    "defaultMessage": "Impor Sesi"
+  },
+  "sessions.importNostr": {
+    "defaultMessage": "Impor Tautan"
+  },
+  "sessions.importNostr.description": {
+    "defaultMessage": "Tempel tautan berbagi Nostr Goose untuk mengambil, mendekripsi, dan mengimpor sesi."
+  },
+  "sessions.importNostr.placeholder": {
+    "defaultMessage": "goose://sessions/nostr?nevent=...&key=..."
+  },
+  "sessions.importNostr.title": {
+    "defaultMessage": "Impor Sesi Nostr"
+  },
+  "sessions.importing": {
+    "defaultMessage": "Mengimpor..."
+  },
+  "sessions.loadingMore": {
+    "defaultMessage": "Memuat lebih banyak sesi..."
+  },
+  "sessions.save": {
+    "defaultMessage": "Simpan"
+  },
+  "sessions.saving": {
+    "defaultMessage": "Menyimpan..."
+  },
+  "sessions.search.noResults": {
+    "defaultMessage": "Tidak ada sesi yang cocok ditemukan"
+  },
+  "sessions.search.noResultsDesc": {
+    "defaultMessage": "Coba sesuaikan kata kunci pencarian Anda"
+  },
+  "sessions.searchPlaceholder": {
+    "defaultMessage": "Cari riwayat..."
+  },
+  "sessions.shareNostr.description": {
+    "defaultMessage": "Siapa pun yang memiliki tautan ini dapat mengambil dan mendekripsi sesi. Perlakukan seperti rahasia."
+  },
+  "sessions.shareNostr.title": {
+    "defaultMessage": "Tautan Berbagi Nostr Terenkripsi"
+  },
+  "sessions.toast.copied": {
+    "defaultMessage": "Disalin ke papan klip"
+  },
+  "sessions.toast.deleteFailed": {
+    "defaultMessage": "Gagal menghapus sesi \"{name}\": {error}"
+  },
+  "sessions.toast.deleted": {
+    "defaultMessage": "Sesi berhasil dihapus"
+  },
+  "sessions.toast.duplicateFailed": {
+    "defaultMessage": "Gagal menggandakan sesi: {error}"
+  },
+  "sessions.toast.duplicated": {
+    "defaultMessage": "Sesi \"{name}\" berhasil digandakan"
+  },
+  "sessions.toast.exported": {
+    "defaultMessage": "Sesi berhasil diekspor"
+  },
+  "sessions.toast.importFailed": {
+    "defaultMessage": "Gagal mengimpor sesi: {error}"
+  },
+  "sessions.toast.imported": {
+    "defaultMessage": "Sesi berhasil diimpor"
+  },
+  "sessions.toast.shareNostr": {
+    "defaultMessage": "Tautan berbagi Nostr terenkripsi dibuat"
+  },
+  "sessions.toast.shareNostrFailed": {
+    "defaultMessage": "Gagal membuat tautan berbagi Nostr: {error}"
+  },
+  "sessions.toast.updateFailed": {
+    "defaultMessage": "Gagal memperbarui deskripsi sesi: {error}"
+  },
+  "sessions.toast.updated": {
+    "defaultMessage": "Deskripsi sesi berhasil diperbarui"
+  },
+  "settings.appearance.description": {
+    "defaultMessage": "Konfigurasikan tampilan goose di sistem Anda"
+  },
+  "settings.appearance.title": {
+    "defaultMessage": "Tampilan"
+  },
+  "settings.close": {
+    "defaultMessage": "Tutup"
+  },
+  "settings.costTracking.description": {
+    "defaultMessage": "Tampilkan harga model dan biaya penggunaan"
+  },
+  "settings.costTracking.title": {
+    "defaultMessage": "Pelacakan Biaya"
+  },
+  "settings.dockIcon.description": {
+    "defaultMessage": "Tampilkan goose di dock"
+  },
+  "settings.dockIcon.title": {
+    "defaultMessage": "Ikon dock"
+  },
+  "settings.help.description": {
+    "defaultMessage": "Bantu kami meningkatkan goose dengan melaporkan masalah atau meminta fitur baru"
+  },
+  "settings.help.reportBug": {
+    "defaultMessage": "Laporkan Bug"
+  },
+  "settings.help.requestFeature": {
+    "defaultMessage": "Minta Fitur"
+  },
+  "settings.help.title": {
+    "defaultMessage": "Bantuan & masukan"
+  },
+  "settings.language.description": {
+    "defaultMessage": "Pilih bahasa tampilan untuk goose"
+  },
+  "settings.language.english": {
+    "defaultMessage": "English"
+  },
+  "settings.language.french": {
+    "defaultMessage": "Bahasa Prancis"
+  },
+  "settings.language.german": {
+    "defaultMessage": "Bahasa Jerman"
+  },
+  "settings.language.hindi": {
+    "defaultMessage": "Bahasa Hindi"
+  },
+  "settings.language.indonesian": {
+    "defaultMessage": "Bahasa Indonesia"
+  },
+  "settings.language.italian": {
+    "defaultMessage": "Bahasa Italia"
+  },
+  "settings.language.japanese": {
+    "defaultMessage": "Bahasa Jepang"
+  },
+  "settings.language.korean": {
+    "defaultMessage": "Bahasa Korea"
+  },
+  "settings.language.malay": {
+    "defaultMessage": "Bahasa Melayu"
+  },
+  "settings.language.portuguese": {
+    "defaultMessage": "Bahasa Portugis"
+  },
+  "settings.language.russian": {
+    "defaultMessage": "Bahasa Rusia"
+  },
+  "settings.language.spanish": {
+    "defaultMessage": "Bahasa Spanyol"
+  },
+  "settings.language.systemDefault": {
+    "defaultMessage": "Default Sistem"
+  },
+  "settings.language.title": {
+    "defaultMessage": "Bahasa"
+  },
+  "settings.language.turkish": {
+    "defaultMessage": "Bahasa Turki"
+  },
+  "settings.language.vietnamese": {
+    "defaultMessage": "Bahasa Vietnam"
+  },
+  "settings.language.zhCN": {
+    "defaultMessage": "Bahasa Tionghoa (Sederhana)"
+  },
+  "settings.language.zhTW": {
+    "defaultMessage": "Bahasa Tionghoa (Tradisional)"
+  },
+  "settings.menuBarIcon.description": {
+    "defaultMessage": "Tampilkan goose di bilah menu"
+  },
+  "settings.menuBarIcon.title": {
+    "defaultMessage": "Ikon bilah menu"
+  },
+  "settings.notifications.configGuide": {
+    "defaultMessage": "Panduan konfigurasi"
+  },
+  "settings.notifications.description": {
+    "defaultMessage": "Notifikasi dikelola oleh OS Anda - {link}"
+  },
+  "settings.notifications.modal.macInstructions": {
+    "defaultMessage": "Untuk mengaktifkan notifikasi di macOS:"
+  },
+  "settings.notifications.modal.macStep1": {
+    "defaultMessage": "Buka System Preferences"
+  },
+  "settings.notifications.modal.macStep2": {
+    "defaultMessage": "Klik Notifications"
+  },
+  "settings.notifications.modal.macStep3": {
+    "defaultMessage": "Temukan dan pilih goose di daftar aplikasi"
+  },
+  "settings.notifications.modal.macStep4": {
+    "defaultMessage": "Aktifkan notifikasi dan sesuaikan pengaturan sesuai keinginan"
+  },
+  "settings.notifications.modal.title": {
+    "defaultMessage": "Cara Mengaktifkan Notifikasi"
+  },
+  "settings.notifications.modal.winInstructions": {
+    "defaultMessage": "Untuk mengaktifkan notifikasi di Windows:"
+  },
+  "settings.notifications.modal.winStep1": {
+    "defaultMessage": "Buka Settings"
+  },
+  "settings.notifications.modal.winStep2": {
+    "defaultMessage": "Buka System > Notifications"
+  },
+  "settings.notifications.modal.winStep3": {
+    "defaultMessage": "Temukan dan pilih goose di daftar aplikasi"
+  },
+  "settings.notifications.modal.winStep4": {
+    "defaultMessage": "Aktifkan notifikasi dan sesuaikan pengaturan sesuai keinginan"
+  },
+  "settings.notifications.openSettings": {
+    "defaultMessage": "Buka Pengaturan"
+  },
+  "settings.notifications.task.description": {
+    "defaultMessage": "Beri tahu saat Goose menyelesaikan tugas selagi jendela berada di latar belakang"
+  },
+  "settings.notifications.task.title": {
+    "defaultMessage": "Notifikasi penyelesaian tugas"
+  },
+  "settings.notifications.title": {
+    "defaultMessage": "Notifikasi"
+  },
+  "settings.preventSleep.description": {
+    "defaultMessage": "Jaga komputer Anda tetap menyala saat goose menjalankan tugas (layar tetap dapat terkunci)"
+  },
+  "settings.preventSleep.title": {
+    "defaultMessage": "Cegah Tidur"
+  },
+  "settings.theme.description": {
+    "defaultMessage": "Sesuaikan tampilan dan nuansa goose"
+  },
+  "settings.theme.title": {
+    "defaultMessage": "Tema"
+  },
+  "settings.updates.description": {
+    "defaultMessage": "Periksa dan instal pembaruan agar goose berjalan optimal"
+  },
+  "settings.updates.title": {
+    "defaultMessage": "Pembaruan"
+  },
+  "settings.version.title": {
+    "defaultMessage": "Versi"
+  },
+  "settingsView.tabApp": {
+    "defaultMessage": "Aplikasi"
+  },
+  "settingsView.tabAuth": {
+    "defaultMessage": "Autentikasi"
+  },
+  "settingsView.tabChat": {
+    "defaultMessage": "Obrolan"
+  },
+  "settingsView.tabKeyboard": {
+    "defaultMessage": "Keyboard"
+  },
+  "settingsView.tabLocalInference": {
+    "defaultMessage": "Inferensi Lokal"
+  },
+  "settingsView.tabModels": {
+    "defaultMessage": "Model"
+  },
+  "settingsView.tabPrompts": {
+    "defaultMessage": "Prompt"
+  },
+  "settingsView.tabSession": {
+    "defaultMessage": "Sesi"
+  },
+  "settingsView.title": {
+    "defaultMessage": "Pengaturan"
+  },
+  "sheet.close": {
+    "defaultMessage": "Tutup"
+  },
+  "shortcutRecorder.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "shortcutRecorder.clickToRecord": {
+    "defaultMessage": "Klik untuk merekam..."
+  },
+  "shortcutRecorder.conflictWarning": {
+    "defaultMessage": "Pintasan ini sudah digunakan oleh {label}. Menyimpan akan menetapkannya ulang ke tindakan ini."
+  },
+  "shortcutRecorder.pressShortcut": {
+    "defaultMessage": "Tekan pintasan..."
+  },
+  "shortcutRecorder.save": {
+    "defaultMessage": "Simpan"
+  },
+  "skillsView.addSkill": {
+    "defaultMessage": "Tambah Keterampilan"
+  },
+  "skillsView.adjustSearchTerms": {
+    "defaultMessage": "Coba sesuaikan kata kunci pencarian Anda"
+  },
+  "skillsView.comingSoon": {
+    "defaultMessage": "Segera hadir"
+  },
+  "skillsView.errorLoadingSkills": {
+    "defaultMessage": "Kesalahan Memuat Keterampilan"
+  },
+  "skillsView.noMatchingSkills": {
+    "defaultMessage": "Tidak ada keterampilan yang cocok ditemukan"
+  },
+  "skillsView.noSkillsDescription": {
+    "defaultMessage": "Keterampilan dimuat dari file SKILL.md di ~/.config/agents/skills/, .goose/skills/, atau direktori lain yang didukung."
+  },
+  "skillsView.noSkillsInstalled": {
+    "defaultMessage": "Tidak ada keterampilan yang terpasang"
+  },
+  "skillsView.searchSkillsPlaceholder": {
+    "defaultMessage": "Cari keterampilan..."
+  },
+  "skillsView.skillsDescription": {
+    "defaultMessage": "Lihat keterampilan terpasang yang memperluas kemampuan Goose. {shortcut} untuk mencari."
+  },
+  "skillsView.skillsTitle": {
+    "defaultMessage": "Keterampilan"
+  },
+  "skillsView.tryAgain": {
+    "defaultMessage": "Coba Lagi"
+  },
+  "spellcheckToggle.description": {
+    "defaultMessage": "Periksa ejaan di input obrolan. Memerlukan mulai ulang agar berlaku."
+  },
+  "spellcheckToggle.title": {
+    "defaultMessage": "Aktifkan Pemeriksaan Ejaan"
+  },
+  "standaloneAppView.failedToLoad": {
+    "defaultMessage": "Gagal Memuat Aplikasi"
+  },
+  "standaloneAppView.initializing": {
+    "defaultMessage": "Menginisialisasi aplikasi..."
+  },
+  "standaloneAppView.missingParams": {
+    "defaultMessage": "Parameter yang diperlukan tidak ada"
+  },
+  "stringUtils.configuredProvider": {
+    "defaultMessage": "Penyedia {name} telah dikonfigurasi"
+  },
+  "stringUtils.ollamaApp": {
+    "defaultMessage": "Aplikasi Ollama"
+  },
+  "stringUtils.ollamaNotConfiguredPrefix": {
+    "defaultMessage": "Untuk menggunakan, salah satu"
+  },
+  "stringUtils.ollamaNotConfiguredSuffix": {
+    "defaultMessage": "harus terpasang di mesin Anda dan terbuka, atau Anda harus memasukkan nilai untuk OLLAMA_HOST."
+  },
+  "subRecipeEditor.addExisting": {
+    "defaultMessage": "Tambahkan yang Sudah Ada"
+  },
+  "subRecipeEditor.createNew": {
+    "defaultMessage": "Buat Subresep Baru"
+  },
+  "subRecipeEditor.deleteSubrecipe": {
+    "defaultMessage": "Hapus subresep {name}"
+  },
+  "subRecipeEditor.description": {
+    "defaultMessage": "Subresep adalah resep yang dapat dipanggil sebagai alat selama eksekusi. Subresep memungkinkan alur kerja multi-langkah dan komponen yang dapat digunakan kembali."
+  },
+  "subRecipeEditor.duplicateName": {
+    "defaultMessage": "Nama Duplikat"
+  },
+  "subRecipeEditor.duplicateNameMsg": {
+    "defaultMessage": "Subresep bernama \"{name}\" sudah ada. Silakan gunakan nama yang unik."
+  },
+  "subRecipeEditor.editSubrecipe": {
+    "defaultMessage": "Edit subresep {name}"
+  },
+  "subRecipeEditor.label": {
+    "defaultMessage": "Subresep"
+  },
+  "subRecipeEditor.preconfiguredValues": {
+    "defaultMessage": "Nilai prakonfigurasi:"
+  },
+  "subRecipeEditor.sequential": {
+    "defaultMessage": "Berurutan"
+  },
+  "subRecipeModal.addTitle": {
+    "defaultMessage": "Tambah Subresep"
+  },
+  "subRecipeModal.apply": {
+    "defaultMessage": "Terapkan"
+  },
+  "subRecipeModal.browse": {
+    "defaultMessage": "Telusuri"
+  },
+  "subRecipeModal.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "subRecipeModal.closeModal": {
+    "defaultMessage": "Tutup modal subresep"
+  },
+  "subRecipeModal.configureTitle": {
+    "defaultMessage": "Konfigurasikan Subresep"
+  },
+  "subRecipeModal.descriptionLabel": {
+    "defaultMessage": "Deskripsi"
+  },
+  "subRecipeModal.descriptionPlaceholder": {
+    "defaultMessage": "Deskripsi opsional tentang apa yang dilakukan subresep ini..."
+  },
+  "subRecipeModal.invalidFile": {
+    "defaultMessage": "File Tidak Valid"
+  },
+  "subRecipeModal.invalidFileMsg": {
+    "defaultMessage": "Silakan pilih file YAML (.yaml atau .yml)."
+  },
+  "subRecipeModal.nameHint": {
+    "defaultMessage": "Pengidentifikasi unik yang digunakan untuk menghasilkan nama alat"
+  },
+  "subRecipeModal.nameLabel": {
+    "defaultMessage": "Nama"
+  },
+  "subRecipeModal.namePlaceholder": {
+    "defaultMessage": "mis., security_scan"
+  },
+  "subRecipeModal.pathHint": {
+    "defaultMessage": "Telusuri file resep yang sudah ada atau masukkan jalur secara manual"
+  },
+  "subRecipeModal.pathLabel": {
+    "defaultMessage": "Jalur"
+  },
+  "subRecipeModal.pathPlaceholder": {
+    "defaultMessage": "mis., ./subrecipes/security-analysis.yaml"
+  },
+  "subRecipeModal.preconfiguredValues": {
+    "defaultMessage": "Nilai Prakonfigurasi"
+  },
+  "subRecipeModal.preconfiguredValuesHint": {
+    "defaultMessage": "Nilai parameter opsional yang selalu diteruskan ke subresep"
+  },
+  "subRecipeModal.sequentialHint": {
+    "defaultMessage": "(Memaksa eksekusi berurutan dari beberapa instans subresep)"
+  },
+  "subRecipeModal.sequentialLabel": {
+    "defaultMessage": "Berurutan saat diulang"
+  },
+  "subRecipeModal.subtitle": {
+    "defaultMessage": "Konfigurasikan subresep yang dapat dipanggil sebagai alat selama eksekusi resep"
+  },
+  "switchModelModal.backToModelList": {
+    "defaultMessage": "Kembali ke daftar model"
+  },
+  "switchModelModal.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "switchModelModal.checkProviderConfig": {
+    "defaultMessage": "Periksa konfigurasi penyedia Anda di Pengaturan → Penyedia"
+  },
+  "switchModelModal.chooseModel": {
+    "defaultMessage": "Pilih model:"
+  },
+  "switchModelModal.claudeAdaptive": {
+    "defaultMessage": "Adaptif - Claude memutuskan kapan dan seberapa banyak harus berpikir"
+  },
+  "switchModelModal.claudeDisabled": {
+    "defaultMessage": "Dinonaktifkan - Tanpa pemikiran lanjutan"
+  },
+  "switchModelModal.claudeEffortHigh": {
+    "defaultMessage": "Tinggi - Penalaran mendalam (default)"
+  },
+  "switchModelModal.claudeEffortLow": {
+    "defaultMessage": "Rendah - Pemikiran minimal, respons tercepat"
+  },
+  "switchModelModal.claudeEffortMax": {
+    "defaultMessage": "Maks - Tanpa batasan pada kedalaman pemikiran"
+  },
+  "switchModelModal.claudeEffortMedium": {
+    "defaultMessage": "Sedang - Pemikiran moderat"
+  },
+  "switchModelModal.claudeEnabled": {
+    "defaultMessage": "Diaktifkan - Anggaran token tetap untuk pemikiran"
+  },
+  "switchModelModal.couldNotContactProvider": {
+    "defaultMessage": "Tidak dapat menghubungi penyedia"
+  },
+  "switchModelModal.customModelName": {
+    "defaultMessage": "Nama model kustom"
+  },
+  "switchModelModal.description": {
+    "defaultMessage": "Pilih penyedia dan model untuk digunakan dalam percakapan Anda."
+  },
+  "switchModelModal.enterModelNotListed": {
+    "defaultMessage": "Masukkan model yang tidak terdaftar..."
+  },
+  "switchModelModal.extendedThinking": {
+    "defaultMessage": "Pemikiran Lanjutan"
+  },
+  "switchModelModal.geminiOnly": {
+    "defaultMessage": "(Hanya model Gemini 3)"
+  },
+  "switchModelModal.goToSettings": {
+    "defaultMessage": "Buka Pengaturan"
+  },
+  "switchModelModal.loadingModels": {
+    "defaultMessage": "Memuat model…"
+  },
+  "switchModelModal.localModelsDescription": {
+    "defaultMessage": "Untuk menggunakan inferensi lokal, Anda perlu mengunduh model ke komputer Anda terlebih dahulu. Buka Pengaturan → Model untuk mengelola model lokal."
+  },
+  "switchModelModal.localModelsTitle": {
+    "defaultMessage": "Model lokal perlu diunduh terlebih dahulu"
+  },
+  "switchModelModal.providerPlaceholder": {
+    "defaultMessage": "Penyedia, ketik untuk mencari"
+  },
+  "switchModelModal.quickStartGuide": {
+    "defaultMessage": "Panduan mulai cepat"
+  },
+  "switchModelModal.recommended": {
+    "defaultMessage": "Direkomendasikan"
+  },
+  "switchModelModal.selectEffortLevel": {
+    "defaultMessage": "Pilih tingkat upaya"
+  },
+  "switchModelModal.selectModel": {
+    "defaultMessage": "Silakan pilih model"
+  },
+  "switchModelModal.selectModelButton": {
+    "defaultMessage": "Pilih model"
+  },
+  "switchModelModal.selectModelPlaceholder": {
+    "defaultMessage": "Pilih model, ketik untuk mencari"
+  },
+  "switchModelModal.selectOrEnterModel": {
+    "defaultMessage": "Silakan pilih atau masukkan model"
+  },
+  "switchModelModal.selectProvider": {
+    "defaultMessage": "Silakan pilih penyedia"
+  },
+  "switchModelModal.selectThinkingLevel": {
+    "defaultMessage": "Pilih tingkat pemikiran"
+  },
+  "switchModelModal.selectThinkingMode": {
+    "defaultMessage": "Pilih mode pemikiran"
+  },
+  "switchModelModal.thinkingBudget": {
+    "defaultMessage": "Anggaran Pemikiran (token)"
+  },
+  "switchModelModal.thinkingEffort": {
+    "defaultMessage": "Upaya Pemikiran"
+  },
+  "switchModelModal.thinkingEffortOff": {
+    "defaultMessage": "Mati - Tanpa pemikiran lanjutan"
+  },
+  "switchModelModal.thinkingLevel": {
+    "defaultMessage": "Tingkat Pemikiran"
+  },
+  "switchModelModal.thinkingLevelHigh": {
+    "defaultMessage": "Tinggi - Penalaran lebih mendalam, latensi lebih tinggi"
+  },
+  "switchModelModal.thinkingLevelLow": {
+    "defaultMessage": "Rendah - Latensi lebih baik, penalaran lebih ringan"
+  },
+  "switchModelModal.title": {
+    "defaultMessage": "Ganti model"
+  },
+  "switchModelModal.typeModelName": {
+    "defaultMessage": "Ketik nama model di sini"
+  },
+  "switchModelModal.useOtherProvider": {
+    "defaultMessage": "Gunakan penyedia lain"
+  },
+  "telemetryConsentPrompt.description": {
+    "defaultMessage": "Apakah Anda ingin membagikan data penggunaan anonim untuk membantu meningkatkan goose? Kami tidak pernah mengumpulkan percakapan, kode, atau data pribadi Anda."
+  },
+  "telemetryConsentPrompt.heading": {
+    "defaultMessage": "Bantu tingkatkan goose"
+  },
+  "telemetryConsentPrompt.learnMore": {
+    "defaultMessage": "Pelajari lebih lanjut"
+  },
+  "telemetryConsentPrompt.optIn": {
+    "defaultMessage": "Ya, bagikan data penggunaan anonim"
+  },
+  "telemetryConsentPrompt.optOut": {
+    "defaultMessage": "Tidak, terima kasih"
+  },
+  "telemetrySettings.configErrorTitle": {
+    "defaultMessage": "Kesalahan Konfigurasi"
+  },
+  "telemetrySettings.description": {
+    "defaultMessage": "Kontrol bagaimana data Anda digunakan"
+  },
+  "telemetrySettings.learnMore": {
+    "defaultMessage": "Pelajari lebih lanjut"
+  },
+  "telemetrySettings.loadError": {
+    "defaultMessage": "Gagal memuat pengaturan telemetri."
+  },
+  "telemetrySettings.title": {
+    "defaultMessage": "Privasi"
+  },
+  "telemetrySettings.toggleDescription": {
+    "defaultMessage": "Bantu tingkatkan goose dengan membagikan statistik penggunaan anonim."
+  },
+  "telemetrySettings.toggleLabel": {
+    "defaultMessage": "Data penggunaan anonim"
+  },
+  "telemetrySettings.updateError": {
+    "defaultMessage": "Gagal memperbarui pengaturan telemetri."
+  },
+  "themeSelector.dark": {
+    "defaultMessage": "Gelap"
+  },
+  "themeSelector.light": {
+    "defaultMessage": "Terang"
+  },
+  "themeSelector.system": {
+    "defaultMessage": "Sistem"
+  },
+  "themeSelector.theme": {
+    "defaultMessage": "Tema"
+  },
+  "toolApprovalButtons.allowOnce": {
+    "defaultMessage": "Izinkan Sekali"
+  },
+  "toolApprovalButtons.allowedOnce": {
+    "defaultMessage": "Diizinkan sekali"
+  },
+  "toolApprovalButtons.alwaysAllow": {
+    "defaultMessage": "Selalu Izinkan"
+  },
+  "toolApprovalButtons.alwaysAllowed": {
+    "defaultMessage": "Selalu diizinkan"
+  },
+  "toolApprovalButtons.cancelled": {
+    "defaultMessage": "Dibatalkan"
+  },
+  "toolApprovalButtons.denied": {
+    "defaultMessage": "Ditolak"
+  },
+  "toolApprovalButtons.deniedOnce": {
+    "defaultMessage": "Ditolak sekali"
+  },
+  "toolApprovalButtons.deny": {
+    "defaultMessage": "Tolak"
+  },
+  "toolApprovalButtons.staleApprovalRequest": {
+    "defaultMessage": "Permintaan persetujuan ini sudah tidak aktif lagi."
+  },
+  "toolCallStatusIndicator.toolStatus": {
+    "defaultMessage": "Status alat: {status}"
+  },
+  "toolCallWithResponse.activityCount": {
+    "defaultMessage": "Aktivitas ({count})"
+  },
+  "toolCallWithResponse.code": {
+    "defaultMessage": "Kode"
+  },
+  "toolCallWithResponse.loadingSpinner": {
+    "defaultMessage": "Pemutar pemuatan"
+  },
+  "toolCallWithResponse.logs": {
+    "defaultMessage": "Log"
+  },
+  "toolCallWithResponse.mcpUiExperimental": {
+    "defaultMessage": "MCP UI bersifat eksperimental dan dapat berubah sewaktu-waktu."
+  },
+  "toolCallWithResponse.output": {
+    "defaultMessage": "Keluaran"
+  },
+  "toolCallWithResponse.toolDetails": {
+    "defaultMessage": "Detail Alat"
+  },
+  "toolCallWithResponse.toolResultAlt": {
+    "defaultMessage": "Hasil alat"
+  },
+  "toolCallWithResponse.viewSubagentSession": {
+    "defaultMessage": "Lihat sesi subagen"
+  },
+  "toolConfirmation.allowToolCallWithName": {
+    "defaultMessage": "Izinkan {toolName}?"
+  },
+  "toolConfirmation.gooseWouldLikeToCallWithName": {
+    "defaultMessage": "Goose ingin memanggil {toolName}. Izinkan?"
+  },
+  "updateSection.autoDownload": {
+    "defaultMessage": "Goose akan mengunduh pembaruan di latar belakang dan menginstalnya saat Anda keluar atau memulai ulang berikutnya."
+  },
+  "updateSection.autoDownloadDisabledByEnv": {
+    "defaultMessage": "Pengunduhan otomatis dinonaktifkan melalui variabel lingkungan GOOSE_DISABLE_AUTO_DOWNLOAD."
+  },
+  "updateSection.autoDownloadDisabledNote": {
+    "defaultMessage": "Pengunduhan otomatis dinonaktifkan. Klik \"Download Now\" untuk mengunduh secara manual."
+  },
+  "updateSection.autoInstallNote": {
+    "defaultMessage": "Tidak diperlukan instalasi manual."
+  },
+  "updateSection.checkForUpdates": {
+    "defaultMessage": "Periksa Pembaruan"
+  },
+  "updateSection.checking": {
+    "defaultMessage": "Memeriksa pembaruan..."
+  },
+  "updateSection.currentVersion": {
+    "defaultMessage": "Versi saat ini"
+  },
+  "updateSection.disableAutoDownload": {
+    "defaultMessage": "Nonaktifkan pengunduhan pembaruan otomatis"
+  },
+  "updateSection.disableAutoDownloadDesc": {
+    "defaultMessage": "Saat diaktifkan, Goose akan memberi tahu Anda tentang versi baru tetapi tidak akan mengunduhnya secara otomatis."
+  },
+  "updateSection.downloadNow": {
+    "defaultMessage": "Unduh Sekarang"
+  },
+  "updateSection.downloadReady": {
+    "defaultMessage": "Pembaruan telah diunduh dan siap dipasang!"
+  },
+  "updateSection.downloadingProgress": {
+    "defaultMessage": "Mengunduh pembaruan... {percent}%"
+  },
+  "updateSection.downloadingUpdate": {
+    "defaultMessage": "Mengunduh pembaruan..."
+  },
+  "updateSection.installAndRestart": {
+    "defaultMessage": "Instal & Mulai Ulang"
+  },
+  "updateSection.installNowHint": {
+    "defaultMessage": "Klik \"Install & Restart\" untuk memperbarui sekarang."
+  },
+  "updateSection.latestVersion": {
+    "defaultMessage": "Anda menjalankan versi terbaru!"
+  },
+  "updateSection.loading": {
+    "defaultMessage": "Memuat..."
+  },
+  "updateSection.manualInstallNote": {
+    "defaultMessage": "Setelah pengunduhan, Anda perlu menginstal pembaruan secara manual."
+  },
+  "updateSection.manualInstallRequired": {
+    "defaultMessage": "Instalasi manual diperlukan untuk metode pembaruan ini."
+  },
+  "updateSection.readyInstallAuto": {
+    "defaultMessage": "✓ Pembaruan sudah siap. Mulai ulang Goose untuk menyelesaikan pemasangan, atau keluar saat Anda selesai."
+  },
+  "updateSection.readyInstallManual": {
+    "defaultMessage": "✓ Pembaruan sudah siap! Klik \"Install & Restart\" untuk petunjuk pemasangan."
+  },
+  "updateSection.upToDate": {
+    "defaultMessage": "(terbaru)"
+  },
+  "updateSection.updateAvailable": {
+    "defaultMessage": "Pembaruan tersedia!"
+  },
+  "updateSection.versionAvailable": {
+    "defaultMessage": "→ {version} tersedia"
+  },
+  "updateSection.versionIsAvailable": {
+    "defaultMessage": "Versi {version} tersedia"
+  },
+  "userMessage.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "userMessage.cancelAriaLabel": {
+    "defaultMessage": "Batalkan pengeditan"
+  },
+  "userMessage.editAriaLabel": {
+    "defaultMessage": "Edit konten pesan"
+  },
+  "userMessage.editButton": {
+    "defaultMessage": "Edit"
+  },
+  "userMessage.editInPlace": {
+    "defaultMessage": "Edit di Tempat"
+  },
+  "userMessage.editInPlaceAriaLabel": {
+    "defaultMessage": "Edit pesan di tempat"
+  },
+  "userMessage.editInPlaceDescription": {
+    "defaultMessage": "<b>Edit di Tempat</b> memperbarui sesi ini • <b>Cabang Sesi</b> membuat sesi baru"
+  },
+  "userMessage.editInPlaceTitle": {
+    "defaultMessage": "Perbarui pesan dalam sesi ini"
+  },
+  "userMessage.editMessageAriaLabel": {
+    "defaultMessage": "Edit pesan: {preview}"
+  },
+  "userMessage.editMessageTitle": {
+    "defaultMessage": "Edit pesan"
+  },
+  "userMessage.editPlaceholder": {
+    "defaultMessage": "Edit pesan Anda..."
+  },
+  "userMessage.emptyError": {
+    "defaultMessage": "Pesan tidak boleh kosong"
+  },
+  "userMessage.forkSession": {
+    "defaultMessage": "Cabang Sesi"
+  },
+  "userMessage.forkSessionAriaLabel": {
+    "defaultMessage": "Cabangkan sesi dengan pesan yang diedit"
+  },
+  "userMessage.forkSessionTitle": {
+    "defaultMessage": "Buat sesi baru dengan pesan yang diedit"
+  }
+}

--- a/ui/desktop/src/i18n/messages/it.json
+++ b/ui/desktop/src/i18n/messages/it.json
@@ -1,0 +1,4574 @@
+{
+  "alertBox.autoCompactAt": {
+    "defaultMessage": "Compattazione automatica a"
+  },
+  "alertBox.compactNow": {
+    "defaultMessage": "Compatta ora"
+  },
+  "alertBox.failedToSaveThreshold": {
+    "defaultMessage": "Impossibile salvare la soglia: {error}"
+  },
+  "announcementModal.gotIt": {
+    "defaultMessage": "Capito!"
+  },
+  "appLayout.collapseNavigation": {
+    "defaultMessage": "Comprimi navigazione"
+  },
+  "appLayout.openNavigation": {
+    "defaultMessage": "Apri navigazione"
+  },
+  "appsView.customApp": {
+    "defaultMessage": "App personalizzata"
+  },
+  "appsView.description": {
+    "defaultMessage": "Applicazioni dai tuoi server MCP e app create da goose stesso. Puoi chiedere di creare nuove app tramite l'interfaccia di chat e appariranno qui."
+  },
+  "appsView.errorLoading": {
+    "defaultMessage": "Errore durante il caricamento delle app: {error}"
+  },
+  "appsView.importApp": {
+    "defaultMessage": "Importa app"
+  },
+  "appsView.launch": {
+    "defaultMessage": "Avvia"
+  },
+  "appsView.loading": {
+    "defaultMessage": "Caricamento app..."
+  },
+  "appsView.noAppsDescription": {
+    "defaultMessage": "Apri una chat e chiedi a goose l'app che desideri avere. Può crearne una per te e apparirà qui. Oppure, se qualcuno ha condiviso un'app, puoi importarla usando il pulsante qui sopra."
+  },
+  "appsView.noAppsTitle": {
+    "defaultMessage": "Nessuna app disponibile"
+  },
+  "appsView.retry": {
+    "defaultMessage": "Riprova"
+  },
+  "appsView.title": {
+    "defaultMessage": "App"
+  },
+  "authSettings.activeProviderWarning": {
+    "defaultMessage": "Questo è il provider attivo. Le nuove richieste potrebbero non riuscire finché non configuri un'altra credenziale."
+  },
+  "authSettings.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "authSettings.delete": {
+    "defaultMessage": "Elimina"
+  },
+  "authSettings.deleteCredential": {
+    "defaultMessage": "Elimina credenziale"
+  },
+  "authSettings.deleteMessage": {
+    "defaultMessage": "Eliminare la credenziale {name} per {provider}?"
+  },
+  "authSettings.deleteTitle": {
+    "defaultMessage": "Elimina credenziale"
+  },
+  "authSettings.deleted": {
+    "defaultMessage": "Credenziale eliminata"
+  },
+  "authSettings.description": {
+    "defaultMessage": "Gestisci le credenziali dei provider memorizzate localmente da goose."
+  },
+  "authSettings.empty": {
+    "defaultMessage": "Nessuna credenziale di provider memorizzata localmente è stata trovata."
+  },
+  "authSettings.expiresAt": {
+    "defaultMessage": "Scade il {date}"
+  },
+  "authSettings.failedToConfigure": {
+    "defaultMessage": "Impossibile configurare la credenziale: {error}"
+  },
+  "authSettings.failedToDelete": {
+    "defaultMessage": "Impossibile eliminare la credenziale: {error}"
+  },
+  "authSettings.failedToLoad": {
+    "defaultMessage": "Impossibile caricare le credenziali dei provider"
+  },
+  "authSettings.loading": {
+    "defaultMessage": "Caricamento credenziali..."
+  },
+  "authSettings.reauthorize": {
+    "defaultMessage": "Riautorizza"
+  },
+  "authSettings.signIn": {
+    "defaultMessage": "Accedi"
+  },
+  "authSettings.signedIn": {
+    "defaultMessage": "Credenziale configurata"
+  },
+  "authSettings.storageProviderCache": {
+    "defaultMessage": "Cache del provider"
+  },
+  "authSettings.storageSecretStore": {
+    "defaultMessage": "Archivio segreti"
+  },
+  "authSettings.title": {
+    "defaultMessage": "Credenziali del provider"
+  },
+  "backButton.back": {
+    "defaultMessage": "Indietro"
+  },
+  "baseChat.failedToLoadSession": {
+    "defaultMessage": "Impossibile caricare la sessione"
+  },
+  "baseChat.goHome": {
+    "defaultMessage": "Vai alla home"
+  },
+  "bottomMenuExtensionSelection.extensionUpdated": {
+    "defaultMessage": "Estensione aggiornata"
+  },
+  "bottomMenuExtensionSelection.extensionWillBeDisabled": {
+    "defaultMessage": "{name} verrà disabilitata nelle nuove chat"
+  },
+  "bottomMenuExtensionSelection.extensionWillBeEnabled": {
+    "defaultMessage": "{name} verrà abilitata nelle nuove chat"
+  },
+  "bottomMenuExtensionSelection.extensionsForNewChats": {
+    "defaultMessage": "Estensioni per le nuove chat"
+  },
+  "bottomMenuExtensionSelection.extensionsForThisSession": {
+    "defaultMessage": "Estensioni per questa sessione di chat"
+  },
+  "bottomMenuExtensionSelection.manageExtensions": {
+    "defaultMessage": "gestisci estensioni"
+  },
+  "bottomMenuExtensionSelection.noExtensionsAvailable": {
+    "defaultMessage": "nessuna estensione disponibile"
+  },
+  "bottomMenuExtensionSelection.noExtensionsFound": {
+    "defaultMessage": "nessuna estensione trovata"
+  },
+  "bottomMenuExtensionSelection.searchExtensions": {
+    "defaultMessage": "cerca estensioni..."
+  },
+  "cardButtons.configure": {
+    "defaultMessage": "Configura"
+  },
+  "cardButtons.launch": {
+    "defaultMessage": "Avvia"
+  },
+  "chat.notification.taskComplete.body": {
+    "defaultMessage": "Fai clic qui per riportare Goose in primo piano."
+  },
+  "chat.notification.taskComplete.title": {
+    "defaultMessage": "Goose ha completato l'attività."
+  },
+  "chatInput.contextWindow": {
+    "defaultMessage": "Finestra di contesto"
+  },
+  "chatInput.dictationError": {
+    "defaultMessage": "Errore di dettatura"
+  },
+  "chatInput.failedToReadImage": {
+    "defaultMessage": "Impossibile leggere il file immagine"
+  },
+  "chatInput.navigationShortcut": {
+    "defaultMessage": "{prefix}↑/{prefix}↓ per navigare tra i messaggi"
+  },
+  "chatInput.processingDroppedFiles": {
+    "defaultMessage": "Elaborazione dei file rilasciati..."
+  },
+  "chatInput.recording": {
+    "defaultMessage": "Registrazione in corso..."
+  },
+  "chatInput.removeFile": {
+    "defaultMessage": "Rimuovi file"
+  },
+  "chatInput.removeImage": {
+    "defaultMessage": "Rimuovi immagine"
+  },
+  "chatInput.restartingSession": {
+    "defaultMessage": "Riavvio della sessione..."
+  },
+  "chatInput.send": {
+    "defaultMessage": "Invia"
+  },
+  "chatInput.transcribing": {
+    "defaultMessage": "Trascrizione in corso..."
+  },
+  "chatInput.typeMessage": {
+    "defaultMessage": "Scrivi un messaggio da inviare"
+  },
+  "chatInput.unknownType": {
+    "defaultMessage": "Tipo sconosciuto"
+  },
+  "chatInput.viewEditRecipe": {
+    "defaultMessage": "Visualizza/Modifica ricetta"
+  },
+  "chatInput.waitingForCancellation": {
+    "defaultMessage": "In attesa del completamento dell'annullamento"
+  },
+  "chatInput.waitingForImages": {
+    "defaultMessage": "In attesa del salvataggio delle immagini..."
+  },
+  "chatSettings.modeDescription": {
+    "defaultMessage": "Scegli la modalità predefinita che Goose usa per le nuove sessioni. Le sessioni esistenti mantengono la loro modalità corrente."
+  },
+  "chatSettings.modeTitle": {
+    "defaultMessage": "Modalità predefinita"
+  },
+  "chatSettings.responseStylesDescription": {
+    "defaultMessage": "Scegli come Goose deve formattare e definire lo stile delle sue risposte"
+  },
+  "chatSettings.responseStylesTitle": {
+    "defaultMessage": "Stili di risposta"
+  },
+  "configSettings.configReset": {
+    "defaultMessage": "Configurazione reimpostata"
+  },
+  "configSettings.configResetMsg": {
+    "defaultMessage": "Tutte le modifiche sono state annullate"
+  },
+  "configSettings.configUpdated": {
+    "defaultMessage": "Configurazione aggiornata"
+  },
+  "configSettings.configUpdatedMsg": {
+    "defaultMessage": "\"{name}\" salvato correttamente"
+  },
+  "configSettings.configurationEditor": {
+    "defaultMessage": "Editor di configurazione"
+  },
+  "configSettings.description": {
+    "defaultMessage": "Modifica le impostazioni di configurazione di goose"
+  },
+  "configSettings.descriptionWithProvider": {
+    "defaultMessage": "Modifica le impostazioni di configurazione di goose (impostazioni correnti per {provider})"
+  },
+  "configSettings.done": {
+    "defaultMessage": "Fatto"
+  },
+  "configSettings.editConfiguration": {
+    "defaultMessage": "Modifica configurazione"
+  },
+  "configSettings.enterValue": {
+    "defaultMessage": "Inserisci {name}"
+  },
+  "configSettings.noSettings": {
+    "defaultMessage": "Nessuna impostazione di configurazione trovata."
+  },
+  "configSettings.resetChanges": {
+    "defaultMessage": "Reimposta modifiche"
+  },
+  "configSettings.saveFailed": {
+    "defaultMessage": "Salvataggio non riuscito"
+  },
+  "configSettings.saveFailedMsg": {
+    "defaultMessage": "Impossibile salvare \"{name}\""
+  },
+  "configSettings.saving": {
+    "defaultMessage": "Salvataggio in corso..."
+  },
+  "configSettings.title": {
+    "defaultMessage": "Configurazione"
+  },
+  "configureApproveMode.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "configureApproveMode.description": {
+    "defaultMessage": "Le richieste di approvazione possono essere applicate a tutte le richieste di strumenti oppure determinare quali azioni potrebbero richiedere un'integrazione"
+  },
+  "configureApproveMode.manualApproval": {
+    "defaultMessage": "Approvazione manuale"
+  },
+  "configureApproveMode.manualApprovalDescription": {
+    "defaultMessage": "Tutti gli strumenti, le estensioni e le modifiche ai file richiederanno l'approvazione umana"
+  },
+  "configureApproveMode.save": {
+    "defaultMessage": "Salva"
+  },
+  "configureApproveMode.saving": {
+    "defaultMessage": "Salvataggio in corso..."
+  },
+  "configureApproveMode.smartApproval": {
+    "defaultMessage": "Approvazione intelligente"
+  },
+  "configureApproveMode.smartApprovalDescription": {
+    "defaultMessage": "Determina in modo intelligente quali azioni richiedono l'approvazione in base al livello di rischio"
+  },
+  "configureApproveMode.title": {
+    "defaultMessage": "Configura la modalità di approvazione"
+  },
+  "confirmationModal.defaultCancel": {
+    "defaultMessage": "No"
+  },
+  "confirmationModal.defaultConfirm": {
+    "defaultMessage": "Sì"
+  },
+  "confirmationModal.processing": {
+    "defaultMessage": "Elaborazione in corso..."
+  },
+  "conversationLimitsDropdown.conversationLimits": {
+    "defaultMessage": "Limiti della conversazione"
+  },
+  "conversationLimitsDropdown.maxTurns": {
+    "defaultMessage": "Numero massimo di turni"
+  },
+  "conversationLimitsDropdown.maxTurnsDescription": {
+    "defaultMessage": "Numero massimo di turni dell'agente prima che Goose richieda l'input dell'utente"
+  },
+  "costTracker.costUnavailable": {
+    "defaultMessage": "Dati sui costi non disponibili per {model} ({inputTokens} token di input, {outputTokens} token di output)"
+  },
+  "costTracker.inputOutputTooltip": {
+    "defaultMessage": "Input: {inputTokens} token ({inputCost}) | Output: {outputTokens} token ({outputCost})"
+  },
+  "costTracker.pricingUnavailable": {
+    "defaultMessage": "Dati sui prezzi non disponibili per {model}"
+  },
+  "costTracker.totalSessionCost": {
+    "defaultMessage": "Costo totale della sessione: {cost}"
+  },
+  "createEditRecipe.clickToGenerateDeeplink": {
+    "defaultMessage": "Fai clic per generare il deeplink"
+  },
+  "createEditRecipe.close": {
+    "defaultMessage": "Chiudi"
+  },
+  "createEditRecipe.copied": {
+    "defaultMessage": "Copiato!"
+  },
+  "createEditRecipe.copy": {
+    "defaultMessage": "Copia"
+  },
+  "createEditRecipe.copyLinkDescription": {
+    "defaultMessage": "Copia questo link per condividerlo con gli amici o incollalo direttamente in Chrome per aprirlo"
+  },
+  "createEditRecipe.createRecipeTitle": {
+    "defaultMessage": "Crea ricetta"
+  },
+  "createEditRecipe.createSubtitle": {
+    "defaultMessage": "Crea una nuova ricetta per definire il comportamento e le funzionalità dell'agente per sessioni di chat riutilizzabili."
+  },
+  "createEditRecipe.editSubtitle": {
+    "defaultMessage": "Puoi modificare la ricetta qui sotto per cambiare il comportamento dell'agente in una nuova sessione."
+  },
+  "createEditRecipe.generatingDeeplink": {
+    "defaultMessage": "Generazione del deeplink..."
+  },
+  "createEditRecipe.learnMore": {
+    "defaultMessage": "Scopri di più"
+  },
+  "createEditRecipe.recipeSavedAndLaunchedMsg": {
+    "defaultMessage": "Ricetta salvata e avviata correttamente"
+  },
+  "createEditRecipe.recipeSavedMsg": {
+    "defaultMessage": "Ricetta salvata correttamente"
+  },
+  "createEditRecipe.saveAndRunFailed": {
+    "defaultMessage": "Salvataggio ed esecuzione non riusciti"
+  },
+  "createEditRecipe.saveAndRunFailedMsg": {
+    "defaultMessage": "Impossibile salvare ed eseguire la ricetta: {error}"
+  },
+  "createEditRecipe.saveAndRunRecipe": {
+    "defaultMessage": "Salva ed esegui ricetta"
+  },
+  "createEditRecipe.saveFailed": {
+    "defaultMessage": "Salvataggio non riuscito"
+  },
+  "createEditRecipe.saveFailedMsg": {
+    "defaultMessage": "Impossibile salvare la ricetta: {error}"
+  },
+  "createEditRecipe.saveRecipe": {
+    "defaultMessage": "Salva ricetta"
+  },
+  "createEditRecipe.saving": {
+    "defaultMessage": "Salvataggio in corso..."
+  },
+  "createEditRecipe.validationFailed": {
+    "defaultMessage": "Convalida non riuscita"
+  },
+  "createEditRecipe.validationMsg": {
+    "defaultMessage": "Compila tutti i campi obbligatori e assicurati che lo schema JSON sia valido."
+  },
+  "createEditRecipe.viewEditRecipeTitle": {
+    "defaultMessage": "Visualizza/modifica ricetta"
+  },
+  "createSubRecipeInline.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "createSubRecipeInline.closeModal": {
+    "defaultMessage": "Chiudi la finestra di creazione della sottoricetta"
+  },
+  "createSubRecipeInline.createAndAdd": {
+    "defaultMessage": "Crea e aggiungi sottoricetta"
+  },
+  "createSubRecipeInline.createdSuccess": {
+    "defaultMessage": "Sottoricetta creata correttamente"
+  },
+  "createSubRecipeInline.creating": {
+    "defaultMessage": "Creazione in corso..."
+  },
+  "createSubRecipeInline.duplicateName": {
+    "defaultMessage": "Nome duplicato"
+  },
+  "createSubRecipeInline.duplicateNameMsg": {
+    "defaultMessage": "Esiste già una sottoricetta denominata \"{name}\". Usa un nome univoco."
+  },
+  "createSubRecipeInline.instructionsLabel": {
+    "defaultMessage": "Istruzioni"
+  },
+  "createSubRecipeInline.instructionsPlaceholder": {
+    "defaultMessage": "Istruzioni per l'IA quando viene chiamata questa sottoricetta..."
+  },
+  "createSubRecipeInline.nameHint": {
+    "defaultMessage": "Identificatore univoco usato per generare il nome dello strumento"
+  },
+  "createSubRecipeInline.nameLabel": {
+    "defaultMessage": "Nome"
+  },
+  "createSubRecipeInline.namePlaceholder": {
+    "defaultMessage": "ad es., security_scan"
+  },
+  "createSubRecipeInline.preconfiguredValues": {
+    "defaultMessage": "Valori preconfigurati"
+  },
+  "createSubRecipeInline.preconfiguredValuesHint": {
+    "defaultMessage": "Valori dei parametri facoltativi che vengono sempre passati alla sottoricetta"
+  },
+  "createSubRecipeInline.recipeDescriptionLabel": {
+    "defaultMessage": "Descrizione della ricetta"
+  },
+  "createSubRecipeInline.recipeDescriptionPlaceholder": {
+    "defaultMessage": "Cosa fa questa ricetta quando viene eseguita"
+  },
+  "createSubRecipeInline.recipeTitleLabel": {
+    "defaultMessage": "Titolo della ricetta"
+  },
+  "createSubRecipeInline.recipeTitlePlaceholder": {
+    "defaultMessage": "ad es., Strumento di analisi della sicurezza"
+  },
+  "createSubRecipeInline.saveFailed": {
+    "defaultMessage": "Salvataggio non riuscito"
+  },
+  "createSubRecipeInline.saveFailedMsg": {
+    "defaultMessage": "Impossibile salvare la sottoricetta: {error}"
+  },
+  "createSubRecipeInline.sequentialHint": {
+    "defaultMessage": "(Forza l'esecuzione sequenziale di più istanze)"
+  },
+  "createSubRecipeInline.sequentialLabel": {
+    "defaultMessage": "Sequenziale quando ripetuta"
+  },
+  "createSubRecipeInline.subtitle": {
+    "defaultMessage": "Crea una ricetta semplice da usare come strumento richiamabile nella tua ricetta principale"
+  },
+  "createSubRecipeInline.title": {
+    "defaultMessage": "Crea nuova sottoricetta"
+  },
+  "createSubRecipeInline.toolDescriptionLabel": {
+    "defaultMessage": "Descrizione dello strumento"
+  },
+  "createSubRecipeInline.toolDescriptionPlaceholder": {
+    "defaultMessage": "Descrizione facoltativa mostrata quando viene chiamata come strumento"
+  },
+  "createSubRecipeInline.validationFailed": {
+    "defaultMessage": "Convalida non riuscita"
+  },
+  "createSubRecipeInline.validationMsg": {
+    "defaultMessage": "Nome, titolo, descrizione della ricetta e istruzioni sono obbligatori."
+  },
+  "creditsExhaustedNotification.addCredits": {
+    "defaultMessage": "Aggiungi crediti"
+  },
+  "creditsExhaustedNotification.insufficientCredits": {
+    "defaultMessage": "Crediti insufficienti"
+  },
+  "cronPicker.april": {
+    "defaultMessage": "Aprile"
+  },
+  "cronPicker.at": {
+    "defaultMessage": "alle"
+  },
+  "cronPicker.atMinute": {
+    "defaultMessage": "al minuto"
+  },
+  "cronPicker.atSecond": {
+    "defaultMessage": "al secondo"
+  },
+  "cronPicker.august": {
+    "defaultMessage": "Agosto"
+  },
+  "cronPicker.cronExpression": {
+    "defaultMessage": "Espressione cron"
+  },
+  "cronPicker.custom": {
+    "defaultMessage": "Cron personalizzato"
+  },
+  "cronPicker.day": {
+    "defaultMessage": "Giorno"
+  },
+  "cronPicker.december": {
+    "defaultMessage": "Dicembre"
+  },
+  "cronPicker.emptyCronError": {
+    "defaultMessage": "L'espressione cron non può essere vuota"
+  },
+  "cronPicker.every": {
+    "defaultMessage": "Ogni"
+  },
+  "cronPicker.february": {
+    "defaultMessage": "Febbraio"
+  },
+  "cronPicker.friday": {
+    "defaultMessage": "Venerdì"
+  },
+  "cronPicker.hour": {
+    "defaultMessage": "Ora"
+  },
+  "cronPicker.inMonth": {
+    "defaultMessage": "in"
+  },
+  "cronPicker.invalidDayOfMonth": {
+    "defaultMessage": "Il giorno deve essere compreso tra 1 e {max}"
+  },
+  "cronPicker.january": {
+    "defaultMessage": "Gennaio"
+  },
+  "cronPicker.july": {
+    "defaultMessage": "Luglio"
+  },
+  "cronPicker.june": {
+    "defaultMessage": "Giugno"
+  },
+  "cronPicker.march": {
+    "defaultMessage": "Marzo"
+  },
+  "cronPicker.may": {
+    "defaultMessage": "Maggio"
+  },
+  "cronPicker.minute": {
+    "defaultMessage": "Minuto"
+  },
+  "cronPicker.mode": {
+    "defaultMessage": "Modalità"
+  },
+  "cronPicker.monday": {
+    "defaultMessage": "Lunedì"
+  },
+  "cronPicker.month": {
+    "defaultMessage": "Mese"
+  },
+  "cronPicker.november": {
+    "defaultMessage": "Novembre"
+  },
+  "cronPicker.october": {
+    "defaultMessage": "Ottobre"
+  },
+  "cronPicker.on": {
+    "defaultMessage": "il"
+  },
+  "cronPicker.onDay": {
+    "defaultMessage": "il giorno"
+  },
+  "cronPicker.quarter": {
+    "defaultMessage": "Trimestre"
+  },
+  "cronPicker.saturday": {
+    "defaultMessage": "Sabato"
+  },
+  "cronPicker.september": {
+    "defaultMessage": "Settembre"
+  },
+  "cronPicker.startingMonth": {
+    "defaultMessage": "mese di inizio"
+  },
+  "cronPicker.sunday": {
+    "defaultMessage": "Domenica"
+  },
+  "cronPicker.thursday": {
+    "defaultMessage": "Giovedì"
+  },
+  "cronPicker.tuesday": {
+    "defaultMessage": "Martedì"
+  },
+  "cronPicker.wednesday": {
+    "defaultMessage": "Mercoledì"
+  },
+  "cronPicker.week": {
+    "defaultMessage": "Settimana"
+  },
+  "cronPicker.year": {
+    "defaultMessage": "Anno"
+  },
+  "customProviderForm.add": {
+    "defaultMessage": "Aggiungi"
+  },
+  "customProviderForm.anthropicCompatible": {
+    "defaultMessage": "Compatibile con Anthropic"
+  },
+  "customProviderForm.apiBasePath": {
+    "defaultMessage": "Percorso base API (facoltativo)"
+  },
+  "customProviderForm.apiBasePathHint": {
+    "defaultMessage": "Sostituisci il percorso API predefinito. Lascia vuoto per usare il percorso predefinito del provider."
+  },
+  "customProviderForm.apiBasePathPlaceholder": {
+    "defaultMessage": "ad es., v1/chat/completions o project_id/v1"
+  },
+  "customProviderForm.apiKey": {
+    "defaultMessage": "Chiave API"
+  },
+  "customProviderForm.apiKeyPlaceholderExisting": {
+    "defaultMessage": "Lascia vuoto per mantenere la chiave esistente"
+  },
+  "customProviderForm.apiKeyPlaceholderNew": {
+    "defaultMessage": "La tua chiave API"
+  },
+  "customProviderForm.apiKeyRequired": {
+    "defaultMessage": "La chiave API è obbligatoria"
+  },
+  "customProviderForm.apiUrl": {
+    "defaultMessage": "URL API"
+  },
+  "customProviderForm.apiUrlPlaceholder": {
+    "defaultMessage": "https://api.example.com"
+  },
+  "customProviderForm.apiUrlRequired": {
+    "defaultMessage": "L'URL API è obbligatorio"
+  },
+  "customProviderForm.attachments": {
+    "defaultMessage": "Allegati"
+  },
+  "customProviderForm.authHint": {
+    "defaultMessage": "Gli LLM locali come Ollama in genere non richiedono una chiave API."
+  },
+  "customProviderForm.authentication": {
+    "defaultMessage": "Autenticazione"
+  },
+  "customProviderForm.availableModels": {
+    "defaultMessage": "Modelli disponibili (separati da virgola)"
+  },
+  "customProviderForm.back": {
+    "defaultMessage": "← Indietro"
+  },
+  "customProviderForm.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "customProviderForm.cannotDeleteActive": {
+    "defaultMessage": "Non puoi eliminare questo provider mentre è attualmente in uso. Passa prima a un modello diverso."
+  },
+  "customProviderForm.chooseSetup": {
+    "defaultMessage": "Scegli come configurare il tuo provider."
+  },
+  "customProviderForm.clear": {
+    "defaultMessage": "Cancella"
+  },
+  "customProviderForm.configureManually": {
+    "defaultMessage": "Configura manualmente"
+  },
+  "customProviderForm.configureManuallyDesc": {
+    "defaultMessage": "Inserisci tu stesso tutti i dettagli del provider"
+  },
+  "customProviderForm.confirmDelete": {
+    "defaultMessage": "Conferma eliminazione"
+  },
+  "customProviderForm.createProvider": {
+    "defaultMessage": "Crea provider"
+  },
+  "customProviderForm.customHeaders": {
+    "defaultMessage": "Intestazioni personalizzate"
+  },
+  "customProviderForm.customHeadersHint": {
+    "defaultMessage": "Aggiungi intestazioni HTTP personalizzate da includere nelle richieste al provider. Fai clic sul pulsante \"+\" per aggiungere dopo aver compilato entrambi i campi."
+  },
+  "customProviderForm.deleteConfirmation": {
+    "defaultMessage": "Sei sicuro di voler eliminare questo provider personalizzato? Questa operazione rimuoverà definitivamente il provider e la sua chiave API memorizzata. Questa azione non può essere annullata."
+  },
+  "customProviderForm.deleteProvider": {
+    "defaultMessage": "Elimina provider"
+  },
+  "customProviderForm.displayName": {
+    "defaultMessage": "Nome visualizzato"
+  },
+  "customProviderForm.displayNamePlaceholder": {
+    "defaultMessage": "Il nome del tuo provider"
+  },
+  "customProviderForm.displayNameRequired": {
+    "defaultMessage": "Il nome visualizzato è obbligatorio"
+  },
+  "customProviderForm.docs": {
+    "defaultMessage": "Documentazione"
+  },
+  "customProviderForm.headerBothRequired": {
+    "defaultMessage": "Devono essere inseriti sia il nome che il valore dell'intestazione"
+  },
+  "customProviderForm.headerDuplicate": {
+    "defaultMessage": "Esiste già un'intestazione con questo nome"
+  },
+  "customProviderForm.headerNamePlaceholder": {
+    "defaultMessage": "Nome intestazione"
+  },
+  "customProviderForm.headerNoSpaces": {
+    "defaultMessage": "Il nome dell'intestazione non può contenere spazi"
+  },
+  "customProviderForm.modelsPlaceholder": {
+    "defaultMessage": "model-a, model-b, model-c"
+  },
+  "customProviderForm.modelsRequired": {
+    "defaultMessage": "È richiesto almeno un modello"
+  },
+  "customProviderForm.ollamaCompatible": {
+    "defaultMessage": "Compatibile con Ollama"
+  },
+  "customProviderForm.openaiCompatible": {
+    "defaultMessage": "Compatibile con OpenAI"
+  },
+  "customProviderForm.providerType": {
+    "defaultMessage": "Tipo di provider"
+  },
+  "customProviderForm.reasoning": {
+    "defaultMessage": "Ragionamento"
+  },
+  "customProviderForm.requiresApiKey": {
+    "defaultMessage": "Questo provider richiede una chiave API"
+  },
+  "customProviderForm.startFromTemplate": {
+    "defaultMessage": "Inizia da un modello di provider"
+  },
+  "customProviderForm.startFromTemplateDesc": {
+    "defaultMessage": "Scegli un provider conosciuto e compileremo automaticamente la configurazione"
+  },
+  "customProviderForm.submitError": {
+    "defaultMessage": "Impossibile salvare il provider. Controlla la configurazione e riprova."
+  },
+  "customProviderForm.supportsStreaming": {
+    "defaultMessage": "Il provider supporta le risposte in streaming"
+  },
+  "customProviderForm.toolCalling": {
+    "defaultMessage": "Chiamata di strumenti"
+  },
+  "customProviderForm.updateProvider": {
+    "defaultMessage": "Aggiorna provider"
+  },
+  "customProviderForm.usingTemplate": {
+    "defaultMessage": "Modello in uso: {name}"
+  },
+  "customProviderForm.valuePlaceholder": {
+    "defaultMessage": "Valore"
+  },
+  "defaultCardButtons.configureSettings": {
+    "defaultMessage": "Configura le impostazioni di {name}"
+  },
+  "defaultCardButtons.deleteSettings": {
+    "defaultMessage": "Elimina le impostazioni di {name}"
+  },
+  "defaultCardButtons.editSettings": {
+    "defaultMessage": "Modifica le impostazioni di {name}"
+  },
+  "defaultCardButtons.getStarted": {
+    "defaultMessage": "Inizia con goose!"
+  },
+  "defaultProviderSetupForm.apiHostLabel": {
+    "defaultMessage": "Host API"
+  },
+  "defaultProviderSetupForm.apiHostPlaceholder": {
+    "defaultMessage": "https://api.example.com"
+  },
+  "defaultProviderSetupForm.apiKeyLabel": {
+    "defaultMessage": "Chiave API"
+  },
+  "defaultProviderSetupForm.apiKeyPlaceholder": {
+    "defaultMessage": "La tua chiave API"
+  },
+  "defaultProviderSetupForm.hideOptions": {
+    "defaultMessage": "Nascondi {count} opzioni"
+  },
+  "defaultProviderSetupForm.loadingConfig": {
+    "defaultMessage": "Caricamento dei valori di configurazione..."
+  },
+  "defaultProviderSetupForm.modelsLabel": {
+    "defaultMessage": "Modelli"
+  },
+  "defaultProviderSetupForm.modelsPlaceholder": {
+    "defaultMessage": "modello-a, modello-b"
+  },
+  "defaultProviderSetupForm.noConfigParameters": {
+    "defaultMessage": "Nessun parametro di configurazione per questo provider."
+  },
+  "defaultProviderSetupForm.showOptions": {
+    "defaultMessage": "Mostra {count} opzioni"
+  },
+  "diagnosticsModal.attachHint": {
+    "defaultMessage": "Se segnali un bug, valuta di allegarvi il report diagnostico."
+  },
+  "diagnosticsModal.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "diagnosticsModal.configSettings": {
+    "defaultMessage": "Impostazioni di configurazione"
+  },
+  "diagnosticsModal.description": {
+    "defaultMessage": "Puoi scaricare un report diagnostico in formato JSON da condividere con il team, oppure segnalare un bug direttamente su GitHub con i dettagli del tuo sistema già compilati. Un report diagnostico contiene quanto segue:"
+  },
+  "diagnosticsModal.diagnosticsErrorMsg": {
+    "defaultMessage": "Impossibile scaricare il report diagnostico"
+  },
+  "diagnosticsModal.diagnosticsErrorTitle": {
+    "defaultMessage": "Errore diagnostico"
+  },
+  "diagnosticsModal.download": {
+    "defaultMessage": "Scarica"
+  },
+  "diagnosticsModal.downloading": {
+    "defaultMessage": "Download in corso..."
+  },
+  "diagnosticsModal.fileBug": {
+    "defaultMessage": "Segnala un bug su GitHub"
+  },
+  "diagnosticsModal.logFiles": {
+    "defaultMessage": "File di log recenti"
+  },
+  "diagnosticsModal.opening": {
+    "defaultMessage": "Apertura in corso..."
+  },
+  "diagnosticsModal.reportProblem": {
+    "defaultMessage": "Segnala un problema"
+  },
+  "diagnosticsModal.sensitiveWarning": {
+    "defaultMessage": "Se la tua sessione contiene informazioni sensibili, non condividere pubblicamente il file diagnostico."
+  },
+  "diagnosticsModal.sessionMessages": {
+    "defaultMessage": "I messaggi della tua sessione corrente"
+  },
+  "diagnosticsModal.systemInfo": {
+    "defaultMessage": "Informazioni di base sul sistema"
+  },
+  "diagnosticsModal.systemInfoErrorMsg": {
+    "defaultMessage": "Impossibile ottenere le informazioni di sistema"
+  },
+  "diagnosticsModal.systemInfoErrorTitle": {
+    "defaultMessage": "Errore"
+  },
+  "dialog.close": {
+    "defaultMessage": "Chiudi"
+  },
+  "dictationSettings.addApiKey": {
+    "defaultMessage": "Aggiungi chiave API"
+  },
+  "dictationSettings.apiKey": {
+    "defaultMessage": "Chiave API"
+  },
+  "dictationSettings.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "dictationSettings.chooseVoiceConversion": {
+    "defaultMessage": "Scegli come convertire la voce in testo"
+  },
+  "dictationSettings.configureApiKey": {
+    "defaultMessage": "Configura la chiave API in <b>{settingsPath}</b>"
+  },
+  "dictationSettings.configured": {
+    "defaultMessage": "(Configurata)"
+  },
+  "dictationSettings.configuredIn": {
+    "defaultMessage": "✓ Configurata in {settingsPath}"
+  },
+  "dictationSettings.disabled": {
+    "defaultMessage": "Disattivata"
+  },
+  "dictationSettings.enterApiKey": {
+    "defaultMessage": "Inserisci la tua chiave API"
+  },
+  "dictationSettings.notConfigured": {
+    "defaultMessage": "(non configurata)"
+  },
+  "dictationSettings.removeApiKey": {
+    "defaultMessage": "Rimuovi chiave API"
+  },
+  "dictationSettings.requiredForTranscription": {
+    "defaultMessage": "Necessaria per la trascrizione"
+  },
+  "dictationSettings.save": {
+    "defaultMessage": "Salva"
+  },
+  "dictationSettings.updateApiKey": {
+    "defaultMessage": "Aggiorna chiave API"
+  },
+  "dictationSettings.voiceDictationProvider": {
+    "defaultMessage": "Provider di dettatura vocale"
+  },
+  "dirSwitcher.chooseDirectory": {
+    "defaultMessage": "Scegli cartella…"
+  },
+  "dirSwitcher.currentDirectory": {
+    "defaultMessage": "Cartella corrente"
+  },
+  "dirSwitcher.failedToUpdateWorkingDir": {
+    "defaultMessage": "Impossibile aggiornare la cartella di lavoro"
+  },
+  "dirSwitcher.gitWorktrees": {
+    "defaultMessage": "Worktree di Git"
+  },
+  "dirSwitcher.noWorktreesFound": {
+    "defaultMessage": "Nessun worktree trovato"
+  },
+  "dirSwitcher.openInFinder": {
+    "defaultMessage": "Apri nel file manager"
+  },
+  "dirSwitcher.recentDirectories": {
+    "defaultMessage": "Cartelle recenti"
+  },
+  "elicitationRequest.accept": {
+    "defaultMessage": "Accetta"
+  },
+  "elicitationRequest.cancelled": {
+    "defaultMessage": "La richiesta di informazioni è stata annullata."
+  },
+  "elicitationRequest.defaultMessage": {
+    "defaultMessage": "Goose ha bisogno di alcune informazioni da te."
+  },
+  "elicitationRequest.expired": {
+    "defaultMessage": "Questa richiesta è scaduta. L'estensione dovrà chiedere di nuovo."
+  },
+  "elicitationRequest.submit": {
+    "defaultMessage": "Invia"
+  },
+  "elicitationRequest.submitError": {
+    "defaultMessage": "Questa richiesta non è più attiva. L'estensione dovrà chiedere di nuovo."
+  },
+  "elicitationRequest.submitted": {
+    "defaultMessage": "Informazioni inviate"
+  },
+  "elicitationRequest.waitingForResponse": {
+    "defaultMessage": "In attesa della tua risposta ({timeRemaining} rimanenti)"
+  },
+  "envVarsSection.add": {
+    "defaultMessage": "Aggiungi"
+  },
+  "envVarsSection.bothRequired": {
+    "defaultMessage": "È necessario inserire sia il nome della variabile sia il valore"
+  },
+  "envVarsSection.envVarsDescription": {
+    "defaultMessage": "Aggiungi coppie chiave-valore per le variabili d'ambiente. Fai clic sul pulsante \"+\" per aggiungere dopo aver compilato entrambi i campi. Per i valori segreti esistenti, fai clic sul pulsante di modifica per modificarli."
+  },
+  "envVarsSection.environmentVariables": {
+    "defaultMessage": "Variabili d'ambiente"
+  },
+  "envVarsSection.noSpaces": {
+    "defaultMessage": "Il nome della variabile non può contenere spazi"
+  },
+  "envVarsSection.value": {
+    "defaultMessage": "Valore"
+  },
+  "envVarsSection.variableName": {
+    "defaultMessage": "Nome della variabile"
+  },
+  "environmentBadge.dev": {
+    "defaultMessage": "Dev"
+  },
+  "errorBoundary.errorGeneric": {
+    "defaultMessage": "Si è verificato un errore."
+  },
+  "errorBoundary.errorWithVersion": {
+    "defaultMessage": "Si è verificato un errore in Goose v{version}."
+  },
+  "errorBoundary.heading": {
+    "defaultMessage": "Honk!"
+  },
+  "errorBoundary.reload": {
+    "defaultMessage": "Ricarica"
+  },
+  "extensionConfigFields.commandLabel": {
+    "defaultMessage": "Comando"
+  },
+  "extensionConfigFields.commandPlaceholder": {
+    "defaultMessage": "es. npx -y @modelcontextprotocol/my-extension [filepath]"
+  },
+  "extensionConfigFields.commandRequired": {
+    "defaultMessage": "Il comando è obbligatorio"
+  },
+  "extensionConfigFields.endpointLabel": {
+    "defaultMessage": "Endpoint"
+  },
+  "extensionConfigFields.endpointPlaceholder": {
+    "defaultMessage": "Inserisci l'URL dell'endpoint..."
+  },
+  "extensionConfigFields.endpointRequired": {
+    "defaultMessage": "L'URL dell'endpoint è obbligatorio"
+  },
+  "extensionInfoFields.descriptionLabel": {
+    "defaultMessage": "Descrizione"
+  },
+  "extensionInfoFields.descriptionPlaceholder": {
+    "defaultMessage": "Descrizione facoltativa..."
+  },
+  "extensionInfoFields.extensionName": {
+    "defaultMessage": "Nome dell'estensione"
+  },
+  "extensionInfoFields.extensionNamePlaceholder": {
+    "defaultMessage": "Inserisci il nome dell'estensione..."
+  },
+  "extensionInfoFields.nameRequired": {
+    "defaultMessage": "Il nome è obbligatorio"
+  },
+  "extensionInfoFields.typeHttp": {
+    "defaultMessage": "HTTP"
+  },
+  "extensionInfoFields.typeLabel": {
+    "defaultMessage": "Tipo"
+  },
+  "extensionInfoFields.typeSseUnsupported": {
+    "defaultMessage": "SSE (non supportato)"
+  },
+  "extensionInfoFields.typeStandardIo": {
+    "defaultMessage": "Standard IO (STDIO)"
+  },
+  "extensionInfoFields.typeStdio": {
+    "defaultMessage": "STDIO"
+  },
+  "extensionInfoFields.typeStreamableHttp": {
+    "defaultMessage": "Streamable HTTP"
+  },
+  "extensionInstallModal.alreadyInstalledMessage": {
+    "defaultMessage": "L'estensione ''{name}'' è già stata installata correttamente. Avvia una nuova sessione di chat per usarla."
+  },
+  "extensionInstallModal.alreadyInstalledTitle": {
+    "defaultMessage": "Estensione ''{name}'' già installata"
+  },
+  "extensionInstallModal.blockedMessage": {
+    "defaultMessage": "Questo comando dell'estensione non è nell'elenco consentito e la sua installazione è bloccata. Estensione: {name} Comando: {command} Contatta il tuo amministratore per richiedere l'approvazione di questa estensione."
+  },
+  "extensionInstallModal.blockedTitle": {
+    "defaultMessage": "Installazione dell'estensione bloccata"
+  },
+  "extensionInstallModal.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "extensionInstallModal.installAnyway": {
+    "defaultMessage": "Installa comunque"
+  },
+  "extensionInstallModal.installing": {
+    "defaultMessage": "Installazione in corso..."
+  },
+  "extensionInstallModal.no": {
+    "defaultMessage": "No"
+  },
+  "extensionInstallModal.ok": {
+    "defaultMessage": "OK"
+  },
+  "extensionInstallModal.trustedMessage": {
+    "defaultMessage": "Vuoi davvero installare l'estensione {name}? Comando: {command}"
+  },
+  "extensionInstallModal.trustedTitle": {
+    "defaultMessage": "Conferma installazione dell'estensione"
+  },
+  "extensionInstallModal.unknownCommand": {
+    "defaultMessage": "Comando sconosciuto"
+  },
+  "extensionInstallModal.untrustedMessageWithCommand": {
+    "defaultMessage": "{securityMessage} Estensione: {name} Comando: {command} Contatta il tuo amministratore se hai dubbi al riguardo."
+  },
+  "extensionInstallModal.untrustedMessageWithUrl": {
+    "defaultMessage": "{securityMessage} Estensione: {name} URL: {url} Contatta il tuo amministratore se hai dubbi al riguardo."
+  },
+  "extensionInstallModal.untrustedSecurityMessage": {
+    "defaultMessage": "Questo comando dell'estensione non è nell'elenco consentito e sarà in grado di accedere alle tue conversazioni e fornire funzionalità aggiuntive. L'installazione di estensioni da fonti non attendibili può comportare rischi per la sicurezza."
+  },
+  "extensionInstallModal.untrustedTitle": {
+    "defaultMessage": "Installare un'estensione non attendibile?"
+  },
+  "extensionInstallModal.yes": {
+    "defaultMessage": "Sì"
+  },
+  "extensionItem.configureExtension": {
+    "defaultMessage": "Configura l'estensione {name}"
+  },
+  "extensionItem.toggleExtension": {
+    "defaultMessage": "Attiva o disattiva l'estensione {name}"
+  },
+  "extensionList.availableExtensions": {
+    "defaultMessage": "Estensioni disponibili ({count})"
+  },
+  "extensionList.builtInExtension": {
+    "defaultMessage": "Estensione integrata"
+  },
+  "extensionList.defaultExtensions": {
+    "defaultMessage": "Estensioni predefinite ({count})"
+  },
+  "extensionList.noExtensions": {
+    "defaultMessage": "Nessuna estensione disponibile"
+  },
+  "extensionModal.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "extensionModal.closeWithoutSaving": {
+    "defaultMessage": "Chiudi senza salvare"
+  },
+  "extensionModal.confirmRemoval": {
+    "defaultMessage": "Conferma rimozione"
+  },
+  "extensionModal.deleteDescription": {
+    "defaultMessage": "Questa azione rimuoverà definitivamente questa estensione e tutte le sue impostazioni."
+  },
+  "extensionModal.deleteExtensionTitle": {
+    "defaultMessage": "Elimina l'estensione \"{name}\""
+  },
+  "extensionModal.installationNotes": {
+    "defaultMessage": "Note di installazione"
+  },
+  "extensionModal.removeExtension": {
+    "defaultMessage": "Rimuovi estensione"
+  },
+  "extensionModal.unsavedChangesMessage": {
+    "defaultMessage": "Hai modifiche non salvate nella configurazione dell'estensione. Vuoi davvero chiudere senza salvare?"
+  },
+  "extensionModal.unsavedChangesTitle": {
+    "defaultMessage": "Modifiche non salvate"
+  },
+  "extensionTimeoutField.timeoutLabel": {
+    "defaultMessage": "Timeout"
+  },
+  "extensionsSection.addCustomExtension": {
+    "defaultMessage": "Aggiungi estensione personalizzata"
+  },
+  "extensionsSection.addExtension": {
+    "defaultMessage": "Aggiungi estensione"
+  },
+  "extensionsSection.browseExtensions": {
+    "defaultMessage": "Sfoglia le estensioni"
+  },
+  "extensionsSection.saveChanges": {
+    "defaultMessage": "Salva modifiche"
+  },
+  "extensionsSection.updateExtension": {
+    "defaultMessage": "Aggiorna estensione"
+  },
+  "extensionsView.addCustomExtension": {
+    "defaultMessage": "Aggiungi estensione personalizzata"
+  },
+  "extensionsView.addExtension": {
+    "defaultMessage": "Aggiungi estensione"
+  },
+  "extensionsView.browseExtensions": {
+    "defaultMessage": "Sfoglia le estensioni"
+  },
+  "extensionsView.defaultNote": {
+    "defaultMessage": "Le estensioni abilitate qui vengono usate come predefinite per le nuove chat. Puoi anche attivare o disattivare le estensioni attive durante una chat."
+  },
+  "extensionsView.description": {
+    "defaultMessage": "Queste estensioni usano il Model Context Protocol (MCP). Possono ampliare le capacità di Goose tramite tre componenti principali: Prompt, Risorse e Strumenti. {searchShortcut} per cercare."
+  },
+  "extensionsView.heading": {
+    "defaultMessage": "Estensioni"
+  },
+  "extensionsView.searchPlaceholder": {
+    "defaultMessage": "Cerca estensioni..."
+  },
+  "externalBackendSection.certFingerprint": {
+    "defaultMessage": "Impronta del certificato (facoltativa)"
+  },
+  "externalBackendSection.certFingerprintHelp": {
+    "defaultMessage": "Fissa un'impronta specifica del certificato TLS. Se omessa, il certificato viene considerato attendibile al primo utilizzo (TOFU)."
+  },
+  "externalBackendSection.certFingerprintPlaceholder": {
+    "defaultMessage": "AA:BB:CC:... o sha256/base64"
+  },
+  "externalBackendSection.description": {
+    "defaultMessage": "Per impostazione predefinita goose avvia un server per te; usa questa opzione per connetterti a un server goose esterno"
+  },
+  "externalBackendSection.restartNote": {
+    "defaultMessage": "Le modifiche richiedono il riavvio di Goose per avere effetto. Le nuove finestre di chat si connetteranno al server esterno."
+  },
+  "externalBackendSection.secretKey": {
+    "defaultMessage": "Chiave segreta"
+  },
+  "externalBackendSection.secretKeyHelp": {
+    "defaultMessage": "La chiave segreta configurata sul server goosed (GOOSE_SERVER__SECRET_KEY)"
+  },
+  "externalBackendSection.secretKeyPlaceholder": {
+    "defaultMessage": "Inserisci la chiave segreta del server"
+  },
+  "externalBackendSection.serverUrl": {
+    "defaultMessage": "URL del server"
+  },
+  "externalBackendSection.title": {
+    "defaultMessage": "Server Goose"
+  },
+  "externalBackendSection.urlFormatError": {
+    "defaultMessage": "Formato URL non valido"
+  },
+  "externalBackendSection.urlProtocolError": {
+    "defaultMessage": "L'URL deve usare il protocollo http o https"
+  },
+  "externalBackendSection.useExternalServer": {
+    "defaultMessage": "Usa un server esterno"
+  },
+  "externalBackendSection.useExternalServerDescription": {
+    "defaultMessage": "Connettiti a un server goose in esecuzione altrove (richiede il riavvio dell'app)"
+  },
+  "freeOptionCards.chooseOption": {
+    "defaultMessage": "Scegli un'opzione per iniziare."
+  },
+  "freeOptionCards.freeAndPrivate": {
+    "defaultMessage": "Gratuito e privato"
+  },
+  "freeOptionCards.localModelDescription": {
+    "defaultMessage": "Scarica un modello ed eseguilo interamente sul tuo computer. Niente chiavi API, niente account."
+  },
+  "freeOptionCards.localModelTitle": {
+    "defaultMessage": "Usa un modello locale"
+  },
+  "freeOptionCards.nanogptDescription": {
+    "defaultMessage": "Registrati per ricevere 60 milioni di token gratuiti per 7 giorni."
+  },
+  "freeOptionCards.nanogptTitle": {
+    "defaultMessage": "NanoGPT"
+  },
+  "freeOptionCards.retry": {
+    "defaultMessage": "Riprova"
+  },
+  "freeOptionCards.tetrateDescription": {
+    "defaultMessage": "Accedi a più modelli di IA con configurazione automatica. Registrati per ricevere 10 $ di credito."
+  },
+  "freeOptionCards.tetrateTitle": {
+    "defaultMessage": "Agent Router di Tetrate"
+  },
+  "freeOptionCards.unexpectedError": {
+    "defaultMessage": "Si è verificato un errore imprevisto durante la configurazione."
+  },
+  "goosehintsModal.close": {
+    "defaultMessage": "Chiudi"
+  },
+  "goosehintsModal.developer": {
+    "defaultMessage": "Developer"
+  },
+  "goosehintsModal.dialogDescription": {
+    "defaultMessage": "Fornisci ulteriore contesto sul tuo progetto per migliorare la comunicazione con Goose"
+  },
+  "goosehintsModal.dialogTitle": {
+    "defaultMessage": "Configura i suggerimenti del progetto (.goosehints)"
+  },
+  "goosehintsModal.errorReading": {
+    "defaultMessage": "Errore durante la lettura del file .goosehints: {error}"
+  },
+  "goosehintsModal.failedToAccess": {
+    "defaultMessage": "Impossibile accedere al file .goosehints"
+  },
+  "goosehintsModal.failedToSave": {
+    "defaultMessage": "Impossibile salvare il file .goosehints"
+  },
+  "goosehintsModal.fileCreating": {
+    "defaultMessage": "Creazione di un nuovo file .goosehints in: {filePath}"
+  },
+  "goosehintsModal.fileFound": {
+    "defaultMessage": "File .goosehints trovato in: {filePath}"
+  },
+  "goosehintsModal.helpText1": {
+    "defaultMessage": ".goosehints è un file di testo usato per fornire ulteriore contesto sul tuo progetto e migliorare la comunicazione con Goose."
+  },
+  "goosehintsModal.helpText2": {
+    "defaultMessage": "Assicurati che l'estensione {bold} sia abilitata nella pagina delle estensioni. Questa estensione è necessaria per usare .goosehints. Dovrai riavviare la sessione affinché gli aggiornamenti di .goosehints abbiano effetto."
+  },
+  "goosehintsModal.helpText3": {
+    "defaultMessage": "Consulta {link} per maggiori informazioni."
+  },
+  "goosehintsModal.helpTextLink": {
+    "defaultMessage": "uso di .goosehints"
+  },
+  "goosehintsModal.placeholder": {
+    "defaultMessage": "Inserisci qui i suggerimenti del progetto..."
+  },
+  "goosehintsModal.save": {
+    "defaultMessage": "Salva"
+  },
+  "goosehintsModal.savedSuccessfully": {
+    "defaultMessage": "Salvato correttamente"
+  },
+  "goosehintsModal.saving": {
+    "defaultMessage": "Salvataggio in corso..."
+  },
+  "goosehintsSection.configure": {
+    "defaultMessage": "Configura"
+  },
+  "goosehintsSection.description": {
+    "defaultMessage": "Configura il file .goosehints del tuo progetto per fornire ulteriore contesto a Goose"
+  },
+  "goosehintsSection.title": {
+    "defaultMessage": "Suggerimenti del progetto (.goosehints)"
+  },
+  "groupedExtensionLoadingToast.askGoose": {
+    "defaultMessage": "Chiedi a goose"
+  },
+  "groupedExtensionLoadingToast.collapseDetails": {
+    "defaultMessage": "Comprimi i dettagli"
+  },
+  "groupedExtensionLoadingToast.copied": {
+    "defaultMessage": "Copiato!"
+  },
+  "groupedExtensionLoadingToast.copyError": {
+    "defaultMessage": "Errore di copia"
+  },
+  "groupedExtensionLoadingToast.expandDetails": {
+    "defaultMessage": "Espandi i dettagli"
+  },
+  "groupedExtensionLoadingToast.failedToAddExtension": {
+    "defaultMessage": "Impossibile aggiungere l'estensione"
+  },
+  "groupedExtensionLoadingToast.failedToLoad": {
+    "defaultMessage": "{count,plural,one{# estensione non caricata} other{# estensioni non caricate}}"
+  },
+  "groupedExtensionLoadingToast.loadingExtensions": {
+    "defaultMessage": "{count,plural,one{Caricamento di # estensione...} other{Caricamento di # estensioni...}}"
+  },
+  "groupedExtensionLoadingToast.partiallyLoaded": {
+    "defaultMessage": "{totalCount,plural,one{Caricata {successCount}/# estensione} other{Caricate {successCount}/# estensioni}}"
+  },
+  "groupedExtensionLoadingToast.showDetails": {
+    "defaultMessage": "Mostra dettagli"
+  },
+  "groupedExtensionLoadingToast.showLess": {
+    "defaultMessage": "Mostra meno"
+  },
+  "groupedExtensionLoadingToast.successfullyLoaded": {
+    "defaultMessage": "{count,plural,one{# estensione caricata correttamente} other{# estensioni caricate correttamente}}"
+  },
+  "headersSection.add": {
+    "defaultMessage": "Aggiungi"
+  },
+  "headersSection.bothRequired": {
+    "defaultMessage": "È necessario inserire sia il nome dell'header sia il valore"
+  },
+  "headersSection.duplicateHeader": {
+    "defaultMessage": "Esiste già un header con questo nome"
+  },
+  "headersSection.headerName": {
+    "defaultMessage": "Nome dell'header"
+  },
+  "headersSection.headersDescription": {
+    "defaultMessage": "Aggiungi header HTTP personalizzati da includere nelle richieste al server MCP. Fai clic sul pulsante \"+\" per aggiungere dopo aver compilato entrambi i campi."
+  },
+  "headersSection.noSpaces": {
+    "defaultMessage": "Il nome dell'header non può contenere spazi"
+  },
+  "headersSection.requestHeaders": {
+    "defaultMessage": "Header della richiesta"
+  },
+  "headersSection.value": {
+    "defaultMessage": "Valore"
+  },
+  "hub.goodAfternoon": {
+    "defaultMessage": "Buon pomeriggio"
+  },
+  "hub.goodEvening": {
+    "defaultMessage": "Buonasera"
+  },
+  "hub.goodMorning": {
+    "defaultMessage": "Buongiorno"
+  },
+  "huggingFaceModelSearch.download": {
+    "defaultMessage": "Scarica"
+  },
+  "huggingFaceModelSearch.downloaded": {
+    "defaultMessage": "Scaricato"
+  },
+  "huggingFaceModelSearch.downloading": {
+    "defaultMessage": "Download in corso…"
+  },
+  "huggingFaceModelSearch.loadingVariants": {
+    "defaultMessage": "Caricamento delle varianti..."
+  },
+  "huggingFaceModelSearch.noGgufModels": {
+    "defaultMessage": "Nessun modello locale compatibile trovato per questa ricerca."
+  },
+  "huggingFaceModelSearch.recommended": {
+    "defaultMessage": "Consigliato"
+  },
+  "huggingFaceModelSearch.searchError": {
+    "defaultMessage": "Errore di ricerca: {details}"
+  },
+  "huggingFaceModelSearch.searchFailed": {
+    "defaultMessage": "Ricerca non riuscita. Riprova."
+  },
+  "huggingFaceModelSearch.searchHuggingFace": {
+    "defaultMessage": "Cerca su HuggingFace"
+  },
+  "huggingFaceModelSearch.searchNoData": {
+    "defaultMessage": "La ricerca non ha restituito dati."
+  },
+  "huggingFaceModelSearch.searchPlaceholder": {
+    "defaultMessage": "Cerca modelli locali..."
+  },
+  "huggingFaceModelSearch.tooLarge": {
+    "defaultMessage": "Potrebbe non entrare in memoria (modello da {size}, {available} disponibili)"
+  },
+  "huggingFaceSignInPrompt.failedToConfigure": {
+    "defaultMessage": "Accesso a Hugging Face non riuscito: {error}"
+  },
+  "huggingFaceSignInPrompt.signIn": {
+    "defaultMessage": "Accedi"
+  },
+  "huggingFaceSignInPrompt.signedIn": {
+    "defaultMessage": "Accesso a Hugging Face effettuato"
+  },
+  "huggingFaceSignInPrompt.signingIn": {
+    "defaultMessage": "Accesso in corso..."
+  },
+  "huggingFaceSignInPrompt.title": {
+    "defaultMessage": "Hugging Face"
+  },
+  "imagePreview.altText": {
+    "defaultMessage": "immagine goose"
+  },
+  "imagePreview.clickToCollapse": {
+    "defaultMessage": "Fai clic per comprimere"
+  },
+  "imagePreview.clickToExpand": {
+    "defaultMessage": "Fai clic per espandere"
+  },
+  "imagePreview.unableToLoad": {
+    "defaultMessage": "Impossibile caricare l'immagine"
+  },
+  "importRecipeForm.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "importRecipeForm.deeplinkHint": {
+    "defaultMessage": "Incolla un deeplink di ricetta che inizia con \"goose://recipe?config=\""
+  },
+  "importRecipeForm.deeplinkPlaceholder": {
+    "defaultMessage": "Incolla qui il tuo deeplink goose://recipe?config=..."
+  },
+  "importRecipeForm.example": {
+    "defaultMessage": "esempio"
+  },
+  "importRecipeForm.expectedRecipeStructure": {
+    "defaultMessage": "Struttura prevista della ricetta"
+  },
+  "importRecipeForm.importRecipeButton": {
+    "defaultMessage": "Importa ricetta"
+  },
+  "importRecipeForm.importRecipeTitle": {
+    "defaultMessage": "Importa ricetta"
+  },
+  "importRecipeForm.importing": {
+    "defaultMessage": "Importazione in corso..."
+  },
+  "importRecipeForm.or": {
+    "defaultMessage": "OPPURE"
+  },
+  "importRecipeForm.recipeDeeplinkLabel": {
+    "defaultMessage": "Deeplink della ricetta"
+  },
+  "importRecipeForm.recipeFileHint": {
+    "defaultMessage": "Carica un file YAML o JSON contenente la struttura della ricetta"
+  },
+  "importRecipeForm.recipeFileLabel": {
+    "defaultMessage": "File della ricetta"
+  },
+  "importRecipeForm.reviewWarning": {
+    "defaultMessage": "Assicurati di esaminare il contenuto dei file delle ricette prima di aggiungerli alla tua interfaccia goose."
+  },
+  "importRecipeForm.schemaDescription": {
+    "defaultMessage": "Il tuo file YAML o JSON deve seguire questa struttura. I campi obbligatori sono: title, description e instructions oppure prompt."
+  },
+  "inlineEditText.clickToEdit": {
+    "defaultMessage": "Fai clic per modificare"
+  },
+  "inlineEditText.doubleClickToEdit": {
+    "defaultMessage": "Fai doppio clic per modificare"
+  },
+  "inlineEditText.enterText": {
+    "defaultMessage": "Inserisci testo"
+  },
+  "inlineEditText.failedToSave": {
+    "defaultMessage": "Salvataggio non riuscito"
+  },
+  "instructionsEditor.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "instructionsEditor.insertExample": {
+    "defaultMessage": "Inserisci esempio"
+  },
+  "instructionsEditor.label": {
+    "defaultMessage": "Istruzioni"
+  },
+  "instructionsEditor.placeholder": {
+    "defaultMessage": "Istruzioni dettagliate per l'IA, nascoste all'utente"
+  },
+  "instructionsEditor.save": {
+    "defaultMessage": "Salva istruzioni"
+  },
+  "instructionsEditor.syntaxHelp": {
+    "defaultMessage": "Usa la sintassi {code} per definire i parametri che gli utenti possono compilare"
+  },
+  "instructionsEditor.title": {
+    "defaultMessage": "Editor delle istruzioni"
+  },
+  "jsonSchemaEditor.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "jsonSchemaEditor.description": {
+    "defaultMessage": "Definisci la struttura prevista della risposta dell'IA usando il formato JSON Schema"
+  },
+  "jsonSchemaEditor.insertExample": {
+    "defaultMessage": "Inserisci esempio"
+  },
+  "jsonSchemaEditor.invalidJson": {
+    "defaultMessage": "Formato JSON non valido"
+  },
+  "jsonSchemaEditor.label": {
+    "defaultMessage": "JSON Schema della risposta"
+  },
+  "jsonSchemaEditor.save": {
+    "defaultMessage": "Salva schema"
+  },
+  "jsonSchemaEditor.title": {
+    "defaultMessage": "Editor JSON Schema"
+  },
+  "jsonSchemaForm.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "jsonSchemaForm.fieldRequired": {
+    "defaultMessage": "Questo campo è obbligatorio"
+  },
+  "jsonSchemaForm.maxLength": {
+    "defaultMessage": "La lunghezza massima è {maxLength}"
+  },
+  "jsonSchemaForm.maxValue": {
+    "defaultMessage": "Il valore massimo è {maximum}"
+  },
+  "jsonSchemaForm.minLength": {
+    "defaultMessage": "La lunghezza minima è {minLength}"
+  },
+  "jsonSchemaForm.minValue": {
+    "defaultMessage": "Il valore minimo è {minimum}"
+  },
+  "jsonSchemaForm.noFields": {
+    "defaultMessage": "Nessun campo da visualizzare"
+  },
+  "jsonSchemaForm.selectPlaceholder": {
+    "defaultMessage": "Seleziona..."
+  },
+  "jsonSchemaForm.submit": {
+    "defaultMessage": "Invia"
+  },
+  "keyValueEditor.addValue": {
+    "defaultMessage": "Aggiungi valore preconfigurato"
+  },
+  "keyValueEditor.defaultKeyPlaceholder": {
+    "defaultMessage": "Nome parametro..."
+  },
+  "keyValueEditor.defaultValuePlaceholder": {
+    "defaultMessage": "Valore parametro..."
+  },
+  "keyValueEditor.removeValue": {
+    "defaultMessage": "Rimuovi valore preconfigurato {key}"
+  },
+  "keyboardShortcuts.alwaysOnTopDescription": {
+    "defaultMessage": "Attiva/disattiva la finestra sempre in primo piano"
+  },
+  "keyboardShortcuts.alwaysOnTopLabel": {
+    "defaultMessage": "Sempre in primo piano"
+  },
+  "keyboardShortcuts.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "keyboardShortcuts.categoryApplication": {
+    "defaultMessage": "Scorciatoie dell'applicazione"
+  },
+  "keyboardShortcuts.categoryApplicationDescription": {
+    "defaultMessage": "Queste scorciatoie funzionano quando Goose è l'applicazione attiva"
+  },
+  "keyboardShortcuts.categoryGlobal": {
+    "defaultMessage": "Scorciatoie globali"
+  },
+  "keyboardShortcuts.categoryGlobalDescription": {
+    "defaultMessage": "Queste scorciatoie funzionano a livello di sistema, anche quando Goose non è in primo piano"
+  },
+  "keyboardShortcuts.categorySearch": {
+    "defaultMessage": "Scorciatoie di ricerca"
+  },
+  "keyboardShortcuts.categorySearchDescription": {
+    "defaultMessage": "Queste scorciatoie funzionano durante la ricerca in una conversazione"
+  },
+  "keyboardShortcuts.categoryWindow": {
+    "defaultMessage": "Scorciatoie finestra"
+  },
+  "keyboardShortcuts.categoryWindowDescription": {
+    "defaultMessage": "Queste scorciatoie controllano il comportamento della finestra"
+  },
+  "keyboardShortcuts.change": {
+    "defaultMessage": "Modifica"
+  },
+  "keyboardShortcuts.disabled": {
+    "defaultMessage": "Disabilitata"
+  },
+  "keyboardShortcuts.dismiss": {
+    "defaultMessage": "Ignora"
+  },
+  "keyboardShortcuts.findDescription": {
+    "defaultMessage": "Apri la ricerca nella conversazione"
+  },
+  "keyboardShortcuts.findLabel": {
+    "defaultMessage": "Trova"
+  },
+  "keyboardShortcuts.findNextDescription": {
+    "defaultMessage": "Vai al risultato di ricerca successivo"
+  },
+  "keyboardShortcuts.findNextLabel": {
+    "defaultMessage": "Trova successivo"
+  },
+  "keyboardShortcuts.findPreviousDescription": {
+    "defaultMessage": "Vai al risultato di ricerca precedente"
+  },
+  "keyboardShortcuts.findPreviousLabel": {
+    "defaultMessage": "Trova precedente"
+  },
+  "keyboardShortcuts.focusWindowDescription": {
+    "defaultMessage": "Porta la finestra di Goose in primo piano da qualsiasi punto"
+  },
+  "keyboardShortcuts.focusWindowLabel": {
+    "defaultMessage": "Metti a fuoco la finestra di Goose"
+  },
+  "keyboardShortcuts.loading": {
+    "defaultMessage": "Caricamento in corso..."
+  },
+  "keyboardShortcuts.newChatDescription": {
+    "defaultMessage": "Crea una nuova chat nella finestra corrente"
+  },
+  "keyboardShortcuts.newChatLabel": {
+    "defaultMessage": "Nuova chat"
+  },
+  "keyboardShortcuts.newChatWindowDescription": {
+    "defaultMessage": "Apri una nuova finestra di Goose"
+  },
+  "keyboardShortcuts.newChatWindowLabel": {
+    "defaultMessage": "Nuova finestra di chat"
+  },
+  "keyboardShortcuts.openDirectoryDescription": {
+    "defaultMessage": "Apri la finestra di selezione della directory"
+  },
+  "keyboardShortcuts.openDirectoryLabel": {
+    "defaultMessage": "Apri directory"
+  },
+  "keyboardShortcuts.quickLauncherDescription": {
+    "defaultMessage": "Apri l'overlay dell'avvio rapido"
+  },
+  "keyboardShortcuts.quickLauncherLabel": {
+    "defaultMessage": "Avvio rapido"
+  },
+  "keyboardShortcuts.reassignShortcut": {
+    "defaultMessage": "Riassegna scorciatoia"
+  },
+  "keyboardShortcuts.resetAllShortcuts": {
+    "defaultMessage": "Reimposta tutte le scorciatoie"
+  },
+  "keyboardShortcuts.resetShortcutsDetail": {
+    "defaultMessage": "Questa operazione ripristinerà tutte le scorciatoie alla loro configurazione originale."
+  },
+  "keyboardShortcuts.resetShortcutsMessage": {
+    "defaultMessage": "Reimpostare tutte le scorciatoie da tastiera ai valori predefiniti?"
+  },
+  "keyboardShortcuts.resetShortcutsTitle": {
+    "defaultMessage": "Reimposta scorciatoie da tastiera"
+  },
+  "keyboardShortcuts.resetToDefaultsDescription": {
+    "defaultMessage": "Ripristina tutte le scorciatoie da tastiera alla loro configurazione originale"
+  },
+  "keyboardShortcuts.resetToDefaultsHeading": {
+    "defaultMessage": "Ripristina i valori predefiniti"
+  },
+  "keyboardShortcuts.restartDescription": {
+    "defaultMessage": "Le modifiche alle scorciatoie dell'applicazione (come Nuova chat, Impostazioni, ecc.) richiedono il riavvio di Goose per avere effetto. Le scorciatoie globali (Metti a fuoco la finestra, Avvio rapido) funzionano immediatamente."
+  },
+  "keyboardShortcuts.restartRequired": {
+    "defaultMessage": "Riavvio necessario"
+  },
+  "keyboardShortcuts.settingsDescription": {
+    "defaultMessage": "Apri il pannello delle impostazioni"
+  },
+  "keyboardShortcuts.settingsLabel": {
+    "defaultMessage": "Impostazioni"
+  },
+  "keyboardShortcuts.shortcutConflictSaveDetail": {
+    "defaultMessage": "Salvando questa modifica la scorciatoia verrà rimossa da \"{conflictLabel}\" e assegnata a \"{targetLabel}\". Vuoi continuare?"
+  },
+  "keyboardShortcuts.shortcutConflictTitle": {
+    "defaultMessage": "Conflitto di scorciatoie"
+  },
+  "keyboardShortcuts.shortcutConflictToggleDetail": {
+    "defaultMessage": "Abilitando questa opzione la scorciatoia verrà rimossa da \"{conflictLabel}\" e assegnata a \"{targetLabel}\". Vuoi continuare?"
+  },
+  "keyboardShortcuts.shortcutConflictToggleMessage": {
+    "defaultMessage": "La scorciatoia {shortcut} è già assegnata a \"{conflictLabel}\"."
+  },
+  "keyboardShortcuts.toggleNavigationDescription": {
+    "defaultMessage": "Mostra o nascondi il menu di navigazione"
+  },
+  "keyboardShortcuts.toggleNavigationLabel": {
+    "defaultMessage": "Attiva/disattiva navigazione"
+  },
+  "launcher.placeholder": {
+    "defaultMessage": "Chiedi qualsiasi cosa a goose..."
+  },
+  "loadingGoose.compacting": {
+    "defaultMessage": "goose sta compattando la conversazione..."
+  },
+  "loadingGoose.idle": {
+    "defaultMessage": "goose ci sta lavorando…"
+  },
+  "loadingGoose.loadingConversation": {
+    "defaultMessage": "caricamento conversazione..."
+  },
+  "loadingGoose.restartingAgent": {
+    "defaultMessage": "riavvio della sessione..."
+  },
+  "loadingGoose.streaming": {
+    "defaultMessage": "goose ci sta lavorando…"
+  },
+  "loadingGoose.thinking": {
+    "defaultMessage": "goose sta pensando…"
+  },
+  "loadingGoose.waiting": {
+    "defaultMessage": "goose è in attesa…"
+  },
+  "localInferenceSettings.deleteConfirm": {
+    "defaultMessage": "Eliminare questo modello? Potrai scaricarlo di nuovo in seguito."
+  },
+  "localInferenceSettings.description": {
+    "defaultMessage": "Scarica e gestisci modelli LLM locali per l'inferenza senza chiavi API. Cerca modelli GGUF o MLX su HuggingFace oppure usa le scelte consigliate qui sotto."
+  },
+  "localInferenceSettings.dismiss": {
+    "defaultMessage": "Ignora"
+  },
+  "localInferenceSettings.download": {
+    "defaultMessage": "Scarica"
+  },
+  "localInferenceSettings.downloadCancelled": {
+    "defaultMessage": "Download annullato"
+  },
+  "localInferenceSettings.downloadFailed": {
+    "defaultMessage": "Download non riuscito"
+  },
+  "localInferenceSettings.downloadProgress": {
+    "defaultMessage": "{downloaded} / {total} ({percent}%)"
+  },
+  "localInferenceSettings.downloadedModels": {
+    "defaultMessage": "Modelli scaricati"
+  },
+  "localInferenceSettings.downloading": {
+    "defaultMessage": "Download in corso"
+  },
+  "localInferenceSettings.featuredModels": {
+    "defaultMessage": "Modelli in evidenza"
+  },
+  "localInferenceSettings.huggingFaceSignInNote": {
+    "defaultMessage": "Accedi per aumentare i limiti di frequenza durante la ricerca e il download dei modelli e per accedere ai repository Hugging Face privati o ad accesso limitato."
+  },
+  "localInferenceSettings.modelSettings": {
+    "defaultMessage": "Impostazioni modello"
+  },
+  "localInferenceSettings.modelSettingsTitle": {
+    "defaultMessage": "Impostazioni modello"
+  },
+  "localInferenceSettings.noModels": {
+    "defaultMessage": "Nessun modello disponibile"
+  },
+  "localInferenceSettings.recommended": {
+    "defaultMessage": "Consigliato"
+  },
+  "localInferenceSettings.remaining": {
+    "defaultMessage": "{time} rimanenti"
+  },
+  "localInferenceSettings.retry": {
+    "defaultMessage": "Riprova"
+  },
+  "localInferenceSettings.showAllFeatured": {
+    "defaultMessage": "Mostra tutti i modelli in evidenza ({count} in più)"
+  },
+  "localInferenceSettings.showRecommendedOnly": {
+    "defaultMessage": "Mostra solo i consigliati"
+  },
+  "localInferenceSettings.title": {
+    "defaultMessage": "Modelli di inferenza locale"
+  },
+  "localInferenceSettings.vision": {
+    "defaultMessage": "Vista"
+  },
+  "localInferenceSettings.visionEncoderDownloading": {
+    "defaultMessage": "Download dell'encoder di visione in corso…"
+  },
+  "localInferenceSettings.visionEncoderNotDownloaded": {
+    "defaultMessage": "Encoder di visione non scaricato"
+  },
+  "localModelManager.active": {
+    "defaultMessage": "Attivo"
+  },
+  "localModelManager.deleteConfirm": {
+    "defaultMessage": "Eliminare questo modello? Potrai scaricarlo di nuovo in seguito."
+  },
+  "localModelManager.download": {
+    "defaultMessage": "Scarica"
+  },
+  "localModelManager.downloaded": {
+    "defaultMessage": "Scaricato"
+  },
+  "localModelManager.gpuAcceleration": {
+    "defaultMessage": "Supporta l'accelerazione GPU (CUDA per NVIDIA, Metal per Apple Silicon). Le funzionalità GPU devono essere abilitate in fase di build per l'accelerazione hardware."
+  },
+  "localModelManager.noModels": {
+    "defaultMessage": "Nessun modello disponibile"
+  },
+  "localModelManager.recommended": {
+    "defaultMessage": "Consigliato"
+  },
+  "localModelManager.recommendedForHardware": {
+    "defaultMessage": "Consigliato per il tuo hardware"
+  },
+  "localModelManager.showAllModels": {
+    "defaultMessage": "Mostra tutti i modelli ({count} in più)"
+  },
+  "localModelManager.showRecommendedOnly": {
+    "defaultMessage": "Mostra solo i consigliati"
+  },
+  "localModelPicker.back": {
+    "defaultMessage": "Indietro"
+  },
+  "localModelPicker.bestForMachine": {
+    "defaultMessage": "Ideale per la tua macchina"
+  },
+  "localModelPicker.cancelDownload": {
+    "defaultMessage": "Annulla download"
+  },
+  "localModelPicker.checkingModels": {
+    "defaultMessage": "Verifica dei modelli disponibili..."
+  },
+  "localModelPicker.downloadModel": {
+    "defaultMessage": "Scarica {modelId} ({size})"
+  },
+  "localModelPicker.downloading": {
+    "defaultMessage": "Download di {modelId} in corso"
+  },
+  "localModelPicker.failedToLoad": {
+    "defaultMessage": "Impossibile caricare i modelli disponibili. Riprova."
+  },
+  "localModelPicker.failedToStartDownload": {
+    "defaultMessage": "Impossibile avviare il download. Riprova."
+  },
+  "localModelPicker.hideOtherSizes": {
+    "defaultMessage": "Nascondi altre dimensioni"
+  },
+  "localModelPicker.localModelsNote": {
+    "defaultMessage": "I modelli locali mantengono tutto sulla tua macchina per la massima privacy. Le prestazioni e la dimensione della finestra di contesto possono variare rispetto ai provider cloud a seconda dell'hardware e della dimensione del modello."
+  },
+  "localModelPicker.lostConnection": {
+    "defaultMessage": "Connessione al download persa. Riprova."
+  },
+  "localModelPicker.modelNotFound": {
+    "defaultMessage": "Modello non trovato"
+  },
+  "localModelPicker.ready": {
+    "defaultMessage": "Pronto"
+  },
+  "localModelPicker.selectModel": {
+    "defaultMessage": "Seleziona un modello"
+  },
+  "localModelPicker.showOtherSizes": {
+    "defaultMessage": "Mostra altre {count} dimensioni"
+  },
+  "localModelPicker.startingDownload": {
+    "defaultMessage": "Avvio del download..."
+  },
+  "localModelPicker.tryAgain": {
+    "defaultMessage": "Riprova"
+  },
+  "localModelPicker.useModel": {
+    "defaultMessage": "Usa {modelId}"
+  },
+  "markdownContent.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "markdownContent.copyCode": {
+    "defaultMessage": "Copia codice"
+  },
+  "markdownContent.failedToOpenLink": {
+    "defaultMessage": "Impossibile aprire il link"
+  },
+  "markdownContent.noApplicationFound": {
+    "defaultMessage": "Nessuna applicazione trovata per aprire questo link."
+  },
+  "markdownContent.open": {
+    "defaultMessage": "Apri"
+  },
+  "markdownContent.openExternalLink": {
+    "defaultMessage": "Apri link esterno"
+  },
+  "markdownContent.openProtocolLink": {
+    "defaultMessage": "Aprire il link {protocol}?"
+  },
+  "markdownContent.thisWillOpen": {
+    "defaultMessage": "Questo aprirà: {href}"
+  },
+  "mcpAppRenderer.appFallbackTitle": {
+    "defaultMessage": "App"
+  },
+  "mcpAppRenderer.cancelButton": {
+    "defaultMessage": "Annulla"
+  },
+  "mcpAppRenderer.close": {
+    "defaultMessage": "Chiudi"
+  },
+  "mcpAppRenderer.exitFullscreen": {
+    "defaultMessage": "Esci dalla modalità a schermo intero"
+  },
+  "mcpAppRenderer.exitFullscreenTitle": {
+    "defaultMessage": "Esci dalla modalità a schermo intero (Esc)"
+  },
+  "mcpAppRenderer.failedToInitSandbox": {
+    "defaultMessage": "Impossibile inizializzare il proxy sandbox"
+  },
+  "mcpAppRenderer.failedToLoadResource": {
+    "defaultMessage": "Impossibile caricare la risorsa"
+  },
+  "mcpAppRenderer.fullscreen": {
+    "defaultMessage": "Schermo intero"
+  },
+  "mcpAppRenderer.invalidUrl": {
+    "defaultMessage": "URL non valido"
+  },
+  "mcpAppRenderer.movePipWindow": {
+    "defaultMessage": "Sposta la finestra Picture-in-Picture (usa i tasti freccia)"
+  },
+  "mcpAppRenderer.openButton": {
+    "defaultMessage": "Apri"
+  },
+  "mcpAppRenderer.openExternalLinkTitle": {
+    "defaultMessage": "Apri link esterno"
+  },
+  "mcpAppRenderer.openLinkDetail": {
+    "defaultMessage": "Questo aprirà: {url}"
+  },
+  "mcpAppRenderer.openProtocolLink": {
+    "defaultMessage": "Aprire il link {protocol}?"
+  },
+  "mcpAppRenderer.pictureInPicture": {
+    "defaultMessage": "Picture-in-Picture"
+  },
+  "mcpAppRenderer.playingInPip": {
+    "defaultMessage": "In riproduzione in Picture-in-Picture"
+  },
+  "mcpUIResourceRenderer.cancelButton": {
+    "defaultMessage": "Annulla"
+  },
+  "mcpUIResourceRenderer.openButton": {
+    "defaultMessage": "Apri"
+  },
+  "mcpUIResourceRenderer.openExternalLinkTitle": {
+    "defaultMessage": "Apri link esterno"
+  },
+  "mcpUIResourceRenderer.openLinkDetail": {
+    "defaultMessage": "Questo aprirà: {url}"
+  },
+  "mcpUIResourceRenderer.openProtocolLink": {
+    "defaultMessage": "Aprire il link {protocol}?"
+  },
+  "mcpUIResourceRenderer.toastMessageReceived": {
+    "defaultMessage": "Messaggio ricevuto per {message}."
+  },
+  "mcpUIResourceRenderer.toastTitle": {
+    "defaultMessage": "Messaggio MCP-UI {messageType}"
+  },
+  "mcpUIResourceRenderer.toastUnsupported": {
+    "defaultMessage": "Messaggio ricevuto per {message}. I messaggi {messageType} non sono ancora supportati, consulta la console per maggiori dettagli."
+  },
+  "mentionPopover.itemsFound": {
+    "defaultMessage": "{count,plural,one{# elemento trovato} other{# elementi trovati}}"
+  },
+  "mentionPopover.loadingCommands": {
+    "defaultMessage": "Caricamento comandi..."
+  },
+  "mentionPopover.noCommandsFound": {
+    "defaultMessage": "Nessun comando trovato corrispondente a \"{query}\""
+  },
+  "mentionPopover.noItemsFound": {
+    "defaultMessage": "Nessun elemento trovato corrispondente a \"{query}\""
+  },
+  "mentionPopover.scanningFiles": {
+    "defaultMessage": "Scansione dei file..."
+  },
+  "messageCopyLink.copied": {
+    "defaultMessage": "Copiato!"
+  },
+  "messageCopyLink.copy": {
+    "defaultMessage": "Copia"
+  },
+  "messageQueue.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "messageQueue.cannotSendWhileEditing": {
+    "defaultMessage": "Impossibile inviare durante la modifica"
+  },
+  "messageQueue.clearAll": {
+    "defaultMessage": "Cancella tutto"
+  },
+  "messageQueue.clickToEdit": {
+    "defaultMessage": "{content} (Clicca per modificare)"
+  },
+  "messageQueue.collapseQueue": {
+    "defaultMessage": "Comprimi coda"
+  },
+  "messageQueue.dragToReorder": {
+    "defaultMessage": "Trascina i messaggi per riordinare la priorità"
+  },
+  "messageQueue.expandQueue": {
+    "defaultMessage": "Espandi coda"
+  },
+  "messageQueue.messageCount": {
+    "defaultMessage": "{count,plural,one{# messaggio {status}} other{# messaggi {status}}}"
+  },
+  "messageQueue.messageQueue": {
+    "defaultMessage": "Coda dei messaggi"
+  },
+  "messageQueue.next": {
+    "defaultMessage": "Successivo"
+  },
+  "messageQueue.paused": {
+    "defaultMessage": "In pausa"
+  },
+  "messageQueue.queuePaused": {
+    "defaultMessage": "Coda in pausa"
+  },
+  "messageQueue.queuePausedCompact": {
+    "defaultMessage": "Coda in pausa - clicca \"Invia\" o aggiungi un nuovo messaggio per riprendere"
+  },
+  "messageQueue.queuePausedExpanded": {
+    "defaultMessage": "Coda in pausa per interruzione. Usa \"Invia ora\" o aggiungi un nuovo messaggio per riprendere."
+  },
+  "messageQueue.queued": {
+    "defaultMessage": "in coda"
+  },
+  "messageQueue.removeFromQueue": {
+    "defaultMessage": "Rimuovi questo messaggio dalla coda"
+  },
+  "messageQueue.save": {
+    "defaultMessage": "Salva"
+  },
+  "messageQueue.sendNow": {
+    "defaultMessage": "Invia subito questo messaggio"
+  },
+  "messageQueue.stopAndSend": {
+    "defaultMessage": "Interrompi l'elaborazione corrente e invia subito questo messaggio"
+  },
+  "messageQueue.waiting": {
+    "defaultMessage": "in attesa"
+  },
+  "microphoneSelector.chooseDescription": {
+    "defaultMessage": "Scegli quale microfono usare per la dettatura"
+  },
+  "microphoneSelector.grantAccess": {
+    "defaultMessage": "Concedi accesso"
+  },
+  "microphoneSelector.grantAccessDescription": {
+    "defaultMessage": "Concedi l'accesso per visualizzare i microfoni disponibili"
+  },
+  "microphoneSelector.microphone": {
+    "defaultMessage": "Microfono"
+  },
+  "microphoneSelector.microphoneLabel": {
+    "defaultMessage": "Microfono {index}"
+  },
+  "microphoneSelector.selectedMicrophone": {
+    "defaultMessage": "Microfono selezionato"
+  },
+  "microphoneSelector.speakToTest": {
+    "defaultMessage": "Parla per testare il tuo microfono ({seconds}s)"
+  },
+  "microphoneSelector.stop": {
+    "defaultMessage": "Ferma"
+  },
+  "microphoneSelector.systemDefault": {
+    "defaultMessage": "Predefinito di sistema"
+  },
+  "microphoneSelector.test": {
+    "defaultMessage": "Prova"
+  },
+  "modeSelectionItem.autonomousDescription": {
+    "defaultMessage": "Funzionalità complete di modifica dei file: modifica, crea ed elimina file liberamente."
+  },
+  "modeSelectionItem.autonomousLabel": {
+    "defaultMessage": "Autonoma"
+  },
+  "modeSelectionItem.chatOnlyDescription": {
+    "defaultMessage": "Interagisci con il provider selezionato senza usare strumenti o estensioni."
+  },
+  "modeSelectionItem.chatOnlyLabel": {
+    "defaultMessage": "Solo chat"
+  },
+  "modeSelectionItem.manualDescription": {
+    "defaultMessage": "Tutti gli strumenti, le estensioni e le modifiche ai file richiederanno l'approvazione umana"
+  },
+  "modeSelectionItem.manualLabel": {
+    "defaultMessage": "Manuale"
+  },
+  "modeSelectionItem.smartDescription": {
+    "defaultMessage": "Determina in modo intelligente quali azioni necessitano di approvazione in base al livello di rischio"
+  },
+  "modeSelectionItem.smartLabel": {
+    "defaultMessage": "Intelligente"
+  },
+  "modelAndProviderContext.modelChangeFailed": {
+    "defaultMessage": "{provider}/{model} non riuscito"
+  },
+  "modelAndProviderContext.modelChangedTitle": {
+    "defaultMessage": "Modello cambiato"
+  },
+  "modelAndProviderContext.selectModel": {
+    "defaultMessage": "Seleziona modello"
+  },
+  "modelAndProviderContext.switchModelSuccess": {
+    "defaultMessage": "Modelli cambiati correttamente -- in uso {model} di {provider}"
+  },
+  "modelAndProviderContext.unknownProviderMsg": {
+    "defaultMessage": "Provider sconosciuto nella configurazione -- controlla il tuo config.yaml"
+  },
+  "modelAndProviderContext.unknownProviderTitle": {
+    "defaultMessage": "Ricerca nome provider"
+  },
+  "modelSettingsButtons.configureProviders": {
+    "defaultMessage": "Configura provider"
+  },
+  "modelSettingsButtons.switchModels": {
+    "defaultMessage": "Cambia modelli"
+  },
+  "modelSettingsPanel.batchSize": {
+    "defaultMessage": "Dimensione batch"
+  },
+  "modelSettingsPanel.batchSizeDescription": {
+    "defaultMessage": "Batch di elaborazione del prompt"
+  },
+  "modelSettingsPanel.builtinChatTemplate": {
+    "defaultMessage": "Template integrato"
+  },
+  "modelSettingsPanel.builtinChatTemplateDescription": {
+    "defaultMessage": "Seleziona il nome di un template integrato di llama.cpp"
+  },
+  "modelSettingsPanel.chatTemplate": {
+    "defaultMessage": "Template chat"
+  },
+  "modelSettingsPanel.chatTemplateBuiltin": {
+    "defaultMessage": "Integrato"
+  },
+  "modelSettingsPanel.chatTemplateCustomInline": {
+    "defaultMessage": "Personalizzato inline"
+  },
+  "modelSettingsPanel.chatTemplateDescription": {
+    "defaultMessage": "Usa i metadati GGUF incorporati, un template integrato di llama.cpp o Jinja inline"
+  },
+  "modelSettingsPanel.chatTemplateEmbedded": {
+    "defaultMessage": "Incorporato"
+  },
+  "modelSettingsPanel.contextAndGeneration": {
+    "defaultMessage": "Contesto e generazione"
+  },
+  "modelSettingsPanel.contextSize": {
+    "defaultMessage": "Dimensione contesto"
+  },
+  "modelSettingsPanel.contextSizeDescription": {
+    "defaultMessage": "Finestra di contesto massima (0 = valore predefinito del modello)"
+  },
+  "modelSettingsPanel.customChatTemplate": {
+    "defaultMessage": "Template chat personalizzato"
+  },
+  "modelSettingsPanel.customChatTemplateDescription": {
+    "defaultMessage": "Incolla il codice sorgente completo del template chat Jinja"
+  },
+  "modelSettingsPanel.etaLearningRate": {
+    "defaultMessage": "Eta (tasso di apprendimento)"
+  },
+  "modelSettingsPanel.flashAttention": {
+    "defaultMessage": "Flash attention"
+  },
+  "modelSettingsPanel.flashAttentionDescription": {
+    "defaultMessage": "Abilita l'ottimizzazione flash attention"
+  },
+  "modelSettingsPanel.frequencyPenalty": {
+    "defaultMessage": "Penalità di frequenza"
+  },
+  "modelSettingsPanel.frequencyPenaltyDescription": {
+    "defaultMessage": "0.0 = disattivata"
+  },
+  "modelSettingsPanel.gpuLayers": {
+    "defaultMessage": "Livelli GPU"
+  },
+  "modelSettingsPanel.gpuLayersDescription": {
+    "defaultMessage": "Livelli da delegare alla GPU"
+  },
+  "modelSettingsPanel.loadingSettings": {
+    "defaultMessage": "Caricamento impostazioni..."
+  },
+  "modelSettingsPanel.lockModelInRam": {
+    "defaultMessage": "Blocca il modello in RAM (mlock)"
+  },
+  "modelSettingsPanel.lockModelInRamDescription": {
+    "defaultMessage": "Impedisce lo swap del modello su disco"
+  },
+  "modelSettingsPanel.maxOutputTokens": {
+    "defaultMessage": "Token di output massimi"
+  },
+  "modelSettingsPanel.maxOutputTokensDescription": {
+    "defaultMessage": "Limite sui token generati"
+  },
+  "modelSettingsPanel.minP": {
+    "defaultMessage": "Min P"
+  },
+  "modelSettingsPanel.performance": {
+    "defaultMessage": "Prestazioni"
+  },
+  "modelSettingsPanel.presencePenalty": {
+    "defaultMessage": "Penalità di presenza"
+  },
+  "modelSettingsPanel.presencePenaltyDescription": {
+    "defaultMessage": "0.0 = disattivata"
+  },
+  "modelSettingsPanel.repeatPenalty": {
+    "defaultMessage": "Penalità di ripetizione"
+  },
+  "modelSettingsPanel.repeatPenaltyDescription": {
+    "defaultMessage": "1.0 = disattivata"
+  },
+  "modelSettingsPanel.repeatWindow": {
+    "defaultMessage": "Finestra di ripetizione"
+  },
+  "modelSettingsPanel.repeatWindowDescription": {
+    "defaultMessage": "Token da considerare a ritroso"
+  },
+  "modelSettingsPanel.repetitionPenalty": {
+    "defaultMessage": "Penalità di ripetizione"
+  },
+  "modelSettingsPanel.reset": {
+    "defaultMessage": "Reimposta"
+  },
+  "modelSettingsPanel.resetToDefaults": {
+    "defaultMessage": "Reimposta i valori predefiniti"
+  },
+  "modelSettingsPanel.samplingStrategy": {
+    "defaultMessage": "Strategia di campionamento"
+  },
+  "modelSettingsPanel.saving": {
+    "defaultMessage": "Salvataggio in corso..."
+  },
+  "modelSettingsPanel.seed": {
+    "defaultMessage": "Seed"
+  },
+  "modelSettingsPanel.tauTargetEntropy": {
+    "defaultMessage": "Tau (entropia target)"
+  },
+  "modelSettingsPanel.temperature": {
+    "defaultMessage": "Temperatura"
+  },
+  "modelSettingsPanel.threads": {
+    "defaultMessage": "Thread"
+  },
+  "modelSettingsPanel.threadsDescription": {
+    "defaultMessage": "Thread CPU per la generazione"
+  },
+  "modelSettingsPanel.toolCalling": {
+    "defaultMessage": "Chiamata strumenti"
+  },
+  "modelSettingsPanel.toolCallingAuto": {
+    "defaultMessage": "Automatica"
+  },
+  "modelSettingsPanel.toolCallingDescription": {
+    "defaultMessage": "Scegli come i modelli locali selezionano la chiamata strumenti nativa o emulata"
+  },
+  "modelSettingsPanel.toolCallingForceEmulated": {
+    "defaultMessage": "Forza emulata"
+  },
+  "modelSettingsPanel.toolCallingForceNative": {
+    "defaultMessage": "Forza nativa"
+  },
+  "modelSettingsPanel.topK": {
+    "defaultMessage": "Top K"
+  },
+  "modelSettingsPanel.topP": {
+    "defaultMessage": "Top P"
+  },
+  "modelsBottomBar.changeModel": {
+    "defaultMessage": "Cambia modello"
+  },
+  "modelsBottomBar.currentModel": {
+    "defaultMessage": "Modello corrente"
+  },
+  "modelsBottomBar.loadingModel": {
+    "defaultMessage": "Caricamento modello..."
+  },
+  "modelsBottomBar.localModelSettings": {
+    "defaultMessage": "Impostazioni modello locale"
+  },
+  "modelsBottomBar.localModelSettingsTitle": {
+    "defaultMessage": "Impostazioni modello locale — {modelName}"
+  },
+  "modelsBottomBar.resolvedModel": {
+    "defaultMessage": "Modello risolto"
+  },
+  "modelsBottomBar.selectModel": {
+    "defaultMessage": "Seleziona modello"
+  },
+  "modelsSection.resetDescription": {
+    "defaultMessage": "Cancella le impostazioni del modello e del provider selezionati per ricominciare da zero"
+  },
+  "modelsSection.resetTitle": {
+    "defaultMessage": "Reimposta provider e modello"
+  },
+  "navigation.itemApps": {
+    "defaultMessage": "App"
+  },
+  "navigation.itemExtensions": {
+    "defaultMessage": "Estensioni"
+  },
+  "navigation.itemHome": {
+    "defaultMessage": "Nuova chat"
+  },
+  "navigation.itemRecipes": {
+    "defaultMessage": "Ricette"
+  },
+  "navigation.itemScheduler": {
+    "defaultMessage": "Pianificatore"
+  },
+  "navigation.itemSessions": {
+    "defaultMessage": "Cronologia sessioni"
+  },
+  "navigation.itemSettings": {
+    "defaultMessage": "Impostazioni"
+  },
+  "navigation.itemSkills": {
+    "defaultMessage": "Competenze"
+  },
+  "navigationPanel.chats": {
+    "defaultMessage": "Chat"
+  },
+  "navigationPanel.noChats": {
+    "defaultMessage": "Nessuna chat recente"
+  },
+  "navigationPanel.untitledSession": {
+    "defaultMessage": "Sessione senza titolo"
+  },
+  "onboardingGuard.checkProviderErrorDescription": {
+    "defaultMessage": "Il server potrebbe essere in fase di avvio o temporaneamente non disponibile."
+  },
+  "onboardingGuard.checkProviderErrorTitle": {
+    "defaultMessage": "Impossibile connettersi al server Goose"
+  },
+  "onboardingGuard.retry": {
+    "defaultMessage": "Riprova"
+  },
+  "onboardingGuard.welcomeDescription": {
+    "defaultMessage": "Il tuo agente IA locale. Collega un provider di modelli IA per iniziare."
+  },
+  "onboardingGuard.welcomeTitle": {
+    "defaultMessage": "Benvenuto in goose"
+  },
+  "onboardingSuccess.allSet": {
+    "defaultMessage": "Tutto è pronto per iniziare a usare goose."
+  },
+  "onboardingSuccess.connectedTo": {
+    "defaultMessage": "Connesso a {providerName}"
+  },
+  "onboardingSuccess.getStarted": {
+    "defaultMessage": "Inizia"
+  },
+  "onboardingSuccess.learnMore": {
+    "defaultMessage": "Scopri di più"
+  },
+  "onboardingSuccess.localModelReady": {
+    "defaultMessage": "Modello locale pronto"
+  },
+  "onboardingSuccess.privacyDescription": {
+    "defaultMessage": "I dati di utilizzo anonimi aiutano a migliorare goose. Non raccogliamo mai le tue conversazioni, il tuo codice o i tuoi dati personali."
+  },
+  "onboardingSuccess.privacyTitle": {
+    "defaultMessage": "Privacy"
+  },
+  "onboardingSuccess.shareUsageData": {
+    "defaultMessage": "Condividi dati di utilizzo anonimi"
+  },
+  "parameterInput.defaultValue": {
+    "defaultMessage": "Valore predefinito"
+  },
+  "parameterInput.defaultValuePlaceholder": {
+    "defaultMessage": "Inserisci il valore predefinito"
+  },
+  "parameterInput.deleteParameter": {
+    "defaultMessage": "Elimina parametro: {key}"
+  },
+  "parameterInput.description": {
+    "defaultMessage": "descrizione"
+  },
+  "parameterInput.descriptionHelp": {
+    "defaultMessage": "Questo è il messaggio che l'utente finale vedrà."
+  },
+  "parameterInput.descriptionPlaceholder": {
+    "defaultMessage": "Es., \"Inserisci il nome del nuovo componente\""
+  },
+  "parameterInput.inputType": {
+    "defaultMessage": "Tipo di input"
+  },
+  "parameterInput.optional": {
+    "defaultMessage": "Facoltativo"
+  },
+  "parameterInput.optionsHelp": {
+    "defaultMessage": "Inserisci ogni opzione su una nuova riga. Verranno mostrate come scelte del menu a discesa."
+  },
+  "parameterInput.optionsLabel": {
+    "defaultMessage": "Opzioni (una per riga)"
+  },
+  "parameterInput.optionsPlaceholder": {
+    "defaultMessage": "Opzione 1 Opzione 2 Opzione 3"
+  },
+  "parameterInput.required": {
+    "defaultMessage": "Obbligatorio"
+  },
+  "parameterInput.requirement": {
+    "defaultMessage": "Requisito"
+  },
+  "parameterInput.typeBoolean": {
+    "defaultMessage": "Booleano"
+  },
+  "parameterInput.typeNumber": {
+    "defaultMessage": "Numero"
+  },
+  "parameterInput.typeSelect": {
+    "defaultMessage": "Selezione"
+  },
+  "parameterInput.typeString": {
+    "defaultMessage": "Stringa"
+  },
+  "parameterInput.unused": {
+    "defaultMessage": "Non utilizzato"
+  },
+  "parameterInput.unusedWarningTitle": {
+    "defaultMessage": "Questo parametro non è utilizzato nelle istruzioni o nel prompt. Sarà disponibile per l'inserimento manuale ma potrebbe non essere necessario."
+  },
+  "parameterInputModal.backToForm": {
+    "defaultMessage": "Torna al modulo dei parametri"
+  },
+  "parameterInputModal.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "parameterInputModal.cancelRecipeSetup": {
+    "defaultMessage": "Annulla configurazione ricetta"
+  },
+  "parameterInputModal.enterValue": {
+    "defaultMessage": "Inserisci il valore per {key}..."
+  },
+  "parameterInputModal.false": {
+    "defaultMessage": "Falso"
+  },
+  "parameterInputModal.recipeParameters": {
+    "defaultMessage": "Parametri ricetta"
+  },
+  "parameterInputModal.select": {
+    "defaultMessage": "Seleziona..."
+  },
+  "parameterInputModal.selectOption": {
+    "defaultMessage": "Seleziona un'opzione..."
+  },
+  "parameterInputModal.startNewChat": {
+    "defaultMessage": "Avvia nuova chat (nessuna ricetta)"
+  },
+  "parameterInputModal.startRecipe": {
+    "defaultMessage": "Avvia ricetta"
+  },
+  "parameterInputModal.true": {
+    "defaultMessage": "Vero"
+  },
+  "parameterInputModal.whatToDo": {
+    "defaultMessage": "Cosa desideri fare?"
+  },
+  "permissionModal.alwaysAllow": {
+    "defaultMessage": "Consenti sempre"
+  },
+  "permissionModal.askBefore": {
+    "defaultMessage": "Chiedi prima"
+  },
+  "permissionModal.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "permissionModal.close": {
+    "defaultMessage": "Chiudi"
+  },
+  "permissionModal.failedToLoadTools": {
+    "defaultMessage": "Impossibile caricare gli strumenti"
+  },
+  "permissionModal.failedToLoadToolsDescription": {
+    "defaultMessage": "Impossibile caricare gli strumenti per questa estensione. L'estensione potrebbe non essere caricata nella sessione corrente."
+  },
+  "permissionModal.neverAllow": {
+    "defaultMessage": "Non consentire mai"
+  },
+  "permissionModal.noActiveSession": {
+    "defaultMessage": "Nessuna sessione attiva"
+  },
+  "permissionModal.noActiveSessionDescription": {
+    "defaultMessage": "Avvia prima una sessione di chat per configurare le autorizzazioni degli strumenti per questa estensione. Le autorizzazioni degli strumenti vengono caricate dalle estensioni della sessione attiva."
+  },
+  "permissionModal.noToolsAvailable": {
+    "defaultMessage": "Nessuno strumento disponibile per questa estensione."
+  },
+  "permissionModal.saveChanges": {
+    "defaultMessage": "Salva modifiche"
+  },
+  "permissionRulesModal.description": {
+    "defaultMessage": "Configura le autorizzazioni degli strumenti per le estensioni per controllare come interagiscono con il tuo sistema."
+  },
+  "permissionRulesModal.extensionRules": {
+    "defaultMessage": "Regole delle estensioni"
+  },
+  "permissionRulesModal.title": {
+    "defaultMessage": "Regole di autorizzazione"
+  },
+  "permissionSetting.extensionRules": {
+    "defaultMessage": "Regole delle estensioni"
+  },
+  "permissionSetting.permissionRules": {
+    "defaultMessage": "Regole di autorizzazione"
+  },
+  "permissionSetting.permissionRulesDescription": {
+    "defaultMessage": "Istruzioni nascoste che verranno passate al provider per aiutare a indirizzare e aggiungere contesto alle tue risposte."
+  },
+  "privacyInfoModal.collectErrors": {
+    "defaultMessage": "Tipi di errore (es. \"rate_limit\", \"auth\" - nessun dettaglio)"
+  },
+  "privacyInfoModal.collectExtensions": {
+    "defaultMessage": "Conteggi di utilizzo di estensioni e strumenti (solo nomi)"
+  },
+  "privacyInfoModal.collectOs": {
+    "defaultMessage": "Sistema operativo, versione e architettura"
+  },
+  "privacyInfoModal.collectProvider": {
+    "defaultMessage": "Provider e modello utilizzati"
+  },
+  "privacyInfoModal.collectSession": {
+    "defaultMessage": "Metriche della sessione (durata, numero di interazioni, utilizzo di token)"
+  },
+  "privacyInfoModal.collectVersion": {
+    "defaultMessage": "Versione di goose e metodo di installazione"
+  },
+  "privacyInfoModal.description": {
+    "defaultMessage": "I dati di utilizzo anonimi ci aiutano a capire come viene usato goose e a individuare le aree di miglioramento."
+  },
+  "privacyInfoModal.neverCollect": {
+    "defaultMessage": "Non raccogliamo mai le tue conversazioni, il tuo codice, gli argomenti degli strumenti, i messaggi di errore o alcun dato personale. Puoi modificare questa impostazione in qualsiasi momento in Impostazioni."
+  },
+  "privacyInfoModal.title": {
+    "defaultMessage": "Dettagli sulla privacy"
+  },
+  "privacyInfoModal.whatWeCollect": {
+    "defaultMessage": "Cosa raccogliamo:"
+  },
+  "progressiveMessageList.loadingMessages": {
+    "defaultMessage": "Caricamento messaggi... ({renderedCount}/{totalCount})"
+  },
+  "progressiveMessageList.modelChanged": {
+    "defaultMessage": "Modello cambiato: {previousModel} → {currentModel}"
+  },
+  "progressiveMessageList.searchHint": {
+    "defaultMessage": "Premi Cmd/Ctrl+F per caricare immediatamente tutti i messaggi per la ricerca"
+  },
+  "promptsSettings.allPromptsReset": {
+    "defaultMessage": "Tutti i prompt ripristinati ai valori predefiniti"
+  },
+  "promptsSettings.backToList": {
+    "defaultMessage": "Torna all'elenco"
+  },
+  "promptsSettings.confirmReplaceWithDefault": {
+    "defaultMessage": "Sostituire il contenuto attuale con quello predefinito? Le tue modifiche andranno perse."
+  },
+  "promptsSettings.confirmResetAll": {
+    "defaultMessage": "Sei sicuro di voler ripristinare tutti i prompt ai loro valori predefiniti? Questa operazione non può essere annullata."
+  },
+  "promptsSettings.confirmResetOne": {
+    "defaultMessage": "Sei sicuro di voler ripristinare questo prompt al suo valore predefinito? Questa operazione non può essere annullata."
+  },
+  "promptsSettings.confirmUnsavedBack": {
+    "defaultMessage": "Hai modifiche non salvate. Sei sicuro di voler tornare indietro?"
+  },
+  "promptsSettings.customized": {
+    "defaultMessage": "Personalizzato"
+  },
+  "promptsSettings.edit": {
+    "defaultMessage": "Modifica"
+  },
+  "promptsSettings.editPromptTitle": {
+    "defaultMessage": "Modifica: {name}"
+  },
+  "promptsSettings.editingLabel": {
+    "defaultMessage": "Modifica in corso: {name}"
+  },
+  "promptsSettings.enterPromptContent": {
+    "defaultMessage": "Inserisci il contenuto del prompt..."
+  },
+  "promptsSettings.failedToLoadPrompt": {
+    "defaultMessage": "Impossibile caricare il prompt"
+  },
+  "promptsSettings.failedToLoadPrompts": {
+    "defaultMessage": "Impossibile caricare i prompt"
+  },
+  "promptsSettings.failedToResetPrompt": {
+    "defaultMessage": "Impossibile ripristinare il prompt"
+  },
+  "promptsSettings.failedToResetPrompts": {
+    "defaultMessage": "Impossibile ripristinare i prompt"
+  },
+  "promptsSettings.failedToSavePrompt": {
+    "defaultMessage": "Impossibile salvare il prompt"
+  },
+  "promptsSettings.promptEditingDescription": {
+    "defaultMessage": "Personalizza i prompt che definiscono il comportamento di goose in diversi contesti. Questi prompt usano la sintassi dei template Jinja2. Fai attenzione quando modifichi le variabili dei template, poiché modifiche errate possono compromettere le funzionalità. Condividi eventuali miglioramenti con la community."
+  },
+  "promptsSettings.promptEditingTitle": {
+    "defaultMessage": "Modifica prompt"
+  },
+  "promptsSettings.promptResetToDefault": {
+    "defaultMessage": "Prompt ripristinato al valore predefinito"
+  },
+  "promptsSettings.promptSaved": {
+    "defaultMessage": "Prompt salvato"
+  },
+  "promptsSettings.resetAll": {
+    "defaultMessage": "Ripristina tutto"
+  },
+  "promptsSettings.resetToDefault": {
+    "defaultMessage": "Ripristina ai valori predefiniti"
+  },
+  "promptsSettings.restoreDefault": {
+    "defaultMessage": "Ripristina predefinito"
+  },
+  "promptsSettings.save": {
+    "defaultMessage": "Salva"
+  },
+  "promptsSettings.templateTip": {
+    "defaultMessage": "Le variabili dei template come {extensionsExample} o {forExample} vengono sostituite con i valori effettivi in fase di esecuzione. Fai attenzione a non rimuovere le variabili obbligatorie."
+  },
+  "promptsSettings.unsavedChanges": {
+    "defaultMessage": "Hai modifiche non salvate"
+  },
+  "providerCard.noMetadata": {
+    "defaultMessage": "Errore ProviderCard: nessun metadato fornito"
+  },
+  "providerCard.unknownProvider": {
+    "defaultMessage": "Provider sconosciuto"
+  },
+  "providerCatalogPicker.anthropicCompatible": {
+    "defaultMessage": "Compatibile con Anthropic"
+  },
+  "providerCatalogPicker.apiFormat": {
+    "defaultMessage": "Formato API"
+  },
+  "providerCatalogPicker.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "providerCatalogPicker.chooseProvider": {
+    "defaultMessage": "Scegli provider"
+  },
+  "providerCatalogPicker.errorPrefix": {
+    "defaultMessage": "Errore: {error}"
+  },
+  "providerCatalogPicker.loadingProviders": {
+    "defaultMessage": "Caricamento provider..."
+  },
+  "providerCatalogPicker.modelsAvailable": {
+    "defaultMessage": "{count} modelli disponibili"
+  },
+  "providerCatalogPicker.noProvidersAvailable": {
+    "defaultMessage": "Nessun provider disponibile"
+  },
+  "providerCatalogPicker.noProvidersFound": {
+    "defaultMessage": "Nessun provider trovato per \"{query}\""
+  },
+  "providerCatalogPicker.openaiCompatible": {
+    "defaultMessage": "Compatibile con OpenAI"
+  },
+  "providerCatalogPicker.requiresEnvVar": {
+    "defaultMessage": "• Richiede {envVar}"
+  },
+  "providerCatalogPicker.searchProviders": {
+    "defaultMessage": "Cerca provider..."
+  },
+  "providerCatalogPicker.selectFormatDescription": {
+    "defaultMessage": "Seleziona un formato API e un provider. Compileremo automaticamente la configurazione per te."
+  },
+  "providerConfigForm.browserWindowOpen": {
+    "defaultMessage": "Si aprirà una finestra del browser per completare l'accesso."
+  },
+  "providerConfigForm.configuring": {
+    "defaultMessage": "Configurazione in corso..."
+  },
+  "providerConfigForm.continue": {
+    "defaultMessage": "Continua"
+  },
+  "providerConfigForm.deviceCodeFlowHint": {
+    "defaultMessage": "Si aprirà una finestra del browser e il codice di verifica verrà copiato negli appunti. Incollalo nel browser per completare l'accesso."
+  },
+  "providerConfigForm.noApiKey": {
+    "defaultMessage": "Non hai una chiave API?"
+  },
+  "providerConfigForm.signInWith": {
+    "defaultMessage": "Accedi con {providerName}"
+  },
+  "providerConfigForm.signingIn": {
+    "defaultMessage": "Accesso in corso..."
+  },
+  "providerConfigurationModal.addApiKeyDescription": {
+    "defaultMessage": "Aggiungi la tua chiave o le tue chiavi API per questo provider da integrare in goose"
+  },
+  "providerConfigurationModal.browserWindowHint": {
+    "defaultMessage": "Si aprirà una finestra del browser per completare l'accesso."
+  },
+  "providerConfigurationModal.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "providerConfigurationModal.cannotDeleteActive": {
+    "defaultMessage": "Non puoi eliminare questo provider mentre è attualmente in uso. Passa prima a un modello diverso."
+  },
+  "providerConfigurationModal.checkConfigAgain": {
+    "defaultMessage": "Controlla di nuovo la tua configurazione per usare questo provider."
+  },
+  "providerConfigurationModal.close": {
+    "defaultMessage": "Chiudi"
+  },
+  "providerConfigurationModal.configureHeader": {
+    "defaultMessage": "Configura {providerName}"
+  },
+  "providerConfigurationModal.deleteConfigHeader": {
+    "defaultMessage": "Elimina configurazione per {providerName}"
+  },
+  "providerConfigurationModal.deleteConfirmation": {
+    "defaultMessage": "Questa operazione eliminerà definitivamente la configurazione attuale del provider."
+  },
+  "providerConfigurationModal.deviceCodeFlowHint": {
+    "defaultMessage": "Si aprirà una finestra del browser e il codice di verifica verrà copiato negli appunti. Incollalo nel browser per completare l'accesso."
+  },
+  "providerConfigurationModal.errorCheckingConfig": {
+    "defaultMessage": "Si è verificato un errore durante la verifica della configurazione di questo provider."
+  },
+  "providerConfigurationModal.errorTitle": {
+    "defaultMessage": "Errore"
+  },
+  "providerConfigurationModal.externalSetupIntro": {
+    "defaultMessage": "Questo provider è configurato al di fuori di goose. Segui questi passaggi:"
+  },
+  "providerConfigurationModal.goBack": {
+    "defaultMessage": "Torna indietro"
+  },
+  "providerConfigurationModal.huggingFaceOAuthDescription": {
+    "defaultMessage": "Accedi per usare gli Inference Providers di Hugging Face senza inserire manualmente un token API."
+  },
+  "providerConfigurationModal.oauthLoginFailed": {
+    "defaultMessage": "Accesso OAuth non riuscito: {error}"
+  },
+  "providerConfigurationModal.oauthSignInDescription": {
+    "defaultMessage": "Accedi con il tuo account {providerName} per usare questo provider"
+  },
+  "providerConfigurationModal.parameterRequired": {
+    "defaultMessage": "{paramName} è obbligatorio"
+  },
+  "providerConfigurationModal.removeConfiguration": {
+    "defaultMessage": "Rimuovi configurazione"
+  },
+  "providerConfigurationModal.seeDocumentation": {
+    "defaultMessage": "Consulta la <link>documentazione</link> per maggiori dettagli."
+  },
+  "providerConfigurationModal.signInWith": {
+    "defaultMessage": "Accedi con {providerName}"
+  },
+  "providerConfigurationModal.signingIn": {
+    "defaultMessage": "Accesso in corso..."
+  },
+  "providerGrid.addProvider": {
+    "defaultMessage": "Aggiungi provider"
+  },
+  "providerGrid.addProviderTitle": {
+    "defaultMessage": "Aggiungi provider"
+  },
+  "providerGrid.chooseModel": {
+    "defaultMessage": "Scegli modello"
+  },
+  "providerGrid.configureProvider": {
+    "defaultMessage": "Configura provider"
+  },
+  "providerGrid.editProvider": {
+    "defaultMessage": "Modifica provider"
+  },
+  "providerGrid.fromTemplateOrManual": {
+    "defaultMessage": "Da modello o configurazione manuale"
+  },
+  "providerLogo.alt": {
+    "defaultMessage": "Logo {providerName}"
+  },
+  "providerSelector.addCustomProvider": {
+    "defaultMessage": "Aggiungi un provider personalizzato"
+  },
+  "providerSelector.addCustomProviderTitle": {
+    "defaultMessage": "Aggiungi provider personalizzato"
+  },
+  "providerSelector.connectProvider": {
+    "defaultMessage": "Connetti a un provider"
+  },
+  "providerSelector.connectProviderDescription": {
+    "defaultMessage": "Connetti OpenAI, Anthropic, Google, ecc."
+  },
+  "providerSelector.freeLocalDescription": {
+    "defaultMessage": "Usa un modello locale o un provider con crediti gratuiti"
+  },
+  "providerSelector.selectProvider": {
+    "defaultMessage": "Seleziona un provider"
+  },
+  "providerSelector.useFreeLocal": {
+    "defaultMessage": "Usa provider gratuiti/locali"
+  },
+  "providerSettings.configurationSettings": {
+    "defaultMessage": "Impostazioni di configurazione del provider"
+  },
+  "providerSettings.loadingProviders": {
+    "defaultMessage": "Caricamento provider..."
+  },
+  "providerSettings.onboardingDescription": {
+    "defaultMessage": "Seleziona un provider di modelli IA per iniziare con goose. Dovrai usare le chiavi API generate da ciascun provider, che verranno crittografate e archiviate localmente. Puoi cambiare provider in qualsiasi momento nelle impostazioni."
+  },
+  "providerSettings.otherProviders": {
+    "defaultMessage": "Altri provider"
+  },
+  "providerSetupActions.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "providerSetupActions.cannotDeleteActive": {
+    "defaultMessage": "Non puoi eliminare {providerName} mentre è attualmente in uso. Passa a un modello diverso prima di eliminare questo provider."
+  },
+  "providerSetupActions.confirmDelete": {
+    "defaultMessage": "Conferma eliminazione"
+  },
+  "providerSetupActions.confirmDeleteMessage": {
+    "defaultMessage": "Sei sicuro di voler eliminare i parametri di configurazione per {providerName}? Questa azione non può essere annullata."
+  },
+  "providerSetupActions.deleteProvider": {
+    "defaultMessage": "Elimina provider"
+  },
+  "providerSetupActions.enableProvider": {
+    "defaultMessage": "Abilita provider"
+  },
+  "providerSetupActions.ok": {
+    "defaultMessage": "Ok"
+  },
+  "providerSetupActions.submit": {
+    "defaultMessage": "Invia"
+  },
+  "recipeActivityEditor.activitiesDescription": {
+    "defaultMessage": "I prompt principali e i pulsanti di attività che verranno visualizzati nella finestra della chat della ricetta."
+  },
+  "recipeActivityEditor.activitiesLabel": {
+    "defaultMessage": "Attività"
+  },
+  "recipeActivityEditor.activityButtonsDescription": {
+    "defaultMessage": "Pulsanti cliccabili che appariranno sotto il messaggio per aiutare gli utenti a interagire con la tua ricetta."
+  },
+  "recipeActivityEditor.activityButtonsLabel": {
+    "defaultMessage": "Pulsanti di attività"
+  },
+  "recipeActivityEditor.addActivity": {
+    "defaultMessage": "Aggiungi attività"
+  },
+  "recipeActivityEditor.addNewActivityPlaceholder": {
+    "defaultMessage": "Aggiungi nuova attività..."
+  },
+  "recipeActivityEditor.messageDescription": {
+    "defaultMessage": "Un messaggio formattato che apparirà nella parte superiore della ricetta. Supporta la formattazione markdown."
+  },
+  "recipeActivityEditor.messageLabel": {
+    "defaultMessage": "Messaggio"
+  },
+  "recipeActivityEditor.messagePlaceholder": {
+    "defaultMessage": "Inserisci un messaggio di introduzione rivolto all'utente per la tua ricetta (supporta **grassetto**, *corsivo*, `codice`, ecc.)"
+  },
+  "recipeExtensionSelector.description": {
+    "defaultMessage": "Seleziona quali estensioni devono essere disponibili durante l'esecuzione di questa ricetta. Lascia vuoto per usare le estensioni predefinite."
+  },
+  "recipeExtensionSelector.extensionsSelected": {
+    "defaultMessage": "{count,plural,one{# estensione selezionata} other{# estensioni selezionate}}"
+  },
+  "recipeExtensionSelector.label": {
+    "defaultMessage": "Estensioni (facoltativo)"
+  },
+  "recipeExtensionSelector.noExtensionsAvailable": {
+    "defaultMessage": "Nessuna estensione disponibile"
+  },
+  "recipeExtensionSelector.noExtensionsFound": {
+    "defaultMessage": "Nessuna estensione trovata"
+  },
+  "recipeExtensionSelector.searchPlaceholder": {
+    "defaultMessage": "Cerca estensioni..."
+  },
+  "recipeFormFields.addParameter": {
+    "defaultMessage": "Aggiungi parametro"
+  },
+  "recipeFormFields.advancedOptions": {
+    "defaultMessage": "Opzioni avanzate"
+  },
+  "recipeFormFields.advancedOptionsHint": {
+    "defaultMessage": "Attività, parametri, modello, estensioni, schema di risposta, sottoricette"
+  },
+  "recipeFormFields.descriptionLabel": {
+    "defaultMessage": "Descrizione"
+  },
+  "recipeFormFields.descriptionPlaceholder": {
+    "defaultMessage": "Breve descrizione di cosa fa questa ricetta"
+  },
+  "recipeFormFields.enterValueFor": {
+    "defaultMessage": "Inserisci il valore per {key}"
+  },
+  "recipeFormFields.initialPrompt": {
+    "defaultMessage": "Prompt iniziale"
+  },
+  "recipeFormFields.instructionsLabel": {
+    "defaultMessage": "Istruzioni"
+  },
+  "recipeFormFields.instructionsPlaceholder": {
+    "defaultMessage": "Istruzioni dettagliate per l'IA, nascoste all'utente"
+  },
+  "recipeFormFields.openEditor": {
+    "defaultMessage": "Apri editor"
+  },
+  "recipeFormFields.parameterNamePlaceholder": {
+    "defaultMessage": "Inserisci il nome del parametro..."
+  },
+  "recipeFormFields.parametersDescription": {
+    "defaultMessage": "I parametri verranno rilevati automaticamente dalla sintassi '{{parameter_name}}' in istruzioni/prompt/attività oppure puoi aggiungerli manualmente di seguito."
+  },
+  "recipeFormFields.parametersLabel": {
+    "defaultMessage": "Parametri"
+  },
+  "recipeFormFields.promptOptionalHint": {
+    "defaultMessage": "(Facoltativo - Sono richieste le istruzioni o il prompt)"
+  },
+  "recipeFormFields.promptPlaceholder": {
+    "defaultMessage": "Prompt precompilato all'avvio della ricetta"
+  },
+  "recipeFormFields.responseJsonSchema": {
+    "defaultMessage": "Schema JSON della risposta"
+  },
+  "recipeFormFields.responseJsonSchemaDescription": {
+    "defaultMessage": "Definisci la struttura prevista della risposta dell'IA usando il formato JSON Schema"
+  },
+  "recipeFormFields.templateVarHint": {
+    "defaultMessage": "Usa '{{parameter_name}}' per definire parametri che possono essere compilati durante l'esecuzione della ricetta."
+  },
+  "recipeFormFields.titleLabel": {
+    "defaultMessage": "Titolo"
+  },
+  "recipeFormFields.titlePlaceholder": {
+    "defaultMessage": "Titolo della ricetta"
+  },
+  "recipeHeader.recipeLabel": {
+    "defaultMessage": "Ricetta"
+  },
+  "recipeModelSelector.backToModelList": {
+    "defaultMessage": "Torna all'elenco dei modelli"
+  },
+  "recipeModelSelector.enterCustomModel": {
+    "defaultMessage": "Inserisci il nome di un modello personalizzato"
+  },
+  "recipeModelSelector.enterModelNotListed": {
+    "defaultMessage": "Inserisci un modello non elencato..."
+  },
+  "recipeModelSelector.fetchError": {
+    "defaultMessage": "Impossibile recuperare i modelli. Riprova più tardi."
+  },
+  "recipeModelSelector.loadingModels": {
+    "defaultMessage": "Caricamento modelli…"
+  },
+  "recipeModelSelector.modelHint": {
+    "defaultMessage": "Lascia vuoto per usare il modello predefinito del provider selezionato"
+  },
+  "recipeModelSelector.modelLabel": {
+    "defaultMessage": "Modello (facoltativo)"
+  },
+  "recipeModelSelector.providerHint": {
+    "defaultMessage": "Lascia vuoto per usare il provider predefinito configurato nelle impostazioni"
+  },
+  "recipeModelSelector.providerLabel": {
+    "defaultMessage": "Provider (facoltativo)"
+  },
+  "recipeModelSelector.selectModel": {
+    "defaultMessage": "Seleziona un modello"
+  },
+  "recipeModelSelector.selectProvider": {
+    "defaultMessage": "Seleziona provider"
+  },
+  "recipeModelSelector.useDefaultProvider": {
+    "defaultMessage": "Usa provider predefinito"
+  },
+  "recipeNameField.defaultLabel": {
+    "defaultMessage": "Nome ricetta"
+  },
+  "recipeNameField.formatHint": {
+    "defaultMessage": "Verrà formattato automaticamente (minuscolo, trattini al posto degli spazi)"
+  },
+  "recipeWarningModal.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "recipeWarningModal.descriptionLabel": {
+    "defaultMessage": "Descrizione:"
+  },
+  "recipeWarningModal.firstTimeDescription": {
+    "defaultMessage": "Stai per eseguire una ricetta che non hai mai eseguito prima."
+  },
+  "recipeWarningModal.hiddenCharsWarning": {
+    "defaultMessage": "Questa ricetta contiene caratteri nascosti che verranno ignorati per la tua sicurezza, poiché potrebbero essere usati per scopi dannosi."
+  },
+  "recipeWarningModal.instructionsLabel": {
+    "defaultMessage": "Istruzioni:"
+  },
+  "recipeWarningModal.newRecipeWarningTitle": {
+    "defaultMessage": "⚠️ Avviso nuova ricetta"
+  },
+  "recipeWarningModal.recipePreview": {
+    "defaultMessage": "Anteprima ricetta:"
+  },
+  "recipeWarningModal.securityWarningTitle": {
+    "defaultMessage": "⚠️ Avviso di sicurezza"
+  },
+  "recipeWarningModal.titleLabel": {
+    "defaultMessage": "Titolo:"
+  },
+  "recipeWarningModal.trustAndExecute": {
+    "defaultMessage": "Considera attendibile ed esegui"
+  },
+  "recipeWarningModal.trustSource": {
+    "defaultMessage": "Procedi solo se ti fidi della fonte di questa ricetta."
+  },
+  "recipesView.addSchedule": {
+    "defaultMessage": "Aggiungi pianificazione"
+  },
+  "recipesView.addSlashCommand": {
+    "defaultMessage": "Aggiungi comando slash"
+  },
+  "recipesView.adjustSearchTerms": {
+    "defaultMessage": "Prova a modificare i termini di ricerca"
+  },
+  "recipesView.allFiles": {
+    "defaultMessage": "Tutti i file"
+  },
+  "recipesView.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "recipesView.copyDeeplink": {
+    "defaultMessage": "Copia deeplink"
+  },
+  "recipesView.copyDeeplinkFailedMsg": {
+    "defaultMessage": "Impossibile copiare il deeplink negli appunti"
+  },
+  "recipesView.copyFailedTitle": {
+    "defaultMessage": "Copia non riuscita"
+  },
+  "recipesView.copyYaml": {
+    "defaultMessage": "Copia YAML"
+  },
+  "recipesView.copyYamlFailedMsg": {
+    "defaultMessage": "Impossibile copiare lo YAML della ricetta negli appunti"
+  },
+  "recipesView.createRecipe": {
+    "defaultMessage": "Crea ricetta"
+  },
+  "recipesView.deeplinkCopiedMsg": {
+    "defaultMessage": "Il deeplink della ricetta è stato copiato negli appunti"
+  },
+  "recipesView.deeplinkCopiedTitle": {
+    "defaultMessage": "Deeplink copiato"
+  },
+  "recipesView.deleteRecipe": {
+    "defaultMessage": "Elimina ricetta"
+  },
+  "recipesView.deleteRecipeConfirm": {
+    "defaultMessage": "Sei sicuro di voler eliminare \"{title}\"?"
+  },
+  "recipesView.deleteRecipeDetail": {
+    "defaultMessage": "Il file della ricetta verrà eliminato."
+  },
+  "recipesView.deleteRecipeTitle": {
+    "defaultMessage": "Elimina ricetta"
+  },
+  "recipesView.editRecipe": {
+    "defaultMessage": "Modifica ricetta"
+  },
+  "recipesView.editSchedule": {
+    "defaultMessage": "Modifica pianificazione"
+  },
+  "recipesView.editSlashCommand": {
+    "defaultMessage": "Modifica comando slash"
+  },
+  "recipesView.errorLoadingRecipes": {
+    "defaultMessage": "Errore durante il caricamento delle ricette"
+  },
+  "recipesView.exportFailedMsg": {
+    "defaultMessage": "Impossibile esportare la ricetta su file"
+  },
+  "recipesView.exportFailedTitle": {
+    "defaultMessage": "Esportazione non riuscita"
+  },
+  "recipesView.exportRecipeDialogTitle": {
+    "defaultMessage": "Esporta ricetta"
+  },
+  "recipesView.exportToFile": {
+    "defaultMessage": "Esporta su file"
+  },
+  "recipesView.noMatchingRecipes": {
+    "defaultMessage": "Nessuna ricetta corrispondente trovata"
+  },
+  "recipesView.noSavedRecipes": {
+    "defaultMessage": "Nessuna ricetta salvata"
+  },
+  "recipesView.noSavedRecipesDescription": {
+    "defaultMessage": "Le ricette salvate dalle chat verranno visualizzate qui."
+  },
+  "recipesView.openInNewWindow": {
+    "defaultMessage": "Apri in una nuova finestra"
+  },
+  "recipesView.recipeDeletedSuccess": {
+    "defaultMessage": "Ricetta eliminata correttamente"
+  },
+  "recipesView.recipeExportedMsg": {
+    "defaultMessage": "Ricetta salvata in {filePath}"
+  },
+  "recipesView.recipeExportedTitle": {
+    "defaultMessage": "Ricetta esportata"
+  },
+  "recipesView.recipesDescription": {
+    "defaultMessage": "Visualizza e gestisci le tue ricette salvate per avviare rapidamente nuove sessioni con configurazioni predefinite. {shortcut} per cercare."
+  },
+  "recipesView.recipesTitle": {
+    "defaultMessage": "Ricette"
+  },
+  "recipesView.remove": {
+    "defaultMessage": "Rimuovi"
+  },
+  "recipesView.removeSchedule": {
+    "defaultMessage": "Rimuovi pianificazione"
+  },
+  "recipesView.runs": {
+    "defaultMessage": "Esecuzioni {schedule}"
+  },
+  "recipesView.save": {
+    "defaultMessage": "Salva"
+  },
+  "recipesView.scheduleDialogTitle": {
+    "defaultMessage": "{action} pianificazione"
+  },
+  "recipesView.scheduleRemovedMsg": {
+    "defaultMessage": "La ricetta non verrà più eseguita automaticamente"
+  },
+  "recipesView.scheduleRemovedTitle": {
+    "defaultMessage": "Pianificazione rimossa"
+  },
+  "recipesView.scheduleSavedMsg": {
+    "defaultMessage": "La ricetta verrà eseguita {schedule}"
+  },
+  "recipesView.scheduleSavedTitle": {
+    "defaultMessage": "Pianificazione salvata"
+  },
+  "recipesView.searchRecipesPlaceholder": {
+    "defaultMessage": "Cerca ricette..."
+  },
+  "recipesView.shareRecipe": {
+    "defaultMessage": "Condividi ricetta"
+  },
+  "recipesView.slashCommandDescription": {
+    "defaultMessage": "Imposta un comando slash per eseguire rapidamente questa ricetta da qualsiasi chat"
+  },
+  "recipesView.slashCommandPlaceholder": {
+    "defaultMessage": "nome-comando"
+  },
+  "recipesView.slashCommandRemovedMsg": {
+    "defaultMessage": "Il comando slash della ricetta è stato rimosso"
+  },
+  "recipesView.slashCommandRemovedTitle": {
+    "defaultMessage": "Comando slash rimosso"
+  },
+  "recipesView.slashCommandSavedMsg": {
+    "defaultMessage": "Usa /{command} per eseguire questa ricetta"
+  },
+  "recipesView.slashCommandSavedTitle": {
+    "defaultMessage": "Comando slash salvato"
+  },
+  "recipesView.slashCommandTitle": {
+    "defaultMessage": "Comando slash"
+  },
+  "recipesView.slashCommandUsageHint": {
+    "defaultMessage": "Usa /{command} in qualsiasi chat per eseguire questa ricetta"
+  },
+  "recipesView.tryAgain": {
+    "defaultMessage": "Riprova"
+  },
+  "recipesView.useRecipe": {
+    "defaultMessage": "Usa ricetta"
+  },
+  "recipesView.yamlCopiedMsg": {
+    "defaultMessage": "Lo YAML della ricetta è stato copiato negli appunti"
+  },
+  "recipesView.yamlCopiedTitle": {
+    "defaultMessage": "YAML copiato"
+  },
+  "recipesView.yamlFiles": {
+    "defaultMessage": "File YAML"
+  },
+  "resetProviderSection.resetButton": {
+    "defaultMessage": "Reimposta provider e modello"
+  },
+  "resetProviderSection.resetDescription": {
+    "defaultMessage": "Questa operazione cancellerà le impostazioni del modello e del provider selezionati. Se non sono disponibili impostazioni predefinite, verrai indirizzato alla schermata di benvenuto per configurarle nuovamente."
+  },
+  "responseStyle.conciseDescription": {
+    "defaultMessage": "Le chiamate agli strumenti sono chiuse per impostazione predefinita e mostrano solo lo strumento utilizzato"
+  },
+  "responseStyle.conciseLabel": {
+    "defaultMessage": "Conciso"
+  },
+  "responseStyle.detailedDescription": {
+    "defaultMessage": "Le chiamate agli strumenti sono mostrate aperte per impostazione predefinita per esporre i dettagli"
+  },
+  "responseStyle.detailedLabel": {
+    "defaultMessage": "Dettagliato"
+  },
+  "scheduleDetailView.actions": {
+    "defaultMessage": "Azioni"
+  },
+  "scheduleDetailView.cannotModifyRunning": {
+    "defaultMessage": "Impossibile attivare o modificare una pianificazione mentre è già in esecuzione."
+  },
+  "scheduleDetailView.completedSession": {
+    "defaultMessage": "Sessione: {sessionId}"
+  },
+  "scheduleDetailView.created": {
+    "defaultMessage": "Creata: {date}"
+  },
+  "scheduleDetailView.cronExpression": {
+    "defaultMessage": "Espressione cron:"
+  },
+  "scheduleDetailView.currentSession": {
+    "defaultMessage": "Sessione corrente:"
+  },
+  "scheduleDetailView.currentlyRunning": {
+    "defaultMessage": "Attualmente in esecuzione"
+  },
+  "scheduleDetailView.dir": {
+    "defaultMessage": "Dir: {path}"
+  },
+  "scheduleDetailView.editSchedule": {
+    "defaultMessage": "Modifica pianificazione"
+  },
+  "scheduleDetailView.errorPrefix": {
+    "defaultMessage": "Errore: {error}"
+  },
+  "scheduleDetailView.idLabel": {
+    "defaultMessage": "ID:"
+  },
+  "scheduleDetailView.inspectJobError": {
+    "defaultMessage": "Errore di ispezione del processo"
+  },
+  "scheduleDetailView.inspectNoInfo": {
+    "defaultMessage": "Nessuna informazione dettagliata disponibile"
+  },
+  "scheduleDetailView.inspectRunningJob": {
+    "defaultMessage": "Ispeziona processo in esecuzione"
+  },
+  "scheduleDetailView.jobCancelled": {
+    "defaultMessage": "Processo annullato"
+  },
+  "scheduleDetailView.jobCancelledMsg": {
+    "defaultMessage": "Il processo è stato annullato durante l'avvio."
+  },
+  "scheduleDetailView.jobInspection": {
+    "defaultMessage": "Ispezione del processo"
+  },
+  "scheduleDetailView.jobKilled": {
+    "defaultMessage": "Processo terminato"
+  },
+  "scheduleDetailView.killJobError": {
+    "defaultMessage": "Errore di terminazione del processo"
+  },
+  "scheduleDetailView.killRunningJob": {
+    "defaultMessage": "Termina processo in esecuzione"
+  },
+  "scheduleDetailView.lastRun": {
+    "defaultMessage": "Ultima esecuzione:"
+  },
+  "scheduleDetailView.loadingSchedule": {
+    "defaultMessage": "Caricamento pianificazione..."
+  },
+  "scheduleDetailView.loadingSessions": {
+    "defaultMessage": "Caricamento sessioni..."
+  },
+  "scheduleDetailView.messages": {
+    "defaultMessage": "Messaggi: {count}"
+  },
+  "scheduleDetailView.noScheduleId": {
+    "defaultMessage": "Nessun ID pianificazione fornito. Torna all'elenco delle pianificazioni."
+  },
+  "scheduleDetailView.noSessions": {
+    "defaultMessage": "Nessuna sessione trovata per questa pianificazione."
+  },
+  "scheduleDetailView.pauseSchedule": {
+    "defaultMessage": "Sospendi pianificazione"
+  },
+  "scheduleDetailView.pauseUnpauseError": {
+    "defaultMessage": "Errore di sospensione/ripresa"
+  },
+  "scheduleDetailView.paused": {
+    "defaultMessage": "Sospesa"
+  },
+  "scheduleDetailView.pausedMsg": {
+    "defaultMessage": "Sospesa \"{id}\""
+  },
+  "scheduleDetailView.pausedWarning": {
+    "defaultMessage": "Questa pianificazione è sospesa e non verrà eseguita automaticamente. Usa \"Esegui pianificazione ora\" per attivarla manualmente o riprendila per ripristinare l'esecuzione automatica."
+  },
+  "scheduleDetailView.processStarted": {
+    "defaultMessage": "Processo avviato:"
+  },
+  "scheduleDetailView.recentSessions": {
+    "defaultMessage": "Sessioni recenti"
+  },
+  "scheduleDetailView.recipeSource": {
+    "defaultMessage": "Origine ricetta:"
+  },
+  "scheduleDetailView.runScheduleError": {
+    "defaultMessage": "Errore di esecuzione della pianificazione"
+  },
+  "scheduleDetailView.runScheduleNow": {
+    "defaultMessage": "Esegui pianificazione ora"
+  },
+  "scheduleDetailView.scheduleCompleted": {
+    "defaultMessage": "Esecuzione completata"
+  },
+  "scheduleDetailView.scheduleDetails": {
+    "defaultMessage": "Dettagli pianificazione"
+  },
+  "scheduleDetailView.scheduleInformation": {
+    "defaultMessage": "Informazioni sulla pianificazione"
+  },
+  "scheduleDetailView.scheduleLabel": {
+    "defaultMessage": "Pianificazione:"
+  },
+  "scheduleDetailView.scheduleNotFound": {
+    "defaultMessage": "Pianificazione non trovata"
+  },
+  "scheduleDetailView.scheduleNotFoundError": {
+    "defaultMessage": "Pianificazione non trovata"
+  },
+  "scheduleDetailView.schedulePaused": {
+    "defaultMessage": "Pianificazione sospesa"
+  },
+  "scheduleDetailView.scheduleUnpaused": {
+    "defaultMessage": "Pianificazione ripresa"
+  },
+  "scheduleDetailView.scheduleUpdated": {
+    "defaultMessage": "Pianificazione aggiornata"
+  },
+  "scheduleDetailView.sessionId": {
+    "defaultMessage": "ID sessione: {id}"
+  },
+  "scheduleDetailView.unpauseSchedule": {
+    "defaultMessage": "Riprendi pianificazione"
+  },
+  "scheduleDetailView.unpausedMsg": {
+    "defaultMessage": "Ripresa \"{id}\""
+  },
+  "scheduleDetailView.updateScheduleError": {
+    "defaultMessage": "Errore di aggiornamento della pianificazione"
+  },
+  "scheduleDetailView.updatedMsg": {
+    "defaultMessage": "Aggiornata \"{id}\""
+  },
+  "scheduleDetailView.viewingScheduleId": {
+    "defaultMessage": "Visualizzazione ID pianificazione: {id}"
+  },
+  "scheduleModal.browseYaml": {
+    "defaultMessage": "Sfoglia file YAML..."
+  },
+  "scheduleModal.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "scheduleModal.createNewSchedule": {
+    "defaultMessage": "Crea nuova pianificazione"
+  },
+  "scheduleModal.createSchedule": {
+    "defaultMessage": "Crea pianificazione"
+  },
+  "scheduleModal.creating": {
+    "defaultMessage": "Creazione in corso..."
+  },
+  "scheduleModal.deepLink": {
+    "defaultMessage": "Deep link"
+  },
+  "scheduleModal.deepLinkPlaceholder": {
+    "defaultMessage": "Incolla qui il link goose://recipe..."
+  },
+  "scheduleModal.editSchedule": {
+    "defaultMessage": "Modifica pianificazione"
+  },
+  "scheduleModal.failedParseRecipe": {
+    "defaultMessage": "Impossibile analizzare la ricetta dal file."
+  },
+  "scheduleModal.failedReadFile": {
+    "defaultMessage": "Impossibile leggere il file selezionato."
+  },
+  "scheduleModal.invalidDeepLink": {
+    "defaultMessage": "Deep link non valido. Usa un link goose://recipe."
+  },
+  "scheduleModal.invalidFileType": {
+    "defaultMessage": "Tipo di file non valido: seleziona un file YAML (.yaml o .yml)"
+  },
+  "scheduleModal.nameLabel": {
+    "defaultMessage": "Nome:"
+  },
+  "scheduleModal.namePlaceholder": {
+    "defaultMessage": "es. daily-summary-job"
+  },
+  "scheduleModal.provideValidRecipe": {
+    "defaultMessage": "Fornisci un'origine ricetta valida."
+  },
+  "scheduleModal.recipeDescription": {
+    "defaultMessage": "Descrizione: {description}"
+  },
+  "scheduleModal.recipeParsed": {
+    "defaultMessage": "Ricetta analizzata correttamente"
+  },
+  "scheduleModal.recipeTitle": {
+    "defaultMessage": "Titolo: {title}"
+  },
+  "scheduleModal.scheduleIdRequired": {
+    "defaultMessage": "L'ID pianificazione è obbligatorio."
+  },
+  "scheduleModal.scheduleLabel": {
+    "defaultMessage": "Pianificazione:"
+  },
+  "scheduleModal.selected": {
+    "defaultMessage": "Selezionato: {path}"
+  },
+  "scheduleModal.sourceLabel": {
+    "defaultMessage": "Origine:"
+  },
+  "scheduleModal.updateSchedule": {
+    "defaultMessage": "Aggiorna pianificazione"
+  },
+  "scheduleModal.updating": {
+    "defaultMessage": "Aggiornamento in corso..."
+  },
+  "scheduleModal.yaml": {
+    "defaultMessage": "YAML"
+  },
+  "schedulesView.confirmDelete": {
+    "defaultMessage": "Rimuovere la pianificazione \"{id}\"? La ricetta verrà mantenuta."
+  },
+  "schedulesView.createSchedule": {
+    "defaultMessage": "Crea pianificazione"
+  },
+  "schedulesView.description": {
+    "defaultMessage": "Crea e gestisci attività pianificate per eseguire le ricette automaticamente a orari specificati."
+  },
+  "schedulesView.edit": {
+    "defaultMessage": "Modifica"
+  },
+  "schedulesView.errorPrefix": {
+    "defaultMessage": "Errore: {error}"
+  },
+  "schedulesView.inspect": {
+    "defaultMessage": "Ispeziona"
+  },
+  "schedulesView.inspectError": {
+    "defaultMessage": "Errore di ispezione del processo"
+  },
+  "schedulesView.inspectNoInfo": {
+    "defaultMessage": "Nessuna informazione dettagliata disponibile per questo processo"
+  },
+  "schedulesView.jobInspection": {
+    "defaultMessage": "Ispezione del processo"
+  },
+  "schedulesView.jobKilled": {
+    "defaultMessage": "Processo terminato"
+  },
+  "schedulesView.kill": {
+    "defaultMessage": "Termina"
+  },
+  "schedulesView.killError": {
+    "defaultMessage": "Errore di terminazione del processo"
+  },
+  "schedulesView.lastRun": {
+    "defaultMessage": "Ultima esecuzione: {date}"
+  },
+  "schedulesView.noSchedules": {
+    "defaultMessage": "Ancora nessuna pianificazione"
+  },
+  "schedulesView.pause": {
+    "defaultMessage": "Sospendi"
+  },
+  "schedulesView.pauseError": {
+    "defaultMessage": "Errore di sospensione della pianificazione"
+  },
+  "schedulesView.paused": {
+    "defaultMessage": "Sospesa"
+  },
+  "schedulesView.refresh": {
+    "defaultMessage": "Aggiorna"
+  },
+  "schedulesView.refreshing": {
+    "defaultMessage": "Aggiornamento in corso..."
+  },
+  "schedulesView.resume": {
+    "defaultMessage": "Riprendi"
+  },
+  "schedulesView.running": {
+    "defaultMessage": "In esecuzione"
+  },
+  "schedulesView.schedulePaused": {
+    "defaultMessage": "Pianificazione sospesa"
+  },
+  "schedulesView.schedulePausedMsg": {
+    "defaultMessage": "Pianificazione \"{id}\" sospesa correttamente"
+  },
+  "schedulesView.scheduleUnpaused": {
+    "defaultMessage": "Pianificazione ripresa"
+  },
+  "schedulesView.scheduleUnpausedMsg": {
+    "defaultMessage": "Pianificazione \"{id}\" ripresa correttamente"
+  },
+  "schedulesView.scheduleUpdated": {
+    "defaultMessage": "Pianificazione aggiornata"
+  },
+  "schedulesView.scheduleUpdatedMsg": {
+    "defaultMessage": "Pianificazione \"{id}\" aggiornata correttamente"
+  },
+  "schedulesView.scheduler": {
+    "defaultMessage": "Pianificatore"
+  },
+  "schedulesView.unpauseError": {
+    "defaultMessage": "Errore di ripresa della pianificazione"
+  },
+  "searchBar.caseSensitive": {
+    "defaultMessage": "Distingui maiuscole/minuscole"
+  },
+  "searchBar.close": {
+    "defaultMessage": "Chiudi ({shortcut})"
+  },
+  "searchBar.next": {
+    "defaultMessage": "Successivo ({shortcut})"
+  },
+  "searchBar.placeholder": {
+    "defaultMessage": "Cerca nella conversazione..."
+  },
+  "searchBar.previous": {
+    "defaultMessage": "Precedente ({shortcut})"
+  },
+  "secureStorageNotice.defaultMessage": {
+    "defaultMessage": "Le chiavi vengono archiviate in modo sicuro nel portachiavi"
+  },
+  "securityToggle.apiTokenDescription": {
+    "defaultMessage": "Token di autenticazione per il servizio di classificazione"
+  },
+  "securityToggle.apiTokenOptional": {
+    "defaultMessage": "Token API (facoltativo)"
+  },
+  "securityToggle.classificationEndpoint": {
+    "defaultMessage": "Endpoint di classificazione"
+  },
+  "securityToggle.classificationEndpointDescription": {
+    "defaultMessage": "Inserisci l'URL completo del tuo servizio di classificazione"
+  },
+  "securityToggle.commandClassifierActive": {
+    "defaultMessage": "Classificatore dei comandi attivo (configurato automaticamente dall'ambiente)"
+  },
+  "securityToggle.commandEndpointDescription": {
+    "defaultMessage": "Inserisci l'URL completo del tuo servizio di classificazione dell'iniezione di comandi"
+  },
+  "securityToggle.commandInjectionDescription": {
+    "defaultMessage": "Usa modelli ML per rilevare comandi shell dannosi"
+  },
+  "securityToggle.detectionModel": {
+    "defaultMessage": "Modello di rilevamento"
+  },
+  "securityToggle.detectionModelDescription": {
+    "defaultMessage": "Seleziona quale modello ML utilizzare per il rilevamento dell'iniezione di prompt"
+  },
+  "securityToggle.detectionThreshold": {
+    "defaultMessage": "Soglia di rilevamento"
+  },
+  "securityToggle.enableCommandInjection": {
+    "defaultMessage": "Abilita il rilevamento ML dell'iniezione di comandi"
+  },
+  "securityToggle.enablePromptInjection": {
+    "defaultMessage": "Abilita il rilevamento dell'iniezione di prompt"
+  },
+  "securityToggle.enablePromptInjectionMl": {
+    "defaultMessage": "Abilita il rilevamento ML dell'iniezione di prompt"
+  },
+  "securityToggle.mlEndpointDescription": {
+    "defaultMessage": "Inserisci l'URL completo del tuo servizio di classificazione ML (incluso l'identificatore del modello)"
+  },
+  "securityToggle.mlTokenDescription": {
+    "defaultMessage": "Token di autenticazione per il servizio ML (es. token HuggingFace)"
+  },
+  "securityToggle.overrideNotice": {
+    "defaultMessage": "Questa impostazione è gestita dalla tua organizzazione e non può essere modificata."
+  },
+  "securityToggle.promptInjectionDescription": {
+    "defaultMessage": "Rileva e previeni potenziali attacchi di iniezione di prompt"
+  },
+  "securityToggle.promptInjectionMlDescription": {
+    "defaultMessage": "Usa modelli ML per rilevare potenziali iniezioni di prompt nella tua chat"
+  },
+  "securityToggle.thresholdDescription": {
+    "defaultMessage": "Valori più alti sono più rigidi (0,01 = molto permissivo, 1,0 = massimo rigore)"
+  },
+  "securityToggle.warpNotice": {
+    "defaultMessage": "Il rilevamento dell'iniezione di comandi funziona al meglio quando si è connessi a WARP (necessario per raggiungere il servizio di classificazione)."
+  },
+  "sessionActionsHeader.actionsLabel": {
+    "defaultMessage": "Azioni sessione"
+  },
+  "sessionActionsHeader.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "sessionActionsHeader.close": {
+    "defaultMessage": "Chiudi"
+  },
+  "sessionActionsHeader.copiedJson": {
+    "defaultMessage": "JSON della sessione copiato"
+  },
+  "sessionActionsHeader.copiedText": {
+    "defaultMessage": "Testo copiato"
+  },
+  "sessionActionsHeader.copyJson": {
+    "defaultMessage": "Copia JSON"
+  },
+  "sessionActionsHeader.copyText": {
+    "defaultMessage": "Copia testo"
+  },
+  "sessionActionsHeader.duplicateFailed": {
+    "defaultMessage": "Impossibile duplicare la sessione: {error}"
+  },
+  "sessionActionsHeader.duplicateSession": {
+    "defaultMessage": "Duplica sessione"
+  },
+  "sessionActionsHeader.duplicated": {
+    "defaultMessage": "Sessione duplicata"
+  },
+  "sessionActionsHeader.fullTextTitle": {
+    "defaultMessage": "Valore di testo"
+  },
+  "sessionActionsHeader.jsonFailed": {
+    "defaultMessage": "Impossibile caricare il JSON della sessione: {error}"
+  },
+  "sessionActionsHeader.jsonTitle": {
+    "defaultMessage": "JSON della sessione"
+  },
+  "sessionActionsHeader.loadingJson": {
+    "defaultMessage": "Caricamento JSON..."
+  },
+  "sessionActionsHeader.renameFailed": {
+    "defaultMessage": "Impossibile rinominare la sessione: {error}"
+  },
+  "sessionActionsHeader.renamePlaceholder": {
+    "defaultMessage": "Inserisci il nome della sessione"
+  },
+  "sessionActionsHeader.renameSession": {
+    "defaultMessage": "Rinomina sessione"
+  },
+  "sessionActionsHeader.renameTitle": {
+    "defaultMessage": "Rinomina sessione"
+  },
+  "sessionActionsHeader.renamed": {
+    "defaultMessage": "Sessione rinominata"
+  },
+  "sessionActionsHeader.save": {
+    "defaultMessage": "Salva"
+  },
+  "sessionActionsHeader.saving": {
+    "defaultMessage": "Salvataggio in corso..."
+  },
+  "sessionActionsHeader.viewJson": {
+    "defaultMessage": "Visualizza JSON della sessione"
+  },
+  "sessionIndicators.error": {
+    "defaultMessage": "La sessione ha riscontrato un errore"
+  },
+  "sessionIndicators.newActivity": {
+    "defaultMessage": "Ha nuova attività"
+  },
+  "sessionIndicators.streaming": {
+    "defaultMessage": "Streaming"
+  },
+  "sessionViewComponents.empty.description": {
+    "defaultMessage": "Questa sessione non contiene messaggi"
+  },
+  "sessionViewComponents.empty.title": {
+    "defaultMessage": "Nessun messaggio trovato"
+  },
+  "sessionViewComponents.error.loading": {
+    "defaultMessage": "Errore durante il caricamento dei dettagli della sessione"
+  },
+  "sessionViewComponents.error.tryAgain": {
+    "defaultMessage": "Riprova"
+  },
+  "sessionViewComponents.role.assistant": {
+    "defaultMessage": "Goose"
+  },
+  "sessionViewComponents.role.user": {
+    "defaultMessage": "Tu"
+  },
+  "sessions.action.delete": {
+    "defaultMessage": "Elimina sessione"
+  },
+  "sessions.action.duplicate": {
+    "defaultMessage": "Duplica sessione"
+  },
+  "sessions.action.editName": {
+    "defaultMessage": "Modifica nome sessione"
+  },
+  "sessions.action.export": {
+    "defaultMessage": "Esporta sessione"
+  },
+  "sessions.action.openNewWindow": {
+    "defaultMessage": "Apri in una nuova finestra"
+  },
+  "sessions.action.shareNostr": {
+    "defaultMessage": "Condividi link Nostr crittografato"
+  },
+  "sessions.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "sessions.chatHistory": {
+    "defaultMessage": "Cronologia chat"
+  },
+  "sessions.chatHistoryDesc": {
+    "defaultMessage": "Visualizza e cerca le tue conversazioni passate con Goose. {shortcut} per cercare."
+  },
+  "sessions.close": {
+    "defaultMessage": "Chiudi"
+  },
+  "sessions.delete.message": {
+    "defaultMessage": "Sei sicuro di voler eliminare la sessione \"{name}\"? Questa azione non può essere annullata."
+  },
+  "sessions.delete.title": {
+    "defaultMessage": "Elimina sessione"
+  },
+  "sessions.edit.placeholder": {
+    "defaultMessage": "Inserisci la descrizione della sessione"
+  },
+  "sessions.edit.title": {
+    "defaultMessage": "Modifica descrizione sessione"
+  },
+  "sessions.empty.description": {
+    "defaultMessage": "La tua cronologia chat apparirà qui"
+  },
+  "sessions.empty.title": {
+    "defaultMessage": "Nessuna sessione chat trovata"
+  },
+  "sessions.error.loading": {
+    "defaultMessage": "Errore durante il caricamento delle sessioni"
+  },
+  "sessions.error.tryAgain": {
+    "defaultMessage": "Riprova"
+  },
+  "sessions.import": {
+    "defaultMessage": "Importa sessione"
+  },
+  "sessions.importNostr": {
+    "defaultMessage": "Importa link"
+  },
+  "sessions.importNostr.description": {
+    "defaultMessage": "Incolla un link di condivisione Nostr di Goose per recuperare, decrittografare e importare la sessione."
+  },
+  "sessions.importNostr.placeholder": {
+    "defaultMessage": "goose://sessions/nostr?nevent=...&key=..."
+  },
+  "sessions.importNostr.title": {
+    "defaultMessage": "Importa sessione Nostr"
+  },
+  "sessions.importing": {
+    "defaultMessage": "Importazione in corso..."
+  },
+  "sessions.loadingMore": {
+    "defaultMessage": "Caricamento di altre sessioni..."
+  },
+  "sessions.save": {
+    "defaultMessage": "Salva"
+  },
+  "sessions.saving": {
+    "defaultMessage": "Salvataggio in corso..."
+  },
+  "sessions.search.noResults": {
+    "defaultMessage": "Nessuna sessione corrispondente trovata"
+  },
+  "sessions.search.noResultsDesc": {
+    "defaultMessage": "Prova a modificare i termini di ricerca"
+  },
+  "sessions.searchPlaceholder": {
+    "defaultMessage": "Cerca nella cronologia..."
+  },
+  "sessions.shareNostr.description": {
+    "defaultMessage": "Chiunque abbia questo link può recuperare e decifrare la sessione. Trattalo come un segreto."
+  },
+  "sessions.shareNostr.title": {
+    "defaultMessage": "Link di condivisione Nostr crittografato"
+  },
+  "sessions.toast.copied": {
+    "defaultMessage": "Copiato negli appunti"
+  },
+  "sessions.toast.deleteFailed": {
+    "defaultMessage": "Impossibile eliminare la sessione \"{name}\": {error}"
+  },
+  "sessions.toast.deleted": {
+    "defaultMessage": "Sessione eliminata correttamente"
+  },
+  "sessions.toast.duplicateFailed": {
+    "defaultMessage": "Impossibile duplicare la sessione: {error}"
+  },
+  "sessions.toast.duplicated": {
+    "defaultMessage": "Sessione \"{name}\" duplicata correttamente"
+  },
+  "sessions.toast.exported": {
+    "defaultMessage": "Sessione esportata correttamente"
+  },
+  "sessions.toast.importFailed": {
+    "defaultMessage": "Impossibile importare la sessione: {error}"
+  },
+  "sessions.toast.imported": {
+    "defaultMessage": "Sessione importata correttamente"
+  },
+  "sessions.toast.shareNostr": {
+    "defaultMessage": "Link di condivisione Nostr crittografato creato"
+  },
+  "sessions.toast.shareNostrFailed": {
+    "defaultMessage": "Impossibile creare il link di condivisione Nostr: {error}"
+  },
+  "sessions.toast.updateFailed": {
+    "defaultMessage": "Impossibile aggiornare la descrizione della sessione: {error}"
+  },
+  "sessions.toast.updated": {
+    "defaultMessage": "Descrizione della sessione aggiornata correttamente"
+  },
+  "settings.appearance.description": {
+    "defaultMessage": "Configura l'aspetto di goose sul tuo sistema"
+  },
+  "settings.appearance.title": {
+    "defaultMessage": "Aspetto"
+  },
+  "settings.close": {
+    "defaultMessage": "Chiudi"
+  },
+  "settings.costTracking.description": {
+    "defaultMessage": "Mostra i prezzi dei modelli e i costi di utilizzo"
+  },
+  "settings.costTracking.title": {
+    "defaultMessage": "Monitoraggio dei costi"
+  },
+  "settings.dockIcon.description": {
+    "defaultMessage": "Mostra goose nel dock"
+  },
+  "settings.dockIcon.title": {
+    "defaultMessage": "Icona del dock"
+  },
+  "settings.help.description": {
+    "defaultMessage": "Aiutaci a migliorare goose segnalando problemi o richiedendo nuove funzionalità"
+  },
+  "settings.help.reportBug": {
+    "defaultMessage": "Segnala un bug"
+  },
+  "settings.help.requestFeature": {
+    "defaultMessage": "Richiedi una funzionalità"
+  },
+  "settings.help.title": {
+    "defaultMessage": "Guida e feedback"
+  },
+  "settings.language.description": {
+    "defaultMessage": "Scegli la lingua di visualizzazione per goose"
+  },
+  "settings.language.english": {
+    "defaultMessage": "English"
+  },
+  "settings.language.french": {
+    "defaultMessage": "Francese"
+  },
+  "settings.language.german": {
+    "defaultMessage": "Tedesco"
+  },
+  "settings.language.hindi": {
+    "defaultMessage": "Hindi"
+  },
+  "settings.language.indonesian": {
+    "defaultMessage": "Indonesiano"
+  },
+  "settings.language.italian": {
+    "defaultMessage": "Italiano"
+  },
+  "settings.language.japanese": {
+    "defaultMessage": "Giapponese"
+  },
+  "settings.language.korean": {
+    "defaultMessage": "Coreano"
+  },
+  "settings.language.malay": {
+    "defaultMessage": "Malese"
+  },
+  "settings.language.portuguese": {
+    "defaultMessage": "Portoghese"
+  },
+  "settings.language.russian": {
+    "defaultMessage": "Russo"
+  },
+  "settings.language.spanish": {
+    "defaultMessage": "Spagnolo"
+  },
+  "settings.language.systemDefault": {
+    "defaultMessage": "Predefinita del sistema"
+  },
+  "settings.language.title": {
+    "defaultMessage": "Lingua"
+  },
+  "settings.language.turkish": {
+    "defaultMessage": "Turco"
+  },
+  "settings.language.vietnamese": {
+    "defaultMessage": "Vietnamita"
+  },
+  "settings.language.zhCN": {
+    "defaultMessage": "Cinese (semplificato)"
+  },
+  "settings.language.zhTW": {
+    "defaultMessage": "Cinese (tradizionale)"
+  },
+  "settings.menuBarIcon.description": {
+    "defaultMessage": "Mostra goose nella barra dei menu"
+  },
+  "settings.menuBarIcon.title": {
+    "defaultMessage": "Icona della barra dei menu"
+  },
+  "settings.notifications.configGuide": {
+    "defaultMessage": "Guida alla configurazione"
+  },
+  "settings.notifications.description": {
+    "defaultMessage": "Le notifiche sono gestite dal tuo sistema operativo - {link}"
+  },
+  "settings.notifications.modal.macInstructions": {
+    "defaultMessage": "Per abilitare le notifiche su macOS:"
+  },
+  "settings.notifications.modal.macStep1": {
+    "defaultMessage": "Apri Preferenze di Sistema"
+  },
+  "settings.notifications.modal.macStep2": {
+    "defaultMessage": "Fai clic su Notifiche"
+  },
+  "settings.notifications.modal.macStep3": {
+    "defaultMessage": "Trova e seleziona goose nell'elenco delle applicazioni"
+  },
+  "settings.notifications.modal.macStep4": {
+    "defaultMessage": "Abilita le notifiche e regola le impostazioni come preferisci"
+  },
+  "settings.notifications.modal.title": {
+    "defaultMessage": "Come abilitare le notifiche"
+  },
+  "settings.notifications.modal.winInstructions": {
+    "defaultMessage": "Per abilitare le notifiche su Windows:"
+  },
+  "settings.notifications.modal.winStep1": {
+    "defaultMessage": "Apri Impostazioni"
+  },
+  "settings.notifications.modal.winStep2": {
+    "defaultMessage": "Vai a Sistema > Notifiche"
+  },
+  "settings.notifications.modal.winStep3": {
+    "defaultMessage": "Trova e seleziona goose nell'elenco delle applicazioni"
+  },
+  "settings.notifications.modal.winStep4": {
+    "defaultMessage": "Attiva le notifiche e regola le impostazioni come preferisci"
+  },
+  "settings.notifications.openSettings": {
+    "defaultMessage": "Apri Impostazioni"
+  },
+  "settings.notifications.task.description": {
+    "defaultMessage": "Notifica quando Goose completa un'attività mentre la finestra è in secondo piano"
+  },
+  "settings.notifications.task.title": {
+    "defaultMessage": "Notifiche di completamento attività"
+  },
+  "settings.notifications.title": {
+    "defaultMessage": "Notifiche"
+  },
+  "settings.preventSleep.description": {
+    "defaultMessage": "Mantieni il computer attivo mentre goose esegue un'attività (lo schermo può comunque bloccarsi)"
+  },
+  "settings.preventSleep.title": {
+    "defaultMessage": "Impedisci la sospensione"
+  },
+  "settings.theme.description": {
+    "defaultMessage": "Personalizza l'aspetto e lo stile di goose"
+  },
+  "settings.theme.title": {
+    "defaultMessage": "Tema"
+  },
+  "settings.updates.description": {
+    "defaultMessage": "Controlla e installa gli aggiornamenti per mantenere goose sempre al meglio"
+  },
+  "settings.updates.title": {
+    "defaultMessage": "Aggiornamenti"
+  },
+  "settings.version.title": {
+    "defaultMessage": "Versione"
+  },
+  "settingsView.tabApp": {
+    "defaultMessage": "App"
+  },
+  "settingsView.tabAuth": {
+    "defaultMessage": "Autenticazione"
+  },
+  "settingsView.tabChat": {
+    "defaultMessage": "Chat"
+  },
+  "settingsView.tabKeyboard": {
+    "defaultMessage": "Tastiera"
+  },
+  "settingsView.tabLocalInference": {
+    "defaultMessage": "Inferenza locale"
+  },
+  "settingsView.tabModels": {
+    "defaultMessage": "Modelli"
+  },
+  "settingsView.tabPrompts": {
+    "defaultMessage": "Prompt"
+  },
+  "settingsView.tabSession": {
+    "defaultMessage": "Sessione"
+  },
+  "settingsView.title": {
+    "defaultMessage": "Impostazioni"
+  },
+  "sheet.close": {
+    "defaultMessage": "Chiudi"
+  },
+  "shortcutRecorder.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "shortcutRecorder.clickToRecord": {
+    "defaultMessage": "Fai clic per registrare..."
+  },
+  "shortcutRecorder.conflictWarning": {
+    "defaultMessage": "Questa scorciatoia è già usata da {label}. Salvando, verrà riassegnata a questa azione."
+  },
+  "shortcutRecorder.pressShortcut": {
+    "defaultMessage": "Premi la scorciatoia..."
+  },
+  "shortcutRecorder.save": {
+    "defaultMessage": "Salva"
+  },
+  "skillsView.addSkill": {
+    "defaultMessage": "Aggiungi competenza"
+  },
+  "skillsView.adjustSearchTerms": {
+    "defaultMessage": "Prova a modificare i termini di ricerca"
+  },
+  "skillsView.comingSoon": {
+    "defaultMessage": "Prossimamente"
+  },
+  "skillsView.errorLoadingSkills": {
+    "defaultMessage": "Errore durante il caricamento delle competenze"
+  },
+  "skillsView.noMatchingSkills": {
+    "defaultMessage": "Nessuna competenza corrispondente trovata"
+  },
+  "skillsView.noSkillsDescription": {
+    "defaultMessage": "Le competenze vengono caricate dai file SKILL.md in ~/.config/agents/skills/, .goose/skills/ o altre directory supportate."
+  },
+  "skillsView.noSkillsInstalled": {
+    "defaultMessage": "Nessuna competenza installata"
+  },
+  "skillsView.searchSkillsPlaceholder": {
+    "defaultMessage": "Cerca competenze..."
+  },
+  "skillsView.skillsDescription": {
+    "defaultMessage": "Visualizza le competenze installate che estendono le funzionalità di Goose. {shortcut} per cercare."
+  },
+  "skillsView.skillsTitle": {
+    "defaultMessage": "Competenze"
+  },
+  "skillsView.tryAgain": {
+    "defaultMessage": "Riprova"
+  },
+  "spellcheckToggle.description": {
+    "defaultMessage": "Controlla l'ortografia nell'input della chat. Richiede il riavvio per avere effetto."
+  },
+  "spellcheckToggle.title": {
+    "defaultMessage": "Abilita controllo ortografico"
+  },
+  "standaloneAppView.failedToLoad": {
+    "defaultMessage": "Impossibile caricare l'app"
+  },
+  "standaloneAppView.initializing": {
+    "defaultMessage": "Inizializzazione dell'app..."
+  },
+  "standaloneAppView.missingParams": {
+    "defaultMessage": "Parametri richiesti mancanti"
+  },
+  "stringUtils.configuredProvider": {
+    "defaultMessage": "Il provider {name} è configurato"
+  },
+  "stringUtils.ollamaApp": {
+    "defaultMessage": "App Ollama"
+  },
+  "stringUtils.ollamaNotConfiguredPrefix": {
+    "defaultMessage": "Per usarlo, l'"
+  },
+  "stringUtils.ollamaNotConfiguredSuffix": {
+    "defaultMessage": "deve essere installata sul tuo computer e aperta, oppure devi inserire un valore per OLLAMA_HOST."
+  },
+  "subRecipeEditor.addExisting": {
+    "defaultMessage": "Aggiungi esistente"
+  },
+  "subRecipeEditor.createNew": {
+    "defaultMessage": "Crea nuova sottoricetta"
+  },
+  "subRecipeEditor.deleteSubrecipe": {
+    "defaultMessage": "Elimina la sottoricetta {name}"
+  },
+  "subRecipeEditor.description": {
+    "defaultMessage": "Le sottoricette sono ricette che possono essere richiamate come strumenti durante l'esecuzione. Consentono flussi di lavoro a più passaggi e componenti riutilizzabili."
+  },
+  "subRecipeEditor.duplicateName": {
+    "defaultMessage": "Nome duplicato"
+  },
+  "subRecipeEditor.duplicateNameMsg": {
+    "defaultMessage": "Esiste già una sottoricetta denominata \"{name}\". Usa un nome univoco."
+  },
+  "subRecipeEditor.editSubrecipe": {
+    "defaultMessage": "Modifica la sottoricetta {name}"
+  },
+  "subRecipeEditor.label": {
+    "defaultMessage": "Sottoricette"
+  },
+  "subRecipeEditor.preconfiguredValues": {
+    "defaultMessage": "Valori preconfigurati:"
+  },
+  "subRecipeEditor.sequential": {
+    "defaultMessage": "Sequenziale"
+  },
+  "subRecipeModal.addTitle": {
+    "defaultMessage": "Aggiungi sottoricetta"
+  },
+  "subRecipeModal.apply": {
+    "defaultMessage": "Applica"
+  },
+  "subRecipeModal.browse": {
+    "defaultMessage": "Sfoglia"
+  },
+  "subRecipeModal.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "subRecipeModal.closeModal": {
+    "defaultMessage": "Chiudi la finestra della sottoricetta"
+  },
+  "subRecipeModal.configureTitle": {
+    "defaultMessage": "Configura sottoricetta"
+  },
+  "subRecipeModal.descriptionLabel": {
+    "defaultMessage": "Descrizione"
+  },
+  "subRecipeModal.descriptionPlaceholder": {
+    "defaultMessage": "Descrizione facoltativa di ciò che fa questa sottoricetta..."
+  },
+  "subRecipeModal.invalidFile": {
+    "defaultMessage": "File non valido"
+  },
+  "subRecipeModal.invalidFileMsg": {
+    "defaultMessage": "Seleziona un file YAML (.yaml o .yml)."
+  },
+  "subRecipeModal.nameHint": {
+    "defaultMessage": "Identificatore univoco usato per generare il nome dello strumento"
+  },
+  "subRecipeModal.nameLabel": {
+    "defaultMessage": "Nome"
+  },
+  "subRecipeModal.namePlaceholder": {
+    "defaultMessage": "es. security_scan"
+  },
+  "subRecipeModal.pathHint": {
+    "defaultMessage": "Cerca un file di ricetta esistente o inserisci manualmente un percorso"
+  },
+  "subRecipeModal.pathLabel": {
+    "defaultMessage": "Percorso"
+  },
+  "subRecipeModal.pathPlaceholder": {
+    "defaultMessage": "es. ./subrecipes/security-analysis.yaml"
+  },
+  "subRecipeModal.preconfiguredValues": {
+    "defaultMessage": "Valori preconfigurati"
+  },
+  "subRecipeModal.preconfiguredValuesHint": {
+    "defaultMessage": "Valori dei parametri facoltativi che vengono sempre passati alla sottoricetta"
+  },
+  "subRecipeModal.sequentialHint": {
+    "defaultMessage": "(Forza l'esecuzione sequenziale di più istanze della sottoricetta)"
+  },
+  "subRecipeModal.sequentialLabel": {
+    "defaultMessage": "Sequenziale se ripetuta"
+  },
+  "subRecipeModal.subtitle": {
+    "defaultMessage": "Configura una sottoricetta che può essere richiamata come strumento durante l'esecuzione della ricetta"
+  },
+  "switchModelModal.backToModelList": {
+    "defaultMessage": "Torna all'elenco dei modelli"
+  },
+  "switchModelModal.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "switchModelModal.checkProviderConfig": {
+    "defaultMessage": "Controlla la configurazione del provider in Impostazioni → Provider"
+  },
+  "switchModelModal.chooseModel": {
+    "defaultMessage": "Scegli un modello:"
+  },
+  "switchModelModal.claudeAdaptive": {
+    "defaultMessage": "Adattivo - Claude decide quando e quanto ragionare"
+  },
+  "switchModelModal.claudeDisabled": {
+    "defaultMessage": "Disabilitato - Nessun ragionamento esteso"
+  },
+  "switchModelModal.claudeEffortHigh": {
+    "defaultMessage": "Alto - Ragionamento profondo (predefinito)"
+  },
+  "switchModelModal.claudeEffortLow": {
+    "defaultMessage": "Basso - Ragionamento minimo, risposte più rapide"
+  },
+  "switchModelModal.claudeEffortMax": {
+    "defaultMessage": "Massimo - Nessun limite alla profondità del ragionamento"
+  },
+  "switchModelModal.claudeEffortMedium": {
+    "defaultMessage": "Medio - Ragionamento moderato"
+  },
+  "switchModelModal.claudeEnabled": {
+    "defaultMessage": "Abilitato - Budget di token fisso per il ragionamento"
+  },
+  "switchModelModal.couldNotContactProvider": {
+    "defaultMessage": "Impossibile contattare il provider"
+  },
+  "switchModelModal.customModelName": {
+    "defaultMessage": "Nome modello personalizzato"
+  },
+  "switchModelModal.description": {
+    "defaultMessage": "Seleziona un provider e un modello da usare per le tue conversazioni."
+  },
+  "switchModelModal.enterModelNotListed": {
+    "defaultMessage": "Inserisci un modello non elencato..."
+  },
+  "switchModelModal.extendedThinking": {
+    "defaultMessage": "Ragionamento esteso"
+  },
+  "switchModelModal.geminiOnly": {
+    "defaultMessage": "(Solo modelli Gemini 3)"
+  },
+  "switchModelModal.goToSettings": {
+    "defaultMessage": "Vai alle Impostazioni"
+  },
+  "switchModelModal.loadingModels": {
+    "defaultMessage": "Caricamento dei modelli…"
+  },
+  "switchModelModal.localModelsDescription": {
+    "defaultMessage": "Per usare l'inferenza locale, devi prima scaricare un modello sul tuo computer. Vai a Impostazioni → Modelli per gestire i modelli locali."
+  },
+  "switchModelModal.localModelsTitle": {
+    "defaultMessage": "I modelli locali devono essere scaricati prima"
+  },
+  "switchModelModal.providerPlaceholder": {
+    "defaultMessage": "Provider, digita per cercare"
+  },
+  "switchModelModal.quickStartGuide": {
+    "defaultMessage": "Guida rapida"
+  },
+  "switchModelModal.recommended": {
+    "defaultMessage": "Consigliato"
+  },
+  "switchModelModal.selectEffortLevel": {
+    "defaultMessage": "Seleziona il livello di impegno"
+  },
+  "switchModelModal.selectModel": {
+    "defaultMessage": "Seleziona un modello"
+  },
+  "switchModelModal.selectModelButton": {
+    "defaultMessage": "Seleziona modello"
+  },
+  "switchModelModal.selectModelPlaceholder": {
+    "defaultMessage": "Seleziona un modello, digita per cercare"
+  },
+  "switchModelModal.selectOrEnterModel": {
+    "defaultMessage": "Seleziona o inserisci un modello"
+  },
+  "switchModelModal.selectProvider": {
+    "defaultMessage": "Seleziona un provider"
+  },
+  "switchModelModal.selectThinkingLevel": {
+    "defaultMessage": "Seleziona il livello di ragionamento"
+  },
+  "switchModelModal.selectThinkingMode": {
+    "defaultMessage": "Seleziona la modalità di ragionamento"
+  },
+  "switchModelModal.thinkingBudget": {
+    "defaultMessage": "Budget di ragionamento (token)"
+  },
+  "switchModelModal.thinkingEffort": {
+    "defaultMessage": "Impegno di ragionamento"
+  },
+  "switchModelModal.thinkingEffortOff": {
+    "defaultMessage": "Disattivato - Nessun ragionamento esteso"
+  },
+  "switchModelModal.thinkingLevel": {
+    "defaultMessage": "Livello di ragionamento"
+  },
+  "switchModelModal.thinkingLevelHigh": {
+    "defaultMessage": "Alto - Ragionamento più profondo, latenza maggiore"
+  },
+  "switchModelModal.thinkingLevelLow": {
+    "defaultMessage": "Basso - Latenza migliore, ragionamento più leggero"
+  },
+  "switchModelModal.title": {
+    "defaultMessage": "Cambia modello"
+  },
+  "switchModelModal.typeModelName": {
+    "defaultMessage": "Digita qui il nome del modello"
+  },
+  "switchModelModal.useOtherProvider": {
+    "defaultMessage": "Usa un altro provider"
+  },
+  "telemetryConsentPrompt.description": {
+    "defaultMessage": "Vuoi condividere dati di utilizzo anonimi per aiutare a migliorare goose? Non raccogliamo mai le tue conversazioni, il tuo codice o i tuoi dati personali."
+  },
+  "telemetryConsentPrompt.heading": {
+    "defaultMessage": "Aiuta a migliorare goose"
+  },
+  "telemetryConsentPrompt.learnMore": {
+    "defaultMessage": "Scopri di più"
+  },
+  "telemetryConsentPrompt.optIn": {
+    "defaultMessage": "Sì, condividi dati di utilizzo anonimi"
+  },
+  "telemetryConsentPrompt.optOut": {
+    "defaultMessage": "No, grazie"
+  },
+  "telemetrySettings.configErrorTitle": {
+    "defaultMessage": "Errore di configurazione"
+  },
+  "telemetrySettings.description": {
+    "defaultMessage": "Controlla come vengono usati i tuoi dati"
+  },
+  "telemetrySettings.learnMore": {
+    "defaultMessage": "Scopri di più"
+  },
+  "telemetrySettings.loadError": {
+    "defaultMessage": "Impossibile caricare le impostazioni di telemetria."
+  },
+  "telemetrySettings.title": {
+    "defaultMessage": "Privacy"
+  },
+  "telemetrySettings.toggleDescription": {
+    "defaultMessage": "Aiuta a migliorare goose condividendo statistiche di utilizzo anonime."
+  },
+  "telemetrySettings.toggleLabel": {
+    "defaultMessage": "Dati di utilizzo anonimi"
+  },
+  "telemetrySettings.updateError": {
+    "defaultMessage": "Impossibile aggiornare le impostazioni di telemetria."
+  },
+  "themeSelector.dark": {
+    "defaultMessage": "Scuro"
+  },
+  "themeSelector.light": {
+    "defaultMessage": "Chiaro"
+  },
+  "themeSelector.system": {
+    "defaultMessage": "Sistema"
+  },
+  "themeSelector.theme": {
+    "defaultMessage": "Tema"
+  },
+  "toolApprovalButtons.allowOnce": {
+    "defaultMessage": "Consenti una volta"
+  },
+  "toolApprovalButtons.allowedOnce": {
+    "defaultMessage": "Consentito una volta"
+  },
+  "toolApprovalButtons.alwaysAllow": {
+    "defaultMessage": "Consenti sempre"
+  },
+  "toolApprovalButtons.alwaysAllowed": {
+    "defaultMessage": "Sempre consentito"
+  },
+  "toolApprovalButtons.cancelled": {
+    "defaultMessage": "Annullato"
+  },
+  "toolApprovalButtons.denied": {
+    "defaultMessage": "Negato"
+  },
+  "toolApprovalButtons.deniedOnce": {
+    "defaultMessage": "Negato una volta"
+  },
+  "toolApprovalButtons.deny": {
+    "defaultMessage": "Nega"
+  },
+  "toolApprovalButtons.staleApprovalRequest": {
+    "defaultMessage": "Questa richiesta di approvazione non è più attiva."
+  },
+  "toolCallStatusIndicator.toolStatus": {
+    "defaultMessage": "Stato dello strumento: {status}"
+  },
+  "toolCallWithResponse.activityCount": {
+    "defaultMessage": "Attività ({count})"
+  },
+  "toolCallWithResponse.code": {
+    "defaultMessage": "Codice"
+  },
+  "toolCallWithResponse.loadingSpinner": {
+    "defaultMessage": "Indicatore di caricamento"
+  },
+  "toolCallWithResponse.logs": {
+    "defaultMessage": "Log"
+  },
+  "toolCallWithResponse.mcpUiExperimental": {
+    "defaultMessage": "L'interfaccia MCP è sperimentale e può cambiare in qualsiasi momento."
+  },
+  "toolCallWithResponse.output": {
+    "defaultMessage": "Output"
+  },
+  "toolCallWithResponse.toolDetails": {
+    "defaultMessage": "Dettagli dello strumento"
+  },
+  "toolCallWithResponse.toolResultAlt": {
+    "defaultMessage": "Risultato dello strumento"
+  },
+  "toolCallWithResponse.viewSubagentSession": {
+    "defaultMessage": "Visualizza la sessione del subagent"
+  },
+  "toolConfirmation.allowToolCallWithName": {
+    "defaultMessage": "Consentire {toolName}?"
+  },
+  "toolConfirmation.gooseWouldLikeToCallWithName": {
+    "defaultMessage": "Goose desidera richiamare {toolName}. Consentire?"
+  },
+  "updateSection.autoDownload": {
+    "defaultMessage": "Goose scaricherà l'aggiornamento in background e lo installerà al prossimo arresto o riavvio."
+  },
+  "updateSection.autoDownloadDisabledByEnv": {
+    "defaultMessage": "I download automatici sono disabilitati tramite la variabile d'ambiente GOOSE_DISABLE_AUTO_DOWNLOAD."
+  },
+  "updateSection.autoDownloadDisabledNote": {
+    "defaultMessage": "Il download automatico è disabilitato. Fai clic su \"Scarica ora\" per scaricare manualmente."
+  },
+  "updateSection.autoInstallNote": {
+    "defaultMessage": "Non è necessaria alcuna installazione manuale."
+  },
+  "updateSection.checkForUpdates": {
+    "defaultMessage": "Controlla aggiornamenti"
+  },
+  "updateSection.checking": {
+    "defaultMessage": "Controllo degli aggiornamenti..."
+  },
+  "updateSection.currentVersion": {
+    "defaultMessage": "Versione attuale"
+  },
+  "updateSection.disableAutoDownload": {
+    "defaultMessage": "Disabilita i download automatici degli aggiornamenti"
+  },
+  "updateSection.disableAutoDownloadDesc": {
+    "defaultMessage": "Se abilitato, Goose ti avviserà delle nuove versioni ma non le scaricherà automaticamente."
+  },
+  "updateSection.downloadNow": {
+    "defaultMessage": "Scarica ora"
+  },
+  "updateSection.downloadReady": {
+    "defaultMessage": "Aggiornamento scaricato e pronto per l'installazione!"
+  },
+  "updateSection.downloadingProgress": {
+    "defaultMessage": "Download dell'aggiornamento... {percent}%"
+  },
+  "updateSection.downloadingUpdate": {
+    "defaultMessage": "Download dell'aggiornamento..."
+  },
+  "updateSection.installAndRestart": {
+    "defaultMessage": "Installa e riavvia"
+  },
+  "updateSection.installNowHint": {
+    "defaultMessage": "Fai clic su \"Installa e riavvia\" per aggiornare ora."
+  },
+  "updateSection.latestVersion": {
+    "defaultMessage": "Stai usando la versione più recente!"
+  },
+  "updateSection.loading": {
+    "defaultMessage": "Caricamento..."
+  },
+  "updateSection.manualInstallNote": {
+    "defaultMessage": "Dopo il download, dovrai installare manualmente l'aggiornamento."
+  },
+  "updateSection.manualInstallRequired": {
+    "defaultMessage": "Installazione manuale richiesta per questo metodo di aggiornamento."
+  },
+  "updateSection.readyInstallAuto": {
+    "defaultMessage": "✓ L'aggiornamento è pronto. Riavvia Goose per completarne l'installazione, oppure chiudilo quando hai finito."
+  },
+  "updateSection.readyInstallManual": {
+    "defaultMessage": "✓ L'aggiornamento è pronto! Fai clic su \"Installa e riavvia\" per le istruzioni di installazione."
+  },
+  "updateSection.upToDate": {
+    "defaultMessage": "(aggiornato)"
+  },
+  "updateSection.updateAvailable": {
+    "defaultMessage": "Aggiornamento disponibile!"
+  },
+  "updateSection.versionAvailable": {
+    "defaultMessage": "→ {version} disponibile"
+  },
+  "updateSection.versionIsAvailable": {
+    "defaultMessage": "La versione {version} è disponibile"
+  },
+  "userMessage.cancel": {
+    "defaultMessage": "Annulla"
+  },
+  "userMessage.cancelAriaLabel": {
+    "defaultMessage": "Annulla modifica"
+  },
+  "userMessage.editAriaLabel": {
+    "defaultMessage": "Modifica il contenuto del messaggio"
+  },
+  "userMessage.editButton": {
+    "defaultMessage": "Modifica"
+  },
+  "userMessage.editInPlace": {
+    "defaultMessage": "Modifica sul posto"
+  },
+  "userMessage.editInPlaceAriaLabel": {
+    "defaultMessage": "Modifica il messaggio sul posto"
+  },
+  "userMessage.editInPlaceDescription": {
+    "defaultMessage": "<b>Modifica sul posto</b> aggiorna questa sessione • <b>Biforca sessione</b> crea una nuova sessione"
+  },
+  "userMessage.editInPlaceTitle": {
+    "defaultMessage": "Aggiorna il messaggio in questa sessione"
+  },
+  "userMessage.editMessageAriaLabel": {
+    "defaultMessage": "Modifica messaggio: {preview}"
+  },
+  "userMessage.editMessageTitle": {
+    "defaultMessage": "Modifica messaggio"
+  },
+  "userMessage.editPlaceholder": {
+    "defaultMessage": "Modifica il tuo messaggio..."
+  },
+  "userMessage.emptyError": {
+    "defaultMessage": "Il messaggio non può essere vuoto"
+  },
+  "userMessage.forkSession": {
+    "defaultMessage": "Biforca sessione"
+  },
+  "userMessage.forkSessionAriaLabel": {
+    "defaultMessage": "Biforca la sessione con il messaggio modificato"
+  },
+  "userMessage.forkSessionTitle": {
+    "defaultMessage": "Crea una nuova sessione con il messaggio modificato"
+  }
+}

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -3887,14 +3887,32 @@
   "settings.language.english": {
     "defaultMessage": "英語"
   },
+  "settings.language.french": {
+    "defaultMessage": "フランス語"
+  },
+  "settings.language.german": {
+    "defaultMessage": "ドイツ語"
+  },
   "settings.language.hindi": {
     "defaultMessage": "ヒンディー語"
+  },
+  "settings.language.indonesian": {
+    "defaultMessage": "インドネシア語"
+  },
+  "settings.language.italian": {
+    "defaultMessage": "イタリア語"
   },
   "settings.language.japanese": {
     "defaultMessage": "日本語"
   },
   "settings.language.korean": {
     "defaultMessage": "韓国語"
+  },
+  "settings.language.malay": {
+    "defaultMessage": "マレー語"
+  },
+  "settings.language.portuguese": {
+    "defaultMessage": "ポルトガル語"
   },
   "settings.language.russian": {
     "defaultMessage": "ロシア語"
@@ -3911,8 +3929,14 @@
   "settings.language.turkish": {
     "defaultMessage": "トルコ語"
   },
+  "settings.language.vietnamese": {
+    "defaultMessage": "ベトナム語"
+  },
   "settings.language.zhCN": {
     "defaultMessage": "中国語（簡体字）"
+  },
+  "settings.language.zhTW": {
+    "defaultMessage": "中国語（繁体字）"
   },
   "settings.menuBarIcon.description": {
     "defaultMessage": "メニューバーにgooseを表示します"

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -3887,14 +3887,32 @@
   "settings.language.english": {
     "defaultMessage": "영어"
   },
+  "settings.language.french": {
+    "defaultMessage": "프랑스어"
+  },
+  "settings.language.german": {
+    "defaultMessage": "독일어"
+  },
   "settings.language.hindi": {
     "defaultMessage": "힌디어"
+  },
+  "settings.language.indonesian": {
+    "defaultMessage": "인도네시아어"
+  },
+  "settings.language.italian": {
+    "defaultMessage": "이탈리아어"
   },
   "settings.language.japanese": {
     "defaultMessage": "일본어"
   },
   "settings.language.korean": {
     "defaultMessage": "한국어"
+  },
+  "settings.language.malay": {
+    "defaultMessage": "말레이어"
+  },
+  "settings.language.portuguese": {
+    "defaultMessage": "포르투갈어"
   },
   "settings.language.russian": {
     "defaultMessage": "러시아어"
@@ -3911,8 +3929,14 @@
   "settings.language.turkish": {
     "defaultMessage": "터키어"
   },
+  "settings.language.vietnamese": {
+    "defaultMessage": "베트남어"
+  },
   "settings.language.zhCN": {
     "defaultMessage": "중국어(간체)"
+  },
+  "settings.language.zhTW": {
+    "defaultMessage": "중국어(번체)"
   },
   "settings.menuBarIcon.description": {
     "defaultMessage": "메뉴 막대에 goose를 표시합니다."

--- a/ui/desktop/src/i18n/messages/ms.json
+++ b/ui/desktop/src/i18n/messages/ms.json
@@ -1,0 +1,4574 @@
+{
+  "alertBox.autoCompactAt": {
+    "defaultMessage": "Padatkan automatik pada"
+  },
+  "alertBox.compactNow": {
+    "defaultMessage": "Padatkan sekarang"
+  },
+  "alertBox.failedToSaveThreshold": {
+    "defaultMessage": "Gagal menyimpan ambang: {error}"
+  },
+  "announcementModal.gotIt": {
+    "defaultMessage": "Faham!"
+  },
+  "appLayout.collapseNavigation": {
+    "defaultMessage": "Runtuhkan navigasi"
+  },
+  "appLayout.openNavigation": {
+    "defaultMessage": "Buka navigasi"
+  },
+  "appsView.customApp": {
+    "defaultMessage": "Apl tersuai"
+  },
+  "appsView.description": {
+    "defaultMessage": "Aplikasi daripada pelayan MCP anda dan Apl yang dibina oleh goose sendiri. Anda boleh memintanya mencipta apl baharu melalui antara muka sembang dan ia akan muncul di sini."
+  },
+  "appsView.errorLoading": {
+    "defaultMessage": "Ralat memuatkan apl: {error}"
+  },
+  "appsView.importApp": {
+    "defaultMessage": "Import Apl"
+  },
+  "appsView.launch": {
+    "defaultMessage": "Lancarkan"
+  },
+  "appsView.loading": {
+    "defaultMessage": "Memuatkan apl..."
+  },
+  "appsView.noAppsDescription": {
+    "defaultMessage": "Buka sembang dan minta goose untuk apl yang anda mahukan. Ia boleh membina satu untuk anda dan ia akan muncul di sini. Atau jika seseorang berkongsi apl, anda boleh mengimportnya menggunakan butang di atas."
+  },
+  "appsView.noAppsTitle": {
+    "defaultMessage": "Tiada apl tersedia"
+  },
+  "appsView.retry": {
+    "defaultMessage": "Cuba semula"
+  },
+  "appsView.title": {
+    "defaultMessage": "Apl"
+  },
+  "authSettings.activeProviderWarning": {
+    "defaultMessage": "Ini ialah pembekal aktif. Permintaan baharu mungkin gagal sehingga anda mengkonfigurasi kelayakan lain."
+  },
+  "authSettings.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "authSettings.delete": {
+    "defaultMessage": "Padam"
+  },
+  "authSettings.deleteCredential": {
+    "defaultMessage": "Padam kelayakan"
+  },
+  "authSettings.deleteMessage": {
+    "defaultMessage": "Padam kelayakan {name} untuk {provider}?"
+  },
+  "authSettings.deleteTitle": {
+    "defaultMessage": "Padam kelayakan"
+  },
+  "authSettings.deleted": {
+    "defaultMessage": "Kelayakan dipadam"
+  },
+  "authSettings.description": {
+    "defaultMessage": "Urus kelayakan pembekal yang disimpan secara setempat oleh goose."
+  },
+  "authSettings.empty": {
+    "defaultMessage": "Tiada kelayakan pembekal yang disimpan secara setempat ditemui."
+  },
+  "authSettings.expiresAt": {
+    "defaultMessage": "Tamat tempoh {date}"
+  },
+  "authSettings.failedToConfigure": {
+    "defaultMessage": "Gagal mengkonfigurasi kelayakan: {error}"
+  },
+  "authSettings.failedToDelete": {
+    "defaultMessage": "Gagal memadam kelayakan: {error}"
+  },
+  "authSettings.failedToLoad": {
+    "defaultMessage": "Gagal memuatkan kelayakan pembekal"
+  },
+  "authSettings.loading": {
+    "defaultMessage": "Memuatkan kelayakan..."
+  },
+  "authSettings.reauthorize": {
+    "defaultMessage": "Sahkan semula"
+  },
+  "authSettings.signIn": {
+    "defaultMessage": "Log masuk"
+  },
+  "authSettings.signedIn": {
+    "defaultMessage": "Kelayakan dikonfigurasi"
+  },
+  "authSettings.storageProviderCache": {
+    "defaultMessage": "Cache pembekal"
+  },
+  "authSettings.storageSecretStore": {
+    "defaultMessage": "Stor rahsia"
+  },
+  "authSettings.title": {
+    "defaultMessage": "Kelayakan Pembekal"
+  },
+  "backButton.back": {
+    "defaultMessage": "Kembali"
+  },
+  "baseChat.failedToLoadSession": {
+    "defaultMessage": "Gagal Memuatkan Sesi"
+  },
+  "baseChat.goHome": {
+    "defaultMessage": "Pergi ke laman utama"
+  },
+  "bottomMenuExtensionSelection.extensionUpdated": {
+    "defaultMessage": "Sambungan Dikemas Kini"
+  },
+  "bottomMenuExtensionSelection.extensionWillBeDisabled": {
+    "defaultMessage": "{name} akan dilumpuhkan dalam sembang baharu"
+  },
+  "bottomMenuExtensionSelection.extensionWillBeEnabled": {
+    "defaultMessage": "{name} akan didayakan dalam sembang baharu"
+  },
+  "bottomMenuExtensionSelection.extensionsForNewChats": {
+    "defaultMessage": "Sambungan untuk sembang baharu"
+  },
+  "bottomMenuExtensionSelection.extensionsForThisSession": {
+    "defaultMessage": "Sambungan untuk sesi sembang ini"
+  },
+  "bottomMenuExtensionSelection.manageExtensions": {
+    "defaultMessage": "urus sambungan"
+  },
+  "bottomMenuExtensionSelection.noExtensionsAvailable": {
+    "defaultMessage": "tiada sambungan tersedia"
+  },
+  "bottomMenuExtensionSelection.noExtensionsFound": {
+    "defaultMessage": "tiada sambungan ditemui"
+  },
+  "bottomMenuExtensionSelection.searchExtensions": {
+    "defaultMessage": "cari sambungan..."
+  },
+  "cardButtons.configure": {
+    "defaultMessage": "Konfigurasi"
+  },
+  "cardButtons.launch": {
+    "defaultMessage": "Lancarkan"
+  },
+  "chat.notification.taskComplete.body": {
+    "defaultMessage": "Klik di sini untuk membawa Goose kembali ke fokus."
+  },
+  "chat.notification.taskComplete.title": {
+    "defaultMessage": "Goose telah menyelesaikan tugasan."
+  },
+  "chatInput.contextWindow": {
+    "defaultMessage": "Tetingkap konteks"
+  },
+  "chatInput.dictationError": {
+    "defaultMessage": "Ralat Imlak"
+  },
+  "chatInput.failedToReadImage": {
+    "defaultMessage": "Gagal membaca fail imej"
+  },
+  "chatInput.navigationShortcut": {
+    "defaultMessage": "{prefix}↑/{prefix}↓ untuk menavigasi mesej"
+  },
+  "chatInput.processingDroppedFiles": {
+    "defaultMessage": "Memproses fail yang dilepaskan..."
+  },
+  "chatInput.recording": {
+    "defaultMessage": "Merakam..."
+  },
+  "chatInput.removeFile": {
+    "defaultMessage": "Alih keluar fail"
+  },
+  "chatInput.removeImage": {
+    "defaultMessage": "Alih keluar imej"
+  },
+  "chatInput.restartingSession": {
+    "defaultMessage": "Memulakan semula sesi..."
+  },
+  "chatInput.send": {
+    "defaultMessage": "Hantar"
+  },
+  "chatInput.transcribing": {
+    "defaultMessage": "Mentranskripsi..."
+  },
+  "chatInput.typeMessage": {
+    "defaultMessage": "Taip mesej untuk dihantar"
+  },
+  "chatInput.unknownType": {
+    "defaultMessage": "Jenis tidak diketahui"
+  },
+  "chatInput.viewEditRecipe": {
+    "defaultMessage": "Lihat/Edit Resipi"
+  },
+  "chatInput.waitingForCancellation": {
+    "defaultMessage": "Menunggu pembatalan selesai"
+  },
+  "chatInput.waitingForImages": {
+    "defaultMessage": "Menunggu imej disimpan..."
+  },
+  "chatSettings.modeDescription": {
+    "defaultMessage": "Pilih mod lalai yang Goose gunakan untuk sesi baharu. Sesi sedia ada mengekalkan mod semasanya."
+  },
+  "chatSettings.modeTitle": {
+    "defaultMessage": "Mod Lalai"
+  },
+  "chatSettings.responseStylesDescription": {
+    "defaultMessage": "Pilih cara Goose memformat dan menggaya respons"
+  },
+  "chatSettings.responseStylesTitle": {
+    "defaultMessage": "Gaya Respons"
+  },
+  "configSettings.configReset": {
+    "defaultMessage": "Konfigurasi Ditetapkan Semula"
+  },
+  "configSettings.configResetMsg": {
+    "defaultMessage": "Semua perubahan telah diundurkan"
+  },
+  "configSettings.configUpdated": {
+    "defaultMessage": "Konfigurasi Dikemas Kini"
+  },
+  "configSettings.configUpdatedMsg": {
+    "defaultMessage": "Berjaya menyimpan \"{name}\""
+  },
+  "configSettings.configurationEditor": {
+    "defaultMessage": "Editor Konfigurasi"
+  },
+  "configSettings.description": {
+    "defaultMessage": "Edit tetapan konfigurasi goose anda"
+  },
+  "configSettings.descriptionWithProvider": {
+    "defaultMessage": "Edit tetapan konfigurasi goose anda (tetapan semasa untuk {provider})"
+  },
+  "configSettings.done": {
+    "defaultMessage": "Selesai"
+  },
+  "configSettings.editConfiguration": {
+    "defaultMessage": "Edit Konfigurasi"
+  },
+  "configSettings.enterValue": {
+    "defaultMessage": "Masukkan {name}"
+  },
+  "configSettings.noSettings": {
+    "defaultMessage": "Tiada tetapan konfigurasi ditemui."
+  },
+  "configSettings.resetChanges": {
+    "defaultMessage": "Tetapkan Semula Perubahan"
+  },
+  "configSettings.saveFailed": {
+    "defaultMessage": "Gagal Menyimpan"
+  },
+  "configSettings.saveFailedMsg": {
+    "defaultMessage": "Gagal menyimpan \"{name}\""
+  },
+  "configSettings.saving": {
+    "defaultMessage": "Menyimpan..."
+  },
+  "configSettings.title": {
+    "defaultMessage": "Konfigurasi"
+  },
+  "configureApproveMode.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "configureApproveMode.description": {
+    "defaultMessage": "Permintaan kelulusan boleh diberikan kepada semua permintaan alat atau menentukan tindakan mana yang mungkin memerlukan penyepaduan"
+  },
+  "configureApproveMode.manualApproval": {
+    "defaultMessage": "Kelulusan manual"
+  },
+  "configureApproveMode.manualApprovalDescription": {
+    "defaultMessage": "Semua alat, sambungan dan pengubahsuaian fail akan memerlukan kelulusan manusia"
+  },
+  "configureApproveMode.save": {
+    "defaultMessage": "Simpan"
+  },
+  "configureApproveMode.saving": {
+    "defaultMessage": "Menyimpan..."
+  },
+  "configureApproveMode.smartApproval": {
+    "defaultMessage": "Kelulusan pintar"
+  },
+  "configureApproveMode.smartApprovalDescription": {
+    "defaultMessage": "Tentukan secara pintar tindakan mana yang memerlukan kelulusan berdasarkan tahap risiko"
+  },
+  "configureApproveMode.title": {
+    "defaultMessage": "Konfigurasi mod kelulusan"
+  },
+  "confirmationModal.defaultCancel": {
+    "defaultMessage": "Tidak"
+  },
+  "confirmationModal.defaultConfirm": {
+    "defaultMessage": "Ya"
+  },
+  "confirmationModal.processing": {
+    "defaultMessage": "Memproses..."
+  },
+  "conversationLimitsDropdown.conversationLimits": {
+    "defaultMessage": "Had Perbualan"
+  },
+  "conversationLimitsDropdown.maxTurns": {
+    "defaultMessage": "Pusingan Maksimum"
+  },
+  "conversationLimitsDropdown.maxTurnsDescription": {
+    "defaultMessage": "Pusingan ejen maksimum sebelum Goose meminta input pengguna"
+  },
+  "costTracker.costUnavailable": {
+    "defaultMessage": "Data kos tidak tersedia untuk {model} ({inputTokens} token input, {outputTokens} token output)"
+  },
+  "costTracker.inputOutputTooltip": {
+    "defaultMessage": "Input: {inputTokens} token ({inputCost}) | Output: {outputTokens} token ({outputCost})"
+  },
+  "costTracker.pricingUnavailable": {
+    "defaultMessage": "Data harga tidak tersedia untuk {model}"
+  },
+  "costTracker.totalSessionCost": {
+    "defaultMessage": "Jumlah kos sesi: {cost}"
+  },
+  "createEditRecipe.clickToGenerateDeeplink": {
+    "defaultMessage": "Klik untuk menjana deeplink"
+  },
+  "createEditRecipe.close": {
+    "defaultMessage": "Tutup"
+  },
+  "createEditRecipe.copied": {
+    "defaultMessage": "Disalin!"
+  },
+  "createEditRecipe.copy": {
+    "defaultMessage": "Salin"
+  },
+  "createEditRecipe.copyLinkDescription": {
+    "defaultMessage": "Salin pautan ini untuk dikongsi dengan rakan atau tampal terus dalam Chrome untuk membuka"
+  },
+  "createEditRecipe.createRecipeTitle": {
+    "defaultMessage": "Cipta Resipi"
+  },
+  "createEditRecipe.createSubtitle": {
+    "defaultMessage": "Cipta resipi baharu untuk menentukan tingkah laku dan keupayaan ejen bagi sesi sembang yang boleh diguna semula."
+  },
+  "createEditRecipe.editSubtitle": {
+    "defaultMessage": "Anda boleh mengedit resipi di bawah untuk mengubah tingkah laku ejen dalam sesi baharu."
+  },
+  "createEditRecipe.generatingDeeplink": {
+    "defaultMessage": "Menjana deeplink..."
+  },
+  "createEditRecipe.learnMore": {
+    "defaultMessage": "Ketahui lebih lanjut"
+  },
+  "createEditRecipe.recipeSavedAndLaunchedMsg": {
+    "defaultMessage": "Resipi berjaya disimpan dan dilancarkan"
+  },
+  "createEditRecipe.recipeSavedMsg": {
+    "defaultMessage": "Resipi berjaya disimpan"
+  },
+  "createEditRecipe.saveAndRunFailed": {
+    "defaultMessage": "Simpan dan Jalankan Gagal"
+  },
+  "createEditRecipe.saveAndRunFailedMsg": {
+    "defaultMessage": "Gagal menyimpan dan menjalankan resipi: {error}"
+  },
+  "createEditRecipe.saveAndRunRecipe": {
+    "defaultMessage": "Simpan & Jalankan Resipi"
+  },
+  "createEditRecipe.saveFailed": {
+    "defaultMessage": "Gagal Menyimpan"
+  },
+  "createEditRecipe.saveFailedMsg": {
+    "defaultMessage": "Gagal menyimpan resipi: {error}"
+  },
+  "createEditRecipe.saveRecipe": {
+    "defaultMessage": "Simpan Resipi"
+  },
+  "createEditRecipe.saving": {
+    "defaultMessage": "Menyimpan..."
+  },
+  "createEditRecipe.validationFailed": {
+    "defaultMessage": "Pengesahan Gagal"
+  },
+  "createEditRecipe.validationMsg": {
+    "defaultMessage": "Sila isi semua medan yang diperlukan dan pastikan skema JSON adalah sah."
+  },
+  "createEditRecipe.viewEditRecipeTitle": {
+    "defaultMessage": "Lihat/edit resipi"
+  },
+  "createSubRecipeInline.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "createSubRecipeInline.closeModal": {
+    "defaultMessage": "Tutup modal cipta subresipi"
+  },
+  "createSubRecipeInline.createAndAdd": {
+    "defaultMessage": "Cipta & Tambah Subresipi"
+  },
+  "createSubRecipeInline.createdSuccess": {
+    "defaultMessage": "Subresipi berjaya dicipta"
+  },
+  "createSubRecipeInline.creating": {
+    "defaultMessage": "Mencipta..."
+  },
+  "createSubRecipeInline.duplicateName": {
+    "defaultMessage": "Nama Pendua"
+  },
+  "createSubRecipeInline.duplicateNameMsg": {
+    "defaultMessage": "Subresipi bernama \"{name}\" sudah wujud. Sila gunakan nama yang unik."
+  },
+  "createSubRecipeInline.instructionsLabel": {
+    "defaultMessage": "Arahan"
+  },
+  "createSubRecipeInline.instructionsPlaceholder": {
+    "defaultMessage": "Arahan untuk AI apabila subresipi ini dipanggil..."
+  },
+  "createSubRecipeInline.nameHint": {
+    "defaultMessage": "Pengecam unik yang digunakan untuk menjana nama alat"
+  },
+  "createSubRecipeInline.nameLabel": {
+    "defaultMessage": "Nama"
+  },
+  "createSubRecipeInline.namePlaceholder": {
+    "defaultMessage": "cth., security_scan"
+  },
+  "createSubRecipeInline.preconfiguredValues": {
+    "defaultMessage": "Nilai Prakonfigurasi"
+  },
+  "createSubRecipeInline.preconfiguredValuesHint": {
+    "defaultMessage": "Nilai parameter pilihan yang sentiasa dihantar ke subresipi"
+  },
+  "createSubRecipeInline.recipeDescriptionLabel": {
+    "defaultMessage": "Penerangan Resipi"
+  },
+  "createSubRecipeInline.recipeDescriptionPlaceholder": {
+    "defaultMessage": "Apa yang resipi ini lakukan apabila dilaksanakan"
+  },
+  "createSubRecipeInline.recipeTitleLabel": {
+    "defaultMessage": "Tajuk Resipi"
+  },
+  "createSubRecipeInline.recipeTitlePlaceholder": {
+    "defaultMessage": "cth., Alat Analisis Keselamatan"
+  },
+  "createSubRecipeInline.saveFailed": {
+    "defaultMessage": "Gagal Menyimpan"
+  },
+  "createSubRecipeInline.saveFailedMsg": {
+    "defaultMessage": "Gagal menyimpan subresipi: {error}"
+  },
+  "createSubRecipeInline.sequentialHint": {
+    "defaultMessage": "(Memaksa pelaksanaan berjujukan bagi berbilang tika)"
+  },
+  "createSubRecipeInline.sequentialLabel": {
+    "defaultMessage": "Berjujukan apabila diulang"
+  },
+  "createSubRecipeInline.subtitle": {
+    "defaultMessage": "Cipta resipi mudah untuk digunakan sebagai alat yang boleh dipanggil dalam resipi utama anda"
+  },
+  "createSubRecipeInline.title": {
+    "defaultMessage": "Cipta Subresipi Baharu"
+  },
+  "createSubRecipeInline.toolDescriptionLabel": {
+    "defaultMessage": "Penerangan Alat"
+  },
+  "createSubRecipeInline.toolDescriptionPlaceholder": {
+    "defaultMessage": "Penerangan pilihan yang dipaparkan apabila ini dipanggil sebagai alat"
+  },
+  "createSubRecipeInline.validationFailed": {
+    "defaultMessage": "Pengesahan Gagal"
+  },
+  "createSubRecipeInline.validationMsg": {
+    "defaultMessage": "Nama, tajuk, penerangan resipi, dan arahan adalah diperlukan."
+  },
+  "creditsExhaustedNotification.addCredits": {
+    "defaultMessage": "Tambah kredit"
+  },
+  "creditsExhaustedNotification.insufficientCredits": {
+    "defaultMessage": "Kredit Tidak Mencukupi"
+  },
+  "cronPicker.april": {
+    "defaultMessage": "April"
+  },
+  "cronPicker.at": {
+    "defaultMessage": "pada"
+  },
+  "cronPicker.atMinute": {
+    "defaultMessage": "pada minit"
+  },
+  "cronPicker.atSecond": {
+    "defaultMessage": "pada saat"
+  },
+  "cronPicker.august": {
+    "defaultMessage": "Ogos"
+  },
+  "cronPicker.cronExpression": {
+    "defaultMessage": "Ungkapan cron"
+  },
+  "cronPicker.custom": {
+    "defaultMessage": "Cron tersuai"
+  },
+  "cronPicker.day": {
+    "defaultMessage": "Hari"
+  },
+  "cronPicker.december": {
+    "defaultMessage": "Disember"
+  },
+  "cronPicker.emptyCronError": {
+    "defaultMessage": "Ungkapan cron tidak boleh kosong"
+  },
+  "cronPicker.every": {
+    "defaultMessage": "Setiap"
+  },
+  "cronPicker.february": {
+    "defaultMessage": "Februari"
+  },
+  "cronPicker.friday": {
+    "defaultMessage": "Jumaat"
+  },
+  "cronPicker.hour": {
+    "defaultMessage": "Jam"
+  },
+  "cronPicker.inMonth": {
+    "defaultMessage": "pada"
+  },
+  "cronPicker.invalidDayOfMonth": {
+    "defaultMessage": "Hari mestilah antara 1 dan {max}"
+  },
+  "cronPicker.january": {
+    "defaultMessage": "Januari"
+  },
+  "cronPicker.july": {
+    "defaultMessage": "Julai"
+  },
+  "cronPicker.june": {
+    "defaultMessage": "Jun"
+  },
+  "cronPicker.march": {
+    "defaultMessage": "Mac"
+  },
+  "cronPicker.may": {
+    "defaultMessage": "Mei"
+  },
+  "cronPicker.minute": {
+    "defaultMessage": "Minit"
+  },
+  "cronPicker.mode": {
+    "defaultMessage": "Mod"
+  },
+  "cronPicker.monday": {
+    "defaultMessage": "Isnin"
+  },
+  "cronPicker.month": {
+    "defaultMessage": "Bulan"
+  },
+  "cronPicker.november": {
+    "defaultMessage": "November"
+  },
+  "cronPicker.october": {
+    "defaultMessage": "Oktober"
+  },
+  "cronPicker.on": {
+    "defaultMessage": "pada"
+  },
+  "cronPicker.onDay": {
+    "defaultMessage": "pada hari"
+  },
+  "cronPicker.quarter": {
+    "defaultMessage": "Suku"
+  },
+  "cronPicker.saturday": {
+    "defaultMessage": "Sabtu"
+  },
+  "cronPicker.september": {
+    "defaultMessage": "September"
+  },
+  "cronPicker.startingMonth": {
+    "defaultMessage": "bulan permulaan"
+  },
+  "cronPicker.sunday": {
+    "defaultMessage": "Ahad"
+  },
+  "cronPicker.thursday": {
+    "defaultMessage": "Khamis"
+  },
+  "cronPicker.tuesday": {
+    "defaultMessage": "Selasa"
+  },
+  "cronPicker.wednesday": {
+    "defaultMessage": "Rabu"
+  },
+  "cronPicker.week": {
+    "defaultMessage": "Minggu"
+  },
+  "cronPicker.year": {
+    "defaultMessage": "Tahun"
+  },
+  "customProviderForm.add": {
+    "defaultMessage": "Tambah"
+  },
+  "customProviderForm.anthropicCompatible": {
+    "defaultMessage": "Serasi Anthropic"
+  },
+  "customProviderForm.apiBasePath": {
+    "defaultMessage": "Laluan Asas API (pilihan)"
+  },
+  "customProviderForm.apiBasePathHint": {
+    "defaultMessage": "Ganti laluan API lalai. Biarkan kosong untuk menggunakan laluan lalai pembekal."
+  },
+  "customProviderForm.apiBasePathPlaceholder": {
+    "defaultMessage": "cth., v1/chat/completions atau project_id/v1"
+  },
+  "customProviderForm.apiKey": {
+    "defaultMessage": "Kunci API"
+  },
+  "customProviderForm.apiKeyPlaceholderExisting": {
+    "defaultMessage": "Biarkan kosong untuk mengekalkan kunci sedia ada"
+  },
+  "customProviderForm.apiKeyPlaceholderNew": {
+    "defaultMessage": "Kunci API anda"
+  },
+  "customProviderForm.apiKeyRequired": {
+    "defaultMessage": "Kunci API diperlukan"
+  },
+  "customProviderForm.apiUrl": {
+    "defaultMessage": "URL API"
+  },
+  "customProviderForm.apiUrlPlaceholder": {
+    "defaultMessage": "https://api.example.com"
+  },
+  "customProviderForm.apiUrlRequired": {
+    "defaultMessage": "URL API diperlukan"
+  },
+  "customProviderForm.attachments": {
+    "defaultMessage": "Lampiran"
+  },
+  "customProviderForm.authHint": {
+    "defaultMessage": "LLM setempat seperti Ollama biasanya tidak memerlukan kunci API."
+  },
+  "customProviderForm.authentication": {
+    "defaultMessage": "Pengesahan"
+  },
+  "customProviderForm.availableModels": {
+    "defaultMessage": "Model Tersedia (dipisahkan dengan koma)"
+  },
+  "customProviderForm.back": {
+    "defaultMessage": "← Kembali"
+  },
+  "customProviderForm.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "customProviderForm.cannotDeleteActive": {
+    "defaultMessage": "Anda tidak boleh memadam pembekal ini semasa ia sedang digunakan. Sila tukar kepada model lain dahulu."
+  },
+  "customProviderForm.chooseSetup": {
+    "defaultMessage": "Pilih cara anda mahu menyediakan pembekal anda."
+  },
+  "customProviderForm.clear": {
+    "defaultMessage": "Kosongkan"
+  },
+  "customProviderForm.configureManually": {
+    "defaultMessage": "Konfigurasi secara manual"
+  },
+  "customProviderForm.configureManuallyDesc": {
+    "defaultMessage": "Masukkan semua butiran pembekal sendiri"
+  },
+  "customProviderForm.confirmDelete": {
+    "defaultMessage": "Sahkan Pemadaman"
+  },
+  "customProviderForm.createProvider": {
+    "defaultMessage": "Cipta Pembekal"
+  },
+  "customProviderForm.customHeaders": {
+    "defaultMessage": "Pengepala Tersuai"
+  },
+  "customProviderForm.customHeadersHint": {
+    "defaultMessage": "Tambah pengepala HTTP tersuai untuk disertakan dalam permintaan kepada pembekal. Klik butang \"+\" untuk menambah selepas mengisi kedua-dua medan."
+  },
+  "customProviderForm.deleteConfirmation": {
+    "defaultMessage": "Adakah anda pasti mahu memadam pembekal tersuai ini? Ini akan mengalih keluar pembekal dan kunci API yang disimpannya secara kekal. Tindakan ini tidak boleh dibatalkan."
+  },
+  "customProviderForm.deleteProvider": {
+    "defaultMessage": "Padam Pembekal"
+  },
+  "customProviderForm.displayName": {
+    "defaultMessage": "Nama Paparan"
+  },
+  "customProviderForm.displayNamePlaceholder": {
+    "defaultMessage": "Nama Pembekal Anda"
+  },
+  "customProviderForm.displayNameRequired": {
+    "defaultMessage": "Nama paparan diperlukan"
+  },
+  "customProviderForm.docs": {
+    "defaultMessage": "Dokumentasi"
+  },
+  "customProviderForm.headerBothRequired": {
+    "defaultMessage": "Kedua-dua nama dan nilai pengepala mesti dimasukkan"
+  },
+  "customProviderForm.headerDuplicate": {
+    "defaultMessage": "Pengepala dengan nama ini sudah wujud"
+  },
+  "customProviderForm.headerNamePlaceholder": {
+    "defaultMessage": "Nama pengepala"
+  },
+  "customProviderForm.headerNoSpaces": {
+    "defaultMessage": "Nama pengepala tidak boleh mengandungi ruang"
+  },
+  "customProviderForm.modelsPlaceholder": {
+    "defaultMessage": "model-a, model-b, model-c"
+  },
+  "customProviderForm.modelsRequired": {
+    "defaultMessage": "Sekurang-kurangnya satu model diperlukan"
+  },
+  "customProviderForm.ollamaCompatible": {
+    "defaultMessage": "Serasi Ollama"
+  },
+  "customProviderForm.openaiCompatible": {
+    "defaultMessage": "Serasi OpenAI"
+  },
+  "customProviderForm.providerType": {
+    "defaultMessage": "Jenis Pembekal"
+  },
+  "customProviderForm.reasoning": {
+    "defaultMessage": "Penaakulan"
+  },
+  "customProviderForm.requiresApiKey": {
+    "defaultMessage": "Pembekal ini memerlukan kunci API"
+  },
+  "customProviderForm.startFromTemplate": {
+    "defaultMessage": "Mula daripada templat pembekal"
+  },
+  "customProviderForm.startFromTemplateDesc": {
+    "defaultMessage": "Pilih pembekal yang dikenali dan kami akan mengisi konfigurasi secara automatik"
+  },
+  "customProviderForm.submitError": {
+    "defaultMessage": "Gagal menyimpan pembekal. Sila semak konfigurasi anda dan cuba lagi."
+  },
+  "customProviderForm.supportsStreaming": {
+    "defaultMessage": "Pembekal menyokong respons penstriman"
+  },
+  "customProviderForm.toolCalling": {
+    "defaultMessage": "Pemanggilan alat"
+  },
+  "customProviderForm.updateProvider": {
+    "defaultMessage": "Kemas Kini Pembekal"
+  },
+  "customProviderForm.usingTemplate": {
+    "defaultMessage": "Menggunakan templat: {name}"
+  },
+  "customProviderForm.valuePlaceholder": {
+    "defaultMessage": "Nilai"
+  },
+  "defaultCardButtons.configureSettings": {
+    "defaultMessage": "Konfigurasikan tetapan {name}"
+  },
+  "defaultCardButtons.deleteSettings": {
+    "defaultMessage": "Padam tetapan {name}"
+  },
+  "defaultCardButtons.editSettings": {
+    "defaultMessage": "Edit tetapan {name}"
+  },
+  "defaultCardButtons.getStarted": {
+    "defaultMessage": "Mulakan dengan goose!"
+  },
+  "defaultProviderSetupForm.apiHostLabel": {
+    "defaultMessage": "Hos API"
+  },
+  "defaultProviderSetupForm.apiHostPlaceholder": {
+    "defaultMessage": "https://api.example.com"
+  },
+  "defaultProviderSetupForm.apiKeyLabel": {
+    "defaultMessage": "Kunci API"
+  },
+  "defaultProviderSetupForm.apiKeyPlaceholder": {
+    "defaultMessage": "Kunci API anda"
+  },
+  "defaultProviderSetupForm.hideOptions": {
+    "defaultMessage": "Sembunyikan {count} pilihan"
+  },
+  "defaultProviderSetupForm.loadingConfig": {
+    "defaultMessage": "Memuatkan nilai konfigurasi..."
+  },
+  "defaultProviderSetupForm.modelsLabel": {
+    "defaultMessage": "Model"
+  },
+  "defaultProviderSetupForm.modelsPlaceholder": {
+    "defaultMessage": "model-a, model-b"
+  },
+  "defaultProviderSetupForm.noConfigParameters": {
+    "defaultMessage": "Tiada parameter konfigurasi untuk pembekal ini."
+  },
+  "defaultProviderSetupForm.showOptions": {
+    "defaultMessage": "Tunjukkan {count} pilihan"
+  },
+  "diagnosticsModal.attachHint": {
+    "defaultMessage": "Jika anda melaporkan pepijat, pertimbangkan untuk melampirkan laporan diagnostik kepadanya."
+  },
+  "diagnosticsModal.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "diagnosticsModal.configSettings": {
+    "defaultMessage": "Tetapan konfigurasi"
+  },
+  "diagnosticsModal.description": {
+    "defaultMessage": "Anda boleh memuat turun laporan JSON diagnostik untuk dikongsi dengan pasukan, atau melaporkan pepijat terus di GitHub dengan butiran sistem anda diisi terlebih dahulu. Laporan diagnostik mengandungi yang berikut:"
+  },
+  "diagnosticsModal.diagnosticsErrorMsg": {
+    "defaultMessage": "Gagal memuat turun laporan diagnostik"
+  },
+  "diagnosticsModal.diagnosticsErrorTitle": {
+    "defaultMessage": "Ralat Diagnostik"
+  },
+  "diagnosticsModal.download": {
+    "defaultMessage": "Muat Turun"
+  },
+  "diagnosticsModal.downloading": {
+    "defaultMessage": "Memuat turun..."
+  },
+  "diagnosticsModal.fileBug": {
+    "defaultMessage": "Laporkan Pepijat di GitHub"
+  },
+  "diagnosticsModal.logFiles": {
+    "defaultMessage": "Fail log terkini"
+  },
+  "diagnosticsModal.opening": {
+    "defaultMessage": "Membuka..."
+  },
+  "diagnosticsModal.reportProblem": {
+    "defaultMessage": "Laporkan Masalah"
+  },
+  "diagnosticsModal.sensitiveWarning": {
+    "defaultMessage": "Jika sesi anda mengandungi maklumat sensitif, jangan kongsi fail diagnostik secara awam."
+  },
+  "diagnosticsModal.sessionMessages": {
+    "defaultMessage": "Mesej sesi semasa anda"
+  },
+  "diagnosticsModal.systemInfo": {
+    "defaultMessage": "Maklumat asas sistem"
+  },
+  "diagnosticsModal.systemInfoErrorMsg": {
+    "defaultMessage": "Gagal mendapatkan maklumat sistem"
+  },
+  "diagnosticsModal.systemInfoErrorTitle": {
+    "defaultMessage": "Ralat"
+  },
+  "dialog.close": {
+    "defaultMessage": "Tutup"
+  },
+  "dictationSettings.addApiKey": {
+    "defaultMessage": "Tambah Kunci API"
+  },
+  "dictationSettings.apiKey": {
+    "defaultMessage": "Kunci API"
+  },
+  "dictationSettings.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "dictationSettings.chooseVoiceConversion": {
+    "defaultMessage": "Pilih cara suara ditukar kepada teks"
+  },
+  "dictationSettings.configureApiKey": {
+    "defaultMessage": "Konfigurasikan kunci API dalam <b>{settingsPath}</b>"
+  },
+  "dictationSettings.configured": {
+    "defaultMessage": "(Dikonfigurasikan)"
+  },
+  "dictationSettings.configuredIn": {
+    "defaultMessage": "✓ Dikonfigurasikan dalam {settingsPath}"
+  },
+  "dictationSettings.disabled": {
+    "defaultMessage": "Dilumpuhkan"
+  },
+  "dictationSettings.enterApiKey": {
+    "defaultMessage": "Masukkan kunci API anda"
+  },
+  "dictationSettings.notConfigured": {
+    "defaultMessage": "(tidak dikonfigurasikan)"
+  },
+  "dictationSettings.removeApiKey": {
+    "defaultMessage": "Buang Kunci API"
+  },
+  "dictationSettings.requiredForTranscription": {
+    "defaultMessage": "Diperlukan untuk transkripsi"
+  },
+  "dictationSettings.save": {
+    "defaultMessage": "Simpan"
+  },
+  "dictationSettings.updateApiKey": {
+    "defaultMessage": "Kemas Kini Kunci API"
+  },
+  "dictationSettings.voiceDictationProvider": {
+    "defaultMessage": "Pembekal Imlak Suara"
+  },
+  "dirSwitcher.chooseDirectory": {
+    "defaultMessage": "Pilih direktori…"
+  },
+  "dirSwitcher.currentDirectory": {
+    "defaultMessage": "Direktori semasa"
+  },
+  "dirSwitcher.failedToUpdateWorkingDir": {
+    "defaultMessage": "Gagal mengemas kini direktori kerja"
+  },
+  "dirSwitcher.gitWorktrees": {
+    "defaultMessage": "Git worktrees"
+  },
+  "dirSwitcher.noWorktreesFound": {
+    "defaultMessage": "Tiada worktree dijumpai"
+  },
+  "dirSwitcher.openInFinder": {
+    "defaultMessage": "Buka dalam pengurus fail"
+  },
+  "dirSwitcher.recentDirectories": {
+    "defaultMessage": "Direktori terkini"
+  },
+  "elicitationRequest.accept": {
+    "defaultMessage": "Terima"
+  },
+  "elicitationRequest.cancelled": {
+    "defaultMessage": "Permintaan maklumat telah dibatalkan."
+  },
+  "elicitationRequest.defaultMessage": {
+    "defaultMessage": "Goose memerlukan beberapa maklumat daripada anda."
+  },
+  "elicitationRequest.expired": {
+    "defaultMessage": "Permintaan ini telah luput. Sambungan perlu bertanya semula."
+  },
+  "elicitationRequest.submit": {
+    "defaultMessage": "Hantar"
+  },
+  "elicitationRequest.submitError": {
+    "defaultMessage": "Permintaan ini tidak lagi aktif. Sambungan perlu bertanya semula."
+  },
+  "elicitationRequest.submitted": {
+    "defaultMessage": "Maklumat dihantar"
+  },
+  "elicitationRequest.waitingForResponse": {
+    "defaultMessage": "Menunggu respons anda ({timeRemaining} lagi)"
+  },
+  "envVarsSection.add": {
+    "defaultMessage": "Tambah"
+  },
+  "envVarsSection.bothRequired": {
+    "defaultMessage": "Kedua-dua nama pemboleh ubah dan nilai mesti dimasukkan"
+  },
+  "envVarsSection.envVarsDescription": {
+    "defaultMessage": "Tambah pasangan kunci-nilai untuk pemboleh ubah persekitaran. Klik butang \"+\" untuk menambah selepas mengisi kedua-dua medan. Untuk nilai rahsia sedia ada, klik butang edit untuk mengubah suai."
+  },
+  "envVarsSection.environmentVariables": {
+    "defaultMessage": "Pemboleh Ubah Persekitaran"
+  },
+  "envVarsSection.noSpaces": {
+    "defaultMessage": "Nama pemboleh ubah tidak boleh mengandungi ruang"
+  },
+  "envVarsSection.value": {
+    "defaultMessage": "Nilai"
+  },
+  "envVarsSection.variableName": {
+    "defaultMessage": "Nama pemboleh ubah"
+  },
+  "environmentBadge.dev": {
+    "defaultMessage": "Dev"
+  },
+  "errorBoundary.errorGeneric": {
+    "defaultMessage": "Satu ralat telah berlaku."
+  },
+  "errorBoundary.errorWithVersion": {
+    "defaultMessage": "Satu ralat telah berlaku dalam Goose v{version}."
+  },
+  "errorBoundary.heading": {
+    "defaultMessage": "Honk!"
+  },
+  "errorBoundary.reload": {
+    "defaultMessage": "Muat Semula"
+  },
+  "extensionConfigFields.commandLabel": {
+    "defaultMessage": "Arahan"
+  },
+  "extensionConfigFields.commandPlaceholder": {
+    "defaultMessage": "cth. npx -y @modelcontextprotocol/my-extension [filepath]"
+  },
+  "extensionConfigFields.commandRequired": {
+    "defaultMessage": "Arahan diperlukan"
+  },
+  "extensionConfigFields.endpointLabel": {
+    "defaultMessage": "Titik Hujung"
+  },
+  "extensionConfigFields.endpointPlaceholder": {
+    "defaultMessage": "Masukkan URL titik hujung..."
+  },
+  "extensionConfigFields.endpointRequired": {
+    "defaultMessage": "URL titik hujung diperlukan"
+  },
+  "extensionInfoFields.descriptionLabel": {
+    "defaultMessage": "Penerangan"
+  },
+  "extensionInfoFields.descriptionPlaceholder": {
+    "defaultMessage": "Penerangan pilihan..."
+  },
+  "extensionInfoFields.extensionName": {
+    "defaultMessage": "Nama Sambungan"
+  },
+  "extensionInfoFields.extensionNamePlaceholder": {
+    "defaultMessage": "Masukkan nama sambungan..."
+  },
+  "extensionInfoFields.nameRequired": {
+    "defaultMessage": "Nama diperlukan"
+  },
+  "extensionInfoFields.typeHttp": {
+    "defaultMessage": "HTTP"
+  },
+  "extensionInfoFields.typeLabel": {
+    "defaultMessage": "Jenis"
+  },
+  "extensionInfoFields.typeSseUnsupported": {
+    "defaultMessage": "SSE (tidak disokong)"
+  },
+  "extensionInfoFields.typeStandardIo": {
+    "defaultMessage": "Standard IO (STDIO)"
+  },
+  "extensionInfoFields.typeStdio": {
+    "defaultMessage": "STDIO"
+  },
+  "extensionInfoFields.typeStreamableHttp": {
+    "defaultMessage": "Streamable HTTP"
+  },
+  "extensionInstallModal.alreadyInstalledMessage": {
+    "defaultMessage": "Sambungan ''{name}'' telah berjaya dipasang. Mulakan sesi sembang baharu untuk menggunakannya."
+  },
+  "extensionInstallModal.alreadyInstalledTitle": {
+    "defaultMessage": "Sambungan ''{name}'' Telah Dipasang"
+  },
+  "extensionInstallModal.blockedMessage": {
+    "defaultMessage": "Arahan sambungan ini tiada dalam senarai yang dibenarkan dan pemasangannya disekat. Sambungan: {name} Arahan: {command} Hubungi pentadbir anda untuk meminta kelulusan bagi sambungan ini."
+  },
+  "extensionInstallModal.blockedTitle": {
+    "defaultMessage": "Pemasangan Sambungan Disekat"
+  },
+  "extensionInstallModal.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "extensionInstallModal.installAnyway": {
+    "defaultMessage": "Pasang Juga"
+  },
+  "extensionInstallModal.installing": {
+    "defaultMessage": "Memasang..."
+  },
+  "extensionInstallModal.no": {
+    "defaultMessage": "Tidak"
+  },
+  "extensionInstallModal.ok": {
+    "defaultMessage": "OK"
+  },
+  "extensionInstallModal.trustedMessage": {
+    "defaultMessage": "Adakah anda pasti mahu memasang sambungan {name}? Arahan: {command}"
+  },
+  "extensionInstallModal.trustedTitle": {
+    "defaultMessage": "Sahkan Pemasangan Sambungan"
+  },
+  "extensionInstallModal.unknownCommand": {
+    "defaultMessage": "Arahan Tidak Diketahui"
+  },
+  "extensionInstallModal.untrustedMessageWithCommand": {
+    "defaultMessage": "{securityMessage} Sambungan: {name} Arahan: {command} Hubungi pentadbir anda jika anda tidak pasti tentang perkara ini."
+  },
+  "extensionInstallModal.untrustedMessageWithUrl": {
+    "defaultMessage": "{securityMessage} Sambungan: {name} URL: {url} Hubungi pentadbir anda jika anda tidak pasti tentang perkara ini."
+  },
+  "extensionInstallModal.untrustedSecurityMessage": {
+    "defaultMessage": "Arahan sambungan ini tiada dalam senarai yang dibenarkan dan akan dapat mengakses perbualan anda serta menyediakan fungsi tambahan. Memasang sambungan daripada sumber yang tidak dipercayai mungkin menimbulkan risiko keselamatan."
+  },
+  "extensionInstallModal.untrustedTitle": {
+    "defaultMessage": "Pasang Sambungan Tidak Dipercayai?"
+  },
+  "extensionInstallModal.yes": {
+    "defaultMessage": "Ya"
+  },
+  "extensionItem.configureExtension": {
+    "defaultMessage": "Konfigurasikan Sambungan {name}"
+  },
+  "extensionItem.toggleExtension": {
+    "defaultMessage": "Togol sambungan {name} Hidup atau Mati"
+  },
+  "extensionList.availableExtensions": {
+    "defaultMessage": "Sambungan Tersedia ({count})"
+  },
+  "extensionList.builtInExtension": {
+    "defaultMessage": "Sambungan terbina dalam"
+  },
+  "extensionList.defaultExtensions": {
+    "defaultMessage": "Sambungan Lalai ({count})"
+  },
+  "extensionList.noExtensions": {
+    "defaultMessage": "Tiada sambungan tersedia"
+  },
+  "extensionModal.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "extensionModal.closeWithoutSaving": {
+    "defaultMessage": "Tutup Tanpa Menyimpan"
+  },
+  "extensionModal.confirmRemoval": {
+    "defaultMessage": "Sahkan pembuangan"
+  },
+  "extensionModal.deleteDescription": {
+    "defaultMessage": "Ini akan membuang sambungan ini dan semua tetapannya secara kekal."
+  },
+  "extensionModal.deleteExtensionTitle": {
+    "defaultMessage": "Padam Sambungan \"{name}\""
+  },
+  "extensionModal.installationNotes": {
+    "defaultMessage": "Nota Pemasangan"
+  },
+  "extensionModal.removeExtension": {
+    "defaultMessage": "Buang sambungan"
+  },
+  "extensionModal.unsavedChangesMessage": {
+    "defaultMessage": "Anda mempunyai perubahan yang belum disimpan pada konfigurasi sambungan. Adakah anda pasti mahu menutup tanpa menyimpan?"
+  },
+  "extensionModal.unsavedChangesTitle": {
+    "defaultMessage": "Perubahan Belum Disimpan"
+  },
+  "extensionTimeoutField.timeoutLabel": {
+    "defaultMessage": "Had Masa"
+  },
+  "extensionsSection.addCustomExtension": {
+    "defaultMessage": "Tambah sambungan tersuai"
+  },
+  "extensionsSection.addExtension": {
+    "defaultMessage": "Tambah Sambungan"
+  },
+  "extensionsSection.browseExtensions": {
+    "defaultMessage": "Layari sambungan"
+  },
+  "extensionsSection.saveChanges": {
+    "defaultMessage": "Simpan Perubahan"
+  },
+  "extensionsSection.updateExtension": {
+    "defaultMessage": "Kemas Kini Sambungan"
+  },
+  "extensionsView.addCustomExtension": {
+    "defaultMessage": "Tambah sambungan tersuai"
+  },
+  "extensionsView.addExtension": {
+    "defaultMessage": "Tambah Sambungan"
+  },
+  "extensionsView.browseExtensions": {
+    "defaultMessage": "Layari sambungan"
+  },
+  "extensionsView.defaultNote": {
+    "defaultMessage": "Sambungan yang didayakan di sini digunakan sebagai lalai untuk sembang baharu. Anda juga boleh menogol sambungan aktif semasa sembang."
+  },
+  "extensionsView.description": {
+    "defaultMessage": "Sambungan ini menggunakan Model Context Protocol (MCP). Ia boleh mengembangkan keupayaan Goose menggunakan tiga komponen utama: Prompts, Resources, dan Tools. {searchShortcut} untuk mencari."
+  },
+  "extensionsView.heading": {
+    "defaultMessage": "Sambungan"
+  },
+  "extensionsView.searchPlaceholder": {
+    "defaultMessage": "Cari sambungan..."
+  },
+  "externalBackendSection.certFingerprint": {
+    "defaultMessage": "Cap Jari Sijil (pilihan)"
+  },
+  "externalBackendSection.certFingerprintHelp": {
+    "defaultMessage": "Sematkan cap jari sijil TLS tertentu. Jika ditinggalkan, sijil akan dipercayai pada penggunaan pertama (TOFU)."
+  },
+  "externalBackendSection.certFingerprintPlaceholder": {
+    "defaultMessage": "AA:BB:CC:... atau sha256/base64"
+  },
+  "externalBackendSection.description": {
+    "defaultMessage": "Secara lalai goose melancarkan pelayan untuk anda, gunakan ini untuk menyambung ke pelayan goose luaran"
+  },
+  "externalBackendSection.restartNote": {
+    "defaultMessage": "Perubahan memerlukan memulakan semula Goose untuk berkuat kuasa. Tetingkap sembang baharu akan menyambung ke pelayan luaran."
+  },
+  "externalBackendSection.secretKey": {
+    "defaultMessage": "Kunci Rahsia"
+  },
+  "externalBackendSection.secretKeyHelp": {
+    "defaultMessage": "Kunci rahsia yang dikonfigurasikan pada pelayan goosed (GOOSE_SERVER__SECRET_KEY)"
+  },
+  "externalBackendSection.secretKeyPlaceholder": {
+    "defaultMessage": "Masukkan kunci rahsia pelayan"
+  },
+  "externalBackendSection.serverUrl": {
+    "defaultMessage": "URL Pelayan"
+  },
+  "externalBackendSection.title": {
+    "defaultMessage": "Pelayan Goose"
+  },
+  "externalBackendSection.urlFormatError": {
+    "defaultMessage": "Format URL tidak sah"
+  },
+  "externalBackendSection.urlProtocolError": {
+    "defaultMessage": "URL mesti menggunakan protokol http atau https"
+  },
+  "externalBackendSection.useExternalServer": {
+    "defaultMessage": "Gunakan pelayan luaran"
+  },
+  "externalBackendSection.useExternalServerDescription": {
+    "defaultMessage": "Sambung ke pelayan goose yang berjalan di tempat lain (memerlukan memulakan semula aplikasi)"
+  },
+  "freeOptionCards.chooseOption": {
+    "defaultMessage": "Pilih satu pilihan untuk bermula."
+  },
+  "freeOptionCards.freeAndPrivate": {
+    "defaultMessage": "Percuma & Peribadi"
+  },
+  "freeOptionCards.localModelDescription": {
+    "defaultMessage": "Muat turun model dan jalankan sepenuhnya pada mesin anda. Tiada kunci API, tiada akaun."
+  },
+  "freeOptionCards.localModelTitle": {
+    "defaultMessage": "Guna Model Tempatan"
+  },
+  "freeOptionCards.nanogptDescription": {
+    "defaultMessage": "Daftar untuk menerima 60J token percuma selama 7 hari."
+  },
+  "freeOptionCards.nanogptTitle": {
+    "defaultMessage": "NanoGPT"
+  },
+  "freeOptionCards.retry": {
+    "defaultMessage": "Cuba Semula"
+  },
+  "freeOptionCards.tetrateDescription": {
+    "defaultMessage": "Akses pelbagai model AI dengan persediaan automatik. Daftar untuk menerima kredit $10."
+  },
+  "freeOptionCards.tetrateTitle": {
+    "defaultMessage": "Agent Router oleh Tetrate"
+  },
+  "freeOptionCards.unexpectedError": {
+    "defaultMessage": "Ralat tidak dijangka berlaku semasa persediaan."
+  },
+  "goosehintsModal.close": {
+    "defaultMessage": "Tutup"
+  },
+  "goosehintsModal.developer": {
+    "defaultMessage": "Pembangun"
+  },
+  "goosehintsModal.dialogDescription": {
+    "defaultMessage": "Berikan konteks tambahan tentang projek anda untuk meningkatkan komunikasi dengan Goose"
+  },
+  "goosehintsModal.dialogTitle": {
+    "defaultMessage": "Konfigurasikan Petunjuk Projek (.goosehints)"
+  },
+  "goosehintsModal.errorReading": {
+    "defaultMessage": "Ralat membaca fail .goosehints: {error}"
+  },
+  "goosehintsModal.failedToAccess": {
+    "defaultMessage": "Gagal mengakses fail .goosehints"
+  },
+  "goosehintsModal.failedToSave": {
+    "defaultMessage": "Gagal menyimpan fail .goosehints"
+  },
+  "goosehintsModal.fileCreating": {
+    "defaultMessage": "Mencipta fail .goosehints baharu di: {filePath}"
+  },
+  "goosehintsModal.fileFound": {
+    "defaultMessage": "Fail .goosehints dijumpai di: {filePath}"
+  },
+  "goosehintsModal.helpText1": {
+    "defaultMessage": ".goosehints ialah fail teks yang digunakan untuk memberikan konteks tambahan tentang projek anda dan meningkatkan komunikasi dengan Goose."
+  },
+  "goosehintsModal.helpText2": {
+    "defaultMessage": "Sila pastikan sambungan {bold} didayakan dalam halaman sambungan. Sambungan ini diperlukan untuk menggunakan .goosehints. Anda perlu memulakan semula sesi anda untuk kemas kini .goosehints berkuat kuasa."
+  },
+  "goosehintsModal.helpText3": {
+    "defaultMessage": "Lihat {link} untuk maklumat lanjut."
+  },
+  "goosehintsModal.helpTextLink": {
+    "defaultMessage": "menggunakan .goosehints"
+  },
+  "goosehintsModal.placeholder": {
+    "defaultMessage": "Masukkan petunjuk projek di sini..."
+  },
+  "goosehintsModal.save": {
+    "defaultMessage": "Simpan"
+  },
+  "goosehintsModal.savedSuccessfully": {
+    "defaultMessage": "Berjaya disimpan"
+  },
+  "goosehintsModal.saving": {
+    "defaultMessage": "Menyimpan..."
+  },
+  "goosehintsSection.configure": {
+    "defaultMessage": "Konfigurasikan"
+  },
+  "goosehintsSection.description": {
+    "defaultMessage": "Konfigurasikan fail .goosehints projek anda untuk memberikan konteks tambahan kepada Goose"
+  },
+  "goosehintsSection.title": {
+    "defaultMessage": "Petunjuk Projek (.goosehints)"
+  },
+  "groupedExtensionLoadingToast.askGoose": {
+    "defaultMessage": "Tanya goose"
+  },
+  "groupedExtensionLoadingToast.collapseDetails": {
+    "defaultMessage": "Runtuhkan butiran"
+  },
+  "groupedExtensionLoadingToast.copied": {
+    "defaultMessage": "Disalin!"
+  },
+  "groupedExtensionLoadingToast.copyError": {
+    "defaultMessage": "Ralat salin"
+  },
+  "groupedExtensionLoadingToast.expandDetails": {
+    "defaultMessage": "Kembangkan butiran"
+  },
+  "groupedExtensionLoadingToast.failedToAddExtension": {
+    "defaultMessage": "Gagal menambah sambungan"
+  },
+  "groupedExtensionLoadingToast.failedToLoad": {
+    "defaultMessage": "{count,plural,one{# sambungan gagal dimuatkan} other{# sambungan gagal dimuatkan}}"
+  },
+  "groupedExtensionLoadingToast.loadingExtensions": {
+    "defaultMessage": "{count,plural,one{Memuatkan # sambungan...} other{Memuatkan # sambungan...}}"
+  },
+  "groupedExtensionLoadingToast.partiallyLoaded": {
+    "defaultMessage": "{totalCount,plural,one{Dimuatkan {successCount}/# sambungan} other{Dimuatkan {successCount}/# sambungan}}"
+  },
+  "groupedExtensionLoadingToast.showDetails": {
+    "defaultMessage": "Tunjukkan butiran"
+  },
+  "groupedExtensionLoadingToast.showLess": {
+    "defaultMessage": "Tunjukkan kurang"
+  },
+  "groupedExtensionLoadingToast.successfullyLoaded": {
+    "defaultMessage": "{count,plural,one{Berjaya memuatkan # sambungan} other{Berjaya memuatkan # sambungan}}"
+  },
+  "headersSection.add": {
+    "defaultMessage": "Tambah"
+  },
+  "headersSection.bothRequired": {
+    "defaultMessage": "Kedua-dua nama pengepala dan nilai mesti dimasukkan"
+  },
+  "headersSection.duplicateHeader": {
+    "defaultMessage": "Pengepala dengan nama ini sudah wujud"
+  },
+  "headersSection.headerName": {
+    "defaultMessage": "Nama pengepala"
+  },
+  "headersSection.headersDescription": {
+    "defaultMessage": "Tambah pengepala HTTP tersuai untuk disertakan dalam permintaan kepada pelayan MCP. Klik butang \"+\" untuk menambah selepas mengisi kedua-dua medan."
+  },
+  "headersSection.noSpaces": {
+    "defaultMessage": "Nama pengepala tidak boleh mengandungi ruang"
+  },
+  "headersSection.requestHeaders": {
+    "defaultMessage": "Pengepala Permintaan"
+  },
+  "headersSection.value": {
+    "defaultMessage": "Nilai"
+  },
+  "hub.goodAfternoon": {
+    "defaultMessage": "Selamat tengah hari"
+  },
+  "hub.goodEvening": {
+    "defaultMessage": "Selamat petang"
+  },
+  "hub.goodMorning": {
+    "defaultMessage": "Selamat pagi"
+  },
+  "huggingFaceModelSearch.download": {
+    "defaultMessage": "Muat Turun"
+  },
+  "huggingFaceModelSearch.downloaded": {
+    "defaultMessage": "Dimuat turun"
+  },
+  "huggingFaceModelSearch.downloading": {
+    "defaultMessage": "Memuat turun…"
+  },
+  "huggingFaceModelSearch.loadingVariants": {
+    "defaultMessage": "Memuatkan varian..."
+  },
+  "huggingFaceModelSearch.noGgufModels": {
+    "defaultMessage": "Tiada model tempatan serasi dijumpai untuk pertanyaan ini."
+  },
+  "huggingFaceModelSearch.recommended": {
+    "defaultMessage": "Disyorkan"
+  },
+  "huggingFaceModelSearch.searchError": {
+    "defaultMessage": "Ralat carian: {details}"
+  },
+  "huggingFaceModelSearch.searchFailed": {
+    "defaultMessage": "Carian gagal. Sila cuba lagi."
+  },
+  "huggingFaceModelSearch.searchHuggingFace": {
+    "defaultMessage": "Cari HuggingFace"
+  },
+  "huggingFaceModelSearch.searchNoData": {
+    "defaultMessage": "Carian tidak mengembalikan sebarang data."
+  },
+  "huggingFaceModelSearch.searchPlaceholder": {
+    "defaultMessage": "Cari model tempatan..."
+  },
+  "huggingFaceModelSearch.tooLarge": {
+    "defaultMessage": "Mungkin tidak muat dalam memori (model {size}, {available} tersedia)"
+  },
+  "huggingFaceSignInPrompt.failedToConfigure": {
+    "defaultMessage": "Gagal log masuk ke Hugging Face: {error}"
+  },
+  "huggingFaceSignInPrompt.signIn": {
+    "defaultMessage": "Log masuk"
+  },
+  "huggingFaceSignInPrompt.signedIn": {
+    "defaultMessage": "Hugging Face telah log masuk"
+  },
+  "huggingFaceSignInPrompt.signingIn": {
+    "defaultMessage": "Sedang log masuk..."
+  },
+  "huggingFaceSignInPrompt.title": {
+    "defaultMessage": "Hugging Face"
+  },
+  "imagePreview.altText": {
+    "defaultMessage": "imej goose"
+  },
+  "imagePreview.clickToCollapse": {
+    "defaultMessage": "Klik untuk meruntuhkan"
+  },
+  "imagePreview.clickToExpand": {
+    "defaultMessage": "Klik untuk mengembangkan"
+  },
+  "imagePreview.unableToLoad": {
+    "defaultMessage": "Tidak dapat memuatkan imej"
+  },
+  "importRecipeForm.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "importRecipeForm.deeplinkHint": {
+    "defaultMessage": "Tampal pautan dalam resipi yang bermula dengan \"goose://recipe?config=\""
+  },
+  "importRecipeForm.deeplinkPlaceholder": {
+    "defaultMessage": "Tampal pautan dalam goose://recipe?config=... anda di sini"
+  },
+  "importRecipeForm.example": {
+    "defaultMessage": "contoh"
+  },
+  "importRecipeForm.expectedRecipeStructure": {
+    "defaultMessage": "Struktur Resipi Dijangka"
+  },
+  "importRecipeForm.importRecipeButton": {
+    "defaultMessage": "Import Resipi"
+  },
+  "importRecipeForm.importRecipeTitle": {
+    "defaultMessage": "Import Resipi"
+  },
+  "importRecipeForm.importing": {
+    "defaultMessage": "Mengimport..."
+  },
+  "importRecipeForm.or": {
+    "defaultMessage": "ATAU"
+  },
+  "importRecipeForm.recipeDeeplinkLabel": {
+    "defaultMessage": "Pautan Dalam Resipi"
+  },
+  "importRecipeForm.recipeFileHint": {
+    "defaultMessage": "Muat naik fail YAML atau JSON yang mengandungi struktur resipi"
+  },
+  "importRecipeForm.recipeFileLabel": {
+    "defaultMessage": "Fail Resipi"
+  },
+  "importRecipeForm.reviewWarning": {
+    "defaultMessage": "Pastikan anda menyemak kandungan fail resipi sebelum menambahnya ke antara muka goose anda."
+  },
+  "importRecipeForm.schemaDescription": {
+    "defaultMessage": "Fail YAML atau JSON anda harus mengikut struktur ini. Medan yang diperlukan ialah: title, description, dan sama ada instructions atau prompt."
+  },
+  "inlineEditText.clickToEdit": {
+    "defaultMessage": "Klik untuk mengedit"
+  },
+  "inlineEditText.doubleClickToEdit": {
+    "defaultMessage": "Klik dua kali untuk mengedit"
+  },
+  "inlineEditText.enterText": {
+    "defaultMessage": "Masukkan teks"
+  },
+  "inlineEditText.failedToSave": {
+    "defaultMessage": "Gagal menyimpan"
+  },
+  "instructionsEditor.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "instructionsEditor.insertExample": {
+    "defaultMessage": "Sisipkan Contoh"
+  },
+  "instructionsEditor.label": {
+    "defaultMessage": "Arahan"
+  },
+  "instructionsEditor.placeholder": {
+    "defaultMessage": "Arahan terperinci untuk AI, tersembunyi daripada pengguna"
+  },
+  "instructionsEditor.save": {
+    "defaultMessage": "Simpan Arahan"
+  },
+  "instructionsEditor.syntaxHelp": {
+    "defaultMessage": "Gunakan sintaks {code} untuk menentukan parameter yang boleh diisi oleh pengguna"
+  },
+  "instructionsEditor.title": {
+    "defaultMessage": "Editor Arahan"
+  },
+  "jsonSchemaEditor.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "jsonSchemaEditor.description": {
+    "defaultMessage": "Tentukan struktur jangkaan respons AI menggunakan format JSON Schema"
+  },
+  "jsonSchemaEditor.insertExample": {
+    "defaultMessage": "Sisipkan Contoh"
+  },
+  "jsonSchemaEditor.invalidJson": {
+    "defaultMessage": "Format JSON tidak sah"
+  },
+  "jsonSchemaEditor.label": {
+    "defaultMessage": "Skema JSON Respons"
+  },
+  "jsonSchemaEditor.save": {
+    "defaultMessage": "Simpan Skema"
+  },
+  "jsonSchemaEditor.title": {
+    "defaultMessage": "Editor JSON Schema"
+  },
+  "jsonSchemaForm.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "jsonSchemaForm.fieldRequired": {
+    "defaultMessage": "Medan ini diperlukan"
+  },
+  "jsonSchemaForm.maxLength": {
+    "defaultMessage": "Panjang maksimum ialah {maxLength}"
+  },
+  "jsonSchemaForm.maxValue": {
+    "defaultMessage": "Nilai maksimum ialah {maximum}"
+  },
+  "jsonSchemaForm.minLength": {
+    "defaultMessage": "Panjang minimum ialah {minLength}"
+  },
+  "jsonSchemaForm.minValue": {
+    "defaultMessage": "Nilai minimum ialah {minimum}"
+  },
+  "jsonSchemaForm.noFields": {
+    "defaultMessage": "Tiada medan untuk dipaparkan"
+  },
+  "jsonSchemaForm.selectPlaceholder": {
+    "defaultMessage": "Pilih..."
+  },
+  "jsonSchemaForm.submit": {
+    "defaultMessage": "Hantar"
+  },
+  "keyValueEditor.addValue": {
+    "defaultMessage": "Tambah nilai prakonfigurasi"
+  },
+  "keyValueEditor.defaultKeyPlaceholder": {
+    "defaultMessage": "Nama parameter..."
+  },
+  "keyValueEditor.defaultValuePlaceholder": {
+    "defaultMessage": "Nilai parameter..."
+  },
+  "keyValueEditor.removeValue": {
+    "defaultMessage": "Buang nilai prakonfigurasi {key}"
+  },
+  "keyboardShortcuts.alwaysOnTopDescription": {
+    "defaultMessage": "Togol tetingkap sentiasa di atas"
+  },
+  "keyboardShortcuts.alwaysOnTopLabel": {
+    "defaultMessage": "Sentiasa di Atas"
+  },
+  "keyboardShortcuts.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "keyboardShortcuts.categoryApplication": {
+    "defaultMessage": "Pintasan Aplikasi"
+  },
+  "keyboardShortcuts.categoryApplicationDescription": {
+    "defaultMessage": "Pintasan ini berfungsi apabila Goose ialah aplikasi aktif"
+  },
+  "keyboardShortcuts.categoryGlobal": {
+    "defaultMessage": "Pintasan Global"
+  },
+  "keyboardShortcuts.categoryGlobalDescription": {
+    "defaultMessage": "Pintasan ini berfungsi di seluruh sistem, walaupun Goose tidak difokuskan"
+  },
+  "keyboardShortcuts.categorySearch": {
+    "defaultMessage": "Pintasan Carian"
+  },
+  "keyboardShortcuts.categorySearchDescription": {
+    "defaultMessage": "Pintasan ini berfungsi apabila mencari dalam perbualan"
+  },
+  "keyboardShortcuts.categoryWindow": {
+    "defaultMessage": "Pintasan Tetingkap"
+  },
+  "keyboardShortcuts.categoryWindowDescription": {
+    "defaultMessage": "Pintasan ini mengawal kelakuan tetingkap"
+  },
+  "keyboardShortcuts.change": {
+    "defaultMessage": "Tukar"
+  },
+  "keyboardShortcuts.disabled": {
+    "defaultMessage": "Dinyahdayakan"
+  },
+  "keyboardShortcuts.dismiss": {
+    "defaultMessage": "Ketepikan"
+  },
+  "keyboardShortcuts.findDescription": {
+    "defaultMessage": "Buka carian dalam perbualan"
+  },
+  "keyboardShortcuts.findLabel": {
+    "defaultMessage": "Cari"
+  },
+  "keyboardShortcuts.findNextDescription": {
+    "defaultMessage": "Lompat ke hasil carian seterusnya"
+  },
+  "keyboardShortcuts.findNextLabel": {
+    "defaultMessage": "Cari Seterusnya"
+  },
+  "keyboardShortcuts.findPreviousDescription": {
+    "defaultMessage": "Lompat ke hasil carian sebelumnya"
+  },
+  "keyboardShortcuts.findPreviousLabel": {
+    "defaultMessage": "Cari Sebelumnya"
+  },
+  "keyboardShortcuts.focusWindowDescription": {
+    "defaultMessage": "Bawa tetingkap Goose ke hadapan dari mana-mana sahaja"
+  },
+  "keyboardShortcuts.focusWindowLabel": {
+    "defaultMessage": "Fokus Tetingkap Goose"
+  },
+  "keyboardShortcuts.loading": {
+    "defaultMessage": "Memuatkan..."
+  },
+  "keyboardShortcuts.newChatDescription": {
+    "defaultMessage": "Cipta sembang baharu dalam tetingkap semasa"
+  },
+  "keyboardShortcuts.newChatLabel": {
+    "defaultMessage": "Sembang Baharu"
+  },
+  "keyboardShortcuts.newChatWindowDescription": {
+    "defaultMessage": "Buka tetingkap Goose baharu"
+  },
+  "keyboardShortcuts.newChatWindowLabel": {
+    "defaultMessage": "Tetingkap Sembang Baharu"
+  },
+  "keyboardShortcuts.openDirectoryDescription": {
+    "defaultMessage": "Buka dialog pemilihan direktori"
+  },
+  "keyboardShortcuts.openDirectoryLabel": {
+    "defaultMessage": "Buka Direktori"
+  },
+  "keyboardShortcuts.quickLauncherDescription": {
+    "defaultMessage": "Buka tindanan pelancar pantas"
+  },
+  "keyboardShortcuts.quickLauncherLabel": {
+    "defaultMessage": "Pelancar Pantas"
+  },
+  "keyboardShortcuts.reassignShortcut": {
+    "defaultMessage": "Tetapkan Semula Pintasan"
+  },
+  "keyboardShortcuts.resetAllShortcuts": {
+    "defaultMessage": "Set Semula Semua Pintasan"
+  },
+  "keyboardShortcuts.resetShortcutsDetail": {
+    "defaultMessage": "Ini akan memulihkan semua pintasan kepada konfigurasi asalnya."
+  },
+  "keyboardShortcuts.resetShortcutsMessage": {
+    "defaultMessage": "Set semula semua pintasan papan kekunci kepada nilai lalainya?"
+  },
+  "keyboardShortcuts.resetShortcutsTitle": {
+    "defaultMessage": "Set Semula Pintasan Papan Kekunci"
+  },
+  "keyboardShortcuts.resetToDefaultsDescription": {
+    "defaultMessage": "Pulihkan semua pintasan papan kekunci kepada konfigurasi asalnya"
+  },
+  "keyboardShortcuts.resetToDefaultsHeading": {
+    "defaultMessage": "Set Semula kepada Lalai"
+  },
+  "keyboardShortcuts.restartDescription": {
+    "defaultMessage": "Perubahan pada pintasan aplikasi (seperti Sembang Baharu, Tetapan, dll.) memerlukan Goose dimulakan semula untuk berkuat kuasa. Pintasan global (Fokus Tetingkap, Pelancar Pantas) berfungsi serta-merta."
+  },
+  "keyboardShortcuts.restartRequired": {
+    "defaultMessage": "Mula Semula Diperlukan"
+  },
+  "keyboardShortcuts.settingsDescription": {
+    "defaultMessage": "Buka panel tetapan"
+  },
+  "keyboardShortcuts.settingsLabel": {
+    "defaultMessage": "Tetapan"
+  },
+  "keyboardShortcuts.shortcutConflictSaveDetail": {
+    "defaultMessage": "Menyimpan ini akan membuang pintasan daripada \"{conflictLabel}\" dan menetapkannya kepada \"{targetLabel}\". Adakah anda mahu meneruskan?"
+  },
+  "keyboardShortcuts.shortcutConflictTitle": {
+    "defaultMessage": "Konflik Pintasan"
+  },
+  "keyboardShortcuts.shortcutConflictToggleDetail": {
+    "defaultMessage": "Mendayakan ini akan membuang pintasan daripada \"{conflictLabel}\" dan menetapkannya kepada \"{targetLabel}\". Adakah anda mahu meneruskan?"
+  },
+  "keyboardShortcuts.shortcutConflictToggleMessage": {
+    "defaultMessage": "Pintasan {shortcut} telah pun ditetapkan kepada \"{conflictLabel}\"."
+  },
+  "keyboardShortcuts.toggleNavigationDescription": {
+    "defaultMessage": "Tunjuk atau sembunyikan menu navigasi"
+  },
+  "keyboardShortcuts.toggleNavigationLabel": {
+    "defaultMessage": "Togol Navigasi"
+  },
+  "launcher.placeholder": {
+    "defaultMessage": "Tanya goose apa sahaja..."
+  },
+  "loadingGoose.compacting": {
+    "defaultMessage": "goose sedang memadatkan perbualan..."
+  },
+  "loadingGoose.idle": {
+    "defaultMessage": "goose sedang mengusahakannya…"
+  },
+  "loadingGoose.loadingConversation": {
+    "defaultMessage": "memuatkan perbualan..."
+  },
+  "loadingGoose.restartingAgent": {
+    "defaultMessage": "memulakan semula sesi..."
+  },
+  "loadingGoose.streaming": {
+    "defaultMessage": "goose sedang mengusahakannya…"
+  },
+  "loadingGoose.thinking": {
+    "defaultMessage": "goose sedang berfikir…"
+  },
+  "loadingGoose.waiting": {
+    "defaultMessage": "goose sedang menunggu…"
+  },
+  "localInferenceSettings.deleteConfirm": {
+    "defaultMessage": "Padam model ini? Anda boleh memuat turunnya semula kemudian."
+  },
+  "localInferenceSettings.description": {
+    "defaultMessage": "Muat turun dan urus model LLM tempatan untuk inferens tanpa kunci API. Cari HuggingFace untuk model GGUF atau MLX, atau gunakan pilihan utama di bawah."
+  },
+  "localInferenceSettings.dismiss": {
+    "defaultMessage": "Ketepikan"
+  },
+  "localInferenceSettings.download": {
+    "defaultMessage": "Muat turun"
+  },
+  "localInferenceSettings.downloadCancelled": {
+    "defaultMessage": "Muat turun dibatalkan"
+  },
+  "localInferenceSettings.downloadFailed": {
+    "defaultMessage": "Muat turun gagal"
+  },
+  "localInferenceSettings.downloadProgress": {
+    "defaultMessage": "{downloaded} / {total} ({percent}%)"
+  },
+  "localInferenceSettings.downloadedModels": {
+    "defaultMessage": "Model Dimuat Turun"
+  },
+  "localInferenceSettings.downloading": {
+    "defaultMessage": "Memuat turun"
+  },
+  "localInferenceSettings.featuredModels": {
+    "defaultMessage": "Model Pilihan"
+  },
+  "localInferenceSettings.huggingFaceSignInNote": {
+    "defaultMessage": "Log masuk untuk meningkatkan had kadar semasa mencari dan memuat turun model, dan untuk mengakses repositori Hugging Face peribadi atau berpagar."
+  },
+  "localInferenceSettings.modelSettings": {
+    "defaultMessage": "Tetapan Model"
+  },
+  "localInferenceSettings.modelSettingsTitle": {
+    "defaultMessage": "Tetapan model"
+  },
+  "localInferenceSettings.noModels": {
+    "defaultMessage": "Tiada model tersedia"
+  },
+  "localInferenceSettings.recommended": {
+    "defaultMessage": "Disyorkan"
+  },
+  "localInferenceSettings.remaining": {
+    "defaultMessage": "{time} berbaki"
+  },
+  "localInferenceSettings.retry": {
+    "defaultMessage": "Cuba semula"
+  },
+  "localInferenceSettings.showAllFeatured": {
+    "defaultMessage": "Tunjukkan semua pilihan ({count} lagi)"
+  },
+  "localInferenceSettings.showRecommendedOnly": {
+    "defaultMessage": "Tunjukkan yang disyorkan sahaja"
+  },
+  "localInferenceSettings.title": {
+    "defaultMessage": "Model Inferens Tempatan"
+  },
+  "localInferenceSettings.vision": {
+    "defaultMessage": "Penglihatan"
+  },
+  "localInferenceSettings.visionEncoderDownloading": {
+    "defaultMessage": "Pengekod penglihatan sedang dimuat turun…"
+  },
+  "localInferenceSettings.visionEncoderNotDownloaded": {
+    "defaultMessage": "Pengekod penglihatan belum dimuat turun"
+  },
+  "localModelManager.active": {
+    "defaultMessage": "Aktif"
+  },
+  "localModelManager.deleteConfirm": {
+    "defaultMessage": "Padam model ini? Anda boleh memuat turunnya semula kemudian."
+  },
+  "localModelManager.download": {
+    "defaultMessage": "Muat turun"
+  },
+  "localModelManager.downloaded": {
+    "defaultMessage": "Dimuat turun"
+  },
+  "localModelManager.gpuAcceleration": {
+    "defaultMessage": "Menyokong pemecutan GPU (CUDA untuk NVIDIA, Metal untuk Apple Silicon). Ciri GPU mesti didayakan pada masa pembinaan untuk pemecutan perkakasan."
+  },
+  "localModelManager.noModels": {
+    "defaultMessage": "Tiada model tersedia"
+  },
+  "localModelManager.recommended": {
+    "defaultMessage": "Disyorkan"
+  },
+  "localModelManager.recommendedForHardware": {
+    "defaultMessage": "Disyorkan untuk perkakasan anda"
+  },
+  "localModelManager.showAllModels": {
+    "defaultMessage": "Tunjukkan semua model ({count} lagi)"
+  },
+  "localModelManager.showRecommendedOnly": {
+    "defaultMessage": "Tunjukkan yang disyorkan sahaja"
+  },
+  "localModelPicker.back": {
+    "defaultMessage": "Kembali"
+  },
+  "localModelPicker.bestForMachine": {
+    "defaultMessage": "Terbaik untuk mesin anda"
+  },
+  "localModelPicker.cancelDownload": {
+    "defaultMessage": "Batalkan Muat Turun"
+  },
+  "localModelPicker.checkingModels": {
+    "defaultMessage": "Menyemak model tersedia..."
+  },
+  "localModelPicker.downloadModel": {
+    "defaultMessage": "Muat turun {modelId} ({size})"
+  },
+  "localModelPicker.downloading": {
+    "defaultMessage": "Memuat turun {modelId}"
+  },
+  "localModelPicker.failedToLoad": {
+    "defaultMessage": "Gagal memuatkan model tersedia. Sila cuba lagi."
+  },
+  "localModelPicker.failedToStartDownload": {
+    "defaultMessage": "Gagal memulakan muat turun. Sila cuba lagi."
+  },
+  "localModelPicker.hideOtherSizes": {
+    "defaultMessage": "Sembunyikan saiz lain"
+  },
+  "localModelPicker.localModelsNote": {
+    "defaultMessage": "Model tempatan menyimpan segala-galanya pada mesin anda untuk privasi penuh. Prestasi dan saiz tetingkap konteks mungkin berbeza berbanding penyedia awan bergantung pada perkakasan dan saiz model anda."
+  },
+  "localModelPicker.lostConnection": {
+    "defaultMessage": "Sambungan ke muat turun terputus. Sila cuba lagi."
+  },
+  "localModelPicker.modelNotFound": {
+    "defaultMessage": "Model tidak dijumpai"
+  },
+  "localModelPicker.ready": {
+    "defaultMessage": "Sedia"
+  },
+  "localModelPicker.selectModel": {
+    "defaultMessage": "Pilih model"
+  },
+  "localModelPicker.showOtherSizes": {
+    "defaultMessage": "Tunjukkan {count} saiz lain"
+  },
+  "localModelPicker.startingDownload": {
+    "defaultMessage": "Memulakan muat turun..."
+  },
+  "localModelPicker.tryAgain": {
+    "defaultMessage": "Cuba Lagi"
+  },
+  "localModelPicker.useModel": {
+    "defaultMessage": "Guna {modelId}"
+  },
+  "markdownContent.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "markdownContent.copyCode": {
+    "defaultMessage": "Salin kod"
+  },
+  "markdownContent.failedToOpenLink": {
+    "defaultMessage": "Gagal Membuka Pautan"
+  },
+  "markdownContent.noApplicationFound": {
+    "defaultMessage": "Tiada aplikasi dijumpai untuk membuka pautan ini."
+  },
+  "markdownContent.open": {
+    "defaultMessage": "Buka"
+  },
+  "markdownContent.openExternalLink": {
+    "defaultMessage": "Buka Pautan Luaran"
+  },
+  "markdownContent.openProtocolLink": {
+    "defaultMessage": "Buka pautan {protocol}?"
+  },
+  "markdownContent.thisWillOpen": {
+    "defaultMessage": "Ini akan membuka: {href}"
+  },
+  "mcpAppRenderer.appFallbackTitle": {
+    "defaultMessage": "Apl"
+  },
+  "mcpAppRenderer.cancelButton": {
+    "defaultMessage": "Batal"
+  },
+  "mcpAppRenderer.close": {
+    "defaultMessage": "Tutup"
+  },
+  "mcpAppRenderer.exitFullscreen": {
+    "defaultMessage": "Keluar skrin penuh"
+  },
+  "mcpAppRenderer.exitFullscreenTitle": {
+    "defaultMessage": "Keluar skrin penuh (Esc)"
+  },
+  "mcpAppRenderer.failedToInitSandbox": {
+    "defaultMessage": "Gagal memulakan proksi kotak pasir"
+  },
+  "mcpAppRenderer.failedToLoadResource": {
+    "defaultMessage": "Gagal memuatkan sumber"
+  },
+  "mcpAppRenderer.fullscreen": {
+    "defaultMessage": "Skrin penuh"
+  },
+  "mcpAppRenderer.invalidUrl": {
+    "defaultMessage": "URL tidak sah"
+  },
+  "mcpAppRenderer.movePipWindow": {
+    "defaultMessage": "Alihkan tetingkap Gambar-dalam-Gambar (gunakan kekunci anak panah)"
+  },
+  "mcpAppRenderer.openButton": {
+    "defaultMessage": "Buka"
+  },
+  "mcpAppRenderer.openExternalLinkTitle": {
+    "defaultMessage": "Buka Pautan Luaran"
+  },
+  "mcpAppRenderer.openLinkDetail": {
+    "defaultMessage": "Ini akan membuka: {url}"
+  },
+  "mcpAppRenderer.openProtocolLink": {
+    "defaultMessage": "Buka pautan {protocol}?"
+  },
+  "mcpAppRenderer.pictureInPicture": {
+    "defaultMessage": "Gambar-dalam-Gambar"
+  },
+  "mcpAppRenderer.playingInPip": {
+    "defaultMessage": "Bermain dalam Gambar-dalam-Gambar"
+  },
+  "mcpUIResourceRenderer.cancelButton": {
+    "defaultMessage": "Batal"
+  },
+  "mcpUIResourceRenderer.openButton": {
+    "defaultMessage": "Buka"
+  },
+  "mcpUIResourceRenderer.openExternalLinkTitle": {
+    "defaultMessage": "Buka Pautan Luaran"
+  },
+  "mcpUIResourceRenderer.openLinkDetail": {
+    "defaultMessage": "Ini akan membuka: {url}"
+  },
+  "mcpUIResourceRenderer.openProtocolLink": {
+    "defaultMessage": "Buka pautan {protocol}?"
+  },
+  "mcpUIResourceRenderer.toastMessageReceived": {
+    "defaultMessage": "Mesej diterima untuk {message}."
+  },
+  "mcpUIResourceRenderer.toastTitle": {
+    "defaultMessage": "Mesej MCP-UI {messageType}"
+  },
+  "mcpUIResourceRenderer.toastUnsupported": {
+    "defaultMessage": "Mesej diterima untuk {message}. Mesej {messageType} belum disokong lagi, rujuk konsol untuk butiran lanjut."
+  },
+  "mentionPopover.itemsFound": {
+    "defaultMessage": "{count,plural,one{# item dijumpai} other{# item dijumpai}}"
+  },
+  "mentionPopover.loadingCommands": {
+    "defaultMessage": "Memuatkan arahan..."
+  },
+  "mentionPopover.noCommandsFound": {
+    "defaultMessage": "Tiada arahan ditemui yang sepadan dengan \"{query}\""
+  },
+  "mentionPopover.noItemsFound": {
+    "defaultMessage": "Tiada item ditemui yang sepadan dengan \"{query}\""
+  },
+  "mentionPopover.scanningFiles": {
+    "defaultMessage": "Mengimbas fail..."
+  },
+  "messageCopyLink.copied": {
+    "defaultMessage": "Disalin!"
+  },
+  "messageCopyLink.copy": {
+    "defaultMessage": "Salin"
+  },
+  "messageQueue.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "messageQueue.cannotSendWhileEditing": {
+    "defaultMessage": "Tidak boleh hantar semasa menyunting"
+  },
+  "messageQueue.clearAll": {
+    "defaultMessage": "Kosongkan Semua"
+  },
+  "messageQueue.clickToEdit": {
+    "defaultMessage": "{content} (Klik untuk menyunting)"
+  },
+  "messageQueue.collapseQueue": {
+    "defaultMessage": "Runtuhkan baris gilir"
+  },
+  "messageQueue.dragToReorder": {
+    "defaultMessage": "Seret mesej untuk menyusun semula keutamaan"
+  },
+  "messageQueue.expandQueue": {
+    "defaultMessage": "Kembangkan baris gilir"
+  },
+  "messageQueue.messageCount": {
+    "defaultMessage": "{count,plural,one{# mesej {status}} other{# mesej {status}}}"
+  },
+  "messageQueue.messageQueue": {
+    "defaultMessage": "Baris Gilir Mesej"
+  },
+  "messageQueue.next": {
+    "defaultMessage": "Seterusnya"
+  },
+  "messageQueue.paused": {
+    "defaultMessage": "Dijeda"
+  },
+  "messageQueue.queuePaused": {
+    "defaultMessage": "Baris Gilir Dijeda"
+  },
+  "messageQueue.queuePausedCompact": {
+    "defaultMessage": "Baris gilir dijeda - klik \"Hantar\" atau tambah mesej baharu untuk menyambung semula"
+  },
+  "messageQueue.queuePausedExpanded": {
+    "defaultMessage": "Baris gilir dijeda oleh gangguan. Gunakan \"Hantar Sekarang\" atau tambah mesej baharu untuk menyambung semula."
+  },
+  "messageQueue.queued": {
+    "defaultMessage": "dalam baris gilir"
+  },
+  "messageQueue.removeFromQueue": {
+    "defaultMessage": "Buang mesej ini daripada baris gilir"
+  },
+  "messageQueue.save": {
+    "defaultMessage": "Simpan"
+  },
+  "messageQueue.sendNow": {
+    "defaultMessage": "Hantar mesej ini sekarang"
+  },
+  "messageQueue.stopAndSend": {
+    "defaultMessage": "Hentikan pemprosesan semasa dan hantar mesej ini sekarang"
+  },
+  "messageQueue.waiting": {
+    "defaultMessage": "menunggu"
+  },
+  "microphoneSelector.chooseDescription": {
+    "defaultMessage": "Pilih mikrofon yang hendak digunakan untuk imlak"
+  },
+  "microphoneSelector.grantAccess": {
+    "defaultMessage": "Berikan Akses"
+  },
+  "microphoneSelector.grantAccessDescription": {
+    "defaultMessage": "Berikan akses untuk melihat mikrofon tersedia"
+  },
+  "microphoneSelector.microphone": {
+    "defaultMessage": "Mikrofon"
+  },
+  "microphoneSelector.microphoneLabel": {
+    "defaultMessage": "Mikrofon {index}"
+  },
+  "microphoneSelector.selectedMicrophone": {
+    "defaultMessage": "Mikrofon Dipilih"
+  },
+  "microphoneSelector.speakToTest": {
+    "defaultMessage": "Bercakap untuk menguji mikrofon anda ({seconds}s)"
+  },
+  "microphoneSelector.stop": {
+    "defaultMessage": "Berhenti"
+  },
+  "microphoneSelector.systemDefault": {
+    "defaultMessage": "Lalai Sistem"
+  },
+  "microphoneSelector.test": {
+    "defaultMessage": "Uji"
+  },
+  "modeSelectionItem.autonomousDescription": {
+    "defaultMessage": "Keupayaan pengubahsuaian fail penuh, sunting, cipta dan padam fail secara bebas."
+  },
+  "modeSelectionItem.autonomousLabel": {
+    "defaultMessage": "Autonomi"
+  },
+  "modeSelectionItem.chatOnlyDescription": {
+    "defaultMessage": "Berinteraksi dengan penyedia yang dipilih tanpa menggunakan alat atau sambungan."
+  },
+  "modeSelectionItem.chatOnlyLabel": {
+    "defaultMessage": "Sembang sahaja"
+  },
+  "modeSelectionItem.manualDescription": {
+    "defaultMessage": "Semua alat, sambungan dan pengubahsuaian fail akan memerlukan kelulusan manusia"
+  },
+  "modeSelectionItem.manualLabel": {
+    "defaultMessage": "Manual"
+  },
+  "modeSelectionItem.smartDescription": {
+    "defaultMessage": "Tentukan secara bijak tindakan yang memerlukan kelulusan berdasarkan tahap risiko"
+  },
+  "modeSelectionItem.smartLabel": {
+    "defaultMessage": "Pintar"
+  },
+  "modelAndProviderContext.modelChangeFailed": {
+    "defaultMessage": "{provider}/{model} gagal"
+  },
+  "modelAndProviderContext.modelChangedTitle": {
+    "defaultMessage": "Model ditukar"
+  },
+  "modelAndProviderContext.selectModel": {
+    "defaultMessage": "Pilih Model"
+  },
+  "modelAndProviderContext.switchModelSuccess": {
+    "defaultMessage": "Berjaya menukar model -- menggunakan {model} daripada {provider}"
+  },
+  "modelAndProviderContext.unknownProviderMsg": {
+    "defaultMessage": "Penyedia tidak diketahui dalam konfigurasi -- sila periksa config.yaml anda"
+  },
+  "modelAndProviderContext.unknownProviderTitle": {
+    "defaultMessage": "Carian nama penyedia"
+  },
+  "modelSettingsButtons.configureProviders": {
+    "defaultMessage": "Konfigurasikan penyedia"
+  },
+  "modelSettingsButtons.switchModels": {
+    "defaultMessage": "Tukar model"
+  },
+  "modelSettingsPanel.batchSize": {
+    "defaultMessage": "Saiz kelompok"
+  },
+  "modelSettingsPanel.batchSizeDescription": {
+    "defaultMessage": "Kelompok pemprosesan gesaan"
+  },
+  "modelSettingsPanel.builtinChatTemplate": {
+    "defaultMessage": "Templat terbina dalam"
+  },
+  "modelSettingsPanel.builtinChatTemplateDescription": {
+    "defaultMessage": "Pilih nama templat terbina dalam llama.cpp"
+  },
+  "modelSettingsPanel.chatTemplate": {
+    "defaultMessage": "Templat sembang"
+  },
+  "modelSettingsPanel.chatTemplateBuiltin": {
+    "defaultMessage": "Terbina dalam"
+  },
+  "modelSettingsPanel.chatTemplateCustomInline": {
+    "defaultMessage": "Sebaris tersuai"
+  },
+  "modelSettingsPanel.chatTemplateDescription": {
+    "defaultMessage": "Gunakan metadata GGUF terbenam, templat terbina dalam llama.cpp, atau Jinja sebaris"
+  },
+  "modelSettingsPanel.chatTemplateEmbedded": {
+    "defaultMessage": "Terbenam"
+  },
+  "modelSettingsPanel.contextAndGeneration": {
+    "defaultMessage": "Konteks & Penjanaan"
+  },
+  "modelSettingsPanel.contextSize": {
+    "defaultMessage": "Saiz konteks"
+  },
+  "modelSettingsPanel.contextSizeDescription": {
+    "defaultMessage": "Tetingkap konteks maksimum (0 = lalai model)"
+  },
+  "modelSettingsPanel.customChatTemplate": {
+    "defaultMessage": "Templat sembang tersuai"
+  },
+  "modelSettingsPanel.customChatTemplateDescription": {
+    "defaultMessage": "Tampal sumber templat sembang Jinja penuh"
+  },
+  "modelSettingsPanel.etaLearningRate": {
+    "defaultMessage": "Eta (kadar pembelajaran)"
+  },
+  "modelSettingsPanel.flashAttention": {
+    "defaultMessage": "Flash attention"
+  },
+  "modelSettingsPanel.flashAttentionDescription": {
+    "defaultMessage": "Dayakan pengoptimuman flash attention"
+  },
+  "modelSettingsPanel.frequencyPenalty": {
+    "defaultMessage": "Penalti frekuensi"
+  },
+  "modelSettingsPanel.frequencyPenaltyDescription": {
+    "defaultMessage": "0.0 = mati"
+  },
+  "modelSettingsPanel.gpuLayers": {
+    "defaultMessage": "Lapisan GPU"
+  },
+  "modelSettingsPanel.gpuLayersDescription": {
+    "defaultMessage": "Lapisan untuk dipunggah ke GPU"
+  },
+  "modelSettingsPanel.loadingSettings": {
+    "defaultMessage": "Memuatkan tetapan..."
+  },
+  "modelSettingsPanel.lockModelInRam": {
+    "defaultMessage": "Kunci model dalam RAM (mlock)"
+  },
+  "modelSettingsPanel.lockModelInRamDescription": {
+    "defaultMessage": "Halang model daripada ditukar ke cakera"
+  },
+  "modelSettingsPanel.maxOutputTokens": {
+    "defaultMessage": "Token output maksimum"
+  },
+  "modelSettingsPanel.maxOutputTokensDescription": {
+    "defaultMessage": "Had pada token yang dijana"
+  },
+  "modelSettingsPanel.minP": {
+    "defaultMessage": "Min P"
+  },
+  "modelSettingsPanel.performance": {
+    "defaultMessage": "Prestasi"
+  },
+  "modelSettingsPanel.presencePenalty": {
+    "defaultMessage": "Penalti kehadiran"
+  },
+  "modelSettingsPanel.presencePenaltyDescription": {
+    "defaultMessage": "0.0 = mati"
+  },
+  "modelSettingsPanel.repeatPenalty": {
+    "defaultMessage": "Penalti ulangan"
+  },
+  "modelSettingsPanel.repeatPenaltyDescription": {
+    "defaultMessage": "1.0 = mati"
+  },
+  "modelSettingsPanel.repeatWindow": {
+    "defaultMessage": "Tetingkap ulangan"
+  },
+  "modelSettingsPanel.repeatWindowDescription": {
+    "defaultMessage": "Token untuk dilihat semula"
+  },
+  "modelSettingsPanel.repetitionPenalty": {
+    "defaultMessage": "Penalti Pengulangan"
+  },
+  "modelSettingsPanel.reset": {
+    "defaultMessage": "Set semula"
+  },
+  "modelSettingsPanel.resetToDefaults": {
+    "defaultMessage": "Set semula kepada lalai"
+  },
+  "modelSettingsPanel.samplingStrategy": {
+    "defaultMessage": "Strategi Pensampelan"
+  },
+  "modelSettingsPanel.saving": {
+    "defaultMessage": "Menyimpan..."
+  },
+  "modelSettingsPanel.seed": {
+    "defaultMessage": "Benih"
+  },
+  "modelSettingsPanel.tauTargetEntropy": {
+    "defaultMessage": "Tau (entropi sasaran)"
+  },
+  "modelSettingsPanel.temperature": {
+    "defaultMessage": "Suhu"
+  },
+  "modelSettingsPanel.threads": {
+    "defaultMessage": "Bebenang"
+  },
+  "modelSettingsPanel.threadsDescription": {
+    "defaultMessage": "Bebenang CPU untuk penjanaan"
+  },
+  "modelSettingsPanel.toolCalling": {
+    "defaultMessage": "Pemanggilan alat"
+  },
+  "modelSettingsPanel.toolCallingAuto": {
+    "defaultMessage": "Auto"
+  },
+  "modelSettingsPanel.toolCallingDescription": {
+    "defaultMessage": "Pilih cara model tempatan memilih pemanggilan alat asli atau ditiru"
+  },
+  "modelSettingsPanel.toolCallingForceEmulated": {
+    "defaultMessage": "Paksa ditiru"
+  },
+  "modelSettingsPanel.toolCallingForceNative": {
+    "defaultMessage": "Paksa asli"
+  },
+  "modelSettingsPanel.topK": {
+    "defaultMessage": "Top K"
+  },
+  "modelSettingsPanel.topP": {
+    "defaultMessage": "Top P"
+  },
+  "modelsBottomBar.changeModel": {
+    "defaultMessage": "Tukar Model"
+  },
+  "modelsBottomBar.currentModel": {
+    "defaultMessage": "Model semasa"
+  },
+  "modelsBottomBar.loadingModel": {
+    "defaultMessage": "Memuatkan model..."
+  },
+  "modelsBottomBar.localModelSettings": {
+    "defaultMessage": "Tetapan Model Tempatan"
+  },
+  "modelsBottomBar.localModelSettingsTitle": {
+    "defaultMessage": "Tetapan Model Tempatan — {modelName}"
+  },
+  "modelsBottomBar.resolvedModel": {
+    "defaultMessage": "Model diselesaikan"
+  },
+  "modelsBottomBar.selectModel": {
+    "defaultMessage": "Pilih Model"
+  },
+  "modelsSection.resetDescription": {
+    "defaultMessage": "Kosongkan tetapan model dan penyedia yang anda pilih untuk bermula semula"
+  },
+  "modelsSection.resetTitle": {
+    "defaultMessage": "Set Semula Penyedia dan Model"
+  },
+  "navigation.itemApps": {
+    "defaultMessage": "Apl"
+  },
+  "navigation.itemExtensions": {
+    "defaultMessage": "Sambungan"
+  },
+  "navigation.itemHome": {
+    "defaultMessage": "Sembang Baharu"
+  },
+  "navigation.itemRecipes": {
+    "defaultMessage": "Resipi"
+  },
+  "navigation.itemScheduler": {
+    "defaultMessage": "Penjadual"
+  },
+  "navigation.itemSessions": {
+    "defaultMessage": "Sejarah Sesi"
+  },
+  "navigation.itemSettings": {
+    "defaultMessage": "Tetapan"
+  },
+  "navigation.itemSkills": {
+    "defaultMessage": "Kemahiran"
+  },
+  "navigationPanel.chats": {
+    "defaultMessage": "Sembang"
+  },
+  "navigationPanel.noChats": {
+    "defaultMessage": "Tiada sembang terkini"
+  },
+  "navigationPanel.untitledSession": {
+    "defaultMessage": "Sesi tanpa tajuk"
+  },
+  "onboardingGuard.checkProviderErrorDescription": {
+    "defaultMessage": "Pelayan mungkin sedang dimulakan atau tidak tersedia buat sementara waktu."
+  },
+  "onboardingGuard.checkProviderErrorTitle": {
+    "defaultMessage": "Tidak dapat menyambung ke pelayan Goose"
+  },
+  "onboardingGuard.retry": {
+    "defaultMessage": "Cuba Semula"
+  },
+  "onboardingGuard.welcomeDescription": {
+    "defaultMessage": "Ejen AI tempatan anda. Sambungkan penyedia model AI untuk bermula."
+  },
+  "onboardingGuard.welcomeTitle": {
+    "defaultMessage": "Selamat datang ke goose"
+  },
+  "onboardingSuccess.allSet": {
+    "defaultMessage": "Anda sudah bersedia untuk mula menggunakan goose."
+  },
+  "onboardingSuccess.connectedTo": {
+    "defaultMessage": "Disambungkan ke {providerName}"
+  },
+  "onboardingSuccess.getStarted": {
+    "defaultMessage": "Mulakan"
+  },
+  "onboardingSuccess.learnMore": {
+    "defaultMessage": "Ketahui lebih lanjut"
+  },
+  "onboardingSuccess.localModelReady": {
+    "defaultMessage": "Model setempat sedia"
+  },
+  "onboardingSuccess.privacyDescription": {
+    "defaultMessage": "Data penggunaan tanpa nama membantu menambah baik goose. Kami tidak sekali-kali mengumpul perbualan, kod atau data peribadi anda."
+  },
+  "onboardingSuccess.privacyTitle": {
+    "defaultMessage": "Privasi"
+  },
+  "onboardingSuccess.shareUsageData": {
+    "defaultMessage": "Kongsi data penggunaan tanpa nama"
+  },
+  "parameterInput.defaultValue": {
+    "defaultMessage": "Nilai Lalai"
+  },
+  "parameterInput.defaultValuePlaceholder": {
+    "defaultMessage": "Masukkan nilai lalai"
+  },
+  "parameterInput.deleteParameter": {
+    "defaultMessage": "Padam parameter: {key}"
+  },
+  "parameterInput.description": {
+    "defaultMessage": "perihalan"
+  },
+  "parameterInput.descriptionHelp": {
+    "defaultMessage": "Ini ialah mesej yang akan dilihat oleh pengguna akhir."
+  },
+  "parameterInput.descriptionPlaceholder": {
+    "defaultMessage": "Cth., \"Masukkan nama untuk komponen baharu\""
+  },
+  "parameterInput.inputType": {
+    "defaultMessage": "Jenis Input"
+  },
+  "parameterInput.optional": {
+    "defaultMessage": "Pilihan"
+  },
+  "parameterInput.optionsHelp": {
+    "defaultMessage": "Masukkan setiap pilihan pada baris baharu. Ini akan dipaparkan sebagai pilihan menu juntai bawah."
+  },
+  "parameterInput.optionsLabel": {
+    "defaultMessage": "Pilihan (satu setiap baris)"
+  },
+  "parameterInput.optionsPlaceholder": {
+    "defaultMessage": "Pilihan 1 Pilihan 2 Pilihan 3"
+  },
+  "parameterInput.required": {
+    "defaultMessage": "Diperlukan"
+  },
+  "parameterInput.requirement": {
+    "defaultMessage": "Keperluan"
+  },
+  "parameterInput.typeBoolean": {
+    "defaultMessage": "Boolean"
+  },
+  "parameterInput.typeNumber": {
+    "defaultMessage": "Nombor"
+  },
+  "parameterInput.typeSelect": {
+    "defaultMessage": "Pilih"
+  },
+  "parameterInput.typeString": {
+    "defaultMessage": "Rentetan"
+  },
+  "parameterInput.unused": {
+    "defaultMessage": "Tidak digunakan"
+  },
+  "parameterInput.unusedWarningTitle": {
+    "defaultMessage": "Parameter ini tidak digunakan dalam arahan atau gesaan. Ia akan tersedia untuk input manual tetapi mungkin tidak diperlukan."
+  },
+  "parameterInputModal.backToForm": {
+    "defaultMessage": "Kembali ke Borang Parameter"
+  },
+  "parameterInputModal.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "parameterInputModal.cancelRecipeSetup": {
+    "defaultMessage": "Batalkan Persediaan Resipi"
+  },
+  "parameterInputModal.enterValue": {
+    "defaultMessage": "Masukkan nilai untuk {key}..."
+  },
+  "parameterInputModal.false": {
+    "defaultMessage": "Salah"
+  },
+  "parameterInputModal.recipeParameters": {
+    "defaultMessage": "Parameter Resipi"
+  },
+  "parameterInputModal.select": {
+    "defaultMessage": "Pilih..."
+  },
+  "parameterInputModal.selectOption": {
+    "defaultMessage": "Pilih satu pilihan..."
+  },
+  "parameterInputModal.startNewChat": {
+    "defaultMessage": "Mulakan Sembang Baharu (Tiada Resipi)"
+  },
+  "parameterInputModal.startRecipe": {
+    "defaultMessage": "Mulakan Resipi"
+  },
+  "parameterInputModal.true": {
+    "defaultMessage": "Benar"
+  },
+  "parameterInputModal.whatToDo": {
+    "defaultMessage": "Apakah yang anda ingin lakukan?"
+  },
+  "permissionModal.alwaysAllow": {
+    "defaultMessage": "Sentiasa benarkan"
+  },
+  "permissionModal.askBefore": {
+    "defaultMessage": "Tanya dahulu"
+  },
+  "permissionModal.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "permissionModal.close": {
+    "defaultMessage": "Tutup"
+  },
+  "permissionModal.failedToLoadTools": {
+    "defaultMessage": "Gagal memuatkan alat"
+  },
+  "permissionModal.failedToLoadToolsDescription": {
+    "defaultMessage": "Tidak dapat memuatkan alat untuk sambungan ini. Sambungan mungkin tidak dimuatkan dalam sesi semasa."
+  },
+  "permissionModal.neverAllow": {
+    "defaultMessage": "Jangan sekali-kali benarkan"
+  },
+  "permissionModal.noActiveSession": {
+    "defaultMessage": "Tiada sesi aktif"
+  },
+  "permissionModal.noActiveSessionDescription": {
+    "defaultMessage": "Mulakan sesi sembang dahulu untuk mengkonfigurasi kebenaran alat bagi sambungan ini. Kebenaran alat dimuatkan daripada sambungan sesi aktif."
+  },
+  "permissionModal.noToolsAvailable": {
+    "defaultMessage": "Tiada alat tersedia untuk sambungan ini."
+  },
+  "permissionModal.saveChanges": {
+    "defaultMessage": "Simpan Perubahan"
+  },
+  "permissionRulesModal.description": {
+    "defaultMessage": "Konfigurasikan kebenaran alat untuk sambungan bagi mengawal cara ia berinteraksi dengan sistem anda."
+  },
+  "permissionRulesModal.extensionRules": {
+    "defaultMessage": "Peraturan sambungan"
+  },
+  "permissionRulesModal.title": {
+    "defaultMessage": "Peraturan Kebenaran"
+  },
+  "permissionSetting.extensionRules": {
+    "defaultMessage": "Peraturan sambungan"
+  },
+  "permissionSetting.permissionRules": {
+    "defaultMessage": "Peraturan Kebenaran"
+  },
+  "permissionSetting.permissionRulesDescription": {
+    "defaultMessage": "Arahan tersembunyi yang akan dihantar kepada penyedia untuk membantu mengarah dan menambah konteks pada respons anda."
+  },
+  "privacyInfoModal.collectErrors": {
+    "defaultMessage": "Jenis ralat (cth., \"rate_limit\", \"auth\" - tanpa butiran)"
+  },
+  "privacyInfoModal.collectExtensions": {
+    "defaultMessage": "Sambungan dan kiraan penggunaan alat (nama sahaja)"
+  },
+  "privacyInfoModal.collectOs": {
+    "defaultMessage": "Sistem pengendalian, versi dan seni bina"
+  },
+  "privacyInfoModal.collectProvider": {
+    "defaultMessage": "Penyedia dan model yang digunakan"
+  },
+  "privacyInfoModal.collectSession": {
+    "defaultMessage": "Metrik sesi (tempoh, kiraan interaksi, penggunaan token)"
+  },
+  "privacyInfoModal.collectVersion": {
+    "defaultMessage": "Versi goose dan kaedah pemasangan"
+  },
+  "privacyInfoModal.description": {
+    "defaultMessage": "Data penggunaan tanpa nama membantu kami memahami cara goose digunakan dan mengenal pasti bidang untuk penambahbaikan."
+  },
+  "privacyInfoModal.neverCollect": {
+    "defaultMessage": "Kami tidak sekali-kali mengumpul perbualan, kod, argumen alat, mesej ralat atau sebarang data peribadi anda. Anda boleh menukar tetapan ini pada bila-bila masa dalam Tetapan."
+  },
+  "privacyInfoModal.title": {
+    "defaultMessage": "Butiran privasi"
+  },
+  "privacyInfoModal.whatWeCollect": {
+    "defaultMessage": "Apa yang kami kumpul:"
+  },
+  "progressiveMessageList.loadingMessages": {
+    "defaultMessage": "Memuatkan mesej... ({renderedCount}/{totalCount})"
+  },
+  "progressiveMessageList.modelChanged": {
+    "defaultMessage": "Model ditukar: {previousModel} → {currentModel}"
+  },
+  "progressiveMessageList.searchHint": {
+    "defaultMessage": "Tekan Cmd/Ctrl+F untuk memuatkan semua mesej dengan serta-merta untuk carian"
+  },
+  "promptsSettings.allPromptsReset": {
+    "defaultMessage": "Semua gesaan ditetapkan semula kepada lalai"
+  },
+  "promptsSettings.backToList": {
+    "defaultMessage": "Kembali ke Senarai"
+  },
+  "promptsSettings.confirmReplaceWithDefault": {
+    "defaultMessage": "Gantikan kandungan semasa dengan lalai? Perubahan anda akan hilang."
+  },
+  "promptsSettings.confirmResetAll": {
+    "defaultMessage": "Adakah anda pasti mahu menetapkan semula semua gesaan kepada lalainya? Tindakan ini tidak boleh dibuat asal."
+  },
+  "promptsSettings.confirmResetOne": {
+    "defaultMessage": "Adakah anda pasti mahu menetapkan semula gesaan ini kepada lalainya? Tindakan ini tidak boleh dibuat asal."
+  },
+  "promptsSettings.confirmUnsavedBack": {
+    "defaultMessage": "Anda mempunyai perubahan yang belum disimpan. Adakah anda pasti mahu kembali?"
+  },
+  "promptsSettings.customized": {
+    "defaultMessage": "Disesuaikan"
+  },
+  "promptsSettings.edit": {
+    "defaultMessage": "Edit"
+  },
+  "promptsSettings.editPromptTitle": {
+    "defaultMessage": "Edit: {name}"
+  },
+  "promptsSettings.editingLabel": {
+    "defaultMessage": "Mengedit: {name}"
+  },
+  "promptsSettings.enterPromptContent": {
+    "defaultMessage": "Masukkan kandungan gesaan..."
+  },
+  "promptsSettings.failedToLoadPrompt": {
+    "defaultMessage": "Gagal memuatkan gesaan"
+  },
+  "promptsSettings.failedToLoadPrompts": {
+    "defaultMessage": "Gagal memuatkan gesaan"
+  },
+  "promptsSettings.failedToResetPrompt": {
+    "defaultMessage": "Gagal menetapkan semula gesaan"
+  },
+  "promptsSettings.failedToResetPrompts": {
+    "defaultMessage": "Gagal menetapkan semula gesaan"
+  },
+  "promptsSettings.failedToSavePrompt": {
+    "defaultMessage": "Gagal menyimpan gesaan"
+  },
+  "promptsSettings.promptEditingDescription": {
+    "defaultMessage": "Sesuaikan gesaan yang mentakrifkan tingkah laku goose dalam konteks yang berbeza. Gesaan ini menggunakan sintaks templat Jinja2. Berhati-hati semasa mengubah suai pemboleh ubah templat, kerana perubahan yang salah boleh merosakkan fungsi. Sila kongsikan sebarang penambahbaikan dengan komuniti."
+  },
+  "promptsSettings.promptEditingTitle": {
+    "defaultMessage": "Pengeditan Gesaan"
+  },
+  "promptsSettings.promptResetToDefault": {
+    "defaultMessage": "Gesaan ditetapkan semula kepada lalai"
+  },
+  "promptsSettings.promptSaved": {
+    "defaultMessage": "Gesaan disimpan"
+  },
+  "promptsSettings.resetAll": {
+    "defaultMessage": "Tetapkan Semula Semua"
+  },
+  "promptsSettings.resetToDefault": {
+    "defaultMessage": "Tetapkan Semula kepada Lalai"
+  },
+  "promptsSettings.restoreDefault": {
+    "defaultMessage": "Pulihkan Lalai"
+  },
+  "promptsSettings.save": {
+    "defaultMessage": "Simpan"
+  },
+  "promptsSettings.templateTip": {
+    "defaultMessage": "Pemboleh ubah templat seperti {extensionsExample} atau {forExample} digantikan dengan nilai sebenar pada masa jalan. Berhati-hati supaya tidak membuang pemboleh ubah yang diperlukan."
+  },
+  "promptsSettings.unsavedChanges": {
+    "defaultMessage": "Anda mempunyai perubahan yang belum disimpan"
+  },
+  "providerCard.noMetadata": {
+    "defaultMessage": "Ralat ProviderCard: Tiada metadata disediakan"
+  },
+  "providerCard.unknownProvider": {
+    "defaultMessage": "Penyedia Tidak Diketahui"
+  },
+  "providerCatalogPicker.anthropicCompatible": {
+    "defaultMessage": "Serasi Anthropic"
+  },
+  "providerCatalogPicker.apiFormat": {
+    "defaultMessage": "Format API"
+  },
+  "providerCatalogPicker.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "providerCatalogPicker.chooseProvider": {
+    "defaultMessage": "Pilih Penyedia"
+  },
+  "providerCatalogPicker.errorPrefix": {
+    "defaultMessage": "Ralat: {error}"
+  },
+  "providerCatalogPicker.loadingProviders": {
+    "defaultMessage": "Memuatkan penyedia..."
+  },
+  "providerCatalogPicker.modelsAvailable": {
+    "defaultMessage": "{count} model tersedia"
+  },
+  "providerCatalogPicker.noProvidersAvailable": {
+    "defaultMessage": "Tiada penyedia tersedia"
+  },
+  "providerCatalogPicker.noProvidersFound": {
+    "defaultMessage": "Tiada penyedia ditemui untuk \"{query}\""
+  },
+  "providerCatalogPicker.openaiCompatible": {
+    "defaultMessage": "Serasi OpenAI"
+  },
+  "providerCatalogPicker.requiresEnvVar": {
+    "defaultMessage": "• Memerlukan {envVar}"
+  },
+  "providerCatalogPicker.searchProviders": {
+    "defaultMessage": "Cari penyedia..."
+  },
+  "providerCatalogPicker.selectFormatDescription": {
+    "defaultMessage": "Pilih format API dan penyedia. Kami akan mengisi konfigurasi secara automatik untuk anda."
+  },
+  "providerConfigForm.browserWindowOpen": {
+    "defaultMessage": "Tetingkap pelayar akan dibuka untuk anda melengkapkan log masuk."
+  },
+  "providerConfigForm.configuring": {
+    "defaultMessage": "Mengkonfigurasi..."
+  },
+  "providerConfigForm.continue": {
+    "defaultMessage": "Teruskan"
+  },
+  "providerConfigForm.deviceCodeFlowHint": {
+    "defaultMessage": "Tetingkap pelayar akan dibuka dan kod pengesahan akan disalin ke papan keratan anda. Tampalkannya dalam pelayar untuk melengkapkan log masuk."
+  },
+  "providerConfigForm.noApiKey": {
+    "defaultMessage": "Tidak mempunyai kunci API?"
+  },
+  "providerConfigForm.signInWith": {
+    "defaultMessage": "Log masuk dengan {providerName}"
+  },
+  "providerConfigForm.signingIn": {
+    "defaultMessage": "Sedang log masuk..."
+  },
+  "providerConfigurationModal.addApiKeyDescription": {
+    "defaultMessage": "Tambah kunci API anda untuk penyedia ini bagi disepadukan ke dalam goose"
+  },
+  "providerConfigurationModal.browserWindowHint": {
+    "defaultMessage": "Tetingkap pelayar akan dibuka untuk anda melengkapkan log masuk."
+  },
+  "providerConfigurationModal.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "providerConfigurationModal.cannotDeleteActive": {
+    "defaultMessage": "Anda tidak boleh memadamkan penyedia ini semasa ia sedang digunakan. Sila tukar ke model lain terlebih dahulu."
+  },
+  "providerConfigurationModal.checkConfigAgain": {
+    "defaultMessage": "Semak semula konfigurasi anda untuk menggunakan penyedia ini."
+  },
+  "providerConfigurationModal.close": {
+    "defaultMessage": "Tutup"
+  },
+  "providerConfigurationModal.configureHeader": {
+    "defaultMessage": "Konfigurasikan {providerName}"
+  },
+  "providerConfigurationModal.deleteConfigHeader": {
+    "defaultMessage": "Padam konfigurasi untuk {providerName}"
+  },
+  "providerConfigurationModal.deleteConfirmation": {
+    "defaultMessage": "Ini akan memadamkan konfigurasi penyedia semasa secara kekal."
+  },
+  "providerConfigurationModal.deviceCodeFlowHint": {
+    "defaultMessage": "Tetingkap pelayar akan dibuka dan kod pengesahan akan disalin ke papan keratan anda. Tampalkannya dalam pelayar untuk melengkapkan log masuk."
+  },
+  "providerConfigurationModal.errorCheckingConfig": {
+    "defaultMessage": "Terdapat ralat semasa menyemak konfigurasi penyedia ini."
+  },
+  "providerConfigurationModal.errorTitle": {
+    "defaultMessage": "Ralat"
+  },
+  "providerConfigurationModal.externalSetupIntro": {
+    "defaultMessage": "Penyedia ini dikonfigurasikan di luar goose. Ikuti langkah-langkah ini:"
+  },
+  "providerConfigurationModal.goBack": {
+    "defaultMessage": "Kembali"
+  },
+  "providerConfigurationModal.huggingFaceOAuthDescription": {
+    "defaultMessage": "Log masuk untuk menggunakan Hugging Face Inference Providers tanpa memasukkan token API secara manual."
+  },
+  "providerConfigurationModal.oauthLoginFailed": {
+    "defaultMessage": "Log masuk OAuth gagal: {error}"
+  },
+  "providerConfigurationModal.oauthSignInDescription": {
+    "defaultMessage": "Log masuk dengan akaun {providerName} anda untuk menggunakan penyedia ini"
+  },
+  "providerConfigurationModal.parameterRequired": {
+    "defaultMessage": "{paramName} diperlukan"
+  },
+  "providerConfigurationModal.removeConfiguration": {
+    "defaultMessage": "Alih Keluar Konfigurasi"
+  },
+  "providerConfigurationModal.seeDocumentation": {
+    "defaultMessage": "Lihat <link>dokumentasi</link> untuk maklumat lanjut."
+  },
+  "providerConfigurationModal.signInWith": {
+    "defaultMessage": "Log masuk dengan {providerName}"
+  },
+  "providerConfigurationModal.signingIn": {
+    "defaultMessage": "Sedang log masuk..."
+  },
+  "providerGrid.addProvider": {
+    "defaultMessage": "Tambah Penyedia"
+  },
+  "providerGrid.addProviderTitle": {
+    "defaultMessage": "Tambah Penyedia"
+  },
+  "providerGrid.chooseModel": {
+    "defaultMessage": "Pilih Model"
+  },
+  "providerGrid.configureProvider": {
+    "defaultMessage": "Konfigurasikan Penyedia"
+  },
+  "providerGrid.editProvider": {
+    "defaultMessage": "Edit Penyedia"
+  },
+  "providerGrid.fromTemplateOrManual": {
+    "defaultMessage": "Daripada templat atau persediaan manual"
+  },
+  "providerLogo.alt": {
+    "defaultMessage": "Logo {providerName}"
+  },
+  "providerSelector.addCustomProvider": {
+    "defaultMessage": "Tambah penyedia tersuai"
+  },
+  "providerSelector.addCustomProviderTitle": {
+    "defaultMessage": "Tambah Penyedia Tersuai"
+  },
+  "providerSelector.connectProvider": {
+    "defaultMessage": "Sambung ke Penyedia"
+  },
+  "providerSelector.connectProviderDescription": {
+    "defaultMessage": "Sambung OpenAI, Anthropic, Google, dll"
+  },
+  "providerSelector.freeLocalDescription": {
+    "defaultMessage": "Gunakan model setempat atau penyedia dengan kredit percuma"
+  },
+  "providerSelector.selectProvider": {
+    "defaultMessage": "Pilih penyedia"
+  },
+  "providerSelector.useFreeLocal": {
+    "defaultMessage": "Gunakan Penyedia Percuma/Setempat"
+  },
+  "providerSettings.configurationSettings": {
+    "defaultMessage": "Tetapan Konfigurasi Penyedia"
+  },
+  "providerSettings.loadingProviders": {
+    "defaultMessage": "Memuatkan penyedia..."
+  },
+  "providerSettings.onboardingDescription": {
+    "defaultMessage": "Pilih penyedia model AI untuk bermula dengan goose. Anda perlu menggunakan kunci API yang dijana oleh setiap penyedia yang akan disulitkan dan disimpan secara setempat. Anda boleh menukar penyedia anda pada bila-bila masa dalam tetapan."
+  },
+  "providerSettings.otherProviders": {
+    "defaultMessage": "Penyedia lain"
+  },
+  "providerSetupActions.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "providerSetupActions.cannotDeleteActive": {
+    "defaultMessage": "Anda tidak boleh memadamkan {providerName} semasa ia sedang digunakan. Sila tukar ke model lain sebelum memadamkan penyedia ini."
+  },
+  "providerSetupActions.confirmDelete": {
+    "defaultMessage": "Sahkan Padam"
+  },
+  "providerSetupActions.confirmDeleteMessage": {
+    "defaultMessage": "Adakah anda pasti mahu memadamkan parameter konfigurasi untuk {providerName}? Tindakan ini tidak boleh dibuat asal."
+  },
+  "providerSetupActions.deleteProvider": {
+    "defaultMessage": "Padam Penyedia"
+  },
+  "providerSetupActions.enableProvider": {
+    "defaultMessage": "Dayakan Penyedia"
+  },
+  "providerSetupActions.ok": {
+    "defaultMessage": "Ok"
+  },
+  "providerSetupActions.submit": {
+    "defaultMessage": "Hantar"
+  },
+  "recipeActivityEditor.activitiesDescription": {
+    "defaultMessage": "Gesaan utama dan butang aktiviti yang akan dipaparkan dalam tetingkap sembang resipi."
+  },
+  "recipeActivityEditor.activitiesLabel": {
+    "defaultMessage": "Aktiviti"
+  },
+  "recipeActivityEditor.activityButtonsDescription": {
+    "defaultMessage": "Butang boleh klik yang akan muncul di bawah mesej untuk membantu pengguna berinteraksi dengan resipi anda."
+  },
+  "recipeActivityEditor.activityButtonsLabel": {
+    "defaultMessage": "Butang Aktiviti"
+  },
+  "recipeActivityEditor.addActivity": {
+    "defaultMessage": "Tambah aktiviti"
+  },
+  "recipeActivityEditor.addNewActivityPlaceholder": {
+    "defaultMessage": "Tambah aktiviti baharu..."
+  },
+  "recipeActivityEditor.messageDescription": {
+    "defaultMessage": "Mesej berformat yang akan muncul di bahagian atas resipi. Menyokong pemformatan markdown."
+  },
+  "recipeActivityEditor.messageLabel": {
+    "defaultMessage": "Mesej"
+  },
+  "recipeActivityEditor.messagePlaceholder": {
+    "defaultMessage": "Masukkan mesej pengenalan yang menghadap pengguna untuk resipi anda (menyokong **tebal**, *condong*, `kod`, dll.)"
+  },
+  "recipeExtensionSelector.description": {
+    "defaultMessage": "Pilih sambungan yang harus tersedia semasa menjalankan resipi ini. Biarkan kosong untuk menggunakan sambungan lalai."
+  },
+  "recipeExtensionSelector.extensionsSelected": {
+    "defaultMessage": "{count,plural,one{# sambungan dipilih} other{# sambungan dipilih}}"
+  },
+  "recipeExtensionSelector.label": {
+    "defaultMessage": "Sambungan (Pilihan)"
+  },
+  "recipeExtensionSelector.noExtensionsAvailable": {
+    "defaultMessage": "Tiada sambungan tersedia"
+  },
+  "recipeExtensionSelector.noExtensionsFound": {
+    "defaultMessage": "Tiada sambungan ditemui"
+  },
+  "recipeExtensionSelector.searchPlaceholder": {
+    "defaultMessage": "Cari sambungan..."
+  },
+  "recipeFormFields.addParameter": {
+    "defaultMessage": "Tambah parameter"
+  },
+  "recipeFormFields.advancedOptions": {
+    "defaultMessage": "Pilihan Lanjutan"
+  },
+  "recipeFormFields.advancedOptionsHint": {
+    "defaultMessage": "Aktiviti, parameter, model, sambungan, skema respons, subresipi"
+  },
+  "recipeFormFields.descriptionLabel": {
+    "defaultMessage": "Perihalan"
+  },
+  "recipeFormFields.descriptionPlaceholder": {
+    "defaultMessage": "Perihalan ringkas tentang apa yang dilakukan oleh resipi ini"
+  },
+  "recipeFormFields.enterValueFor": {
+    "defaultMessage": "Masukkan nilai untuk {key}"
+  },
+  "recipeFormFields.initialPrompt": {
+    "defaultMessage": "Gesaan Awal"
+  },
+  "recipeFormFields.instructionsLabel": {
+    "defaultMessage": "Arahan"
+  },
+  "recipeFormFields.instructionsPlaceholder": {
+    "defaultMessage": "Arahan terperinci untuk AI, tersembunyi daripada pengguna"
+  },
+  "recipeFormFields.openEditor": {
+    "defaultMessage": "Buka Editor"
+  },
+  "recipeFormFields.parameterNamePlaceholder": {
+    "defaultMessage": "Masukkan nama parameter..."
+  },
+  "recipeFormFields.parametersDescription": {
+    "defaultMessage": "Parameter akan dikesan secara automatik daripada sintaks '{{parameter_name}}' dalam arahan/gesaan/aktiviti atau anda boleh menambahnya secara manual di bawah."
+  },
+  "recipeFormFields.parametersLabel": {
+    "defaultMessage": "Parameter"
+  },
+  "recipeFormFields.promptOptionalHint": {
+    "defaultMessage": "(Pilihan - Arahan atau Gesaan diperlukan)"
+  },
+  "recipeFormFields.promptPlaceholder": {
+    "defaultMessage": "Gesaan pra-isi apabila resipi bermula"
+  },
+  "recipeFormFields.responseJsonSchema": {
+    "defaultMessage": "Skema JSON Respons"
+  },
+  "recipeFormFields.responseJsonSchemaDescription": {
+    "defaultMessage": "Tentukan struktur respons AI yang dijangka menggunakan format JSON Schema"
+  },
+  "recipeFormFields.templateVarHint": {
+    "defaultMessage": "Gunakan '{{parameter_name}}' untuk mentakrifkan parameter yang boleh diisi semasa menjalankan resipi."
+  },
+  "recipeFormFields.titleLabel": {
+    "defaultMessage": "Tajuk"
+  },
+  "recipeFormFields.titlePlaceholder": {
+    "defaultMessage": "Tajuk resipi"
+  },
+  "recipeHeader.recipeLabel": {
+    "defaultMessage": "Resipi"
+  },
+  "recipeModelSelector.backToModelList": {
+    "defaultMessage": "Kembali ke senarai model"
+  },
+  "recipeModelSelector.enterCustomModel": {
+    "defaultMessage": "Masukkan nama model tersuai"
+  },
+  "recipeModelSelector.enterModelNotListed": {
+    "defaultMessage": "Masukkan model yang tidak disenaraikan..."
+  },
+  "recipeModelSelector.fetchError": {
+    "defaultMessage": "Gagal mendapatkan model. Sila cuba lagi kemudian."
+  },
+  "recipeModelSelector.loadingModels": {
+    "defaultMessage": "Memuatkan model…"
+  },
+  "recipeModelSelector.modelHint": {
+    "defaultMessage": "Biarkan kosong untuk menggunakan model lalai bagi penyedia yang dipilih"
+  },
+  "recipeModelSelector.modelLabel": {
+    "defaultMessage": "Model (Pilihan)"
+  },
+  "recipeModelSelector.providerHint": {
+    "defaultMessage": "Biarkan kosong untuk menggunakan penyedia lalai yang dikonfigurasikan dalam tetapan"
+  },
+  "recipeModelSelector.providerLabel": {
+    "defaultMessage": "Penyedia (Pilihan)"
+  },
+  "recipeModelSelector.selectModel": {
+    "defaultMessage": "Pilih model"
+  },
+  "recipeModelSelector.selectProvider": {
+    "defaultMessage": "Pilih penyedia"
+  },
+  "recipeModelSelector.useDefaultProvider": {
+    "defaultMessage": "Gunakan penyedia lalai"
+  },
+  "recipeNameField.defaultLabel": {
+    "defaultMessage": "Nama Resipi"
+  },
+  "recipeNameField.formatHint": {
+    "defaultMessage": "Akan diformat secara automatik (huruf kecil, sengkang untuk ruang)"
+  },
+  "recipeWarningModal.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "recipeWarningModal.descriptionLabel": {
+    "defaultMessage": "Perihalan:"
+  },
+  "recipeWarningModal.firstTimeDescription": {
+    "defaultMessage": "Anda akan melaksanakan resipi yang belum pernah anda jalankan sebelum ini."
+  },
+  "recipeWarningModal.hiddenCharsWarning": {
+    "defaultMessage": "Resipi ini mengandungi aksara tersembunyi yang akan diabaikan demi keselamatan anda, kerana ia boleh digunakan untuk tujuan berniat jahat."
+  },
+  "recipeWarningModal.instructionsLabel": {
+    "defaultMessage": "Arahan:"
+  },
+  "recipeWarningModal.newRecipeWarningTitle": {
+    "defaultMessage": "⚠️ Amaran Resipi Baharu"
+  },
+  "recipeWarningModal.recipePreview": {
+    "defaultMessage": "Pratonton Resipi:"
+  },
+  "recipeWarningModal.securityWarningTitle": {
+    "defaultMessage": "⚠️ Amaran Keselamatan"
+  },
+  "recipeWarningModal.titleLabel": {
+    "defaultMessage": "Tajuk:"
+  },
+  "recipeWarningModal.trustAndExecute": {
+    "defaultMessage": "Percaya dan Laksanakan"
+  },
+  "recipeWarningModal.trustSource": {
+    "defaultMessage": "Teruskan hanya jika anda mempercayai sumber resipi ini."
+  },
+  "recipesView.addSchedule": {
+    "defaultMessage": "Tambah jadual"
+  },
+  "recipesView.addSlashCommand": {
+    "defaultMessage": "Tambah arahan garis miring"
+  },
+  "recipesView.adjustSearchTerms": {
+    "defaultMessage": "Cuba laraskan istilah carian anda"
+  },
+  "recipesView.allFiles": {
+    "defaultMessage": "Semua Fail"
+  },
+  "recipesView.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "recipesView.copyDeeplink": {
+    "defaultMessage": "Salin Pautan Dalam"
+  },
+  "recipesView.copyDeeplinkFailedMsg": {
+    "defaultMessage": "Gagal menyalin pautan dalam ke papan keratan"
+  },
+  "recipesView.copyFailedTitle": {
+    "defaultMessage": "Salinan gagal"
+  },
+  "recipesView.copyYaml": {
+    "defaultMessage": "Salin YAML"
+  },
+  "recipesView.copyYamlFailedMsg": {
+    "defaultMessage": "Gagal menyalin YAML resipi ke papan keratan"
+  },
+  "recipesView.createRecipe": {
+    "defaultMessage": "Cipta Resipi"
+  },
+  "recipesView.deeplinkCopiedMsg": {
+    "defaultMessage": "Pautan dalam resipi telah disalin ke papan keratan"
+  },
+  "recipesView.deeplinkCopiedTitle": {
+    "defaultMessage": "Pautan dalam disalin"
+  },
+  "recipesView.deleteRecipe": {
+    "defaultMessage": "Padam resipi"
+  },
+  "recipesView.deleteRecipeConfirm": {
+    "defaultMessage": "Adakah anda pasti mahu memadamkan \"{title}\"?"
+  },
+  "recipesView.deleteRecipeDetail": {
+    "defaultMessage": "Fail resipi akan dipadamkan."
+  },
+  "recipesView.deleteRecipeTitle": {
+    "defaultMessage": "Padam Resipi"
+  },
+  "recipesView.editRecipe": {
+    "defaultMessage": "Edit resipi"
+  },
+  "recipesView.editSchedule": {
+    "defaultMessage": "Edit jadual"
+  },
+  "recipesView.editSlashCommand": {
+    "defaultMessage": "Edit arahan garis miring"
+  },
+  "recipesView.errorLoadingRecipes": {
+    "defaultMessage": "Ralat Memuatkan Resipi"
+  },
+  "recipesView.exportFailedMsg": {
+    "defaultMessage": "Gagal mengeksport resipi ke fail"
+  },
+  "recipesView.exportFailedTitle": {
+    "defaultMessage": "Eksport gagal"
+  },
+  "recipesView.exportRecipeDialogTitle": {
+    "defaultMessage": "Eksport Resipi"
+  },
+  "recipesView.exportToFile": {
+    "defaultMessage": "Eksport ke Fail"
+  },
+  "recipesView.noMatchingRecipes": {
+    "defaultMessage": "Tiada resipi sepadan ditemui"
+  },
+  "recipesView.noSavedRecipes": {
+    "defaultMessage": "Tiada resipi disimpan"
+  },
+  "recipesView.noSavedRecipesDescription": {
+    "defaultMessage": "Resipi yang disimpan daripada sembang akan dipaparkan di sini."
+  },
+  "recipesView.openInNewWindow": {
+    "defaultMessage": "Buka dalam tetingkap baharu"
+  },
+  "recipesView.recipeDeletedSuccess": {
+    "defaultMessage": "Resipi berjaya dipadam"
+  },
+  "recipesView.recipeExportedMsg": {
+    "defaultMessage": "Resipi disimpan ke {filePath}"
+  },
+  "recipesView.recipeExportedTitle": {
+    "defaultMessage": "Resipi dieksport"
+  },
+  "recipesView.recipesDescription": {
+    "defaultMessage": "Lihat dan urus resipi tersimpan anda untuk memulakan sesi baharu dengan pantas menggunakan konfigurasi yang telah ditakrifkan. {shortcut} untuk mencari."
+  },
+  "recipesView.recipesTitle": {
+    "defaultMessage": "Resipi"
+  },
+  "recipesView.remove": {
+    "defaultMessage": "Alih keluar"
+  },
+  "recipesView.removeSchedule": {
+    "defaultMessage": "Alih Keluar Jadual"
+  },
+  "recipesView.runs": {
+    "defaultMessage": "Berjalan {schedule}"
+  },
+  "recipesView.save": {
+    "defaultMessage": "Simpan"
+  },
+  "recipesView.scheduleDialogTitle": {
+    "defaultMessage": "{action} Jadual"
+  },
+  "recipesView.scheduleRemovedMsg": {
+    "defaultMessage": "Resipi tidak lagi akan berjalan secara automatik"
+  },
+  "recipesView.scheduleRemovedTitle": {
+    "defaultMessage": "Jadual dialih keluar"
+  },
+  "recipesView.scheduleSavedMsg": {
+    "defaultMessage": "Resipi akan berjalan {schedule}"
+  },
+  "recipesView.scheduleSavedTitle": {
+    "defaultMessage": "Jadual disimpan"
+  },
+  "recipesView.searchRecipesPlaceholder": {
+    "defaultMessage": "Cari resipi..."
+  },
+  "recipesView.shareRecipe": {
+    "defaultMessage": "Kongsi resipi"
+  },
+  "recipesView.slashCommandDescription": {
+    "defaultMessage": "Tetapkan arahan garis miring untuk menjalankan resipi ini dengan pantas daripada mana-mana sembang"
+  },
+  "recipesView.slashCommandPlaceholder": {
+    "defaultMessage": "command-name"
+  },
+  "recipesView.slashCommandRemovedMsg": {
+    "defaultMessage": "Arahan garis miring resipi telah dialih keluar"
+  },
+  "recipesView.slashCommandRemovedTitle": {
+    "defaultMessage": "Arahan garis miring dialih keluar"
+  },
+  "recipesView.slashCommandSavedMsg": {
+    "defaultMessage": "Gunakan /{command} untuk menjalankan resipi ini"
+  },
+  "recipesView.slashCommandSavedTitle": {
+    "defaultMessage": "Arahan garis miring disimpan"
+  },
+  "recipesView.slashCommandTitle": {
+    "defaultMessage": "Arahan Garis Miring"
+  },
+  "recipesView.slashCommandUsageHint": {
+    "defaultMessage": "Gunakan /{command} dalam mana-mana sembang untuk menjalankan resipi ini"
+  },
+  "recipesView.tryAgain": {
+    "defaultMessage": "Cuba Lagi"
+  },
+  "recipesView.useRecipe": {
+    "defaultMessage": "Guna resipi"
+  },
+  "recipesView.yamlCopiedMsg": {
+    "defaultMessage": "YAML resipi telah disalin ke papan keratan"
+  },
+  "recipesView.yamlCopiedTitle": {
+    "defaultMessage": "YAML disalin"
+  },
+  "recipesView.yamlFiles": {
+    "defaultMessage": "Fail YAML"
+  },
+  "resetProviderSection.resetButton": {
+    "defaultMessage": "Tetapkan Semula Penyedia dan Model"
+  },
+  "resetProviderSection.resetDescription": {
+    "defaultMessage": "Ini akan mengosongkan tetapan model dan penyedia yang anda pilih. Jika tiada lalai tersedia, anda akan dibawa ke skrin alu-aluan untuk menetapkannya semula."
+  },
+  "responseStyle.conciseDescription": {
+    "defaultMessage": "Panggilan alat secara lalai ditutup dan hanya menunjukkan alat yang digunakan"
+  },
+  "responseStyle.conciseLabel": {
+    "defaultMessage": "Ringkas"
+  },
+  "responseStyle.detailedDescription": {
+    "defaultMessage": "Panggilan alat secara lalai dipaparkan terbuka untuk mendedahkan butiran"
+  },
+  "responseStyle.detailedLabel": {
+    "defaultMessage": "Terperinci"
+  },
+  "scheduleDetailView.actions": {
+    "defaultMessage": "Tindakan"
+  },
+  "scheduleDetailView.cannotModifyRunning": {
+    "defaultMessage": "Tidak boleh mencetuskan atau mengubah suai jadual semasa ia sedang berjalan."
+  },
+  "scheduleDetailView.completedSession": {
+    "defaultMessage": "Sesi: {sessionId}"
+  },
+  "scheduleDetailView.created": {
+    "defaultMessage": "Dicipta: {date}"
+  },
+  "scheduleDetailView.cronExpression": {
+    "defaultMessage": "Ungkapan Cron:"
+  },
+  "scheduleDetailView.currentSession": {
+    "defaultMessage": "Sesi Semasa:"
+  },
+  "scheduleDetailView.currentlyRunning": {
+    "defaultMessage": "Sedang Berjalan"
+  },
+  "scheduleDetailView.dir": {
+    "defaultMessage": "Dir: {path}"
+  },
+  "scheduleDetailView.editSchedule": {
+    "defaultMessage": "Edit Jadual"
+  },
+  "scheduleDetailView.errorPrefix": {
+    "defaultMessage": "Ralat: {error}"
+  },
+  "scheduleDetailView.idLabel": {
+    "defaultMessage": "ID:"
+  },
+  "scheduleDetailView.inspectJobError": {
+    "defaultMessage": "Periksa Ralat Kerja"
+  },
+  "scheduleDetailView.inspectNoInfo": {
+    "defaultMessage": "Tiada maklumat terperinci tersedia"
+  },
+  "scheduleDetailView.inspectRunningJob": {
+    "defaultMessage": "Periksa Kerja Sedang Berjalan"
+  },
+  "scheduleDetailView.jobCancelled": {
+    "defaultMessage": "Kerja Dibatalkan"
+  },
+  "scheduleDetailView.jobCancelledMsg": {
+    "defaultMessage": "Kerja itu dibatalkan semasa permulaan."
+  },
+  "scheduleDetailView.jobInspection": {
+    "defaultMessage": "Pemeriksaan Kerja"
+  },
+  "scheduleDetailView.jobKilled": {
+    "defaultMessage": "Kerja Dihentikan"
+  },
+  "scheduleDetailView.killJobError": {
+    "defaultMessage": "Ralat Henti Kerja"
+  },
+  "scheduleDetailView.killRunningJob": {
+    "defaultMessage": "Hentikan Kerja Sedang Berjalan"
+  },
+  "scheduleDetailView.lastRun": {
+    "defaultMessage": "Larian Terakhir:"
+  },
+  "scheduleDetailView.loadingSchedule": {
+    "defaultMessage": "Memuatkan jadual..."
+  },
+  "scheduleDetailView.loadingSessions": {
+    "defaultMessage": "Memuatkan sesi..."
+  },
+  "scheduleDetailView.messages": {
+    "defaultMessage": "Mesej: {count}"
+  },
+  "scheduleDetailView.noScheduleId": {
+    "defaultMessage": "Tiada ID jadual disediakan. Kembali ke senarai jadual."
+  },
+  "scheduleDetailView.noSessions": {
+    "defaultMessage": "Tiada sesi ditemui untuk jadual ini."
+  },
+  "scheduleDetailView.pauseSchedule": {
+    "defaultMessage": "Jeda Jadual"
+  },
+  "scheduleDetailView.pauseUnpauseError": {
+    "defaultMessage": "Ralat Jeda/Nyahjeda"
+  },
+  "scheduleDetailView.paused": {
+    "defaultMessage": "Dijeda"
+  },
+  "scheduleDetailView.pausedMsg": {
+    "defaultMessage": "Dijeda \"{id}\""
+  },
+  "scheduleDetailView.pausedWarning": {
+    "defaultMessage": "Jadual ini dijeda dan tidak akan berjalan secara automatik. Gunakan \"Jalankan Jadual Sekarang\" untuk mencetuskannya secara manual atau nyahjeda untuk menyambung semula pelaksanaan automatik."
+  },
+  "scheduleDetailView.processStarted": {
+    "defaultMessage": "Proses Dimulakan:"
+  },
+  "scheduleDetailView.recentSessions": {
+    "defaultMessage": "Sesi Terkini"
+  },
+  "scheduleDetailView.recipeSource": {
+    "defaultMessage": "Sumber Resipi:"
+  },
+  "scheduleDetailView.runScheduleError": {
+    "defaultMessage": "Ralat Jalankan Jadual"
+  },
+  "scheduleDetailView.runScheduleNow": {
+    "defaultMessage": "Jalankan Jadual Sekarang"
+  },
+  "scheduleDetailView.scheduleCompleted": {
+    "defaultMessage": "Larian selesai"
+  },
+  "scheduleDetailView.scheduleDetails": {
+    "defaultMessage": "Butiran Jadual"
+  },
+  "scheduleDetailView.scheduleInformation": {
+    "defaultMessage": "Maklumat Jadual"
+  },
+  "scheduleDetailView.scheduleLabel": {
+    "defaultMessage": "Jadual:"
+  },
+  "scheduleDetailView.scheduleNotFound": {
+    "defaultMessage": "Jadual Tidak Ditemui"
+  },
+  "scheduleDetailView.scheduleNotFoundError": {
+    "defaultMessage": "Jadual tidak ditemui"
+  },
+  "scheduleDetailView.schedulePaused": {
+    "defaultMessage": "Jadual Dijeda"
+  },
+  "scheduleDetailView.scheduleUnpaused": {
+    "defaultMessage": "Jadual Dinyahjeda"
+  },
+  "scheduleDetailView.scheduleUpdated": {
+    "defaultMessage": "Jadual Dikemas Kini"
+  },
+  "scheduleDetailView.sessionId": {
+    "defaultMessage": "ID Sesi: {id}"
+  },
+  "scheduleDetailView.unpauseSchedule": {
+    "defaultMessage": "Nyahjeda Jadual"
+  },
+  "scheduleDetailView.unpausedMsg": {
+    "defaultMessage": "Dinyahjeda \"{id}\""
+  },
+  "scheduleDetailView.updateScheduleError": {
+    "defaultMessage": "Ralat Kemas Kini Jadual"
+  },
+  "scheduleDetailView.updatedMsg": {
+    "defaultMessage": "Dikemas kini \"{id}\""
+  },
+  "scheduleDetailView.viewingScheduleId": {
+    "defaultMessage": "Melihat ID Jadual: {id}"
+  },
+  "scheduleModal.browseYaml": {
+    "defaultMessage": "Layari fail YAML..."
+  },
+  "scheduleModal.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "scheduleModal.createNewSchedule": {
+    "defaultMessage": "Cipta Jadual Baharu"
+  },
+  "scheduleModal.createSchedule": {
+    "defaultMessage": "Cipta Jadual"
+  },
+  "scheduleModal.creating": {
+    "defaultMessage": "Mencipta..."
+  },
+  "scheduleModal.deepLink": {
+    "defaultMessage": "Pautan dalam"
+  },
+  "scheduleModal.deepLinkPlaceholder": {
+    "defaultMessage": "Tampal pautan goose://recipe di sini..."
+  },
+  "scheduleModal.editSchedule": {
+    "defaultMessage": "Edit Jadual"
+  },
+  "scheduleModal.failedParseRecipe": {
+    "defaultMessage": "Gagal menghuraikan resipi daripada fail."
+  },
+  "scheduleModal.failedReadFile": {
+    "defaultMessage": "Gagal membaca fail yang dipilih."
+  },
+  "scheduleModal.invalidDeepLink": {
+    "defaultMessage": "Pautan dalam tidak sah. Sila gunakan pautan goose://recipe."
+  },
+  "scheduleModal.invalidFileType": {
+    "defaultMessage": "Jenis fail tidak sah: Sila pilih fail YAML (.yaml atau .yml)"
+  },
+  "scheduleModal.nameLabel": {
+    "defaultMessage": "Nama:"
+  },
+  "scheduleModal.namePlaceholder": {
+    "defaultMessage": "cth., daily-summary-job"
+  },
+  "scheduleModal.provideValidRecipe": {
+    "defaultMessage": "Sila sediakan sumber resipi yang sah."
+  },
+  "scheduleModal.recipeDescription": {
+    "defaultMessage": "Penerangan: {description}"
+  },
+  "scheduleModal.recipeParsed": {
+    "defaultMessage": "Resipi berjaya dihuraikan"
+  },
+  "scheduleModal.recipeTitle": {
+    "defaultMessage": "Tajuk: {title}"
+  },
+  "scheduleModal.scheduleIdRequired": {
+    "defaultMessage": "ID jadual diperlukan."
+  },
+  "scheduleModal.scheduleLabel": {
+    "defaultMessage": "Jadual:"
+  },
+  "scheduleModal.selected": {
+    "defaultMessage": "Dipilih: {path}"
+  },
+  "scheduleModal.sourceLabel": {
+    "defaultMessage": "Sumber:"
+  },
+  "scheduleModal.updateSchedule": {
+    "defaultMessage": "Kemas Kini Jadual"
+  },
+  "scheduleModal.updating": {
+    "defaultMessage": "Mengemas kini..."
+  },
+  "scheduleModal.yaml": {
+    "defaultMessage": "YAML"
+  },
+  "schedulesView.confirmDelete": {
+    "defaultMessage": "Alih keluar jadual \"{id}\"? Resipi akan dikekalkan."
+  },
+  "schedulesView.createSchedule": {
+    "defaultMessage": "Cipta Jadual"
+  },
+  "schedulesView.description": {
+    "defaultMessage": "Cipta dan urus tugas berjadual untuk menjalankan resipi secara automatik pada masa yang ditentukan."
+  },
+  "schedulesView.edit": {
+    "defaultMessage": "Edit"
+  },
+  "schedulesView.errorPrefix": {
+    "defaultMessage": "Ralat: {error}"
+  },
+  "schedulesView.inspect": {
+    "defaultMessage": "Periksa"
+  },
+  "schedulesView.inspectError": {
+    "defaultMessage": "Periksa Ralat Kerja"
+  },
+  "schedulesView.inspectNoInfo": {
+    "defaultMessage": "Tiada maklumat terperinci tersedia untuk kerja ini"
+  },
+  "schedulesView.jobInspection": {
+    "defaultMessage": "Pemeriksaan Kerja"
+  },
+  "schedulesView.jobKilled": {
+    "defaultMessage": "Kerja Dihentikan"
+  },
+  "schedulesView.kill": {
+    "defaultMessage": "Hentikan"
+  },
+  "schedulesView.killError": {
+    "defaultMessage": "Ralat Henti Kerja"
+  },
+  "schedulesView.lastRun": {
+    "defaultMessage": "Larian terakhir: {date}"
+  },
+  "schedulesView.noSchedules": {
+    "defaultMessage": "Tiada jadual lagi"
+  },
+  "schedulesView.pause": {
+    "defaultMessage": "Jeda"
+  },
+  "schedulesView.pauseError": {
+    "defaultMessage": "Ralat Jeda Jadual"
+  },
+  "schedulesView.paused": {
+    "defaultMessage": "Dijeda"
+  },
+  "schedulesView.refresh": {
+    "defaultMessage": "Muat Semula"
+  },
+  "schedulesView.refreshing": {
+    "defaultMessage": "Memuat semula..."
+  },
+  "schedulesView.resume": {
+    "defaultMessage": "Sambung Semula"
+  },
+  "schedulesView.running": {
+    "defaultMessage": "Berjalan"
+  },
+  "schedulesView.schedulePaused": {
+    "defaultMessage": "Jadual Dijeda"
+  },
+  "schedulesView.schedulePausedMsg": {
+    "defaultMessage": "Berjaya menjeda jadual \"{id}\""
+  },
+  "schedulesView.scheduleUnpaused": {
+    "defaultMessage": "Jadual Dinyahjeda"
+  },
+  "schedulesView.scheduleUnpausedMsg": {
+    "defaultMessage": "Berjaya menyahjeda jadual \"{id}\""
+  },
+  "schedulesView.scheduleUpdated": {
+    "defaultMessage": "Jadual Dikemas Kini"
+  },
+  "schedulesView.scheduleUpdatedMsg": {
+    "defaultMessage": "Berjaya mengemas kini jadual \"{id}\""
+  },
+  "schedulesView.scheduler": {
+    "defaultMessage": "Penjadual"
+  },
+  "schedulesView.unpauseError": {
+    "defaultMessage": "Ralat Nyahjeda Jadual"
+  },
+  "searchBar.caseSensitive": {
+    "defaultMessage": "Sensitif Huruf Besar/Kecil"
+  },
+  "searchBar.close": {
+    "defaultMessage": "Tutup ({shortcut})"
+  },
+  "searchBar.next": {
+    "defaultMessage": "Seterusnya ({shortcut})"
+  },
+  "searchBar.placeholder": {
+    "defaultMessage": "Cari perbualan..."
+  },
+  "searchBar.previous": {
+    "defaultMessage": "Sebelumnya ({shortcut})"
+  },
+  "secureStorageNotice.defaultMessage": {
+    "defaultMessage": "Kunci disimpan dengan selamat dalam rantai kunci"
+  },
+  "securityToggle.apiTokenDescription": {
+    "defaultMessage": "Token pengesahan untuk perkhidmatan pengelasan"
+  },
+  "securityToggle.apiTokenOptional": {
+    "defaultMessage": "Token API (Pilihan)"
+  },
+  "securityToggle.classificationEndpoint": {
+    "defaultMessage": "Titik Akhir Pengelasan"
+  },
+  "securityToggle.classificationEndpointDescription": {
+    "defaultMessage": "Masukkan URL penuh untuk perkhidmatan pengelasan anda"
+  },
+  "securityToggle.commandClassifierActive": {
+    "defaultMessage": "Pengelas arahan aktif (dikonfigurasi automatik daripada persekitaran)"
+  },
+  "securityToggle.commandEndpointDescription": {
+    "defaultMessage": "Masukkan URL penuh untuk perkhidmatan pengelasan suntikan arahan anda"
+  },
+  "securityToggle.commandInjectionDescription": {
+    "defaultMessage": "Gunakan model ML untuk mengesan arahan shell yang berniat jahat"
+  },
+  "securityToggle.detectionModel": {
+    "defaultMessage": "Model Pengesanan"
+  },
+  "securityToggle.detectionModelDescription": {
+    "defaultMessage": "Pilih model ML yang hendak digunakan untuk pengesanan suntikan gesaan"
+  },
+  "securityToggle.detectionThreshold": {
+    "defaultMessage": "Ambang Pengesanan"
+  },
+  "securityToggle.enableCommandInjection": {
+    "defaultMessage": "Dayakan Pengesanan ML Suntikan Arahan"
+  },
+  "securityToggle.enablePromptInjection": {
+    "defaultMessage": "Dayakan Pengesanan Suntikan Gesaan"
+  },
+  "securityToggle.enablePromptInjectionMl": {
+    "defaultMessage": "Dayakan Pengesanan ML Suntikan Gesaan"
+  },
+  "securityToggle.mlEndpointDescription": {
+    "defaultMessage": "Masukkan URL penuh untuk perkhidmatan pengelasan ML anda (termasuk pengecam model)"
+  },
+  "securityToggle.mlTokenDescription": {
+    "defaultMessage": "Token pengesahan untuk perkhidmatan ML (cth., token HuggingFace)"
+  },
+  "securityToggle.overrideNotice": {
+    "defaultMessage": "Tetapan ini diurus oleh organisasi anda dan tidak boleh diubah."
+  },
+  "securityToggle.promptInjectionDescription": {
+    "defaultMessage": "Kesan dan halang potensi serangan suntikan gesaan"
+  },
+  "securityToggle.promptInjectionMlDescription": {
+    "defaultMessage": "Gunakan model ML untuk mengesan potensi suntikan gesaan dalam sembang anda"
+  },
+  "securityToggle.thresholdDescription": {
+    "defaultMessage": "Nilai yang lebih tinggi adalah lebih ketat (0.01 = sangat longgar, 1.0 = paling ketat)"
+  },
+  "securityToggle.warpNotice": {
+    "defaultMessage": "Pengesanan suntikan arahan berfungsi paling baik apabila disambungkan ke WARP (diperlukan untuk mencapai perkhidmatan pengelasan)."
+  },
+  "sessionActionsHeader.actionsLabel": {
+    "defaultMessage": "Tindakan sesi"
+  },
+  "sessionActionsHeader.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "sessionActionsHeader.close": {
+    "defaultMessage": "Tutup"
+  },
+  "sessionActionsHeader.copiedJson": {
+    "defaultMessage": "JSON sesi disalin"
+  },
+  "sessionActionsHeader.copiedText": {
+    "defaultMessage": "Teks disalin"
+  },
+  "sessionActionsHeader.copyJson": {
+    "defaultMessage": "Salin JSON"
+  },
+  "sessionActionsHeader.copyText": {
+    "defaultMessage": "Salin teks"
+  },
+  "sessionActionsHeader.duplicateFailed": {
+    "defaultMessage": "Gagal menduplikasi sesi: {error}"
+  },
+  "sessionActionsHeader.duplicateSession": {
+    "defaultMessage": "Duplikasi sesi"
+  },
+  "sessionActionsHeader.duplicated": {
+    "defaultMessage": "Sesi diduplikasi"
+  },
+  "sessionActionsHeader.fullTextTitle": {
+    "defaultMessage": "Nilai teks"
+  },
+  "sessionActionsHeader.jsonFailed": {
+    "defaultMessage": "Gagal memuatkan JSON sesi: {error}"
+  },
+  "sessionActionsHeader.jsonTitle": {
+    "defaultMessage": "JSON Sesi"
+  },
+  "sessionActionsHeader.loadingJson": {
+    "defaultMessage": "Memuatkan JSON..."
+  },
+  "sessionActionsHeader.renameFailed": {
+    "defaultMessage": "Gagal menamakan semula sesi: {error}"
+  },
+  "sessionActionsHeader.renamePlaceholder": {
+    "defaultMessage": "Masukkan nama sesi"
+  },
+  "sessionActionsHeader.renameSession": {
+    "defaultMessage": "Namakan semula sesi"
+  },
+  "sessionActionsHeader.renameTitle": {
+    "defaultMessage": "Namakan Semula Sesi"
+  },
+  "sessionActionsHeader.renamed": {
+    "defaultMessage": "Sesi dinamakan semula"
+  },
+  "sessionActionsHeader.save": {
+    "defaultMessage": "Simpan"
+  },
+  "sessionActionsHeader.saving": {
+    "defaultMessage": "Menyimpan..."
+  },
+  "sessionActionsHeader.viewJson": {
+    "defaultMessage": "Lihat JSON sesi"
+  },
+  "sessionIndicators.error": {
+    "defaultMessage": "Sesi mengalami ralat"
+  },
+  "sessionIndicators.newActivity": {
+    "defaultMessage": "Mempunyai aktiviti baharu"
+  },
+  "sessionIndicators.streaming": {
+    "defaultMessage": "Penstriman"
+  },
+  "sessionViewComponents.empty.description": {
+    "defaultMessage": "Sesi ini tidak mengandungi sebarang mesej"
+  },
+  "sessionViewComponents.empty.title": {
+    "defaultMessage": "Tiada mesej ditemui"
+  },
+  "sessionViewComponents.error.loading": {
+    "defaultMessage": "Ralat Memuatkan Butiran Sesi"
+  },
+  "sessionViewComponents.error.tryAgain": {
+    "defaultMessage": "Cuba Lagi"
+  },
+  "sessionViewComponents.role.assistant": {
+    "defaultMessage": "Goose"
+  },
+  "sessionViewComponents.role.user": {
+    "defaultMessage": "Anda"
+  },
+  "sessions.action.delete": {
+    "defaultMessage": "Padam sesi"
+  },
+  "sessions.action.duplicate": {
+    "defaultMessage": "Duplikasi sesi"
+  },
+  "sessions.action.editName": {
+    "defaultMessage": "Edit nama sesi"
+  },
+  "sessions.action.export": {
+    "defaultMessage": "Eksport sesi"
+  },
+  "sessions.action.openNewWindow": {
+    "defaultMessage": "Buka dalam tetingkap baharu"
+  },
+  "sessions.action.shareNostr": {
+    "defaultMessage": "Kongsi pautan Nostr tersulit"
+  },
+  "sessions.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "sessions.chatHistory": {
+    "defaultMessage": "Sejarah sembang"
+  },
+  "sessions.chatHistoryDesc": {
+    "defaultMessage": "Lihat dan cari perbualan lepas anda dengan Goose. {shortcut} untuk mencari."
+  },
+  "sessions.close": {
+    "defaultMessage": "Tutup"
+  },
+  "sessions.delete.message": {
+    "defaultMessage": "Adakah anda pasti mahu memadam sesi \"{name}\"? Tindakan ini tidak boleh dibuat asal."
+  },
+  "sessions.delete.title": {
+    "defaultMessage": "Padam Sesi"
+  },
+  "sessions.edit.placeholder": {
+    "defaultMessage": "Masukkan penerangan sesi"
+  },
+  "sessions.edit.title": {
+    "defaultMessage": "Edit Penerangan Sesi"
+  },
+  "sessions.empty.description": {
+    "defaultMessage": "Sejarah sembang anda akan muncul di sini"
+  },
+  "sessions.empty.title": {
+    "defaultMessage": "Tiada sesi sembang ditemui"
+  },
+  "sessions.error.loading": {
+    "defaultMessage": "Ralat Memuatkan Sesi"
+  },
+  "sessions.error.tryAgain": {
+    "defaultMessage": "Cuba Lagi"
+  },
+  "sessions.import": {
+    "defaultMessage": "Import Sesi"
+  },
+  "sessions.importNostr": {
+    "defaultMessage": "Import Pautan"
+  },
+  "sessions.importNostr.description": {
+    "defaultMessage": "Tampal pautan kongsi Nostr Goose untuk mengambil, menyahsulit, dan mengimport sesi."
+  },
+  "sessions.importNostr.placeholder": {
+    "defaultMessage": "goose://sessions/nostr?nevent=...&key=..."
+  },
+  "sessions.importNostr.title": {
+    "defaultMessage": "Import Sesi Nostr"
+  },
+  "sessions.importing": {
+    "defaultMessage": "Mengimport..."
+  },
+  "sessions.loadingMore": {
+    "defaultMessage": "Memuatkan lebih banyak sesi..."
+  },
+  "sessions.save": {
+    "defaultMessage": "Simpan"
+  },
+  "sessions.saving": {
+    "defaultMessage": "Menyimpan..."
+  },
+  "sessions.search.noResults": {
+    "defaultMessage": "Tiada sesi sepadan ditemui"
+  },
+  "sessions.search.noResultsDesc": {
+    "defaultMessage": "Cuba laraskan terma carian anda"
+  },
+  "sessions.searchPlaceholder": {
+    "defaultMessage": "Cari sejarah..."
+  },
+  "sessions.shareNostr.description": {
+    "defaultMessage": "Sesiapa sahaja yang mempunyai pautan ini boleh mengambil dan menyahsulit sesi tersebut. Anggap ia sebagai rahsia."
+  },
+  "sessions.shareNostr.title": {
+    "defaultMessage": "Pautan Kongsi Nostr Tersulit"
+  },
+  "sessions.toast.copied": {
+    "defaultMessage": "Disalin ke papan keratan"
+  },
+  "sessions.toast.deleteFailed": {
+    "defaultMessage": "Gagal memadam sesi \"{name}\": {error}"
+  },
+  "sessions.toast.deleted": {
+    "defaultMessage": "Sesi berjaya dipadam"
+  },
+  "sessions.toast.duplicateFailed": {
+    "defaultMessage": "Gagal menduplikasi sesi: {error}"
+  },
+  "sessions.toast.duplicated": {
+    "defaultMessage": "Sesi \"{name}\" berjaya diduplikasi"
+  },
+  "sessions.toast.exported": {
+    "defaultMessage": "Sesi berjaya dieksport"
+  },
+  "sessions.toast.importFailed": {
+    "defaultMessage": "Gagal mengimport sesi: {error}"
+  },
+  "sessions.toast.imported": {
+    "defaultMessage": "Sesi berjaya diimport"
+  },
+  "sessions.toast.shareNostr": {
+    "defaultMessage": "Pautan kongsi Nostr tersulit dicipta"
+  },
+  "sessions.toast.shareNostrFailed": {
+    "defaultMessage": "Gagal mencipta pautan kongsi Nostr: {error}"
+  },
+  "sessions.toast.updateFailed": {
+    "defaultMessage": "Gagal mengemas kini penerangan sesi: {error}"
+  },
+  "sessions.toast.updated": {
+    "defaultMessage": "Penerangan sesi berjaya dikemas kini"
+  },
+  "settings.appearance.description": {
+    "defaultMessage": "Konfigurasikan cara goose muncul pada sistem anda"
+  },
+  "settings.appearance.title": {
+    "defaultMessage": "Penampilan"
+  },
+  "settings.close": {
+    "defaultMessage": "Tutup"
+  },
+  "settings.costTracking.description": {
+    "defaultMessage": "Tunjukkan harga model dan kos penggunaan"
+  },
+  "settings.costTracking.title": {
+    "defaultMessage": "Penjejakan Kos"
+  },
+  "settings.dockIcon.description": {
+    "defaultMessage": "Tunjukkan goose dalam dok"
+  },
+  "settings.dockIcon.title": {
+    "defaultMessage": "Ikon dok"
+  },
+  "settings.help.description": {
+    "defaultMessage": "Bantu kami menambah baik goose dengan melaporkan isu atau meminta ciri baharu"
+  },
+  "settings.help.reportBug": {
+    "defaultMessage": "Laporkan Pepijat"
+  },
+  "settings.help.requestFeature": {
+    "defaultMessage": "Minta Ciri"
+  },
+  "settings.help.title": {
+    "defaultMessage": "Bantuan & maklum balas"
+  },
+  "settings.language.description": {
+    "defaultMessage": "Pilih bahasa paparan untuk goose"
+  },
+  "settings.language.english": {
+    "defaultMessage": "English"
+  },
+  "settings.language.french": {
+    "defaultMessage": "Bahasa Perancis"
+  },
+  "settings.language.german": {
+    "defaultMessage": "Bahasa Jerman"
+  },
+  "settings.language.hindi": {
+    "defaultMessage": "Bahasa Hindi"
+  },
+  "settings.language.indonesian": {
+    "defaultMessage": "Bahasa Indonesia"
+  },
+  "settings.language.italian": {
+    "defaultMessage": "Bahasa Itali"
+  },
+  "settings.language.japanese": {
+    "defaultMessage": "Bahasa Jepun"
+  },
+  "settings.language.korean": {
+    "defaultMessage": "Bahasa Korea"
+  },
+  "settings.language.malay": {
+    "defaultMessage": "Bahasa Melayu"
+  },
+  "settings.language.portuguese": {
+    "defaultMessage": "Bahasa Portugis"
+  },
+  "settings.language.russian": {
+    "defaultMessage": "Bahasa Rusia"
+  },
+  "settings.language.spanish": {
+    "defaultMessage": "Bahasa Sepanyol"
+  },
+  "settings.language.systemDefault": {
+    "defaultMessage": "Lalai Sistem"
+  },
+  "settings.language.title": {
+    "defaultMessage": "Bahasa"
+  },
+  "settings.language.turkish": {
+    "defaultMessage": "Bahasa Turki"
+  },
+  "settings.language.vietnamese": {
+    "defaultMessage": "Bahasa Vietnam"
+  },
+  "settings.language.zhCN": {
+    "defaultMessage": "Bahasa Cina (Ringkas)"
+  },
+  "settings.language.zhTW": {
+    "defaultMessage": "Bahasa Cina (Tradisional)"
+  },
+  "settings.menuBarIcon.description": {
+    "defaultMessage": "Tunjukkan goose dalam bar menu"
+  },
+  "settings.menuBarIcon.title": {
+    "defaultMessage": "Ikon bar menu"
+  },
+  "settings.notifications.configGuide": {
+    "defaultMessage": "Panduan konfigurasi"
+  },
+  "settings.notifications.description": {
+    "defaultMessage": "Pemberitahuan diuruskan oleh OS anda - {link}"
+  },
+  "settings.notifications.modal.macInstructions": {
+    "defaultMessage": "Untuk mendayakan pemberitahuan pada macOS:"
+  },
+  "settings.notifications.modal.macStep1": {
+    "defaultMessage": "Buka System Preferences"
+  },
+  "settings.notifications.modal.macStep2": {
+    "defaultMessage": "Klik pada Notifications"
+  },
+  "settings.notifications.modal.macStep3": {
+    "defaultMessage": "Cari dan pilih goose dalam senarai aplikasi"
+  },
+  "settings.notifications.modal.macStep4": {
+    "defaultMessage": "Dayakan pemberitahuan dan laraskan tetapan mengikut kehendak"
+  },
+  "settings.notifications.modal.title": {
+    "defaultMessage": "Cara Mendayakan Pemberitahuan"
+  },
+  "settings.notifications.modal.winInstructions": {
+    "defaultMessage": "Untuk mendayakan pemberitahuan pada Windows:"
+  },
+  "settings.notifications.modal.winStep1": {
+    "defaultMessage": "Buka Settings"
+  },
+  "settings.notifications.modal.winStep2": {
+    "defaultMessage": "Pergi ke System > Notifications"
+  },
+  "settings.notifications.modal.winStep3": {
+    "defaultMessage": "Cari dan pilih goose dalam senarai aplikasi"
+  },
+  "settings.notifications.modal.winStep4": {
+    "defaultMessage": "Hidupkan pemberitahuan dan laraskan tetapan mengikut kehendak"
+  },
+  "settings.notifications.openSettings": {
+    "defaultMessage": "Buka Tetapan"
+  },
+  "settings.notifications.task.description": {
+    "defaultMessage": "Beritahu apabila Goose menyelesaikan tugasan semasa tetingkap berada di latar belakang"
+  },
+  "settings.notifications.task.title": {
+    "defaultMessage": "Pemberitahuan penyelesaian tugasan"
+  },
+  "settings.notifications.title": {
+    "defaultMessage": "Pemberitahuan"
+  },
+  "settings.preventSleep.description": {
+    "defaultMessage": "Pastikan komputer anda kekal terjaga semasa goose sedang menjalankan tugasan (skrin masih boleh dikunci)"
+  },
+  "settings.preventSleep.title": {
+    "defaultMessage": "Cegah Tidur"
+  },
+  "settings.theme.description": {
+    "defaultMessage": "Sesuaikan rupa dan rasa goose"
+  },
+  "settings.theme.title": {
+    "defaultMessage": "Tema"
+  },
+  "settings.updates.description": {
+    "defaultMessage": "Semak dan pasang kemas kini untuk memastikan goose berjalan dengan terbaik"
+  },
+  "settings.updates.title": {
+    "defaultMessage": "Kemas Kini"
+  },
+  "settings.version.title": {
+    "defaultMessage": "Versi"
+  },
+  "settingsView.tabApp": {
+    "defaultMessage": "Aplikasi"
+  },
+  "settingsView.tabAuth": {
+    "defaultMessage": "Pengesahan"
+  },
+  "settingsView.tabChat": {
+    "defaultMessage": "Sembang"
+  },
+  "settingsView.tabKeyboard": {
+    "defaultMessage": "Papan Kekunci"
+  },
+  "settingsView.tabLocalInference": {
+    "defaultMessage": "Inferens Tempatan"
+  },
+  "settingsView.tabModels": {
+    "defaultMessage": "Model"
+  },
+  "settingsView.tabPrompts": {
+    "defaultMessage": "Gesaan"
+  },
+  "settingsView.tabSession": {
+    "defaultMessage": "Sesi"
+  },
+  "settingsView.title": {
+    "defaultMessage": "Tetapan"
+  },
+  "sheet.close": {
+    "defaultMessage": "Tutup"
+  },
+  "shortcutRecorder.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "shortcutRecorder.clickToRecord": {
+    "defaultMessage": "Klik untuk merakam..."
+  },
+  "shortcutRecorder.conflictWarning": {
+    "defaultMessage": "Pintasan ini sudah digunakan oleh {label}. Menyimpan akan menetapkannya semula kepada tindakan ini."
+  },
+  "shortcutRecorder.pressShortcut": {
+    "defaultMessage": "Tekan pintasan..."
+  },
+  "shortcutRecorder.save": {
+    "defaultMessage": "Simpan"
+  },
+  "skillsView.addSkill": {
+    "defaultMessage": "Tambah Kemahiran"
+  },
+  "skillsView.adjustSearchTerms": {
+    "defaultMessage": "Cuba laraskan terma carian anda"
+  },
+  "skillsView.comingSoon": {
+    "defaultMessage": "Akan datang"
+  },
+  "skillsView.errorLoadingSkills": {
+    "defaultMessage": "Ralat Memuatkan Kemahiran"
+  },
+  "skillsView.noMatchingSkills": {
+    "defaultMessage": "Tiada kemahiran sepadan ditemui"
+  },
+  "skillsView.noSkillsDescription": {
+    "defaultMessage": "Kemahiran dimuatkan daripada fail SKILL.md dalam ~/.config/agents/skills/, .goose/skills/, atau direktori lain yang disokong."
+  },
+  "skillsView.noSkillsInstalled": {
+    "defaultMessage": "Tiada kemahiran dipasang"
+  },
+  "skillsView.searchSkillsPlaceholder": {
+    "defaultMessage": "Cari kemahiran..."
+  },
+  "skillsView.skillsDescription": {
+    "defaultMessage": "Lihat kemahiran terpasang yang meluaskan keupayaan Goose. {shortcut} untuk mencari."
+  },
+  "skillsView.skillsTitle": {
+    "defaultMessage": "Kemahiran"
+  },
+  "skillsView.tryAgain": {
+    "defaultMessage": "Cuba Lagi"
+  },
+  "spellcheckToggle.description": {
+    "defaultMessage": "Semak ejaan dalam input sembang. Memerlukan mula semula untuk berkuat kuasa."
+  },
+  "spellcheckToggle.title": {
+    "defaultMessage": "Dayakan Semakan Ejaan"
+  },
+  "standaloneAppView.failedToLoad": {
+    "defaultMessage": "Gagal Memuatkan Aplikasi"
+  },
+  "standaloneAppView.initializing": {
+    "defaultMessage": "Memulakan aplikasi..."
+  },
+  "standaloneAppView.missingParams": {
+    "defaultMessage": "Parameter yang diperlukan tiada"
+  },
+  "stringUtils.configuredProvider": {
+    "defaultMessage": "Penyedia {name} telah dikonfigurasikan"
+  },
+  "stringUtils.ollamaApp": {
+    "defaultMessage": "Aplikasi Ollama"
+  },
+  "stringUtils.ollamaNotConfiguredPrefix": {
+    "defaultMessage": "Untuk menggunakannya, sama ada"
+  },
+  "stringUtils.ollamaNotConfiguredSuffix": {
+    "defaultMessage": "mesti dipasang pada mesin anda dan dibuka, atau anda mesti memasukkan nilai untuk OLLAMA_HOST."
+  },
+  "subRecipeEditor.addExisting": {
+    "defaultMessage": "Tambah Sedia Ada"
+  },
+  "subRecipeEditor.createNew": {
+    "defaultMessage": "Cipta Subresipi Baharu"
+  },
+  "subRecipeEditor.deleteSubrecipe": {
+    "defaultMessage": "Padam subresipi {name}"
+  },
+  "subRecipeEditor.description": {
+    "defaultMessage": "Subresipi ialah resipi yang boleh dipanggil sebagai alat semasa pelaksanaan. Ia membolehkan aliran kerja berbilang langkah dan komponen yang boleh diguna semula."
+  },
+  "subRecipeEditor.duplicateName": {
+    "defaultMessage": "Nama Berganda"
+  },
+  "subRecipeEditor.duplicateNameMsg": {
+    "defaultMessage": "Subresipi bernama \"{name}\" sudah wujud. Sila gunakan nama yang unik."
+  },
+  "subRecipeEditor.editSubrecipe": {
+    "defaultMessage": "Sunting subresipi {name}"
+  },
+  "subRecipeEditor.label": {
+    "defaultMessage": "Subresipi"
+  },
+  "subRecipeEditor.preconfiguredValues": {
+    "defaultMessage": "Nilai prakonfigurasi:"
+  },
+  "subRecipeEditor.sequential": {
+    "defaultMessage": "Berjujukan"
+  },
+  "subRecipeModal.addTitle": {
+    "defaultMessage": "Tambah Subresipi"
+  },
+  "subRecipeModal.apply": {
+    "defaultMessage": "Gunakan"
+  },
+  "subRecipeModal.browse": {
+    "defaultMessage": "Semak Imbas"
+  },
+  "subRecipeModal.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "subRecipeModal.closeModal": {
+    "defaultMessage": "Tutup modal subresipi"
+  },
+  "subRecipeModal.configureTitle": {
+    "defaultMessage": "Konfigurasikan Subresipi"
+  },
+  "subRecipeModal.descriptionLabel": {
+    "defaultMessage": "Penerangan"
+  },
+  "subRecipeModal.descriptionPlaceholder": {
+    "defaultMessage": "Penerangan pilihan tentang apa yang dilakukan subresipi ini..."
+  },
+  "subRecipeModal.invalidFile": {
+    "defaultMessage": "Fail Tidak Sah"
+  },
+  "subRecipeModal.invalidFileMsg": {
+    "defaultMessage": "Sila pilih fail YAML (.yaml atau .yml)."
+  },
+  "subRecipeModal.nameHint": {
+    "defaultMessage": "Pengecam unik yang digunakan untuk menjana nama alat"
+  },
+  "subRecipeModal.nameLabel": {
+    "defaultMessage": "Nama"
+  },
+  "subRecipeModal.namePlaceholder": {
+    "defaultMessage": "cth., security_scan"
+  },
+  "subRecipeModal.pathHint": {
+    "defaultMessage": "Semak imbas untuk fail resipi sedia ada atau masukkan laluan secara manual"
+  },
+  "subRecipeModal.pathLabel": {
+    "defaultMessage": "Laluan"
+  },
+  "subRecipeModal.pathPlaceholder": {
+    "defaultMessage": "cth., ./subrecipes/security-analysis.yaml"
+  },
+  "subRecipeModal.preconfiguredValues": {
+    "defaultMessage": "Nilai Prakonfigurasi"
+  },
+  "subRecipeModal.preconfiguredValuesHint": {
+    "defaultMessage": "Nilai parameter pilihan yang sentiasa dihantar kepada subresipi"
+  },
+  "subRecipeModal.sequentialHint": {
+    "defaultMessage": "(Memaksa pelaksanaan berjujukan bagi berbilang tika subresipi)"
+  },
+  "subRecipeModal.sequentialLabel": {
+    "defaultMessage": "Berjujukan apabila diulang"
+  },
+  "subRecipeModal.subtitle": {
+    "defaultMessage": "Konfigurasikan subresipi yang boleh dipanggil sebagai alat semasa pelaksanaan resipi"
+  },
+  "switchModelModal.backToModelList": {
+    "defaultMessage": "Kembali ke senarai model"
+  },
+  "switchModelModal.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "switchModelModal.checkProviderConfig": {
+    "defaultMessage": "Semak konfigurasi penyedia anda dalam Tetapan → Penyedia"
+  },
+  "switchModelModal.chooseModel": {
+    "defaultMessage": "Pilih model:"
+  },
+  "switchModelModal.claudeAdaptive": {
+    "defaultMessage": "Adaptif - Claude menentukan bila dan sebanyak mana untuk berfikir"
+  },
+  "switchModelModal.claudeDisabled": {
+    "defaultMessage": "Dilumpuhkan - Tiada pemikiran lanjutan"
+  },
+  "switchModelModal.claudeEffortHigh": {
+    "defaultMessage": "Tinggi - Penaakulan mendalam (lalai)"
+  },
+  "switchModelModal.claudeEffortLow": {
+    "defaultMessage": "Rendah - Pemikiran minimum, respons terpantas"
+  },
+  "switchModelModal.claudeEffortMax": {
+    "defaultMessage": "Maksimum - Tiada kekangan pada kedalaman pemikiran"
+  },
+  "switchModelModal.claudeEffortMedium": {
+    "defaultMessage": "Sederhana - Pemikiran sederhana"
+  },
+  "switchModelModal.claudeEnabled": {
+    "defaultMessage": "Didayakan - Bajet token tetap untuk pemikiran"
+  },
+  "switchModelModal.couldNotContactProvider": {
+    "defaultMessage": "Tidak dapat menghubungi penyedia"
+  },
+  "switchModelModal.customModelName": {
+    "defaultMessage": "Nama model tersuai"
+  },
+  "switchModelModal.description": {
+    "defaultMessage": "Pilih penyedia dan model untuk digunakan bagi perbualan anda."
+  },
+  "switchModelModal.enterModelNotListed": {
+    "defaultMessage": "Masukkan model yang tidak tersenarai..."
+  },
+  "switchModelModal.extendedThinking": {
+    "defaultMessage": "Pemikiran Lanjutan"
+  },
+  "switchModelModal.geminiOnly": {
+    "defaultMessage": "(Model Gemini 3 sahaja)"
+  },
+  "switchModelModal.goToSettings": {
+    "defaultMessage": "Pergi ke Tetapan"
+  },
+  "switchModelModal.loadingModels": {
+    "defaultMessage": "Memuatkan model…"
+  },
+  "switchModelModal.localModelsDescription": {
+    "defaultMessage": "Untuk menggunakan inferens setempat, anda perlu memuat turun model ke komputer anda terlebih dahulu. Pergi ke Tetapan → Model untuk mengurus model setempat."
+  },
+  "switchModelModal.localModelsTitle": {
+    "defaultMessage": "Model setempat perlu dimuat turun terlebih dahulu"
+  },
+  "switchModelModal.providerPlaceholder": {
+    "defaultMessage": "Penyedia, taip untuk mencari"
+  },
+  "switchModelModal.quickStartGuide": {
+    "defaultMessage": "Panduan permulaan pantas"
+  },
+  "switchModelModal.recommended": {
+    "defaultMessage": "Disyorkan"
+  },
+  "switchModelModal.selectEffortLevel": {
+    "defaultMessage": "Pilih tahap usaha"
+  },
+  "switchModelModal.selectModel": {
+    "defaultMessage": "Sila pilih model"
+  },
+  "switchModelModal.selectModelButton": {
+    "defaultMessage": "Pilih model"
+  },
+  "switchModelModal.selectModelPlaceholder": {
+    "defaultMessage": "Pilih model, taip untuk mencari"
+  },
+  "switchModelModal.selectOrEnterModel": {
+    "defaultMessage": "Sila pilih atau masukkan model"
+  },
+  "switchModelModal.selectProvider": {
+    "defaultMessage": "Sila pilih penyedia"
+  },
+  "switchModelModal.selectThinkingLevel": {
+    "defaultMessage": "Pilih tahap pemikiran"
+  },
+  "switchModelModal.selectThinkingMode": {
+    "defaultMessage": "Pilih mod pemikiran"
+  },
+  "switchModelModal.thinkingBudget": {
+    "defaultMessage": "Bajet Pemikiran (token)"
+  },
+  "switchModelModal.thinkingEffort": {
+    "defaultMessage": "Usaha Pemikiran"
+  },
+  "switchModelModal.thinkingEffortOff": {
+    "defaultMessage": "Mati - Tiada pemikiran lanjutan"
+  },
+  "switchModelModal.thinkingLevel": {
+    "defaultMessage": "Tahap Pemikiran"
+  },
+  "switchModelModal.thinkingLevelHigh": {
+    "defaultMessage": "Tinggi - Penaakulan lebih mendalam, latensi lebih tinggi"
+  },
+  "switchModelModal.thinkingLevelLow": {
+    "defaultMessage": "Rendah - Latensi lebih baik, penaakulan lebih ringan"
+  },
+  "switchModelModal.title": {
+    "defaultMessage": "Tukar model"
+  },
+  "switchModelModal.typeModelName": {
+    "defaultMessage": "Taip nama model di sini"
+  },
+  "switchModelModal.useOtherProvider": {
+    "defaultMessage": "Gunakan penyedia lain"
+  },
+  "telemetryConsentPrompt.description": {
+    "defaultMessage": "Adakah anda ingin berkongsi data penggunaan tanpa nama untuk membantu menambah baik goose? Kami tidak pernah mengumpul perbualan, kod, atau data peribadi anda."
+  },
+  "telemetryConsentPrompt.heading": {
+    "defaultMessage": "Bantu menambah baik goose"
+  },
+  "telemetryConsentPrompt.learnMore": {
+    "defaultMessage": "Ketahui lebih lanjut"
+  },
+  "telemetryConsentPrompt.optIn": {
+    "defaultMessage": "Ya, kongsi data penggunaan tanpa nama"
+  },
+  "telemetryConsentPrompt.optOut": {
+    "defaultMessage": "Tidak, terima kasih"
+  },
+  "telemetrySettings.configErrorTitle": {
+    "defaultMessage": "Ralat Konfigurasi"
+  },
+  "telemetrySettings.description": {
+    "defaultMessage": "Kawal cara data anda digunakan"
+  },
+  "telemetrySettings.learnMore": {
+    "defaultMessage": "Ketahui lebih lanjut"
+  },
+  "telemetrySettings.loadError": {
+    "defaultMessage": "Gagal memuatkan tetapan telemetri."
+  },
+  "telemetrySettings.title": {
+    "defaultMessage": "Privasi"
+  },
+  "telemetrySettings.toggleDescription": {
+    "defaultMessage": "Bantu menambah baik goose dengan berkongsi statistik penggunaan tanpa nama."
+  },
+  "telemetrySettings.toggleLabel": {
+    "defaultMessage": "Data penggunaan tanpa nama"
+  },
+  "telemetrySettings.updateError": {
+    "defaultMessage": "Gagal mengemas kini tetapan telemetri."
+  },
+  "themeSelector.dark": {
+    "defaultMessage": "Gelap"
+  },
+  "themeSelector.light": {
+    "defaultMessage": "Cerah"
+  },
+  "themeSelector.system": {
+    "defaultMessage": "Sistem"
+  },
+  "themeSelector.theme": {
+    "defaultMessage": "Tema"
+  },
+  "toolApprovalButtons.allowOnce": {
+    "defaultMessage": "Benarkan Sekali"
+  },
+  "toolApprovalButtons.allowedOnce": {
+    "defaultMessage": "Dibenarkan sekali"
+  },
+  "toolApprovalButtons.alwaysAllow": {
+    "defaultMessage": "Sentiasa Benarkan"
+  },
+  "toolApprovalButtons.alwaysAllowed": {
+    "defaultMessage": "Sentiasa dibenarkan"
+  },
+  "toolApprovalButtons.cancelled": {
+    "defaultMessage": "Dibatalkan"
+  },
+  "toolApprovalButtons.denied": {
+    "defaultMessage": "Dinafikan"
+  },
+  "toolApprovalButtons.deniedOnce": {
+    "defaultMessage": "Dinafikan sekali"
+  },
+  "toolApprovalButtons.deny": {
+    "defaultMessage": "Nafikan"
+  },
+  "toolApprovalButtons.staleApprovalRequest": {
+    "defaultMessage": "Permintaan kelulusan ini tidak lagi aktif."
+  },
+  "toolCallStatusIndicator.toolStatus": {
+    "defaultMessage": "Status alat: {status}"
+  },
+  "toolCallWithResponse.activityCount": {
+    "defaultMessage": "Aktiviti ({count})"
+  },
+  "toolCallWithResponse.code": {
+    "defaultMessage": "Kod"
+  },
+  "toolCallWithResponse.loadingSpinner": {
+    "defaultMessage": "Pemutar pemuatan"
+  },
+  "toolCallWithResponse.logs": {
+    "defaultMessage": "Log"
+  },
+  "toolCallWithResponse.mcpUiExperimental": {
+    "defaultMessage": "MCP UI adalah eksperimen dan boleh berubah pada bila-bila masa."
+  },
+  "toolCallWithResponse.output": {
+    "defaultMessage": "Output"
+  },
+  "toolCallWithResponse.toolDetails": {
+    "defaultMessage": "Butiran Alat"
+  },
+  "toolCallWithResponse.toolResultAlt": {
+    "defaultMessage": "Hasil alat"
+  },
+  "toolCallWithResponse.viewSubagentSession": {
+    "defaultMessage": "Lihat sesi subejen"
+  },
+  "toolConfirmation.allowToolCallWithName": {
+    "defaultMessage": "Benarkan {toolName}?"
+  },
+  "toolConfirmation.gooseWouldLikeToCallWithName": {
+    "defaultMessage": "Goose ingin memanggil {toolName}. Benarkan?"
+  },
+  "updateSection.autoDownload": {
+    "defaultMessage": "Goose akan memuat turun kemas kini di latar belakang dan memasangnya pada kali seterusnya anda keluar atau mula semula."
+  },
+  "updateSection.autoDownloadDisabledByEnv": {
+    "defaultMessage": "Muat turun automatik dilumpuhkan melalui pemboleh ubah persekitaran GOOSE_DISABLE_AUTO_DOWNLOAD."
+  },
+  "updateSection.autoDownloadDisabledNote": {
+    "defaultMessage": "Muat turun automatik dilumpuhkan. Klik \"Muat Turun Sekarang\" untuk memuat turun secara manual."
+  },
+  "updateSection.autoInstallNote": {
+    "defaultMessage": "Tiada pemasangan manual diperlukan."
+  },
+  "updateSection.checkForUpdates": {
+    "defaultMessage": "Semak Kemas Kini"
+  },
+  "updateSection.checking": {
+    "defaultMessage": "Menyemak kemas kini..."
+  },
+  "updateSection.currentVersion": {
+    "defaultMessage": "Versi semasa"
+  },
+  "updateSection.disableAutoDownload": {
+    "defaultMessage": "Lumpuhkan muat turun kemas kini automatik"
+  },
+  "updateSection.disableAutoDownloadDesc": {
+    "defaultMessage": "Apabila didayakan, Goose akan memberitahu anda tentang versi baharu tetapi tidak akan memuat turunnya secara automatik."
+  },
+  "updateSection.downloadNow": {
+    "defaultMessage": "Muat Turun Sekarang"
+  },
+  "updateSection.downloadReady": {
+    "defaultMessage": "Kemas kini dimuat turun dan sedia untuk dipasang!"
+  },
+  "updateSection.downloadingProgress": {
+    "defaultMessage": "Memuat turun kemas kini... {percent}%"
+  },
+  "updateSection.downloadingUpdate": {
+    "defaultMessage": "Memuat turun kemas kini..."
+  },
+  "updateSection.installAndRestart": {
+    "defaultMessage": "Pasang & Mula Semula"
+  },
+  "updateSection.installNowHint": {
+    "defaultMessage": "Klik \"Pasang & Mula Semula\" untuk mengemas kini sekarang."
+  },
+  "updateSection.latestVersion": {
+    "defaultMessage": "Anda sedang menjalankan versi terkini!"
+  },
+  "updateSection.loading": {
+    "defaultMessage": "Memuatkan..."
+  },
+  "updateSection.manualInstallNote": {
+    "defaultMessage": "Selepas muat turun, anda perlu memasang kemas kini secara manual."
+  },
+  "updateSection.manualInstallRequired": {
+    "defaultMessage": "Pemasangan manual diperlukan untuk kaedah kemas kini ini."
+  },
+  "updateSection.readyInstallAuto": {
+    "defaultMessage": "✓ Kemas kini sudah sedia. Mula semula Goose untuk menyelesaikan pemasangannya, atau keluar apabila anda selesai."
+  },
+  "updateSection.readyInstallManual": {
+    "defaultMessage": "✓ Kemas kini sudah sedia! Klik \"Pasang & Mula Semula\" untuk arahan pemasangan."
+  },
+  "updateSection.upToDate": {
+    "defaultMessage": "(terkini)"
+  },
+  "updateSection.updateAvailable": {
+    "defaultMessage": "Kemas kini tersedia!"
+  },
+  "updateSection.versionAvailable": {
+    "defaultMessage": "→ {version} tersedia"
+  },
+  "updateSection.versionIsAvailable": {
+    "defaultMessage": "Versi {version} tersedia"
+  },
+  "userMessage.cancel": {
+    "defaultMessage": "Batal"
+  },
+  "userMessage.cancelAriaLabel": {
+    "defaultMessage": "Batal penyuntingan"
+  },
+  "userMessage.editAriaLabel": {
+    "defaultMessage": "Sunting kandungan mesej"
+  },
+  "userMessage.editButton": {
+    "defaultMessage": "Sunting"
+  },
+  "userMessage.editInPlace": {
+    "defaultMessage": "Sunting di Tempat"
+  },
+  "userMessage.editInPlaceAriaLabel": {
+    "defaultMessage": "Sunting mesej di tempat"
+  },
+  "userMessage.editInPlaceDescription": {
+    "defaultMessage": "<b>Sunting di Tempat</b> mengemas kini sesi ini • <b>Cabang Sesi</b> mencipta sesi baharu"
+  },
+  "userMessage.editInPlaceTitle": {
+    "defaultMessage": "Kemas kini mesej dalam sesi ini"
+  },
+  "userMessage.editMessageAriaLabel": {
+    "defaultMessage": "Sunting mesej: {preview}"
+  },
+  "userMessage.editMessageTitle": {
+    "defaultMessage": "Sunting mesej"
+  },
+  "userMessage.editPlaceholder": {
+    "defaultMessage": "Sunting mesej anda..."
+  },
+  "userMessage.emptyError": {
+    "defaultMessage": "Mesej tidak boleh kosong"
+  },
+  "userMessage.forkSession": {
+    "defaultMessage": "Cabang Sesi"
+  },
+  "userMessage.forkSessionAriaLabel": {
+    "defaultMessage": "Cabang sesi dengan mesej yang disunting"
+  },
+  "userMessage.forkSessionTitle": {
+    "defaultMessage": "Cipta sesi baharu dengan mesej yang disunting"
+  }
+}

--- a/ui/desktop/src/i18n/messages/pt.json
+++ b/ui/desktop/src/i18n/messages/pt.json
@@ -1,0 +1,4574 @@
+{
+  "alertBox.autoCompactAt": {
+    "defaultMessage": "Compactação automática em"
+  },
+  "alertBox.compactNow": {
+    "defaultMessage": "Compactar agora"
+  },
+  "alertBox.failedToSaveThreshold": {
+    "defaultMessage": "Falha ao guardar o limite: {error}"
+  },
+  "announcementModal.gotIt": {
+    "defaultMessage": "Entendido!"
+  },
+  "appLayout.collapseNavigation": {
+    "defaultMessage": "Recolher navegação"
+  },
+  "appLayout.openNavigation": {
+    "defaultMessage": "Abrir navegação"
+  },
+  "appsView.customApp": {
+    "defaultMessage": "Aplicação personalizada"
+  },
+  "appsView.description": {
+    "defaultMessage": "Aplicações dos seus servidores MCP e aplicações criadas pelo próprio goose. Pode pedir-lhe para criar novas aplicações através da interface de chat e elas aparecerão aqui."
+  },
+  "appsView.errorLoading": {
+    "defaultMessage": "Erro ao carregar aplicações: {error}"
+  },
+  "appsView.importApp": {
+    "defaultMessage": "Importar aplicação"
+  },
+  "appsView.launch": {
+    "defaultMessage": "Iniciar"
+  },
+  "appsView.loading": {
+    "defaultMessage": "A carregar aplicações..."
+  },
+  "appsView.noAppsDescription": {
+    "defaultMessage": "Abra um chat e peça ao goose a aplicação que pretende. Ele pode criar uma para si e ela aparecerá aqui. Ou, se alguém tiver partilhado uma aplicação, pode importá-la com o botão acima."
+  },
+  "appsView.noAppsTitle": {
+    "defaultMessage": "Nenhuma aplicação disponível"
+  },
+  "appsView.retry": {
+    "defaultMessage": "Tentar novamente"
+  },
+  "appsView.title": {
+    "defaultMessage": "Aplicações"
+  },
+  "authSettings.activeProviderWarning": {
+    "defaultMessage": "Este é o fornecedor ativo. Os novos pedidos podem falhar até configurar outra credencial."
+  },
+  "authSettings.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "authSettings.delete": {
+    "defaultMessage": "Eliminar"
+  },
+  "authSettings.deleteCredential": {
+    "defaultMessage": "Eliminar credencial"
+  },
+  "authSettings.deleteMessage": {
+    "defaultMessage": "Eliminar a credencial {name} de {provider}?"
+  },
+  "authSettings.deleteTitle": {
+    "defaultMessage": "Eliminar credencial"
+  },
+  "authSettings.deleted": {
+    "defaultMessage": "Credencial eliminada"
+  },
+  "authSettings.description": {
+    "defaultMessage": "Faça a gestão das credenciais de fornecedores armazenadas localmente pelo goose."
+  },
+  "authSettings.empty": {
+    "defaultMessage": "Não foram encontradas credenciais de fornecedores armazenadas localmente."
+  },
+  "authSettings.expiresAt": {
+    "defaultMessage": "Expira em {date}"
+  },
+  "authSettings.failedToConfigure": {
+    "defaultMessage": "Falha ao configurar a credencial: {error}"
+  },
+  "authSettings.failedToDelete": {
+    "defaultMessage": "Falha ao eliminar a credencial: {error}"
+  },
+  "authSettings.failedToLoad": {
+    "defaultMessage": "Falha ao carregar as credenciais dos fornecedores"
+  },
+  "authSettings.loading": {
+    "defaultMessage": "A carregar credenciais..."
+  },
+  "authSettings.reauthorize": {
+    "defaultMessage": "Reautorizar"
+  },
+  "authSettings.signIn": {
+    "defaultMessage": "Iniciar sessão"
+  },
+  "authSettings.signedIn": {
+    "defaultMessage": "Credencial configurada"
+  },
+  "authSettings.storageProviderCache": {
+    "defaultMessage": "Cache do fornecedor"
+  },
+  "authSettings.storageSecretStore": {
+    "defaultMessage": "Cofre de segredos"
+  },
+  "authSettings.title": {
+    "defaultMessage": "Credenciais dos fornecedores"
+  },
+  "backButton.back": {
+    "defaultMessage": "Voltar"
+  },
+  "baseChat.failedToLoadSession": {
+    "defaultMessage": "Falha ao carregar a sessão"
+  },
+  "baseChat.goHome": {
+    "defaultMessage": "Ir para o início"
+  },
+  "bottomMenuExtensionSelection.extensionUpdated": {
+    "defaultMessage": "Extensão atualizada"
+  },
+  "bottomMenuExtensionSelection.extensionWillBeDisabled": {
+    "defaultMessage": "{name} será desativada em novos chats"
+  },
+  "bottomMenuExtensionSelection.extensionWillBeEnabled": {
+    "defaultMessage": "{name} será ativada em novos chats"
+  },
+  "bottomMenuExtensionSelection.extensionsForNewChats": {
+    "defaultMessage": "Extensões para novos chats"
+  },
+  "bottomMenuExtensionSelection.extensionsForThisSession": {
+    "defaultMessage": "Extensões para esta sessão de chat"
+  },
+  "bottomMenuExtensionSelection.manageExtensions": {
+    "defaultMessage": "gerir extensões"
+  },
+  "bottomMenuExtensionSelection.noExtensionsAvailable": {
+    "defaultMessage": "nenhuma extensão disponível"
+  },
+  "bottomMenuExtensionSelection.noExtensionsFound": {
+    "defaultMessage": "nenhuma extensão encontrada"
+  },
+  "bottomMenuExtensionSelection.searchExtensions": {
+    "defaultMessage": "procurar extensões..."
+  },
+  "cardButtons.configure": {
+    "defaultMessage": "Configurar"
+  },
+  "cardButtons.launch": {
+    "defaultMessage": "Iniciar"
+  },
+  "chat.notification.taskComplete.body": {
+    "defaultMessage": "Clique aqui para colocar o Goose novamente em foco."
+  },
+  "chat.notification.taskComplete.title": {
+    "defaultMessage": "O Goose concluiu a tarefa."
+  },
+  "chatInput.contextWindow": {
+    "defaultMessage": "Janela de contexto"
+  },
+  "chatInput.dictationError": {
+    "defaultMessage": "Erro de ditado"
+  },
+  "chatInput.failedToReadImage": {
+    "defaultMessage": "Falha ao ler o ficheiro de imagem"
+  },
+  "chatInput.navigationShortcut": {
+    "defaultMessage": "{prefix}↑/{prefix}↓ para navegar entre mensagens"
+  },
+  "chatInput.processingDroppedFiles": {
+    "defaultMessage": "A processar ficheiros largados..."
+  },
+  "chatInput.recording": {
+    "defaultMessage": "A gravar..."
+  },
+  "chatInput.removeFile": {
+    "defaultMessage": "Remover ficheiro"
+  },
+  "chatInput.removeImage": {
+    "defaultMessage": "Remover imagem"
+  },
+  "chatInput.restartingSession": {
+    "defaultMessage": "A reiniciar a sessão..."
+  },
+  "chatInput.send": {
+    "defaultMessage": "Enviar"
+  },
+  "chatInput.transcribing": {
+    "defaultMessage": "A transcrever..."
+  },
+  "chatInput.typeMessage": {
+    "defaultMessage": "Escreva uma mensagem para enviar"
+  },
+  "chatInput.unknownType": {
+    "defaultMessage": "Tipo desconhecido"
+  },
+  "chatInput.viewEditRecipe": {
+    "defaultMessage": "Ver/editar receita"
+  },
+  "chatInput.waitingForCancellation": {
+    "defaultMessage": "A aguardar a conclusão do cancelamento"
+  },
+  "chatInput.waitingForImages": {
+    "defaultMessage": "A aguardar que as imagens sejam guardadas..."
+  },
+  "chatSettings.modeDescription": {
+    "defaultMessage": "Escolha o modo predefinido que o Goose utiliza para novas sessões. As sessões existentes mantêm o seu modo atual."
+  },
+  "chatSettings.modeTitle": {
+    "defaultMessage": "Modo predefinido"
+  },
+  "chatSettings.responseStylesDescription": {
+    "defaultMessage": "Escolha como o Goose deve formatar e estilizar as suas respostas"
+  },
+  "chatSettings.responseStylesTitle": {
+    "defaultMessage": "Estilos de resposta"
+  },
+  "configSettings.configReset": {
+    "defaultMessage": "Configuração reposta"
+  },
+  "configSettings.configResetMsg": {
+    "defaultMessage": "Todas as alterações foram revertidas"
+  },
+  "configSettings.configUpdated": {
+    "defaultMessage": "Configuração atualizada"
+  },
+  "configSettings.configUpdatedMsg": {
+    "defaultMessage": "\"{name}\" guardado com sucesso"
+  },
+  "configSettings.configurationEditor": {
+    "defaultMessage": "Editor de configuração"
+  },
+  "configSettings.description": {
+    "defaultMessage": "Edite as definições de configuração do seu goose"
+  },
+  "configSettings.descriptionWithProvider": {
+    "defaultMessage": "Edite as definições de configuração do seu goose (definições atuais de {provider})"
+  },
+  "configSettings.done": {
+    "defaultMessage": "Concluído"
+  },
+  "configSettings.editConfiguration": {
+    "defaultMessage": "Editar configuração"
+  },
+  "configSettings.enterValue": {
+    "defaultMessage": "Introduza {name}"
+  },
+  "configSettings.noSettings": {
+    "defaultMessage": "Nenhuma definição de configuração encontrada."
+  },
+  "configSettings.resetChanges": {
+    "defaultMessage": "Repor alterações"
+  },
+  "configSettings.saveFailed": {
+    "defaultMessage": "Falha ao guardar"
+  },
+  "configSettings.saveFailedMsg": {
+    "defaultMessage": "Falha ao guardar \"{name}\""
+  },
+  "configSettings.saving": {
+    "defaultMessage": "A guardar..."
+  },
+  "configSettings.title": {
+    "defaultMessage": "Configuração"
+  },
+  "configureApproveMode.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "configureApproveMode.description": {
+    "defaultMessage": "Os pedidos de aprovação podem ser concedidos a todos os pedidos de ferramentas ou determinar quais as ações que podem necessitar de integração"
+  },
+  "configureApproveMode.manualApproval": {
+    "defaultMessage": "Aprovação manual"
+  },
+  "configureApproveMode.manualApprovalDescription": {
+    "defaultMessage": "Todas as ferramentas, extensões e modificações de ficheiros exigirão aprovação humana"
+  },
+  "configureApproveMode.save": {
+    "defaultMessage": "Guardar"
+  },
+  "configureApproveMode.saving": {
+    "defaultMessage": "A guardar..."
+  },
+  "configureApproveMode.smartApproval": {
+    "defaultMessage": "Aprovação inteligente"
+  },
+  "configureApproveMode.smartApprovalDescription": {
+    "defaultMessage": "Determinar de forma inteligente quais as ações que necessitam de aprovação com base no nível de risco"
+  },
+  "configureApproveMode.title": {
+    "defaultMessage": "Configurar modo de aprovação"
+  },
+  "confirmationModal.defaultCancel": {
+    "defaultMessage": "Não"
+  },
+  "confirmationModal.defaultConfirm": {
+    "defaultMessage": "Sim"
+  },
+  "confirmationModal.processing": {
+    "defaultMessage": "A processar..."
+  },
+  "conversationLimitsDropdown.conversationLimits": {
+    "defaultMessage": "Limites da conversa"
+  },
+  "conversationLimitsDropdown.maxTurns": {
+    "defaultMessage": "Máximo de turnos"
+  },
+  "conversationLimitsDropdown.maxTurnsDescription": {
+    "defaultMessage": "Número máximo de turnos do agente antes de o Goose solicitar a intervenção do utilizador"
+  },
+  "costTracker.costUnavailable": {
+    "defaultMessage": "Dados de custo não disponíveis para {model} ({inputTokens} tokens de entrada, {outputTokens} tokens de saída)"
+  },
+  "costTracker.inputOutputTooltip": {
+    "defaultMessage": "Entrada: {inputTokens} tokens ({inputCost}) | Saída: {outputTokens} tokens ({outputCost})"
+  },
+  "costTracker.pricingUnavailable": {
+    "defaultMessage": "Dados de preços não disponíveis para {model}"
+  },
+  "costTracker.totalSessionCost": {
+    "defaultMessage": "Custo total da sessão: {cost}"
+  },
+  "createEditRecipe.clickToGenerateDeeplink": {
+    "defaultMessage": "Clique para gerar o deeplink"
+  },
+  "createEditRecipe.close": {
+    "defaultMessage": "Fechar"
+  },
+  "createEditRecipe.copied": {
+    "defaultMessage": "Copiado!"
+  },
+  "createEditRecipe.copy": {
+    "defaultMessage": "Copiar"
+  },
+  "createEditRecipe.copyLinkDescription": {
+    "defaultMessage": "Copie este link para partilhar com amigos ou cole-o diretamente no Chrome para abrir"
+  },
+  "createEditRecipe.createRecipeTitle": {
+    "defaultMessage": "Criar receita"
+  },
+  "createEditRecipe.createSubtitle": {
+    "defaultMessage": "Crie uma nova receita para definir o comportamento e as capacidades do agente em sessões de chat reutilizáveis."
+  },
+  "createEditRecipe.editSubtitle": {
+    "defaultMessage": "Pode editar a receita abaixo para alterar o comportamento do agente numa nova sessão."
+  },
+  "createEditRecipe.generatingDeeplink": {
+    "defaultMessage": "A gerar deeplink..."
+  },
+  "createEditRecipe.learnMore": {
+    "defaultMessage": "Saber mais"
+  },
+  "createEditRecipe.recipeSavedAndLaunchedMsg": {
+    "defaultMessage": "Receita guardada e iniciada com sucesso"
+  },
+  "createEditRecipe.recipeSavedMsg": {
+    "defaultMessage": "Receita guardada com sucesso"
+  },
+  "createEditRecipe.saveAndRunFailed": {
+    "defaultMessage": "Falha ao guardar e executar"
+  },
+  "createEditRecipe.saveAndRunFailedMsg": {
+    "defaultMessage": "Falha ao guardar e executar a receita: {error}"
+  },
+  "createEditRecipe.saveAndRunRecipe": {
+    "defaultMessage": "Guardar e executar receita"
+  },
+  "createEditRecipe.saveFailed": {
+    "defaultMessage": "Falha ao guardar"
+  },
+  "createEditRecipe.saveFailedMsg": {
+    "defaultMessage": "Falha ao guardar a receita: {error}"
+  },
+  "createEditRecipe.saveRecipe": {
+    "defaultMessage": "Guardar receita"
+  },
+  "createEditRecipe.saving": {
+    "defaultMessage": "A guardar..."
+  },
+  "createEditRecipe.validationFailed": {
+    "defaultMessage": "Falha na validação"
+  },
+  "createEditRecipe.validationMsg": {
+    "defaultMessage": "Preencha todos os campos obrigatórios e certifique-se de que o esquema JSON é válido."
+  },
+  "createEditRecipe.viewEditRecipeTitle": {
+    "defaultMessage": "Ver/editar receita"
+  },
+  "createSubRecipeInline.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "createSubRecipeInline.closeModal": {
+    "defaultMessage": "Fechar janela de criação de subreceita"
+  },
+  "createSubRecipeInline.createAndAdd": {
+    "defaultMessage": "Criar e adicionar subreceita"
+  },
+  "createSubRecipeInline.createdSuccess": {
+    "defaultMessage": "Subreceita criada com sucesso"
+  },
+  "createSubRecipeInline.creating": {
+    "defaultMessage": "A criar..."
+  },
+  "createSubRecipeInline.duplicateName": {
+    "defaultMessage": "Nome duplicado"
+  },
+  "createSubRecipeInline.duplicateNameMsg": {
+    "defaultMessage": "Já existe uma subreceita com o nome \"{name}\". Utilize um nome único."
+  },
+  "createSubRecipeInline.instructionsLabel": {
+    "defaultMessage": "Instruções"
+  },
+  "createSubRecipeInline.instructionsPlaceholder": {
+    "defaultMessage": "Instruções para a IA quando esta subreceita é chamada..."
+  },
+  "createSubRecipeInline.nameHint": {
+    "defaultMessage": "Identificador único utilizado para gerar o nome da ferramenta"
+  },
+  "createSubRecipeInline.nameLabel": {
+    "defaultMessage": "Nome"
+  },
+  "createSubRecipeInline.namePlaceholder": {
+    "defaultMessage": "ex.: security_scan"
+  },
+  "createSubRecipeInline.preconfiguredValues": {
+    "defaultMessage": "Valores pré-configurados"
+  },
+  "createSubRecipeInline.preconfiguredValuesHint": {
+    "defaultMessage": "Valores de parâmetros opcionais que são sempre passados à subreceita"
+  },
+  "createSubRecipeInline.recipeDescriptionLabel": {
+    "defaultMessage": "Descrição da receita"
+  },
+  "createSubRecipeInline.recipeDescriptionPlaceholder": {
+    "defaultMessage": "O que esta receita faz quando é executada"
+  },
+  "createSubRecipeInline.recipeTitleLabel": {
+    "defaultMessage": "Título da receita"
+  },
+  "createSubRecipeInline.recipeTitlePlaceholder": {
+    "defaultMessage": "ex.: Ferramenta de análise de segurança"
+  },
+  "createSubRecipeInline.saveFailed": {
+    "defaultMessage": "Falha ao guardar"
+  },
+  "createSubRecipeInline.saveFailedMsg": {
+    "defaultMessage": "Falha ao guardar a subreceita: {error}"
+  },
+  "createSubRecipeInline.sequentialHint": {
+    "defaultMessage": "(Força a execução sequencial de múltiplas instâncias)"
+  },
+  "createSubRecipeInline.sequentialLabel": {
+    "defaultMessage": "Sequencial quando repetida"
+  },
+  "createSubRecipeInline.subtitle": {
+    "defaultMessage": "Crie uma receita simples para utilizar como ferramenta invocável na sua receita principal"
+  },
+  "createSubRecipeInline.title": {
+    "defaultMessage": "Criar nova subreceita"
+  },
+  "createSubRecipeInline.toolDescriptionLabel": {
+    "defaultMessage": "Descrição da ferramenta"
+  },
+  "createSubRecipeInline.toolDescriptionPlaceholder": {
+    "defaultMessage": "Descrição opcional apresentada quando isto é chamado como ferramenta"
+  },
+  "createSubRecipeInline.validationFailed": {
+    "defaultMessage": "Falha na validação"
+  },
+  "createSubRecipeInline.validationMsg": {
+    "defaultMessage": "O nome, o título, a descrição da receita e as instruções são obrigatórios."
+  },
+  "creditsExhaustedNotification.addCredits": {
+    "defaultMessage": "Adicionar créditos"
+  },
+  "creditsExhaustedNotification.insufficientCredits": {
+    "defaultMessage": "Créditos insuficientes"
+  },
+  "cronPicker.april": {
+    "defaultMessage": "Abril"
+  },
+  "cronPicker.at": {
+    "defaultMessage": "às"
+  },
+  "cronPicker.atMinute": {
+    "defaultMessage": "ao minuto"
+  },
+  "cronPicker.atSecond": {
+    "defaultMessage": "ao segundo"
+  },
+  "cronPicker.august": {
+    "defaultMessage": "Agosto"
+  },
+  "cronPicker.cronExpression": {
+    "defaultMessage": "Expressão cron"
+  },
+  "cronPicker.custom": {
+    "defaultMessage": "Cron personalizada"
+  },
+  "cronPicker.day": {
+    "defaultMessage": "Dia"
+  },
+  "cronPicker.december": {
+    "defaultMessage": "Dezembro"
+  },
+  "cronPicker.emptyCronError": {
+    "defaultMessage": "A expressão cron não pode estar vazia"
+  },
+  "cronPicker.every": {
+    "defaultMessage": "A cada"
+  },
+  "cronPicker.february": {
+    "defaultMessage": "Fevereiro"
+  },
+  "cronPicker.friday": {
+    "defaultMessage": "Sexta-feira"
+  },
+  "cronPicker.hour": {
+    "defaultMessage": "Hora"
+  },
+  "cronPicker.inMonth": {
+    "defaultMessage": "em"
+  },
+  "cronPicker.invalidDayOfMonth": {
+    "defaultMessage": "O dia deve estar entre 1 e {max}"
+  },
+  "cronPicker.january": {
+    "defaultMessage": "Janeiro"
+  },
+  "cronPicker.july": {
+    "defaultMessage": "Julho"
+  },
+  "cronPicker.june": {
+    "defaultMessage": "Junho"
+  },
+  "cronPicker.march": {
+    "defaultMessage": "Março"
+  },
+  "cronPicker.may": {
+    "defaultMessage": "Maio"
+  },
+  "cronPicker.minute": {
+    "defaultMessage": "Minuto"
+  },
+  "cronPicker.mode": {
+    "defaultMessage": "Modo"
+  },
+  "cronPicker.monday": {
+    "defaultMessage": "Segunda-feira"
+  },
+  "cronPicker.month": {
+    "defaultMessage": "Mês"
+  },
+  "cronPicker.november": {
+    "defaultMessage": "Novembro"
+  },
+  "cronPicker.october": {
+    "defaultMessage": "Outubro"
+  },
+  "cronPicker.on": {
+    "defaultMessage": "em"
+  },
+  "cronPicker.onDay": {
+    "defaultMessage": "no dia"
+  },
+  "cronPicker.quarter": {
+    "defaultMessage": "Trimestre"
+  },
+  "cronPicker.saturday": {
+    "defaultMessage": "Sábado"
+  },
+  "cronPicker.september": {
+    "defaultMessage": "Setembro"
+  },
+  "cronPicker.startingMonth": {
+    "defaultMessage": "mês de início"
+  },
+  "cronPicker.sunday": {
+    "defaultMessage": "Domingo"
+  },
+  "cronPicker.thursday": {
+    "defaultMessage": "Quinta-feira"
+  },
+  "cronPicker.tuesday": {
+    "defaultMessage": "Terça-feira"
+  },
+  "cronPicker.wednesday": {
+    "defaultMessage": "Quarta-feira"
+  },
+  "cronPicker.week": {
+    "defaultMessage": "Semana"
+  },
+  "cronPicker.year": {
+    "defaultMessage": "Ano"
+  },
+  "customProviderForm.add": {
+    "defaultMessage": "Adicionar"
+  },
+  "customProviderForm.anthropicCompatible": {
+    "defaultMessage": "Compatível com Anthropic"
+  },
+  "customProviderForm.apiBasePath": {
+    "defaultMessage": "Caminho base da API (opcional)"
+  },
+  "customProviderForm.apiBasePathHint": {
+    "defaultMessage": "Substitua o caminho predefinido da API. Deixe em branco para utilizar o caminho predefinido do fornecedor."
+  },
+  "customProviderForm.apiBasePathPlaceholder": {
+    "defaultMessage": "ex.: v1/chat/completions ou project_id/v1"
+  },
+  "customProviderForm.apiKey": {
+    "defaultMessage": "Chave de API"
+  },
+  "customProviderForm.apiKeyPlaceholderExisting": {
+    "defaultMessage": "Deixe em branco para manter a chave existente"
+  },
+  "customProviderForm.apiKeyPlaceholderNew": {
+    "defaultMessage": "A sua chave de API"
+  },
+  "customProviderForm.apiKeyRequired": {
+    "defaultMessage": "A chave de API é obrigatória"
+  },
+  "customProviderForm.apiUrl": {
+    "defaultMessage": "URL da API"
+  },
+  "customProviderForm.apiUrlPlaceholder": {
+    "defaultMessage": "https://api.example.com"
+  },
+  "customProviderForm.apiUrlRequired": {
+    "defaultMessage": "O URL da API é obrigatório"
+  },
+  "customProviderForm.attachments": {
+    "defaultMessage": "Anexos"
+  },
+  "customProviderForm.authHint": {
+    "defaultMessage": "LLMs locais como o Ollama normalmente não requerem uma chave de API."
+  },
+  "customProviderForm.authentication": {
+    "defaultMessage": "Autenticação"
+  },
+  "customProviderForm.availableModels": {
+    "defaultMessage": "Modelos disponíveis (separados por vírgulas)"
+  },
+  "customProviderForm.back": {
+    "defaultMessage": "← Voltar"
+  },
+  "customProviderForm.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "customProviderForm.cannotDeleteActive": {
+    "defaultMessage": "Não pode eliminar este fornecedor enquanto estiver a ser utilizado. Mude primeiro para um modelo diferente."
+  },
+  "customProviderForm.chooseSetup": {
+    "defaultMessage": "Escolha como pretende configurar o seu fornecedor."
+  },
+  "customProviderForm.clear": {
+    "defaultMessage": "Limpar"
+  },
+  "customProviderForm.configureManually": {
+    "defaultMessage": "Configurar manualmente"
+  },
+  "customProviderForm.configureManuallyDesc": {
+    "defaultMessage": "Introduza você mesmo todos os detalhes do fornecedor"
+  },
+  "customProviderForm.confirmDelete": {
+    "defaultMessage": "Confirmar eliminação"
+  },
+  "customProviderForm.createProvider": {
+    "defaultMessage": "Criar fornecedor"
+  },
+  "customProviderForm.customHeaders": {
+    "defaultMessage": "Cabeçalhos personalizados"
+  },
+  "customProviderForm.customHeadersHint": {
+    "defaultMessage": "Adicione cabeçalhos HTTP personalizados para incluir nos pedidos ao fornecedor. Clique no botão \"+\" para adicionar depois de preencher ambos os campos."
+  },
+  "customProviderForm.deleteConfirmation": {
+    "defaultMessage": "Tem a certeza de que pretende eliminar este fornecedor personalizado? Esta ação removerá permanentemente o fornecedor e a sua chave de API armazenada. Esta ação não pode ser anulada."
+  },
+  "customProviderForm.deleteProvider": {
+    "defaultMessage": "Eliminar fornecedor"
+  },
+  "customProviderForm.displayName": {
+    "defaultMessage": "Nome a apresentar"
+  },
+  "customProviderForm.displayNamePlaceholder": {
+    "defaultMessage": "O nome do seu fornecedor"
+  },
+  "customProviderForm.displayNameRequired": {
+    "defaultMessage": "O nome a apresentar é obrigatório"
+  },
+  "customProviderForm.docs": {
+    "defaultMessage": "Documentação"
+  },
+  "customProviderForm.headerBothRequired": {
+    "defaultMessage": "É necessário introduzir o nome e o valor do cabeçalho"
+  },
+  "customProviderForm.headerDuplicate": {
+    "defaultMessage": "Já existe um cabeçalho com este nome"
+  },
+  "customProviderForm.headerNamePlaceholder": {
+    "defaultMessage": "Nome do cabeçalho"
+  },
+  "customProviderForm.headerNoSpaces": {
+    "defaultMessage": "O nome do cabeçalho não pode conter espaços"
+  },
+  "customProviderForm.modelsPlaceholder": {
+    "defaultMessage": "modelo-a, modelo-b, modelo-c"
+  },
+  "customProviderForm.modelsRequired": {
+    "defaultMessage": "É necessário pelo menos um modelo"
+  },
+  "customProviderForm.ollamaCompatible": {
+    "defaultMessage": "Compatível com Ollama"
+  },
+  "customProviderForm.openaiCompatible": {
+    "defaultMessage": "Compatível com OpenAI"
+  },
+  "customProviderForm.providerType": {
+    "defaultMessage": "Tipo de fornecedor"
+  },
+  "customProviderForm.reasoning": {
+    "defaultMessage": "Raciocínio"
+  },
+  "customProviderForm.requiresApiKey": {
+    "defaultMessage": "Este fornecedor requer uma chave de API"
+  },
+  "customProviderForm.startFromTemplate": {
+    "defaultMessage": "Começar a partir de um modelo de fornecedor"
+  },
+  "customProviderForm.startFromTemplateDesc": {
+    "defaultMessage": "Escolha um fornecedor conhecido e preencheremos automaticamente a configuração"
+  },
+  "customProviderForm.submitError": {
+    "defaultMessage": "Falha ao guardar o fornecedor. Verifique a sua configuração e tente novamente."
+  },
+  "customProviderForm.supportsStreaming": {
+    "defaultMessage": "O provedor suporta respostas em streaming"
+  },
+  "customProviderForm.toolCalling": {
+    "defaultMessage": "Chamada de ferramentas"
+  },
+  "customProviderForm.updateProvider": {
+    "defaultMessage": "Atualizar provedor"
+  },
+  "customProviderForm.usingTemplate": {
+    "defaultMessage": "Usando modelo: {name}"
+  },
+  "customProviderForm.valuePlaceholder": {
+    "defaultMessage": "Valor"
+  },
+  "defaultCardButtons.configureSettings": {
+    "defaultMessage": "Configurar definições de {name}"
+  },
+  "defaultCardButtons.deleteSettings": {
+    "defaultMessage": "Excluir definições de {name}"
+  },
+  "defaultCardButtons.editSettings": {
+    "defaultMessage": "Editar definições de {name}"
+  },
+  "defaultCardButtons.getStarted": {
+    "defaultMessage": "Comece a usar o goose!"
+  },
+  "defaultProviderSetupForm.apiHostLabel": {
+    "defaultMessage": "Host da API"
+  },
+  "defaultProviderSetupForm.apiHostPlaceholder": {
+    "defaultMessage": "https://api.example.com"
+  },
+  "defaultProviderSetupForm.apiKeyLabel": {
+    "defaultMessage": "Chave de API"
+  },
+  "defaultProviderSetupForm.apiKeyPlaceholder": {
+    "defaultMessage": "Sua chave de API"
+  },
+  "defaultProviderSetupForm.hideOptions": {
+    "defaultMessage": "Ocultar {count} opções"
+  },
+  "defaultProviderSetupForm.loadingConfig": {
+    "defaultMessage": "Carregando valores de configuração..."
+  },
+  "defaultProviderSetupForm.modelsLabel": {
+    "defaultMessage": "Modelos"
+  },
+  "defaultProviderSetupForm.modelsPlaceholder": {
+    "defaultMessage": "modelo-a, modelo-b"
+  },
+  "defaultProviderSetupForm.noConfigParameters": {
+    "defaultMessage": "Nenhum parâmetro de configuração para este provedor."
+  },
+  "defaultProviderSetupForm.showOptions": {
+    "defaultMessage": "Mostrar {count} opções"
+  },
+  "diagnosticsModal.attachHint": {
+    "defaultMessage": "Se você registrar um bug, considere anexar o relatório de diagnóstico a ele."
+  },
+  "diagnosticsModal.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "diagnosticsModal.configSettings": {
+    "defaultMessage": "Definições de configuração"
+  },
+  "diagnosticsModal.description": {
+    "defaultMessage": "Você pode baixar um relatório de diagnóstico em JSON para compartilhar com a equipe ou registrar um bug diretamente no GitHub com os detalhes do seu sistema já preenchidos. Um relatório de diagnóstico contém o seguinte:"
+  },
+  "diagnosticsModal.diagnosticsErrorMsg": {
+    "defaultMessage": "Falha ao baixar o relatório de diagnóstico"
+  },
+  "diagnosticsModal.diagnosticsErrorTitle": {
+    "defaultMessage": "Erro de diagnóstico"
+  },
+  "diagnosticsModal.download": {
+    "defaultMessage": "Baixar"
+  },
+  "diagnosticsModal.downloading": {
+    "defaultMessage": "Baixando..."
+  },
+  "diagnosticsModal.fileBug": {
+    "defaultMessage": "Registrar bug no GitHub"
+  },
+  "diagnosticsModal.logFiles": {
+    "defaultMessage": "Arquivos de log recentes"
+  },
+  "diagnosticsModal.opening": {
+    "defaultMessage": "Abrindo..."
+  },
+  "diagnosticsModal.reportProblem": {
+    "defaultMessage": "Relatar um problema"
+  },
+  "diagnosticsModal.sensitiveWarning": {
+    "defaultMessage": "Se sua sessão contiver informações sensíveis, não compartilhe o arquivo de diagnóstico publicamente."
+  },
+  "diagnosticsModal.sessionMessages": {
+    "defaultMessage": "As mensagens da sua sessão atual"
+  },
+  "diagnosticsModal.systemInfo": {
+    "defaultMessage": "Informações básicas do sistema"
+  },
+  "diagnosticsModal.systemInfoErrorMsg": {
+    "defaultMessage": "Falha ao obter informações do sistema"
+  },
+  "diagnosticsModal.systemInfoErrorTitle": {
+    "defaultMessage": "Erro"
+  },
+  "dialog.close": {
+    "defaultMessage": "Fechar"
+  },
+  "dictationSettings.addApiKey": {
+    "defaultMessage": "Adicionar chave de API"
+  },
+  "dictationSettings.apiKey": {
+    "defaultMessage": "Chave de API"
+  },
+  "dictationSettings.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "dictationSettings.chooseVoiceConversion": {
+    "defaultMessage": "Escolha como a voz é convertida em texto"
+  },
+  "dictationSettings.configureApiKey": {
+    "defaultMessage": "Configure a chave de API em <b>{settingsPath}</b>"
+  },
+  "dictationSettings.configured": {
+    "defaultMessage": "(Configurado)"
+  },
+  "dictationSettings.configuredIn": {
+    "defaultMessage": "✓ Configurado em {settingsPath}"
+  },
+  "dictationSettings.disabled": {
+    "defaultMessage": "Desativado"
+  },
+  "dictationSettings.enterApiKey": {
+    "defaultMessage": "Insira sua chave de API"
+  },
+  "dictationSettings.notConfigured": {
+    "defaultMessage": "(não configurado)"
+  },
+  "dictationSettings.removeApiKey": {
+    "defaultMessage": "Remover chave de API"
+  },
+  "dictationSettings.requiredForTranscription": {
+    "defaultMessage": "Necessário para transcrição"
+  },
+  "dictationSettings.save": {
+    "defaultMessage": "Salvar"
+  },
+  "dictationSettings.updateApiKey": {
+    "defaultMessage": "Atualizar chave de API"
+  },
+  "dictationSettings.voiceDictationProvider": {
+    "defaultMessage": "Provedor de ditado por voz"
+  },
+  "dirSwitcher.chooseDirectory": {
+    "defaultMessage": "Escolher diretório…"
+  },
+  "dirSwitcher.currentDirectory": {
+    "defaultMessage": "Diretório atual"
+  },
+  "dirSwitcher.failedToUpdateWorkingDir": {
+    "defaultMessage": "Falha ao atualizar o diretório de trabalho"
+  },
+  "dirSwitcher.gitWorktrees": {
+    "defaultMessage": "Worktrees do Git"
+  },
+  "dirSwitcher.noWorktreesFound": {
+    "defaultMessage": "Nenhuma worktree encontrada"
+  },
+  "dirSwitcher.openInFinder": {
+    "defaultMessage": "Abrir no gerenciador de arquivos"
+  },
+  "dirSwitcher.recentDirectories": {
+    "defaultMessage": "Diretórios recentes"
+  },
+  "elicitationRequest.accept": {
+    "defaultMessage": "Aceitar"
+  },
+  "elicitationRequest.cancelled": {
+    "defaultMessage": "A solicitação de informações foi cancelada."
+  },
+  "elicitationRequest.defaultMessage": {
+    "defaultMessage": "O Goose precisa de algumas informações suas."
+  },
+  "elicitationRequest.expired": {
+    "defaultMessage": "Esta solicitação expirou. A extensão precisará perguntar novamente."
+  },
+  "elicitationRequest.submit": {
+    "defaultMessage": "Enviar"
+  },
+  "elicitationRequest.submitError": {
+    "defaultMessage": "Esta solicitação não está mais ativa. A extensão precisará perguntar novamente."
+  },
+  "elicitationRequest.submitted": {
+    "defaultMessage": "Informações enviadas"
+  },
+  "elicitationRequest.waitingForResponse": {
+    "defaultMessage": "Aguardando sua resposta ({timeRemaining} restante)"
+  },
+  "envVarsSection.add": {
+    "defaultMessage": "Adicionar"
+  },
+  "envVarsSection.bothRequired": {
+    "defaultMessage": "Tanto o nome quanto o valor da variável devem ser informados"
+  },
+  "envVarsSection.envVarsDescription": {
+    "defaultMessage": "Adicione pares chave-valor para variáveis de ambiente. Clique no botão \"+\" para adicionar após preencher ambos os campos. Para valores secretos existentes, clique no botão de edição para modificar."
+  },
+  "envVarsSection.environmentVariables": {
+    "defaultMessage": "Variáveis de ambiente"
+  },
+  "envVarsSection.noSpaces": {
+    "defaultMessage": "O nome da variável não pode conter espaços"
+  },
+  "envVarsSection.value": {
+    "defaultMessage": "Valor"
+  },
+  "envVarsSection.variableName": {
+    "defaultMessage": "Nome da variável"
+  },
+  "environmentBadge.dev": {
+    "defaultMessage": "Dev"
+  },
+  "errorBoundary.errorGeneric": {
+    "defaultMessage": "Ocorreu um erro."
+  },
+  "errorBoundary.errorWithVersion": {
+    "defaultMessage": "Ocorreu um erro no Goose v{version}."
+  },
+  "errorBoundary.heading": {
+    "defaultMessage": "Honk!"
+  },
+  "errorBoundary.reload": {
+    "defaultMessage": "Recarregar"
+  },
+  "extensionConfigFields.commandLabel": {
+    "defaultMessage": "Comando"
+  },
+  "extensionConfigFields.commandPlaceholder": {
+    "defaultMessage": "ex.: npx -y @modelcontextprotocol/my-extension [filepath]"
+  },
+  "extensionConfigFields.commandRequired": {
+    "defaultMessage": "O comando é obrigatório"
+  },
+  "extensionConfigFields.endpointLabel": {
+    "defaultMessage": "Endpoint"
+  },
+  "extensionConfigFields.endpointPlaceholder": {
+    "defaultMessage": "Insira a URL do endpoint..."
+  },
+  "extensionConfigFields.endpointRequired": {
+    "defaultMessage": "A URL do endpoint é obrigatória"
+  },
+  "extensionInfoFields.descriptionLabel": {
+    "defaultMessage": "Descrição"
+  },
+  "extensionInfoFields.descriptionPlaceholder": {
+    "defaultMessage": "Descrição opcional..."
+  },
+  "extensionInfoFields.extensionName": {
+    "defaultMessage": "Nome da extensão"
+  },
+  "extensionInfoFields.extensionNamePlaceholder": {
+    "defaultMessage": "Insira o nome da extensão..."
+  },
+  "extensionInfoFields.nameRequired": {
+    "defaultMessage": "O nome é obrigatório"
+  },
+  "extensionInfoFields.typeHttp": {
+    "defaultMessage": "HTTP"
+  },
+  "extensionInfoFields.typeLabel": {
+    "defaultMessage": "Tipo"
+  },
+  "extensionInfoFields.typeSseUnsupported": {
+    "defaultMessage": "SSE (não suportado)"
+  },
+  "extensionInfoFields.typeStandardIo": {
+    "defaultMessage": "Standard IO (STDIO)"
+  },
+  "extensionInfoFields.typeStdio": {
+    "defaultMessage": "STDIO"
+  },
+  "extensionInfoFields.typeStreamableHttp": {
+    "defaultMessage": "Streamable HTTP"
+  },
+  "extensionInstallModal.alreadyInstalledMessage": {
+    "defaultMessage": "A extensão ''{name}'' já foi instalada com sucesso. Inicie uma nova sessão de chat para usá-la."
+  },
+  "extensionInstallModal.alreadyInstalledTitle": {
+    "defaultMessage": "Extensão ''{name}'' já instalada"
+  },
+  "extensionInstallModal.blockedMessage": {
+    "defaultMessage": "Este comando de extensão não está na lista de permitidos e sua instalação está bloqueada. Extensão: {name} Comando: {command} Entre em contato com seu administrador para solicitar a aprovação desta extensão."
+  },
+  "extensionInstallModal.blockedTitle": {
+    "defaultMessage": "Instalação de extensão bloqueada"
+  },
+  "extensionInstallModal.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "extensionInstallModal.installAnyway": {
+    "defaultMessage": "Instalar mesmo assim"
+  },
+  "extensionInstallModal.installing": {
+    "defaultMessage": "Instalando..."
+  },
+  "extensionInstallModal.no": {
+    "defaultMessage": "Não"
+  },
+  "extensionInstallModal.ok": {
+    "defaultMessage": "OK"
+  },
+  "extensionInstallModal.trustedMessage": {
+    "defaultMessage": "Tem certeza de que deseja instalar a extensão {name}? Comando: {command}"
+  },
+  "extensionInstallModal.trustedTitle": {
+    "defaultMessage": "Confirmar instalação da extensão"
+  },
+  "extensionInstallModal.unknownCommand": {
+    "defaultMessage": "Comando desconhecido"
+  },
+  "extensionInstallModal.untrustedMessageWithCommand": {
+    "defaultMessage": "{securityMessage} Extensão: {name} Comando: {command} Entre em contato com seu administrador se tiver dúvidas sobre isto."
+  },
+  "extensionInstallModal.untrustedMessageWithUrl": {
+    "defaultMessage": "{securityMessage} Extensão: {name} URL: {url} Entre em contato com seu administrador se tiver dúvidas sobre isto."
+  },
+  "extensionInstallModal.untrustedSecurityMessage": {
+    "defaultMessage": "Este comando de extensão não está na lista de permitidos e poderá acessar suas conversas e fornecer funcionalidades adicionais. Instalar extensões de fontes não confiáveis pode representar riscos de segurança."
+  },
+  "extensionInstallModal.untrustedTitle": {
+    "defaultMessage": "Instalar extensão não confiável?"
+  },
+  "extensionInstallModal.yes": {
+    "defaultMessage": "Sim"
+  },
+  "extensionItem.configureExtension": {
+    "defaultMessage": "Configurar extensão {name}"
+  },
+  "extensionItem.toggleExtension": {
+    "defaultMessage": "Ativar ou desativar a extensão {name}"
+  },
+  "extensionList.availableExtensions": {
+    "defaultMessage": "Extensões disponíveis ({count})"
+  },
+  "extensionList.builtInExtension": {
+    "defaultMessage": "Extensão integrada"
+  },
+  "extensionList.defaultExtensions": {
+    "defaultMessage": "Extensões padrão ({count})"
+  },
+  "extensionList.noExtensions": {
+    "defaultMessage": "Nenhuma extensão disponível"
+  },
+  "extensionModal.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "extensionModal.closeWithoutSaving": {
+    "defaultMessage": "Fechar sem salvar"
+  },
+  "extensionModal.confirmRemoval": {
+    "defaultMessage": "Confirmar remoção"
+  },
+  "extensionModal.deleteDescription": {
+    "defaultMessage": "Isto removerá permanentemente esta extensão e todas as suas definições."
+  },
+  "extensionModal.deleteExtensionTitle": {
+    "defaultMessage": "Excluir extensão \"{name}\""
+  },
+  "extensionModal.installationNotes": {
+    "defaultMessage": "Notas de instalação"
+  },
+  "extensionModal.removeExtension": {
+    "defaultMessage": "Remover extensão"
+  },
+  "extensionModal.unsavedChangesMessage": {
+    "defaultMessage": "Você tem alterações não salvas na configuração da extensão. Tem certeza de que deseja fechar sem salvar?"
+  },
+  "extensionModal.unsavedChangesTitle": {
+    "defaultMessage": "Alterações não salvas"
+  },
+  "extensionTimeoutField.timeoutLabel": {
+    "defaultMessage": "Tempo limite"
+  },
+  "extensionsSection.addCustomExtension": {
+    "defaultMessage": "Adicionar extensão personalizada"
+  },
+  "extensionsSection.addExtension": {
+    "defaultMessage": "Adicionar extensão"
+  },
+  "extensionsSection.browseExtensions": {
+    "defaultMessage": "Procurar extensões"
+  },
+  "extensionsSection.saveChanges": {
+    "defaultMessage": "Salvar alterações"
+  },
+  "extensionsSection.updateExtension": {
+    "defaultMessage": "Atualizar extensão"
+  },
+  "extensionsView.addCustomExtension": {
+    "defaultMessage": "Adicionar extensão personalizada"
+  },
+  "extensionsView.addExtension": {
+    "defaultMessage": "Adicionar extensão"
+  },
+  "extensionsView.browseExtensions": {
+    "defaultMessage": "Procurar extensões"
+  },
+  "extensionsView.defaultNote": {
+    "defaultMessage": "As extensões ativadas aqui são usadas como padrão para novos chats. Você também pode ativar ou desativar extensões durante o chat."
+  },
+  "extensionsView.description": {
+    "defaultMessage": "Essas extensões usam o Model Context Protocol (MCP). Elas podem expandir as capacidades do Goose usando três componentes principais: Prompts, Recursos e Ferramentas. {searchShortcut} para pesquisar."
+  },
+  "extensionsView.heading": {
+    "defaultMessage": "Extensões"
+  },
+  "extensionsView.searchPlaceholder": {
+    "defaultMessage": "Pesquisar extensões..."
+  },
+  "externalBackendSection.certFingerprint": {
+    "defaultMessage": "Impressão digital do certificado (opcional)"
+  },
+  "externalBackendSection.certFingerprintHelp": {
+    "defaultMessage": "Fixe uma impressão digital de certificado TLS específica. Se omitida, o certificado é confiado no primeiro uso (TOFU)."
+  },
+  "externalBackendSection.certFingerprintPlaceholder": {
+    "defaultMessage": "AA:BB:CC:... ou sha256/base64"
+  },
+  "externalBackendSection.description": {
+    "defaultMessage": "Por padrão, o goose inicia um servidor para você; use isto para conectar-se a um servidor goose externo"
+  },
+  "externalBackendSection.restartNote": {
+    "defaultMessage": "As alterações exigem reiniciar o Goose para entrar em vigor. As novas janelas de chat se conectarão ao servidor externo."
+  },
+  "externalBackendSection.secretKey": {
+    "defaultMessage": "Chave secreta"
+  },
+  "externalBackendSection.secretKeyHelp": {
+    "defaultMessage": "A chave secreta configurada no servidor goosed (GOOSE_SERVER__SECRET_KEY)"
+  },
+  "externalBackendSection.secretKeyPlaceholder": {
+    "defaultMessage": "Insira a chave secreta do servidor"
+  },
+  "externalBackendSection.serverUrl": {
+    "defaultMessage": "URL do servidor"
+  },
+  "externalBackendSection.title": {
+    "defaultMessage": "Servidor Goose"
+  },
+  "externalBackendSection.urlFormatError": {
+    "defaultMessage": "Formato de URL inválido"
+  },
+  "externalBackendSection.urlProtocolError": {
+    "defaultMessage": "A URL deve usar o protocolo http ou https"
+  },
+  "externalBackendSection.useExternalServer": {
+    "defaultMessage": "Usar servidor externo"
+  },
+  "externalBackendSection.useExternalServerDescription": {
+    "defaultMessage": "Conecte-se a um servidor goose em execução em outro lugar (requer reinicialização do app)"
+  },
+  "freeOptionCards.chooseOption": {
+    "defaultMessage": "Escolha uma opção para começar."
+  },
+  "freeOptionCards.freeAndPrivate": {
+    "defaultMessage": "Gratuito e privado"
+  },
+  "freeOptionCards.localModelDescription": {
+    "defaultMessage": "Baixe um modelo e execute-o inteiramente na sua máquina. Sem chaves de API, sem contas."
+  },
+  "freeOptionCards.localModelTitle": {
+    "defaultMessage": "Usar um modelo local"
+  },
+  "freeOptionCards.nanogptDescription": {
+    "defaultMessage": "Inscreva-se para receber 60 milhões de tokens gratuitos por 7 dias."
+  },
+  "freeOptionCards.nanogptTitle": {
+    "defaultMessage": "NanoGPT"
+  },
+  "freeOptionCards.retry": {
+    "defaultMessage": "Tentar novamente"
+  },
+  "freeOptionCards.tetrateDescription": {
+    "defaultMessage": "Acesse vários modelos de IA com configuração automática. Inscreva-se para receber US$ 10 em crédito."
+  },
+  "freeOptionCards.tetrateTitle": {
+    "defaultMessage": "Agent Router by Tetrate"
+  },
+  "freeOptionCards.unexpectedError": {
+    "defaultMessage": "Ocorreu um erro inesperado durante a configuração."
+  },
+  "goosehintsModal.close": {
+    "defaultMessage": "Fechar"
+  },
+  "goosehintsModal.developer": {
+    "defaultMessage": "Desenvolvedor"
+  },
+  "goosehintsModal.dialogDescription": {
+    "defaultMessage": "Forneça contexto adicional sobre seu projeto para melhorar a comunicação com o Goose"
+  },
+  "goosehintsModal.dialogTitle": {
+    "defaultMessage": "Configurar dicas do projeto (.goosehints)"
+  },
+  "goosehintsModal.errorReading": {
+    "defaultMessage": "Erro ao ler o arquivo .goosehints: {error}"
+  },
+  "goosehintsModal.failedToAccess": {
+    "defaultMessage": "Falha ao acessar o arquivo .goosehints"
+  },
+  "goosehintsModal.failedToSave": {
+    "defaultMessage": "Falha ao salvar o arquivo .goosehints"
+  },
+  "goosehintsModal.fileCreating": {
+    "defaultMessage": "Criando novo arquivo .goosehints em: {filePath}"
+  },
+  "goosehintsModal.fileFound": {
+    "defaultMessage": "Arquivo .goosehints encontrado em: {filePath}"
+  },
+  "goosehintsModal.helpText1": {
+    "defaultMessage": ".goosehints é um arquivo de texto usado para fornecer contexto adicional sobre seu projeto e melhorar a comunicação com o Goose."
+  },
+  "goosehintsModal.helpText2": {
+    "defaultMessage": "Verifique se a extensão {bold} está ativada na página de extensões. Esta extensão é necessária para usar o .goosehints. Você precisará reiniciar sua sessão para que as atualizações do .goosehints entrem em vigor."
+  },
+  "goosehintsModal.helpText3": {
+    "defaultMessage": "Consulte {link} para mais informações."
+  },
+  "goosehintsModal.helpTextLink": {
+    "defaultMessage": "usando .goosehints"
+  },
+  "goosehintsModal.placeholder": {
+    "defaultMessage": "Insira as dicas do projeto aqui..."
+  },
+  "goosehintsModal.save": {
+    "defaultMessage": "Salvar"
+  },
+  "goosehintsModal.savedSuccessfully": {
+    "defaultMessage": "Salvo com sucesso"
+  },
+  "goosehintsModal.saving": {
+    "defaultMessage": "Salvando..."
+  },
+  "goosehintsSection.configure": {
+    "defaultMessage": "Configurar"
+  },
+  "goosehintsSection.description": {
+    "defaultMessage": "Configure o arquivo .goosehints do seu projeto para fornecer contexto adicional ao Goose"
+  },
+  "goosehintsSection.title": {
+    "defaultMessage": "Dicas do projeto (.goosehints)"
+  },
+  "groupedExtensionLoadingToast.askGoose": {
+    "defaultMessage": "Pergunte ao goose"
+  },
+  "groupedExtensionLoadingToast.collapseDetails": {
+    "defaultMessage": "Recolher detalhes"
+  },
+  "groupedExtensionLoadingToast.copied": {
+    "defaultMessage": "Copiado!"
+  },
+  "groupedExtensionLoadingToast.copyError": {
+    "defaultMessage": "Erro ao copiar"
+  },
+  "groupedExtensionLoadingToast.expandDetails": {
+    "defaultMessage": "Expandir detalhes"
+  },
+  "groupedExtensionLoadingToast.failedToAddExtension": {
+    "defaultMessage": "Falha ao adicionar extensão"
+  },
+  "groupedExtensionLoadingToast.failedToLoad": {
+    "defaultMessage": "{count,plural,one{# extensão falhou ao carregar} other{# extensões falharam ao carregar}}"
+  },
+  "groupedExtensionLoadingToast.loadingExtensions": {
+    "defaultMessage": "{count,plural,one{Carregando # extensão...} other{Carregando # extensões...}}"
+  },
+  "groupedExtensionLoadingToast.partiallyLoaded": {
+    "defaultMessage": "{totalCount,plural,one{{successCount}/# extensão carregada} other{{successCount}/# extensões carregadas}}"
+  },
+  "groupedExtensionLoadingToast.showDetails": {
+    "defaultMessage": "Mostrar detalhes"
+  },
+  "groupedExtensionLoadingToast.showLess": {
+    "defaultMessage": "Mostrar menos"
+  },
+  "groupedExtensionLoadingToast.successfullyLoaded": {
+    "defaultMessage": "{count,plural,one{# extensão carregada com sucesso} other{# extensões carregadas com sucesso}}"
+  },
+  "headersSection.add": {
+    "defaultMessage": "Adicionar"
+  },
+  "headersSection.bothRequired": {
+    "defaultMessage": "Tanto o nome quanto o valor do cabeçalho devem ser informados"
+  },
+  "headersSection.duplicateHeader": {
+    "defaultMessage": "Já existe um cabeçalho com este nome"
+  },
+  "headersSection.headerName": {
+    "defaultMessage": "Nome do cabeçalho"
+  },
+  "headersSection.headersDescription": {
+    "defaultMessage": "Adicione cabeçalhos HTTP personalizados para incluir nas requisições ao servidor MCP. Clique no botão \"+\" para adicionar após preencher ambos os campos."
+  },
+  "headersSection.noSpaces": {
+    "defaultMessage": "O nome do cabeçalho não pode conter espaços"
+  },
+  "headersSection.requestHeaders": {
+    "defaultMessage": "Cabeçalhos da requisição"
+  },
+  "headersSection.value": {
+    "defaultMessage": "Valor"
+  },
+  "hub.goodAfternoon": {
+    "defaultMessage": "Boa tarde"
+  },
+  "hub.goodEvening": {
+    "defaultMessage": "Boa noite"
+  },
+  "hub.goodMorning": {
+    "defaultMessage": "Bom dia"
+  },
+  "huggingFaceModelSearch.download": {
+    "defaultMessage": "Baixar"
+  },
+  "huggingFaceModelSearch.downloaded": {
+    "defaultMessage": "Baixado"
+  },
+  "huggingFaceModelSearch.downloading": {
+    "defaultMessage": "Baixando…"
+  },
+  "huggingFaceModelSearch.loadingVariants": {
+    "defaultMessage": "Carregando variantes..."
+  },
+  "huggingFaceModelSearch.noGgufModels": {
+    "defaultMessage": "Nenhum modelo local compatível encontrado para esta consulta."
+  },
+  "huggingFaceModelSearch.recommended": {
+    "defaultMessage": "Recomendado"
+  },
+  "huggingFaceModelSearch.searchError": {
+    "defaultMessage": "Erro na pesquisa: {details}"
+  },
+  "huggingFaceModelSearch.searchFailed": {
+    "defaultMessage": "A pesquisa falhou. Tente novamente."
+  },
+  "huggingFaceModelSearch.searchHuggingFace": {
+    "defaultMessage": "Pesquisar no HuggingFace"
+  },
+  "huggingFaceModelSearch.searchNoData": {
+    "defaultMessage": "A pesquisa não retornou dados."
+  },
+  "huggingFaceModelSearch.searchPlaceholder": {
+    "defaultMessage": "Pesquisar modelos locais..."
+  },
+  "huggingFaceModelSearch.tooLarge": {
+    "defaultMessage": "Pode não caber na memória (modelo de {size}, {available} disponível)"
+  },
+  "huggingFaceSignInPrompt.failedToConfigure": {
+    "defaultMessage": "Falha ao entrar no Hugging Face: {error}"
+  },
+  "huggingFaceSignInPrompt.signIn": {
+    "defaultMessage": "Entrar"
+  },
+  "huggingFaceSignInPrompt.signedIn": {
+    "defaultMessage": "Conectado ao Hugging Face"
+  },
+  "huggingFaceSignInPrompt.signingIn": {
+    "defaultMessage": "Entrando..."
+  },
+  "huggingFaceSignInPrompt.title": {
+    "defaultMessage": "Hugging Face"
+  },
+  "imagePreview.altText": {
+    "defaultMessage": "imagem do goose"
+  },
+  "imagePreview.clickToCollapse": {
+    "defaultMessage": "Clique para recolher"
+  },
+  "imagePreview.clickToExpand": {
+    "defaultMessage": "Clique para expandir"
+  },
+  "imagePreview.unableToLoad": {
+    "defaultMessage": "Não foi possível carregar a imagem"
+  },
+  "importRecipeForm.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "importRecipeForm.deeplinkHint": {
+    "defaultMessage": "Cole um deeplink de receita começando com \"goose://recipe?config=\""
+  },
+  "importRecipeForm.deeplinkPlaceholder": {
+    "defaultMessage": "Cole seu deeplink goose://recipe?config=... aqui"
+  },
+  "importRecipeForm.example": {
+    "defaultMessage": "exemplo"
+  },
+  "importRecipeForm.expectedRecipeStructure": {
+    "defaultMessage": "Estrutura de receita esperada"
+  },
+  "importRecipeForm.importRecipeButton": {
+    "defaultMessage": "Importar receita"
+  },
+  "importRecipeForm.importRecipeTitle": {
+    "defaultMessage": "Importar receita"
+  },
+  "importRecipeForm.importing": {
+    "defaultMessage": "Importando..."
+  },
+  "importRecipeForm.or": {
+    "defaultMessage": "OU"
+  },
+  "importRecipeForm.recipeDeeplinkLabel": {
+    "defaultMessage": "Deeplink da receita"
+  },
+  "importRecipeForm.recipeFileHint": {
+    "defaultMessage": "Carregue um arquivo YAML ou JSON contendo a estrutura da receita"
+  },
+  "importRecipeForm.recipeFileLabel": {
+    "defaultMessage": "Arquivo da receita"
+  },
+  "importRecipeForm.reviewWarning": {
+    "defaultMessage": "Certifique-se de revisar o conteúdo dos arquivos de receita antes de adicioná-los à sua interface do goose."
+  },
+  "importRecipeForm.schemaDescription": {
+    "defaultMessage": "Seu arquivo YAML ou JSON deve seguir esta estrutura. Os campos obrigatórios são: title, description e instructions ou prompt."
+  },
+  "inlineEditText.clickToEdit": {
+    "defaultMessage": "Clique para editar"
+  },
+  "inlineEditText.doubleClickToEdit": {
+    "defaultMessage": "Clique duas vezes para editar"
+  },
+  "inlineEditText.enterText": {
+    "defaultMessage": "Insira o texto"
+  },
+  "inlineEditText.failedToSave": {
+    "defaultMessage": "Falha ao salvar"
+  },
+  "instructionsEditor.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "instructionsEditor.insertExample": {
+    "defaultMessage": "Inserir exemplo"
+  },
+  "instructionsEditor.label": {
+    "defaultMessage": "Instruções"
+  },
+  "instructionsEditor.placeholder": {
+    "defaultMessage": "Instruções detalhadas para a IA, ocultas do usuário"
+  },
+  "instructionsEditor.save": {
+    "defaultMessage": "Salvar instruções"
+  },
+  "instructionsEditor.syntaxHelp": {
+    "defaultMessage": "Use a sintaxe {code} para definir parâmetros que os usuários podem preencher"
+  },
+  "instructionsEditor.title": {
+    "defaultMessage": "Editor de instruções"
+  },
+  "jsonSchemaEditor.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "jsonSchemaEditor.description": {
+    "defaultMessage": "Defina a estrutura esperada da resposta da IA usando o formato JSON Schema"
+  },
+  "jsonSchemaEditor.insertExample": {
+    "defaultMessage": "Inserir exemplo"
+  },
+  "jsonSchemaEditor.invalidJson": {
+    "defaultMessage": "Formato JSON inválido"
+  },
+  "jsonSchemaEditor.label": {
+    "defaultMessage": "JSON Schema da resposta"
+  },
+  "jsonSchemaEditor.save": {
+    "defaultMessage": "Salvar Schema"
+  },
+  "jsonSchemaEditor.title": {
+    "defaultMessage": "Editor de JSON Schema"
+  },
+  "jsonSchemaForm.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "jsonSchemaForm.fieldRequired": {
+    "defaultMessage": "Este campo é obrigatório"
+  },
+  "jsonSchemaForm.maxLength": {
+    "defaultMessage": "O comprimento máximo é {maxLength}"
+  },
+  "jsonSchemaForm.maxValue": {
+    "defaultMessage": "O valor máximo é {maximum}"
+  },
+  "jsonSchemaForm.minLength": {
+    "defaultMessage": "O comprimento mínimo é {minLength}"
+  },
+  "jsonSchemaForm.minValue": {
+    "defaultMessage": "O valor mínimo é {minimum}"
+  },
+  "jsonSchemaForm.noFields": {
+    "defaultMessage": "Nenhum campo para exibir"
+  },
+  "jsonSchemaForm.selectPlaceholder": {
+    "defaultMessage": "Selecionar..."
+  },
+  "jsonSchemaForm.submit": {
+    "defaultMessage": "Enviar"
+  },
+  "keyValueEditor.addValue": {
+    "defaultMessage": "Adicionar valor pré-configurado"
+  },
+  "keyValueEditor.defaultKeyPlaceholder": {
+    "defaultMessage": "Nome do parâmetro..."
+  },
+  "keyValueEditor.defaultValuePlaceholder": {
+    "defaultMessage": "Valor do parâmetro..."
+  },
+  "keyValueEditor.removeValue": {
+    "defaultMessage": "Remover valor pré-configurado {key}"
+  },
+  "keyboardShortcuts.alwaysOnTopDescription": {
+    "defaultMessage": "Alternar janela sempre no topo"
+  },
+  "keyboardShortcuts.alwaysOnTopLabel": {
+    "defaultMessage": "Sempre no Topo"
+  },
+  "keyboardShortcuts.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "keyboardShortcuts.categoryApplication": {
+    "defaultMessage": "Atalhos do Aplicativo"
+  },
+  "keyboardShortcuts.categoryApplicationDescription": {
+    "defaultMessage": "Estes atalhos funcionam quando o Goose é o aplicativo ativo"
+  },
+  "keyboardShortcuts.categoryGlobal": {
+    "defaultMessage": "Atalhos Globais"
+  },
+  "keyboardShortcuts.categoryGlobalDescription": {
+    "defaultMessage": "Estes atalhos funcionam em todo o sistema, mesmo quando o Goose não está em foco"
+  },
+  "keyboardShortcuts.categorySearch": {
+    "defaultMessage": "Atalhos de Busca"
+  },
+  "keyboardShortcuts.categorySearchDescription": {
+    "defaultMessage": "Estes atalhos funcionam ao buscar em uma conversa"
+  },
+  "keyboardShortcuts.categoryWindow": {
+    "defaultMessage": "Atalhos de Janela"
+  },
+  "keyboardShortcuts.categoryWindowDescription": {
+    "defaultMessage": "Estes atalhos controlam o comportamento da janela"
+  },
+  "keyboardShortcuts.change": {
+    "defaultMessage": "Alterar"
+  },
+  "keyboardShortcuts.disabled": {
+    "defaultMessage": "Desativado"
+  },
+  "keyboardShortcuts.dismiss": {
+    "defaultMessage": "Dispensar"
+  },
+  "keyboardShortcuts.findDescription": {
+    "defaultMessage": "Abrir busca na conversa"
+  },
+  "keyboardShortcuts.findLabel": {
+    "defaultMessage": "Buscar"
+  },
+  "keyboardShortcuts.findNextDescription": {
+    "defaultMessage": "Ir para o próximo resultado da busca"
+  },
+  "keyboardShortcuts.findNextLabel": {
+    "defaultMessage": "Buscar Próximo"
+  },
+  "keyboardShortcuts.findPreviousDescription": {
+    "defaultMessage": "Ir para o resultado anterior da busca"
+  },
+  "keyboardShortcuts.findPreviousLabel": {
+    "defaultMessage": "Buscar Anterior"
+  },
+  "keyboardShortcuts.focusWindowDescription": {
+    "defaultMessage": "Trazer a janela do Goose para frente de qualquer lugar"
+  },
+  "keyboardShortcuts.focusWindowLabel": {
+    "defaultMessage": "Focar a Janela do Goose"
+  },
+  "keyboardShortcuts.loading": {
+    "defaultMessage": "Carregando..."
+  },
+  "keyboardShortcuts.newChatDescription": {
+    "defaultMessage": "Criar uma nova conversa na janela atual"
+  },
+  "keyboardShortcuts.newChatLabel": {
+    "defaultMessage": "Nova Conversa"
+  },
+  "keyboardShortcuts.newChatWindowDescription": {
+    "defaultMessage": "Abrir uma nova janela do Goose"
+  },
+  "keyboardShortcuts.newChatWindowLabel": {
+    "defaultMessage": "Nova Janela de Conversa"
+  },
+  "keyboardShortcuts.openDirectoryDescription": {
+    "defaultMessage": "Abrir a caixa de diálogo de seleção de diretório"
+  },
+  "keyboardShortcuts.openDirectoryLabel": {
+    "defaultMessage": "Abrir Diretório"
+  },
+  "keyboardShortcuts.quickLauncherDescription": {
+    "defaultMessage": "Abrir a sobreposição do iniciador rápido"
+  },
+  "keyboardShortcuts.quickLauncherLabel": {
+    "defaultMessage": "Iniciador Rápido"
+  },
+  "keyboardShortcuts.reassignShortcut": {
+    "defaultMessage": "Reatribuir Atalho"
+  },
+  "keyboardShortcuts.resetAllShortcuts": {
+    "defaultMessage": "Redefinir Todos os Atalhos"
+  },
+  "keyboardShortcuts.resetShortcutsDetail": {
+    "defaultMessage": "Isto restaurará todos os atalhos para sua configuração original."
+  },
+  "keyboardShortcuts.resetShortcutsMessage": {
+    "defaultMessage": "Redefinir todos os atalhos de teclado para seus valores padrão?"
+  },
+  "keyboardShortcuts.resetShortcutsTitle": {
+    "defaultMessage": "Redefinir Atalhos de Teclado"
+  },
+  "keyboardShortcuts.resetToDefaultsDescription": {
+    "defaultMessage": "Restaurar todos os atalhos de teclado para sua configuração original"
+  },
+  "keyboardShortcuts.resetToDefaultsHeading": {
+    "defaultMessage": "Redefinir para os Padrões"
+  },
+  "keyboardShortcuts.restartDescription": {
+    "defaultMessage": "Alterações nos atalhos do aplicativo (como Nova Conversa, Configurações, etc.) exigem reiniciar o Goose para entrar em vigor. Os atalhos globais (Focar a Janela, Iniciador Rápido) funcionam imediatamente."
+  },
+  "keyboardShortcuts.restartRequired": {
+    "defaultMessage": "Reinício Necessário"
+  },
+  "keyboardShortcuts.settingsDescription": {
+    "defaultMessage": "Abrir o painel de configurações"
+  },
+  "keyboardShortcuts.settingsLabel": {
+    "defaultMessage": "Configurações"
+  },
+  "keyboardShortcuts.shortcutConflictSaveDetail": {
+    "defaultMessage": "Salvar isto removerá o atalho de \"{conflictLabel}\" e o atribuirá a \"{targetLabel}\". Deseja continuar?"
+  },
+  "keyboardShortcuts.shortcutConflictTitle": {
+    "defaultMessage": "Conflito de Atalho"
+  },
+  "keyboardShortcuts.shortcutConflictToggleDetail": {
+    "defaultMessage": "Ativar isto removerá o atalho de \"{conflictLabel}\" e o atribuirá a \"{targetLabel}\". Deseja continuar?"
+  },
+  "keyboardShortcuts.shortcutConflictToggleMessage": {
+    "defaultMessage": "O atalho {shortcut} já está atribuído a \"{conflictLabel}\"."
+  },
+  "keyboardShortcuts.toggleNavigationDescription": {
+    "defaultMessage": "Mostrar ou ocultar o menu de navegação"
+  },
+  "keyboardShortcuts.toggleNavigationLabel": {
+    "defaultMessage": "Alternar Navegação"
+  },
+  "launcher.placeholder": {
+    "defaultMessage": "Pergunte qualquer coisa ao goose..."
+  },
+  "loadingGoose.compacting": {
+    "defaultMessage": "o goose está compactando a conversa..."
+  },
+  "loadingGoose.idle": {
+    "defaultMessage": "o goose está trabalhando nisso…"
+  },
+  "loadingGoose.loadingConversation": {
+    "defaultMessage": "carregando conversa..."
+  },
+  "loadingGoose.restartingAgent": {
+    "defaultMessage": "reiniciando sessão..."
+  },
+  "loadingGoose.streaming": {
+    "defaultMessage": "o goose está trabalhando nisso…"
+  },
+  "loadingGoose.thinking": {
+    "defaultMessage": "o goose está pensando…"
+  },
+  "loadingGoose.waiting": {
+    "defaultMessage": "o goose está aguardando…"
+  },
+  "localInferenceSettings.deleteConfirm": {
+    "defaultMessage": "Excluir este modelo? Você poderá baixá-lo novamente mais tarde."
+  },
+  "localInferenceSettings.description": {
+    "defaultMessage": "Baixe e gerencie modelos de LLM locais para inferência sem chaves de API. Pesquise no HuggingFace por modelos GGUF ou MLX, ou use as opções em destaque abaixo."
+  },
+  "localInferenceSettings.dismiss": {
+    "defaultMessage": "Dispensar"
+  },
+  "localInferenceSettings.download": {
+    "defaultMessage": "Baixar"
+  },
+  "localInferenceSettings.downloadCancelled": {
+    "defaultMessage": "Download cancelado"
+  },
+  "localInferenceSettings.downloadFailed": {
+    "defaultMessage": "Falha no download"
+  },
+  "localInferenceSettings.downloadProgress": {
+    "defaultMessage": "{downloaded} / {total} ({percent}%)"
+  },
+  "localInferenceSettings.downloadedModels": {
+    "defaultMessage": "Modelos Baixados"
+  },
+  "localInferenceSettings.downloading": {
+    "defaultMessage": "Baixando"
+  },
+  "localInferenceSettings.featuredModels": {
+    "defaultMessage": "Modelos em Destaque"
+  },
+  "localInferenceSettings.huggingFaceSignInNote": {
+    "defaultMessage": "Faça login para aumentar os limites de taxa ao pesquisar e baixar modelos, e para acessar repositórios privados ou restritos do Hugging Face."
+  },
+  "localInferenceSettings.modelSettings": {
+    "defaultMessage": "Configurações do Modelo"
+  },
+  "localInferenceSettings.modelSettingsTitle": {
+    "defaultMessage": "Configurações do modelo"
+  },
+  "localInferenceSettings.noModels": {
+    "defaultMessage": "Nenhum modelo disponível"
+  },
+  "localInferenceSettings.recommended": {
+    "defaultMessage": "Recomendado"
+  },
+  "localInferenceSettings.remaining": {
+    "defaultMessage": "{time} restante"
+  },
+  "localInferenceSettings.retry": {
+    "defaultMessage": "Tentar novamente"
+  },
+  "localInferenceSettings.showAllFeatured": {
+    "defaultMessage": "Mostrar todos os destacados (mais {count})"
+  },
+  "localInferenceSettings.showRecommendedOnly": {
+    "defaultMessage": "Mostrar apenas os recomendados"
+  },
+  "localInferenceSettings.title": {
+    "defaultMessage": "Modelos de Inferência Local"
+  },
+  "localInferenceSettings.vision": {
+    "defaultMessage": "Visão"
+  },
+  "localInferenceSettings.visionEncoderDownloading": {
+    "defaultMessage": "Baixando codificador de visão…"
+  },
+  "localInferenceSettings.visionEncoderNotDownloaded": {
+    "defaultMessage": "Codificador de visão não baixado"
+  },
+  "localModelManager.active": {
+    "defaultMessage": "Ativo"
+  },
+  "localModelManager.deleteConfirm": {
+    "defaultMessage": "Excluir este modelo? Você poderá baixá-lo novamente mais tarde."
+  },
+  "localModelManager.download": {
+    "defaultMessage": "Baixar"
+  },
+  "localModelManager.downloaded": {
+    "defaultMessage": "Baixado"
+  },
+  "localModelManager.gpuAcceleration": {
+    "defaultMessage": "Suporta aceleração de GPU (CUDA para NVIDIA, Metal para Apple Silicon). Os recursos de GPU devem ser ativados no momento da compilação para aceleração de hardware."
+  },
+  "localModelManager.noModels": {
+    "defaultMessage": "Nenhum modelo disponível"
+  },
+  "localModelManager.recommended": {
+    "defaultMessage": "Recomendado"
+  },
+  "localModelManager.recommendedForHardware": {
+    "defaultMessage": "Recomendado para o seu hardware"
+  },
+  "localModelManager.showAllModels": {
+    "defaultMessage": "Mostrar todos os modelos (mais {count})"
+  },
+  "localModelManager.showRecommendedOnly": {
+    "defaultMessage": "Mostrar apenas os recomendados"
+  },
+  "localModelPicker.back": {
+    "defaultMessage": "Voltar"
+  },
+  "localModelPicker.bestForMachine": {
+    "defaultMessage": "Melhor para a sua máquina"
+  },
+  "localModelPicker.cancelDownload": {
+    "defaultMessage": "Cancelar Download"
+  },
+  "localModelPicker.checkingModels": {
+    "defaultMessage": "Verificando modelos disponíveis..."
+  },
+  "localModelPicker.downloadModel": {
+    "defaultMessage": "Baixar {modelId} ({size})"
+  },
+  "localModelPicker.downloading": {
+    "defaultMessage": "Baixando {modelId}"
+  },
+  "localModelPicker.failedToLoad": {
+    "defaultMessage": "Falha ao carregar os modelos disponíveis. Tente novamente."
+  },
+  "localModelPicker.failedToStartDownload": {
+    "defaultMessage": "Falha ao iniciar o download. Tente novamente."
+  },
+  "localModelPicker.hideOtherSizes": {
+    "defaultMessage": "Ocultar outros tamanhos"
+  },
+  "localModelPicker.localModelsNote": {
+    "defaultMessage": "Os modelos locais mantêm tudo na sua máquina para total privacidade. O desempenho e o tamanho da janela de contexto podem variar em comparação com os provedores de nuvem, dependendo do seu hardware e do tamanho do modelo."
+  },
+  "localModelPicker.lostConnection": {
+    "defaultMessage": "Conexão com o download perdida. Tente novamente."
+  },
+  "localModelPicker.modelNotFound": {
+    "defaultMessage": "Modelo não encontrado"
+  },
+  "localModelPicker.ready": {
+    "defaultMessage": "Pronto"
+  },
+  "localModelPicker.selectModel": {
+    "defaultMessage": "Selecione um modelo"
+  },
+  "localModelPicker.showOtherSizes": {
+    "defaultMessage": "Mostrar {count} outros tamanhos"
+  },
+  "localModelPicker.startingDownload": {
+    "defaultMessage": "Iniciando download..."
+  },
+  "localModelPicker.tryAgain": {
+    "defaultMessage": "Tentar Novamente"
+  },
+  "localModelPicker.useModel": {
+    "defaultMessage": "Usar {modelId}"
+  },
+  "markdownContent.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "markdownContent.copyCode": {
+    "defaultMessage": "Copiar código"
+  },
+  "markdownContent.failedToOpenLink": {
+    "defaultMessage": "Falha ao Abrir o Link"
+  },
+  "markdownContent.noApplicationFound": {
+    "defaultMessage": "Nenhum aplicativo encontrado para abrir este link."
+  },
+  "markdownContent.open": {
+    "defaultMessage": "Abrir"
+  },
+  "markdownContent.openExternalLink": {
+    "defaultMessage": "Abrir Link Externo"
+  },
+  "markdownContent.openProtocolLink": {
+    "defaultMessage": "Abrir link {protocol}?"
+  },
+  "markdownContent.thisWillOpen": {
+    "defaultMessage": "Isto abrirá: {href}"
+  },
+  "mcpAppRenderer.appFallbackTitle": {
+    "defaultMessage": "Aplicativo"
+  },
+  "mcpAppRenderer.cancelButton": {
+    "defaultMessage": "Cancelar"
+  },
+  "mcpAppRenderer.close": {
+    "defaultMessage": "Fechar"
+  },
+  "mcpAppRenderer.exitFullscreen": {
+    "defaultMessage": "Sair da tela cheia"
+  },
+  "mcpAppRenderer.exitFullscreenTitle": {
+    "defaultMessage": "Sair da tela cheia (Esc)"
+  },
+  "mcpAppRenderer.failedToInitSandbox": {
+    "defaultMessage": "Falha ao inicializar o proxy do sandbox"
+  },
+  "mcpAppRenderer.failedToLoadResource": {
+    "defaultMessage": "Falha ao carregar o recurso"
+  },
+  "mcpAppRenderer.fullscreen": {
+    "defaultMessage": "Tela cheia"
+  },
+  "mcpAppRenderer.invalidUrl": {
+    "defaultMessage": "URL inválida"
+  },
+  "mcpAppRenderer.movePipWindow": {
+    "defaultMessage": "Mover a janela Picture-in-Picture (use as teclas de seta)"
+  },
+  "mcpAppRenderer.openButton": {
+    "defaultMessage": "Abrir"
+  },
+  "mcpAppRenderer.openExternalLinkTitle": {
+    "defaultMessage": "Abrir Link Externo"
+  },
+  "mcpAppRenderer.openLinkDetail": {
+    "defaultMessage": "Isto abrirá: {url}"
+  },
+  "mcpAppRenderer.openProtocolLink": {
+    "defaultMessage": "Abrir link {protocol}?"
+  },
+  "mcpAppRenderer.pictureInPicture": {
+    "defaultMessage": "Picture-in-Picture"
+  },
+  "mcpAppRenderer.playingInPip": {
+    "defaultMessage": "Reproduzindo em Picture-in-Picture"
+  },
+  "mcpUIResourceRenderer.cancelButton": {
+    "defaultMessage": "Cancelar"
+  },
+  "mcpUIResourceRenderer.openButton": {
+    "defaultMessage": "Abrir"
+  },
+  "mcpUIResourceRenderer.openExternalLinkTitle": {
+    "defaultMessage": "Abrir Link Externo"
+  },
+  "mcpUIResourceRenderer.openLinkDetail": {
+    "defaultMessage": "Isto abrirá: {url}"
+  },
+  "mcpUIResourceRenderer.openProtocolLink": {
+    "defaultMessage": "Abrir link {protocol}?"
+  },
+  "mcpUIResourceRenderer.toastMessageReceived": {
+    "defaultMessage": "Mensagem recebida para {message}."
+  },
+  "mcpUIResourceRenderer.toastTitle": {
+    "defaultMessage": "Mensagem {messageType} do MCP-UI"
+  },
+  "mcpUIResourceRenderer.toastUnsupported": {
+    "defaultMessage": "Mensagem recebida para {message}. As mensagens {messageType} ainda não são suportadas, consulte o console para mais detalhes."
+  },
+  "mentionPopover.itemsFound": {
+    "defaultMessage": "{count,plural,one{# item encontrado} other{# itens encontrados}}"
+  },
+  "mentionPopover.loadingCommands": {
+    "defaultMessage": "Carregando comandos..."
+  },
+  "mentionPopover.noCommandsFound": {
+    "defaultMessage": "Nenhum comando encontrado correspondente a \"{query}\""
+  },
+  "mentionPopover.noItemsFound": {
+    "defaultMessage": "Nenhum item encontrado correspondente a \"{query}\""
+  },
+  "mentionPopover.scanningFiles": {
+    "defaultMessage": "Verificando arquivos..."
+  },
+  "messageCopyLink.copied": {
+    "defaultMessage": "Copiado!"
+  },
+  "messageCopyLink.copy": {
+    "defaultMessage": "Copiar"
+  },
+  "messageQueue.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "messageQueue.cannotSendWhileEditing": {
+    "defaultMessage": "Não é possível enviar durante a edição"
+  },
+  "messageQueue.clearAll": {
+    "defaultMessage": "Limpar Tudo"
+  },
+  "messageQueue.clickToEdit": {
+    "defaultMessage": "{content} (Clique para editar)"
+  },
+  "messageQueue.collapseQueue": {
+    "defaultMessage": "Recolher fila"
+  },
+  "messageQueue.dragToReorder": {
+    "defaultMessage": "Arraste as mensagens para reordenar a prioridade"
+  },
+  "messageQueue.expandQueue": {
+    "defaultMessage": "Expandir fila"
+  },
+  "messageQueue.messageCount": {
+    "defaultMessage": "{count,plural,one{# mensagem {status}} other{# mensagens {status}}}"
+  },
+  "messageQueue.messageQueue": {
+    "defaultMessage": "Fila de Mensagens"
+  },
+  "messageQueue.next": {
+    "defaultMessage": "Próxima"
+  },
+  "messageQueue.paused": {
+    "defaultMessage": "Pausada"
+  },
+  "messageQueue.queuePaused": {
+    "defaultMessage": "Fila Pausada"
+  },
+  "messageQueue.queuePausedCompact": {
+    "defaultMessage": "Fila pausada - clique em \"Enviar\" ou adicione uma nova mensagem para retomar"
+  },
+  "messageQueue.queuePausedExpanded": {
+    "defaultMessage": "Fila pausada por interrupção. Use \"Enviar Agora\" ou adicione uma nova mensagem para retomar."
+  },
+  "messageQueue.queued": {
+    "defaultMessage": "na fila"
+  },
+  "messageQueue.removeFromQueue": {
+    "defaultMessage": "Remover esta mensagem da fila"
+  },
+  "messageQueue.save": {
+    "defaultMessage": "Salvar"
+  },
+  "messageQueue.sendNow": {
+    "defaultMessage": "Enviar esta mensagem agora"
+  },
+  "messageQueue.stopAndSend": {
+    "defaultMessage": "Parar o processamento atual e enviar esta mensagem agora"
+  },
+  "messageQueue.waiting": {
+    "defaultMessage": "aguardando"
+  },
+  "microphoneSelector.chooseDescription": {
+    "defaultMessage": "Escolha qual microfone usar para o ditado"
+  },
+  "microphoneSelector.grantAccess": {
+    "defaultMessage": "Conceder Acesso"
+  },
+  "microphoneSelector.grantAccessDescription": {
+    "defaultMessage": "Conceda acesso para ver os microfones disponíveis"
+  },
+  "microphoneSelector.microphone": {
+    "defaultMessage": "Microfone"
+  },
+  "microphoneSelector.microphoneLabel": {
+    "defaultMessage": "Microfone {index}"
+  },
+  "microphoneSelector.selectedMicrophone": {
+    "defaultMessage": "Microfone Selecionado"
+  },
+  "microphoneSelector.speakToTest": {
+    "defaultMessage": "Fale para testar seu microfone ({seconds}s)"
+  },
+  "microphoneSelector.stop": {
+    "defaultMessage": "Parar"
+  },
+  "microphoneSelector.systemDefault": {
+    "defaultMessage": "Padrão do Sistema"
+  },
+  "microphoneSelector.test": {
+    "defaultMessage": "Testar"
+  },
+  "modeSelectionItem.autonomousDescription": {
+    "defaultMessage": "Capacidades completas de modificação de arquivos: edite, crie e exclua arquivos livremente."
+  },
+  "modeSelectionItem.autonomousLabel": {
+    "defaultMessage": "Autônomo"
+  },
+  "modeSelectionItem.chatOnlyDescription": {
+    "defaultMessage": "Interaja com o provedor selecionado sem usar ferramentas ou extensões."
+  },
+  "modeSelectionItem.chatOnlyLabel": {
+    "defaultMessage": "Apenas conversa"
+  },
+  "modeSelectionItem.manualDescription": {
+    "defaultMessage": "Todas as ferramentas, extensões e modificações de arquivos exigirão aprovação humana"
+  },
+  "modeSelectionItem.manualLabel": {
+    "defaultMessage": "Manual"
+  },
+  "modeSelectionItem.smartDescription": {
+    "defaultMessage": "Determinar de forma inteligente quais ações precisam de aprovação com base no nível de risco"
+  },
+  "modeSelectionItem.smartLabel": {
+    "defaultMessage": "Inteligente"
+  },
+  "modelAndProviderContext.modelChangeFailed": {
+    "defaultMessage": "{provider}/{model} falhou"
+  },
+  "modelAndProviderContext.modelChangedTitle": {
+    "defaultMessage": "Modelo alterado"
+  },
+  "modelAndProviderContext.selectModel": {
+    "defaultMessage": "Selecionar Modelo"
+  },
+  "modelAndProviderContext.switchModelSuccess": {
+    "defaultMessage": "Modelos trocados com sucesso -- usando {model} de {provider}"
+  },
+  "modelAndProviderContext.unknownProviderMsg": {
+    "defaultMessage": "Provedor desconhecido na configuração -- inspecione seu config.yaml"
+  },
+  "modelAndProviderContext.unknownProviderTitle": {
+    "defaultMessage": "Busca de nome de provedor"
+  },
+  "modelSettingsButtons.configureProviders": {
+    "defaultMessage": "Configurar provedores"
+  },
+  "modelSettingsButtons.switchModels": {
+    "defaultMessage": "Trocar modelos"
+  },
+  "modelSettingsPanel.batchSize": {
+    "defaultMessage": "Tamanho do lote"
+  },
+  "modelSettingsPanel.batchSizeDescription": {
+    "defaultMessage": "Lote de processamento de prompts"
+  },
+  "modelSettingsPanel.builtinChatTemplate": {
+    "defaultMessage": "Modelo integrado"
+  },
+  "modelSettingsPanel.builtinChatTemplateDescription": {
+    "defaultMessage": "Selecione o nome de um modelo integrado do llama.cpp"
+  },
+  "modelSettingsPanel.chatTemplate": {
+    "defaultMessage": "Modelo de conversa"
+  },
+  "modelSettingsPanel.chatTemplateBuiltin": {
+    "defaultMessage": "Integrado"
+  },
+  "modelSettingsPanel.chatTemplateCustomInline": {
+    "defaultMessage": "Personalizado em linha"
+  },
+  "modelSettingsPanel.chatTemplateDescription": {
+    "defaultMessage": "Use os metadados GGUF incorporados, um modelo integrado do llama.cpp ou Jinja em linha"
+  },
+  "modelSettingsPanel.chatTemplateEmbedded": {
+    "defaultMessage": "Incorporado"
+  },
+  "modelSettingsPanel.contextAndGeneration": {
+    "defaultMessage": "Contexto e Geração"
+  },
+  "modelSettingsPanel.contextSize": {
+    "defaultMessage": "Tamanho do contexto"
+  },
+  "modelSettingsPanel.contextSizeDescription": {
+    "defaultMessage": "Janela de contexto máxima (0 = padrão do modelo)"
+  },
+  "modelSettingsPanel.customChatTemplate": {
+    "defaultMessage": "Modelo de conversa personalizado"
+  },
+  "modelSettingsPanel.customChatTemplateDescription": {
+    "defaultMessage": "Cole o código-fonte completo do modelo de conversa Jinja"
+  },
+  "modelSettingsPanel.etaLearningRate": {
+    "defaultMessage": "Eta (taxa de aprendizado)"
+  },
+  "modelSettingsPanel.flashAttention": {
+    "defaultMessage": "Flash attention"
+  },
+  "modelSettingsPanel.flashAttentionDescription": {
+    "defaultMessage": "Ativar a otimização de flash attention"
+  },
+  "modelSettingsPanel.frequencyPenalty": {
+    "defaultMessage": "Penalidade de frequência"
+  },
+  "modelSettingsPanel.frequencyPenaltyDescription": {
+    "defaultMessage": "0.0 = desativado"
+  },
+  "modelSettingsPanel.gpuLayers": {
+    "defaultMessage": "Camadas de GPU"
+  },
+  "modelSettingsPanel.gpuLayersDescription": {
+    "defaultMessage": "Camadas a descarregar na GPU"
+  },
+  "modelSettingsPanel.loadingSettings": {
+    "defaultMessage": "Carregando configurações..."
+  },
+  "modelSettingsPanel.lockModelInRam": {
+    "defaultMessage": "Bloquear modelo na RAM (mlock)"
+  },
+  "modelSettingsPanel.lockModelInRamDescription": {
+    "defaultMessage": "Impedir que o modelo seja transferido para o disco"
+  },
+  "modelSettingsPanel.maxOutputTokens": {
+    "defaultMessage": "Máximo de tokens de saída"
+  },
+  "modelSettingsPanel.maxOutputTokensDescription": {
+    "defaultMessage": "Limite de tokens gerados"
+  },
+  "modelSettingsPanel.minP": {
+    "defaultMessage": "Min P"
+  },
+  "modelSettingsPanel.performance": {
+    "defaultMessage": "Desempenho"
+  },
+  "modelSettingsPanel.presencePenalty": {
+    "defaultMessage": "Penalidade de presença"
+  },
+  "modelSettingsPanel.presencePenaltyDescription": {
+    "defaultMessage": "0.0 = desativado"
+  },
+  "modelSettingsPanel.repeatPenalty": {
+    "defaultMessage": "Penalidade de repetição"
+  },
+  "modelSettingsPanel.repeatPenaltyDescription": {
+    "defaultMessage": "1.0 = desativado"
+  },
+  "modelSettingsPanel.repeatWindow": {
+    "defaultMessage": "Janela de repetição"
+  },
+  "modelSettingsPanel.repeatWindowDescription": {
+    "defaultMessage": "Tokens a considerar retroativamente"
+  },
+  "modelSettingsPanel.repetitionPenalty": {
+    "defaultMessage": "Penalidade de Repetição"
+  },
+  "modelSettingsPanel.reset": {
+    "defaultMessage": "Redefinir"
+  },
+  "modelSettingsPanel.resetToDefaults": {
+    "defaultMessage": "Redefinir para os padrões"
+  },
+  "modelSettingsPanel.samplingStrategy": {
+    "defaultMessage": "Estratégia de Amostragem"
+  },
+  "modelSettingsPanel.saving": {
+    "defaultMessage": "Salvando..."
+  },
+  "modelSettingsPanel.seed": {
+    "defaultMessage": "Seed"
+  },
+  "modelSettingsPanel.tauTargetEntropy": {
+    "defaultMessage": "Tau (entropia alvo)"
+  },
+  "modelSettingsPanel.temperature": {
+    "defaultMessage": "Temperatura"
+  },
+  "modelSettingsPanel.threads": {
+    "defaultMessage": "Threads"
+  },
+  "modelSettingsPanel.threadsDescription": {
+    "defaultMessage": "Threads de CPU para geração"
+  },
+  "modelSettingsPanel.toolCalling": {
+    "defaultMessage": "Chamada de ferramentas"
+  },
+  "modelSettingsPanel.toolCallingAuto": {
+    "defaultMessage": "Automático"
+  },
+  "modelSettingsPanel.toolCallingDescription": {
+    "defaultMessage": "Escolha como os modelos locais selecionam a chamada de ferramentas nativa ou emulada"
+  },
+  "modelSettingsPanel.toolCallingForceEmulated": {
+    "defaultMessage": "Forçar emulada"
+  },
+  "modelSettingsPanel.toolCallingForceNative": {
+    "defaultMessage": "Forçar nativa"
+  },
+  "modelSettingsPanel.topK": {
+    "defaultMessage": "Top K"
+  },
+  "modelSettingsPanel.topP": {
+    "defaultMessage": "Top P"
+  },
+  "modelsBottomBar.changeModel": {
+    "defaultMessage": "Alterar Modelo"
+  },
+  "modelsBottomBar.currentModel": {
+    "defaultMessage": "Modelo atual"
+  },
+  "modelsBottomBar.loadingModel": {
+    "defaultMessage": "Carregando modelo..."
+  },
+  "modelsBottomBar.localModelSettings": {
+    "defaultMessage": "Configurações do Modelo Local"
+  },
+  "modelsBottomBar.localModelSettingsTitle": {
+    "defaultMessage": "Configurações do Modelo Local — {modelName}"
+  },
+  "modelsBottomBar.resolvedModel": {
+    "defaultMessage": "Modelo resolvido"
+  },
+  "modelsBottomBar.selectModel": {
+    "defaultMessage": "Selecionar Modelo"
+  },
+  "modelsSection.resetDescription": {
+    "defaultMessage": "Limpe suas configurações de modelo e provedor selecionados para começar do zero"
+  },
+  "modelsSection.resetTitle": {
+    "defaultMessage": "Redefinir Provedor e Modelo"
+  },
+  "navigation.itemApps": {
+    "defaultMessage": "Aplicativos"
+  },
+  "navigation.itemExtensions": {
+    "defaultMessage": "Extensões"
+  },
+  "navigation.itemHome": {
+    "defaultMessage": "Nova conversa"
+  },
+  "navigation.itemRecipes": {
+    "defaultMessage": "Receitas"
+  },
+  "navigation.itemScheduler": {
+    "defaultMessage": "Agendador"
+  },
+  "navigation.itemSessions": {
+    "defaultMessage": "Histórico de sessões"
+  },
+  "navigation.itemSettings": {
+    "defaultMessage": "Definições"
+  },
+  "navigation.itemSkills": {
+    "defaultMessage": "Competências"
+  },
+  "navigationPanel.chats": {
+    "defaultMessage": "Conversas"
+  },
+  "navigationPanel.noChats": {
+    "defaultMessage": "Sem conversas recentes"
+  },
+  "navigationPanel.untitledSession": {
+    "defaultMessage": "Sessão sem título"
+  },
+  "onboardingGuard.checkProviderErrorDescription": {
+    "defaultMessage": "O servidor pode estar a iniciar ou temporariamente indisponível."
+  },
+  "onboardingGuard.checkProviderErrorTitle": {
+    "defaultMessage": "Não foi possível ligar ao servidor Goose"
+  },
+  "onboardingGuard.retry": {
+    "defaultMessage": "Tentar novamente"
+  },
+  "onboardingGuard.welcomeDescription": {
+    "defaultMessage": "O seu agente de IA local. Ligue um fornecedor de modelos de IA para começar."
+  },
+  "onboardingGuard.welcomeTitle": {
+    "defaultMessage": "Bem-vindo ao goose"
+  },
+  "onboardingSuccess.allSet": {
+    "defaultMessage": "Está tudo pronto para começar a usar o goose."
+  },
+  "onboardingSuccess.connectedTo": {
+    "defaultMessage": "Ligado a {providerName}"
+  },
+  "onboardingSuccess.getStarted": {
+    "defaultMessage": "Começar"
+  },
+  "onboardingSuccess.learnMore": {
+    "defaultMessage": "Saber mais"
+  },
+  "onboardingSuccess.localModelReady": {
+    "defaultMessage": "Modelo local pronto"
+  },
+  "onboardingSuccess.privacyDescription": {
+    "defaultMessage": "Os dados de utilização anónimos ajudam a melhorar o goose. Nunca recolhemos as suas conversas, código ou dados pessoais."
+  },
+  "onboardingSuccess.privacyTitle": {
+    "defaultMessage": "Privacidade"
+  },
+  "onboardingSuccess.shareUsageData": {
+    "defaultMessage": "Partilhar dados de utilização anónimos"
+  },
+  "parameterInput.defaultValue": {
+    "defaultMessage": "Valor predefinido"
+  },
+  "parameterInput.defaultValuePlaceholder": {
+    "defaultMessage": "Introduza o valor predefinido"
+  },
+  "parameterInput.deleteParameter": {
+    "defaultMessage": "Eliminar parâmetro: {key}"
+  },
+  "parameterInput.description": {
+    "defaultMessage": "descrição"
+  },
+  "parameterInput.descriptionHelp": {
+    "defaultMessage": "Esta é a mensagem que o utilizador final irá ver."
+  },
+  "parameterInput.descriptionPlaceholder": {
+    "defaultMessage": "Ex.: \"Introduza o nome do novo componente\""
+  },
+  "parameterInput.inputType": {
+    "defaultMessage": "Tipo de entrada"
+  },
+  "parameterInput.optional": {
+    "defaultMessage": "Opcional"
+  },
+  "parameterInput.optionsHelp": {
+    "defaultMessage": "Introduza cada opção numa nova linha. Estas serão apresentadas como escolhas num menu pendente."
+  },
+  "parameterInput.optionsLabel": {
+    "defaultMessage": "Opções (uma por linha)"
+  },
+  "parameterInput.optionsPlaceholder": {
+    "defaultMessage": "Opção 1 Opção 2 Opção 3"
+  },
+  "parameterInput.required": {
+    "defaultMessage": "Obrigatório"
+  },
+  "parameterInput.requirement": {
+    "defaultMessage": "Requisito"
+  },
+  "parameterInput.typeBoolean": {
+    "defaultMessage": "Booleano"
+  },
+  "parameterInput.typeNumber": {
+    "defaultMessage": "Número"
+  },
+  "parameterInput.typeSelect": {
+    "defaultMessage": "Seleção"
+  },
+  "parameterInput.typeString": {
+    "defaultMessage": "Cadeia de texto"
+  },
+  "parameterInput.unused": {
+    "defaultMessage": "Não utilizado"
+  },
+  "parameterInput.unusedWarningTitle": {
+    "defaultMessage": "Este parâmetro não é utilizado nas instruções ou no prompt. Ficará disponível para introdução manual, mas pode não ser necessário."
+  },
+  "parameterInputModal.backToForm": {
+    "defaultMessage": "Voltar ao formulário de parâmetros"
+  },
+  "parameterInputModal.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "parameterInputModal.cancelRecipeSetup": {
+    "defaultMessage": "Cancelar configuração da receita"
+  },
+  "parameterInputModal.enterValue": {
+    "defaultMessage": "Introduza o valor para {key}..."
+  },
+  "parameterInputModal.false": {
+    "defaultMessage": "Falso"
+  },
+  "parameterInputModal.recipeParameters": {
+    "defaultMessage": "Parâmetros da receita"
+  },
+  "parameterInputModal.select": {
+    "defaultMessage": "Selecionar..."
+  },
+  "parameterInputModal.selectOption": {
+    "defaultMessage": "Selecione uma opção..."
+  },
+  "parameterInputModal.startNewChat": {
+    "defaultMessage": "Iniciar nova conversa (sem receita)"
+  },
+  "parameterInputModal.startRecipe": {
+    "defaultMessage": "Iniciar receita"
+  },
+  "parameterInputModal.true": {
+    "defaultMessage": "Verdadeiro"
+  },
+  "parameterInputModal.whatToDo": {
+    "defaultMessage": "O que pretende fazer?"
+  },
+  "permissionModal.alwaysAllow": {
+    "defaultMessage": "Permitir sempre"
+  },
+  "permissionModal.askBefore": {
+    "defaultMessage": "Perguntar antes"
+  },
+  "permissionModal.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "permissionModal.close": {
+    "defaultMessage": "Fechar"
+  },
+  "permissionModal.failedToLoadTools": {
+    "defaultMessage": "Falha ao carregar as ferramentas"
+  },
+  "permissionModal.failedToLoadToolsDescription": {
+    "defaultMessage": "Não foi possível carregar as ferramentas desta extensão. A extensão pode não estar carregada na sessão atual."
+  },
+  "permissionModal.neverAllow": {
+    "defaultMessage": "Nunca permitir"
+  },
+  "permissionModal.noActiveSession": {
+    "defaultMessage": "Nenhuma sessão ativa"
+  },
+  "permissionModal.noActiveSessionDescription": {
+    "defaultMessage": "Inicie primeiro uma sessão de conversa para configurar as permissões das ferramentas desta extensão. As permissões das ferramentas são carregadas a partir das extensões da sessão ativa."
+  },
+  "permissionModal.noToolsAvailable": {
+    "defaultMessage": "Não há ferramentas disponíveis para esta extensão."
+  },
+  "permissionModal.saveChanges": {
+    "defaultMessage": "Guardar alterações"
+  },
+  "permissionRulesModal.description": {
+    "defaultMessage": "Configure as permissões das ferramentas para as extensões para controlar como interagem com o seu sistema."
+  },
+  "permissionRulesModal.extensionRules": {
+    "defaultMessage": "Regras de extensões"
+  },
+  "permissionRulesModal.title": {
+    "defaultMessage": "Regras de permissão"
+  },
+  "permissionSetting.extensionRules": {
+    "defaultMessage": "Regras de extensões"
+  },
+  "permissionSetting.permissionRules": {
+    "defaultMessage": "Regras de permissão"
+  },
+  "permissionSetting.permissionRulesDescription": {
+    "defaultMessage": "Instruções ocultas que serão passadas ao fornecedor para ajudar a orientar e adicionar contexto às suas respostas."
+  },
+  "privacyInfoModal.collectErrors": {
+    "defaultMessage": "Tipos de erro (ex.: \"rate_limit\", \"auth\" - sem detalhes)"
+  },
+  "privacyInfoModal.collectExtensions": {
+    "defaultMessage": "Extensões e contagens de utilização de ferramentas (apenas nomes)"
+  },
+  "privacyInfoModal.collectOs": {
+    "defaultMessage": "Sistema operativo, versão e arquitetura"
+  },
+  "privacyInfoModal.collectProvider": {
+    "defaultMessage": "Fornecedor e modelo utilizados"
+  },
+  "privacyInfoModal.collectSession": {
+    "defaultMessage": "Métricas da sessão (duração, número de interações, utilização de tokens)"
+  },
+  "privacyInfoModal.collectVersion": {
+    "defaultMessage": "Versão do goose e método de instalação"
+  },
+  "privacyInfoModal.description": {
+    "defaultMessage": "Os dados de utilização anónimos ajudam-nos a compreender como o goose é utilizado e a identificar áreas a melhorar."
+  },
+  "privacyInfoModal.neverCollect": {
+    "defaultMessage": "Nunca recolhemos as suas conversas, código, argumentos de ferramentas, mensagens de erro ou quaisquer dados pessoais. Pode alterar esta definição a qualquer momento em Definições."
+  },
+  "privacyInfoModal.title": {
+    "defaultMessage": "Detalhes de privacidade"
+  },
+  "privacyInfoModal.whatWeCollect": {
+    "defaultMessage": "O que recolhemos:"
+  },
+  "progressiveMessageList.loadingMessages": {
+    "defaultMessage": "A carregar mensagens... ({renderedCount}/{totalCount})"
+  },
+  "progressiveMessageList.modelChanged": {
+    "defaultMessage": "Modelo alterado: {previousModel} → {currentModel}"
+  },
+  "progressiveMessageList.searchHint": {
+    "defaultMessage": "Prima Cmd/Ctrl+F para carregar todas as mensagens imediatamente para pesquisa"
+  },
+  "promptsSettings.allPromptsReset": {
+    "defaultMessage": "Todos os prompts repostos para as predefinições"
+  },
+  "promptsSettings.backToList": {
+    "defaultMessage": "Voltar à lista"
+  },
+  "promptsSettings.confirmReplaceWithDefault": {
+    "defaultMessage": "Substituir o conteúdo atual pelo predefinido? As suas alterações serão perdidas."
+  },
+  "promptsSettings.confirmResetAll": {
+    "defaultMessage": "Tem a certeza de que pretende repor todos os prompts para as respetivas predefinições? Esta ação não pode ser anulada."
+  },
+  "promptsSettings.confirmResetOne": {
+    "defaultMessage": "Tem a certeza de que pretende repor este prompt para a predefinição? Esta ação não pode ser anulada."
+  },
+  "promptsSettings.confirmUnsavedBack": {
+    "defaultMessage": "Tem alterações por guardar. Tem a certeza de que pretende voltar?"
+  },
+  "promptsSettings.customized": {
+    "defaultMessage": "Personalizado"
+  },
+  "promptsSettings.edit": {
+    "defaultMessage": "Editar"
+  },
+  "promptsSettings.editPromptTitle": {
+    "defaultMessage": "Editar: {name}"
+  },
+  "promptsSettings.editingLabel": {
+    "defaultMessage": "A editar: {name}"
+  },
+  "promptsSettings.enterPromptContent": {
+    "defaultMessage": "Introduza o conteúdo do prompt..."
+  },
+  "promptsSettings.failedToLoadPrompt": {
+    "defaultMessage": "Falha ao carregar o prompt"
+  },
+  "promptsSettings.failedToLoadPrompts": {
+    "defaultMessage": "Falha ao carregar os prompts"
+  },
+  "promptsSettings.failedToResetPrompt": {
+    "defaultMessage": "Falha ao repor o prompt"
+  },
+  "promptsSettings.failedToResetPrompts": {
+    "defaultMessage": "Falha ao repor os prompts"
+  },
+  "promptsSettings.failedToSavePrompt": {
+    "defaultMessage": "Falha ao guardar o prompt"
+  },
+  "promptsSettings.promptEditingDescription": {
+    "defaultMessage": "Personalize os prompts que definem o comportamento do goose em diferentes contextos. Estes prompts usam a sintaxe de templating Jinja2. Tenha cuidado ao modificar as variáveis de template, pois alterações incorretas podem quebrar a funcionalidade. Partilhe quaisquer melhorias com a comunidade."
+  },
+  "promptsSettings.promptEditingTitle": {
+    "defaultMessage": "Edição de prompts"
+  },
+  "promptsSettings.promptResetToDefault": {
+    "defaultMessage": "Prompt reposto para a predefinição"
+  },
+  "promptsSettings.promptSaved": {
+    "defaultMessage": "Prompt guardado"
+  },
+  "promptsSettings.resetAll": {
+    "defaultMessage": "Repor tudo"
+  },
+  "promptsSettings.resetToDefault": {
+    "defaultMessage": "Repor predefinição"
+  },
+  "promptsSettings.restoreDefault": {
+    "defaultMessage": "Restaurar predefinição"
+  },
+  "promptsSettings.save": {
+    "defaultMessage": "Guardar"
+  },
+  "promptsSettings.templateTip": {
+    "defaultMessage": "As variáveis de template como {extensionsExample} ou {forExample} são substituídas por valores reais em tempo de execução. Tenha cuidado para não remover variáveis obrigatórias."
+  },
+  "promptsSettings.unsavedChanges": {
+    "defaultMessage": "Tem alterações por guardar"
+  },
+  "providerCard.noMetadata": {
+    "defaultMessage": "Erro de ProviderCard: nenhum metadado fornecido"
+  },
+  "providerCard.unknownProvider": {
+    "defaultMessage": "Fornecedor desconhecido"
+  },
+  "providerCatalogPicker.anthropicCompatible": {
+    "defaultMessage": "Compatível com Anthropic"
+  },
+  "providerCatalogPicker.apiFormat": {
+    "defaultMessage": "Formato da API"
+  },
+  "providerCatalogPicker.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "providerCatalogPicker.chooseProvider": {
+    "defaultMessage": "Escolher fornecedor"
+  },
+  "providerCatalogPicker.errorPrefix": {
+    "defaultMessage": "Erro: {error}"
+  },
+  "providerCatalogPicker.loadingProviders": {
+    "defaultMessage": "A carregar fornecedores..."
+  },
+  "providerCatalogPicker.modelsAvailable": {
+    "defaultMessage": "{count} modelos disponíveis"
+  },
+  "providerCatalogPicker.noProvidersAvailable": {
+    "defaultMessage": "Não há fornecedores disponíveis"
+  },
+  "providerCatalogPicker.noProvidersFound": {
+    "defaultMessage": "Não foram encontrados fornecedores para \"{query}\""
+  },
+  "providerCatalogPicker.openaiCompatible": {
+    "defaultMessage": "Compatível com OpenAI"
+  },
+  "providerCatalogPicker.requiresEnvVar": {
+    "defaultMessage": "• Requer {envVar}"
+  },
+  "providerCatalogPicker.searchProviders": {
+    "defaultMessage": "Pesquisar fornecedores..."
+  },
+  "providerCatalogPicker.selectFormatDescription": {
+    "defaultMessage": "Selecione um formato de API e um fornecedor. Preencheremos a configuração automaticamente por si."
+  },
+  "providerConfigForm.browserWindowOpen": {
+    "defaultMessage": "Será aberta uma janela do navegador para concluir o início de sessão."
+  },
+  "providerConfigForm.configuring": {
+    "defaultMessage": "A configurar..."
+  },
+  "providerConfigForm.continue": {
+    "defaultMessage": "Continuar"
+  },
+  "providerConfigForm.deviceCodeFlowHint": {
+    "defaultMessage": "Será aberta uma janela do navegador e o código de verificação será copiado para a área de transferência. Cole-o no navegador para concluir o início de sessão."
+  },
+  "providerConfigForm.noApiKey": {
+    "defaultMessage": "Não tem uma chave de API?"
+  },
+  "providerConfigForm.signInWith": {
+    "defaultMessage": "Iniciar sessão com {providerName}"
+  },
+  "providerConfigForm.signingIn": {
+    "defaultMessage": "A iniciar sessão..."
+  },
+  "providerConfigurationModal.addApiKeyDescription": {
+    "defaultMessage": "Adicione a(s) sua(s) chave(s) de API deste fornecedor para integrar no goose"
+  },
+  "providerConfigurationModal.browserWindowHint": {
+    "defaultMessage": "Será aberta uma janela do navegador para concluir o início de sessão."
+  },
+  "providerConfigurationModal.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "providerConfigurationModal.cannotDeleteActive": {
+    "defaultMessage": "Não pode eliminar este fornecedor enquanto estiver em utilização. Mude primeiro para um modelo diferente."
+  },
+  "providerConfigurationModal.checkConfigAgain": {
+    "defaultMessage": "Verifique novamente a sua configuração para utilizar este fornecedor."
+  },
+  "providerConfigurationModal.close": {
+    "defaultMessage": "Fechar"
+  },
+  "providerConfigurationModal.configureHeader": {
+    "defaultMessage": "Configurar {providerName}"
+  },
+  "providerConfigurationModal.deleteConfigHeader": {
+    "defaultMessage": "Eliminar configuração de {providerName}"
+  },
+  "providerConfigurationModal.deleteConfirmation": {
+    "defaultMessage": "Isto irá eliminar permanentemente a configuração atual do fornecedor."
+  },
+  "providerConfigurationModal.deviceCodeFlowHint": {
+    "defaultMessage": "Será aberta uma janela do navegador e o código de verificação será copiado para a área de transferência. Cole-o no navegador para concluir o início de sessão."
+  },
+  "providerConfigurationModal.errorCheckingConfig": {
+    "defaultMessage": "Ocorreu um erro ao verificar a configuração deste fornecedor."
+  },
+  "providerConfigurationModal.errorTitle": {
+    "defaultMessage": "Erro"
+  },
+  "providerConfigurationModal.externalSetupIntro": {
+    "defaultMessage": "Este fornecedor é configurado fora do goose. Siga estes passos:"
+  },
+  "providerConfigurationModal.goBack": {
+    "defaultMessage": "Voltar"
+  },
+  "providerConfigurationModal.huggingFaceOAuthDescription": {
+    "defaultMessage": "Inicie sessão para usar os Inference Providers da Hugging Face sem introduzir manualmente um token de API."
+  },
+  "providerConfigurationModal.oauthLoginFailed": {
+    "defaultMessage": "Falha no início de sessão OAuth: {error}"
+  },
+  "providerConfigurationModal.oauthSignInDescription": {
+    "defaultMessage": "Inicie sessão com a sua conta {providerName} para usar este fornecedor"
+  },
+  "providerConfigurationModal.parameterRequired": {
+    "defaultMessage": "{paramName} é obrigatório"
+  },
+  "providerConfigurationModal.removeConfiguration": {
+    "defaultMessage": "Remover configuração"
+  },
+  "providerConfigurationModal.seeDocumentation": {
+    "defaultMessage": "Consulte a <link>documentação</link> para mais detalhes."
+  },
+  "providerConfigurationModal.signInWith": {
+    "defaultMessage": "Iniciar sessão com {providerName}"
+  },
+  "providerConfigurationModal.signingIn": {
+    "defaultMessage": "A iniciar sessão..."
+  },
+  "providerGrid.addProvider": {
+    "defaultMessage": "Adicionar fornecedor"
+  },
+  "providerGrid.addProviderTitle": {
+    "defaultMessage": "Adicionar fornecedor"
+  },
+  "providerGrid.chooseModel": {
+    "defaultMessage": "Escolher modelo"
+  },
+  "providerGrid.configureProvider": {
+    "defaultMessage": "Configurar fornecedor"
+  },
+  "providerGrid.editProvider": {
+    "defaultMessage": "Editar fornecedor"
+  },
+  "providerGrid.fromTemplateOrManual": {
+    "defaultMessage": "A partir de um modelo ou configuração manual"
+  },
+  "providerLogo.alt": {
+    "defaultMessage": "Logótipo de {providerName}"
+  },
+  "providerSelector.addCustomProvider": {
+    "defaultMessage": "Adicionar um fornecedor personalizado"
+  },
+  "providerSelector.addCustomProviderTitle": {
+    "defaultMessage": "Adicionar fornecedor personalizado"
+  },
+  "providerSelector.connectProvider": {
+    "defaultMessage": "Ligar a um fornecedor"
+  },
+  "providerSelector.connectProviderDescription": {
+    "defaultMessage": "Ligar OpenAI, Anthropic, Google, etc."
+  },
+  "providerSelector.freeLocalDescription": {
+    "defaultMessage": "Use um modelo local ou um fornecedor com créditos gratuitos"
+  },
+  "providerSelector.selectProvider": {
+    "defaultMessage": "Selecione um fornecedor"
+  },
+  "providerSelector.useFreeLocal": {
+    "defaultMessage": "Usar fornecedores gratuitos/locais"
+  },
+  "providerSettings.configurationSettings": {
+    "defaultMessage": "Definições de configuração do fornecedor"
+  },
+  "providerSettings.loadingProviders": {
+    "defaultMessage": "A carregar fornecedores..."
+  },
+  "providerSettings.onboardingDescription": {
+    "defaultMessage": "Selecione um fornecedor de modelos de IA para começar a usar o goose. Terá de usar chaves de API geradas por cada fornecedor, que serão encriptadas e armazenadas localmente. Pode alterar o seu fornecedor a qualquer momento nas definições."
+  },
+  "providerSettings.otherProviders": {
+    "defaultMessage": "Outros fornecedores"
+  },
+  "providerSetupActions.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "providerSetupActions.cannotDeleteActive": {
+    "defaultMessage": "Não pode eliminar {providerName} enquanto estiver em utilização. Mude para um modelo diferente antes de eliminar este fornecedor."
+  },
+  "providerSetupActions.confirmDelete": {
+    "defaultMessage": "Confirmar eliminação"
+  },
+  "providerSetupActions.confirmDeleteMessage": {
+    "defaultMessage": "Tem a certeza de que pretende eliminar os parâmetros de configuração de {providerName}? Esta ação não pode ser anulada."
+  },
+  "providerSetupActions.deleteProvider": {
+    "defaultMessage": "Eliminar fornecedor"
+  },
+  "providerSetupActions.enableProvider": {
+    "defaultMessage": "Ativar fornecedor"
+  },
+  "providerSetupActions.ok": {
+    "defaultMessage": "Ok"
+  },
+  "providerSetupActions.submit": {
+    "defaultMessage": "Submeter"
+  },
+  "recipeActivityEditor.activitiesDescription": {
+    "defaultMessage": "Os prompts principais e os botões de atividade que serão apresentados na janela de conversa da receita."
+  },
+  "recipeActivityEditor.activitiesLabel": {
+    "defaultMessage": "Atividades"
+  },
+  "recipeActivityEditor.activityButtonsDescription": {
+    "defaultMessage": "Botões clicáveis que aparecerão abaixo da mensagem para ajudar os utilizadores a interagir com a sua receita."
+  },
+  "recipeActivityEditor.activityButtonsLabel": {
+    "defaultMessage": "Botões de atividade"
+  },
+  "recipeActivityEditor.addActivity": {
+    "defaultMessage": "Adicionar atividade"
+  },
+  "recipeActivityEditor.addNewActivityPlaceholder": {
+    "defaultMessage": "Adicionar nova atividade..."
+  },
+  "recipeActivityEditor.messageDescription": {
+    "defaultMessage": "Uma mensagem formatada que aparecerá no topo da receita. Suporta formatação markdown."
+  },
+  "recipeActivityEditor.messageLabel": {
+    "defaultMessage": "Mensagem"
+  },
+  "recipeActivityEditor.messagePlaceholder": {
+    "defaultMessage": "Introduza uma mensagem de introdução visível para o utilizador para a sua receita (suporta **negrito**, *itálico*, `código`, etc.)"
+  },
+  "recipeExtensionSelector.description": {
+    "defaultMessage": "Selecione que extensões devem estar disponíveis ao executar esta receita. Deixe em branco para usar as extensões predefinidas."
+  },
+  "recipeExtensionSelector.extensionsSelected": {
+    "defaultMessage": "{count,plural,one{# extensão selecionada} other{# extensões selecionadas}}"
+  },
+  "recipeExtensionSelector.label": {
+    "defaultMessage": "Extensões (opcional)"
+  },
+  "recipeExtensionSelector.noExtensionsAvailable": {
+    "defaultMessage": "Não há extensões disponíveis"
+  },
+  "recipeExtensionSelector.noExtensionsFound": {
+    "defaultMessage": "Não foram encontradas extensões"
+  },
+  "recipeExtensionSelector.searchPlaceholder": {
+    "defaultMessage": "Pesquisar extensões..."
+  },
+  "recipeFormFields.addParameter": {
+    "defaultMessage": "Adicionar parâmetro"
+  },
+  "recipeFormFields.advancedOptions": {
+    "defaultMessage": "Opções avançadas"
+  },
+  "recipeFormFields.advancedOptionsHint": {
+    "defaultMessage": "Atividades, parâmetros, modelo, extensões, esquema de resposta, subreceitas"
+  },
+  "recipeFormFields.descriptionLabel": {
+    "defaultMessage": "Descrição"
+  },
+  "recipeFormFields.descriptionPlaceholder": {
+    "defaultMessage": "Breve descrição do que esta receita faz"
+  },
+  "recipeFormFields.enterValueFor": {
+    "defaultMessage": "Introduza o valor para {key}"
+  },
+  "recipeFormFields.initialPrompt": {
+    "defaultMessage": "Prompt inicial"
+  },
+  "recipeFormFields.instructionsLabel": {
+    "defaultMessage": "Instruções"
+  },
+  "recipeFormFields.instructionsPlaceholder": {
+    "defaultMessage": "Instruções detalhadas para a IA, ocultas do utilizador"
+  },
+  "recipeFormFields.openEditor": {
+    "defaultMessage": "Abrir editor"
+  },
+  "recipeFormFields.parameterNamePlaceholder": {
+    "defaultMessage": "Introduza o nome do parâmetro..."
+  },
+  "recipeFormFields.parametersDescription": {
+    "defaultMessage": "Os parâmetros serão detetados automaticamente a partir da sintaxe '{{parameter_name}}' nas instruções/prompt/atividades, ou pode adicioná-los manualmente abaixo."
+  },
+  "recipeFormFields.parametersLabel": {
+    "defaultMessage": "Parâmetros"
+  },
+  "recipeFormFields.promptOptionalHint": {
+    "defaultMessage": "(Opcional - São necessárias as instruções ou o prompt)"
+  },
+  "recipeFormFields.promptPlaceholder": {
+    "defaultMessage": "Prompt pré-preenchido quando a receita é iniciada"
+  },
+  "recipeFormFields.responseJsonSchema": {
+    "defaultMessage": "Esquema JSON da resposta"
+  },
+  "recipeFormFields.responseJsonSchemaDescription": {
+    "defaultMessage": "Defina a estrutura esperada da resposta da IA usando o formato JSON Schema"
+  },
+  "recipeFormFields.templateVarHint": {
+    "defaultMessage": "Utilize '{{parameter_name}}' para definir parâmetros que podem ser preenchidos ao executar a receita."
+  },
+  "recipeFormFields.titleLabel": {
+    "defaultMessage": "Título"
+  },
+  "recipeFormFields.titlePlaceholder": {
+    "defaultMessage": "Título da receita"
+  },
+  "recipeHeader.recipeLabel": {
+    "defaultMessage": "Receita"
+  },
+  "recipeModelSelector.backToModelList": {
+    "defaultMessage": "Voltar à lista de modelos"
+  },
+  "recipeModelSelector.enterCustomModel": {
+    "defaultMessage": "Introduza o nome do modelo personalizado"
+  },
+  "recipeModelSelector.enterModelNotListed": {
+    "defaultMessage": "Introduza um modelo não listado..."
+  },
+  "recipeModelSelector.fetchError": {
+    "defaultMessage": "Falha ao obter os modelos. Tente novamente mais tarde."
+  },
+  "recipeModelSelector.loadingModels": {
+    "defaultMessage": "A carregar modelos…"
+  },
+  "recipeModelSelector.modelHint": {
+    "defaultMessage": "Deixe em branco para usar o modelo predefinido do fornecedor selecionado"
+  },
+  "recipeModelSelector.modelLabel": {
+    "defaultMessage": "Modelo (opcional)"
+  },
+  "recipeModelSelector.providerHint": {
+    "defaultMessage": "Deixe em branco para usar o fornecedor predefinido configurado nas definições"
+  },
+  "recipeModelSelector.providerLabel": {
+    "defaultMessage": "Fornecedor (opcional)"
+  },
+  "recipeModelSelector.selectModel": {
+    "defaultMessage": "Selecione um modelo"
+  },
+  "recipeModelSelector.selectProvider": {
+    "defaultMessage": "Selecione um fornecedor"
+  },
+  "recipeModelSelector.useDefaultProvider": {
+    "defaultMessage": "Usar fornecedor predefinido"
+  },
+  "recipeNameField.defaultLabel": {
+    "defaultMessage": "Nome da receita"
+  },
+  "recipeNameField.formatHint": {
+    "defaultMessage": "Será formatado automaticamente (minúsculas, traços nos espaços)"
+  },
+  "recipeWarningModal.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "recipeWarningModal.descriptionLabel": {
+    "defaultMessage": "Descrição:"
+  },
+  "recipeWarningModal.firstTimeDescription": {
+    "defaultMessage": "Está prestes a executar uma receita que nunca executou antes."
+  },
+  "recipeWarningModal.hiddenCharsWarning": {
+    "defaultMessage": "Esta receita contém caracteres ocultos que serão ignorados para sua segurança, pois podem ser usados para fins maliciosos."
+  },
+  "recipeWarningModal.instructionsLabel": {
+    "defaultMessage": "Instruções:"
+  },
+  "recipeWarningModal.newRecipeWarningTitle": {
+    "defaultMessage": "⚠️ Aviso de nova receita"
+  },
+  "recipeWarningModal.recipePreview": {
+    "defaultMessage": "Pré-visualização da receita:"
+  },
+  "recipeWarningModal.securityWarningTitle": {
+    "defaultMessage": "⚠️ Aviso de segurança"
+  },
+  "recipeWarningModal.titleLabel": {
+    "defaultMessage": "Título:"
+  },
+  "recipeWarningModal.trustAndExecute": {
+    "defaultMessage": "Confiar e executar"
+  },
+  "recipeWarningModal.trustSource": {
+    "defaultMessage": "Avance apenas se confiar na origem desta receita."
+  },
+  "recipesView.addSchedule": {
+    "defaultMessage": "Adicionar agendamento"
+  },
+  "recipesView.addSlashCommand": {
+    "defaultMessage": "Adicionar comando de barra"
+  },
+  "recipesView.adjustSearchTerms": {
+    "defaultMessage": "Tente ajustar os termos de pesquisa"
+  },
+  "recipesView.allFiles": {
+    "defaultMessage": "Todos os ficheiros"
+  },
+  "recipesView.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "recipesView.copyDeeplink": {
+    "defaultMessage": "Copiar deeplink"
+  },
+  "recipesView.copyDeeplinkFailedMsg": {
+    "defaultMessage": "Falha ao copiar o deeplink para a área de transferência"
+  },
+  "recipesView.copyFailedTitle": {
+    "defaultMessage": "Falha ao copiar"
+  },
+  "recipesView.copyYaml": {
+    "defaultMessage": "Copiar YAML"
+  },
+  "recipesView.copyYamlFailedMsg": {
+    "defaultMessage": "Falha ao copiar o YAML da receita para a área de transferência"
+  },
+  "recipesView.createRecipe": {
+    "defaultMessage": "Criar receita"
+  },
+  "recipesView.deeplinkCopiedMsg": {
+    "defaultMessage": "O deeplink da receita foi copiado para a área de transferência"
+  },
+  "recipesView.deeplinkCopiedTitle": {
+    "defaultMessage": "Deeplink copiado"
+  },
+  "recipesView.deleteRecipe": {
+    "defaultMessage": "Eliminar receita"
+  },
+  "recipesView.deleteRecipeConfirm": {
+    "defaultMessage": "Tem a certeza de que pretende eliminar \"{title}\"?"
+  },
+  "recipesView.deleteRecipeDetail": {
+    "defaultMessage": "O ficheiro da receita será eliminado."
+  },
+  "recipesView.deleteRecipeTitle": {
+    "defaultMessage": "Eliminar receita"
+  },
+  "recipesView.editRecipe": {
+    "defaultMessage": "Editar receita"
+  },
+  "recipesView.editSchedule": {
+    "defaultMessage": "Editar agendamento"
+  },
+  "recipesView.editSlashCommand": {
+    "defaultMessage": "Editar comando de barra"
+  },
+  "recipesView.errorLoadingRecipes": {
+    "defaultMessage": "Erro ao carregar as receitas"
+  },
+  "recipesView.exportFailedMsg": {
+    "defaultMessage": "Falha ao exportar a receita para o ficheiro"
+  },
+  "recipesView.exportFailedTitle": {
+    "defaultMessage": "Falha na exportação"
+  },
+  "recipesView.exportRecipeDialogTitle": {
+    "defaultMessage": "Exportar receita"
+  },
+  "recipesView.exportToFile": {
+    "defaultMessage": "Exportar para ficheiro"
+  },
+  "recipesView.noMatchingRecipes": {
+    "defaultMessage": "Nenhuma receita correspondente encontrada"
+  },
+  "recipesView.noSavedRecipes": {
+    "defaultMessage": "Sem receitas guardadas"
+  },
+  "recipesView.noSavedRecipesDescription": {
+    "defaultMessage": "As receitas guardadas a partir de conversas aparecerão aqui."
+  },
+  "recipesView.openInNewWindow": {
+    "defaultMessage": "Abrir numa nova janela"
+  },
+  "recipesView.recipeDeletedSuccess": {
+    "defaultMessage": "Receita eliminada com sucesso"
+  },
+  "recipesView.recipeExportedMsg": {
+    "defaultMessage": "Receita guardada em {filePath}"
+  },
+  "recipesView.recipeExportedTitle": {
+    "defaultMessage": "Receita exportada"
+  },
+  "recipesView.recipesDescription": {
+    "defaultMessage": "Veja e faça a gestão das suas receitas guardadas para iniciar rapidamente novas sessões com configurações predefinidas. {shortcut} para pesquisar."
+  },
+  "recipesView.recipesTitle": {
+    "defaultMessage": "Receitas"
+  },
+  "recipesView.remove": {
+    "defaultMessage": "Remover"
+  },
+  "recipesView.removeSchedule": {
+    "defaultMessage": "Remover agendamento"
+  },
+  "recipesView.runs": {
+    "defaultMessage": "Executa {schedule}"
+  },
+  "recipesView.save": {
+    "defaultMessage": "Guardar"
+  },
+  "recipesView.scheduleDialogTitle": {
+    "defaultMessage": "{action} agendamento"
+  },
+  "recipesView.scheduleRemovedMsg": {
+    "defaultMessage": "A receita já não será executada automaticamente"
+  },
+  "recipesView.scheduleRemovedTitle": {
+    "defaultMessage": "Agendamento removido"
+  },
+  "recipesView.scheduleSavedMsg": {
+    "defaultMessage": "A receita será executada {schedule}"
+  },
+  "recipesView.scheduleSavedTitle": {
+    "defaultMessage": "Agendamento guardado"
+  },
+  "recipesView.searchRecipesPlaceholder": {
+    "defaultMessage": "Pesquisar receitas..."
+  },
+  "recipesView.shareRecipe": {
+    "defaultMessage": "Partilhar receita"
+  },
+  "recipesView.slashCommandDescription": {
+    "defaultMessage": "Defina um comando de barra para executar rapidamente esta receita a partir de qualquer conversa"
+  },
+  "recipesView.slashCommandPlaceholder": {
+    "defaultMessage": "nome-do-comando"
+  },
+  "recipesView.slashCommandRemovedMsg": {
+    "defaultMessage": "O comando de barra da receita foi removido"
+  },
+  "recipesView.slashCommandRemovedTitle": {
+    "defaultMessage": "Comando de barra removido"
+  },
+  "recipesView.slashCommandSavedMsg": {
+    "defaultMessage": "Use /{command} para executar esta receita"
+  },
+  "recipesView.slashCommandSavedTitle": {
+    "defaultMessage": "Comando de barra guardado"
+  },
+  "recipesView.slashCommandTitle": {
+    "defaultMessage": "Comando de barra"
+  },
+  "recipesView.slashCommandUsageHint": {
+    "defaultMessage": "Use /{command} em qualquer conversa para executar esta receita"
+  },
+  "recipesView.tryAgain": {
+    "defaultMessage": "Tentar novamente"
+  },
+  "recipesView.useRecipe": {
+    "defaultMessage": "Usar receita"
+  },
+  "recipesView.yamlCopiedMsg": {
+    "defaultMessage": "O YAML da receita foi copiado para a área de transferência"
+  },
+  "recipesView.yamlCopiedTitle": {
+    "defaultMessage": "YAML copiado"
+  },
+  "recipesView.yamlFiles": {
+    "defaultMessage": "Ficheiros YAML"
+  },
+  "resetProviderSection.resetButton": {
+    "defaultMessage": "Repor fornecedor e modelo"
+  },
+  "resetProviderSection.resetDescription": {
+    "defaultMessage": "Isto irá limpar as definições do modelo e do fornecedor selecionados. Se não houver predefinições disponíveis, será encaminhado para o ecrã de boas-vindas para os configurar novamente."
+  },
+  "responseStyle.conciseDescription": {
+    "defaultMessage": "As chamadas de ferramentas estão fechadas por predefinição e mostram apenas a ferramenta utilizada"
+  },
+  "responseStyle.conciseLabel": {
+    "defaultMessage": "Conciso"
+  },
+  "responseStyle.detailedDescription": {
+    "defaultMessage": "As chamadas de ferramentas são mostradas abertas por predefinição para expor os detalhes"
+  },
+  "responseStyle.detailedLabel": {
+    "defaultMessage": "Detalhado"
+  },
+  "scheduleDetailView.actions": {
+    "defaultMessage": "Ações"
+  },
+  "scheduleDetailView.cannotModifyRunning": {
+    "defaultMessage": "Não é possível acionar ou modificar um agendamento enquanto este já está em execução."
+  },
+  "scheduleDetailView.completedSession": {
+    "defaultMessage": "Sessão: {sessionId}"
+  },
+  "scheduleDetailView.created": {
+    "defaultMessage": "Criado: {date}"
+  },
+  "scheduleDetailView.cronExpression": {
+    "defaultMessage": "Expressão Cron:"
+  },
+  "scheduleDetailView.currentSession": {
+    "defaultMessage": "Sessão atual:"
+  },
+  "scheduleDetailView.currentlyRunning": {
+    "defaultMessage": "Atualmente em execução"
+  },
+  "scheduleDetailView.dir": {
+    "defaultMessage": "Dir: {path}"
+  },
+  "scheduleDetailView.editSchedule": {
+    "defaultMessage": "Editar agendamento"
+  },
+  "scheduleDetailView.errorPrefix": {
+    "defaultMessage": "Erro: {error}"
+  },
+  "scheduleDetailView.idLabel": {
+    "defaultMessage": "ID:"
+  },
+  "scheduleDetailView.inspectJobError": {
+    "defaultMessage": "Erro ao inspecionar tarefa"
+  },
+  "scheduleDetailView.inspectNoInfo": {
+    "defaultMessage": "Nenhuma informação detalhada disponível"
+  },
+  "scheduleDetailView.inspectRunningJob": {
+    "defaultMessage": "Inspecionar tarefa em execução"
+  },
+  "scheduleDetailView.jobCancelled": {
+    "defaultMessage": "Tarefa cancelada"
+  },
+  "scheduleDetailView.jobCancelledMsg": {
+    "defaultMessage": "A tarefa foi cancelada durante o arranque."
+  },
+  "scheduleDetailView.jobInspection": {
+    "defaultMessage": "Inspeção de tarefa"
+  },
+  "scheduleDetailView.jobKilled": {
+    "defaultMessage": "Tarefa terminada"
+  },
+  "scheduleDetailView.killJobError": {
+    "defaultMessage": "Erro ao terminar tarefa"
+  },
+  "scheduleDetailView.killRunningJob": {
+    "defaultMessage": "Terminar tarefa em execução"
+  },
+  "scheduleDetailView.lastRun": {
+    "defaultMessage": "Última execução:"
+  },
+  "scheduleDetailView.loadingSchedule": {
+    "defaultMessage": "A carregar agendamento..."
+  },
+  "scheduleDetailView.loadingSessions": {
+    "defaultMessage": "A carregar sessões..."
+  },
+  "scheduleDetailView.messages": {
+    "defaultMessage": "Mensagens: {count}"
+  },
+  "scheduleDetailView.noScheduleId": {
+    "defaultMessage": "Nenhum ID de agendamento fornecido. Regresse à lista de agendamentos."
+  },
+  "scheduleDetailView.noSessions": {
+    "defaultMessage": "Nenhuma sessão encontrada para este agendamento."
+  },
+  "scheduleDetailView.pauseSchedule": {
+    "defaultMessage": "Pausar agendamento"
+  },
+  "scheduleDetailView.pauseUnpauseError": {
+    "defaultMessage": "Erro ao pausar/retomar"
+  },
+  "scheduleDetailView.paused": {
+    "defaultMessage": "Em pausa"
+  },
+  "scheduleDetailView.pausedMsg": {
+    "defaultMessage": "\"{id}\" pausado"
+  },
+  "scheduleDetailView.pausedWarning": {
+    "defaultMessage": "Este agendamento está em pausa e não será executado automaticamente. Use \"Executar agendamento agora\" para o acionar manualmente ou retome para repor a execução automática."
+  },
+  "scheduleDetailView.processStarted": {
+    "defaultMessage": "Processo iniciado:"
+  },
+  "scheduleDetailView.recentSessions": {
+    "defaultMessage": "Sessões recentes"
+  },
+  "scheduleDetailView.recipeSource": {
+    "defaultMessage": "Origem da receita:"
+  },
+  "scheduleDetailView.runScheduleError": {
+    "defaultMessage": "Erro ao executar agendamento"
+  },
+  "scheduleDetailView.runScheduleNow": {
+    "defaultMessage": "Executar agendamento agora"
+  },
+  "scheduleDetailView.scheduleCompleted": {
+    "defaultMessage": "Execução concluída"
+  },
+  "scheduleDetailView.scheduleDetails": {
+    "defaultMessage": "Detalhes do agendamento"
+  },
+  "scheduleDetailView.scheduleInformation": {
+    "defaultMessage": "Informação do agendamento"
+  },
+  "scheduleDetailView.scheduleLabel": {
+    "defaultMessage": "Agendamento:"
+  },
+  "scheduleDetailView.scheduleNotFound": {
+    "defaultMessage": "Agendamento não encontrado"
+  },
+  "scheduleDetailView.scheduleNotFoundError": {
+    "defaultMessage": "Agendamento não encontrado"
+  },
+  "scheduleDetailView.schedulePaused": {
+    "defaultMessage": "Agendamento em pausa"
+  },
+  "scheduleDetailView.scheduleUnpaused": {
+    "defaultMessage": "Agendamento retomado"
+  },
+  "scheduleDetailView.scheduleUpdated": {
+    "defaultMessage": "Agendamento atualizado"
+  },
+  "scheduleDetailView.sessionId": {
+    "defaultMessage": "ID da sessão: {id}"
+  },
+  "scheduleDetailView.unpauseSchedule": {
+    "defaultMessage": "Retomar agendamento"
+  },
+  "scheduleDetailView.unpausedMsg": {
+    "defaultMessage": "\"{id}\" retomado"
+  },
+  "scheduleDetailView.updateScheduleError": {
+    "defaultMessage": "Erro ao atualizar agendamento"
+  },
+  "scheduleDetailView.updatedMsg": {
+    "defaultMessage": "\"{id}\" atualizado"
+  },
+  "scheduleDetailView.viewingScheduleId": {
+    "defaultMessage": "A visualizar o ID do agendamento: {id}"
+  },
+  "scheduleModal.browseYaml": {
+    "defaultMessage": "Procurar ficheiro YAML..."
+  },
+  "scheduleModal.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "scheduleModal.createNewSchedule": {
+    "defaultMessage": "Criar novo agendamento"
+  },
+  "scheduleModal.createSchedule": {
+    "defaultMessage": "Criar agendamento"
+  },
+  "scheduleModal.creating": {
+    "defaultMessage": "A criar..."
+  },
+  "scheduleModal.deepLink": {
+    "defaultMessage": "Ligação profunda"
+  },
+  "scheduleModal.deepLinkPlaceholder": {
+    "defaultMessage": "Cole aqui a ligação goose://recipe..."
+  },
+  "scheduleModal.editSchedule": {
+    "defaultMessage": "Editar agendamento"
+  },
+  "scheduleModal.failedParseRecipe": {
+    "defaultMessage": "Falha ao analisar a receita a partir do ficheiro."
+  },
+  "scheduleModal.failedReadFile": {
+    "defaultMessage": "Falha ao ler o ficheiro selecionado."
+  },
+  "scheduleModal.invalidDeepLink": {
+    "defaultMessage": "Ligação profunda inválida. Use uma ligação goose://recipe."
+  },
+  "scheduleModal.invalidFileType": {
+    "defaultMessage": "Tipo de ficheiro inválido: selecione um ficheiro YAML (.yaml ou .yml)"
+  },
+  "scheduleModal.nameLabel": {
+    "defaultMessage": "Nome:"
+  },
+  "scheduleModal.namePlaceholder": {
+    "defaultMessage": "p. ex., tarefa-resumo-diario"
+  },
+  "scheduleModal.provideValidRecipe": {
+    "defaultMessage": "Forneça uma origem de receita válida."
+  },
+  "scheduleModal.recipeDescription": {
+    "defaultMessage": "Descrição: {description}"
+  },
+  "scheduleModal.recipeParsed": {
+    "defaultMessage": "Receita analisada com sucesso"
+  },
+  "scheduleModal.recipeTitle": {
+    "defaultMessage": "Título: {title}"
+  },
+  "scheduleModal.scheduleIdRequired": {
+    "defaultMessage": "O ID do agendamento é obrigatório."
+  },
+  "scheduleModal.scheduleLabel": {
+    "defaultMessage": "Agendamento:"
+  },
+  "scheduleModal.selected": {
+    "defaultMessage": "Selecionado: {path}"
+  },
+  "scheduleModal.sourceLabel": {
+    "defaultMessage": "Origem:"
+  },
+  "scheduleModal.updateSchedule": {
+    "defaultMessage": "Atualizar agendamento"
+  },
+  "scheduleModal.updating": {
+    "defaultMessage": "A atualizar..."
+  },
+  "scheduleModal.yaml": {
+    "defaultMessage": "YAML"
+  },
+  "schedulesView.confirmDelete": {
+    "defaultMessage": "Remover o agendamento \"{id}\"? A receita será mantida."
+  },
+  "schedulesView.createSchedule": {
+    "defaultMessage": "Criar agendamento"
+  },
+  "schedulesView.description": {
+    "defaultMessage": "Crie e faça a gestão de tarefas agendadas para executar receitas automaticamente em horários específicos."
+  },
+  "schedulesView.edit": {
+    "defaultMessage": "Editar"
+  },
+  "schedulesView.errorPrefix": {
+    "defaultMessage": "Erro: {error}"
+  },
+  "schedulesView.inspect": {
+    "defaultMessage": "Inspecionar"
+  },
+  "schedulesView.inspectError": {
+    "defaultMessage": "Erro ao inspecionar tarefa"
+  },
+  "schedulesView.inspectNoInfo": {
+    "defaultMessage": "Nenhuma informação detalhada disponível para esta tarefa"
+  },
+  "schedulesView.jobInspection": {
+    "defaultMessage": "Inspeção de tarefa"
+  },
+  "schedulesView.jobKilled": {
+    "defaultMessage": "Tarefa terminada"
+  },
+  "schedulesView.kill": {
+    "defaultMessage": "Terminar"
+  },
+  "schedulesView.killError": {
+    "defaultMessage": "Erro ao terminar tarefa"
+  },
+  "schedulesView.lastRun": {
+    "defaultMessage": "Última execução: {date}"
+  },
+  "schedulesView.noSchedules": {
+    "defaultMessage": "Ainda não há agendamentos"
+  },
+  "schedulesView.pause": {
+    "defaultMessage": "Pausar"
+  },
+  "schedulesView.pauseError": {
+    "defaultMessage": "Erro ao pausar agendamento"
+  },
+  "schedulesView.paused": {
+    "defaultMessage": "Em pausa"
+  },
+  "schedulesView.refresh": {
+    "defaultMessage": "Atualizar"
+  },
+  "schedulesView.refreshing": {
+    "defaultMessage": "A atualizar..."
+  },
+  "schedulesView.resume": {
+    "defaultMessage": "Retomar"
+  },
+  "schedulesView.running": {
+    "defaultMessage": "Em execução"
+  },
+  "schedulesView.schedulePaused": {
+    "defaultMessage": "Agendamento em pausa"
+  },
+  "schedulesView.schedulePausedMsg": {
+    "defaultMessage": "Agendamento \"{id}\" pausado com sucesso"
+  },
+  "schedulesView.scheduleUnpaused": {
+    "defaultMessage": "Agendamento retomado"
+  },
+  "schedulesView.scheduleUnpausedMsg": {
+    "defaultMessage": "Agendamento \"{id}\" retomado com sucesso"
+  },
+  "schedulesView.scheduleUpdated": {
+    "defaultMessage": "Agendamento atualizado"
+  },
+  "schedulesView.scheduleUpdatedMsg": {
+    "defaultMessage": "Agendamento \"{id}\" atualizado com sucesso"
+  },
+  "schedulesView.scheduler": {
+    "defaultMessage": "Agendador"
+  },
+  "schedulesView.unpauseError": {
+    "defaultMessage": "Erro ao retomar agendamento"
+  },
+  "searchBar.caseSensitive": {
+    "defaultMessage": "Sensível a maiúsculas/minúsculas"
+  },
+  "searchBar.close": {
+    "defaultMessage": "Fechar ({shortcut})"
+  },
+  "searchBar.next": {
+    "defaultMessage": "Seguinte ({shortcut})"
+  },
+  "searchBar.placeholder": {
+    "defaultMessage": "Pesquisar conversa..."
+  },
+  "searchBar.previous": {
+    "defaultMessage": "Anterior ({shortcut})"
+  },
+  "secureStorageNotice.defaultMessage": {
+    "defaultMessage": "As chaves são armazenadas de forma segura no porta-chaves"
+  },
+  "securityToggle.apiTokenDescription": {
+    "defaultMessage": "Token de autenticação para o serviço de classificação"
+  },
+  "securityToggle.apiTokenOptional": {
+    "defaultMessage": "Token de API (opcional)"
+  },
+  "securityToggle.classificationEndpoint": {
+    "defaultMessage": "Endpoint de classificação"
+  },
+  "securityToggle.classificationEndpointDescription": {
+    "defaultMessage": "Introduza o URL completo do seu serviço de classificação"
+  },
+  "securityToggle.commandClassifierActive": {
+    "defaultMessage": "Classificador de comandos ativo (configurado automaticamente a partir do ambiente)"
+  },
+  "securityToggle.commandEndpointDescription": {
+    "defaultMessage": "Introduza o URL completo do seu serviço de classificação de injeção de comandos"
+  },
+  "securityToggle.commandInjectionDescription": {
+    "defaultMessage": "Usar modelos de ML para detetar comandos de shell maliciosos"
+  },
+  "securityToggle.detectionModel": {
+    "defaultMessage": "Modelo de deteção"
+  },
+  "securityToggle.detectionModelDescription": {
+    "defaultMessage": "Selecione o modelo de ML a usar para a deteção de injeção de prompts"
+  },
+  "securityToggle.detectionThreshold": {
+    "defaultMessage": "Limiar de deteção"
+  },
+  "securityToggle.enableCommandInjection": {
+    "defaultMessage": "Ativar deteção de injeção de comandos por ML"
+  },
+  "securityToggle.enablePromptInjection": {
+    "defaultMessage": "Ativar deteção de injeção de prompts"
+  },
+  "securityToggle.enablePromptInjectionMl": {
+    "defaultMessage": "Ativar deteção de injeção de prompts por ML"
+  },
+  "securityToggle.mlEndpointDescription": {
+    "defaultMessage": "Introduza o URL completo do seu serviço de classificação por ML (incluindo o identificador do modelo)"
+  },
+  "securityToggle.mlTokenDescription": {
+    "defaultMessage": "Token de autenticação para o serviço de ML (p. ex., token do HuggingFace)"
+  },
+  "securityToggle.overrideNotice": {
+    "defaultMessage": "Esta definição é gerida pela sua organização e não pode ser alterada."
+  },
+  "securityToggle.promptInjectionDescription": {
+    "defaultMessage": "Detetar e prevenir potenciais ataques de injeção de prompts"
+  },
+  "securityToggle.promptInjectionMlDescription": {
+    "defaultMessage": "Usar modelos de ML para detetar potenciais injeções de prompts na sua conversa"
+  },
+  "securityToggle.thresholdDescription": {
+    "defaultMessage": "Valores mais altos são mais rigorosos (0,01 = muito tolerante, 1,0 = rigor máximo)"
+  },
+  "securityToggle.warpNotice": {
+    "defaultMessage": "A deteção de injeção de comandos funciona melhor quando ligada ao WARP (necessário para aceder ao serviço de classificação)."
+  },
+  "sessionActionsHeader.actionsLabel": {
+    "defaultMessage": "Ações da sessão"
+  },
+  "sessionActionsHeader.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "sessionActionsHeader.close": {
+    "defaultMessage": "Fechar"
+  },
+  "sessionActionsHeader.copiedJson": {
+    "defaultMessage": "JSON da sessão copiado"
+  },
+  "sessionActionsHeader.copiedText": {
+    "defaultMessage": "Texto copiado"
+  },
+  "sessionActionsHeader.copyJson": {
+    "defaultMessage": "Copiar JSON"
+  },
+  "sessionActionsHeader.copyText": {
+    "defaultMessage": "Copiar texto"
+  },
+  "sessionActionsHeader.duplicateFailed": {
+    "defaultMessage": "Falha ao duplicar a sessão: {error}"
+  },
+  "sessionActionsHeader.duplicateSession": {
+    "defaultMessage": "Duplicar sessão"
+  },
+  "sessionActionsHeader.duplicated": {
+    "defaultMessage": "Sessão duplicada"
+  },
+  "sessionActionsHeader.fullTextTitle": {
+    "defaultMessage": "Valor do texto"
+  },
+  "sessionActionsHeader.jsonFailed": {
+    "defaultMessage": "Falha ao carregar o JSON da sessão: {error}"
+  },
+  "sessionActionsHeader.jsonTitle": {
+    "defaultMessage": "JSON da sessão"
+  },
+  "sessionActionsHeader.loadingJson": {
+    "defaultMessage": "A carregar JSON..."
+  },
+  "sessionActionsHeader.renameFailed": {
+    "defaultMessage": "Falha ao renomear a sessão: {error}"
+  },
+  "sessionActionsHeader.renamePlaceholder": {
+    "defaultMessage": "Introduza o nome da sessão"
+  },
+  "sessionActionsHeader.renameSession": {
+    "defaultMessage": "Renomear sessão"
+  },
+  "sessionActionsHeader.renameTitle": {
+    "defaultMessage": "Renomear sessão"
+  },
+  "sessionActionsHeader.renamed": {
+    "defaultMessage": "Sessão renomeada"
+  },
+  "sessionActionsHeader.save": {
+    "defaultMessage": "Guardar"
+  },
+  "sessionActionsHeader.saving": {
+    "defaultMessage": "A guardar..."
+  },
+  "sessionActionsHeader.viewJson": {
+    "defaultMessage": "Ver JSON da sessão"
+  },
+  "sessionIndicators.error": {
+    "defaultMessage": "A sessão encontrou um erro"
+  },
+  "sessionIndicators.newActivity": {
+    "defaultMessage": "Tem nova atividade"
+  },
+  "sessionIndicators.streaming": {
+    "defaultMessage": "Em transmissão"
+  },
+  "sessionViewComponents.empty.description": {
+    "defaultMessage": "Esta sessão não contém mensagens"
+  },
+  "sessionViewComponents.empty.title": {
+    "defaultMessage": "Nenhuma mensagem encontrada"
+  },
+  "sessionViewComponents.error.loading": {
+    "defaultMessage": "Erro ao carregar os detalhes da sessão"
+  },
+  "sessionViewComponents.error.tryAgain": {
+    "defaultMessage": "Tentar novamente"
+  },
+  "sessionViewComponents.role.assistant": {
+    "defaultMessage": "Goose"
+  },
+  "sessionViewComponents.role.user": {
+    "defaultMessage": "Você"
+  },
+  "sessions.action.delete": {
+    "defaultMessage": "Eliminar sessão"
+  },
+  "sessions.action.duplicate": {
+    "defaultMessage": "Duplicar sessão"
+  },
+  "sessions.action.editName": {
+    "defaultMessage": "Editar nome da sessão"
+  },
+  "sessions.action.export": {
+    "defaultMessage": "Exportar sessão"
+  },
+  "sessions.action.openNewWindow": {
+    "defaultMessage": "Abrir numa nova janela"
+  },
+  "sessions.action.shareNostr": {
+    "defaultMessage": "Partilhar ligação Nostr encriptada"
+  },
+  "sessions.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "sessions.chatHistory": {
+    "defaultMessage": "Histórico de conversas"
+  },
+  "sessions.chatHistoryDesc": {
+    "defaultMessage": "Veja e pesquise as suas conversas anteriores com o Goose. {shortcut} para pesquisar."
+  },
+  "sessions.close": {
+    "defaultMessage": "Fechar"
+  },
+  "sessions.delete.message": {
+    "defaultMessage": "Tem a certeza de que pretende eliminar a sessão \"{name}\"? Esta ação não pode ser anulada."
+  },
+  "sessions.delete.title": {
+    "defaultMessage": "Eliminar sessão"
+  },
+  "sessions.edit.placeholder": {
+    "defaultMessage": "Introduza a descrição da sessão"
+  },
+  "sessions.edit.title": {
+    "defaultMessage": "Editar descrição da sessão"
+  },
+  "sessions.empty.description": {
+    "defaultMessage": "O seu histórico de conversas aparecerá aqui"
+  },
+  "sessions.empty.title": {
+    "defaultMessage": "Nenhuma sessão de conversa encontrada"
+  },
+  "sessions.error.loading": {
+    "defaultMessage": "Erro ao carregar sessões"
+  },
+  "sessions.error.tryAgain": {
+    "defaultMessage": "Tentar novamente"
+  },
+  "sessions.import": {
+    "defaultMessage": "Importar sessão"
+  },
+  "sessions.importNostr": {
+    "defaultMessage": "Importar ligação"
+  },
+  "sessions.importNostr.description": {
+    "defaultMessage": "Cole uma ligação de partilha Nostr do Goose para obter, desencriptar e importar a sessão."
+  },
+  "sessions.importNostr.placeholder": {
+    "defaultMessage": "goose://sessions/nostr?nevent=...&key=..."
+  },
+  "sessions.importNostr.title": {
+    "defaultMessage": "Importar sessão Nostr"
+  },
+  "sessions.importing": {
+    "defaultMessage": "A importar..."
+  },
+  "sessions.loadingMore": {
+    "defaultMessage": "A carregar mais sessões..."
+  },
+  "sessions.save": {
+    "defaultMessage": "Guardar"
+  },
+  "sessions.saving": {
+    "defaultMessage": "A guardar..."
+  },
+  "sessions.search.noResults": {
+    "defaultMessage": "Nenhuma sessão correspondente encontrada"
+  },
+  "sessions.search.noResultsDesc": {
+    "defaultMessage": "Tente ajustar os termos da pesquisa"
+  },
+  "sessions.searchPlaceholder": {
+    "defaultMessage": "Pesquisar no histórico..."
+  },
+  "sessions.shareNostr.description": {
+    "defaultMessage": "Qualquer pessoa com este link pode obter e descriptografar a sessão. Trate-o como um segredo."
+  },
+  "sessions.shareNostr.title": {
+    "defaultMessage": "Link de Partilha Nostr Criptografado"
+  },
+  "sessions.toast.copied": {
+    "defaultMessage": "Copiado para a área de transferência"
+  },
+  "sessions.toast.deleteFailed": {
+    "defaultMessage": "Falha ao eliminar a sessão \"{name}\": {error}"
+  },
+  "sessions.toast.deleted": {
+    "defaultMessage": "Sessão eliminada com êxito"
+  },
+  "sessions.toast.duplicateFailed": {
+    "defaultMessage": "Falha ao duplicar a sessão: {error}"
+  },
+  "sessions.toast.duplicated": {
+    "defaultMessage": "Sessão \"{name}\" duplicada com êxito"
+  },
+  "sessions.toast.exported": {
+    "defaultMessage": "Sessão exportada com êxito"
+  },
+  "sessions.toast.importFailed": {
+    "defaultMessage": "Falha ao importar a sessão: {error}"
+  },
+  "sessions.toast.imported": {
+    "defaultMessage": "Sessão importada com êxito"
+  },
+  "sessions.toast.shareNostr": {
+    "defaultMessage": "Link de partilha Nostr criptografado criado"
+  },
+  "sessions.toast.shareNostrFailed": {
+    "defaultMessage": "Falha ao criar o link de partilha Nostr: {error}"
+  },
+  "sessions.toast.updateFailed": {
+    "defaultMessage": "Falha ao atualizar a descrição da sessão: {error}"
+  },
+  "sessions.toast.updated": {
+    "defaultMessage": "Descrição da sessão atualizada com êxito"
+  },
+  "settings.appearance.description": {
+    "defaultMessage": "Configure como o goose aparece no seu sistema"
+  },
+  "settings.appearance.title": {
+    "defaultMessage": "Aparência"
+  },
+  "settings.close": {
+    "defaultMessage": "Fechar"
+  },
+  "settings.costTracking.description": {
+    "defaultMessage": "Mostrar os preços do modelo e os custos de utilização"
+  },
+  "settings.costTracking.title": {
+    "defaultMessage": "Acompanhamento de Custos"
+  },
+  "settings.dockIcon.description": {
+    "defaultMessage": "Mostrar o goose na dock"
+  },
+  "settings.dockIcon.title": {
+    "defaultMessage": "Ícone da dock"
+  },
+  "settings.help.description": {
+    "defaultMessage": "Ajude-nos a melhorar o goose comunicando problemas ou solicitando novas funcionalidades"
+  },
+  "settings.help.reportBug": {
+    "defaultMessage": "Comunicar um Erro"
+  },
+  "settings.help.requestFeature": {
+    "defaultMessage": "Solicitar uma Funcionalidade"
+  },
+  "settings.help.title": {
+    "defaultMessage": "Ajuda e comentários"
+  },
+  "settings.language.description": {
+    "defaultMessage": "Escolha o idioma de exibição do goose"
+  },
+  "settings.language.english": {
+    "defaultMessage": "English"
+  },
+  "settings.language.french": {
+    "defaultMessage": "Francês"
+  },
+  "settings.language.german": {
+    "defaultMessage": "Alemão"
+  },
+  "settings.language.hindi": {
+    "defaultMessage": "Hindi"
+  },
+  "settings.language.indonesian": {
+    "defaultMessage": "Indonésio"
+  },
+  "settings.language.italian": {
+    "defaultMessage": "Italiano"
+  },
+  "settings.language.japanese": {
+    "defaultMessage": "Japonês"
+  },
+  "settings.language.korean": {
+    "defaultMessage": "Coreano"
+  },
+  "settings.language.malay": {
+    "defaultMessage": "Malaio"
+  },
+  "settings.language.portuguese": {
+    "defaultMessage": "Português"
+  },
+  "settings.language.russian": {
+    "defaultMessage": "Russo"
+  },
+  "settings.language.spanish": {
+    "defaultMessage": "Espanhol"
+  },
+  "settings.language.systemDefault": {
+    "defaultMessage": "Predefinição do Sistema"
+  },
+  "settings.language.title": {
+    "defaultMessage": "Idioma"
+  },
+  "settings.language.turkish": {
+    "defaultMessage": "Turco"
+  },
+  "settings.language.vietnamese": {
+    "defaultMessage": "Vietnamita"
+  },
+  "settings.language.zhCN": {
+    "defaultMessage": "Chinês (simplificado)"
+  },
+  "settings.language.zhTW": {
+    "defaultMessage": "Chinês (tradicional)"
+  },
+  "settings.menuBarIcon.description": {
+    "defaultMessage": "Mostrar o goose na barra de menus"
+  },
+  "settings.menuBarIcon.title": {
+    "defaultMessage": "Ícone da barra de menus"
+  },
+  "settings.notifications.configGuide": {
+    "defaultMessage": "Guia de configuração"
+  },
+  "settings.notifications.description": {
+    "defaultMessage": "As notificações são geridas pelo seu sistema operativo - {link}"
+  },
+  "settings.notifications.modal.macInstructions": {
+    "defaultMessage": "Para ativar as notificações no macOS:"
+  },
+  "settings.notifications.modal.macStep1": {
+    "defaultMessage": "Abra as Preferências do Sistema"
+  },
+  "settings.notifications.modal.macStep2": {
+    "defaultMessage": "Clique em Notificações"
+  },
+  "settings.notifications.modal.macStep3": {
+    "defaultMessage": "Encontre e selecione o goose na lista de aplicações"
+  },
+  "settings.notifications.modal.macStep4": {
+    "defaultMessage": "Ative as notificações e ajuste as definições conforme pretendido"
+  },
+  "settings.notifications.modal.title": {
+    "defaultMessage": "Como Ativar as Notificações"
+  },
+  "settings.notifications.modal.winInstructions": {
+    "defaultMessage": "Para ativar as notificações no Windows:"
+  },
+  "settings.notifications.modal.winStep1": {
+    "defaultMessage": "Abra as Definições"
+  },
+  "settings.notifications.modal.winStep2": {
+    "defaultMessage": "Vá para Sistema > Notificações"
+  },
+  "settings.notifications.modal.winStep3": {
+    "defaultMessage": "Encontre e selecione o goose na lista de aplicações"
+  },
+  "settings.notifications.modal.winStep4": {
+    "defaultMessage": "Ative as notificações e ajuste as definições conforme pretendido"
+  },
+  "settings.notifications.openSettings": {
+    "defaultMessage": "Abrir Definições"
+  },
+  "settings.notifications.task.description": {
+    "defaultMessage": "Notificar quando o Goose concluir uma tarefa enquanto a janela está em segundo plano"
+  },
+  "settings.notifications.task.title": {
+    "defaultMessage": "Notificações de conclusão de tarefas"
+  },
+  "settings.notifications.title": {
+    "defaultMessage": "Notificações"
+  },
+  "settings.preventSleep.description": {
+    "defaultMessage": "Manter o computador ativo enquanto o goose executa uma tarefa (o ecrã ainda pode ser bloqueado)"
+  },
+  "settings.preventSleep.title": {
+    "defaultMessage": "Impedir Suspensão"
+  },
+  "settings.theme.description": {
+    "defaultMessage": "Personalize a aparência e o comportamento do goose"
+  },
+  "settings.theme.title": {
+    "defaultMessage": "Tema"
+  },
+  "settings.updates.description": {
+    "defaultMessage": "Verifique e instale atualizações para manter o goose a funcionar no seu melhor"
+  },
+  "settings.updates.title": {
+    "defaultMessage": "Atualizações"
+  },
+  "settings.version.title": {
+    "defaultMessage": "Versão"
+  },
+  "settingsView.tabApp": {
+    "defaultMessage": "Aplicação"
+  },
+  "settingsView.tabAuth": {
+    "defaultMessage": "Autenticação"
+  },
+  "settingsView.tabChat": {
+    "defaultMessage": "Conversa"
+  },
+  "settingsView.tabKeyboard": {
+    "defaultMessage": "Teclado"
+  },
+  "settingsView.tabLocalInference": {
+    "defaultMessage": "Inferência local"
+  },
+  "settingsView.tabModels": {
+    "defaultMessage": "Modelos"
+  },
+  "settingsView.tabPrompts": {
+    "defaultMessage": "Prompts"
+  },
+  "settingsView.tabSession": {
+    "defaultMessage": "Sessão"
+  },
+  "settingsView.title": {
+    "defaultMessage": "Definições"
+  },
+  "sheet.close": {
+    "defaultMessage": "Fechar"
+  },
+  "shortcutRecorder.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "shortcutRecorder.clickToRecord": {
+    "defaultMessage": "Clique para gravar..."
+  },
+  "shortcutRecorder.conflictWarning": {
+    "defaultMessage": "Este atalho já é utilizado por {label}. Ao guardar, será reatribuído a esta ação."
+  },
+  "shortcutRecorder.pressShortcut": {
+    "defaultMessage": "Prima o atalho..."
+  },
+  "shortcutRecorder.save": {
+    "defaultMessage": "Guardar"
+  },
+  "skillsView.addSkill": {
+    "defaultMessage": "Adicionar Competência"
+  },
+  "skillsView.adjustSearchTerms": {
+    "defaultMessage": "Tente ajustar os termos da pesquisa"
+  },
+  "skillsView.comingSoon": {
+    "defaultMessage": "Em breve"
+  },
+  "skillsView.errorLoadingSkills": {
+    "defaultMessage": "Erro ao Carregar Competências"
+  },
+  "skillsView.noMatchingSkills": {
+    "defaultMessage": "Nenhuma competência correspondente encontrada"
+  },
+  "skillsView.noSkillsDescription": {
+    "defaultMessage": "As competências são carregadas a partir de ficheiros SKILL.md em ~/.config/agents/skills/, .goose/skills/ ou outros diretórios suportados."
+  },
+  "skillsView.noSkillsInstalled": {
+    "defaultMessage": "Nenhuma competência instalada"
+  },
+  "skillsView.searchSkillsPlaceholder": {
+    "defaultMessage": "Pesquisar competências..."
+  },
+  "skillsView.skillsDescription": {
+    "defaultMessage": "Veja as competências instaladas que ampliam as capacidades do Goose. {shortcut} para pesquisar."
+  },
+  "skillsView.skillsTitle": {
+    "defaultMessage": "Competências"
+  },
+  "skillsView.tryAgain": {
+    "defaultMessage": "Tentar Novamente"
+  },
+  "spellcheckToggle.description": {
+    "defaultMessage": "Verificar a ortografia na entrada de conversa. Requer reinício para entrar em vigor."
+  },
+  "spellcheckToggle.title": {
+    "defaultMessage": "Ativar Verificação Ortográfica"
+  },
+  "standaloneAppView.failedToLoad": {
+    "defaultMessage": "Falha ao Carregar a Aplicação"
+  },
+  "standaloneAppView.initializing": {
+    "defaultMessage": "A inicializar a aplicação..."
+  },
+  "standaloneAppView.missingParams": {
+    "defaultMessage": "Parâmetros obrigatórios em falta"
+  },
+  "stringUtils.configuredProvider": {
+    "defaultMessage": "O fornecedor {name} está configurado"
+  },
+  "stringUtils.ollamaApp": {
+    "defaultMessage": "Aplicação Ollama"
+  },
+  "stringUtils.ollamaNotConfiguredPrefix": {
+    "defaultMessage": "Para utilizar, ou a"
+  },
+  "stringUtils.ollamaNotConfiguredSuffix": {
+    "defaultMessage": "deve estar instalada e aberta na sua máquina, ou deve introduzir um valor para OLLAMA_HOST."
+  },
+  "subRecipeEditor.addExisting": {
+    "defaultMessage": "Adicionar Existente"
+  },
+  "subRecipeEditor.createNew": {
+    "defaultMessage": "Criar Nova Subrreceita"
+  },
+  "subRecipeEditor.deleteSubrecipe": {
+    "defaultMessage": "Eliminar subrreceita {name}"
+  },
+  "subRecipeEditor.description": {
+    "defaultMessage": "As subrreceitas são receitas que podem ser invocadas como ferramentas durante a execução. Permitem fluxos de trabalho com vários passos e componentes reutilizáveis."
+  },
+  "subRecipeEditor.duplicateName": {
+    "defaultMessage": "Nome Duplicado"
+  },
+  "subRecipeEditor.duplicateNameMsg": {
+    "defaultMessage": "Já existe uma subrreceita com o nome \"{name}\". Utilize um nome exclusivo."
+  },
+  "subRecipeEditor.editSubrecipe": {
+    "defaultMessage": "Editar subrreceita {name}"
+  },
+  "subRecipeEditor.label": {
+    "defaultMessage": "Subrreceitas"
+  },
+  "subRecipeEditor.preconfiguredValues": {
+    "defaultMessage": "Valores pré-configurados:"
+  },
+  "subRecipeEditor.sequential": {
+    "defaultMessage": "Sequencial"
+  },
+  "subRecipeModal.addTitle": {
+    "defaultMessage": "Adicionar Subrreceita"
+  },
+  "subRecipeModal.apply": {
+    "defaultMessage": "Aplicar"
+  },
+  "subRecipeModal.browse": {
+    "defaultMessage": "Procurar"
+  },
+  "subRecipeModal.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "subRecipeModal.closeModal": {
+    "defaultMessage": "Fechar a janela da subrreceita"
+  },
+  "subRecipeModal.configureTitle": {
+    "defaultMessage": "Configurar Subrreceita"
+  },
+  "subRecipeModal.descriptionLabel": {
+    "defaultMessage": "Descrição"
+  },
+  "subRecipeModal.descriptionPlaceholder": {
+    "defaultMessage": "Descrição opcional do que esta subrreceita faz..."
+  },
+  "subRecipeModal.invalidFile": {
+    "defaultMessage": "Ficheiro Inválido"
+  },
+  "subRecipeModal.invalidFileMsg": {
+    "defaultMessage": "Selecione um ficheiro YAML (.yaml ou .yml)."
+  },
+  "subRecipeModal.nameHint": {
+    "defaultMessage": "Identificador exclusivo utilizado para gerar o nome da ferramenta"
+  },
+  "subRecipeModal.nameLabel": {
+    "defaultMessage": "Nome"
+  },
+  "subRecipeModal.namePlaceholder": {
+    "defaultMessage": "ex.: security_scan"
+  },
+  "subRecipeModal.pathHint": {
+    "defaultMessage": "Procure um ficheiro de receita existente ou introduza um caminho manualmente"
+  },
+  "subRecipeModal.pathLabel": {
+    "defaultMessage": "Caminho"
+  },
+  "subRecipeModal.pathPlaceholder": {
+    "defaultMessage": "ex.: ./subrecipes/security-analysis.yaml"
+  },
+  "subRecipeModal.preconfiguredValues": {
+    "defaultMessage": "Valores Pré-configurados"
+  },
+  "subRecipeModal.preconfiguredValuesHint": {
+    "defaultMessage": "Valores de parâmetros opcionais que são sempre passados à subrreceita"
+  },
+  "subRecipeModal.sequentialHint": {
+    "defaultMessage": "(Força a execução sequencial de várias instâncias da subrreceita)"
+  },
+  "subRecipeModal.sequentialLabel": {
+    "defaultMessage": "Sequencial quando repetida"
+  },
+  "subRecipeModal.subtitle": {
+    "defaultMessage": "Configure uma subrreceita que pode ser invocada como ferramenta durante a execução da receita"
+  },
+  "switchModelModal.backToModelList": {
+    "defaultMessage": "Voltar à lista de modelos"
+  },
+  "switchModelModal.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "switchModelModal.checkProviderConfig": {
+    "defaultMessage": "Verifique a configuração do seu fornecedor em Definições → Fornecedores"
+  },
+  "switchModelModal.chooseModel": {
+    "defaultMessage": "Escolha um modelo:"
+  },
+  "switchModelModal.claudeAdaptive": {
+    "defaultMessage": "Adaptativo - O Claude decide quando e quanto pensar"
+  },
+  "switchModelModal.claudeDisabled": {
+    "defaultMessage": "Desativado - Sem raciocínio prolongado"
+  },
+  "switchModelModal.claudeEffortHigh": {
+    "defaultMessage": "Alto - Raciocínio aprofundado (predefinição)"
+  },
+  "switchModelModal.claudeEffortLow": {
+    "defaultMessage": "Baixo - Raciocínio mínimo, respostas mais rápidas"
+  },
+  "switchModelModal.claudeEffortMax": {
+    "defaultMessage": "Máximo - Sem restrições à profundidade do raciocínio"
+  },
+  "switchModelModal.claudeEffortMedium": {
+    "defaultMessage": "Médio - Raciocínio moderado"
+  },
+  "switchModelModal.claudeEnabled": {
+    "defaultMessage": "Ativado - Orçamento de tokens fixo para o raciocínio"
+  },
+  "switchModelModal.couldNotContactProvider": {
+    "defaultMessage": "Não foi possível contactar o fornecedor"
+  },
+  "switchModelModal.customModelName": {
+    "defaultMessage": "Nome do modelo personalizado"
+  },
+  "switchModelModal.description": {
+    "defaultMessage": "Selecione um fornecedor e um modelo para utilizar nas suas conversas."
+  },
+  "switchModelModal.enterModelNotListed": {
+    "defaultMessage": "Introduza um modelo não listado..."
+  },
+  "switchModelModal.extendedThinking": {
+    "defaultMessage": "Raciocínio Prolongado"
+  },
+  "switchModelModal.geminiOnly": {
+    "defaultMessage": "(Apenas modelos Gemini 3)"
+  },
+  "switchModelModal.goToSettings": {
+    "defaultMessage": "Ir para as Definições"
+  },
+  "switchModelModal.loadingModels": {
+    "defaultMessage": "A carregar modelos…"
+  },
+  "switchModelModal.localModelsDescription": {
+    "defaultMessage": "Para utilizar a inferência local, primeiro tem de transferir um modelo para o seu computador. Vá a Definições → Modelos para gerir os modelos locais."
+  },
+  "switchModelModal.localModelsTitle": {
+    "defaultMessage": "Os modelos locais têm de ser transferidos primeiro"
+  },
+  "switchModelModal.providerPlaceholder": {
+    "defaultMessage": "Fornecedor, escreva para pesquisar"
+  },
+  "switchModelModal.quickStartGuide": {
+    "defaultMessage": "Guia de introdução rápida"
+  },
+  "switchModelModal.recommended": {
+    "defaultMessage": "Recomendado"
+  },
+  "switchModelModal.selectEffortLevel": {
+    "defaultMessage": "Selecione o nível de esforço"
+  },
+  "switchModelModal.selectModel": {
+    "defaultMessage": "Selecione um modelo"
+  },
+  "switchModelModal.selectModelButton": {
+    "defaultMessage": "Selecionar modelo"
+  },
+  "switchModelModal.selectModelPlaceholder": {
+    "defaultMessage": "Selecione um modelo, escreva para pesquisar"
+  },
+  "switchModelModal.selectOrEnterModel": {
+    "defaultMessage": "Selecione ou introduza um modelo"
+  },
+  "switchModelModal.selectProvider": {
+    "defaultMessage": "Selecione um fornecedor"
+  },
+  "switchModelModal.selectThinkingLevel": {
+    "defaultMessage": "Selecione o nível de raciocínio"
+  },
+  "switchModelModal.selectThinkingMode": {
+    "defaultMessage": "Selecione o modo de raciocínio"
+  },
+  "switchModelModal.thinkingBudget": {
+    "defaultMessage": "Orçamento de Raciocínio (tokens)"
+  },
+  "switchModelModal.thinkingEffort": {
+    "defaultMessage": "Esforço de Raciocínio"
+  },
+  "switchModelModal.thinkingEffortOff": {
+    "defaultMessage": "Desligado - Sem raciocínio prolongado"
+  },
+  "switchModelModal.thinkingLevel": {
+    "defaultMessage": "Nível de Raciocínio"
+  },
+  "switchModelModal.thinkingLevelHigh": {
+    "defaultMessage": "Alto - Raciocínio mais aprofundado, maior latência"
+  },
+  "switchModelModal.thinkingLevelLow": {
+    "defaultMessage": "Baixo - Melhor latência, raciocínio mais ligeiro"
+  },
+  "switchModelModal.title": {
+    "defaultMessage": "Mudar de modelo"
+  },
+  "switchModelModal.typeModelName": {
+    "defaultMessage": "Escreva aqui o nome do modelo"
+  },
+  "switchModelModal.useOtherProvider": {
+    "defaultMessage": "Utilizar outro fornecedor"
+  },
+  "telemetryConsentPrompt.description": {
+    "defaultMessage": "Gostaria de partilhar dados de utilização anónimos para ajudar a melhorar o goose? Nunca recolhemos as suas conversas, código ou dados pessoais."
+  },
+  "telemetryConsentPrompt.heading": {
+    "defaultMessage": "Ajude a melhorar o goose"
+  },
+  "telemetryConsentPrompt.learnMore": {
+    "defaultMessage": "Saber mais"
+  },
+  "telemetryConsentPrompt.optIn": {
+    "defaultMessage": "Sim, partilhar dados de utilização anónimos"
+  },
+  "telemetryConsentPrompt.optOut": {
+    "defaultMessage": "Não, obrigado"
+  },
+  "telemetrySettings.configErrorTitle": {
+    "defaultMessage": "Erro de Configuração"
+  },
+  "telemetrySettings.description": {
+    "defaultMessage": "Controle como os seus dados são utilizados"
+  },
+  "telemetrySettings.learnMore": {
+    "defaultMessage": "Saber mais"
+  },
+  "telemetrySettings.loadError": {
+    "defaultMessage": "Falha ao carregar as definições de telemetria."
+  },
+  "telemetrySettings.title": {
+    "defaultMessage": "Privacidade"
+  },
+  "telemetrySettings.toggleDescription": {
+    "defaultMessage": "Ajude a melhorar o goose partilhando estatísticas de utilização anónimas."
+  },
+  "telemetrySettings.toggleLabel": {
+    "defaultMessage": "Dados de utilização anónimos"
+  },
+  "telemetrySettings.updateError": {
+    "defaultMessage": "Falha ao atualizar as definições de telemetria."
+  },
+  "themeSelector.dark": {
+    "defaultMessage": "Escuro"
+  },
+  "themeSelector.light": {
+    "defaultMessage": "Claro"
+  },
+  "themeSelector.system": {
+    "defaultMessage": "Sistema"
+  },
+  "themeSelector.theme": {
+    "defaultMessage": "Tema"
+  },
+  "toolApprovalButtons.allowOnce": {
+    "defaultMessage": "Permitir Uma Vez"
+  },
+  "toolApprovalButtons.allowedOnce": {
+    "defaultMessage": "Permitido uma vez"
+  },
+  "toolApprovalButtons.alwaysAllow": {
+    "defaultMessage": "Permitir Sempre"
+  },
+  "toolApprovalButtons.alwaysAllowed": {
+    "defaultMessage": "Sempre permitido"
+  },
+  "toolApprovalButtons.cancelled": {
+    "defaultMessage": "Cancelado"
+  },
+  "toolApprovalButtons.denied": {
+    "defaultMessage": "Recusado"
+  },
+  "toolApprovalButtons.deniedOnce": {
+    "defaultMessage": "Recusado uma vez"
+  },
+  "toolApprovalButtons.deny": {
+    "defaultMessage": "Recusar"
+  },
+  "toolApprovalButtons.staleApprovalRequest": {
+    "defaultMessage": "Este pedido de aprovação já não está ativo."
+  },
+  "toolCallStatusIndicator.toolStatus": {
+    "defaultMessage": "Estado da ferramenta: {status}"
+  },
+  "toolCallWithResponse.activityCount": {
+    "defaultMessage": "Atividade ({count})"
+  },
+  "toolCallWithResponse.code": {
+    "defaultMessage": "Código"
+  },
+  "toolCallWithResponse.loadingSpinner": {
+    "defaultMessage": "Indicador de carregamento"
+  },
+  "toolCallWithResponse.logs": {
+    "defaultMessage": "Registos"
+  },
+  "toolCallWithResponse.mcpUiExperimental": {
+    "defaultMessage": "A IU do MCP é experimental e pode mudar a qualquer momento."
+  },
+  "toolCallWithResponse.output": {
+    "defaultMessage": "Saída"
+  },
+  "toolCallWithResponse.toolDetails": {
+    "defaultMessage": "Detalhes da Ferramenta"
+  },
+  "toolCallWithResponse.toolResultAlt": {
+    "defaultMessage": "Resultado da ferramenta"
+  },
+  "toolCallWithResponse.viewSubagentSession": {
+    "defaultMessage": "Ver sessão do subagente"
+  },
+  "toolConfirmation.allowToolCallWithName": {
+    "defaultMessage": "Permitir {toolName}?"
+  },
+  "toolConfirmation.gooseWouldLikeToCallWithName": {
+    "defaultMessage": "O Goose gostaria de invocar {toolName}. Permitir?"
+  },
+  "updateSection.autoDownload": {
+    "defaultMessage": "O Goose transferirá a atualização em segundo plano e instalá-la-á da próxima vez que sair ou reiniciar."
+  },
+  "updateSection.autoDownloadDisabledByEnv": {
+    "defaultMessage": "As transferências automáticas estão desativadas através da variável de ambiente GOOSE_DISABLE_AUTO_DOWNLOAD."
+  },
+  "updateSection.autoDownloadDisabledNote": {
+    "defaultMessage": "A transferência automática está desativada. Clique em \"Transferir Agora\" para transferir manualmente."
+  },
+  "updateSection.autoInstallNote": {
+    "defaultMessage": "Não é necessária instalação manual."
+  },
+  "updateSection.checkForUpdates": {
+    "defaultMessage": "Verificar Atualizações"
+  },
+  "updateSection.checking": {
+    "defaultMessage": "A verificar atualizações..."
+  },
+  "updateSection.currentVersion": {
+    "defaultMessage": "Versão atual"
+  },
+  "updateSection.disableAutoDownload": {
+    "defaultMessage": "Desativar as transferências automáticas de atualizações"
+  },
+  "updateSection.disableAutoDownloadDesc": {
+    "defaultMessage": "Quando ativado, o Goose notificá-lo-á de novas versões, mas não as transferirá automaticamente."
+  },
+  "updateSection.downloadNow": {
+    "defaultMessage": "Transferir Agora"
+  },
+  "updateSection.downloadReady": {
+    "defaultMessage": "Atualização transferida e pronta para instalar!"
+  },
+  "updateSection.downloadingProgress": {
+    "defaultMessage": "A transferir a atualização... {percent}%"
+  },
+  "updateSection.downloadingUpdate": {
+    "defaultMessage": "A transferir a atualização..."
+  },
+  "updateSection.installAndRestart": {
+    "defaultMessage": "Instalar e Reiniciar"
+  },
+  "updateSection.installNowHint": {
+    "defaultMessage": "Clique em \"Instalar e Reiniciar\" para atualizar agora."
+  },
+  "updateSection.latestVersion": {
+    "defaultMessage": "Está a executar a versão mais recente!"
+  },
+  "updateSection.loading": {
+    "defaultMessage": "A carregar..."
+  },
+  "updateSection.manualInstallNote": {
+    "defaultMessage": "Após a transferência, terá de instalar a atualização manualmente."
+  },
+  "updateSection.manualInstallRequired": {
+    "defaultMessage": "Instalação manual necessária para este método de atualização."
+  },
+  "updateSection.readyInstallAuto": {
+    "defaultMessage": "✓ A atualização está pronta. Reinicie o Goose para concluir a instalação, ou saia quando terminar."
+  },
+  "updateSection.readyInstallManual": {
+    "defaultMessage": "✓ A atualização está pronta! Clique em \"Instalar e Reiniciar\" para ver as instruções de instalação."
+  },
+  "updateSection.upToDate": {
+    "defaultMessage": "(atualizado)"
+  },
+  "updateSection.updateAvailable": {
+    "defaultMessage": "Atualização disponível!"
+  },
+  "updateSection.versionAvailable": {
+    "defaultMessage": "→ {version} disponível"
+  },
+  "updateSection.versionIsAvailable": {
+    "defaultMessage": "A versão {version} está disponível"
+  },
+  "userMessage.cancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "userMessage.cancelAriaLabel": {
+    "defaultMessage": "Cancelar edição"
+  },
+  "userMessage.editAriaLabel": {
+    "defaultMessage": "Editar o conteúdo da mensagem"
+  },
+  "userMessage.editButton": {
+    "defaultMessage": "Editar"
+  },
+  "userMessage.editInPlace": {
+    "defaultMessage": "Editar no Local"
+  },
+  "userMessage.editInPlaceAriaLabel": {
+    "defaultMessage": "Editar a mensagem no local"
+  },
+  "userMessage.editInPlaceDescription": {
+    "defaultMessage": "<b>Editar no Local</b> atualiza esta sessão • <b>Bifurcar Sessão</b> cria uma nova sessão"
+  },
+  "userMessage.editInPlaceTitle": {
+    "defaultMessage": "Atualizar a mensagem nesta sessão"
+  },
+  "userMessage.editMessageAriaLabel": {
+    "defaultMessage": "Editar mensagem: {preview}"
+  },
+  "userMessage.editMessageTitle": {
+    "defaultMessage": "Editar mensagem"
+  },
+  "userMessage.editPlaceholder": {
+    "defaultMessage": "Edite a sua mensagem..."
+  },
+  "userMessage.emptyError": {
+    "defaultMessage": "A mensagem não pode estar vazia"
+  },
+  "userMessage.forkSession": {
+    "defaultMessage": "Bifurcar Sessão"
+  },
+  "userMessage.forkSessionAriaLabel": {
+    "defaultMessage": "Bifurcar a sessão com a mensagem editada"
+  },
+  "userMessage.forkSessionTitle": {
+    "defaultMessage": "Criar uma nova sessão com a mensagem editada"
+  }
+}

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -3887,14 +3887,32 @@
   "settings.language.english": {
     "defaultMessage": "Английский"
   },
+  "settings.language.french": {
+    "defaultMessage": "Французский"
+  },
+  "settings.language.german": {
+    "defaultMessage": "Немецкий"
+  },
   "settings.language.hindi": {
     "defaultMessage": "Хинди"
+  },
+  "settings.language.indonesian": {
+    "defaultMessage": "Индонезийский"
+  },
+  "settings.language.italian": {
+    "defaultMessage": "Итальянский"
   },
   "settings.language.japanese": {
     "defaultMessage": "Японский"
   },
   "settings.language.korean": {
     "defaultMessage": "Корейский"
+  },
+  "settings.language.malay": {
+    "defaultMessage": "Малайский"
+  },
+  "settings.language.portuguese": {
+    "defaultMessage": "Португальский"
   },
   "settings.language.russian": {
     "defaultMessage": "Русский"
@@ -3911,8 +3929,14 @@
   "settings.language.turkish": {
     "defaultMessage": "Турецкий"
   },
+  "settings.language.vietnamese": {
+    "defaultMessage": "Вьетнамский"
+  },
   "settings.language.zhCN": {
     "defaultMessage": "Китайский (упрощенный)"
+  },
+  "settings.language.zhTW": {
+    "defaultMessage": "Китайский (традиционный)"
   },
   "settings.menuBarIcon.description": {
     "defaultMessage": "Показывать goose в строке меню"

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -3887,14 +3887,32 @@
   "settings.language.english": {
     "defaultMessage": "İngilizce"
   },
+  "settings.language.french": {
+    "defaultMessage": "Fransızca"
+  },
+  "settings.language.german": {
+    "defaultMessage": "Almanca"
+  },
   "settings.language.hindi": {
     "defaultMessage": "Hintçe"
+  },
+  "settings.language.indonesian": {
+    "defaultMessage": "Endonezce"
+  },
+  "settings.language.italian": {
+    "defaultMessage": "İtalyanca"
   },
   "settings.language.japanese": {
     "defaultMessage": "Japonca"
   },
   "settings.language.korean": {
     "defaultMessage": "Korece"
+  },
+  "settings.language.malay": {
+    "defaultMessage": "Malayca"
+  },
+  "settings.language.portuguese": {
+    "defaultMessage": "Portekizce"
   },
   "settings.language.russian": {
     "defaultMessage": "Rusça"
@@ -3911,8 +3929,14 @@
   "settings.language.turkish": {
     "defaultMessage": "Türkçe"
   },
+  "settings.language.vietnamese": {
+    "defaultMessage": "Vietnamca"
+  },
   "settings.language.zhCN": {
     "defaultMessage": "Çince (Basitleştirilmiş)"
+  },
+  "settings.language.zhTW": {
+    "defaultMessage": "Çince (Geleneksel)"
   },
   "settings.menuBarIcon.description": {
     "defaultMessage": "Menü çubuğunda goose'yi göster"

--- a/ui/desktop/src/i18n/messages/vi.json
+++ b/ui/desktop/src/i18n/messages/vi.json
@@ -1,0 +1,4574 @@
+{
+  "alertBox.autoCompactAt": {
+    "defaultMessage": "Tự động nén tại"
+  },
+  "alertBox.compactNow": {
+    "defaultMessage": "Nén ngay"
+  },
+  "alertBox.failedToSaveThreshold": {
+    "defaultMessage": "Không thể lưu ngưỡng: {error}"
+  },
+  "announcementModal.gotIt": {
+    "defaultMessage": "Đã hiểu!"
+  },
+  "appLayout.collapseNavigation": {
+    "defaultMessage": "Thu gọn điều hướng"
+  },
+  "appLayout.openNavigation": {
+    "defaultMessage": "Mở điều hướng"
+  },
+  "appsView.customApp": {
+    "defaultMessage": "Ứng dụng tùy chỉnh"
+  },
+  "appsView.description": {
+    "defaultMessage": "Các ứng dụng từ máy chủ MCP của bạn và các ứng dụng do goose tự tạo. Bạn có thể yêu cầu nó tạo ứng dụng mới thông qua giao diện trò chuyện và chúng sẽ xuất hiện ở đây."
+  },
+  "appsView.errorLoading": {
+    "defaultMessage": "Lỗi khi tải ứng dụng: {error}"
+  },
+  "appsView.importApp": {
+    "defaultMessage": "Nhập ứng dụng"
+  },
+  "appsView.launch": {
+    "defaultMessage": "Khởi chạy"
+  },
+  "appsView.loading": {
+    "defaultMessage": "Đang tải ứng dụng..."
+  },
+  "appsView.noAppsDescription": {
+    "defaultMessage": "Mở một cuộc trò chuyện và yêu cầu goose tạo ứng dụng bạn muốn. Nó có thể tạo cho bạn và ứng dụng sẽ xuất hiện ở đây. Hoặc nếu ai đó đã chia sẻ một ứng dụng, bạn có thể nhập nó bằng nút phía trên."
+  },
+  "appsView.noAppsTitle": {
+    "defaultMessage": "Không có ứng dụng nào"
+  },
+  "appsView.retry": {
+    "defaultMessage": "Thử lại"
+  },
+  "appsView.title": {
+    "defaultMessage": "Ứng dụng"
+  },
+  "authSettings.activeProviderWarning": {
+    "defaultMessage": "Đây là nhà cung cấp đang hoạt động. Các yêu cầu mới có thể thất bại cho đến khi bạn cấu hình thông tin xác thực khác."
+  },
+  "authSettings.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "authSettings.delete": {
+    "defaultMessage": "Xóa"
+  },
+  "authSettings.deleteCredential": {
+    "defaultMessage": "Xóa thông tin xác thực"
+  },
+  "authSettings.deleteMessage": {
+    "defaultMessage": "Xóa thông tin xác thực {name} cho {provider}?"
+  },
+  "authSettings.deleteTitle": {
+    "defaultMessage": "Xóa thông tin xác thực"
+  },
+  "authSettings.deleted": {
+    "defaultMessage": "Đã xóa thông tin xác thực"
+  },
+  "authSettings.description": {
+    "defaultMessage": "Quản lý thông tin xác thực nhà cung cấp được goose lưu trữ cục bộ."
+  },
+  "authSettings.empty": {
+    "defaultMessage": "Không tìm thấy thông tin xác thực nhà cung cấp nào được lưu trữ cục bộ."
+  },
+  "authSettings.expiresAt": {
+    "defaultMessage": "Hết hạn {date}"
+  },
+  "authSettings.failedToConfigure": {
+    "defaultMessage": "Không thể cấu hình thông tin xác thực: {error}"
+  },
+  "authSettings.failedToDelete": {
+    "defaultMessage": "Không thể xóa thông tin xác thực: {error}"
+  },
+  "authSettings.failedToLoad": {
+    "defaultMessage": "Không thể tải thông tin xác thực nhà cung cấp"
+  },
+  "authSettings.loading": {
+    "defaultMessage": "Đang tải thông tin xác thực..."
+  },
+  "authSettings.reauthorize": {
+    "defaultMessage": "Cấp quyền lại"
+  },
+  "authSettings.signIn": {
+    "defaultMessage": "Đăng nhập"
+  },
+  "authSettings.signedIn": {
+    "defaultMessage": "Đã cấu hình thông tin xác thực"
+  },
+  "authSettings.storageProviderCache": {
+    "defaultMessage": "Bộ nhớ đệm nhà cung cấp"
+  },
+  "authSettings.storageSecretStore": {
+    "defaultMessage": "Kho lưu trữ bí mật"
+  },
+  "authSettings.title": {
+    "defaultMessage": "Thông tin xác thực nhà cung cấp"
+  },
+  "backButton.back": {
+    "defaultMessage": "Quay lại"
+  },
+  "baseChat.failedToLoadSession": {
+    "defaultMessage": "Không thể tải phiên"
+  },
+  "baseChat.goHome": {
+    "defaultMessage": "Về trang chủ"
+  },
+  "bottomMenuExtensionSelection.extensionUpdated": {
+    "defaultMessage": "Đã cập nhật tiện ích mở rộng"
+  },
+  "bottomMenuExtensionSelection.extensionWillBeDisabled": {
+    "defaultMessage": "{name} sẽ bị vô hiệu hóa trong các cuộc trò chuyện mới"
+  },
+  "bottomMenuExtensionSelection.extensionWillBeEnabled": {
+    "defaultMessage": "{name} sẽ được bật trong các cuộc trò chuyện mới"
+  },
+  "bottomMenuExtensionSelection.extensionsForNewChats": {
+    "defaultMessage": "Tiện ích mở rộng cho các cuộc trò chuyện mới"
+  },
+  "bottomMenuExtensionSelection.extensionsForThisSession": {
+    "defaultMessage": "Tiện ích mở rộng cho phiên trò chuyện này"
+  },
+  "bottomMenuExtensionSelection.manageExtensions": {
+    "defaultMessage": "quản lý tiện ích mở rộng"
+  },
+  "bottomMenuExtensionSelection.noExtensionsAvailable": {
+    "defaultMessage": "không có tiện ích mở rộng nào"
+  },
+  "bottomMenuExtensionSelection.noExtensionsFound": {
+    "defaultMessage": "không tìm thấy tiện ích mở rộng nào"
+  },
+  "bottomMenuExtensionSelection.searchExtensions": {
+    "defaultMessage": "tìm kiếm tiện ích mở rộng..."
+  },
+  "cardButtons.configure": {
+    "defaultMessage": "Cấu hình"
+  },
+  "cardButtons.launch": {
+    "defaultMessage": "Khởi chạy"
+  },
+  "chat.notification.taskComplete.body": {
+    "defaultMessage": "Nhấp vào đây để đưa Goose trở lại tiêu điểm."
+  },
+  "chat.notification.taskComplete.title": {
+    "defaultMessage": "Goose đã hoàn thành tác vụ."
+  },
+  "chatInput.contextWindow": {
+    "defaultMessage": "Cửa sổ ngữ cảnh"
+  },
+  "chatInput.dictationError": {
+    "defaultMessage": "Lỗi đọc chính tả"
+  },
+  "chatInput.failedToReadImage": {
+    "defaultMessage": "Không thể đọc tệp hình ảnh"
+  },
+  "chatInput.navigationShortcut": {
+    "defaultMessage": "{prefix}↑/{prefix}↓ để điều hướng tin nhắn"
+  },
+  "chatInput.processingDroppedFiles": {
+    "defaultMessage": "Đang xử lý các tệp đã thả..."
+  },
+  "chatInput.recording": {
+    "defaultMessage": "Đang ghi âm..."
+  },
+  "chatInput.removeFile": {
+    "defaultMessage": "Xóa tệp"
+  },
+  "chatInput.removeImage": {
+    "defaultMessage": "Xóa hình ảnh"
+  },
+  "chatInput.restartingSession": {
+    "defaultMessage": "Đang khởi động lại phiên..."
+  },
+  "chatInput.send": {
+    "defaultMessage": "Gửi"
+  },
+  "chatInput.transcribing": {
+    "defaultMessage": "Đang chuyển lời nói thành văn bản..."
+  },
+  "chatInput.typeMessage": {
+    "defaultMessage": "Nhập tin nhắn để gửi"
+  },
+  "chatInput.unknownType": {
+    "defaultMessage": "Loại không xác định"
+  },
+  "chatInput.viewEditRecipe": {
+    "defaultMessage": "Xem/Chỉnh sửa công thức"
+  },
+  "chatInput.waitingForCancellation": {
+    "defaultMessage": "Đang chờ hủy hoàn tất"
+  },
+  "chatInput.waitingForImages": {
+    "defaultMessage": "Đang chờ lưu hình ảnh..."
+  },
+  "chatSettings.modeDescription": {
+    "defaultMessage": "Chọn chế độ mặc định mà Goose sử dụng cho các phiên mới. Các phiên hiện có vẫn giữ chế độ hiện tại của chúng."
+  },
+  "chatSettings.modeTitle": {
+    "defaultMessage": "Chế độ mặc định"
+  },
+  "chatSettings.responseStylesDescription": {
+    "defaultMessage": "Chọn cách Goose định dạng và tạo phong cách cho các phản hồi của mình"
+  },
+  "chatSettings.responseStylesTitle": {
+    "defaultMessage": "Phong cách phản hồi"
+  },
+  "configSettings.configReset": {
+    "defaultMessage": "Đặt lại cấu hình"
+  },
+  "configSettings.configResetMsg": {
+    "defaultMessage": "Tất cả thay đổi đã được hoàn nguyên"
+  },
+  "configSettings.configUpdated": {
+    "defaultMessage": "Đã cập nhật cấu hình"
+  },
+  "configSettings.configUpdatedMsg": {
+    "defaultMessage": "Đã lưu thành công \"{name}\""
+  },
+  "configSettings.configurationEditor": {
+    "defaultMessage": "Trình chỉnh sửa cấu hình"
+  },
+  "configSettings.description": {
+    "defaultMessage": "Chỉnh sửa cài đặt cấu hình goose của bạn"
+  },
+  "configSettings.descriptionWithProvider": {
+    "defaultMessage": "Chỉnh sửa cài đặt cấu hình goose của bạn (cài đặt hiện tại cho {provider})"
+  },
+  "configSettings.done": {
+    "defaultMessage": "Xong"
+  },
+  "configSettings.editConfiguration": {
+    "defaultMessage": "Chỉnh sửa cấu hình"
+  },
+  "configSettings.enterValue": {
+    "defaultMessage": "Nhập {name}"
+  },
+  "configSettings.noSettings": {
+    "defaultMessage": "Không tìm thấy cài đặt cấu hình nào."
+  },
+  "configSettings.resetChanges": {
+    "defaultMessage": "Đặt lại thay đổi"
+  },
+  "configSettings.saveFailed": {
+    "defaultMessage": "Lưu thất bại"
+  },
+  "configSettings.saveFailedMsg": {
+    "defaultMessage": "Không thể lưu \"{name}\""
+  },
+  "configSettings.saving": {
+    "defaultMessage": "Đang lưu..."
+  },
+  "configSettings.title": {
+    "defaultMessage": "Cấu hình"
+  },
+  "configureApproveMode.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "configureApproveMode.description": {
+    "defaultMessage": "Yêu cầu phê duyệt có thể được áp dụng cho tất cả các yêu cầu công cụ hoặc xác định những hành động nào có thể cần tích hợp"
+  },
+  "configureApproveMode.manualApproval": {
+    "defaultMessage": "Phê duyệt thủ công"
+  },
+  "configureApproveMode.manualApprovalDescription": {
+    "defaultMessage": "Tất cả các công cụ, tiện ích mở rộng và thay đổi tệp sẽ yêu cầu phê duyệt của con người"
+  },
+  "configureApproveMode.save": {
+    "defaultMessage": "Lưu"
+  },
+  "configureApproveMode.saving": {
+    "defaultMessage": "Đang lưu..."
+  },
+  "configureApproveMode.smartApproval": {
+    "defaultMessage": "Phê duyệt thông minh"
+  },
+  "configureApproveMode.smartApprovalDescription": {
+    "defaultMessage": "Xác định một cách thông minh những hành động nào cần phê duyệt dựa trên mức độ rủi ro"
+  },
+  "configureApproveMode.title": {
+    "defaultMessage": "Cấu hình chế độ phê duyệt"
+  },
+  "confirmationModal.defaultCancel": {
+    "defaultMessage": "Không"
+  },
+  "confirmationModal.defaultConfirm": {
+    "defaultMessage": "Có"
+  },
+  "confirmationModal.processing": {
+    "defaultMessage": "Đang xử lý..."
+  },
+  "conversationLimitsDropdown.conversationLimits": {
+    "defaultMessage": "Giới hạn cuộc trò chuyện"
+  },
+  "conversationLimitsDropdown.maxTurns": {
+    "defaultMessage": "Số lượt tối đa"
+  },
+  "conversationLimitsDropdown.maxTurnsDescription": {
+    "defaultMessage": "Số lượt tác nhân tối đa trước khi Goose yêu cầu người dùng nhập liệu"
+  },
+  "costTracker.costUnavailable": {
+    "defaultMessage": "Không có dữ liệu chi phí cho {model} ({inputTokens} token đầu vào, {outputTokens} token đầu ra)"
+  },
+  "costTracker.inputOutputTooltip": {
+    "defaultMessage": "Đầu vào: {inputTokens} token ({inputCost}) | Đầu ra: {outputTokens} token ({outputCost})"
+  },
+  "costTracker.pricingUnavailable": {
+    "defaultMessage": "Không có dữ liệu giá cho {model}"
+  },
+  "costTracker.totalSessionCost": {
+    "defaultMessage": "Tổng chi phí phiên: {cost}"
+  },
+  "createEditRecipe.clickToGenerateDeeplink": {
+    "defaultMessage": "Nhấp để tạo deeplink"
+  },
+  "createEditRecipe.close": {
+    "defaultMessage": "Đóng"
+  },
+  "createEditRecipe.copied": {
+    "defaultMessage": "Đã sao chép!"
+  },
+  "createEditRecipe.copy": {
+    "defaultMessage": "Sao chép"
+  },
+  "createEditRecipe.copyLinkDescription": {
+    "defaultMessage": "Sao chép liên kết này để chia sẻ với bạn bè hoặc dán trực tiếp vào Chrome để mở"
+  },
+  "createEditRecipe.createRecipeTitle": {
+    "defaultMessage": "Tạo công thức"
+  },
+  "createEditRecipe.createSubtitle": {
+    "defaultMessage": "Tạo công thức mới để xác định hành vi và khả năng của tác nhân cho các phiên trò chuyện có thể tái sử dụng."
+  },
+  "createEditRecipe.editSubtitle": {
+    "defaultMessage": "Bạn có thể chỉnh sửa công thức bên dưới để thay đổi hành vi của tác nhân trong một phiên mới."
+  },
+  "createEditRecipe.generatingDeeplink": {
+    "defaultMessage": "Đang tạo deeplink..."
+  },
+  "createEditRecipe.learnMore": {
+    "defaultMessage": "Tìm hiểu thêm"
+  },
+  "createEditRecipe.recipeSavedAndLaunchedMsg": {
+    "defaultMessage": "Đã lưu và khởi chạy công thức thành công"
+  },
+  "createEditRecipe.recipeSavedMsg": {
+    "defaultMessage": "Đã lưu công thức thành công"
+  },
+  "createEditRecipe.saveAndRunFailed": {
+    "defaultMessage": "Lưu và chạy thất bại"
+  },
+  "createEditRecipe.saveAndRunFailedMsg": {
+    "defaultMessage": "Không thể lưu và chạy công thức: {error}"
+  },
+  "createEditRecipe.saveAndRunRecipe": {
+    "defaultMessage": "Lưu & Chạy công thức"
+  },
+  "createEditRecipe.saveFailed": {
+    "defaultMessage": "Lưu thất bại"
+  },
+  "createEditRecipe.saveFailedMsg": {
+    "defaultMessage": "Không thể lưu công thức: {error}"
+  },
+  "createEditRecipe.saveRecipe": {
+    "defaultMessage": "Lưu công thức"
+  },
+  "createEditRecipe.saving": {
+    "defaultMessage": "Đang lưu..."
+  },
+  "createEditRecipe.validationFailed": {
+    "defaultMessage": "Xác thực thất bại"
+  },
+  "createEditRecipe.validationMsg": {
+    "defaultMessage": "Vui lòng điền tất cả các trường bắt buộc và đảm bảo lược đồ JSON hợp lệ."
+  },
+  "createEditRecipe.viewEditRecipeTitle": {
+    "defaultMessage": "Xem/chỉnh sửa công thức"
+  },
+  "createSubRecipeInline.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "createSubRecipeInline.closeModal": {
+    "defaultMessage": "Đóng hộp thoại tạo công thức con"
+  },
+  "createSubRecipeInline.createAndAdd": {
+    "defaultMessage": "Tạo & Thêm công thức con"
+  },
+  "createSubRecipeInline.createdSuccess": {
+    "defaultMessage": "Đã tạo công thức con thành công"
+  },
+  "createSubRecipeInline.creating": {
+    "defaultMessage": "Đang tạo..."
+  },
+  "createSubRecipeInline.duplicateName": {
+    "defaultMessage": "Tên trùng lặp"
+  },
+  "createSubRecipeInline.duplicateNameMsg": {
+    "defaultMessage": "Đã tồn tại một công thức con có tên \"{name}\". Vui lòng sử dụng tên duy nhất."
+  },
+  "createSubRecipeInline.instructionsLabel": {
+    "defaultMessage": "Hướng dẫn"
+  },
+  "createSubRecipeInline.instructionsPlaceholder": {
+    "defaultMessage": "Hướng dẫn cho AI khi công thức con này được gọi..."
+  },
+  "createSubRecipeInline.nameHint": {
+    "defaultMessage": "Định danh duy nhất dùng để tạo tên công cụ"
+  },
+  "createSubRecipeInline.nameLabel": {
+    "defaultMessage": "Tên"
+  },
+  "createSubRecipeInline.namePlaceholder": {
+    "defaultMessage": "ví dụ: security_scan"
+  },
+  "createSubRecipeInline.preconfiguredValues": {
+    "defaultMessage": "Giá trị được cấu hình sẵn"
+  },
+  "createSubRecipeInline.preconfiguredValuesHint": {
+    "defaultMessage": "Các giá trị tham số tùy chọn luôn được truyền cho công thức con"
+  },
+  "createSubRecipeInline.recipeDescriptionLabel": {
+    "defaultMessage": "Mô tả công thức"
+  },
+  "createSubRecipeInline.recipeDescriptionPlaceholder": {
+    "defaultMessage": "Công thức này làm gì khi được thực thi"
+  },
+  "createSubRecipeInline.recipeTitleLabel": {
+    "defaultMessage": "Tiêu đề công thức"
+  },
+  "createSubRecipeInline.recipeTitlePlaceholder": {
+    "defaultMessage": "ví dụ: Công cụ phân tích bảo mật"
+  },
+  "createSubRecipeInline.saveFailed": {
+    "defaultMessage": "Lưu thất bại"
+  },
+  "createSubRecipeInline.saveFailedMsg": {
+    "defaultMessage": "Không thể lưu công thức con: {error}"
+  },
+  "createSubRecipeInline.sequentialHint": {
+    "defaultMessage": "(Buộc thực thi tuần tự nhiều phiên bản)"
+  },
+  "createSubRecipeInline.sequentialLabel": {
+    "defaultMessage": "Tuần tự khi lặp lại"
+  },
+  "createSubRecipeInline.subtitle": {
+    "defaultMessage": "Tạo một công thức đơn giản để dùng làm công cụ có thể gọi trong công thức chính của bạn"
+  },
+  "createSubRecipeInline.title": {
+    "defaultMessage": "Tạo công thức con mới"
+  },
+  "createSubRecipeInline.toolDescriptionLabel": {
+    "defaultMessage": "Mô tả công cụ"
+  },
+  "createSubRecipeInline.toolDescriptionPlaceholder": {
+    "defaultMessage": "Mô tả tùy chọn được hiển thị khi công thức này được gọi như một công cụ"
+  },
+  "createSubRecipeInline.validationFailed": {
+    "defaultMessage": "Xác thực thất bại"
+  },
+  "createSubRecipeInline.validationMsg": {
+    "defaultMessage": "Tên, tiêu đề, mô tả công thức và hướng dẫn là bắt buộc."
+  },
+  "creditsExhaustedNotification.addCredits": {
+    "defaultMessage": "Thêm tín dụng"
+  },
+  "creditsExhaustedNotification.insufficientCredits": {
+    "defaultMessage": "Không đủ tín dụng"
+  },
+  "cronPicker.april": {
+    "defaultMessage": "Tháng Tư"
+  },
+  "cronPicker.at": {
+    "defaultMessage": "lúc"
+  },
+  "cronPicker.atMinute": {
+    "defaultMessage": "tại phút"
+  },
+  "cronPicker.atSecond": {
+    "defaultMessage": "tại giây"
+  },
+  "cronPicker.august": {
+    "defaultMessage": "Tháng Tám"
+  },
+  "cronPicker.cronExpression": {
+    "defaultMessage": "Biểu thức cron"
+  },
+  "cronPicker.custom": {
+    "defaultMessage": "Cron tùy chỉnh"
+  },
+  "cronPicker.day": {
+    "defaultMessage": "Ngày"
+  },
+  "cronPicker.december": {
+    "defaultMessage": "Tháng Mười Hai"
+  },
+  "cronPicker.emptyCronError": {
+    "defaultMessage": "Biểu thức cron không được để trống"
+  },
+  "cronPicker.every": {
+    "defaultMessage": "Mỗi"
+  },
+  "cronPicker.february": {
+    "defaultMessage": "Tháng Hai"
+  },
+  "cronPicker.friday": {
+    "defaultMessage": "Thứ Sáu"
+  },
+  "cronPicker.hour": {
+    "defaultMessage": "Giờ"
+  },
+  "cronPicker.inMonth": {
+    "defaultMessage": "vào"
+  },
+  "cronPicker.invalidDayOfMonth": {
+    "defaultMessage": "Ngày phải nằm trong khoảng từ 1 đến {max}"
+  },
+  "cronPicker.january": {
+    "defaultMessage": "Tháng Một"
+  },
+  "cronPicker.july": {
+    "defaultMessage": "Tháng Bảy"
+  },
+  "cronPicker.june": {
+    "defaultMessage": "Tháng Sáu"
+  },
+  "cronPicker.march": {
+    "defaultMessage": "Tháng Ba"
+  },
+  "cronPicker.may": {
+    "defaultMessage": "Tháng Năm"
+  },
+  "cronPicker.minute": {
+    "defaultMessage": "Phút"
+  },
+  "cronPicker.mode": {
+    "defaultMessage": "Chế độ"
+  },
+  "cronPicker.monday": {
+    "defaultMessage": "Thứ Hai"
+  },
+  "cronPicker.month": {
+    "defaultMessage": "Tháng"
+  },
+  "cronPicker.november": {
+    "defaultMessage": "Tháng Mười Một"
+  },
+  "cronPicker.october": {
+    "defaultMessage": "Tháng Mười"
+  },
+  "cronPicker.on": {
+    "defaultMessage": "vào"
+  },
+  "cronPicker.onDay": {
+    "defaultMessage": "vào ngày"
+  },
+  "cronPicker.quarter": {
+    "defaultMessage": "Quý"
+  },
+  "cronPicker.saturday": {
+    "defaultMessage": "Thứ Bảy"
+  },
+  "cronPicker.september": {
+    "defaultMessage": "Tháng Chín"
+  },
+  "cronPicker.startingMonth": {
+    "defaultMessage": "tháng bắt đầu"
+  },
+  "cronPicker.sunday": {
+    "defaultMessage": "Chủ Nhật"
+  },
+  "cronPicker.thursday": {
+    "defaultMessage": "Thứ Năm"
+  },
+  "cronPicker.tuesday": {
+    "defaultMessage": "Thứ Ba"
+  },
+  "cronPicker.wednesday": {
+    "defaultMessage": "Thứ Tư"
+  },
+  "cronPicker.week": {
+    "defaultMessage": "Tuần"
+  },
+  "cronPicker.year": {
+    "defaultMessage": "Năm"
+  },
+  "customProviderForm.add": {
+    "defaultMessage": "Thêm"
+  },
+  "customProviderForm.anthropicCompatible": {
+    "defaultMessage": "Tương thích Anthropic"
+  },
+  "customProviderForm.apiBasePath": {
+    "defaultMessage": "Đường dẫn API cơ sở (tùy chọn)"
+  },
+  "customProviderForm.apiBasePathHint": {
+    "defaultMessage": "Ghi đè đường dẫn API mặc định. Để trống để sử dụng đường dẫn mặc định của nhà cung cấp."
+  },
+  "customProviderForm.apiBasePathPlaceholder": {
+    "defaultMessage": "ví dụ: v1/chat/completions hoặc project_id/v1"
+  },
+  "customProviderForm.apiKey": {
+    "defaultMessage": "Khóa API"
+  },
+  "customProviderForm.apiKeyPlaceholderExisting": {
+    "defaultMessage": "Để trống để giữ khóa hiện tại"
+  },
+  "customProviderForm.apiKeyPlaceholderNew": {
+    "defaultMessage": "Khóa API của bạn"
+  },
+  "customProviderForm.apiKeyRequired": {
+    "defaultMessage": "Khóa API là bắt buộc"
+  },
+  "customProviderForm.apiUrl": {
+    "defaultMessage": "URL API"
+  },
+  "customProviderForm.apiUrlPlaceholder": {
+    "defaultMessage": "https://api.example.com"
+  },
+  "customProviderForm.apiUrlRequired": {
+    "defaultMessage": "URL API là bắt buộc"
+  },
+  "customProviderForm.attachments": {
+    "defaultMessage": "Tệp đính kèm"
+  },
+  "customProviderForm.authHint": {
+    "defaultMessage": "Các LLM cục bộ như Ollama thường không yêu cầu khóa API."
+  },
+  "customProviderForm.authentication": {
+    "defaultMessage": "Xác thực"
+  },
+  "customProviderForm.availableModels": {
+    "defaultMessage": "Các mô hình khả dụng (phân tách bằng dấu phẩy)"
+  },
+  "customProviderForm.back": {
+    "defaultMessage": "← Quay lại"
+  },
+  "customProviderForm.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "customProviderForm.cannotDeleteActive": {
+    "defaultMessage": "Bạn không thể xóa nhà cung cấp này khi nó đang được sử dụng. Vui lòng chuyển sang mô hình khác trước."
+  },
+  "customProviderForm.chooseSetup": {
+    "defaultMessage": "Chọn cách bạn muốn thiết lập nhà cung cấp của mình."
+  },
+  "customProviderForm.clear": {
+    "defaultMessage": "Xóa"
+  },
+  "customProviderForm.configureManually": {
+    "defaultMessage": "Cấu hình thủ công"
+  },
+  "customProviderForm.configureManuallyDesc": {
+    "defaultMessage": "Tự nhập tất cả thông tin chi tiết của nhà cung cấp"
+  },
+  "customProviderForm.confirmDelete": {
+    "defaultMessage": "Xác nhận xóa"
+  },
+  "customProviderForm.createProvider": {
+    "defaultMessage": "Tạo nhà cung cấp"
+  },
+  "customProviderForm.customHeaders": {
+    "defaultMessage": "Tiêu đề tùy chỉnh"
+  },
+  "customProviderForm.customHeadersHint": {
+    "defaultMessage": "Thêm các tiêu đề HTTP tùy chỉnh để đưa vào các yêu cầu gửi đến nhà cung cấp. Nhấp vào nút \"+\" để thêm sau khi điền cả hai trường."
+  },
+  "customProviderForm.deleteConfirmation": {
+    "defaultMessage": "Bạn có chắc chắn muốn xóa nhà cung cấp tùy chỉnh này không? Thao tác này sẽ xóa vĩnh viễn nhà cung cấp và khóa API đã lưu trữ của nó. Hành động này không thể hoàn tác."
+  },
+  "customProviderForm.deleteProvider": {
+    "defaultMessage": "Xóa nhà cung cấp"
+  },
+  "customProviderForm.displayName": {
+    "defaultMessage": "Tên hiển thị"
+  },
+  "customProviderForm.displayNamePlaceholder": {
+    "defaultMessage": "Tên nhà cung cấp của bạn"
+  },
+  "customProviderForm.displayNameRequired": {
+    "defaultMessage": "Tên hiển thị là bắt buộc"
+  },
+  "customProviderForm.docs": {
+    "defaultMessage": "Tài liệu"
+  },
+  "customProviderForm.headerBothRequired": {
+    "defaultMessage": "Phải nhập cả tên và giá trị tiêu đề"
+  },
+  "customProviderForm.headerDuplicate": {
+    "defaultMessage": "Đã tồn tại một tiêu đề có tên này"
+  },
+  "customProviderForm.headerNamePlaceholder": {
+    "defaultMessage": "Tên tiêu đề"
+  },
+  "customProviderForm.headerNoSpaces": {
+    "defaultMessage": "Tên tiêu đề không được chứa khoảng trắng"
+  },
+  "customProviderForm.modelsPlaceholder": {
+    "defaultMessage": "model-a, model-b, model-c"
+  },
+  "customProviderForm.modelsRequired": {
+    "defaultMessage": "Cần có ít nhất một mô hình"
+  },
+  "customProviderForm.ollamaCompatible": {
+    "defaultMessage": "Tương thích Ollama"
+  },
+  "customProviderForm.openaiCompatible": {
+    "defaultMessage": "Tương thích OpenAI"
+  },
+  "customProviderForm.providerType": {
+    "defaultMessage": "Loại nhà cung cấp"
+  },
+  "customProviderForm.reasoning": {
+    "defaultMessage": "Suy luận"
+  },
+  "customProviderForm.requiresApiKey": {
+    "defaultMessage": "Nhà cung cấp này yêu cầu khóa API"
+  },
+  "customProviderForm.startFromTemplate": {
+    "defaultMessage": "Bắt đầu từ mẫu nhà cung cấp"
+  },
+  "customProviderForm.startFromTemplateDesc": {
+    "defaultMessage": "Chọn một nhà cung cấp đã biết và chúng tôi sẽ tự động điền cấu hình"
+  },
+  "customProviderForm.submitError": {
+    "defaultMessage": "Không thể lưu nhà cung cấp. Vui lòng kiểm tra cấu hình của bạn và thử lại."
+  },
+  "customProviderForm.supportsStreaming": {
+    "defaultMessage": "Nhà cung cấp hỗ trợ phản hồi theo luồng (streaming)"
+  },
+  "customProviderForm.toolCalling": {
+    "defaultMessage": "Gọi công cụ"
+  },
+  "customProviderForm.updateProvider": {
+    "defaultMessage": "Cập nhật nhà cung cấp"
+  },
+  "customProviderForm.usingTemplate": {
+    "defaultMessage": "Đang dùng mẫu: {name}"
+  },
+  "customProviderForm.valuePlaceholder": {
+    "defaultMessage": "Giá trị"
+  },
+  "defaultCardButtons.configureSettings": {
+    "defaultMessage": "Cấu hình thiết lập {name}"
+  },
+  "defaultCardButtons.deleteSettings": {
+    "defaultMessage": "Xóa thiết lập {name}"
+  },
+  "defaultCardButtons.editSettings": {
+    "defaultMessage": "Chỉnh sửa thiết lập {name}"
+  },
+  "defaultCardButtons.getStarted": {
+    "defaultMessage": "Bắt đầu với goose!"
+  },
+  "defaultProviderSetupForm.apiHostLabel": {
+    "defaultMessage": "Máy chủ API"
+  },
+  "defaultProviderSetupForm.apiHostPlaceholder": {
+    "defaultMessage": "https://api.example.com"
+  },
+  "defaultProviderSetupForm.apiKeyLabel": {
+    "defaultMessage": "Khóa API"
+  },
+  "defaultProviderSetupForm.apiKeyPlaceholder": {
+    "defaultMessage": "Khóa API của bạn"
+  },
+  "defaultProviderSetupForm.hideOptions": {
+    "defaultMessage": "Ẩn {count} tùy chọn"
+  },
+  "defaultProviderSetupForm.loadingConfig": {
+    "defaultMessage": "Đang tải các giá trị cấu hình..."
+  },
+  "defaultProviderSetupForm.modelsLabel": {
+    "defaultMessage": "Mô hình"
+  },
+  "defaultProviderSetupForm.modelsPlaceholder": {
+    "defaultMessage": "model-a, model-b"
+  },
+  "defaultProviderSetupForm.noConfigParameters": {
+    "defaultMessage": "Không có tham số cấu hình cho nhà cung cấp này."
+  },
+  "defaultProviderSetupForm.showOptions": {
+    "defaultMessage": "Hiện {count} tùy chọn"
+  },
+  "diagnosticsModal.attachHint": {
+    "defaultMessage": "Nếu bạn báo lỗi, hãy cân nhắc đính kèm báo cáo chẩn đoán vào đó."
+  },
+  "diagnosticsModal.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "diagnosticsModal.configSettings": {
+    "defaultMessage": "Thiết lập cấu hình"
+  },
+  "diagnosticsModal.description": {
+    "defaultMessage": "Bạn có thể tải xuống báo cáo chẩn đoán dạng JSON để chia sẻ với nhóm, hoặc báo lỗi trực tiếp trên GitHub với thông tin hệ thống được điền sẵn. Báo cáo chẩn đoán bao gồm những nội dung sau:"
+  },
+  "diagnosticsModal.diagnosticsErrorMsg": {
+    "defaultMessage": "Không thể tải xuống báo cáo chẩn đoán"
+  },
+  "diagnosticsModal.diagnosticsErrorTitle": {
+    "defaultMessage": "Lỗi chẩn đoán"
+  },
+  "diagnosticsModal.download": {
+    "defaultMessage": "Tải xuống"
+  },
+  "diagnosticsModal.downloading": {
+    "defaultMessage": "Đang tải xuống..."
+  },
+  "diagnosticsModal.fileBug": {
+    "defaultMessage": "Báo lỗi trên GitHub"
+  },
+  "diagnosticsModal.logFiles": {
+    "defaultMessage": "Tệp nhật ký gần đây"
+  },
+  "diagnosticsModal.opening": {
+    "defaultMessage": "Đang mở..."
+  },
+  "diagnosticsModal.reportProblem": {
+    "defaultMessage": "Báo cáo sự cố"
+  },
+  "diagnosticsModal.sensitiveWarning": {
+    "defaultMessage": "Nếu phiên của bạn chứa thông tin nhạy cảm, đừng chia sẻ tệp chẩn đoán công khai."
+  },
+  "diagnosticsModal.sessionMessages": {
+    "defaultMessage": "Tin nhắn phiên hiện tại của bạn"
+  },
+  "diagnosticsModal.systemInfo": {
+    "defaultMessage": "Thông tin hệ thống cơ bản"
+  },
+  "diagnosticsModal.systemInfoErrorMsg": {
+    "defaultMessage": "Không thể lấy thông tin hệ thống"
+  },
+  "diagnosticsModal.systemInfoErrorTitle": {
+    "defaultMessage": "Lỗi"
+  },
+  "dialog.close": {
+    "defaultMessage": "Đóng"
+  },
+  "dictationSettings.addApiKey": {
+    "defaultMessage": "Thêm khóa API"
+  },
+  "dictationSettings.apiKey": {
+    "defaultMessage": "Khóa API"
+  },
+  "dictationSettings.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "dictationSettings.chooseVoiceConversion": {
+    "defaultMessage": "Chọn cách chuyển giọng nói thành văn bản"
+  },
+  "dictationSettings.configureApiKey": {
+    "defaultMessage": "Cấu hình khóa API trong <b>{settingsPath}</b>"
+  },
+  "dictationSettings.configured": {
+    "defaultMessage": "(Đã cấu hình)"
+  },
+  "dictationSettings.configuredIn": {
+    "defaultMessage": "✓ Đã cấu hình trong {settingsPath}"
+  },
+  "dictationSettings.disabled": {
+    "defaultMessage": "Đã tắt"
+  },
+  "dictationSettings.enterApiKey": {
+    "defaultMessage": "Nhập khóa API của bạn"
+  },
+  "dictationSettings.notConfigured": {
+    "defaultMessage": "(chưa cấu hình)"
+  },
+  "dictationSettings.removeApiKey": {
+    "defaultMessage": "Xóa khóa API"
+  },
+  "dictationSettings.requiredForTranscription": {
+    "defaultMessage": "Bắt buộc để phiên âm"
+  },
+  "dictationSettings.save": {
+    "defaultMessage": "Lưu"
+  },
+  "dictationSettings.updateApiKey": {
+    "defaultMessage": "Cập nhật khóa API"
+  },
+  "dictationSettings.voiceDictationProvider": {
+    "defaultMessage": "Nhà cung cấp đọc chính tả bằng giọng nói"
+  },
+  "dirSwitcher.chooseDirectory": {
+    "defaultMessage": "Chọn thư mục…"
+  },
+  "dirSwitcher.currentDirectory": {
+    "defaultMessage": "Thư mục hiện tại"
+  },
+  "dirSwitcher.failedToUpdateWorkingDir": {
+    "defaultMessage": "Không thể cập nhật thư mục làm việc"
+  },
+  "dirSwitcher.gitWorktrees": {
+    "defaultMessage": "Git worktree"
+  },
+  "dirSwitcher.noWorktreesFound": {
+    "defaultMessage": "Không tìm thấy worktree nào"
+  },
+  "dirSwitcher.openInFinder": {
+    "defaultMessage": "Mở trong trình quản lý tệp"
+  },
+  "dirSwitcher.recentDirectories": {
+    "defaultMessage": "Thư mục gần đây"
+  },
+  "elicitationRequest.accept": {
+    "defaultMessage": "Chấp nhận"
+  },
+  "elicitationRequest.cancelled": {
+    "defaultMessage": "Yêu cầu thông tin đã bị hủy."
+  },
+  "elicitationRequest.defaultMessage": {
+    "defaultMessage": "Goose cần một số thông tin từ bạn."
+  },
+  "elicitationRequest.expired": {
+    "defaultMessage": "Yêu cầu này đã hết hạn. Tiện ích mở rộng sẽ cần hỏi lại."
+  },
+  "elicitationRequest.submit": {
+    "defaultMessage": "Gửi"
+  },
+  "elicitationRequest.submitError": {
+    "defaultMessage": "Yêu cầu này không còn hiệu lực. Tiện ích mở rộng sẽ cần hỏi lại."
+  },
+  "elicitationRequest.submitted": {
+    "defaultMessage": "Đã gửi thông tin"
+  },
+  "elicitationRequest.waitingForResponse": {
+    "defaultMessage": "Đang chờ phản hồi của bạn (còn {timeRemaining})"
+  },
+  "envVarsSection.add": {
+    "defaultMessage": "Thêm"
+  },
+  "envVarsSection.bothRequired": {
+    "defaultMessage": "Phải nhập cả tên biến và giá trị"
+  },
+  "envVarsSection.envVarsDescription": {
+    "defaultMessage": "Thêm các cặp khóa-giá trị cho biến môi trường. Nhấp vào nút \"+\" để thêm sau khi đã điền cả hai trường. Đối với các giá trị bí mật hiện có, nhấp vào nút chỉnh sửa để sửa đổi."
+  },
+  "envVarsSection.environmentVariables": {
+    "defaultMessage": "Biến môi trường"
+  },
+  "envVarsSection.noSpaces": {
+    "defaultMessage": "Tên biến không được chứa khoảng trắng"
+  },
+  "envVarsSection.value": {
+    "defaultMessage": "Giá trị"
+  },
+  "envVarsSection.variableName": {
+    "defaultMessage": "Tên biến"
+  },
+  "environmentBadge.dev": {
+    "defaultMessage": "Dev"
+  },
+  "errorBoundary.errorGeneric": {
+    "defaultMessage": "Đã xảy ra lỗi."
+  },
+  "errorBoundary.errorWithVersion": {
+    "defaultMessage": "Đã xảy ra lỗi trong Goose v{version}."
+  },
+  "errorBoundary.heading": {
+    "defaultMessage": "Honk!"
+  },
+  "errorBoundary.reload": {
+    "defaultMessage": "Tải lại"
+  },
+  "extensionConfigFields.commandLabel": {
+    "defaultMessage": "Lệnh"
+  },
+  "extensionConfigFields.commandPlaceholder": {
+    "defaultMessage": "ví dụ: npx -y @modelcontextprotocol/my-extension [filepath]"
+  },
+  "extensionConfigFields.commandRequired": {
+    "defaultMessage": "Bắt buộc nhập lệnh"
+  },
+  "extensionConfigFields.endpointLabel": {
+    "defaultMessage": "Điểm cuối"
+  },
+  "extensionConfigFields.endpointPlaceholder": {
+    "defaultMessage": "Nhập URL điểm cuối..."
+  },
+  "extensionConfigFields.endpointRequired": {
+    "defaultMessage": "Bắt buộc nhập URL điểm cuối"
+  },
+  "extensionInfoFields.descriptionLabel": {
+    "defaultMessage": "Mô tả"
+  },
+  "extensionInfoFields.descriptionPlaceholder": {
+    "defaultMessage": "Mô tả tùy chọn..."
+  },
+  "extensionInfoFields.extensionName": {
+    "defaultMessage": "Tên tiện ích mở rộng"
+  },
+  "extensionInfoFields.extensionNamePlaceholder": {
+    "defaultMessage": "Nhập tên tiện ích mở rộng..."
+  },
+  "extensionInfoFields.nameRequired": {
+    "defaultMessage": "Bắt buộc nhập tên"
+  },
+  "extensionInfoFields.typeHttp": {
+    "defaultMessage": "HTTP"
+  },
+  "extensionInfoFields.typeLabel": {
+    "defaultMessage": "Loại"
+  },
+  "extensionInfoFields.typeSseUnsupported": {
+    "defaultMessage": "SSE (không được hỗ trợ)"
+  },
+  "extensionInfoFields.typeStandardIo": {
+    "defaultMessage": "Standard IO (STDIO)"
+  },
+  "extensionInfoFields.typeStdio": {
+    "defaultMessage": "STDIO"
+  },
+  "extensionInfoFields.typeStreamableHttp": {
+    "defaultMessage": "Streamable HTTP"
+  },
+  "extensionInstallModal.alreadyInstalledMessage": {
+    "defaultMessage": "Tiện ích mở rộng ''{name}'' đã được cài đặt thành công. Hãy bắt đầu một phiên trò chuyện mới để sử dụng."
+  },
+  "extensionInstallModal.alreadyInstalledTitle": {
+    "defaultMessage": "Tiện ích mở rộng ''{name}'' đã được cài đặt"
+  },
+  "extensionInstallModal.blockedMessage": {
+    "defaultMessage": "Lệnh của tiện ích mở rộng này không nằm trong danh sách cho phép và việc cài đặt đã bị chặn. Tiện ích mở rộng: {name} Lệnh: {command} Hãy liên hệ với quản trị viên của bạn để yêu cầu phê duyệt tiện ích mở rộng này."
+  },
+  "extensionInstallModal.blockedTitle": {
+    "defaultMessage": "Đã chặn cài đặt tiện ích mở rộng"
+  },
+  "extensionInstallModal.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "extensionInstallModal.installAnyway": {
+    "defaultMessage": "Vẫn cài đặt"
+  },
+  "extensionInstallModal.installing": {
+    "defaultMessage": "Đang cài đặt..."
+  },
+  "extensionInstallModal.no": {
+    "defaultMessage": "Không"
+  },
+  "extensionInstallModal.ok": {
+    "defaultMessage": "OK"
+  },
+  "extensionInstallModal.trustedMessage": {
+    "defaultMessage": "Bạn có chắc chắn muốn cài đặt tiện ích mở rộng {name} không? Lệnh: {command}"
+  },
+  "extensionInstallModal.trustedTitle": {
+    "defaultMessage": "Xác nhận cài đặt tiện ích mở rộng"
+  },
+  "extensionInstallModal.unknownCommand": {
+    "defaultMessage": "Lệnh không xác định"
+  },
+  "extensionInstallModal.untrustedMessageWithCommand": {
+    "defaultMessage": "{securityMessage} Tiện ích mở rộng: {name} Lệnh: {command} Hãy liên hệ với quản trị viên của bạn nếu bạn không chắc chắn về điều này."
+  },
+  "extensionInstallModal.untrustedMessageWithUrl": {
+    "defaultMessage": "{securityMessage} Tiện ích mở rộng: {name} URL: {url} Hãy liên hệ với quản trị viên của bạn nếu bạn không chắc chắn về điều này."
+  },
+  "extensionInstallModal.untrustedSecurityMessage": {
+    "defaultMessage": "Lệnh của tiện ích mở rộng này không nằm trong danh sách cho phép và sẽ có thể truy cập các cuộc trò chuyện của bạn cũng như cung cấp chức năng bổ sung. Việc cài đặt tiện ích mở rộng từ nguồn không đáng tin cậy có thể gây ra rủi ro bảo mật."
+  },
+  "extensionInstallModal.untrustedTitle": {
+    "defaultMessage": "Cài đặt tiện ích mở rộng không đáng tin cậy?"
+  },
+  "extensionInstallModal.yes": {
+    "defaultMessage": "Có"
+  },
+  "extensionItem.configureExtension": {
+    "defaultMessage": "Cấu hình tiện ích mở rộng {name}"
+  },
+  "extensionItem.toggleExtension": {
+    "defaultMessage": "Bật hoặc tắt tiện ích mở rộng {name}"
+  },
+  "extensionList.availableExtensions": {
+    "defaultMessage": "Tiện ích mở rộng khả dụng ({count})"
+  },
+  "extensionList.builtInExtension": {
+    "defaultMessage": "Tiện ích mở rộng tích hợp sẵn"
+  },
+  "extensionList.defaultExtensions": {
+    "defaultMessage": "Tiện ích mở rộng mặc định ({count})"
+  },
+  "extensionList.noExtensions": {
+    "defaultMessage": "Không có tiện ích mở rộng nào khả dụng"
+  },
+  "extensionModal.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "extensionModal.closeWithoutSaving": {
+    "defaultMessage": "Đóng mà không lưu"
+  },
+  "extensionModal.confirmRemoval": {
+    "defaultMessage": "Xác nhận xóa"
+  },
+  "extensionModal.deleteDescription": {
+    "defaultMessage": "Thao tác này sẽ xóa vĩnh viễn tiện ích mở rộng này và toàn bộ thiết lập của nó."
+  },
+  "extensionModal.deleteExtensionTitle": {
+    "defaultMessage": "Xóa tiện ích mở rộng \"{name}\""
+  },
+  "extensionModal.installationNotes": {
+    "defaultMessage": "Ghi chú cài đặt"
+  },
+  "extensionModal.removeExtension": {
+    "defaultMessage": "Xóa tiện ích mở rộng"
+  },
+  "extensionModal.unsavedChangesMessage": {
+    "defaultMessage": "Bạn có các thay đổi chưa lưu đối với cấu hình tiện ích mở rộng. Bạn có chắc chắn muốn đóng mà không lưu không?"
+  },
+  "extensionModal.unsavedChangesTitle": {
+    "defaultMessage": "Thay đổi chưa lưu"
+  },
+  "extensionTimeoutField.timeoutLabel": {
+    "defaultMessage": "Thời gian chờ"
+  },
+  "extensionsSection.addCustomExtension": {
+    "defaultMessage": "Thêm tiện ích mở rộng tùy chỉnh"
+  },
+  "extensionsSection.addExtension": {
+    "defaultMessage": "Thêm tiện ích mở rộng"
+  },
+  "extensionsSection.browseExtensions": {
+    "defaultMessage": "Duyệt tiện ích mở rộng"
+  },
+  "extensionsSection.saveChanges": {
+    "defaultMessage": "Lưu thay đổi"
+  },
+  "extensionsSection.updateExtension": {
+    "defaultMessage": "Cập nhật tiện ích mở rộng"
+  },
+  "extensionsView.addCustomExtension": {
+    "defaultMessage": "Thêm tiện ích mở rộng tùy chỉnh"
+  },
+  "extensionsView.addExtension": {
+    "defaultMessage": "Thêm tiện ích mở rộng"
+  },
+  "extensionsView.browseExtensions": {
+    "defaultMessage": "Duyệt tiện ích mở rộng"
+  },
+  "extensionsView.defaultNote": {
+    "defaultMessage": "Các tiện ích mở rộng được bật ở đây sẽ được dùng làm mặc định cho các cuộc trò chuyện mới. Bạn cũng có thể bật/tắt các tiện ích mở rộng đang hoạt động trong khi trò chuyện."
+  },
+  "extensionsView.description": {
+    "defaultMessage": "Các tiện ích mở rộng này sử dụng Model Context Protocol (MCP). Chúng có thể mở rộng khả năng của Goose bằng ba thành phần chính: Lời nhắc, Tài nguyên và Công cụ. {searchShortcut} để tìm kiếm."
+  },
+  "extensionsView.heading": {
+    "defaultMessage": "Tiện ích mở rộng"
+  },
+  "extensionsView.searchPlaceholder": {
+    "defaultMessage": "Tìm kiếm tiện ích mở rộng..."
+  },
+  "externalBackendSection.certFingerprint": {
+    "defaultMessage": "Dấu vân tay chứng chỉ (tùy chọn)"
+  },
+  "externalBackendSection.certFingerprintHelp": {
+    "defaultMessage": "Ghim một dấu vân tay chứng chỉ TLS cụ thể. Nếu bỏ trống, chứng chỉ sẽ được tin cậy ở lần sử dụng đầu tiên (TOFU)."
+  },
+  "externalBackendSection.certFingerprintPlaceholder": {
+    "defaultMessage": "AA:BB:CC:... hoặc sha256/base64"
+  },
+  "externalBackendSection.description": {
+    "defaultMessage": "Theo mặc định goose khởi chạy một máy chủ cho bạn, hãy dùng tùy chọn này để kết nối tới một máy chủ goose bên ngoài"
+  },
+  "externalBackendSection.restartNote": {
+    "defaultMessage": "Các thay đổi cần khởi động lại Goose để có hiệu lực. Các cửa sổ trò chuyện mới sẽ kết nối tới máy chủ bên ngoài."
+  },
+  "externalBackendSection.secretKey": {
+    "defaultMessage": "Khóa bí mật"
+  },
+  "externalBackendSection.secretKeyHelp": {
+    "defaultMessage": "Khóa bí mật được cấu hình trên máy chủ goosed (GOOSE_SERVER__SECRET_KEY)"
+  },
+  "externalBackendSection.secretKeyPlaceholder": {
+    "defaultMessage": "Nhập khóa bí mật của máy chủ"
+  },
+  "externalBackendSection.serverUrl": {
+    "defaultMessage": "URL máy chủ"
+  },
+  "externalBackendSection.title": {
+    "defaultMessage": "Máy chủ Goose"
+  },
+  "externalBackendSection.urlFormatError": {
+    "defaultMessage": "Định dạng URL không hợp lệ"
+  },
+  "externalBackendSection.urlProtocolError": {
+    "defaultMessage": "URL phải sử dụng giao thức http hoặc https"
+  },
+  "externalBackendSection.useExternalServer": {
+    "defaultMessage": "Sử dụng máy chủ bên ngoài"
+  },
+  "externalBackendSection.useExternalServerDescription": {
+    "defaultMessage": "Kết nối tới một máy chủ goose đang chạy ở nơi khác (cần khởi động lại ứng dụng)"
+  },
+  "freeOptionCards.chooseOption": {
+    "defaultMessage": "Chọn một tùy chọn để bắt đầu."
+  },
+  "freeOptionCards.freeAndPrivate": {
+    "defaultMessage": "Miễn phí & Riêng tư"
+  },
+  "freeOptionCards.localModelDescription": {
+    "defaultMessage": "Tải xuống một mô hình và chạy hoàn toàn trên máy của bạn. Không cần khóa API, không cần tài khoản."
+  },
+  "freeOptionCards.localModelTitle": {
+    "defaultMessage": "Sử dụng mô hình cục bộ"
+  },
+  "freeOptionCards.nanogptDescription": {
+    "defaultMessage": "Đăng ký để nhận 60 triệu token miễn phí trong 7 ngày."
+  },
+  "freeOptionCards.nanogptTitle": {
+    "defaultMessage": "NanoGPT"
+  },
+  "freeOptionCards.retry": {
+    "defaultMessage": "Thử lại"
+  },
+  "freeOptionCards.tetrateDescription": {
+    "defaultMessage": "Truy cập nhiều mô hình AI với thiết lập tự động. Đăng ký để nhận 10 đô la tín dụng."
+  },
+  "freeOptionCards.tetrateTitle": {
+    "defaultMessage": "Agent Router by Tetrate"
+  },
+  "freeOptionCards.unexpectedError": {
+    "defaultMessage": "Đã xảy ra lỗi không mong muốn trong quá trình thiết lập."
+  },
+  "goosehintsModal.close": {
+    "defaultMessage": "Đóng"
+  },
+  "goosehintsModal.developer": {
+    "defaultMessage": "Nhà phát triển"
+  },
+  "goosehintsModal.dialogDescription": {
+    "defaultMessage": "Cung cấp thêm ngữ cảnh về dự án của bạn để cải thiện giao tiếp với Goose"
+  },
+  "goosehintsModal.dialogTitle": {
+    "defaultMessage": "Cấu hình gợi ý dự án (.goosehints)"
+  },
+  "goosehintsModal.errorReading": {
+    "defaultMessage": "Lỗi khi đọc tệp .goosehints: {error}"
+  },
+  "goosehintsModal.failedToAccess": {
+    "defaultMessage": "Không thể truy cập tệp .goosehints"
+  },
+  "goosehintsModal.failedToSave": {
+    "defaultMessage": "Không thể lưu tệp .goosehints"
+  },
+  "goosehintsModal.fileCreating": {
+    "defaultMessage": "Đang tạo tệp .goosehints mới tại: {filePath}"
+  },
+  "goosehintsModal.fileFound": {
+    "defaultMessage": "Đã tìm thấy tệp .goosehints tại: {filePath}"
+  },
+  "goosehintsModal.helpText1": {
+    "defaultMessage": ".goosehints là một tệp văn bản dùng để cung cấp thêm ngữ cảnh về dự án của bạn và cải thiện giao tiếp với Goose."
+  },
+  "goosehintsModal.helpText2": {
+    "defaultMessage": "Hãy đảm bảo tiện ích mở rộng {bold} được bật trong trang tiện ích mở rộng. Tiện ích mở rộng này là bắt buộc để sử dụng .goosehints. Bạn cần khởi động lại phiên để các cập nhật .goosehints có hiệu lực."
+  },
+  "goosehintsModal.helpText3": {
+    "defaultMessage": "Xem {link} để biết thêm thông tin."
+  },
+  "goosehintsModal.helpTextLink": {
+    "defaultMessage": "cách sử dụng .goosehints"
+  },
+  "goosehintsModal.placeholder": {
+    "defaultMessage": "Nhập gợi ý dự án ở đây..."
+  },
+  "goosehintsModal.save": {
+    "defaultMessage": "Lưu"
+  },
+  "goosehintsModal.savedSuccessfully": {
+    "defaultMessage": "Đã lưu thành công"
+  },
+  "goosehintsModal.saving": {
+    "defaultMessage": "Đang lưu..."
+  },
+  "goosehintsSection.configure": {
+    "defaultMessage": "Cấu hình"
+  },
+  "goosehintsSection.description": {
+    "defaultMessage": "Cấu hình tệp .goosehints của dự án để cung cấp thêm ngữ cảnh cho Goose"
+  },
+  "goosehintsSection.title": {
+    "defaultMessage": "Gợi ý dự án (.goosehints)"
+  },
+  "groupedExtensionLoadingToast.askGoose": {
+    "defaultMessage": "Hỏi goose"
+  },
+  "groupedExtensionLoadingToast.collapseDetails": {
+    "defaultMessage": "Thu gọn chi tiết"
+  },
+  "groupedExtensionLoadingToast.copied": {
+    "defaultMessage": "Đã sao chép!"
+  },
+  "groupedExtensionLoadingToast.copyError": {
+    "defaultMessage": "Lỗi sao chép"
+  },
+  "groupedExtensionLoadingToast.expandDetails": {
+    "defaultMessage": "Mở rộng chi tiết"
+  },
+  "groupedExtensionLoadingToast.failedToAddExtension": {
+    "defaultMessage": "Không thể thêm tiện ích mở rộng"
+  },
+  "groupedExtensionLoadingToast.failedToLoad": {
+    "defaultMessage": "{count,plural,one{# tiện ích mở rộng không tải được} other{# tiện ích mở rộng không tải được}}"
+  },
+  "groupedExtensionLoadingToast.loadingExtensions": {
+    "defaultMessage": "{count,plural,one{Đang tải # tiện ích mở rộng...} other{Đang tải # tiện ích mở rộng...}}"
+  },
+  "groupedExtensionLoadingToast.partiallyLoaded": {
+    "defaultMessage": "{totalCount,plural,one{Đã tải {successCount}/# tiện ích mở rộng} other{Đã tải {successCount}/# tiện ích mở rộng}}"
+  },
+  "groupedExtensionLoadingToast.showDetails": {
+    "defaultMessage": "Hiện chi tiết"
+  },
+  "groupedExtensionLoadingToast.showLess": {
+    "defaultMessage": "Hiện ít hơn"
+  },
+  "groupedExtensionLoadingToast.successfullyLoaded": {
+    "defaultMessage": "{count,plural,one{Đã tải thành công # tiện ích mở rộng} other{Đã tải thành công # tiện ích mở rộng}}"
+  },
+  "headersSection.add": {
+    "defaultMessage": "Thêm"
+  },
+  "headersSection.bothRequired": {
+    "defaultMessage": "Phải nhập cả tên tiêu đề và giá trị"
+  },
+  "headersSection.duplicateHeader": {
+    "defaultMessage": "Đã tồn tại một tiêu đề với tên này"
+  },
+  "headersSection.headerName": {
+    "defaultMessage": "Tên tiêu đề"
+  },
+  "headersSection.headersDescription": {
+    "defaultMessage": "Thêm các tiêu đề HTTP tùy chỉnh để đưa vào các yêu cầu gửi đến máy chủ MCP. Nhấp vào nút \"+\" để thêm sau khi đã điền cả hai trường."
+  },
+  "headersSection.noSpaces": {
+    "defaultMessage": "Tên tiêu đề không được chứa khoảng trắng"
+  },
+  "headersSection.requestHeaders": {
+    "defaultMessage": "Tiêu đề yêu cầu"
+  },
+  "headersSection.value": {
+    "defaultMessage": "Giá trị"
+  },
+  "hub.goodAfternoon": {
+    "defaultMessage": "Chào buổi chiều"
+  },
+  "hub.goodEvening": {
+    "defaultMessage": "Chào buổi tối"
+  },
+  "hub.goodMorning": {
+    "defaultMessage": "Chào buổi sáng"
+  },
+  "huggingFaceModelSearch.download": {
+    "defaultMessage": "Tải xuống"
+  },
+  "huggingFaceModelSearch.downloaded": {
+    "defaultMessage": "Đã tải xuống"
+  },
+  "huggingFaceModelSearch.downloading": {
+    "defaultMessage": "Đang tải xuống…"
+  },
+  "huggingFaceModelSearch.loadingVariants": {
+    "defaultMessage": "Đang tải các biến thể..."
+  },
+  "huggingFaceModelSearch.noGgufModels": {
+    "defaultMessage": "Không tìm thấy mô hình cục bộ tương thích nào cho truy vấn này."
+  },
+  "huggingFaceModelSearch.recommended": {
+    "defaultMessage": "Được khuyến nghị"
+  },
+  "huggingFaceModelSearch.searchError": {
+    "defaultMessage": "Lỗi tìm kiếm: {details}"
+  },
+  "huggingFaceModelSearch.searchFailed": {
+    "defaultMessage": "Tìm kiếm thất bại. Vui lòng thử lại."
+  },
+  "huggingFaceModelSearch.searchHuggingFace": {
+    "defaultMessage": "Tìm kiếm HuggingFace"
+  },
+  "huggingFaceModelSearch.searchNoData": {
+    "defaultMessage": "Tìm kiếm không trả về dữ liệu nào."
+  },
+  "huggingFaceModelSearch.searchPlaceholder": {
+    "defaultMessage": "Tìm kiếm mô hình cục bộ..."
+  },
+  "huggingFaceModelSearch.tooLarge": {
+    "defaultMessage": "Có thể không vừa với bộ nhớ (mô hình {size}, khả dụng {available})"
+  },
+  "huggingFaceSignInPrompt.failedToConfigure": {
+    "defaultMessage": "Không thể đăng nhập vào Hugging Face: {error}"
+  },
+  "huggingFaceSignInPrompt.signIn": {
+    "defaultMessage": "Đăng nhập"
+  },
+  "huggingFaceSignInPrompt.signedIn": {
+    "defaultMessage": "Đã đăng nhập Hugging Face"
+  },
+  "huggingFaceSignInPrompt.signingIn": {
+    "defaultMessage": "Đang đăng nhập..."
+  },
+  "huggingFaceSignInPrompt.title": {
+    "defaultMessage": "Hugging Face"
+  },
+  "imagePreview.altText": {
+    "defaultMessage": "hình ảnh goose"
+  },
+  "imagePreview.clickToCollapse": {
+    "defaultMessage": "Nhấp để thu gọn"
+  },
+  "imagePreview.clickToExpand": {
+    "defaultMessage": "Nhấp để mở rộng"
+  },
+  "imagePreview.unableToLoad": {
+    "defaultMessage": "Không thể tải hình ảnh"
+  },
+  "importRecipeForm.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "importRecipeForm.deeplinkHint": {
+    "defaultMessage": "Dán một deeplink công thức bắt đầu bằng \"goose://recipe?config=\""
+  },
+  "importRecipeForm.deeplinkPlaceholder": {
+    "defaultMessage": "Dán deeplink goose://recipe?config=... của bạn vào đây"
+  },
+  "importRecipeForm.example": {
+    "defaultMessage": "ví dụ"
+  },
+  "importRecipeForm.expectedRecipeStructure": {
+    "defaultMessage": "Cấu trúc công thức dự kiến"
+  },
+  "importRecipeForm.importRecipeButton": {
+    "defaultMessage": "Nhập công thức"
+  },
+  "importRecipeForm.importRecipeTitle": {
+    "defaultMessage": "Nhập công thức"
+  },
+  "importRecipeForm.importing": {
+    "defaultMessage": "Đang nhập..."
+  },
+  "importRecipeForm.or": {
+    "defaultMessage": "HOẶC"
+  },
+  "importRecipeForm.recipeDeeplinkLabel": {
+    "defaultMessage": "Deeplink công thức"
+  },
+  "importRecipeForm.recipeFileHint": {
+    "defaultMessage": "Tải lên tệp YAML hoặc JSON chứa cấu trúc công thức"
+  },
+  "importRecipeForm.recipeFileLabel": {
+    "defaultMessage": "Tệp công thức"
+  },
+  "importRecipeForm.reviewWarning": {
+    "defaultMessage": "Hãy đảm bảo bạn xem lại nội dung của các tệp công thức trước khi thêm chúng vào giao diện goose của bạn."
+  },
+  "importRecipeForm.schemaDescription": {
+    "defaultMessage": "Tệp YAML hoặc JSON của bạn phải tuân theo cấu trúc này. Các trường bắt buộc là: title, description, và instructions hoặc prompt."
+  },
+  "inlineEditText.clickToEdit": {
+    "defaultMessage": "Nhấp để chỉnh sửa"
+  },
+  "inlineEditText.doubleClickToEdit": {
+    "defaultMessage": "Nhấp đúp để chỉnh sửa"
+  },
+  "inlineEditText.enterText": {
+    "defaultMessage": "Nhập văn bản"
+  },
+  "inlineEditText.failedToSave": {
+    "defaultMessage": "Không thể lưu"
+  },
+  "instructionsEditor.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "instructionsEditor.insertExample": {
+    "defaultMessage": "Chèn ví dụ"
+  },
+  "instructionsEditor.label": {
+    "defaultMessage": "Hướng dẫn"
+  },
+  "instructionsEditor.placeholder": {
+    "defaultMessage": "Hướng dẫn chi tiết cho AI, ẩn khỏi người dùng"
+  },
+  "instructionsEditor.save": {
+    "defaultMessage": "Lưu hướng dẫn"
+  },
+  "instructionsEditor.syntaxHelp": {
+    "defaultMessage": "Dùng cú pháp {code} để định nghĩa các tham số mà người dùng có thể điền vào"
+  },
+  "instructionsEditor.title": {
+    "defaultMessage": "Trình chỉnh sửa hướng dẫn"
+  },
+  "jsonSchemaEditor.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "jsonSchemaEditor.description": {
+    "defaultMessage": "Định nghĩa cấu trúc dự kiến của phản hồi từ AI bằng định dạng JSON Schema"
+  },
+  "jsonSchemaEditor.insertExample": {
+    "defaultMessage": "Chèn ví dụ"
+  },
+  "jsonSchemaEditor.invalidJson": {
+    "defaultMessage": "Định dạng JSON không hợp lệ"
+  },
+  "jsonSchemaEditor.label": {
+    "defaultMessage": "JSON Schema phản hồi"
+  },
+  "jsonSchemaEditor.save": {
+    "defaultMessage": "Lưu Schema"
+  },
+  "jsonSchemaEditor.title": {
+    "defaultMessage": "Trình chỉnh sửa JSON Schema"
+  },
+  "jsonSchemaForm.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "jsonSchemaForm.fieldRequired": {
+    "defaultMessage": "Trường này là bắt buộc"
+  },
+  "jsonSchemaForm.maxLength": {
+    "defaultMessage": "Độ dài tối đa là {maxLength}"
+  },
+  "jsonSchemaForm.maxValue": {
+    "defaultMessage": "Giá trị tối đa là {maximum}"
+  },
+  "jsonSchemaForm.minLength": {
+    "defaultMessage": "Độ dài tối thiểu là {minLength}"
+  },
+  "jsonSchemaForm.minValue": {
+    "defaultMessage": "Giá trị tối thiểu là {minimum}"
+  },
+  "jsonSchemaForm.noFields": {
+    "defaultMessage": "Không có trường nào để hiển thị"
+  },
+  "jsonSchemaForm.selectPlaceholder": {
+    "defaultMessage": "Chọn..."
+  },
+  "jsonSchemaForm.submit": {
+    "defaultMessage": "Gửi"
+  },
+  "keyValueEditor.addValue": {
+    "defaultMessage": "Thêm giá trị được cấu hình sẵn"
+  },
+  "keyValueEditor.defaultKeyPlaceholder": {
+    "defaultMessage": "Tên tham số..."
+  },
+  "keyValueEditor.defaultValuePlaceholder": {
+    "defaultMessage": "Giá trị tham số..."
+  },
+  "keyValueEditor.removeValue": {
+    "defaultMessage": "Xóa giá trị được cấu hình sẵn {key}"
+  },
+  "keyboardShortcuts.alwaysOnTopDescription": {
+    "defaultMessage": "Bật/tắt cửa sổ luôn ở trên cùng"
+  },
+  "keyboardShortcuts.alwaysOnTopLabel": {
+    "defaultMessage": "Luôn ở trên cùng"
+  },
+  "keyboardShortcuts.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "keyboardShortcuts.categoryApplication": {
+    "defaultMessage": "Phím tắt ứng dụng"
+  },
+  "keyboardShortcuts.categoryApplicationDescription": {
+    "defaultMessage": "Các phím tắt này hoạt động khi Goose là ứng dụng đang hoạt động"
+  },
+  "keyboardShortcuts.categoryGlobal": {
+    "defaultMessage": "Phím tắt toàn cục"
+  },
+  "keyboardShortcuts.categoryGlobalDescription": {
+    "defaultMessage": "Các phím tắt này hoạt động trên toàn hệ thống, ngay cả khi Goose không được lấy nét"
+  },
+  "keyboardShortcuts.categorySearch": {
+    "defaultMessage": "Phím tắt tìm kiếm"
+  },
+  "keyboardShortcuts.categorySearchDescription": {
+    "defaultMessage": "Các phím tắt này hoạt động khi tìm kiếm trong một cuộc trò chuyện"
+  },
+  "keyboardShortcuts.categoryWindow": {
+    "defaultMessage": "Phím tắt cửa sổ"
+  },
+  "keyboardShortcuts.categoryWindowDescription": {
+    "defaultMessage": "Các phím tắt này điều khiển hành vi của cửa sổ"
+  },
+  "keyboardShortcuts.change": {
+    "defaultMessage": "Thay đổi"
+  },
+  "keyboardShortcuts.disabled": {
+    "defaultMessage": "Đã tắt"
+  },
+  "keyboardShortcuts.dismiss": {
+    "defaultMessage": "Bỏ qua"
+  },
+  "keyboardShortcuts.findDescription": {
+    "defaultMessage": "Mở tìm kiếm trong cuộc trò chuyện"
+  },
+  "keyboardShortcuts.findLabel": {
+    "defaultMessage": "Tìm"
+  },
+  "keyboardShortcuts.findNextDescription": {
+    "defaultMessage": "Chuyển đến kết quả tìm kiếm tiếp theo"
+  },
+  "keyboardShortcuts.findNextLabel": {
+    "defaultMessage": "Tìm tiếp theo"
+  },
+  "keyboardShortcuts.findPreviousDescription": {
+    "defaultMessage": "Chuyển đến kết quả tìm kiếm trước đó"
+  },
+  "keyboardShortcuts.findPreviousLabel": {
+    "defaultMessage": "Tìm trước đó"
+  },
+  "keyboardShortcuts.focusWindowDescription": {
+    "defaultMessage": "Đưa cửa sổ Goose lên phía trước từ bất kỳ đâu"
+  },
+  "keyboardShortcuts.focusWindowLabel": {
+    "defaultMessage": "Lấy nét cửa sổ Goose"
+  },
+  "keyboardShortcuts.loading": {
+    "defaultMessage": "Đang tải..."
+  },
+  "keyboardShortcuts.newChatDescription": {
+    "defaultMessage": "Tạo một cuộc trò chuyện mới trong cửa sổ hiện tại"
+  },
+  "keyboardShortcuts.newChatLabel": {
+    "defaultMessage": "Trò chuyện mới"
+  },
+  "keyboardShortcuts.newChatWindowDescription": {
+    "defaultMessage": "Mở một cửa sổ Goose mới"
+  },
+  "keyboardShortcuts.newChatWindowLabel": {
+    "defaultMessage": "Cửa sổ trò chuyện mới"
+  },
+  "keyboardShortcuts.openDirectoryDescription": {
+    "defaultMessage": "Mở hộp thoại chọn thư mục"
+  },
+  "keyboardShortcuts.openDirectoryLabel": {
+    "defaultMessage": "Mở thư mục"
+  },
+  "keyboardShortcuts.quickLauncherDescription": {
+    "defaultMessage": "Mở lớp phủ trình khởi chạy nhanh"
+  },
+  "keyboardShortcuts.quickLauncherLabel": {
+    "defaultMessage": "Trình khởi chạy nhanh"
+  },
+  "keyboardShortcuts.reassignShortcut": {
+    "defaultMessage": "Gán lại phím tắt"
+  },
+  "keyboardShortcuts.resetAllShortcuts": {
+    "defaultMessage": "Đặt lại tất cả phím tắt"
+  },
+  "keyboardShortcuts.resetShortcutsDetail": {
+    "defaultMessage": "Thao tác này sẽ khôi phục tất cả phím tắt về cấu hình ban đầu."
+  },
+  "keyboardShortcuts.resetShortcutsMessage": {
+    "defaultMessage": "Đặt lại tất cả phím tắt bàn phím về giá trị mặc định?"
+  },
+  "keyboardShortcuts.resetShortcutsTitle": {
+    "defaultMessage": "Đặt lại phím tắt bàn phím"
+  },
+  "keyboardShortcuts.resetToDefaultsDescription": {
+    "defaultMessage": "Khôi phục tất cả phím tắt bàn phím về cấu hình ban đầu"
+  },
+  "keyboardShortcuts.resetToDefaultsHeading": {
+    "defaultMessage": "Đặt lại về mặc định"
+  },
+  "keyboardShortcuts.restartDescription": {
+    "defaultMessage": "Các thay đổi đối với phím tắt ứng dụng (như Trò chuyện mới, Cài đặt, v.v.) yêu cầu khởi động lại Goose để có hiệu lực. Phím tắt toàn cục (Lấy nét cửa sổ, Trình khởi chạy nhanh) hoạt động ngay lập tức."
+  },
+  "keyboardShortcuts.restartRequired": {
+    "defaultMessage": "Cần khởi động lại"
+  },
+  "keyboardShortcuts.settingsDescription": {
+    "defaultMessage": "Mở bảng cài đặt"
+  },
+  "keyboardShortcuts.settingsLabel": {
+    "defaultMessage": "Cài đặt"
+  },
+  "keyboardShortcuts.shortcutConflictSaveDetail": {
+    "defaultMessage": "Lưu thao tác này sẽ xóa phím tắt khỏi \"{conflictLabel}\" và gán nó cho \"{targetLabel}\". Bạn có muốn tiếp tục không?"
+  },
+  "keyboardShortcuts.shortcutConflictTitle": {
+    "defaultMessage": "Xung đột phím tắt"
+  },
+  "keyboardShortcuts.shortcutConflictToggleDetail": {
+    "defaultMessage": "Bật thao tác này sẽ xóa phím tắt khỏi \"{conflictLabel}\" và gán nó cho \"{targetLabel}\". Bạn có muốn tiếp tục không?"
+  },
+  "keyboardShortcuts.shortcutConflictToggleMessage": {
+    "defaultMessage": "Phím tắt {shortcut} đã được gán cho \"{conflictLabel}\"."
+  },
+  "keyboardShortcuts.toggleNavigationDescription": {
+    "defaultMessage": "Hiện hoặc ẩn menu điều hướng"
+  },
+  "keyboardShortcuts.toggleNavigationLabel": {
+    "defaultMessage": "Bật/tắt điều hướng"
+  },
+  "launcher.placeholder": {
+    "defaultMessage": "Hỏi goose bất cứ điều gì..."
+  },
+  "loadingGoose.compacting": {
+    "defaultMessage": "goose đang nén cuộc trò chuyện..."
+  },
+  "loadingGoose.idle": {
+    "defaultMessage": "goose đang xử lý…"
+  },
+  "loadingGoose.loadingConversation": {
+    "defaultMessage": "đang tải cuộc trò chuyện..."
+  },
+  "loadingGoose.restartingAgent": {
+    "defaultMessage": "đang khởi động lại phiên..."
+  },
+  "loadingGoose.streaming": {
+    "defaultMessage": "goose đang xử lý…"
+  },
+  "loadingGoose.thinking": {
+    "defaultMessage": "goose đang suy nghĩ…"
+  },
+  "loadingGoose.waiting": {
+    "defaultMessage": "goose đang chờ…"
+  },
+  "localInferenceSettings.deleteConfirm": {
+    "defaultMessage": "Xóa mô hình này? Bạn có thể tải lại sau."
+  },
+  "localInferenceSettings.description": {
+    "defaultMessage": "Tải xuống và quản lý các mô hình LLM cục bộ để suy luận mà không cần khóa API. Tìm kiếm các mô hình GGUF hoặc MLX trên HuggingFace, hoặc sử dụng các lựa chọn nổi bật bên dưới."
+  },
+  "localInferenceSettings.dismiss": {
+    "defaultMessage": "Bỏ qua"
+  },
+  "localInferenceSettings.download": {
+    "defaultMessage": "Tải xuống"
+  },
+  "localInferenceSettings.downloadCancelled": {
+    "defaultMessage": "Đã hủy tải xuống"
+  },
+  "localInferenceSettings.downloadFailed": {
+    "defaultMessage": "Tải xuống thất bại"
+  },
+  "localInferenceSettings.downloadProgress": {
+    "defaultMessage": "{downloaded} / {total} ({percent}%)"
+  },
+  "localInferenceSettings.downloadedModels": {
+    "defaultMessage": "Các mô hình đã tải xuống"
+  },
+  "localInferenceSettings.downloading": {
+    "defaultMessage": "Đang tải xuống"
+  },
+  "localInferenceSettings.featuredModels": {
+    "defaultMessage": "Mô hình nổi bật"
+  },
+  "localInferenceSettings.huggingFaceSignInNote": {
+    "defaultMessage": "Đăng nhập để tăng giới hạn tốc độ khi tìm kiếm và tải xuống mô hình, và để truy cập các kho lưu trữ Hugging Face riêng tư hoặc bị giới hạn."
+  },
+  "localInferenceSettings.modelSettings": {
+    "defaultMessage": "Cài đặt mô hình"
+  },
+  "localInferenceSettings.modelSettingsTitle": {
+    "defaultMessage": "Cài đặt mô hình"
+  },
+  "localInferenceSettings.noModels": {
+    "defaultMessage": "Không có mô hình nào khả dụng"
+  },
+  "localInferenceSettings.recommended": {
+    "defaultMessage": "Được đề xuất"
+  },
+  "localInferenceSettings.remaining": {
+    "defaultMessage": "Còn lại {time}"
+  },
+  "localInferenceSettings.retry": {
+    "defaultMessage": "Thử lại"
+  },
+  "localInferenceSettings.showAllFeatured": {
+    "defaultMessage": "Hiển thị tất cả nổi bật (thêm {count})"
+  },
+  "localInferenceSettings.showRecommendedOnly": {
+    "defaultMessage": "Chỉ hiển thị được đề xuất"
+  },
+  "localInferenceSettings.title": {
+    "defaultMessage": "Mô hình suy luận cục bộ"
+  },
+  "localInferenceSettings.vision": {
+    "defaultMessage": "Thị giác"
+  },
+  "localInferenceSettings.visionEncoderDownloading": {
+    "defaultMessage": "Đang tải bộ mã hóa thị giác…"
+  },
+  "localInferenceSettings.visionEncoderNotDownloaded": {
+    "defaultMessage": "Bộ mã hóa thị giác chưa được tải xuống"
+  },
+  "localModelManager.active": {
+    "defaultMessage": "Đang hoạt động"
+  },
+  "localModelManager.deleteConfirm": {
+    "defaultMessage": "Xóa mô hình này? Bạn có thể tải lại sau."
+  },
+  "localModelManager.download": {
+    "defaultMessage": "Tải xuống"
+  },
+  "localModelManager.downloaded": {
+    "defaultMessage": "Đã tải xuống"
+  },
+  "localModelManager.gpuAcceleration": {
+    "defaultMessage": "Hỗ trợ tăng tốc GPU (CUDA cho NVIDIA, Metal cho Apple Silicon). Các tính năng GPU phải được bật khi biên dịch để có tăng tốc phần cứng."
+  },
+  "localModelManager.noModels": {
+    "defaultMessage": "Không có mô hình nào khả dụng"
+  },
+  "localModelManager.recommended": {
+    "defaultMessage": "Được đề xuất"
+  },
+  "localModelManager.recommendedForHardware": {
+    "defaultMessage": "Được đề xuất cho phần cứng của bạn"
+  },
+  "localModelManager.showAllModels": {
+    "defaultMessage": "Hiển thị tất cả mô hình (thêm {count})"
+  },
+  "localModelManager.showRecommendedOnly": {
+    "defaultMessage": "Chỉ hiển thị được đề xuất"
+  },
+  "localModelPicker.back": {
+    "defaultMessage": "Quay lại"
+  },
+  "localModelPicker.bestForMachine": {
+    "defaultMessage": "Tốt nhất cho máy của bạn"
+  },
+  "localModelPicker.cancelDownload": {
+    "defaultMessage": "Hủy tải xuống"
+  },
+  "localModelPicker.checkingModels": {
+    "defaultMessage": "Đang kiểm tra các mô hình khả dụng..."
+  },
+  "localModelPicker.downloadModel": {
+    "defaultMessage": "Tải xuống {modelId} ({size})"
+  },
+  "localModelPicker.downloading": {
+    "defaultMessage": "Đang tải xuống {modelId}"
+  },
+  "localModelPicker.failedToLoad": {
+    "defaultMessage": "Không tải được các mô hình khả dụng. Vui lòng thử lại."
+  },
+  "localModelPicker.failedToStartDownload": {
+    "defaultMessage": "Không bắt đầu được tải xuống. Vui lòng thử lại."
+  },
+  "localModelPicker.hideOtherSizes": {
+    "defaultMessage": "Ẩn các kích thước khác"
+  },
+  "localModelPicker.localModelsNote": {
+    "defaultMessage": "Mô hình cục bộ giữ mọi thứ trên máy của bạn để đảm bảo quyền riêng tư hoàn toàn. Hiệu suất và kích thước cửa sổ ngữ cảnh có thể khác nhau so với các nhà cung cấp đám mây tùy thuộc vào phần cứng và kích thước mô hình của bạn."
+  },
+  "localModelPicker.lostConnection": {
+    "defaultMessage": "Mất kết nối tải xuống. Vui lòng thử lại."
+  },
+  "localModelPicker.modelNotFound": {
+    "defaultMessage": "Không tìm thấy mô hình"
+  },
+  "localModelPicker.ready": {
+    "defaultMessage": "Sẵn sàng"
+  },
+  "localModelPicker.selectModel": {
+    "defaultMessage": "Chọn một mô hình"
+  },
+  "localModelPicker.showOtherSizes": {
+    "defaultMessage": "Hiển thị {count} kích thước khác"
+  },
+  "localModelPicker.startingDownload": {
+    "defaultMessage": "Đang bắt đầu tải xuống..."
+  },
+  "localModelPicker.tryAgain": {
+    "defaultMessage": "Thử lại"
+  },
+  "localModelPicker.useModel": {
+    "defaultMessage": "Sử dụng {modelId}"
+  },
+  "markdownContent.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "markdownContent.copyCode": {
+    "defaultMessage": "Sao chép mã"
+  },
+  "markdownContent.failedToOpenLink": {
+    "defaultMessage": "Không mở được liên kết"
+  },
+  "markdownContent.noApplicationFound": {
+    "defaultMessage": "Không tìm thấy ứng dụng nào để mở liên kết này."
+  },
+  "markdownContent.open": {
+    "defaultMessage": "Mở"
+  },
+  "markdownContent.openExternalLink": {
+    "defaultMessage": "Mở liên kết bên ngoài"
+  },
+  "markdownContent.openProtocolLink": {
+    "defaultMessage": "Mở liên kết {protocol}?"
+  },
+  "markdownContent.thisWillOpen": {
+    "defaultMessage": "Thao tác này sẽ mở: {href}"
+  },
+  "mcpAppRenderer.appFallbackTitle": {
+    "defaultMessage": "Ứng dụng"
+  },
+  "mcpAppRenderer.cancelButton": {
+    "defaultMessage": "Hủy"
+  },
+  "mcpAppRenderer.close": {
+    "defaultMessage": "Đóng"
+  },
+  "mcpAppRenderer.exitFullscreen": {
+    "defaultMessage": "Thoát toàn màn hình"
+  },
+  "mcpAppRenderer.exitFullscreenTitle": {
+    "defaultMessage": "Thoát toàn màn hình (Esc)"
+  },
+  "mcpAppRenderer.failedToInitSandbox": {
+    "defaultMessage": "Không khởi tạo được proxy hộp cát"
+  },
+  "mcpAppRenderer.failedToLoadResource": {
+    "defaultMessage": "Không tải được tài nguyên"
+  },
+  "mcpAppRenderer.fullscreen": {
+    "defaultMessage": "Toàn màn hình"
+  },
+  "mcpAppRenderer.invalidUrl": {
+    "defaultMessage": "URL không hợp lệ"
+  },
+  "mcpAppRenderer.movePipWindow": {
+    "defaultMessage": "Di chuyển cửa sổ Hình-trong-hình (dùng phím mũi tên)"
+  },
+  "mcpAppRenderer.openButton": {
+    "defaultMessage": "Mở"
+  },
+  "mcpAppRenderer.openExternalLinkTitle": {
+    "defaultMessage": "Mở liên kết bên ngoài"
+  },
+  "mcpAppRenderer.openLinkDetail": {
+    "defaultMessage": "Thao tác này sẽ mở: {url}"
+  },
+  "mcpAppRenderer.openProtocolLink": {
+    "defaultMessage": "Mở liên kết {protocol}?"
+  },
+  "mcpAppRenderer.pictureInPicture": {
+    "defaultMessage": "Hình-trong-hình"
+  },
+  "mcpAppRenderer.playingInPip": {
+    "defaultMessage": "Đang phát ở chế độ Hình-trong-hình"
+  },
+  "mcpUIResourceRenderer.cancelButton": {
+    "defaultMessage": "Hủy"
+  },
+  "mcpUIResourceRenderer.openButton": {
+    "defaultMessage": "Mở"
+  },
+  "mcpUIResourceRenderer.openExternalLinkTitle": {
+    "defaultMessage": "Mở liên kết bên ngoài"
+  },
+  "mcpUIResourceRenderer.openLinkDetail": {
+    "defaultMessage": "Thao tác này sẽ mở: {url}"
+  },
+  "mcpUIResourceRenderer.openProtocolLink": {
+    "defaultMessage": "Mở liên kết {protocol}?"
+  },
+  "mcpUIResourceRenderer.toastMessageReceived": {
+    "defaultMessage": "Đã nhận thông báo cho {message}."
+  },
+  "mcpUIResourceRenderer.toastTitle": {
+    "defaultMessage": "Thông báo MCP-UI {messageType}"
+  },
+  "mcpUIResourceRenderer.toastUnsupported": {
+    "defaultMessage": "Đã nhận thông báo cho {message}. Thông báo {messageType} chưa được hỗ trợ, hãy tham khảo console để biết thêm chi tiết."
+  },
+  "mentionPopover.itemsFound": {
+    "defaultMessage": "{count,plural,one{# mục được tìm thấy} other{# mục được tìm thấy}}"
+  },
+  "mentionPopover.loadingCommands": {
+    "defaultMessage": "Đang tải lệnh..."
+  },
+  "mentionPopover.noCommandsFound": {
+    "defaultMessage": "Không tìm thấy lệnh nào khớp với \"{query}\""
+  },
+  "mentionPopover.noItemsFound": {
+    "defaultMessage": "Không tìm thấy mục nào khớp với \"{query}\""
+  },
+  "mentionPopover.scanningFiles": {
+    "defaultMessage": "Đang quét tệp..."
+  },
+  "messageCopyLink.copied": {
+    "defaultMessage": "Đã sao chép!"
+  },
+  "messageCopyLink.copy": {
+    "defaultMessage": "Sao chép"
+  },
+  "messageQueue.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "messageQueue.cannotSendWhileEditing": {
+    "defaultMessage": "Không thể gửi khi đang chỉnh sửa"
+  },
+  "messageQueue.clearAll": {
+    "defaultMessage": "Xóa tất cả"
+  },
+  "messageQueue.clickToEdit": {
+    "defaultMessage": "{content} (Nhấp để chỉnh sửa)"
+  },
+  "messageQueue.collapseQueue": {
+    "defaultMessage": "Thu gọn hàng đợi"
+  },
+  "messageQueue.dragToReorder": {
+    "defaultMessage": "Kéo tin nhắn để sắp xếp lại mức ưu tiên"
+  },
+  "messageQueue.expandQueue": {
+    "defaultMessage": "Mở rộng hàng đợi"
+  },
+  "messageQueue.messageCount": {
+    "defaultMessage": "{count,plural,one{# tin nhắn {status}} other{# tin nhắn {status}}}"
+  },
+  "messageQueue.messageQueue": {
+    "defaultMessage": "Hàng đợi tin nhắn"
+  },
+  "messageQueue.next": {
+    "defaultMessage": "Tiếp theo"
+  },
+  "messageQueue.paused": {
+    "defaultMessage": "Đã tạm dừng"
+  },
+  "messageQueue.queuePaused": {
+    "defaultMessage": "Hàng đợi đã tạm dừng"
+  },
+  "messageQueue.queuePausedCompact": {
+    "defaultMessage": "Hàng đợi đã tạm dừng - nhấp \"Gửi\" hoặc thêm tin nhắn mới để tiếp tục"
+  },
+  "messageQueue.queuePausedExpanded": {
+    "defaultMessage": "Hàng đợi bị tạm dừng do gián đoạn. Sử dụng \"Gửi ngay\" hoặc thêm tin nhắn mới để tiếp tục."
+  },
+  "messageQueue.queued": {
+    "defaultMessage": "đã xếp hàng"
+  },
+  "messageQueue.removeFromQueue": {
+    "defaultMessage": "Xóa tin nhắn này khỏi hàng đợi"
+  },
+  "messageQueue.save": {
+    "defaultMessage": "Lưu"
+  },
+  "messageQueue.sendNow": {
+    "defaultMessage": "Gửi tin nhắn này ngay"
+  },
+  "messageQueue.stopAndSend": {
+    "defaultMessage": "Dừng xử lý hiện tại và gửi tin nhắn này ngay"
+  },
+  "messageQueue.waiting": {
+    "defaultMessage": "đang chờ"
+  },
+  "microphoneSelector.chooseDescription": {
+    "defaultMessage": "Chọn micrô nào để sử dụng cho việc đọc chính tả"
+  },
+  "microphoneSelector.grantAccess": {
+    "defaultMessage": "Cấp quyền truy cập"
+  },
+  "microphoneSelector.grantAccessDescription": {
+    "defaultMessage": "Cấp quyền truy cập để xem các micrô khả dụng"
+  },
+  "microphoneSelector.microphone": {
+    "defaultMessage": "Micrô"
+  },
+  "microphoneSelector.microphoneLabel": {
+    "defaultMessage": "Micrô {index}"
+  },
+  "microphoneSelector.selectedMicrophone": {
+    "defaultMessage": "Micrô đã chọn"
+  },
+  "microphoneSelector.speakToTest": {
+    "defaultMessage": "Hãy nói để kiểm tra micrô của bạn ({seconds}s)"
+  },
+  "microphoneSelector.stop": {
+    "defaultMessage": "Dừng"
+  },
+  "microphoneSelector.systemDefault": {
+    "defaultMessage": "Mặc định của hệ thống"
+  },
+  "microphoneSelector.test": {
+    "defaultMessage": "Kiểm tra"
+  },
+  "modeSelectionItem.autonomousDescription": {
+    "defaultMessage": "Khả năng chỉnh sửa tệp đầy đủ, chỉnh sửa, tạo và xóa tệp một cách tự do."
+  },
+  "modeSelectionItem.autonomousLabel": {
+    "defaultMessage": "Tự động"
+  },
+  "modeSelectionItem.chatOnlyDescription": {
+    "defaultMessage": "Tương tác với nhà cung cấp đã chọn mà không sử dụng công cụ hoặc tiện ích mở rộng."
+  },
+  "modeSelectionItem.chatOnlyLabel": {
+    "defaultMessage": "Chỉ trò chuyện"
+  },
+  "modeSelectionItem.manualDescription": {
+    "defaultMessage": "Tất cả công cụ, tiện ích mở rộng và chỉnh sửa tệp sẽ yêu cầu sự phê duyệt của con người"
+  },
+  "modeSelectionItem.manualLabel": {
+    "defaultMessage": "Thủ công"
+  },
+  "modeSelectionItem.smartDescription": {
+    "defaultMessage": "Tự động xác định một cách thông minh những hành động nào cần phê duyệt dựa trên mức độ rủi ro"
+  },
+  "modeSelectionItem.smartLabel": {
+    "defaultMessage": "Thông minh"
+  },
+  "modelAndProviderContext.modelChangeFailed": {
+    "defaultMessage": "{provider}/{model} thất bại"
+  },
+  "modelAndProviderContext.modelChangedTitle": {
+    "defaultMessage": "Đã thay đổi mô hình"
+  },
+  "modelAndProviderContext.selectModel": {
+    "defaultMessage": "Chọn mô hình"
+  },
+  "modelAndProviderContext.switchModelSuccess": {
+    "defaultMessage": "Đã chuyển đổi mô hình thành công -- đang sử dụng {model} từ {provider}"
+  },
+  "modelAndProviderContext.unknownProviderMsg": {
+    "defaultMessage": "Nhà cung cấp không xác định trong cấu hình -- vui lòng kiểm tra config.yaml của bạn"
+  },
+  "modelAndProviderContext.unknownProviderTitle": {
+    "defaultMessage": "Tra cứu tên nhà cung cấp"
+  },
+  "modelSettingsButtons.configureProviders": {
+    "defaultMessage": "Cấu hình nhà cung cấp"
+  },
+  "modelSettingsButtons.switchModels": {
+    "defaultMessage": "Chuyển đổi mô hình"
+  },
+  "modelSettingsPanel.batchSize": {
+    "defaultMessage": "Kích thước lô"
+  },
+  "modelSettingsPanel.batchSizeDescription": {
+    "defaultMessage": "Lô xử lý lời nhắc"
+  },
+  "modelSettingsPanel.builtinChatTemplate": {
+    "defaultMessage": "Mẫu tích hợp sẵn"
+  },
+  "modelSettingsPanel.builtinChatTemplateDescription": {
+    "defaultMessage": "Chọn tên mẫu tích hợp sẵn của llama.cpp"
+  },
+  "modelSettingsPanel.chatTemplate": {
+    "defaultMessage": "Mẫu trò chuyện"
+  },
+  "modelSettingsPanel.chatTemplateBuiltin": {
+    "defaultMessage": "Tích hợp sẵn"
+  },
+  "modelSettingsPanel.chatTemplateCustomInline": {
+    "defaultMessage": "Tùy chỉnh nội tuyến"
+  },
+  "modelSettingsPanel.chatTemplateDescription": {
+    "defaultMessage": "Sử dụng siêu dữ liệu GGUF được nhúng, mẫu tích hợp sẵn của llama.cpp, hoặc Jinja nội tuyến"
+  },
+  "modelSettingsPanel.chatTemplateEmbedded": {
+    "defaultMessage": "Được nhúng"
+  },
+  "modelSettingsPanel.contextAndGeneration": {
+    "defaultMessage": "Ngữ cảnh & Sinh nội dung"
+  },
+  "modelSettingsPanel.contextSize": {
+    "defaultMessage": "Kích thước ngữ cảnh"
+  },
+  "modelSettingsPanel.contextSizeDescription": {
+    "defaultMessage": "Cửa sổ ngữ cảnh tối đa (0 = mặc định của mô hình)"
+  },
+  "modelSettingsPanel.customChatTemplate": {
+    "defaultMessage": "Mẫu trò chuyện tùy chỉnh"
+  },
+  "modelSettingsPanel.customChatTemplateDescription": {
+    "defaultMessage": "Dán toàn bộ mã nguồn mẫu trò chuyện Jinja"
+  },
+  "modelSettingsPanel.etaLearningRate": {
+    "defaultMessage": "Eta (tốc độ học)"
+  },
+  "modelSettingsPanel.flashAttention": {
+    "defaultMessage": "Flash attention"
+  },
+  "modelSettingsPanel.flashAttentionDescription": {
+    "defaultMessage": "Bật tối ưu hóa flash attention"
+  },
+  "modelSettingsPanel.frequencyPenalty": {
+    "defaultMessage": "Phạt tần suất"
+  },
+  "modelSettingsPanel.frequencyPenaltyDescription": {
+    "defaultMessage": "0.0 = tắt"
+  },
+  "modelSettingsPanel.gpuLayers": {
+    "defaultMessage": "Lớp GPU"
+  },
+  "modelSettingsPanel.gpuLayersDescription": {
+    "defaultMessage": "Số lớp chuyển sang GPU"
+  },
+  "modelSettingsPanel.loadingSettings": {
+    "defaultMessage": "Đang tải cài đặt..."
+  },
+  "modelSettingsPanel.lockModelInRam": {
+    "defaultMessage": "Khóa mô hình trong RAM (mlock)"
+  },
+  "modelSettingsPanel.lockModelInRamDescription": {
+    "defaultMessage": "Ngăn mô hình bị hoán đổi sang đĩa"
+  },
+  "modelSettingsPanel.maxOutputTokens": {
+    "defaultMessage": "Số token đầu ra tối đa"
+  },
+  "modelSettingsPanel.maxOutputTokensDescription": {
+    "defaultMessage": "Giới hạn số token được sinh ra"
+  },
+  "modelSettingsPanel.minP": {
+    "defaultMessage": "Min P"
+  },
+  "modelSettingsPanel.performance": {
+    "defaultMessage": "Hiệu suất"
+  },
+  "modelSettingsPanel.presencePenalty": {
+    "defaultMessage": "Phạt hiện diện"
+  },
+  "modelSettingsPanel.presencePenaltyDescription": {
+    "defaultMessage": "0.0 = tắt"
+  },
+  "modelSettingsPanel.repeatPenalty": {
+    "defaultMessage": "Phạt lặp lại"
+  },
+  "modelSettingsPanel.repeatPenaltyDescription": {
+    "defaultMessage": "1.0 = tắt"
+  },
+  "modelSettingsPanel.repeatWindow": {
+    "defaultMessage": "Cửa sổ lặp lại"
+  },
+  "modelSettingsPanel.repeatWindowDescription": {
+    "defaultMessage": "Số token cần xem lại"
+  },
+  "modelSettingsPanel.repetitionPenalty": {
+    "defaultMessage": "Phạt lặp lại"
+  },
+  "modelSettingsPanel.reset": {
+    "defaultMessage": "Đặt lại"
+  },
+  "modelSettingsPanel.resetToDefaults": {
+    "defaultMessage": "Đặt lại về mặc định"
+  },
+  "modelSettingsPanel.samplingStrategy": {
+    "defaultMessage": "Chiến lược lấy mẫu"
+  },
+  "modelSettingsPanel.saving": {
+    "defaultMessage": "Đang lưu..."
+  },
+  "modelSettingsPanel.seed": {
+    "defaultMessage": "Hạt giống"
+  },
+  "modelSettingsPanel.tauTargetEntropy": {
+    "defaultMessage": "Tau (entropy mục tiêu)"
+  },
+  "modelSettingsPanel.temperature": {
+    "defaultMessage": "Nhiệt độ"
+  },
+  "modelSettingsPanel.threads": {
+    "defaultMessage": "Luồng"
+  },
+  "modelSettingsPanel.threadsDescription": {
+    "defaultMessage": "Số luồng CPU dùng để sinh nội dung"
+  },
+  "modelSettingsPanel.toolCalling": {
+    "defaultMessage": "Gọi công cụ"
+  },
+  "modelSettingsPanel.toolCallingAuto": {
+    "defaultMessage": "Tự động"
+  },
+  "modelSettingsPanel.toolCallingDescription": {
+    "defaultMessage": "Chọn cách các mô hình cục bộ chọn gọi công cụ gốc hay mô phỏng"
+  },
+  "modelSettingsPanel.toolCallingForceEmulated": {
+    "defaultMessage": "Buộc mô phỏng"
+  },
+  "modelSettingsPanel.toolCallingForceNative": {
+    "defaultMessage": "Buộc dùng gốc"
+  },
+  "modelSettingsPanel.topK": {
+    "defaultMessage": "Top K"
+  },
+  "modelSettingsPanel.topP": {
+    "defaultMessage": "Top P"
+  },
+  "modelsBottomBar.changeModel": {
+    "defaultMessage": "Thay đổi mô hình"
+  },
+  "modelsBottomBar.currentModel": {
+    "defaultMessage": "Mô hình hiện tại"
+  },
+  "modelsBottomBar.loadingModel": {
+    "defaultMessage": "Đang tải mô hình..."
+  },
+  "modelsBottomBar.localModelSettings": {
+    "defaultMessage": "Cài đặt mô hình cục bộ"
+  },
+  "modelsBottomBar.localModelSettingsTitle": {
+    "defaultMessage": "Cài đặt mô hình cục bộ — {modelName}"
+  },
+  "modelsBottomBar.resolvedModel": {
+    "defaultMessage": "Mô hình đã phân giải"
+  },
+  "modelsBottomBar.selectModel": {
+    "defaultMessage": "Chọn mô hình"
+  },
+  "modelsSection.resetDescription": {
+    "defaultMessage": "Xóa các cài đặt mô hình và nhà cung cấp đã chọn để bắt đầu lại từ đầu"
+  },
+  "modelsSection.resetTitle": {
+    "defaultMessage": "Đặt lại nhà cung cấp và mô hình"
+  },
+  "navigation.itemApps": {
+    "defaultMessage": "Ứng dụng"
+  },
+  "navigation.itemExtensions": {
+    "defaultMessage": "Tiện ích mở rộng"
+  },
+  "navigation.itemHome": {
+    "defaultMessage": "Trò chuyện mới"
+  },
+  "navigation.itemRecipes": {
+    "defaultMessage": "Công thức"
+  },
+  "navigation.itemScheduler": {
+    "defaultMessage": "Bộ lập lịch"
+  },
+  "navigation.itemSessions": {
+    "defaultMessage": "Lịch sử phiên"
+  },
+  "navigation.itemSettings": {
+    "defaultMessage": "Cài đặt"
+  },
+  "navigation.itemSkills": {
+    "defaultMessage": "Kỹ năng"
+  },
+  "navigationPanel.chats": {
+    "defaultMessage": "Cuộc trò chuyện"
+  },
+  "navigationPanel.noChats": {
+    "defaultMessage": "Không có cuộc trò chuyện gần đây"
+  },
+  "navigationPanel.untitledSession": {
+    "defaultMessage": "Phiên chưa đặt tên"
+  },
+  "onboardingGuard.checkProviderErrorDescription": {
+    "defaultMessage": "Máy chủ có thể đang khởi động hoặc tạm thời không khả dụng."
+  },
+  "onboardingGuard.checkProviderErrorTitle": {
+    "defaultMessage": "Không thể kết nối với máy chủ Goose"
+  },
+  "onboardingGuard.retry": {
+    "defaultMessage": "Thử lại"
+  },
+  "onboardingGuard.welcomeDescription": {
+    "defaultMessage": "Tác nhân AI cục bộ của bạn. Kết nối một nhà cung cấp mô hình AI để bắt đầu."
+  },
+  "onboardingGuard.welcomeTitle": {
+    "defaultMessage": "Chào mừng đến với goose"
+  },
+  "onboardingSuccess.allSet": {
+    "defaultMessage": "Bạn đã sẵn sàng bắt đầu sử dụng goose."
+  },
+  "onboardingSuccess.connectedTo": {
+    "defaultMessage": "Đã kết nối với {providerName}"
+  },
+  "onboardingSuccess.getStarted": {
+    "defaultMessage": "Bắt đầu"
+  },
+  "onboardingSuccess.learnMore": {
+    "defaultMessage": "Tìm hiểu thêm"
+  },
+  "onboardingSuccess.localModelReady": {
+    "defaultMessage": "Mô hình cục bộ đã sẵn sàng"
+  },
+  "onboardingSuccess.privacyDescription": {
+    "defaultMessage": "Dữ liệu sử dụng ẩn danh giúp cải thiện goose. Chúng tôi không bao giờ thu thập cuộc trò chuyện, mã nguồn hoặc dữ liệu cá nhân của bạn."
+  },
+  "onboardingSuccess.privacyTitle": {
+    "defaultMessage": "Quyền riêng tư"
+  },
+  "onboardingSuccess.shareUsageData": {
+    "defaultMessage": "Chia sẻ dữ liệu sử dụng ẩn danh"
+  },
+  "parameterInput.defaultValue": {
+    "defaultMessage": "Giá trị mặc định"
+  },
+  "parameterInput.defaultValuePlaceholder": {
+    "defaultMessage": "Nhập giá trị mặc định"
+  },
+  "parameterInput.deleteParameter": {
+    "defaultMessage": "Xóa tham số: {key}"
+  },
+  "parameterInput.description": {
+    "defaultMessage": "mô tả"
+  },
+  "parameterInput.descriptionHelp": {
+    "defaultMessage": "Đây là thông báo mà người dùng cuối sẽ thấy."
+  },
+  "parameterInput.descriptionPlaceholder": {
+    "defaultMessage": "Ví dụ: \"Nhập tên cho thành phần mới\""
+  },
+  "parameterInput.inputType": {
+    "defaultMessage": "Kiểu nhập"
+  },
+  "parameterInput.optional": {
+    "defaultMessage": "Tùy chọn"
+  },
+  "parameterInput.optionsHelp": {
+    "defaultMessage": "Nhập mỗi lựa chọn trên một dòng mới. Các lựa chọn này sẽ hiển thị dưới dạng danh sách thả xuống."
+  },
+  "parameterInput.optionsLabel": {
+    "defaultMessage": "Lựa chọn (mỗi dòng một lựa chọn)"
+  },
+  "parameterInput.optionsPlaceholder": {
+    "defaultMessage": "Lựa chọn 1 Lựa chọn 2 Lựa chọn 3"
+  },
+  "parameterInput.required": {
+    "defaultMessage": "Bắt buộc"
+  },
+  "parameterInput.requirement": {
+    "defaultMessage": "Yêu cầu"
+  },
+  "parameterInput.typeBoolean": {
+    "defaultMessage": "Boolean"
+  },
+  "parameterInput.typeNumber": {
+    "defaultMessage": "Số"
+  },
+  "parameterInput.typeSelect": {
+    "defaultMessage": "Lựa chọn"
+  },
+  "parameterInput.typeString": {
+    "defaultMessage": "Chuỗi"
+  },
+  "parameterInput.unused": {
+    "defaultMessage": "Không dùng"
+  },
+  "parameterInput.unusedWarningTitle": {
+    "defaultMessage": "Tham số này không được sử dụng trong hướng dẫn hoặc lời nhắc. Nó sẽ khả dụng để nhập thủ công nhưng có thể không cần thiết."
+  },
+  "parameterInputModal.backToForm": {
+    "defaultMessage": "Quay lại biểu mẫu tham số"
+  },
+  "parameterInputModal.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "parameterInputModal.cancelRecipeSetup": {
+    "defaultMessage": "Hủy thiết lập công thức"
+  },
+  "parameterInputModal.enterValue": {
+    "defaultMessage": "Nhập giá trị cho {key}..."
+  },
+  "parameterInputModal.false": {
+    "defaultMessage": "Sai"
+  },
+  "parameterInputModal.recipeParameters": {
+    "defaultMessage": "Tham số công thức"
+  },
+  "parameterInputModal.select": {
+    "defaultMessage": "Chọn..."
+  },
+  "parameterInputModal.selectOption": {
+    "defaultMessage": "Chọn một lựa chọn..."
+  },
+  "parameterInputModal.startNewChat": {
+    "defaultMessage": "Bắt đầu trò chuyện mới (Không dùng công thức)"
+  },
+  "parameterInputModal.startRecipe": {
+    "defaultMessage": "Bắt đầu công thức"
+  },
+  "parameterInputModal.true": {
+    "defaultMessage": "Đúng"
+  },
+  "parameterInputModal.whatToDo": {
+    "defaultMessage": "Bạn muốn làm gì?"
+  },
+  "permissionModal.alwaysAllow": {
+    "defaultMessage": "Luôn cho phép"
+  },
+  "permissionModal.askBefore": {
+    "defaultMessage": "Hỏi trước"
+  },
+  "permissionModal.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "permissionModal.close": {
+    "defaultMessage": "Đóng"
+  },
+  "permissionModal.failedToLoadTools": {
+    "defaultMessage": "Không tải được công cụ"
+  },
+  "permissionModal.failedToLoadToolsDescription": {
+    "defaultMessage": "Không thể tải công cụ cho phần mở rộng này. Phần mở rộng có thể chưa được tải trong phiên hiện tại."
+  },
+  "permissionModal.neverAllow": {
+    "defaultMessage": "Không bao giờ cho phép"
+  },
+  "permissionModal.noActiveSession": {
+    "defaultMessage": "Không có phiên đang hoạt động"
+  },
+  "permissionModal.noActiveSessionDescription": {
+    "defaultMessage": "Hãy bắt đầu một phiên trò chuyện trước để cấu hình quyền công cụ cho phần mở rộng này. Quyền công cụ được tải từ các phần mở rộng của phiên đang hoạt động."
+  },
+  "permissionModal.noToolsAvailable": {
+    "defaultMessage": "Không có công cụ nào khả dụng cho phần mở rộng này."
+  },
+  "permissionModal.saveChanges": {
+    "defaultMessage": "Lưu thay đổi"
+  },
+  "permissionRulesModal.description": {
+    "defaultMessage": "Cấu hình quyền công cụ cho các phần mở rộng để kiểm soát cách chúng tương tác với hệ thống của bạn."
+  },
+  "permissionRulesModal.extensionRules": {
+    "defaultMessage": "Quy tắc phần mở rộng"
+  },
+  "permissionRulesModal.title": {
+    "defaultMessage": "Quy tắc quyền"
+  },
+  "permissionSetting.extensionRules": {
+    "defaultMessage": "Quy tắc phần mở rộng"
+  },
+  "permissionSetting.permissionRules": {
+    "defaultMessage": "Quy tắc quyền"
+  },
+  "permissionSetting.permissionRulesDescription": {
+    "defaultMessage": "Các hướng dẫn ẩn sẽ được chuyển đến nhà cung cấp để giúp định hướng và bổ sung ngữ cảnh cho các phản hồi của bạn."
+  },
+  "privacyInfoModal.collectErrors": {
+    "defaultMessage": "Loại lỗi (ví dụ: \"rate_limit\", \"auth\" - không có chi tiết)"
+  },
+  "privacyInfoModal.collectExtensions": {
+    "defaultMessage": "Số lần sử dụng phần mở rộng và công cụ (chỉ tên)"
+  },
+  "privacyInfoModal.collectOs": {
+    "defaultMessage": "Hệ điều hành, phiên bản và kiến trúc"
+  },
+  "privacyInfoModal.collectProvider": {
+    "defaultMessage": "Nhà cung cấp và mô hình được sử dụng"
+  },
+  "privacyInfoModal.collectSession": {
+    "defaultMessage": "Số liệu phiên (thời lượng, số lần tương tác, lượng token sử dụng)"
+  },
+  "privacyInfoModal.collectVersion": {
+    "defaultMessage": "Phiên bản goose và phương thức cài đặt"
+  },
+  "privacyInfoModal.description": {
+    "defaultMessage": "Dữ liệu sử dụng ẩn danh giúp chúng tôi hiểu cách goose được sử dụng và xác định các lĩnh vực cần cải thiện."
+  },
+  "privacyInfoModal.neverCollect": {
+    "defaultMessage": "Chúng tôi không bao giờ thu thập cuộc trò chuyện, mã nguồn, đối số công cụ, thông báo lỗi hoặc bất kỳ dữ liệu cá nhân nào của bạn. Bạn có thể thay đổi cài đặt này bất cứ lúc nào trong Cài đặt."
+  },
+  "privacyInfoModal.title": {
+    "defaultMessage": "Chi tiết quyền riêng tư"
+  },
+  "privacyInfoModal.whatWeCollect": {
+    "defaultMessage": "Những gì chúng tôi thu thập:"
+  },
+  "progressiveMessageList.loadingMessages": {
+    "defaultMessage": "Đang tải tin nhắn... ({renderedCount}/{totalCount})"
+  },
+  "progressiveMessageList.modelChanged": {
+    "defaultMessage": "Mô hình đã thay đổi: {previousModel} → {currentModel}"
+  },
+  "progressiveMessageList.searchHint": {
+    "defaultMessage": "Nhấn Cmd/Ctrl+F để tải ngay tất cả tin nhắn nhằm tìm kiếm"
+  },
+  "promptsSettings.allPromptsReset": {
+    "defaultMessage": "Tất cả lời nhắc đã được đặt lại về mặc định"
+  },
+  "promptsSettings.backToList": {
+    "defaultMessage": "Quay lại danh sách"
+  },
+  "promptsSettings.confirmReplaceWithDefault": {
+    "defaultMessage": "Thay thế nội dung hiện tại bằng mặc định? Các thay đổi của bạn sẽ bị mất."
+  },
+  "promptsSettings.confirmResetAll": {
+    "defaultMessage": "Bạn có chắc chắn muốn đặt lại tất cả lời nhắc về mặc định không? Thao tác này không thể hoàn tác."
+  },
+  "promptsSettings.confirmResetOne": {
+    "defaultMessage": "Bạn có chắc chắn muốn đặt lại lời nhắc này về mặc định không? Thao tác này không thể hoàn tác."
+  },
+  "promptsSettings.confirmUnsavedBack": {
+    "defaultMessage": "Bạn có các thay đổi chưa lưu. Bạn có chắc chắn muốn quay lại không?"
+  },
+  "promptsSettings.customized": {
+    "defaultMessage": "Đã tùy chỉnh"
+  },
+  "promptsSettings.edit": {
+    "defaultMessage": "Chỉnh sửa"
+  },
+  "promptsSettings.editPromptTitle": {
+    "defaultMessage": "Chỉnh sửa: {name}"
+  },
+  "promptsSettings.editingLabel": {
+    "defaultMessage": "Đang chỉnh sửa: {name}"
+  },
+  "promptsSettings.enterPromptContent": {
+    "defaultMessage": "Nhập nội dung lời nhắc..."
+  },
+  "promptsSettings.failedToLoadPrompt": {
+    "defaultMessage": "Không tải được lời nhắc"
+  },
+  "promptsSettings.failedToLoadPrompts": {
+    "defaultMessage": "Không tải được các lời nhắc"
+  },
+  "promptsSettings.failedToResetPrompt": {
+    "defaultMessage": "Không đặt lại được lời nhắc"
+  },
+  "promptsSettings.failedToResetPrompts": {
+    "defaultMessage": "Không đặt lại được các lời nhắc"
+  },
+  "promptsSettings.failedToSavePrompt": {
+    "defaultMessage": "Không lưu được lời nhắc"
+  },
+  "promptsSettings.promptEditingDescription": {
+    "defaultMessage": "Tùy chỉnh các lời nhắc xác định hành vi của goose trong các ngữ cảnh khác nhau. Các lời nhắc này sử dụng cú pháp mẫu Jinja2. Hãy cẩn thận khi sửa đổi các biến mẫu, vì thay đổi không đúng có thể làm hỏng chức năng. Vui lòng chia sẻ mọi cải tiến với cộng đồng."
+  },
+  "promptsSettings.promptEditingTitle": {
+    "defaultMessage": "Chỉnh sửa lời nhắc"
+  },
+  "promptsSettings.promptResetToDefault": {
+    "defaultMessage": "Lời nhắc đã được đặt lại về mặc định"
+  },
+  "promptsSettings.promptSaved": {
+    "defaultMessage": "Lời nhắc đã được lưu"
+  },
+  "promptsSettings.resetAll": {
+    "defaultMessage": "Đặt lại tất cả"
+  },
+  "promptsSettings.resetToDefault": {
+    "defaultMessage": "Đặt lại về mặc định"
+  },
+  "promptsSettings.restoreDefault": {
+    "defaultMessage": "Khôi phục mặc định"
+  },
+  "promptsSettings.save": {
+    "defaultMessage": "Lưu"
+  },
+  "promptsSettings.templateTip": {
+    "defaultMessage": "Các biến mẫu như {extensionsExample} hoặc {forExample} được thay thế bằng giá trị thực tế khi chạy. Hãy cẩn thận không xóa các biến bắt buộc."
+  },
+  "promptsSettings.unsavedChanges": {
+    "defaultMessage": "Bạn có các thay đổi chưa lưu"
+  },
+  "providerCard.noMetadata": {
+    "defaultMessage": "Lỗi ProviderCard: Không có metadata được cung cấp"
+  },
+  "providerCard.unknownProvider": {
+    "defaultMessage": "Nhà cung cấp không xác định"
+  },
+  "providerCatalogPicker.anthropicCompatible": {
+    "defaultMessage": "Tương thích Anthropic"
+  },
+  "providerCatalogPicker.apiFormat": {
+    "defaultMessage": "Định dạng API"
+  },
+  "providerCatalogPicker.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "providerCatalogPicker.chooseProvider": {
+    "defaultMessage": "Chọn nhà cung cấp"
+  },
+  "providerCatalogPicker.errorPrefix": {
+    "defaultMessage": "Lỗi: {error}"
+  },
+  "providerCatalogPicker.loadingProviders": {
+    "defaultMessage": "Đang tải nhà cung cấp..."
+  },
+  "providerCatalogPicker.modelsAvailable": {
+    "defaultMessage": "{count} mô hình khả dụng"
+  },
+  "providerCatalogPicker.noProvidersAvailable": {
+    "defaultMessage": "Không có nhà cung cấp nào khả dụng"
+  },
+  "providerCatalogPicker.noProvidersFound": {
+    "defaultMessage": "Không tìm thấy nhà cung cấp nào cho \"{query}\""
+  },
+  "providerCatalogPicker.openaiCompatible": {
+    "defaultMessage": "Tương thích OpenAI"
+  },
+  "providerCatalogPicker.requiresEnvVar": {
+    "defaultMessage": "• Yêu cầu {envVar}"
+  },
+  "providerCatalogPicker.searchProviders": {
+    "defaultMessage": "Tìm kiếm nhà cung cấp..."
+  },
+  "providerCatalogPicker.selectFormatDescription": {
+    "defaultMessage": "Chọn một định dạng API và nhà cung cấp. Chúng tôi sẽ tự động điền cấu hình cho bạn."
+  },
+  "providerConfigForm.browserWindowOpen": {
+    "defaultMessage": "Một cửa sổ trình duyệt sẽ mở ra để bạn hoàn tất đăng nhập."
+  },
+  "providerConfigForm.configuring": {
+    "defaultMessage": "Đang cấu hình..."
+  },
+  "providerConfigForm.continue": {
+    "defaultMessage": "Tiếp tục"
+  },
+  "providerConfigForm.deviceCodeFlowHint": {
+    "defaultMessage": "Một cửa sổ trình duyệt sẽ mở ra và mã xác minh sẽ được sao chép vào bộ nhớ tạm của bạn. Dán mã vào trình duyệt để hoàn tất đăng nhập."
+  },
+  "providerConfigForm.noApiKey": {
+    "defaultMessage": "Bạn chưa có khóa API?"
+  },
+  "providerConfigForm.signInWith": {
+    "defaultMessage": "Đăng nhập bằng {providerName}"
+  },
+  "providerConfigForm.signingIn": {
+    "defaultMessage": "Đang đăng nhập..."
+  },
+  "providerConfigurationModal.addApiKeyDescription": {
+    "defaultMessage": "Thêm khóa API của bạn cho nhà cung cấp này để tích hợp vào goose"
+  },
+  "providerConfigurationModal.browserWindowHint": {
+    "defaultMessage": "Một cửa sổ trình duyệt sẽ mở ra để bạn hoàn tất đăng nhập."
+  },
+  "providerConfigurationModal.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "providerConfigurationModal.cannotDeleteActive": {
+    "defaultMessage": "Bạn không thể xóa nhà cung cấp này trong khi nó đang được sử dụng. Vui lòng chuyển sang mô hình khác trước."
+  },
+  "providerConfigurationModal.checkConfigAgain": {
+    "defaultMessage": "Kiểm tra lại cấu hình của bạn để sử dụng nhà cung cấp này."
+  },
+  "providerConfigurationModal.close": {
+    "defaultMessage": "Đóng"
+  },
+  "providerConfigurationModal.configureHeader": {
+    "defaultMessage": "Cấu hình {providerName}"
+  },
+  "providerConfigurationModal.deleteConfigHeader": {
+    "defaultMessage": "Xóa cấu hình cho {providerName}"
+  },
+  "providerConfigurationModal.deleteConfirmation": {
+    "defaultMessage": "Thao tác này sẽ xóa vĩnh viễn cấu hình nhà cung cấp hiện tại."
+  },
+  "providerConfigurationModal.deviceCodeFlowHint": {
+    "defaultMessage": "Một cửa sổ trình duyệt sẽ mở ra và mã xác minh sẽ được sao chép vào bộ nhớ tạm của bạn. Dán mã vào trình duyệt để hoàn tất đăng nhập."
+  },
+  "providerConfigurationModal.errorCheckingConfig": {
+    "defaultMessage": "Đã xảy ra lỗi khi kiểm tra cấu hình nhà cung cấp này."
+  },
+  "providerConfigurationModal.errorTitle": {
+    "defaultMessage": "Lỗi"
+  },
+  "providerConfigurationModal.externalSetupIntro": {
+    "defaultMessage": "Nhà cung cấp này được cấu hình bên ngoài goose. Hãy làm theo các bước sau:"
+  },
+  "providerConfigurationModal.goBack": {
+    "defaultMessage": "Quay lại"
+  },
+  "providerConfigurationModal.huggingFaceOAuthDescription": {
+    "defaultMessage": "Đăng nhập để sử dụng Hugging Face Inference Providers mà không cần nhập thủ công token API."
+  },
+  "providerConfigurationModal.oauthLoginFailed": {
+    "defaultMessage": "Đăng nhập OAuth thất bại: {error}"
+  },
+  "providerConfigurationModal.oauthSignInDescription": {
+    "defaultMessage": "Đăng nhập bằng tài khoản {providerName} của bạn để sử dụng nhà cung cấp này"
+  },
+  "providerConfigurationModal.parameterRequired": {
+    "defaultMessage": "{paramName} là bắt buộc"
+  },
+  "providerConfigurationModal.removeConfiguration": {
+    "defaultMessage": "Xóa cấu hình"
+  },
+  "providerConfigurationModal.seeDocumentation": {
+    "defaultMessage": "Xem <link>tài liệu</link> để biết thêm chi tiết."
+  },
+  "providerConfigurationModal.signInWith": {
+    "defaultMessage": "Đăng nhập bằng {providerName}"
+  },
+  "providerConfigurationModal.signingIn": {
+    "defaultMessage": "Đang đăng nhập..."
+  },
+  "providerGrid.addProvider": {
+    "defaultMessage": "Thêm nhà cung cấp"
+  },
+  "providerGrid.addProviderTitle": {
+    "defaultMessage": "Thêm nhà cung cấp"
+  },
+  "providerGrid.chooseModel": {
+    "defaultMessage": "Chọn mô hình"
+  },
+  "providerGrid.configureProvider": {
+    "defaultMessage": "Cấu hình nhà cung cấp"
+  },
+  "providerGrid.editProvider": {
+    "defaultMessage": "Chỉnh sửa nhà cung cấp"
+  },
+  "providerGrid.fromTemplateOrManual": {
+    "defaultMessage": "Từ mẫu hoặc thiết lập thủ công"
+  },
+  "providerLogo.alt": {
+    "defaultMessage": "Logo {providerName}"
+  },
+  "providerSelector.addCustomProvider": {
+    "defaultMessage": "Thêm nhà cung cấp tùy chỉnh"
+  },
+  "providerSelector.addCustomProviderTitle": {
+    "defaultMessage": "Thêm nhà cung cấp tùy chỉnh"
+  },
+  "providerSelector.connectProvider": {
+    "defaultMessage": "Kết nối với nhà cung cấp"
+  },
+  "providerSelector.connectProviderDescription": {
+    "defaultMessage": "Kết nối OpenAI, Anthropic, Google, v.v."
+  },
+  "providerSelector.freeLocalDescription": {
+    "defaultMessage": "Sử dụng mô hình cục bộ hoặc nhà cung cấp có tín dụng miễn phí"
+  },
+  "providerSelector.selectProvider": {
+    "defaultMessage": "Chọn một nhà cung cấp"
+  },
+  "providerSelector.useFreeLocal": {
+    "defaultMessage": "Sử dụng nhà cung cấp Miễn phí/Cục bộ"
+  },
+  "providerSettings.configurationSettings": {
+    "defaultMessage": "Cài đặt cấu hình nhà cung cấp"
+  },
+  "providerSettings.loadingProviders": {
+    "defaultMessage": "Đang tải nhà cung cấp..."
+  },
+  "providerSettings.onboardingDescription": {
+    "defaultMessage": "Chọn một nhà cung cấp mô hình AI để bắt đầu với goose. Bạn sẽ cần sử dụng khóa API do mỗi nhà cung cấp tạo ra, khóa này sẽ được mã hóa và lưu trữ cục bộ. Bạn có thể thay đổi nhà cung cấp bất cứ lúc nào trong cài đặt."
+  },
+  "providerSettings.otherProviders": {
+    "defaultMessage": "Nhà cung cấp khác"
+  },
+  "providerSetupActions.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "providerSetupActions.cannotDeleteActive": {
+    "defaultMessage": "Bạn không thể xóa {providerName} trong khi nó đang được sử dụng. Vui lòng chuyển sang mô hình khác trước khi xóa nhà cung cấp này."
+  },
+  "providerSetupActions.confirmDelete": {
+    "defaultMessage": "Xác nhận xóa"
+  },
+  "providerSetupActions.confirmDeleteMessage": {
+    "defaultMessage": "Bạn có chắc chắn muốn xóa các tham số cấu hình cho {providerName} không? Thao tác này không thể hoàn tác."
+  },
+  "providerSetupActions.deleteProvider": {
+    "defaultMessage": "Xóa nhà cung cấp"
+  },
+  "providerSetupActions.enableProvider": {
+    "defaultMessage": "Bật nhà cung cấp"
+  },
+  "providerSetupActions.ok": {
+    "defaultMessage": "Ok"
+  },
+  "providerSetupActions.submit": {
+    "defaultMessage": "Gửi"
+  },
+  "recipeActivityEditor.activitiesDescription": {
+    "defaultMessage": "Các lời nhắc nổi bật và nút hoạt động sẽ hiển thị trong cửa sổ trò chuyện công thức."
+  },
+  "recipeActivityEditor.activitiesLabel": {
+    "defaultMessage": "Hoạt động"
+  },
+  "recipeActivityEditor.activityButtonsDescription": {
+    "defaultMessage": "Các nút có thể nhấp sẽ xuất hiện bên dưới tin nhắn để giúp người dùng tương tác với công thức của bạn."
+  },
+  "recipeActivityEditor.activityButtonsLabel": {
+    "defaultMessage": "Nút hoạt động"
+  },
+  "recipeActivityEditor.addActivity": {
+    "defaultMessage": "Thêm hoạt động"
+  },
+  "recipeActivityEditor.addNewActivityPlaceholder": {
+    "defaultMessage": "Thêm hoạt động mới..."
+  },
+  "recipeActivityEditor.messageDescription": {
+    "defaultMessage": "Một tin nhắn được định dạng sẽ xuất hiện ở đầu công thức. Hỗ trợ định dạng markdown."
+  },
+  "recipeActivityEditor.messageLabel": {
+    "defaultMessage": "Tin nhắn"
+  },
+  "recipeActivityEditor.messagePlaceholder": {
+    "defaultMessage": "Nhập tin nhắn giới thiệu hướng tới người dùng cho công thức của bạn (hỗ trợ **đậm**, *nghiêng*, `mã`, v.v.)"
+  },
+  "recipeExtensionSelector.description": {
+    "defaultMessage": "Chọn các phần mở rộng sẽ khả dụng khi chạy công thức này. Để trống để sử dụng các phần mở rộng mặc định."
+  },
+  "recipeExtensionSelector.extensionsSelected": {
+    "defaultMessage": "{count,plural,one{# phần mở rộng được chọn} other{# phần mở rộng được chọn}}"
+  },
+  "recipeExtensionSelector.label": {
+    "defaultMessage": "Phần mở rộng (Tùy chọn)"
+  },
+  "recipeExtensionSelector.noExtensionsAvailable": {
+    "defaultMessage": "Không có phần mở rộng nào khả dụng"
+  },
+  "recipeExtensionSelector.noExtensionsFound": {
+    "defaultMessage": "Không tìm thấy phần mở rộng nào"
+  },
+  "recipeExtensionSelector.searchPlaceholder": {
+    "defaultMessage": "Tìm kiếm phần mở rộng..."
+  },
+  "recipeFormFields.addParameter": {
+    "defaultMessage": "Thêm tham số"
+  },
+  "recipeFormFields.advancedOptions": {
+    "defaultMessage": "Tùy chọn nâng cao"
+  },
+  "recipeFormFields.advancedOptionsHint": {
+    "defaultMessage": "Hoạt động, tham số, mô hình, phần mở rộng, lược đồ phản hồi, công thức con"
+  },
+  "recipeFormFields.descriptionLabel": {
+    "defaultMessage": "Mô tả"
+  },
+  "recipeFormFields.descriptionPlaceholder": {
+    "defaultMessage": "Mô tả ngắn gọn về chức năng của công thức này"
+  },
+  "recipeFormFields.enterValueFor": {
+    "defaultMessage": "Nhập giá trị cho {key}"
+  },
+  "recipeFormFields.initialPrompt": {
+    "defaultMessage": "Lời nhắc ban đầu"
+  },
+  "recipeFormFields.instructionsLabel": {
+    "defaultMessage": "Hướng dẫn"
+  },
+  "recipeFormFields.instructionsPlaceholder": {
+    "defaultMessage": "Hướng dẫn chi tiết cho AI, ẩn khỏi người dùng"
+  },
+  "recipeFormFields.openEditor": {
+    "defaultMessage": "Mở trình chỉnh sửa"
+  },
+  "recipeFormFields.parameterNamePlaceholder": {
+    "defaultMessage": "Nhập tên tham số..."
+  },
+  "recipeFormFields.parametersDescription": {
+    "defaultMessage": "Tham số sẽ được tự động phát hiện từ cú pháp '{{parameter_name}}' trong hướng dẫn/lời nhắc/hoạt động, hoặc bạn có thể thêm thủ công bên dưới."
+  },
+  "recipeFormFields.parametersLabel": {
+    "defaultMessage": "Tham số"
+  },
+  "recipeFormFields.promptOptionalHint": {
+    "defaultMessage": "(Tùy chọn - Bắt buộc có Hướng dẫn hoặc Lời nhắc)"
+  },
+  "recipeFormFields.promptPlaceholder": {
+    "defaultMessage": "Lời nhắc điền sẵn khi công thức bắt đầu"
+  },
+  "recipeFormFields.responseJsonSchema": {
+    "defaultMessage": "Lược đồ JSON phản hồi"
+  },
+  "recipeFormFields.responseJsonSchemaDescription": {
+    "defaultMessage": "Xác định cấu trúc mong đợi của phản hồi từ AI bằng định dạng JSON Schema"
+  },
+  "recipeFormFields.templateVarHint": {
+    "defaultMessage": "Dùng '{{parameter_name}}' để định nghĩa các tham số có thể điền khi chạy công thức."
+  },
+  "recipeFormFields.titleLabel": {
+    "defaultMessage": "Tiêu đề"
+  },
+  "recipeFormFields.titlePlaceholder": {
+    "defaultMessage": "Tiêu đề công thức"
+  },
+  "recipeHeader.recipeLabel": {
+    "defaultMessage": "Công thức"
+  },
+  "recipeModelSelector.backToModelList": {
+    "defaultMessage": "Quay lại danh sách mô hình"
+  },
+  "recipeModelSelector.enterCustomModel": {
+    "defaultMessage": "Nhập tên mô hình tùy chỉnh"
+  },
+  "recipeModelSelector.enterModelNotListed": {
+    "defaultMessage": "Nhập một mô hình không có trong danh sách..."
+  },
+  "recipeModelSelector.fetchError": {
+    "defaultMessage": "Không lấy được danh sách mô hình. Vui lòng thử lại sau."
+  },
+  "recipeModelSelector.loadingModels": {
+    "defaultMessage": "Đang tải mô hình…"
+  },
+  "recipeModelSelector.modelHint": {
+    "defaultMessage": "Để trống để sử dụng mô hình mặc định cho nhà cung cấp đã chọn"
+  },
+  "recipeModelSelector.modelLabel": {
+    "defaultMessage": "Mô hình (Tùy chọn)"
+  },
+  "recipeModelSelector.providerHint": {
+    "defaultMessage": "Để trống để sử dụng nhà cung cấp mặc định đã cấu hình trong cài đặt"
+  },
+  "recipeModelSelector.providerLabel": {
+    "defaultMessage": "Nhà cung cấp (Tùy chọn)"
+  },
+  "recipeModelSelector.selectModel": {
+    "defaultMessage": "Chọn một mô hình"
+  },
+  "recipeModelSelector.selectProvider": {
+    "defaultMessage": "Chọn nhà cung cấp"
+  },
+  "recipeModelSelector.useDefaultProvider": {
+    "defaultMessage": "Sử dụng nhà cung cấp mặc định"
+  },
+  "recipeNameField.defaultLabel": {
+    "defaultMessage": "Tên công thức"
+  },
+  "recipeNameField.formatHint": {
+    "defaultMessage": "Sẽ được định dạng tự động (chữ thường, dấu gạch ngang thay cho khoảng trắng)"
+  },
+  "recipeWarningModal.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "recipeWarningModal.descriptionLabel": {
+    "defaultMessage": "Mô tả:"
+  },
+  "recipeWarningModal.firstTimeDescription": {
+    "defaultMessage": "Bạn sắp thực thi một công thức mà bạn chưa từng chạy trước đây."
+  },
+  "recipeWarningModal.hiddenCharsWarning": {
+    "defaultMessage": "Công thức này chứa các ký tự ẩn sẽ bị bỏ qua vì sự an toàn của bạn, vì chúng có thể được sử dụng cho mục đích độc hại."
+  },
+  "recipeWarningModal.instructionsLabel": {
+    "defaultMessage": "Hướng dẫn:"
+  },
+  "recipeWarningModal.newRecipeWarningTitle": {
+    "defaultMessage": "⚠️ Cảnh báo công thức mới"
+  },
+  "recipeWarningModal.recipePreview": {
+    "defaultMessage": "Xem trước công thức:"
+  },
+  "recipeWarningModal.securityWarningTitle": {
+    "defaultMessage": "⚠️ Cảnh báo bảo mật"
+  },
+  "recipeWarningModal.titleLabel": {
+    "defaultMessage": "Tiêu đề:"
+  },
+  "recipeWarningModal.trustAndExecute": {
+    "defaultMessage": "Tin cậy và thực thi"
+  },
+  "recipeWarningModal.trustSource": {
+    "defaultMessage": "Chỉ tiếp tục nếu bạn tin cậy nguồn của công thức này."
+  },
+  "recipesView.addSchedule": {
+    "defaultMessage": "Thêm lịch"
+  },
+  "recipesView.addSlashCommand": {
+    "defaultMessage": "Thêm lệnh gạch chéo"
+  },
+  "recipesView.adjustSearchTerms": {
+    "defaultMessage": "Thử điều chỉnh từ khóa tìm kiếm của bạn"
+  },
+  "recipesView.allFiles": {
+    "defaultMessage": "Tất cả tệp"
+  },
+  "recipesView.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "recipesView.copyDeeplink": {
+    "defaultMessage": "Sao chép deeplink"
+  },
+  "recipesView.copyDeeplinkFailedMsg": {
+    "defaultMessage": "Không sao chép được deeplink vào bộ nhớ tạm"
+  },
+  "recipesView.copyFailedTitle": {
+    "defaultMessage": "Sao chép thất bại"
+  },
+  "recipesView.copyYaml": {
+    "defaultMessage": "Sao chép YAML"
+  },
+  "recipesView.copyYamlFailedMsg": {
+    "defaultMessage": "Không sao chép được YAML công thức vào bộ nhớ tạm"
+  },
+  "recipesView.createRecipe": {
+    "defaultMessage": "Tạo công thức"
+  },
+  "recipesView.deeplinkCopiedMsg": {
+    "defaultMessage": "Deeplink công thức đã được sao chép vào bộ nhớ tạm"
+  },
+  "recipesView.deeplinkCopiedTitle": {
+    "defaultMessage": "Đã sao chép deeplink"
+  },
+  "recipesView.deleteRecipe": {
+    "defaultMessage": "Xóa công thức"
+  },
+  "recipesView.deleteRecipeConfirm": {
+    "defaultMessage": "Bạn có chắc chắn muốn xóa \"{title}\" không?"
+  },
+  "recipesView.deleteRecipeDetail": {
+    "defaultMessage": "Tệp công thức sẽ bị xóa."
+  },
+  "recipesView.deleteRecipeTitle": {
+    "defaultMessage": "Xóa công thức"
+  },
+  "recipesView.editRecipe": {
+    "defaultMessage": "Chỉnh sửa công thức"
+  },
+  "recipesView.editSchedule": {
+    "defaultMessage": "Chỉnh sửa lịch"
+  },
+  "recipesView.editSlashCommand": {
+    "defaultMessage": "Chỉnh sửa lệnh gạch chéo"
+  },
+  "recipesView.errorLoadingRecipes": {
+    "defaultMessage": "Lỗi khi tải công thức"
+  },
+  "recipesView.exportFailedMsg": {
+    "defaultMessage": "Không xuất được công thức ra tệp"
+  },
+  "recipesView.exportFailedTitle": {
+    "defaultMessage": "Xuất thất bại"
+  },
+  "recipesView.exportRecipeDialogTitle": {
+    "defaultMessage": "Xuất công thức"
+  },
+  "recipesView.exportToFile": {
+    "defaultMessage": "Xuất ra tệp"
+  },
+  "recipesView.noMatchingRecipes": {
+    "defaultMessage": "Không tìm thấy công thức phù hợp"
+  },
+  "recipesView.noSavedRecipes": {
+    "defaultMessage": "Chưa có công thức nào được lưu"
+  },
+  "recipesView.noSavedRecipesDescription": {
+    "defaultMessage": "Các công thức được lưu từ cuộc trò chuyện sẽ hiển thị ở đây."
+  },
+  "recipesView.openInNewWindow": {
+    "defaultMessage": "Mở trong cửa sổ mới"
+  },
+  "recipesView.recipeDeletedSuccess": {
+    "defaultMessage": "Đã xóa công thức thành công"
+  },
+  "recipesView.recipeExportedMsg": {
+    "defaultMessage": "Đã lưu công thức vào {filePath}"
+  },
+  "recipesView.recipeExportedTitle": {
+    "defaultMessage": "Đã xuất công thức"
+  },
+  "recipesView.recipesDescription": {
+    "defaultMessage": "Xem và quản lý các công thức đã lưu để nhanh chóng bắt đầu phiên mới với các cấu hình định sẵn. {shortcut} để tìm kiếm."
+  },
+  "recipesView.recipesTitle": {
+    "defaultMessage": "Công thức"
+  },
+  "recipesView.remove": {
+    "defaultMessage": "Xóa"
+  },
+  "recipesView.removeSchedule": {
+    "defaultMessage": "Xóa lịch trình"
+  },
+  "recipesView.runs": {
+    "defaultMessage": "Chạy {schedule}"
+  },
+  "recipesView.save": {
+    "defaultMessage": "Lưu"
+  },
+  "recipesView.scheduleDialogTitle": {
+    "defaultMessage": "{action} lịch trình"
+  },
+  "recipesView.scheduleRemovedMsg": {
+    "defaultMessage": "Công thức sẽ không còn chạy tự động nữa"
+  },
+  "recipesView.scheduleRemovedTitle": {
+    "defaultMessage": "Đã xóa lịch trình"
+  },
+  "recipesView.scheduleSavedMsg": {
+    "defaultMessage": "Công thức sẽ chạy {schedule}"
+  },
+  "recipesView.scheduleSavedTitle": {
+    "defaultMessage": "Đã lưu lịch trình"
+  },
+  "recipesView.searchRecipesPlaceholder": {
+    "defaultMessage": "Tìm công thức..."
+  },
+  "recipesView.shareRecipe": {
+    "defaultMessage": "Chia sẻ công thức"
+  },
+  "recipesView.slashCommandDescription": {
+    "defaultMessage": "Đặt một lệnh gạch chéo để nhanh chóng chạy công thức này từ bất kỳ cuộc trò chuyện nào"
+  },
+  "recipesView.slashCommandPlaceholder": {
+    "defaultMessage": "command-name"
+  },
+  "recipesView.slashCommandRemovedMsg": {
+    "defaultMessage": "Đã xóa lệnh gạch chéo của công thức"
+  },
+  "recipesView.slashCommandRemovedTitle": {
+    "defaultMessage": "Đã xóa lệnh gạch chéo"
+  },
+  "recipesView.slashCommandSavedMsg": {
+    "defaultMessage": "Dùng /{command} để chạy công thức này"
+  },
+  "recipesView.slashCommandSavedTitle": {
+    "defaultMessage": "Đã lưu lệnh gạch chéo"
+  },
+  "recipesView.slashCommandTitle": {
+    "defaultMessage": "Lệnh gạch chéo"
+  },
+  "recipesView.slashCommandUsageHint": {
+    "defaultMessage": "Dùng /{command} trong bất kỳ cuộc trò chuyện nào để chạy công thức này"
+  },
+  "recipesView.tryAgain": {
+    "defaultMessage": "Thử lại"
+  },
+  "recipesView.useRecipe": {
+    "defaultMessage": "Dùng công thức"
+  },
+  "recipesView.yamlCopiedMsg": {
+    "defaultMessage": "Đã sao chép YAML của công thức vào bộ nhớ tạm"
+  },
+  "recipesView.yamlCopiedTitle": {
+    "defaultMessage": "Đã sao chép YAML"
+  },
+  "recipesView.yamlFiles": {
+    "defaultMessage": "Tệp YAML"
+  },
+  "resetProviderSection.resetButton": {
+    "defaultMessage": "Đặt lại nhà cung cấp và mô hình"
+  },
+  "resetProviderSection.resetDescription": {
+    "defaultMessage": "Thao tác này sẽ xóa cài đặt mô hình và nhà cung cấp đã chọn của bạn. Nếu không có giá trị mặc định nào khả dụng, bạn sẽ được đưa đến màn hình chào mừng để thiết lập lại."
+  },
+  "responseStyle.conciseDescription": {
+    "defaultMessage": "Theo mặc định, các lệnh gọi công cụ được đóng lại và chỉ hiển thị công cụ đã dùng"
+  },
+  "responseStyle.conciseLabel": {
+    "defaultMessage": "Ngắn gọn"
+  },
+  "responseStyle.detailedDescription": {
+    "defaultMessage": "Theo mặc định, các lệnh gọi công cụ được hiển thị mở ra để lộ chi tiết"
+  },
+  "responseStyle.detailedLabel": {
+    "defaultMessage": "Chi tiết"
+  },
+  "scheduleDetailView.actions": {
+    "defaultMessage": "Hành động"
+  },
+  "scheduleDetailView.cannotModifyRunning": {
+    "defaultMessage": "Không thể kích hoạt hoặc sửa đổi lịch trình khi nó đang chạy."
+  },
+  "scheduleDetailView.completedSession": {
+    "defaultMessage": "Phiên: {sessionId}"
+  },
+  "scheduleDetailView.created": {
+    "defaultMessage": "Đã tạo: {date}"
+  },
+  "scheduleDetailView.cronExpression": {
+    "defaultMessage": "Biểu thức Cron:"
+  },
+  "scheduleDetailView.currentSession": {
+    "defaultMessage": "Phiên hiện tại:"
+  },
+  "scheduleDetailView.currentlyRunning": {
+    "defaultMessage": "Đang chạy"
+  },
+  "scheduleDetailView.dir": {
+    "defaultMessage": "Thư mục: {path}"
+  },
+  "scheduleDetailView.editSchedule": {
+    "defaultMessage": "Sửa lịch trình"
+  },
+  "scheduleDetailView.errorPrefix": {
+    "defaultMessage": "Lỗi: {error}"
+  },
+  "scheduleDetailView.idLabel": {
+    "defaultMessage": "ID:"
+  },
+  "scheduleDetailView.inspectJobError": {
+    "defaultMessage": "Lỗi kiểm tra công việc"
+  },
+  "scheduleDetailView.inspectNoInfo": {
+    "defaultMessage": "Không có thông tin chi tiết"
+  },
+  "scheduleDetailView.inspectRunningJob": {
+    "defaultMessage": "Kiểm tra công việc đang chạy"
+  },
+  "scheduleDetailView.jobCancelled": {
+    "defaultMessage": "Đã hủy công việc"
+  },
+  "scheduleDetailView.jobCancelledMsg": {
+    "defaultMessage": "Công việc đã bị hủy trong khi khởi động."
+  },
+  "scheduleDetailView.jobInspection": {
+    "defaultMessage": "Kiểm tra công việc"
+  },
+  "scheduleDetailView.jobKilled": {
+    "defaultMessage": "Đã chấm dứt công việc"
+  },
+  "scheduleDetailView.killJobError": {
+    "defaultMessage": "Lỗi chấm dứt công việc"
+  },
+  "scheduleDetailView.killRunningJob": {
+    "defaultMessage": "Chấm dứt công việc đang chạy"
+  },
+  "scheduleDetailView.lastRun": {
+    "defaultMessage": "Lần chạy gần nhất:"
+  },
+  "scheduleDetailView.loadingSchedule": {
+    "defaultMessage": "Đang tải lịch trình..."
+  },
+  "scheduleDetailView.loadingSessions": {
+    "defaultMessage": "Đang tải các phiên..."
+  },
+  "scheduleDetailView.messages": {
+    "defaultMessage": "Tin nhắn: {count}"
+  },
+  "scheduleDetailView.noScheduleId": {
+    "defaultMessage": "Không có ID lịch trình. Quay lại danh sách lịch trình."
+  },
+  "scheduleDetailView.noSessions": {
+    "defaultMessage": "Không tìm thấy phiên nào cho lịch trình này."
+  },
+  "scheduleDetailView.pauseSchedule": {
+    "defaultMessage": "Tạm dừng lịch trình"
+  },
+  "scheduleDetailView.pauseUnpauseError": {
+    "defaultMessage": "Lỗi tạm dừng/tiếp tục"
+  },
+  "scheduleDetailView.paused": {
+    "defaultMessage": "Đã tạm dừng"
+  },
+  "scheduleDetailView.pausedMsg": {
+    "defaultMessage": "Đã tạm dừng \"{id}\""
+  },
+  "scheduleDetailView.pausedWarning": {
+    "defaultMessage": "Lịch trình này đang tạm dừng và sẽ không chạy tự động. Dùng \"Chạy lịch trình ngay\" để kích hoạt thủ công hoặc tiếp tục để khôi phục chạy tự động."
+  },
+  "scheduleDetailView.processStarted": {
+    "defaultMessage": "Tiến trình đã bắt đầu:"
+  },
+  "scheduleDetailView.recentSessions": {
+    "defaultMessage": "Phiên gần đây"
+  },
+  "scheduleDetailView.recipeSource": {
+    "defaultMessage": "Nguồn công thức:"
+  },
+  "scheduleDetailView.runScheduleError": {
+    "defaultMessage": "Lỗi chạy lịch trình"
+  },
+  "scheduleDetailView.runScheduleNow": {
+    "defaultMessage": "Chạy lịch trình ngay"
+  },
+  "scheduleDetailView.scheduleCompleted": {
+    "defaultMessage": "Đã hoàn tất lần chạy"
+  },
+  "scheduleDetailView.scheduleDetails": {
+    "defaultMessage": "Chi tiết lịch trình"
+  },
+  "scheduleDetailView.scheduleInformation": {
+    "defaultMessage": "Thông tin lịch trình"
+  },
+  "scheduleDetailView.scheduleLabel": {
+    "defaultMessage": "Lịch trình:"
+  },
+  "scheduleDetailView.scheduleNotFound": {
+    "defaultMessage": "Không tìm thấy lịch trình"
+  },
+  "scheduleDetailView.scheduleNotFoundError": {
+    "defaultMessage": "Không tìm thấy lịch trình"
+  },
+  "scheduleDetailView.schedulePaused": {
+    "defaultMessage": "Đã tạm dừng lịch trình"
+  },
+  "scheduleDetailView.scheduleUnpaused": {
+    "defaultMessage": "Đã tiếp tục lịch trình"
+  },
+  "scheduleDetailView.scheduleUpdated": {
+    "defaultMessage": "Đã cập nhật lịch trình"
+  },
+  "scheduleDetailView.sessionId": {
+    "defaultMessage": "ID phiên: {id}"
+  },
+  "scheduleDetailView.unpauseSchedule": {
+    "defaultMessage": "Tiếp tục lịch trình"
+  },
+  "scheduleDetailView.unpausedMsg": {
+    "defaultMessage": "Đã tiếp tục \"{id}\""
+  },
+  "scheduleDetailView.updateScheduleError": {
+    "defaultMessage": "Lỗi cập nhật lịch trình"
+  },
+  "scheduleDetailView.updatedMsg": {
+    "defaultMessage": "Đã cập nhật \"{id}\""
+  },
+  "scheduleDetailView.viewingScheduleId": {
+    "defaultMessage": "Đang xem ID lịch trình: {id}"
+  },
+  "scheduleModal.browseYaml": {
+    "defaultMessage": "Duyệt tìm tệp YAML..."
+  },
+  "scheduleModal.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "scheduleModal.createNewSchedule": {
+    "defaultMessage": "Tạo lịch trình mới"
+  },
+  "scheduleModal.createSchedule": {
+    "defaultMessage": "Tạo lịch trình"
+  },
+  "scheduleModal.creating": {
+    "defaultMessage": "Đang tạo..."
+  },
+  "scheduleModal.deepLink": {
+    "defaultMessage": "Liên kết sâu"
+  },
+  "scheduleModal.deepLinkPlaceholder": {
+    "defaultMessage": "Dán liên kết goose://recipe vào đây..."
+  },
+  "scheduleModal.editSchedule": {
+    "defaultMessage": "Sửa lịch trình"
+  },
+  "scheduleModal.failedParseRecipe": {
+    "defaultMessage": "Không thể phân tích công thức từ tệp."
+  },
+  "scheduleModal.failedReadFile": {
+    "defaultMessage": "Không thể đọc tệp đã chọn."
+  },
+  "scheduleModal.invalidDeepLink": {
+    "defaultMessage": "Liên kết sâu không hợp lệ. Vui lòng dùng liên kết goose://recipe."
+  },
+  "scheduleModal.invalidFileType": {
+    "defaultMessage": "Loại tệp không hợp lệ: Vui lòng chọn tệp YAML (.yaml hoặc .yml)"
+  },
+  "scheduleModal.nameLabel": {
+    "defaultMessage": "Tên:"
+  },
+  "scheduleModal.namePlaceholder": {
+    "defaultMessage": "ví dụ: daily-summary-job"
+  },
+  "scheduleModal.provideValidRecipe": {
+    "defaultMessage": "Vui lòng cung cấp nguồn công thức hợp lệ."
+  },
+  "scheduleModal.recipeDescription": {
+    "defaultMessage": "Mô tả: {description}"
+  },
+  "scheduleModal.recipeParsed": {
+    "defaultMessage": "Đã phân tích công thức thành công"
+  },
+  "scheduleModal.recipeTitle": {
+    "defaultMessage": "Tiêu đề: {title}"
+  },
+  "scheduleModal.scheduleIdRequired": {
+    "defaultMessage": "Bắt buộc phải có ID lịch trình."
+  },
+  "scheduleModal.scheduleLabel": {
+    "defaultMessage": "Lịch trình:"
+  },
+  "scheduleModal.selected": {
+    "defaultMessage": "Đã chọn: {path}"
+  },
+  "scheduleModal.sourceLabel": {
+    "defaultMessage": "Nguồn:"
+  },
+  "scheduleModal.updateSchedule": {
+    "defaultMessage": "Cập nhật lịch trình"
+  },
+  "scheduleModal.updating": {
+    "defaultMessage": "Đang cập nhật..."
+  },
+  "scheduleModal.yaml": {
+    "defaultMessage": "YAML"
+  },
+  "schedulesView.confirmDelete": {
+    "defaultMessage": "Xóa lịch trình \"{id}\"? Công thức sẽ được giữ lại."
+  },
+  "schedulesView.createSchedule": {
+    "defaultMessage": "Tạo lịch trình"
+  },
+  "schedulesView.description": {
+    "defaultMessage": "Tạo và quản lý các tác vụ theo lịch để chạy công thức tự động vào những thời điểm đã định."
+  },
+  "schedulesView.edit": {
+    "defaultMessage": "Sửa"
+  },
+  "schedulesView.errorPrefix": {
+    "defaultMessage": "Lỗi: {error}"
+  },
+  "schedulesView.inspect": {
+    "defaultMessage": "Kiểm tra"
+  },
+  "schedulesView.inspectError": {
+    "defaultMessage": "Lỗi kiểm tra công việc"
+  },
+  "schedulesView.inspectNoInfo": {
+    "defaultMessage": "Không có thông tin chi tiết cho công việc này"
+  },
+  "schedulesView.jobInspection": {
+    "defaultMessage": "Kiểm tra công việc"
+  },
+  "schedulesView.jobKilled": {
+    "defaultMessage": "Đã chấm dứt công việc"
+  },
+  "schedulesView.kill": {
+    "defaultMessage": "Chấm dứt"
+  },
+  "schedulesView.killError": {
+    "defaultMessage": "Lỗi chấm dứt công việc"
+  },
+  "schedulesView.lastRun": {
+    "defaultMessage": "Lần chạy gần nhất: {date}"
+  },
+  "schedulesView.noSchedules": {
+    "defaultMessage": "Chưa có lịch trình nào"
+  },
+  "schedulesView.pause": {
+    "defaultMessage": "Tạm dừng"
+  },
+  "schedulesView.pauseError": {
+    "defaultMessage": "Lỗi tạm dừng lịch trình"
+  },
+  "schedulesView.paused": {
+    "defaultMessage": "Đã tạm dừng"
+  },
+  "schedulesView.refresh": {
+    "defaultMessage": "Làm mới"
+  },
+  "schedulesView.refreshing": {
+    "defaultMessage": "Đang làm mới..."
+  },
+  "schedulesView.resume": {
+    "defaultMessage": "Tiếp tục"
+  },
+  "schedulesView.running": {
+    "defaultMessage": "Đang chạy"
+  },
+  "schedulesView.schedulePaused": {
+    "defaultMessage": "Đã tạm dừng lịch trình"
+  },
+  "schedulesView.schedulePausedMsg": {
+    "defaultMessage": "Đã tạm dừng lịch trình \"{id}\" thành công"
+  },
+  "schedulesView.scheduleUnpaused": {
+    "defaultMessage": "Đã tiếp tục lịch trình"
+  },
+  "schedulesView.scheduleUnpausedMsg": {
+    "defaultMessage": "Đã tiếp tục lịch trình \"{id}\" thành công"
+  },
+  "schedulesView.scheduleUpdated": {
+    "defaultMessage": "Đã cập nhật lịch trình"
+  },
+  "schedulesView.scheduleUpdatedMsg": {
+    "defaultMessage": "Đã cập nhật lịch trình \"{id}\" thành công"
+  },
+  "schedulesView.scheduler": {
+    "defaultMessage": "Bộ lập lịch"
+  },
+  "schedulesView.unpauseError": {
+    "defaultMessage": "Lỗi tiếp tục lịch trình"
+  },
+  "searchBar.caseSensitive": {
+    "defaultMessage": "Phân biệt chữ hoa/thường"
+  },
+  "searchBar.close": {
+    "defaultMessage": "Đóng ({shortcut})"
+  },
+  "searchBar.next": {
+    "defaultMessage": "Tiếp theo ({shortcut})"
+  },
+  "searchBar.placeholder": {
+    "defaultMessage": "Tìm trong cuộc trò chuyện..."
+  },
+  "searchBar.previous": {
+    "defaultMessage": "Trước đó ({shortcut})"
+  },
+  "secureStorageNotice.defaultMessage": {
+    "defaultMessage": "Khóa được lưu trữ an toàn trong keychain"
+  },
+  "securityToggle.apiTokenDescription": {
+    "defaultMessage": "Mã thông báo xác thực cho dịch vụ phân loại"
+  },
+  "securityToggle.apiTokenOptional": {
+    "defaultMessage": "Mã thông báo API (Tùy chọn)"
+  },
+  "securityToggle.classificationEndpoint": {
+    "defaultMessage": "Điểm cuối phân loại"
+  },
+  "securityToggle.classificationEndpointDescription": {
+    "defaultMessage": "Nhập URL đầy đủ cho dịch vụ phân loại của bạn"
+  },
+  "securityToggle.commandClassifierActive": {
+    "defaultMessage": "Bộ phân loại lệnh đang hoạt động (tự động cấu hình từ môi trường)"
+  },
+  "securityToggle.commandEndpointDescription": {
+    "defaultMessage": "Nhập URL đầy đủ cho dịch vụ phân loại tấn công chèn lệnh của bạn"
+  },
+  "securityToggle.commandInjectionDescription": {
+    "defaultMessage": "Sử dụng các mô hình ML để phát hiện các lệnh shell độc hại"
+  },
+  "securityToggle.detectionModel": {
+    "defaultMessage": "Mô hình phát hiện"
+  },
+  "securityToggle.detectionModelDescription": {
+    "defaultMessage": "Chọn mô hình ML để dùng cho việc phát hiện chèn lời nhắc"
+  },
+  "securityToggle.detectionThreshold": {
+    "defaultMessage": "Ngưỡng phát hiện"
+  },
+  "securityToggle.enableCommandInjection": {
+    "defaultMessage": "Bật phát hiện chèn lệnh bằng ML"
+  },
+  "securityToggle.enablePromptInjection": {
+    "defaultMessage": "Bật phát hiện chèn lời nhắc"
+  },
+  "securityToggle.enablePromptInjectionMl": {
+    "defaultMessage": "Bật phát hiện chèn lời nhắc bằng ML"
+  },
+  "securityToggle.mlEndpointDescription": {
+    "defaultMessage": "Nhập URL đầy đủ cho dịch vụ phân loại ML của bạn (bao gồm mã định danh mô hình)"
+  },
+  "securityToggle.mlTokenDescription": {
+    "defaultMessage": "Mã thông báo xác thực cho dịch vụ ML (ví dụ: mã thông báo HuggingFace)"
+  },
+  "securityToggle.overrideNotice": {
+    "defaultMessage": "Cài đặt này do tổ chức của bạn quản lý và không thể thay đổi."
+  },
+  "securityToggle.promptInjectionDescription": {
+    "defaultMessage": "Phát hiện và ngăn chặn các cuộc tấn công chèn lời nhắc tiềm ẩn"
+  },
+  "securityToggle.promptInjectionMlDescription": {
+    "defaultMessage": "Sử dụng các mô hình ML để phát hiện việc chèn lời nhắc tiềm ẩn trong cuộc trò chuyện của bạn"
+  },
+  "securityToggle.thresholdDescription": {
+    "defaultMessage": "Giá trị cao hơn thì nghiêm ngặt hơn (0.01 = rất khoan dung, 1.0 = nghiêm ngặt tối đa)"
+  },
+  "securityToggle.warpNotice": {
+    "defaultMessage": "Phát hiện chèn lệnh hoạt động tốt nhất khi được kết nối với WARP (bắt buộc để truy cập dịch vụ phân loại)."
+  },
+  "sessionActionsHeader.actionsLabel": {
+    "defaultMessage": "Hành động phiên"
+  },
+  "sessionActionsHeader.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "sessionActionsHeader.close": {
+    "defaultMessage": "Đóng"
+  },
+  "sessionActionsHeader.copiedJson": {
+    "defaultMessage": "Đã sao chép JSON của phiên"
+  },
+  "sessionActionsHeader.copiedText": {
+    "defaultMessage": "Đã sao chép văn bản"
+  },
+  "sessionActionsHeader.copyJson": {
+    "defaultMessage": "Sao chép JSON"
+  },
+  "sessionActionsHeader.copyText": {
+    "defaultMessage": "Sao chép văn bản"
+  },
+  "sessionActionsHeader.duplicateFailed": {
+    "defaultMessage": "Không thể nhân bản phiên: {error}"
+  },
+  "sessionActionsHeader.duplicateSession": {
+    "defaultMessage": "Nhân bản phiên"
+  },
+  "sessionActionsHeader.duplicated": {
+    "defaultMessage": "Đã nhân bản phiên"
+  },
+  "sessionActionsHeader.fullTextTitle": {
+    "defaultMessage": "Giá trị văn bản"
+  },
+  "sessionActionsHeader.jsonFailed": {
+    "defaultMessage": "Không thể tải JSON của phiên: {error}"
+  },
+  "sessionActionsHeader.jsonTitle": {
+    "defaultMessage": "JSON của phiên"
+  },
+  "sessionActionsHeader.loadingJson": {
+    "defaultMessage": "Đang tải JSON..."
+  },
+  "sessionActionsHeader.renameFailed": {
+    "defaultMessage": "Không thể đổi tên phiên: {error}"
+  },
+  "sessionActionsHeader.renamePlaceholder": {
+    "defaultMessage": "Nhập tên phiên"
+  },
+  "sessionActionsHeader.renameSession": {
+    "defaultMessage": "Đổi tên phiên"
+  },
+  "sessionActionsHeader.renameTitle": {
+    "defaultMessage": "Đổi tên phiên"
+  },
+  "sessionActionsHeader.renamed": {
+    "defaultMessage": "Đã đổi tên phiên"
+  },
+  "sessionActionsHeader.save": {
+    "defaultMessage": "Lưu"
+  },
+  "sessionActionsHeader.saving": {
+    "defaultMessage": "Đang lưu..."
+  },
+  "sessionActionsHeader.viewJson": {
+    "defaultMessage": "Xem JSON của phiên"
+  },
+  "sessionIndicators.error": {
+    "defaultMessage": "Phiên gặp lỗi"
+  },
+  "sessionIndicators.newActivity": {
+    "defaultMessage": "Có hoạt động mới"
+  },
+  "sessionIndicators.streaming": {
+    "defaultMessage": "Đang truyền phát"
+  },
+  "sessionViewComponents.empty.description": {
+    "defaultMessage": "Phiên này không chứa tin nhắn nào"
+  },
+  "sessionViewComponents.empty.title": {
+    "defaultMessage": "Không tìm thấy tin nhắn nào"
+  },
+  "sessionViewComponents.error.loading": {
+    "defaultMessage": "Lỗi khi tải chi tiết phiên"
+  },
+  "sessionViewComponents.error.tryAgain": {
+    "defaultMessage": "Thử lại"
+  },
+  "sessionViewComponents.role.assistant": {
+    "defaultMessage": "Goose"
+  },
+  "sessionViewComponents.role.user": {
+    "defaultMessage": "Bạn"
+  },
+  "sessions.action.delete": {
+    "defaultMessage": "Xóa phiên"
+  },
+  "sessions.action.duplicate": {
+    "defaultMessage": "Nhân bản phiên"
+  },
+  "sessions.action.editName": {
+    "defaultMessage": "Sửa tên phiên"
+  },
+  "sessions.action.export": {
+    "defaultMessage": "Xuất phiên"
+  },
+  "sessions.action.openNewWindow": {
+    "defaultMessage": "Mở trong cửa sổ mới"
+  },
+  "sessions.action.shareNostr": {
+    "defaultMessage": "Chia sẻ liên kết Nostr được mã hóa"
+  },
+  "sessions.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "sessions.chatHistory": {
+    "defaultMessage": "Lịch sử trò chuyện"
+  },
+  "sessions.chatHistoryDesc": {
+    "defaultMessage": "Xem và tìm kiếm các cuộc trò chuyện trước đây của bạn với Goose. {shortcut} để tìm kiếm."
+  },
+  "sessions.close": {
+    "defaultMessage": "Đóng"
+  },
+  "sessions.delete.message": {
+    "defaultMessage": "Bạn có chắc chắn muốn xóa phiên \"{name}\" không? Hành động này không thể hoàn tác."
+  },
+  "sessions.delete.title": {
+    "defaultMessage": "Xóa phiên"
+  },
+  "sessions.edit.placeholder": {
+    "defaultMessage": "Nhập mô tả phiên"
+  },
+  "sessions.edit.title": {
+    "defaultMessage": "Sửa mô tả phiên"
+  },
+  "sessions.empty.description": {
+    "defaultMessage": "Lịch sử trò chuyện của bạn sẽ hiển thị ở đây"
+  },
+  "sessions.empty.title": {
+    "defaultMessage": "Không tìm thấy phiên trò chuyện nào"
+  },
+  "sessions.error.loading": {
+    "defaultMessage": "Lỗi khi tải các phiên"
+  },
+  "sessions.error.tryAgain": {
+    "defaultMessage": "Thử lại"
+  },
+  "sessions.import": {
+    "defaultMessage": "Nhập phiên"
+  },
+  "sessions.importNostr": {
+    "defaultMessage": "Nhập liên kết"
+  },
+  "sessions.importNostr.description": {
+    "defaultMessage": "Dán một liên kết chia sẻ Nostr của Goose để tìm nạp, giải mã và nhập phiên."
+  },
+  "sessions.importNostr.placeholder": {
+    "defaultMessage": "goose://sessions/nostr?nevent=...&key=..."
+  },
+  "sessions.importNostr.title": {
+    "defaultMessage": "Nhập phiên Nostr"
+  },
+  "sessions.importing": {
+    "defaultMessage": "Đang nhập..."
+  },
+  "sessions.loadingMore": {
+    "defaultMessage": "Đang tải thêm phiên..."
+  },
+  "sessions.save": {
+    "defaultMessage": "Lưu"
+  },
+  "sessions.saving": {
+    "defaultMessage": "Đang lưu..."
+  },
+  "sessions.search.noResults": {
+    "defaultMessage": "Không tìm thấy phiên phù hợp"
+  },
+  "sessions.search.noResultsDesc": {
+    "defaultMessage": "Hãy thử điều chỉnh từ khóa tìm kiếm của bạn"
+  },
+  "sessions.searchPlaceholder": {
+    "defaultMessage": "Tìm kiếm lịch sử..."
+  },
+  "sessions.shareNostr.description": {
+    "defaultMessage": "Bất kỳ ai có liên kết này đều có thể tải về và giải mã phiên làm việc. Hãy coi nó như một bí mật."
+  },
+  "sessions.shareNostr.title": {
+    "defaultMessage": "Liên kết chia sẻ Nostr được mã hóa"
+  },
+  "sessions.toast.copied": {
+    "defaultMessage": "Đã sao chép vào bộ nhớ tạm"
+  },
+  "sessions.toast.deleteFailed": {
+    "defaultMessage": "Không thể xóa phiên làm việc \"{name}\": {error}"
+  },
+  "sessions.toast.deleted": {
+    "defaultMessage": "Đã xóa phiên làm việc thành công"
+  },
+  "sessions.toast.duplicateFailed": {
+    "defaultMessage": "Không thể nhân bản phiên làm việc: {error}"
+  },
+  "sessions.toast.duplicated": {
+    "defaultMessage": "Đã nhân bản phiên làm việc \"{name}\" thành công"
+  },
+  "sessions.toast.exported": {
+    "defaultMessage": "Đã xuất phiên làm việc thành công"
+  },
+  "sessions.toast.importFailed": {
+    "defaultMessage": "Không thể nhập phiên làm việc: {error}"
+  },
+  "sessions.toast.imported": {
+    "defaultMessage": "Đã nhập phiên làm việc thành công"
+  },
+  "sessions.toast.shareNostr": {
+    "defaultMessage": "Đã tạo liên kết chia sẻ Nostr được mã hóa"
+  },
+  "sessions.toast.shareNostrFailed": {
+    "defaultMessage": "Không thể tạo liên kết chia sẻ Nostr: {error}"
+  },
+  "sessions.toast.updateFailed": {
+    "defaultMessage": "Không thể cập nhật mô tả phiên làm việc: {error}"
+  },
+  "sessions.toast.updated": {
+    "defaultMessage": "Đã cập nhật mô tả phiên làm việc thành công"
+  },
+  "settings.appearance.description": {
+    "defaultMessage": "Định cấu hình cách goose hiển thị trên hệ thống của bạn"
+  },
+  "settings.appearance.title": {
+    "defaultMessage": "Giao diện"
+  },
+  "settings.close": {
+    "defaultMessage": "Đóng"
+  },
+  "settings.costTracking.description": {
+    "defaultMessage": "Hiển thị giá mô hình và chi phí sử dụng"
+  },
+  "settings.costTracking.title": {
+    "defaultMessage": "Theo dõi chi phí"
+  },
+  "settings.dockIcon.description": {
+    "defaultMessage": "Hiển thị goose trên dock"
+  },
+  "settings.dockIcon.title": {
+    "defaultMessage": "Biểu tượng dock"
+  },
+  "settings.help.description": {
+    "defaultMessage": "Giúp chúng tôi cải thiện goose bằng cách báo cáo sự cố hoặc yêu cầu tính năng mới"
+  },
+  "settings.help.reportBug": {
+    "defaultMessage": "Báo cáo lỗi"
+  },
+  "settings.help.requestFeature": {
+    "defaultMessage": "Yêu cầu tính năng"
+  },
+  "settings.help.title": {
+    "defaultMessage": "Trợ giúp & phản hồi"
+  },
+  "settings.language.description": {
+    "defaultMessage": "Chọn ngôn ngữ hiển thị cho goose"
+  },
+  "settings.language.english": {
+    "defaultMessage": "English"
+  },
+  "settings.language.french": {
+    "defaultMessage": "Tiếng Pháp"
+  },
+  "settings.language.german": {
+    "defaultMessage": "Tiếng Đức"
+  },
+  "settings.language.hindi": {
+    "defaultMessage": "Tiếng Hindi"
+  },
+  "settings.language.indonesian": {
+    "defaultMessage": "Tiếng Indonesia"
+  },
+  "settings.language.italian": {
+    "defaultMessage": "Tiếng Ý"
+  },
+  "settings.language.japanese": {
+    "defaultMessage": "Tiếng Nhật"
+  },
+  "settings.language.korean": {
+    "defaultMessage": "Tiếng Hàn"
+  },
+  "settings.language.malay": {
+    "defaultMessage": "Tiếng Mã Lai"
+  },
+  "settings.language.portuguese": {
+    "defaultMessage": "Tiếng Bồ Đào Nha"
+  },
+  "settings.language.russian": {
+    "defaultMessage": "Tiếng Nga"
+  },
+  "settings.language.spanish": {
+    "defaultMessage": "Tiếng Tây Ban Nha"
+  },
+  "settings.language.systemDefault": {
+    "defaultMessage": "Mặc định hệ thống"
+  },
+  "settings.language.title": {
+    "defaultMessage": "Ngôn ngữ"
+  },
+  "settings.language.turkish": {
+    "defaultMessage": "Tiếng Thổ Nhĩ Kỳ"
+  },
+  "settings.language.vietnamese": {
+    "defaultMessage": "Tiếng Việt"
+  },
+  "settings.language.zhCN": {
+    "defaultMessage": "Tiếng Trung (Giản thể)"
+  },
+  "settings.language.zhTW": {
+    "defaultMessage": "Tiếng Trung (Phồn thể)"
+  },
+  "settings.menuBarIcon.description": {
+    "defaultMessage": "Hiển thị goose trên thanh menu"
+  },
+  "settings.menuBarIcon.title": {
+    "defaultMessage": "Biểu tượng thanh menu"
+  },
+  "settings.notifications.configGuide": {
+    "defaultMessage": "Hướng dẫn cấu hình"
+  },
+  "settings.notifications.description": {
+    "defaultMessage": "Thông báo được quản lý bởi hệ điều hành của bạn - {link}"
+  },
+  "settings.notifications.modal.macInstructions": {
+    "defaultMessage": "Để bật thông báo trên macOS:"
+  },
+  "settings.notifications.modal.macStep1": {
+    "defaultMessage": "Mở System Preferences"
+  },
+  "settings.notifications.modal.macStep2": {
+    "defaultMessage": "Nhấp vào Notifications"
+  },
+  "settings.notifications.modal.macStep3": {
+    "defaultMessage": "Tìm và chọn goose trong danh sách ứng dụng"
+  },
+  "settings.notifications.modal.macStep4": {
+    "defaultMessage": "Bật thông báo và điều chỉnh cài đặt theo ý muốn"
+  },
+  "settings.notifications.modal.title": {
+    "defaultMessage": "Cách bật thông báo"
+  },
+  "settings.notifications.modal.winInstructions": {
+    "defaultMessage": "Để bật thông báo trên Windows:"
+  },
+  "settings.notifications.modal.winStep1": {
+    "defaultMessage": "Mở Settings"
+  },
+  "settings.notifications.modal.winStep2": {
+    "defaultMessage": "Đi tới System > Notifications"
+  },
+  "settings.notifications.modal.winStep3": {
+    "defaultMessage": "Tìm và chọn goose trong danh sách ứng dụng"
+  },
+  "settings.notifications.modal.winStep4": {
+    "defaultMessage": "Bật thông báo và điều chỉnh cài đặt theo ý muốn"
+  },
+  "settings.notifications.openSettings": {
+    "defaultMessage": "Mở Settings"
+  },
+  "settings.notifications.task.description": {
+    "defaultMessage": "Thông báo khi Goose hoàn thành một tác vụ trong khi cửa sổ đang ở chế độ nền"
+  },
+  "settings.notifications.task.title": {
+    "defaultMessage": "Thông báo hoàn thành tác vụ"
+  },
+  "settings.notifications.title": {
+    "defaultMessage": "Thông báo"
+  },
+  "settings.preventSleep.description": {
+    "defaultMessage": "Giữ máy tính của bạn luôn hoạt động trong khi goose đang chạy một tác vụ (màn hình vẫn có thể khóa)"
+  },
+  "settings.preventSleep.title": {
+    "defaultMessage": "Ngăn chế độ ngủ"
+  },
+  "settings.theme.description": {
+    "defaultMessage": "Tùy chỉnh giao diện và cảm nhận của goose"
+  },
+  "settings.theme.title": {
+    "defaultMessage": "Chủ đề"
+  },
+  "settings.updates.description": {
+    "defaultMessage": "Kiểm tra và cài đặt bản cập nhật để goose luôn hoạt động tốt nhất"
+  },
+  "settings.updates.title": {
+    "defaultMessage": "Cập nhật"
+  },
+  "settings.version.title": {
+    "defaultMessage": "Phiên bản"
+  },
+  "settingsView.tabApp": {
+    "defaultMessage": "Ứng dụng"
+  },
+  "settingsView.tabAuth": {
+    "defaultMessage": "Xác thực"
+  },
+  "settingsView.tabChat": {
+    "defaultMessage": "Trò chuyện"
+  },
+  "settingsView.tabKeyboard": {
+    "defaultMessage": "Bàn phím"
+  },
+  "settingsView.tabLocalInference": {
+    "defaultMessage": "Suy luận cục bộ"
+  },
+  "settingsView.tabModels": {
+    "defaultMessage": "Mô hình"
+  },
+  "settingsView.tabPrompts": {
+    "defaultMessage": "Lời nhắc"
+  },
+  "settingsView.tabSession": {
+    "defaultMessage": "Phiên làm việc"
+  },
+  "settingsView.title": {
+    "defaultMessage": "Cài đặt"
+  },
+  "sheet.close": {
+    "defaultMessage": "Đóng"
+  },
+  "shortcutRecorder.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "shortcutRecorder.clickToRecord": {
+    "defaultMessage": "Nhấp để ghi lại..."
+  },
+  "shortcutRecorder.conflictWarning": {
+    "defaultMessage": "Phím tắt này đã được sử dụng bởi {label}. Việc lưu sẽ gán lại nó cho hành động này."
+  },
+  "shortcutRecorder.pressShortcut": {
+    "defaultMessage": "Nhấn phím tắt..."
+  },
+  "shortcutRecorder.save": {
+    "defaultMessage": "Lưu"
+  },
+  "skillsView.addSkill": {
+    "defaultMessage": "Thêm kỹ năng"
+  },
+  "skillsView.adjustSearchTerms": {
+    "defaultMessage": "Hãy thử điều chỉnh từ khóa tìm kiếm của bạn"
+  },
+  "skillsView.comingSoon": {
+    "defaultMessage": "Sắp ra mắt"
+  },
+  "skillsView.errorLoadingSkills": {
+    "defaultMessage": "Lỗi khi tải kỹ năng"
+  },
+  "skillsView.noMatchingSkills": {
+    "defaultMessage": "Không tìm thấy kỹ năng phù hợp"
+  },
+  "skillsView.noSkillsDescription": {
+    "defaultMessage": "Kỹ năng được tải từ các tệp SKILL.md trong ~/.config/agents/skills/, .goose/skills/, hoặc các thư mục được hỗ trợ khác."
+  },
+  "skillsView.noSkillsInstalled": {
+    "defaultMessage": "Chưa cài đặt kỹ năng nào"
+  },
+  "skillsView.searchSkillsPlaceholder": {
+    "defaultMessage": "Tìm kiếm kỹ năng..."
+  },
+  "skillsView.skillsDescription": {
+    "defaultMessage": "Xem các kỹ năng đã cài đặt giúp mở rộng khả năng của Goose. {shortcut} để tìm kiếm."
+  },
+  "skillsView.skillsTitle": {
+    "defaultMessage": "Kỹ năng"
+  },
+  "skillsView.tryAgain": {
+    "defaultMessage": "Thử lại"
+  },
+  "spellcheckToggle.description": {
+    "defaultMessage": "Kiểm tra chính tả trong ô nhập trò chuyện. Cần khởi động lại để có hiệu lực."
+  },
+  "spellcheckToggle.title": {
+    "defaultMessage": "Bật kiểm tra chính tả"
+  },
+  "standaloneAppView.failedToLoad": {
+    "defaultMessage": "Không thể tải ứng dụng"
+  },
+  "standaloneAppView.initializing": {
+    "defaultMessage": "Đang khởi tạo ứng dụng..."
+  },
+  "standaloneAppView.missingParams": {
+    "defaultMessage": "Thiếu tham số bắt buộc"
+  },
+  "stringUtils.configuredProvider": {
+    "defaultMessage": "Nhà cung cấp {name} đã được định cấu hình"
+  },
+  "stringUtils.ollamaApp": {
+    "defaultMessage": "Ứng dụng Ollama"
+  },
+  "stringUtils.ollamaNotConfiguredPrefix": {
+    "defaultMessage": "Để sử dụng, hoặc là"
+  },
+  "stringUtils.ollamaNotConfiguredSuffix": {
+    "defaultMessage": "phải được cài đặt trên máy của bạn và đang mở, hoặc bạn phải nhập một giá trị cho OLLAMA_HOST."
+  },
+  "subRecipeEditor.addExisting": {
+    "defaultMessage": "Thêm hiện có"
+  },
+  "subRecipeEditor.createNew": {
+    "defaultMessage": "Tạo công thức con mới"
+  },
+  "subRecipeEditor.deleteSubrecipe": {
+    "defaultMessage": "Xóa công thức con {name}"
+  },
+  "subRecipeEditor.description": {
+    "defaultMessage": "Công thức con là các công thức có thể được gọi như công cụ trong quá trình thực thi. Chúng cho phép quy trình làm việc nhiều bước và các thành phần có thể tái sử dụng."
+  },
+  "subRecipeEditor.duplicateName": {
+    "defaultMessage": "Tên trùng lặp"
+  },
+  "subRecipeEditor.duplicateNameMsg": {
+    "defaultMessage": "Đã tồn tại một công thức con có tên \"{name}\". Vui lòng sử dụng một tên duy nhất."
+  },
+  "subRecipeEditor.editSubrecipe": {
+    "defaultMessage": "Chỉnh sửa công thức con {name}"
+  },
+  "subRecipeEditor.label": {
+    "defaultMessage": "Công thức con"
+  },
+  "subRecipeEditor.preconfiguredValues": {
+    "defaultMessage": "Giá trị được cấu hình sẵn:"
+  },
+  "subRecipeEditor.sequential": {
+    "defaultMessage": "Tuần tự"
+  },
+  "subRecipeModal.addTitle": {
+    "defaultMessage": "Thêm công thức con"
+  },
+  "subRecipeModal.apply": {
+    "defaultMessage": "Áp dụng"
+  },
+  "subRecipeModal.browse": {
+    "defaultMessage": "Duyệt"
+  },
+  "subRecipeModal.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "subRecipeModal.closeModal": {
+    "defaultMessage": "Đóng hộp thoại công thức con"
+  },
+  "subRecipeModal.configureTitle": {
+    "defaultMessage": "Định cấu hình công thức con"
+  },
+  "subRecipeModal.descriptionLabel": {
+    "defaultMessage": "Mô tả"
+  },
+  "subRecipeModal.descriptionPlaceholder": {
+    "defaultMessage": "Mô tả tùy chọn về chức năng của công thức con này..."
+  },
+  "subRecipeModal.invalidFile": {
+    "defaultMessage": "Tệp không hợp lệ"
+  },
+  "subRecipeModal.invalidFileMsg": {
+    "defaultMessage": "Vui lòng chọn một tệp YAML (.yaml hoặc .yml)."
+  },
+  "subRecipeModal.nameHint": {
+    "defaultMessage": "Định danh duy nhất được dùng để tạo tên công cụ"
+  },
+  "subRecipeModal.nameLabel": {
+    "defaultMessage": "Tên"
+  },
+  "subRecipeModal.namePlaceholder": {
+    "defaultMessage": "ví dụ: security_scan"
+  },
+  "subRecipeModal.pathHint": {
+    "defaultMessage": "Duyệt tìm một tệp công thức hiện có hoặc nhập đường dẫn theo cách thủ công"
+  },
+  "subRecipeModal.pathLabel": {
+    "defaultMessage": "Đường dẫn"
+  },
+  "subRecipeModal.pathPlaceholder": {
+    "defaultMessage": "ví dụ: ./subrecipes/security-analysis.yaml"
+  },
+  "subRecipeModal.preconfiguredValues": {
+    "defaultMessage": "Giá trị được cấu hình sẵn"
+  },
+  "subRecipeModal.preconfiguredValuesHint": {
+    "defaultMessage": "Giá trị tham số tùy chọn luôn được truyền vào công thức con"
+  },
+  "subRecipeModal.sequentialHint": {
+    "defaultMessage": "(Buộc thực thi tuần tự nhiều phiên bản của công thức con)"
+  },
+  "subRecipeModal.sequentialLabel": {
+    "defaultMessage": "Tuần tự khi lặp lại"
+  },
+  "subRecipeModal.subtitle": {
+    "defaultMessage": "Định cấu hình một công thức con có thể được gọi như công cụ trong quá trình thực thi công thức"
+  },
+  "switchModelModal.backToModelList": {
+    "defaultMessage": "Quay lại danh sách mô hình"
+  },
+  "switchModelModal.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "switchModelModal.checkProviderConfig": {
+    "defaultMessage": "Kiểm tra cấu hình nhà cung cấp của bạn trong Cài đặt → Nhà cung cấp"
+  },
+  "switchModelModal.chooseModel": {
+    "defaultMessage": "Chọn một mô hình:"
+  },
+  "switchModelModal.claudeAdaptive": {
+    "defaultMessage": "Thích ứng - Claude tự quyết định khi nào và suy nghĩ bao nhiêu"
+  },
+  "switchModelModal.claudeDisabled": {
+    "defaultMessage": "Đã tắt - Không có suy nghĩ mở rộng"
+  },
+  "switchModelModal.claudeEffortHigh": {
+    "defaultMessage": "Cao - Lập luận sâu (mặc định)"
+  },
+  "switchModelModal.claudeEffortLow": {
+    "defaultMessage": "Thấp - Suy nghĩ tối thiểu, phản hồi nhanh nhất"
+  },
+  "switchModelModal.claudeEffortMax": {
+    "defaultMessage": "Tối đa - Không giới hạn về độ sâu suy nghĩ"
+  },
+  "switchModelModal.claudeEffortMedium": {
+    "defaultMessage": "Trung bình - Suy nghĩ vừa phải"
+  },
+  "switchModelModal.claudeEnabled": {
+    "defaultMessage": "Đã bật - Ngân sách token cố định cho suy nghĩ"
+  },
+  "switchModelModal.couldNotContactProvider": {
+    "defaultMessage": "Không thể liên hệ với nhà cung cấp"
+  },
+  "switchModelModal.customModelName": {
+    "defaultMessage": "Tên mô hình tùy chỉnh"
+  },
+  "switchModelModal.description": {
+    "defaultMessage": "Chọn một nhà cung cấp và mô hình để sử dụng cho các cuộc trò chuyện của bạn."
+  },
+  "switchModelModal.enterModelNotListed": {
+    "defaultMessage": "Nhập một mô hình không có trong danh sách..."
+  },
+  "switchModelModal.extendedThinking": {
+    "defaultMessage": "Suy nghĩ mở rộng"
+  },
+  "switchModelModal.geminiOnly": {
+    "defaultMessage": "(Chỉ dành cho các mô hình Gemini 3)"
+  },
+  "switchModelModal.goToSettings": {
+    "defaultMessage": "Đi tới Cài đặt"
+  },
+  "switchModelModal.loadingModels": {
+    "defaultMessage": "Đang tải mô hình…"
+  },
+  "switchModelModal.localModelsDescription": {
+    "defaultMessage": "Để sử dụng suy luận cục bộ, bạn cần tải một mô hình về máy tính trước. Đi tới Cài đặt → Mô hình để quản lý các mô hình cục bộ."
+  },
+  "switchModelModal.localModelsTitle": {
+    "defaultMessage": "Các mô hình cục bộ cần được tải về trước"
+  },
+  "switchModelModal.providerPlaceholder": {
+    "defaultMessage": "Nhà cung cấp, nhập để tìm kiếm"
+  },
+  "switchModelModal.quickStartGuide": {
+    "defaultMessage": "Hướng dẫn bắt đầu nhanh"
+  },
+  "switchModelModal.recommended": {
+    "defaultMessage": "Được đề xuất"
+  },
+  "switchModelModal.selectEffortLevel": {
+    "defaultMessage": "Chọn mức độ nỗ lực"
+  },
+  "switchModelModal.selectModel": {
+    "defaultMessage": "Vui lòng chọn một mô hình"
+  },
+  "switchModelModal.selectModelButton": {
+    "defaultMessage": "Chọn mô hình"
+  },
+  "switchModelModal.selectModelPlaceholder": {
+    "defaultMessage": "Chọn một mô hình, nhập để tìm kiếm"
+  },
+  "switchModelModal.selectOrEnterModel": {
+    "defaultMessage": "Vui lòng chọn hoặc nhập một mô hình"
+  },
+  "switchModelModal.selectProvider": {
+    "defaultMessage": "Vui lòng chọn một nhà cung cấp"
+  },
+  "switchModelModal.selectThinkingLevel": {
+    "defaultMessage": "Chọn mức độ suy nghĩ"
+  },
+  "switchModelModal.selectThinkingMode": {
+    "defaultMessage": "Chọn chế độ suy nghĩ"
+  },
+  "switchModelModal.thinkingBudget": {
+    "defaultMessage": "Ngân sách suy nghĩ (token)"
+  },
+  "switchModelModal.thinkingEffort": {
+    "defaultMessage": "Nỗ lực suy nghĩ"
+  },
+  "switchModelModal.thinkingEffortOff": {
+    "defaultMessage": "Tắt - Không có suy nghĩ mở rộng"
+  },
+  "switchModelModal.thinkingLevel": {
+    "defaultMessage": "Mức độ suy nghĩ"
+  },
+  "switchModelModal.thinkingLevelHigh": {
+    "defaultMessage": "Cao - Lập luận sâu hơn, độ trễ cao hơn"
+  },
+  "switchModelModal.thinkingLevelLow": {
+    "defaultMessage": "Thấp - Độ trễ tốt hơn, lập luận nhẹ hơn"
+  },
+  "switchModelModal.title": {
+    "defaultMessage": "Chuyển đổi mô hình"
+  },
+  "switchModelModal.typeModelName": {
+    "defaultMessage": "Nhập tên mô hình tại đây"
+  },
+  "switchModelModal.useOtherProvider": {
+    "defaultMessage": "Sử dụng nhà cung cấp khác"
+  },
+  "telemetryConsentPrompt.description": {
+    "defaultMessage": "Bạn có muốn chia sẻ dữ liệu sử dụng ẩn danh để giúp cải thiện goose không? Chúng tôi không bao giờ thu thập các cuộc trò chuyện, mã hoặc dữ liệu cá nhân của bạn."
+  },
+  "telemetryConsentPrompt.heading": {
+    "defaultMessage": "Giúp cải thiện goose"
+  },
+  "telemetryConsentPrompt.learnMore": {
+    "defaultMessage": "Tìm hiểu thêm"
+  },
+  "telemetryConsentPrompt.optIn": {
+    "defaultMessage": "Có, chia sẻ dữ liệu sử dụng ẩn danh"
+  },
+  "telemetryConsentPrompt.optOut": {
+    "defaultMessage": "Không, cảm ơn"
+  },
+  "telemetrySettings.configErrorTitle": {
+    "defaultMessage": "Lỗi cấu hình"
+  },
+  "telemetrySettings.description": {
+    "defaultMessage": "Kiểm soát cách dữ liệu của bạn được sử dụng"
+  },
+  "telemetrySettings.learnMore": {
+    "defaultMessage": "Tìm hiểu thêm"
+  },
+  "telemetrySettings.loadError": {
+    "defaultMessage": "Không thể tải cài đặt đo từ xa."
+  },
+  "telemetrySettings.title": {
+    "defaultMessage": "Quyền riêng tư"
+  },
+  "telemetrySettings.toggleDescription": {
+    "defaultMessage": "Giúp cải thiện goose bằng cách chia sẻ số liệu thống kê sử dụng ẩn danh."
+  },
+  "telemetrySettings.toggleLabel": {
+    "defaultMessage": "Dữ liệu sử dụng ẩn danh"
+  },
+  "telemetrySettings.updateError": {
+    "defaultMessage": "Không thể cập nhật cài đặt đo từ xa."
+  },
+  "themeSelector.dark": {
+    "defaultMessage": "Tối"
+  },
+  "themeSelector.light": {
+    "defaultMessage": "Sáng"
+  },
+  "themeSelector.system": {
+    "defaultMessage": "Hệ thống"
+  },
+  "themeSelector.theme": {
+    "defaultMessage": "Chủ đề"
+  },
+  "toolApprovalButtons.allowOnce": {
+    "defaultMessage": "Cho phép một lần"
+  },
+  "toolApprovalButtons.allowedOnce": {
+    "defaultMessage": "Đã cho phép một lần"
+  },
+  "toolApprovalButtons.alwaysAllow": {
+    "defaultMessage": "Luôn cho phép"
+  },
+  "toolApprovalButtons.alwaysAllowed": {
+    "defaultMessage": "Luôn được cho phép"
+  },
+  "toolApprovalButtons.cancelled": {
+    "defaultMessage": "Đã hủy"
+  },
+  "toolApprovalButtons.denied": {
+    "defaultMessage": "Đã từ chối"
+  },
+  "toolApprovalButtons.deniedOnce": {
+    "defaultMessage": "Đã từ chối một lần"
+  },
+  "toolApprovalButtons.deny": {
+    "defaultMessage": "Từ chối"
+  },
+  "toolApprovalButtons.staleApprovalRequest": {
+    "defaultMessage": "Yêu cầu phê duyệt này không còn hiệu lực."
+  },
+  "toolCallStatusIndicator.toolStatus": {
+    "defaultMessage": "Trạng thái công cụ: {status}"
+  },
+  "toolCallWithResponse.activityCount": {
+    "defaultMessage": "Hoạt động ({count})"
+  },
+  "toolCallWithResponse.code": {
+    "defaultMessage": "Mã"
+  },
+  "toolCallWithResponse.loadingSpinner": {
+    "defaultMessage": "Biểu tượng tải"
+  },
+  "toolCallWithResponse.logs": {
+    "defaultMessage": "Nhật ký"
+  },
+  "toolCallWithResponse.mcpUiExperimental": {
+    "defaultMessage": "MCP UI là thử nghiệm và có thể thay đổi bất kỳ lúc nào."
+  },
+  "toolCallWithResponse.output": {
+    "defaultMessage": "Đầu ra"
+  },
+  "toolCallWithResponse.toolDetails": {
+    "defaultMessage": "Chi tiết công cụ"
+  },
+  "toolCallWithResponse.toolResultAlt": {
+    "defaultMessage": "Kết quả công cụ"
+  },
+  "toolCallWithResponse.viewSubagentSession": {
+    "defaultMessage": "Xem phiên làm việc của tác nhân con"
+  },
+  "toolConfirmation.allowToolCallWithName": {
+    "defaultMessage": "Cho phép {toolName}?"
+  },
+  "toolConfirmation.gooseWouldLikeToCallWithName": {
+    "defaultMessage": "Goose muốn gọi {toolName}. Cho phép?"
+  },
+  "updateSection.autoDownload": {
+    "defaultMessage": "Goose sẽ tải bản cập nhật ở chế độ nền và cài đặt vào lần tiếp theo khi bạn thoát hoặc khởi động lại."
+  },
+  "updateSection.autoDownloadDisabledByEnv": {
+    "defaultMessage": "Tải xuống tự động đã bị tắt thông qua biến môi trường GOOSE_DISABLE_AUTO_DOWNLOAD."
+  },
+  "updateSection.autoDownloadDisabledNote": {
+    "defaultMessage": "Tải xuống tự động đã bị tắt. Nhấp vào \"Tải ngay\" để tải xuống theo cách thủ công."
+  },
+  "updateSection.autoInstallNote": {
+    "defaultMessage": "Không cần cài đặt thủ công."
+  },
+  "updateSection.checkForUpdates": {
+    "defaultMessage": "Kiểm tra bản cập nhật"
+  },
+  "updateSection.checking": {
+    "defaultMessage": "Đang kiểm tra bản cập nhật..."
+  },
+  "updateSection.currentVersion": {
+    "defaultMessage": "Phiên bản hiện tại"
+  },
+  "updateSection.disableAutoDownload": {
+    "defaultMessage": "Tắt tải xuống cập nhật tự động"
+  },
+  "updateSection.disableAutoDownloadDesc": {
+    "defaultMessage": "Khi được bật, Goose sẽ thông báo cho bạn về các phiên bản mới nhưng sẽ không tự động tải xuống."
+  },
+  "updateSection.downloadNow": {
+    "defaultMessage": "Tải ngay"
+  },
+  "updateSection.downloadReady": {
+    "defaultMessage": "Bản cập nhật đã được tải về và sẵn sàng cài đặt!"
+  },
+  "updateSection.downloadingProgress": {
+    "defaultMessage": "Đang tải bản cập nhật... {percent}%"
+  },
+  "updateSection.downloadingUpdate": {
+    "defaultMessage": "Đang tải bản cập nhật..."
+  },
+  "updateSection.installAndRestart": {
+    "defaultMessage": "Cài đặt & khởi động lại"
+  },
+  "updateSection.installNowHint": {
+    "defaultMessage": "Nhấp vào \"Cài đặt & khởi động lại\" để cập nhật ngay."
+  },
+  "updateSection.latestVersion": {
+    "defaultMessage": "Bạn đang chạy phiên bản mới nhất!"
+  },
+  "updateSection.loading": {
+    "defaultMessage": "Đang tải..."
+  },
+  "updateSection.manualInstallNote": {
+    "defaultMessage": "Sau khi tải xuống, bạn sẽ cần cài đặt bản cập nhật theo cách thủ công."
+  },
+  "updateSection.manualInstallRequired": {
+    "defaultMessage": "Cần cài đặt thủ công cho phương thức cập nhật này."
+  },
+  "updateSection.readyInstallAuto": {
+    "defaultMessage": "✓ Bản cập nhật đã sẵn sàng. Khởi động lại Goose để hoàn tất cài đặt, hoặc thoát khi bạn đã xong."
+  },
+  "updateSection.readyInstallManual": {
+    "defaultMessage": "✓ Bản cập nhật đã sẵn sàng! Nhấp vào \"Cài đặt & khởi động lại\" để xem hướng dẫn cài đặt."
+  },
+  "updateSection.upToDate": {
+    "defaultMessage": "(đã cập nhật)"
+  },
+  "updateSection.updateAvailable": {
+    "defaultMessage": "Có bản cập nhật!"
+  },
+  "updateSection.versionAvailable": {
+    "defaultMessage": "→ {version} có sẵn"
+  },
+  "updateSection.versionIsAvailable": {
+    "defaultMessage": "Đã có phiên bản {version}"
+  },
+  "userMessage.cancel": {
+    "defaultMessage": "Hủy"
+  },
+  "userMessage.cancelAriaLabel": {
+    "defaultMessage": "Hủy chỉnh sửa"
+  },
+  "userMessage.editAriaLabel": {
+    "defaultMessage": "Chỉnh sửa nội dung tin nhắn"
+  },
+  "userMessage.editButton": {
+    "defaultMessage": "Chỉnh sửa"
+  },
+  "userMessage.editInPlace": {
+    "defaultMessage": "Chỉnh sửa tại chỗ"
+  },
+  "userMessage.editInPlaceAriaLabel": {
+    "defaultMessage": "Chỉnh sửa tin nhắn tại chỗ"
+  },
+  "userMessage.editInPlaceDescription": {
+    "defaultMessage": "<b>Chỉnh sửa tại chỗ</b> cập nhật phiên làm việc này • <b>Tách nhánh phiên làm việc</b> tạo một phiên làm việc mới"
+  },
+  "userMessage.editInPlaceTitle": {
+    "defaultMessage": "Cập nhật tin nhắn trong phiên làm việc này"
+  },
+  "userMessage.editMessageAriaLabel": {
+    "defaultMessage": "Chỉnh sửa tin nhắn: {preview}"
+  },
+  "userMessage.editMessageTitle": {
+    "defaultMessage": "Chỉnh sửa tin nhắn"
+  },
+  "userMessage.editPlaceholder": {
+    "defaultMessage": "Chỉnh sửa tin nhắn của bạn..."
+  },
+  "userMessage.emptyError": {
+    "defaultMessage": "Tin nhắn không được để trống"
+  },
+  "userMessage.forkSession": {
+    "defaultMessage": "Tách nhánh phiên làm việc"
+  },
+  "userMessage.forkSessionAriaLabel": {
+    "defaultMessage": "Tách nhánh phiên làm việc với tin nhắn đã chỉnh sửa"
+  },
+  "userMessage.forkSessionTitle": {
+    "defaultMessage": "Tạo một phiên làm việc mới với tin nhắn đã chỉnh sửa"
+  }
+}

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -3887,14 +3887,32 @@
   "settings.language.english": {
     "defaultMessage": "英语"
   },
+  "settings.language.french": {
+    "defaultMessage": "法语"
+  },
+  "settings.language.german": {
+    "defaultMessage": "德语"
+  },
   "settings.language.hindi": {
     "defaultMessage": "印地语"
+  },
+  "settings.language.indonesian": {
+    "defaultMessage": "印度尼西亚语"
+  },
+  "settings.language.italian": {
+    "defaultMessage": "意大利语"
   },
   "settings.language.japanese": {
     "defaultMessage": "日语"
   },
   "settings.language.korean": {
     "defaultMessage": "韩语"
+  },
+  "settings.language.malay": {
+    "defaultMessage": "马来语"
+  },
+  "settings.language.portuguese": {
+    "defaultMessage": "葡萄牙语"
   },
   "settings.language.russian": {
     "defaultMessage": "俄语"
@@ -3911,8 +3929,14 @@
   "settings.language.turkish": {
     "defaultMessage": "土耳其语"
   },
+  "settings.language.vietnamese": {
+    "defaultMessage": "越南语"
+  },
   "settings.language.zhCN": {
     "defaultMessage": "简体中文"
+  },
+  "settings.language.zhTW": {
+    "defaultMessage": "中文（繁体）"
   },
   "settings.menuBarIcon.description": {
     "defaultMessage": "在菜单栏显示 goose"

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -1,0 +1,4574 @@
+{
+  "alertBox.autoCompactAt": {
+    "defaultMessage": "自動壓縮於"
+  },
+  "alertBox.compactNow": {
+    "defaultMessage": "立即壓縮"
+  },
+  "alertBox.failedToSaveThreshold": {
+    "defaultMessage": "無法儲存閾值：{error}"
+  },
+  "announcementModal.gotIt": {
+    "defaultMessage": "知道了！"
+  },
+  "appLayout.collapseNavigation": {
+    "defaultMessage": "收合導覽列"
+  },
+  "appLayout.openNavigation": {
+    "defaultMessage": "開啟導覽列"
+  },
+  "appsView.customApp": {
+    "defaultMessage": "自訂應用程式"
+  },
+  "appsView.description": {
+    "defaultMessage": "來自您 MCP 伺服器的應用程式，以及由 goose 自行建立的應用程式。您可以透過聊天介面要求它建立新的應用程式，它們便會出現在這裡。"
+  },
+  "appsView.errorLoading": {
+    "defaultMessage": "載入應用程式時發生錯誤：{error}"
+  },
+  "appsView.importApp": {
+    "defaultMessage": "匯入應用程式"
+  },
+  "appsView.launch": {
+    "defaultMessage": "啟動"
+  },
+  "appsView.loading": {
+    "defaultMessage": "正在載入應用程式…"
+  },
+  "appsView.noAppsDescription": {
+    "defaultMessage": "開啟聊天並向 goose 索取您想要的應用程式。它可以為您建立一個，並顯示在這裡。或者，如果有人分享了應用程式，您可以使用上方的按鈕匯入。"
+  },
+  "appsView.noAppsTitle": {
+    "defaultMessage": "沒有可用的應用程式"
+  },
+  "appsView.retry": {
+    "defaultMessage": "重試"
+  },
+  "appsView.title": {
+    "defaultMessage": "應用程式"
+  },
+  "authSettings.activeProviderWarning": {
+    "defaultMessage": "這是目前使用中的供應商。在您設定其他憑證之前，新的請求可能會失敗。"
+  },
+  "authSettings.cancel": {
+    "defaultMessage": "取消"
+  },
+  "authSettings.delete": {
+    "defaultMessage": "刪除"
+  },
+  "authSettings.deleteCredential": {
+    "defaultMessage": "刪除憑證"
+  },
+  "authSettings.deleteMessage": {
+    "defaultMessage": "要刪除 {provider} 的 {name} 憑證嗎？"
+  },
+  "authSettings.deleteTitle": {
+    "defaultMessage": "刪除憑證"
+  },
+  "authSettings.deleted": {
+    "defaultMessage": "憑證已刪除"
+  },
+  "authSettings.description": {
+    "defaultMessage": "管理 goose 在本機儲存的供應商憑證。"
+  },
+  "authSettings.empty": {
+    "defaultMessage": "找不到本機儲存的供應商憑證。"
+  },
+  "authSettings.expiresAt": {
+    "defaultMessage": "於 {date} 到期"
+  },
+  "authSettings.failedToConfigure": {
+    "defaultMessage": "無法設定憑證：{error}"
+  },
+  "authSettings.failedToDelete": {
+    "defaultMessage": "無法刪除憑證：{error}"
+  },
+  "authSettings.failedToLoad": {
+    "defaultMessage": "無法載入供應商憑證"
+  },
+  "authSettings.loading": {
+    "defaultMessage": "正在載入憑證…"
+  },
+  "authSettings.reauthorize": {
+    "defaultMessage": "重新授權"
+  },
+  "authSettings.signIn": {
+    "defaultMessage": "登入"
+  },
+  "authSettings.signedIn": {
+    "defaultMessage": "憑證已設定"
+  },
+  "authSettings.storageProviderCache": {
+    "defaultMessage": "供應商快取"
+  },
+  "authSettings.storageSecretStore": {
+    "defaultMessage": "密鑰儲存區"
+  },
+  "authSettings.title": {
+    "defaultMessage": "供應商憑證"
+  },
+  "backButton.back": {
+    "defaultMessage": "返回"
+  },
+  "baseChat.failedToLoadSession": {
+    "defaultMessage": "無法載入工作階段"
+  },
+  "baseChat.goHome": {
+    "defaultMessage": "回到首頁"
+  },
+  "bottomMenuExtensionSelection.extensionUpdated": {
+    "defaultMessage": "擴充功能已更新"
+  },
+  "bottomMenuExtensionSelection.extensionWillBeDisabled": {
+    "defaultMessage": "{name} 將在新的聊天中停用"
+  },
+  "bottomMenuExtensionSelection.extensionWillBeEnabled": {
+    "defaultMessage": "{name} 將在新的聊天中啟用"
+  },
+  "bottomMenuExtensionSelection.extensionsForNewChats": {
+    "defaultMessage": "新聊天的擴充功能"
+  },
+  "bottomMenuExtensionSelection.extensionsForThisSession": {
+    "defaultMessage": "此聊天工作階段的擴充功能"
+  },
+  "bottomMenuExtensionSelection.manageExtensions": {
+    "defaultMessage": "管理擴充功能"
+  },
+  "bottomMenuExtensionSelection.noExtensionsAvailable": {
+    "defaultMessage": "沒有可用的擴充功能"
+  },
+  "bottomMenuExtensionSelection.noExtensionsFound": {
+    "defaultMessage": "找不到擴充功能"
+  },
+  "bottomMenuExtensionSelection.searchExtensions": {
+    "defaultMessage": "搜尋擴充功能…"
+  },
+  "cardButtons.configure": {
+    "defaultMessage": "設定"
+  },
+  "cardButtons.launch": {
+    "defaultMessage": "啟動"
+  },
+  "chat.notification.taskComplete.body": {
+    "defaultMessage": "按一下這裡讓 Goose 重新回到焦點。"
+  },
+  "chat.notification.taskComplete.title": {
+    "defaultMessage": "Goose 已完成工作。"
+  },
+  "chatInput.contextWindow": {
+    "defaultMessage": "上下文視窗"
+  },
+  "chatInput.dictationError": {
+    "defaultMessage": "聽寫錯誤"
+  },
+  "chatInput.failedToReadImage": {
+    "defaultMessage": "無法讀取影像檔案"
+  },
+  "chatInput.navigationShortcut": {
+    "defaultMessage": "{prefix}↑/{prefix}↓ 可瀏覽訊息"
+  },
+  "chatInput.processingDroppedFiles": {
+    "defaultMessage": "正在處理拖放的檔案…"
+  },
+  "chatInput.recording": {
+    "defaultMessage": "錄音中…"
+  },
+  "chatInput.removeFile": {
+    "defaultMessage": "移除檔案"
+  },
+  "chatInput.removeImage": {
+    "defaultMessage": "移除影像"
+  },
+  "chatInput.restartingSession": {
+    "defaultMessage": "正在重新啟動工作階段…"
+  },
+  "chatInput.send": {
+    "defaultMessage": "傳送"
+  },
+  "chatInput.transcribing": {
+    "defaultMessage": "正在轉錄…"
+  },
+  "chatInput.typeMessage": {
+    "defaultMessage": "輸入要傳送的訊息"
+  },
+  "chatInput.unknownType": {
+    "defaultMessage": "未知的類型"
+  },
+  "chatInput.viewEditRecipe": {
+    "defaultMessage": "檢視/編輯食譜"
+  },
+  "chatInput.waitingForCancellation": {
+    "defaultMessage": "正在等待取消作業完成"
+  },
+  "chatInput.waitingForImages": {
+    "defaultMessage": "正在等待影像儲存…"
+  },
+  "chatSettings.modeDescription": {
+    "defaultMessage": "選擇 Goose 用於新工作階段的預設模式。現有的工作階段會維持目前的模式。"
+  },
+  "chatSettings.modeTitle": {
+    "defaultMessage": "預設模式"
+  },
+  "chatSettings.responseStylesDescription": {
+    "defaultMessage": "選擇 Goose 設定回應格式與樣式的方式"
+  },
+  "chatSettings.responseStylesTitle": {
+    "defaultMessage": "回應樣式"
+  },
+  "configSettings.configReset": {
+    "defaultMessage": "設定已重設"
+  },
+  "configSettings.configResetMsg": {
+    "defaultMessage": "所有變更皆已還原"
+  },
+  "configSettings.configUpdated": {
+    "defaultMessage": "設定已更新"
+  },
+  "configSettings.configUpdatedMsg": {
+    "defaultMessage": "已成功儲存「{name}」"
+  },
+  "configSettings.configurationEditor": {
+    "defaultMessage": "設定編輯器"
+  },
+  "configSettings.description": {
+    "defaultMessage": "編輯您的 goose 設定"
+  },
+  "configSettings.descriptionWithProvider": {
+    "defaultMessage": "編輯您的 goose 設定（{provider} 的目前設定）"
+  },
+  "configSettings.done": {
+    "defaultMessage": "完成"
+  },
+  "configSettings.editConfiguration": {
+    "defaultMessage": "編輯設定"
+  },
+  "configSettings.enterValue": {
+    "defaultMessage": "輸入 {name}"
+  },
+  "configSettings.noSettings": {
+    "defaultMessage": "找不到任何設定。"
+  },
+  "configSettings.resetChanges": {
+    "defaultMessage": "重設變更"
+  },
+  "configSettings.saveFailed": {
+    "defaultMessage": "儲存失敗"
+  },
+  "configSettings.saveFailedMsg": {
+    "defaultMessage": "無法儲存「{name}」"
+  },
+  "configSettings.saving": {
+    "defaultMessage": "正在儲存…"
+  },
+  "configSettings.title": {
+    "defaultMessage": "設定"
+  },
+  "configureApproveMode.cancel": {
+    "defaultMessage": "取消"
+  },
+  "configureApproveMode.description": {
+    "defaultMessage": "核准請求可以套用至所有工具請求，或判斷哪些動作可能需要整合"
+  },
+  "configureApproveMode.manualApproval": {
+    "defaultMessage": "手動核准"
+  },
+  "configureApproveMode.manualApprovalDescription": {
+    "defaultMessage": "所有工具、擴充功能與檔案修改都將需要人工核准"
+  },
+  "configureApproveMode.save": {
+    "defaultMessage": "儲存"
+  },
+  "configureApproveMode.saving": {
+    "defaultMessage": "正在儲存…"
+  },
+  "configureApproveMode.smartApproval": {
+    "defaultMessage": "智慧核准"
+  },
+  "configureApproveMode.smartApprovalDescription": {
+    "defaultMessage": "根據風險等級智慧判斷哪些動作需要核准"
+  },
+  "configureApproveMode.title": {
+    "defaultMessage": "設定核准模式"
+  },
+  "confirmationModal.defaultCancel": {
+    "defaultMessage": "否"
+  },
+  "confirmationModal.defaultConfirm": {
+    "defaultMessage": "是"
+  },
+  "confirmationModal.processing": {
+    "defaultMessage": "正在處理…"
+  },
+  "conversationLimitsDropdown.conversationLimits": {
+    "defaultMessage": "對話限制"
+  },
+  "conversationLimitsDropdown.maxTurns": {
+    "defaultMessage": "最大回合數"
+  },
+  "conversationLimitsDropdown.maxTurnsDescription": {
+    "defaultMessage": "Goose 要求使用者輸入前的最大代理回合數"
+  },
+  "costTracker.costUnavailable": {
+    "defaultMessage": "{model} 無可用的費用資料（輸入 {inputTokens} 個權杖，輸出 {outputTokens} 個權杖）"
+  },
+  "costTracker.inputOutputTooltip": {
+    "defaultMessage": "輸入：{inputTokens} 個權杖（{inputCost}）｜輸出：{outputTokens} 個權杖（{outputCost}）"
+  },
+  "costTracker.pricingUnavailable": {
+    "defaultMessage": "{model} 無可用的定價資料"
+  },
+  "costTracker.totalSessionCost": {
+    "defaultMessage": "工作階段總費用：{cost}"
+  },
+  "createEditRecipe.clickToGenerateDeeplink": {
+    "defaultMessage": "按一下以產生深層連結"
+  },
+  "createEditRecipe.close": {
+    "defaultMessage": "關閉"
+  },
+  "createEditRecipe.copied": {
+    "defaultMessage": "已複製！"
+  },
+  "createEditRecipe.copy": {
+    "defaultMessage": "複製"
+  },
+  "createEditRecipe.copyLinkDescription": {
+    "defaultMessage": "複製此連結與好友分享，或直接貼到 Chrome 中開啟"
+  },
+  "createEditRecipe.createRecipeTitle": {
+    "defaultMessage": "建立食譜"
+  },
+  "createEditRecipe.createSubtitle": {
+    "defaultMessage": "建立新食譜以定義代理行為與功能，供可重複使用的聊天工作階段使用。"
+  },
+  "createEditRecipe.editSubtitle": {
+    "defaultMessage": "您可以編輯下方的食譜，以變更代理在新工作階段中的行為。"
+  },
+  "createEditRecipe.generatingDeeplink": {
+    "defaultMessage": "正在產生深層連結…"
+  },
+  "createEditRecipe.learnMore": {
+    "defaultMessage": "瞭解更多"
+  },
+  "createEditRecipe.recipeSavedAndLaunchedMsg": {
+    "defaultMessage": "食譜已成功儲存並啟動"
+  },
+  "createEditRecipe.recipeSavedMsg": {
+    "defaultMessage": "食譜已成功儲存"
+  },
+  "createEditRecipe.saveAndRunFailed": {
+    "defaultMessage": "儲存並執行失敗"
+  },
+  "createEditRecipe.saveAndRunFailedMsg": {
+    "defaultMessage": "無法儲存並執行食譜：{error}"
+  },
+  "createEditRecipe.saveAndRunRecipe": {
+    "defaultMessage": "儲存並執行食譜"
+  },
+  "createEditRecipe.saveFailed": {
+    "defaultMessage": "儲存失敗"
+  },
+  "createEditRecipe.saveFailedMsg": {
+    "defaultMessage": "無法儲存食譜：{error}"
+  },
+  "createEditRecipe.saveRecipe": {
+    "defaultMessage": "儲存食譜"
+  },
+  "createEditRecipe.saving": {
+    "defaultMessage": "正在儲存…"
+  },
+  "createEditRecipe.validationFailed": {
+    "defaultMessage": "驗證失敗"
+  },
+  "createEditRecipe.validationMsg": {
+    "defaultMessage": "請填寫所有必填欄位，並確保 JSON 結構描述有效。"
+  },
+  "createEditRecipe.viewEditRecipeTitle": {
+    "defaultMessage": "檢視/編輯食譜"
+  },
+  "createSubRecipeInline.cancel": {
+    "defaultMessage": "取消"
+  },
+  "createSubRecipeInline.closeModal": {
+    "defaultMessage": "關閉建立子食譜對話框"
+  },
+  "createSubRecipeInline.createAndAdd": {
+    "defaultMessage": "建立並新增子食譜"
+  },
+  "createSubRecipeInline.createdSuccess": {
+    "defaultMessage": "子食譜已成功建立"
+  },
+  "createSubRecipeInline.creating": {
+    "defaultMessage": "正在建立…"
+  },
+  "createSubRecipeInline.duplicateName": {
+    "defaultMessage": "名稱重複"
+  },
+  "createSubRecipeInline.duplicateNameMsg": {
+    "defaultMessage": "已存在名為「{name}」的子食譜。請使用不重複的名稱。"
+  },
+  "createSubRecipeInline.instructionsLabel": {
+    "defaultMessage": "指示"
+  },
+  "createSubRecipeInline.instructionsPlaceholder": {
+    "defaultMessage": "呼叫此子食譜時提供給 AI 的指示…"
+  },
+  "createSubRecipeInline.nameHint": {
+    "defaultMessage": "用於產生工具名稱的唯一識別碼"
+  },
+  "createSubRecipeInline.nameLabel": {
+    "defaultMessage": "名稱"
+  },
+  "createSubRecipeInline.namePlaceholder": {
+    "defaultMessage": "例如：security_scan"
+  },
+  "createSubRecipeInline.preconfiguredValues": {
+    "defaultMessage": "預先設定的值"
+  },
+  "createSubRecipeInline.preconfiguredValuesHint": {
+    "defaultMessage": "永遠會傳遞給子食譜的選用參數值"
+  },
+  "createSubRecipeInline.recipeDescriptionLabel": {
+    "defaultMessage": "食譜描述"
+  },
+  "createSubRecipeInline.recipeDescriptionPlaceholder": {
+    "defaultMessage": "此食譜執行時的作用"
+  },
+  "createSubRecipeInline.recipeTitleLabel": {
+    "defaultMessage": "食譜標題"
+  },
+  "createSubRecipeInline.recipeTitlePlaceholder": {
+    "defaultMessage": "例如：安全分析工具"
+  },
+  "createSubRecipeInline.saveFailed": {
+    "defaultMessage": "儲存失敗"
+  },
+  "createSubRecipeInline.saveFailedMsg": {
+    "defaultMessage": "無法儲存子食譜：{error}"
+  },
+  "createSubRecipeInline.sequentialHint": {
+    "defaultMessage": "（強制多個執行個體依序執行）"
+  },
+  "createSubRecipeInline.sequentialLabel": {
+    "defaultMessage": "重複時依序執行"
+  },
+  "createSubRecipeInline.subtitle": {
+    "defaultMessage": "建立一個簡單的食譜，作為主食譜中可呼叫的工具"
+  },
+  "createSubRecipeInline.title": {
+    "defaultMessage": "建立新子食譜"
+  },
+  "createSubRecipeInline.toolDescriptionLabel": {
+    "defaultMessage": "工具描述"
+  },
+  "createSubRecipeInline.toolDescriptionPlaceholder": {
+    "defaultMessage": "作為工具呼叫時顯示的選用描述"
+  },
+  "createSubRecipeInline.validationFailed": {
+    "defaultMessage": "驗證失敗"
+  },
+  "createSubRecipeInline.validationMsg": {
+    "defaultMessage": "名稱、標題、食譜描述與指示為必填。"
+  },
+  "creditsExhaustedNotification.addCredits": {
+    "defaultMessage": "新增點數"
+  },
+  "creditsExhaustedNotification.insufficientCredits": {
+    "defaultMessage": "點數不足"
+  },
+  "cronPicker.april": {
+    "defaultMessage": "四月"
+  },
+  "cronPicker.at": {
+    "defaultMessage": "於"
+  },
+  "cronPicker.atMinute": {
+    "defaultMessage": "於第幾分"
+  },
+  "cronPicker.atSecond": {
+    "defaultMessage": "於第幾秒"
+  },
+  "cronPicker.august": {
+    "defaultMessage": "八月"
+  },
+  "cronPicker.cronExpression": {
+    "defaultMessage": "Cron 運算式"
+  },
+  "cronPicker.custom": {
+    "defaultMessage": "自訂 cron"
+  },
+  "cronPicker.day": {
+    "defaultMessage": "日"
+  },
+  "cronPicker.december": {
+    "defaultMessage": "十二月"
+  },
+  "cronPicker.emptyCronError": {
+    "defaultMessage": "Cron 運算式不可為空白"
+  },
+  "cronPicker.every": {
+    "defaultMessage": "每"
+  },
+  "cronPicker.february": {
+    "defaultMessage": "二月"
+  },
+  "cronPicker.friday": {
+    "defaultMessage": "星期五"
+  },
+  "cronPicker.hour": {
+    "defaultMessage": "時"
+  },
+  "cronPicker.inMonth": {
+    "defaultMessage": "於"
+  },
+  "cronPicker.invalidDayOfMonth": {
+    "defaultMessage": "日期必須介於 1 與 {max} 之間"
+  },
+  "cronPicker.january": {
+    "defaultMessage": "一月"
+  },
+  "cronPicker.july": {
+    "defaultMessage": "七月"
+  },
+  "cronPicker.june": {
+    "defaultMessage": "六月"
+  },
+  "cronPicker.march": {
+    "defaultMessage": "三月"
+  },
+  "cronPicker.may": {
+    "defaultMessage": "五月"
+  },
+  "cronPicker.minute": {
+    "defaultMessage": "分"
+  },
+  "cronPicker.mode": {
+    "defaultMessage": "模式"
+  },
+  "cronPicker.monday": {
+    "defaultMessage": "星期一"
+  },
+  "cronPicker.month": {
+    "defaultMessage": "月"
+  },
+  "cronPicker.november": {
+    "defaultMessage": "十一月"
+  },
+  "cronPicker.october": {
+    "defaultMessage": "十月"
+  },
+  "cronPicker.on": {
+    "defaultMessage": "於"
+  },
+  "cronPicker.onDay": {
+    "defaultMessage": "於第幾日"
+  },
+  "cronPicker.quarter": {
+    "defaultMessage": "季"
+  },
+  "cronPicker.saturday": {
+    "defaultMessage": "星期六"
+  },
+  "cronPicker.september": {
+    "defaultMessage": "九月"
+  },
+  "cronPicker.startingMonth": {
+    "defaultMessage": "起始月份"
+  },
+  "cronPicker.sunday": {
+    "defaultMessage": "星期日"
+  },
+  "cronPicker.thursday": {
+    "defaultMessage": "星期四"
+  },
+  "cronPicker.tuesday": {
+    "defaultMessage": "星期二"
+  },
+  "cronPicker.wednesday": {
+    "defaultMessage": "星期三"
+  },
+  "cronPicker.week": {
+    "defaultMessage": "週"
+  },
+  "cronPicker.year": {
+    "defaultMessage": "年"
+  },
+  "customProviderForm.add": {
+    "defaultMessage": "新增"
+  },
+  "customProviderForm.anthropicCompatible": {
+    "defaultMessage": "Anthropic 相容"
+  },
+  "customProviderForm.apiBasePath": {
+    "defaultMessage": "API 基底路徑（選用）"
+  },
+  "customProviderForm.apiBasePathHint": {
+    "defaultMessage": "覆寫預設的 API 路徑。留空則使用供應商的預設路徑。"
+  },
+  "customProviderForm.apiBasePathPlaceholder": {
+    "defaultMessage": "例如：v1/chat/completions 或 project_id/v1"
+  },
+  "customProviderForm.apiKey": {
+    "defaultMessage": "API 金鑰"
+  },
+  "customProviderForm.apiKeyPlaceholderExisting": {
+    "defaultMessage": "留空以保留現有金鑰"
+  },
+  "customProviderForm.apiKeyPlaceholderNew": {
+    "defaultMessage": "您的 API 金鑰"
+  },
+  "customProviderForm.apiKeyRequired": {
+    "defaultMessage": "API 金鑰為必填"
+  },
+  "customProviderForm.apiUrl": {
+    "defaultMessage": "API URL"
+  },
+  "customProviderForm.apiUrlPlaceholder": {
+    "defaultMessage": "https://api.example.com"
+  },
+  "customProviderForm.apiUrlRequired": {
+    "defaultMessage": "API URL 為必填"
+  },
+  "customProviderForm.attachments": {
+    "defaultMessage": "附件"
+  },
+  "customProviderForm.authHint": {
+    "defaultMessage": "Ollama 等本機 LLM 通常不需要 API 金鑰。"
+  },
+  "customProviderForm.authentication": {
+    "defaultMessage": "驗證"
+  },
+  "customProviderForm.availableModels": {
+    "defaultMessage": "可用模型（以逗號分隔）"
+  },
+  "customProviderForm.back": {
+    "defaultMessage": "← 返回"
+  },
+  "customProviderForm.cancel": {
+    "defaultMessage": "取消"
+  },
+  "customProviderForm.cannotDeleteActive": {
+    "defaultMessage": "此供應商目前正在使用中，無法刪除。請先切換至其他模型。"
+  },
+  "customProviderForm.chooseSetup": {
+    "defaultMessage": "選擇您要設定供應商的方式。"
+  },
+  "customProviderForm.clear": {
+    "defaultMessage": "清除"
+  },
+  "customProviderForm.configureManually": {
+    "defaultMessage": "手動設定"
+  },
+  "customProviderForm.configureManuallyDesc": {
+    "defaultMessage": "自行輸入所有供應商詳細資料"
+  },
+  "customProviderForm.confirmDelete": {
+    "defaultMessage": "確認刪除"
+  },
+  "customProviderForm.createProvider": {
+    "defaultMessage": "建立供應商"
+  },
+  "customProviderForm.customHeaders": {
+    "defaultMessage": "自訂標頭"
+  },
+  "customProviderForm.customHeadersHint": {
+    "defaultMessage": "新增自訂 HTTP 標頭，以納入傳送給供應商的請求中。填妥兩個欄位後，按一下「+」按鈕即可新增。"
+  },
+  "customProviderForm.deleteConfirmation": {
+    "defaultMessage": "您確定要刪除這個自訂供應商嗎？這會永久移除該供應商及其儲存的 API 金鑰。此動作無法復原。"
+  },
+  "customProviderForm.deleteProvider": {
+    "defaultMessage": "刪除供應商"
+  },
+  "customProviderForm.displayName": {
+    "defaultMessage": "顯示名稱"
+  },
+  "customProviderForm.displayNamePlaceholder": {
+    "defaultMessage": "您的供應商名稱"
+  },
+  "customProviderForm.displayNameRequired": {
+    "defaultMessage": "顯示名稱為必填"
+  },
+  "customProviderForm.docs": {
+    "defaultMessage": "文件"
+  },
+  "customProviderForm.headerBothRequired": {
+    "defaultMessage": "標頭名稱與值都必須輸入"
+  },
+  "customProviderForm.headerDuplicate": {
+    "defaultMessage": "已存在使用此名稱的標頭"
+  },
+  "customProviderForm.headerNamePlaceholder": {
+    "defaultMessage": "標頭名稱"
+  },
+  "customProviderForm.headerNoSpaces": {
+    "defaultMessage": "標頭名稱不可包含空格"
+  },
+  "customProviderForm.modelsPlaceholder": {
+    "defaultMessage": "model-a, model-b, model-c"
+  },
+  "customProviderForm.modelsRequired": {
+    "defaultMessage": "至少需要一個模型"
+  },
+  "customProviderForm.ollamaCompatible": {
+    "defaultMessage": "Ollama 相容"
+  },
+  "customProviderForm.openaiCompatible": {
+    "defaultMessage": "OpenAI 相容"
+  },
+  "customProviderForm.providerType": {
+    "defaultMessage": "供應商類型"
+  },
+  "customProviderForm.reasoning": {
+    "defaultMessage": "推理"
+  },
+  "customProviderForm.requiresApiKey": {
+    "defaultMessage": "此供應商需要 API 金鑰"
+  },
+  "customProviderForm.startFromTemplate": {
+    "defaultMessage": "從供應商範本開始"
+  },
+  "customProviderForm.startFromTemplateDesc": {
+    "defaultMessage": "選擇一個已知的供應商，我們會自動填入設定"
+  },
+  "customProviderForm.submitError": {
+    "defaultMessage": "無法儲存供應商。請檢查您的設定後再試一次。"
+  },
+  "customProviderForm.supportsStreaming": {
+    "defaultMessage": "供應商支援串流回應"
+  },
+  "customProviderForm.toolCalling": {
+    "defaultMessage": "工具呼叫"
+  },
+  "customProviderForm.updateProvider": {
+    "defaultMessage": "更新供應商"
+  },
+  "customProviderForm.usingTemplate": {
+    "defaultMessage": "使用範本：{name}"
+  },
+  "customProviderForm.valuePlaceholder": {
+    "defaultMessage": "值"
+  },
+  "defaultCardButtons.configureSettings": {
+    "defaultMessage": "設定 {name} 設定"
+  },
+  "defaultCardButtons.deleteSettings": {
+    "defaultMessage": "刪除 {name} 設定"
+  },
+  "defaultCardButtons.editSettings": {
+    "defaultMessage": "編輯 {name} 設定"
+  },
+  "defaultCardButtons.getStarted": {
+    "defaultMessage": "開始使用 goose！"
+  },
+  "defaultProviderSetupForm.apiHostLabel": {
+    "defaultMessage": "API 主機"
+  },
+  "defaultProviderSetupForm.apiHostPlaceholder": {
+    "defaultMessage": "https://api.example.com"
+  },
+  "defaultProviderSetupForm.apiKeyLabel": {
+    "defaultMessage": "API 金鑰"
+  },
+  "defaultProviderSetupForm.apiKeyPlaceholder": {
+    "defaultMessage": "您的 API 金鑰"
+  },
+  "defaultProviderSetupForm.hideOptions": {
+    "defaultMessage": "隱藏 {count} 個選項"
+  },
+  "defaultProviderSetupForm.loadingConfig": {
+    "defaultMessage": "正在載入設定值…"
+  },
+  "defaultProviderSetupForm.modelsLabel": {
+    "defaultMessage": "模型"
+  },
+  "defaultProviderSetupForm.modelsPlaceholder": {
+    "defaultMessage": "model-a, model-b"
+  },
+  "defaultProviderSetupForm.noConfigParameters": {
+    "defaultMessage": "此供應商沒有設定參數。"
+  },
+  "defaultProviderSetupForm.showOptions": {
+    "defaultMessage": "顯示 {count} 個選項"
+  },
+  "diagnosticsModal.attachHint": {
+    "defaultMessage": "如果您要回報錯誤，建議將診斷報告一併附上。"
+  },
+  "diagnosticsModal.cancel": {
+    "defaultMessage": "取消"
+  },
+  "diagnosticsModal.configSettings": {
+    "defaultMessage": "設定項目"
+  },
+  "diagnosticsModal.description": {
+    "defaultMessage": "您可以下載診斷 JSON 報告與團隊分享，或直接在 GitHub 上回報錯誤並預先填入您的系統詳細資料。診斷報告包含下列內容："
+  },
+  "diagnosticsModal.diagnosticsErrorMsg": {
+    "defaultMessage": "無法下載診斷報告"
+  },
+  "diagnosticsModal.diagnosticsErrorTitle": {
+    "defaultMessage": "診斷錯誤"
+  },
+  "diagnosticsModal.download": {
+    "defaultMessage": "下載"
+  },
+  "diagnosticsModal.downloading": {
+    "defaultMessage": "正在下載…"
+  },
+  "diagnosticsModal.fileBug": {
+    "defaultMessage": "在 GitHub 上回報錯誤"
+  },
+  "diagnosticsModal.logFiles": {
+    "defaultMessage": "最近的記錄檔"
+  },
+  "diagnosticsModal.opening": {
+    "defaultMessage": "正在開啟…"
+  },
+  "diagnosticsModal.reportProblem": {
+    "defaultMessage": "回報問題"
+  },
+  "diagnosticsModal.sensitiveWarning": {
+    "defaultMessage": "如果您的工作階段包含敏感資訊，請勿公開分享診斷檔案。"
+  },
+  "diagnosticsModal.sessionMessages": {
+    "defaultMessage": "您目前工作階段的訊息"
+  },
+  "diagnosticsModal.systemInfo": {
+    "defaultMessage": "基本系統資訊"
+  },
+  "diagnosticsModal.systemInfoErrorMsg": {
+    "defaultMessage": "無法取得系統資訊"
+  },
+  "diagnosticsModal.systemInfoErrorTitle": {
+    "defaultMessage": "錯誤"
+  },
+  "dialog.close": {
+    "defaultMessage": "關閉"
+  },
+  "dictationSettings.addApiKey": {
+    "defaultMessage": "新增 API 金鑰"
+  },
+  "dictationSettings.apiKey": {
+    "defaultMessage": "API 金鑰"
+  },
+  "dictationSettings.cancel": {
+    "defaultMessage": "取消"
+  },
+  "dictationSettings.chooseVoiceConversion": {
+    "defaultMessage": "選擇語音轉換為文字的方式"
+  },
+  "dictationSettings.configureApiKey": {
+    "defaultMessage": "在 <b>{settingsPath}</b> 中設定 API 金鑰"
+  },
+  "dictationSettings.configured": {
+    "defaultMessage": "（已設定）"
+  },
+  "dictationSettings.configuredIn": {
+    "defaultMessage": "✓ 已在 {settingsPath} 中設定"
+  },
+  "dictationSettings.disabled": {
+    "defaultMessage": "已停用"
+  },
+  "dictationSettings.enterApiKey": {
+    "defaultMessage": "輸入您的 API 金鑰"
+  },
+  "dictationSettings.notConfigured": {
+    "defaultMessage": "（尚未設定）"
+  },
+  "dictationSettings.removeApiKey": {
+    "defaultMessage": "移除 API 金鑰"
+  },
+  "dictationSettings.requiredForTranscription": {
+    "defaultMessage": "轉錄所需"
+  },
+  "dictationSettings.save": {
+    "defaultMessage": "儲存"
+  },
+  "dictationSettings.updateApiKey": {
+    "defaultMessage": "更新 API 金鑰"
+  },
+  "dictationSettings.voiceDictationProvider": {
+    "defaultMessage": "語音聽寫供應商"
+  },
+  "dirSwitcher.chooseDirectory": {
+    "defaultMessage": "選擇目錄…"
+  },
+  "dirSwitcher.currentDirectory": {
+    "defaultMessage": "目前目錄"
+  },
+  "dirSwitcher.failedToUpdateWorkingDir": {
+    "defaultMessage": "無法更新工作目錄"
+  },
+  "dirSwitcher.gitWorktrees": {
+    "defaultMessage": "Git 工作樹"
+  },
+  "dirSwitcher.noWorktreesFound": {
+    "defaultMessage": "找不到工作樹"
+  },
+  "dirSwitcher.openInFinder": {
+    "defaultMessage": "在檔案管理員中開啟"
+  },
+  "dirSwitcher.recentDirectories": {
+    "defaultMessage": "最近的目錄"
+  },
+  "elicitationRequest.accept": {
+    "defaultMessage": "接受"
+  },
+  "elicitationRequest.cancelled": {
+    "defaultMessage": "資訊要求已取消。"
+  },
+  "elicitationRequest.defaultMessage": {
+    "defaultMessage": "Goose 需要您提供一些資訊。"
+  },
+  "elicitationRequest.expired": {
+    "defaultMessage": "此要求已過期。擴充功能需要重新詢問。"
+  },
+  "elicitationRequest.submit": {
+    "defaultMessage": "提交"
+  },
+  "elicitationRequest.submitError": {
+    "defaultMessage": "此要求已不再有效。擴充功能需要重新詢問。"
+  },
+  "elicitationRequest.submitted": {
+    "defaultMessage": "資訊已提交"
+  },
+  "elicitationRequest.waitingForResponse": {
+    "defaultMessage": "正在等待您的回應（剩餘 {timeRemaining}）"
+  },
+  "envVarsSection.add": {
+    "defaultMessage": "新增"
+  },
+  "envVarsSection.bothRequired": {
+    "defaultMessage": "必須同時輸入變數名稱與值"
+  },
+  "envVarsSection.envVarsDescription": {
+    "defaultMessage": "新增環境變數的鍵值組。填妥兩個欄位後，按一下「+」按鈕即可新增。若要修改現有的密碼值，請按一下編輯按鈕。"
+  },
+  "envVarsSection.environmentVariables": {
+    "defaultMessage": "環境變數"
+  },
+  "envVarsSection.noSpaces": {
+    "defaultMessage": "變數名稱不可包含空格"
+  },
+  "envVarsSection.value": {
+    "defaultMessage": "值"
+  },
+  "envVarsSection.variableName": {
+    "defaultMessage": "變數名稱"
+  },
+  "environmentBadge.dev": {
+    "defaultMessage": "開發"
+  },
+  "errorBoundary.errorGeneric": {
+    "defaultMessage": "發生錯誤。"
+  },
+  "errorBoundary.errorWithVersion": {
+    "defaultMessage": "Goose v{version} 發生錯誤。"
+  },
+  "errorBoundary.heading": {
+    "defaultMessage": "Honk！"
+  },
+  "errorBoundary.reload": {
+    "defaultMessage": "重新載入"
+  },
+  "extensionConfigFields.commandLabel": {
+    "defaultMessage": "命令"
+  },
+  "extensionConfigFields.commandPlaceholder": {
+    "defaultMessage": "例如 npx -y @modelcontextprotocol/my-extension [filepath]"
+  },
+  "extensionConfigFields.commandRequired": {
+    "defaultMessage": "命令為必填"
+  },
+  "extensionConfigFields.endpointLabel": {
+    "defaultMessage": "端點"
+  },
+  "extensionConfigFields.endpointPlaceholder": {
+    "defaultMessage": "輸入端點 URL…"
+  },
+  "extensionConfigFields.endpointRequired": {
+    "defaultMessage": "端點 URL 為必填"
+  },
+  "extensionInfoFields.descriptionLabel": {
+    "defaultMessage": "說明"
+  },
+  "extensionInfoFields.descriptionPlaceholder": {
+    "defaultMessage": "選填說明…"
+  },
+  "extensionInfoFields.extensionName": {
+    "defaultMessage": "擴充功能名稱"
+  },
+  "extensionInfoFields.extensionNamePlaceholder": {
+    "defaultMessage": "輸入擴充功能名稱…"
+  },
+  "extensionInfoFields.nameRequired": {
+    "defaultMessage": "名稱為必填"
+  },
+  "extensionInfoFields.typeHttp": {
+    "defaultMessage": "HTTP"
+  },
+  "extensionInfoFields.typeLabel": {
+    "defaultMessage": "類型"
+  },
+  "extensionInfoFields.typeSseUnsupported": {
+    "defaultMessage": "SSE（不支援）"
+  },
+  "extensionInfoFields.typeStandardIo": {
+    "defaultMessage": "標準 IO (STDIO)"
+  },
+  "extensionInfoFields.typeStdio": {
+    "defaultMessage": "STDIO"
+  },
+  "extensionInfoFields.typeStreamableHttp": {
+    "defaultMessage": "Streamable HTTP"
+  },
+  "extensionInstallModal.alreadyInstalledMessage": {
+    "defaultMessage": "「{name}」擴充功能已成功安裝。請開始新的聊天工作階段以使用它。"
+  },
+  "extensionInstallModal.alreadyInstalledTitle": {
+    "defaultMessage": "擴充功能「{name}」已安裝"
+  },
+  "extensionInstallModal.blockedMessage": {
+    "defaultMessage": "此擴充功能命令不在允許清單中，安裝已遭封鎖。擴充功能：{name} 命令：{command} 請聯絡您的管理員以要求核准此擴充功能。"
+  },
+  "extensionInstallModal.blockedTitle": {
+    "defaultMessage": "擴充功能安裝遭封鎖"
+  },
+  "extensionInstallModal.cancel": {
+    "defaultMessage": "取消"
+  },
+  "extensionInstallModal.installAnyway": {
+    "defaultMessage": "仍要安裝"
+  },
+  "extensionInstallModal.installing": {
+    "defaultMessage": "正在安裝…"
+  },
+  "extensionInstallModal.no": {
+    "defaultMessage": "否"
+  },
+  "extensionInstallModal.ok": {
+    "defaultMessage": "確定"
+  },
+  "extensionInstallModal.trustedMessage": {
+    "defaultMessage": "您確定要安裝 {name} 擴充功能嗎？命令：{command}"
+  },
+  "extensionInstallModal.trustedTitle": {
+    "defaultMessage": "確認安裝擴充功能"
+  },
+  "extensionInstallModal.unknownCommand": {
+    "defaultMessage": "未知命令"
+  },
+  "extensionInstallModal.untrustedMessageWithCommand": {
+    "defaultMessage": "{securityMessage} 擴充功能：{name} 命令：{command} 如有疑問，請聯絡您的管理員。"
+  },
+  "extensionInstallModal.untrustedMessageWithUrl": {
+    "defaultMessage": "{securityMessage} 擴充功能：{name} URL：{url} 如有疑問，請聯絡您的管理員。"
+  },
+  "extensionInstallModal.untrustedSecurityMessage": {
+    "defaultMessage": "此擴充功能命令不在允許清單中，將能夠存取您的對話並提供額外功能。從不受信任的來源安裝擴充功能可能帶來安全風險。"
+  },
+  "extensionInstallModal.untrustedTitle": {
+    "defaultMessage": "要安裝不受信任的擴充功能嗎？"
+  },
+  "extensionInstallModal.yes": {
+    "defaultMessage": "是"
+  },
+  "extensionItem.configureExtension": {
+    "defaultMessage": "設定 {name} 擴充功能"
+  },
+  "extensionItem.toggleExtension": {
+    "defaultMessage": "開啟或關閉 {name} 擴充功能"
+  },
+  "extensionList.availableExtensions": {
+    "defaultMessage": "可用的擴充功能（{count}）"
+  },
+  "extensionList.builtInExtension": {
+    "defaultMessage": "內建擴充功能"
+  },
+  "extensionList.defaultExtensions": {
+    "defaultMessage": "預設擴充功能（{count}）"
+  },
+  "extensionList.noExtensions": {
+    "defaultMessage": "沒有可用的擴充功能"
+  },
+  "extensionModal.cancel": {
+    "defaultMessage": "取消"
+  },
+  "extensionModal.closeWithoutSaving": {
+    "defaultMessage": "不儲存並關閉"
+  },
+  "extensionModal.confirmRemoval": {
+    "defaultMessage": "確認移除"
+  },
+  "extensionModal.deleteDescription": {
+    "defaultMessage": "這將永久移除此擴充功能及其所有設定。"
+  },
+  "extensionModal.deleteExtensionTitle": {
+    "defaultMessage": "刪除擴充功能「{name}」"
+  },
+  "extensionModal.installationNotes": {
+    "defaultMessage": "安裝注意事項"
+  },
+  "extensionModal.removeExtension": {
+    "defaultMessage": "移除擴充功能"
+  },
+  "extensionModal.unsavedChangesMessage": {
+    "defaultMessage": "您對擴充功能設定有尚未儲存的變更。您確定要不儲存就關閉嗎？"
+  },
+  "extensionModal.unsavedChangesTitle": {
+    "defaultMessage": "尚未儲存的變更"
+  },
+  "extensionTimeoutField.timeoutLabel": {
+    "defaultMessage": "逾時"
+  },
+  "extensionsSection.addCustomExtension": {
+    "defaultMessage": "新增自訂擴充功能"
+  },
+  "extensionsSection.addExtension": {
+    "defaultMessage": "新增擴充功能"
+  },
+  "extensionsSection.browseExtensions": {
+    "defaultMessage": "瀏覽擴充功能"
+  },
+  "extensionsSection.saveChanges": {
+    "defaultMessage": "儲存變更"
+  },
+  "extensionsSection.updateExtension": {
+    "defaultMessage": "更新擴充功能"
+  },
+  "extensionsView.addCustomExtension": {
+    "defaultMessage": "新增自訂擴充功能"
+  },
+  "extensionsView.addExtension": {
+    "defaultMessage": "新增擴充功能"
+  },
+  "extensionsView.browseExtensions": {
+    "defaultMessage": "瀏覽擴充功能"
+  },
+  "extensionsView.defaultNote": {
+    "defaultMessage": "在此啟用的擴充功能會作為新聊天的預設值。您也可以在聊天期間切換使用中的擴充功能。"
+  },
+  "extensionsView.description": {
+    "defaultMessage": "這些擴充功能使用模型內容協定 (MCP)。它們可透過三個主要元件擴充 Goose 的能力：提示、資源與工具。{searchShortcut} 即可搜尋。"
+  },
+  "extensionsView.heading": {
+    "defaultMessage": "擴充功能"
+  },
+  "extensionsView.searchPlaceholder": {
+    "defaultMessage": "搜尋擴充功能…"
+  },
+  "externalBackendSection.certFingerprint": {
+    "defaultMessage": "憑證指紋（選填）"
+  },
+  "externalBackendSection.certFingerprintHelp": {
+    "defaultMessage": "釘選特定的 TLS 憑證指紋。若未填寫，將於首次使用時信任該憑證 (TOFU)。"
+  },
+  "externalBackendSection.certFingerprintPlaceholder": {
+    "defaultMessage": "AA:BB:CC:… 或 sha256/base64"
+  },
+  "externalBackendSection.description": {
+    "defaultMessage": "goose 預設會為您啟動伺服器，使用此選項以連線至外部 goose 伺服器"
+  },
+  "externalBackendSection.restartNote": {
+    "defaultMessage": "變更需要重新啟動 Goose 才會生效。新的聊天視窗將連線至外部伺服器。"
+  },
+  "externalBackendSection.secretKey": {
+    "defaultMessage": "密鑰"
+  },
+  "externalBackendSection.secretKeyHelp": {
+    "defaultMessage": "在 goosed 伺服器上設定的密鑰 (GOOSE_SERVER__SECRET_KEY)"
+  },
+  "externalBackendSection.secretKeyPlaceholder": {
+    "defaultMessage": "輸入伺服器的密鑰"
+  },
+  "externalBackendSection.serverUrl": {
+    "defaultMessage": "伺服器 URL"
+  },
+  "externalBackendSection.title": {
+    "defaultMessage": "Goose 伺服器"
+  },
+  "externalBackendSection.urlFormatError": {
+    "defaultMessage": "URL 格式無效"
+  },
+  "externalBackendSection.urlProtocolError": {
+    "defaultMessage": "URL 必須使用 http 或 https 通訊協定"
+  },
+  "externalBackendSection.useExternalServer": {
+    "defaultMessage": "使用外部伺服器"
+  },
+  "externalBackendSection.useExternalServerDescription": {
+    "defaultMessage": "連線至在其他位置執行的 goose 伺服器（需要重新啟動應用程式）"
+  },
+  "freeOptionCards.chooseOption": {
+    "defaultMessage": "選擇一個選項以開始使用。"
+  },
+  "freeOptionCards.freeAndPrivate": {
+    "defaultMessage": "免費且私密"
+  },
+  "freeOptionCards.localModelDescription": {
+    "defaultMessage": "下載模型並完全在您的電腦上執行。無需 API 金鑰，無需帳號。"
+  },
+  "freeOptionCards.localModelTitle": {
+    "defaultMessage": "使用本機模型"
+  },
+  "freeOptionCards.nanogptDescription": {
+    "defaultMessage": "註冊即可獲得 7 天 6,000 萬個免費權杖。"
+  },
+  "freeOptionCards.nanogptTitle": {
+    "defaultMessage": "NanoGPT"
+  },
+  "freeOptionCards.retry": {
+    "defaultMessage": "重試"
+  },
+  "freeOptionCards.tetrateDescription": {
+    "defaultMessage": "透過自動設定存取多種 AI 模型。註冊即可獲得 $10 點數。"
+  },
+  "freeOptionCards.tetrateTitle": {
+    "defaultMessage": "Tetrate 的 Agent Router"
+  },
+  "freeOptionCards.unexpectedError": {
+    "defaultMessage": "設定期間發生非預期的錯誤。"
+  },
+  "goosehintsModal.close": {
+    "defaultMessage": "關閉"
+  },
+  "goosehintsModal.developer": {
+    "defaultMessage": "開發者"
+  },
+  "goosehintsModal.dialogDescription": {
+    "defaultMessage": "提供有關您專案的額外內容，以改善與 Goose 的溝通"
+  },
+  "goosehintsModal.dialogTitle": {
+    "defaultMessage": "設定專案提示 (.goosehints)"
+  },
+  "goosehintsModal.errorReading": {
+    "defaultMessage": "讀取 .goosehints 檔案時發生錯誤：{error}"
+  },
+  "goosehintsModal.failedToAccess": {
+    "defaultMessage": "無法存取 .goosehints 檔案"
+  },
+  "goosehintsModal.failedToSave": {
+    "defaultMessage": "無法儲存 .goosehints 檔案"
+  },
+  "goosehintsModal.fileCreating": {
+    "defaultMessage": "正在於此處建立新的 .goosehints 檔案：{filePath}"
+  },
+  "goosehintsModal.fileFound": {
+    "defaultMessage": "在此處找到 .goosehints 檔案：{filePath}"
+  },
+  "goosehintsModal.helpText1": {
+    "defaultMessage": ".goosehints 是一個文字檔，用於提供有關您專案的額外內容，並改善與 Goose 的溝通。"
+  },
+  "goosehintsModal.helpText2": {
+    "defaultMessage": "請確認擴充功能頁面中已啟用 {bold} 擴充功能。使用 .goosehints 需要此擴充功能。您需要重新啟動工作階段，.goosehints 的更新才會生效。"
+  },
+  "goosehintsModal.helpText3": {
+    "defaultMessage": "如需更多資訊，請參閱 {link}。"
+  },
+  "goosehintsModal.helpTextLink": {
+    "defaultMessage": "使用 .goosehints"
+  },
+  "goosehintsModal.placeholder": {
+    "defaultMessage": "在此輸入專案提示…"
+  },
+  "goosehintsModal.save": {
+    "defaultMessage": "儲存"
+  },
+  "goosehintsModal.savedSuccessfully": {
+    "defaultMessage": "已成功儲存"
+  },
+  "goosehintsModal.saving": {
+    "defaultMessage": "正在儲存…"
+  },
+  "goosehintsSection.configure": {
+    "defaultMessage": "設定"
+  },
+  "goosehintsSection.description": {
+    "defaultMessage": "設定您專案的 .goosehints 檔案，為 Goose 提供額外內容"
+  },
+  "goosehintsSection.title": {
+    "defaultMessage": "專案提示 (.goosehints)"
+  },
+  "groupedExtensionLoadingToast.askGoose": {
+    "defaultMessage": "詢問 goose"
+  },
+  "groupedExtensionLoadingToast.collapseDetails": {
+    "defaultMessage": "收合詳細資料"
+  },
+  "groupedExtensionLoadingToast.copied": {
+    "defaultMessage": "已複製！"
+  },
+  "groupedExtensionLoadingToast.copyError": {
+    "defaultMessage": "複製錯誤"
+  },
+  "groupedExtensionLoadingToast.expandDetails": {
+    "defaultMessage": "展開詳細資料"
+  },
+  "groupedExtensionLoadingToast.failedToAddExtension": {
+    "defaultMessage": "無法新增擴充功能"
+  },
+  "groupedExtensionLoadingToast.failedToLoad": {
+    "defaultMessage": "{count,plural,one{# 個擴充功能載入失敗} other{# 個擴充功能載入失敗}}"
+  },
+  "groupedExtensionLoadingToast.loadingExtensions": {
+    "defaultMessage": "{count,plural,one{正在載入 # 個擴充功能…} other{正在載入 # 個擴充功能…}}"
+  },
+  "groupedExtensionLoadingToast.partiallyLoaded": {
+    "defaultMessage": "{totalCount,plural,one{已載入 {successCount}/# 個擴充功能} other{已載入 {successCount}/# 個擴充功能}}"
+  },
+  "groupedExtensionLoadingToast.showDetails": {
+    "defaultMessage": "顯示詳細資料"
+  },
+  "groupedExtensionLoadingToast.showLess": {
+    "defaultMessage": "顯示較少"
+  },
+  "groupedExtensionLoadingToast.successfullyLoaded": {
+    "defaultMessage": "{count,plural,one{已成功載入 # 個擴充功能} other{已成功載入 # 個擴充功能}}"
+  },
+  "headersSection.add": {
+    "defaultMessage": "新增"
+  },
+  "headersSection.bothRequired": {
+    "defaultMessage": "必須同時輸入標頭名稱與值"
+  },
+  "headersSection.duplicateHeader": {
+    "defaultMessage": "已存在同名的標頭"
+  },
+  "headersSection.headerName": {
+    "defaultMessage": "標頭名稱"
+  },
+  "headersSection.headersDescription": {
+    "defaultMessage": "新增要在傳送至 MCP 伺服器的要求中包含的自訂 HTTP 標頭。填妥兩個欄位後，按一下「+」按鈕即可新增。"
+  },
+  "headersSection.noSpaces": {
+    "defaultMessage": "標頭名稱不可包含空格"
+  },
+  "headersSection.requestHeaders": {
+    "defaultMessage": "要求標頭"
+  },
+  "headersSection.value": {
+    "defaultMessage": "值"
+  },
+  "hub.goodAfternoon": {
+    "defaultMessage": "午安"
+  },
+  "hub.goodEvening": {
+    "defaultMessage": "晚安"
+  },
+  "hub.goodMorning": {
+    "defaultMessage": "早安"
+  },
+  "huggingFaceModelSearch.download": {
+    "defaultMessage": "下載"
+  },
+  "huggingFaceModelSearch.downloaded": {
+    "defaultMessage": "已下載"
+  },
+  "huggingFaceModelSearch.downloading": {
+    "defaultMessage": "正在下載…"
+  },
+  "huggingFaceModelSearch.loadingVariants": {
+    "defaultMessage": "正在載入變體…"
+  },
+  "huggingFaceModelSearch.noGgufModels": {
+    "defaultMessage": "找不到符合此查詢的相容本機模型。"
+  },
+  "huggingFaceModelSearch.recommended": {
+    "defaultMessage": "推薦"
+  },
+  "huggingFaceModelSearch.searchError": {
+    "defaultMessage": "搜尋錯誤：{details}"
+  },
+  "huggingFaceModelSearch.searchFailed": {
+    "defaultMessage": "搜尋失敗。請再試一次。"
+  },
+  "huggingFaceModelSearch.searchHuggingFace": {
+    "defaultMessage": "搜尋 HuggingFace"
+  },
+  "huggingFaceModelSearch.searchNoData": {
+    "defaultMessage": "搜尋未傳回任何資料。"
+  },
+  "huggingFaceModelSearch.searchPlaceholder": {
+    "defaultMessage": "搜尋本機模型…"
+  },
+  "huggingFaceModelSearch.tooLarge": {
+    "defaultMessage": "可能無法載入記憶體（模型 {size}，可用 {available}）"
+  },
+  "huggingFaceSignInPrompt.failedToConfigure": {
+    "defaultMessage": "登入 Hugging Face 失敗：{error}"
+  },
+  "huggingFaceSignInPrompt.signIn": {
+    "defaultMessage": "登入"
+  },
+  "huggingFaceSignInPrompt.signedIn": {
+    "defaultMessage": "已登入 Hugging Face"
+  },
+  "huggingFaceSignInPrompt.signingIn": {
+    "defaultMessage": "正在登入…"
+  },
+  "huggingFaceSignInPrompt.title": {
+    "defaultMessage": "Hugging Face"
+  },
+  "imagePreview.altText": {
+    "defaultMessage": "goose 圖片"
+  },
+  "imagePreview.clickToCollapse": {
+    "defaultMessage": "按一下以收合"
+  },
+  "imagePreview.clickToExpand": {
+    "defaultMessage": "按一下以展開"
+  },
+  "imagePreview.unableToLoad": {
+    "defaultMessage": "無法載入圖片"
+  },
+  "importRecipeForm.cancel": {
+    "defaultMessage": "取消"
+  },
+  "importRecipeForm.deeplinkHint": {
+    "defaultMessage": "貼上以「goose://recipe?config=」開頭的食譜深層連結"
+  },
+  "importRecipeForm.deeplinkPlaceholder": {
+    "defaultMessage": "在此貼上您的 goose://recipe?config=… 深層連結"
+  },
+  "importRecipeForm.example": {
+    "defaultMessage": "範例"
+  },
+  "importRecipeForm.expectedRecipeStructure": {
+    "defaultMessage": "預期的食譜結構"
+  },
+  "importRecipeForm.importRecipeButton": {
+    "defaultMessage": "匯入食譜"
+  },
+  "importRecipeForm.importRecipeTitle": {
+    "defaultMessage": "匯入食譜"
+  },
+  "importRecipeForm.importing": {
+    "defaultMessage": "正在匯入…"
+  },
+  "importRecipeForm.or": {
+    "defaultMessage": "或"
+  },
+  "importRecipeForm.recipeDeeplinkLabel": {
+    "defaultMessage": "食譜深層連結"
+  },
+  "importRecipeForm.recipeFileHint": {
+    "defaultMessage": "上傳包含食譜結構的 YAML 或 JSON 檔案"
+  },
+  "importRecipeForm.recipeFileLabel": {
+    "defaultMessage": "食譜檔案"
+  },
+  "importRecipeForm.reviewWarning": {
+    "defaultMessage": "在將食譜檔案加入您的 goose 介面之前，請務必檢閱其內容。"
+  },
+  "importRecipeForm.schemaDescription": {
+    "defaultMessage": "您的 YAML 或 JSON 檔案應遵循此結構。必填欄位為：title、description，以及 instructions 或 prompt 其中之一。"
+  },
+  "inlineEditText.clickToEdit": {
+    "defaultMessage": "按一下以編輯"
+  },
+  "inlineEditText.doubleClickToEdit": {
+    "defaultMessage": "按兩下以編輯"
+  },
+  "inlineEditText.enterText": {
+    "defaultMessage": "輸入文字"
+  },
+  "inlineEditText.failedToSave": {
+    "defaultMessage": "儲存失敗"
+  },
+  "instructionsEditor.cancel": {
+    "defaultMessage": "取消"
+  },
+  "instructionsEditor.insertExample": {
+    "defaultMessage": "插入範例"
+  },
+  "instructionsEditor.label": {
+    "defaultMessage": "指示"
+  },
+  "instructionsEditor.placeholder": {
+    "defaultMessage": "提供給 AI 的詳細指示，使用者看不到"
+  },
+  "instructionsEditor.save": {
+    "defaultMessage": "儲存指示"
+  },
+  "instructionsEditor.syntaxHelp": {
+    "defaultMessage": "使用 {code} 語法定義使用者可填入的參數"
+  },
+  "instructionsEditor.title": {
+    "defaultMessage": "指示編輯器"
+  },
+  "jsonSchemaEditor.cancel": {
+    "defaultMessage": "取消"
+  },
+  "jsonSchemaEditor.description": {
+    "defaultMessage": "使用 JSON Schema 格式定義 AI 回應的預期結構"
+  },
+  "jsonSchemaEditor.insertExample": {
+    "defaultMessage": "插入範例"
+  },
+  "jsonSchemaEditor.invalidJson": {
+    "defaultMessage": "JSON 格式無效"
+  },
+  "jsonSchemaEditor.label": {
+    "defaultMessage": "回應 JSON Schema"
+  },
+  "jsonSchemaEditor.save": {
+    "defaultMessage": "儲存結構描述"
+  },
+  "jsonSchemaEditor.title": {
+    "defaultMessage": "JSON Schema 編輯器"
+  },
+  "jsonSchemaForm.cancel": {
+    "defaultMessage": "取消"
+  },
+  "jsonSchemaForm.fieldRequired": {
+    "defaultMessage": "此欄位為必填"
+  },
+  "jsonSchemaForm.maxLength": {
+    "defaultMessage": "最大長度為 {maxLength}"
+  },
+  "jsonSchemaForm.maxValue": {
+    "defaultMessage": "最大值為 {maximum}"
+  },
+  "jsonSchemaForm.minLength": {
+    "defaultMessage": "最小長度為 {minLength}"
+  },
+  "jsonSchemaForm.minValue": {
+    "defaultMessage": "最小值為 {minimum}"
+  },
+  "jsonSchemaForm.noFields": {
+    "defaultMessage": "沒有可顯示的欄位"
+  },
+  "jsonSchemaForm.selectPlaceholder": {
+    "defaultMessage": "請選擇…"
+  },
+  "jsonSchemaForm.submit": {
+    "defaultMessage": "提交"
+  },
+  "keyValueEditor.addValue": {
+    "defaultMessage": "新增預先設定的值"
+  },
+  "keyValueEditor.defaultKeyPlaceholder": {
+    "defaultMessage": "參數名稱…"
+  },
+  "keyValueEditor.defaultValuePlaceholder": {
+    "defaultMessage": "參數值…"
+  },
+  "keyValueEditor.removeValue": {
+    "defaultMessage": "移除預先設定的值 {key}"
+  },
+  "keyboardShortcuts.alwaysOnTopDescription": {
+    "defaultMessage": "切換視窗永遠在最上層"
+  },
+  "keyboardShortcuts.alwaysOnTopLabel": {
+    "defaultMessage": "永遠在最上層"
+  },
+  "keyboardShortcuts.cancel": {
+    "defaultMessage": "取消"
+  },
+  "keyboardShortcuts.categoryApplication": {
+    "defaultMessage": "應用程式快速鍵"
+  },
+  "keyboardShortcuts.categoryApplicationDescription": {
+    "defaultMessage": "這些快速鍵在 Goose 為使用中的應用程式時生效"
+  },
+  "keyboardShortcuts.categoryGlobal": {
+    "defaultMessage": "全域快速鍵"
+  },
+  "keyboardShortcuts.categoryGlobalDescription": {
+    "defaultMessage": "這些快速鍵在整個系統都可使用，即使 Goose 並非焦點視窗"
+  },
+  "keyboardShortcuts.categorySearch": {
+    "defaultMessage": "搜尋快速鍵"
+  },
+  "keyboardShortcuts.categorySearchDescription": {
+    "defaultMessage": "這些快速鍵在對話中搜尋時生效"
+  },
+  "keyboardShortcuts.categoryWindow": {
+    "defaultMessage": "視窗快速鍵"
+  },
+  "keyboardShortcuts.categoryWindowDescription": {
+    "defaultMessage": "這些快速鍵用於控制視窗行為"
+  },
+  "keyboardShortcuts.change": {
+    "defaultMessage": "變更"
+  },
+  "keyboardShortcuts.disabled": {
+    "defaultMessage": "已停用"
+  },
+  "keyboardShortcuts.dismiss": {
+    "defaultMessage": "關閉"
+  },
+  "keyboardShortcuts.findDescription": {
+    "defaultMessage": "在對話中開啟搜尋"
+  },
+  "keyboardShortcuts.findLabel": {
+    "defaultMessage": "尋找"
+  },
+  "keyboardShortcuts.findNextDescription": {
+    "defaultMessage": "跳至下一個搜尋結果"
+  },
+  "keyboardShortcuts.findNextLabel": {
+    "defaultMessage": "尋找下一個"
+  },
+  "keyboardShortcuts.findPreviousDescription": {
+    "defaultMessage": "跳至上一個搜尋結果"
+  },
+  "keyboardShortcuts.findPreviousLabel": {
+    "defaultMessage": "尋找上一個"
+  },
+  "keyboardShortcuts.focusWindowDescription": {
+    "defaultMessage": "從任何位置將 Goose 視窗帶到前景"
+  },
+  "keyboardShortcuts.focusWindowLabel": {
+    "defaultMessage": "聚焦 Goose 視窗"
+  },
+  "keyboardShortcuts.loading": {
+    "defaultMessage": "載入中…"
+  },
+  "keyboardShortcuts.newChatDescription": {
+    "defaultMessage": "在目前視窗中建立新的對話"
+  },
+  "keyboardShortcuts.newChatLabel": {
+    "defaultMessage": "新對話"
+  },
+  "keyboardShortcuts.newChatWindowDescription": {
+    "defaultMessage": "開啟新的 Goose 視窗"
+  },
+  "keyboardShortcuts.newChatWindowLabel": {
+    "defaultMessage": "新對話視窗"
+  },
+  "keyboardShortcuts.openDirectoryDescription": {
+    "defaultMessage": "開啟目錄選擇對話框"
+  },
+  "keyboardShortcuts.openDirectoryLabel": {
+    "defaultMessage": "開啟目錄"
+  },
+  "keyboardShortcuts.quickLauncherDescription": {
+    "defaultMessage": "開啟快速啟動器覆蓋層"
+  },
+  "keyboardShortcuts.quickLauncherLabel": {
+    "defaultMessage": "快速啟動器"
+  },
+  "keyboardShortcuts.reassignShortcut": {
+    "defaultMessage": "重新指派快速鍵"
+  },
+  "keyboardShortcuts.resetAllShortcuts": {
+    "defaultMessage": "重設所有快速鍵"
+  },
+  "keyboardShortcuts.resetShortcutsDetail": {
+    "defaultMessage": "這會將所有快速鍵還原為原始設定。"
+  },
+  "keyboardShortcuts.resetShortcutsMessage": {
+    "defaultMessage": "要將所有鍵盤快速鍵重設為預設值嗎？"
+  },
+  "keyboardShortcuts.resetShortcutsTitle": {
+    "defaultMessage": "重設鍵盤快速鍵"
+  },
+  "keyboardShortcuts.resetToDefaultsDescription": {
+    "defaultMessage": "將所有鍵盤快速鍵還原為原始設定"
+  },
+  "keyboardShortcuts.resetToDefaultsHeading": {
+    "defaultMessage": "重設為預設值"
+  },
+  "keyboardShortcuts.restartDescription": {
+    "defaultMessage": "變更應用程式快速鍵（例如「新對話」、「設定」等）需要重新啟動 Goose 才會生效。全域快速鍵（聚焦視窗、快速啟動器）則會立即生效。"
+  },
+  "keyboardShortcuts.restartRequired": {
+    "defaultMessage": "需要重新啟動"
+  },
+  "keyboardShortcuts.settingsDescription": {
+    "defaultMessage": "開啟設定面板"
+  },
+  "keyboardShortcuts.settingsLabel": {
+    "defaultMessage": "設定"
+  },
+  "keyboardShortcuts.shortcutConflictSaveDetail": {
+    "defaultMessage": "儲存後會將此快速鍵從「{conflictLabel}」移除並指派給「{targetLabel}」。要繼續嗎？"
+  },
+  "keyboardShortcuts.shortcutConflictTitle": {
+    "defaultMessage": "快速鍵衝突"
+  },
+  "keyboardShortcuts.shortcutConflictToggleDetail": {
+    "defaultMessage": "啟用後會將此快速鍵從「{conflictLabel}」移除並指派給「{targetLabel}」。要繼續嗎？"
+  },
+  "keyboardShortcuts.shortcutConflictToggleMessage": {
+    "defaultMessage": "快速鍵 {shortcut} 已指派給「{conflictLabel}」。"
+  },
+  "keyboardShortcuts.toggleNavigationDescription": {
+    "defaultMessage": "顯示或隱藏導覽選單"
+  },
+  "keyboardShortcuts.toggleNavigationLabel": {
+    "defaultMessage": "切換導覽"
+  },
+  "launcher.placeholder": {
+    "defaultMessage": "向 goose 詢問任何問題…"
+  },
+  "loadingGoose.compacting": {
+    "defaultMessage": "goose 正在壓縮對話…"
+  },
+  "loadingGoose.idle": {
+    "defaultMessage": "goose 正在處理…"
+  },
+  "loadingGoose.loadingConversation": {
+    "defaultMessage": "正在載入對話…"
+  },
+  "loadingGoose.restartingAgent": {
+    "defaultMessage": "正在重新啟動工作階段…"
+  },
+  "loadingGoose.streaming": {
+    "defaultMessage": "goose 正在處理…"
+  },
+  "loadingGoose.thinking": {
+    "defaultMessage": "goose 正在思考…"
+  },
+  "loadingGoose.waiting": {
+    "defaultMessage": "goose 正在等待…"
+  },
+  "localInferenceSettings.deleteConfirm": {
+    "defaultMessage": "要刪除此模型嗎？您之後可以重新下載。"
+  },
+  "localInferenceSettings.description": {
+    "defaultMessage": "下載並管理本機 LLM 模型，無需 API 金鑰即可進行推論。在 HuggingFace 搜尋 GGUF 或 MLX 模型，或使用下方的精選推薦。"
+  },
+  "localInferenceSettings.dismiss": {
+    "defaultMessage": "關閉"
+  },
+  "localInferenceSettings.download": {
+    "defaultMessage": "下載"
+  },
+  "localInferenceSettings.downloadCancelled": {
+    "defaultMessage": "下載已取消"
+  },
+  "localInferenceSettings.downloadFailed": {
+    "defaultMessage": "下載失敗"
+  },
+  "localInferenceSettings.downloadProgress": {
+    "defaultMessage": "{downloaded} / {total}（{percent}%）"
+  },
+  "localInferenceSettings.downloadedModels": {
+    "defaultMessage": "已下載的模型"
+  },
+  "localInferenceSettings.downloading": {
+    "defaultMessage": "下載中"
+  },
+  "localInferenceSettings.featuredModels": {
+    "defaultMessage": "精選模型"
+  },
+  "localInferenceSettings.huggingFaceSignInNote": {
+    "defaultMessage": "登入以在搜尋與下載模型時提高速率上限，並存取私人或受限的 Hugging Face 儲存庫。"
+  },
+  "localInferenceSettings.modelSettings": {
+    "defaultMessage": "模型設定"
+  },
+  "localInferenceSettings.modelSettingsTitle": {
+    "defaultMessage": "模型設定"
+  },
+  "localInferenceSettings.noModels": {
+    "defaultMessage": "沒有可用的模型"
+  },
+  "localInferenceSettings.recommended": {
+    "defaultMessage": "建議"
+  },
+  "localInferenceSettings.remaining": {
+    "defaultMessage": "剩餘 {time}"
+  },
+  "localInferenceSettings.retry": {
+    "defaultMessage": "重試"
+  },
+  "localInferenceSettings.showAllFeatured": {
+    "defaultMessage": "顯示全部精選（還有 {count} 個）"
+  },
+  "localInferenceSettings.showRecommendedOnly": {
+    "defaultMessage": "僅顯示建議項目"
+  },
+  "localInferenceSettings.title": {
+    "defaultMessage": "本機推論模型"
+  },
+  "localInferenceSettings.vision": {
+    "defaultMessage": "視覺"
+  },
+  "localInferenceSettings.visionEncoderDownloading": {
+    "defaultMessage": "正在下載視覺編碼器…"
+  },
+  "localInferenceSettings.visionEncoderNotDownloaded": {
+    "defaultMessage": "尚未下載視覺編碼器"
+  },
+  "localModelManager.active": {
+    "defaultMessage": "使用中"
+  },
+  "localModelManager.deleteConfirm": {
+    "defaultMessage": "要刪除此模型嗎？您之後可以重新下載。"
+  },
+  "localModelManager.download": {
+    "defaultMessage": "下載"
+  },
+  "localModelManager.downloaded": {
+    "defaultMessage": "已下載"
+  },
+  "localModelManager.gpuAcceleration": {
+    "defaultMessage": "支援 GPU 加速（NVIDIA 使用 CUDA，Apple Silicon 使用 Metal）。硬體加速的 GPU 功能必須在建置時啟用。"
+  },
+  "localModelManager.noModels": {
+    "defaultMessage": "沒有可用的模型"
+  },
+  "localModelManager.recommended": {
+    "defaultMessage": "建議"
+  },
+  "localModelManager.recommendedForHardware": {
+    "defaultMessage": "為您的硬體建議"
+  },
+  "localModelManager.showAllModels": {
+    "defaultMessage": "顯示所有模型（還有 {count} 個）"
+  },
+  "localModelManager.showRecommendedOnly": {
+    "defaultMessage": "僅顯示建議項目"
+  },
+  "localModelPicker.back": {
+    "defaultMessage": "返回"
+  },
+  "localModelPicker.bestForMachine": {
+    "defaultMessage": "最適合您的電腦"
+  },
+  "localModelPicker.cancelDownload": {
+    "defaultMessage": "取消下載"
+  },
+  "localModelPicker.checkingModels": {
+    "defaultMessage": "正在檢查可用的模型…"
+  },
+  "localModelPicker.downloadModel": {
+    "defaultMessage": "下載 {modelId}（{size}）"
+  },
+  "localModelPicker.downloading": {
+    "defaultMessage": "正在下載 {modelId}"
+  },
+  "localModelPicker.failedToLoad": {
+    "defaultMessage": "載入可用模型失敗。請再試一次。"
+  },
+  "localModelPicker.failedToStartDownload": {
+    "defaultMessage": "無法開始下載。請再試一次。"
+  },
+  "localModelPicker.hideOtherSizes": {
+    "defaultMessage": "隱藏其他大小"
+  },
+  "localModelPicker.localModelsNote": {
+    "defaultMessage": "本機模型會將所有資料保留在您的電腦上，以確保完全的隱私。效能與上下文視窗大小可能因您的硬體與模型大小而異，與雲端供應商相比會有所不同。"
+  },
+  "localModelPicker.lostConnection": {
+    "defaultMessage": "與下載的連線中斷。請再試一次。"
+  },
+  "localModelPicker.modelNotFound": {
+    "defaultMessage": "找不到模型"
+  },
+  "localModelPicker.ready": {
+    "defaultMessage": "就緒"
+  },
+  "localModelPicker.selectModel": {
+    "defaultMessage": "選擇模型"
+  },
+  "localModelPicker.showOtherSizes": {
+    "defaultMessage": "顯示其他 {count} 種大小"
+  },
+  "localModelPicker.startingDownload": {
+    "defaultMessage": "正在開始下載…"
+  },
+  "localModelPicker.tryAgain": {
+    "defaultMessage": "再試一次"
+  },
+  "localModelPicker.useModel": {
+    "defaultMessage": "使用 {modelId}"
+  },
+  "markdownContent.cancel": {
+    "defaultMessage": "取消"
+  },
+  "markdownContent.copyCode": {
+    "defaultMessage": "複製程式碼"
+  },
+  "markdownContent.failedToOpenLink": {
+    "defaultMessage": "開啟連結失敗"
+  },
+  "markdownContent.noApplicationFound": {
+    "defaultMessage": "找不到可開啟此連結的應用程式。"
+  },
+  "markdownContent.open": {
+    "defaultMessage": "開啟"
+  },
+  "markdownContent.openExternalLink": {
+    "defaultMessage": "開啟外部連結"
+  },
+  "markdownContent.openProtocolLink": {
+    "defaultMessage": "要開啟 {protocol} 連結嗎？"
+  },
+  "markdownContent.thisWillOpen": {
+    "defaultMessage": "這會開啟：{href}"
+  },
+  "mcpAppRenderer.appFallbackTitle": {
+    "defaultMessage": "應用程式"
+  },
+  "mcpAppRenderer.cancelButton": {
+    "defaultMessage": "取消"
+  },
+  "mcpAppRenderer.close": {
+    "defaultMessage": "關閉"
+  },
+  "mcpAppRenderer.exitFullscreen": {
+    "defaultMessage": "結束全螢幕"
+  },
+  "mcpAppRenderer.exitFullscreenTitle": {
+    "defaultMessage": "結束全螢幕（Esc）"
+  },
+  "mcpAppRenderer.failedToInitSandbox": {
+    "defaultMessage": "初始化沙箱代理失敗"
+  },
+  "mcpAppRenderer.failedToLoadResource": {
+    "defaultMessage": "載入資源失敗"
+  },
+  "mcpAppRenderer.fullscreen": {
+    "defaultMessage": "全螢幕"
+  },
+  "mcpAppRenderer.invalidUrl": {
+    "defaultMessage": "無效的 URL"
+  },
+  "mcpAppRenderer.movePipWindow": {
+    "defaultMessage": "移動子母畫面視窗（使用方向鍵）"
+  },
+  "mcpAppRenderer.openButton": {
+    "defaultMessage": "開啟"
+  },
+  "mcpAppRenderer.openExternalLinkTitle": {
+    "defaultMessage": "開啟外部連結"
+  },
+  "mcpAppRenderer.openLinkDetail": {
+    "defaultMessage": "這會開啟：{url}"
+  },
+  "mcpAppRenderer.openProtocolLink": {
+    "defaultMessage": "要開啟 {protocol} 連結嗎？"
+  },
+  "mcpAppRenderer.pictureInPicture": {
+    "defaultMessage": "子母畫面"
+  },
+  "mcpAppRenderer.playingInPip": {
+    "defaultMessage": "正在子母畫面中播放"
+  },
+  "mcpUIResourceRenderer.cancelButton": {
+    "defaultMessage": "取消"
+  },
+  "mcpUIResourceRenderer.openButton": {
+    "defaultMessage": "開啟"
+  },
+  "mcpUIResourceRenderer.openExternalLinkTitle": {
+    "defaultMessage": "開啟外部連結"
+  },
+  "mcpUIResourceRenderer.openLinkDetail": {
+    "defaultMessage": "這會開啟：{url}"
+  },
+  "mcpUIResourceRenderer.openProtocolLink": {
+    "defaultMessage": "要開啟 {protocol} 連結嗎？"
+  },
+  "mcpUIResourceRenderer.toastMessageReceived": {
+    "defaultMessage": "已收到 {message} 的訊息。"
+  },
+  "mcpUIResourceRenderer.toastTitle": {
+    "defaultMessage": "MCP-UI {messageType} 訊息"
+  },
+  "mcpUIResourceRenderer.toastUnsupported": {
+    "defaultMessage": "已收到 {message} 的訊息。目前尚不支援 {messageType} 訊息，詳情請參閱主控台。"
+  },
+  "mentionPopover.itemsFound": {
+    "defaultMessage": "{count,plural,one{找到 # 個項目} other{找到 # 個項目}}"
+  },
+  "mentionPopover.loadingCommands": {
+    "defaultMessage": "正在載入指令…"
+  },
+  "mentionPopover.noCommandsFound": {
+    "defaultMessage": "找不到符合「{query}」的指令"
+  },
+  "mentionPopover.noItemsFound": {
+    "defaultMessage": "找不到符合「{query}」的項目"
+  },
+  "mentionPopover.scanningFiles": {
+    "defaultMessage": "正在掃描檔案…"
+  },
+  "messageCopyLink.copied": {
+    "defaultMessage": "已複製！"
+  },
+  "messageCopyLink.copy": {
+    "defaultMessage": "複製"
+  },
+  "messageQueue.cancel": {
+    "defaultMessage": "取消"
+  },
+  "messageQueue.cannotSendWhileEditing": {
+    "defaultMessage": "編輯時無法傳送"
+  },
+  "messageQueue.clearAll": {
+    "defaultMessage": "全部清除"
+  },
+  "messageQueue.clickToEdit": {
+    "defaultMessage": "{content}（點擊以編輯）"
+  },
+  "messageQueue.collapseQueue": {
+    "defaultMessage": "收合佇列"
+  },
+  "messageQueue.dragToReorder": {
+    "defaultMessage": "拖曳訊息以重新排序優先順序"
+  },
+  "messageQueue.expandQueue": {
+    "defaultMessage": "展開佇列"
+  },
+  "messageQueue.messageCount": {
+    "defaultMessage": "{count,plural,one{# 則訊息 {status}} other{# 則訊息 {status}}}"
+  },
+  "messageQueue.messageQueue": {
+    "defaultMessage": "訊息佇列"
+  },
+  "messageQueue.next": {
+    "defaultMessage": "下一個"
+  },
+  "messageQueue.paused": {
+    "defaultMessage": "已暫停"
+  },
+  "messageQueue.queuePaused": {
+    "defaultMessage": "佇列已暫停"
+  },
+  "messageQueue.queuePausedCompact": {
+    "defaultMessage": "佇列已暫停 - 點擊「傳送」或新增訊息以繼續"
+  },
+  "messageQueue.queuePausedExpanded": {
+    "defaultMessage": "佇列因中斷而暫停。請使用「立即傳送」或新增訊息以繼續。"
+  },
+  "messageQueue.queued": {
+    "defaultMessage": "已排入佇列"
+  },
+  "messageQueue.removeFromQueue": {
+    "defaultMessage": "從佇列中移除此訊息"
+  },
+  "messageQueue.save": {
+    "defaultMessage": "儲存"
+  },
+  "messageQueue.sendNow": {
+    "defaultMessage": "立即傳送此訊息"
+  },
+  "messageQueue.stopAndSend": {
+    "defaultMessage": "停止目前的處理並立即傳送此訊息"
+  },
+  "messageQueue.waiting": {
+    "defaultMessage": "等待中"
+  },
+  "microphoneSelector.chooseDescription": {
+    "defaultMessage": "選擇要用於聽寫的麥克風"
+  },
+  "microphoneSelector.grantAccess": {
+    "defaultMessage": "授予存取權"
+  },
+  "microphoneSelector.grantAccessDescription": {
+    "defaultMessage": "授予存取權以查看可用的麥克風"
+  },
+  "microphoneSelector.microphone": {
+    "defaultMessage": "麥克風"
+  },
+  "microphoneSelector.microphoneLabel": {
+    "defaultMessage": "麥克風 {index}"
+  },
+  "microphoneSelector.selectedMicrophone": {
+    "defaultMessage": "已選擇的麥克風"
+  },
+  "microphoneSelector.speakToTest": {
+    "defaultMessage": "說話以測試您的麥克風（{seconds} 秒）"
+  },
+  "microphoneSelector.stop": {
+    "defaultMessage": "停止"
+  },
+  "microphoneSelector.systemDefault": {
+    "defaultMessage": "系統預設"
+  },
+  "microphoneSelector.test": {
+    "defaultMessage": "測試"
+  },
+  "modeSelectionItem.autonomousDescription": {
+    "defaultMessage": "完整的檔案修改能力，可自由編輯、建立與刪除檔案。"
+  },
+  "modeSelectionItem.autonomousLabel": {
+    "defaultMessage": "自主"
+  },
+  "modeSelectionItem.chatOnlyDescription": {
+    "defaultMessage": "與選定的供應商互動，不使用工具或擴充功能。"
+  },
+  "modeSelectionItem.chatOnlyLabel": {
+    "defaultMessage": "僅對話"
+  },
+  "modeSelectionItem.manualDescription": {
+    "defaultMessage": "所有工具、擴充功能與檔案修改都需要人工核准"
+  },
+  "modeSelectionItem.manualLabel": {
+    "defaultMessage": "手動"
+  },
+  "modeSelectionItem.smartDescription": {
+    "defaultMessage": "根據風險程度智慧判斷哪些動作需要核准"
+  },
+  "modeSelectionItem.smartLabel": {
+    "defaultMessage": "智慧"
+  },
+  "modelAndProviderContext.modelChangeFailed": {
+    "defaultMessage": "{provider}/{model} 失敗"
+  },
+  "modelAndProviderContext.modelChangedTitle": {
+    "defaultMessage": "模型已變更"
+  },
+  "modelAndProviderContext.selectModel": {
+    "defaultMessage": "選擇模型"
+  },
+  "modelAndProviderContext.switchModelSuccess": {
+    "defaultMessage": "已成功切換模型 -- 正在使用來自 {provider} 的 {model}"
+  },
+  "modelAndProviderContext.unknownProviderMsg": {
+    "defaultMessage": "設定中有未知的供應商 -- 請檢查您的 config.yaml"
+  },
+  "modelAndProviderContext.unknownProviderTitle": {
+    "defaultMessage": "供應商名稱查詢"
+  },
+  "modelSettingsButtons.configureProviders": {
+    "defaultMessage": "設定供應商"
+  },
+  "modelSettingsButtons.switchModels": {
+    "defaultMessage": "切換模型"
+  },
+  "modelSettingsPanel.batchSize": {
+    "defaultMessage": "批次大小"
+  },
+  "modelSettingsPanel.batchSizeDescription": {
+    "defaultMessage": "提示處理批次"
+  },
+  "modelSettingsPanel.builtinChatTemplate": {
+    "defaultMessage": "內建範本"
+  },
+  "modelSettingsPanel.builtinChatTemplateDescription": {
+    "defaultMessage": "選擇 llama.cpp 內建範本名稱"
+  },
+  "modelSettingsPanel.chatTemplate": {
+    "defaultMessage": "對話範本"
+  },
+  "modelSettingsPanel.chatTemplateBuiltin": {
+    "defaultMessage": "內建"
+  },
+  "modelSettingsPanel.chatTemplateCustomInline": {
+    "defaultMessage": "自訂內嵌"
+  },
+  "modelSettingsPanel.chatTemplateDescription": {
+    "defaultMessage": "使用內嵌的 GGUF 中繼資料、llama.cpp 內建範本或內嵌 Jinja"
+  },
+  "modelSettingsPanel.chatTemplateEmbedded": {
+    "defaultMessage": "內嵌"
+  },
+  "modelSettingsPanel.contextAndGeneration": {
+    "defaultMessage": "上下文與生成"
+  },
+  "modelSettingsPanel.contextSize": {
+    "defaultMessage": "上下文大小"
+  },
+  "modelSettingsPanel.contextSizeDescription": {
+    "defaultMessage": "最大上下文視窗（0 = 模型預設值）"
+  },
+  "modelSettingsPanel.customChatTemplate": {
+    "defaultMessage": "自訂對話範本"
+  },
+  "modelSettingsPanel.customChatTemplateDescription": {
+    "defaultMessage": "貼上完整的 Jinja 對話範本原始碼"
+  },
+  "modelSettingsPanel.etaLearningRate": {
+    "defaultMessage": "Eta（學習率）"
+  },
+  "modelSettingsPanel.flashAttention": {
+    "defaultMessage": "Flash attention"
+  },
+  "modelSettingsPanel.flashAttentionDescription": {
+    "defaultMessage": "啟用 flash attention 最佳化"
+  },
+  "modelSettingsPanel.frequencyPenalty": {
+    "defaultMessage": "頻率懲罰"
+  },
+  "modelSettingsPanel.frequencyPenaltyDescription": {
+    "defaultMessage": "0.0 = 關閉"
+  },
+  "modelSettingsPanel.gpuLayers": {
+    "defaultMessage": "GPU 層數"
+  },
+  "modelSettingsPanel.gpuLayersDescription": {
+    "defaultMessage": "要卸載至 GPU 的層數"
+  },
+  "modelSettingsPanel.loadingSettings": {
+    "defaultMessage": "正在載入設定…"
+  },
+  "modelSettingsPanel.lockModelInRam": {
+    "defaultMessage": "將模型鎖定在 RAM 中（mlock）"
+  },
+  "modelSettingsPanel.lockModelInRamDescription": {
+    "defaultMessage": "防止模型被置換到磁碟"
+  },
+  "modelSettingsPanel.maxOutputTokens": {
+    "defaultMessage": "最大輸出 token 數"
+  },
+  "modelSettingsPanel.maxOutputTokensDescription": {
+    "defaultMessage": "生成 token 的上限"
+  },
+  "modelSettingsPanel.minP": {
+    "defaultMessage": "Min P"
+  },
+  "modelSettingsPanel.performance": {
+    "defaultMessage": "效能"
+  },
+  "modelSettingsPanel.presencePenalty": {
+    "defaultMessage": "出現懲罰"
+  },
+  "modelSettingsPanel.presencePenaltyDescription": {
+    "defaultMessage": "0.0 = 關閉"
+  },
+  "modelSettingsPanel.repeatPenalty": {
+    "defaultMessage": "重複懲罰"
+  },
+  "modelSettingsPanel.repeatPenaltyDescription": {
+    "defaultMessage": "1.0 = 關閉"
+  },
+  "modelSettingsPanel.repeatWindow": {
+    "defaultMessage": "重複視窗"
+  },
+  "modelSettingsPanel.repeatWindowDescription": {
+    "defaultMessage": "回溯的 token 數"
+  },
+  "modelSettingsPanel.repetitionPenalty": {
+    "defaultMessage": "重複懲罰"
+  },
+  "modelSettingsPanel.reset": {
+    "defaultMessage": "重設"
+  },
+  "modelSettingsPanel.resetToDefaults": {
+    "defaultMessage": "重設為預設值"
+  },
+  "modelSettingsPanel.samplingStrategy": {
+    "defaultMessage": "取樣策略"
+  },
+  "modelSettingsPanel.saving": {
+    "defaultMessage": "正在儲存…"
+  },
+  "modelSettingsPanel.seed": {
+    "defaultMessage": "種子"
+  },
+  "modelSettingsPanel.tauTargetEntropy": {
+    "defaultMessage": "Tau（目標熵）"
+  },
+  "modelSettingsPanel.temperature": {
+    "defaultMessage": "溫度"
+  },
+  "modelSettingsPanel.threads": {
+    "defaultMessage": "執行緒"
+  },
+  "modelSettingsPanel.threadsDescription": {
+    "defaultMessage": "用於生成的 CPU 執行緒"
+  },
+  "modelSettingsPanel.toolCalling": {
+    "defaultMessage": "工具呼叫"
+  },
+  "modelSettingsPanel.toolCallingAuto": {
+    "defaultMessage": "自動"
+  },
+  "modelSettingsPanel.toolCallingDescription": {
+    "defaultMessage": "選擇本機模型如何使用原生或模擬的工具呼叫"
+  },
+  "modelSettingsPanel.toolCallingForceEmulated": {
+    "defaultMessage": "強制模擬"
+  },
+  "modelSettingsPanel.toolCallingForceNative": {
+    "defaultMessage": "強制原生"
+  },
+  "modelSettingsPanel.topK": {
+    "defaultMessage": "Top K"
+  },
+  "modelSettingsPanel.topP": {
+    "defaultMessage": "Top P"
+  },
+  "modelsBottomBar.changeModel": {
+    "defaultMessage": "變更模型"
+  },
+  "modelsBottomBar.currentModel": {
+    "defaultMessage": "目前模型"
+  },
+  "modelsBottomBar.loadingModel": {
+    "defaultMessage": "正在載入模型…"
+  },
+  "modelsBottomBar.localModelSettings": {
+    "defaultMessage": "本機模型設定"
+  },
+  "modelsBottomBar.localModelSettingsTitle": {
+    "defaultMessage": "本機模型設定 — {modelName}"
+  },
+  "modelsBottomBar.resolvedModel": {
+    "defaultMessage": "已解析的模型"
+  },
+  "modelsBottomBar.selectModel": {
+    "defaultMessage": "選擇模型"
+  },
+  "modelsSection.resetDescription": {
+    "defaultMessage": "清除您選定的模型與供應商設定以重新開始"
+  },
+  "modelsSection.resetTitle": {
+    "defaultMessage": "重設供應商與模型"
+  },
+  "navigation.itemApps": {
+    "defaultMessage": "應用程式"
+  },
+  "navigation.itemExtensions": {
+    "defaultMessage": "擴充功能"
+  },
+  "navigation.itemHome": {
+    "defaultMessage": "新交談"
+  },
+  "navigation.itemRecipes": {
+    "defaultMessage": "配方"
+  },
+  "navigation.itemScheduler": {
+    "defaultMessage": "排程器"
+  },
+  "navigation.itemSessions": {
+    "defaultMessage": "工作階段紀錄"
+  },
+  "navigation.itemSettings": {
+    "defaultMessage": "設定"
+  },
+  "navigation.itemSkills": {
+    "defaultMessage": "技能"
+  },
+  "navigationPanel.chats": {
+    "defaultMessage": "交談"
+  },
+  "navigationPanel.noChats": {
+    "defaultMessage": "沒有最近的交談"
+  },
+  "navigationPanel.untitledSession": {
+    "defaultMessage": "未命名工作階段"
+  },
+  "onboardingGuard.checkProviderErrorDescription": {
+    "defaultMessage": "伺服器可能正在啟動或暫時無法使用。"
+  },
+  "onboardingGuard.checkProviderErrorTitle": {
+    "defaultMessage": "無法連線到 Goose 伺服器"
+  },
+  "onboardingGuard.retry": {
+    "defaultMessage": "重試"
+  },
+  "onboardingGuard.welcomeDescription": {
+    "defaultMessage": "您的本機 AI 代理。連線 AI 模型供應商即可開始使用。"
+  },
+  "onboardingGuard.welcomeTitle": {
+    "defaultMessage": "歡迎使用 goose"
+  },
+  "onboardingSuccess.allSet": {
+    "defaultMessage": "一切就緒，您可以開始使用 goose 了。"
+  },
+  "onboardingSuccess.connectedTo": {
+    "defaultMessage": "已連線到 {providerName}"
+  },
+  "onboardingSuccess.getStarted": {
+    "defaultMessage": "開始使用"
+  },
+  "onboardingSuccess.learnMore": {
+    "defaultMessage": "瞭解更多"
+  },
+  "onboardingSuccess.localModelReady": {
+    "defaultMessage": "本機模型已就緒"
+  },
+  "onboardingSuccess.privacyDescription": {
+    "defaultMessage": "匿名使用資料有助於改善 goose。我們絕不會收集您的對話、程式碼或個人資料。"
+  },
+  "onboardingSuccess.privacyTitle": {
+    "defaultMessage": "隱私權"
+  },
+  "onboardingSuccess.shareUsageData": {
+    "defaultMessage": "分享匿名使用資料"
+  },
+  "parameterInput.defaultValue": {
+    "defaultMessage": "預設值"
+  },
+  "parameterInput.defaultValuePlaceholder": {
+    "defaultMessage": "輸入預設值"
+  },
+  "parameterInput.deleteParameter": {
+    "defaultMessage": "刪除參數：{key}"
+  },
+  "parameterInput.description": {
+    "defaultMessage": "說明"
+  },
+  "parameterInput.descriptionHelp": {
+    "defaultMessage": "這是最終使用者將會看到的訊息。"
+  },
+  "parameterInput.descriptionPlaceholder": {
+    "defaultMessage": "例如：「輸入新元件的名稱」"
+  },
+  "parameterInput.inputType": {
+    "defaultMessage": "輸入類型"
+  },
+  "parameterInput.optional": {
+    "defaultMessage": "選用"
+  },
+  "parameterInput.optionsHelp": {
+    "defaultMessage": "每個選項各佔一行。這些選項將顯示為下拉式清單選項。"
+  },
+  "parameterInput.optionsLabel": {
+    "defaultMessage": "選項（每行一個）"
+  },
+  "parameterInput.optionsPlaceholder": {
+    "defaultMessage": "選項 1 選項 2 選項 3"
+  },
+  "parameterInput.required": {
+    "defaultMessage": "必填"
+  },
+  "parameterInput.requirement": {
+    "defaultMessage": "需求"
+  },
+  "parameterInput.typeBoolean": {
+    "defaultMessage": "布林值"
+  },
+  "parameterInput.typeNumber": {
+    "defaultMessage": "數字"
+  },
+  "parameterInput.typeSelect": {
+    "defaultMessage": "選取"
+  },
+  "parameterInput.typeString": {
+    "defaultMessage": "字串"
+  },
+  "parameterInput.unused": {
+    "defaultMessage": "未使用"
+  },
+  "parameterInput.unusedWarningTitle": {
+    "defaultMessage": "此參數未在指示或提示中使用。它可供手動輸入，但可能並非必要。"
+  },
+  "parameterInputModal.backToForm": {
+    "defaultMessage": "返回參數表單"
+  },
+  "parameterInputModal.cancel": {
+    "defaultMessage": "取消"
+  },
+  "parameterInputModal.cancelRecipeSetup": {
+    "defaultMessage": "取消配方設定"
+  },
+  "parameterInputModal.enterValue": {
+    "defaultMessage": "輸入 {key} 的值..."
+  },
+  "parameterInputModal.false": {
+    "defaultMessage": "False"
+  },
+  "parameterInputModal.recipeParameters": {
+    "defaultMessage": "配方參數"
+  },
+  "parameterInputModal.select": {
+    "defaultMessage": "選取..."
+  },
+  "parameterInputModal.selectOption": {
+    "defaultMessage": "選取一個選項..."
+  },
+  "parameterInputModal.startNewChat": {
+    "defaultMessage": "開始新交談（無配方）"
+  },
+  "parameterInputModal.startRecipe": {
+    "defaultMessage": "啟動配方"
+  },
+  "parameterInputModal.true": {
+    "defaultMessage": "True"
+  },
+  "parameterInputModal.whatToDo": {
+    "defaultMessage": "您想要執行什麼操作？"
+  },
+  "permissionModal.alwaysAllow": {
+    "defaultMessage": "一律允許"
+  },
+  "permissionModal.askBefore": {
+    "defaultMessage": "事前詢問"
+  },
+  "permissionModal.cancel": {
+    "defaultMessage": "取消"
+  },
+  "permissionModal.close": {
+    "defaultMessage": "關閉"
+  },
+  "permissionModal.failedToLoadTools": {
+    "defaultMessage": "無法載入工具"
+  },
+  "permissionModal.failedToLoadToolsDescription": {
+    "defaultMessage": "無法為此擴充功能載入工具。該擴充功能可能未在目前的工作階段中載入。"
+  },
+  "permissionModal.neverAllow": {
+    "defaultMessage": "永不允許"
+  },
+  "permissionModal.noActiveSession": {
+    "defaultMessage": "沒有作用中的工作階段"
+  },
+  "permissionModal.noActiveSessionDescription": {
+    "defaultMessage": "請先開始交談工作階段，以便為此擴充功能設定工具權限。工具權限會從作用中工作階段的擴充功能載入。"
+  },
+  "permissionModal.noToolsAvailable": {
+    "defaultMessage": "此擴充功能沒有可用的工具。"
+  },
+  "permissionModal.saveChanges": {
+    "defaultMessage": "儲存變更"
+  },
+  "permissionRulesModal.description": {
+    "defaultMessage": "為擴充功能設定工具權限，以控制它們與您系統互動的方式。"
+  },
+  "permissionRulesModal.extensionRules": {
+    "defaultMessage": "擴充功能規則"
+  },
+  "permissionRulesModal.title": {
+    "defaultMessage": "權限規則"
+  },
+  "permissionSetting.extensionRules": {
+    "defaultMessage": "擴充功能規則"
+  },
+  "permissionSetting.permissionRules": {
+    "defaultMessage": "權限規則"
+  },
+  "permissionSetting.permissionRulesDescription": {
+    "defaultMessage": "將傳遞給提供者的隱藏指示，用於引導並為您的回應補充背景資訊。"
+  },
+  "privacyInfoModal.collectErrors": {
+    "defaultMessage": "錯誤類型（例如「rate_limit」、「auth」－不含詳細資料）"
+  },
+  "privacyInfoModal.collectExtensions": {
+    "defaultMessage": "擴充功能與工具使用次數（僅名稱）"
+  },
+  "privacyInfoModal.collectOs": {
+    "defaultMessage": "作業系統、版本與架構"
+  },
+  "privacyInfoModal.collectProvider": {
+    "defaultMessage": "所使用的提供者與模型"
+  },
+  "privacyInfoModal.collectSession": {
+    "defaultMessage": "工作階段指標（持續時間、互動次數、權杖用量）"
+  },
+  "privacyInfoModal.collectVersion": {
+    "defaultMessage": "goose 版本與安裝方式"
+  },
+  "privacyInfoModal.description": {
+    "defaultMessage": "匿名使用資料有助於我們瞭解 goose 的使用情況並找出可改善的方面。"
+  },
+  "privacyInfoModal.neverCollect": {
+    "defaultMessage": "我們絕不會收集您的對話、程式碼、工具引數、錯誤訊息或任何個人資料。您隨時可以在「設定」中變更此設定。"
+  },
+  "privacyInfoModal.title": {
+    "defaultMessage": "隱私權詳細資料"
+  },
+  "privacyInfoModal.whatWeCollect": {
+    "defaultMessage": "我們收集的內容："
+  },
+  "progressiveMessageList.loadingMessages": {
+    "defaultMessage": "正在載入訊息... ({renderedCount}/{totalCount})"
+  },
+  "progressiveMessageList.modelChanged": {
+    "defaultMessage": "模型已變更：{previousModel} → {currentModel}"
+  },
+  "progressiveMessageList.searchHint": {
+    "defaultMessage": "按 Cmd/Ctrl+F 立即載入所有訊息以進行搜尋"
+  },
+  "promptsSettings.allPromptsReset": {
+    "defaultMessage": "所有提示已重設為預設值"
+  },
+  "promptsSettings.backToList": {
+    "defaultMessage": "返回清單"
+  },
+  "promptsSettings.confirmReplaceWithDefault": {
+    "defaultMessage": "要以預設內容取代目前的內容嗎？您的變更將會遺失。"
+  },
+  "promptsSettings.confirmResetAll": {
+    "defaultMessage": "您確定要將所有提示重設為預設值嗎？此操作無法復原。"
+  },
+  "promptsSettings.confirmResetOne": {
+    "defaultMessage": "您確定要將此提示重設為預設值嗎？此操作無法復原。"
+  },
+  "promptsSettings.confirmUnsavedBack": {
+    "defaultMessage": "您有未儲存的變更。您確定要返回嗎？"
+  },
+  "promptsSettings.customized": {
+    "defaultMessage": "已自訂"
+  },
+  "promptsSettings.edit": {
+    "defaultMessage": "編輯"
+  },
+  "promptsSettings.editPromptTitle": {
+    "defaultMessage": "編輯：{name}"
+  },
+  "promptsSettings.editingLabel": {
+    "defaultMessage": "正在編輯：{name}"
+  },
+  "promptsSettings.enterPromptContent": {
+    "defaultMessage": "輸入提示內容..."
+  },
+  "promptsSettings.failedToLoadPrompt": {
+    "defaultMessage": "無法載入提示"
+  },
+  "promptsSettings.failedToLoadPrompts": {
+    "defaultMessage": "無法載入提示"
+  },
+  "promptsSettings.failedToResetPrompt": {
+    "defaultMessage": "無法重設提示"
+  },
+  "promptsSettings.failedToResetPrompts": {
+    "defaultMessage": "無法重設提示"
+  },
+  "promptsSettings.failedToSavePrompt": {
+    "defaultMessage": "無法儲存提示"
+  },
+  "promptsSettings.promptEditingDescription": {
+    "defaultMessage": "自訂在不同情境中定義 goose 行為的提示。這些提示使用 Jinja2 範本語法。修改範本變數時請務必小心，因為不正確的變更可能會破壞功能。請與社群分享任何改善內容。"
+  },
+  "promptsSettings.promptEditingTitle": {
+    "defaultMessage": "提示編輯"
+  },
+  "promptsSettings.promptResetToDefault": {
+    "defaultMessage": "提示已重設為預設值"
+  },
+  "promptsSettings.promptSaved": {
+    "defaultMessage": "提示已儲存"
+  },
+  "promptsSettings.resetAll": {
+    "defaultMessage": "全部重設"
+  },
+  "promptsSettings.resetToDefault": {
+    "defaultMessage": "重設為預設值"
+  },
+  "promptsSettings.restoreDefault": {
+    "defaultMessage": "還原預設值"
+  },
+  "promptsSettings.save": {
+    "defaultMessage": "儲存"
+  },
+  "promptsSettings.templateTip": {
+    "defaultMessage": "範本變數（例如 {extensionsExample} 或 {forExample}）會在執行階段以實際值取代。請小心不要移除必要的變數。"
+  },
+  "promptsSettings.unsavedChanges": {
+    "defaultMessage": "您有未儲存的變更"
+  },
+  "providerCard.noMetadata": {
+    "defaultMessage": "ProviderCard 錯誤：未提供中繼資料"
+  },
+  "providerCard.unknownProvider": {
+    "defaultMessage": "未知的提供者"
+  },
+  "providerCatalogPicker.anthropicCompatible": {
+    "defaultMessage": "Anthropic 相容"
+  },
+  "providerCatalogPicker.apiFormat": {
+    "defaultMessage": "API 格式"
+  },
+  "providerCatalogPicker.cancel": {
+    "defaultMessage": "取消"
+  },
+  "providerCatalogPicker.chooseProvider": {
+    "defaultMessage": "選擇提供者"
+  },
+  "providerCatalogPicker.errorPrefix": {
+    "defaultMessage": "錯誤：{error}"
+  },
+  "providerCatalogPicker.loadingProviders": {
+    "defaultMessage": "正在載入提供者..."
+  },
+  "providerCatalogPicker.modelsAvailable": {
+    "defaultMessage": "{count} 個可用模型"
+  },
+  "providerCatalogPicker.noProvidersAvailable": {
+    "defaultMessage": "沒有可用的提供者"
+  },
+  "providerCatalogPicker.noProvidersFound": {
+    "defaultMessage": "找不到符合「{query}」的提供者"
+  },
+  "providerCatalogPicker.openaiCompatible": {
+    "defaultMessage": "OpenAI 相容"
+  },
+  "providerCatalogPicker.requiresEnvVar": {
+    "defaultMessage": "• 需要 {envVar}"
+  },
+  "providerCatalogPicker.searchProviders": {
+    "defaultMessage": "搜尋提供者..."
+  },
+  "providerCatalogPicker.selectFormatDescription": {
+    "defaultMessage": "選取 API 格式與提供者。我們會為您自動填入組態。"
+  },
+  "providerConfigForm.browserWindowOpen": {
+    "defaultMessage": "將開啟瀏覽器視窗供您完成登入。"
+  },
+  "providerConfigForm.configuring": {
+    "defaultMessage": "正在設定..."
+  },
+  "providerConfigForm.continue": {
+    "defaultMessage": "繼續"
+  },
+  "providerConfigForm.deviceCodeFlowHint": {
+    "defaultMessage": "將開啟瀏覽器視窗，且驗證碼會複製到您的剪貼簿。將其貼到瀏覽器中以完成登入。"
+  },
+  "providerConfigForm.noApiKey": {
+    "defaultMessage": "沒有 API 金鑰嗎？"
+  },
+  "providerConfigForm.signInWith": {
+    "defaultMessage": "使用 {providerName} 登入"
+  },
+  "providerConfigForm.signingIn": {
+    "defaultMessage": "正在登入..."
+  },
+  "providerConfigurationModal.addApiKeyDescription": {
+    "defaultMessage": "新增此提供者的 API 金鑰以整合至 goose"
+  },
+  "providerConfigurationModal.browserWindowHint": {
+    "defaultMessage": "將開啟瀏覽器視窗供您完成登入。"
+  },
+  "providerConfigurationModal.cancel": {
+    "defaultMessage": "取消"
+  },
+  "providerConfigurationModal.cannotDeleteActive": {
+    "defaultMessage": "此提供者目前正在使用中，您無法將其刪除。請先切換到其他模型。"
+  },
+  "providerConfigurationModal.checkConfigAgain": {
+    "defaultMessage": "再次檢查您的組態以使用此提供者。"
+  },
+  "providerConfigurationModal.close": {
+    "defaultMessage": "關閉"
+  },
+  "providerConfigurationModal.configureHeader": {
+    "defaultMessage": "設定 {providerName}"
+  },
+  "providerConfigurationModal.deleteConfigHeader": {
+    "defaultMessage": "刪除 {providerName} 的組態"
+  },
+  "providerConfigurationModal.deleteConfirmation": {
+    "defaultMessage": "這將永久刪除目前的提供者組態。"
+  },
+  "providerConfigurationModal.deviceCodeFlowHint": {
+    "defaultMessage": "將開啟瀏覽器視窗，且驗證碼會複製到您的剪貼簿。將其貼到瀏覽器中以完成登入。"
+  },
+  "providerConfigurationModal.errorCheckingConfig": {
+    "defaultMessage": "檢查此提供者組態時發生錯誤。"
+  },
+  "providerConfigurationModal.errorTitle": {
+    "defaultMessage": "錯誤"
+  },
+  "providerConfigurationModal.externalSetupIntro": {
+    "defaultMessage": "此提供者是在 goose 之外設定的。請依照下列步驟操作："
+  },
+  "providerConfigurationModal.goBack": {
+    "defaultMessage": "返回"
+  },
+  "providerConfigurationModal.huggingFaceOAuthDescription": {
+    "defaultMessage": "登入即可使用 Hugging Face 推論提供者，無需手動輸入 API 權杖。"
+  },
+  "providerConfigurationModal.oauthLoginFailed": {
+    "defaultMessage": "OAuth 登入失敗：{error}"
+  },
+  "providerConfigurationModal.oauthSignInDescription": {
+    "defaultMessage": "使用您的 {providerName} 帳戶登入以使用此提供者"
+  },
+  "providerConfigurationModal.parameterRequired": {
+    "defaultMessage": "{paramName} 為必填"
+  },
+  "providerConfigurationModal.removeConfiguration": {
+    "defaultMessage": "移除組態"
+  },
+  "providerConfigurationModal.seeDocumentation": {
+    "defaultMessage": "如需更多詳細資料，請參閱<link>說明文件</link>。"
+  },
+  "providerConfigurationModal.signInWith": {
+    "defaultMessage": "使用 {providerName} 登入"
+  },
+  "providerConfigurationModal.signingIn": {
+    "defaultMessage": "正在登入..."
+  },
+  "providerGrid.addProvider": {
+    "defaultMessage": "新增提供者"
+  },
+  "providerGrid.addProviderTitle": {
+    "defaultMessage": "新增提供者"
+  },
+  "providerGrid.chooseModel": {
+    "defaultMessage": "選擇模型"
+  },
+  "providerGrid.configureProvider": {
+    "defaultMessage": "設定提供者"
+  },
+  "providerGrid.editProvider": {
+    "defaultMessage": "編輯提供者"
+  },
+  "providerGrid.fromTemplateOrManual": {
+    "defaultMessage": "從範本或手動設定"
+  },
+  "providerLogo.alt": {
+    "defaultMessage": "{providerName} 標誌"
+  },
+  "providerSelector.addCustomProvider": {
+    "defaultMessage": "新增自訂提供者"
+  },
+  "providerSelector.addCustomProviderTitle": {
+    "defaultMessage": "新增自訂提供者"
+  },
+  "providerSelector.connectProvider": {
+    "defaultMessage": "連線到提供者"
+  },
+  "providerSelector.connectProviderDescription": {
+    "defaultMessage": "連線到 OpenAI、Anthropic、Google 等"
+  },
+  "providerSelector.freeLocalDescription": {
+    "defaultMessage": "使用本機模型或提供免費額度的提供者"
+  },
+  "providerSelector.selectProvider": {
+    "defaultMessage": "選取提供者"
+  },
+  "providerSelector.useFreeLocal": {
+    "defaultMessage": "使用免費／本機提供者"
+  },
+  "providerSettings.configurationSettings": {
+    "defaultMessage": "提供者組態設定"
+  },
+  "providerSettings.loadingProviders": {
+    "defaultMessage": "正在載入提供者..."
+  },
+  "providerSettings.onboardingDescription": {
+    "defaultMessage": "選取一個 AI 模型提供者以開始使用 goose。您需要使用各提供者產生的 API 金鑰，這些金鑰將會加密並儲存在本機。您隨時可以在設定中變更提供者。"
+  },
+  "providerSettings.otherProviders": {
+    "defaultMessage": "其他提供者"
+  },
+  "providerSetupActions.cancel": {
+    "defaultMessage": "取消"
+  },
+  "providerSetupActions.cannotDeleteActive": {
+    "defaultMessage": "{providerName} 目前正在使用中，您無法將其刪除。請先切換到其他模型再刪除此提供者。"
+  },
+  "providerSetupActions.confirmDelete": {
+    "defaultMessage": "確認刪除"
+  },
+  "providerSetupActions.confirmDeleteMessage": {
+    "defaultMessage": "您確定要刪除 {providerName} 的組態參數嗎？此操作無法復原。"
+  },
+  "providerSetupActions.deleteProvider": {
+    "defaultMessage": "刪除提供者"
+  },
+  "providerSetupActions.enableProvider": {
+    "defaultMessage": "啟用提供者"
+  },
+  "providerSetupActions.ok": {
+    "defaultMessage": "確定"
+  },
+  "providerSetupActions.submit": {
+    "defaultMessage": "提交"
+  },
+  "recipeActivityEditor.activitiesDescription": {
+    "defaultMessage": "將顯示在配方交談視窗中的頂端提示與活動按鈕。"
+  },
+  "recipeActivityEditor.activitiesLabel": {
+    "defaultMessage": "活動"
+  },
+  "recipeActivityEditor.activityButtonsDescription": {
+    "defaultMessage": "顯示在訊息下方的可點擊按鈕，協助使用者與您的配方互動。"
+  },
+  "recipeActivityEditor.activityButtonsLabel": {
+    "defaultMessage": "活動按鈕"
+  },
+  "recipeActivityEditor.addActivity": {
+    "defaultMessage": "新增活動"
+  },
+  "recipeActivityEditor.addNewActivityPlaceholder": {
+    "defaultMessage": "新增活動..."
+  },
+  "recipeActivityEditor.messageDescription": {
+    "defaultMessage": "顯示在配方頂端的格式化訊息。支援 Markdown 格式。"
+  },
+  "recipeActivityEditor.messageLabel": {
+    "defaultMessage": "訊息"
+  },
+  "recipeActivityEditor.messagePlaceholder": {
+    "defaultMessage": "為您的配方輸入一段面向使用者的介紹訊息（支援 **粗體**、*斜體*、`程式碼` 等）"
+  },
+  "recipeExtensionSelector.description": {
+    "defaultMessage": "選取執行此配方時應可使用的擴充功能。留空則使用預設擴充功能。"
+  },
+  "recipeExtensionSelector.extensionsSelected": {
+    "defaultMessage": "{count,plural,one{已選取 # 個擴充功能} other{已選取 # 個擴充功能}}"
+  },
+  "recipeExtensionSelector.label": {
+    "defaultMessage": "擴充功能（選用）"
+  },
+  "recipeExtensionSelector.noExtensionsAvailable": {
+    "defaultMessage": "沒有可用的擴充功能"
+  },
+  "recipeExtensionSelector.noExtensionsFound": {
+    "defaultMessage": "找不到擴充功能"
+  },
+  "recipeExtensionSelector.searchPlaceholder": {
+    "defaultMessage": "搜尋擴充功能..."
+  },
+  "recipeFormFields.addParameter": {
+    "defaultMessage": "新增參數"
+  },
+  "recipeFormFields.advancedOptions": {
+    "defaultMessage": "進階選項"
+  },
+  "recipeFormFields.advancedOptionsHint": {
+    "defaultMessage": "活動、參數、模型、擴充功能、回應結構描述、子配方"
+  },
+  "recipeFormFields.descriptionLabel": {
+    "defaultMessage": "說明"
+  },
+  "recipeFormFields.descriptionPlaceholder": {
+    "defaultMessage": "簡述此配方的功能"
+  },
+  "recipeFormFields.enterValueFor": {
+    "defaultMessage": "輸入 {key} 的值"
+  },
+  "recipeFormFields.initialPrompt": {
+    "defaultMessage": "初始提示"
+  },
+  "recipeFormFields.instructionsLabel": {
+    "defaultMessage": "指示"
+  },
+  "recipeFormFields.instructionsPlaceholder": {
+    "defaultMessage": "給 AI 的詳細指示，對使用者隱藏"
+  },
+  "recipeFormFields.openEditor": {
+    "defaultMessage": "開啟編輯器"
+  },
+  "recipeFormFields.parameterNamePlaceholder": {
+    "defaultMessage": "輸入參數名稱..."
+  },
+  "recipeFormFields.parametersDescription": {
+    "defaultMessage": "系統會自動從指示／提示／活動中的'{{parameter_name}}'語法偵測參數，您也可以在下方手動新增。"
+  },
+  "recipeFormFields.parametersLabel": {
+    "defaultMessage": "參數"
+  },
+  "recipeFormFields.promptOptionalHint": {
+    "defaultMessage": "（選用－必須提供指示或提示）"
+  },
+  "recipeFormFields.promptPlaceholder": {
+    "defaultMessage": "配方啟動時預先填入的提示"
+  },
+  "recipeFormFields.responseJsonSchema": {
+    "defaultMessage": "回應 JSON 結構描述"
+  },
+  "recipeFormFields.responseJsonSchemaDescription": {
+    "defaultMessage": "使用 JSON Schema 格式定義 AI 回應的預期結構"
+  },
+  "recipeFormFields.templateVarHint": {
+    "defaultMessage": "使用'{{parameter_name}}'來定義執行配方時可填入的參數。"
+  },
+  "recipeFormFields.titleLabel": {
+    "defaultMessage": "標題"
+  },
+  "recipeFormFields.titlePlaceholder": {
+    "defaultMessage": "配方標題"
+  },
+  "recipeHeader.recipeLabel": {
+    "defaultMessage": "配方"
+  },
+  "recipeModelSelector.backToModelList": {
+    "defaultMessage": "返回模型清單"
+  },
+  "recipeModelSelector.enterCustomModel": {
+    "defaultMessage": "輸入自訂模型名稱"
+  },
+  "recipeModelSelector.enterModelNotListed": {
+    "defaultMessage": "輸入未列出的模型..."
+  },
+  "recipeModelSelector.fetchError": {
+    "defaultMessage": "無法擷取模型。請稍後再試。"
+  },
+  "recipeModelSelector.loadingModels": {
+    "defaultMessage": "正在載入模型…"
+  },
+  "recipeModelSelector.modelHint": {
+    "defaultMessage": "留空則使用所選提供者的預設模型"
+  },
+  "recipeModelSelector.modelLabel": {
+    "defaultMessage": "模型（選用）"
+  },
+  "recipeModelSelector.providerHint": {
+    "defaultMessage": "留空則使用設定中所設定的預設提供者"
+  },
+  "recipeModelSelector.providerLabel": {
+    "defaultMessage": "提供者（選用）"
+  },
+  "recipeModelSelector.selectModel": {
+    "defaultMessage": "選取模型"
+  },
+  "recipeModelSelector.selectProvider": {
+    "defaultMessage": "選取提供者"
+  },
+  "recipeModelSelector.useDefaultProvider": {
+    "defaultMessage": "使用預設提供者"
+  },
+  "recipeNameField.defaultLabel": {
+    "defaultMessage": "配方名稱"
+  },
+  "recipeNameField.formatHint": {
+    "defaultMessage": "將自動格式化（小寫，空格以連字號取代）"
+  },
+  "recipeWarningModal.cancel": {
+    "defaultMessage": "取消"
+  },
+  "recipeWarningModal.descriptionLabel": {
+    "defaultMessage": "說明："
+  },
+  "recipeWarningModal.firstTimeDescription": {
+    "defaultMessage": "您即將執行一個尚未執行過的配方。"
+  },
+  "recipeWarningModal.hiddenCharsWarning": {
+    "defaultMessage": "為了您的安全，此配方包含的隱藏字元將被忽略，因為它們可能被用於惡意目的。"
+  },
+  "recipeWarningModal.instructionsLabel": {
+    "defaultMessage": "指示："
+  },
+  "recipeWarningModal.newRecipeWarningTitle": {
+    "defaultMessage": "⚠️ 新配方警告"
+  },
+  "recipeWarningModal.recipePreview": {
+    "defaultMessage": "配方預覽："
+  },
+  "recipeWarningModal.securityWarningTitle": {
+    "defaultMessage": "⚠️ 安全性警告"
+  },
+  "recipeWarningModal.titleLabel": {
+    "defaultMessage": "標題："
+  },
+  "recipeWarningModal.trustAndExecute": {
+    "defaultMessage": "信任並執行"
+  },
+  "recipeWarningModal.trustSource": {
+    "defaultMessage": "只有在您信任此配方的來源時才繼續進行。"
+  },
+  "recipesView.addSchedule": {
+    "defaultMessage": "新增排程"
+  },
+  "recipesView.addSlashCommand": {
+    "defaultMessage": "新增斜線命令"
+  },
+  "recipesView.adjustSearchTerms": {
+    "defaultMessage": "請嘗試調整您的搜尋字詞"
+  },
+  "recipesView.allFiles": {
+    "defaultMessage": "所有檔案"
+  },
+  "recipesView.cancel": {
+    "defaultMessage": "取消"
+  },
+  "recipesView.copyDeeplink": {
+    "defaultMessage": "複製深層連結"
+  },
+  "recipesView.copyDeeplinkFailedMsg": {
+    "defaultMessage": "無法將深層連結複製到剪貼簿"
+  },
+  "recipesView.copyFailedTitle": {
+    "defaultMessage": "複製失敗"
+  },
+  "recipesView.copyYaml": {
+    "defaultMessage": "複製 YAML"
+  },
+  "recipesView.copyYamlFailedMsg": {
+    "defaultMessage": "無法將配方 YAML 複製到剪貼簿"
+  },
+  "recipesView.createRecipe": {
+    "defaultMessage": "建立配方"
+  },
+  "recipesView.deeplinkCopiedMsg": {
+    "defaultMessage": "配方深層連結已複製到剪貼簿"
+  },
+  "recipesView.deeplinkCopiedTitle": {
+    "defaultMessage": "深層連結已複製"
+  },
+  "recipesView.deleteRecipe": {
+    "defaultMessage": "刪除配方"
+  },
+  "recipesView.deleteRecipeConfirm": {
+    "defaultMessage": "您確定要刪除「{title}」嗎？"
+  },
+  "recipesView.deleteRecipeDetail": {
+    "defaultMessage": "配方檔案將會被刪除。"
+  },
+  "recipesView.deleteRecipeTitle": {
+    "defaultMessage": "刪除配方"
+  },
+  "recipesView.editRecipe": {
+    "defaultMessage": "編輯配方"
+  },
+  "recipesView.editSchedule": {
+    "defaultMessage": "編輯排程"
+  },
+  "recipesView.editSlashCommand": {
+    "defaultMessage": "編輯斜線命令"
+  },
+  "recipesView.errorLoadingRecipes": {
+    "defaultMessage": "載入配方時發生錯誤"
+  },
+  "recipesView.exportFailedMsg": {
+    "defaultMessage": "無法將配方匯出至檔案"
+  },
+  "recipesView.exportFailedTitle": {
+    "defaultMessage": "匯出失敗"
+  },
+  "recipesView.exportRecipeDialogTitle": {
+    "defaultMessage": "匯出配方"
+  },
+  "recipesView.exportToFile": {
+    "defaultMessage": "匯出至檔案"
+  },
+  "recipesView.noMatchingRecipes": {
+    "defaultMessage": "找不到符合的食譜"
+  },
+  "recipesView.noSavedRecipes": {
+    "defaultMessage": "尚無已儲存的食譜"
+  },
+  "recipesView.noSavedRecipesDescription": {
+    "defaultMessage": "從聊天儲存的食譜會顯示在這裡。"
+  },
+  "recipesView.openInNewWindow": {
+    "defaultMessage": "在新視窗中開啟"
+  },
+  "recipesView.recipeDeletedSuccess": {
+    "defaultMessage": "食譜已成功刪除"
+  },
+  "recipesView.recipeExportedMsg": {
+    "defaultMessage": "食譜已儲存至 {filePath}"
+  },
+  "recipesView.recipeExportedTitle": {
+    "defaultMessage": "食譜已匯出"
+  },
+  "recipesView.recipesDescription": {
+    "defaultMessage": "檢視並管理您已儲存的食譜，以使用預先定義的設定快速開始新的工作階段。{shortcut} 即可搜尋。"
+  },
+  "recipesView.recipesTitle": {
+    "defaultMessage": "食譜"
+  },
+  "recipesView.remove": {
+    "defaultMessage": "移除"
+  },
+  "recipesView.removeSchedule": {
+    "defaultMessage": "移除排程"
+  },
+  "recipesView.runs": {
+    "defaultMessage": "執行 {schedule}"
+  },
+  "recipesView.save": {
+    "defaultMessage": "儲存"
+  },
+  "recipesView.scheduleDialogTitle": {
+    "defaultMessage": "{action}排程"
+  },
+  "recipesView.scheduleRemovedMsg": {
+    "defaultMessage": "食譜將不再自動執行"
+  },
+  "recipesView.scheduleRemovedTitle": {
+    "defaultMessage": "排程已移除"
+  },
+  "recipesView.scheduleSavedMsg": {
+    "defaultMessage": "食譜將於 {schedule} 執行"
+  },
+  "recipesView.scheduleSavedTitle": {
+    "defaultMessage": "排程已儲存"
+  },
+  "recipesView.searchRecipesPlaceholder": {
+    "defaultMessage": "搜尋食譜…"
+  },
+  "recipesView.shareRecipe": {
+    "defaultMessage": "分享食譜"
+  },
+  "recipesView.slashCommandDescription": {
+    "defaultMessage": "設定一個斜線指令，以便從任何聊天中快速執行此食譜"
+  },
+  "recipesView.slashCommandPlaceholder": {
+    "defaultMessage": "command-name"
+  },
+  "recipesView.slashCommandRemovedMsg": {
+    "defaultMessage": "食譜的斜線指令已移除"
+  },
+  "recipesView.slashCommandRemovedTitle": {
+    "defaultMessage": "斜線指令已移除"
+  },
+  "recipesView.slashCommandSavedMsg": {
+    "defaultMessage": "使用 /{command} 來執行此食譜"
+  },
+  "recipesView.slashCommandSavedTitle": {
+    "defaultMessage": "斜線指令已儲存"
+  },
+  "recipesView.slashCommandTitle": {
+    "defaultMessage": "斜線指令"
+  },
+  "recipesView.slashCommandUsageHint": {
+    "defaultMessage": "在任何聊天中使用 /{command} 來執行此食譜"
+  },
+  "recipesView.tryAgain": {
+    "defaultMessage": "再試一次"
+  },
+  "recipesView.useRecipe": {
+    "defaultMessage": "使用食譜"
+  },
+  "recipesView.yamlCopiedMsg": {
+    "defaultMessage": "食譜 YAML 已複製到剪貼簿"
+  },
+  "recipesView.yamlCopiedTitle": {
+    "defaultMessage": "YAML 已複製"
+  },
+  "recipesView.yamlFiles": {
+    "defaultMessage": "YAML 檔案"
+  },
+  "resetProviderSection.resetButton": {
+    "defaultMessage": "重設供應商與模型"
+  },
+  "resetProviderSection.resetDescription": {
+    "defaultMessage": "這會清除您所選的模型與供應商設定。若沒有可用的預設值，系統將帶您回到歡迎畫面重新進行設定。"
+  },
+  "responseStyle.conciseDescription": {
+    "defaultMessage": "工具呼叫預設為收合，僅顯示所使用的工具"
+  },
+  "responseStyle.conciseLabel": {
+    "defaultMessage": "精簡"
+  },
+  "responseStyle.detailedDescription": {
+    "defaultMessage": "工具呼叫預設為展開，以顯示詳細內容"
+  },
+  "responseStyle.detailedLabel": {
+    "defaultMessage": "詳細"
+  },
+  "scheduleDetailView.actions": {
+    "defaultMessage": "動作"
+  },
+  "scheduleDetailView.cannotModifyRunning": {
+    "defaultMessage": "排程正在執行時，無法觸發或修改。"
+  },
+  "scheduleDetailView.completedSession": {
+    "defaultMessage": "工作階段：{sessionId}"
+  },
+  "scheduleDetailView.created": {
+    "defaultMessage": "建立時間：{date}"
+  },
+  "scheduleDetailView.cronExpression": {
+    "defaultMessage": "Cron 運算式："
+  },
+  "scheduleDetailView.currentSession": {
+    "defaultMessage": "目前工作階段："
+  },
+  "scheduleDetailView.currentlyRunning": {
+    "defaultMessage": "目前正在執行"
+  },
+  "scheduleDetailView.dir": {
+    "defaultMessage": "目錄：{path}"
+  },
+  "scheduleDetailView.editSchedule": {
+    "defaultMessage": "編輯排程"
+  },
+  "scheduleDetailView.errorPrefix": {
+    "defaultMessage": "錯誤：{error}"
+  },
+  "scheduleDetailView.idLabel": {
+    "defaultMessage": "ID："
+  },
+  "scheduleDetailView.inspectJobError": {
+    "defaultMessage": "檢查工作錯誤"
+  },
+  "scheduleDetailView.inspectNoInfo": {
+    "defaultMessage": "沒有可用的詳細資訊"
+  },
+  "scheduleDetailView.inspectRunningJob": {
+    "defaultMessage": "檢查執行中的工作"
+  },
+  "scheduleDetailView.jobCancelled": {
+    "defaultMessage": "工作已取消"
+  },
+  "scheduleDetailView.jobCancelledMsg": {
+    "defaultMessage": "工作在啟動過程中已被取消。"
+  },
+  "scheduleDetailView.jobInspection": {
+    "defaultMessage": "工作檢查"
+  },
+  "scheduleDetailView.jobKilled": {
+    "defaultMessage": "工作已終止"
+  },
+  "scheduleDetailView.killJobError": {
+    "defaultMessage": "終止工作錯誤"
+  },
+  "scheduleDetailView.killRunningJob": {
+    "defaultMessage": "終止執行中的工作"
+  },
+  "scheduleDetailView.lastRun": {
+    "defaultMessage": "上次執行："
+  },
+  "scheduleDetailView.loadingSchedule": {
+    "defaultMessage": "正在載入排程…"
+  },
+  "scheduleDetailView.loadingSessions": {
+    "defaultMessage": "正在載入工作階段…"
+  },
+  "scheduleDetailView.messages": {
+    "defaultMessage": "訊息：{count}"
+  },
+  "scheduleDetailView.noScheduleId": {
+    "defaultMessage": "未提供排程 ID。請返回排程清單。"
+  },
+  "scheduleDetailView.noSessions": {
+    "defaultMessage": "找不到此排程的工作階段。"
+  },
+  "scheduleDetailView.pauseSchedule": {
+    "defaultMessage": "暫停排程"
+  },
+  "scheduleDetailView.pauseUnpauseError": {
+    "defaultMessage": "暫停／取消暫停錯誤"
+  },
+  "scheduleDetailView.paused": {
+    "defaultMessage": "已暫停"
+  },
+  "scheduleDetailView.pausedMsg": {
+    "defaultMessage": "已暫停「{id}」"
+  },
+  "scheduleDetailView.pausedWarning": {
+    "defaultMessage": "此排程已暫停，將不會自動執行。請使用「立即執行排程」手動觸發，或取消暫停以恢復自動執行。"
+  },
+  "scheduleDetailView.processStarted": {
+    "defaultMessage": "程序已啟動："
+  },
+  "scheduleDetailView.recentSessions": {
+    "defaultMessage": "最近的工作階段"
+  },
+  "scheduleDetailView.recipeSource": {
+    "defaultMessage": "食譜來源："
+  },
+  "scheduleDetailView.runScheduleError": {
+    "defaultMessage": "執行排程錯誤"
+  },
+  "scheduleDetailView.runScheduleNow": {
+    "defaultMessage": "立即執行排程"
+  },
+  "scheduleDetailView.scheduleCompleted": {
+    "defaultMessage": "執行已完成"
+  },
+  "scheduleDetailView.scheduleDetails": {
+    "defaultMessage": "排程詳細資料"
+  },
+  "scheduleDetailView.scheduleInformation": {
+    "defaultMessage": "排程資訊"
+  },
+  "scheduleDetailView.scheduleLabel": {
+    "defaultMessage": "排程："
+  },
+  "scheduleDetailView.scheduleNotFound": {
+    "defaultMessage": "找不到排程"
+  },
+  "scheduleDetailView.scheduleNotFoundError": {
+    "defaultMessage": "找不到排程"
+  },
+  "scheduleDetailView.schedulePaused": {
+    "defaultMessage": "排程已暫停"
+  },
+  "scheduleDetailView.scheduleUnpaused": {
+    "defaultMessage": "排程已取消暫停"
+  },
+  "scheduleDetailView.scheduleUpdated": {
+    "defaultMessage": "排程已更新"
+  },
+  "scheduleDetailView.sessionId": {
+    "defaultMessage": "工作階段 ID：{id}"
+  },
+  "scheduleDetailView.unpauseSchedule": {
+    "defaultMessage": "取消暫停排程"
+  },
+  "scheduleDetailView.unpausedMsg": {
+    "defaultMessage": "已取消暫停「{id}」"
+  },
+  "scheduleDetailView.updateScheduleError": {
+    "defaultMessage": "更新排程錯誤"
+  },
+  "scheduleDetailView.updatedMsg": {
+    "defaultMessage": "已更新「{id}」"
+  },
+  "scheduleDetailView.viewingScheduleId": {
+    "defaultMessage": "正在檢視排程 ID：{id}"
+  },
+  "scheduleModal.browseYaml": {
+    "defaultMessage": "瀏覽 YAML 檔案…"
+  },
+  "scheduleModal.cancel": {
+    "defaultMessage": "取消"
+  },
+  "scheduleModal.createNewSchedule": {
+    "defaultMessage": "建立新排程"
+  },
+  "scheduleModal.createSchedule": {
+    "defaultMessage": "建立排程"
+  },
+  "scheduleModal.creating": {
+    "defaultMessage": "正在建立…"
+  },
+  "scheduleModal.deepLink": {
+    "defaultMessage": "深層連結"
+  },
+  "scheduleModal.deepLinkPlaceholder": {
+    "defaultMessage": "在此貼上 goose://recipe 連結…"
+  },
+  "scheduleModal.editSchedule": {
+    "defaultMessage": "編輯排程"
+  },
+  "scheduleModal.failedParseRecipe": {
+    "defaultMessage": "無法從檔案剖析食譜。"
+  },
+  "scheduleModal.failedReadFile": {
+    "defaultMessage": "無法讀取所選檔案。"
+  },
+  "scheduleModal.invalidDeepLink": {
+    "defaultMessage": "無效的深層連結。請使用 goose://recipe 連結。"
+  },
+  "scheduleModal.invalidFileType": {
+    "defaultMessage": "無效的檔案類型：請選擇 YAML 檔案（.yaml 或 .yml）"
+  },
+  "scheduleModal.nameLabel": {
+    "defaultMessage": "名稱："
+  },
+  "scheduleModal.namePlaceholder": {
+    "defaultMessage": "例如：daily-summary-job"
+  },
+  "scheduleModal.provideValidRecipe": {
+    "defaultMessage": "請提供有效的食譜來源。"
+  },
+  "scheduleModal.recipeDescription": {
+    "defaultMessage": "描述：{description}"
+  },
+  "scheduleModal.recipeParsed": {
+    "defaultMessage": "食譜剖析成功"
+  },
+  "scheduleModal.recipeTitle": {
+    "defaultMessage": "標題：{title}"
+  },
+  "scheduleModal.scheduleIdRequired": {
+    "defaultMessage": "排程 ID 為必填。"
+  },
+  "scheduleModal.scheduleLabel": {
+    "defaultMessage": "排程："
+  },
+  "scheduleModal.selected": {
+    "defaultMessage": "已選取：{path}"
+  },
+  "scheduleModal.sourceLabel": {
+    "defaultMessage": "來源："
+  },
+  "scheduleModal.updateSchedule": {
+    "defaultMessage": "更新排程"
+  },
+  "scheduleModal.updating": {
+    "defaultMessage": "正在更新…"
+  },
+  "scheduleModal.yaml": {
+    "defaultMessage": "YAML"
+  },
+  "schedulesView.confirmDelete": {
+    "defaultMessage": "移除排程「{id}」？食譜將會保留。"
+  },
+  "schedulesView.createSchedule": {
+    "defaultMessage": "建立排程"
+  },
+  "schedulesView.description": {
+    "defaultMessage": "建立並管理排程任務，以在指定時間自動執行食譜。"
+  },
+  "schedulesView.edit": {
+    "defaultMessage": "編輯"
+  },
+  "schedulesView.errorPrefix": {
+    "defaultMessage": "錯誤：{error}"
+  },
+  "schedulesView.inspect": {
+    "defaultMessage": "檢查"
+  },
+  "schedulesView.inspectError": {
+    "defaultMessage": "檢查工作錯誤"
+  },
+  "schedulesView.inspectNoInfo": {
+    "defaultMessage": "此工作沒有可用的詳細資訊"
+  },
+  "schedulesView.jobInspection": {
+    "defaultMessage": "工作檢查"
+  },
+  "schedulesView.jobKilled": {
+    "defaultMessage": "工作已終止"
+  },
+  "schedulesView.kill": {
+    "defaultMessage": "終止"
+  },
+  "schedulesView.killError": {
+    "defaultMessage": "終止工作錯誤"
+  },
+  "schedulesView.lastRun": {
+    "defaultMessage": "上次執行：{date}"
+  },
+  "schedulesView.noSchedules": {
+    "defaultMessage": "尚無排程"
+  },
+  "schedulesView.pause": {
+    "defaultMessage": "暫停"
+  },
+  "schedulesView.pauseError": {
+    "defaultMessage": "暫停排程錯誤"
+  },
+  "schedulesView.paused": {
+    "defaultMessage": "已暫停"
+  },
+  "schedulesView.refresh": {
+    "defaultMessage": "重新整理"
+  },
+  "schedulesView.refreshing": {
+    "defaultMessage": "正在重新整理…"
+  },
+  "schedulesView.resume": {
+    "defaultMessage": "繼續"
+  },
+  "schedulesView.running": {
+    "defaultMessage": "執行中"
+  },
+  "schedulesView.schedulePaused": {
+    "defaultMessage": "排程已暫停"
+  },
+  "schedulesView.schedulePausedMsg": {
+    "defaultMessage": "已成功暫停排程「{id}」"
+  },
+  "schedulesView.scheduleUnpaused": {
+    "defaultMessage": "排程已取消暫停"
+  },
+  "schedulesView.scheduleUnpausedMsg": {
+    "defaultMessage": "已成功取消暫停排程「{id}」"
+  },
+  "schedulesView.scheduleUpdated": {
+    "defaultMessage": "排程已更新"
+  },
+  "schedulesView.scheduleUpdatedMsg": {
+    "defaultMessage": "已成功更新排程「{id}」"
+  },
+  "schedulesView.scheduler": {
+    "defaultMessage": "排程器"
+  },
+  "schedulesView.unpauseError": {
+    "defaultMessage": "取消暫停排程錯誤"
+  },
+  "searchBar.caseSensitive": {
+    "defaultMessage": "區分大小寫"
+  },
+  "searchBar.close": {
+    "defaultMessage": "關閉（{shortcut}）"
+  },
+  "searchBar.next": {
+    "defaultMessage": "下一個（{shortcut}）"
+  },
+  "searchBar.placeholder": {
+    "defaultMessage": "搜尋對話…"
+  },
+  "searchBar.previous": {
+    "defaultMessage": "上一個（{shortcut}）"
+  },
+  "secureStorageNotice.defaultMessage": {
+    "defaultMessage": "金鑰會安全地儲存在金鑰鏈中"
+  },
+  "securityToggle.apiTokenDescription": {
+    "defaultMessage": "分類服務的驗證權杖"
+  },
+  "securityToggle.apiTokenOptional": {
+    "defaultMessage": "API 權杖（選填）"
+  },
+  "securityToggle.classificationEndpoint": {
+    "defaultMessage": "分類端點"
+  },
+  "securityToggle.classificationEndpointDescription": {
+    "defaultMessage": "輸入您分類服務的完整 URL"
+  },
+  "securityToggle.commandClassifierActive": {
+    "defaultMessage": "指令分類器已啟用（已從環境自動設定）"
+  },
+  "securityToggle.commandEndpointDescription": {
+    "defaultMessage": "輸入您指令注入分類服務的完整 URL"
+  },
+  "securityToggle.commandInjectionDescription": {
+    "defaultMessage": "使用 ML 模型偵測惡意的 shell 指令"
+  },
+  "securityToggle.detectionModel": {
+    "defaultMessage": "偵測模型"
+  },
+  "securityToggle.detectionModelDescription": {
+    "defaultMessage": "選擇要用於提示注入偵測的 ML 模型"
+  },
+  "securityToggle.detectionThreshold": {
+    "defaultMessage": "偵測門檻"
+  },
+  "securityToggle.enableCommandInjection": {
+    "defaultMessage": "啟用指令注入 ML 偵測"
+  },
+  "securityToggle.enablePromptInjection": {
+    "defaultMessage": "啟用提示注入偵測"
+  },
+  "securityToggle.enablePromptInjectionMl": {
+    "defaultMessage": "啟用提示注入 ML 偵測"
+  },
+  "securityToggle.mlEndpointDescription": {
+    "defaultMessage": "輸入您 ML 分類服務的完整 URL（包含模型識別碼）"
+  },
+  "securityToggle.mlTokenDescription": {
+    "defaultMessage": "ML 服務的驗證權杖（例如 HuggingFace 權杖）"
+  },
+  "securityToggle.overrideNotice": {
+    "defaultMessage": "此設定由您的組織管理，無法變更。"
+  },
+  "securityToggle.promptInjectionDescription": {
+    "defaultMessage": "偵測並防範潛在的提示注入攻擊"
+  },
+  "securityToggle.promptInjectionMlDescription": {
+    "defaultMessage": "使用 ML 模型偵測您聊天中潛在的提示注入"
+  },
+  "securityToggle.thresholdDescription": {
+    "defaultMessage": "數值越高越嚴格（0.01 = 非常寬鬆，1.0 = 最嚴格）"
+  },
+  "securityToggle.warpNotice": {
+    "defaultMessage": "連線至 WARP 時，指令注入偵測的效果最佳（為了連接分類服務所必需）。"
+  },
+  "sessionActionsHeader.actionsLabel": {
+    "defaultMessage": "工作階段動作"
+  },
+  "sessionActionsHeader.cancel": {
+    "defaultMessage": "取消"
+  },
+  "sessionActionsHeader.close": {
+    "defaultMessage": "關閉"
+  },
+  "sessionActionsHeader.copiedJson": {
+    "defaultMessage": "工作階段 JSON 已複製"
+  },
+  "sessionActionsHeader.copiedText": {
+    "defaultMessage": "文字已複製"
+  },
+  "sessionActionsHeader.copyJson": {
+    "defaultMessage": "複製 JSON"
+  },
+  "sessionActionsHeader.copyText": {
+    "defaultMessage": "複製文字"
+  },
+  "sessionActionsHeader.duplicateFailed": {
+    "defaultMessage": "複製工作階段失敗：{error}"
+  },
+  "sessionActionsHeader.duplicateSession": {
+    "defaultMessage": "複製工作階段"
+  },
+  "sessionActionsHeader.duplicated": {
+    "defaultMessage": "工作階段已複製"
+  },
+  "sessionActionsHeader.fullTextTitle": {
+    "defaultMessage": "文字值"
+  },
+  "sessionActionsHeader.jsonFailed": {
+    "defaultMessage": "載入工作階段 JSON 失敗：{error}"
+  },
+  "sessionActionsHeader.jsonTitle": {
+    "defaultMessage": "工作階段 JSON"
+  },
+  "sessionActionsHeader.loadingJson": {
+    "defaultMessage": "正在載入 JSON…"
+  },
+  "sessionActionsHeader.renameFailed": {
+    "defaultMessage": "重新命名工作階段失敗：{error}"
+  },
+  "sessionActionsHeader.renamePlaceholder": {
+    "defaultMessage": "輸入工作階段名稱"
+  },
+  "sessionActionsHeader.renameSession": {
+    "defaultMessage": "重新命名工作階段"
+  },
+  "sessionActionsHeader.renameTitle": {
+    "defaultMessage": "重新命名工作階段"
+  },
+  "sessionActionsHeader.renamed": {
+    "defaultMessage": "工作階段已重新命名"
+  },
+  "sessionActionsHeader.save": {
+    "defaultMessage": "儲存"
+  },
+  "sessionActionsHeader.saving": {
+    "defaultMessage": "正在儲存…"
+  },
+  "sessionActionsHeader.viewJson": {
+    "defaultMessage": "檢視工作階段 JSON"
+  },
+  "sessionIndicators.error": {
+    "defaultMessage": "工作階段發生錯誤"
+  },
+  "sessionIndicators.newActivity": {
+    "defaultMessage": "有新活動"
+  },
+  "sessionIndicators.streaming": {
+    "defaultMessage": "串流中"
+  },
+  "sessionViewComponents.empty.description": {
+    "defaultMessage": "此工作階段不包含任何訊息"
+  },
+  "sessionViewComponents.empty.title": {
+    "defaultMessage": "找不到訊息"
+  },
+  "sessionViewComponents.error.loading": {
+    "defaultMessage": "載入工作階段詳細資料時發生錯誤"
+  },
+  "sessionViewComponents.error.tryAgain": {
+    "defaultMessage": "再試一次"
+  },
+  "sessionViewComponents.role.assistant": {
+    "defaultMessage": "Goose"
+  },
+  "sessionViewComponents.role.user": {
+    "defaultMessage": "您"
+  },
+  "sessions.action.delete": {
+    "defaultMessage": "刪除工作階段"
+  },
+  "sessions.action.duplicate": {
+    "defaultMessage": "複製工作階段"
+  },
+  "sessions.action.editName": {
+    "defaultMessage": "編輯工作階段名稱"
+  },
+  "sessions.action.export": {
+    "defaultMessage": "匯出工作階段"
+  },
+  "sessions.action.openNewWindow": {
+    "defaultMessage": "在新視窗中開啟"
+  },
+  "sessions.action.shareNostr": {
+    "defaultMessage": "分享加密的 Nostr 連結"
+  },
+  "sessions.cancel": {
+    "defaultMessage": "取消"
+  },
+  "sessions.chatHistory": {
+    "defaultMessage": "聊天記錄"
+  },
+  "sessions.chatHistoryDesc": {
+    "defaultMessage": "檢視並搜尋您與 Goose 過去的對話。{shortcut} 即可搜尋。"
+  },
+  "sessions.close": {
+    "defaultMessage": "關閉"
+  },
+  "sessions.delete.message": {
+    "defaultMessage": "您確定要刪除工作階段「{name}」嗎？此動作無法復原。"
+  },
+  "sessions.delete.title": {
+    "defaultMessage": "刪除工作階段"
+  },
+  "sessions.edit.placeholder": {
+    "defaultMessage": "輸入工作階段描述"
+  },
+  "sessions.edit.title": {
+    "defaultMessage": "編輯工作階段描述"
+  },
+  "sessions.empty.description": {
+    "defaultMessage": "您的聊天記錄將會顯示在這裡"
+  },
+  "sessions.empty.title": {
+    "defaultMessage": "找不到聊天工作階段"
+  },
+  "sessions.error.loading": {
+    "defaultMessage": "載入工作階段時發生錯誤"
+  },
+  "sessions.error.tryAgain": {
+    "defaultMessage": "再試一次"
+  },
+  "sessions.import": {
+    "defaultMessage": "匯入工作階段"
+  },
+  "sessions.importNostr": {
+    "defaultMessage": "匯入連結"
+  },
+  "sessions.importNostr.description": {
+    "defaultMessage": "貼上 Goose Nostr 分享連結，以擷取、解密並匯入該工作階段。"
+  },
+  "sessions.importNostr.placeholder": {
+    "defaultMessage": "goose://sessions/nostr?nevent=...&key=..."
+  },
+  "sessions.importNostr.title": {
+    "defaultMessage": "匯入 Nostr 工作階段"
+  },
+  "sessions.importing": {
+    "defaultMessage": "正在匯入…"
+  },
+  "sessions.loadingMore": {
+    "defaultMessage": "正在載入更多工作階段…"
+  },
+  "sessions.save": {
+    "defaultMessage": "儲存"
+  },
+  "sessions.saving": {
+    "defaultMessage": "正在儲存…"
+  },
+  "sessions.search.noResults": {
+    "defaultMessage": "找不到符合的工作階段"
+  },
+  "sessions.search.noResultsDesc": {
+    "defaultMessage": "請嘗試調整您的搜尋字詞"
+  },
+  "sessions.searchPlaceholder": {
+    "defaultMessage": "搜尋記錄..."
+  },
+  "sessions.shareNostr.description": {
+    "defaultMessage": "任何持有此連結的人都能擷取並解密該工作階段。請將其視為機密。"
+  },
+  "sessions.shareNostr.title": {
+    "defaultMessage": "加密的 Nostr 分享連結"
+  },
+  "sessions.toast.copied": {
+    "defaultMessage": "已複製到剪貼簿"
+  },
+  "sessions.toast.deleteFailed": {
+    "defaultMessage": "無法刪除工作階段「{name}」：{error}"
+  },
+  "sessions.toast.deleted": {
+    "defaultMessage": "已成功刪除工作階段"
+  },
+  "sessions.toast.duplicateFailed": {
+    "defaultMessage": "無法複製工作階段：{error}"
+  },
+  "sessions.toast.duplicated": {
+    "defaultMessage": "已成功複製工作階段「{name}」"
+  },
+  "sessions.toast.exported": {
+    "defaultMessage": "已成功匯出工作階段"
+  },
+  "sessions.toast.importFailed": {
+    "defaultMessage": "無法匯入工作階段：{error}"
+  },
+  "sessions.toast.imported": {
+    "defaultMessage": "已成功匯入工作階段"
+  },
+  "sessions.toast.shareNostr": {
+    "defaultMessage": "已建立加密的 Nostr 分享連結"
+  },
+  "sessions.toast.shareNostrFailed": {
+    "defaultMessage": "無法建立 Nostr 分享連結：{error}"
+  },
+  "sessions.toast.updateFailed": {
+    "defaultMessage": "無法更新工作階段描述：{error}"
+  },
+  "sessions.toast.updated": {
+    "defaultMessage": "已成功更新工作階段描述"
+  },
+  "settings.appearance.description": {
+    "defaultMessage": "設定 goose 在您系統上的顯示方式"
+  },
+  "settings.appearance.title": {
+    "defaultMessage": "外觀"
+  },
+  "settings.close": {
+    "defaultMessage": "關閉"
+  },
+  "settings.costTracking.description": {
+    "defaultMessage": "顯示模型定價與使用費用"
+  },
+  "settings.costTracking.title": {
+    "defaultMessage": "費用追蹤"
+  },
+  "settings.dockIcon.description": {
+    "defaultMessage": "在 Dock 中顯示 goose"
+  },
+  "settings.dockIcon.title": {
+    "defaultMessage": "Dock 圖示"
+  },
+  "settings.help.description": {
+    "defaultMessage": "回報問題或申請新功能，協助我們改善 goose"
+  },
+  "settings.help.reportBug": {
+    "defaultMessage": "回報錯誤"
+  },
+  "settings.help.requestFeature": {
+    "defaultMessage": "申請功能"
+  },
+  "settings.help.title": {
+    "defaultMessage": "說明與意見回饋"
+  },
+  "settings.language.description": {
+    "defaultMessage": "選擇 goose 的顯示語言"
+  },
+  "settings.language.english": {
+    "defaultMessage": "English"
+  },
+  "settings.language.french": {
+    "defaultMessage": "法語"
+  },
+  "settings.language.german": {
+    "defaultMessage": "德語"
+  },
+  "settings.language.hindi": {
+    "defaultMessage": "印地語"
+  },
+  "settings.language.indonesian": {
+    "defaultMessage": "印尼語"
+  },
+  "settings.language.italian": {
+    "defaultMessage": "義大利語"
+  },
+  "settings.language.japanese": {
+    "defaultMessage": "日語"
+  },
+  "settings.language.korean": {
+    "defaultMessage": "韓語"
+  },
+  "settings.language.malay": {
+    "defaultMessage": "馬來語"
+  },
+  "settings.language.portuguese": {
+    "defaultMessage": "葡萄牙語"
+  },
+  "settings.language.russian": {
+    "defaultMessage": "俄語"
+  },
+  "settings.language.spanish": {
+    "defaultMessage": "西班牙語"
+  },
+  "settings.language.systemDefault": {
+    "defaultMessage": "系統預設"
+  },
+  "settings.language.title": {
+    "defaultMessage": "語言"
+  },
+  "settings.language.turkish": {
+    "defaultMessage": "土耳其語"
+  },
+  "settings.language.vietnamese": {
+    "defaultMessage": "越南語"
+  },
+  "settings.language.zhCN": {
+    "defaultMessage": "中文（簡體）"
+  },
+  "settings.language.zhTW": {
+    "defaultMessage": "中文（繁體）"
+  },
+  "settings.menuBarIcon.description": {
+    "defaultMessage": "在選單列中顯示 goose"
+  },
+  "settings.menuBarIcon.title": {
+    "defaultMessage": "選單列圖示"
+  },
+  "settings.notifications.configGuide": {
+    "defaultMessage": "設定指南"
+  },
+  "settings.notifications.description": {
+    "defaultMessage": "通知由您的作業系統管理 - {link}"
+  },
+  "settings.notifications.modal.macInstructions": {
+    "defaultMessage": "若要在 macOS 上啟用通知："
+  },
+  "settings.notifications.modal.macStep1": {
+    "defaultMessage": "開啟「系統偏好設定」"
+  },
+  "settings.notifications.modal.macStep2": {
+    "defaultMessage": "點選「通知」"
+  },
+  "settings.notifications.modal.macStep3": {
+    "defaultMessage": "在應用程式清單中找到並選取 goose"
+  },
+  "settings.notifications.modal.macStep4": {
+    "defaultMessage": "啟用通知並依需求調整設定"
+  },
+  "settings.notifications.modal.title": {
+    "defaultMessage": "如何啟用通知"
+  },
+  "settings.notifications.modal.winInstructions": {
+    "defaultMessage": "若要在 Windows 上啟用通知："
+  },
+  "settings.notifications.modal.winStep1": {
+    "defaultMessage": "開啟「設定」"
+  },
+  "settings.notifications.modal.winStep2": {
+    "defaultMessage": "前往「系統」>「通知」"
+  },
+  "settings.notifications.modal.winStep3": {
+    "defaultMessage": "在應用程式清單中找到並選取 goose"
+  },
+  "settings.notifications.modal.winStep4": {
+    "defaultMessage": "開啟通知並依需求調整設定"
+  },
+  "settings.notifications.openSettings": {
+    "defaultMessage": "開啟設定"
+  },
+  "settings.notifications.task.description": {
+    "defaultMessage": "當視窗在背景執行時，Goose 完成工作後發出通知"
+  },
+  "settings.notifications.task.title": {
+    "defaultMessage": "工作完成通知"
+  },
+  "settings.notifications.title": {
+    "defaultMessage": "通知"
+  },
+  "settings.preventSleep.description": {
+    "defaultMessage": "在 goose 執行工作時讓電腦保持喚醒狀態（螢幕仍可鎖定）"
+  },
+  "settings.preventSleep.title": {
+    "defaultMessage": "防止睡眠"
+  },
+  "settings.theme.description": {
+    "defaultMessage": "自訂 goose 的外觀與風格"
+  },
+  "settings.theme.title": {
+    "defaultMessage": "佈景主題"
+  },
+  "settings.updates.description": {
+    "defaultMessage": "檢查並安裝更新，讓 goose 保持最佳運作狀態"
+  },
+  "settings.updates.title": {
+    "defaultMessage": "更新"
+  },
+  "settings.version.title": {
+    "defaultMessage": "版本"
+  },
+  "settingsView.tabApp": {
+    "defaultMessage": "應用程式"
+  },
+  "settingsView.tabAuth": {
+    "defaultMessage": "驗證"
+  },
+  "settingsView.tabChat": {
+    "defaultMessage": "聊天"
+  },
+  "settingsView.tabKeyboard": {
+    "defaultMessage": "鍵盤"
+  },
+  "settingsView.tabLocalInference": {
+    "defaultMessage": "本機推論"
+  },
+  "settingsView.tabModels": {
+    "defaultMessage": "模型"
+  },
+  "settingsView.tabPrompts": {
+    "defaultMessage": "提示"
+  },
+  "settingsView.tabSession": {
+    "defaultMessage": "工作階段"
+  },
+  "settingsView.title": {
+    "defaultMessage": "設定"
+  },
+  "sheet.close": {
+    "defaultMessage": "關閉"
+  },
+  "shortcutRecorder.cancel": {
+    "defaultMessage": "取消"
+  },
+  "shortcutRecorder.clickToRecord": {
+    "defaultMessage": "點選以錄製..."
+  },
+  "shortcutRecorder.conflictWarning": {
+    "defaultMessage": "此快速鍵已由 {label} 使用。儲存後將重新指派給此動作。"
+  },
+  "shortcutRecorder.pressShortcut": {
+    "defaultMessage": "請按下快速鍵..."
+  },
+  "shortcutRecorder.save": {
+    "defaultMessage": "儲存"
+  },
+  "skillsView.addSkill": {
+    "defaultMessage": "新增技能"
+  },
+  "skillsView.adjustSearchTerms": {
+    "defaultMessage": "請嘗試調整您的搜尋字詞"
+  },
+  "skillsView.comingSoon": {
+    "defaultMessage": "即將推出"
+  },
+  "skillsView.errorLoadingSkills": {
+    "defaultMessage": "載入技能時發生錯誤"
+  },
+  "skillsView.noMatchingSkills": {
+    "defaultMessage": "找不到符合的技能"
+  },
+  "skillsView.noSkillsDescription": {
+    "defaultMessage": "技能會從 ~/.config/agents/skills/、.goose/skills/ 或其他支援目錄中的 SKILL.md 檔案載入。"
+  },
+  "skillsView.noSkillsInstalled": {
+    "defaultMessage": "未安裝任何技能"
+  },
+  "skillsView.searchSkillsPlaceholder": {
+    "defaultMessage": "搜尋技能..."
+  },
+  "skillsView.skillsDescription": {
+    "defaultMessage": "檢視可擴充 Goose 功能的已安裝技能。{shortcut} 即可搜尋。"
+  },
+  "skillsView.skillsTitle": {
+    "defaultMessage": "技能"
+  },
+  "skillsView.tryAgain": {
+    "defaultMessage": "重試"
+  },
+  "spellcheckToggle.description": {
+    "defaultMessage": "檢查聊天輸入中的拼字。需重新啟動才會生效。"
+  },
+  "spellcheckToggle.title": {
+    "defaultMessage": "啟用拼字檢查"
+  },
+  "standaloneAppView.failedToLoad": {
+    "defaultMessage": "無法載入應用程式"
+  },
+  "standaloneAppView.initializing": {
+    "defaultMessage": "正在初始化應用程式..."
+  },
+  "standaloneAppView.missingParams": {
+    "defaultMessage": "缺少必要參數"
+  },
+  "stringUtils.configuredProvider": {
+    "defaultMessage": "已設定 {name} 提供者"
+  },
+  "stringUtils.ollamaApp": {
+    "defaultMessage": "Ollama 應用程式"
+  },
+  "stringUtils.ollamaNotConfiguredPrefix": {
+    "defaultMessage": "若要使用，請選擇"
+  },
+  "stringUtils.ollamaNotConfiguredSuffix": {
+    "defaultMessage": "必須安裝在您的電腦上並開啟，或者您必須輸入 OLLAMA_HOST 的值。"
+  },
+  "subRecipeEditor.addExisting": {
+    "defaultMessage": "新增現有項目"
+  },
+  "subRecipeEditor.createNew": {
+    "defaultMessage": "建立新的子配方"
+  },
+  "subRecipeEditor.deleteSubrecipe": {
+    "defaultMessage": "刪除子配方 {name}"
+  },
+  "subRecipeEditor.description": {
+    "defaultMessage": "子配方是可在執行期間作為工具呼叫的配方。它們可實現多步驟工作流程與可重複使用的元件。"
+  },
+  "subRecipeEditor.duplicateName": {
+    "defaultMessage": "名稱重複"
+  },
+  "subRecipeEditor.duplicateNameMsg": {
+    "defaultMessage": "名為「{name}」的子配方已存在。請使用唯一的名稱。"
+  },
+  "subRecipeEditor.editSubrecipe": {
+    "defaultMessage": "編輯子配方 {name}"
+  },
+  "subRecipeEditor.label": {
+    "defaultMessage": "子配方"
+  },
+  "subRecipeEditor.preconfiguredValues": {
+    "defaultMessage": "預先設定的值："
+  },
+  "subRecipeEditor.sequential": {
+    "defaultMessage": "循序"
+  },
+  "subRecipeModal.addTitle": {
+    "defaultMessage": "新增子配方"
+  },
+  "subRecipeModal.apply": {
+    "defaultMessage": "套用"
+  },
+  "subRecipeModal.browse": {
+    "defaultMessage": "瀏覽"
+  },
+  "subRecipeModal.cancel": {
+    "defaultMessage": "取消"
+  },
+  "subRecipeModal.closeModal": {
+    "defaultMessage": "關閉子配方對話方塊"
+  },
+  "subRecipeModal.configureTitle": {
+    "defaultMessage": "設定子配方"
+  },
+  "subRecipeModal.descriptionLabel": {
+    "defaultMessage": "描述"
+  },
+  "subRecipeModal.descriptionPlaceholder": {
+    "defaultMessage": "選填，說明此子配方的功能..."
+  },
+  "subRecipeModal.invalidFile": {
+    "defaultMessage": "無效的檔案"
+  },
+  "subRecipeModal.invalidFileMsg": {
+    "defaultMessage": "請選擇 YAML 檔案（.yaml 或 .yml）。"
+  },
+  "subRecipeModal.nameHint": {
+    "defaultMessage": "用於產生工具名稱的唯一識別碼"
+  },
+  "subRecipeModal.nameLabel": {
+    "defaultMessage": "名稱"
+  },
+  "subRecipeModal.namePlaceholder": {
+    "defaultMessage": "例如：security_scan"
+  },
+  "subRecipeModal.pathHint": {
+    "defaultMessage": "瀏覽現有的配方檔案或手動輸入路徑"
+  },
+  "subRecipeModal.pathLabel": {
+    "defaultMessage": "路徑"
+  },
+  "subRecipeModal.pathPlaceholder": {
+    "defaultMessage": "例如：./subrecipes/security-analysis.yaml"
+  },
+  "subRecipeModal.preconfiguredValues": {
+    "defaultMessage": "預先設定的值"
+  },
+  "subRecipeModal.preconfiguredValuesHint": {
+    "defaultMessage": "選填，一律會傳遞給子配方的參數值"
+  },
+  "subRecipeModal.sequentialHint": {
+    "defaultMessage": "（強制循序執行多個子配方執行個體）"
+  },
+  "subRecipeModal.sequentialLabel": {
+    "defaultMessage": "重複時循序執行"
+  },
+  "subRecipeModal.subtitle": {
+    "defaultMessage": "設定可在配方執行期間作為工具呼叫的子配方"
+  },
+  "switchModelModal.backToModelList": {
+    "defaultMessage": "返回模型清單"
+  },
+  "switchModelModal.cancel": {
+    "defaultMessage": "取消"
+  },
+  "switchModelModal.checkProviderConfig": {
+    "defaultMessage": "請在「設定」→「提供者」中檢查您的提供者設定"
+  },
+  "switchModelModal.chooseModel": {
+    "defaultMessage": "選擇模型："
+  },
+  "switchModelModal.claudeAdaptive": {
+    "defaultMessage": "適應性 - 由 Claude 決定何時思考及思考程度"
+  },
+  "switchModelModal.claudeDisabled": {
+    "defaultMessage": "停用 - 不進行延伸思考"
+  },
+  "switchModelModal.claudeEffortHigh": {
+    "defaultMessage": "高 - 深度推理（預設）"
+  },
+  "switchModelModal.claudeEffortLow": {
+    "defaultMessage": "低 - 最少思考，回應最快"
+  },
+  "switchModelModal.claudeEffortMax": {
+    "defaultMessage": "最高 - 思考深度不受限制"
+  },
+  "switchModelModal.claudeEffortMedium": {
+    "defaultMessage": "中 - 適度思考"
+  },
+  "switchModelModal.claudeEnabled": {
+    "defaultMessage": "啟用 - 思考使用固定的權杖預算"
+  },
+  "switchModelModal.couldNotContactProvider": {
+    "defaultMessage": "無法連絡提供者"
+  },
+  "switchModelModal.customModelName": {
+    "defaultMessage": "自訂模型名稱"
+  },
+  "switchModelModal.description": {
+    "defaultMessage": "選擇要用於對話的提供者與模型。"
+  },
+  "switchModelModal.enterModelNotListed": {
+    "defaultMessage": "輸入未列出的模型..."
+  },
+  "switchModelModal.extendedThinking": {
+    "defaultMessage": "延伸思考"
+  },
+  "switchModelModal.geminiOnly": {
+    "defaultMessage": "（僅限 Gemini 3 模型）"
+  },
+  "switchModelModal.goToSettings": {
+    "defaultMessage": "前往設定"
+  },
+  "switchModelModal.loadingModels": {
+    "defaultMessage": "正在載入模型…"
+  },
+  "switchModelModal.localModelsDescription": {
+    "defaultMessage": "若要使用本機推論，您必須先將模型下載到電腦。請前往「設定」→「模型」以管理本機模型。"
+  },
+  "switchModelModal.localModelsTitle": {
+    "defaultMessage": "本機模型需要先行下載"
+  },
+  "switchModelModal.providerPlaceholder": {
+    "defaultMessage": "提供者，輸入以搜尋"
+  },
+  "switchModelModal.quickStartGuide": {
+    "defaultMessage": "快速入門指南"
+  },
+  "switchModelModal.recommended": {
+    "defaultMessage": "建議"
+  },
+  "switchModelModal.selectEffortLevel": {
+    "defaultMessage": "選擇用力程度"
+  },
+  "switchModelModal.selectModel": {
+    "defaultMessage": "請選擇模型"
+  },
+  "switchModelModal.selectModelButton": {
+    "defaultMessage": "選擇模型"
+  },
+  "switchModelModal.selectModelPlaceholder": {
+    "defaultMessage": "選擇模型，輸入以搜尋"
+  },
+  "switchModelModal.selectOrEnterModel": {
+    "defaultMessage": "請選擇或輸入模型"
+  },
+  "switchModelModal.selectProvider": {
+    "defaultMessage": "請選擇提供者"
+  },
+  "switchModelModal.selectThinkingLevel": {
+    "defaultMessage": "選擇思考層級"
+  },
+  "switchModelModal.selectThinkingMode": {
+    "defaultMessage": "選擇思考模式"
+  },
+  "switchModelModal.thinkingBudget": {
+    "defaultMessage": "思考預算（權杖）"
+  },
+  "switchModelModal.thinkingEffort": {
+    "defaultMessage": "思考用力程度"
+  },
+  "switchModelModal.thinkingEffortOff": {
+    "defaultMessage": "關閉 - 不進行延伸思考"
+  },
+  "switchModelModal.thinkingLevel": {
+    "defaultMessage": "思考層級"
+  },
+  "switchModelModal.thinkingLevelHigh": {
+    "defaultMessage": "高 - 更深入的推理，延遲較高"
+  },
+  "switchModelModal.thinkingLevelLow": {
+    "defaultMessage": "低 - 延遲較佳，推理較輕量"
+  },
+  "switchModelModal.title": {
+    "defaultMessage": "切換模型"
+  },
+  "switchModelModal.typeModelName": {
+    "defaultMessage": "在此輸入模型名稱"
+  },
+  "switchModelModal.useOtherProvider": {
+    "defaultMessage": "使用其他提供者"
+  },
+  "telemetryConsentPrompt.description": {
+    "defaultMessage": "您願意分享匿名使用資料以協助改善 goose 嗎？我們絕不會收集您的對話、程式碼或個人資料。"
+  },
+  "telemetryConsentPrompt.heading": {
+    "defaultMessage": "協助改善 goose"
+  },
+  "telemetryConsentPrompt.learnMore": {
+    "defaultMessage": "瞭解詳情"
+  },
+  "telemetryConsentPrompt.optIn": {
+    "defaultMessage": "好的，分享匿名使用資料"
+  },
+  "telemetryConsentPrompt.optOut": {
+    "defaultMessage": "不用了，謝謝"
+  },
+  "telemetrySettings.configErrorTitle": {
+    "defaultMessage": "設定錯誤"
+  },
+  "telemetrySettings.description": {
+    "defaultMessage": "控制您的資料使用方式"
+  },
+  "telemetrySettings.learnMore": {
+    "defaultMessage": "瞭解詳情"
+  },
+  "telemetrySettings.loadError": {
+    "defaultMessage": "無法載入遙測設定。"
+  },
+  "telemetrySettings.title": {
+    "defaultMessage": "隱私"
+  },
+  "telemetrySettings.toggleDescription": {
+    "defaultMessage": "分享匿名使用統計資料以協助改善 goose。"
+  },
+  "telemetrySettings.toggleLabel": {
+    "defaultMessage": "匿名使用資料"
+  },
+  "telemetrySettings.updateError": {
+    "defaultMessage": "無法更新遙測設定。"
+  },
+  "themeSelector.dark": {
+    "defaultMessage": "深色"
+  },
+  "themeSelector.light": {
+    "defaultMessage": "淺色"
+  },
+  "themeSelector.system": {
+    "defaultMessage": "系統"
+  },
+  "themeSelector.theme": {
+    "defaultMessage": "佈景主題"
+  },
+  "toolApprovalButtons.allowOnce": {
+    "defaultMessage": "允許一次"
+  },
+  "toolApprovalButtons.allowedOnce": {
+    "defaultMessage": "已允許一次"
+  },
+  "toolApprovalButtons.alwaysAllow": {
+    "defaultMessage": "一律允許"
+  },
+  "toolApprovalButtons.alwaysAllowed": {
+    "defaultMessage": "已設為一律允許"
+  },
+  "toolApprovalButtons.cancelled": {
+    "defaultMessage": "已取消"
+  },
+  "toolApprovalButtons.denied": {
+    "defaultMessage": "已拒絕"
+  },
+  "toolApprovalButtons.deniedOnce": {
+    "defaultMessage": "已拒絕一次"
+  },
+  "toolApprovalButtons.deny": {
+    "defaultMessage": "拒絕"
+  },
+  "toolApprovalButtons.staleApprovalRequest": {
+    "defaultMessage": "此核准要求已不再有效。"
+  },
+  "toolCallStatusIndicator.toolStatus": {
+    "defaultMessage": "工具狀態：{status}"
+  },
+  "toolCallWithResponse.activityCount": {
+    "defaultMessage": "活動（{count}）"
+  },
+  "toolCallWithResponse.code": {
+    "defaultMessage": "程式碼"
+  },
+  "toolCallWithResponse.loadingSpinner": {
+    "defaultMessage": "載入指示器"
+  },
+  "toolCallWithResponse.logs": {
+    "defaultMessage": "記錄"
+  },
+  "toolCallWithResponse.mcpUiExperimental": {
+    "defaultMessage": "MCP UI 為實驗性功能，可能隨時變更。"
+  },
+  "toolCallWithResponse.output": {
+    "defaultMessage": "輸出"
+  },
+  "toolCallWithResponse.toolDetails": {
+    "defaultMessage": "工具詳細資料"
+  },
+  "toolCallWithResponse.toolResultAlt": {
+    "defaultMessage": "工具結果"
+  },
+  "toolCallWithResponse.viewSubagentSession": {
+    "defaultMessage": "檢視子代理工作階段"
+  },
+  "toolConfirmation.allowToolCallWithName": {
+    "defaultMessage": "允許 {toolName}？"
+  },
+  "toolConfirmation.gooseWouldLikeToCallWithName": {
+    "defaultMessage": "Goose 想要呼叫 {toolName}。要允許嗎？"
+  },
+  "updateSection.autoDownload": {
+    "defaultMessage": "Goose 會在背景下載更新，並於您下次結束或重新啟動時安裝。"
+  },
+  "updateSection.autoDownloadDisabledByEnv": {
+    "defaultMessage": "已透過 GOOSE_DISABLE_AUTO_DOWNLOAD 環境變數停用自動下載。"
+  },
+  "updateSection.autoDownloadDisabledNote": {
+    "defaultMessage": "已停用自動下載。請點選「立即下載」以手動下載。"
+  },
+  "updateSection.autoInstallNote": {
+    "defaultMessage": "無需手動安裝。"
+  },
+  "updateSection.checkForUpdates": {
+    "defaultMessage": "檢查更新"
+  },
+  "updateSection.checking": {
+    "defaultMessage": "正在檢查更新..."
+  },
+  "updateSection.currentVersion": {
+    "defaultMessage": "目前版本"
+  },
+  "updateSection.disableAutoDownload": {
+    "defaultMessage": "停用自動下載更新"
+  },
+  "updateSection.disableAutoDownloadDesc": {
+    "defaultMessage": "啟用後，Goose 會通知您有新版本，但不會自動下載。"
+  },
+  "updateSection.downloadNow": {
+    "defaultMessage": "立即下載"
+  },
+  "updateSection.downloadReady": {
+    "defaultMessage": "更新已下載完成並可供安裝！"
+  },
+  "updateSection.downloadingProgress": {
+    "defaultMessage": "正在下載更新... {percent}%"
+  },
+  "updateSection.downloadingUpdate": {
+    "defaultMessage": "正在下載更新..."
+  },
+  "updateSection.installAndRestart": {
+    "defaultMessage": "安裝並重新啟動"
+  },
+  "updateSection.installNowHint": {
+    "defaultMessage": "請點選「安裝並重新啟動」以立即更新。"
+  },
+  "updateSection.latestVersion": {
+    "defaultMessage": "您執行的是最新版本！"
+  },
+  "updateSection.loading": {
+    "defaultMessage": "載入中..."
+  },
+  "updateSection.manualInstallNote": {
+    "defaultMessage": "下載後，您需要手動安裝更新。"
+  },
+  "updateSection.manualInstallRequired": {
+    "defaultMessage": "此更新方式需要手動安裝。"
+  },
+  "updateSection.readyInstallAuto": {
+    "defaultMessage": "✓ 更新已就緒。重新啟動 Goose 即可完成安裝，或在您完成後結束。"
+  },
+  "updateSection.readyInstallManual": {
+    "defaultMessage": "✓ 更新已就緒！請點選「安裝並重新啟動」以取得安裝指示。"
+  },
+  "updateSection.upToDate": {
+    "defaultMessage": "（為最新版本）"
+  },
+  "updateSection.updateAvailable": {
+    "defaultMessage": "有可用的更新！"
+  },
+  "updateSection.versionAvailable": {
+    "defaultMessage": "→ 有可用的 {version}"
+  },
+  "updateSection.versionIsAvailable": {
+    "defaultMessage": "{version} 版本已可使用"
+  },
+  "userMessage.cancel": {
+    "defaultMessage": "取消"
+  },
+  "userMessage.cancelAriaLabel": {
+    "defaultMessage": "取消編輯"
+  },
+  "userMessage.editAriaLabel": {
+    "defaultMessage": "編輯訊息內容"
+  },
+  "userMessage.editButton": {
+    "defaultMessage": "編輯"
+  },
+  "userMessage.editInPlace": {
+    "defaultMessage": "就地編輯"
+  },
+  "userMessage.editInPlaceAriaLabel": {
+    "defaultMessage": "就地編輯訊息"
+  },
+  "userMessage.editInPlaceDescription": {
+    "defaultMessage": "<b>就地編輯</b>會更新此工作階段 • <b>分支工作階段</b>會建立新的工作階段"
+  },
+  "userMessage.editInPlaceTitle": {
+    "defaultMessage": "更新此工作階段中的訊息"
+  },
+  "userMessage.editMessageAriaLabel": {
+    "defaultMessage": "編輯訊息：{preview}"
+  },
+  "userMessage.editMessageTitle": {
+    "defaultMessage": "編輯訊息"
+  },
+  "userMessage.editPlaceholder": {
+    "defaultMessage": "編輯您的訊息..."
+  },
+  "userMessage.emptyError": {
+    "defaultMessage": "訊息不可為空白"
+  },
+  "userMessage.forkSession": {
+    "defaultMessage": "分支工作階段"
+  },
+  "userMessage.forkSessionAriaLabel": {
+    "defaultMessage": "以編輯後的訊息分支工作階段"
+  },
+  "userMessage.forkSessionTitle": {
+    "defaultMessage": "以編輯後的訊息建立新的工作階段"
+  }
+}

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -172,12 +172,20 @@ const validLanguageSettings = new Set<Settings['language']>([
   'system',
   'en',
   'es',
+  'fr',
+  'de',
+  'it',
+  'pt',
+  'id',
+  'ms',
+  'vi',
   'hi',
   'ja',
   'ko',
   'ru',
   'tr',
   'zh-CN',
+  'zh-TW',
 ]);
 
 function isValidLanguageSetting(value: unknown): value is Settings['language'] {

--- a/ui/desktop/src/utils/settings.ts
+++ b/ui/desktop/src/utils/settings.ts
@@ -23,7 +23,10 @@ export type DefaultKeyboardShortcuts = {
   [K in keyof KeyboardShortcuts]: string;
 };
 
-export type LanguageSetting = 'system' | 'en' | 'es' | 'hi' | 'ja' | 'ko' | 'ru' | 'tr' | 'zh-CN';
+// prettier-ignore
+export type LanguageSetting =
+  | 'system' | 'en' | 'es' | 'fr' | 'de' | 'it' | 'pt' | 'id' | 'ms' | 'vi'
+  | 'hi' | 'ja' | 'ko' | 'ru' | 'tr' | 'zh-CN' | 'zh-TW';
 
 export interface Settings {
   // Desktop app settings


### PR DESCRIPTION
## What

Adds 8 desktop UI locales: French (`fr`), German (`de`), Italian (`it`), Portuguese (`pt`), Indonesian (`id`), Malay (`ms`), Vietnamese (`vi`), and Traditional Chinese (`zh-TW`).

Closes #10067.

## Details

- `i18n/index.ts`: extend `SUPPORTED_LOCALES`; route Traditional-Chinese tags (`zh-Hant*`, `zh-TW`, `zh-HK`, `zh-MO`) to the new `zh-TW` catalog — previously these fell through to English.
- `utils/settings.ts` + `main.ts`: extend the `LanguageSetting` union and the runtime `validLanguageSettings` allow-list so the new codes are accepted.
- `components/settings/app/AppSettingsSection.tsx`: add the 8 languages to the **Settings → App** language picker, with display-name strings.
- New catalogs `i18n/messages/{fr,de,it,pt,id,ms,vi,zh-TW}.json`, each key- and ICU-placeholder-consistent with `en.json`; the existing catalogs gain the new language-name labels.

`zh-TW` is genuine Traditional Chinese (Taiwan), not a Simplified copy.

## Checks

`i18n:check` (all 15 locales, 1524 messages), `typecheck`, `eslint`, and the full `vitest` suite pass locally.

## Note

Native-speaker review and corrections for any locale are very welcome. These can also land incrementally (one language per PR, as `es` did in #9419) if that's easier to review — happy to split.
