### PR TITLE
fix(providers): fall back to predefined model list when /models endpoint fails 

### DIFF
--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -231,7 +231,19 @@ impl Provider for AnthropicProvider {
                     );
                     return Ok(custom_models.clone());
                 }
-                Err(e) => return Err(e),
+                Err(e) => {
+                    // Fall back to the predefined list on any other error (invalid
+                    // JSON, auth failure, server error, wrong base URL, ...) so that
+                    // a misconfigured /models endpoint does not prevent the provider
+                    // from being used. The predefined list is already known-good.
+                    tracing::warn!(
+                        "Failed to fetch models from API for provider '{}': {}. \
+                         Falling back to predefined model list.",
+                        self.name,
+                        e
+                    );
+                    return Ok(custom_models.clone());
+                }
             }
         }
 
@@ -285,5 +297,63 @@ impl Provider for AnthropicProvider {
                 yield (message, usage);
             }
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_provider_with_custom_models(
+        name: &str,
+        host: &str,
+        custom_models: Vec<String>,
+        dynamic_models: Option<bool>,
+    ) -> AnthropicProvider {
+        AnthropicProvider {
+            api_client: ApiClient::new_with_tls(
+                host.to_string(),
+                crate::api_client::AuthMethod::NoAuth,
+                None,
+            )
+            .unwrap(),
+            supports_streaming: true,
+            name: name.to_string(),
+            custom_models: Some(custom_models),
+            dynamic_models,
+            skip_canonical_filtering: false,
+            format_options: AnthropicFormatOptions::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_supported_models_falls_back_on_non_404_error() {
+        let predefined = vec!["glm-5.2".to_string(), "glm-4.5".to_string()];
+        let provider = make_provider_with_custom_models(
+            "zai",
+            "http://127.0.0.1:1",
+            predefined.clone(),
+            Some(true),
+        );
+
+        let models = provider
+            .fetch_supported_models()
+            .await
+            .expect("should fall back to predefined list on API error");
+        assert_eq!(models, predefined);
+    }
+
+    #[tokio::test]
+    async fn fetch_supported_models_returns_static_when_dynamic_false() {
+        let predefined = vec!["MiniMax-M2.5".to_string()];
+        let provider = make_provider_with_custom_models(
+            "minimax",
+            "http://127.0.0.1:1",
+            predefined.clone(),
+            Some(false),
+        );
+
+        let models = provider.fetch_supported_models().await.unwrap();
+        assert_eq!(models, predefined);
     }
 }

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -567,7 +567,19 @@ impl Provider for OpenAiProvider {
                     );
                     return Ok(custom_models.clone());
                 }
-                Err(e) => return Err(e),
+                Err(e) => {
+                    // Fall back to the predefined list on any other error (invalid
+                    // JSON, auth failure, server error, wrong base URL, ...) so that
+                    // a misconfigured /models endpoint does not prevent the provider
+                    // from being used. The predefined list is already known-good.
+                    tracing::warn!(
+                        "Failed to fetch models from API for provider '{}': {}. \
+                         Falling back to predefined model list.",
+                        self.name,
+                        e
+                    );
+                    return Ok(custom_models.clone());
+                }
             }
         }
 
@@ -969,5 +981,62 @@ mod tests {
             ]
         });
         assert_eq!(parse_n_ctx_from_models(&body, "model-c"), None);
+    }
+
+    fn make_provider_with_custom_models(
+        name: &str,
+        host: &str,
+        custom_models: Vec<String>,
+        dynamic_models: Option<bool>,
+    ) -> OpenAiProvider {
+        OpenAiProvider {
+            api_client: ApiClient::new_with_tls(host.to_string(), AuthMethod::NoAuth, None)
+                .unwrap(),
+            base_path: "v1/chat/completions".to_string(),
+            organization: None,
+            project: None,
+            custom_headers: None,
+            supports_streaming: true,
+            name: name.to_string(),
+            custom_models: Some(custom_models),
+            dynamic_models,
+            skip_canonical_filtering: false,
+            preserve_thinking_context: false,
+            n_ctx_cache: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_supported_models_falls_back_on_non_404_error() {
+        // Point at a port that is almost certainly not listening so the API
+        // call fails with a network/JSON error (NOT a 404). The provider
+        // should still succeed by falling back to the predefined list.
+        let predefined = vec!["glm-4.5".to_string(), "glm-5".to_string()];
+        let provider = make_provider_with_custom_models(
+            "zhipu",
+            "http://127.0.0.1:1",
+            predefined.clone(),
+            Some(true),
+        );
+
+        let models = provider
+            .fetch_supported_models()
+            .await
+            .expect("should fall back to predefined list on API error");
+        assert_eq!(models, predefined);
+    }
+
+    #[tokio::test]
+    async fn fetch_supported_models_returns_static_when_dynamic_false() {
+        let predefined = vec!["model-a".to_string()];
+        let provider = make_provider_with_custom_models(
+            "test-provider",
+            "http://127.0.0.1:1",
+            predefined.clone(),
+            Some(false),
+        );
+
+        let models = provider.fetch_supported_models().await.unwrap();
+        assert_eq!(models, predefined);
     }
 }


### PR DESCRIPTION
## Summary
  - Fix provider configuration failure when the `/models` API endpoint returns non-404 errors (invalid JSON, auth errors, server errors, wrong base URL,    
  etc.)                                                                                                                                                     
  - Both `OpenAiProvider` and `AnthropicProvider` now fall back to their predefined static model list on **any** API error, not just 404                    
  - A `tracing::warn` log is emitted so the failure is observable                                                                                           
  - Adds regression tests for both providers 

Fixes #10074 

  ## Root Cause                                                                                                                                             
                                                                                                                                                          
  When configuring Zhipu AI (or any provider with `dynamic_models: true` and a non-standard base URL), the derived `/models` endpoint URL may be wrong. For 
  example, entering `https://open.bigmodel.cn` instead of `https://open.bigmodel.cn/api/paas/v4` produces a models URL of                                 
  `https://open.bigmodel.cn/v1/models`, which does not exist.                                                                                               
                                                                                                                                                          
  The endpoint returns HTTP 200 with a non-JSON body (e.g. an HTML page), causing `handle_response` to fail with `ProviderError::RequestFailed("Response    
  body is not valid JSON: ...")`. Previously, `fetch_supported_models` only fell back to the static list on `EndpointNotFound` (404), so this
  `RequestFailed` error propagated up and blocked the provider configuration entirely.                                                                      
                                                                                                                                                          
  ## Changes                                                                                                                                                
   
  ### `crates/goose-providers/src/openai.rs`                                                                                                                
  - `OpenAiProvider::fetch_supported_models`: replace the catch-all `Err(e) => return Err(e)` branch with a fallback to `custom_models` plus a `warn` log 
  - Add `make_provider_with_custom_models` test helper and two `#[tokio::test]` cases                                                                       
                                                                                                                                                            
  ### `crates/goose-providers/src/anthropic.rs`                                                                                                             
  - `AnthropicProvider::fetch_supported_models`: same fallback change (the `zai` and `minimax` declarative providers are also affected)                     
  - Add a `#[cfg(test)]` module with matching test cases 

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
  - [x] `cargo test -p goose-providers --lib openai::tests::fetch_supported_models_falls_back_on_non_404_error`                                             
  - [x] `cargo test -p goose-providers --lib openai::tests::fetch_supported_models_returns_static_when_dynamic_false`                                     
  - [x] `cargo test -p goose-providers --lib anthropic::tests::fetch_supported_models_falls_back_on_non_404_error`                                          
  - [x] `cargo test -p goose-providers --lib anthropic::tests::fetch_supported_models_returns_static_when_dynamic_false` 

### Related Issues
Relates to #10074  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

