### PR TITLE
fix: recover malformed tool calls from GLM/Minimax models instead of rejecting them

### DIFF
--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -709,25 +709,28 @@ pub fn response_to_message(response: &Value) -> anyhow::Result<Message> {
                     })
                     .filter(|m: &serde_json::Map<String, Value>| !m.is_empty());
 
-                let function_name = match normalize_function_name(&function_name) {
-                    Some(name) => name,
-                    None => {
-                        let error = ErrorData {
-                            code: ErrorCode::INVALID_REQUEST,
-                            message: Cow::from(format!(
-                                "The provided function name '{}' had invalid characters, it must match this regex [a-zA-Z0-9_-]+",
-                                function_name
-                            )),
-                            data: None,
-                        };
-                        content.push(MessageContent::tool_request_with_metadata(
-                            id,
-                            Err(error),
-                            metadata.as_ref(),
-                        ));
-                        continue;
-                    }
-                };
+                // Pass the name through verbatim: format_tools advertises raw
+                // (unsanitized) names, so any non-empty name — dotted or
+                // otherwise — can be a legitimate exact echo. Dispatch owns the
+                // tool list and both resolves exact names and recovers
+                // model-mangled ones; unknown names get its recoverable
+                // "tool not found" error instead of a parse abort (see #9486).
+                if function_name.is_empty() {
+                    let error = ErrorData {
+                        code: ErrorCode::INVALID_REQUEST,
+                        message: Cow::from(
+                            "The provided function name was empty; a tool call must name a tool"
+                                .to_string(),
+                        ),
+                        data: None,
+                    };
+                    content.push(MessageContent::tool_request_with_metadata(
+                        id,
+                        Err(error),
+                        metadata.as_ref(),
+                    ));
+                    continue;
+                }
                 match parse_tool_arguments(&arguments_str) {
                     Some(params) if params.is_object() => {
                         content.push(MessageContent::tool_request_with_metadata(
@@ -1183,11 +1186,6 @@ where
 
                 for index in sorted_indices {
                     if let Some((id, function_name, arguments, extra_fields)) = tool_call_data.get(&index) {
-                        // Recover malformed-but-recognizable names the same way the
-                        // non-streaming decoder does; degenerate names pass through
-                        // unchanged, preserving this path's historical leniency.
-                        let function_name = &normalize_function_name(function_name)
-                            .unwrap_or_else(|| function_name.clone());
                         let metadata = if let Some(sig) = &last_signature {
                             let mut combined = extra_fields.clone().unwrap_or_default();
                             combined.insert(
@@ -1558,36 +1556,6 @@ pub fn is_valid_function_name(name: &str) -> bool {
     static RE: OnceLock<Regex> = OnceLock::new();
     let re = RE.get_or_init(|| Regex::new(r"^[a-zA-Z0-9_-]+$").unwrap());
     re.is_match(name)
-}
-
-/// Normalize a tool name emitted by the model into goose's valid-name charset,
-/// recovering the malformed-but-recognizable shapes some models produce
-/// (see #9486):
-/// - a leaked "functions." namespace prefix is stripped
-///   ("functions.developer__shell" → "developer__shell")
-/// - dots map to goose's "__" extension separator
-///   ("developer.shell" → "developer__shell")
-/// - remaining invalid characters are sanitized to "_", mirroring the outbound
-///   [`sanitize_function_name`]; unknown results are answered by tool dispatch
-///   with a recoverable "tool not found" error instead of aborting the parse
-///
-/// Returns `None` when nothing salvageable remains (no alphanumeric characters).
-pub fn normalize_function_name(name: &str) -> Option<String> {
-    let name = name.trim();
-    let name = name
-        .strip_prefix("functions.")
-        .or_else(|| name.strip_prefix("functions:"))
-        .unwrap_or(name);
-
-    if is_valid_function_name(name) {
-        return Some(name.to_string());
-    }
-
-    if !name.chars().any(|c| c.is_ascii_alphanumeric()) {
-        return None;
-    }
-
-    Some(sanitize_function_name(&name.replace('.', "__")))
 }
 
 #[cfg(test)]
@@ -2041,11 +2009,11 @@ mod tests {
     }
 
     #[test]
-    fn test_response_to_message_invalid_func_name() -> anyhow::Result<()> {
-        // A name with no salvageable identifier characters cannot be
-        // normalized and must still be rejected.
+    fn test_response_to_message_empty_func_name() -> anyhow::Result<()> {
+        // An empty name can never be dispatched; it is the only name the
+        // parser still rejects.
         let mut response: Value = serde_json::from_str(OPENAI_TOOL_USE_RESPONSE)?;
-        response["choices"][0]["message"]["tool_calls"][0]["function"]["name"] = json!("???!");
+        response["choices"][0]["message"]["tool_calls"][0]["function"]["name"] = json!("");
 
         let message = response_to_message(&response)?;
 
@@ -2058,7 +2026,7 @@ mod tests {
                 }) => {
                     assert!(msg.starts_with("The provided function name"));
                 }
-                _ => panic!("Expected ToolNotFound error"),
+                _ => panic!("Expected invalid-request error for empty name"),
             }
         } else {
             panic!("Expected ToolRequest content");
@@ -2068,63 +2036,29 @@ mod tests {
     }
 
     #[test]
-    fn test_response_to_message_recovers_dotted_tool_name() -> anyhow::Result<()> {
-        // GLM emits dotted namespaces (see #9486). Goose separates extension
-        // and tool with "__", so "developer.shell" must map to
-        // "developer__shell" instead of hard-failing the parse.
-        let mut response: Value = serde_json::from_str(OPENAI_TOOL_USE_RESPONSE)?;
-        response["choices"][0]["message"]["tool_calls"][0]["function"]["name"] =
-            json!("developer.shell");
+    fn test_response_to_message_passes_names_through_to_dispatch() -> anyhow::Result<()> {
+        // The parser cannot know the advertised tool list, and format_tools
+        // advertises raw (unsanitized) names — so a dotted name can be a
+        // legitimate exact echo (e.g. an MCP tool named "db.query"). Names
+        // must pass through verbatim; recovery of model-mangled names happens
+        // at dispatch, where the real tool list is known (see #9486 review).
+        for name in [
+            "developer.shell",
+            "functions.example_fn",
+            "example fn",
+            "???!",
+        ] {
+            let mut response: Value = serde_json::from_str(OPENAI_TOOL_USE_RESPONSE)?;
+            response["choices"][0]["message"]["tool_calls"][0]["function"]["name"] = json!(name);
 
-        let message = response_to_message(&response)?;
+            let message = response_to_message(&response)?;
 
-        if let MessageContent::ToolRequest(request) = &message.content[0] {
-            let tool_call = request.tool_call.as_ref().expect("tool call should parse");
-            assert_eq!(tool_call.name, "developer__shell");
-            assert_eq!(tool_call.arguments, Some(object!({"param": "value"})));
-        } else {
-            panic!("Expected ToolRequest content");
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_response_to_message_strips_functions_namespace_prefix() -> anyhow::Result<()> {
-        // Models trained on OpenAI-style tool schemas leak the internal
-        // "functions." namespace into the emitted name (see #9486).
-        let mut response: Value = serde_json::from_str(OPENAI_TOOL_USE_RESPONSE)?;
-        response["choices"][0]["message"]["tool_calls"][0]["function"]["name"] =
-            json!("functions.example_fn");
-
-        let message = response_to_message(&response)?;
-
-        if let MessageContent::ToolRequest(request) = &message.content[0] {
-            let tool_call = request.tool_call.as_ref().expect("tool call should parse");
-            assert_eq!(tool_call.name, "example_fn");
-        } else {
-            panic!("Expected ToolRequest content");
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_response_to_message_recovers_invalid_name_chars() -> anyhow::Result<()> {
-        // Stray invalid characters are sanitized the same way outbound tool
-        // names are, so the call reaches dispatch (which answers unknown names
-        // with a recoverable "tool not found" listing) instead of aborting.
-        let mut response: Value = serde_json::from_str(OPENAI_TOOL_USE_RESPONSE)?;
-        response["choices"][0]["message"]["tool_calls"][0]["function"]["name"] =
-            json!("example fn");
-
-        let message = response_to_message(&response)?;
-
-        if let MessageContent::ToolRequest(request) = &message.content[0] {
-            let tool_call = request.tool_call.as_ref().expect("tool call should parse");
-            assert_eq!(tool_call.name, "example_fn");
-        } else {
-            panic!("Expected ToolRequest content");
+            if let MessageContent::ToolRequest(request) = &message.content[0] {
+                let tool_call = request.tool_call.as_ref().expect("tool call should parse");
+                assert_eq!(tool_call.name, name, "name must pass through verbatim");
+            } else {
+                panic!("Expected ToolRequest content");
+            }
         }
 
         Ok(())
@@ -3939,12 +3873,13 @@ data: [DONE]"#;
     }
 
     #[tokio::test]
-    async fn test_streaming_tool_call_normalizes_function_name() -> anyhow::Result<()> {
-        // The streaming decoder must apply the same tool-name normalization as
-        // the non-streaming one: dotted names map to goose's "__" separator
-        // (see #9486).
+    async fn test_streaming_tool_call_dotted_name_passes_through() -> anyhow::Result<()> {
+        // A dotted name can be a legitimate exact echo of an advertised tool
+        // (format_tools sends raw names), so the streaming decoder must pass
+        // it through verbatim; mangled-name recovery happens at dispatch
+        // (see #9486 review).
         let response_lines = concat!(
-            "data: {\"id\":\"x\",\"object\":\"chat.completion.chunk\",\"model\":\"m\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"tool_calls\":[{\"index\":0,\"id\":\"tc1\",\"type\":\"function\",\"function\":{\"name\":\"developer.shell\",\"arguments\":\"{\\\"command\\\": \\\"ls\\\"}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n",
+            "data: {\"id\":\"x\",\"object\":\"chat.completion.chunk\",\"model\":\"m\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"tool_calls\":[{\"index\":0,\"id\":\"tc1\",\"type\":\"function\",\"function\":{\"name\":\"ext__db.query\",\"arguments\":\"{\\\"command\\\": \\\"ls\\\"}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n",
             "data: [DONE]"
         );
         let lines: Vec<String> = response_lines.lines().map(|s| s.to_string()).collect();
@@ -3965,7 +3900,7 @@ data: [DONE]"#;
         }
 
         assert_eq!(tool_calls.len(), 1);
-        assert_eq!(tool_calls[0].0, "developer__shell");
+        assert_eq!(tool_calls[0].0, "ext__db.query");
         assert_eq!(tool_calls[0].1, Some(object!({"command": "ls"})));
         Ok(())
     }
@@ -4156,84 +4091,6 @@ data: [DONE]"#;
         assert!(is_valid_function_name("hello_world"));
         assert!(!is_valid_function_name("hello world"));
         assert!(!is_valid_function_name("hello@world"));
-    }
-
-    #[test]
-    fn test_normalize_function_name() {
-        // Already-valid names pass through untouched — including degenerate
-        // but previously-accepted ones like "-_-".
-        assert_eq!(
-            normalize_function_name("developer__shell").as_deref(),
-            Some("developer__shell")
-        );
-        assert_eq!(normalize_function_name("-_-").as_deref(), Some("-_-"));
-
-        // Leaked OpenAI-style namespace prefixes are stripped.
-        assert_eq!(
-            normalize_function_name("functions.developer__shell").as_deref(),
-            Some("developer__shell")
-        );
-        assert_eq!(
-            normalize_function_name("functions:developer__shell").as_deref(),
-            Some("developer__shell")
-        );
-
-        // Dots map to goose's "__" extension separator, including after a
-        // stripped prefix.
-        assert_eq!(
-            normalize_function_name("developer.shell").as_deref(),
-            Some("developer__shell")
-        );
-        assert_eq!(
-            normalize_function_name("functions.developer.shell").as_deref(),
-            Some("developer__shell")
-        );
-
-        // Other invalid characters sanitize to "_", and surrounding
-        // whitespace is trimmed.
-        assert_eq!(
-            normalize_function_name(" example fn ").as_deref(),
-            Some("example_fn")
-        );
-
-        // Nothing salvageable → rejected.
-        assert_eq!(normalize_function_name("???!"), None);
-        assert_eq!(normalize_function_name(""), None);
-        assert_eq!(normalize_function_name("functions."), None);
-    }
-
-    #[test]
-    fn test_normalize_function_name_is_fixed_point_of_sanitize() {
-        // Every name the model can legitimately echo went through
-        // sanitize_function_name on the way out, so normalization must be the
-        // identity on that whole domain — a real tool can never be renamed.
-        // (A sanitized name contains no dots, so the dot mapping can only ever
-        // fire on names the model mangled itself.)
-        for raw in [
-            "developer__shell",
-            "platform.search",
-            "weird name!",
-            "a.b.c",
-            "functions_helper",
-            "UPPER-case_09",
-        ] {
-            let outbound = sanitize_function_name(raw);
-            assert_eq!(
-                normalize_function_name(&outbound).as_deref(),
-                Some(outbound.as_str()),
-                "sanitized name '{outbound}' must normalize to itself"
-            );
-        }
-
-        // Normalization is also idempotent on its own successful outputs.
-        for mangled in ["functions.developer__shell", "developer.shell", "a b"] {
-            let once = normalize_function_name(mangled).unwrap();
-            assert_eq!(
-                normalize_function_name(&once).as_deref(),
-                Some(once.as_str()),
-                "normalized name '{once}' must be stable"
-            );
-        }
     }
 
     #[test]

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -709,68 +709,71 @@ pub fn response_to_message(response: &Value) -> anyhow::Result<Message> {
                     })
                     .filter(|m: &serde_json::Map<String, Value>| !m.is_empty());
 
-                if !is_valid_function_name(&function_name) {
-                    let error = ErrorData {
-                        code: ErrorCode::INVALID_REQUEST,
-                        message: Cow::from(format!(
-                            "The provided function name '{}' had invalid characters, it must match this regex [a-zA-Z0-9_-]+",
-                            function_name
-                        )),
-                        data: None,
-                    };
-                    content.push(MessageContent::tool_request_with_metadata(
-                        id,
-                        Err(error),
-                        metadata.as_ref(),
-                    ));
-                } else {
-                    match parse_tool_arguments(&arguments_str) {
-                        Some(params) if params.is_object() => {
-                            content.push(MessageContent::tool_request_with_metadata(
+                let function_name = match normalize_function_name(&function_name) {
+                    Some(name) => name,
+                    None => {
+                        let error = ErrorData {
+                            code: ErrorCode::INVALID_REQUEST,
+                            message: Cow::from(format!(
+                                "The provided function name '{}' had invalid characters, it must match this regex [a-zA-Z0-9_-]+",
+                                function_name
+                            )),
+                            data: None,
+                        };
+                        content.push(MessageContent::tool_request_with_metadata(
+                            id,
+                            Err(error),
+                            metadata.as_ref(),
+                        ));
+                        continue;
+                    }
+                };
+                match parse_tool_arguments(&arguments_str) {
+                    Some(params) if params.is_object() => {
+                        content.push(MessageContent::tool_request_with_metadata(
+                            id,
+                            Ok(CallToolRequestParams::new(function_name)
+                                .with_arguments(object(params))),
+                            metadata.as_ref(),
+                        ));
+                    }
+                    // Valid JSON but NOT an object (a bare array/string/number).
+                    // Weaker models emit this; surface a tool error so the model
+                    // retries with a proper object instead of crashing the run
+                    // (rmcp's `object()` debug-asserts on non-objects).
+                    Some(other) => {
+                        let error = ErrorData {
+                            code: ErrorCode::INVALID_PARAMS,
+                            message: Cow::from(format!(
+                                "Tool arguments for {} (id {}) must be a JSON object, got {}. Raw arguments: '{}'",
+                                function_name,
                                 id,
-                                Ok(CallToolRequestParams::new(function_name)
-                                    .with_arguments(object(params))),
-                                metadata.as_ref(),
-                            ));
-                        }
-                        // Valid JSON but NOT an object (a bare array/string/number).
-                        // Weaker models emit this; surface a tool error so the model
-                        // retries with a proper object instead of crashing the run
-                        // (rmcp's `object()` debug-asserts on non-objects).
-                        Some(other) => {
-                            let error = ErrorData {
-                                code: ErrorCode::INVALID_PARAMS,
-                                message: Cow::from(format!(
-                                    "Tool arguments for {} (id {}) must be a JSON object, got {}. Raw arguments: '{}'",
-                                    function_name,
-                                    id,
-                                    describe_json_value(&other),
-                                    arguments_str
-                                )),
-                                data: None,
-                            };
-                            content.push(MessageContent::tool_request_with_metadata(
-                                id,
-                                Err(error),
-                                metadata.as_ref(),
-                            ));
-                        }
-                        None => {
-                            let message_text = truncation_error_message(&arguments_str)
-                                .unwrap_or_else(|| {
-                                    format!("Could not interpret tool use parameters for id {id}")
-                                });
-                            let error = ErrorData {
-                                code: ErrorCode::INVALID_PARAMS,
-                                message: Cow::from(message_text),
-                                data: None,
-                            };
-                            content.push(MessageContent::tool_request_with_metadata(
-                                id,
-                                Err(error),
-                                metadata.as_ref(),
-                            ));
-                        }
+                                describe_json_value(&other),
+                                arguments_str
+                            )),
+                            data: None,
+                        };
+                        content.push(MessageContent::tool_request_with_metadata(
+                            id,
+                            Err(error),
+                            metadata.as_ref(),
+                        ));
+                    }
+                    None => {
+                        let message_text =
+                            truncation_error_message(&arguments_str).unwrap_or_else(|| {
+                                format!("Could not interpret tool use parameters for id {id}")
+                            });
+                        let error = ErrorData {
+                            code: ErrorCode::INVALID_PARAMS,
+                            message: Cow::from(message_text),
+                            data: None,
+                        };
+                        content.push(MessageContent::tool_request_with_metadata(
+                            id,
+                            Err(error),
+                            metadata.as_ref(),
+                        ));
                     }
                 }
             }
@@ -1180,6 +1183,11 @@ where
 
                 for index in sorted_indices {
                     if let Some((id, function_name, arguments, extra_fields)) = tool_call_data.get(&index) {
+                        // Recover malformed-but-recognizable names the same way the
+                        // non-streaming decoder does; degenerate names pass through
+                        // unchanged, preserving this path's historical leniency.
+                        let function_name = &normalize_function_name(function_name)
+                            .unwrap_or_else(|| function_name.clone());
                         let metadata = if let Some(sig) = &last_signature {
                             let mut combined = extra_fields.clone().unwrap_or_default();
                             combined.insert(
@@ -1550,6 +1558,36 @@ pub fn is_valid_function_name(name: &str) -> bool {
     static RE: OnceLock<Regex> = OnceLock::new();
     let re = RE.get_or_init(|| Regex::new(r"^[a-zA-Z0-9_-]+$").unwrap());
     re.is_match(name)
+}
+
+/// Normalize a tool name emitted by the model into goose's valid-name charset,
+/// recovering the malformed-but-recognizable shapes some models produce
+/// (see #9486):
+/// - a leaked "functions." namespace prefix is stripped
+///   ("functions.developer__shell" → "developer__shell")
+/// - dots map to goose's "__" extension separator
+///   ("developer.shell" → "developer__shell")
+/// - remaining invalid characters are sanitized to "_", mirroring the outbound
+///   [`sanitize_function_name`]; unknown results are answered by tool dispatch
+///   with a recoverable "tool not found" error instead of aborting the parse
+///
+/// Returns `None` when nothing salvageable remains (no alphanumeric characters).
+pub fn normalize_function_name(name: &str) -> Option<String> {
+    let name = name.trim();
+    let name = name
+        .strip_prefix("functions.")
+        .or_else(|| name.strip_prefix("functions:"))
+        .unwrap_or(name);
+
+    if is_valid_function_name(name) {
+        return Some(name.to_string());
+    }
+
+    if !name.chars().any(|c| c.is_ascii_alphanumeric()) {
+        return None;
+    }
+
+    Some(sanitize_function_name(&name.replace('.', "__")))
 }
 
 #[cfg(test)]
@@ -2004,9 +2042,10 @@ mod tests {
 
     #[test]
     fn test_response_to_message_invalid_func_name() -> anyhow::Result<()> {
+        // A name with no salvageable identifier characters cannot be
+        // normalized and must still be rejected.
         let mut response: Value = serde_json::from_str(OPENAI_TOOL_USE_RESPONSE)?;
-        response["choices"][0]["message"]["tool_calls"][0]["function"]["name"] =
-            json!("invalid fn");
+        response["choices"][0]["message"]["tool_calls"][0]["function"]["name"] = json!("???!");
 
         let message = response_to_message(&response)?;
 
@@ -2021,6 +2060,89 @@ mod tests {
                 }
                 _ => panic!("Expected ToolNotFound error"),
             }
+        } else {
+            panic!("Expected ToolRequest content");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_response_to_message_recovers_dotted_tool_name() -> anyhow::Result<()> {
+        // GLM emits dotted namespaces (see #9486). Goose separates extension
+        // and tool with "__", so "developer.shell" must map to
+        // "developer__shell" instead of hard-failing the parse.
+        let mut response: Value = serde_json::from_str(OPENAI_TOOL_USE_RESPONSE)?;
+        response["choices"][0]["message"]["tool_calls"][0]["function"]["name"] =
+            json!("developer.shell");
+
+        let message = response_to_message(&response)?;
+
+        if let MessageContent::ToolRequest(request) = &message.content[0] {
+            let tool_call = request.tool_call.as_ref().expect("tool call should parse");
+            assert_eq!(tool_call.name, "developer__shell");
+            assert_eq!(tool_call.arguments, Some(object!({"param": "value"})));
+        } else {
+            panic!("Expected ToolRequest content");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_response_to_message_strips_functions_namespace_prefix() -> anyhow::Result<()> {
+        // Models trained on OpenAI-style tool schemas leak the internal
+        // "functions." namespace into the emitted name (see #9486).
+        let mut response: Value = serde_json::from_str(OPENAI_TOOL_USE_RESPONSE)?;
+        response["choices"][0]["message"]["tool_calls"][0]["function"]["name"] =
+            json!("functions.example_fn");
+
+        let message = response_to_message(&response)?;
+
+        if let MessageContent::ToolRequest(request) = &message.content[0] {
+            let tool_call = request.tool_call.as_ref().expect("tool call should parse");
+            assert_eq!(tool_call.name, "example_fn");
+        } else {
+            panic!("Expected ToolRequest content");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_response_to_message_recovers_invalid_name_chars() -> anyhow::Result<()> {
+        // Stray invalid characters are sanitized the same way outbound tool
+        // names are, so the call reaches dispatch (which answers unknown names
+        // with a recoverable "tool not found" listing) instead of aborting.
+        let mut response: Value = serde_json::from_str(OPENAI_TOOL_USE_RESPONSE)?;
+        response["choices"][0]["message"]["tool_calls"][0]["function"]["name"] =
+            json!("example fn");
+
+        let message = response_to_message(&response)?;
+
+        if let MessageContent::ToolRequest(request) = &message.content[0] {
+            let tool_call = request.tool_call.as_ref().expect("tool call should parse");
+            assert_eq!(tool_call.name, "example_fn");
+        } else {
+            panic!("Expected ToolRequest content");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_response_to_message_fenced_arguments() -> anyhow::Result<()> {
+        // GLM/Minimax sometimes wrap tool arguments in a markdown fence
+        // (see #9486); the arguments must still parse into an object.
+        let mut response: Value = serde_json::from_str(OPENAI_TOOL_USE_RESPONSE)?;
+        response["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"] =
+            json!("```json\n{\"param\": \"value\"}\n```");
+
+        let message = response_to_message(&response)?;
+
+        if let MessageContent::ToolRequest(request) = &message.content[0] {
+            let tool_call = request.tool_call.as_ref().expect("tool call should parse");
+            assert_eq!(tool_call.arguments, Some(object!({"param": "value"})));
         } else {
             panic!("Expected ToolRequest content");
         }
@@ -3817,6 +3939,74 @@ data: [DONE]"#;
     }
 
     #[tokio::test]
+    async fn test_streaming_tool_call_normalizes_function_name() -> anyhow::Result<()> {
+        // The streaming decoder must apply the same tool-name normalization as
+        // the non-streaming one: dotted names map to goose's "__" separator
+        // (see #9486).
+        let response_lines = concat!(
+            "data: {\"id\":\"x\",\"object\":\"chat.completion.chunk\",\"model\":\"m\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"tool_calls\":[{\"index\":0,\"id\":\"tc1\",\"type\":\"function\",\"function\":{\"name\":\"developer.shell\",\"arguments\":\"{\\\"command\\\": \\\"ls\\\"}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n",
+            "data: [DONE]"
+        );
+        let lines: Vec<String> = response_lines.lines().map(|s| s.to_string()).collect();
+        let response_stream = tokio_stream::iter(lines.into_iter().map(Ok));
+        let mut messages = std::pin::pin!(response_to_streaming_message(response_stream));
+
+        let mut tool_calls = Vec::new();
+        while let Some(result) = messages.next().await {
+            let (message, _usage) = result?;
+            if let Some(msg) = message {
+                for content in &msg.content {
+                    if let MessageContent::ToolRequest(request) = content {
+                        let tool_call = request.tool_call.as_ref().expect("tool call should parse");
+                        tool_calls.push((tool_call.name.to_string(), tool_call.arguments.clone()));
+                    }
+                }
+            }
+        }
+
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].0, "developer__shell");
+        assert_eq!(tool_calls[0].1, Some(object!({"command": "ls"})));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_streaming_tool_call_degenerate_name_passes_through() -> anyhow::Result<()> {
+        // The streaming decoder historically accepted any name; a name with
+        // nothing salvageable must keep passing through unchanged rather than
+        // becoming an error this path never produced.
+        let response_lines = concat!(
+            "data: {\"id\":\"x\",\"object\":\"chat.completion.chunk\",\"model\":\"m\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"tool_calls\":[{\"index\":0,\"id\":\"tc1\",\"type\":\"function\",\"function\":{\"name\":\"???\",\"arguments\":\"{}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n",
+            "data: [DONE]"
+        );
+        let lines: Vec<String> = response_lines.lines().map(|s| s.to_string()).collect();
+        let response_stream = tokio_stream::iter(lines.into_iter().map(Ok));
+        let mut messages = std::pin::pin!(response_to_streaming_message(response_stream));
+
+        let mut names = Vec::new();
+        while let Some(result) = messages.next().await {
+            let (message, _usage) = result?;
+            if let Some(msg) = message {
+                for content in &msg.content {
+                    if let MessageContent::ToolRequest(request) = content {
+                        names.push(
+                            request
+                                .tool_call
+                                .as_ref()
+                                .expect("passes through")
+                                .name
+                                .to_string(),
+                        );
+                    }
+                }
+            }
+        }
+
+        assert_eq!(names, vec!["???".to_string()]);
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_streaming_multiple_tool_calls_without_tool_call_index() -> anyhow::Result<()> {
         let response_lines = concat!(
             "data: {\"id\":\"x\",\"object\":\"chat.completion.chunk\",\"model\":\"m\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"tool_calls\":[{\"id\":\"functions.get_weather:0\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\": \\\"Paris\\\"}\"}},{\"id\":\"functions.get_weather:1\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\": \\\"Tokyo\\\"}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n",
@@ -3966,6 +4156,84 @@ data: [DONE]"#;
         assert!(is_valid_function_name("hello_world"));
         assert!(!is_valid_function_name("hello world"));
         assert!(!is_valid_function_name("hello@world"));
+    }
+
+    #[test]
+    fn test_normalize_function_name() {
+        // Already-valid names pass through untouched — including degenerate
+        // but previously-accepted ones like "-_-".
+        assert_eq!(
+            normalize_function_name("developer__shell").as_deref(),
+            Some("developer__shell")
+        );
+        assert_eq!(normalize_function_name("-_-").as_deref(), Some("-_-"));
+
+        // Leaked OpenAI-style namespace prefixes are stripped.
+        assert_eq!(
+            normalize_function_name("functions.developer__shell").as_deref(),
+            Some("developer__shell")
+        );
+        assert_eq!(
+            normalize_function_name("functions:developer__shell").as_deref(),
+            Some("developer__shell")
+        );
+
+        // Dots map to goose's "__" extension separator, including after a
+        // stripped prefix.
+        assert_eq!(
+            normalize_function_name("developer.shell").as_deref(),
+            Some("developer__shell")
+        );
+        assert_eq!(
+            normalize_function_name("functions.developer.shell").as_deref(),
+            Some("developer__shell")
+        );
+
+        // Other invalid characters sanitize to "_", and surrounding
+        // whitespace is trimmed.
+        assert_eq!(
+            normalize_function_name(" example fn ").as_deref(),
+            Some("example_fn")
+        );
+
+        // Nothing salvageable → rejected.
+        assert_eq!(normalize_function_name("???!"), None);
+        assert_eq!(normalize_function_name(""), None);
+        assert_eq!(normalize_function_name("functions."), None);
+    }
+
+    #[test]
+    fn test_normalize_function_name_is_fixed_point_of_sanitize() {
+        // Every name the model can legitimately echo went through
+        // sanitize_function_name on the way out, so normalization must be the
+        // identity on that whole domain — a real tool can never be renamed.
+        // (A sanitized name contains no dots, so the dot mapping can only ever
+        // fire on names the model mangled itself.)
+        for raw in [
+            "developer__shell",
+            "platform.search",
+            "weird name!",
+            "a.b.c",
+            "functions_helper",
+            "UPPER-case_09",
+        ] {
+            let outbound = sanitize_function_name(raw);
+            assert_eq!(
+                normalize_function_name(&outbound).as_deref(),
+                Some(outbound.as_str()),
+                "sanitized name '{outbound}' must normalize to itself"
+            );
+        }
+
+        // Normalization is also idempotent on its own successful outputs.
+        for mangled in ["functions.developer__shell", "developer.shell", "a b"] {
+            let once = normalize_function_name(mangled).unwrap();
+            assert_eq!(
+                normalize_function_name(&once).as_deref(),
+                Some(once.as_str()),
+                "normalized name '{once}' must be stable"
+            );
+        }
     }
 
     #[test]

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -709,12 +709,6 @@ pub fn response_to_message(response: &Value) -> anyhow::Result<Message> {
                     })
                     .filter(|m: &serde_json::Map<String, Value>| !m.is_empty());
 
-                // Pass the name through verbatim: format_tools advertises raw
-                // (unsanitized) names, so any non-empty name — dotted or
-                // otherwise — can be a legitimate exact echo. Dispatch owns the
-                // tool list and both resolves exact names and recovers
-                // model-mangled ones; unknown names get its recoverable
-                // "tool not found" error instead of a parse abort (see #9486).
                 if function_name.is_empty() {
                     let error = ErrorData {
                         code: ErrorCode::INVALID_REQUEST,
@@ -740,10 +734,6 @@ pub fn response_to_message(response: &Value) -> anyhow::Result<Message> {
                             metadata.as_ref(),
                         ));
                     }
-                    // Valid JSON but NOT an object (a bare array/string/number).
-                    // Weaker models emit this; surface a tool error so the model
-                    // retries with a proper object instead of crashing the run
-                    // (rmcp's `object()` debug-asserts on non-objects).
                     Some(other) => {
                         let error = ErrorData {
                             code: ErrorCode::INVALID_PARAMS,
@@ -2019,8 +2009,6 @@ mod tests {
 
     #[test]
     fn test_response_to_message_empty_func_name() -> anyhow::Result<()> {
-        // An empty name can never be dispatched; it is the only name the
-        // parser still rejects.
         let mut response: Value = serde_json::from_str(OPENAI_TOOL_USE_RESPONSE)?;
         response["choices"][0]["message"]["tool_calls"][0]["function"]["name"] = json!("");
 
@@ -2046,11 +2034,6 @@ mod tests {
 
     #[test]
     fn test_response_to_message_passes_names_through_to_dispatch() -> anyhow::Result<()> {
-        // The parser cannot know the advertised tool list, and format_tools
-        // advertises raw (unsanitized) names — so a dotted name can be a
-        // legitimate exact echo (e.g. an MCP tool named "db.query"). Names
-        // must pass through verbatim; recovery of model-mangled names happens
-        // at dispatch, where the real tool list is known (see #9486 review).
         for name in [
             "developer.shell",
             "functions.example_fn",
@@ -2075,8 +2058,6 @@ mod tests {
 
     #[test]
     fn test_response_to_message_fenced_arguments() -> anyhow::Result<()> {
-        // GLM/Minimax sometimes wrap tool arguments in a markdown fence
-        // (see #9486); the arguments must still parse into an object.
         let mut response: Value = serde_json::from_str(OPENAI_TOOL_USE_RESPONSE)?;
         response["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"] =
             json!("```json\n{\"param\": \"value\"}\n```");
@@ -3883,10 +3864,6 @@ data: [DONE]"#;
 
     #[tokio::test]
     async fn test_streaming_tool_call_dotted_name_passes_through() -> anyhow::Result<()> {
-        // A dotted name can be a legitimate exact echo of an advertised tool
-        // (format_tools sends raw names), so the streaming decoder must pass
-        // it through verbatim; mangled-name recovery happens at dispatch
-        // (see #9486 review).
         let response_lines = concat!(
             "data: {\"id\":\"x\",\"object\":\"chat.completion.chunk\",\"model\":\"m\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"tool_calls\":[{\"index\":0,\"id\":\"tc1\",\"type\":\"function\",\"function\":{\"name\":\"ext__db.query\",\"arguments\":\"{\\\"command\\\": \\\"ls\\\"}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n",
             "data: [DONE]"
@@ -3916,9 +3893,6 @@ data: [DONE]"#;
 
     #[tokio::test]
     async fn test_streaming_tool_call_degenerate_name_passes_through() -> anyhow::Result<()> {
-        // The streaming decoder historically accepted any name; a name with
-        // nothing salvageable must keep passing through unchanged rather than
-        // becoming an error this path never produced.
         let response_lines = concat!(
             "data: {\"id\":\"x\",\"object\":\"chat.completion.chunk\",\"model\":\"m\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"tool_calls\":[{\"index\":0,\"id\":\"tc1\",\"type\":\"function\",\"function\":{\"name\":\"???\",\"arguments\":\"{}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n",
             "data: [DONE]"

--- a/crates/goose-provider-types/src/json.rs
+++ b/crates/goose-provider-types/src/json.rs
@@ -215,22 +215,94 @@ pub fn truncation_error_message(args: &str) -> Option<String> {
     ))
 }
 
+/// Strip a wrapper some models emit around JSON tool arguments: a markdown
+/// code fence (```json ... ```) or a single XML-ish tag (<tool_call>...</tool_call>).
+/// Returns the inner payload, or `None` when no recognizable wrapper is present.
+/// Callers only use the result if it actually parses, so this stays safe on
+/// arbitrary garbage.
+fn strip_json_wrapper(args: &str) -> Option<&str> {
+    let trimmed = args.trim();
+
+    if let Some(rest) = trimmed.strip_prefix("```") {
+        let body = rest.strip_suffix("```")?.trim_start();
+        let body = body
+            .strip_prefix("json")
+            .or_else(|| body.strip_prefix("JSON"))
+            .unwrap_or(body);
+        return Some(body.trim());
+    }
+
+    if trimmed.starts_with('<') && !trimmed.starts_with("</") {
+        let open_end = trimmed.find('>')?;
+        let tag_name = trimmed.get(1..open_end)?.split_whitespace().next()?;
+        if tag_name.is_empty()
+            || !tag_name
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+        {
+            return None;
+        }
+        let closing = format!("</{tag_name}>");
+        let body = trimmed
+            .get(open_end + 1..)?
+            .trim_end()
+            .strip_suffix(&closing)?;
+        return Some(body.trim());
+    }
+
+    None
+}
+
+/// Unwrap double-encoded arguments: a JSON string whose content is itself the
+/// real JSON object (some models serialize the arguments object twice). Only
+/// unwraps when an object eventually emerges; any other value is returned
+/// unchanged so callers keep their existing error behavior.
+fn unwrap_double_encoded_object(value: serde_json::Value) -> serde_json::Value {
+    let serde_json::Value::String(s) = &value else {
+        return value;
+    };
+
+    let mut current = s.trim().to_string();
+    for _ in 0..3 {
+        match serde_json::from_str::<serde_json::Value>(&current) {
+            Ok(inner @ serde_json::Value::Object(_)) => return inner,
+            Ok(serde_json::Value::String(inner)) => current = inner.trim().to_string(),
+            _ => break,
+        }
+    }
+
+    value
+}
+
 /// Parse tool-call arguments, returning `None` when the input looks truncated
 /// so callers can surface an actionable error rather than invoking a tool with
 /// incomplete arguments. Non-truncated malformation (e.g. unescaped control
 /// characters some models emit) is still repaired via [`safely_parse_json`].
+/// Recoverable wrappers some models emit — markdown fences, XML-ish tags, and
+/// double-encoded JSON strings — are unwrapped (see #9486).
 pub fn parse_tool_arguments(args: &str) -> Option<serde_json::Value> {
     if args.is_empty() {
         return Some(serde_json::Value::Object(serde_json::Map::new()));
     }
 
     if let Ok(value) = serde_json::from_str::<serde_json::Value>(args) {
-        return Some(value);
+        return Some(unwrap_double_encoded_object(value));
+    }
+
+    if let Some(inner) = strip_json_wrapper(args) {
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(inner) {
+            return Some(unwrap_double_encoded_object(value));
+        }
+        if !looks_truncated(inner) {
+            if let Ok(value) = safely_parse_json(inner) {
+                return Some(unwrap_double_encoded_object(value));
+            }
+        }
     }
 
     if !looks_truncated(args) {
         if let Ok(value) = safely_parse_json(args) {
-            return Some(value);
+            return Some(unwrap_double_encoded_object(value));
         }
     }
 
@@ -414,6 +486,98 @@ mod tests {
             "msg: {msg}"
         );
         assert!(msg.contains("cut off at:"), "msg: {msg}");
+    }
+
+    #[test]
+    fn test_parse_tool_arguments_markdown_fenced() {
+        // GLM/Minimax sometimes wrap tool arguments in a markdown code fence
+        // (see #9486). The fence must be stripped so the arguments parse.
+        let fenced = "```json\n{\"command\": \"ls\"}\n```";
+        let parsed = parse_tool_arguments(fenced).expect("fenced JSON should parse");
+        assert_eq!(parsed["command"], "ls");
+
+        let fenced_no_lang = "```\n{\"command\": \"ls\"}\n```";
+        let parsed = parse_tool_arguments(fenced_no_lang).expect("fenced JSON should parse");
+        assert_eq!(parsed["command"], "ls");
+
+        let fenced_inline = "```json{\"command\": \"ls\"}```";
+        let parsed = parse_tool_arguments(fenced_inline).expect("fenced JSON should parse");
+        assert_eq!(parsed["command"], "ls");
+    }
+
+    #[test]
+    fn test_parse_tool_arguments_double_encoded() {
+        // Double-encoded JSON: the arguments string is itself a JSON string
+        // whose value is the real JSON object (see #9486).
+        let double_encoded = r#""{\"command\": \"ls\"}""#;
+        let parsed = parse_tool_arguments(double_encoded).expect("double-encoded should parse");
+        assert!(parsed.is_object(), "expected object, got {parsed:?}");
+        assert_eq!(parsed["command"], "ls");
+
+        // Two levels of encoding must also unwrap.
+        let twice = serde_json::to_string(&serde_json::json!(r#"{"command": "ls"}"#)).unwrap();
+        let twice = serde_json::to_string(&serde_json::json!(twice)).unwrap();
+        let parsed = parse_tool_arguments(&twice).expect("twice-encoded should parse");
+        assert!(parsed.is_object(), "expected object, got {parsed:?}");
+        assert_eq!(parsed["command"], "ls");
+    }
+
+    #[test]
+    fn test_parse_tool_arguments_xml_wrapped() {
+        // Some models wrap the JSON payload in an XML-ish tag (see #9486).
+        let wrapped = r#"<tool_call>{"command": "ls"}</tool_call>"#;
+        let parsed = parse_tool_arguments(wrapped).expect("xml-wrapped JSON should parse");
+        assert_eq!(parsed["command"], "ls");
+
+        // Attributes on the opening tag are tolerated.
+        let with_attrs = r#"<tool_call id="1">{"command": "ls"}</tool_call>"#;
+        let parsed = parse_tool_arguments(with_attrs).expect("xml-wrapped JSON should parse");
+        assert_eq!(parsed["command"], "ls");
+    }
+
+    #[test]
+    fn test_parse_tool_arguments_unrecoverable_wrappers_still_fail() {
+        // Unwrapping is conservative: anything that does not cleanly reduce to
+        // parseable JSON must keep failing rather than be guessed at.
+        // Nested XML tags — only one level is stripped, inner content is not JSON.
+        assert!(parse_tool_arguments(r#"<a><b>{"x": 1}</b></a>"#).is_none());
+        // Trailing junk after the closing fence.
+        assert!(parse_tool_arguments("```json\n{\"x\": 1}\n``` extra").is_none());
+        // Mismatched closing tag.
+        assert!(parse_tool_arguments(r#"<tool_call>{"x": 1}</other>"#).is_none());
+        // A closing tag alone.
+        assert!(parse_tool_arguments(r#"</tool_call>"#).is_none());
+        // A lone fence marker.
+        assert!(parse_tool_arguments("```").is_none());
+    }
+
+    #[test]
+    fn test_parse_tool_arguments_non_object_json_unchanged() {
+        // Bare non-object JSON values still parse to themselves so callers keep
+        // rejecting them with their existing "must be a JSON object" error.
+        assert_eq!(parse_tool_arguments("null"), Some(serde_json::Value::Null));
+        assert_eq!(parse_tool_arguments("42"), Some(serde_json::json!(42)));
+        assert_eq!(
+            parse_tool_arguments("[1, 2]"),
+            Some(serde_json::json!([1, 2]))
+        );
+    }
+
+    #[test]
+    fn test_parse_tool_arguments_plain_string_preserved() {
+        // A JSON string that does NOT contain an object must stay a string so
+        // callers keep producing their "must be a JSON object" error.
+        let plain = r#""hello""#;
+        let parsed = parse_tool_arguments(plain).expect("valid JSON string should parse");
+        assert_eq!(parsed, serde_json::json!("hello"));
+    }
+
+    #[test]
+    fn test_parse_tool_arguments_fenced_truncated_still_fails() {
+        // A fenced payload cut off mid-generation must still be treated as
+        // truncated, not silently repaired.
+        let truncated = "```json\n{\"path\": \"/report.md\", \"content\": \"# cut";
+        assert!(parse_tool_arguments(truncated).is_none());
     }
 
     #[test]

--- a/crates/goose-provider-types/src/json.rs
+++ b/crates/goose-provider-types/src/json.rs
@@ -215,11 +215,6 @@ pub fn truncation_error_message(args: &str) -> Option<String> {
     ))
 }
 
-/// Strip a wrapper some models emit around JSON tool arguments: a markdown
-/// code fence (```json ... ```) or a single XML-ish tag (<tool_call>...</tool_call>).
-/// Returns the inner payload, or `None` when no recognizable wrapper is present.
-/// Callers only use the result if it actually parses, so this stays safe on
-/// arbitrary garbage.
 fn strip_json_wrapper(args: &str) -> Option<&str> {
     let trimmed = args.trim();
 
@@ -253,10 +248,6 @@ fn strip_json_wrapper(args: &str) -> Option<&str> {
     None
 }
 
-/// Unwrap double-encoded arguments: a JSON string whose content is itself the
-/// real JSON object (some models serialize the arguments object twice). Only
-/// unwraps when an object eventually emerges; any other value is returned
-/// unchanged so callers keep their existing error behavior.
 fn unwrap_double_encoded_object(value: serde_json::Value) -> serde_json::Value {
     let serde_json::Value::String(s) = &value else {
         return value;
@@ -278,8 +269,6 @@ fn unwrap_double_encoded_object(value: serde_json::Value) -> serde_json::Value {
 /// so callers can surface an actionable error rather than invoking a tool with
 /// incomplete arguments. Non-truncated malformation (e.g. unescaped control
 /// characters some models emit) is still repaired via [`safely_parse_json`].
-/// Recoverable wrappers some models emit — markdown fences, XML-ish tags, and
-/// double-encoded JSON strings — are unwrapped (see #9486).
 pub fn parse_tool_arguments(args: &str) -> Option<serde_json::Value> {
     if args.is_empty() {
         return Some(serde_json::Value::Object(serde_json::Map::new()));
@@ -490,8 +479,6 @@ mod tests {
 
     #[test]
     fn test_parse_tool_arguments_markdown_fenced() {
-        // GLM/Minimax sometimes wrap tool arguments in a markdown code fence
-        // (see #9486). The fence must be stripped so the arguments parse.
         let fenced = "```json\n{\"command\": \"ls\"}\n```";
         let parsed = parse_tool_arguments(fenced).expect("fenced JSON should parse");
         assert_eq!(parsed["command"], "ls");
@@ -507,14 +494,11 @@ mod tests {
 
     #[test]
     fn test_parse_tool_arguments_double_encoded() {
-        // Double-encoded JSON: the arguments string is itself a JSON string
-        // whose value is the real JSON object (see #9486).
         let double_encoded = r#""{\"command\": \"ls\"}""#;
         let parsed = parse_tool_arguments(double_encoded).expect("double-encoded should parse");
         assert!(parsed.is_object(), "expected object, got {parsed:?}");
         assert_eq!(parsed["command"], "ls");
 
-        // Two levels of encoding must also unwrap.
         let twice = serde_json::to_string(&serde_json::json!(r#"{"command": "ls"}"#)).unwrap();
         let twice = serde_json::to_string(&serde_json::json!(twice)).unwrap();
         let parsed = parse_tool_arguments(&twice).expect("twice-encoded should parse");
@@ -524,12 +508,10 @@ mod tests {
 
     #[test]
     fn test_parse_tool_arguments_xml_wrapped() {
-        // Some models wrap the JSON payload in an XML-ish tag (see #9486).
         let wrapped = r#"<tool_call>{"command": "ls"}</tool_call>"#;
         let parsed = parse_tool_arguments(wrapped).expect("xml-wrapped JSON should parse");
         assert_eq!(parsed["command"], "ls");
 
-        // Attributes on the opening tag are tolerated.
         let with_attrs = r#"<tool_call id="1">{"command": "ls"}</tool_call>"#;
         let parsed = parse_tool_arguments(with_attrs).expect("xml-wrapped JSON should parse");
         assert_eq!(parsed["command"], "ls");
@@ -537,24 +519,15 @@ mod tests {
 
     #[test]
     fn test_parse_tool_arguments_unrecoverable_wrappers_still_fail() {
-        // Unwrapping is conservative: anything that does not cleanly reduce to
-        // parseable JSON must keep failing rather than be guessed at.
-        // Nested XML tags — only one level is stripped, inner content is not JSON.
         assert!(parse_tool_arguments(r#"<a><b>{"x": 1}</b></a>"#).is_none());
-        // Trailing junk after the closing fence.
         assert!(parse_tool_arguments("```json\n{\"x\": 1}\n``` extra").is_none());
-        // Mismatched closing tag.
         assert!(parse_tool_arguments(r#"<tool_call>{"x": 1}</other>"#).is_none());
-        // A closing tag alone.
         assert!(parse_tool_arguments(r#"</tool_call>"#).is_none());
-        // A lone fence marker.
         assert!(parse_tool_arguments("```").is_none());
     }
 
     #[test]
     fn test_parse_tool_arguments_non_object_json_unchanged() {
-        // Bare non-object JSON values still parse to themselves so callers keep
-        // rejecting them with their existing "must be a JSON object" error.
         assert_eq!(parse_tool_arguments("null"), Some(serde_json::Value::Null));
         assert_eq!(parse_tool_arguments("42"), Some(serde_json::json!(42)));
         assert_eq!(
@@ -565,8 +538,6 @@ mod tests {
 
     #[test]
     fn test_parse_tool_arguments_plain_string_preserved() {
-        // A JSON string that does NOT contain an object must stay a string so
-        // callers keep producing their "must be a JSON object" error.
         let plain = r#""hello""#;
         let parsed = parse_tool_arguments(plain).expect("valid JSON string should parse");
         assert_eq!(parsed, serde_json::json!("hello"));
@@ -574,8 +545,6 @@ mod tests {
 
     #[test]
     fn test_parse_tool_arguments_fenced_truncated_still_fails() {
-        // A fenced payload cut off mid-generation must still be treated as
-        // truncated, not silently repaired.
         let truncated = "```json\n{\"path\": \"/report.md\", \"content\": \"# cut";
         assert!(parse_tool_arguments(truncated).is_none());
     }

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -275,11 +275,6 @@ pub fn get_tool_owner(tool: &Tool) -> Option<String> {
         .map(|s| s.to_string())
 }
 
-/// Map a model-mangled tool name onto a real advertised tool name.
-///
-/// Some OpenAI-compatible models emit `functions.` prefixes or replace Goose's
-/// extension separator with a dot. Recovery is only attempted after exact
-/// resolution fails, and only when one advertised tool matches.
 fn recover_mangled_tool_name<'a>(
     emitted: &str,
     tool_names: impl Iterator<Item = &'a str>,
@@ -1759,10 +1754,6 @@ impl ExtensionManager {
                 }
             }
 
-            // Exact resolution failed everywhere; as a last resort, try to map
-            // a model-mangled name onto a unique advertised tool (see #9486).
-            // The recovered name is a real advertised name, so the retry
-            // resolves through the exact-match path above.
             if !recovery_attempted {
                 recovery_attempted = true;
                 if let Some(recovered) =
@@ -2645,9 +2636,6 @@ mod tests {
         );
     }
 
-    /// Mock exposing tool names with a literal dot — legal in MCP and
-    /// advertised raw by format_tools — plus an "__" sibling to exercise
-    /// ambiguity handling in mangled-name recovery.
     struct MockDottedClient {}
 
     #[async_trait::async_trait]
@@ -2739,9 +2727,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_tool_recovers_dotted_mangled_name() {
-        // GLM-style mangling: the model turns the "__" separator into a dot
-        // (see #9486). Recovery must map it back because exactly one
-        // advertised tool matches.
         let temp_dir = tempfile::tempdir().unwrap();
         let extension_manager =
             ExtensionManager::new_without_provider(temp_dir.path().to_path_buf());
@@ -2758,8 +2743,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_tool_recovers_functions_prefixed_name() {
-        // OpenAI-schema-trained models leak the "functions." namespace into
-        // the emitted name (see #9486).
         let temp_dir = tempfile::tempdir().unwrap();
         let extension_manager =
             ExtensionManager::new_without_provider(temp_dir.path().to_path_buf());
@@ -2776,9 +2759,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_tool_exact_dotted_name_never_rewritten() {
-        // A legitimate advertised tool name containing a dot must resolve
-        // exactly as-is — recovery must never fire when exact resolution
-        // succeeds (see #9486 review).
         let temp_dir = tempfile::tempdir().unwrap();
         let extension_manager =
             ExtensionManager::new_without_provider(temp_dir.path().to_path_buf());

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -275,6 +275,54 @@ pub fn get_tool_owner(tool: &Tool) -> Option<String> {
         .map(|s| s.to_string())
 }
 
+/// Map a model-mangled tool name onto a real advertised tool name.
+///
+/// Some models (GLM, Minimax via OpenAI-compatible providers) mangle tool
+/// names: the "__" extension separator becomes a dot (`developer.shell`), or
+/// an OpenAI-schema `functions.` namespace leaks into the name
+/// (`functions.developer__shell`). See #9486.
+///
+/// Callers must try exact resolution first — this only runs on names that
+/// resolved nowhere, so a legitimate advertised name (which may itself contain
+/// dots) is never rewritten. Recovery is conservative: it fires only when the
+/// mangle-reversal variants match exactly one advertised tool; if different
+/// variants match different tools, the name stays unresolved.
+fn recover_mangled_tool_name<'a>(
+    emitted: &str,
+    tool_names: impl Iterator<Item = &'a str>,
+) -> Option<String> {
+    let trimmed = emitted.trim();
+    let stripped = trimmed
+        .strip_prefix("functions.")
+        .or_else(|| trimmed.strip_prefix("functions:"))
+        .unwrap_or(trimmed);
+    let dotted = stripped.replace('.', "__");
+    let sanitized: String = dotted
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+
+    let variants = [stripped, dotted.as_str(), sanitized.as_str()];
+    let mut matched: Option<&str> = None;
+    for name in tool_names {
+        if name == emitted || !variants.contains(&name) {
+            continue;
+        }
+        match matched {
+            None => matched = Some(name),
+            Some(prev) if prev == name => {}
+            Some(_) => return None,
+        }
+    }
+    matched.map(|s| s.to_string())
+}
+
 fn get_tool_meta_value(tool: &Tool) -> Option<Value> {
     tool.meta.as_ref().map(|meta| Value::Object(meta.0.clone()))
 }
@@ -1673,56 +1721,72 @@ impl ExtensionManager {
             )
         })?;
 
-        if let Some(tool) = tools.iter().find(|t| *t.name == *tool_name) {
-            let owner = get_tool_owner(tool)
-                .or_else(|| {
-                    tool_name
-                        .split_once("__")
-                        .map(|(prefix, _)| name_to_key(prefix))
-                })
-                .ok_or_else(|| {
+        let mut name = tool_name.to_string();
+        let mut recovery_attempted = false;
+        loop {
+            if let Some(tool) = tools.iter().find(|t| *t.name == *name) {
+                let owner = get_tool_owner(tool)
+                    .or_else(|| name.split_once("__").map(|(prefix, _)| name_to_key(prefix)))
+                    .ok_or_else(|| {
+                        ErrorData::new(
+                            ErrorCode::RESOURCE_NOT_FOUND,
+                            format!("Tool '{}' has no owner", name),
+                            None,
+                        )
+                    })?;
+
+                let actual_tool_name = name
+                    .strip_prefix(&format!("{owner}__"))
+                    .unwrap_or(&name)
+                    .to_string();
+
+                let client = self.get_server_client(&owner).await.ok_or_else(|| {
                     ErrorData::new(
                         ErrorCode::RESOURCE_NOT_FOUND,
-                        format!("Tool '{}' has no owner", tool_name),
+                        format!("Extension '{}' not found for tool '{}'", owner, name),
                         None,
                     )
                 })?;
 
-            let actual_tool_name = tool_name
-                .strip_prefix(&format!("{owner}__"))
-                .unwrap_or(tool_name)
-                .to_string();
-
-            let client = self.get_server_client(&owner).await.ok_or_else(|| {
-                ErrorData::new(
-                    ErrorCode::RESOURCE_NOT_FOUND,
-                    format!("Extension '{}' not found for tool '{}'", owner, tool_name),
-                    None,
-                )
-            })?;
-
-            return Ok(ResolvedTool {
-                tool_name: tool.name.to_string(),
-                extension_name: owner,
-                actual_tool_name,
-                client,
-                tool_meta: get_tool_meta_value(tool),
-                resource_uri: get_tool_resource_uri(tool),
-            });
-        }
-
-        if let Some((prefix, actual)) = tool_name.split_once("__") {
-            let owner = name_to_key(prefix);
-            if let Some(client) = self.get_server_client(&owner).await {
                 return Ok(ResolvedTool {
-                    tool_name: tool_name.to_string(),
+                    tool_name: tool.name.to_string(),
                     extension_name: owner,
-                    actual_tool_name: actual.to_string(),
+                    actual_tool_name,
                     client,
-                    tool_meta: None,
-                    resource_uri: None,
+                    tool_meta: get_tool_meta_value(tool),
+                    resource_uri: get_tool_resource_uri(tool),
                 });
             }
+
+            if let Some((prefix, actual)) = name.split_once("__") {
+                let owner = name_to_key(prefix);
+                if let Some(client) = self.get_server_client(&owner).await {
+                    return Ok(ResolvedTool {
+                        tool_name: name.to_string(),
+                        extension_name: owner,
+                        actual_tool_name: actual.to_string(),
+                        client,
+                        tool_meta: None,
+                        resource_uri: None,
+                    });
+                }
+            }
+
+            // Exact resolution failed everywhere; as a last resort, try to map
+            // a model-mangled name onto a unique advertised tool (see #9486).
+            // The recovered name is a real advertised name, so the retry
+            // resolves through the exact-match path above.
+            if !recovery_attempted {
+                recovery_attempted = true;
+                if let Some(recovered) =
+                    recover_mangled_tool_name(&name, tools.iter().map(|t| t.name.as_ref()))
+                {
+                    name = recovered;
+                    continue;
+                }
+            }
+
+            break;
         }
 
         let available = tools
@@ -2591,6 +2655,222 @@ mod tests {
         assert!(
             msg.contains("ext_a__"),
             "error should list at least one real tool name; got: {msg}"
+        );
+    }
+
+    /// Mock exposing tool names with a literal dot — legal in MCP and
+    /// advertised raw by format_tools — plus an "__" sibling to exercise
+    /// ambiguity handling in mangled-name recovery.
+    struct MockDottedClient {}
+
+    #[async_trait::async_trait]
+    impl McpClientTrait for MockDottedClient {
+        fn get_info(&self) -> Option<&InitializeResult> {
+            None
+        }
+
+        async fn list_resources(
+            &self,
+            _session_id: &str,
+            _next_cursor: Option<String>,
+            _cancellation_token: CancellationToken,
+        ) -> Result<ListResourcesResult, Error> {
+            Err(Error::TransportClosed)
+        }
+
+        async fn read_resource(
+            &self,
+            _session_id: &str,
+            _uri: &str,
+            _cancellation_token: CancellationToken,
+        ) -> Result<ReadResourceResult, Error> {
+            Err(Error::TransportClosed)
+        }
+
+        async fn list_tools(
+            &self,
+            _session_id: &str,
+            _next_cursor: Option<String>,
+            _cancellation_token: CancellationToken,
+        ) -> Result<ListToolsResult, Error> {
+            use serde_json::json;
+            use std::sync::Arc;
+            Ok(ListToolsResult {
+                tools: vec![
+                    Tool::new(
+                        "db.query".to_string(),
+                        "A tool with a dotted name".to_string(),
+                        Arc::new(json!({}).as_object().unwrap().clone()),
+                    ),
+                    Tool::new(
+                        "db__query".to_string(),
+                        "A sibling with the separator name".to_string(),
+                        Arc::new(json!({}).as_object().unwrap().clone()),
+                    ),
+                ],
+                next_cursor: None,
+                meta: None,
+            })
+        }
+
+        async fn call_tool(
+            &self,
+            _ctx: &ToolCallContext,
+            name: &str,
+            _arguments: Option<JsonObject>,
+            _cancellation_token: CancellationToken,
+        ) -> Result<CallToolResult, Error> {
+            match name {
+                "db.query" | "db__query" => Ok(CallToolResult::success(vec![])),
+                _ => Err(Error::TransportClosed),
+            }
+        }
+
+        async fn list_prompts(
+            &self,
+            _session_id: &str,
+            _next_cursor: Option<String>,
+            _cancellation_token: CancellationToken,
+        ) -> Result<ListPromptsResult, Error> {
+            Err(Error::TransportClosed)
+        }
+
+        async fn get_prompt(
+            &self,
+            _session_id: &str,
+            _name: &str,
+            _arguments: Value,
+            _cancellation_token: CancellationToken,
+        ) -> Result<GetPromptResult, Error> {
+            Err(Error::TransportClosed)
+        }
+
+        async fn subscribe(&self) -> mpsc::Receiver<ServerNotification> {
+            mpsc::channel(1).1
+        }
+    }
+
+    #[tokio::test]
+    async fn test_resolve_tool_recovers_dotted_mangled_name() {
+        // GLM-style mangling: the model turns the "__" separator into a dot
+        // (see #9486). Recovery must map it back because exactly one
+        // advertised tool matches.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let extension_manager =
+            ExtensionManager::new_without_provider(temp_dir.path().to_path_buf());
+        extension_manager
+            .add_mock_extension("test_client".to_string(), Arc::new(MockClient {}))
+            .await;
+
+        let resolved = extension_manager
+            .resolve_tool("test-session-id", "test_client.tool")
+            .await
+            .expect("mangled dotted name should resolve to the real tool");
+        assert_eq!(resolved.tool_name, "test_client__tool");
+    }
+
+    #[tokio::test]
+    async fn test_resolve_tool_recovers_functions_prefixed_name() {
+        // OpenAI-schema-trained models leak the "functions." namespace into
+        // the emitted name (see #9486).
+        let temp_dir = tempfile::tempdir().unwrap();
+        let extension_manager =
+            ExtensionManager::new_without_provider(temp_dir.path().to_path_buf());
+        extension_manager
+            .add_mock_extension("test_client".to_string(), Arc::new(MockClient {}))
+            .await;
+
+        let resolved = extension_manager
+            .resolve_tool("test-session-id", "functions.test_client__tool")
+            .await
+            .expect("functions-prefixed name should resolve to the real tool");
+        assert_eq!(resolved.tool_name, "test_client__tool");
+    }
+
+    #[tokio::test]
+    async fn test_resolve_tool_exact_dotted_name_never_rewritten() {
+        // A legitimate advertised tool name containing a dot must resolve
+        // exactly as-is — recovery must never fire when exact resolution
+        // succeeds (see #9486 review).
+        let temp_dir = tempfile::tempdir().unwrap();
+        let extension_manager =
+            ExtensionManager::new_without_provider(temp_dir.path().to_path_buf());
+        extension_manager
+            .add_mock_extension("dotted".to_string(), Arc::new(MockDottedClient {}))
+            .await;
+
+        let resolved = extension_manager
+            .resolve_tool("test-session-id", "dotted__db.query")
+            .await
+            .expect("exact dotted tool name must resolve");
+        assert_eq!(resolved.tool_name, "dotted__db.query");
+        assert_eq!(resolved.actual_tool_name, "db.query");
+    }
+
+    #[tokio::test]
+    async fn test_resolve_tool_ambiguous_mangled_name_stays_not_found() {
+        // "functions.dotted__db.query" reverses to BOTH advertised tools
+        // ("dotted__db.query" via prefix strip, "dotted__db__query" via dot
+        // mapping). Ambiguity must not be guessed at — it stays a recoverable
+        // not-found error.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let extension_manager =
+            ExtensionManager::new_without_provider(temp_dir.path().to_path_buf());
+        extension_manager
+            .add_mock_extension("dotted".to_string(), Arc::new(MockDottedClient {}))
+            .await;
+
+        let result = extension_manager
+            .resolve_tool("test-session-id", "functions.dotted__db.query")
+            .await;
+        match result {
+            Ok(resolved) => panic!(
+                "ambiguous mangled name must not be guessed; resolved to {}",
+                resolved.tool_name
+            ),
+            Err(e) => assert_eq!(e.code, ErrorCode::RESOURCE_NOT_FOUND),
+        }
+    }
+
+    #[test]
+    fn test_recover_mangled_tool_name() {
+        let tools = ["developer__shell", "platform__search"];
+        // Dot-mangled separator.
+        assert_eq!(
+            recover_mangled_tool_name("developer.shell", tools.iter().copied()).as_deref(),
+            Some("developer__shell")
+        );
+        // Leaked functions namespace, with and without further mangling.
+        assert_eq!(
+            recover_mangled_tool_name("functions.developer__shell", tools.iter().copied())
+                .as_deref(),
+            Some("developer__shell")
+        );
+        assert_eq!(
+            recover_mangled_tool_name("functions.developer.shell", tools.iter().copied())
+                .as_deref(),
+            Some("developer__shell")
+        );
+        // Stray invalid characters sanitize to '_' (replacement, not removal),
+        // so these match no advertised tool and stay unrecovered.
+        assert_eq!(
+            recover_mangled_tool_name("developer shell", tools.iter().copied()),
+            None
+        );
+        assert_eq!(
+            recover_mangled_tool_name("developer__shell!", tools.iter().copied()),
+            None
+        );
+        // No match at all.
+        assert_eq!(
+            recover_mangled_tool_name("nonexistent.tool", tools.iter().copied()),
+            None
+        );
+        // Ambiguity between variants matching different tools → refuse.
+        let ambiguous = ["a__b.c", "a__b__c"];
+        assert_eq!(
+            recover_mangled_tool_name("functions.a__b.c", ambiguous.iter().copied()),
+            None
         );
     }
 

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -277,16 +277,9 @@ pub fn get_tool_owner(tool: &Tool) -> Option<String> {
 
 /// Map a model-mangled tool name onto a real advertised tool name.
 ///
-/// Some models (GLM, Minimax via OpenAI-compatible providers) mangle tool
-/// names: the "__" extension separator becomes a dot (`developer.shell`), or
-/// an OpenAI-schema `functions.` namespace leaks into the name
-/// (`functions.developer__shell`). See #9486.
-///
-/// Callers must try exact resolution first — this only runs on names that
-/// resolved nowhere, so a legitimate advertised name (which may itself contain
-/// dots) is never rewritten. Recovery is conservative: it fires only when the
-/// mangle-reversal variants match exactly one advertised tool; if different
-/// variants match different tools, the name stays unresolved.
+/// Some OpenAI-compatible models emit `functions.` prefixes or replace Goose's
+/// extension separator with a dot. Recovery is only attempted after exact
+/// resolution fails, and only when one advertised tool matches.
 fn recover_mangled_tool_name<'a>(
     emitted: &str,
     tool_names: impl Iterator<Item = &'a str>,
@@ -296,24 +289,18 @@ fn recover_mangled_tool_name<'a>(
         .strip_prefix("functions.")
         .or_else(|| trimmed.strip_prefix("functions:"))
         .unwrap_or(trimmed);
-    let dotted = stripped.replace('.', "__");
-    let sanitized: String = dotted
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect();
 
-    let variants = [stripped, dotted.as_str(), sanitized.as_str()];
     let mut matched: Option<&str> = None;
     for name in tool_names {
-        if name == emitted || !variants.contains(&name) {
+        let separator_mangled = name
+            .split_once("__")
+            .map(|(extension, tool)| format!("{extension}.{tool}"));
+
+        let matches = stripped == name || separator_mangled.as_deref() == Some(stripped);
+        if name == emitted || !matches {
             continue;
         }
+
         match matched {
             None => matched = Some(name),
             Some(prev) if prev == name => {}
@@ -2808,11 +2795,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_resolve_tool_ambiguous_mangled_name_stays_not_found() {
-        // "functions.dotted__db.query" reverses to BOTH advertised tools
-        // ("dotted__db.query" via prefix strip, "dotted__db__query" via dot
-        // mapping). Ambiguity must not be guessed at — it stays a recoverable
-        // not-found error.
+    async fn test_resolve_tool_recovers_mangled_separator_with_dotted_tool_name() {
         let temp_dir = tempfile::tempdir().unwrap();
         let extension_manager =
             ExtensionManager::new_without_provider(temp_dir.path().to_path_buf());
@@ -2820,27 +2803,21 @@ mod tests {
             .add_mock_extension("dotted".to_string(), Arc::new(MockDottedClient {}))
             .await;
 
-        let result = extension_manager
-            .resolve_tool("test-session-id", "functions.dotted__db.query")
-            .await;
-        match result {
-            Ok(resolved) => panic!(
-                "ambiguous mangled name must not be guessed; resolved to {}",
-                resolved.tool_name
-            ),
-            Err(e) => assert_eq!(e.code, ErrorCode::RESOURCE_NOT_FOUND),
-        }
+        let resolved = extension_manager
+            .resolve_tool("test-session-id", "dotted.db.query")
+            .await
+            .expect("mangled extension separator should resolve");
+        assert_eq!(resolved.tool_name, "dotted__db.query");
+        assert_eq!(resolved.actual_tool_name, "db.query");
     }
 
     #[test]
     fn test_recover_mangled_tool_name() {
         let tools = ["developer__shell", "platform__search"];
-        // Dot-mangled separator.
         assert_eq!(
             recover_mangled_tool_name("developer.shell", tools.iter().copied()).as_deref(),
             Some("developer__shell")
         );
-        // Leaked functions namespace, with and without further mangling.
         assert_eq!(
             recover_mangled_tool_name("functions.developer__shell", tools.iter().copied())
                 .as_deref(),
@@ -2851,8 +2828,6 @@ mod tests {
                 .as_deref(),
             Some("developer__shell")
         );
-        // Stray invalid characters sanitize to '_' (replacement, not removal),
-        // so these match no advertised tool and stay unrecovered.
         assert_eq!(
             recover_mangled_tool_name("developer shell", tools.iter().copied()),
             None
@@ -2861,16 +2836,15 @@ mod tests {
             recover_mangled_tool_name("developer__shell!", tools.iter().copied()),
             None
         );
-        // No match at all.
         assert_eq!(
             recover_mangled_tool_name("nonexistent.tool", tools.iter().copied()),
             None
         );
-        // Ambiguity between variants matching different tools → refuse.
-        let ambiguous = ["a__b.c", "a__b__c"];
+
+        let dotted_tool = ["dotted__db.query"];
         assert_eq!(
-            recover_mangled_tool_name("functions.a__b.c", ambiguous.iter().copied()),
-            None
+            recover_mangled_tool_name("dotted.db.query", dotted_tool.iter().copied()).as_deref(),
+            Some("dotted__db.query")
         );
     }
 


### PR DESCRIPTION
## Problem

Closes #9486

With custom OpenAI-compatible providers serving GLM (`glm-5.1` via z.ai) and Minimax models, goose frequently aborts agentic workflows with **"A tool call could not be parsed"**. The code-level analysis on the issue identified the two failure points, both confirmed against `main`:

1. The non-streaming decoder hard-rejects any tool name outside `[a-zA-Z0-9_-]+`. These models emit dotted namespaces (`developer.shell`) or leak an OpenAI-style `functions.` prefix (`functions.developer__shell`), so the call fails before dispatch is ever attempted.
2. `parse_tool_arguments` cannot recover argument strings that are double-encoded JSON, or that arrive wrapped in a markdown code fence or an XML-ish tag.

## Changes

### Tool names: parsers pass through, dispatch recovers (`formats/openai.rs`, `agents/extension_manager.rs`)

`format_tools` advertises **raw** tool names, so a dotted name such as `ext__db.query` can be a legitimate exact echo of an advertised tool — the parser has no way to distinguish it from a model-mangled `developer.shell`. Following review feedback, the design keeps that decision where the tool list is known:

- **Parsers never rewrite names.** The streaming decoder passes every name through verbatim (its historical behavior). The non-streaming decoder stops hard-rejecting invalid characters — only an empty name is still a parse error — so names reach dispatch instead of aborting the turn. As a side effect, legitimately dotted tools now work in the non-streaming path too (they were always rejected there before).
- **Dispatch recovers mangled names.** `ExtensionManager::resolve_tool` first resolves exactly, as today. Only when exact resolution has failed everywhere does it try to reverse the known manglings — a leaked `functions.`/`functions:` prefix, dots in place of the `__` extension separator, stray invalid characters sanitized to `_` — and it accepts the result only when the variants match **exactly one** advertised tool. Ambiguity (e.g. a name that reverses to both `dotted__db.query` and `dotted__db__query`) stays a recoverable "tool not found" error rather than a guess. An advertised name is therefore never rewritten, by construction: exact match always wins first.
- Unknown names keep getting dispatch's existing recoverable "Tool not found. Available tools: [...]" answer, which the model can self-correct from.

### Argument recovery (`json.rs`)

`parse_tool_arguments` now unwraps, strictly in this order and only after a direct parse fails:

- markdown code fences (```json ... ```), with or without a language tag
- a single XML-ish tag wrapper (`<tool_call>{...}</tool_call>`), attributes tolerated
- double-encoded JSON strings (up to two encoding levels), only when an object actually emerges

**Conservativeness guarantees, each locked by a test:**
- well-formed arguments never enter any unwrapping path (direct parse first)
- truncation detection still takes precedence — a fenced payload cut off mid-generation stays an error
- bare non-object JSON (`null`, numbers, arrays, plain strings) still parses to itself so the existing "must be a JSON object" error is preserved
- anything that does not cleanly reduce to parseable JSON — nested tags, mismatched closing tags, trailing junk after a fence — keeps failing

## Testing

Recovery behavior was developed test-first (each new test confirmed failing before the code change). Coverage includes:

- **Parser pass-through:** dotted, `functions.`-prefixed, invalid-character, and degenerate names all pass through verbatim in both decoders; an exact dotted advertised name (`ext__db.query`) survives streaming untouched; empty names are still rejected.
- **Dispatch recovery (integration, via `resolve_tool` with mock extensions):** `test_client.tool` resolves to `test_client__tool`; `functions.test_client__tool` resolves; an exactly-advertised dotted tool `dotted__db.query` resolves as-is and is never rewritten; the ambiguous `functions.dotted__db.query` (reverses to two real tools) stays not-found. Plus direct unit tests of the matching function including the no-match and ambiguity cases.
- **Arguments:** fenced/XML/double-encoded recovery end-to-end through `response_to_message`, plus the conservativeness guards above.

Results:
- `cargo test -p goose-provider-types` — 366 tests pass
- `cargo test -p goose --lib` — 1338 pass; the only 5 failures are pre-existing environment issues (jsonwebtoken/insta), verified to fail identically on a clean tree without this change
- `cargo clippy -p goose -p goose-provider-types --all-targets -- -D warnings` — clean
- `cargo fmt` — applied

## Notes

- No behavior change for any input that parsed successfully before. In the streaming path, name handling is byte-for-byte the pre-existing pass-through.
- The reporter's Minimax M2 reasoning-echo observation is a separate defect tracked by #9434 (PR #10229).