### PR TITLE
feat(otel): nest headless runs under a parent trace from --traceparent

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -39,6 +39,7 @@ use goose::session::SessionManager;
 use std::io::Read;
 use std::path::PathBuf;
 use tracing::warn;
+use tracing::Instrument;
 
 const GOOSE_SERVER_SECRET_KEY_ENV: &str = "GOOSE_SERVER__SECRET_KEY";
 
@@ -376,6 +377,15 @@ pub struct RunBehavior {
         hide = true
     )]
     pub scheduled_job_id: Option<String>,
+
+    /// W3C traceparent to nest this run's traces under
+    #[arg(
+        long = "traceparent",
+        value_name = "TRACEPARENT",
+        help = "W3C traceparent to nest this run's traces under (falls back to the TRACEPARENT env var)",
+        long_help = "A W3C trace-context header value, e.g. 00-<32 hex trace-id>-<16 hex span-id>-01. When set, this headless run's OpenTelemetry spans are parented to it and, if Langfuse is configured, its observations attach to the matching trace instead of a freshly generated one. Falls back to the TRACEPARENT environment variable when the flag is omitted."
+    )]
+    pub traceparent: Option<String>,
 }
 
 async fn get_or_create_session_id(
@@ -1763,7 +1773,33 @@ async fn handle_run_command(
             "Headless session started"
         );
 
-        let result = session.headless(contents).await;
+        // A headless run is often launched as a child process by a larger
+        // orchestrator. When the caller passes its active span down via a W3C
+        // traceparent (the --traceparent flag, falling back to the TRACEPARENT
+        // env var), nest this run under it so the traces join up; otherwise this
+        // span is simply a local trace root.
+        let traceparent = run_behavior
+            .traceparent
+            .clone()
+            .or_else(|| std::env::var("TRACEPARENT").ok())
+            .filter(|tp| !tp.trim().is_empty());
+
+        // Seed Langfuse (when configured) so its observations attach to the
+        // caller's trace rather than a freshly generated UUID.
+        if let Some(trace_id) = traceparent
+            .as_deref()
+            .and_then(goose::tracing::langfuse_layer::traceparent_trace_id)
+        {
+            goose::tracing::langfuse_layer::seed_external_trace_id(trace_id).await;
+        }
+
+        let run_span = tracing::info_span!("goose.run.headless", session_type);
+        #[cfg(feature = "otel")]
+        if let Some(traceparent) = traceparent.as_deref() {
+            goose::otel::otlp::set_span_parent_from_traceparent(&run_span, traceparent);
+        }
+
+        let result = session.headless(contents).instrument(run_span).await;
         log_session_completion(&session, session_start, session_type, result.is_ok()).await;
         result
     } else {

--- a/crates/goose-test-support/src/otel.rs
+++ b/crates/goose-test-support/src/otel.rs
@@ -47,6 +47,8 @@ pub fn clear_otel_env(overrides: &[(&'static str, &'static str)]) -> OtelTestGua
         "OTEL_SDK_DISABLED",
         "OTEL_SERVICE_NAME",
         "OTEL_TRACES_EXPORTER",
+        "TRACEPARENT",
+        "TRACESTATE",
     ];
     for &(k, _) in overrides {
         if !keys.contains(&k) {

--- a/crates/goose/src/otel/otlp.rs
+++ b/crates/goose/src/otel/otlp.rs
@@ -1,5 +1,6 @@
-use opentelemetry::trace::TracerProvider;
-use opentelemetry::{global, KeyValue};
+use opentelemetry::propagation::TextMapPropagator;
+use opentelemetry::trace::{TraceContextExt, TracerProvider};
+use opentelemetry::{global, Context, KeyValue};
 use opentelemetry_appender_tracing::layer::{OpenTelemetryTracingBridge, TracingSpanAttributes};
 use opentelemetry_sdk::logs::{SdkLogger, SdkLoggerProvider};
 use opentelemetry_sdk::metrics::{SdkMeterProvider, Temporality};
@@ -7,6 +8,7 @@ use opentelemetry_sdk::propagation::TraceContextPropagator;
 use opentelemetry_sdk::resource::{EnvResourceDetector, TelemetryResourceDetector};
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use opentelemetry_sdk::Resource;
+use std::collections::HashMap;
 use std::env;
 use std::sync::{Arc, Mutex};
 use tracing::{Level, Metadata};
@@ -323,6 +325,69 @@ pub fn init_otlp_layers(
     layers
 }
 
+/// Extracts a parent [`Context`] from a W3C `traceparent` value (and optional
+/// `tracestate`).
+///
+/// Headless runs (`goose run`) are commonly launched as a child process by a
+/// larger orchestrator. Without a parent context goose starts a brand-new trace
+/// and its spans cannot be nested under the caller's span. When the orchestrator
+/// passes its active span down via a `traceparent`, this returns a context the
+/// caller can install as the parent of the run's root span so the two traces
+/// join up.
+///
+/// Returns `None` when `traceparent` is empty or unparseable, leaving the run as
+/// its own root trace.
+pub fn parent_context_from_traceparent(
+    traceparent: &str,
+    tracestate: Option<&str>,
+) -> Option<Context> {
+    if traceparent.trim().is_empty() {
+        return None;
+    }
+    let mut carrier = HashMap::new();
+    carrier.insert("traceparent".to_string(), traceparent.to_string());
+    if let Some(tracestate) = tracestate {
+        if !tracestate.trim().is_empty() {
+            carrier.insert("tracestate".to_string(), tracestate.to_string());
+        }
+    }
+    // Extract with a W3C propagator directly rather than the global one: the
+    // semantics of `traceparent` are W3C by definition, and this works even when
+    // the global propagator has not been initialised (e.g. telemetry disabled).
+    let cx = TraceContextPropagator::new().extract(&carrier);
+    // The propagator never errors; an unparseable header yields an invalid
+    // remote span context. Treat that as "no parent" rather than attaching a
+    // bogus one.
+    if cx.span().span_context().is_valid() {
+        Some(cx)
+    } else {
+        None
+    }
+}
+
+/// Extracts a parent [`Context`] from the standard W3C `TRACEPARENT` (and
+/// optional `TRACESTATE`) environment variables. See
+/// [`parent_context_from_traceparent`].
+pub fn parent_context_from_env() -> Option<Context> {
+    let traceparent = env::var("TRACEPARENT").ok()?;
+    let tracestate = env::var("TRACESTATE").ok();
+    parent_context_from_traceparent(&traceparent, tracestate.as_deref())
+}
+
+/// Installs the parent trace context parsed from a W3C `traceparent` onto
+/// `span`, so a headless run nests under the orchestrator's trace. No-op when
+/// `traceparent` is empty or unparseable.
+pub fn set_span_parent_from_traceparent(span: &tracing::Span, traceparent: &str) {
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+    if let Some(cx) = parent_context_from_traceparent(traceparent, None) {
+        // Best-effort: a failure here (e.g. the OTel layer is not installed)
+        // must not break the run, it just leaves the span as a local root.
+        if let Err(e) = span.set_parent(cx) {
+            tracing::debug!("failed to set parent trace context from traceparent: {e}");
+        }
+    }
+}
+
 fn create_otlp_tracing_layer() -> OtlpResult<OtlpTracingLayer> {
     let exporter = signal_exporter("traces").ok_or("Traces not enabled")?;
     let resource = create_resource();
@@ -626,6 +691,60 @@ mod tests {
     use goose_test_support::otel::clear_otel_env;
     use opentelemetry_sdk::metrics::Temporality;
     use test_case::test_case;
+
+    #[test]
+    fn parent_context_from_env_unset_returns_none() {
+        let _guard = clear_otel_env(&[]);
+        assert!(parent_context_from_env().is_none());
+    }
+
+    #[test]
+    fn parent_context_from_env_empty_returns_none() {
+        let _guard = clear_otel_env(&[("TRACEPARENT", "")]);
+        assert!(parent_context_from_env().is_none());
+    }
+
+    #[test]
+    fn parent_context_from_env_invalid_returns_none() {
+        let _guard = clear_otel_env(&[("TRACEPARENT", "not-a-valid-traceparent")]);
+        assert!(parent_context_from_env().is_none());
+    }
+
+    #[test]
+    fn parent_context_from_env_extracts_remote_span() {
+        let _guard = clear_otel_env(&[(
+            "TRACEPARENT",
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+        )]);
+
+        let cx = parent_context_from_env().expect("a valid traceparent yields a context");
+        let span_context = cx.span().span_context().clone();
+
+        assert!(span_context.is_valid());
+        assert!(span_context.is_remote());
+        assert!(span_context.is_sampled());
+        assert_eq!(
+            span_context.trace_id().to_string(),
+            "0af7651916cd43dd8448eb211c80319c"
+        );
+        assert_eq!(span_context.span_id().to_string(), "b7ad6b7169203331");
+    }
+
+    #[test]
+    fn parent_context_from_traceparent_parses_valid_and_rejects_invalid() {
+        let cx = parent_context_from_traceparent(
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+            None,
+        )
+        .expect("valid traceparent yields a context");
+        assert_eq!(
+            cx.span().span_context().trace_id().to_string(),
+            "0af7651916cd43dd8448eb211c80319c"
+        );
+
+        assert!(parent_context_from_traceparent("", None).is_none());
+        assert!(parent_context_from_traceparent("garbage", None).is_none());
+    }
 
     #[test]
     fn exporter_type_from_env_value() {

--- a/crates/goose/src/tracing/langfuse_layer.rs
+++ b/crates/goose/src/tracing/langfuse_layer.rs
@@ -4,13 +4,56 @@ use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::env;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use std::time::Duration;
 use tokio::sync::Mutex;
 use url::Url;
 use uuid::Uuid;
 
 const DEFAULT_LANGFUSE_URL: &str = "http://localhost:3000";
+
+/// Handle to the live observer's span tracker, so a parent trace id resolved
+/// after logging setup (e.g. from a `--traceparent` flag) can be seeded into it.
+/// Set by [`create_langfuse_observer`]; `None` when Langfuse is not configured.
+static OBSERVER_SPAN_TRACKER: OnceLock<StdMutex<Option<Arc<Mutex<SpanTracker>>>>> = OnceLock::new();
+
+fn observer_span_tracker() -> &'static StdMutex<Option<Arc<Mutex<SpanTracker>>>> {
+    OBSERVER_SPAN_TRACKER.get_or_init(|| StdMutex::new(None))
+}
+
+/// Extracts the 32-hex trace-id field from a W3C `traceparent` value.
+///
+/// Returns `None` unless the value is well-formed (`version-traceid-spanid-flags`)
+/// with a non-zero 32-hex trace id. The trace id is lowercased so it can double
+/// as a stable Langfuse trace id shared with the OpenTelemetry trace.
+pub fn traceparent_trace_id(traceparent: &str) -> Option<String> {
+    let parts: Vec<&str> = traceparent.trim().split('-').collect();
+    if parts.len() != 4 {
+        return None;
+    }
+    let trace_id = parts[1];
+    if trace_id.len() != 32
+        || !trace_id.bytes().all(|b| b.is_ascii_hexdigit())
+        || trace_id.bytes().all(|b| b == b'0')
+    {
+        return None;
+    }
+    Some(trace_id.to_ascii_lowercase())
+}
+
+/// Seeds the live Langfuse observer's trace id with one resolved from an
+/// external source (e.g. a W3C `traceparent`), so this run's observations attach
+/// to the caller's existing trace instead of a freshly generated UUID. No-op
+/// when Langfuse is not configured or a trace id is already set.
+pub async fn seed_external_trace_id(trace_id: String) {
+    let tracker = observer_span_tracker()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone();
+    if let Some(tracker) = tracker {
+        tracker.lock().await.set_trace_id_if_unset(trace_id);
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 struct LangfuseIngestionResponse {
@@ -179,9 +222,16 @@ pub fn create_langfuse_observer() -> Option<ObservationLayer> {
         LangfuseBatchManager::spawn_sender(batch_manager.clone());
     }
 
+    let span_tracker = Arc::new(Mutex::new(SpanTracker::new()));
+    // Expose the tracker so a parent trace id resolved later (after logging is
+    // set up) can be seeded via `seed_external_trace_id`.
+    *observer_span_tracker()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner()) = Some(span_tracker.clone());
+
     Some(ObservationLayer {
         batch_manager,
-        span_tracker: Arc::new(Mutex::new(SpanTracker::new())),
+        span_tracker,
     })
 }
 
@@ -194,6 +244,30 @@ mod tests {
     use tracing::dispatcher;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn traceparent_trace_id_extracts_valid_and_rejects_invalid() {
+        assert_eq!(
+            traceparent_trace_id("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
+            Some("0af7651916cd43dd8448eb211c80319c".to_string())
+        );
+        // uppercase hex is normalised to lowercase
+        assert_eq!(
+            traceparent_trace_id("00-0AF7651916CD43DD8448EB211C80319C-B7AD6B7169203331-01"),
+            Some("0af7651916cd43dd8448eb211c80319c".to_string())
+        );
+        // an all-zero trace id is invalid per W3C
+        assert_eq!(
+            traceparent_trace_id("00-00000000000000000000000000000000-b7ad6b7169203331-01"),
+            None
+        );
+        assert_eq!(traceparent_trace_id(""), None);
+        assert_eq!(traceparent_trace_id("not-a-traceparent"), None);
+        assert_eq!(
+            traceparent_trace_id("00-tooshort-b7ad6b7169203331-01"),
+            None
+        );
+    }
 
     struct TestFixture {
         original_subscriber: Option<dispatcher::Dispatch>,

--- a/crates/goose/src/tracing/observation_layer.rs
+++ b/crates/goose/src/tracing/observation_layer.rs
@@ -92,6 +92,15 @@ impl SpanTracker {
     pub fn remove_span(&mut self, span_id: u64) -> Option<String> {
         self.active_spans.remove(&span_id)
     }
+
+    /// Seeds the trace id from an external source (e.g. a W3C `traceparent`) so
+    /// observations attach to the caller's existing trace instead of a freshly
+    /// generated UUID. No-op once a trace id has already been set.
+    pub fn set_trace_id_if_unset(&mut self, trace_id: String) {
+        if self.current_trace_id.is_none() {
+            self.current_trace_id = Some(trace_id);
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -378,6 +387,14 @@ mod tests {
     use std::time::Duration;
     use tokio::sync::mpsc;
     use tracing::dispatcher;
+
+    #[test]
+    fn set_trace_id_if_unset_only_sets_once() {
+        let mut tracker = SpanTracker::new();
+        tracker.set_trace_id_if_unset("first".to_string());
+        tracker.set_trace_id_if_unset("second".to_string());
+        assert_eq!(tracker.current_trace_id.as_deref(), Some("first"));
+    }
 
     type Events = Arc<Mutex<Vec<(String, Value)>>>;
     struct TestFixture {


### PR DESCRIPTION
## Summary

Headless `goose run` is frequently launched as a child process by a larger orchestrator. Until now goose always started a brand-new trace, so its spans could not be nested under the caller's span in an observability backend.

This adds a `--traceparent` flag on `goose run` (falling back to the standard `TRACEPARENT` env var) carrying a W3C trace context. When present:

- **OpenTelemetry**: the extracted remote context is installed as the parent of the headless run's root span, so OTLP spans nest under the caller's trace.
- **Langfuse**: when configured, the observer's trace id is seeded from the traceparent's trace-id, so observations attach to the caller's trace instead of a freshly generated UUID.

With no, empty, or unparseable traceparent, the run stays its own root trace, so existing behaviour is unchanged.

Details:
- `parent_context_from_traceparent` / `parent_context_from_env` / `set_span_parent_from_traceparent` in the otel module. Extraction uses a W3C `TraceContextPropagator` directly so it works even when the global propagator has not been initialised (e.g. telemetry disabled).
- `traceparent_trace_id` + `seed_external_trace_id` in the langfuse layer, plus `SpanTracker::set_trace_id_if_unset`. The live observer's tracker is exposed via a process static so a trace id resolved after logging setup (the flag is parsed after logging is initialised) can be seeded.
- The CLI wraps the headless call in a `goose.run.headless` span; the OTel parenting is behind the existing `otel` feature, while Langfuse seeding is independent of it.

### Testing

- `cargo test -p goose --features otel` for the new unit tests: traceparent parsing (valid / empty / invalid / all-zero), env extraction of the remote span, and seed-once behaviour. Existing langfuse/observation tests still pass.
- `cargo fmt --check`, `cargo clippy -p goose --features otel -- -D warnings`, and `cargo clippy -p goose-cli -- -D warnings` all clean.
- Manual: with an OTLP endpoint configured, `goose run --traceparent 00-<trace>-<span>-01 --text ...` produces spans nested under the supplied trace; without it, behaviour is unchanged.