### PR TITLE
fix(cli): update help text for --session-id

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -75,7 +75,7 @@ pub struct Identifier {
         alias = "id",
         value_name = "SESSION_ID",
         help = "Session ID (e.g., '20250921_143022')",
-        long_help = "Specify a session ID directly. When used with --resume, will resume this specific session if it exists."
+        long_help = "Specify a session ID to resume. Requires --resume."
     )]
     pub session_id: Option<String>,
 


### PR DESCRIPTION
## Summary

Updates the help text for `--session-id` to be representative of how it works. See #10076.

### Testing

Manual

### Related Issues

Fixes #10076
Relates to #5360 
