### PR TITLE
feat(providers): add MiniMax M3 model

### DIFF
--- a/crates/goose/src/providers/declarative/minimax.json
+++ b/crates/goose/src/providers/declarative/minimax.json
@@ -7,6 +7,10 @@
   "base_url": "https://api.minimax.io/anthropic",
   "models": [
     {
+      "name": "MiniMax-M3",
+      "context_limit": 1000000
+    },
+    {
       "name": "MiniMax-M2.5",
       "context_limit": 204800
     },


### PR DESCRIPTION
What: Add MiniMax-M3 to the minimax declarative provider (1M context).
Why: Lets users select MiniMax-M3 without manual config.
Refs: follows existing M2.5 entries in minimax.json
