### PR TITLE
fix(config): canonical model limits win over GOOSE_CONTEXT_LIMIT

### DIFF
--- a/crates/goose/src/model_config.rs
+++ b/crates/goose/src/model_config.rs
@@ -32,12 +32,21 @@ pub fn model_config_from_user_config_with_session_settings(
         .with_inherited_session_settings_from(previous, request_params)
         .with_default_thinking_effort(config.get_goose_thinking_effort());
 
-    Ok(model.with_canonical_limits(provider_name))
+    // Canonical (model-specific) limits win; GOOSE_CONTEXT_LIMIT is only a
+    // last-resort default for models with no known limit, never a cap over them.
+    Ok(model
+        .with_canonical_limits(provider_name)
+        .with_default_context_limit(config.get_goose_context_limit()?))
 }
 
 pub fn materialize_model_config(provider_name: &str, model: ModelConfig) -> Result<ModelConfig> {
+    let config = Config::global();
     let model = materialize_model_config_inner(model, provider_name, true)?;
-    Ok(model.with_canonical_limits(provider_name))
+    // Canonical (model-specific) limits win; GOOSE_CONTEXT_LIMIT is only a
+    // last-resort default for models with no known limit, never a cap over them.
+    Ok(model
+        .with_canonical_limits(provider_name)
+        .with_default_context_limit(config.get_goose_context_limit()?))
 }
 
 fn materialize_model_config_inner(
@@ -55,9 +64,9 @@ fn materialize_model_config_inner(
         model = model.with_toolshim_model(get_goose_toolshim_model(config)?);
     }
 
-    model = model
-        .with_default_context_limit(config.get_goose_context_limit()?)
-        .with_default_max_tokens(config.get_goose_max_tokens()?);
+    // GOOSE_CONTEXT_LIMIT is applied later, after canonical limits, so a model's
+    // known context window is never overridden by the global default.
+    model = model.with_default_max_tokens(config.get_goose_max_tokens()?);
 
     if include_default_thinking_effort {
         model = model.with_default_thinking_effort(config.get_goose_thinking_effort());
@@ -243,5 +252,42 @@ fn parse_yaml_bool_config(key: &str, value: serde_yaml::Value) -> Result<bool> {
             serde_yaml::to_string(&other).unwrap_or_else(|_| "<unprintable>".to_string()).trim()
         ))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_limit_wins_over_global_context_limit() {
+        let _guard = env_lock::lock_env([("GOOSE_CONTEXT_LIMIT", Some("1000"))]);
+
+        // A model with a known canonical context window keeps it instead of
+        // being capped to the much smaller global default.
+        let canonical = ModelConfig::new("claude-3-5-sonnet-20241022")
+            .with_canonical_limits("anthropic")
+            .context_limit();
+        assert!(
+            canonical > 1000,
+            "expected a canonical context limit for the test model, got {canonical}"
+        );
+
+        let materialized =
+            materialize_model_config("anthropic", ModelConfig::new("claude-3-5-sonnet-20241022"))
+                .expect("materialize");
+        assert_eq!(materialized.context_limit(), canonical);
+    }
+
+    #[test]
+    fn global_context_limit_is_last_resort_for_unknown_models() {
+        let _guard = env_lock::lock_env([("GOOSE_CONTEXT_LIMIT", Some("1000"))]);
+
+        let materialized = materialize_model_config(
+            "anthropic",
+            ModelConfig::new("a-model-not-in-the-canonical-registry-xyz"),
+        )
+        .expect("materialize");
+        assert_eq!(materialized.context_limit(), 1000);
     }
 }

--- a/documentation/docs/guides/environment-variables.md
+++ b/documentation/docs/guides/environment-variables.md
@@ -257,7 +257,7 @@ These variables allow you to override the default context window size (token lim
 
 | Variable | Purpose | Values | Default |
 |----------|---------|---------|---------|
-| `GOOSE_CONTEXT_LIMIT` | Override context limit for the main model | Integer (number of tokens) | Model-specific default or 128,000 |
+| `GOOSE_CONTEXT_LIMIT` | Context limit for models without a known context window (a model's known limit takes precedence) | Integer (number of tokens) | Known model limit or 128,000 |
 | `GOOSE_INPUT_LIMIT` | Override input prompt limit for ollama requests (maps to `num_ctx`) | Integer (number of tokens) | Falls back to `GOOSE_CONTEXT_LIMIT` or model default |
 | `GOOSE_PLANNER_CONTEXT_LIMIT` | Override context limit for the [planner model](/docs/guides/context-engineering/creating-plans) | Integer (number of tokens) | Falls back to `GOOSE_CONTEXT_LIMIT` or model default |
 

--- a/documentation/docs/guides/sessions/smart-context-management.md
+++ b/documentation/docs/guides/sessions/smart-context-management.md
@@ -292,7 +292,7 @@ Context limits are automatically detected based on your model name, but goose pr
 
 | Model | Description | Best For | Setting |
 |-------|-------------|----------|---------|
-| **Main** | Set context limit for the main model (also serves as fallback for other models) | LiteLLM proxies, custom models with non-standard names | `GOOSE_CONTEXT_LIMIT` |
+| **Main** | Set the context limit for models goose has no known context window for (a model's known limit takes precedence) | LiteLLM proxies, custom models with non-standard names | `GOOSE_CONTEXT_LIMIT` |
 | **Planner** | Set context for [planner models](/docs/guides/context-engineering/creating-plans) | Large planning tasks requiring extensive context | `GOOSE_PLANNER_CONTEXT_LIMIT` |
 
 :::info
@@ -310,8 +310,8 @@ goose resolves context limits with the following precedence (highest to lowest):
 
 1. Explicit context_limit in model configuration (if set programmatically)
 2. Specific environment variable (e.g., `GOOSE_PLANNER_CONTEXT_LIMIT`)
-3. Global environment variable (`GOOSE_CONTEXT_LIMIT`)
-4. Model-specific default based on name pattern matching
+3. The model's known context window from goose's canonical model data
+4. Global environment variable (`GOOSE_CONTEXT_LIMIT`)
 5. Global default (128,000 tokens)
 
 **Configuration**


### PR DESCRIPTION
Follow-up to #10033 (closed) and #10032.

In #10033 the read was that @jamadeo's provider refactor (#9769) already gave canonical model limits precedence over `GOOSE_CONTEXT_LIMIT`, so perhaps only the regression tests were still worth contributing. When I verified against current `main`, the precedence gap is still present, so this PR contributes both the fix for the new structure and the regression tests.

### The gap

`materialize_model_config` applies `with_default_context_limit(GOOSE_CONTEXT_LIMIT)` inside `materialize_model_config_inner`, then `with_canonical_limits` afterward. Both `with_default_context_limit` and `with_canonical_limits` only set `context_limit` when it is still unset (see `crates/goose-providers/src/model.rs`), so whichever runs first claims the slot. The global default runs first, so a model with a known canonical window gets capped to `GOOSE_CONTEXT_LIMIT`.

Concretely, with `GOOSE_CONTEXT_LIMIT=1000`, `claude-3-5-sonnet-20241022` (canonical 200000) materializes to a context limit of 1000. The added `canonical_limit_wins_over_global_context_limit` test fails on `main` (`left: 1000, right: 200000`) and passes with this change.

### The fix

Apply `with_canonical_limits` first, then `with_default_context_limit(GOOSE_CONTEXT_LIMIT)` as a last-resort default, in both `materialize_model_config` and `model_config_from_user_config_with_session_settings`. Net effect:

- Known model: its real context window wins; `GOOSE_CONTEXT_LIMIT` never caps it.
- Unknown model: `GOOSE_CONTEXT_LIMIT` still applies as the fallback.

### Tests

- `canonical_limit_wins_over_global_context_limit`
- `global_context_limit_is_last_resort_for_unknown_models`

`cargo test -p goose --lib model_config::tests`, `cargo fmt`, and `cargo clippy -p goose --all-targets` are clean.