### PR TITLE
fix(providers): add claude-sonnet-5 to canonical model registry

### DIFF
--- a/crates/goose-providers/src/canonical/data/canonical_models.json
+++ b/crates/goose-providers/src/canonical/data/canonical_models.json
@@ -13243,6 +13243,39 @@
     }
   },
   {
+    "id": "amazon-bedrock/global.anthropic.claude-sonnet-5",
+    "name": "Claude Sonnet 5 (Global)",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-06-01",
+    "last_updated": "2026-07-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 64000
+    }
+  },
+  {
     "id": "amazon-bedrock/google.gemma-3-12b-it",
     "name": "Google Gemma 3 12B",
     "family": "gemma",
@@ -15780,6 +15813,40 @@
     "knowledge": "2025-08-31",
     "release_date": "2026-02-17",
     "last_updated": "2026-03-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "anthropic/claude-sonnet-5",
+    "name": "Claude Sonnet 5",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "thinking_mode": "adaptive",
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-06-01",
+    "last_updated": "2026-07-01",
     "modalities": {
       "input": [
         "text",

--- a/crates/goose-providers/src/canonical/name_builder.rs
+++ b/crates/goose-providers/src/canonical/name_builder.rs
@@ -390,6 +390,14 @@ mod tests {
             map_to_canonical_model("bedrock", "claude-3-5-sonnet", r),
             Some("anthropic/claude-3.5-sonnet".to_string())
         );
+        assert_eq!(
+            map_to_canonical_model("aws_bedrock", "global.anthropic.claude-sonnet-5", r),
+            Some("amazon-bedrock/global.anthropic.claude-sonnet-5".to_string())
+        );
+        assert_eq!(
+            map_to_canonical_model("anthropic", "claude-sonnet-5", r),
+            Some("anthropic/claude-sonnet-5".to_string())
+        );
 
         // === OpenAI GPT ===
         assert_eq!(

--- a/crates/goose-providers/src/model.rs
+++ b/crates/goose-providers/src/model.rs
@@ -565,6 +565,20 @@ mod tests {
         }
 
         #[test]
+        fn resolves_claude_sonnet_5_on_aws_bedrock() {
+            let _guard = env_lock::lock_env([
+                ("GOOSE_MAX_TOKENS", None::<&str>),
+                ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+            ]);
+            let config = ModelConfig::new("global.anthropic.claude-sonnet-5")
+                .with_canonical_limits("aws_bedrock");
+
+            assert_eq!(config.context_limit, Some(1_000_000));
+            assert_eq!(config.max_tokens, Some(64_000));
+            assert_eq!(config.reasoning, Some(true));
+        }
+
+        #[test]
         fn unknown_model_leaves_fields_none() {
             let _guard = env_lock::lock_env([
                 ("GOOSE_MAX_TOKENS", None::<&str>),

--- a/crates/goose/src/bin/build_canonical_models.rs
+++ b/crates/goose/src/bin/build_canonical_models.rs
@@ -361,6 +361,7 @@ fn inferred_thinking_mode(canonical_id: &str) -> Option<ThinkingMode> {
         "anthropic/claude-opus-4.7" => Some(ThinkingMode::Adaptive),
         "anthropic/claude-opus-4.8" => Some(ThinkingMode::Adaptive),
         "anthropic/claude-sonnet-4.6" => Some(ThinkingMode::Adaptive),
+        "anthropic/claude-sonnet-5" => Some(ThinkingMode::Adaptive),
         _ => None,
     }
 }

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -37,6 +37,7 @@ pub const BEDROCK_DOC_LINK: &str =
 
 pub const BEDROCK_DEFAULT_MODEL: &str = "us.anthropic.claude-sonnet-4-5-20250929-v1:0";
 pub const BEDROCK_KNOWN_MODELS: &[&str] = &[
+    "global.anthropic.claude-sonnet-5",
     "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
     "us.anthropic.claude-sonnet-4-20250514-v1:0",
     "us.anthropic.claude-3-7-sonnet-20250219-v1:0",


### PR DESCRIPTION
## Summary

Add `claude-sonnet-5` entries to the canonical model registry so AWS Bedrock users get the correct 1M context window instead of the 128k default fallback.

## Motivation

`global.anthropic.claude-sonnet-5` on the `aws_bedrock` provider currently resolves no canonical entry, so `with_canonical_limits()` leaves `context_limit` unset and `context_limit()` falls back to 128,000 tokens. The wiring is correct — this is a pure data gap until models.dev lists the model.

Fixes #10179

## Changes

- Add `amazon-bedrock/global.anthropic.claude-sonnet-5` to `canonical_models.json` (context: 1,000,000; output: 64,000), mirroring the `claude-sonnet-4.6` global entry
- Add `anthropic/claude-sonnet-5` with the same limits and `thinking_mode: adaptive`
- Register `global.anthropic.claude-sonnet-5` in `BEDROCK_KNOWN_MODELS` for model-picker visibility
- Add `anthropic/claude-sonnet-5` to `inferred_thinking_mode` in `build_canonical_models.rs` for future registry rebuilds
- Add unit tests for canonical lookup on `aws_bedrock` and `anthropic`

## Tests

```bash
cargo test -p goose-providers with_canonical_limits
cargo test -p goose-providers test_map_to_canonical_model
```

All 7 `with_canonical_limits` tests and `test_map_to_canonical_model` pass.

## Notes

- models.dev does not yet list `claude-sonnet-5`, so these entries are hand-added per the issue's proposed fix. They can be refreshed via `cargo run --bin build_canonical_models` once models.dev catches up.
- Regional Bedrock variants (e.g. `us.anthropic.claude-sonnet-5`) are out of scope for this PR; only the global ID reported in #10179 is covered.