### PR TITLE
fix: Skip downstream github jobs for release branch build

### DIFF
--- a/.github/workflows/build-notify.yml
+++ b/.github/workflows/build-notify.yml
@@ -7,6 +7,8 @@ on:
       - Release
       - Canary
     types: [completed]
+    branches-ignore:
+      - "release/**"
 
 
 jobs:

--- a/.github/workflows/goose-release-notes.yml
+++ b/.github/workflows/goose-release-notes.yml
@@ -15,6 +15,8 @@ on:
       - Release
     types:
       - completed
+    branches-ignore:
+      - "release/**"
 
   # Allow manual trigger for testing
   workflow_dispatch:
@@ -76,7 +78,7 @@ jobs:
   generate-release-notes:
     name: Generate Release Notes
     runs-on: ubuntu-latest
-    # For workflow_run: only run if Release succeeded and tag is not 'stable'
+    # For workflow_run: release branch preflight builds are ignored by the trigger.
     # For workflow_dispatch: only run if tag is not 'stable'
     if: |
       (github.event_name == 'workflow_dispatch' && inputs.tag != 'stable') ||


### PR DESCRIPTION
## Summary

### Why

Release branch builds now run through the `Release` workflow before a tag is pushed. Those builds should not trigger release notes or build notifications.

### What
Ignore `release/**` branches in workflows that listen for the `Release` workflow to finish. Tag releases like `v1.40.0` still trigger them.

Ideal fix is to have a separate pipeline that reuse the release.yml pipeline, so that the downstream jobs does not have these changes.  Next release (ui -> acp) is a big one so we are going to do the ideal way after next release while simplify the release post acp migration 