### PR TITLE
fix(cli): restore terminal cursor after configure Ctrl+C

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5046,6 +5046,7 @@ dependencies = [
  "goose-mcp",
  "goose-providers",
  "indicatif 0.18.4",
+ "libc",
  "open",
  "rand 0.10.1",
  "regex",

--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -65,6 +65,7 @@ sha2 = { workspace = true }
 sigstore-verify = { version = "0.9", default-features = false, optional = true }
 axum.workspace = true
 clap_complete_nushell = { version = "4", default-features = false }
+libc = { version = "0.2.182", default-features = false, features = ["std"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 anstream = { version = "1", default-features = false, features = ["wincon"] }

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -42,6 +42,8 @@ pub async fn handle_configure() -> anyhow::Result<()> {
         );
     }
 
+    let _terminal_guard = crate::terminal::TerminalGuard::new();
+
     let config = Config::global();
 
     if !config.exists() {

--- a/crates/goose-cli/src/lib.rs
+++ b/crates/goose-cli/src/lib.rs
@@ -12,6 +12,7 @@ pub mod recipes;
 pub mod scenario_tests;
 pub mod session;
 pub mod signal;
+pub mod terminal;
 
 // Re-export commonly used types
 pub use cli::Cli;

--- a/crates/goose-cli/src/terminal.rs
+++ b/crates/goose-cli/src/terminal.rs
@@ -16,12 +16,17 @@ pub struct TerminalGuard {
     old_sigint: libc::sighandler_t,
 }
 
+impl Default for TerminalGuard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TerminalGuard {
     pub fn new() -> Self {
         #[cfg(unix)]
-        let old_sigint = unsafe {
-            libc::signal(libc::SIGINT, sigint_handler as libc::sighandler_t)
-        };
+        let old_sigint =
+            unsafe { libc::signal(libc::SIGINT, sigint_handler as libc::sighandler_t) };
         Self {
             #[cfg(unix)]
             old_sigint,

--- a/crates/goose-cli/src/terminal.rs
+++ b/crates/goose-cli/src/terminal.rs
@@ -1,0 +1,58 @@
+use console::Term;
+use std::io::Write;
+
+/// Restore terminal cursor visibility after cliclack dialogs (DECTCEM show).
+pub fn restore_terminal() {
+    let term = Term::stderr();
+    let _ = term.show_cursor();
+    // Belt-and-suspenders: ensure DECTCEM show even if Term API misses it.
+    let _ = std::io::stderr().write_all(b"\x1b[?25h");
+    let _ = term.flush();
+}
+
+/// Ensure terminal state is restored on normal exit, panic, or SIGINT.
+pub struct TerminalGuard {
+    #[cfg(unix)]
+    old_sigint: libc::sighandler_t,
+}
+
+impl TerminalGuard {
+    pub fn new() -> Self {
+        #[cfg(unix)]
+        let old_sigint = unsafe {
+            libc::signal(libc::SIGINT, sigint_handler as libc::sighandler_t)
+        };
+        Self {
+            #[cfg(unix)]
+            old_sigint,
+        }
+    }
+}
+
+#[cfg(unix)]
+extern "C" fn sigint_handler(_: libc::c_int) {
+    restore_terminal();
+    unsafe {
+        libc::_exit(130);
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        restore_terminal();
+        #[cfg(unix)]
+        unsafe {
+            libc::signal(libc::SIGINT, self.old_sigint);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn restore_terminal_does_not_panic() {
+        restore_terminal();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a terminal state leak where pressing Ctrl+C during `goose configure` left the cursor hidden.

## Motivation

cliclack hides the terminal cursor (`\e[?25l`) during interactive configure prompts. When the user presses Ctrl+C during a prompt, console re-raises SIGINT and the process exits before cliclack can emit the matching show-cursor sequence (`\e[?25h`). Users must manually run `tput cnorm` to recover.

Fixes #10018

## Changes

- Add `crates/goose-cli/src/terminal.rs` with `restore_terminal()` and a scoped `TerminalGuard`
- Install the guard at the start of `handle_configure()`
- On Unix, register a temporary SIGINT handler that restores the terminal and exits with status 130
- Restore the previous SIGINT handler and cursor visibility on normal exit via `Drop`

## Tests

```bash
cargo test -p goose-cli --no-default-features --features "code-mode,tui,telemetry,rustls-tls,system-keyring,update" terminal::
cargo build -p goose-cli --no-default-features --features "code-mode,tui,telemetry,rustls-tls,system-keyring,update"
```

- `terminal::restore_terminal_does_not_panic` — passed
- Build — succeeded

## Notes

- Manual verification recommended: run `goose configure`, press Ctrl+C during a provider input prompt, confirm cursor is visible in the shell.
- Windows uses `Drop`-only restoration; SIGINT handler is Unix-only.
