### PR TITLE
Fix Desktop local goosed requests from renderer

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -17,7 +17,6 @@ import {
   Tray,
 } from 'electron';
 import { pathToFileURL, format as formatUrl, URLSearchParams } from 'node:url';
-import { Buffer } from 'node:buffer';
 import fs from 'node:fs/promises';
 import fsSync from 'node:fs';
 import started from 'electron-squirrel-startup';
@@ -53,6 +52,13 @@ import { GooseApp } from './api';
 import installExtension, { REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer';
 import { BLOCKED_PROTOCOLS, WEB_PROTOCOLS } from './utils/urlSecurity';
 import { buildCSP } from './utils/csp';
+import {
+  handleGoosedCertificateError,
+  installGoosedCertificateVerifier,
+  installGoosedCertificateVerifierForWindow,
+  setGoosedPinnedCertFingerprint,
+  setTrustedExternalGoosedHostname,
+} from './utils/goosedCertificateVerifier';
 
 function shouldSetupUpdater(): boolean {
   // Setup updater if either the flag is enabled OR dev updates are enabled
@@ -290,58 +296,11 @@ async function configureProxy() {
 
 if (started) app.quit();
 
-// Certificate trust for goosed servers (local and external).
-// Both certificate-error (renderer) and setCertificateVerifyProc (main-process
-// net.fetch) pin to the exact cert fingerprint. For locally-spawned goosed the
-// fingerprint comes from its stdout; for external backends we use Trust-On-First-Use
-// (TOFU) — the first TLS handshake pins the cert for the lifetime of the process.
-let pinnedCertFingerprint: string | null = null;
-
-// Cached hostname of the configured external goosed server, updated when a
-// chat is created so we don't hit the filesystem on every TLS handshake.
-let trustedExternalHostname: string | null = null;
-
-function isLocalhost(hostname: string): boolean {
-  return hostname === '127.0.0.1' || hostname === 'localhost';
-}
-
-function isTrustedHost(hostname: string): boolean {
-  if (isLocalhost(hostname)) return true;
-  return trustedExternalHostname !== null && hostname === trustedExternalHostname;
-}
-
-function normalizeFingerprint(fp: string): string {
-  if (fp.startsWith('sha256/')) {
-    const b64 = fp.slice('sha256/'.length);
-    const buf = Buffer.from(b64, 'base64');
-    return Array.from(buf)
-      .map((b) => b.toString(16).padStart(2, '0'))
-      .join(':')
-      .toUpperCase();
-  }
-  return fp.toUpperCase();
-}
-
 // Renderer requests: pin to the exact cert goosed generated once known.
 // Before the fingerprint is available (during the health-check bootstrap
 // window) any localhost cert is accepted so the server can come up.
 app.on('certificate-error', (event, _webContents, url, _error, certificate, callback) => {
-  const parsed = new URL(url);
-  if (!isTrustedHost(parsed.hostname)) {
-    callback(false);
-    return;
-  }
-  if (pinnedCertFingerprint) {
-    const match =
-      normalizeFingerprint(certificate.fingerprint) === pinnedCertFingerprint.toUpperCase();
-    event.preventDefault();
-    callback(match);
-  } else {
-    // TOFU: pin the certificate from the first successful handshake.
-    pinnedCertFingerprint = normalizeFingerprint(certificate.fingerprint);
-    event.preventDefault();
-    callback(true);
-  }
+  handleGoosedCertificateError(event, url, certificate, callback);
 });
 
 app.whenReady().then(() => {
@@ -350,21 +309,7 @@ app.whenReady().then(() => {
 
 // Main-process net.fetch: pin to the exact cert goosed generated.
 app.whenReady().then(() => {
-  session.defaultSession.setCertificateVerifyProc((request, callback) => {
-    if (!isTrustedHost(request.hostname)) {
-      callback(-3);
-      return;
-    }
-    if (!pinnedCertFingerprint) {
-      // TOFU: pin the certificate from the first successful handshake.
-      pinnedCertFingerprint = normalizeFingerprint(request.certificate.fingerprint);
-      callback(0);
-      return;
-    }
-    const match =
-      normalizeFingerprint(request.certificate.fingerprint) === pinnedCertFingerprint.toUpperCase();
-    callback(match ? 0 : -2);
-  });
+  installGoosedCertificateVerifier(session.defaultSession);
 });
 
 if (process.env.ENABLE_PLAYWRIGHT) {
@@ -906,20 +851,20 @@ const createChat = async (app: App, options: CreateChatOptions = {}) => {
   // connections to the configured remote backend.
   if (settings.externalGoosed?.enabled && settings.externalGoosed.url) {
     try {
-      trustedExternalHostname = new URL(settings.externalGoosed.url).hostname;
+      setTrustedExternalGoosedHostname(new URL(settings.externalGoosed.url).hostname);
     } catch {
-      trustedExternalHostname = null;
+      setTrustedExternalGoosedHostname(null);
     }
   } else {
-    trustedExternalHostname = null;
+    setTrustedExternalGoosedHostname(null);
   }
 
   // If the user provided a cert fingerprint for the external backend, pin it
   // directly (skips TOFU). Otherwise reset so the first handshake pins via TOFU.
   if (settings.externalGoosed?.enabled && settings.externalGoosed.certFingerprint) {
-    pinnedCertFingerprint = normalizeFingerprint(settings.externalGoosed.certFingerprint);
+    setGoosedPinnedCertFingerprint(settings.externalGoosed.certFingerprint);
   } else {
-    pinnedCertFingerprint = null;
+    setGoosedPinnedCertFingerprint(null);
   }
 
   const goosedResult = await startGoosed({
@@ -939,7 +884,7 @@ const createChat = async (app: App, options: CreateChatOptions = {}) => {
   // For external backends the TOFU path in the cert handlers will pin
   // the fingerprint on the first successful TLS handshake.
   if (goosedResult.certFingerprint) {
-    pinnedCertFingerprint = goosedResult.certFingerprint;
+    setGoosedPinnedCertFingerprint(goosedResult.certFingerprint);
   }
 
   const {
@@ -956,6 +901,9 @@ const createChat = async (app: App, options: CreateChatOptions = {}) => {
     defaultWidth: 940,
     defaultHeight: 800,
   });
+
+  const mainWindowSession = session.fromPartition('persist:goose');
+  installGoosedCertificateVerifier(mainWindowSession);
 
   const mainWindow = new BrowserWindow({
     titleBarStyle: process.platform === 'darwin' ? 'hidden' : 'default',
@@ -1001,6 +949,8 @@ const createChat = async (app: App, options: CreateChatOptions = {}) => {
       partition: 'persist:goose',
     },
   });
+
+  installGoosedCertificateVerifierForWindow(mainWindow);
 
   if (!app.isPackaged) {
     installExtension(REACT_DEVELOPER_TOOLS, {
@@ -1772,6 +1722,62 @@ ipcMain.handle('get-goosed-host-port', async (event) => {
   }
   return client.getConfig().baseUrl || null;
 });
+
+ipcMain.handle(
+  'goosed-fetch',
+  async (
+    event,
+    input: string,
+    init?: { method?: string; headers?: Record<string, string>; body?: string | null }
+  ) => {
+    const windowId = BrowserWindow.fromWebContents(event.sender)?.id;
+    if (!windowId) {
+      throw new Error('Missing window for goosed request');
+    }
+
+    const client = goosedClients.get(windowId);
+    const baseUrl = client?.getConfig().baseUrl;
+    if (!baseUrl) {
+      throw new Error('Missing goosed backend for window');
+    }
+
+    const requestedUrl = new URL(input);
+    const allowedUrl = new URL(baseUrl);
+    if (requestedUrl.origin !== allowedUrl.origin) {
+      throw new Error('Blocked non-goosed request');
+    }
+
+    const requestInit = {
+      method: init?.method,
+      headers: init?.headers,
+      body: init?.body ?? undefined,
+    };
+
+    let response: Response | null = null;
+    for (let attempt = 0; attempt < 4; attempt++) {
+      try {
+        response = await net.fetch(requestedUrl.toString(), requestInit);
+        break;
+      } catch (error) {
+        if (!String(error).includes('ERR_NETWORK_CHANGED') || attempt === 3) {
+          throw error;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 250));
+      }
+    }
+
+    if (!response) {
+      throw new Error('goosed request failed');
+    }
+
+    return {
+      status: response.status,
+      statusText: response.statusText,
+      headers: Object.fromEntries(response.headers.entries()),
+      body: await response.text(),
+    };
+  }
+);
 
 ipcMain.handle('get-acp-url', async (event) => {
   const windowId = BrowserWindow.fromWebContents(event.sender)?.id;

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -132,6 +132,19 @@ type ElectronAPI = {
   setSetting: <K extends SettingKey>(key: K, value: Settings[K]) => Promise<void>;
   getSecretKey: () => Promise<string>;
   getGoosedHostPort: () => Promise<string | null>;
+  goosedFetch: (
+    input: string,
+    init?: {
+      method?: string;
+      headers?: Record<string, string>;
+      body?: string | null;
+    }
+  ) => Promise<{
+    status: number;
+    statusText: string;
+    headers: Record<string, string>;
+    body: string;
+  }>;
   getAcpUrl: () => Promise<string | null>;
   setWakelock: (enable: boolean) => Promise<boolean>;
   getWakelockState: () => Promise<boolean>;
@@ -255,6 +268,7 @@ const electronAPI: ElectronAPI = {
   },
   getSecretKey: () => ipcRenderer.invoke('get-secret-key'),
   getGoosedHostPort: () => ipcRenderer.invoke('get-goosed-host-port'),
+  goosedFetch: (input, init) => ipcRenderer.invoke('goosed-fetch', input, init),
   getAcpUrl: () => ipcRenderer.invoke('get-acp-url'),
   setWakelock: (enable: boolean) => ipcRenderer.invoke('set-wakelock', enable),
   getWakelockState: () => ipcRenderer.invoke('get-wakelock-state'),

--- a/ui/desktop/src/renderer.tsx
+++ b/ui/desktop/src/renderer.tsx
@@ -41,8 +41,24 @@ function handleIntlError(err: { code: string; message?: string }) {
       window.alert('failed to start goose backend process');
       return;
     }
+    const goosedFetch: typeof fetch = async (input, init) => {
+      const request = new Request(input, init);
+      const body = await request.text();
+      const response = await window.electron.goosedFetch(request.url, {
+        method: request.method,
+        headers: Object.fromEntries(request.headers.entries()),
+        body: body || null,
+      });
+
+      return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+    };
     client.setConfig({
       baseUrl: gooseApiHost,
+      fetch: goosedFetch,
       headers: {
         'Content-Type': 'application/json',
         'X-Secret-Key': await window.electron.getSecretKey(),

--- a/ui/desktop/src/utils/goosedCertificateVerifier.test.ts
+++ b/ui/desktop/src/utils/goosedCertificateVerifier.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  installGoosedCertificateVerifier,
+  installGoosedCertificateVerifierForWindow,
+} from './goosedCertificateVerifier';
+
+describe('goosed certificate verifier', () => {
+  it('installs the verifier on the BrowserWindow session', () => {
+    const setCertificateVerifyProc = vi.fn();
+
+    installGoosedCertificateVerifierForWindow({
+      webContents: {
+        session: { setCertificateVerifyProc },
+      },
+    });
+
+    expect(setCertificateVerifyProc).toHaveBeenCalledOnce();
+    expect(setCertificateVerifyProc).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('does not reinstall the verifier for the same session', () => {
+    const session = { setCertificateVerifyProc: vi.fn() };
+
+    installGoosedCertificateVerifier(session);
+    installGoosedCertificateVerifier(session);
+
+    expect(session.setCertificateVerifyProc).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/desktop/src/utils/goosedCertificateVerifier.ts
+++ b/ui/desktop/src/utils/goosedCertificateVerifier.ts
@@ -1,0 +1,105 @@
+type Certificate = {
+  fingerprint: string;
+};
+
+type CertificateVerifyRequest = {
+  hostname: string;
+  certificate: Certificate;
+};
+
+type CertificateVerifyProc = (
+  request: CertificateVerifyRequest,
+  callback: (verificationResult: number) => void
+) => void;
+
+type CertificateVerifierSession = {
+  setCertificateVerifyProc: (proc: CertificateVerifyProc) => void;
+};
+
+type WindowWithSession = {
+  webContents: {
+    session: CertificateVerifierSession;
+  };
+};
+
+let pinnedCertFingerprint: string | null = null;
+let trustedExternalHostname: string | null = null;
+const installedSessions = new WeakSet<CertificateVerifierSession>();
+
+function isLocalhost(hostname: string): boolean {
+  return hostname === '127.0.0.1' || hostname === 'localhost';
+}
+
+function isTrustedHost(hostname: string): boolean {
+  if (isLocalhost(hostname)) return true;
+  return trustedExternalHostname !== null && hostname === trustedExternalHostname;
+}
+
+function normalizeFingerprint(fp: string): string {
+  if (fp.startsWith('sha256/')) {
+    const b64 = fp.slice('sha256/'.length);
+    const buf = Buffer.from(b64, 'base64');
+    return Array.from(buf)
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join(':')
+      .toUpperCase();
+  }
+  return fp.toUpperCase();
+}
+
+export function setGoosedPinnedCertFingerprint(fingerprint: string | null) {
+  pinnedCertFingerprint = fingerprint ? normalizeFingerprint(fingerprint) : null;
+}
+
+export function setTrustedExternalGoosedHostname(hostname: string | null) {
+  trustedExternalHostname = hostname;
+}
+
+export function handleGoosedCertificateError(
+  event: { preventDefault: () => void },
+  url: string,
+  certificate: Certificate,
+  callback: (isTrusted: boolean) => void
+) {
+  const parsed = new URL(url);
+  if (!isTrustedHost(parsed.hostname)) {
+    callback(false);
+    return;
+  }
+
+  event.preventDefault();
+
+  const fingerprint = normalizeFingerprint(certificate.fingerprint);
+  if (!pinnedCertFingerprint) {
+    pinnedCertFingerprint = fingerprint;
+    callback(true);
+    return;
+  }
+
+  callback(fingerprint === pinnedCertFingerprint.toUpperCase());
+}
+
+export function installGoosedCertificateVerifier(session: CertificateVerifierSession) {
+  if (installedSessions.has(session)) return;
+  installedSessions.add(session);
+
+  session.setCertificateVerifyProc((request, callback) => {
+    if (!isTrustedHost(request.hostname)) {
+      callback(-3);
+      return;
+    }
+
+    const fingerprint = normalizeFingerprint(request.certificate.fingerprint);
+    if (!pinnedCertFingerprint) {
+      pinnedCertFingerprint = fingerprint;
+      callback(0);
+      return;
+    }
+
+    callback(fingerprint === pinnedCertFingerprint.toUpperCase() ? 0 : -2);
+  });
+}
+
+export function installGoosedCertificateVerifierForWindow(window: WindowWithSession) {
+  installGoosedCertificateVerifier(window.webContents.session);
+}


### PR DESCRIPTION
## Summary

This fixes a Desktop failure mode where chat/session loading can fail with a generic `Failed to fetch` even though the local `goosed` backend is running and the session data is valid.

The failure happens when the renderer process sends REST API requests directly to the local HTTPS `goosed` server. That server uses a self-signed localhost certificate. In the failing case, Chromium rejects the renderer request at the certificate validation layer before the request reaches `goosed`, so the UI reports the generic browser `TypeError: Failed to fetch`.

## Root cause

The local backend itself is healthy:

- `goosed` starts successfully.
- `POST /agent/resume` returns `200` from a trusted main-process/Node request path.
- ACP/session data can be loaded successfully from the backend.

The failure is isolated to renderer-process network requests:

- Renderer `fetch(https://127.0.0.1:<port>/agent/resume)` fails with `TypeError: Failed to fetch`.
- Chromium netlog shows the local request failing with `net_error: -202` and `cert_status: 4`, which indicates the self-signed localhost certificate is not trusted by the renderer request.

The existing certificate pinning logic was also only installed for the default session. Chat windows use the `persist:goose` partition, so this PR moves the certificate verifier logic into a shared helper and installs it for that partition as well. However, renderer `fetch` remains fragile around Electron/Chromium certificate handling, so the REST API client now uses a main-process fetch bridge instead of making direct renderer requests to the self-signed local HTTPS origin.

## What changed

- Extracted goosed certificate pinning into `goosedCertificateVerifier` so the same logic is reused for:
  - `certificate-error`
  - `session.defaultSession.setCertificateVerifyProc`
  - the `persist:goose` BrowserWindow session
- Added a restricted `goosed-fetch` IPC handler.
  - It resolves the `goosed` backend associated with the calling window.
  - It only allows requests whose origin matches that window's `goosed` base URL.
  - It uses Electron main-process `net.fetch`, which already participates in the pinned certificate handling path.
- Updated the generated API client configuration in the renderer to use this bridge as its `fetch` implementation.
- Added a bounded retry for transient `net::ERR_NETWORK_CHANGED` from `net.fetch` during Desktop startup.
- Added a small unit test for installing the goosed certificate verifier on BrowserWindow sessions and avoiding duplicate installs.

## Security notes

The new IPC path is intentionally not a general network proxy:

- The renderer provides a URL, but the main process checks it against the current window's `goosed` origin.
- Requests to any other origin are rejected.
- Existing `X-Secret-Key` authentication is still sent by the renderer API client as before.
- Certificate pinning is still retained for the main-process `net.fetch` path.

## Validation

Ran:

```bash
cd ui/desktop
pnpm test:run src/utils/goosedCertificateVerifier.test.ts
pnpm run typecheck
pnpm run package
```

Manual/local validation:

- Replaced the locally installed Desktop `app.asar` with the packaged output.
- Started Desktop with the local `goosed` backend.
- Verified via DevTools that `window.electron.goosedFetch(.../agent/resume)` returns `200` and session JSON on the first request.
- Confirmed the previous renderer direct `fetch` failure was caused by Chromium certificate rejection rather than missing session data or a backend crash.
