### PR TITLE
Fix Kimi Code provider showing as not configured after login

### DIFF
--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -112,7 +112,10 @@ async fn init_registry() -> RwLock<ProviderRegistry> {
             true,
             Some(registrations::huggingface_inventory()),
         );
-        registry.register::<KimiCodeProvider>(true);
+        registry.register_with_inventory::<KimiCodeProvider>(
+            true,
+            Some(registrations::kimi_code_inventory()),
+        );
         registry.register::<LiteLLMProvider>(false);
         registry.register::<NanoGptProvider>(true);
         registry.register_with_inventory::<OllamaProviderDef>(

--- a/crates/goose/src/providers/inventory/registrations.rs
+++ b/crates/goose/src/providers/inventory/registrations.rs
@@ -14,6 +14,7 @@ use crate::providers::formats::anthropic::ANTHROPIC_PROVIDER_NAME;
 use crate::providers::google::{GOOGLE_API_HOST, GOOGLE_PROVIDER_NAME};
 use crate::providers::huggingface::HuggingFaceProvider;
 use crate::providers::huggingface_auth;
+use crate::providers::kimicode::TokenCache as KimiCodeTokenCache;
 use crate::providers::ollama::OLLAMA_PROVIDER_NAME;
 use crate::providers::openai::{OPEN_AI_DEFAULT_BASE_PATH, OPEN_AI_PROVIDER_NAME};
 use crate::providers::pi_acp::{PI_ACP_BINARY, PI_ACP_PROVIDER_NAME};
@@ -162,6 +163,15 @@ pub fn xai_oauth_inventory() -> InventoryRegistration {
         configured: None,
     }
     .with_configured(|| XaiOAuthTokenCache::new().has_token())
+}
+
+pub fn kimi_code_inventory() -> InventoryRegistration {
+    InventoryRegistration {
+        supports_refresh: false,
+        identity: default_inventory_identity_resolver(),
+        configured: None,
+    }
+    .with_configured(|| KimiCodeTokenCache::new().has_token())
 }
 
 pub fn acp_inventory(

--- a/crates/goose/src/providers/kimicode.rs
+++ b/crates/goose/src/providers/kimicode.rs
@@ -88,12 +88,12 @@ fn tokens_to_kimi(tokens: DeviceFlowTokens, prior_refresh: Option<&str>) -> Kimi
 }
 
 #[derive(Debug)]
-struct TokenCache {
+pub(crate) struct TokenCache {
     path: std::path::PathBuf,
 }
 
 impl TokenCache {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             path: Paths::in_config_dir("kimicode/token.json"),
         }
@@ -112,6 +112,13 @@ impl TokenCache {
                 None
             }
         }
+    }
+
+    pub(crate) fn has_token(&self) -> bool {
+        let Ok(raw) = std::fs::read_to_string(&self.path) else {
+            return false;
+        };
+        serde_json::from_str::<KimiToken>(&raw).is_ok()
     }
 
     async fn save(&self, token: &KimiToken) -> Result<()> {
@@ -521,6 +528,42 @@ mod tests {
         assert_eq!(decoded.access_token, token.access_token);
         assert_eq!(decoded.refresh_token, token.refresh_token);
         assert_eq!(decoded.expires_at.timestamp(), token.expires_at.timestamp());
+    }
+
+    // ── TokenCache::has_token ────────────────────────────────────────────────
+
+    #[test]
+    fn has_token_returns_false_when_no_file() {
+        let cache = TokenCache {
+            path: std::env::temp_dir()
+                .join(format!("goose-kimicode-notoken-{}.json", Uuid::new_v4())),
+        };
+        assert!(!cache.has_token());
+    }
+
+    #[test]
+    fn has_token_returns_true_when_valid_token_exists() {
+        let path =
+            std::env::temp_dir().join(format!("goose-kimicode-hastoken-{}.json", Uuid::new_v4()));
+        let token = KimiToken {
+            access_token: "acc".to_string(),
+            refresh_token: "ref".to_string(),
+            expires_at: Utc::now() + Duration::seconds(3600),
+        };
+        std::fs::write(&path, serde_json::to_string(&token).unwrap()).unwrap();
+
+        let cache = TokenCache { path };
+        assert!(cache.has_token());
+    }
+
+    #[test]
+    fn has_token_returns_false_when_file_is_corrupted() {
+        let path =
+            std::env::temp_dir().join(format!("goose-kimicode-corrupt-{}.json", Uuid::new_v4()));
+        std::fs::write(&path, "not json").unwrap();
+
+        let cache = TokenCache { path };
+        assert!(!cache.has_token());
     }
 
     // ── Headers ───────────────────────────────────────────────────────────────

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -2476,6 +2476,11 @@ mod tests {
             .await
             .unwrap();
 
+        sm.update(&session.id)
+            .model_config(ModelConfig::new("test-model"))
+            .apply()
+            .await
+            .unwrap();
         add_user_message(&sm, &session.id).await;
 
         let update = sm


### PR DESCRIPTION
## Summary
- The Kimi Code provider always showed as "not configured" in the desktop UI even after a successful OAuth device-flow login.
- Root cause: the provider was registered with the default `inventory_configured` check, which looks for a `KIMI_CODE_TOKEN` secret in the config store. But `configure_oauth()` stores the token in a file (`~/.config/goose/kimicode/token.json`) and never writes that config secret, so the check always returned false.
- Fix: add `has_token()` to the Kimi `TokenCache` and register the provider with a custom `inventory_configured` closure that checks the token file, matching the pattern already used by ChatGPT Codex and xAI OAuth.

## Test plan
- [x] `cargo test -p goose --lib -- kimicode` (15 tests pass, including 3 new regression tests)
- [x] `cargo clippy -p goose -- -D warnings` (clean)
- [x] `cargo fmt`