### PR TITLE
Drop unsupported gpt-5.3-codex from chatgpt_codex provider

### DIFF
--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -60,10 +60,6 @@ pub const CHATGPT_CODEX_KNOWN_MODELS: &[ChatGptCodexModelAttrs] = &[
         name: "gpt-5.4",
         reasoning_levels: &["low", "medium", "high", "xhigh"],
     },
-    ChatGptCodexModelAttrs {
-        name: "gpt-5.3-codex",
-        reasoning_levels: &["low", "medium", "high", "xhigh"],
-    },
 ];
 
 const CHATGPT_CODEX_DOC_URL: &str = "https://openai.com/chatgpt";
@@ -81,14 +77,6 @@ pub fn reasoning_levels_for_model(model_name: &str) -> &'static [&'static str] {
 fn known_model_names() -> Vec<&'static str> {
     CHATGPT_CODEX_KNOWN_MODELS.iter().map(|m| m.name).collect()
 }
-
-const GPT_53_CODEX_TOOL_PREAMBLE: &str = "\
-You are a coding agent. You have access to tools to accomplish tasks. \
-Always use your tools to fulfill requests - do not just describe what you would do. \
-Keep going until the query is completely resolved before yielding back to the user. \
-Autonomously resolve the query using the tools available to you. \
-Do NOT guess or make up an answer. \
-Before making tool calls, send a brief message explaining what you're about to do.";
 
 #[derive(Debug)]
 struct ChatGptCodexAuthState {
@@ -259,16 +247,11 @@ fn create_codex_request(
     let input_items = build_input_items(messages)?;
     let reasoning_effort = reasoning_effort_for_config(model_config);
 
-    let instructions = match model_config.model_name.as_str() {
-        "gpt-5.3-codex" => format!("{GPT_53_CODEX_TOOL_PREAMBLE}\n\n{system}"),
-        _ => system.to_string(),
-    };
-
     let mut payload = json!({
         "model": model_config.model_name,
         "input": input_items,
         "store": false,
-        "instructions": instructions,
+        "instructions": system,
     });
 
     let payload_obj = payload
@@ -1197,7 +1180,7 @@ mod tests {
     fn test_create_codex_request_reasoning_effort_from_unified_thinking() {
         let mut params = std::collections::HashMap::new();
         params.insert("thinking_effort".to_string(), json!("max"));
-        let mut config = ModelConfig::new("gpt-5.3-codex");
+        let mut config = ModelConfig::new("gpt-5.5");
         config.request_params = Some(params);
 
         let payload = create_codex_request(&config, "sys", &[], &[]).unwrap();
@@ -1397,16 +1380,7 @@ mod tests {
     }
 
     #[test]
-    fn test_gpt53_preamble_injected() {
-        let model = ModelConfig::new("gpt-5.3-codex");
-        let payload = create_codex_request(&model, "system prompt", &[], &[]).unwrap();
-        let instructions = payload["instructions"].as_str().unwrap();
-        assert!(instructions.contains(GPT_53_CODEX_TOOL_PREAMBLE));
-        assert!(instructions.contains("system prompt"));
-    }
-
-    #[test]
-    fn test_other_models_no_preamble() {
+    fn test_instructions_passed_through() {
         let model = ModelConfig::new("gpt-5.4");
         let payload = create_codex_request(&model, "system prompt", &[], &[]).unwrap();
         let instructions = payload["instructions"].as_str().unwrap();


### PR DESCRIPTION
## Summary
- The `chatgpt_codex` provider (Codex via ChatGPT subscription) advertised `gpt-5.3-codex` as a known model, but OpenAI's API rejects it on the ChatGPT-account path. The error users hit:

  ```
  Request failed: Bad request (400): {"detail":"The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account."}
  ```
- Removed `gpt-5.3-codex` from `CHATGPT_CODEX_KNOWN_MODELS` so it is no longer offered. The `-codex` models are only valid for API-key Codex access (the separate `codex` provider).
- Removed the now-dead `GPT_53_CODEX_TOOL_PREAMBLE` and simplified `create_codex_request` to pass the system prompt through directly.
- Side benefit: `enhance_model_error`'s "Available models" hint now correctly surfaces `gpt-5.5, gpt-5.4` instead of re-suggesting the failing model.

## Review Notes
- Production-safety review passed (2 rounds).
- Scope is intentionally narrow: only the `chatgpt_codex` provider. Other `gpt-5.3-codex` references (`githubcopilot`, `openai.rs` context-window map, `model.rs` classification, `openai_responses` format test) belong to other providers/paths and are correctly left untouched.
- `ModelConfig::new` is infallible on `main` (no `.unwrap()`), so the updated tests match the current API.

## Decision Log
**Hardest decision:** Whether to also gracefully remap a user who has `gpt-5.3-codex` explicitly configured in their config to a supported model. I decided against silent remapping — the model genuinely isn't supported, so the honest behavior is to let the API error surface while the available-models hint now correctly steers them to `gpt-5.5`/`gpt-5.4`. Silent remapping would mask a misconfiguration and could confuse users about which model is actually running.

**Alternatives rejected:**
- Keep `gpt-5.3-codex` in the list but block it client-side: rejected — duplicates the API's validation and adds maintenance surface for a model that can never work on this path.
- Auto-remap `gpt-5.3-codex` → `gpt-5.5`: rejected — see hardest decision; masking misconfig is worse than a clear error.

**Least confident about:** Nothing significant. The change is a pure data-list removal plus dead-code cleanup, fully covered by the existing inline tests. If anything, a reviewer may prefer a different default guidance message, but the current `enhance_model_error` path already handles it.

## Test plan
- [ ] CI passes
- [ ] `cargo test -p goose --lib providers::chatgpt_codex` — all provider tests pass (note: `test_parse_jwt_claims_verified_with_issuer` fails on pristine `main` too due to a `jsonwebtoken` CryptoProvider feature issue — unrelated to this change, confirmed via stash)
- [ ] `cargo clippy -p goose --all-targets -- -D warnings` clean
