### PR TITLE
docs(cli): clarify session --edit context retention

### DIFF
--- a/documentation/docs/guides/sessions/in-session-actions.md
+++ b/documentation/docs/guides/sessions/in-session-actions.md
@@ -65,11 +65,7 @@ Editing in place is useful when:
         goose session --resume <session-id> --edit
         ```
 
-        This opens `$VISUAL` / `$EDITOR` / `vi` with the conversation serialized as YAML. After editing and saving, goose continues the session from the edited conversation.
-
-        :::warning Deleted Context
-        With `--edit`, subsequent conversation history is permanently deleted from the session and removed from goose's context. Use this option only if you don't need goose to remember the context that follows the edited message.
-        :::
+        This opens `$VISUAL` / `$EDITOR` / `vi` with the conversation serialized as YAML. After editing and saving, goose continues the session from the edited conversation. Any later messages you leave in the YAML remain in the session and in goose's context.
 
     </TabItem>
 </Tabs>

--- a/documentation/docs/guides/sessions/in-session-actions.md
+++ b/documentation/docs/guides/sessions/in-session-actions.md
@@ -65,7 +65,7 @@ Editing in place is useful when:
         goose session --resume <session-id> --edit
         ```
 
-        This opens `$VISUAL` / `$EDITOR` / `vi` with the conversation serialized as YAML. After editing and saving, goose continues the session from the edited conversation. Any later messages you leave in the YAML remain in the session and in goose's context.
+        This opens `$VISUAL` / `$EDITOR` / `vi` with the conversation serialized as YAML. After editing and saving, goose continues the session from the edited conversation. Any later messages you leave in the YAML remain in the session and in goose's context; remove messages from the YAML if you want goose to forget them.
 
     </TabItem>
 </Tabs>


### PR DESCRIPTION
## Summary

Fixes #10231.

Updates the CLI `--edit` docs so they match the current implementation: goose opens the whole conversation as YAML and keeps any later messages the user leaves in that file.

AI-assisted: prepared with Codex and manually reviewed before submission.

### Testing

- `source ./bin/activate-hermit && cargo fmt --check`
- `source ./bin/activate-hermit && cargo check -p goose-cli`
- `git diff --check`

### Related Issues

Relates to #10231

### Screenshots/Demos (for UX changes)

Before: N/A

After: N/A
