### PR TITLE
fix(test): stop flaky unparseable-tool-call test by disabling session naming

### DIFF
--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -739,7 +739,7 @@ mod tests {
                 Arc::new(PermissionManager::new(data_dir)),
                 None,
                 GooseMode::default(),
-                false,
+                true,
                 GoosePlatform::GooseCli,
             ));
             let provider = Arc::new(UnparseableToolProvider::new());


### PR DESCRIPTION
## Problem

`crates/goose/tests/agent.rs::tests::unparseable_tool_call_tests::test_unparseable_tool_call_feeds_back_and_continues` is flaky (~3%).
Observed failure (e.g. [run 28390239968 attempt 1](https://github.com/aaif-goose/goose/actions/runs/28390239968)):

```
crates/goose/tests/agent.rs:798
expected an error tool response fed back to the model for the unparseable call
```

The first assertion fires - the error tool response is never observed - and a re-run passes.

## Root cause

`Agent::reply` spawns a background `tokio::spawn` session-naming task (`agent.rs`, gated on `!disable_session_naming`) that calls `maybe_update_name -> generate_session_name`, which hits the **same provider** concurrently with the main reply loop.

The mock `UnparseableToolProvider` scripts its responses by a single shared `call_count` atomic:

- call 0 -> the errored ("unparseable") tool request
- call 1+ -> "Recovered after the bad tool call."

When the background naming task wins the race for call 0, it consumes the unparseable response (discarded as a session-name candidate). The main loop then only sees call 1 (recovery text), so no error tool response is fed back and the first assert fails. It is a pure intra-test async race, so it is OS-independent and rare.

Instrumented repro confirmed the signature exactly: `call_count=2`, `saw_recovery_text=true`, and zero errored-request events.

## Fix

Set `disable_session_naming = true` in the test's `AgentConfig::new`. This is already the established convention in this file - sibling tests do the same, one with the comment *"disable session naming so it doesn't consume a provider call."* This test simply missed the guard.

## Verification

| Condition | Failures |
|---|---|
| Naming enabled (before), full binary, `--test-threads=8` | 2 / 60 (~3%) |
| Naming disabled (after), single test | 0 / 150 |
| Naming disabled (after), full binary | 0 / 80 |

assisted by claude code