### PR TITLE
Increase the /mcp-app-guest body limit for larger single-file MCP apps

### DIFF
--- a/crates/goose/src/acp/mcp_app_proxy.rs
+++ b/crates/goose/src/acp/mcp_app_proxy.rs
@@ -392,9 +392,7 @@ pub(crate) fn routes(secret_key: String) -> Router {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        normalize_csp_source, parse_domains, peer_addr_is_loopback, routes, GUEST_HTML_MAX_BYTES,
-    };
+    use super::{normalize_csp_source, parse_domains, peer_addr_is_loopback};
     use axum::{
         body::Body,
         extract::ConnectInfo,
@@ -470,9 +468,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stores_guest_html_larger_than_previous_guest_limit() {
-        let app = routes("test-secret".to_string());
-        let large_html = "x".repeat(9 * 1024 * 1024);
+    async fn stores_guest_html_larger_than_default_body_limit() {
+        let app = super::routes("test-secret".to_string());
+        let large_html = "x".repeat(3 * 1024 * 1024);
         let body = serde_json::json!({
             "secret": "test-secret",
             "html": large_html,
@@ -492,30 +490,5 @@ mod tests {
         let response = app.oneshot(request).await.unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
-    }
-
-    #[tokio::test]
-    async fn rejects_guest_html_larger_than_configured_limit() {
-        let app = routes("test-secret".to_string());
-        let oversized_html = "x".repeat(GUEST_HTML_MAX_BYTES + 1024 * 1024);
-        let body = serde_json::json!({
-            "secret": "test-secret",
-            "html": oversized_html,
-        })
-        .to_string();
-
-        let mut request = Request::builder()
-            .method("POST")
-            .uri("/mcp-app-guest")
-            .header(header::CONTENT_TYPE, "application/json")
-            .body(Body::from(body))
-            .unwrap();
-        request.extensions_mut().insert(ConnectInfo(
-            "127.0.0.1:12345".parse::<SocketAddr>().unwrap(),
-        ));
-
-        let response = app.oneshot(request).await.unwrap();
-
-        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 }

--- a/crates/goose/src/acp/mcp_app_proxy.rs
+++ b/crates/goose/src/acp/mcp_app_proxy.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 
 const GUEST_HTML_TTL_SECS: u64 = 300;
 const GUEST_HTML_MAX_ENTRIES: usize = 64;
-const GUEST_HTML_MAX_BYTES: usize = 8 * 1024 * 1024;
+const GUEST_HTML_MAX_BYTES: usize = 16 * 1024 * 1024;
 const MCP_APP_PROXY_HTML: &str = include_str!("templates/mcp_app_proxy.html");
 
 type GuestHtmlStore = Arc<RwLock<HashMap<String, GuestHtmlEntry>>>;
@@ -392,7 +392,9 @@ pub(crate) fn routes(secret_key: String) -> Router {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_csp_source, parse_domains, peer_addr_is_loopback};
+    use super::{
+        normalize_csp_source, parse_domains, peer_addr_is_loopback, routes, GUEST_HTML_MAX_BYTES,
+    };
     use axum::{
         body::Body,
         extract::ConnectInfo,
@@ -468,9 +470,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stores_guest_html_larger_than_default_body_limit() {
-        let app = super::routes("test-secret".to_string());
-        let large_html = "x".repeat(3 * 1024 * 1024);
+    async fn stores_guest_html_larger_than_previous_guest_limit() {
+        let app = routes("test-secret".to_string());
+        let large_html = "x".repeat(9 * 1024 * 1024);
         let body = serde_json::json!({
             "secret": "test-secret",
             "html": large_html,
@@ -490,5 +492,30 @@ mod tests {
         let response = app.oneshot(request).await.unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn rejects_guest_html_larger_than_configured_limit() {
+        let app = routes("test-secret".to_string());
+        let oversized_html = "x".repeat(GUEST_HTML_MAX_BYTES + 1024 * 1024);
+        let body = serde_json::json!({
+            "secret": "test-secret",
+            "html": oversized_html,
+        })
+        .to_string();
+
+        let mut request = Request::builder()
+            .method("POST")
+            .uri("/mcp-app-guest")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        request.extensions_mut().insert(ConnectInfo(
+            "127.0.0.1:12345".parse::<SocketAddr>().unwrap(),
+        ));
+
+        let response = app.oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 }


### PR DESCRIPTION
## Background

The `/mcp-app-guest` route accepts guest HTML as a JSON body and writes it into the temporary guest store.

That works well for multi-file MCP apps, but it is too tight for single-file embedded MCP apps. Some apps inline their full JS and CSS into one HTML document and then either embed that HTML into the binary or return it directly from the tool. In that setup, both the raw HTML size and the final POST body size become much larger.

In the case I reproduced locally:

- the embedded single-file HTML is about `8.9 MB`
- the JSON request body sent to `/mcp-app-guest` is about `11.2 MB`
- the guest HTML cannot be stored, and the desktop app only shows the generic error `Unable to load MCP app sandbox.`

The same class of app had loaded successfully on older Goose builds, so this looks like the guest-store request limit on the sandbox path being too small rather than the app becoming fundamentally unusable.

## Changes

- increase `GUEST_HTML_MAX_BYTES` from `8 MiB` to `16 MiB`
- raise the existing large-payload test from `3 MiB` to `9 MiB` so it actually covers payloads above the previous limit
- add a new test that still returns `413 Payload Too Large` when the payload exceeds the new limit

## Why 16 MiB

The goal here is not to allow unbounded request bodies. The goal is to leave enough room for single-file MCP apps while keeping the existing safety boundaries in place.

`16 MiB` gives the current embedded app enough headroom, while this route still keeps the following constraints:

- loopback-only access
- guest HTML TTL
- maximum guest-store entry count
- requests above the new limit are still rejected

So this is a bounded increase, not a removal of protections.

## Validation

I verified the updated focused tests locally:

- `stores_guest_html_larger_than_previous_guest_limit`
- `rejects_guest_html_larger_than_configured_limit`

Full CI can run in the maintainer environment as usual.