### PR TITLE
fix: guard llama.cpp backend init against SIGILL on x86_64 CPUs without FMA/AVX2

### DIFF
--- a/crates/goose-local-inference/src/llamacpp/mod.rs
+++ b/crates/goose-local-inference/src/llamacpp/mod.rs
@@ -318,6 +318,9 @@ fn check_cpu_supports_local_inference() -> Result<()> {
     let missing_features = [
         (!std::arch::is_x86_feature_detected!("fma")).then_some("FMA"),
         (!std::arch::is_x86_feature_detected!("avx2")).then_some("AVX2"),
+        (!std::arch::is_x86_feature_detected!("f16c")).then_some("F16C"),
+        (!std::arch::is_x86_feature_detected!("bmi2")).then_some("BMI2"),
+        (!std::arch::is_x86_feature_detected!("sse4.2")).then_some("SSE4.2"),
     ]
     .into_iter()
     .flatten()
@@ -747,7 +750,10 @@ mod tests {
         #[cfg(target_arch = "x86_64")]
         {
             let supports_required_features = std::arch::is_x86_feature_detected!("fma")
-                && std::arch::is_x86_feature_detected!("avx2");
+                && std::arch::is_x86_feature_detected!("avx2")
+                && std::arch::is_x86_feature_detected!("f16c")
+                && std::arch::is_x86_feature_detected!("bmi2")
+                && std::arch::is_x86_feature_detected!("sse4.2");
 
             if supports_required_features {
                 assert!(

--- a/crates/goose-local-inference/src/llamacpp/mod.rs
+++ b/crates/goose-local-inference/src/llamacpp/mod.rs
@@ -742,7 +742,25 @@ mod tests {
 
     #[test]
     fn local_inference_cpu_support_check_accepts_current_host() {
-        check_cpu_supports_local_inference().unwrap();
+        let result = check_cpu_supports_local_inference();
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            let supports_required_features = std::arch::is_x86_feature_detected!("fma")
+                && std::arch::is_x86_feature_detected!("avx2");
+
+            if supports_required_features {
+                assert!(
+                    result.is_ok(),
+                    "expected supported x86_64 host to pass: {result:?}"
+                );
+            } else {
+                assert!(result.is_err(), "expected unsupported x86_64 host to fail");
+            }
+        }
+
+        #[cfg(not(target_arch = "x86_64"))]
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/crates/goose-local-inference/src/llamacpp/mod.rs
+++ b/crates/goose-local-inference/src/llamacpp/mod.rs
@@ -303,12 +303,48 @@ fn select_generation_template<'a>(
     })
 }
 
+#[cfg(any(target_arch = "x86_64", test))]
+fn unsupported_cpu_features_error_message(missing_features: &[&str]) -> String {
+    format!(
+        "Local inference with the bundled llama.cpp backend requires CPU support for {}. \
+         This CPU is missing {}. Use a CPU with those instruction sets or switch to a non-local provider.",
+        missing_features.join(" and "),
+        missing_features.join(", ")
+    )
+}
+
+#[cfg(target_arch = "x86_64")]
+fn check_cpu_supports_local_inference() -> Result<()> {
+    let missing_features = [
+        (!std::arch::is_x86_feature_detected!("fma")).then_some("FMA"),
+        (!std::arch::is_x86_feature_detected!("avx2")).then_some("AVX2"),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>();
+
+    if missing_features.is_empty() {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(unsupported_cpu_features_error_message(
+            &missing_features
+        )))
+    }
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+fn check_cpu_supports_local_inference() -> Result<()> {
+    Ok(())
+}
+
 pub(super) struct LlamaCppBackend {
     backend: LlamaBackend,
 }
 
 impl LlamaCppBackend {
     pub(super) fn new() -> Result<Self> {
+        check_cpu_supports_local_inference()?;
+
         let backend = match LlamaBackend::init() {
             Ok(backend) => backend,
             Err(llama_cpp_2::LlamaCppError::BackendAlreadyInitialized) => {
@@ -702,5 +738,18 @@ mod tests {
         assert!(!is_legacy_builtin_template_name(
             "{% for message in messages %}{{ message.content }}{% endfor %}"
         ));
+    }
+
+    #[test]
+    fn local_inference_cpu_support_check_accepts_current_host() {
+        check_cpu_supports_local_inference().unwrap();
+    }
+
+    #[test]
+    fn local_inference_cpu_support_error_names_missing_instruction_sets() {
+        let message = unsupported_cpu_features_error_message(&["FMA", "AVX2"]);
+
+        assert!(message.contains("FMA"));
+        assert!(message.contains("AVX2"));
     }
 }


### PR DESCRIPTION
## Summary

On Linux x86_64, `goosed` aborts with SIGILL on older Intel CPUs that lack FMA (the reporter's Ivy Bridge i5-3230M has AVX + F16C but no FMA/AVX2). The faulting instruction is `vfmadd213ss` inside `ggml_cpu_init`, which the bundled llama.cpp (ggml) CPU backend runs unconditionally when `LlamaBackend::init()` is called from `LlamaCppBackend::new()`. Because the illegal instruction takes down the whole backend process, the Desktop frontend then loses every backend-dependent feature (Skills, Apps, session history, ACP websocket).

This adds an x86_64 CPU capability precheck that runs before `LlamaBackend::init()`. When a required instruction set is missing, it returns a clear, actionable error naming the missing features instead of letting ggml execute an illegal instruction, so local inference is cleanly disabled and the rest of the backend stays alive.

- `check_cpu_supports_local_inference()` is gated by `#[cfg(target_arch = "x86_64")]` and uses `std::arch::is_x86_feature_detected!` to check the instruction sets the bundled ggml CPU build relies on: FMA, AVX2, F16C, BMI2, and SSE4.2.
- On non-x86_64 targets (ARM, macOS metal) it compiles to an unconditional `Ok(())`, leaving those paths untouched.
- The error message names every missing instruction set so users get an actionable diagnostic.

### Testing

`cargo test -p goose --features local-inference --lib -- providers::local_inference::llamacpp` (the two added unit tests pass):

- `local_inference_cpu_support_check_accepts_current_host` derives its expectation from the host's detected features, so it asserts `Ok` on a supported host and `Err` on an x86_64 host missing the required sets (the exact environment this fix handles) rather than spuriously panicking there.
- `local_inference_cpu_support_error_names_missing_instruction_sets` checks the error message names the missing sets.

Also verified with `cargo fmt --check` and `cargo clippy -p goose --features local-inference -- -D warnings`.

### Related Issues

Closes #10073

### Screenshots/Demos (for UX changes)

N/A. This is a backend change to local inference initialization with no UI surface.
