### PR TITLE
feat(cli): run shell commands inline with a leading '!'

### DIFF
--- a/crates/goose-cli/src/session/input.rs
+++ b/crates/goose-cli/src/session/input.rs
@@ -30,6 +30,7 @@ pub enum InputResult {
     Edit(Option<String>),
     ListSkills,
     LoadSkills(Vec<String>),
+    ShellCommand(String),
 }
 
 #[derive(Debug)]
@@ -164,6 +165,16 @@ pub fn get_input(
         editor.add_history_entry(input.as_str())?;
     }
 
+    // A leading '!' runs the rest of the line as a shell command and feeds the
+    // output back into the conversation, mirroring the convention in other
+    // agent CLIs. Checked before the slash-command and message paths so it wins.
+    if input.starts_with('!') {
+        return Ok(match parse_bang_command(&input) {
+            Some(command) => InputResult::ShellCommand(command.to_string()),
+            None => InputResult::Retry,
+        });
+    }
+
     // Handle non-slash commands first
     if !input.starts_with('/') {
         let trimmed = input.trim();
@@ -185,6 +196,13 @@ pub fn get_input(
         Some(result) => Ok(result),
         None => Ok(InputResult::Message(input.trim().to_string())),
     }
+}
+
+/// The shell command from a leading-`!` line, or `None` when nothing follows
+/// the `!`. Input is expected to start with `!`.
+fn parse_bang_command(input: &str) -> Option<&str> {
+    let command = input.strip_prefix('!')?.trim();
+    (!command.is_empty()).then_some(command)
 }
 
 fn handle_slash_command(input: &str) -> Option<InputResult> {
@@ -431,6 +449,7 @@ fn print_help() {
 /skills - List available skills or enable skills by name (usage: /skills [<name>...])
 /? or /help - Display this help message
 /clear - Clears the current chat history
+!<command> - Run a shell command and add its output to the conversation context
 
 Navigation:
 Ctrl+C - Clear current line if text is entered, otherwise exit the session
@@ -533,6 +552,17 @@ mod tests {
 
         // Test unknown commands
         assert!(handle_slash_command("/unknown").is_none());
+    }
+
+    #[test]
+    fn test_parse_bang_command() {
+        assert_eq!(parse_bang_command("!ls -la"), Some("ls -la"));
+        assert_eq!(parse_bang_command("!  git status  "), Some("git status"));
+        // A bare '!' or whitespace-only remainder is not a command.
+        assert_eq!(parse_bang_command("!"), None);
+        assert_eq!(parse_bang_command("!   "), None);
+        // The '!' must lead; embedded bangs are left to the message path.
+        assert_eq!(parse_bang_command("echo !"), None);
     }
 
     #[test]

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -679,7 +679,82 @@ impl CliSession {
                 history.save(editor);
                 self.handle_list_skills().await?;
             }
+            InputResult::ShellCommand(command) => {
+                history.save(editor);
+                self.handle_shell_command(&command).await?;
+            }
         }
+        Ok(())
+    }
+
+    /// Run `command` in the user's shell and add its output to the conversation
+    /// so the agent can act on the result. Output shown to the user is not
+    /// truncated; the copy folded into context is capped to protect the window.
+    async fn handle_shell_command(&mut self, command: &str) -> Result<()> {
+        const MAX_CONTEXT_CHARS: usize = 16_000;
+
+        output::render_shell_command(command);
+
+        let shell = env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+        let result = tokio::process::Command::new(shell)
+            .arg("-c")
+            .arg(command)
+            .output()
+            .await;
+
+        let output = match result {
+            Ok(output) => output,
+            Err(e) => {
+                output::render_error(&format!("Failed to run shell command: {e}"));
+                return Ok(());
+            }
+        };
+
+        let mut combined = String::new();
+        combined.push_str(&String::from_utf8_lossy(&output.stdout));
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.is_empty() {
+            if !combined.is_empty() && !combined.ends_with('\n') {
+                combined.push('\n');
+            }
+            combined.push_str(&stderr);
+        }
+        let combined = combined.trim_end();
+
+        let exit_note = (!output.status.success()).then(|| match output.status.code() {
+            Some(code) => format!("[exited with status {code}]"),
+            None => "[terminated by signal]".to_string(),
+        });
+        output::render_shell_output(combined, exit_note.as_deref());
+
+        let truncated = combined.chars().count() > MAX_CONTEXT_CHARS;
+        let context_body: String = if truncated {
+            combined.chars().take(MAX_CONTEXT_CHARS).collect()
+        } else {
+            combined.to_string()
+        };
+        let mut context = format!("I ran the shell command `{command}`.");
+        if let Some(note) = &exit_note {
+            context.push_str(&format!(" It {}.", note.trim_matches(['[', ']'])));
+        }
+        if context_body.is_empty() {
+            context.push_str(" It produced no output.");
+        } else {
+            context.push_str("\n\nOutput:\n```\n");
+            context.push_str(&context_body);
+            if truncated {
+                context.push_str("\n... (output truncated)");
+            }
+            context.push_str("\n```");
+        }
+
+        let message = Message::user().with_text(&context);
+        self.push_message(message.clone());
+        self.agent
+            .config
+            .session_manager
+            .add_message(&self.session_id, &message)
+            .await?;
         Ok(())
     }
 

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -584,6 +584,24 @@ pub fn render_error(message: &str) {
     println!("\n  {} {}\n", style("error:").red().bold(), message);
 }
 
+pub fn render_shell_command(command: &str) {
+    println!(
+        "\n{} {}",
+        style("shell").magenta().bold(),
+        style(command).dim()
+    );
+}
+
+pub fn render_shell_output(output: &str, exit_note: Option<&str>) {
+    if !output.is_empty() {
+        println!("{}", style(output).dim());
+    }
+    if let Some(note) = exit_note {
+        println!("{}", style(note).yellow());
+    }
+    println!();
+}
+
 pub fn render_prompts(prompts: &HashMap<String, Vec<String>>) {
     println!();
     for (extension, prompts) in prompts {


### PR DESCRIPTION
## What

Adds inline shell passthrough to the interactive CLI: a line beginning with `!` runs the rest as a shell command and folds its output back into the conversation as context.

```
> !git status --short
 M crates/goose-cli/src/session/input.rs

> what did I change and why might it fail CI?
```

This mirrors a convention users coming from other agent CLIs already reach for, and removes the round trip of leaving the session (or asking the agent to spawn a tool call) just to run a quick `ls`, `git status`, `cat`, or `grep` and let the model see the result.

## Behavior

- `!<command>` runs via the user's `$SHELL -c` (falling back to `/bin/sh`), inheriting the session's working directory and environment, so aliases and `PATH` work as in a normal shell.
- stdout and stderr are shown to the user in full, followed by an exit-status note when the command fails.
- A copy of the command and its combined output is appended as a user message so the agent can act on it on the next turn. That copy is capped (16k chars) to protect the context window; the on-screen output is never truncated.
- A bare `!` (or `!` followed only by whitespace) is a no-op that returns to the prompt.
- The `!` must lead the line; an embedded `!` (`echo !`) is still an ordinary message.
- Documented in `/help`.

Interactive/full-screen programs (`vim`, `less`) are not given a TTY; this is for the quick non-interactive commands that make up the common case, matching how the same feature behaves elsewhere.

## Tests

- `test_parse_bang_command` covers the parse rules (command extraction, whitespace trimming, bare-`!` and embedded-`!` rejection).
- `cargo fmt`, `cargo clippy --all-targets -D warnings`, and `cargo test -p goose-cli` are green.
