### PR TITLE
fix(acp): include structuredContent from MCP tool response

### DIFF
--- a/ui/desktop/src/acp/adapter/tools.ts
+++ b/ui/desktop/src/acp/adapter/tools.ts
@@ -184,11 +184,17 @@ function toolResultValue(
   update: ToolCallUpdate,
   mcpAppMeta: DesktopMcpAppMeta | undefined
 ): ToolResultValue {
-  return {
+  const toolResult: ToolResultValue = {
     content: toolResultContent(update),
     isError: false,
     ...(mcpAppMeta ? { _meta: mcpAppMeta } : {}),
   };
+
+  if (update.rawOutput !== undefined) {
+    toolResult.structuredContent = update.rawOutput;
+  }
+
+  return toolResult;
 }
 
 function toolResultContent(update: ToolCallUpdate): GooseContentBlock[] {


### PR DESCRIPTION
## Summary
Pass rawOutput from tool call updates as structuredContent in the tool result, preserving structured data from MCP server responses.

### Testing
Call a tool call that includes `structuredContent` in the response and check if `structuredContent` exists in the ToolResponse object in the message array.

### Related Issues
Relates to #10125


### Screenshots/Demos (for UX changes)
Before:  
<img width="1438" height="936" alt="Screenshot 2026-06-30 at 4 09 01 PM" src="https://github.com/user-attachments/assets/5b14f1b7-e028-4691-9b9f-d5363039cda3" />

After:   
<img width="1435" height="937" alt="Screenshot 2026-06-30 at 4 10 34 PM" src="https://github.com/user-attachments/assets/a01c7adb-1074-42e5-af33-93adb29c045a" />

