### PR TITLE
feat(cli): add /copy to copy the last assistant response to the clipboard

### DIFF
--- a/crates/goose-cli/src/session/clipboard.rs
+++ b/crates/goose-cli/src/session/clipboard.rs
@@ -1,0 +1,87 @@
+use anyhow::{anyhow, Result};
+use base64::{engine::general_purpose, Engine as _};
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+/// Most terminals cap OSC 52 payloads around 100KB of base64; beyond that the
+/// copy silently truncates, which is worse than failing.
+const OSC52_MAX_BYTES: usize = 100_000;
+
+/// Copy text to the system clipboard, returning the mechanism that worked.
+/// Tries the platform's clipboard command first, then falls back to the
+/// OSC 52 escape sequence so copying still works over SSH.
+pub fn copy(text: &str) -> Result<&'static str> {
+    for (name, command, args) in platform_commands() {
+        if copy_via_command(command, args, text).is_ok() {
+            return Ok(name);
+        }
+    }
+    copy_via_osc52(text)
+}
+
+fn platform_commands() -> &'static [(&'static str, &'static str, &'static [&'static str])] {
+    if cfg!(target_os = "macos") {
+        &[("pbcopy", "pbcopy", &[])]
+    } else if cfg!(target_os = "windows") {
+        &[("clip", "clip", &[])]
+    } else {
+        &[
+            ("wl-copy", "wl-copy", &[]),
+            ("xclip", "xclip", &["-selection", "clipboard"]),
+            ("xsel", "xsel", &["--clipboard", "--input"]),
+        ]
+    }
+}
+
+fn copy_via_command(command: &str, args: &[&str], text: &str) -> Result<()> {
+    let mut child = Command::new(command)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("failed to open stdin for {command}"))?
+        .write_all(text.as_bytes())?;
+    let status = child.wait()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(anyhow!("{command} exited with {status}"))
+    }
+}
+
+fn copy_via_osc52(text: &str) -> Result<&'static str> {
+    if text.len() > OSC52_MAX_BYTES {
+        return Err(anyhow!(
+            "no clipboard tool found and the response is too large for the OSC 52 fallback"
+        ));
+    }
+    let mut stdout = std::io::stdout();
+    stdout.write_all(osc52_sequence(text).as_bytes())?;
+    stdout.flush()?;
+    Ok("OSC 52")
+}
+
+fn osc52_sequence(text: &str) -> String {
+    let encoded = general_purpose::STANDARD.encode(text.as_bytes());
+    format!("\x1b]52;c;{encoded}\x07")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn osc52_sequence_encodes_payload() {
+        assert_eq!(osc52_sequence("hi"), "\x1b]52;c;aGk=\x07");
+    }
+
+    #[test]
+    fn osc52_rejects_oversized_payloads() {
+        let big = "a".repeat(OSC52_MAX_BYTES + 1);
+        assert!(copy_via_osc52(&big).is_err());
+    }
+}

--- a/crates/goose-cli/src/session/completion.rs
+++ b/crates/goose-cli/src/session/completion.rs
@@ -168,6 +168,7 @@ impl GooseCompleter {
             "/recipe",
             "/skills",
             "/status",
+            "/copy",
         ];
 
         // Find commands that match the prefix

--- a/crates/goose-cli/src/session/input.rs
+++ b/crates/goose-cli/src/session/input.rs
@@ -30,6 +30,7 @@ pub enum InputResult {
     Edit(Option<String>),
     ListSkills,
     LoadSkills(Vec<String>),
+    Copy,
 }
 
 #[derive(Debug)]
@@ -208,6 +209,7 @@ fn handle_slash_command(input: &str) -> Option<InputResult> {
     const CMD_EDIT: &str = "/edit";
     const CMD_EDIT_WITH_SPACE: &str = "/edit ";
     const CMD_SKILLS: &str = "/skills";
+    const CMD_COPY: &str = "/copy";
 
     match input {
         "/exit" | "/quit" => Some(InputResult::Exit),
@@ -299,6 +301,7 @@ fn handle_slash_command(input: &str) -> Option<InputResult> {
             Some(InputResult::Compact)
         }
         "/r" => Some(InputResult::ToggleFullToolOutput),
+        s if s == CMD_COPY => Some(InputResult::Copy),
         s if s == CMD_EDIT => Some(InputResult::Edit(None)),
         s if s.starts_with(CMD_EDIT_WITH_SPACE) => {
             let prefill = s
@@ -426,6 +429,7 @@ fn print_help() {
                        If no filepath is provided, it will be saved to ./recipe.yaml.
 /compact - Compact the current conversation to reduce context length while preserving key information.
 /status - Show session status: model, provider, mode, and token usage.
+/copy - Copy the last assistant response to the clipboard.
 /edit [text] - Open your prompt editor to compose a message. Optionally pre-fill with text.
                Uses $GOOSE_PROMPT_EDITOR, $VISUAL, or $EDITOR (in that order).
 /skills - List available skills or enable skills by name (usage: /skills [<name>...])
@@ -747,6 +751,15 @@ mod tests {
     #[test]
     fn test_editor_always_explicit_false_without_editor() {
         assert!(!should_use_editor_always(None, Some(false)));
+    }
+
+    #[test]
+    fn test_copy_command() {
+        assert!(matches!(
+            handle_slash_command("/copy"),
+            Some(InputResult::Copy)
+        ));
+        assert!(handle_slash_command("/copyextra").is_none());
     }
 
     #[test]

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -1,4 +1,5 @@
 mod builder;
+mod clipboard;
 mod completion;
 pub mod editor;
 mod elicitation;
@@ -596,6 +597,10 @@ impl CliSession {
             InputResult::ToggleFullToolOutput => {
                 history.save(editor);
                 self.handle_toggle_full_tool_output();
+            }
+            InputResult::Copy => {
+                history.save(editor);
+                self.handle_copy();
             }
             InputResult::SelectTheme(theme_name) => {
                 history.save(editor);
@@ -1754,12 +1759,43 @@ impl CliSession {
     fn push_message(&mut self, message: Message) {
         self.messages.push(message);
     }
+
+    fn handle_copy(&self) {
+        let Some(text) = last_assistant_text(self.messages.messages()) else {
+            output::render_error("No assistant response to copy yet.");
+            return;
+        };
+        match clipboard::copy(&text) {
+            Ok(method) => output::render_copied(text.chars().count(), method),
+            Err(e) => output::render_error(&format!("Could not copy the response: {e}")),
+        }
+    }
 }
 
 fn message_has_text(message: &Message) -> bool {
     message.content.iter().any(
         |content| matches!(content, MessageContent::Text(text) if !text.text.trim().is_empty()),
     )
+}
+
+fn last_assistant_text(messages: &[Message]) -> Option<String> {
+    messages
+        .iter()
+        .rev()
+        .filter(|message| message.role == rmcp::model::Role::Assistant)
+        .find_map(|message| {
+            let text = message
+                .content
+                .iter()
+                .filter_map(|content| match content {
+                    MessageContent::Text(text) => Some(text.text.as_str()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            let text = text.trim();
+            (!text.is_empty()).then(|| text.to_string())
+        })
 }
 
 fn print_run_stats(
@@ -2298,6 +2334,38 @@ mod tests {
     use std::collections::HashMap;
     use std::time::Duration;
     use test_case::test_case;
+
+    #[test]
+    fn last_assistant_text_returns_most_recent_text() {
+        let messages = vec![
+            Message::assistant().with_text("first answer"),
+            Message::user().with_text("next question"),
+            Message::assistant().with_text("second answer"),
+        ];
+        assert_eq!(
+            last_assistant_text(&messages).as_deref(),
+            Some("second answer")
+        );
+    }
+
+    #[test]
+    fn last_assistant_text_skips_messages_without_text() {
+        let messages = vec![
+            Message::assistant().with_text("real answer"),
+            Message::user().with_text("run the tool"),
+            Message::assistant().with_text("   "),
+        ];
+        assert_eq!(
+            last_assistant_text(&messages).as_deref(),
+            Some("real answer")
+        );
+    }
+
+    #[test]
+    fn last_assistant_text_empty_when_no_assistant_messages() {
+        let messages = vec![Message::user().with_text("hello")];
+        assert_eq!(last_assistant_text(&messages), None);
+    }
 
     #[test]
     fn test_format_elapsed_time_under_60_seconds() {

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -629,6 +629,16 @@ fn render_arguments(info: &PromptInfo) {
     }
 }
 
+pub fn render_copied(chars: usize, method: &str) {
+    println!(
+        "{}",
+        style(format!(
+            "Copied last response to the clipboard ({chars} chars via {method})"
+        ))
+        .dim()
+    );
+}
+
 pub fn render_extension_success(name: &str) {
     println!();
     println!(


### PR DESCRIPTION
## What

Adds `/copy` to the interactive CLI: copies the last assistant response to the system clipboard.

Grabbing an answer out of the terminal today means mouse-selecting across wrapped lines and scrollback, which mangles formatting and picks up the UI chrome. Other agent CLIs ship a one-keystroke copy for exactly this reason; this brings goose in line.

## Behavior

- `/copy` copies the most recent assistant message that contains text. Assistant messages that carry only tool calls are skipped, so you get the last real answer rather than an empty string.
- Copy goes through the platform clipboard tool first: `pbcopy` on macOS, `wl-copy` / `xclip` / `xsel` on Linux (tried in that order), `clip` on Windows.
- If no clipboard tool is available (for example over SSH), it falls back to the OSC 52 escape sequence, which modern terminals translate into a local clipboard write. Payloads beyond the common OSC 52 size limit fail with a clear error instead of silently truncating.
- Confirmation shows the size and the mechanism used; with no assistant response yet it explains that instead.
- Listed in `/help` and included in slash-command tab completion.

This lives in the CLI input layer (like `/t` and `/edit`) rather than the shared builtin commands, since the system clipboard is a property of the user's terminal, not of the agent session.

## Tests

- `test_copy_command` covers parsing (`/copy` matches, `/copyextra` does not).
- `last_assistant_text_*` (3 tests) cover message selection: most recent text wins, tool-call-only and whitespace-only messages are skipped, and no assistant message yields none.
- `osc52_*` (2 tests) cover the escape-sequence encoding and the oversized-payload guard.
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo test -p goose-cli` are green.
