### PR TITLE
fix(desktop): renderer permissions, Origin rewrite scope, route state fallbacks

### DIFF
--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -91,8 +91,7 @@ const PairRouteWrapper = ({
 }) => {
   const { extensionsList } = useConfig();
   const location = useLocation();
-  const routeState =
-    (location.state as PairRouteState) || (window.history.state as PairRouteState) || {};
+  const routeState = (location.state as PairRouteState) ?? {};
   const [searchParams, setSearchParams] = useSearchParams();
   const isCreatingSessionRef = useRef(false);
   const navigate = useNavigate();
@@ -185,15 +184,11 @@ const SettingsRoute = () => {
   const [searchParams] = useSearchParams();
   const setView = useNavigation();
 
-  // Get viewOptions from location.state, history.state, or URL search params
-  const viewOptions =
-    (location.state as SettingsViewOptions) || (window.history.state as SettingsViewOptions) || {};
-
-  // If section is provided via URL search params, add it to viewOptions
   const sectionFromUrl = searchParams.get('section');
-  if (sectionFromUrl) {
-    viewOptions.section = sectionFromUrl;
-  }
+  const viewOptions: SettingsViewOptions = {
+    ...((location.state as SettingsViewOptions) ?? {}),
+    ...(sectionFromUrl ? { section: sectionFromUrl } : {}),
+  };
 
   return <SettingsView onClose={() => navigate('/')} setView={setView} viewOptions={viewOptions} />;
 };
@@ -272,11 +267,7 @@ const ExtensionsRoute = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  // Get viewOptions from location.state or history.state (for deep link extensions)
-  const viewOptions =
-    (location.state as ExtensionsViewOptions) ||
-    (window.history.state as ExtensionsViewOptions) ||
-    {};
+  const viewOptions = (location.state as ExtensionsViewOptions) ?? {};
 
   return (
     <ExtensionsView

--- a/ui/desktop/src/components/ProgressiveMessageList.tsx
+++ b/ui/desktop/src/components/ProgressiveMessageList.tsx
@@ -299,8 +299,7 @@ export default function ProgressiveMessageList({
                   toolCallNotifications={toolCallNotifications}
                   isStreaming={
                     isStreamingMessage &&
-                    !isUser &&
-                    index === messagesToRender.length - 1 &&
+                    index === messages.length - 1 &&
                     message.role === 'assistant'
                   }
                   submitElicitationResponse={submitElicitationResponse}

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -306,6 +306,15 @@ interface BackendCertificateTrustRegistration {
 
 const trustedBackendCertificates = new Set<BackendCertificateTrust>();
 
+function isLoopbackUrl(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
+  } catch {
+    return false;
+  }
+}
+
 function normalizeHostname(hostname: string): string {
   return hostname.toLowerCase();
 }
@@ -2415,16 +2424,15 @@ async function appMain() {
 
   registerUpdateIpcHandlers();
 
-  // Handle microphone permission requests
+  // 'media' covers the dictation microphone; 'clipboard-sanitized-write'
+  // covers navigator.clipboard copy buttons. Everything else is denied.
+  const allowedRendererPermissions = new Set(['media', 'clipboard-sanitized-write']);
   session.defaultSession.setPermissionRequestHandler((_webContents, permission, callback) => {
-    console.log('Permission requested:', permission);
-    // Allow microphone and media access
-    if (permission === 'media') {
-      callback(true);
-    } else {
-      // Default behavior for other permissions
-      callback(true);
+    const allowed = allowedRendererPermissions.has(permission);
+    if (!allowed) {
+      log.warn(`Denied renderer permission request: ${permission}`);
     }
+    callback(allowed);
   });
 
   // Add CSP headers to all sessions, recomputed on every response so external
@@ -2451,9 +2459,14 @@ async function appMain() {
   // Register global shortcuts based on settings
   registerGlobalShortcuts();
 
+  // goosed validates the Origin header of incoming requests. Rewrite it for
+  // loopback (goosed) targets only; other hosts must not receive a fabricated
+  // localhost origin.
   session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
-    details.requestHeaders['Origin'] = 'http://localhost:5173';
-    callback({ cancel: false, requestHeaders: details.requestHeaders });
+    if (isLoopbackUrl(details.url)) {
+      details.requestHeaders['Origin'] = 'http://localhost:5173';
+    }
+    callback({ requestHeaders: details.requestHeaders });
   });
 
   if (settings.showMenuBarIcon) {


### PR DESCRIPTION
Phase 2 of the ui/desktop cleanup: four bug fixes found during the audit. Stacked on #10313 (base retargets to `main` automatically when that merges).

## Fixes

**1. Permission handler granted everything** ([main.ts](../blob/ui-desktop-bug-fixes/ui/desktop/src/main.ts))
The handler's comment said "allow microphone", but both branches of its `if` called `callback(true)` — every renderer permission request (geolocation, notifications, anything a compromised page asks for) was approved. Now only `media` (dictation microphone) and `clipboard-sanitized-write` (the `navigator.clipboard` copy buttons) are granted; everything else is denied and logged.

**2. `Origin: http://localhost:5173` forced on every outgoing request**
Added in #1727 for a long-gone session-sharing flow, the `onBeforeSendHeaders` hook rewrote the Origin header on *all* requests — GitHub update checks, HuggingFace downloads, external MCP hosts all received a fabricated localhost origin. goosed's origin policy (loopback + `file://` + `null`) only concerns loopback targets, so the rewrite is now scoped to them.

**3. `window.history.state` fallbacks in route wrappers**
react-router stores user state under `history.state.usr`, so `(location.state) || (window.history.state) || {}` could only ever fall back to the router's `{usr, key, idx}` wrapper — never real view options. SettingsRoute then *mutated* that object to inject `section`. The wrappers now read `location.state` only, and SettingsRoute builds a fresh options object.

**4. Streaming indicator targeted the wrong message**
ProgressiveMessageList marked the last *rendered* message as streaming (`index === messagesToRender.length - 1`). While progressive batches are still loading, the last rendered message is not the conversation's last message. It now compares against the full list.

## Verification
- `pnpm run lint:check` passes (tsc, eslint `--max-warnings 0`, i18n:check)
- `pnpm run test:run`: 549 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)