### PR TITLE
fix(acp): load sessions when stored recipe hydration fails

### DIFF
--- a/crates/goose/src/acp/server/fork_session.rs
+++ b/crates/goose/src/acp/server/fork_session.rs
@@ -52,7 +52,9 @@ impl GooseAcpAgent {
             .await?;
 
         let (agent, extension_results) = self.prepare_acp_session_agent(cx, &goose_session).await?;
-        self.apply_session_recipe(&agent, &goose_session).await?;
+        let recipe_hydration_error = self
+            .apply_session_recipe_best_effort(&agent, &goose_session)
+            .await;
         self.register_acp_session(goose_session.id.clone(), agent, HashMap::new())
             .await;
 
@@ -60,6 +62,12 @@ impl GooseAcpAgent {
         let mut meta = session_meta(&goose_session);
         if let Ok(v) = serde_json::to_value(&extension_results) {
             meta.insert("extensionResults".to_string(), v);
+        }
+        if let Some(error) = recipe_hydration_error {
+            meta.insert(
+                "recipeHydrationError".to_string(),
+                serde_json::Value::String(error),
+            );
         }
 
         let (mode_state, config_options) =

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -191,7 +191,9 @@ impl GooseAcpAgent {
 
         let replay_tool_requests = replay_conversation_to_client(cx, &session)?;
         let (agent, extension_results) = self.prepare_acp_session_agent(cx, &session).await?;
-        self.apply_session_recipe(&agent, &session).await?;
+        let recipe_hydration_error = self
+            .apply_session_recipe_best_effort(&agent, &session)
+            .await;
         self.register_acp_session(session_id_str.clone(), agent.clone(), replay_tool_requests)
             .await;
 
@@ -216,7 +218,14 @@ impl GooseAcpAgent {
             response = response.config_options(co);
         }
 
-        response = response.meta(session_response_meta(&session, &extension_results));
+        let mut meta = session_response_meta(&session, &extension_results);
+        if let Some(error) = recipe_hydration_error {
+            meta.insert(
+                "recipeHydrationError".to_string(),
+                serde_json::Value::String(error),
+            );
+        }
+        response = response.meta(meta);
 
         debug!(
             target: "perf",

--- a/crates/goose/src/acp/server/recipe/mod.rs
+++ b/crates/goose/src/acp/server/recipe/mod.rs
@@ -348,6 +348,31 @@ impl GooseAcpAgent {
         Ok(())
     }
 
+    /// Best-effort variant for session reload paths where the transcript must load even when
+    /// stored recipe metadata is stale or no longer passes current validation rules.
+    pub(super) async fn apply_session_recipe_best_effort(
+        &self,
+        agent: &Arc<Agent>,
+        session: &Session,
+    ) -> Option<String> {
+        if let Err(err) = self.apply_session_recipe(agent, session).await {
+            let message = err
+                .data
+                .as_ref()
+                .and_then(|value| value.as_str())
+                .map(str::to_string)
+                .unwrap_or_else(|| "failed to hydrate session recipe".to_string());
+            tracing::warn!(
+                session_id = %session.id,
+                error = %message,
+                "failed to hydrate session recipe; continuing with transcript only"
+            );
+            Some(message)
+        } else {
+            None
+        }
+    }
+
     pub(super) async fn render_recipe_for_session(
         &self,
         cx: &ConnectionTo<Client>,
@@ -566,5 +591,18 @@ mod tests {
             message.starts_with("Save recipe validation failed: invalid type: string"),
             "{message}"
         );
+    }
+
+    #[test]
+    fn session_recipe_hydration_error_preserves_error_data() {
+        let err = agent_client_protocol::Error::internal_error()
+            .data("recipe: Invalid recipe:\nUnnecessary parameter definitions: pr.");
+        let message = err
+            .data
+            .as_ref()
+            .and_then(|value| value.as_str())
+            .map(str::to_string)
+            .unwrap_or_else(|| "failed to hydrate session recipe".to_string());
+        assert!(message.contains("Unnecessary parameter definitions: pr."));
     }
 }


### PR DESCRIPTION
## Summary

When reloading a recipe-backed ACP session, invalid or stale stored recipe metadata no longer blocks the session transcript from loading.

## Motivation

Fixes the first problem described in #10113: `loadSession` previously failed hard when `apply_session_recipe` could not render/validate the stored recipe (for example after recipe validation rules change). The conversation history is still valid and should remain accessible.

## Changes

- Add `apply_session_recipe_best_effort()` that logs hydration failures and continues instead of returning an RPC error
- Use best-effort recipe hydration in `handle_load_session` and `handle_fork_session`
- Surface `recipeHydrationError` in session response metadata so clients can warn users
- Add a unit test for hydration error message extraction

## Tests

- `cargo test -p goose --lib acp::server::recipe::tests` — 3 passed
- `cargo test -p goose --test acp_server_test test_load_session` — 3 passed
- `cargo fmt --check` — passed

## Notes

This is intentionally scoped to session reload paths. Other items in #10113 (CLI recipe metadata persistence, recipe base directory preservation) are left for follow-up work.

Fixes #10113