### PR TITLE
fix: refresh canonical model registry to add claude-sonnet-5

### DIFF
--- a/crates/goose-providers/src/canonical/data/canonical_models.json
+++ b/crates/goose-providers/src/canonical/data/canonical_models.json
@@ -12205,6 +12205,39 @@
     }
   },
   {
+    "id": "amazon-bedrock/anthropic.claude-fable-5",
+    "name": "Claude Fable 5",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-09",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "amazon-bedrock/anthropic.claude-haiku-4.5-20251001-v1:0",
     "name": "Claude Haiku 4.5",
     "family": "claude-haiku",
@@ -12468,6 +12501,39 @@
     }
   },
   {
+    "id": "amazon-bedrock/anthropic.claude-sonnet-5",
+    "name": "Claude Sonnet 5",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 10.0,
+      "cache_read": 0.2,
+      "cache_write": 2.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "amazon-bedrock/au.anthropic.claude-haiku-4.5-20251001-v1:0",
     "name": "Claude Haiku 4.5 (AU)",
     "family": "claude-haiku",
@@ -12632,6 +12698,39 @@
     }
   },
   {
+    "id": "amazon-bedrock/au.anthropic.claude-sonnet-5",
+    "name": "Claude Sonnet 5 (AU)",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 10.0,
+      "cache_read": 0.2,
+      "cache_write": 2.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "amazon-bedrock/deepseek.r1-v1:0",
     "name": "DeepSeek-R1",
     "family": "deepseek-thinking",
@@ -12732,7 +12831,8 @@
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -12981,6 +13081,39 @@
     }
   },
   {
+    "id": "amazon-bedrock/eu.anthropic.claude-sonnet-5",
+    "name": "Claude Sonnet 5 (EU)",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.2,
+      "output": 11.0,
+      "cache_read": 0.22,
+      "cache_write": 2.75
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "amazon-bedrock/global.anthropic.claude-fable-5",
     "name": "Claude Fable 5 (Global)",
     "family": "claude-fable",
@@ -12994,7 +13127,8 @@
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -13243,6 +13377,39 @@
     }
   },
   {
+    "id": "amazon-bedrock/global.anthropic.claude-sonnet-5",
+    "name": "Claude Sonnet 5 (Global)",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 10.0,
+      "cache_read": 0.2,
+      "cache_write": 2.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "amazon-bedrock/google.gemma-3-12b-it",
     "name": "Google Gemma 3 12B",
     "family": "gemma",
@@ -13460,6 +13627,39 @@
     "limit": {
       "context": 1000000,
       "output": 64000
+    }
+  },
+  {
+    "id": "amazon-bedrock/jp.anthropic.claude-sonnet-5",
+    "name": "Claude Sonnet 5 (JP)",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 10.0,
+      "cache_read": 0.2,
+      "cache_write": 2.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
     }
   },
   {
@@ -14568,7 +14768,8 @@
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -14847,6 +15048,39 @@
     "limit": {
       "context": 1000000,
       "output": 64000
+    }
+  },
+  {
+    "id": "amazon-bedrock/us.anthropic.claude-sonnet-5",
+    "name": "Claude Sonnet 5 (US)",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 10.0,
+      "cache_read": 0.2,
+      "cache_write": 2.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
     }
   },
   {
@@ -15800,6 +16034,39 @@
     "limit": {
       "context": 1000000,
       "output": 64000
+    }
+  },
+  {
+    "id": "anthropic/claude-sonnet-5",
+    "name": "Claude Sonnet 5",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 10.0,
+      "cache_read": 0.2,
+      "cache_write": 2.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
     }
   },
   {
@@ -20247,6 +20514,39 @@
     }
   },
   {
+    "id": "azure/claude-sonnet-5",
+    "name": "Claude Sonnet 5",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 10.0,
+      "cache_read": 0.2,
+      "cache_write": 2.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "azure/codestral",
     "name": "Codestral 25.01",
     "family": "codestral",
@@ -23797,6 +24097,35 @@
     }
   },
   {
+    "id": "cerebras/gemma-4-31b",
+    "name": "Gemma 4 31B IT",
+    "family": "gemma",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-02",
+    "last_updated": "2026-07-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.99,
+      "output": 1.49
+    },
+    "limit": {
+      "context": 131072,
+      "output": 40960
+    }
+  },
+  {
     "id": "cerebras/gpt-oss-120b",
     "name": "GPT OSS 120B",
     "family": "gpt-oss",
@@ -25317,6 +25646,39 @@
     "limit": {
       "context": 1000000,
       "output": 64000
+    }
+  },
+  {
+    "id": "cloudflare-ai-gateway/anthropic/claude-sonnet-5",
+    "name": "Claude Sonnet 5",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 10.0,
+      "cache_read": 0.2,
+      "cache_write": 2.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
     }
   },
   {
@@ -31771,6 +32133,38 @@
     "limit": {
       "context": 262144,
       "output": 16384
+    }
+  },
+  {
+    "id": "deepinfra/moonshotai/Kimi-K2.7-Code",
+    "name": "Kimi K2.7 Code",
+    "family": "kimi-k2",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-01",
+    "release_date": "2026-06-12",
+    "last_updated": "2026-06-12",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.74,
+      "output": 3.5,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
     }
   },
   {
@@ -38617,6 +39011,39 @@
     }
   },
   {
+    "id": "github-copilot/claude-sonnet-5",
+    "name": "Claude Sonnet 5",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 10.0,
+      "cache_read": 0.2,
+      "cache_write": 2.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "github-copilot/gemini-2.5-pro",
     "name": "Gemini 2.5 Pro",
     "family": "gemini-pro",
@@ -41848,6 +42275,39 @@
     }
   },
   {
+    "id": "google-vertex-anthropic/claude-sonnet-5@default",
+    "name": "Claude Sonnet 5",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 10.0,
+      "cache_read": 0.2,
+      "cache_write": 2.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "google-vertex/claude-3.5-haiku",
     "name": "Claude Haiku 3.5",
     "family": "claude-haiku",
@@ -42203,6 +42663,39 @@
       "output": 15.0,
       "cache_read": 0.3,
       "cache_write": 3.75
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "google-vertex/claude-sonnet-5@default",
+    "name": "Claude Sonnet 5",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 10.0,
+      "cache_read": 0.2,
+      "cache_write": 2.5
     },
     "limit": {
       "context": 1000000,
@@ -61224,6 +61717,39 @@
     }
   },
   {
+    "id": "llmgateway/claude-fable-5",
+    "name": "Claude Fable 5",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-09",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "llmgateway/claude-haiku-4.5",
     "name": "Claude Haiku 4.5 (latest)",
     "family": "claude-haiku",
@@ -61514,6 +62040,38 @@
     "limit": {
       "context": 1000000,
       "output": 64000
+    }
+  },
+  {
+    "id": "llmgateway/claude-sonnet-5",
+    "name": "Claude Sonnet 5",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 1000000
     }
   },
   {
@@ -63691,8 +64249,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.0,
-      "output": 6.0,
+      "input": 1.25,
+      "output": 2.5,
       "cache_read": 0.2
     },
     "limit": {
@@ -63722,8 +64280,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.0,
-      "output": 6.0,
+      "input": 1.25,
+      "output": 2.5,
       "cache_read": 0.2
     },
     "limit": {
@@ -65369,7 +65927,7 @@
       "output": 0.58
     },
     "limit": {
-      "context": 262000,
+      "context": 262144,
       "output": 8192
     }
   },
@@ -65688,7 +66246,7 @@
     "open_weights": true,
     "cost": {
       "input": 0.15,
-      "output": 1.5
+      "output": 1.2
     },
     "limit": {
       "context": 131072,
@@ -100943,7 +101501,7 @@
   },
   {
     "id": "opencode-go/minimax-m2.5",
-    "name": "MiniMax M2.5",
+    "name": "MiniMax-M2.5",
     "family": "minimax-m2.5",
     "attachment": false,
     "reasoning": true,
@@ -100973,7 +101531,7 @@
   },
   {
     "id": "opencode-go/minimax-m2.7",
-    "name": "MiniMax M2.7",
+    "name": "MiniMax-M2.7",
     "family": "minimax-m2.7",
     "attachment": false,
     "reasoning": true,
@@ -101003,7 +101561,7 @@
   },
   {
     "id": "opencode-go/minimax-m3",
-    "name": "MiniMax M3 (3x usage)",
+    "name": "MiniMax-M3",
     "family": "minimax-m3",
     "attachment": false,
     "reasoning": true,
@@ -101024,9 +101582,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.1,
-      "output": 0.4,
-      "cache_read": 0.02
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.06
     },
     "limit": {
       "context": 1000000,
@@ -101552,6 +102110,39 @@
     "limit": {
       "context": 1000000,
       "output": 64000
+    }
+  },
+  {
+    "id": "opencode/claude-sonnet-5",
+    "name": "Claude Sonnet 5",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 10.0,
+      "cache_read": 0.2,
+      "cache_write": 2.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
     }
   },
   {
@@ -102770,6 +103361,38 @@
     }
   },
   {
+    "id": "opencode/kimi-k2.7-code",
+    "name": "Kimi K2.7 Code",
+    "family": "kimi-k2",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-01",
+    "release_date": "2026-06-12",
+    "last_updated": "2026-06-12",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.95,
+      "output": 4.0,
+      "cache_read": 0.19
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
     "id": "opencode/ling-2.6-flash-free",
     "name": "Ling 2.6 Flash Free",
     "family": "ling-flash-free",
@@ -102926,7 +103549,7 @@
   },
   {
     "id": "opencode/minimax-m2.1",
-    "name": "MiniMax M2.1",
+    "name": "MiniMax-M2.1",
     "family": "minimax",
     "attachment": false,
     "reasoning": true,
@@ -102956,7 +103579,7 @@
   },
   {
     "id": "opencode/minimax-m2.1-free",
-    "name": "MiniMax M2.1 Free",
+    "name": "MiniMax-M2.1 Free",
     "family": "minimax-free",
     "attachment": false,
     "reasoning": true,
@@ -102986,7 +103609,7 @@
   },
   {
     "id": "opencode/minimax-m2.5",
-    "name": "MiniMax M2.5",
+    "name": "MiniMax-M2.5",
     "family": "minimax",
     "attachment": false,
     "reasoning": true,
@@ -103016,7 +103639,7 @@
   },
   {
     "id": "opencode/minimax-m2.5-free",
-    "name": "MiniMax M2.5 Free",
+    "name": "MiniMax-M2.5 Free",
     "family": "minimax-free",
     "attachment": false,
     "reasoning": true,
@@ -103046,7 +103669,7 @@
   },
   {
     "id": "opencode/minimax-m2.7",
-    "name": "MiniMax M2.7",
+    "name": "MiniMax-M2.7",
     "family": "minimax",
     "attachment": false,
     "reasoning": true,
@@ -103075,8 +103698,39 @@
     }
   },
   {
+    "id": "opencode/minimax-m3",
+    "name": "MiniMax-M3",
+    "family": "minimax",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-01",
+    "last_updated": "2026-06-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.06
+    },
+    "limit": {
+      "context": 512000,
+      "output": 128000
+    }
+  },
+  {
     "id": "opencode/minimax-m3-free",
-    "name": "MiniMax M3 Free",
+    "name": "MiniMax-M3 Free",
     "family": "minimax-m3-free",
     "attachment": false,
     "reasoning": true,
@@ -103759,6 +104413,39 @@
     }
   },
   {
+    "id": "openrouter/anthropic/claude-fable-5",
+    "name": "Claude Fable 5",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-09",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "openrouter/anthropic/claude-haiku-4.5",
     "name": "Claude Haiku 4.5 (latest)",
     "family": "claude-haiku",
@@ -104145,6 +104832,39 @@
       "output": 15.0,
       "cache_read": 0.3,
       "cache_write": 3.75
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/anthropic/claude-sonnet-5",
+    "name": "Claude Sonnet 5",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 10.0,
+      "cache_read": 0.2,
+      "cache_write": 2.5
     },
     "limit": {
       "context": 1000000,
@@ -104695,8 +105415,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.2,
-      "output": 0.77,
+      "input": 0.24,
+      "output": 0.9,
       "cache_read": 0.135
     },
     "limit": {
@@ -104904,11 +105624,11 @@
     "cost": {
       "input": 0.09,
       "output": 0.18,
-      "cache_read": 0.02
+      "cache_read": 0.018
     },
     "limit": {
-      "context": 1000000,
-      "output": 65536
+      "context": 1048576,
+      "output": 16384
     }
   },
   {
@@ -105377,6 +106097,37 @@
     "limit": {
       "context": 1048576,
       "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/google/gemini-3.1-flash-lite-image",
+    "name": "Nano Banana 2 Lite (Gemini 3.1 Flash Lite Image)",
+    "family": "gemini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-01-01",
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "image",
+        "text"
+      ],
+      "output": [
+        "image",
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 1.5
+    },
+    "limit": {
+      "context": 65536,
+      "output": 66000
     }
   },
   {
@@ -106631,35 +107382,6 @@
     }
   },
   {
-    "id": "openrouter/microsoft/phi-4-mini-instruct",
-    "name": "Phi 4 Mini Instruct",
-    "family": "phi",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2025-10-17",
-    "last_updated": "2025-10-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.08,
-      "output": 0.35,
-      "cache_read": 0.08
-    },
-    "limit": {
-      "context": 128000,
-      "output": 128000
-    }
-  },
-  {
     "id": "openrouter/microsoft/wizardlm-2-8x22b",
     "name": "WizardLM-2 8x22B",
     "attachment": false,
@@ -106767,12 +107489,11 @@
     "open_weights": true,
     "cost": {
       "input": 0.255,
-      "output": 1.0,
-      "cache_read": 0.03
+      "output": 1.02
     },
     "limit": {
-      "context": 196608,
-      "output": 196608
+      "context": 204800,
+      "output": 131072
     }
   },
   {
@@ -106824,13 +107545,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.29,
-      "output": 0.95,
+      "input": 0.3,
+      "output": 1.2,
       "cache_read": 0.03
     },
     "limit": {
-      "context": 196608,
-      "output": 196608
+      "context": 204800,
+      "output": 131072
     }
   },
   {
@@ -107491,11 +108212,11 @@
     "cost": {
       "input": 0.6,
       "output": 2.5,
-      "cache_read": 0.6
+      "cache_read": 0.15
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 100352
     }
   },
   {
@@ -110008,34 +110729,6 @@
     }
   },
   {
-    "id": "openrouter/openrouter/owl-alpha",
-    "name": "Owl Alpha",
-    "family": "alpha",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-04-28",
-    "last_updated": "2026-04-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 1048756,
-      "output": 262144
-    }
-  },
-  {
     "id": "openrouter/openrouter/pareto-code",
     "name": "Pareto Code Router",
     "attachment": false,
@@ -110600,12 +111293,11 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.1,
-      "output": 0.1,
-      "cache_read": 0.1
+      "input": 0.1495,
+      "output": 1.495
     },
     "limit": {
-      "context": 262144,
+      "context": 131072,
       "output": 262144
     }
   },
@@ -110688,13 +111380,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.08,
-      "output": 0.4,
-      "cache_read": 0.08
+      "input": 0.13,
+      "output": 1.56
     },
     "limit": {
-      "context": 131072,
-      "output": 131072
+      "context": 81920,
+      "output": 32768
     }
   },
   {
@@ -110747,12 +111438,11 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.05,
-      "output": 0.4,
-      "cache_read": 0.05
+      "input": 0.117,
+      "output": 0.455
     },
     "limit": {
-      "context": 40960,
+      "context": 131072,
       "output": 8192
     }
   },
@@ -111553,8 +112243,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.2596,
-      "output": 2.385
+      "input": 0.285,
+      "output": 2.4
     },
     "limit": {
       "context": 262140,
@@ -111862,6 +112552,7 @@
   {
     "id": "openrouter/sakana/fugu-ultra",
     "name": "Fugu Ultra",
+    "family": "fugu",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
@@ -112825,12 +113516,11 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.98,
-      "output": 3.08,
-      "cache_read": 0.182
+      "input": 0.975,
+      "output": 4.3
     },
     "limit": {
-      "context": 202752,
+      "context": 65536,
       "output": 128000
     }
   },
@@ -112854,7 +113544,7 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.94,
+      "input": 0.93,
       "output": 3.0,
       "cache_read": 0.18
     },
@@ -112997,7 +113687,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
     "release_date": "2026-04-27",
     "last_updated": "2026-04-27",
     "modalities": {
@@ -113012,10 +113702,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.3,
-      "cache_write": 3.75
+      "input": 2.0,
+      "output": 10.0,
+      "cache_read": 0.2,
+      "cache_write": 2.5
     },
     "limit": {
       "context": 1000000,
@@ -125610,6 +126300,62 @@
     }
   },
   {
+    "id": "sakana/fugu",
+    "name": "Fugu",
+    "family": "fugu",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-06-15",
+    "last_updated": "2026-06-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 1000000,
+      "output": 1000000
+    }
+  },
+  {
+    "id": "sakana/fugu-ultra",
+    "name": "Fugu Ultra",
+    "family": "fugu",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-06-15",
+    "last_updated": "2026-06-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 1000000
+    }
+  },
+  {
     "id": "sap-ai-core/anthropic--claude-3-haiku",
     "name": "anthropic--claude-3-haiku",
     "family": "claude-haiku",
@@ -130916,36 +131662,6 @@
     }
   },
   {
-    "id": "synthetic/hf:Qwen/Qwen3.5-397B-A17B",
-    "name": "Qwen3.5 397B-A17B",
-    "family": "qwen",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-02-15",
-    "last_updated": "2026-02-15",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.6,
-      "output": 3.6,
-      "cache_read": 0.6
-    },
-    "limit": {
-      "context": 262144,
-      "output": 65536
-    }
-  },
-  {
     "id": "synthetic/hf:Qwen/Qwen3.6-27B",
     "name": "Qwen3.6 27B",
     "family": "qwen",
@@ -130976,16 +131692,16 @@
     }
   },
   {
-    "id": "synthetic/hf:moonshotai/Kimi-K2.6",
-    "name": "Kimi K2.6",
+    "id": "synthetic/hf:moonshotai/Kimi-K2.7-Code",
+    "name": "Kimi K2.7 Code",
     "family": "kimi-k2",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
+    "temperature": false,
     "knowledge": "2025-01",
-    "release_date": "2026-04-21",
-    "last_updated": "2026-04-21",
+    "release_date": "2026-06-12",
+    "last_updated": "2026-06-12",
     "modalities": {
       "input": [
         "text",
@@ -131065,36 +131781,6 @@
     }
   },
   {
-    "id": "synthetic/hf:zai-org/GLM-4.7",
-    "name": "GLM-4.7",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-04",
-    "release_date": "2025-12-22",
-    "last_updated": "2025-12-22",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.45,
-      "output": 2.19,
-      "cache_read": 0.45
-    },
-    "limit": {
-      "context": 202752,
-      "output": 65536
-    }
-  },
-  {
     "id": "synthetic/hf:zai-org/GLM-4.7-Flash",
     "name": "GLM-4.7-Flash",
     "family": "glm-flash",
@@ -131118,35 +131804,6 @@
       "input": 0.1,
       "output": 0.5,
       "cache_read": 0.1
-    },
-    "limit": {
-      "context": 196608,
-      "output": 65536
-    }
-  },
-  {
-    "id": "synthetic/hf:zai-org/GLM-5.1",
-    "name": "GLM-5.1",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-04-07",
-    "last_updated": "2026-04-07",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 1.0,
-      "output": 3.0,
-      "cache_read": 1.0
     },
     "limit": {
       "context": 196608,
@@ -133344,34 +134001,6 @@
     }
   },
   {
-    "id": "venice/arcee-trinity-large-thinking",
-    "name": "Trinity Large Thinking",
-    "family": "trinity",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "release_date": "2026-04-02",
-    "last_updated": "2026-06-11",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.3125,
-      "output": 1.125,
-      "cache_read": 0.075
-    },
-    "limit": {
-      "context": 256000,
-      "output": 65536
-    }
-  },
-  {
     "id": "venice/claude-fable-5",
     "name": "Claude Fable 5",
     "family": "claude-fable",
@@ -133651,6 +134280,38 @@
       "output": 18.0,
       "cache_read": 0.36,
       "cache_write": 4.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "venice/claude-sonnet-5",
+    "name": "Claude Sonnet 5",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-29",
+    "last_updated": "2026-07-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
     },
     "limit": {
       "context": 1000000,
@@ -136717,6 +137378,39 @@
     }
   },
   {
+    "id": "vercel/anthropic/claude-fable-5",
+    "name": "Claude Fable 5",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-07-01",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "vercel/anthropic/claude-haiku-4.5",
     "name": "Claude Haiku 4.5",
     "family": "claude-haiku",
@@ -137039,6 +137733,39 @@
       "output": 15.0,
       "cache_read": 0.3,
       "cache_write": 3.75
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "vercel/anthropic/claude-sonnet-5",
+    "name": "Claude Sonnet 5",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-29",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 10.0,
+      "cache_read": 0.2,
+      "cache_write": 2.5
     },
     "limit": {
       "context": 1000000,
@@ -138330,6 +139057,37 @@
     "limit": {
       "context": 1000000,
       "output": 65000
+    }
+  },
+  {
+    "id": "vercel/google/gemini-3.1-flash-lite-image",
+    "name": "Gemini 3.1 Flash Lite Image (Nano Banana 2 Lite)",
+    "family": "gemini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 1.5,
+      "cache_read": 0.03
+    },
+    "limit": {
+      "context": 65536,
+      "output": 4096
     }
   },
   {
@@ -147243,7 +148001,7 @@
   {
     "id": "zeldoc/z-code",
     "name": "Z-Code",
-    "attachment": true,
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -147252,9 +148010,7 @@
     "last_updated": "2026-04-15",
     "modalities": {
       "input": [
-        "text",
-        "image",
-        "video"
+        "text"
       ],
       "output": [
         "text"
@@ -147266,8 +148022,8 @@
       "output": 0.0
     },
     "limit": {
-      "context": 262144,
-      "output": 262144
+      "context": 1000000,
+      "output": 131072
     }
   },
   {
@@ -151202,9 +151958,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 6.0,
-      "output": 24.0,
-      "cache_read": 1.3,
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26,
       "cache_write": 0.0
     },
     "limit": {

--- a/crates/goose-providers/src/canonical/data/provider_metadata.json
+++ b/crates/goose-providers/src/canonical/data/provider_metadata.json
@@ -384,7 +384,7 @@
     "env": [
       "GITHUB_TOKEN"
     ],
-    "model_count": 22
+    "model_count": 23
   },
   {
     "id": "github-models",
@@ -560,7 +560,7 @@
     "env": [
       "LLMGATEWAY_API_KEY"
     ],
-    "model_count": 180
+    "model_count": 182
   },
   {
     "id": "llmtr",
@@ -836,7 +836,7 @@
     "env": [
       "OPENCODE_API_KEY"
     ],
-    "model_count": 71
+    "model_count": 74
   },
   {
     "id": "opencode-go",
@@ -972,6 +972,17 @@
     "model_count": 26
   },
   {
+    "id": "sakana",
+    "display_name": "Sakana AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.sakana.ai/v1",
+    "doc": "https://console.sakana.ai/models",
+    "env": [
+      "SAKANA_API_KEY"
+    ],
+    "model_count": 3
+  },
+  {
     "id": "sarvam",
     "display_name": "Sarvam AI",
     "npm": "@ai-sdk/openai-compatible",
@@ -1091,7 +1102,7 @@
     "env": [
       "SYNTHETIC_API_KEY"
     ],
-    "model_count": 10
+    "model_count": 7
   },
   {
     "id": "tencent-coding-plan",

--- a/crates/goose-providers/src/model.rs
+++ b/crates/goose-providers/src/model.rs
@@ -526,6 +526,19 @@ mod tests {
         }
 
         #[test]
+        fn resolves_claude_sonnet_5_on_bedrock() {
+            // Regression test for #10179: claude-sonnet-5 was missing from the
+            // canonical registry and fell back to the 128k default on Bedrock.
+            let _guard = env_lock::lock_env([
+                ("GOOSE_MAX_TOKENS", None::<&str>),
+                ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+            ]);
+            let config = ModelConfig::new("claude-sonnet-5").with_canonical_limits("aws_bedrock");
+
+            assert_eq!(config.context_limit, Some(1_000_000));
+        }
+
+        #[test]
         fn does_not_override_existing_context_limit() {
             let _guard = env_lock::lock_env([
                 ("GOOSE_MAX_TOKENS", None::<&str>),


### PR DESCRIPTION
## Summary

Fixes #10179.

`claude-sonnet-5` was missing from the canonical model registry, so it fell back to the 128k `DEFAULT_CONTEXT_LIMIT` on `aws_bedrock` (and every other provider) instead of its actual 1M context window.

The registry snapshot (`canonical_models.json`) was last refreshed on 2026-06-09 (#9709), before sonnet-5 shipped. This PR regenerates it the standard way:

```bash
cargo run --bin build_canonical_models
```

## Changes

- **`canonical_models.json` / `provider_metadata.json`** — mechanical regeneration from OpenRouter. Now includes `amazon-bedrock/anthropic.claude-sonnet-5` (plus `au.`-prefixed regional variant), `anthropic/claude-sonnet-5`, `google-vertex/claude-sonnet-5@default`, and other providers — all with `context: 1000000`, `output: 128000`, and current pricing. Picks up ~3 weeks of other upstream registry changes as well.
- **`model.rs`** — regression test `resolves_claude_sonnet_5_on_bedrock` asserting `ModelConfig::new("claude-sonnet-5").with_canonical_limits("aws_bedrock")` resolves to 1M context (exercises the `aws_bedrock` → `amazon-bedrock` namespace mapping and version-suffix matching the issue verified as correctly wired).

## Testing

- `cargo test -p goose-providers canonical` — all pass
- `cargo test -p goose-providers resolves_claude_sonnet_5` — passes (fails without the registry refresh)
- `cargo fmt`

Note: `cargo clippy -p goose-providers --all-targets -- -D warnings` reports 3 pre-existing `collapsible-if-in-match` errors in `json.rs`/`thinking.rs` on main — unrelated to this change, left untouched.

## Follow-up

The registry only updates when someone manually runs the build script and commits (last time: June 9). A scheduled workflow to auto-refresh it would prevent this class of issue recurring — happy to file separately.