### PR TITLE
Expose the "read_file" functionality as a tool in  Developer

### DIFF
--- a/crates/goose/src/agents/platform_extensions/developer/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/mod.rs
@@ -8,7 +8,7 @@ use crate::agents::mcp_client::{Error, McpClientTrait};
 use crate::agents::ToolCallContext;
 use anyhow::Result;
 use async_trait::async_trait;
-use edit::{EditTools, FileEditParams, FileWriteParams};
+use edit::{EditTools, FileEditParams, FileReadParams, FileWriteParams};
 use image::{ImageReadParams, ImageTool};
 use indoc::indoc;
 use rmcp::model::{
@@ -44,7 +44,7 @@ fn developer_instructions() -> &'static str {
 
             For editing software, prefer the flow of using tree to understand the codebase structure
             and file sizes. When you need to search, prefer findstr or Select-String (via shell).
-            Then use type or Get-Content to gather the context you need, always reading before
+            Then use read to gather the context you need, always reading before
             editing. Use write and edit to efficiently make changes. Test and verify as appropriate.
         "}
     } else {
@@ -58,7 +58,7 @@ fn developer_instructions() -> &'static str {
 
             For editing software, prefer the flow of using tree to understand the codebase structure
             and file sizes. When you need to search, prefer rg which correctly respects gitignored
-            content. Then use cat or sed to gather the context you need, always reading before editing.
+            content. Then use read or sed to gather the context you need, always reading before editing.
             Use write and edit to efficiently make changes. Test and verify as appropriate.
 
             When running Python scripts or commands, always use `python3` instead of `python`.
@@ -100,6 +100,18 @@ impl DeveloperClient {
 
     pub(crate) fn get_tools() -> Vec<Tool> {
         vec![
+            Tool::new(
+                "read".to_string(),
+                "Reads the contents of a file at the specified path.".to_string(),
+                Self::schema::<FileReadParams>(),
+            )
+            .annotate(ToolAnnotations::from_raw(
+                Some("Read".to_string()),
+                Some(true),
+                None,
+                None,
+                Some(false),
+            )),
             Tool::new(
                 "write".to_string(),
                 "Create a new file or overwrite an existing file. Creates parent directories if needed.".to_string(),
@@ -200,6 +212,13 @@ impl McpClientTrait for DeveloperClient {
                 Ok(params) => Ok(self.shell_tool.shell_with_cwd(params, working_dir).await),
                 Err(error) => Ok(ShellTool::error_result(&format!("Error: {error}"), None)),
             },
+            "read" => match Self::parse_args::<FileReadParams>(arguments) {
+                Ok(params) => Ok(self.edit_tools.file_read_with_cwd(params, working_dir)),
+                Err(error) => Ok(CallToolResult::error(vec![Content::text(format!(
+                    "Error: {error}"
+                ))
+                .with_priority(0.0)])),
+            },
             "write" => match Self::parse_args::<FileWriteParams>(arguments) {
                 Ok(params) => Ok(self.edit_tools.file_write_with_cwd(params, working_dir)),
                 Err(error) => Ok(CallToolResult::error(vec![Content::text(format!(
@@ -258,7 +277,10 @@ mod tests {
             .map(|t| t.name.to_string())
             .collect();
 
-        assert_eq!(names, vec!["write", "edit", "shell", "tree", "read_image"]);
+        assert_eq!(
+            names,
+            vec!["read", "write", "edit", "shell", "tree", "read_image"]
+        );
     }
 
     fn test_context(data_dir: std::path::PathBuf) -> PlatformExtensionContext {
@@ -302,6 +324,21 @@ mod tests {
             fs::read_to_string(cwd.join("notes.txt")).unwrap(),
             "first line"
         );
+
+        let read = client
+            .call_tool(
+                &ctx,
+                "read",
+                Some(object!({
+                    "path": "notes.txt"
+                })),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(read.is_error, Some(false));
+        assert_eq!(first_text(&read), "first line");
 
         let edit = client
             .call_tool(

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
@@ -109,7 +109,7 @@ cost the user money.
 
 For editing software, prefer the flow of using tree to understand the codebase structure
 and file sizes. When you need to search, prefer rg which correctly respects gitignored
-content. Then use cat or sed to gather the context you need, always reading before editing.
+content. Then use read or sed to gather the context you need, always reading before editing.
 Use write and edit to efficiently make changes. Test and verify as appropriate.
 
 When running Python scripts or commands, always use `python3` instead of `python`.

--- a/documentation/docs/mcp/developer-mcp.md
+++ b/documentation/docs/mcp/developer-mcp.md
@@ -181,13 +181,14 @@ See the [Quick Setup Example](#quick-setup-example) below for some ways to confi
 
 The Developer extension provides these tools:
 
-| Tool | Description | Use Cases | Risk Level |
-|------|-------------|-----------|------------|
-| `shell` | Execute shell commands | Running tests, installing packages, git operations | ⚠️ High<br />Can run any system command with your user privileges |
-| `text_editor` | Read, write, and edit files | Code refactoring, creating files, updating configs | ⚠️ High<br />Can modify any accessible file |
-| `analyze` | Analyze code structure | Understanding codebase, finding dependencies | ✅ Low<br />Read-only code analysis |
-| `screen_capture` | Take screenshots | Debugging UI issues, documenting state | ✅ Low<br />Visual information only |
-| `image_processor` | Process and resize images | Optimizing assets, format conversion | ✅ Low<br />Image manipulation only |
+| Tool         | Description       | Use Cases                                           | Risk Level                  |
+|--------------|-------------------|-----------------------------------------------------|-----------------------------|
+| `shell` | Execute shell commands | Running tests, installing packages, git operations  | ⚠️ High<br />Can run any system command with your user privileges |
+| `read` | Read files  | Analyzing the content of tiles | ✅ Low<br />Read-only file access |
+| `write` | Write to files | Creating files, adding new configs | ⚠️ High<br />Can modify any accessible file |
+| `edit` | Edit the content of files | Code refactoring, modifying files, updating configs | ⚠️ High<br />Can modify any accessible file |
+| `tree` | List a directory tree | Navigating a project, find a specific file | ✅ Low<br />Read-only file view |
+| `read_image` | Read a local image | Showing an image to the model | ✅ Low<br />Image load only |
 
 ### Access Control Features
 


### PR DESCRIPTION
## Summary
Added a "read" tool in the Developer extension. 

As someone who runs local models on an unprotected environment, having the agent rely on the shell tool slows down the process, as it requires my constant attendance for the work to proceed. I started with creating a new local extension that adds this tool separately, but I realized that the instructions in Developer still led the agent to prefer using `cat` to my own permissive tool. Since the infrastructure is already there to support it, I preferred adding it here.

I understand that there has been an effort to keep this extension lean in recent months. However, given that there has been a recent addition of `read_image` as a tool, it feels a bit silly not to have a simple text `read` too. This also reduces variations in instructions between Windows and Unix environments (I'm hoping to have a grep-like tool too in a future change).

### Testing
- cargo build -p goose, cargo clippy -p goose --lib, cargo fmt — clean
- Prompted an agent with "Can you tell me what's around line 30 in the file edit.rs?", and the tool was called successfully. It did use the `line` parameter, though it got confused and went 30 lines into the result after that.

### Related Issues

It has some overlap with #10223 on documentation changes. I'll probably have to merge it if it gets merged first.
It adds on top of the issue of #9910, but that one probably needs to disable some default extensions instead rather than avoid adding tools to Developer. 