### PR TITLE
perf(core): avoid cloning repetition inspector state

### DIFF
--- a/crates/goose/src/tool_monitor.rs
+++ b/crates/goose/src/tool_monitor.rs
@@ -84,6 +84,17 @@ impl RepetitionInspector {
         self.repeat_count = 0;
         self.call_counts.clear();
     }
+
+    fn would_exceed_limit(&self, tool_call: &CallToolRequestParams) -> bool {
+        let Some(max) = self.max_repetitions else {
+            return false;
+        };
+        let internal_call = InternalToolCall::from_tool_call(tool_call);
+        match &self.last_call {
+            Some(last) if last.matches(&internal_call) => self.repeat_count + 1 > max,
+            _ => false,
+        }
+    }
 }
 
 #[async_trait]
@@ -108,13 +119,7 @@ impl ToolInspector for RepetitionInspector {
         // Check repetition limits for each tool request
         for tool_request in tool_requests {
             if let Ok(tool_call) = &tool_request.tool_call {
-                // Create a temporary clone to check without modifying state
-                let mut temp_inspector = RepetitionInspector::new(self.max_repetitions);
-                temp_inspector.last_call = self.last_call.clone();
-                temp_inspector.repeat_count = self.repeat_count;
-                temp_inspector.call_counts = self.call_counts.clone();
-
-                if !temp_inspector.check_tool_call(tool_call.clone()) {
+                if self.would_exceed_limit(tool_call) {
                     results.push(InspectionResult {
                         tool_request_id: tool_request.id.clone(),
                         action: InspectionAction::Deny,


### PR DESCRIPTION
```markdown
## Summary

RepetitionInspector::inspect now uses a borrowed read-only helper, `would_exceed_limit()`, to predict whether a tool call would exceed the consecutive repetition limit.

Previously, inspection constructed a temporary `RepetitionInspector`, cloned `last_call`, `repeat_count`, the call-count map, and the tool call, then ran the mutating `check_tool_call()` path on that temporary copy. The new helper computes the same verdict from the existing inspector state without cloning the inspector’s internal map or request payload.

This keeps behavior unchanged while reducing per-tool-call allocation and copy overhead on the tool approval inspection path.

### Testing

- Ran `source bin/activate-hermit && cargo fmt`.
- Verified the change by comparing against the same performance fix in the Gosling fork, where this patch was already applied as part of hot-path allocation reduction work.
- Build/tests not run.

### Related Issues

Relates to N/A  
Discussion: N/A

### Screenshots/Demos (for UX changes)

Before: N/A

After: N/A
```