### PR TITLE
Update EmpirioLabs provider display name to EmpirioLabs AI

### DIFF
--- a/crates/goose/src/providers/declarative/empiriolabs.json
+++ b/crates/goose/src/providers/declarative/empiriolabs.json
@@ -1,7 +1,7 @@
 {
   "name": "empiriolabs",
   "engine": "openai",
-  "display_name": "EmpirioLabs",
+  "display_name": "EmpirioLabs AI",
   "description": "Frontier open and proprietary chat models through one OpenAI-compatible API with streaming support",
   "api_key_env": "EMPIRIOLABS_API_KEY",
   "base_url": "https://api.empiriolabs.ai/v1/chat/completions",

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -31,7 +31,7 @@ goose is compatible with a wide range of LLM providers, allowing you to choose a
 | [ChatGPT Codex](https://chatgpt.com/codex) | Access GPT-5 Codex models optimized for code generation and understanding. **Requires a ChatGPT Plus/Pro subscription.** | No manual key. Uses browser-based OAuth authentication for both CLI and Desktop. |
 | [Databricks](https://www.databricks.com/)                                   | Unified data analytics and AI platform for building and deploying models.                                                                                                                                                 | `DATABRICKS_HOST`, `DATABRICKS_TOKEN` |
 | [Docker Model Runner](https://docs.docker.com/ai/model-runner/)                             | Local models running in Docker Desktop or Docker CE with OpenAI-compatible API endpoints. **Because this provider runs locally, you must first [download a model](#local-llms).**                     | `OPENAI_HOST`, `OPENAI_BASE_PATH`   |
-| [EmpirioLabs](https://empiriolabs.ai/)                                      | Frontier open and proprietary chat models (Qwen, DeepSeek, GLM, Kimi, MiniMax) through one OpenAI-compatible API with streaming. Catalog available at `https://api.empiriolabs.ai/v1/models`.        | `EMPIRIOLABS_API_KEY`                                                                                                                                                              |
+| [EmpirioLabs AI](https://empiriolabs.ai/)                                      | Frontier open and proprietary chat models (Qwen, DeepSeek, GLM, Kimi, MiniMax) through one OpenAI-compatible API with streaming. Catalog available at `https://api.empiriolabs.ai/v1/models`.        | `EMPIRIOLABS_API_KEY`                                                                                                                                                              |
 | [FuturMix](https://futurmix.ai/)                                            | Unified AI gateway providing access to models from Anthropic, Google, OpenAI, and DeepSeek through an OpenAI-compatible API.                                                                          | `FUTURMIX_API_KEY`                                                                                                                                                                  |
 | [Gemini](https://ai.google.dev/gemini-api/docs)                             | Advanced LLMs by Google with multimodal capabilities (text, images). Gemini 3 models support configurable [thinking levels](#gemini-3-thinking-levels).                                                                                                | `GOOGLE_API_KEY`, `GEMINI3_THINKING_LEVEL` (optional)                                                                                                                              |
 | [GCP Vertex AI](https://cloud.google.com/vertex-ai)                         | Google Cloud's Vertex AI platform, supporting Gemini and Claude models. **Credentials must be [configured in advance](https://cloud.google.com/vertex-ai/docs/authentication).** Filters for allowed models by organization policy (if configured). | `GCP_PROJECT_ID`, `GCP_LOCATION` and optionally `GCP_MAX_RATE_LIMIT_RETRIES` (5), `GCP_MAX_OVERLOADED_RETRIES` (5), `GCP_INITIAL_RETRY_INTERVAL_MS` (5000), `GCP_BACKOFF_MULTIPLIER` (2.0), `GCP_MAX_RETRY_INTERVAL_MS` (320_000). |
@@ -703,8 +703,8 @@ To set up Groq with goose, follow these steps:
   </TabItem>
 </Tabs>
 
-### EmpirioLabs
-[EmpirioLabs](https://empiriolabs.ai/) provides access to frontier open and proprietary chat models through a single OpenAI-compatible API with streaming. To use EmpirioLabs with goose, you need an API key from [EmpirioLabs](https://platform.empiriolabs.ai/dashboard/api-keys).
+### EmpirioLabs AI
+[EmpirioLabs AI](https://empiriolabs.ai/) provides access to frontier open and proprietary chat models through a single OpenAI-compatible API with streaming. To use EmpirioLabs with goose, you need an API key from [EmpirioLabs](https://platform.empiriolabs.ai/dashboard/api-keys).
 
 EmpirioLabs offers models that support tool calling, including:
 - **qwen3-7-plus** - Qwen3.7 Plus with a 1M context window
@@ -727,7 +727,7 @@ To set up EmpirioLabs with goose, follow these steps:
     2. Click the `Settings` button on the sidebar.
     3. Click the `Models` tab.
     4. Click `Configure Providers`
-    5. Choose `EmpirioLabs` as provider from the list.
+    5. Choose `EmpirioLabs AI` as provider from the list.
     6. Click `Configure`, enter your API key, and click `Submit`.
     7. Select the EmpirioLabs model of your choice.
 
@@ -738,7 +738,7 @@ To set up EmpirioLabs with goose, follow these steps:
     goose configure
     ```
     2. Select `Configure Providers` from the menu.
-    3. Follow the prompts to choose `EmpirioLabs` as the provider.
+    3. Follow the prompts to choose `EmpirioLabs AI` as the provider.
     4. Enter your API key when prompted.
     5. Select the EmpirioLabs model of your choice.
   </TabItem>


### PR DESCRIPTION
This updates the EmpirioLabs provider display name to `EmpirioLabs AI`, matching the brand name used across the EmpirioLabs site and docs.

Only the display name changes. The provider id (`empiriolabs`) and the `EMPIRIOLABS_API_KEY` environment variable are unchanged, so existing configurations keep working. The setup steps in the docs are updated to match what now appears in the provider list.