### PR TITLE
feat(desktop): add git worktree creation from chat input

### DIFF
--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -10,6 +10,7 @@ import { ChatState } from '../types/chatState';
 import debounce from 'lodash/debounce';
 import { LocalMessageStorage } from '../utils/localMessageStorage';
 import { DirSwitcher } from './bottom_menu/DirSwitcher';
+import { WorktreeCreator } from './bottom_menu/WorktreeCreator';
 import ModelsBottomBar from './settings/models/bottom_bar/ModelsBottomBar';
 import { BottomMenuExtensionSelection } from './bottom_menu/BottomMenuExtensionSelection';
 import { cn } from '../utils';
@@ -1673,6 +1674,18 @@ export default function ChatInput({
         {!isBottomBarNarrow && (
           <DirSwitcher
             className=""
+            sessionId={sessionId ?? undefined}
+            workingDir={currentWorkingDir}
+            onWorkingDirChange={async (newDir) => {
+              await onWorkingDirChange?.(newDir);
+              setWorkingDirOverride(newDir);
+            }}
+          />
+        )}
+
+        {/* Left: create git worktree (only when working dir is a git repo) */}
+        {!isBottomBarNarrow && (
+          <WorktreeCreator
             sessionId={sessionId ?? undefined}
             workingDir={currentWorkingDir}
             onWorkingDirChange={async (newDir) => {

--- a/ui/desktop/src/components/bottom_menu/WorktreeCreator.tsx
+++ b/ui/desktop/src/components/bottom_menu/WorktreeCreator.tsx
@@ -1,0 +1,191 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { GitBranch } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/Tooltip';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { toast } from 'react-toastify';
+import { defineMessages, useIntl } from '../../i18n';
+
+const i18n = defineMessages({
+  createWorktree: {
+    id: 'worktreeCreator.createWorktree',
+    defaultMessage: 'Create a git worktree',
+  },
+  enterBranchName: {
+    id: 'worktreeCreator.enterBranchName',
+    defaultMessage: 'Enter a branch name for the new worktree',
+  },
+  branchName: {
+    id: 'worktreeCreator.branchName',
+    defaultMessage: 'Branch name',
+  },
+  branchNamePlaceholder: {
+    id: 'worktreeCreator.branchNamePlaceholder',
+    defaultMessage: 'my-feature-branch',
+  },
+  create: {
+    id: 'worktreeCreator.create',
+    defaultMessage: 'Create',
+  },
+  cancel: {
+    id: 'worktreeCreator.cancel',
+    defaultMessage: 'Cancel',
+  },
+  failedToCreate: {
+    id: 'worktreeCreator.failedToCreate',
+    defaultMessage: 'Failed to create worktree',
+  },
+  invalidBranchName: {
+    id: 'worktreeCreator.invalidBranchName',
+    defaultMessage:
+      'Branch name can only contain letters, numbers, hyphens, underscores, dots, and slashes',
+  },
+});
+
+interface WorktreeCreatorProps {
+  sessionId: string | undefined;
+  workingDir: string;
+  onWorkingDirChange?: (newDir: string) => Promise<void> | void;
+  onRestartStart?: () => void;
+  onRestartEnd?: () => void;
+}
+
+const BRANCH_NAME_PATTERN = /^[\w./-]+$/;
+
+export const WorktreeCreator: React.FC<WorktreeCreatorProps> = ({
+  sessionId,
+  workingDir,
+  onWorkingDirChange,
+  onRestartStart,
+  onRestartEnd,
+}) => {
+  const intl = useIntl();
+  const [isGitRepo, setIsGitRepoState] = useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [branchName, setBranchName] = useState('');
+  const [isCreating, setIsCreating] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!workingDir?.trim()) {
+      setIsGitRepoState(false);
+      return;
+    }
+    window.electron
+      .isGitRepo(workingDir)
+      .then((result) => {
+        if (!cancelled) setIsGitRepoState(result);
+      })
+      .catch(() => {
+        if (!cancelled) setIsGitRepoState(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workingDir]);
+
+  const applyDirectoryChange = useCallback(
+    async (newDir: string) => {
+      window.electron.addRecentDir(newDir);
+
+      if (sessionId) {
+        onRestartStart?.();
+        try {
+          await onWorkingDirChange?.(newDir);
+        } catch (error) {
+          console.error('[WorktreeCreator] Failed to switch to worktree:', error);
+          toast.error(intl.formatMessage(i18n.failedToCreate));
+        } finally {
+          onRestartEnd?.();
+        }
+      } else {
+        await onWorkingDirChange?.(newDir);
+      }
+    },
+    [sessionId, onRestartStart, onRestartEnd, onWorkingDirChange, intl]
+  );
+
+  const handleCreate = async () => {
+    const trimmed = branchName.trim();
+    if (!trimmed || !BRANCH_NAME_PATTERN.test(trimmed)) {
+      toast.error(intl.formatMessage(i18n.invalidBranchName));
+      return;
+    }
+
+    setIsCreating(true);
+    try {
+      const worktreePath = await window.electron.createGitWorktree(workingDir, trimmed);
+      setIsDialogOpen(false);
+      setBranchName('');
+      await applyDirectoryChange(worktreePath);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : intl.formatMessage(i18n.failedToCreate);
+      toast.error(message);
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  if (!isGitRepo) {
+    return null;
+  }
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            className="text-text-primary/70 hover:cursor-pointer hover:text-text-primary text-xs flex items-center transition-colors pl-1 [&>svg]:size-4"
+            onClick={() => setIsDialogOpen(true)}
+          >
+            <GitBranch size={16} className="mr-px" />
+            <span className="text-[10px] leading-none -ml-px">+</span>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top">{intl.formatMessage(i18n.createWorktree)}</TooltipContent>
+      </Tooltip>
+
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{intl.formatMessage(i18n.createWorktree)}</DialogTitle>
+            <DialogDescription>{intl.formatMessage(i18n.enterBranchName)}</DialogDescription>
+          </DialogHeader>
+          <div className="py-4">
+            <label className="text-sm font-medium mb-2 block">
+              {intl.formatMessage(i18n.branchName)}
+            </label>
+            <Input
+              value={branchName}
+              onChange={(e) => setBranchName(e.target.value)}
+              placeholder={intl.formatMessage(i18n.branchNamePlaceholder)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !isCreating) {
+                  void handleCreate();
+                }
+              }}
+              autoFocus
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsDialogOpen(false)} disabled={isCreating}>
+              {intl.formatMessage(i18n.cancel)}
+            </Button>
+            <Button onClick={() => void handleCreate()} disabled={isCreating || !branchName.trim()}>
+              {intl.formatMessage(i18n.create)}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </TooltipProvider>
+  );
+};

--- a/ui/desktop/src/i18n/messages/de.json
+++ b/ui/desktop/src/i18n/messages/de.json
@@ -4525,5 +4525,29 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Eine neue Sitzung mit der bearbeiteten Nachricht erstellen"
+  },
+  "worktreeCreator.branchName": {
+    "defaultMessage": "Branch name"
+  },
+  "worktreeCreator.branchNamePlaceholder": {
+    "defaultMessage": "my-feature-branch"
+  },
+  "worktreeCreator.cancel": {
+    "defaultMessage": "Cancel"
+  },
+  "worktreeCreator.create": {
+    "defaultMessage": "Create"
+  },
+  "worktreeCreator.createWorktree": {
+    "defaultMessage": "Create a git worktree"
+  },
+  "worktreeCreator.enterBranchName": {
+    "defaultMessage": "Enter a branch name for the new worktree"
+  },
+  "worktreeCreator.failedToCreate": {
+    "defaultMessage": "Failed to create worktree"
+  },
+  "worktreeCreator.invalidBranchName": {
+    "defaultMessage": "Branch name can only contain letters, numbers, hyphens, underscores, dots, and slashes"
   }
 }

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -4525,5 +4525,29 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Create a new session with the edited message"
+  },
+  "worktreeCreator.branchName": {
+    "defaultMessage": "Branch name"
+  },
+  "worktreeCreator.branchNamePlaceholder": {
+    "defaultMessage": "my-feature-branch"
+  },
+  "worktreeCreator.cancel": {
+    "defaultMessage": "Cancel"
+  },
+  "worktreeCreator.create": {
+    "defaultMessage": "Create"
+  },
+  "worktreeCreator.createWorktree": {
+    "defaultMessage": "Create a git worktree"
+  },
+  "worktreeCreator.enterBranchName": {
+    "defaultMessage": "Enter a branch name for the new worktree"
+  },
+  "worktreeCreator.failedToCreate": {
+    "defaultMessage": "Failed to create worktree"
+  },
+  "worktreeCreator.invalidBranchName": {
+    "defaultMessage": "Branch name can only contain letters, numbers, hyphens, underscores, dots, and slashes"
   }
 }

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -4525,5 +4525,29 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Crear una nueva sesión con el mensaje editado"
+  },
+  "worktreeCreator.branchName": {
+    "defaultMessage": "Branch name"
+  },
+  "worktreeCreator.branchNamePlaceholder": {
+    "defaultMessage": "my-feature-branch"
+  },
+  "worktreeCreator.cancel": {
+    "defaultMessage": "Cancel"
+  },
+  "worktreeCreator.create": {
+    "defaultMessage": "Create"
+  },
+  "worktreeCreator.createWorktree": {
+    "defaultMessage": "Create a git worktree"
+  },
+  "worktreeCreator.enterBranchName": {
+    "defaultMessage": "Enter a branch name for the new worktree"
+  },
+  "worktreeCreator.failedToCreate": {
+    "defaultMessage": "Failed to create worktree"
+  },
+  "worktreeCreator.invalidBranchName": {
+    "defaultMessage": "Branch name can only contain letters, numbers, hyphens, underscores, dots, and slashes"
   }
 }

--- a/ui/desktop/src/i18n/messages/fr.json
+++ b/ui/desktop/src/i18n/messages/fr.json
@@ -4525,5 +4525,29 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Créer une nouvelle session avec le message modifié"
+  },
+  "worktreeCreator.branchName": {
+    "defaultMessage": "Branch name"
+  },
+  "worktreeCreator.branchNamePlaceholder": {
+    "defaultMessage": "my-feature-branch"
+  },
+  "worktreeCreator.cancel": {
+    "defaultMessage": "Cancel"
+  },
+  "worktreeCreator.create": {
+    "defaultMessage": "Create"
+  },
+  "worktreeCreator.createWorktree": {
+    "defaultMessage": "Create a git worktree"
+  },
+  "worktreeCreator.enterBranchName": {
+    "defaultMessage": "Enter a branch name for the new worktree"
+  },
+  "worktreeCreator.failedToCreate": {
+    "defaultMessage": "Failed to create worktree"
+  },
+  "worktreeCreator.invalidBranchName": {
+    "defaultMessage": "Branch name can only contain letters, numbers, hyphens, underscores, dots, and slashes"
   }
 }

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -4525,5 +4525,29 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "संपादित संदेश के साथ एक नया सत्र बनाएं"
+  },
+  "worktreeCreator.branchName": {
+    "defaultMessage": "Branch name"
+  },
+  "worktreeCreator.branchNamePlaceholder": {
+    "defaultMessage": "my-feature-branch"
+  },
+  "worktreeCreator.cancel": {
+    "defaultMessage": "Cancel"
+  },
+  "worktreeCreator.create": {
+    "defaultMessage": "Create"
+  },
+  "worktreeCreator.createWorktree": {
+    "defaultMessage": "Create a git worktree"
+  },
+  "worktreeCreator.enterBranchName": {
+    "defaultMessage": "Enter a branch name for the new worktree"
+  },
+  "worktreeCreator.failedToCreate": {
+    "defaultMessage": "Failed to create worktree"
+  },
+  "worktreeCreator.invalidBranchName": {
+    "defaultMessage": "Branch name can only contain letters, numbers, hyphens, underscores, dots, and slashes"
   }
 }

--- a/ui/desktop/src/i18n/messages/id.json
+++ b/ui/desktop/src/i18n/messages/id.json
@@ -4525,5 +4525,29 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Buat sesi baru dengan pesan yang diedit"
+  },
+  "worktreeCreator.branchName": {
+    "defaultMessage": "Branch name"
+  },
+  "worktreeCreator.branchNamePlaceholder": {
+    "defaultMessage": "my-feature-branch"
+  },
+  "worktreeCreator.cancel": {
+    "defaultMessage": "Cancel"
+  },
+  "worktreeCreator.create": {
+    "defaultMessage": "Create"
+  },
+  "worktreeCreator.createWorktree": {
+    "defaultMessage": "Create a git worktree"
+  },
+  "worktreeCreator.enterBranchName": {
+    "defaultMessage": "Enter a branch name for the new worktree"
+  },
+  "worktreeCreator.failedToCreate": {
+    "defaultMessage": "Failed to create worktree"
+  },
+  "worktreeCreator.invalidBranchName": {
+    "defaultMessage": "Branch name can only contain letters, numbers, hyphens, underscores, dots, and slashes"
   }
 }

--- a/ui/desktop/src/i18n/messages/it.json
+++ b/ui/desktop/src/i18n/messages/it.json
@@ -4525,5 +4525,29 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Crea una nuova sessione con il messaggio modificato"
+  },
+  "worktreeCreator.branchName": {
+    "defaultMessage": "Branch name"
+  },
+  "worktreeCreator.branchNamePlaceholder": {
+    "defaultMessage": "my-feature-branch"
+  },
+  "worktreeCreator.cancel": {
+    "defaultMessage": "Cancel"
+  },
+  "worktreeCreator.create": {
+    "defaultMessage": "Create"
+  },
+  "worktreeCreator.createWorktree": {
+    "defaultMessage": "Create a git worktree"
+  },
+  "worktreeCreator.enterBranchName": {
+    "defaultMessage": "Enter a branch name for the new worktree"
+  },
+  "worktreeCreator.failedToCreate": {
+    "defaultMessage": "Failed to create worktree"
+  },
+  "worktreeCreator.invalidBranchName": {
+    "defaultMessage": "Branch name can only contain letters, numbers, hyphens, underscores, dots, and slashes"
   }
 }

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -4525,5 +4525,29 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "編集したメッセージで新しいセッションを作成"
+  },
+  "worktreeCreator.branchName": {
+    "defaultMessage": "Branch name"
+  },
+  "worktreeCreator.branchNamePlaceholder": {
+    "defaultMessage": "my-feature-branch"
+  },
+  "worktreeCreator.cancel": {
+    "defaultMessage": "Cancel"
+  },
+  "worktreeCreator.create": {
+    "defaultMessage": "Create"
+  },
+  "worktreeCreator.createWorktree": {
+    "defaultMessage": "Create a git worktree"
+  },
+  "worktreeCreator.enterBranchName": {
+    "defaultMessage": "Enter a branch name for the new worktree"
+  },
+  "worktreeCreator.failedToCreate": {
+    "defaultMessage": "Failed to create worktree"
+  },
+  "worktreeCreator.invalidBranchName": {
+    "defaultMessage": "Branch name can only contain letters, numbers, hyphens, underscores, dots, and slashes"
   }
 }

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -4525,5 +4525,29 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "편집한 메시지로 새 세션 만들기"
+  },
+  "worktreeCreator.branchName": {
+    "defaultMessage": "Branch name"
+  },
+  "worktreeCreator.branchNamePlaceholder": {
+    "defaultMessage": "my-feature-branch"
+  },
+  "worktreeCreator.cancel": {
+    "defaultMessage": "Cancel"
+  },
+  "worktreeCreator.create": {
+    "defaultMessage": "Create"
+  },
+  "worktreeCreator.createWorktree": {
+    "defaultMessage": "Create a git worktree"
+  },
+  "worktreeCreator.enterBranchName": {
+    "defaultMessage": "Enter a branch name for the new worktree"
+  },
+  "worktreeCreator.failedToCreate": {
+    "defaultMessage": "Failed to create worktree"
+  },
+  "worktreeCreator.invalidBranchName": {
+    "defaultMessage": "Branch name can only contain letters, numbers, hyphens, underscores, dots, and slashes"
   }
 }

--- a/ui/desktop/src/i18n/messages/ms.json
+++ b/ui/desktop/src/i18n/messages/ms.json
@@ -4525,5 +4525,29 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Cipta sesi baharu dengan mesej yang disunting"
+  },
+  "worktreeCreator.branchName": {
+    "defaultMessage": "Branch name"
+  },
+  "worktreeCreator.branchNamePlaceholder": {
+    "defaultMessage": "my-feature-branch"
+  },
+  "worktreeCreator.cancel": {
+    "defaultMessage": "Cancel"
+  },
+  "worktreeCreator.create": {
+    "defaultMessage": "Create"
+  },
+  "worktreeCreator.createWorktree": {
+    "defaultMessage": "Create a git worktree"
+  },
+  "worktreeCreator.enterBranchName": {
+    "defaultMessage": "Enter a branch name for the new worktree"
+  },
+  "worktreeCreator.failedToCreate": {
+    "defaultMessage": "Failed to create worktree"
+  },
+  "worktreeCreator.invalidBranchName": {
+    "defaultMessage": "Branch name can only contain letters, numbers, hyphens, underscores, dots, and slashes"
   }
 }

--- a/ui/desktop/src/i18n/messages/pt.json
+++ b/ui/desktop/src/i18n/messages/pt.json
@@ -4525,5 +4525,29 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Criar uma nova sessão com a mensagem editada"
+  },
+  "worktreeCreator.branchName": {
+    "defaultMessage": "Branch name"
+  },
+  "worktreeCreator.branchNamePlaceholder": {
+    "defaultMessage": "my-feature-branch"
+  },
+  "worktreeCreator.cancel": {
+    "defaultMessage": "Cancel"
+  },
+  "worktreeCreator.create": {
+    "defaultMessage": "Create"
+  },
+  "worktreeCreator.createWorktree": {
+    "defaultMessage": "Create a git worktree"
+  },
+  "worktreeCreator.enterBranchName": {
+    "defaultMessage": "Enter a branch name for the new worktree"
+  },
+  "worktreeCreator.failedToCreate": {
+    "defaultMessage": "Failed to create worktree"
+  },
+  "worktreeCreator.invalidBranchName": {
+    "defaultMessage": "Branch name can only contain letters, numbers, hyphens, underscores, dots, and slashes"
   }
 }

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -4525,5 +4525,29 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Создать новый сеанс с измененным сообщением"
+  },
+  "worktreeCreator.branchName": {
+    "defaultMessage": "Branch name"
+  },
+  "worktreeCreator.branchNamePlaceholder": {
+    "defaultMessage": "my-feature-branch"
+  },
+  "worktreeCreator.cancel": {
+    "defaultMessage": "Cancel"
+  },
+  "worktreeCreator.create": {
+    "defaultMessage": "Create"
+  },
+  "worktreeCreator.createWorktree": {
+    "defaultMessage": "Create a git worktree"
+  },
+  "worktreeCreator.enterBranchName": {
+    "defaultMessage": "Enter a branch name for the new worktree"
+  },
+  "worktreeCreator.failedToCreate": {
+    "defaultMessage": "Failed to create worktree"
+  },
+  "worktreeCreator.invalidBranchName": {
+    "defaultMessage": "Branch name can only contain letters, numbers, hyphens, underscores, dots, and slashes"
   }
 }

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -4525,5 +4525,29 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Düzenlenen mesajla yeni bir oturum oluşturun"
+  },
+  "worktreeCreator.branchName": {
+    "defaultMessage": "Branch name"
+  },
+  "worktreeCreator.branchNamePlaceholder": {
+    "defaultMessage": "my-feature-branch"
+  },
+  "worktreeCreator.cancel": {
+    "defaultMessage": "Cancel"
+  },
+  "worktreeCreator.create": {
+    "defaultMessage": "Create"
+  },
+  "worktreeCreator.createWorktree": {
+    "defaultMessage": "Create a git worktree"
+  },
+  "worktreeCreator.enterBranchName": {
+    "defaultMessage": "Enter a branch name for the new worktree"
+  },
+  "worktreeCreator.failedToCreate": {
+    "defaultMessage": "Failed to create worktree"
+  },
+  "worktreeCreator.invalidBranchName": {
+    "defaultMessage": "Branch name can only contain letters, numbers, hyphens, underscores, dots, and slashes"
   }
 }

--- a/ui/desktop/src/i18n/messages/vi.json
+++ b/ui/desktop/src/i18n/messages/vi.json
@@ -4525,5 +4525,29 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "Tạo một phiên làm việc mới với tin nhắn đã chỉnh sửa"
+  },
+  "worktreeCreator.branchName": {
+    "defaultMessage": "Branch name"
+  },
+  "worktreeCreator.branchNamePlaceholder": {
+    "defaultMessage": "my-feature-branch"
+  },
+  "worktreeCreator.cancel": {
+    "defaultMessage": "Cancel"
+  },
+  "worktreeCreator.create": {
+    "defaultMessage": "Create"
+  },
+  "worktreeCreator.createWorktree": {
+    "defaultMessage": "Create a git worktree"
+  },
+  "worktreeCreator.enterBranchName": {
+    "defaultMessage": "Enter a branch name for the new worktree"
+  },
+  "worktreeCreator.failedToCreate": {
+    "defaultMessage": "Failed to create worktree"
+  },
+  "worktreeCreator.invalidBranchName": {
+    "defaultMessage": "Branch name can only contain letters, numbers, hyphens, underscores, dots, and slashes"
   }
 }

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -4525,5 +4525,29 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "用编辑过的消息创建新会话"
+  },
+  "worktreeCreator.branchName": {
+    "defaultMessage": "Branch name"
+  },
+  "worktreeCreator.branchNamePlaceholder": {
+    "defaultMessage": "my-feature-branch"
+  },
+  "worktreeCreator.cancel": {
+    "defaultMessage": "Cancel"
+  },
+  "worktreeCreator.create": {
+    "defaultMessage": "Create"
+  },
+  "worktreeCreator.createWorktree": {
+    "defaultMessage": "Create a git worktree"
+  },
+  "worktreeCreator.enterBranchName": {
+    "defaultMessage": "Enter a branch name for the new worktree"
+  },
+  "worktreeCreator.failedToCreate": {
+    "defaultMessage": "Failed to create worktree"
+  },
+  "worktreeCreator.invalidBranchName": {
+    "defaultMessage": "Branch name can only contain letters, numbers, hyphens, underscores, dots, and slashes"
   }
 }

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -4525,5 +4525,29 @@
   },
   "userMessage.forkSessionTitle": {
     "defaultMessage": "以編輯後的訊息建立新的工作階段"
+  },
+  "worktreeCreator.branchName": {
+    "defaultMessage": "Branch name"
+  },
+  "worktreeCreator.branchNamePlaceholder": {
+    "defaultMessage": "my-feature-branch"
+  },
+  "worktreeCreator.cancel": {
+    "defaultMessage": "Cancel"
+  },
+  "worktreeCreator.create": {
+    "defaultMessage": "Create"
+  },
+  "worktreeCreator.createWorktree": {
+    "defaultMessage": "Create a git worktree"
+  },
+  "worktreeCreator.enterBranchName": {
+    "defaultMessage": "Enter a branch name for the new worktree"
+  },
+  "worktreeCreator.failedToCreate": {
+    "defaultMessage": "Failed to create worktree"
+  },
+  "worktreeCreator.invalidBranchName": {
+    "defaultMessage": "Branch name can only contain letters, numbers, hyphens, underscores, dots, and slashes"
   }
 }

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -272,6 +272,51 @@ function listGitWorktreeDirs(dir: string): Promise<string[]> {
   });
 }
 
+function isGitRepo(dir: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    if (!dir?.trim()) {
+      resolve(false);
+      return;
+    }
+
+    execFile(
+      'git',
+      ['-C', dir, 'rev-parse', '--is-inside-work-tree'],
+      { timeout: 3000 },
+      (error, stdout) => {
+        resolve(!error && stdout.trim() === 'true');
+      }
+    );
+  });
+}
+
+function createGitWorktree(dir: string, branchName: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    if (!dir?.trim() || !branchName?.trim()) {
+      reject(new Error('Directory and branch name are required'));
+      return;
+    }
+
+    const sanitizedBranch = branchName.trim();
+    const parentDir = path.dirname(dir);
+    const repoName = path.basename(dir.replace(/\/+$/, ''));
+    const worktreePath = path.join(parentDir, `${repoName}-${sanitizedBranch}`);
+
+    execFile(
+      'git',
+      ['-C', dir, 'worktree', 'add', '-b', sanitizedBranch, worktreePath],
+      { timeout: 10000 },
+      (error, _stdout, stderr) => {
+        if (error) {
+          reject(new Error(stderr?.trim() || error.message));
+          return;
+        }
+        resolve(worktreePath);
+      }
+    );
+  });
+}
+
 async function configureProxy() {
   const httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy;
   const httpProxy = process.env.HTTP_PROXY || process.env.http_proxy;
@@ -1904,6 +1949,14 @@ ipcMain.handle('list-recent-dirs', () => {
 
 ipcMain.handle('list-git-worktree-dirs', async (_event, dir: string) => {
   return await listGitWorktreeDirs(dir);
+});
+
+ipcMain.handle('is-git-repo', async (_event, dir: string) => {
+  return await isGitRepo(dir);
+});
+
+ipcMain.handle('create-git-worktree', async (_event, dir: string, branchName: string) => {
+  return await createGitWorktree(dir, branchName);
 });
 
 ipcMain.handle('get-setting', (_event, key: SettingKey) => {

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -178,6 +178,8 @@ type ElectronAPI = {
   addRecentDir: (dir: string) => Promise<boolean>;
   listRecentDirs: () => Promise<string[]>;
   listGitWorktreeDirs: (dir: string) => Promise<string[]>;
+  isGitRepo: (dir: string) => Promise<boolean>;
+  createGitWorktree: (dir: string, branchName: string) => Promise<string>;
 };
 
 type AppConfigAPI = {
@@ -335,6 +337,9 @@ const electronAPI: ElectronAPI = {
   addRecentDir: (dir: string) => ipcRenderer.invoke('add-recent-dir', dir),
   listRecentDirs: () => ipcRenderer.invoke('list-recent-dirs'),
   listGitWorktreeDirs: (dir: string) => ipcRenderer.invoke('list-git-worktree-dirs', dir),
+  isGitRepo: (dir: string) => ipcRenderer.invoke('is-git-repo', dir),
+  createGitWorktree: (dir: string, branchName: string) =>
+    ipcRenderer.invoke('create-git-worktree', dir, branchName),
 };
 
 function getAppLocale(): unknown {


### PR DESCRIPTION
## Summary
- Add `WorktreeCreator` component beside `DirSwitcher` in the chat input bottom bar
- Renders only when the working directory is a git repo (checked via `git rev-parse --is-inside-work-tree`)
- Clicking opens a dialog to enter a branch name; creates the worktree with `git worktree add` and auto-switches the working directory to it
- New IPC handlers: `is-git-repo`, `create-git-worktree` (both use `execFile`, no shell)
- i18n keys added to all 16 locale files

## Review Notes
- Production-safety review passed (2 rounds)
- `execFile` is used for all git subprocess calls — no shell injection surface
- Branch name validated client-side (`/^[\w./-]+$/`) and by git's own branch-name validation
- Component returns `null` when not a git repo — zero footprint in non-git contexts
- The `GitBranch` icon + `+` span is used because `GitBranchPlus` is not available in the installed lucide-react version

## Decision Log
**Hardest decision:** Worktree path convention — `<parentDir>/<repoName>-<branch>`. This places the worktree as a sibling of the main repo. The alternative was a `.worktrees/` subdirectory inside the repo, but that could interfere with gitignored build artifacts and felt less discoverable on disk. The sibling approach matches how most developers manually create worktrees.

**Alternatives rejected:**
- `.worktrees/<branch>` subdirectory: risks conflict with existing gitignored paths, less visible on disk
- User-chosen destination path: adds friction and a second input field for marginal benefit at this stage

**Least confident about:** The branch name regex `/^[\w./-]+$/` allows `.` and `/` which are valid in git branch names but could theoretically construct traversal paths. In practice, `git worktree add -b` rejects branch names containing `..`, so git provides defense-in-depth. Still, a stricter server-side check in `createGitWorktree` would be more robust.

## Test plan
- [ ] CI passes
- [ ] Open Goose Desktop in a git repo — verify the worktree icon appears beside the directory switcher
- [ ] Open in a non-git directory — verify the icon does NOT appear
- [ ] Click the icon, enter a branch name, verify the worktree is created and the working directory switches to it
- [ ] Enter an invalid branch name — verify the validation toast appears
- [ ] Enter a branch name that already exists — verify the error toast shows git's error message
