### PR TITLE
Fix canonical model output paths

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -313,8 +313,8 @@ prepare-release version:
         ui/desktop/package.json \
         ui/pnpm-lock.yaml \
         ui/desktop/openapi.json \
-        crates/goose-providers/src/canonical/data/canonical_models.json \
-        crates/goose-providers/src/canonical/data/provider_metadata.json
+        crates/goose-provider-types/src/canonical/data/canonical_models.json \
+        crates/goose-provider-types/src/canonical/data/provider_metadata.json
     @git commit --message "chore(release): release version {{ version }}"
 
 set-openapi-version version:

--- a/crates/goose-provider-types/src/canonical/README.md
+++ b/crates/goose-provider-types/src/canonical/README.md
@@ -13,11 +13,11 @@ cargo run --bin build_canonical_models --no-check   # Build only, skip checker
 
 This script performs two operations by default:
 1. **Builds canonical models** - Fetches from OpenRouter API and updates the registry
-   - Writes to: `crates/goose-providers/src/canonical/data/canonical_models.json`
+   - Writes to: `crates/goose-provider-types/src/canonical/data/canonical_models.json`
 2. **Checks model mappings** (unless `--no-check` is passed) - Tests provider mappings and tracks changes over time
    - Reports unmapped models
    - Compares with previous runs (like a lock file)
    - Shows changed/added/removed mappings
-   - Writes to: `crates/goose-providers/src/canonical/data/canonical_mapping_report.json`
+   - Writes to: `crates/goose-provider-types/src/canonical/data/canonical_mapping_report.json`
 
 The script is currently built from `crates/goose/src/bin/build_canonical_models.rs` and writes into this crate's `src/canonical/data` directory.

--- a/crates/goose/src/bin/build_canonical_models.rs
+++ b/crates/goose/src/bin/build_canonical_models.rs
@@ -321,7 +321,7 @@ impl MappingReport {
 
 fn data_file_path(filename: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../goose-providers/src/canonical/data")
+        .join("../goose-provider-types/src/canonical/data")
         .join(filename)
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -11,8 +11,9 @@ ignore = [
     # the reachable path is through jsonwebtoken.
     "RUSTSEC-2023-0071",
 
-    # quick-xml: quadratic duplicate-attribute checks. Current paths are through
-    # docx-rs, umya-spreadsheet, and bat/plist, and their latest releases do not
-    # yet expose a quick-xml >= 0.41.0 upgrade path.
+    # quick-xml: duplicate-attribute and namespace-declaration allocation issues.
+    # Current paths are through docx-rs, umya-spreadsheet, and bat/plist, and their
+    # latest releases do not yet expose a quick-xml >= 0.41.0 upgrade path.
     "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]


### PR DESCRIPTION
The canonical model builder still wrote to the old goose-providers data directory after the canonical data moved into goose-provider-types.

This updates the builder output path and matching release/docs references so `just build-canonical-models` writes to the existing provider-types data directory.

Also added a deny.toml ignore for a second quick-xml vuln which we can't immediately remediate