### PR TITLE
fix(desktop): dedupe React in renderer bundle

### DIFF
--- a/ui/desktop/vite.renderer.config.mts
+++ b/ui/desktop/vite.renderer.config.mts
@@ -9,6 +9,10 @@ export default defineConfig({
 
   plugins: [tailwindcss()],
 
+  resolve: {
+    dedupe: ['react', 'react-dom', 'react/jsx-runtime', 'react/jsx-dev-runtime'],
+  },
+
   // Vite caches a copy of @aaif/goose-sdk and doesn't notice when we rebuild it
   // locally, so it serves stale code until you clear node_modules/.vite by hand.
   // Excluding it makes Vite always read the latest ui/sdk/dist build.


### PR DESCRIPTION
## Summary
Fix the desktop renderer bundle (Linux flatpack) resolving multiple React instances by deduping React packages in the Vite renderer config.

This prevents packaged/dev renderer crashes like `Cannot read properties of null (reading 'useRef')` when dependencies such as React Router or react-intl are bundled against a different React copy than the app.

### Testing
- run 
``` 
rm -rf ui/desktop/node_modules
cd ui
pnpm install
cd desktop
pnpm run make --targets=@electron-forge/maker-flatpak
flatpak install --user --reinstall out/make/flatpak/x86_64/*.flatpak
```
- Manually verified in a downstream Linux packaged Electron build that the renderer reaches `React ready event received` after this change instead of crashing on `useRef`.

### Related Issues
Relates to #8757

### Screenshots/Demos (for UX changes)
Before:

<img width="943" height="803" alt="image" src="https://github.com/user-attachments/assets/c524e78c-dee4-4f8f-aa86-b2438dd6b583" />


After:

<img width="943" height="803" alt="image" src="https://github.com/user-attachments/assets/c34b7b11-adf2-405b-929e-765376b42d47" />
