### PR TITLE
fix(docs): show manual-setup indicator for extensions without an install link

### DIFF
--- a/documentation/src/components/server-card.tsx
+++ b/documentation/src/components/server-card.tsx
@@ -149,7 +149,17 @@ export function ServerCard({ server }: { server: MCPServer }) {
                     <span>Install</span>
                     <Download className="h-4 w-4" />
                   </a>
-                ) : null}
+                ) : (
+                  <div
+                    className="manual-setup-badge"
+                    title={
+                      server.installation_notes ||
+                      "This extension requires manual setup. See details for instructions."
+                    }
+                  >
+                    Manual setup
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/documentation/src/css/extensions.css
+++ b/documentation/src/css/extensions.css
@@ -281,7 +281,8 @@
   color: #fa5204;
 }
 
-.built-in-badge {
+.built-in-badge,
+.manual-setup-badge {
   font-size: 0.75rem;
   padding: 0.25rem 0.5rem;
   border-radius: 999px;
@@ -322,6 +323,7 @@ html[data-theme="dark"] .command-content {
   background-color: rgba(255, 255, 255, 0.05);
 }
 
-html[data-theme="dark"] .built-in-badge {
+html[data-theme="dark"] .built-in-badge,
+html[data-theme="dark"] .manual-setup-badge {
   background-color: rgba(255, 255, 255, 0.1);
 }

--- a/documentation/src/pages/extensions/detail.tsx
+++ b/documentation/src/pages/extensions/detail.tsx
@@ -225,7 +225,14 @@ const getDocumentationPath = (serverId: string): string => {
                         <span>Install</span>
                         <Download className="h-4 w-4" />
                       </a>
-                    ) : null}
+                    ) : (
+                      <div
+                        className="manual-setup-badge"
+                        title="This extension requires manual setup. See the installation notes above."
+                      >
+                        Manual setup
+                      </div>
+                    )}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
Extensions with a placeholder-path install command (Cognee, mbot) set `show_install_link: false` in `servers.json` so a broken one-click `goose://` link isn't offered. Previously this rendered nothing in the card/detail action slot, which reads as a missing or broken button — that's what #10202 reports for the Cognee card.

Since the flag's intent is "no deep link is possible here," this proposes rendering a small "Manual setup" badge in that slot instead, matching the existing "Built-in" badge's styling, with a tooltip pointing to the extension's `installation_notes`. If you'd rather see a different treatment for non-deep-linkable extensions, happy to adjust.

### Testing
- `npm run typecheck` — no new errors (verified identical pre-existing error set before/after).
- `npm run build` — full Docusaurus production build succeeds.
- Manual visual verification: built and served the site locally, screenshotted both the `/extensions` grid (where the issue was reported) and `/extensions/detail?id=cognee-mcp` before and after the change to confirm the badge renders where the blank space was.

### Related Issues
Relates to #10202

### Screenshots/Demos (for UX changes)
Before (grid — Cognee's action slot blank; detail page):

<img src="https://raw.githubusercontent.com/conorbronsdon/goose/pr-assets/grid-before.png" width="380" alt="Extensions grid before: Cognee card has an empty action slot while neighbors show Install buttons"> <img src="https://raw.githubusercontent.com/conorbronsdon/goose/pr-assets/before-detail-cognee.png" width="380" alt="Cognee detail page before: no action shown">

After (grid — Manual setup badge; detail page):

<img src="https://raw.githubusercontent.com/conorbronsdon/goose/pr-assets/grid-after.png" width="380" alt="Extensions grid after: Cognee card shows a Manual setup badge in the action slot"> <img src="https://raw.githubusercontent.com/conorbronsdon/goose/pr-assets/after-detail-cognee.png" width="380" alt="Cognee detail page after: Manual setup badge rendered">
