### PR TITLE
fix(cli): clarify --session-id only works with --resume in help text

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -74,8 +74,8 @@ pub struct Identifier {
         long = "session-id",
         alias = "id",
         value_name = "SESSION_ID",
-        help = "Session ID (e.g., '20250921_143022')",
-        long_help = "Specify a session ID directly. When used with --resume, will resume this specific session if it exists."
+        help = "Session ID to resume; only valid with --resume (e.g., '20250921_143022')",
+        long_help = "Specify a session ID to resume a specific session. Only valid together with --resume; passing --session-id without --resume is an error."
     )]
     pub session_id: Option<String>,
 


### PR DESCRIPTION
## Summary
The `goose session --help` text described `--session-id` as a top-level option that has special behavior when combined with `--resume`. In practice, passing it without `--resume` errors out:

```
Error: --session-id can only be used with --resume flag
```

This updates both `help` and `long_help` on the `session_id` arg so the docs match the actual behavior introduced in #5360.

### Testing
Doc-string-only change to a `#[arg(...)]` attribute. `rustfmt --check` passes on the touched file. A full workspace build is blocked locally by the `llama-cpp-sys-2` native dependency (needs libclang), which is unrelated to this change; CI builds the full tree.

### Related Issues
Relates to #10076