### PR TITLE
fix(compaction): bound re-appended user message to stop thrash

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -31,7 +31,7 @@ use crate::config::extensions::name_to_key;
 use crate::config::permission::PermissionManager;
 use crate::config::{get_enabled_extensions, Config, GooseMode};
 use crate::context_mgmt::{
-    check_if_compaction_needed, compact_messages, DEFAULT_COMPACTION_THRESHOLD,
+    check_if_compaction_needed, compact_messages, CompactionMode, DEFAULT_COMPACTION_THRESHOLD,
 };
 use crate::conversation::message::{
     ActionRequiredData, InferenceMetadata, Message, MessageContent, ProviderMetadata,
@@ -1742,13 +1742,23 @@ impl Agent {
                     )
                 );
 
-                let compact_model_config = self.model_config_for_session(&session_config.id).await?;
+                let (compact_tools, _, mut compact_system_prompt, compact_model_config) = self
+                    .prepare_tools_and_prompt(&session_config.id, session.working_dir.as_path())
+                    .await?;
+                // Include project instructions so the budget matches the prompt reply_internal sends.
+                if let Some(project_addendum) = self.load_project_instructions(&session).await {
+                    compact_system_prompt =
+                        format!("{compact_system_prompt}\n\n{project_addendum}");
+                }
                 match compact_messages(
                     self.provider().await?.as_ref(),
                     &compact_model_config,
                     &session_config.id,
                     &conversation_to_compact,
-                    false,
+                    CompactionMode::Auto {
+                        system_prompt: &compact_system_prompt,
+                        tools: &compact_tools,
+                    },
                 )
                 .await
                 {
@@ -2403,7 +2413,10 @@ impl Agent {
                                 &model_config,
                                 &session_config.id,
                                 &conversation,
-                                false,
+                                CompactionMode::Auto {
+                                    system_prompt: &system_prompt,
+                                    tools: &tools,
+                                },
                             )
                             .await
                             {

--- a/crates/goose/src/agents/execute_commands.rs
+++ b/crates/goose/src/agents/execute_commands.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use anyhow::{anyhow, Result};
 
-use crate::context_mgmt::compact_messages;
+use crate::context_mgmt::{compact_messages, CompactionMode};
 use crate::conversation::message::Message;
 use crate::slash_commands::{recipe_slash_command, skill_slash_command};
 
@@ -162,7 +162,7 @@ impl Agent {
             &model_config,
             session_id,
             &conversation,
-            true, // is_manual_compact
+            CompactionMode::Manual,
         )
         .await?;
 

--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -11,7 +11,7 @@ use goose_providers::conversation::token_usage::ProviderUsage;
 use goose_providers::errors::ProviderError;
 use goose_providers::model::ModelConfig;
 use indoc::indoc;
-use rmcp::model::Role;
+use rmcp::model::{Role, Tool};
 use serde::Serialize;
 use std::sync::Arc;
 use tokio::task::JoinHandle;
@@ -21,6 +21,17 @@ use tracing::log::warn;
 pub const DEFAULT_COMPACTION_THRESHOLD: f64 = 0.8;
 
 const TOOLCALL_SUMMARIZATION_BATCH_SIZE: usize = 10;
+
+fn compaction_threshold() -> f64 {
+    let threshold = Config::global()
+        .get_param::<f64>("GOOSE_AUTO_COMPACT_THRESHOLD")
+        .unwrap_or(DEFAULT_COMPACTION_THRESHOLD);
+    if threshold > 0.0 && threshold < 1.0 {
+        threshold
+    } else {
+        DEFAULT_COMPACTION_THRESHOLD
+    }
+}
 
 fn tool_pair_summarization_enabled() -> bool {
     Config::global()
@@ -48,17 +59,21 @@ struct SummarizeContext {
     messages: String,
 }
 
+/// `Auto` carries the system prompt and tools so the re-appended user message can
+/// be sized against the real prompt overhead; `Manual` preserves no message.
+pub enum CompactionMode<'a> {
+    Auto {
+        system_prompt: &'a str,
+        tools: &'a [Tool],
+    },
+    Manual,
+}
+
 /// Compact messages by summarizing them
 ///
 /// This function performs the actual compaction by summarizing messages and updating
 /// their visibility metadata. It does not check thresholds - use `check_if_compaction_needed`
 /// first to determine if compaction is necessary.
-///
-/// # Arguments
-/// * `provider` - The provider to use for summarization
-/// * `session_id` - The session to use for summarization
-/// * `conversation` - The current conversation history
-/// * `manual_compact` - If true, this is a manual compaction (don't preserve user message)
 ///
 /// # Returns
 /// * A tuple containing:
@@ -69,10 +84,11 @@ pub async fn compact_messages(
     model_config: &ModelConfig,
     session_id: &str,
     conversation: &Conversation,
-    manual_compact: bool,
+    mode: CompactionMode<'_>,
 ) -> Result<(Conversation, ProviderUsage)> {
     info!("Performing message compaction");
 
+    let manual_compact = matches!(mode, CompactionMode::Manual);
     let messages = conversation.messages();
 
     let has_text_only = |msg: &Message| {
@@ -172,8 +188,46 @@ pub async fn compact_messages(
     let (merged_continuation, _issues) = merge_consecutive_messages(continuation_messages);
     final_messages.extend(merged_continuation);
 
-    if let Some(user_msg) = preserved_user_message {
+    // Without a bound, a large preserved message pins the compacted prompt at the
+    // threshold and the agent recompacts every turn. Reserve room for the next turn
+    // (the reply, plus per-turn additions like the turn-context block goose prepends
+    // to the latest user message); the summary keeps the full text.
+    if let (
+        Some(user_msg),
+        CompactionMode::Auto {
+            system_prompt,
+            tools,
+        },
+    ) = (preserved_user_message, mode)
+    {
         if let Some(text) = extract_text(&user_msg) {
+            let context_limit = provider
+                .get_context_limit(model_config)
+                .await
+                .unwrap_or_else(|_| model_config.context_limit());
+            let threshold = compaction_threshold();
+            let target = (context_limit as f64 * threshold) as usize;
+            let threshold_gap = (context_limit as f64 * (1.0 - threshold)) as usize;
+            let max_output = model_config.max_output_tokens().max(0) as usize;
+            let reserve = threshold_gap + max_output;
+
+            let text = match create_token_counter().await {
+                Ok(counter) => {
+                    let mut accounted: Vec<Message> = final_messages
+                        .iter()
+                        .filter(|m| m.is_agent_visible())
+                        .cloned()
+                        .collect();
+                    accounted.push(Message::user().with_text(""));
+                    let used = counter.count_chat_tokens(system_prompt, &accounted, tools);
+
+                    // Floor at 1: an empty user message is dropped by conversation
+                    // validation, leaving the conversation on an assistant tail.
+                    let budget = target.saturating_sub(used + reserve).max(1);
+                    counter.truncate_to_token_budget_middle_out(&text, budget)
+                }
+                Err(_) => text,
+            };
             final_messages.push(Message::user().with_text(&text));
         }
     }
@@ -724,7 +778,10 @@ mod tests {
             &model_config,
             "test-session-id",
             &conversation,
-            false,
+            CompactionMode::Auto {
+                system_prompt: "",
+                tools: &[],
+            },
         )
         .await
         .unwrap();
@@ -763,7 +820,10 @@ mod tests {
             &model_config,
             "test-session-id",
             &conversation,
-            false,
+            CompactionMode::Auto {
+                system_prompt: "",
+                tools: &[],
+            },
         )
         .await;
 
@@ -771,6 +831,155 @@ mod tests {
             result.is_ok(),
             "Should succeed with progressive removal: {:?}",
             result.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_compaction_does_not_thrash_on_large_user_message() {
+        let counter = create_token_counter().await.unwrap();
+
+        // Real prompt overhead the bound must account for.
+        let system_prompt = "You are a careful software engineering agent. ".repeat(80);
+        let tools = vec![Tool::new(
+            "read_file".to_string(),
+            "Read the contents of a file from disk.".to_string(),
+            serde_json::Map::new(),
+        )];
+
+        // Stays the most-recent text-only user message because later turns are all
+        // tool calls/responses - a long task prompt or big paste mid-agentic-loop.
+        let large_text =
+            "Investigate the failing build and summarize the root cause. ".repeat(4000);
+
+        const CONTEXT_LIMIT: usize = 40_000;
+        let provider = MockProvider::new(
+            Message::assistant().with_text("<mock summary>"),
+            CONTEXT_LIMIT,
+        );
+        let model_config = provider.config.clone();
+
+        let threshold = compaction_threshold();
+        let target = (CONTEXT_LIMIT as f64 * threshold) as usize;
+        let reserve = ((CONTEXT_LIMIT as f64 * (1.0 - threshold)) as usize)
+            + (model_config.max_output_tokens().max(0) as usize);
+
+        let large_user_tokens =
+            counter.count_chat_tokens("", &[Message::user().with_text(&large_text)], &[]);
+        assert!(
+            large_user_tokens > target,
+            "test setup: the large user message ({large_user_tokens}) must exceed the \
+             auto-compact target ({target}) to exercise the thrash path"
+        );
+
+        let mut messages = vec![Message::user().with_text(&large_text)];
+        messages.extend(create_tool_pair(
+            "call0",
+            "resp0",
+            "read_file",
+            "build log line",
+        ));
+        messages.extend(create_tool_pair(
+            "call1",
+            "resp1",
+            "read_file",
+            "another log line",
+        ));
+
+        let conversation = Conversation::new_unvalidated(messages);
+
+        let before = counter.count_chat_tokens(&system_prompt, conversation.messages(), &tools);
+
+        let (compacted, _usage) = compact_messages(
+            &provider,
+            &model_config,
+            "test-session-id",
+            &conversation,
+            CompactionMode::Auto {
+                system_prompt: &system_prompt,
+                tools: &tools,
+            },
+        )
+        .await
+        .unwrap();
+
+        let after = counter.count_chat_tokens(&system_prompt, compacted.messages(), &tools);
+
+        println!(
+            "compaction thrash repro: context_limit={CONTEXT_LIMIT}, target={target}, \
+             reserve={reserve}, full prompt tokens before={before}, after={after}"
+        );
+
+        // Must stay at least `reserve` below the threshold; sitting exactly at it
+        // would let the next turn's growth re-trigger compaction (thrash).
+        assert!(
+            after + reserve <= target,
+            "post-compaction prompt ({after}) must leave at least the reserve ({reserve}) \
+             below the auto-compaction target ({target}); otherwise the next turn re-triggers \
+             compaction and the agent thrashes"
+        );
+        assert!(
+            after < before,
+            "compaction must actually reduce the prompt (before={before}, after={after})"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_compaction_reserves_room_for_large_model_output() {
+        // Max output (16k) exceeds the threshold gap (8k), so the reserve must
+        // cover the output for a full reply to fit next turn.
+        let counter = create_token_counter().await.unwrap();
+        let system_prompt = "You are a careful software engineering agent. ".repeat(80);
+        let tools: Vec<Tool> = vec![];
+
+        const CONTEXT_LIMIT: usize = 40_000;
+        const MAX_OUTPUT: i32 = 16_000;
+
+        let mut provider = MockProvider::new(
+            Message::assistant().with_text("<mock summary>"),
+            CONTEXT_LIMIT,
+        );
+        provider.config.max_tokens = Some(MAX_OUTPUT);
+        let model_config = provider.config.clone();
+
+        let threshold = compaction_threshold();
+        let target = (CONTEXT_LIMIT as f64 * threshold) as usize;
+        let max_output = model_config.max_output_tokens().max(0) as usize;
+        assert!(
+            max_output > (CONTEXT_LIMIT as f64 * (1.0 - threshold)) as usize,
+            "test setup: max output must exceed the threshold gap"
+        );
+
+        let large_text = "Refactor the module and explain each step. ".repeat(4000);
+        let conversation =
+            Conversation::new_unvalidated(vec![Message::user().with_text(&large_text)]);
+
+        let (compacted, _usage) = compact_messages(
+            &provider,
+            &model_config,
+            "test-session-id",
+            &conversation,
+            CompactionMode::Auto {
+                system_prompt: &system_prompt,
+                tools: &tools,
+            },
+        )
+        .await
+        .unwrap();
+
+        let after = counter.count_chat_tokens(&system_prompt, compacted.messages(), &tools);
+
+        // reply_internal prepends a turn-context block to the latest user message;
+        // oversize it here to keep the assertion conservative.
+        let turn_context = "<turn-context>\ncurrent time, working dir, compaction status, \
+             turn budget, extension-provided context\n</turn-context>\n"
+            .repeat(8);
+        let moim_tokens = counter.count_tokens(&turn_context);
+
+        // Prompt + turn-context + a full reply must stay under the target.
+        assert!(
+            after + moim_tokens + max_output <= target,
+            "post-compaction prompt ({after}) + turn-context ({moim_tokens}) + max reply \
+             ({max_output}) must stay at or below the target ({target})"
         );
     }
 

--- a/crates/goose/src/token_counter.rs
+++ b/crates/goose/src/token_counter.rs
@@ -187,6 +187,57 @@ impl TokenCounter {
         num_tokens
     }
 
+    pub fn truncate_to_token_budget_middle_out(&self, text: &str, max_tokens: usize) -> String {
+        let tokens = self.tokenizer.encode_with_special_tokens(text);
+        if tokens.len() <= max_tokens {
+            return text.to_string();
+        }
+        if max_tokens == 0 {
+            return String::new();
+        }
+
+        const MARKER: &str = "\n\n[... content truncated to fit context budget ...]\n\n";
+        let marker_tokens = self.tokenizer.encode_with_special_tokens(MARKER).len();
+
+        let candidate = if max_tokens > marker_tokens {
+            let keep = max_tokens - marker_tokens;
+            let head_len = keep / 2;
+            let tail_len = keep - head_len;
+            let head = self.decode_lossy(&tokens[..head_len]);
+            let tail = self.decode_lossy(&tokens[tokens.len() - tail_len..]);
+            format!("{head}{MARKER}{tail}")
+        } else {
+            // No room for the marker; keep what fits from the head.
+            self.decode_lossy(&tokens[..max_tokens])
+        };
+
+        // Rejoining decoded slices can drift the token count at the seams, so verify
+        // and fall back to the largest head prefix that fits.
+        if self.count_tokens(&candidate) <= max_tokens {
+            candidate
+        } else {
+            self.decode_prefix_within_budget(&tokens, max_tokens)
+        }
+    }
+
+    fn decode_lossy(&self, tokens: &[u32]) -> String {
+        self.tokenizer
+            .decode_bytes(tokens)
+            .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+            .unwrap_or_default()
+    }
+
+    fn decode_prefix_within_budget(&self, tokens: &[u32], max_tokens: usize) -> String {
+        let mut n = max_tokens.min(tokens.len());
+        loop {
+            let candidate = self.decode_lossy(&tokens[..n]);
+            if n == 0 || self.count_tokens(&candidate) <= max_tokens {
+                return candidate;
+            }
+            n -= 1;
+        }
+    }
+
     pub fn clear_cache(&self) {
         self.token_cache
             .lock()

--- a/crates/goose/tests/compaction.rs
+++ b/crates/goose/tests/compaction.rs
@@ -14,7 +14,7 @@ use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
 use goose_providers::errors::ProviderError;
 use goose_providers::model::ModelConfig;
 use rmcp::model::Tool;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use tempfile::TempDir;
 
@@ -747,6 +747,200 @@ async fn test_context_limit_recovery_compaction() -> Result<()> {
         .conversation
         .expect("Session should have conversation");
     assert_conversation_compacted(&updated_conversation);
+
+    Ok(())
+}
+
+/// Provider whose reported input usage tracks the actual agent-visible prompt
+/// size, so the re-appended user message's size flows back into the next
+/// auto-compaction check - exactly the loop the thrash bug exploits.
+struct ThrashProbeProvider {
+    context_limit: usize,
+    compaction_calls: Arc<AtomicUsize>,
+}
+
+impl ThrashProbeProvider {
+    fn new(context_limit: usize) -> Self {
+        Self {
+            context_limit,
+            compaction_calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
+#[async_trait]
+impl Provider for ThrashProbeProvider {
+    async fn stream(
+        &self,
+        _model_config: &ModelConfig,
+        system_prompt: &str,
+        messages: &[Message],
+        _tools: &[Tool],
+    ) -> Result<MessageStream, ProviderError> {
+        // Match the exact do_compact request, not the session-naming or
+        // tool-summary calls that also mention "summarize".
+        let is_compaction = messages.iter().any(|msg| {
+            msg.content.iter().any(|c| {
+                matches!(c, MessageContent::Text(t)
+                    if t.text.to_lowercase().contains("summarize the conversation history"))
+            })
+        });
+
+        if is_compaction {
+            self.compaction_calls.fetch_add(1, Ordering::SeqCst);
+            // Summary is small; its output becomes the post-compaction context.
+            let usage = ProviderUsage::new(
+                "mock-model".to_string(),
+                Usage::new(Some(500), Some(200), Some(700)),
+            );
+            return Ok(stream_from_single_message(
+                Message::assistant().with_text("<mock summary of conversation>"),
+                usage,
+            ));
+        }
+
+        // Regular call: input reflects the real agent-visible prompt (system +
+        // every message body), so a large re-appended message keeps usage high.
+        let system_tokens = if system_prompt.is_empty() { 0 } else { 6000 };
+        let message_tokens: i32 = messages
+            .iter()
+            .flat_map(|msg| &msg.content)
+            .map(|c| match c {
+                MessageContent::Text(t) => (t.text.len() / 4) as i32,
+                _ => 0,
+            })
+            .sum();
+        let input = system_tokens + message_tokens;
+        let output = 50;
+        let usage = ProviderUsage::new(
+            "mock-model".to_string(),
+            Usage::new(Some(input), Some(output), Some(input + output)),
+        );
+        Ok(stream_from_single_message(
+            Message::assistant().with_text("Done."),
+            usage,
+        ))
+    }
+
+    fn get_name(&self) -> &str {
+        "thrash-probe"
+    }
+
+    async fn get_context_limit(&self, _model_config: &ModelConfig) -> Result<usize, ProviderError> {
+        Ok(self.context_limit)
+    }
+}
+
+/// End-to-end repro of the compaction-thrash bug, driving the real `agent.reply`
+/// loop. A large most-recent user message is re-appended after compaction; the
+/// fix bounds it so post-compaction usage drops below the threshold and the next
+/// turn does not re-compact. Without the fix, usage stays pinned at/above the
+/// threshold and every turn recompacts.
+#[tokio::test]
+async fn test_large_user_message_does_not_thrash_compaction() -> Result<()> {
+    const CONTEXT_LIMIT: usize = 40_000;
+    let threshold_tokens = (CONTEXT_LIMIT as f64 * 0.8) as i32; // 32_000
+
+    let temp_dir = TempDir::new()?;
+    let agent = Agent::new();
+
+    let session = setup_test_session(
+        &agent,
+        &temp_dir,
+        "thrash-repro",
+        vec![
+            Message::user().with_text("Start the task."),
+            Message::assistant().with_text("Working on it."),
+        ],
+    )
+    .await?;
+
+    let provider = Arc::new(ThrashProbeProvider::new(CONTEXT_LIMIT));
+    let compaction_calls = provider.compaction_calls.clone();
+    agent
+        .update_provider(
+            provider,
+            ModelConfig::new("mock-model").with_context_limit(Some(CONTEXT_LIMIT)),
+            &session.id,
+        )
+        .await?;
+
+    // Seed usage above the threshold so the first reply auto-compacts.
+    agent
+        .config
+        .session_manager
+        .update(&session.id)
+        .usage(Usage::new(Some(38_000), Some(0), Some(38_000)))
+        .apply()
+        .await?;
+
+    let session_config = SessionConfig {
+        id: session.id.clone(),
+        schedule_id: None,
+        max_turns: None,
+        retry_config: None,
+    };
+
+    // A large most-recent user message - a long task prompt or big paste.
+    let large_message = Message::user().with_text("Analyze this log. ".repeat(40_000));
+
+    let stream = agent
+        .reply(large_message, session_config.clone(), None)
+        .await?;
+    tokio::pin!(stream);
+    let mut turn1_compacted = false;
+    while let Some(event) = stream.next().await {
+        if let Ok(AgentEvent::HistoryReplaced(_)) = event {
+            turn1_compacted = true;
+        }
+    }
+
+    assert!(
+        turn1_compacted,
+        "first reply should auto-compact (seeded usage 38k > 32k threshold)"
+    );
+
+    let after_turn1 = agent
+        .config
+        .session_manager
+        .get_session(&session.id, true)
+        .await?
+        .usage
+        .total_tokens
+        .expect("usage recorded");
+
+    // The thrash signature: post-compaction usage stays at/above the threshold.
+    // The fix bounds the re-appended message so it lands below, leaving headroom.
+    assert!(
+        after_turn1 < threshold_tokens,
+        "post-compaction usage ({after_turn1}) must drop below the threshold \
+         ({threshold_tokens}); otherwise the next turn re-compacts and the agent thrashes"
+    );
+
+    let compactions_after_turn1 = compaction_calls.load(Ordering::SeqCst);
+
+    // Second turn: a small follow-up must NOT trigger another compaction, since
+    // usage is now below the threshold.
+    let stream = agent
+        .reply(Message::user().with_text("Continue."), session_config, None)
+        .await?;
+    tokio::pin!(stream);
+    let mut turn2_compacted = false;
+    while let Some(event) = stream.next().await {
+        if let Ok(AgentEvent::HistoryReplaced(_)) = event {
+            turn2_compacted = true;
+        }
+    }
+
+    assert!(
+        !turn2_compacted,
+        "follow-up turn must not re-compact once usage is below the threshold"
+    );
+    assert_eq!(
+        compaction_calls.load(Ordering::SeqCst),
+        compactions_after_turn1,
+        "no additional summarization LLM call should fire on the follow-up turn"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
**What**
Auto-compaction re-appends the latest user message verbatim. When it's large (a big paste, or a long task prompt that stays the most-recent text message across tool-calling turns), post-compaction context lands right back over the threshold - so every turn fires another full summarization call that never relieves the pressure (~2x input tokens, context pinned near the ceiling).

**Why it matters**
For long agentic runs and small/clamped context windows this means a summarization LLM call *every turn* - real cost, added latency, and a path to spiralling into context-length errors. Short interactive chats are unaffected.

**Fix**
Middle-out truncate the re-appended message to a budget derived entirely from real values: context limit, compaction threshold, current overhead (system + tools + summary), and a reserve for the next turn (model max output + per-turn additions like the turn-context block). Post-compaction context now drops below the threshold with headroom, so the next turn doesn't re-compact. No change for small messages (no truncation).

**Impact** (E2E through the real reply loop, 40K context clamp / 32K threshold)
- Before: post-compaction usage **186K tokens** (~5.8x over) -> re-compacts every turn
- After: **sub-32K** -> next turn clean, no re-compaction

**Tests**: E2E integration test driving the real reply loop (reproduces the thrash without the fix, green with it) + unit tests for the budget invariant, large-output models, and truncation edge cases (zero/tiny/unicode budgets).

Reserve policy is `threshold_gap + max_output` - fully derived, no magic constants; flagging it as the one design lever worth a look. Validated against a mock provider (loop, compaction, MOIM, and usage accounting all real; token counts simulated).

assisted by claude code