### PR TITLE
Broadcast ACP session updates across clients

### DIFF
--- a/crates/goose/src/acp/mod.rs
+++ b/crates/goose/src/acp/mod.rs
@@ -5,6 +5,7 @@ mod provider;
 mod response_builder;
 pub mod server;
 pub mod server_factory;
+pub(crate) mod session_events;
 pub(crate) mod tools;
 pub mod transport;
 

--- a/crates/goose/src/acp/response_builder.rs
+++ b/crates/goose/src/acp/response_builder.rs
@@ -73,6 +73,14 @@ pub(super) fn session_meta(session: &Session) -> serde_json::Map<String, serde_j
     }
 }
 
+pub(super) fn build_session_broadcast_meta(
+    session: &Session,
+) -> serde_json::Map<String, serde_json::Value> {
+    let mut meta = session_meta(session);
+    meta.remove("lastMessageSnippet");
+    meta
+}
+
 pub(super) fn session_response_meta(
     session: &Session,
     extension_results: &[ExtensionLoadResult],
@@ -403,27 +411,70 @@ pub(super) fn send_session_setup_notifications(
     session: &Session,
     supports_goose_custom_notifications: bool,
 ) -> Result<(), agent_client_protocol::Error> {
-    let session_id = SessionId::new(session.id.clone());
     if let Some(updates) = build_usage_updates(session) {
         if supports_goose_custom_notifications {
             cx.send_notification(updates.custom)?;
         }
-        cx.send_notification(SessionNotification::new(
+    }
+    for notification in session_setup_notifications(session) {
+        cx.send_notification(notification)?;
+    }
+    Ok(())
+}
+
+pub(super) fn session_setup_notifications(session: &Session) -> Vec<SessionNotification> {
+    let session_id = SessionId::new(session.id.clone());
+    let mut notifications = Vec::new();
+    if let Some(updates) = build_usage_updates(session) {
+        notifications.push(SessionNotification::new(
             session_id.clone(),
             SessionUpdate::UsageUpdate(updates.standard),
-        ))?;
+        ));
     }
-    cx.send_notification(SessionNotification::new(
+    notifications.push(SessionNotification::new(
         session_id,
         SessionUpdate::AvailableCommandsUpdate(available_commands_update(&session.working_dir)),
-    ))
+    ));
+    notifications
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use agent_client_protocol::schema::v1::SessionConfigKind;
+    use chrono::Utc;
+    use goose_providers::conversation::token_usage::Usage;
+    use std::path::PathBuf;
     use test_case::test_case;
+
+    fn session_with_snippet() -> Session {
+        let now = Utc::now();
+        Session {
+            id: "session-with-snippet".to_string(),
+            working_dir: PathBuf::from("/tmp/acp-session-broadcast-meta"),
+            name: "Snippet session".to_string(),
+            user_set_name: false,
+            session_type: crate::session::SessionType::Acp,
+            created_at: now,
+            updated_at: now,
+            extension_data: crate::session::ExtensionData::default(),
+            usage: Usage::default(),
+            accumulated_usage: Usage::default(),
+            accumulated_cost: None,
+            schedule_id: None,
+            recipe: None,
+            user_recipe_values: None,
+            conversation: None,
+            message_count: 1,
+            last_message_at: Some(now),
+            provider_name: None,
+            model_config: None,
+            goose_mode: GooseMode::default(),
+            archived_at: None,
+            project_id: None,
+            last_message_snippet: Some("sensitive snippet".to_string()),
+        }
+    }
 
     fn model_selection(current: &str, models: &[&str]) -> ModelSelection {
         ModelSelection {
@@ -436,6 +487,17 @@ mod tests {
                 })
                 .collect(),
         }
+    }
+
+    #[test]
+    fn test_build_session_broadcast_meta_removes_last_message_snippet() {
+        let session = session_with_snippet();
+
+        assert_eq!(
+            session_meta(&session).get("lastMessageSnippet"),
+            Some(&serde_json::Value::String("sensitive snippet".to_string()))
+        );
+        assert!(!build_session_broadcast_meta(&session).contains_key("lastMessageSnippet"));
     }
 
     #[test_case(

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -67,7 +67,8 @@ use fs_err as fs;
 use futures::future::{BoxFuture, FutureExt};
 use futures::stream::{self, StreamExt};
 use rmcp::model::{
-    AnnotateAble, CallToolResult, RawContent, RawTextContent, ResourceContents, Role,
+    AnnotateAble, CallToolResult, RawContent, RawImageContent, RawTextContent, ResourceContents,
+    Role,
 };
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
@@ -118,6 +119,24 @@ pub type AcpProviderFactory = Arc<
         + Send
         + Sync,
 >;
+
+fn acp_audience_annotations(audience: &[Role]) -> Annotations {
+    Annotations::new().audience(
+        audience
+            .iter()
+            .map(|role| match role {
+                Role::Assistant => agent_client_protocol::schema::v1::Role::Assistant,
+                Role::User => agent_client_protocol::schema::v1::Role::User,
+            })
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn audience_allows_user(audience: Option<&[Role]>) -> bool {
+    audience
+        .map(|roles| roles.contains(&Role::User))
+        .unwrap_or(true)
+}
 
 /// Convenience conversions from any `Display` error into an `agent_client_protocol::Error`.
 ///
@@ -1468,7 +1487,44 @@ impl GooseAcpAgent {
                     message = message.with_content(MessageContent::Text(annotated));
                 }
                 ContentBlock::Image(image) => {
-                    message = message.with_image(&image.data, &image.mime_type);
+                    let annotated = if let Some(ref ann) = image.annotations {
+                        let audience: Vec<Role> = ann
+                            .audience
+                            .as_ref()
+                            .map(|roles| {
+                                roles
+                                    .iter()
+                                    .filter_map(|r| match r {
+                                        agent_client_protocol::schema::v1::Role::Assistant => {
+                                            Some(Role::Assistant)
+                                        }
+                                        agent_client_protocol::schema::v1::Role::User => {
+                                            Some(Role::User)
+                                        }
+                                        _ => None,
+                                    })
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        let raw = RawImageContent {
+                            data: image.data.clone(),
+                            mime_type: image.mime_type.clone(),
+                            meta: None,
+                        };
+                        if audience.is_empty() {
+                            raw.no_annotation()
+                        } else {
+                            raw.no_annotation().with_audience(audience)
+                        }
+                    } else {
+                        RawImageContent {
+                            data: image.data.clone(),
+                            mime_type: image.mime_type.clone(),
+                            meta: None,
+                        }
+                        .no_annotation()
+                    };
+                    message = message.with_content(MessageContent::Image(annotated));
                 }
                 ContentBlock::Resource(resource) => {
                     if let EmbeddedResourceResource::TextResourceContents(text_resource) =
@@ -1618,10 +1674,25 @@ impl GooseAcpAgent {
             }
             let block = match content_item {
                 MessageContent::Text(text) => {
-                    ContentBlock::Text(TextContent::new(text.text.clone()))
+                    if !audience_allows_user(text.audience().map(Vec::as_slice)) {
+                        continue;
+                    }
+                    let mut text_content = TextContent::new(text.text.clone());
+                    if let Some(audience) = text.audience() {
+                        text_content = text_content.annotations(acp_audience_annotations(audience));
+                    }
+                    ContentBlock::Text(text_content)
                 }
                 MessageContent::Image(image) => {
-                    ContentBlock::Image(ImageContent::new(&image.data, &image.mime_type))
+                    if !audience_allows_user(image.audience().map(Vec::as_slice)) {
+                        continue;
+                    }
+                    let mut image_content = ImageContent::new(&image.data, &image.mime_type);
+                    if let Some(audience) = image.audience() {
+                        image_content =
+                            image_content.annotations(acp_audience_annotations(audience));
+                    }
+                    ContentBlock::Image(image_content)
                 }
                 _ => continue,
             };

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -3,9 +3,11 @@ use crate::acp::custom_requests::*;
 use crate::acp::fs::AcpTools;
 pub(super) use crate::acp::response_builder::{
     build_config_options, build_mode_state, build_model_state, build_provider_options,
-    build_session_info, build_session_setup_config, send_session_setup_notifications, session_meta,
-    session_provider_selection, session_response_meta, should_refresh_inventory_for_session_init,
+    build_session_broadcast_meta, build_session_info, build_session_setup_config,
+    send_session_setup_notifications, session_meta, session_provider_selection,
+    session_response_meta, session_setup_notifications, should_refresh_inventory_for_session_init,
 };
+use crate::acp::session_events::AcpSessionEventStore;
 use crate::acp::tools::AcpAwareToolMeta;
 use crate::acp::{PermissionDecision, ACP_CURRENT_MODEL};
 use crate::agents::extension::{Envs, PLATFORM_EXTENSIONS};
@@ -72,7 +74,7 @@ use std::collections::{HashMap, HashSet};
 use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tokio::sync::{Mutex, OnceCell};
+use tokio::sync::{mpsc, Mutex, OnceCell};
 use tokio_util::compat::{TokioAsyncReadCompatExt as _, TokioAsyncWriteCompatExt as _};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
@@ -211,6 +213,7 @@ pub struct GooseAcpAgentOptions {
 
 pub struct GooseAcpAgent {
     sessions: Arc<Mutex<HashMap<String, GooseAcpSession>>>,
+    loading_session_ids: Arc<Mutex<HashSet<String>>>,
     active_prompt_runs: Arc<Mutex<HashMap<String, ActivePromptRun>>>,
     closed_session_ids: Arc<Mutex<HashSet<String>>>,
     agent_manager: Arc<AgentManager>,
@@ -224,6 +227,10 @@ pub struct GooseAcpAgent {
     client_supports_recipe_param_requests: OnceCell<bool>,
     use_login_shell_path: OnceCell<bool>,
     client_cx: OnceCell<ConnectionTo<Client>>,
+    session_event_forwarder_started: OnceCell<()>,
+    session_event_source_id: String,
+    session_events: Arc<AcpSessionEventStore>,
+    session_event_tx: mpsc::UnboundedSender<SessionNotification>,
     config_dir: std::path::PathBuf,
     session_manager: Arc<SessionManager>,
     permission_manager: Arc<PermissionManager>,
@@ -275,6 +282,7 @@ fn agent_capabilities_meta() -> Option<Meta> {
 
 fn spawn_session_name_update_notifier(
     cx: ConnectionTo<Client>,
+    session_event_tx: mpsc::UnboundedSender<SessionNotification>,
 ) -> tokio::sync::mpsc::UnboundedSender<crate::session::SessionNameUpdate> {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<crate::session::SessionNameUpdate>();
     tokio::spawn(async move {
@@ -297,11 +305,18 @@ fn spawn_session_name_update_notifier(
                         .meta(meta),
                 ),
             );
-            if let Err(error) = cx.send_notification(notification) {
+            if let Err(error) = cx.send_notification(notification.clone()) {
                 warn!(
                     session_id = %update.session_id,
                     error = %error,
                     "Failed to send generated session name update"
+                );
+            }
+            if let Err(error) = session_event_tx.send(notification) {
+                warn!(
+                    session_id = %update.session_id,
+                    error = %error,
+                    "Failed to publish generated session name update"
                 );
             }
         }
@@ -732,6 +747,27 @@ struct PendingToolCall {
     fallback_title: String,
 }
 
+fn session_update_can_forward_without_registered_session(update: &SessionUpdate) -> bool {
+    matches!(update, SessionUpdate::SessionInfoUpdate(_))
+}
+
+async fn should_forward_session_event(
+    notification: &SessionNotification,
+    sessions: &Arc<Mutex<HashMap<String, GooseAcpSession>>>,
+    loading_session_ids: &Arc<Mutex<HashSet<String>>>,
+) -> bool {
+    if session_update_can_forward_without_registered_session(&notification.update) {
+        return true;
+    }
+
+    let session_id = notification.session_id.0.as_ref();
+    if sessions.lock().await.contains_key(session_id) {
+        return true;
+    }
+
+    loading_session_ids.lock().await.contains(session_id)
+}
+
 /// If `buffer` holds a multi-tool run (≥ 2 tool requests), (re)register a
 /// [`ToolChain`] in `chain_membership` anchored on the **first** tool's
 /// message_id (the row [`SessionManager::update_tool_request_meta`] will patch
@@ -904,8 +940,140 @@ impl GooseAcpAgent {
             .unwrap_or(false)
     }
 
+    fn start_session_event_forwarder(
+        &self,
+        cx: &ConnectionTo<Client>,
+    ) -> Result<(), agent_client_protocol::Error> {
+        if self.session_event_forwarder_started.set(()).is_err() {
+            return Ok(());
+        }
+
+        let session_events = Arc::clone(&self.session_events);
+        let sessions = Arc::clone(&self.sessions);
+        let loading_session_ids = Arc::clone(&self.loading_session_ids);
+        let source_id = self.session_event_source_id.clone();
+        let cx = cx.clone();
+        cx.clone().spawn(async move {
+            let mut last_event_id = match session_events.latest_event_id().await {
+                Ok(id) => id,
+                Err(error) => {
+                    warn!(%error, "failed to initialize ACP session event cursor");
+                    0
+                }
+            };
+            let mut interval = tokio::time::interval(std::time::Duration::from_millis(100));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+            loop {
+                interval.tick().await;
+                match session_events
+                    .events_after(last_event_id, &source_id, 100)
+                    .await
+                {
+                    Ok(events) => {
+                        for event in events {
+                            last_event_id = event.id;
+                            if should_forward_session_event(
+                                &event.notification,
+                                &sessions,
+                                &loading_session_ids,
+                            )
+                            .await
+                            {
+                                let session_id = event.notification.session_id.0.to_string();
+                                if let Err(error) = cx.send_notification(event.notification) {
+                                    warn!(
+                                        session_id = %session_id,
+                                        event_id = event.id,
+                                        error = %error,
+                                        "failed to forward ACP session event"
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        warn!(%error, "failed to read ACP session events");
+                    }
+                }
+            }
+        })?;
+
+        Ok(())
+    }
+
+    async fn publish_session_notification(
+        &self,
+        notification: &SessionNotification,
+    ) -> Result<(), agent_client_protocol::Error> {
+        self.session_event_tx
+            .send(notification.clone())
+            .map_err(|_| {
+                agent_client_protocol::Error::internal_error()
+                    .data("Failed to enqueue ACP session notification")
+            })
+    }
+
+    pub(super) async fn send_and_publish_session_notification(
+        &self,
+        cx: &ConnectionTo<Client>,
+        notification: SessionNotification,
+    ) -> Result<(), agent_client_protocol::Error> {
+        cx.send_notification(notification.clone())?;
+        self.publish_session_notification(&notification).await
+    }
+
+    fn session_info_notification(session: &Session) -> SessionNotification {
+        let mut update = SessionInfoUpdate::new()
+            .updated_at(session.updated_at.to_rfc3339())
+            .meta(build_session_broadcast_meta(session));
+        if !session.name.is_empty() {
+            update = update.title(session.name.clone());
+        }
+        SessionNotification::new(
+            SessionId::new(session.id.clone()),
+            SessionUpdate::SessionInfoUpdate(update),
+        )
+    }
+
+    async fn send_and_publish_session_setup_notifications(
+        &self,
+        cx: &ConnectionTo<Client>,
+        session: &Session,
+    ) -> Result<(), agent_client_protocol::Error> {
+        if let Some(updates) = build_usage_updates(session) {
+            if self.supports_goose_custom_notifications() {
+                cx.send_notification(updates.custom)?;
+            }
+        }
+        for notification in session_setup_notifications(session) {
+            self.send_and_publish_session_notification(cx, notification)
+                .await?;
+        }
+        Ok(())
+    }
+
     // TODO: goose reads Paths::in_state_dir globally (e.g. RequestLog), ignoring this data_dir.
     pub async fn new(options: GooseAcpAgentOptions) -> Result<Self> {
+        let session_events = Arc::new(AcpSessionEventStore::new(options.data_dir.clone()));
+        let session_event_source_id = Uuid::new_v4().to_string();
+        let (session_event_tx, mut session_event_rx) =
+            mpsc::unbounded_channel::<SessionNotification>();
+        {
+            let session_events = Arc::clone(&session_events);
+            let source_id = session_event_source_id.clone();
+            tokio::spawn(async move {
+                while let Some(notification) = session_event_rx.recv().await {
+                    if let Err(error) = session_events.publish(&source_id, &notification).await {
+                        warn!(
+                            session_id = %notification.session_id.0.as_ref(),
+                            error = %error,
+                            "failed to publish ACP session notification"
+                        );
+                    }
+                }
+            });
+        }
         let session_manager = Arc::new(SessionManager::new(options.data_dir));
 
         // Eagerly initialize the SQLite pool so it's ready when providers/sessions need it.
@@ -928,6 +1096,7 @@ impl GooseAcpAgent {
 
         Ok(Self {
             sessions: Arc::new(Mutex::new(HashMap::new())),
+            loading_session_ids: Arc::new(Mutex::new(HashSet::new())),
             active_prompt_runs: Arc::new(Mutex::new(HashMap::new())),
             closed_session_ids: Arc::new(Mutex::new(HashSet::new())),
             agent_manager,
@@ -941,6 +1110,10 @@ impl GooseAcpAgent {
             client_supports_recipe_param_requests: OnceCell::new(),
             use_login_shell_path: OnceCell::new(),
             client_cx: OnceCell::new(),
+            session_event_forwarder_started: OnceCell::new(),
+            session_event_source_id,
+            session_events,
+            session_event_tx,
             config_dir: options.config_dir,
             session_manager,
             permission_manager,
@@ -1010,8 +1183,12 @@ impl GooseAcpAgent {
                 RuntimeContext {
                     mcp_host_info: self.client_mcp_host_info.get().cloned(),
                     use_login_shell_path: self.use_login_shell_path.get().copied(),
-                    session_name_update_tx: (!self.disable_session_naming)
-                        .then(|| spawn_session_name_update_notifier(cx.clone())),
+                    session_name_update_tx: (!self.disable_session_naming).then(|| {
+                        spawn_session_name_update_notifier(
+                            cx.clone(),
+                            self.session_event_tx.clone(),
+                        )
+                    }),
                 },
             )
             .await
@@ -1336,7 +1513,11 @@ impl GooseAcpAgent {
                     Role::User => SessionUpdate::UserMessageChunk(chunk),
                     Role::Assistant => SessionUpdate::AgentMessageChunk(chunk),
                 };
-                cx.send_notification(SessionNotification::new(session_id.clone(), update))?;
+                self.send_and_publish_session_notification(
+                    cx,
+                    SessionNotification::new(session_id.clone(), update),
+                )
+                .await?;
             }
             MessageContent::ToolRequest(tool_request) => {
                 self.handle_tool_request(
@@ -1361,19 +1542,23 @@ impl GooseAcpAgent {
                 .await?;
             }
             MessageContent::Thinking(thinking) => {
-                cx.send_notification(SessionNotification::new(
-                    session_id.clone(),
-                    SessionUpdate::AgentThoughtChunk(
-                        ContentChunk::new(ContentBlock::Text(TextContent::new(
-                            thinking.thinking.clone(),
-                        )))
-                        .meta(message_update_meta(
-                            message_id,
-                            message_created,
-                            steer,
-                        )),
+                self.send_and_publish_session_notification(
+                    cx,
+                    SessionNotification::new(
+                        session_id.clone(),
+                        SessionUpdate::AgentThoughtChunk(
+                            ContentChunk::new(ContentBlock::Text(TextContent::new(
+                                thinking.thinking.clone(),
+                            )))
+                            .meta(message_update_meta(
+                                message_id,
+                                message_created,
+                                steer,
+                            )),
+                        ),
                     ),
-                ))?;
+                )
+                .await?;
             }
             MessageContent::ActionRequired(action_required) => match &action_required.data {
                 ActionRequiredData::ToolConfirmation {
@@ -1422,6 +1607,39 @@ impl GooseAcpAgent {
         Ok(())
     }
 
+    async fn publish_prompt_message(
+        &self,
+        session_id: &SessionId,
+        message: &Message,
+    ) -> Result<(), agent_client_protocol::Error> {
+        for content_item in &message.content {
+            if let Some(error) = prompt_error_from_message_content(content_item) {
+                return Err(error);
+            }
+            let block = match content_item {
+                MessageContent::Text(text) => {
+                    ContentBlock::Text(TextContent::new(text.text.clone()))
+                }
+                MessageContent::Image(image) => {
+                    ContentBlock::Image(ImageContent::new(&image.data, &image.mime_type))
+                }
+                _ => continue,
+            };
+            let chunk = ContentChunk::new(block).meta(message_update_meta(
+                message.id.as_deref(),
+                message.created,
+                message.metadata.steer,
+            ));
+            self.publish_session_notification(&SessionNotification::new(
+                session_id.clone(),
+                SessionUpdate::UserMessageChunk(chunk),
+            ))
+            .await?;
+        }
+
+        Ok(())
+    }
+
     async fn handle_tool_request(
         &self,
         tool_request: &crate::conversation::message::ToolRequest,
@@ -1439,10 +1657,14 @@ impl GooseAcpAgent {
         let initial_tool_call = pending_tool_call
             .tool_call
             .meta(pending_tool_call.identity_meta.clone());
-        cx.send_notification(SessionNotification::new(
-            session_id.clone(),
-            SessionUpdate::ToolCall(initial_tool_call),
-        ))?;
+        self.send_and_publish_session_notification(
+            cx,
+            SessionNotification::new(
+                session_id.clone(),
+                SessionUpdate::ToolCall(initial_tool_call),
+            ),
+        )
+        .await?;
 
         if Config::global()
             .get_goose_disable_tool_call_summary()
@@ -1462,6 +1684,7 @@ impl GooseAcpAgent {
             let session_id_for_persist = session_id_for_persist.to_string();
             let message_id_for_persist = message_id.map(|s| s.to_string());
             let session_manager = self.session_manager.clone();
+            let session_event_tx = self.session_event_tx.clone();
             let args_json = tool_call
                 .arguments
                 .as_ref()
@@ -1570,13 +1793,21 @@ impl GooseAcpAgent {
                 };
 
                 let fields = ToolCallUpdateFields::new().title(title.clone());
-                let _ = cx.send_notification(SessionNotification::new(
-                    sid,
+                let notification = SessionNotification::new(
+                    sid.clone(),
                     SessionUpdate::ToolCallUpdate(
                         ToolCallUpdate::new(ToolCallId::new(request_id.clone()), fields)
                             .meta(identity_meta),
                     ),
-                ));
+                );
+                let _ = cx.send_notification(notification.clone());
+                if let Err(error) = session_event_tx.send(notification) {
+                    warn!(
+                        tool_call_id = %request_id,
+                        error = %error,
+                        "failed to publish tool call title update"
+                    );
+                }
 
                 // Best-effort persistence: only persist the LLM-generated title
                 // (not the deterministic fallback) so reload uses fallback_title
@@ -1652,10 +1883,11 @@ impl GooseAcpAgent {
 
         let update = ToolCallUpdate::new(ToolCallId::new(tool_response.id.clone()), fields)
             .meta(extract_tool_call_update_meta(tool_response));
-        cx.send_notification(SessionNotification::new(
-            session_id.clone(),
-            SessionUpdate::ToolCallUpdate(update),
-        ))?;
+        self.send_and_publish_session_notification(
+            cx,
+            SessionNotification::new(session_id.clone(), SessionUpdate::ToolCallUpdate(update)),
+        )
+        .await?;
 
         // Chain summarization: when this response completes a multi-tool
         // chain, fire one LLM summary covering the run.
@@ -1753,6 +1985,7 @@ impl GooseAcpAgent {
         let chain_for_task = chain.clone();
         let cx = cx.clone();
         let session_manager = self.session_manager.clone();
+        let session_event_tx = self.session_event_tx.clone();
 
         let first_id = first_id.clone();
         tokio::spawn(async move {
@@ -1869,12 +2102,19 @@ impl GooseAcpAgent {
 
             let meta = with_tool_chain_summary_meta(identity_meta, &summary, count);
             let fields = ToolCallUpdateFields::new();
-            let _ = cx.send_notification(SessionNotification::new(
-                sid,
+            let notification = SessionNotification::new(
+                sid.clone(),
                 SessionUpdate::ToolCallUpdate(
                     ToolCallUpdate::new(ToolCallId::new(first_id), fields).meta(meta),
                 ),
-            ));
+            );
+            let _ = cx.send_notification(notification.clone());
+            if let Err(error) = session_event_tx.send(notification) {
+                warn!(
+                    error = %error,
+                    "failed to publish tool chain summary update"
+                );
+            }
         });
     }
 
@@ -2384,20 +2624,26 @@ impl GooseAcpAgent {
         meta
     }
 
-    fn send_active_run_update(
+    async fn send_and_publish_active_run_update(
+        &self,
         cx: &ConnectionTo<Client>,
         session_id: &SessionId,
         active_run_id: Option<&str>,
     ) -> Result<(), agent_client_protocol::Error> {
-        cx.send_notification(SessionNotification::new(
-            session_id.clone(),
-            SessionUpdate::SessionInfoUpdate(
-                SessionInfoUpdate::new().meta(Self::active_run_meta(active_run_id)),
+        self.send_and_publish_session_notification(
+            cx,
+            SessionNotification::new(
+                session_id.clone(),
+                SessionUpdate::SessionInfoUpdate(
+                    SessionInfoUpdate::new().meta(Self::active_run_meta(active_run_id)),
+                ),
             ),
-        ))
+        )
+        .await
     }
 
-    fn send_queued_steer_update(
+    async fn send_and_publish_queued_steer_update(
+        &self,
         cx: &ConnectionTo<Client>,
         session_id: &SessionId,
         message_id: &str,
@@ -2414,10 +2660,14 @@ impl GooseAcpAgent {
         let mut meta = serde_json::Map::new();
         meta.insert("goose".to_string(), serde_json::Value::Object(goose));
 
-        cx.send_notification(SessionNotification::new(
-            session_id.clone(),
-            SessionUpdate::SessionInfoUpdate(SessionInfoUpdate::new().meta(meta)),
-        ))
+        self.send_and_publish_session_notification(
+            cx,
+            SessionNotification::new(
+                session_id.clone(),
+                SessionUpdate::SessionInfoUpdate(SessionInfoUpdate::new().meta(meta)),
+            ),
+        )
+        .await
     }
 
     async fn on_load_session(
@@ -2453,19 +2703,25 @@ impl GooseAcpAgent {
 
         if cancel_token.is_cancelled() {
             self.clear_active_run(&session_id, &run_id).await;
-            Self::send_active_run_update(cx, &args.session_id, None)?;
+            self.send_and_publish_active_run_update(cx, &args.session_id, None)
+                .await?;
             return Ok(PromptResponse::new(StopReason::Cancelled));
         }
 
-        if let Err(error) = Self::send_active_run_update(cx, &args.session_id, Some(&run_id)) {
+        if let Err(error) = self
+            .send_and_publish_active_run_update(cx, &args.session_id, Some(&run_id))
+            .await
+        {
             self.clear_active_run(&session_id, &run_id).await;
             return Err(error);
         }
 
-        let user_message = Self::convert_acp_prompt_to_message(&args.prompt);
+        let user_message = Self::convert_acp_prompt_to_message(&args.prompt).with_generated_id();
 
         let message_text = user_message.as_concat_text();
-        if let Some(parsed) = crate::agents::execute_commands::parse_slash_command(&message_text) {
+        let parsed_slash_command =
+            crate::agents::execute_commands::parse_slash_command(&message_text);
+        if let Some(parsed) = &parsed_slash_command {
             let full_command = format!("/{}", parsed.command);
 
             if !Self::is_builtin_agent_command(parsed.command) {
@@ -2475,23 +2731,33 @@ impl GooseAcpAgent {
                     )
                 {
                     if recipe_path.exists() {
-                        if let Err(error) = cx.send_notification(SessionNotification::new(
-                            args.session_id.clone(),
-                            SessionUpdate::AgentMessageChunk(ContentChunk::new(
-                                ContentBlock::Text(TextContent::new(format!(
-                                    "Running recipe: {}",
-                                    full_command
-                                ))),
-                            )),
-                        )) {
+                        if let Err(error) = self
+                            .send_and_publish_session_notification(
+                                cx,
+                                SessionNotification::new(
+                                    args.session_id.clone(),
+                                    SessionUpdate::AgentMessageChunk(ContentChunk::new(
+                                        ContentBlock::Text(TextContent::new(format!(
+                                            "Running recipe: {}",
+                                            full_command
+                                        ))),
+                                    )),
+                                ),
+                            )
+                            .await
+                        {
                             self.clear_active_run(&session_id, &run_id).await;
-                            let _ = Self::send_active_run_update(cx, &args.session_id, None);
+                            let _ = self
+                                .send_and_publish_active_run_update(cx, &args.session_id, None)
+                                .await;
                             return Err(error);
                         }
                     }
                 }
             }
         }
+        let should_publish_prompt_message = parsed_slash_command.is_none();
+        let live_user_message = user_message.clone();
 
         let session_config = SessionConfig {
             id: session_id.clone(),
@@ -2507,11 +2773,25 @@ impl GooseAcpAgent {
             Ok(stream) => stream,
             Err(error) => {
                 self.clear_active_run(&session_id, &run_id).await;
-                let _ = Self::send_active_run_update(cx, &args.session_id, None);
+                let _ = self
+                    .send_and_publish_active_run_update(cx, &args.session_id, None)
+                    .await;
                 return Err(agent_client_protocol::Error::internal_error()
                     .data(format!("Error getting agent reply: {error}")));
             }
         };
+        if should_publish_prompt_message {
+            if let Err(error) = self
+                .publish_prompt_message(&args.session_id, &live_user_message)
+                .await
+            {
+                self.clear_active_run(&session_id, &run_id).await;
+                let _ = self
+                    .send_and_publish_active_run_update(cx, &args.session_id, None)
+                    .await;
+                return Err(error);
+            }
+        }
 
         let mut was_cancelled = false;
         let mut first_event_logged = false;
@@ -2619,10 +2899,11 @@ impl GooseAcpAgent {
                     if let Some(update) =
                         tool_notifications::tool_notification_update(request_id, notification)
                     {
-                        cx.send_notification(SessionNotification::new(
-                            args.session_id.clone(),
-                            update,
-                        ))?;
+                        self.send_and_publish_session_notification(
+                            cx,
+                            SessionNotification::new(args.session_id.clone(), update),
+                        )
+                        .await?;
                     }
                 }
                 Ok(_) => {}
@@ -2647,7 +2928,8 @@ impl GooseAcpAgent {
             }
         }
         self.clear_active_run(&session_id, &run_id).await;
-        Self::send_active_run_update(cx, &args.session_id, None)?;
+        self.send_and_publish_active_run_update(cx, &args.session_id, None)
+            .await?;
         if let Some(error) = stream_error {
             return Err(error);
         }
@@ -2664,10 +2946,14 @@ impl GooseAcpAgent {
             // Standard ACP notification — emitted alongside the custom one for
             // backwards compatibility. Remove once all known clients have
             // migrated to `_goose/unstable/session/update`.
-            cx.send_notification(SessionNotification::new(
-                args.session_id.clone(),
-                SessionUpdate::UsageUpdate(updates.standard),
-            ))?;
+            self.send_and_publish_session_notification(
+                cx,
+                SessionNotification::new(
+                    args.session_id.clone(),
+                    SessionUpdate::UsageUpdate(updates.standard),
+                ),
+            )
+            .await?;
         }
 
         debug!(
@@ -2719,12 +3005,14 @@ impl GooseAcpAgent {
         agent.steer(&req.session_id, message).await;
 
         if let Some(cx) = self.client_cx.get() {
-            let _ = Self::send_queued_steer_update(
-                cx,
-                &SessionId::new(req.session_id.clone()),
-                &message_id,
-                &active_run_id,
-            );
+            let _ = self
+                .send_and_publish_queued_steer_update(
+                    cx,
+                    &SessionId::new(req.session_id.clone()),
+                    &message_id,
+                    &active_run_id,
+                )
+                .await;
         }
 
         Ok(SteerSessionResponse {

--- a/crates/goose/src/acp/server/dispatch.rs
+++ b/crates/goose/src/acp/server/dispatch.rs
@@ -29,7 +29,16 @@ impl HandleDispatchFrom<Client> for GooseAcpHandler {
             MatchDispatchFrom::new(message, &cx)
                 .if_request(
                     |req: InitializeRequest, responder: Responder<InitializeResponse>| async {
-                        responder.respond_with_result(agent.on_initialize(req).await)
+                        let response = agent.on_initialize(req).await;
+                        if response.is_ok() {
+                            if let Err(error) = agent.start_session_event_forwarder(&cx) {
+                                warn!(
+                                    error = %error,
+                                    "failed to start ACP session event forwarder"
+                                );
+                            }
+                        }
+                        responder.respond_with_result(response)
                     },
                 )
                 .await
@@ -145,7 +154,9 @@ impl HandleDispatchFrom<Client> for GooseAcpHandler {
                             }
                             // Respond immediately using the current provider inventory snapshot.
                             let (notification, config_options) = agent.build_config_update(&session_id).await?;
-                            cx.send_notification(notification)?;
+                            agent
+                                .send_and_publish_session_notification(&cx, notification)
+                                .await?;
                             responder.respond(SetSessionConfigOptionResponse::new(config_options))?;
 
                             let maybe_refresh = if config_id == "provider" {
@@ -239,8 +250,12 @@ impl HandleDispatchFrom<Client> for GooseAcpHandler {
                                             match agent_bg.build_config_update(&session_id_bg).await
                                             {
                                                 Ok((fresh_notification, _)) => {
-                                                    let _ = cx_bg
-                                                        .send_notification(fresh_notification);
+                                                    let _ = agent_bg
+                                                        .send_and_publish_session_notification(
+                                                            &cx_bg,
+                                                            fresh_notification,
+                                                        )
+                                                        .await;
                                                 }
                                                 Err(error) => warn!(
                                                     provider = %refresh_provider_id,
@@ -302,12 +317,17 @@ impl HandleDispatchFrom<Client> for GooseAcpHandler {
                             match agent.on_set_mode(&session_id.0, &mode_id.0).await {
                                 Ok(resp) => {
                                     // Notify before responding so clients see the mode update before block_task unblocks.
-                                    cx.send_notification(SessionNotification::new(
-                                        session_id,
-                                        SessionUpdate::CurrentModeUpdate(
-                                            CurrentModeUpdate::new(mode_id),
-                                        ),
-                                    ))?;
+                                    agent
+                                        .send_and_publish_session_notification(
+                                            &cx,
+                                            SessionNotification::new(
+                                                session_id,
+                                                SessionUpdate::CurrentModeUpdate(
+                                                    CurrentModeUpdate::new(mode_id),
+                                                ),
+                                            ),
+                                        )
+                                        .await?;
                                     responder.respond(resp)?;
                                 }
                                 Err(e) => {

--- a/crates/goose/src/acp/server/fork_session.rs
+++ b/crates/goose/src/acp/server/fork_session.rs
@@ -72,11 +72,13 @@ impl GooseAcpAgent {
         if let Some(co) = config_options {
             response = response.config_options(co);
         }
-        send_session_setup_notifications(
+        self.send_and_publish_session_notification(
             cx,
-            &goose_session,
-            self.supports_goose_custom_notifications(),
-        )?;
+            Self::session_info_notification(&goose_session),
+        )
+        .await?;
+        self.send_and_publish_session_setup_notifications(cx, &goose_session)
+            .await?;
         Ok(response)
     }
 }

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -1,17 +1,5 @@
 use super::*;
 
-fn replay_audience_annotations(audience: &[Role]) -> Annotations {
-    Annotations::new().audience(
-        audience
-            .iter()
-            .map(|role| match role {
-                Role::Assistant => agent_client_protocol::schema::v1::Role::Assistant,
-                Role::User => agent_client_protocol::schema::v1::Role::User,
-            })
-            .collect::<Vec<_>>(),
-    )
-}
-
 fn send_replay_content_chunk(
     cx: &ConnectionTo<Client>,
     session_id: &SessionId,
@@ -59,7 +47,7 @@ fn replay_conversation_to_client(
                 MessageContent::Text(text) => {
                     let mut tc = TextContent::new(text.text.clone());
                     if let Some(audience) = text.audience() {
-                        tc = tc.annotations(replay_audience_annotations(audience));
+                        tc = tc.annotations(acp_audience_annotations(audience));
                     }
                     send_replay_content_chunk(cx, &session_id, message, ContentBlock::Text(tc))?;
                 }
@@ -68,7 +56,7 @@ fn replay_conversation_to_client(
                         ImageContent::new(image.data.clone(), image.mime_type.clone());
                     if let Some(audience) = image.audience() {
                         image_content =
-                            image_content.annotations(replay_audience_annotations(audience));
+                            image_content.annotations(acp_audience_annotations(audience));
                     }
                     send_replay_content_chunk(
                         cx,
@@ -176,19 +164,28 @@ impl GooseAcpAgent {
         let sid = sid_short(&session_id_str);
         let t_start = std::time::Instant::now();
 
-        let mut session = self
-            .session_manager
-            .get_session(&session_id_str, true)
-            .await
-            .map_err(|_| {
-                agent_client_protocol::Error::resource_not_found(Some(session_id_str.clone()))
-                    .data(format!("Session not found: {}", session_id_str))
-            })?;
-
         self.loading_session_ids
             .lock()
             .await
             .insert(session_id_str.clone());
+
+        let mut session = match self
+            .session_manager
+            .get_session(&session_id_str, true)
+            .await
+        {
+            Ok(session) => session,
+            Err(_) => {
+                self.loading_session_ids
+                    .lock()
+                    .await
+                    .remove(&session_id_str);
+                return Err(agent_client_protocol::Error::resource_not_found(Some(
+                    session_id_str.clone(),
+                ))
+                .data(format!("Session not found: {}", session_id_str)));
+            }
+        };
 
         let load_result: Result<LoadSessionResponse, agent_client_protocol::Error> = async {
             session = self

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -185,46 +185,65 @@ impl GooseAcpAgent {
                     .data(format!("Session not found: {}", session_id_str))
             })?;
 
-        session = self
-            .prepare_session_for_activation(session, args.cwd.clone(), args.mcp_servers, true)
-            .await?;
-
-        let replay_tool_requests = replay_conversation_to_client(cx, &session)?;
-        let (agent, extension_results) = self.prepare_acp_session_agent(cx, &session).await?;
-        self.apply_session_recipe(&agent, &session).await?;
-        self.register_acp_session(session_id_str.clone(), agent.clone(), replay_tool_requests)
-            .await;
-
-        session = self
-            .session_manager
-            .get_session(&session_id_str, true)
+        self.loading_session_ids
+            .lock()
             .await
-            .internal_err_ctx("Failed to reload session")?;
+            .insert(session_id_str.clone());
 
-        agent
-            .extension_manager
-            .update_working_dir(&session.working_dir)
-            .await;
+        let load_result: Result<LoadSessionResponse, agent_client_protocol::Error> = async {
+            session = self
+                .prepare_session_for_activation(session, args.cwd.clone(), args.mcp_servers, true)
+                .await?;
 
-        let (mode_state, config_options) =
-            build_session_setup_config(&self.provider_inventory, &session).await?;
+            let replay_tool_requests = replay_conversation_to_client(cx, &session)?;
+            let (agent, extension_results) = self.prepare_acp_session_agent(cx, &session).await?;
+            self.apply_session_recipe(&agent, &session).await?;
+            self.register_acp_session(session_id_str.clone(), agent.clone(), replay_tool_requests)
+                .await;
 
-        send_session_setup_notifications(cx, &session, self.supports_goose_custom_notifications())?;
+            session = self
+                .session_manager
+                .get_session(&session_id_str, true)
+                .await
+                .internal_err_ctx("Failed to reload session")?;
 
-        let mut response = LoadSessionResponse::new().modes(mode_state);
-        if let Some(co) = config_options {
-            response = response.config_options(co);
+            agent
+                .extension_manager
+                .update_working_dir(&session.working_dir)
+                .await;
+
+            let (mode_state, config_options) =
+                build_session_setup_config(&self.provider_inventory, &session).await?;
+
+            send_session_setup_notifications(
+                cx,
+                &session,
+                self.supports_goose_custom_notifications(),
+            )?;
+
+            let mut response = LoadSessionResponse::new().modes(mode_state);
+            if let Some(co) = config_options {
+                response = response.config_options(co);
+            }
+
+            response = response.meta(session_response_meta(&session, &extension_results));
+
+            debug!(
+                target: "perf",
+                sid = %sid,
+                ms = t_start.elapsed().as_millis() as u64,
+                "perf: load_session_refactor done"
+            );
+            self.closed_session_ids.lock().await.remove(&session_id_str);
+            Ok(response)
         }
+        .await;
 
-        response = response.meta(session_response_meta(&session, &extension_results));
+        self.loading_session_ids
+            .lock()
+            .await
+            .remove(&session_id_str);
 
-        debug!(
-            target: "perf",
-            sid = %sid,
-            ms = t_start.elapsed().as_millis() as u64,
-            "perf: load_session_refactor done"
-        );
-        self.closed_session_ids.lock().await.remove(&session_id_str);
-        Ok(response)
+        load_result
     }
 }

--- a/crates/goose/src/acp/server/new_session.rs
+++ b/crates/goose/src/acp/server/new_session.rs
@@ -83,11 +83,13 @@ impl GooseAcpAgent {
         let response = self
             .build_new_session_response(&reloaded_session, &extension_results)
             .await?;
-        super::send_session_setup_notifications(
+        self.send_and_publish_session_notification(
             cx,
-            &reloaded_session,
-            self.supports_goose_custom_notifications(),
-        )?;
+            Self::session_info_notification(&reloaded_session),
+        )
+        .await?;
+        self.send_and_publish_session_setup_notifications(cx, &reloaded_session)
+            .await?;
         Ok(response)
     }
 

--- a/crates/goose/src/acp/session_events.rs
+++ b/crates/goose/src/acp/session_events.rs
@@ -1,0 +1,443 @@
+use crate::session::session_manager::{DB_NAME, SESSIONS_FOLDER};
+use agent_client_protocol::schema::v1::SessionNotification;
+use anyhow::{Context, Result};
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlx::{Pool, Row, Sqlite};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+use tokio::sync::OnceCell;
+
+const MAX_STORED_EVENTS: i64 = 10_000;
+const EVENT_RETENTION_SECONDS: i64 = 10 * 60;
+const PRUNE_EVERY_EVENTS: u64 = 128;
+
+pub(crate) struct AcpSessionEvent {
+    pub(crate) id: i64,
+    pub(crate) notification: SessionNotification,
+}
+
+pub(crate) struct AcpSessionEventStore {
+    pool: Pool<Sqlite>,
+    initialized: OnceCell<()>,
+    published_event_count: AtomicU64,
+}
+
+impl AcpSessionEventStore {
+    pub(crate) fn new(data_dir: PathBuf) -> Self {
+        let db_path = data_dir.join(SESSIONS_FOLDER).join(DB_NAME);
+        Self {
+            pool: Self::create_pool(&db_path),
+            initialized: OnceCell::new(),
+            published_event_count: AtomicU64::new(0),
+        }
+    }
+
+    fn create_pool(path: &Path) -> Pool<Sqlite> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("Failed to create session database directory");
+        }
+
+        let options = SqliteConnectOptions::new()
+            .filename(path)
+            .create_if_missing(true)
+            .foreign_keys(true)
+            .busy_timeout(Duration::from_secs(30))
+            .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal);
+
+        SqlitePoolOptions::new().connect_lazy_with(options)
+    }
+
+    async fn pool(&self) -> Result<&Pool<Sqlite>> {
+        self.initialized
+            .get_or_try_init(|| async {
+                sqlx::query(
+                    r#"
+                    CREATE TABLE IF NOT EXISTS acp_session_events (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        source_id TEXT NOT NULL,
+                        session_id TEXT NOT NULL,
+                        notification_json TEXT NOT NULL,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    )
+                    "#,
+                )
+                .execute(&self.pool)
+                .await?;
+
+                sqlx::query(
+                    r#"
+                    CREATE INDEX IF NOT EXISTS idx_acp_session_events_id_source
+                    ON acp_session_events(id, source_id)
+                    "#,
+                )
+                .execute(&self.pool)
+                .await?;
+
+                sqlx::query(
+                    r#"
+                    CREATE INDEX IF NOT EXISTS idx_acp_session_events_created_at
+                    ON acp_session_events(created_at)
+                    "#,
+                )
+                .execute(&self.pool)
+                .await?;
+
+                sqlx::query(
+                    r#"
+                    CREATE INDEX IF NOT EXISTS idx_acp_session_events_session_id
+                    ON acp_session_events(session_id)
+                    "#,
+                )
+                .execute(&self.pool)
+                .await?;
+
+                Self::prune_events(&self.pool).await?;
+
+                Ok::<(), anyhow::Error>(())
+            })
+            .await?;
+        Ok(&self.pool)
+    }
+
+    async fn session_table_exists(pool: &Pool<Sqlite>) -> Result<bool> {
+        let exists = sqlx::query_scalar::<_, bool>(
+            r#"
+            SELECT EXISTS (
+                SELECT 1
+                FROM sqlite_master
+                WHERE type = 'table' AND name = 'sessions'
+            )
+            "#,
+        )
+        .fetch_one(pool)
+        .await?;
+        Ok(exists)
+    }
+
+    async fn prune_events(pool: &Pool<Sqlite>) -> Result<()> {
+        sqlx::query(
+            r#"
+            DELETE FROM acp_session_events
+            WHERE created_at < datetime('now', '-' || ? || ' seconds')
+            "#,
+        )
+        .bind(EVENT_RETENTION_SECONDS)
+        .execute(pool)
+        .await?;
+
+        sqlx::query(
+            r#"
+            DELETE FROM acp_session_events
+            WHERE id <= (
+                SELECT COALESCE(MAX(id), 0) - ?
+                FROM acp_session_events
+            )
+            "#,
+        )
+        .bind(MAX_STORED_EVENTS)
+        .execute(pool)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn insert_event(
+        pool: &Pool<Sqlite>,
+        source_id: &str,
+        session_id: &str,
+        notification_json: String,
+    ) -> Result<u64> {
+        let result = if Self::session_table_exists(pool).await? {
+            sqlx::query(
+                r#"
+                INSERT INTO acp_session_events (source_id, session_id, notification_json)
+                SELECT ?, ?, ?
+                WHERE EXISTS (SELECT 1 FROM sessions WHERE id = ?)
+                "#,
+            )
+            .bind(source_id)
+            .bind(session_id)
+            .bind(notification_json)
+            .bind(session_id)
+            .execute(pool)
+            .await?
+        } else {
+            sqlx::query(
+                r#"
+                INSERT INTO acp_session_events (source_id, session_id, notification_json)
+                VALUES (?, ?, ?)
+                "#,
+            )
+            .bind(source_id)
+            .bind(session_id)
+            .bind(notification_json)
+            .execute(pool)
+            .await?
+        };
+
+        Ok(result.rows_affected())
+    }
+
+    fn should_prune_after_publish(&self) -> bool {
+        let count = self.published_event_count.fetch_add(1, Ordering::Relaxed) + 1;
+        count.is_multiple_of(PRUNE_EVERY_EVENTS)
+    }
+
+    pub(crate) async fn latest_event_id(&self) -> Result<i64> {
+        let pool = self.pool().await?;
+        let id = sqlx::query_scalar::<_, Option<i64>>("SELECT MAX(id) FROM acp_session_events")
+            .fetch_one(pool)
+            .await?
+            .unwrap_or(0);
+        Ok(id)
+    }
+
+    pub(crate) async fn publish(
+        &self,
+        source_id: &str,
+        notification: &SessionNotification,
+    ) -> Result<()> {
+        let pool = self.pool().await?;
+        let session_id = notification.session_id.0.as_ref();
+        let notification_json =
+            serde_json::to_string(notification).context("serialize ACP session notification")?;
+        let inserted = Self::insert_event(pool, source_id, session_id, notification_json).await?;
+        if inserted == 0 {
+            return Ok(());
+        }
+
+        if self.should_prune_after_publish() {
+            Self::prune_events(pool).await?;
+        }
+
+        Ok(())
+    }
+
+    pub(crate) async fn events_after(
+        &self,
+        last_seen_id: i64,
+        source_id: &str,
+        limit: i64,
+    ) -> Result<Vec<AcpSessionEvent>> {
+        let pool = self.pool().await?;
+        let rows = sqlx::query(
+            r#"
+            SELECT id, notification_json
+            FROM acp_session_events
+            WHERE id > ? AND source_id != ?
+            ORDER BY id ASC
+            LIMIT ?
+            "#,
+        )
+        .bind(last_seen_id)
+        .bind(source_id)
+        .bind(limit)
+        .fetch_all(pool)
+        .await?;
+
+        rows.into_iter()
+            .map(|row| {
+                let id: i64 = row.try_get("id")?;
+                let notification_json: String = row.try_get("notification_json")?;
+                let notification = serde_json::from_str(&notification_json)
+                    .with_context(|| format!("deserialize ACP session event {id}"))?;
+                Ok(AcpSessionEvent { id, notification })
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::GooseMode;
+    use crate::session::{SessionManager, SessionType};
+    use agent_client_protocol::schema::v1::{
+        ContentBlock, ContentChunk, SessionId, SessionUpdate, TextContent,
+    };
+    use std::path::PathBuf;
+
+    fn notification(session_id: &str, text: &str) -> SessionNotification {
+        SessionNotification::new(
+            SessionId::new(session_id.to_string()),
+            SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(
+                TextContent::new(text.to_string()),
+            ))),
+        )
+    }
+
+    #[tokio::test]
+    async fn events_after_excludes_same_source_and_preserves_order() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let data_dir = temp_dir.path().to_path_buf();
+        let store = AcpSessionEventStore::new(data_dir.clone());
+        let session_manager = SessionManager::new(data_dir);
+        let session = session_manager
+            .create_session(
+                PathBuf::from("/tmp/acp-session-event-order"),
+                "event order".to_string(),
+                SessionType::Acp,
+                GooseMode::default(),
+            )
+            .await
+            .unwrap();
+
+        let baseline = store.latest_event_id().await.unwrap();
+        store
+            .publish("source-a", &notification(&session.id, "first"))
+            .await
+            .unwrap();
+        store
+            .publish("source-b", &notification(&session.id, "second"))
+            .await
+            .unwrap();
+        store
+            .publish("source-c", &notification(&session.id, "third"))
+            .await
+            .unwrap();
+
+        let events = store.events_after(baseline, "source-a", 100).await.unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].notification.session_id.0.as_ref(), session.id);
+        assert_eq!(events[1].notification.session_id.0.as_ref(), session.id);
+        assert!(events[0].id > baseline);
+        assert!(events[1].id > events[0].id);
+
+        let value = serde_json::to_value(&events[0].notification).unwrap();
+        assert_eq!(
+            value["update"]["content"]["text"],
+            serde_json::Value::String("second".to_string())
+        );
+        let value = serde_json::to_value(&events[1].notification).unwrap();
+        assert_eq!(
+            value["update"]["content"]["text"],
+            serde_json::Value::String("third".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn events_after_reads_multiple_batches_in_order() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let data_dir = temp_dir.path().to_path_buf();
+        let store = AcpSessionEventStore::new(data_dir.clone());
+        let session_manager = SessionManager::new(data_dir);
+        let session = session_manager
+            .create_session(
+                PathBuf::from("/tmp/acp-session-event-batches"),
+                "event batches".to_string(),
+                SessionType::Acp,
+                GooseMode::default(),
+            )
+            .await
+            .unwrap();
+
+        let baseline = store.latest_event_id().await.unwrap();
+        for index in 0..5 {
+            store
+                .publish(
+                    "source-a",
+                    &notification(&session.id, &format!("event-{index}")),
+                )
+                .await
+                .unwrap();
+        }
+
+        let mut cursor = baseline;
+        let mut texts = Vec::new();
+        loop {
+            let events = store.events_after(cursor, "source-b", 2).await.unwrap();
+            if events.is_empty() {
+                break;
+            }
+            cursor = events.last().unwrap().id;
+            texts.extend(events.into_iter().map(|event| {
+                let value = serde_json::to_value(&event.notification).unwrap();
+                value["update"]["content"]["text"]
+                    .as_str()
+                    .unwrap()
+                    .to_string()
+            }));
+        }
+
+        assert_eq!(
+            texts,
+            vec!["event-0", "event-1", "event-2", "event-3", "event-4"]
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_session_removes_events_for_session_and_preserves_others() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let data_dir = temp_dir.path().to_path_buf();
+        let store = AcpSessionEventStore::new(data_dir.clone());
+        let session_manager = SessionManager::new(data_dir);
+        let deleted_session = session_manager
+            .create_session(
+                PathBuf::from("/tmp/acp-session-event-delete"),
+                "event delete".to_string(),
+                SessionType::Acp,
+                GooseMode::default(),
+            )
+            .await
+            .unwrap();
+        let retained_session = session_manager
+            .create_session(
+                PathBuf::from("/tmp/acp-session-event-retain"),
+                "event retain".to_string(),
+                SessionType::Acp,
+                GooseMode::default(),
+            )
+            .await
+            .unwrap();
+
+        let baseline = store.latest_event_id().await.unwrap();
+        store
+            .publish("source-a", &notification(&deleted_session.id, "first"))
+            .await
+            .unwrap();
+        store
+            .publish("source-b", &notification(&retained_session.id, "second"))
+            .await
+            .unwrap();
+
+        session_manager
+            .delete_session(&deleted_session.id)
+            .await
+            .unwrap();
+
+        let events = store.events_after(baseline, "source-c", 100).await.unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].notification.session_id.0.as_ref(),
+            retained_session.id
+        );
+    }
+
+    #[tokio::test]
+    async fn publish_skips_events_for_deleted_session() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let data_dir = temp_dir.path().to_path_buf();
+        let store = AcpSessionEventStore::new(data_dir.clone());
+        let session_manager = SessionManager::new(data_dir);
+        let session = session_manager
+            .create_session(
+                PathBuf::from("/tmp/acp-session-event-deleted-publish"),
+                "event deleted publish".to_string(),
+                SessionType::Acp,
+                GooseMode::default(),
+            )
+            .await
+            .unwrap();
+
+        let baseline = store.latest_event_id().await.unwrap();
+        session_manager.delete_session(&session.id).await.unwrap();
+        store
+            .publish("source-a", &notification(&session.id, "deleted"))
+            .await
+            .unwrap();
+
+        let events = store.events_after(baseline, "source-b", 100).await.unwrap();
+        assert!(events.is_empty());
+    }
+}

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -797,6 +797,32 @@ impl SessionStorage {
         Ok(&self.pool)
     }
 
+    async fn delete_acp_session_events_if_present(
+        tx: &mut sqlx::Transaction<'_, Sqlite>,
+        session_id: &str,
+    ) -> Result<()> {
+        let table_exists = sqlx::query_scalar::<_, bool>(
+            r#"
+            SELECT EXISTS (
+                SELECT 1
+                FROM sqlite_master
+                WHERE type = 'table' AND name = 'acp_session_events'
+            )
+            "#,
+        )
+        .fetch_one(&mut **tx)
+        .await?;
+
+        if table_exists {
+            sqlx::query("DELETE FROM acp_session_events WHERE session_id = ?")
+                .bind(session_id)
+                .execute(&mut **tx)
+                .await?;
+        }
+
+        Ok(())
+    }
+
     pub async fn create(session_dir: &Path) -> Result<Self> {
         let storage = Self::new(session_dir.to_path_buf());
         Self::create_schema(&storage.pool).await?;
@@ -1863,6 +1889,8 @@ impl SessionStorage {
             .bind(session_id)
             .execute(&mut *tx)
             .await?;
+
+        Self::delete_acp_session_events_if_present(&mut tx, session_id).await?;
 
         sqlx::query("DELETE FROM sessions WHERE id = ?")
             .bind(session_id)

--- a/crates/goose/tests/acp_fixtures/server.rs
+++ b/crates/goose/tests/acp_fixtures/server.rs
@@ -95,6 +95,15 @@ impl AcpServerSession {
 
         Ok(TestOutput { text, tool_status })
     }
+
+    #[allow(dead_code)]
+    pub async fn prompt_blocks(
+        &mut self,
+        content: Vec<ContentBlock>,
+        decision: PermissionDecision,
+    ) -> anyhow::Result<TestOutput> {
+        self.send_prompt(content, decision).await
+    }
 }
 
 impl AcpServerConnection {

--- a/crates/goose/tests/acp_fixtures/server.rs
+++ b/crates/goose/tests/acp_fixtures/server.rs
@@ -20,6 +20,7 @@ use goose_test_support::{ExpectedSessionId, IgnoreSessionId};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::Notify;
+use tokio::time::Instant;
 
 pub struct AcpServerConnection {
     cx: ConnectionTo<Agent>,
@@ -100,6 +101,54 @@ impl AcpServerConnection {
     #[allow(dead_code)]
     pub fn cx(&self) -> &ConnectionTo<Agent> {
         &self.cx
+    }
+
+    #[allow(dead_code)]
+    pub fn clear_session_notifications(&self) {
+        self.updates.lock().unwrap().clear();
+    }
+
+    #[allow(dead_code)]
+    pub fn session_updates(&self) -> Vec<SessionUpdate> {
+        self.updates
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|notification| notification.update.clone())
+            .collect()
+    }
+
+    #[allow(dead_code)]
+    pub async fn wait_for_session_update<F>(&self, timeout: Duration, predicate: F) -> bool
+    where
+        F: Fn(&SessionUpdate) -> bool,
+    {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if self
+                .updates
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|notification| predicate(&notification.update))
+            {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            if tokio::time::timeout_at(deadline, self.notify.notified())
+                .await
+                .is_err()
+            {
+                return self
+                    .updates
+                    .lock()
+                    .unwrap()
+                    .iter()
+                    .any(|notification| predicate(&notification.update));
+            }
+        }
     }
 }
 

--- a/crates/goose/tests/acp_server_test.rs
+++ b/crates/goose/tests/acp_server_test.rs
@@ -2,9 +2,9 @@
 #[path = "acp_common_tests/mod.rs"]
 mod common_tests;
 use agent_client_protocol::schema::v1::{
-    ListSessionsRequest, ListSessionsResponse, NewSessionRequest, SessionConfigKind,
-    SessionConfigOptionCategory, SessionConfigOptionValue, SessionInfo, SessionUpdate,
-    SetSessionConfigOptionRequest,
+    Annotations, ContentBlock, ListSessionsRequest, ListSessionsResponse, NewSessionRequest,
+    Role as AcpRole, SessionConfigKind, SessionConfigOptionCategory, SessionConfigOptionValue,
+    SessionInfo, SessionUpdate, SetSessionConfigOptionRequest, TextContent,
 };
 use agent_client_protocol::ErrorCode;
 use common_tests::fixtures::server::AcpServerConnection;
@@ -311,6 +311,86 @@ fn test_session_updates_broadcast_between_connections() {
                     | SessionUpdate::ToolCallUpdate(_)
             )),
             "list-only connection received content updates: {list_only_updates:#?}"
+        );
+    });
+}
+
+#[test]
+fn test_prompt_broadcast_filters_assistant_only_content() {
+    run_test(async {
+        let data_root = tempfile::tempdir().unwrap();
+        let actor_openai = OpenAiFixture::new(
+            vec![(
+                "Visible user prompt".to_string(),
+                include_str!("acp_test_data/openai_basic.txt"),
+            )],
+            <AcpServerConnection as Connection>::expected_session_id(),
+        )
+        .await;
+        let observer_openai = OpenAiFixture::new(
+            vec![],
+            <AcpServerConnection as Connection>::expected_session_id(),
+        )
+        .await;
+        let data_root_path = data_root.path().to_path_buf();
+        let mut observer = <AcpServerConnection as Connection>::new(
+            TestConnectionConfig {
+                data_root: data_root_path.clone(),
+                ..Default::default()
+            },
+            observer_openai,
+        )
+        .await;
+        let mut actor = <AcpServerConnection as Connection>::new(
+            TestConnectionConfig {
+                data_root: data_root_path,
+                ..Default::default()
+            },
+            actor_openai,
+        )
+        .await;
+
+        let SessionData {
+            session: mut actor_session,
+            ..
+        } = actor.new_session().await.unwrap();
+        let session_id = actor_session.session_id().0.to_string();
+        let _observer_session = observer.load_session(&session_id, vec![]).await.unwrap();
+        observer.clear_session_notifications();
+
+        let output = actor_session
+            .prompt_blocks(
+                vec![
+                    ContentBlock::Text(
+                        TextContent::new("hidden assistant context")
+                            .annotations(Annotations::new().audience(vec![AcpRole::Assistant])),
+                    ),
+                    ContentBlock::Text(TextContent::new("Visible user prompt")),
+                ],
+                common_tests::fixtures::PermissionDecision::Cancel,
+            )
+            .await
+            .unwrap();
+        assert_eq!(output.text, "2");
+
+        assert!(
+            observer
+                .wait_for_session_update(Duration::from_secs(2), |update| {
+                    matches!(
+                        update,
+                        agent_client_protocol::schema::v1::SessionUpdate::UserMessageChunk(_)
+                    ) && text_chunk(update) == Some("Visible user prompt")
+                })
+                .await,
+            "observer did not receive visible user prompt"
+        );
+
+        let updates = observer.session_updates();
+        assert!(
+            !updates
+                .iter()
+                .any(|update| text_chunk(update) == Some("hidden assistant context")),
+            "observer received assistant-only prompt content: {updates:#?}"
         );
     });
 }

--- a/crates/goose/tests/acp_server_test.rs
+++ b/crates/goose/tests/acp_server_test.rs
@@ -3,12 +3,14 @@
 mod common_tests;
 use agent_client_protocol::schema::v1::{
     ListSessionsRequest, ListSessionsResponse, NewSessionRequest, SessionConfigKind,
-    SessionConfigOptionCategory, SessionConfigOptionValue, SessionInfo,
+    SessionConfigOptionCategory, SessionConfigOptionValue, SessionInfo, SessionUpdate,
     SetSessionConfigOptionRequest,
 };
 use agent_client_protocol::ErrorCode;
 use common_tests::fixtures::server::AcpServerConnection;
-use common_tests::fixtures::{run_test, Connection, OpenAiFixture, Session, TestConnectionConfig};
+use common_tests::fixtures::{
+    run_test, Connection, OpenAiFixture, Session, SessionData, TestConnectionConfig,
+};
 #[cfg(feature = "code-mode")]
 use common_tests::run_prompt_codemode;
 use common_tests::{
@@ -30,6 +32,7 @@ use goose::recipe::{Recipe, Settings};
 use goose::recipe_deeplink;
 use goose::session::{SessionManager, SessionType};
 use std::path::Path;
+use std::time::Duration;
 
 tests_config_option_set_error!(AcpServerConnection);
 tests_mode_set_error!(AcpServerConnection);
@@ -138,6 +141,33 @@ fn last_message_snippet(session: &SessionInfo) -> Option<&str> {
         .and_then(serde_json::Value::as_str)
 }
 
+fn text_chunk(update: &SessionUpdate) -> Option<&str> {
+    match update {
+        SessionUpdate::UserMessageChunk(chunk) | SessionUpdate::AgentMessageChunk(chunk) => {
+            match &chunk.content {
+                agent_client_protocol::schema::v1::ContentBlock::Text(text) => {
+                    Some(text.text.as_str())
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn is_active_run_idle_update(update: &SessionUpdate) -> bool {
+    let SessionUpdate::SessionInfoUpdate(info) = update else {
+        return false;
+    };
+
+    info.meta
+        .as_ref()
+        .and_then(|meta| meta.get("goose"))
+        .and_then(serde_json::Value::as_object)
+        .and_then(|goose| goose.get("activeRunId"))
+        .is_some_and(serde_json::Value::is_null)
+}
+
 #[test]
 fn test_config_mcp() {
     run_test(async { run_config_mcp::<AcpServerConnection>().await });
@@ -151,6 +181,138 @@ fn test_config_option_mode_set() {
 #[test]
 fn test_list_sessions() {
     run_test(async { run_list_sessions::<AcpServerConnection>().await });
+}
+
+#[test]
+fn test_session_updates_broadcast_between_connections() {
+    run_test(async {
+        let data_root = tempfile::tempdir().unwrap();
+        let actor_openai = OpenAiFixture::new(
+            vec![(
+                "Cross-client broadcast prompt".to_string(),
+                include_str!("acp_test_data/openai_basic.txt"),
+            )],
+            <AcpServerConnection as Connection>::expected_session_id(),
+        )
+        .await;
+        let observer_openai = OpenAiFixture::new(
+            vec![],
+            <AcpServerConnection as Connection>::expected_session_id(),
+        )
+        .await;
+        let list_only_openai = OpenAiFixture::new(
+            vec![],
+            <AcpServerConnection as Connection>::expected_session_id(),
+        )
+        .await;
+        let data_root_path = data_root.path().to_path_buf();
+        let mut actor = <AcpServerConnection as Connection>::new(
+            TestConnectionConfig {
+                data_root: data_root_path.clone(),
+                ..Default::default()
+            },
+            actor_openai,
+        )
+        .await;
+        let mut observer = <AcpServerConnection as Connection>::new(
+            TestConnectionConfig {
+                data_root: data_root_path,
+                ..Default::default()
+            },
+            observer_openai,
+        )
+        .await;
+        let list_only = <AcpServerConnection as Connection>::new(
+            TestConnectionConfig {
+                data_root: data_root.path().to_path_buf(),
+                ..Default::default()
+            },
+            list_only_openai,
+        )
+        .await;
+
+        let SessionData {
+            session: mut actor_session,
+            ..
+        } = actor.new_session().await.unwrap();
+        let session_id = actor_session.session_id().0.to_string();
+        assert!(
+            observer
+                .wait_for_session_update(Duration::from_secs(2), |update| matches!(
+                    update,
+                    agent_client_protocol::schema::v1::SessionUpdate::SessionInfoUpdate(_)
+                ))
+                .await,
+            "observer did not receive session_info_update for session/new"
+        );
+        assert!(
+            list_only
+                .wait_for_session_update(Duration::from_secs(2), |update| matches!(
+                    update,
+                    agent_client_protocol::schema::v1::SessionUpdate::SessionInfoUpdate(_)
+                ))
+                .await,
+            "list-only connection did not receive session_info_update for session/new"
+        );
+
+        let _observer_session = observer.load_session(&session_id, vec![]).await.unwrap();
+        observer.clear_session_notifications();
+        list_only.clear_session_notifications();
+
+        let prompt_task = tokio::spawn(async move {
+            actor_session
+                .prompt(
+                    "Cross-client broadcast prompt",
+                    common_tests::fixtures::PermissionDecision::Cancel,
+                )
+                .await
+                .unwrap();
+        });
+
+        assert!(
+            observer
+                .wait_for_session_update(Duration::from_secs(2), |update| {
+                    matches!(
+                        update,
+                        agent_client_protocol::schema::v1::SessionUpdate::UserMessageChunk(_)
+                    ) && text_chunk(update) == Some("Cross-client broadcast prompt")
+                })
+                .await,
+            "observer did not receive live user_message_chunk"
+        );
+        prompt_task.await.unwrap();
+        let received_agent_chunk = observer
+            .wait_for_session_update(Duration::from_secs(2), |update| {
+                matches!(
+                    update,
+                    agent_client_protocol::schema::v1::SessionUpdate::AgentMessageChunk(_)
+                )
+            })
+            .await;
+        assert!(
+            received_agent_chunk,
+            "observer did not receive live agent_message_chunk; updates: {:#?}",
+            observer.session_updates()
+        );
+        assert!(
+            list_only
+                .wait_for_session_update(Duration::from_secs(2), is_active_run_idle_update)
+                .await,
+            "list-only connection did not receive active-run completion barrier"
+        );
+        let list_only_updates = list_only.session_updates();
+        assert!(
+            !list_only_updates.iter().any(|update| matches!(
+                update,
+                SessionUpdate::UserMessageChunk(_)
+                    | SessionUpdate::AgentMessageChunk(_)
+                    | SessionUpdate::AgentThoughtChunk(_)
+                    | SessionUpdate::ToolCall(_)
+                    | SessionUpdate::ToolCallUpdate(_)
+            )),
+            "list-only connection received content updates: {list_only_updates:#?}"
+        );
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Broadcast ACP `session/update` notifications across clients that share a Goose data directory, so sessions created or prompted from one ACP connection update other connected clients.

This adds a SQLite-backed live event queue used by both `goose serve` WebSocket agents and separate `goose acp` stdio processes. Transcript/content updates are only forwarded to clients that have loaded or are loading that session; list-only clients receive session metadata only.

The queue skips events for deleted sessions, prunes stale events, strips `lastMessageSnippet` from broadcast metadata, and purges event rows when a session is deleted.

Fixes #10130.

## Testing

- Focused Rust coverage for event ordering, batch delivery, session-scoped deletion cleanup, deleted-session publish drops, broadcast metadata redaction, and cross-connection ACP updates.
- Full ACP server test binary plus fork/truncate focused tests.
- Clippy with warnings denied.
- Built `goose-cli`.
- Manual black-box probes for `goose serve` WebSocket clients and separate `goose acp` stdio processes using a mock OpenAI stream; observer clients received live user and assistant chunks before the actor prompt resolved, while list-only clients received no content updates.

*🤖 This PR was authored [with an agent](codex://threads/019f1b22-d652-7702-8ae3-64ac1ee98420).*
