### PR TITLE
fix: treat empty-string finish_reason as non-terminal in streaming

### DIFF
--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -138,9 +138,6 @@ struct StreamingChoice {
     #[serde(default)]
     delta: Delta,
     index: Option<i32>,
-    /// Some OpenAI-compatible servers send `"finish_reason": ""` (rather than
-    /// null) on intermediate chunks; normalize that to `None` here so no
-    /// consumer mistakes an empty string for a terminal chunk.
     #[serde(default, deserialize_with = "empty_finish_reason_as_none")]
     finish_reason: Option<String>,
 }
@@ -2697,12 +2694,6 @@ data: [DONE]
 
     #[tokio::test]
     async fn test_streaming_empty_finish_reason_is_not_terminal() -> anyhow::Result<()> {
-        // Some OpenAI-compatible servers send `"finish_reason": ""` (rather
-        // than null) on intermediate chunks. An empty string must not read as
-        // terminal: here it would end tool-call accumulation after the first
-        // argument fragment, and the remaining fragments (which carry no
-        // id/name) could never rejoin the call — leaving truncated,
-        // unparseable arguments.
         let response_lines = r#"
 data: {"model":"m","choices":[{"delta":{"role":"assistant","content":"Checking."},"index":0,"finish_reason":""}],"object":"chat.completion.chunk","id":"1","created":1753288340}
 data: {"model":"m","choices":[{"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"developer__shell","arguments":""}}]},"index":0,"finish_reason":""}],"object":"chat.completion.chunk","id":"1","created":1753288340}

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -138,7 +138,19 @@ struct StreamingChoice {
     #[serde(default)]
     delta: Delta,
     index: Option<i32>,
+    /// Some OpenAI-compatible servers send `"finish_reason": ""` (rather than
+    /// null) on intermediate chunks; normalize that to `None` here so no
+    /// consumer mistakes an empty string for a terminal chunk.
+    #[serde(default, deserialize_with = "empty_finish_reason_as_none")]
     finish_reason: Option<String>,
+}
+
+fn empty_finish_reason_as_none<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<String>::deserialize(deserializer)?;
+    Ok(value.filter(|reason| !reason.is_empty()))
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -2679,6 +2691,36 @@ data: [DONE]
             .all(|name| name == "developer__shell"));
 
         assert_usage_yielded_once(&result, 4982, 122, 5104);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_streaming_empty_finish_reason_is_not_terminal() -> anyhow::Result<()> {
+        // Some OpenAI-compatible servers send `"finish_reason": ""` (rather
+        // than null) on intermediate chunks. An empty string must not read as
+        // terminal: here it would end tool-call accumulation after the first
+        // argument fragment, and the remaining fragments (which carry no
+        // id/name) could never rejoin the call — leaving truncated,
+        // unparseable arguments.
+        let response_lines = r#"
+data: {"model":"m","choices":[{"delta":{"role":"assistant","content":"Checking."},"index":0,"finish_reason":""}],"object":"chat.completion.chunk","id":"1","created":1753288340}
+data: {"model":"m","choices":[{"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"developer__shell","arguments":""}}]},"index":0,"finish_reason":""}],"object":"chat.completion.chunk","id":"1","created":1753288340}
+data: {"model":"m","choices":[{"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"function":{"arguments":"{\"command\""}}]},"index":0,"finish_reason":""}],"object":"chat.completion.chunk","id":"1","created":1753288340}
+data: {"model":"m","choices":[{"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"function":{"arguments":": \"ls\"}"}}]},"index":0,"finish_reason":""}],"object":"chat.completion.chunk","id":"1","created":1753288340}
+data: {"model":"m","choices":[{"delta":{"role":"assistant","content":""},"index":0,"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":100,"completion_tokens":20,"total_tokens":120},"object":"chat.completion.chunk","id":"1","created":1753288340}
+data: [DONE]
+"#;
+
+        let result = run_streaming_test(response_lines).await?;
+
+        assert!(result.has_text_content, "Expected text content in response");
+        assert_eq!(
+            result.tool_calls,
+            vec!["developer__shell"],
+            "tool call must survive intermediate empty-string finish_reason"
+        );
+        assert_usage_yielded_once(&result, 100, 20, 120);
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
Some OpenAI-compatible servers send "finish_reason": "" (rather than null) on intermediate streaming chunks. The decoder checked finish_reason.is_some(), so an empty string read as terminal: inside tool-call accumulation it set done after the first argument fragment, and the remaining fragments (which carry no id/name) could never rejoin the call, leaving truncated, unparseable arguments — the tool call was lost entirely. The same check gates when usage is attached to a yielded message.

Normalize "" to None at deserialization on StreamingChoice so every consumer of finish_reason sees the same thing, and add a streaming test that splits tool-call arguments across chunks that all carry an empty-string finish_reason.

### Testing
Unit test

### Related Issues
None


### Screenshots/Demos (for UX changes)
N/A