### PR TITLE
Respect system hour cycle in timestamps

### DIFF
--- a/ui/desktop/src/utils/timeUtils.test.ts
+++ b/ui/desktop/src/utils/timeUtils.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { formatMessageTimestamp, getMessageTimeFormatOptions } from './timeUtils';
+
+const originalDateTimeFormat = Intl.DateTimeFormat;
+
+function mockSystemHourCycle(hourCycle?: Intl.DateTimeFormatOptions['hourCycle']) {
+  vi.spyOn(Intl, 'DateTimeFormat').mockImplementation(function (
+    locales?: Intl.LocalesArgument,
+    options?: Intl.DateTimeFormatOptions
+  ) {
+    if (locales === undefined && options?.hour === 'numeric') {
+      return {
+        resolvedOptions: () => ({ hourCycle }),
+      } as unknown as Intl.DateTimeFormat;
+    }
+
+    return new originalDateTimeFormat(locales, options);
+  } as typeof Intl.DateTimeFormat);
+}
+
+describe('timeUtils', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('uses the system hour cycle for message time options', () => {
+    mockSystemHourCycle('h23');
+
+    expect(getMessageTimeFormatOptions()).toEqual({
+      hour: 'numeric',
+      minute: '2-digit',
+      hourCycle: 'h23',
+    });
+  });
+
+  it('omits hourCycle when Intl does not expose a system preference', () => {
+    mockSystemHourCycle();
+
+    expect(getMessageTimeFormatOptions()).toEqual({
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  });
+
+  it('formats timestamps with the resolved system hour cycle', () => {
+    mockSystemHourCycle('h24');
+    const toLocaleTimeString = vi
+      .spyOn(Date.prototype, 'toLocaleTimeString')
+      .mockReturnValue('13:05');
+
+    expect(formatMessageTimestamp(Date.now() / 1000)).toBe('13:05');
+    expect(toLocaleTimeString).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        hour: 'numeric',
+        minute: '2-digit',
+        hourCycle: 'h24',
+      })
+    );
+  });
+});

--- a/ui/desktop/src/utils/timeUtils.ts
+++ b/ui/desktop/src/utils/timeUtils.ts
@@ -1,14 +1,26 @@
 import { currentLocale } from '../i18n';
 
+type ResolvedTimeFormatOptions = Intl.ResolvedDateTimeFormatOptions & {
+  hourCycle?: Intl.DateTimeFormatOptions['hourCycle'];
+};
+
+export function getMessageTimeFormatOptions(): Intl.DateTimeFormatOptions {
+  const { hourCycle } = new Intl.DateTimeFormat(undefined, {
+    hour: 'numeric',
+  }).resolvedOptions() as ResolvedTimeFormatOptions;
+
+  return {
+    hour: 'numeric',
+    minute: '2-digit',
+    ...(hourCycle ? { hourCycle } : {}),
+  };
+}
+
 export function formatMessageTimestamp(timestamp?: number): string {
   const date = timestamp ? new Date(timestamp * 1000) : new Date();
   const now = new Date();
 
-  // Format time using locale's default hour cycle
-  const timeStr = date.toLocaleTimeString(currentLocale, {
-    hour: 'numeric',
-    minute: '2-digit',
-  });
+  const timeStr = date.toLocaleTimeString(currentLocale, getMessageTimeFormatOptions());
 
   // Check if the message is from today
   if (


### PR DESCRIPTION
## Summary
- use the resolved system hour cycle for desktop message timestamps
- keep the existing locale-based date and language formatting
- add focused coverage for hour-cycle handling

This keeps the settings surface unchanged and relies on the platform preference exposed through `Intl`.

## Testing
- `../../bin/pnpm test:run src/utils/timeUtils.test.ts`
- `../../bin/pnpm lint:check`
- `../../bin/pnpm exec prettier --check src/utils/timeUtils.ts src/utils/timeUtils.test.ts`
- `git diff --check`

Closes #9492