### PR TITLE
fix: swap disarm/cleanup order to prevent active-request leak

### DIFF
--- a/crates/goose-server/src/routes/session_events.rs
+++ b/crates/goose-server/src/routes/session_events.rs
@@ -591,8 +591,13 @@ pub async fn session_reply(
         )
         .await;
 
-        _guard.disarm();
+        // Clean up the active-request entry before disarming the guard.
+        // Reversing this order (disarm → cleanup) creates a race: if the
+        // tokio task is cancelled between the two calls, cleanup is skipped
+        // AND the Drop fallback is a no-op because `disarmed == true`,
+        // leaving a dangling entry in the active_requests HashMap forever.
         task_bus.cleanup_request(&task_request_id).await;
+        _guard.disarm();
     }));
 
     Ok(Json(SessionReplyResponse { request_id }))

--- a/crates/goose-server/src/session_event_bus.rs
+++ b/crates/goose-server/src/session_event_bus.rs
@@ -295,4 +295,69 @@ mod tests {
         let cancelled = bus.cancel_request("req-1").await;
         assert!(!cancelled);
     }
+
+    #[tokio::test]
+    async fn test_guard_drop_cleans_up_when_not_disarmed() {
+        let bus = std::sync::Arc::new(SessionEventBus::new());
+        bus.register_request("req-1".to_string()).await;
+
+        {
+            let _guard = RequestGuard::new(bus.clone(), "req-1".to_string());
+            // guard dropped here without disarm → Drop spawns cleanup task
+        }
+
+        // Give the spawned cleanup task time to run
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Active request should have been cleaned up by Drop
+        let ids = bus.active_request_ids().await;
+        assert!(ids.is_empty(), "expected no active requests after guard drop, got: {:?}", ids);
+    }
+
+    #[tokio::test]
+    async fn test_guard_disarmed_skips_drop_cleanup() {
+        let bus = std::sync::Arc::new(SessionEventBus::new());
+        bus.register_request("req-1".to_string()).await;
+
+        {
+            let mut guard = RequestGuard::new(bus.clone(), "req-1".to_string());
+            guard.disarm();
+            // guard dropped here with disarm → Drop is no-op
+        }
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Active request should still be present (disarmed guard does not clean up)
+        let ids = bus.active_request_ids().await;
+        assert_eq!(ids.len(), 1, "expected active request to remain after disarmed guard drop");
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_before_disarm_is_safe() {
+        // Verifies the correct ordering: cleanup_request() then disarm().
+        // If the task is cancelled after cleanup but before disarm, the
+        // entry is already removed. The Drop fallback runs (guard still
+        // armed) but cleanup_request for a missing key is a harmless no-op.
+        let bus = std::sync::Arc::new(SessionEventBus::new());
+        bus.register_request("req-1".to_string()).await;
+
+        // Simulate: cleanup succeeds
+        bus.cleanup_request("req-1").await;
+
+        // Then task is cancelled before disarm → guard drops while still armed
+        {
+            let _guard = RequestGuard::new(bus.clone(), "req-1".to_string());
+            // Drop runs cleanup again (no-op for missing key)
+        }
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Should be clean — no dangling entries
+        let ids = bus.active_request_ids().await;
+        assert!(ids.is_empty());
+
+        // New request should succeed
+        let result = bus.try_register_request("req-2".to_string()).await;
+        assert!(result.is_ok());
+    }
 }

--- a/crates/goose-server/src/session_event_bus.rs
+++ b/crates/goose-server/src/session_event_bus.rs
@@ -311,7 +311,11 @@ mod tests {
 
         // Active request should have been cleaned up by Drop
         let ids = bus.active_request_ids().await;
-        assert!(ids.is_empty(), "expected no active requests after guard drop, got: {:?}", ids);
+        assert!(
+            ids.is_empty(),
+            "expected no active requests after guard drop, got: {:?}",
+            ids
+        );
     }
 
     #[tokio::test]
@@ -329,7 +333,11 @@ mod tests {
 
         // Active request should still be present (disarmed guard does not clean up)
         let ids = bus.active_request_ids().await;
-        assert_eq!(ids.len(), 1, "expected active request to remain after disarmed guard drop");
+        assert_eq!(
+            ids.len(),
+            1,
+            "expected active request to remain after disarmed guard drop"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #10237.

Swaps the order of `_guard.disarm()` and `task_bus.cleanup_request()` at the end of the session reply handler (`session_events.rs:594-595`) to close a race condition where the active-request entry leaks.

**Before (buggy):**
```rust
_guard.disarm();                                    // disables Drop fallback
task_bus.cleanup_request(&task_request_id).await;   // removes entry from HashMap
```

If the tokio task is cancelled between these two lines, cleanup is skipped AND the Drop fallback is a no-op (`disarmed == true`). The entry stays in `active_requests` forever, blocking all future requests to that session.

**After (fixed):**
```rust
task_bus.cleanup_request(&task_request_id).await;   // removes entry first
_guard.disarm();                                    // then disables Drop fallback
```

Now cancellation at any point is safe:
- Before cleanup: guard still armed → Drop runs cleanup ✓
- After cleanup, before disarm: entry removed, Drop runs cleanup again (no-op) ✓
- Normal path: cleanup → disarm → Drop is no-op ✓

## Observed in production

Session `20260703_119` (186K tokens, 796 messages, 28-minute run) completed normally (`exit_type: "normal"`, SSE `Finish:stop` sent), but the active-request entry remained. For 63 minutes, goosed had zero activity for this session. When the user tried to resume, every attempt got `"Session already has an active request. Cancel it first."` Required manual `POST /cancel` to recover.

Related: #9082, #10110

## Testing

Added three unit tests to `session_event_bus.rs`:
- `test_guard_drop_cleans_up_when_not_disarmed` — verifies Drop fallback works
- `test_guard_disarmed_skips_drop_cleanup` — verifies disarmed guard does not clean up
- `test_cleanup_before_disarm_is_safe` — verifies the new ordering: cleanup first, then if task is cancelled before disarm, the double cleanup is harmless

```
cargo test -p goose-server session_event_bus --lib
```