### PR TITLE
fix(acp): propagate agent cleanup errors on session delete

### DIFF
--- a/crates/goose-server/src/routes/agent.rs
+++ b/crates/goose-server/src/routes/agent.rs
@@ -799,8 +799,14 @@ async fn restart_agent_internal(
     session_id: &str,
     session: &Session,
 ) -> Result<Vec<ExtensionLoadResult>, ErrorResponse> {
-    // Remove existing agent (ignore error if not found)
-    let _ = state.agent_manager.remove_session(session_id).await;
+    state
+        .agent_manager
+        .remove_session_if_loaded(session_id)
+        .await
+        .map_err(|e| ErrorResponse {
+            message: format!("Failed to remove in-memory agent for session {session_id}: {e}"),
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+        })?;
 
     let agent = state
         .get_agent_for_route(session_id.to_string())

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1177,7 +1177,10 @@ impl GooseAcpAgent {
                 .await
                 .internal_err_ctx("Failed to update session")?;
 
-            let _ = self.agent_manager.remove_session(&session_id).await;
+            self.agent_manager
+                .remove_session_if_loaded(&session_id)
+                .await
+                .internal_err_ctx("Failed to remove in-memory agent")?;
 
             session = self
                 .session_manager
@@ -2336,7 +2339,17 @@ impl GooseAcpAgent {
 
         if self.closed_session_ids.lock().await.contains(session_id) {
             self.sessions.lock().await.remove(session_id);
-            let _ = self.agent_manager.remove_session(session_id).await;
+            if let Err(error) = self
+                .agent_manager
+                .remove_session_if_loaded(session_id)
+                .await
+            {
+                tracing::warn!(
+                    session_id,
+                    %error,
+                    "Failed to remove in-memory agent for closed session"
+                );
+            }
         }
     }
 
@@ -2968,7 +2981,10 @@ impl GooseAcpAgent {
         sessions.remove(session_id);
         drop(sessions);
 
-        let _ = self.agent_manager.remove_session(session_id).await;
+        self.agent_manager
+            .remove_session_if_loaded(session_id)
+            .await
+            .internal_err_ctx("Failed to remove in-memory agent")?;
 
         info!(session_id = %session_id, "ACP session closed");
         Ok(CloseSessionResponse::new())

--- a/crates/goose/src/acp/server/manage_sessions.rs
+++ b/crates/goose/src/acp/server/manage_sessions.rs
@@ -104,7 +104,10 @@ impl GooseAcpAgent {
             .await
             .internal_err()?;
         self.sessions.lock().await.remove(&req.session_id);
-        let _ = self.agent_manager.remove_session(&req.session_id).await;
+        self.agent_manager
+            .remove_session_if_loaded(&req.session_id)
+            .await
+            .internal_err_ctx("Failed to remove in-memory agent")?;
         Ok(EmptyResponse {})
     }
 
@@ -254,7 +257,10 @@ impl GooseAcpAgent {
             .await
             .internal_err()?;
         self.sessions.lock().await.remove(&req.session_id);
-        let _ = self.agent_manager.remove_session(&req.session_id).await;
+        self.agent_manager
+            .remove_session_if_loaded(&req.session_id)
+            .await
+            .internal_err_ctx("Failed to remove in-memory agent")?;
         Ok(EmptyResponse {})
     }
 

--- a/crates/goose/src/acp/server/new_session.rs
+++ b/crates/goose/src/acp/server/new_session.rs
@@ -11,6 +11,7 @@ use agent_client_protocol::{Client, ConnectionTo};
 use goose_providers::model::ModelConfig;
 use std::collections::HashMap;
 use std::path::PathBuf;
+use tracing::warn;
 
 struct InitialSessionConfig {
     provider: String,
@@ -92,9 +93,25 @@ impl GooseAcpAgent {
     }
 
     async fn cleanup_failed_new_session(&self, session_id: &str) {
-        let _ = self.session_manager.delete_session(session_id).await;
+        if let Err(error) = self.session_manager.delete_session(session_id).await {
+            warn!(
+                session_id,
+                %error,
+                "Failed to delete session during new-session cleanup"
+            );
+        }
         self.sessions.lock().await.remove(session_id);
-        let _ = self.agent_manager.remove_session(session_id).await;
+        if let Err(error) = self
+            .agent_manager
+            .remove_session_if_loaded(session_id)
+            .await
+        {
+            warn!(
+                session_id,
+                %error,
+                "Failed to remove in-memory agent during new-session cleanup"
+            );
+        }
     }
 
     async fn configure_new_session(

--- a/crates/goose/src/execution/manager.rs
+++ b/crates/goose/src/execution/manager.rs
@@ -330,11 +330,19 @@ impl AgentManager {
 
     /// Drops an in-memory agent when one is loaded for `session_id`.
     /// Returns `Ok(false)` when no agent was loaded, `Ok(true)` when removed.
+    /// Concurrent callers for the same session_id are safe: only the first removal
+    /// returns `Ok(true)`; the rest get `Ok(false)`.
     pub async fn remove_session_if_loaded(&self, session_id: &str) -> Result<bool> {
-        if !self.has_session(session_id).await {
+        if let Some(token) = self.cancel_tokens.write().await.remove(session_id) {
+            token.cancel();
+        }
+        let mut sessions = self.sessions.write().await;
+        if sessions.pop(session_id).is_none() {
             return Ok(false);
         }
-        self.remove_session(session_id).await?;
+        drop(sessions);
+        self.prune_creation_lock(session_id).await;
+        info!("Removed session {}", session_id);
         Ok(true)
     }
 
@@ -504,6 +512,29 @@ mod tests {
 
         manager.get_or_create_agent(session.clone()).await.unwrap();
         assert!(manager.remove_session_if_loaded(&session).await.unwrap());
+        assert!(!manager.has_session(&session).await);
+        assert!(!manager.remove_session_if_loaded(&session).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_remove_session_if_loaded() {
+        let temp_dir = TempDir::new().unwrap();
+        let manager = Arc::new(create_test_manager(&temp_dir).await);
+        let session = String::from("concurrent-remove-if-loaded");
+
+        manager.get_or_create_agent(session.clone()).await.unwrap();
+
+        let mgr_a = Arc::clone(&manager);
+        let mgr_b = Arc::clone(&manager);
+        let sid_a = session.clone();
+        let sid_b = session.clone();
+        let (a, b) = tokio::join!(
+            tokio::spawn(async move { mgr_a.remove_session_if_loaded(&sid_a).await }),
+            tokio::spawn(async move { mgr_b.remove_session_if_loaded(&sid_b).await }),
+        );
+
+        let results = [a.unwrap().unwrap(), b.unwrap().unwrap()];
+        assert!(results.iter().filter(|removed| **removed).count() == 1);
         assert!(!manager.has_session(&session).await);
     }
 

--- a/crates/goose/src/execution/manager.rs
+++ b/crates/goose/src/execution/manager.rs
@@ -328,6 +328,16 @@ impl AgentManager {
         Ok(())
     }
 
+    /// Drops an in-memory agent when one is loaded for `session_id`.
+    /// Returns `Ok(false)` when no agent was loaded, `Ok(true)` when removed.
+    pub async fn remove_session_if_loaded(&self, session_id: &str) -> Result<bool> {
+        if !self.has_session(session_id).await {
+            return Ok(false);
+        }
+        self.remove_session(session_id).await?;
+        Ok(true)
+    }
+
     pub async fn has_session(&self, session_id: &str) -> bool {
         self.sessions.read().await.contains(session_id)
     }
@@ -482,6 +492,19 @@ mod tests {
         assert!(!manager.has_session(&session).await);
 
         assert!(manager.remove_session(&session).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_remove_session_if_loaded() {
+        let temp_dir = TempDir::new().unwrap();
+        let manager = create_test_manager(&temp_dir).await;
+        let session = String::from("remove-if-loaded-test");
+
+        assert!(!manager.remove_session_if_loaded(&session).await.unwrap());
+
+        manager.get_or_create_agent(session.clone()).await.unwrap();
+        assert!(manager.remove_session_if_loaded(&session).await.unwrap());
+        assert!(!manager.has_session(&session).await);
     }
 
     #[tokio::test]

--- a/crates/goose/src/execution/manager.rs
+++ b/crates/goose/src/execution/manager.rs
@@ -329,21 +329,18 @@ impl AgentManager {
     }
 
     /// Drops an in-memory agent when one is loaded for `session_id`.
-    /// Returns `Ok(false)` when no agent was loaded, `Ok(true)` when removed.
-    /// Concurrent callers for the same session_id are safe: only the first removal
-    /// returns `Ok(true)`; the rest get `Ok(false)`.
-    pub async fn remove_session_if_loaded(&self, session_id: &str) -> Result<bool> {
+    pub async fn remove_session_if_loaded(&self, session_id: &str) -> Result<()> {
         if let Some(token) = self.cancel_tokens.write().await.remove(session_id) {
             token.cancel();
         }
         let mut sessions = self.sessions.write().await;
         if sessions.pop(session_id).is_none() {
-            return Ok(false);
+            return Ok(());
         }
         drop(sessions);
         self.prune_creation_lock(session_id).await;
         info!("Removed session {}", session_id);
-        Ok(true)
+        Ok(())
     }
 
     pub async fn has_session(&self, session_id: &str) -> bool {
@@ -508,34 +505,12 @@ mod tests {
         let manager = create_test_manager(&temp_dir).await;
         let session = String::from("remove-if-loaded-test");
 
-        assert!(!manager.remove_session_if_loaded(&session).await.unwrap());
+        manager.remove_session_if_loaded(&session).await.unwrap();
 
         manager.get_or_create_agent(session.clone()).await.unwrap();
-        assert!(manager.remove_session_if_loaded(&session).await.unwrap());
+        manager.remove_session_if_loaded(&session).await.unwrap();
         assert!(!manager.has_session(&session).await);
-        assert!(!manager.remove_session_if_loaded(&session).await.unwrap());
-    }
-
-    #[tokio::test]
-    async fn test_concurrent_remove_session_if_loaded() {
-        let temp_dir = TempDir::new().unwrap();
-        let manager = Arc::new(create_test_manager(&temp_dir).await);
-        let session = String::from("concurrent-remove-if-loaded");
-
-        manager.get_or_create_agent(session.clone()).await.unwrap();
-
-        let mgr_a = Arc::clone(&manager);
-        let mgr_b = Arc::clone(&manager);
-        let sid_a = session.clone();
-        let sid_b = session.clone();
-        let (a, b) = tokio::join!(
-            tokio::spawn(async move { mgr_a.remove_session_if_loaded(&sid_a).await }),
-            tokio::spawn(async move { mgr_b.remove_session_if_loaded(&sid_b).await }),
-        );
-
-        let results = [a.unwrap().unwrap(), b.unwrap().unwrap()];
-        assert!(results.iter().filter(|removed| **removed).count() == 1);
-        assert!(!manager.has_session(&session).await);
+        manager.remove_session_if_loaded(&session).await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/goose/src/gateway/handler.rs
+++ b/crates/goose/src/gateway/handler.rs
@@ -308,7 +308,9 @@ impl GatewayHandler {
         // extension processes don't linger.
         let extensions_changed = self.sync_session_config(&session).await?;
         if extensions_changed {
-            let _ = self.agent_manager.remove_session(session_id).await;
+            self.agent_manager
+                .remove_session_if_loaded(session_id)
+                .await?;
         }
 
         let agent = self


### PR DESCRIPTION
### Summary

This PR stops swallowing errors when tearing down in-memory agents during ACP session delete, archive, and close. It adds remove_session_if_loaded so cleanup is skipped when no agent is loaded and failures are propagated when one is, following up on the session lifecycle work in #7857.

### Testing

mannual
