### PR TITLE
CLI: Add interactive session resume picker

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -1566,6 +1566,7 @@ async fn handle_session_subcommand(command: SessionCommand) -> Result<()> {
                 match crate::commands::session::prompt_interactive_session_selection(
                     &session_manager,
                     "Select a session to export:",
+                    None,
                 )
                 .await
                 {
@@ -1596,6 +1597,7 @@ async fn handle_session_subcommand(command: SessionCommand) -> Result<()> {
                 match crate::commands::session::prompt_interactive_session_selection(
                     &session_manager,
                     "Select a session for diagnostics:",
+                    None,
                 )
                 .await
                 {
@@ -1673,6 +1675,7 @@ async fn handle_interactive_session(args: InteractiveSessionArgs) -> Result<()> 
         let session_id = crate::commands::session::prompt_interactive_session_selection(
             &session_manager,
             "Select a session to resume:",
+            Some(&[SessionType::User]),
         )
         .await?;
 

--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -933,6 +933,16 @@ enum Command {
         )]
         history: bool,
 
+        /// Interactively select which session to resume
+        #[arg(
+            long = "select",
+            requires = "resume",
+            conflicts_with_all = ["name", "session_id", "path"],
+            help = "Choose the session to resume from an interactive fuzzy picker",
+            long_help = "Choose the session to resume from an interactive fuzzy picker. Must be used with --resume."
+        )]
+        select_session: bool,
+
         #[command(flatten)]
         session_opts: SessionOptions,
 
@@ -1555,6 +1565,7 @@ async fn handle_session_subcommand(command: SessionCommand) -> Result<()> {
             } else {
                 match crate::commands::session::prompt_interactive_session_selection(
                     &session_manager,
+                    "Select a session to export:",
                 )
                 .await
                 {
@@ -1584,6 +1595,7 @@ async fn handle_session_subcommand(command: SessionCommand) -> Result<()> {
             } else {
                 match crate::commands::session::prompt_interactive_session_selection(
                     &session_manager,
+                    "Select a session for diagnostics:",
                 )
                 .await
                 {
@@ -1600,15 +1612,29 @@ async fn handle_session_subcommand(command: SessionCommand) -> Result<()> {
     Ok(())
 }
 
-async fn handle_interactive_session(
+struct InteractiveSessionArgs {
     identifier: Option<Identifier>,
     resume: bool,
     fork: bool,
     edit: bool,
     history: bool,
+    select_session: bool,
     session_opts: SessionOptions,
     extension_opts: ExtensionOptions,
-) -> Result<()> {
+}
+
+async fn handle_interactive_session(args: InteractiveSessionArgs) -> Result<()> {
+    let InteractiveSessionArgs {
+        identifier,
+        resume,
+        fork,
+        edit,
+        history,
+        select_session,
+        session_opts,
+        extension_opts,
+    } = args;
+
     #[cfg(feature = "telemetry")]
     if get_telemetry_choice().is_none() {
         configure_telemetry_consent_dialog()?;
@@ -1642,6 +1668,22 @@ async fn handle_interactive_session(
     }
 
     let goose_mode = Config::global().get_goose_mode().unwrap_or_default();
+    let identifier = if select_session {
+        let session_manager = SessionManager::instance();
+        let session_id = crate::commands::session::prompt_interactive_session_selection(
+            &session_manager,
+            "Select a session to resume:",
+        )
+        .await?;
+
+        Some(Identifier {
+            name: None,
+            session_id: Some(session_id),
+            path: None,
+        })
+    } else {
+        identifier
+    };
     let mut session_id = get_or_create_session_id(identifier, resume, false, goose_mode).await?;
 
     if edit || fork {
@@ -2263,18 +2305,20 @@ pub async fn cli() -> anyhow::Result<()> {
             fork,
             edit,
             history,
+            select_session,
             session_opts,
             extension_opts,
         }) => {
-            handle_interactive_session(
+            handle_interactive_session(InteractiveSessionArgs {
                 identifier,
                 resume,
                 fork,
                 edit,
                 history,
+                select_session,
                 session_opts,
                 extension_opts,
-            )
+            })
             .await
         }
         Some(Command::Project {}) => {
@@ -2447,6 +2491,45 @@ mod tests {
             }) => {}
             _ => panic!("expected skills list command"),
         }
+    }
+
+    #[test]
+    fn session_resume_accepts_select_picker_flag() {
+        let cli = Cli::try_parse_from(["goose", "session", "--resume", "--select"])
+            .expect("parse failed");
+
+        match cli.command {
+            Some(Command::Session {
+                command: None,
+                resume,
+                select_session,
+                ..
+            }) => {
+                assert!(resume);
+                assert!(select_session);
+            }
+            _ => panic!("expected session command"),
+        }
+    }
+
+    #[test]
+    fn session_select_requires_resume() {
+        let err = match Cli::try_parse_from(["goose", "session", "--select"]) {
+            Ok(_) => panic!("parse ok"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn session_select_conflicts_with_named_resume() {
+        let err = match Cli::try_parse_from([
+            "goose", "session", "--resume", "--select", "--name", "x",
+        ]) {
+            Ok(_) => panic!("parse ok"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
     #[test]

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -551,8 +551,21 @@ fn search_session_dialog(prompt: &str, items: &[(String, String, String)]) -> Re
 pub async fn prompt_interactive_session_selection(
     session_manager: &SessionManager,
     prompt: &str,
+    session_types: Option<&[SessionType]>,
 ) -> Result<String> {
-    let sessions = session_manager.list_sessions().await?;
+    // `None` keeps the previous behavior of listing every session type
+    // (used by export/diagnostics). `Some(types)` restricts the picker to the
+    // given types — the resume flow must only offer `SessionType::User`
+    // sessions, because resuming a `SessionType::Scheduled` run rebuilds the
+    // interactive session with `scheduled_job_id: None` and the next usage
+    // update would write `schedule_id = NULL`, detaching it from its schedule
+    // (see cli.rs `--select` resume path). Implicit resume already filters to
+    // `SessionType::User` via `list_sessions_by_types`, so this keeps the
+    // interactive picker consistent with it.
+    let sessions = match session_types {
+        Some(types) => session_manager.list_sessions_by_types(types).await?,
+        None => session_manager.list_sessions().await?,
+    };
 
     if sessions.is_empty() {
         return Err(anyhow::anyhow!("No sessions found"));

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -485,8 +485,8 @@ fn fuzzy_filter_session_items(
             // name or id (codex P2 on #10265).
             let label = item.1.to_lowercase();
             let hint = item.2.to_lowercase();
-            let similarity = strsim::jaro_winkler(&label, &query)
-                .max(strsim::jaro_winkler(&hint, &query));
+            let similarity =
+                strsim::jaro_winkler(&label, &query).max(strsim::jaro_winkler(&hint, &query));
             let word_match_bonus = query_words
                 .iter()
                 .all(|word| label.contains(*word) || hint.contains(*word))
@@ -497,10 +497,7 @@ fn fuzzy_filter_session_items(
         .collect();
 
     scored.sort_by(|a, b| b.0.total_cmp(&a.0));
-    scored
-        .into_iter()
-        .map(|(_, item)| item.clone())
-        .collect()
+    scored.into_iter().map(|(_, item)| item.clone()).collect()
 }
 
 /// Standalone fuzzy-search step for long session lists, avoiding the

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -480,10 +480,17 @@ fn fuzzy_filter_session_items(
     let mut scored: Vec<_> = items
         .iter()
         .filter_map(|item| {
+            // Match against both the display label (name/id/timestamp) and the
+            // working-directory hint so users can also filter by path, not just
+            // name or id (codex P2 on #10265).
             let label = item.1.to_lowercase();
-            let similarity = strsim::jaro_winkler(&label, &query);
-            let word_match_bonus =
-                query_words.iter().all(|word| label.contains(*word)) as u8 as f64;
+            let hint = item.2.to_lowercase();
+            let similarity = strsim::jaro_winkler(&label, &query)
+                .max(strsim::jaro_winkler(&hint, &query));
+            let word_match_bonus = query_words
+                .iter()
+                .all(|word| label.contains(*word) || hint.contains(*word))
+                as u8 as f64;
             let score = similarity + word_match_bonus;
             (score > 0.6).then_some((score, item))
         })

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -528,7 +528,7 @@ fn search_session_dialog(prompt: &str, items: &[(String, String, String)]) -> Re
             "Enter a different search term".to_string(),
         ));
 
-        match cliclack::select("Select a session")
+        match cliclack::select(prompt)
             .items(&display)
             .max_rows(MAX_SESSION_ROWS)
             .interact()?

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -438,6 +438,7 @@ fn export_session_to_markdown(
 /// Shows a list of available sessions and lets the user select one
 pub async fn prompt_interactive_session_selection(
     session_manager: &SessionManager,
+    prompt: &str,
 ) -> Result<String> {
     let sessions = session_manager.list_sessions().await?;
 
@@ -445,47 +446,36 @@ pub async fn prompt_interactive_session_selection(
         return Err(anyhow::anyhow!("No sessions found"));
     }
 
-    // Build the selection prompt
-    let mut selector = select("Select a session to export:");
+    let mut selector = select(prompt).filter_mode().max_rows(10);
 
-    // Map to display text
-    let display_map: std::collections::HashMap<String, Session> = sessions
-        .iter()
-        .map(|s| {
-            let desc = if s.name.is_empty() {
-                "(no name)"
-            } else {
-                &s.name
-            };
-            let truncated_desc = safe_truncate(desc, TRUNCATED_DESC_LENGTH);
+    for session in sessions {
+        let desc = if session.name.is_empty() {
+            "(no name)"
+        } else {
+            &session.name
+        };
+        let truncated_desc = safe_truncate(desc, TRUNCATED_DESC_LENGTH);
+        let display_text = format!(
+            "{} - {} ({})",
+            session_activity_at(&session),
+            truncated_desc,
+            session.id
+        );
+        let hint = display_path_with_tilde(&session.working_dir);
 
-            let display_text = format!("{} - {} ({})", s.updated_at, truncated_desc, s.id);
-            (display_text, s.clone())
-        })
-        .collect();
-
-    // Add each session as an option
-    for display_text in display_map.keys() {
-        selector = selector.item(display_text.clone(), display_text.clone(), "");
+        selector = selector.item(session.id, display_text, hint);
     }
 
-    // Add a cancel option
     let cancel_value = String::from("cancel");
-    selector = selector.item(cancel_value, "Cancel", "Cancel export");
+    selector = selector.item(cancel_value.clone(), "Cancel", "Cancel selection");
 
-    // Get user selection
-    let selected_display_text: String = selector.interact()?;
+    let selected_session_id: String = selector.interact()?;
 
-    if selected_display_text == "cancel" {
-        return Err(anyhow::anyhow!("Export canceled"));
+    if selected_session_id == cancel_value {
+        return Err(anyhow::anyhow!("Selection canceled"));
     }
 
-    // Retrieve the selected session
-    if let Some(session) = display_map.get(&selected_display_text) {
-        Ok(session.id.clone())
-    } else {
-        Err(anyhow::anyhow!("Invalid selection"))
-    }
+    Ok(selected_session_id)
 }
 
 #[cfg(test)]

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -19,6 +19,15 @@ use std::path::PathBuf;
 
 const TRUNCATED_DESC_LENGTH: usize = 60;
 
+/// Maximum rows shown in a single paginated cliclack select before falling
+/// back to the separate fuzzy-search step.
+const MAX_SESSION_ROWS: usize = 10;
+/// Sentinel value for the "Search all sessions..." entry in the paginated
+/// picker (kept out of the way of real session ids).
+const SEARCH_SESSIONS_VALUE: &str = "__search_all_sessions__";
+/// Sentinel value for the "Cancel" entry.
+const CANCEL_SESSION_VALUE: &str = "cancel";
+
 fn display_path_with_tilde(path: &Path) -> String {
     #[cfg(not(target_os = "windows"))]
     if let Ok(home) = home_dir() {
@@ -433,9 +442,105 @@ fn export_session_to_markdown(
     markdown_output
 }
 
+/// Build the selectable (id, display, hint) tuples for the session picker.
+fn session_picker_items(sessions: &[Session]) -> Vec<(String, String, String)> {
+    sessions
+        .iter()
+        .map(|session| {
+            let desc = if session.name.is_empty() {
+                "(no name)"
+            } else {
+                &session.name
+            };
+            let truncated_desc = safe_truncate(desc, TRUNCATED_DESC_LENGTH);
+            let display_text = format!(
+                "{} - {} ({})",
+                session_activity_at(session),
+                truncated_desc,
+                session.id
+            );
+            let hint = display_path_with_tilde(&session.working_dir);
+            (session.id.clone(), display_text, hint)
+        })
+        .collect()
+}
+
+/// Fuzzy-match session rows against a free-text query, mirroring the provider
+/// picker's `fuzzy_filter_provider_items` in `configure.rs`.
+fn fuzzy_filter_session_items(
+    items: &[(String, String, String)],
+    query: &str,
+) -> Vec<(String, String, String)> {
+    let query = query.trim().to_lowercase();
+    if query.is_empty() {
+        return items.to_vec();
+    }
+
+    let query_words: Vec<_> = query.split_whitespace().collect();
+    let mut scored: Vec<_> = items
+        .iter()
+        .filter_map(|item| {
+            let label = item.1.to_lowercase();
+            let similarity = strsim::jaro_winkler(&label, &query);
+            let word_match_bonus =
+                query_words.iter().all(|word| label.contains(*word)) as u8 as f64;
+            let score = similarity + word_match_bonus;
+            (score > 0.6).then_some((score, item))
+        })
+        .collect();
+
+    scored.sort_by(|a, b| b.0.total_cmp(&a.0));
+    scored
+        .into_iter()
+        .map(|(_, item)| item.clone())
+        .collect()
+}
+
+/// Standalone fuzzy-search step for long session lists, avoiding the
+/// `filter_mode` + `max_rows` combination that `cliclack` 0.5.5 mis-handles
+/// (see the provider picker in `configure.rs`).
+fn search_session_dialog(prompt: &str, items: &[(String, String, String)]) -> Result<String> {
+    let mut query = String::new();
+    loop {
+        let input: String = cliclack::input("Search sessions")
+            .placeholder("Filter by name, path, or id")
+            .default_input(&query)
+            .interact()?;
+        query = input.trim().to_string();
+
+        let filtered = fuzzy_filter_session_items(items, &query);
+        if filtered.is_empty() {
+            cliclack::log::warning("No matching sessions. Try a different search term.")?;
+            continue;
+        }
+
+        let mut display = filtered;
+        display.push((
+            SEARCH_SESSIONS_VALUE.to_string(),
+            "Search again...".to_string(),
+            "Enter a different search term".to_string(),
+        ));
+
+        match cliclack::select("Select a session")
+            .items(&display)
+            .max_rows(MAX_SESSION_ROWS)
+            .interact()?
+        {
+            s if s == SEARCH_SESSIONS_VALUE => continue,
+            id => return Ok(id),
+        }
+    }
+}
+
 /// Prompt the user to interactively select a session
 ///
-/// Shows a list of available sessions and lets the user select one
+/// Shows a list of available sessions and lets the user select one.
+///
+/// `cliclack` 0.5.5 does not reset its private list offset when filtering a
+/// paginated select, so we avoid combining `filter_mode` with `max_rows` (the
+/// same caveat handled in the provider picker in `configure.rs`): short lists
+/// use plain `filter_mode`, while long lists paginate and offer a separate
+/// fuzzy-search step.
 pub async fn prompt_interactive_session_selection(
     session_manager: &SessionManager,
     prompt: &str,
@@ -446,30 +551,47 @@ pub async fn prompt_interactive_session_selection(
         return Err(anyhow::anyhow!("No sessions found"));
     }
 
-    let mut selector = select(prompt).filter_mode().max_rows(10);
+    let items = session_picker_items(&sessions);
+    let cancel_value = CANCEL_SESSION_VALUE.to_string();
 
-    for session in sessions {
-        let desc = if session.name.is_empty() {
-            "(no name)"
-        } else {
-            &session.name
-        };
-        let truncated_desc = safe_truncate(desc, TRUNCATED_DESC_LENGTH);
-        let display_text = format!(
-            "{} - {} ({})",
-            session_activity_at(&session),
-            truncated_desc,
-            session.id
+    let selected_session_id = if items.len() <= MAX_SESSION_ROWS {
+        let mut short_items = items.clone();
+        short_items.push((
+            cancel_value.clone(),
+            "Cancel".to_string(),
+            "Cancel selection".to_string(),
+        ));
+        select(prompt)
+            .filter_mode()
+            .items(&short_items)
+            .interact()?
+    } else {
+        let mut paginated = items.clone();
+        paginated.insert(
+            MAX_SESSION_ROWS - 1,
+            (
+                SEARCH_SESSIONS_VALUE.to_string(),
+                "Search all sessions...".to_string(),
+                "Filter the complete session list".to_string(),
+            ),
         );
-        let hint = display_path_with_tilde(&session.working_dir);
+        paginated.push((
+            cancel_value.clone(),
+            "Cancel".to_string(),
+            "Cancel selection".to_string(),
+        ));
 
-        selector = selector.item(session.id, display_text, hint);
-    }
+        let chosen = select(prompt)
+            .items(&paginated)
+            .max_rows(MAX_SESSION_ROWS)
+            .interact()?;
 
-    let cancel_value = String::from("cancel");
-    selector = selector.item(cancel_value.clone(), "Cancel", "Cancel selection");
-
-    let selected_session_id: String = selector.interact()?;
+        if chosen == SEARCH_SESSIONS_VALUE {
+            search_session_dialog(prompt, &items)?
+        } else {
+            chosen
+        }
+    };
 
     if selected_session_id == cancel_value {
         return Err(anyhow::anyhow!("Selection canceled"));

--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -209,6 +209,7 @@ Start or resume interactive chat sessions.
 - **`--edit`**: Open the session's conversation in your editor (`$VISUAL` / `$EDITOR` / `vi`) as YAML. Edit, trim, or rewrite messages, then save and close to continue the session with the edited conversation. Must be used with `--resume`. Can be combined with `--fork` to create a new session from the edited result.
 - **`--fork`**: Create a new duplicate session with copied history. Must be used with `--resume`. Provide `--name` or `--session-id` to fork a specific session. Otherwise, forks the most recent session.
 - **`--history`**: Show previous messages when resuming a session
+- **`--select`**: Choose the session to resume from an interactive fuzzy picker. Must be used with `--resume`.
 - **`--container <container_id>`**: Run extensions inside a [Docker container](/docs/tutorials/goose-in-docker#running-extensions-in-docker-containers).
 - **`--debug`**: Enable debug mode to output complete tool responses, detailed parameter values, and full file paths
 - **`--max-tool-repetitions <NUMBER>`**: Set the maximum number of times the same tool can be called consecutively with identical parameters. Helps prevent infinite loops.
@@ -229,6 +230,9 @@ goose session --resume -n my-project
 goose session --resume --session-id 20251108_2
 goose session --resume --path ./session.json    # exported session
 goose session --resume --path ./session.jsonl   # legacy session storage
+
+# Pick a session interactively
+goose session --resume --select
 
 # Fork a specific session by name
 goose session --resume --fork --name my-project

--- a/documentation/docs/guides/sessions/session-management.md
+++ b/documentation/docs/guides/sessions/session-management.md
@@ -308,6 +308,15 @@ Search allows you to find specific content within sessions or find specific sess
         ```
         goose session -r --name <name>
         ```
+
+        To choose from your session history interactively, run:
+
+        ```
+        goose session -r --select
+        ```
+
+        Type to fuzzy-filter the list, then press `Enter` to resume the selected session.
+
         For example, to resume the session named `react-migration`, you would run:
 
         ```


### PR DESCRIPTION
## Summary

- Add `goose session --resume --select` to choose a session from an interactive fuzzy picker before resuming.
- Reuse the existing session selection prompt for export and diagnostics with action-specific prompt text.
- Document the new resume picker in the CLI command reference and session management guide.

Fixes #9915

## Test plan

- `cargo fmt --check`
- `cargo test -p goose-cli session_`
- `cargo clippy -p goose-cli --all-targets -- -D warnings`
- `cargo run -p goose-cli --bin goose -- session --help`