### PR TITLE
Disable thinking preservation for Groq

### DIFF
--- a/crates/goose-providers/src/declarative.rs
+++ b/crates/goose-providers/src/declarative.rs
@@ -358,14 +358,11 @@ mod tests {
     }
 
     #[test]
-    fn existing_json_files_still_deserialize_without_new_fields() {
+    fn groq_json_disables_thinking_preservation() {
         let config =
             deserialize_provider_config(crate::groq::JSON).expect("groq.json should parse");
-        assert!(config.env_vars.is_none());
-        assert!(config.dynamic_models.is_none());
-        assert!(config.model_doc_link.is_none());
-        assert!(config.setup_steps.is_empty());
-        assert!(config.preserves_thinking);
+
+        assert!(!config.preserves_thinking);
     }
 
     fn placeholder_var_names(template: &str) -> Vec<String> {

--- a/crates/goose-providers/src/declarative/definitions/groq.json
+++ b/crates/goose-providers/src/declarative/definitions/groq.json
@@ -57,5 +57,6 @@
       "max_tokens": 1024
     }
   ],
-  "supports_streaming": true
+  "supports_streaming": true,
+  "preserves_thinking": false
 }


### PR DESCRIPTION
## Summary
Disable thinking preservation for Groq to avoid sending unsupported `reasoning_content` fields.

### Testing
- `cargo fmt --check`
- `cargo test -p goose-providers groq_json_disables_thinking_preservation`
- `cargo test -p goose-providers from_json_defaults_openai_preserves_thinking_to_true`

### Related Issues
Resolves #10200


### Screenshots/Demos (for UX changes)
Before:

After:
