### PR TITLE
Broadcast ACP session updates across WebSocket clients

### DIFF
--- a/crates/goose/src/acp/fs.rs
+++ b/crates/goose/src/acp/fs.rs
@@ -1,3 +1,4 @@
+use crate::acp::session_broadcast::SessionBroadcastHub;
 use crate::acp::tools::AcpAwareToolMeta;
 use crate::agents::mcp_client::{Error as McpError, McpClientTrait};
 use crate::agents::platform_extensions::developer::edit::{
@@ -64,6 +65,8 @@ pub(crate) struct AcpTools {
     pub(crate) inner: Arc<dyn McpClientTrait>,
     pub(crate) cx: ConnectionTo<Client>,
     pub(crate) session_id: SessionId,
+    pub(crate) session_broadcast: Option<Arc<SessionBroadcastHub>>,
+    pub(crate) session_broadcast_source_id: String,
     pub(crate) fs_read: bool,
     pub(crate) fs_write: bool,
     pub(crate) terminal: bool,
@@ -95,16 +98,20 @@ fn read_tool() -> Tool {
 impl AcpTools {
     fn update_tool_call(&self, ctx: &crate::agents::ToolCallContext, fields: ToolCallUpdateFields) {
         if let Some(ref req_id) = ctx.tool_call_request_id {
+            let notification = SessionNotification::new(
+                self.session_id.clone(),
+                SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+                    ToolCallId::new(req_id.clone()),
+                    fields,
+                )),
+            );
             let _ = self
                 .cx
-                .send_notification(SessionNotification::new(
-                    self.session_id.clone(),
-                    SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
-                        ToolCallId::new(req_id.clone()),
-                        fields,
-                    )),
-                ))
+                .send_notification(notification.clone())
                 .inspect_err(|e| tracing::error!("error updating tool call with client: {}", e));
+            if let Some(hub) = &self.session_broadcast {
+                hub.publish(&self.session_broadcast_source_id, notification);
+            }
         }
     }
 

--- a/crates/goose/src/acp/mod.rs
+++ b/crates/goose/src/acp/mod.rs
@@ -5,6 +5,7 @@ mod provider;
 mod response_builder;
 pub mod server;
 pub mod server_factory;
+pub(crate) mod session_broadcast;
 pub(crate) mod tools;
 pub mod transport;
 

--- a/crates/goose/src/acp/response_builder.rs
+++ b/crates/goose/src/acp/response_builder.rs
@@ -403,20 +403,31 @@ pub(super) fn send_session_setup_notifications(
     session: &Session,
     supports_goose_custom_notifications: bool,
 ) -> Result<(), agent_client_protocol::Error> {
-    let session_id = SessionId::new(session.id.clone());
     if let Some(updates) = build_usage_updates(session) {
         if supports_goose_custom_notifications {
             cx.send_notification(updates.custom)?;
         }
-        cx.send_notification(SessionNotification::new(
+    }
+    for notification in session_setup_notifications(session) {
+        cx.send_notification(notification)?;
+    }
+    Ok(())
+}
+
+pub(super) fn session_setup_notifications(session: &Session) -> Vec<SessionNotification> {
+    let session_id = SessionId::new(session.id.clone());
+    let mut notifications = Vec::new();
+    if let Some(updates) = build_usage_updates(session) {
+        notifications.push(SessionNotification::new(
             session_id.clone(),
             SessionUpdate::UsageUpdate(updates.standard),
-        ))?;
+        ));
     }
-    cx.send_notification(SessionNotification::new(
+    notifications.push(SessionNotification::new(
         session_id,
         SessionUpdate::AvailableCommandsUpdate(available_commands_update(&session.working_dir)),
-    ))
+    ));
+    notifications
 }
 
 #[cfg(test)]

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -2564,10 +2564,13 @@ impl GooseAcpAgent {
         message: &Message,
     ) -> Result<(), agent_client_protocol::Error> {
         for content_item in &message.content {
-            if let Some(error) = prompt_error_from_message_content(content_item) {
+            let Some(content_item) = content_item.filter_for_audience(Role::User) else {
+                continue;
+            };
+            if let Some(error) = prompt_error_from_message_content(&content_item) {
                 return Err(error);
             }
-            let block = match content_item {
+            let block = match &content_item {
                 MessageContent::Text(text) => {
                     ContentBlock::Text(TextContent::new(text.text.clone()))
                 }

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -987,34 +987,6 @@ impl GooseAcpAgent {
         )
     }
 
-    async fn slash_command_has_registered_handler(
-        &self,
-        command: &str,
-        session_id: &str,
-    ) -> Result<bool, agent_client_protocol::Error> {
-        if Self::is_builtin_agent_command(command) {
-            return Ok(true);
-        }
-
-        let full_command = format!("/{command}");
-        if crate::slash_commands::recipe_slash_command::get_recipe_for_command(&full_command)
-            .is_some_and(|path| path.exists())
-        {
-            return Ok(true);
-        }
-
-        let session = self
-            .session_manager
-            .get_session(session_id, false)
-            .await
-            .internal_err_ctx("Failed to load session")?;
-        Ok(
-            crate::skills::list_installed_skills(Some(&session.working_dir))
-                .into_iter()
-                .any(|skill| skill.name.eq_ignore_ascii_case(command)),
-        )
-    }
-
     pub(super) fn send_and_broadcast_session_setup_notifications(
         &self,
         cx: &ConnectionTo<Client>,
@@ -2702,11 +2674,7 @@ impl GooseAcpAgent {
             }
         }
         let should_broadcast_prompt_message = match &parsed_slash_command {
-            Some(parsed) => {
-                !self
-                    .slash_command_has_registered_handler(parsed.command, &session_id)
-                    .await?
-            }
+            Some(parsed) => !Self::is_builtin_agent_command(parsed.command),
             None => true,
         };
         let live_user_message = user_message.clone();

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -4,8 +4,10 @@ use crate::acp::fs::AcpTools;
 pub(super) use crate::acp::response_builder::{
     build_config_options, build_mode_state, build_model_state, build_provider_options,
     build_session_info, build_session_setup_config, send_session_setup_notifications, session_meta,
-    session_provider_selection, session_response_meta, should_refresh_inventory_for_session_init,
+    session_provider_selection, session_response_meta, session_setup_notifications,
+    should_refresh_inventory_for_session_init,
 };
+use crate::acp::session_broadcast::SessionBroadcastHub;
 use crate::acp::tools::AcpAwareToolMeta;
 use crate::acp::{PermissionDecision, ACP_CURRENT_MODEL};
 use crate::agents::extension::{Envs, PLATFORM_EXTENSIONS};
@@ -224,6 +226,9 @@ pub struct GooseAcpAgent {
     client_supports_recipe_param_requests: OnceCell<bool>,
     use_login_shell_path: OnceCell<bool>,
     client_cx: OnceCell<ConnectionTo<Client>>,
+    session_broadcast: OnceCell<Arc<SessionBroadcastHub>>,
+    session_broadcast_forwarder_started: OnceCell<()>,
+    session_broadcast_source_id: String,
     config_dir: std::path::PathBuf,
     session_manager: Arc<SessionManager>,
     permission_manager: Arc<PermissionManager>,
@@ -275,6 +280,8 @@ fn agent_capabilities_meta() -> Option<Meta> {
 
 fn spawn_session_name_update_notifier(
     cx: ConnectionTo<Client>,
+    session_broadcast: Option<Arc<SessionBroadcastHub>>,
+    source_id: String,
 ) -> tokio::sync::mpsc::UnboundedSender<crate::session::SessionNameUpdate> {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<crate::session::SessionNameUpdate>();
     tokio::spawn(async move {
@@ -297,12 +304,15 @@ fn spawn_session_name_update_notifier(
                         .meta(meta),
                 ),
             );
-            if let Err(error) = cx.send_notification(notification) {
+            if let Err(error) = cx.send_notification(notification.clone()) {
                 warn!(
                     session_id = %update.session_id,
                     error = %error,
                     "Failed to send generated session name update"
                 );
+            }
+            if let Some(hub) = &session_broadcast {
+                hub.publish(&source_id, notification);
             }
         }
     });
@@ -904,6 +914,123 @@ impl GooseAcpAgent {
             .unwrap_or(false)
     }
 
+    fn enable_session_broadcast(&self, hub: Arc<SessionBroadcastHub>) {
+        let _ = self.session_broadcast.set(hub);
+    }
+
+    fn start_session_broadcast_forwarder(
+        &self,
+        cx: &ConnectionTo<Client>,
+    ) -> Result<(), agent_client_protocol::Error> {
+        let Some(hub) = self.session_broadcast.get() else {
+            return Ok(());
+        };
+        if self.session_broadcast_forwarder_started.set(()).is_err() {
+            return Ok(());
+        }
+
+        let mut rx = hub.subscribe();
+        let source_id = self.session_broadcast_source_id.clone();
+        let cx_for_task = cx.clone();
+        cx.clone().spawn(async move {
+            loop {
+                match rx.recv().await {
+                    Ok(event) => {
+                        if event.source_id != source_id {
+                            if let Err(error) = cx_for_task.send_notification(event.notification) {
+                                warn!(%error, "failed to forward ACP session broadcast");
+                            }
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                        warn!(skipped, "ACP session broadcast receiver lagged");
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+
+    fn broadcast_session_notification(&self, notification: &SessionNotification) {
+        if let Some(hub) = self.session_broadcast.get() {
+            hub.publish(&self.session_broadcast_source_id, notification.clone());
+        }
+    }
+
+    pub(super) fn send_and_broadcast_session_notification(
+        &self,
+        cx: &ConnectionTo<Client>,
+        notification: SessionNotification,
+    ) -> Result<(), agent_client_protocol::Error> {
+        if let Some(hub) = self.session_broadcast.get() {
+            cx.send_notification(notification.clone())?;
+            hub.publish(&self.session_broadcast_source_id, notification);
+        } else {
+            cx.send_notification(notification)?;
+        }
+        Ok(())
+    }
+
+    fn session_info_notification(session: &Session) -> SessionNotification {
+        let mut update = SessionInfoUpdate::new()
+            .updated_at(session.updated_at.to_rfc3339())
+            .meta(session_meta(session));
+        if !session.name.is_empty() {
+            update = update.title(session.name.clone());
+        }
+        SessionNotification::new(
+            SessionId::new(session.id.clone()),
+            SessionUpdate::SessionInfoUpdate(update),
+        )
+    }
+
+    async fn slash_command_has_registered_handler(
+        &self,
+        command: &str,
+        session_id: &str,
+    ) -> Result<bool, agent_client_protocol::Error> {
+        if Self::is_builtin_agent_command(command) {
+            return Ok(true);
+        }
+
+        let full_command = format!("/{command}");
+        if crate::slash_commands::recipe_slash_command::get_recipe_for_command(&full_command)
+            .is_some_and(|path| path.exists())
+        {
+            return Ok(true);
+        }
+
+        let session = self
+            .session_manager
+            .get_session(session_id, false)
+            .await
+            .internal_err_ctx("Failed to load session")?;
+        Ok(
+            crate::skills::list_installed_skills(Some(&session.working_dir))
+                .into_iter()
+                .any(|skill| skill.name.eq_ignore_ascii_case(command)),
+        )
+    }
+
+    pub(super) fn send_and_broadcast_session_setup_notifications(
+        &self,
+        cx: &ConnectionTo<Client>,
+        session: &Session,
+    ) -> Result<(), agent_client_protocol::Error> {
+        if let Some(updates) = build_usage_updates(session) {
+            if self.supports_goose_custom_notifications() {
+                cx.send_notification(updates.custom)?;
+            }
+        }
+        for notification in session_setup_notifications(session) {
+            self.send_and_broadcast_session_notification(cx, notification)?;
+        }
+        Ok(())
+    }
+
     // TODO: goose reads Paths::in_state_dir globally (e.g. RequestLog), ignoring this data_dir.
     pub async fn new(options: GooseAcpAgentOptions) -> Result<Self> {
         let session_manager = Arc::new(SessionManager::new(options.data_dir));
@@ -941,6 +1068,9 @@ impl GooseAcpAgent {
             client_supports_recipe_param_requests: OnceCell::new(),
             use_login_shell_path: OnceCell::new(),
             client_cx: OnceCell::new(),
+            session_broadcast: OnceCell::new(),
+            session_broadcast_forwarder_started: OnceCell::new(),
+            session_broadcast_source_id: Uuid::new_v4().to_string(),
             config_dir: options.config_dir,
             session_manager,
             permission_manager,
@@ -1010,8 +1140,13 @@ impl GooseAcpAgent {
                 RuntimeContext {
                     mcp_host_info: self.client_mcp_host_info.get().cloned(),
                     use_login_shell_path: self.use_login_shell_path.get().copied(),
-                    session_name_update_tx: (!self.disable_session_naming)
-                        .then(|| spawn_session_name_update_notifier(cx.clone())),
+                    session_name_update_tx: (!self.disable_session_naming).then(|| {
+                        spawn_session_name_update_notifier(
+                            cx.clone(),
+                            self.session_broadcast.get().cloned(),
+                            self.session_broadcast_source_id.clone(),
+                        )
+                    }),
                 },
             )
             .await
@@ -1100,6 +1235,8 @@ impl GooseAcpAgent {
             inner: Arc::new(dev_client),
             cx: cx.clone(),
             session_id: SessionId::new(session.id.clone()),
+            session_broadcast: self.session_broadcast.get().cloned(),
+            session_broadcast_source_id: self.session_broadcast_source_id.clone(),
             fs_read: client_fs_capabilities.read_text_file,
             fs_write: client_fs_capabilities.write_text_file,
             terminal: client_terminal,
@@ -1336,7 +1473,10 @@ impl GooseAcpAgent {
                     Role::User => SessionUpdate::UserMessageChunk(chunk),
                     Role::Assistant => SessionUpdate::AgentMessageChunk(chunk),
                 };
-                cx.send_notification(SessionNotification::new(session_id.clone(), update))?;
+                self.send_and_broadcast_session_notification(
+                    cx,
+                    SessionNotification::new(session_id.clone(), update),
+                )?;
             }
             MessageContent::ToolRequest(tool_request) => {
                 self.handle_tool_request(
@@ -1361,19 +1501,22 @@ impl GooseAcpAgent {
                 .await?;
             }
             MessageContent::Thinking(thinking) => {
-                cx.send_notification(SessionNotification::new(
-                    session_id.clone(),
-                    SessionUpdate::AgentThoughtChunk(
-                        ContentChunk::new(ContentBlock::Text(TextContent::new(
-                            thinking.thinking.clone(),
-                        )))
-                        .meta(message_update_meta(
-                            message_id,
-                            message_created,
-                            steer,
-                        )),
+                self.send_and_broadcast_session_notification(
+                    cx,
+                    SessionNotification::new(
+                        session_id.clone(),
+                        SessionUpdate::AgentThoughtChunk(
+                            ContentChunk::new(ContentBlock::Text(TextContent::new(
+                                thinking.thinking.clone(),
+                            )))
+                            .meta(message_update_meta(
+                                message_id,
+                                message_created,
+                                steer,
+                            )),
+                        ),
                     ),
-                ))?;
+                )?;
             }
             MessageContent::ActionRequired(action_required) => match &action_required.data {
                 ActionRequiredData::ToolConfirmation {
@@ -1439,10 +1582,13 @@ impl GooseAcpAgent {
         let initial_tool_call = pending_tool_call
             .tool_call
             .meta(pending_tool_call.identity_meta.clone());
-        cx.send_notification(SessionNotification::new(
-            session_id.clone(),
-            SessionUpdate::ToolCall(initial_tool_call),
-        ))?;
+        self.send_and_broadcast_session_notification(
+            cx,
+            SessionNotification::new(
+                session_id.clone(),
+                SessionUpdate::ToolCall(initial_tool_call),
+            ),
+        )?;
 
         if Config::global()
             .get_goose_disable_tool_call_summary()
@@ -1462,6 +1608,8 @@ impl GooseAcpAgent {
             let session_id_for_persist = session_id_for_persist.to_string();
             let message_id_for_persist = message_id.map(|s| s.to_string());
             let session_manager = self.session_manager.clone();
+            let session_broadcast = self.session_broadcast.get().cloned();
+            let source_id = self.session_broadcast_source_id.clone();
             let args_json = tool_call
                 .arguments
                 .as_ref()
@@ -1570,13 +1718,17 @@ impl GooseAcpAgent {
                 };
 
                 let fields = ToolCallUpdateFields::new().title(title.clone());
-                let _ = cx.send_notification(SessionNotification::new(
+                let notification = SessionNotification::new(
                     sid,
                     SessionUpdate::ToolCallUpdate(
                         ToolCallUpdate::new(ToolCallId::new(request_id.clone()), fields)
                             .meta(identity_meta),
                     ),
-                ));
+                );
+                let _ = cx.send_notification(notification.clone());
+                if let Some(hub) = &session_broadcast {
+                    hub.publish(&source_id, notification);
+                }
 
                 // Best-effort persistence: only persist the LLM-generated title
                 // (not the deterministic fallback) so reload uses fallback_title
@@ -1652,10 +1804,10 @@ impl GooseAcpAgent {
 
         let update = ToolCallUpdate::new(ToolCallId::new(tool_response.id.clone()), fields)
             .meta(extract_tool_call_update_meta(tool_response));
-        cx.send_notification(SessionNotification::new(
-            session_id.clone(),
-            SessionUpdate::ToolCallUpdate(update),
-        ))?;
+        self.send_and_broadcast_session_notification(
+            cx,
+            SessionNotification::new(session_id.clone(), SessionUpdate::ToolCallUpdate(update)),
+        )?;
 
         // Chain summarization: when this response completes a multi-tool
         // chain, fire one LLM summary covering the run.
@@ -1753,6 +1905,8 @@ impl GooseAcpAgent {
         let chain_for_task = chain.clone();
         let cx = cx.clone();
         let session_manager = self.session_manager.clone();
+        let session_broadcast = self.session_broadcast.get().cloned();
+        let source_id = self.session_broadcast_source_id.clone();
 
         let first_id = first_id.clone();
         tokio::spawn(async move {
@@ -1869,12 +2023,16 @@ impl GooseAcpAgent {
 
             let meta = with_tool_chain_summary_meta(identity_meta, &summary, count);
             let fields = ToolCallUpdateFields::new();
-            let _ = cx.send_notification(SessionNotification::new(
+            let notification = SessionNotification::new(
                 sid,
                 SessionUpdate::ToolCallUpdate(
                     ToolCallUpdate::new(ToolCallId::new(first_id), fields).meta(meta),
                 ),
-            ));
+            );
+            let _ = cx.send_notification(notification.clone());
+            if let Some(hub) = &session_broadcast {
+                hub.publish(&source_id, notification);
+            }
         });
     }
 
@@ -2384,20 +2542,25 @@ impl GooseAcpAgent {
         meta
     }
 
-    fn send_active_run_update(
+    fn send_and_broadcast_active_run_update(
+        &self,
         cx: &ConnectionTo<Client>,
         session_id: &SessionId,
         active_run_id: Option<&str>,
     ) -> Result<(), agent_client_protocol::Error> {
-        cx.send_notification(SessionNotification::new(
-            session_id.clone(),
-            SessionUpdate::SessionInfoUpdate(
-                SessionInfoUpdate::new().meta(Self::active_run_meta(active_run_id)),
+        self.send_and_broadcast_session_notification(
+            cx,
+            SessionNotification::new(
+                session_id.clone(),
+                SessionUpdate::SessionInfoUpdate(
+                    SessionInfoUpdate::new().meta(Self::active_run_meta(active_run_id)),
+                ),
             ),
-        ))
+        )
     }
 
-    fn send_queued_steer_update(
+    fn send_and_broadcast_queued_steer_update(
+        &self,
         cx: &ConnectionTo<Client>,
         session_id: &SessionId,
         message_id: &str,
@@ -2414,10 +2577,45 @@ impl GooseAcpAgent {
         let mut meta = serde_json::Map::new();
         meta.insert("goose".to_string(), serde_json::Value::Object(goose));
 
-        cx.send_notification(SessionNotification::new(
-            session_id.clone(),
-            SessionUpdate::SessionInfoUpdate(SessionInfoUpdate::new().meta(meta)),
-        ))
+        self.send_and_broadcast_session_notification(
+            cx,
+            SessionNotification::new(
+                session_id.clone(),
+                SessionUpdate::SessionInfoUpdate(SessionInfoUpdate::new().meta(meta)),
+            ),
+        )
+    }
+
+    fn broadcast_prompt_message(
+        &self,
+        session_id: &SessionId,
+        message: &Message,
+    ) -> Result<(), agent_client_protocol::Error> {
+        for content_item in &message.content {
+            if let Some(error) = prompt_error_from_message_content(content_item) {
+                return Err(error);
+            }
+            let block = match content_item {
+                MessageContent::Text(text) => {
+                    ContentBlock::Text(TextContent::new(text.text.clone()))
+                }
+                MessageContent::Image(image) => ContentBlock::Image(ImageContent::new(
+                    image.data.clone(),
+                    image.mime_type.clone(),
+                )),
+                _ => continue,
+            };
+            let chunk = ContentChunk::new(block).meta(message_update_meta(
+                message.id.as_deref(),
+                message.created,
+                message.metadata.steer,
+            ));
+            self.broadcast_session_notification(&SessionNotification::new(
+                session_id.clone(),
+                SessionUpdate::UserMessageChunk(chunk),
+            ));
+        }
+        Ok(())
     }
 
     async fn on_load_session(
@@ -2453,19 +2651,23 @@ impl GooseAcpAgent {
 
         if cancel_token.is_cancelled() {
             self.clear_active_run(&session_id, &run_id).await;
-            Self::send_active_run_update(cx, &args.session_id, None)?;
+            self.send_and_broadcast_active_run_update(cx, &args.session_id, None)?;
             return Ok(PromptResponse::new(StopReason::Cancelled));
         }
 
-        if let Err(error) = Self::send_active_run_update(cx, &args.session_id, Some(&run_id)) {
+        if let Err(error) =
+            self.send_and_broadcast_active_run_update(cx, &args.session_id, Some(&run_id))
+        {
             self.clear_active_run(&session_id, &run_id).await;
             return Err(error);
         }
 
-        let user_message = Self::convert_acp_prompt_to_message(&args.prompt);
+        let user_message = Self::convert_acp_prompt_to_message(&args.prompt).with_generated_id();
 
         let message_text = user_message.as_concat_text();
-        if let Some(parsed) = crate::agents::execute_commands::parse_slash_command(&message_text) {
+        let parsed_slash_command =
+            crate::agents::execute_commands::parse_slash_command(&message_text);
+        if let Some(parsed) = &parsed_slash_command {
             let full_command = format!("/{}", parsed.command);
 
             if !Self::is_builtin_agent_command(parsed.command) {
@@ -2475,23 +2677,39 @@ impl GooseAcpAgent {
                     )
                 {
                     if recipe_path.exists() {
-                        if let Err(error) = cx.send_notification(SessionNotification::new(
-                            args.session_id.clone(),
-                            SessionUpdate::AgentMessageChunk(ContentChunk::new(
-                                ContentBlock::Text(TextContent::new(format!(
-                                    "Running recipe: {}",
-                                    full_command
-                                ))),
-                            )),
-                        )) {
+                        if let Err(error) = self.send_and_broadcast_session_notification(
+                            cx,
+                            SessionNotification::new(
+                                args.session_id.clone(),
+                                SessionUpdate::AgentMessageChunk(ContentChunk::new(
+                                    ContentBlock::Text(TextContent::new(format!(
+                                        "Running recipe: {}",
+                                        full_command
+                                    ))),
+                                )),
+                            ),
+                        ) {
                             self.clear_active_run(&session_id, &run_id).await;
-                            let _ = Self::send_active_run_update(cx, &args.session_id, None);
+                            let _ = self.send_and_broadcast_active_run_update(
+                                cx,
+                                &args.session_id,
+                                None,
+                            );
                             return Err(error);
                         }
                     }
                 }
             }
         }
+        let should_broadcast_prompt_message = match &parsed_slash_command {
+            Some(parsed) => {
+                !self
+                    .slash_command_has_registered_handler(parsed.command, &session_id)
+                    .await?
+            }
+            None => true,
+        };
+        let live_user_message = user_message.clone();
 
         let session_config = SessionConfig {
             id: session_id.clone(),
@@ -2507,11 +2725,19 @@ impl GooseAcpAgent {
             Ok(stream) => stream,
             Err(error) => {
                 self.clear_active_run(&session_id, &run_id).await;
-                let _ = Self::send_active_run_update(cx, &args.session_id, None);
+                let _ = self.send_and_broadcast_active_run_update(cx, &args.session_id, None);
                 return Err(agent_client_protocol::Error::internal_error()
                     .data(format!("Error getting agent reply: {error}")));
             }
         };
+        if should_broadcast_prompt_message {
+            if let Err(error) = self.broadcast_prompt_message(&args.session_id, &live_user_message)
+            {
+                self.clear_active_run(&session_id, &run_id).await;
+                let _ = self.send_and_broadcast_active_run_update(cx, &args.session_id, None);
+                return Err(error);
+            }
+        }
 
         let mut was_cancelled = false;
         let mut first_event_logged = false;
@@ -2619,10 +2845,10 @@ impl GooseAcpAgent {
                     if let Some(update) =
                         tool_notifications::tool_notification_update(request_id, notification)
                     {
-                        cx.send_notification(SessionNotification::new(
-                            args.session_id.clone(),
-                            update,
-                        ))?;
+                        self.send_and_broadcast_session_notification(
+                            cx,
+                            SessionNotification::new(args.session_id.clone(), update),
+                        )?;
                     }
                 }
                 Ok(_) => {}
@@ -2647,7 +2873,7 @@ impl GooseAcpAgent {
             }
         }
         self.clear_active_run(&session_id, &run_id).await;
-        Self::send_active_run_update(cx, &args.session_id, None)?;
+        self.send_and_broadcast_active_run_update(cx, &args.session_id, None)?;
         if let Some(error) = stream_error {
             return Err(error);
         }
@@ -2664,10 +2890,13 @@ impl GooseAcpAgent {
             // Standard ACP notification — emitted alongside the custom one for
             // backwards compatibility. Remove once all known clients have
             // migrated to `_goose/unstable/session/update`.
-            cx.send_notification(SessionNotification::new(
-                args.session_id.clone(),
-                SessionUpdate::UsageUpdate(updates.standard),
-            ))?;
+            self.send_and_broadcast_session_notification(
+                cx,
+                SessionNotification::new(
+                    args.session_id.clone(),
+                    SessionUpdate::UsageUpdate(updates.standard),
+                ),
+            )?;
         }
 
         debug!(
@@ -2719,7 +2948,7 @@ impl GooseAcpAgent {
         agent.steer(&req.session_id, message).await;
 
         if let Some(cx) = self.client_cx.get() {
-            let _ = Self::send_queued_steer_update(
+            let _ = self.send_and_broadcast_queued_steer_update(
                 cx,
                 &SessionId::new(req.session_id.clone()),
                 &message_id,
@@ -3025,6 +3254,7 @@ impl agent_client_protocol::ConnectTo<Client> for GooseAgentConnection {
         client: impl agent_client_protocol::ConnectTo<SacpAgent>,
     ) -> std::result::Result<(), agent_client_protocol::Error> {
         let agent = self.server.create_agent().await.internal_err()?;
+        agent.enable_session_broadcast(self.server.session_broadcast());
         let handler = GooseAcpHandler { agent };
         SacpAgent
             .builder()

--- a/crates/goose/src/acp/server/dispatch.rs
+++ b/crates/goose/src/acp/server/dispatch.rs
@@ -29,7 +29,11 @@ impl HandleDispatchFrom<Client> for GooseAcpHandler {
             MatchDispatchFrom::new(message, &cx)
                 .if_request(
                     |req: InitializeRequest, responder: Responder<InitializeResponse>| async {
-                        responder.respond_with_result(agent.on_initialize(req).await)
+                        let response = agent.on_initialize(req).await;
+                        if response.is_ok() {
+                            agent.start_session_broadcast_forwarder(&cx)?;
+                        }
+                        responder.respond_with_result(response)
                     },
                 )
                 .await
@@ -151,7 +155,7 @@ impl HandleDispatchFrom<Client> for GooseAcpHandler {
                             }
                             // Respond immediately using the current provider inventory snapshot.
                             let (notification, config_options) = agent.build_config_update(&session_id).await?;
-                            cx.send_notification(notification)?;
+                            agent.send_and_broadcast_session_notification(&cx, notification)?;
                             responder.respond(SetSessionConfigOptionResponse::new(config_options))?;
 
                             let maybe_refresh = if config_id == "provider" {
@@ -245,8 +249,11 @@ impl HandleDispatchFrom<Client> for GooseAcpHandler {
                                             match agent_bg.build_config_update(&session_id_bg).await
                                             {
                                                 Ok((fresh_notification, _)) => {
-                                                    let _ = cx_bg
-                                                        .send_notification(fresh_notification);
+                                                    let _ = agent_bg
+                                                        .send_and_broadcast_session_notification(
+                                                            &cx_bg,
+                                                            fresh_notification,
+                                                        );
                                                 }
                                                 Err(error) => warn!(
                                                     provider = %refresh_provider_id,
@@ -308,12 +315,15 @@ impl HandleDispatchFrom<Client> for GooseAcpHandler {
                             match agent.on_set_mode(&session_id.0, &mode_id.0).await {
                                 Ok(resp) => {
                                     // Notify before responding so clients see the mode update before block_task unblocks.
-                                    cx.send_notification(SessionNotification::new(
-                                        session_id,
-                                        SessionUpdate::CurrentModeUpdate(
-                                            CurrentModeUpdate::new(mode_id),
+                                    agent.send_and_broadcast_session_notification(
+                                        &cx,
+                                        SessionNotification::new(
+                                            session_id,
+                                            SessionUpdate::CurrentModeUpdate(
+                                                CurrentModeUpdate::new(mode_id),
+                                            ),
                                         ),
-                                    ))?;
+                                    )?;
                                     responder.respond(resp)?;
                                 }
                                 Err(e) => {

--- a/crates/goose/src/acp/server/fork_session.rs
+++ b/crates/goose/src/acp/server/fork_session.rs
@@ -72,11 +72,8 @@ impl GooseAcpAgent {
         if let Some(co) = config_options {
             response = response.config_options(co);
         }
-        send_session_setup_notifications(
-            cx,
-            &goose_session,
-            self.supports_goose_custom_notifications(),
-        )?;
+        self.broadcast_session_notification(&Self::session_info_notification(&goose_session));
+        self.send_and_broadcast_session_setup_notifications(cx, &goose_session)?;
         Ok(response)
     }
 }

--- a/crates/goose/src/acp/server/manage_sessions.rs
+++ b/crates/goose/src/acp/server/manage_sessions.rs
@@ -247,14 +247,21 @@ impl GooseAcpAgent {
         &self,
         req: ArchiveSessionRequest,
     ) -> Result<EmptyResponse, agent_client_protocol::Error> {
+        let session_id = req.session_id;
         self.session_manager
-            .update(&req.session_id)
+            .update(&session_id)
             .archived_at(Some(chrono::Utc::now()))
             .apply()
             .await
             .internal_err()?;
-        self.sessions.lock().await.remove(&req.session_id);
-        let _ = self.agent_manager.remove_session(&req.session_id).await;
+        let session = self
+            .session_manager
+            .get_session(&session_id, false)
+            .await
+            .internal_err()?;
+        self.broadcast_session_notification(&Self::session_info_notification(&session));
+        self.sessions.lock().await.remove(&session_id);
+        let _ = self.agent_manager.remove_session(&session_id).await;
         Ok(EmptyResponse {})
     }
 
@@ -262,12 +269,19 @@ impl GooseAcpAgent {
         &self,
         req: UnarchiveSessionRequest,
     ) -> Result<EmptyResponse, agent_client_protocol::Error> {
+        let session_id = req.session_id;
         self.session_manager
-            .update(&req.session_id)
+            .update(&session_id)
             .archived_at(None)
             .apply()
             .await
             .internal_err()?;
+        let session = self
+            .session_manager
+            .get_session(&session_id, false)
+            .await
+            .internal_err()?;
+        self.broadcast_session_notification(&Self::session_info_notification(&session));
         Ok(EmptyResponse {})
     }
 }

--- a/crates/goose/src/acp/server/new_session.rs
+++ b/crates/goose/src/acp/server/new_session.rs
@@ -83,11 +83,8 @@ impl GooseAcpAgent {
         let response = self
             .build_new_session_response(&reloaded_session, &extension_results)
             .await?;
-        super::send_session_setup_notifications(
-            cx,
-            &reloaded_session,
-            self.supports_goose_custom_notifications(),
-        )?;
+        self.broadcast_session_notification(&Self::session_info_notification(&reloaded_session));
+        self.send_and_broadcast_session_setup_notifications(cx, &reloaded_session)?;
         Ok(response)
     }
 

--- a/crates/goose/src/acp/server_factory.rs
+++ b/crates/goose/src/acp/server_factory.rs
@@ -1,4 +1,5 @@
 use crate::acp::server::{AcpProviderFactory, GooseAcpAgent, GooseAcpAgentOptions};
+use crate::acp::session_broadcast::SessionBroadcastHub;
 use crate::agents::GoosePlatform;
 use crate::scheduler_trait::SchedulerTrait;
 use crate::session::SessionManager;
@@ -23,6 +24,7 @@ pub struct AcpServerFactoryConfig {
 pub struct AcpServer {
     config: AcpServerFactoryConfig,
     scheduler: OnceCell<Arc<dyn SchedulerTrait>>,
+    session_broadcast: Arc<SessionBroadcastHub>,
 }
 
 impl AcpServer {
@@ -30,6 +32,7 @@ impl AcpServer {
         Self {
             config,
             scheduler: OnceCell::new(),
+            session_broadcast: Arc::new(SessionBroadcastHub::new()),
         }
     }
 
@@ -89,5 +92,9 @@ impl AcpServer {
         info!("Created new ACP agent");
 
         Ok(Arc::new(agent))
+    }
+
+    pub(crate) fn session_broadcast(&self) -> Arc<SessionBroadcastHub> {
+        Arc::clone(&self.session_broadcast)
     }
 }

--- a/crates/goose/src/acp/session_broadcast.rs
+++ b/crates/goose/src/acp/session_broadcast.rs
@@ -1,0 +1,66 @@
+use agent_client_protocol::schema::v1::SessionNotification;
+use tokio::sync::broadcast;
+
+#[derive(Clone, Debug)]
+pub(crate) struct SessionBroadcastEvent {
+    pub(crate) source_id: String,
+    pub(crate) notification: SessionNotification,
+}
+
+pub(crate) struct SessionBroadcastHub {
+    tx: broadcast::Sender<SessionBroadcastEvent>,
+}
+
+impl SessionBroadcastHub {
+    pub(crate) fn new() -> Self {
+        let (tx, _) = broadcast::channel(1024);
+        Self { tx }
+    }
+
+    pub(crate) fn subscribe(&self) -> broadcast::Receiver<SessionBroadcastEvent> {
+        self.tx.subscribe()
+    }
+
+    pub(crate) fn publish(&self, source_id: &str, notification: SessionNotification) {
+        let _ = self.tx.send(SessionBroadcastEvent {
+            source_id: source_id.to_string(),
+            notification,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agent_client_protocol::schema::v1::{
+        ContentBlock, ContentChunk, SessionId, SessionUpdate, TextContent,
+    };
+
+    fn notification(text: &str) -> SessionNotification {
+        SessionNotification::new(
+            SessionId::new("session-a"),
+            SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(
+                TextContent::new(text),
+            ))),
+        )
+    }
+
+    #[tokio::test]
+    async fn broadcasts_live_events_to_subscribers() {
+        let hub = SessionBroadcastHub::new();
+        let mut first = hub.subscribe();
+        let mut second = hub.subscribe();
+
+        hub.publish("source-a", notification("hello"));
+
+        let first_event = first.recv().await.unwrap();
+        let second_event = second.recv().await.unwrap();
+
+        assert_eq!(first_event.source_id, "source-a");
+        assert_eq!(second_event.source_id, "source-a");
+        assert_eq!(
+            serde_json::to_value(first_event.notification).unwrap()["update"]["content"]["text"],
+            "hello"
+        );
+    }
+}

--- a/crates/goose/tests/acp_server_test.rs
+++ b/crates/goose/tests/acp_server_test.rs
@@ -34,7 +34,9 @@ use goose::config::base::CONFIG_YAML_NAME;
 use goose::config::paths::Paths;
 use goose::config::GooseMode;
 use goose::conversation::message::{Message, MessageMetadata};
-use goose::custom_requests::{GetSessionInfoRequest, GetSessionInfoResponse};
+use goose::custom_requests::{
+    ArchiveSessionRequest, GetSessionInfoRequest, GetSessionInfoResponse,
+};
 use goose::recipe::{Recipe, Settings};
 use goose::recipe_deeplink;
 use goose::session::{SessionManager, SessionType};
@@ -480,7 +482,7 @@ fn test_session_updates_broadcast_between_shared_server_connections() {
         actor
             .cx
             .send_request(PromptRequest::new(
-                session_id,
+                session_id.clone(),
                 vec![
                     ContentBlock::Text(
                         TextContent::new(
@@ -509,6 +511,34 @@ fn test_session_updates_broadcast_between_shared_server_connections() {
                     && text_chunk(update) == Some("Visible prompt after hidden context")
             }),
             "observer did not receive visible user prompt after hidden context: {observer_updates:#?}"
+        );
+
+        actor.clear_session_notifications();
+        observer.clear_session_notifications();
+
+        actor
+            .cx
+            .send_request(ArchiveSessionRequest {
+                session_id: session_id.to_string(),
+            })
+            .block_task()
+            .await
+            .unwrap();
+
+        assert!(
+            observer
+                .wait_for_session_update(Duration::from_secs(2), |update| {
+                    let SessionUpdate::SessionInfoUpdate(info) = update else {
+                        return false;
+                    };
+                    info.meta
+                        .as_ref()
+                        .and_then(|meta| meta.get("archivedAt"))
+                        .and_then(serde_json::Value::as_str)
+                        .is_some()
+                })
+                .await,
+            "observer did not receive archive session_info_update"
         );
     });
 }

--- a/crates/goose/tests/acp_server_test.rs
+++ b/crates/goose/tests/acp_server_test.rs
@@ -1,8 +1,9 @@
 #[allow(dead_code)]
 #[path = "acp_common_tests/mod.rs"]
 mod common_tests;
+use agent_client_protocol::schema::v1::Role as AcpRole;
 use agent_client_protocol::schema::v1::{
-    ClientCapabilities, ContentBlock, FileSystemCapabilities, InitializeRequest,
+    Annotations, ClientCapabilities, ContentBlock, FileSystemCapabilities, InitializeRequest,
     ListSessionsRequest, ListSessionsResponse, LoadSessionRequest, NewSessionRequest,
     PromptRequest, SessionConfigKind, SessionConfigOptionCategory, SessionConfigOptionValue,
     SessionInfo, SessionNotification, SessionUpdate, SetSessionConfigOptionRequest, TextContent,
@@ -332,6 +333,10 @@ fn test_session_updates_broadcast_between_shared_server_connections() {
                     "/review please".to_string(),
                     include_str!("acp_test_data/openai_basic.txt"),
                 ),
+                (
+                    "Visible prompt after hidden context".to_string(),
+                    include_str!("acp_test_data/openai_basic.txt"),
+                ),
             ],
             <AcpServerConnection as Connection>::expected_session_id(),
         )
@@ -452,7 +457,7 @@ fn test_session_updates_broadcast_between_shared_server_connections() {
         actor
             .cx
             .send_request(PromptRequest::new(
-                session_id,
+                session_id.clone(),
                 vec![ContentBlock::Text(TextContent::new("/review please"))],
             ))
             .block_task()
@@ -467,6 +472,43 @@ fn test_session_updates_broadcast_between_shared_server_connections() {
                 })
                 .await,
             "observer did not receive registered skill slash prompt user_message_chunk"
+        );
+
+        actor.clear_session_notifications();
+        observer.clear_session_notifications();
+
+        actor
+            .cx
+            .send_request(PromptRequest::new(
+                session_id,
+                vec![
+                    ContentBlock::Text(
+                        TextContent::new(
+                            "<artifact-folder>\nThis hidden context should not render.\n</artifact-folder>",
+                        )
+                        .annotations(Annotations::new().audience(vec![AcpRole::Assistant])),
+                    ),
+                    ContentBlock::Text(TextContent::new("Visible prompt after hidden context")),
+                ],
+            ))
+            .block_task()
+            .await
+            .unwrap();
+
+        let observer_updates = observer.session_updates();
+        assert!(
+            !observer_updates.iter().any(|update| {
+                matches!(update, SessionUpdate::UserMessageChunk(_))
+                    && text_chunk(update).is_some_and(|text| text.contains("<artifact-folder>"))
+            }),
+            "observer received hidden artifact-folder prompt context: {observer_updates:#?}"
+        );
+        assert!(
+            observer_updates.iter().any(|update| {
+                matches!(update, SessionUpdate::UserMessageChunk(_))
+                    && text_chunk(update) == Some("Visible prompt after hidden context")
+            }),
+            "observer did not receive visible user prompt after hidden context: {observer_updates:#?}"
         );
     });
 }

--- a/crates/goose/tests/acp_server_test.rs
+++ b/crates/goose/tests/acp_server_test.rs
@@ -305,6 +305,19 @@ fn last_message_snippet(session: &SessionInfo) -> Option<&str> {
 fn test_session_updates_broadcast_between_shared_server_connections() {
     run_test(async {
         let data_root = tempfile::tempdir().unwrap();
+        let work_dir = tempfile::tempdir().unwrap();
+        let skill_dir = work_dir
+            .path()
+            .join(".agents")
+            .join("skills")
+            .join("review");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: review\ndescription: Review the current task\n---\nReview carefully.",
+        )
+        .unwrap();
+
         let openai = OpenAiFixture::new(
             vec![
                 (
@@ -313,6 +326,10 @@ fn test_session_updates_broadcast_between_shared_server_connections() {
                 ),
                 (
                     "/unknown-broadcast-command prompt".to_string(),
+                    include_str!("acp_test_data/openai_basic.txt"),
+                ),
+                (
+                    "/review please".to_string(),
                     include_str!("acp_test_data/openai_basic.txt"),
                 ),
             ],
@@ -332,7 +349,6 @@ fn test_session_updates_broadcast_between_shared_server_connections() {
         let actor = connect_shared_server_client(server.clone()).await;
         let observer = connect_shared_server_client(server).await;
 
-        let work_dir = tempfile::tempdir().unwrap();
         let response = actor
             .cx
             .send_request(NewSessionRequest::new(work_dir.path()))
@@ -411,7 +427,7 @@ fn test_session_updates_broadcast_between_shared_server_connections() {
         actor
             .cx
             .send_request(PromptRequest::new(
-                session_id,
+                session_id.clone(),
                 vec![ContentBlock::Text(TextContent::new(
                     "/unknown-broadcast-command prompt",
                 ))],
@@ -428,6 +444,29 @@ fn test_session_updates_broadcast_between_shared_server_connections() {
                 })
                 .await,
             "observer did not receive unresolved slash prompt user_message_chunk"
+        );
+
+        actor.clear_session_notifications();
+        observer.clear_session_notifications();
+
+        actor
+            .cx
+            .send_request(PromptRequest::new(
+                session_id,
+                vec![ContentBlock::Text(TextContent::new("/review please"))],
+            ))
+            .block_task()
+            .await
+            .unwrap();
+
+        assert!(
+            observer
+                .wait_for_session_update(Duration::from_secs(2), |update| {
+                    matches!(update, SessionUpdate::UserMessageChunk(_))
+                        && text_chunk(update) == Some("/review please")
+                })
+                .await,
+            "observer did not receive registered skill slash prompt user_message_chunk"
         );
     });
 }

--- a/crates/goose/tests/acp_server_test.rs
+++ b/crates/goose/tests/acp_server_test.rs
@@ -2,11 +2,14 @@
 #[path = "acp_common_tests/mod.rs"]
 mod common_tests;
 use agent_client_protocol::schema::v1::{
-    ListSessionsRequest, ListSessionsResponse, NewSessionRequest, SessionConfigKind,
-    SessionConfigOptionCategory, SessionConfigOptionValue, SessionInfo,
-    SetSessionConfigOptionRequest,
+    ClientCapabilities, ContentBlock, FileSystemCapabilities, InitializeRequest,
+    ListSessionsRequest, ListSessionsResponse, LoadSessionRequest, NewSessionRequest,
+    PromptRequest, SessionConfigKind, SessionConfigOptionCategory, SessionConfigOptionValue,
+    SessionInfo, SessionNotification, SessionUpdate, SetSessionConfigOptionRequest, TextContent,
 };
+use agent_client_protocol::schema::ProtocolVersion;
 use agent_client_protocol::ErrorCode;
+use agent_client_protocol::{Agent, Client, ConnectionTo};
 use common_tests::fixtures::server::AcpServerConnection;
 use common_tests::fixtures::{run_test, Connection, OpenAiFixture, Session, TestConnectionConfig};
 #[cfg(feature = "code-mode")]
@@ -23,13 +26,24 @@ use common_tests::{
     run_prompt_model_mismatch, run_prompt_skill, run_session_name_update_notification,
     run_shell_terminal_false, run_shell_terminal_true,
 };
+use goose::acp::server::GooseAgentConnection;
+use goose::acp::server_factory::{AcpServer, AcpServerFactoryConfig};
+use goose::agents::GoosePlatform;
+use goose::config::base::CONFIG_YAML_NAME;
+use goose::config::paths::Paths;
 use goose::config::GooseMode;
 use goose::conversation::message::{Message, MessageMetadata};
 use goose::custom_requests::{GetSessionInfoRequest, GetSessionInfoResponse};
 use goose::recipe::{Recipe, Settings};
 use goose::recipe_deeplink;
 use goose::session::{SessionManager, SessionType};
+use goose_test_support::TEST_MODEL;
+use std::future;
 use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
 
 tests_config_option_set_error!(AcpServerConnection);
 tests_mode_set_error!(AcpServerConnection);
@@ -92,6 +106,155 @@ async fn new_connection(data_root: &Path) -> AcpServerConnection {
     .await
 }
 
+struct SharedServerClient {
+    cx: ConnectionTo<Agent>,
+    updates: Arc<Mutex<Vec<SessionNotification>>>,
+    notify: Arc<Notify>,
+    task: JoinHandle<()>,
+}
+
+impl Drop for SharedServerClient {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+impl SharedServerClient {
+    fn clear_session_notifications(&self) {
+        self.updates.lock().unwrap().clear();
+    }
+
+    fn session_updates(&self) -> Vec<SessionUpdate> {
+        self.updates
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|notification| notification.update.clone())
+            .collect()
+    }
+
+    async fn wait_for_session_update<F>(&self, timeout: Duration, predicate: F) -> bool
+    where
+        F: Fn(&SessionUpdate) -> bool,
+    {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if self
+                .updates
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|notification| predicate(&notification.update))
+            {
+                return true;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return false;
+            }
+            if tokio::time::timeout_at(deadline, self.notify.notified())
+                .await
+                .is_err()
+            {
+                return self
+                    .updates
+                    .lock()
+                    .unwrap()
+                    .iter()
+                    .any(|notification| predicate(&notification.update));
+            }
+        }
+    }
+}
+
+fn text_chunk(update: &SessionUpdate) -> Option<&str> {
+    match update {
+        SessionUpdate::UserMessageChunk(chunk) | SessionUpdate::AgentMessageChunk(chunk) => {
+            match &chunk.content {
+                ContentBlock::Text(text) => Some(text.text.as_str()),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn write_shared_server_config(config_dir: &Path, openai_base_url: &str) {
+    let contents = format!(
+        "GOOSE_MODEL: {TEST_MODEL}\nGOOSE_PROVIDER: openai\nGOOSE_MODE: auto\nGOOSE_DISABLE_SESSION_NAMING: true\nOPENAI_HOST: {openai_base_url}\n"
+    );
+    std::fs::create_dir_all(config_dir).unwrap();
+    std::fs::write(config_dir.join(CONFIG_YAML_NAME), &contents).unwrap();
+
+    let global_config_dir = Paths::config_dir();
+    std::fs::create_dir_all(&global_config_dir).unwrap();
+    std::fs::write(global_config_dir.join(CONFIG_YAML_NAME), contents).unwrap();
+}
+
+async fn connect_shared_server_client(server: Arc<AcpServer>) -> SharedServerClient {
+    let updates = Arc::new(Mutex::new(Vec::new()));
+    let notify = Arc::new(Notify::new());
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+
+    let task = tokio::spawn({
+        let updates = updates.clone();
+        let notify = notify.clone();
+        async move {
+            let result = Client
+                .builder()
+                .on_receive_notification(
+                    {
+                        let updates = updates.clone();
+                        let notify = notify.clone();
+                        async move |notification: SessionNotification, _cx| {
+                            updates.lock().unwrap().push(notification);
+                            notify.notify_waiters();
+                            Ok(())
+                        }
+                    },
+                    agent_client_protocol::on_receive_notification!(),
+                )
+                .connect_with(GooseAgentConnection::new(server), async move |cx| {
+                    let response = cx
+                        .send_request(
+                            InitializeRequest::new(ProtocolVersion::LATEST).client_capabilities(
+                                ClientCapabilities::new()
+                                    .fs(FileSystemCapabilities::default())
+                                    .terminal(false),
+                            ),
+                        )
+                        .block_task()
+                        .await;
+                    match response {
+                        Ok(response) => {
+                            assert_eq!(
+                                response.agent_info.as_ref().map(|info| info.name.as_str()),
+                                Some("goose")
+                            );
+                            let _ = ready_tx.send(Ok(cx.clone()));
+                        }
+                        Err(error) => {
+                            let _ = ready_tx.send(Err(error.to_string()));
+                            return Err(error);
+                        }
+                    }
+                    future::pending::<Result<(), agent_client_protocol::Error>>().await
+                })
+                .await;
+            if let Err(error) = result {
+                tracing::error!(%error, "shared ACP client task ended");
+            }
+        }
+    });
+
+    let cx = ready_rx.await.unwrap().unwrap();
+    SharedServerClient {
+        cx,
+        updates,
+        notify,
+        task,
+    }
+}
+
 async fn list_sessions_request(
     conn: &AcpServerConnection,
     request: ListSessionsRequest,
@@ -136,6 +299,137 @@ fn last_message_snippet(session: &SessionInfo) -> Option<&str> {
         .as_ref()
         .and_then(|meta| meta.get("lastMessageSnippet"))
         .and_then(serde_json::Value::as_str)
+}
+
+#[test]
+fn test_session_updates_broadcast_between_shared_server_connections() {
+    run_test(async {
+        let data_root = tempfile::tempdir().unwrap();
+        let openai = OpenAiFixture::new(
+            vec![
+                (
+                    "Cross-client broadcast prompt".to_string(),
+                    include_str!("acp_test_data/openai_basic.txt"),
+                ),
+                (
+                    "/unknown-broadcast-command prompt".to_string(),
+                    include_str!("acp_test_data/openai_basic.txt"),
+                ),
+            ],
+            <AcpServerConnection as Connection>::expected_session_id(),
+        )
+        .await;
+        write_shared_server_config(data_root.path(), openai.uri());
+
+        let server = Arc::new(AcpServer::new(AcpServerFactoryConfig {
+            builtins: Vec::new(),
+            data_dir: data_root.path().to_path_buf(),
+            config_dir: data_root.path().to_path_buf(),
+            goose_platform: GoosePlatform::GooseCli,
+            additional_source_roots: Vec::new(),
+            scheduler: None,
+        }));
+        let actor = connect_shared_server_client(server.clone()).await;
+        let observer = connect_shared_server_client(server).await;
+
+        let work_dir = tempfile::tempdir().unwrap();
+        let response = actor
+            .cx
+            .send_request(NewSessionRequest::new(work_dir.path()))
+            .block_task()
+            .await
+            .unwrap();
+        let session_id = response.session_id.clone();
+        assert!(
+            observer
+                .wait_for_session_update(Duration::from_secs(2), |update| {
+                    matches!(update, SessionUpdate::SessionInfoUpdate(_))
+                })
+                .await,
+            "observer did not receive session_info_update for session/new"
+        );
+
+        let observer_work_dir = tempfile::tempdir().unwrap();
+        observer
+            .cx
+            .send_request(LoadSessionRequest::new(
+                session_id.clone(),
+                observer_work_dir.path(),
+            ))
+            .block_task()
+            .await
+            .unwrap();
+        actor.clear_session_notifications();
+        observer.clear_session_notifications();
+
+        let actor_cx = actor.cx.clone();
+        let prompt_session_id = session_id.clone();
+        let prompt_task = tokio::spawn(async move {
+            actor_cx
+                .send_request(PromptRequest::new(
+                    prompt_session_id,
+                    vec![ContentBlock::Text(TextContent::new(
+                        "Cross-client broadcast prompt",
+                    ))],
+                ))
+                .block_task()
+                .await
+                .unwrap();
+        });
+
+        assert!(
+            observer
+                .wait_for_session_update(Duration::from_secs(2), |update| {
+                    matches!(update, SessionUpdate::UserMessageChunk(_))
+                        && text_chunk(update) == Some("Cross-client broadcast prompt")
+                })
+                .await,
+            "observer did not receive live user_message_chunk"
+        );
+        assert!(
+            observer
+                .wait_for_session_update(Duration::from_secs(2), |update| {
+                    matches!(update, SessionUpdate::AgentMessageChunk(_))
+                })
+                .await,
+            "observer did not receive live agent_message_chunk"
+        );
+        prompt_task.await.unwrap();
+
+        let actor_updates = actor.session_updates();
+        assert!(
+            !actor_updates.iter().any(|update| {
+                matches!(update, SessionUpdate::UserMessageChunk(_))
+                    && text_chunk(update) == Some("Cross-client broadcast prompt")
+            }),
+            "actor received duplicate own-user prompt update: {actor_updates:#?}"
+        );
+
+        actor.clear_session_notifications();
+        observer.clear_session_notifications();
+
+        actor
+            .cx
+            .send_request(PromptRequest::new(
+                session_id,
+                vec![ContentBlock::Text(TextContent::new(
+                    "/unknown-broadcast-command prompt",
+                ))],
+            ))
+            .block_task()
+            .await
+            .unwrap();
+
+        assert!(
+            observer
+                .wait_for_session_update(Duration::from_secs(2), |update| {
+                    matches!(update, SessionUpdate::UserMessageChunk(_))
+                        && text_chunk(update) == Some("/unknown-broadcast-command prompt")
+                })
+                .await,
+            "observer did not receive unresolved slash prompt user_message_chunk"
+        );
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds a process-local ACP session broadcast hub owned by `AcpServer` and shared by WebSocket ACP connections created by the same `goose serve` process. Live `session/update` notifications are sent to the initiating client as before and fanned out to other initialized clients with a per-connection source id so the actor does not receive duplicate own-user prompt notifications.

`session/load` replay remains local to the loading client. Independent `goose acp` stdio processes are intentionally out of scope for this in-memory fanout because they do not share an `AcpServer` process.

## Testing

- Reproduced on `main`: two WebSocket clients connected to one `goose serve`; actor `session/new` produced no observer `session/update` notifications.
- Added `test_session_updates_broadcast_between_shared_server_connections` for shared-server cross-client session creation, prompt forwarding, unresolved slash prompt forwarding, and source-client deduplication.
- Ran ACP focused and full integration tests, `goose-cli` build, and clippy.
- Validated with two WebSocket clients against `goose serve` and a delayed mock OpenAI stream: observer received live `session_info_update`, external user prompt, and streamed assistant chunks before the actor prompt completed; actor received zero duplicate own-user prompt chunks.
- Ran local Claude Code Opus/xhigh review loop; addressed verified findings around forwarder error handling and unresolved slash prompt forwarding.

*🤖 This PR was authored [with an agent](codex://threads/019f1b54-9a2d-7f12-913e-d7ddf44586d0).*
