### PR TITLE
Confirm before continuing after resolved model mismatch

### DIFF
--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -1,12 +1,12 @@
 use agent_client_protocol::schema::v1::{
-    ClientCapabilities, CloseSessionRequest, ContentBlock, ContentChunk, EnvVariable, HttpHeader,
-    ImageContent, InitializeRequest, InitializeResponse, McpCapabilities, McpServer, McpServerHttp,
-    McpServerStdio, NewSessionRequest, NewSessionResponse, PromptRequest, PromptResponse,
-    RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
-    SessionConfigKind, SessionConfigOption, SessionConfigOptionCategory,
-    SessionConfigSelectOptions, SessionId, SessionNotification, SessionUpdate,
-    SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModeResponse, StopReason,
-    TextContent, ToolCallContent, ToolCallStatus, ToolKind,
+    AgentNotification, ClientCapabilities, CloseSessionRequest, ContentBlock, ContentChunk,
+    EnvVariable, ExtNotification, HttpHeader, ImageContent, InitializeRequest, InitializeResponse,
+    McpCapabilities, McpServer, McpServerHttp, McpServerStdio, NewSessionRequest,
+    NewSessionResponse, PromptRequest, PromptResponse, RequestPermissionOutcome,
+    RequestPermissionRequest, RequestPermissionResponse, SessionConfigKind, SessionConfigOption,
+    SessionConfigOptionCategory, SessionConfigSelectOptions, SessionId, SessionNotification,
+    SessionUpdate, SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModeResponse,
+    StopReason, TextContent, ToolCallContent, ToolCallStatus, ToolKind,
 };
 use agent_client_protocol::schema::ProtocolVersion;
 use agent_client_protocol::{Agent, Client, ConnectionTo};
@@ -34,7 +34,9 @@ use tokio_util::compat::{TokioAsyncReadCompatExt as _, TokioAsyncWriteCompatExt 
 use crate::acp::{map_permission_response, PermissionDecision};
 use crate::config::{ExtensionConfig, GooseMode};
 use crate::context_mgmt::format_message_for_compacting;
-use crate::conversation::message::{Message, MessageContent, TOOL_META_EXTERNAL_DISPATCH_KEY};
+use crate::conversation::message::{
+    InferenceMetadata, Message, MessageContent, TOOL_META_EXTERNAL_DISPATCH_KEY,
+};
 use crate::permission::permission_confirmation::PrincipalType;
 use crate::permission::{Permission, PermissionConfirmation};
 use crate::providers::base::{MessageStream, PermissionRouting, Provider};
@@ -115,6 +117,7 @@ enum AcpUpdate {
         request: Box<RequestPermissionRequest>,
         response_tx: oneshot::Sender<RequestPermissionResponse>,
     },
+    Model(String),
     Complete(StopReason, Option<AcpUsage>),
     Error(String),
 }
@@ -504,13 +507,25 @@ impl Provider for AcpProvider {
 
         let reject_all_tools = goose_mode == GooseMode::Chat;
         let model_name = model_config.model_name.clone();
+        let provider_name = self.name.clone();
 
         Ok(Box::pin(try_stream! {
             let mut suppress_text = false;
             let mut rejected_tool_calls: HashSet<String> = HashSet::new();
+            let mut actual_model: Option<String> = None;
             // Stable id+timestamp per contiguous run so Desktop coalesces chunks into one bubble.
             let mut text_run: Option<(String, i64)> = None;
             let mut thought_run: Option<(String, i64)> = None;
+
+            let inference_for_actual_model = |actual_model: &str| {
+                (model_name != ACP_CURRENT_MODEL && actual_model != model_name).then(|| {
+                    InferenceMetadata {
+                        provider: provider_name.clone(),
+                        requested_model: model_name.clone(),
+                        resolved_model: Some(actual_model.to_string()),
+                    }
+                })
+            };
 
             while let Some(update) = rx.recv().await {
                 match update {
@@ -519,9 +534,15 @@ impl Provider for AcpProvider {
                             let (id, ts) = text_run
                                 .get_or_insert_with(fresh_text_run)
                                 .clone();
-                            let message = Message::new(Role::Assistant, ts, vec![])
+                            let mut message = Message::new(Role::Assistant, ts, vec![])
                                 .with_text(text)
                                 .with_id(id);
+                            if let Some(inference) = actual_model
+                                .as_deref()
+                                .and_then(&inference_for_actual_model)
+                            {
+                                message = message.with_inference(inference);
+                            }
                             yield (Some(message), None);
                         }
                     }
@@ -634,6 +655,15 @@ impl Provider for AcpProvider {
                             rejected_tool_calls.insert(request.tool_call.tool_call_id.0.to_string());
                         }
                         let _ = response_tx.send(map_permission_response(&request, decision));
+                    }
+                    AcpUpdate::Model(model) => {
+                        let changed = actual_model.as_deref() != Some(model.as_str());
+                        actual_model = Some(model.clone());
+                        if changed && text_run.is_some() {
+                            if let Some(inference) = inference_for_actual_model(&model) {
+                                yield (Some(Message::assistant().with_inference(inference)), None);
+                            }
+                        }
                     }
                     AcpUpdate::Complete(_reason, usage) => {
                         if let Some(usage) = usage {
@@ -762,7 +792,26 @@ impl AcpClientLoop {
                     let goose_mode = goose_mode.clone();
                     let pending_tool_updates = pending_tool_updates.clone();
                     let context_size = context_size.clone();
-                    async move |notification: SessionNotification, _cx| {
+                    async move |agent_notification: AgentNotification, _cx| {
+                        let notification = match agent_notification {
+                            AgentNotification::SessionNotification(notification) => notification,
+                            AgentNotification::ExtNotification(notification) => {
+                                if let Some(model) = extract_claude_sdk_message_model(&notification)
+                                {
+                                    if let Some(tx) = prompt_response_tx
+                                        .lock()
+                                        .ok()
+                                        .as_ref()
+                                        .and_then(|g| g.as_ref().cloned())
+                                    {
+                                        let _ = tx.try_send(AcpUpdate::Model(model));
+                                    }
+                                }
+                                return Ok(());
+                            }
+                            _ => return Ok(()),
+                        };
+
                         if let Some(ref cb) = notification_callback {
                             cb(notification.clone());
                         }
@@ -1536,6 +1585,27 @@ fn resolve_model_info(
     )))
 }
 
+fn extract_claude_sdk_message_model(notification: &ExtNotification) -> Option<String> {
+    match notification.method.as_ref() {
+        "claude/sdkMessage" | "_claude/sdkMessage" => {}
+        _ => return None,
+    }
+
+    let params: serde_json::Value = serde_json::from_str(notification.params.get()).ok()?;
+    let message = params.get("message")?;
+
+    let extracted = [
+        message.pointer("/event/message/model"),
+        message.pointer("/message/model"),
+    ]
+    .into_iter()
+    .flatten()
+    .filter_map(serde_json::Value::as_str)
+    .find(|model| !model.trim().is_empty() && *model != "<synthetic>")
+    .map(str::to_string);
+    extracted
+}
+
 fn reverse_mode_mapping(
     mode_mapping: &HashMap<GooseMode, String>,
 ) -> HashMap<String, Vec<GooseMode>> {
@@ -1811,6 +1881,50 @@ mod tests {
         assert!(rx.try_recv().is_err());
     }
 
+    #[tokio::test]
+    async fn stream_attaches_runtime_model_mismatch_to_assistant_text() {
+        use futures::StreamExt;
+
+        let (tx, mut rx) = mpsc::channel(1);
+        let (provider, _model) = test_provider_with_tx(Some(tx));
+        let mut stream = provider
+            .stream(
+                &ModelConfig::new("claude-fable-5"),
+                "",
+                &[Message::user().with_text("hello")],
+                &[],
+            )
+            .await
+            .unwrap();
+
+        match rx.recv().await.expect("expected prompt request") {
+            ClientRequest::Prompt { response_tx, .. } => {
+                response_tx
+                    .send(AcpUpdate::Model("claude-opus-4-8".to_string()))
+                    .await
+                    .unwrap();
+                response_tx
+                    .send(AcpUpdate::Text("hi".to_string()))
+                    .await
+                    .unwrap();
+            }
+            _ => panic!("expected prompt request"),
+        }
+
+        let (message, usage) = stream.next().await.unwrap().unwrap();
+        assert!(usage.is_none());
+        let message = message.expect("expected assistant message");
+        assert_eq!(message.as_concat_text(), "hi");
+        assert_eq!(
+            message.metadata.inference,
+            Some(InferenceMetadata {
+                provider: "acp-test".to_string(),
+                requested_model: "claude-fable-5".to_string(),
+                resolved_model: Some("claude-opus-4-8".to_string()),
+            })
+        );
+    }
+
     #[test]
     fn messages_to_prompt_includes_all_prior_handoff_context() {
         let messages = vec![
@@ -2033,6 +2147,87 @@ mod tests {
         response: NewSessionResponse,
     ) -> Result<(String, Vec<String>), ProviderError> {
         resolve_model_info("test", &response)
+    }
+
+    fn ext_notification(method: &str, params: serde_json::Value) -> ExtNotification {
+        let raw = serde_json::value::RawValue::from_string(params.to_string()).unwrap();
+        ExtNotification::new(method, std::sync::Arc::from(raw))
+    }
+
+    #[test]
+    fn extracts_model_from_claude_sdk_message_start() {
+        let notification = ext_notification(
+            "claude/sdkMessage",
+            serde_json::json!({
+                "sessionId": "session-1",
+                "message": {
+                    "type": "assistant",
+                    "event": {
+                        "type": "message_start",
+                        "message": {
+                            "model": "claude-opus-4-8"
+                        }
+                    }
+                }
+            }),
+        );
+
+        assert_eq!(
+            extract_claude_sdk_message_model(&notification),
+            Some("claude-opus-4-8".to_string())
+        );
+    }
+
+    #[test]
+    fn extracts_model_from_final_claude_sdk_assistant_message() {
+        let notification = ext_notification(
+            "_claude/sdkMessage",
+            serde_json::json!({
+                "sessionId": "session-1",
+                "message": {
+                    "type": "assistant",
+                    "message": {
+                        "model": "claude-sonnet-4-6"
+                    }
+                }
+            }),
+        );
+
+        assert_eq!(
+            extract_claude_sdk_message_model(&notification),
+            Some("claude-sonnet-4-6".to_string())
+        );
+    }
+
+    #[test]
+    fn ignores_synthetic_or_unrelated_ext_model_notifications() {
+        let synthetic = ext_notification(
+            "claude/sdkMessage",
+            serde_json::json!({
+                "message": {
+                    "event": {
+                        "message": {
+                            "model": "<synthetic>"
+                        }
+                    }
+                }
+            }),
+        );
+        let unrelated = ext_notification(
+            "other/sdkMessage",
+            serde_json::json!({
+                "message": {
+                    "event": {
+                        "message": {
+                            "model": "claude-opus-4-8"
+                        }
+                    }
+                }
+            }),
+        );
+
+        assert_eq!(extract_claude_sdk_message_model(&synthetic), None);
+        assert_eq!(extract_claude_sdk_message_model(&unrelated), None);
     }
 
     fn codex_reverse_modes() -> HashMap<String, Vec<GooseMode>> {

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -485,7 +485,8 @@ impl Agent {
         }
 
         let mut filtered_message =
-            Message::new(response.role.clone(), response.created, filtered_content);
+            Message::new(response.role.clone(), response.created, filtered_content)
+                .with_metadata(response.metadata.clone());
 
         // Preserve the ID if it exists
         if let Some(id) = response.id.clone() {
@@ -796,6 +797,26 @@ mod tests {
             filtered_message.content[0],
             MessageContent::ToolRequest(_)
         ));
+    }
+
+    #[tokio::test]
+    async fn categorize_tool_requests_preserves_response_metadata() {
+        let agent = crate::agents::Agent::new();
+        let response = Message::assistant().with_text("hello").with_inference(
+            crate::conversation::message::InferenceMetadata {
+                provider: "claude-acp".to_string(),
+                requested_model: "claude-fable-5".to_string(),
+                resolved_model: Some("claude-opus-4-8".to_string()),
+            },
+        );
+
+        let (_frontend_requests, _other_requests, filtered_message) =
+            agent.categorize_tool_requests(&response, &[], false).await;
+
+        assert_eq!(
+            filtered_message.metadata.inference,
+            response.metadata.inference
+        );
     }
 
     #[tokio::test]

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -200,7 +200,7 @@ export default function BaseChat({
   const sessionModel = session?.model_config?.model_name ?? null;
   const sessionProvider = session?.provider_name ?? null;
   const sessionLoaded = session !== undefined;
-  const latestInference = useMemo(() => {
+  const latestInferenceState = useMemo(() => {
     for (let i = messages.length - 1; i >= 0; i--) {
       const message = messages[i];
       if (
@@ -208,11 +208,16 @@ export default function BaseChat({
         message.metadata.userVisible &&
         message.metadata.inference
       ) {
-        return message.metadata.inference;
+        return {
+          inference: message.metadata.inference,
+          messageId: message.id ?? `${message.created}:${i}`,
+        };
       }
     }
     return null;
   }, [messages]);
+  const latestInference = latestInferenceState?.inference ?? null;
+  const latestInferenceMessageId = latestInferenceState?.messageId ?? null;
 
   useEffect(() => {
     if (!recipe || !isActiveSession || session?.session_type === 'scheduled') return;
@@ -524,6 +529,7 @@ export default function BaseChat({
             workingDir={session?.working_dir}
             onWorkingDirChange={handleWorkingDirChange}
             latestInference={latestInference}
+            latestInferenceMessageId={latestInferenceMessageId}
             {...customChatInputProps}
           />
         </ChatInputCard>

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -1,8 +1,16 @@
 import { AppEvents } from '../constants/events';
 import React, { useRef, useState, useEffect, useMemo, useCallback } from 'react';
-import { ArrowUp, Bug, ScrollText } from 'lucide-react';
+import { AlertTriangle, ArrowUp, Bug, ScrollText } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/Tooltip';
 import { Button } from './ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './ui/dialog';
 import type { View } from '../utils/navigationUtils';
 import Stop from './ui/Stop';
 import { Attach, Close, Microphone } from './icons';
@@ -29,12 +37,16 @@ import { detectInterruption } from '../utils/interruptionDetector';
 import { DiagnosticsModal } from './ui/Diagnostics';
 import type { Message } from '../types/message';
 import { getInitialWorkingDir } from '../utils/workingDir';
-import { getPredefinedModelsFromEnv } from './settings/models/predefinedModelsUtils';
+import {
+  getModelDisplayName,
+  getPredefinedModelsFromEnv,
+} from './settings/models/predefinedModelsUtils';
 import { trackFileAttached, trackVoiceDictation, trackDiagnosticsOpened } from '../utils/analytics';
 import { getNavigationShortcutText } from '../utils/keyboardShortcuts';
 import { UserInput, ImageData } from '../types/message';
 import { compressImageDataUrl } from '../utils/conversionUtils';
 import { fetchCanonicalModelInfo } from '../utils/canonical';
+import { getModelResolutionMismatch } from '../utils/modelResolutionMismatch';
 import { defineMessages, useIntl } from '../i18n';
 import TurndownService from 'turndown';
 import type { NextChatExtensionDraft } from '../utils/nextChatExtensions';
@@ -154,6 +166,27 @@ const i18n = defineMessages({
     id: 'chatInput.viewEditRecipe',
     defaultMessage: 'View/Edit Recipe',
   },
+  modelResolutionMismatchTitle: {
+    id: 'chatInput.modelResolutionMismatchTitle',
+    defaultMessage: 'Provider resolved a different model',
+  },
+  modelResolutionMismatchNotice: {
+    id: 'chatInput.modelResolutionMismatchNotice',
+    defaultMessage: '{requestedModel} was requested, but the last response ran on {resolvedModel}.',
+  },
+  modelResolutionMismatchDetail: {
+    id: 'chatInput.modelResolutionMismatchDetail',
+    defaultMessage:
+      'Choose how to proceed before sending another prompt. Goose will keep requesting {requestedModel} unless you change models.',
+  },
+  retryRequestedModel: {
+    id: 'chatInput.retryRequestedModel',
+    defaultMessage: 'Edit prompt and retry {requestedModel}',
+  },
+  continueWithResolvedModel: {
+    id: 'chatInput.continueWithResolvedModel',
+    defaultMessage: 'Continue with {resolvedModel}',
+  },
 });
 
 interface ChatInputProps {
@@ -187,6 +220,7 @@ interface ChatInputProps {
   sessionLoaded?: boolean;
   workingDir?: string | null;
   latestInference?: Message['metadata']['inference'] | null;
+  latestInferenceMessageId?: string | null;
   nextChatExtensionDraft?: NextChatExtensionDraft;
   onNextChatExtensionDraftChange?: (draft: NextChatExtensionDraft) => void;
 }
@@ -222,6 +256,7 @@ export default function ChatInput({
   sessionLoaded,
   workingDir,
   latestInference,
+  latestInferenceMessageId,
   nextChatExtensionDraft,
   onNextChatExtensionDraftChange,
 }: ChatInputProps) {
@@ -296,6 +331,37 @@ export default function ChatInput({
   );
   const effectiveModel = modelOverride?.model ?? sessionModel ?? configModel;
   const effectiveProvider = modelOverride?.provider ?? sessionProvider ?? configProvider;
+  const isModelLoading = Boolean(sessionId && !sessionLoaded);
+  const modelResolutionMismatch = useMemo(
+    () =>
+      getModelResolutionMismatch({
+        latestInference,
+        currentProvider: effectiveProvider,
+        currentModel: effectiveModel,
+        isModelLoading,
+        sessionId,
+        latestInferenceMessageId,
+        getDisplayName: getModelDisplayName,
+      }),
+    [
+      latestInference,
+      effectiveProvider,
+      effectiveModel,
+      isModelLoading,
+      sessionId,
+      latestInferenceMessageId,
+    ]
+  );
+  const [acknowledgedModelMismatchKey, setAcknowledgedModelMismatchKey] = useState<string | null>(
+    null
+  );
+  const [isModelMismatchPromptOpen, setIsModelMismatchPromptOpen] = useState(false);
+  const [pendingModelMismatchAction, setPendingModelMismatchAction] = useState<
+    { type: 'submit'; text?: string } | { type: 'queued'; messageId: string } | null
+  >(null);
+  const isModelMismatchBlocked = Boolean(
+    modelResolutionMismatch && modelResolutionMismatch.key !== acknowledgedModelMismatchKey
+  );
 
   // Clear override when the underlying data catches up (session props for
   // active chats, config defaults for Hub / no-session contexts).
@@ -400,6 +466,15 @@ export default function ChatInput({
       const shouldProcessQueue = !queuePausedRef.current || lastInterruption || shouldSendAfterStop;
 
       if (shouldProcessQueue) {
+        if (isModelMismatchBlocked) {
+          pauseRemainingQueue();
+          setPendingModelMismatchAction({ type: 'queued', messageId: messageToSend.id });
+          setIsModelMismatchPromptOpen(true);
+          wasLoadingRef.current = isLoading;
+          wasQueueProcessingBlockedRef.current = queueProcessingBlocked;
+          return;
+        }
+
         LocalMessageStorage.addMessage(messageToSend.content);
         handleSubmit({ msg: messageToSend.content, images: messageToSend.images });
         if (shouldSendAfterStop) {
@@ -438,7 +513,43 @@ export default function ChatInput({
     clearPendingSendAfterStop,
     clearQueueState,
     pauseRemainingQueue,
+    isModelMismatchBlocked,
   ]);
+
+  useEffect(() => {
+    if (
+      !isModelMismatchBlocked ||
+      isLoading ||
+      queueProcessingBlocked ||
+      queuedMessages.length === 0
+    ) {
+      return;
+    }
+
+    const pendingSendAfterStopId = sendAfterStopMessageIdRef.current;
+    const messageToSend = pendingSendAfterStopId
+      ? queuedMessages.find((message) => message.id === pendingSendAfterStopId)
+      : queuedMessages[0];
+
+    if (!messageToSend) return;
+
+    const shouldSendAfterStop = pendingSendAfterStopId === messageToSend.id;
+    const shouldProcessQueue = !queuePausedRef.current || lastInterruption || shouldSendAfterStop;
+
+    if (!shouldProcessQueue) return;
+
+    pauseRemainingQueue();
+    setPendingModelMismatchAction({ type: 'queued', messageId: messageToSend.id });
+    setIsModelMismatchPromptOpen(true);
+  }, [
+    isModelMismatchBlocked,
+    isLoading,
+    queueProcessingBlocked,
+    queuedMessages,
+    lastInterruption,
+    pauseRemainingQueue,
+  ]);
+
   const [mentionPopover, setMentionPopover] = useState<{
     isOpen: boolean;
     position: { x: number; y: number };
@@ -1089,7 +1200,13 @@ export default function ChatInput({
       allDroppedFiles.some((file) => !file.error && !file.isLoading));
 
   const performSubmit = useCallback(
-    (text?: string) => {
+    (text?: string, options?: { allowModelMismatch?: boolean }) => {
+      if (!options?.allowModelMismatch && isModelMismatchBlocked) {
+        setPendingModelMismatchAction({ type: 'submit', text });
+        setIsModelMismatchPromptOpen(true);
+        return;
+      }
+
       const imageData = convertImagesToImageData();
       const textToSend = appendDroppedFilePaths(text ?? displayValue.trim());
 
@@ -1134,6 +1251,7 @@ export default function ChatInput({
       handleSubmit,
       lastInterruption,
       clearInputState,
+      isModelMismatchBlocked,
     ]
   );
 
@@ -1375,6 +1493,13 @@ export default function ChatInput({
     if (queueProcessingBlocked) return;
 
     if (!isLoading) {
+      if (isModelMismatchBlocked) {
+        pauseRemainingQueue();
+        setPendingModelMismatchAction({ type: 'queued', messageId });
+        setIsModelMismatchPromptOpen(true);
+        return;
+      }
+
       setQueuedMessages((prev) => removeQueuedMessage(prev, messageId));
       LocalMessageStorage.addMessage(messageToSend.content);
       handleSubmit({ msg: messageToSend.content, images: messageToSend.images });
@@ -1446,6 +1571,13 @@ export default function ChatInput({
     setLastInterruption(null);
     if (!isLoading && !queueProcessingBlocked && queuedMessages.length > 0) {
       const nextMessage = queuedMessages[0];
+      if (isModelMismatchBlocked) {
+        pauseRemainingQueue();
+        setPendingModelMismatchAction({ type: 'queued', messageId: nextMessage.id });
+        setIsModelMismatchPromptOpen(true);
+        return;
+      }
+
       LocalMessageStorage.addMessage(nextMessage.content);
       handleSubmit({ msg: nextMessage.content, images: nextMessage.images });
       setQueuedMessages((prev) => {
@@ -1457,6 +1589,61 @@ export default function ChatInput({
         }
         return newQueue;
       });
+    }
+  };
+
+  const acknowledgeModelMismatch = () => {
+    if (modelResolutionMismatch) {
+      setAcknowledgedModelMismatchKey(modelResolutionMismatch.key);
+    }
+  };
+
+  const handleEditPromptAndRetryModel = () => {
+    acknowledgeModelMismatch();
+    setPendingModelMismatchAction(null);
+    setIsModelMismatchPromptOpen(false);
+    textAreaRef.current?.focus();
+  };
+
+  const handleContinueWithResolvedModel = () => {
+    const pendingAction = pendingModelMismatchAction;
+    acknowledgeModelMismatch();
+    setPendingModelMismatchAction(null);
+    setIsModelMismatchPromptOpen(false);
+
+    if (pendingAction?.type === 'submit') {
+      performSubmit(pendingAction.text, { allowModelMismatch: true });
+      return;
+    }
+
+    if (pendingAction?.type === 'queued') {
+      const messageToSend = queuedMessages.find(
+        (message) => message.id === pendingAction.messageId
+      );
+      if (!messageToSend) return;
+
+      clearPendingSendAfterStop(messageToSend.id);
+      LocalMessageStorage.addMessage(messageToSend.content);
+      handleSubmit({ msg: messageToSend.content, images: messageToSend.images });
+      setQueuedMessages((prev) => {
+        const newQueue = removeQueuedMessage(prev, messageToSend.id);
+        if (newQueue.length === 0) {
+          clearQueueState();
+        } else {
+          pauseRemainingQueue();
+        }
+        return newQueue;
+      });
+      return;
+    }
+
+    textAreaRef.current?.focus();
+  };
+
+  const handleModelMismatchPromptOpenChange = (open: boolean) => {
+    setIsModelMismatchPromptOpen(open);
+    if (!open) {
+      setPendingModelMismatchAction(null);
     }
   };
 
@@ -1495,6 +1682,49 @@ export default function ChatInput({
           isPaused={queuePausedRef.current}
           className="border-b border-border-primary"
         />
+      )}
+      {isModelMismatchBlocked && modelResolutionMismatch && (
+        <div
+          className="mx-3 mb-2 rounded-md border border-yellow-600/30 bg-yellow-500/10 p-3 text-sm"
+          role="status"
+        >
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-yellow-600 dark:text-yellow-400" />
+            <div className="min-w-0 flex-1">
+              <p className="font-medium text-text-primary">
+                {intl.formatMessage(i18n.modelResolutionMismatchTitle)}
+              </p>
+              <p className="mt-1 text-xs leading-5 text-text-secondary">
+                {intl.formatMessage(i18n.modelResolutionMismatchNotice, {
+                  requestedModel: modelResolutionMismatch.requestedDisplayName,
+                  resolvedModel: modelResolutionMismatch.resolvedDisplayName,
+                })}
+              </p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  size="xs"
+                  variant="outline"
+                  onClick={handleEditPromptAndRetryModel}
+                >
+                  {intl.formatMessage(i18n.retryRequestedModel, {
+                    requestedModel: modelResolutionMismatch.requestedDisplayName,
+                  })}
+                </Button>
+                <Button
+                  type="button"
+                  size="xs"
+                  variant="secondary"
+                  onClick={handleContinueWithResolvedModel}
+                >
+                  {intl.formatMessage(i18n.continueWithResolvedModel, {
+                    resolvedModel: modelResolutionMismatch.resolvedDisplayName,
+                  })}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
       )}
       {/* Input row with inline action buttons wrapped in form */}
       <form onSubmit={onFormSubmit} className="relative">
@@ -1851,6 +2081,52 @@ export default function ChatInput({
             sessionId={sessionId}
           />
         )}
+        <Dialog
+          open={Boolean(
+            isModelMismatchPromptOpen && isModelMismatchBlocked && modelResolutionMismatch
+          )}
+          onOpenChange={handleModelMismatchPromptOpenChange}
+        >
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <AlertTriangle className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
+                {intl.formatMessage(i18n.modelResolutionMismatchTitle)}
+              </DialogTitle>
+              {modelResolutionMismatch && (
+                <DialogDescription asChild>
+                  <div className="space-y-2 text-sm">
+                    <p>
+                      {intl.formatMessage(i18n.modelResolutionMismatchNotice, {
+                        requestedModel: modelResolutionMismatch.requestedDisplayName,
+                        resolvedModel: modelResolutionMismatch.resolvedDisplayName,
+                      })}
+                    </p>
+                    <p>
+                      {intl.formatMessage(i18n.modelResolutionMismatchDetail, {
+                        requestedModel: modelResolutionMismatch.requestedDisplayName,
+                      })}
+                    </p>
+                  </div>
+                </DialogDescription>
+              )}
+            </DialogHeader>
+            {modelResolutionMismatch && (
+              <DialogFooter>
+                <Button type="button" variant="outline" onClick={handleEditPromptAndRetryModel}>
+                  {intl.formatMessage(i18n.retryRequestedModel, {
+                    requestedModel: modelResolutionMismatch.requestedDisplayName,
+                  })}
+                </Button>
+                <Button type="button" onClick={handleContinueWithResolvedModel}>
+                  {intl.formatMessage(i18n.continueWithResolvedModel, {
+                    resolvedModel: modelResolutionMismatch.resolvedDisplayName,
+                  })}
+                </Button>
+              </DialogFooter>
+            )}
+          </DialogContent>
+        </Dialog>
         <MentionPopover
           ref={mentionPopoverRef}
           isOpen={mentionPopover.isOpen}

--- a/ui/desktop/src/i18n/messages/de.json
+++ b/ui/desktop/src/i18n/messages/de.json
@@ -4525,5 +4525,20 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Eine neue Sitzung mit der bearbeiteten Nachricht erstellen"
+  },
+  "chatInput.continueWithResolvedModel": {
+    "defaultMessage": "Continue with {resolvedModel}"
+  },
+  "chatInput.modelResolutionMismatchDetail": {
+    "defaultMessage": "Choose how to proceed before sending another prompt. Goose will keep requesting {requestedModel} unless you change models."
+  },
+  "chatInput.modelResolutionMismatchNotice": {
+    "defaultMessage": "{requestedModel} was requested, but the last response ran on {resolvedModel}."
+  },
+  "chatInput.modelResolutionMismatchTitle": {
+    "defaultMessage": "Provider resolved a different model"
+  },
+  "chatInput.retryRequestedModel": {
+    "defaultMessage": "Edit prompt and retry {requestedModel}"
   }
 }

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -164,11 +164,23 @@
   "chatInput.contextWindow": {
     "defaultMessage": "Context window"
   },
+  "chatInput.continueWithResolvedModel": {
+    "defaultMessage": "Continue with {resolvedModel}"
+  },
   "chatInput.dictationError": {
     "defaultMessage": "Dictation Error"
   },
   "chatInput.failedToReadImage": {
     "defaultMessage": "Failed to read image file"
+  },
+  "chatInput.modelResolutionMismatchDetail": {
+    "defaultMessage": "Choose how to proceed before sending another prompt. Goose will keep requesting {requestedModel} unless you change models."
+  },
+  "chatInput.modelResolutionMismatchNotice": {
+    "defaultMessage": "{requestedModel} was requested, but the last response ran on {resolvedModel}."
+  },
+  "chatInput.modelResolutionMismatchTitle": {
+    "defaultMessage": "Provider resolved a different model"
   },
   "chatInput.navigationShortcut": {
     "defaultMessage": "{prefix}↑/{prefix}↓ to navigate messages"
@@ -187,6 +199,9 @@
   },
   "chatInput.restartingSession": {
     "defaultMessage": "Restarting session..."
+  },
+  "chatInput.retryRequestedModel": {
+    "defaultMessage": "Edit prompt and retry {requestedModel}"
   },
   "chatInput.send": {
     "defaultMessage": "Send"

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -4525,5 +4525,20 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Crear una nueva sesión con el mensaje editado"
+  },
+  "chatInput.continueWithResolvedModel": {
+    "defaultMessage": "Continue with {resolvedModel}"
+  },
+  "chatInput.modelResolutionMismatchDetail": {
+    "defaultMessage": "Choose how to proceed before sending another prompt. Goose will keep requesting {requestedModel} unless you change models."
+  },
+  "chatInput.modelResolutionMismatchNotice": {
+    "defaultMessage": "{requestedModel} was requested, but the last response ran on {resolvedModel}."
+  },
+  "chatInput.modelResolutionMismatchTitle": {
+    "defaultMessage": "Provider resolved a different model"
+  },
+  "chatInput.retryRequestedModel": {
+    "defaultMessage": "Edit prompt and retry {requestedModel}"
   }
 }

--- a/ui/desktop/src/i18n/messages/fr.json
+++ b/ui/desktop/src/i18n/messages/fr.json
@@ -4525,5 +4525,20 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Créer une nouvelle session avec le message modifié"
+  },
+  "chatInput.continueWithResolvedModel": {
+    "defaultMessage": "Continue with {resolvedModel}"
+  },
+  "chatInput.modelResolutionMismatchDetail": {
+    "defaultMessage": "Choose how to proceed before sending another prompt. Goose will keep requesting {requestedModel} unless you change models."
+  },
+  "chatInput.modelResolutionMismatchNotice": {
+    "defaultMessage": "{requestedModel} was requested, but the last response ran on {resolvedModel}."
+  },
+  "chatInput.modelResolutionMismatchTitle": {
+    "defaultMessage": "Provider resolved a different model"
+  },
+  "chatInput.retryRequestedModel": {
+    "defaultMessage": "Edit prompt and retry {requestedModel}"
   }
 }

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -4525,5 +4525,20 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "संपादित संदेश के साथ एक नया सत्र बनाएं"
+  },
+  "chatInput.continueWithResolvedModel": {
+    "defaultMessage": "Continue with {resolvedModel}"
+  },
+  "chatInput.modelResolutionMismatchDetail": {
+    "defaultMessage": "Choose how to proceed before sending another prompt. Goose will keep requesting {requestedModel} unless you change models."
+  },
+  "chatInput.modelResolutionMismatchNotice": {
+    "defaultMessage": "{requestedModel} was requested, but the last response ran on {resolvedModel}."
+  },
+  "chatInput.modelResolutionMismatchTitle": {
+    "defaultMessage": "Provider resolved a different model"
+  },
+  "chatInput.retryRequestedModel": {
+    "defaultMessage": "Edit prompt and retry {requestedModel}"
   }
 }

--- a/ui/desktop/src/i18n/messages/id.json
+++ b/ui/desktop/src/i18n/messages/id.json
@@ -4525,5 +4525,20 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Buat sesi baru dengan pesan yang diedit"
+  },
+  "chatInput.continueWithResolvedModel": {
+    "defaultMessage": "Continue with {resolvedModel}"
+  },
+  "chatInput.modelResolutionMismatchDetail": {
+    "defaultMessage": "Choose how to proceed before sending another prompt. Goose will keep requesting {requestedModel} unless you change models."
+  },
+  "chatInput.modelResolutionMismatchNotice": {
+    "defaultMessage": "{requestedModel} was requested, but the last response ran on {resolvedModel}."
+  },
+  "chatInput.modelResolutionMismatchTitle": {
+    "defaultMessage": "Provider resolved a different model"
+  },
+  "chatInput.retryRequestedModel": {
+    "defaultMessage": "Edit prompt and retry {requestedModel}"
   }
 }

--- a/ui/desktop/src/i18n/messages/it.json
+++ b/ui/desktop/src/i18n/messages/it.json
@@ -4525,5 +4525,20 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Crea una nuova sessione con il messaggio modificato"
+  },
+  "chatInput.continueWithResolvedModel": {
+    "defaultMessage": "Continue with {resolvedModel}"
+  },
+  "chatInput.modelResolutionMismatchDetail": {
+    "defaultMessage": "Choose how to proceed before sending another prompt. Goose will keep requesting {requestedModel} unless you change models."
+  },
+  "chatInput.modelResolutionMismatchNotice": {
+    "defaultMessage": "{requestedModel} was requested, but the last response ran on {resolvedModel}."
+  },
+  "chatInput.modelResolutionMismatchTitle": {
+    "defaultMessage": "Provider resolved a different model"
+  },
+  "chatInput.retryRequestedModel": {
+    "defaultMessage": "Edit prompt and retry {requestedModel}"
   }
 }

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -4525,5 +4525,20 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "編集したメッセージで新しいセッションを作成"
+  },
+  "chatInput.continueWithResolvedModel": {
+    "defaultMessage": "Continue with {resolvedModel}"
+  },
+  "chatInput.modelResolutionMismatchDetail": {
+    "defaultMessage": "Choose how to proceed before sending another prompt. Goose will keep requesting {requestedModel} unless you change models."
+  },
+  "chatInput.modelResolutionMismatchNotice": {
+    "defaultMessage": "{requestedModel} was requested, but the last response ran on {resolvedModel}."
+  },
+  "chatInput.modelResolutionMismatchTitle": {
+    "defaultMessage": "Provider resolved a different model"
+  },
+  "chatInput.retryRequestedModel": {
+    "defaultMessage": "Edit prompt and retry {requestedModel}"
   }
 }

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -4525,5 +4525,20 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "편집한 메시지로 새 세션 만들기"
+  },
+  "chatInput.continueWithResolvedModel": {
+    "defaultMessage": "Continue with {resolvedModel}"
+  },
+  "chatInput.modelResolutionMismatchDetail": {
+    "defaultMessage": "Choose how to proceed before sending another prompt. Goose will keep requesting {requestedModel} unless you change models."
+  },
+  "chatInput.modelResolutionMismatchNotice": {
+    "defaultMessage": "{requestedModel} was requested, but the last response ran on {resolvedModel}."
+  },
+  "chatInput.modelResolutionMismatchTitle": {
+    "defaultMessage": "Provider resolved a different model"
+  },
+  "chatInput.retryRequestedModel": {
+    "defaultMessage": "Edit prompt and retry {requestedModel}"
   }
 }

--- a/ui/desktop/src/i18n/messages/ms.json
+++ b/ui/desktop/src/i18n/messages/ms.json
@@ -4525,5 +4525,20 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Cipta sesi baharu dengan mesej yang disunting"
+  },
+  "chatInput.continueWithResolvedModel": {
+    "defaultMessage": "Continue with {resolvedModel}"
+  },
+  "chatInput.modelResolutionMismatchDetail": {
+    "defaultMessage": "Choose how to proceed before sending another prompt. Goose will keep requesting {requestedModel} unless you change models."
+  },
+  "chatInput.modelResolutionMismatchNotice": {
+    "defaultMessage": "{requestedModel} was requested, but the last response ran on {resolvedModel}."
+  },
+  "chatInput.modelResolutionMismatchTitle": {
+    "defaultMessage": "Provider resolved a different model"
+  },
+  "chatInput.retryRequestedModel": {
+    "defaultMessage": "Edit prompt and retry {requestedModel}"
   }
 }

--- a/ui/desktop/src/i18n/messages/pt.json
+++ b/ui/desktop/src/i18n/messages/pt.json
@@ -4525,5 +4525,20 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Criar uma nova sessão com a mensagem editada"
+  },
+  "chatInput.continueWithResolvedModel": {
+    "defaultMessage": "Continue with {resolvedModel}"
+  },
+  "chatInput.modelResolutionMismatchDetail": {
+    "defaultMessage": "Choose how to proceed before sending another prompt. Goose will keep requesting {requestedModel} unless you change models."
+  },
+  "chatInput.modelResolutionMismatchNotice": {
+    "defaultMessage": "{requestedModel} was requested, but the last response ran on {resolvedModel}."
+  },
+  "chatInput.modelResolutionMismatchTitle": {
+    "defaultMessage": "Provider resolved a different model"
+  },
+  "chatInput.retryRequestedModel": {
+    "defaultMessage": "Edit prompt and retry {requestedModel}"
   }
 }

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -4525,5 +4525,20 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Создать новый сеанс с измененным сообщением"
+  },
+  "chatInput.continueWithResolvedModel": {
+    "defaultMessage": "Continue with {resolvedModel}"
+  },
+  "chatInput.modelResolutionMismatchDetail": {
+    "defaultMessage": "Choose how to proceed before sending another prompt. Goose will keep requesting {requestedModel} unless you change models."
+  },
+  "chatInput.modelResolutionMismatchNotice": {
+    "defaultMessage": "{requestedModel} was requested, but the last response ran on {resolvedModel}."
+  },
+  "chatInput.modelResolutionMismatchTitle": {
+    "defaultMessage": "Provider resolved a different model"
+  },
+  "chatInput.retryRequestedModel": {
+    "defaultMessage": "Edit prompt and retry {requestedModel}"
   }
 }

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -4525,5 +4525,20 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Düzenlenen mesajla yeni bir oturum oluşturun"
+  },
+  "chatInput.continueWithResolvedModel": {
+    "defaultMessage": "Continue with {resolvedModel}"
+  },
+  "chatInput.modelResolutionMismatchDetail": {
+    "defaultMessage": "Choose how to proceed before sending another prompt. Goose will keep requesting {requestedModel} unless you change models."
+  },
+  "chatInput.modelResolutionMismatchNotice": {
+    "defaultMessage": "{requestedModel} was requested, but the last response ran on {resolvedModel}."
+  },
+  "chatInput.modelResolutionMismatchTitle": {
+    "defaultMessage": "Provider resolved a different model"
+  },
+  "chatInput.retryRequestedModel": {
+    "defaultMessage": "Edit prompt and retry {requestedModel}"
   }
 }

--- a/ui/desktop/src/i18n/messages/vi.json
+++ b/ui/desktop/src/i18n/messages/vi.json
@@ -4525,5 +4525,20 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Tạo một phiên làm việc mới với tin nhắn đã chỉnh sửa"
+  },
+  "chatInput.continueWithResolvedModel": {
+    "defaultMessage": "Continue with {resolvedModel}"
+  },
+  "chatInput.modelResolutionMismatchDetail": {
+    "defaultMessage": "Choose how to proceed before sending another prompt. Goose will keep requesting {requestedModel} unless you change models."
+  },
+  "chatInput.modelResolutionMismatchNotice": {
+    "defaultMessage": "{requestedModel} was requested, but the last response ran on {resolvedModel}."
+  },
+  "chatInput.modelResolutionMismatchTitle": {
+    "defaultMessage": "Provider resolved a different model"
+  },
+  "chatInput.retryRequestedModel": {
+    "defaultMessage": "Edit prompt and retry {requestedModel}"
   }
 }

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -4525,5 +4525,20 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "用编辑过的消息创建新会话"
+  },
+  "chatInput.continueWithResolvedModel": {
+    "defaultMessage": "Continue with {resolvedModel}"
+  },
+  "chatInput.modelResolutionMismatchDetail": {
+    "defaultMessage": "Choose how to proceed before sending another prompt. Goose will keep requesting {requestedModel} unless you change models."
+  },
+  "chatInput.modelResolutionMismatchNotice": {
+    "defaultMessage": "{requestedModel} was requested, but the last response ran on {resolvedModel}."
+  },
+  "chatInput.modelResolutionMismatchTitle": {
+    "defaultMessage": "Provider resolved a different model"
+  },
+  "chatInput.retryRequestedModel": {
+    "defaultMessage": "Edit prompt and retry {requestedModel}"
   }
 }

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -4525,5 +4525,20 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "以編輯後的訊息建立新的工作階段"
+  },
+  "chatInput.continueWithResolvedModel": {
+    "defaultMessage": "Continue with {resolvedModel}"
+  },
+  "chatInput.modelResolutionMismatchDetail": {
+    "defaultMessage": "Choose how to proceed before sending another prompt. Goose will keep requesting {requestedModel} unless you change models."
+  },
+  "chatInput.modelResolutionMismatchNotice": {
+    "defaultMessage": "{requestedModel} was requested, but the last response ran on {resolvedModel}."
+  },
+  "chatInput.modelResolutionMismatchTitle": {
+    "defaultMessage": "Provider resolved a different model"
+  },
+  "chatInput.retryRequestedModel": {
+    "defaultMessage": "Edit prompt and retry {requestedModel}"
   }
 }

--- a/ui/desktop/src/utils/modelResolutionMismatch.test.ts
+++ b/ui/desktop/src/utils/modelResolutionMismatch.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { getModelResolutionMismatch } from './modelResolutionMismatch';
+
+describe('getModelResolutionMismatch', () => {
+  it('returns a mismatch when the provider resolves the current model to a different model', () => {
+    expect(
+      getModelResolutionMismatch({
+        latestInference: {
+          provider: 'claude-acp',
+          requestedModel: 'claude-fable-5',
+          resolvedModel: 'claude-opus-4-8',
+        },
+        currentProvider: 'claude-acp',
+        currentModel: 'claude-fable-5',
+        sessionId: 'session-1',
+        latestInferenceMessageId: 'assistant-1',
+        getDisplayName: (model) => `Display ${model}`,
+      })
+    ).toEqual({
+      key: 'session-1:assistant-1',
+      provider: 'claude-acp',
+      requestedModel: 'claude-fable-5',
+      requestedDisplayName: 'Display claude-fable-5',
+      resolvedModel: 'claude-opus-4-8',
+      resolvedDisplayName: 'Display claude-opus-4-8',
+    });
+  });
+
+  it('ignores matching model resolution', () => {
+    expect(
+      getModelResolutionMismatch({
+        latestInference: {
+          provider: 'claude-acp',
+          requestedModel: 'claude-fable-5',
+          resolvedModel: 'claude-fable-5',
+        },
+        currentProvider: 'claude-acp',
+        currentModel: 'claude-fable-5',
+      })
+    ).toBeNull();
+  });
+
+  it('ignores inference metadata for a previous provider or model', () => {
+    expect(
+      getModelResolutionMismatch({
+        latestInference: {
+          provider: 'claude-acp',
+          requestedModel: 'claude-fable-5',
+          resolvedModel: 'claude-opus-4-8',
+        },
+        currentProvider: 'openai',
+        currentModel: 'claude-fable-5',
+      })
+    ).toBeNull();
+
+    expect(
+      getModelResolutionMismatch({
+        latestInference: {
+          provider: 'claude-acp',
+          requestedModel: 'claude-fable-5',
+          resolvedModel: 'claude-opus-4-8',
+        },
+        currentProvider: 'claude-acp',
+        currentModel: 'claude-sonnet-5',
+      })
+    ).toBeNull();
+  });
+
+  it('ignores incomplete or loading model state', () => {
+    expect(
+      getModelResolutionMismatch({
+        latestInference: {
+          provider: 'claude-acp',
+          requestedModel: 'claude-fable-5',
+          resolvedModel: 'claude-opus-4-8',
+        },
+        currentProvider: 'claude-acp',
+        currentModel: 'claude-fable-5',
+        isModelLoading: true,
+      })
+    ).toBeNull();
+
+    expect(
+      getModelResolutionMismatch({
+        latestInference: {
+          provider: 'claude-acp',
+          requestedModel: 'claude-fable-5',
+          resolvedModel: null,
+        },
+        currentProvider: 'claude-acp',
+        currentModel: 'claude-fable-5',
+      })
+    ).toBeNull();
+  });
+});

--- a/ui/desktop/src/utils/modelResolutionMismatch.ts
+++ b/ui/desktop/src/utils/modelResolutionMismatch.ts
@@ -1,0 +1,60 @@
+import type { InferenceMetadata } from '../types/message';
+
+export type ModelResolutionMismatch = {
+  key: string;
+  provider: string;
+  requestedModel: string;
+  requestedDisplayName: string;
+  resolvedModel: string;
+  resolvedDisplayName: string;
+};
+
+type ModelResolutionMismatchParams = {
+  latestInference?: InferenceMetadata | null;
+  currentProvider?: string | null;
+  currentModel?: string | null;
+  isModelLoading?: boolean;
+  sessionId?: string | null;
+  latestInferenceMessageId?: string | null;
+  getDisplayName?: (model: string) => string;
+};
+
+const defaultDisplayName = (model: string) => model;
+
+export function getModelResolutionMismatch({
+  latestInference,
+  currentProvider,
+  currentModel,
+  isModelLoading = false,
+  sessionId,
+  latestInferenceMessageId,
+  getDisplayName = defaultDisplayName,
+}: ModelResolutionMismatchParams): ModelResolutionMismatch | null {
+  const resolvedModel = latestInference?.resolvedModel?.trim();
+
+  if (
+    isModelLoading ||
+    !latestInference ||
+    !resolvedModel ||
+    !currentProvider ||
+    !currentModel ||
+    latestInference.provider !== currentProvider ||
+    latestInference.requestedModel !== currentModel ||
+    resolvedModel === currentModel
+  ) {
+    return null;
+  }
+
+  const eventId =
+    latestInferenceMessageId ??
+    `${latestInference.provider}:${latestInference.requestedModel}:${resolvedModel}`;
+
+  return {
+    key: `${sessionId ?? 'global'}:${eventId}`,
+    provider: latestInference.provider,
+    requestedModel: latestInference.requestedModel,
+    requestedDisplayName: getDisplayName(latestInference.requestedModel),
+    resolvedModel,
+    resolvedDisplayName: getDisplayName(resolvedModel),
+  };
+}


### PR DESCRIPTION
## Summary
- detect when the latest assistant response was resolved to a different model than the active requested model
- show an inline warning and confirmation prompt before the next manual send or queued message proceeds
- let users either edit/retry the requested model or explicitly continue after accepting the resolved model mismatch
- add focused mismatch detection tests and i18n catalog entries

## Notes
This uses existing inference metadata (`requestedModel` / `resolvedModel`) and keys acknowledgements to the assistant message that reported the mismatch, so a later fallback prompts again instead of being silently suppressed.

Goose can only know an ACP/provider fallback after the provider reports the resolved model, so this guards the next prompt/queued item once the mismatch is detected.

## Testing
- `pnpm run lint:check`
- `pnpm test:run src/utils/modelResolutionMismatch.test.ts`
- `pnpm exec prettier --check src/components/BaseChat.tsx src/components/ChatInput.tsx src/utils/modelResolutionMismatch.ts src/utils/modelResolutionMismatch.test.ts src/i18n/messages/en.json src/i18n/messages/de.json src/i18n/messages/es.json src/i18n/messages/fr.json src/i18n/messages/hi.json src/i18n/messages/id.json src/i18n/messages/it.json src/i18n/messages/ja.json src/i18n/messages/ko.json src/i18n/messages/ms.json src/i18n/messages/pt.json src/i18n/messages/ru.json src/i18n/messages/tr.json src/i18n/messages/vi.json src/i18n/messages/zh-CN.json src/i18n/messages/zh-TW.json`
