### PR TITLE
feat(providers): add TokenLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ goose is a general-purpose AI agent that runs on your machine. Not just for code
 
 A native desktop app for macOS, Linux, and Windows. A full CLI for terminal workflows. An API to embed it anywhere. Built in Rust for performance and portability.
 
-goose works with 15+ providers — Anthropic, OpenAI, Google, Ollama, OpenRouter, Azure, Bedrock, and more. Use API keys or your existing Claude, ChatGPT, or Gemini subscriptions via [ACP](https://goose-docs.ai/docs/guides/acp-providers). Connect to 70+ extensions via the [Model Context Protocol](https://modelcontextprotocol.io/) open standard.
+goose works with 15+ providers — Anthropic, OpenAI, Google, Ollama, OpenRouter, TokenLab, Azure, Bedrock, and more. Use API keys or your existing Claude, ChatGPT, or Gemini subscriptions via [ACP](https://goose-docs.ai/docs/guides/acp-providers). Connect to 70+ extensions via the [Model Context Protocol](https://modelcontextprotocol.io/) open standard.
 
 goose is part of the [Agentic AI Foundation (AAIF)](https://aaif.io/) at the Linux Foundation.
 

--- a/crates/goose-providers/src/declarative.rs
+++ b/crates/goose-providers/src/declarative.rs
@@ -44,6 +44,7 @@ pub(crate) mod declarative_providers {
         scaleway,
         tanzu,
         tensorix,
+        tokenlab,
         together,
         venice,
         vercel_ai_gateway,

--- a/crates/goose-providers/src/declarative/definitions/tokenlab.json
+++ b/crates/goose-providers/src/declarative/definitions/tokenlab.json
@@ -1,0 +1,99 @@
+{
+  "name": "tokenlab",
+  "engine": "openai",
+  "display_name": "TokenLab",
+  "description": "Unified model gateway with OpenAI-compatible chat completions and native Responses, Anthropic Messages, and Gemini endpoints",
+  "api_key_env": "TOKENLAB_API_KEY",
+  "base_url": "https://api.tokenlab.sh/v1/chat/completions",
+  "models": [
+    {
+      "name": "claude-fable-5",
+      "context_limit": 1000000,
+      "max_tokens": 128000
+    },
+    {
+      "name": "claude-opus-4-8",
+      "context_limit": 1000000,
+      "max_tokens": 128000
+    },
+    {
+      "name": "claude-sonnet-5",
+      "context_limit": 1000000,
+      "max_tokens": 128000
+    },
+    {
+      "name": "glm-5.2",
+      "context_limit": 1000000,
+      "max_tokens": 128000
+    },
+    {
+      "name": "deepseek-v4-pro",
+      "context_limit": 1000000,
+      "max_tokens": 384000
+    },
+    {
+      "name": "deepseek-v4-flash",
+      "context_limit": 1000000,
+      "max_tokens": 384000
+    },
+    {
+      "name": "gpt-5.5",
+      "context_limit": 1000000,
+      "max_tokens": 128000
+    },
+    {
+      "name": "gpt-5.4",
+      "context_limit": 400000,
+      "max_tokens": 128000
+    },
+    {
+      "name": "gpt-5.4-mini",
+      "context_limit": 400000,
+      "max_tokens": 128000
+    },
+    {
+      "name": "minimax-m3",
+      "context_limit": 1048576,
+      "max_tokens": 524288
+    },
+    {
+      "name": "kimi-k2.7-code",
+      "context_limit": 262144,
+      "max_tokens": 131072
+    },
+    {
+      "name": "qwen3.7-max",
+      "context_limit": 991808,
+      "max_tokens": 65536
+    },
+    {
+      "name": "gemini-3.5-flash",
+      "context_limit": 1048576,
+      "max_tokens": 65536
+    },
+    {
+      "name": "gemini-3.1-flash-lite",
+      "context_limit": 1048576,
+      "max_tokens": 65536
+    },
+    {
+      "name": "grok-4.3",
+      "context_limit": 1000000,
+      "max_tokens": 131072
+    },
+    {
+      "name": "grok-4-fast",
+      "context_limit": 2000000,
+      "max_tokens": 16384
+    }
+  ],
+  "supports_streaming": true,
+  "dynamic_models": false,
+  "skip_canonical_filtering": true,
+  "model_doc_link": "https://tokenlab.sh/",
+  "setup_steps": [
+    "Go to https://tokenlab.sh/",
+    "Create or copy an existing API key",
+    "Paste the key above as TOKENLAB_API_KEY"
+  ]
+}

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -57,6 +57,7 @@ goose is compatible with a wide range of LLM providers, allowing you to choose a
 | [Snowflake](https://docs.snowflake.com/user-guide/snowflake-cortex/aisql#choosing-a-model) | Access the latest models using Snowflake Cortex services, including Claude models. **Requires a Snowflake account and programmatic access token (PAT)**.                                                     | `SNOWFLAKE_HOST`, `SNOWFLAKE_TOKEN`                                                                                                                                                                 |
 | [VMware Tanzu Platform](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/ai-services/10-3/ai/index.html) | Enterprise-managed LLM access through AI Services on VMware Tanzu Platform. Models are fetched dynamically from the endpoint. | `TANZU_AI_API_KEY`, `TANZU_AI_ENDPOINT` |
 | [Tetrate Agent Router Service](https://router.tetrate.ai)                   | Unified API gateway for AI models including Claude, Gemini, GPT, open-weight models, and others. Supports PKCE authentication flow for secure API key generation.                                                                                | `TETRATE_API_KEY`, `TETRATE_HOST` (optional)                                                                                                                                        |
+| [TokenLab](https://tokenlab.sh/)                                             | Unified model gateway with OpenAI-compatible chat completions and native Responses, Anthropic Messages, and Gemini endpoints.                                                                                                                     | `TOKENLAB_API_KEY`                                                                                                                                                                  |
 | [Venice AI](https://venice.ai/home)                                         | Provides access to open source models like Llama, Mistral, and Qwen while prioritizing user privacy. **Requires an account and an [API key](https://docs.venice.ai/overview/guides/generating-api-key)**.                 | `VENICE_API_KEY`, `VENICE_HOST` (optional), `VENICE_BASE_PATH` (optional), `VENICE_MODELS_PATH` (optional)                                                                          |
 | [Cerebras](https://cerebras.ai/)                                            | Fast inference on Cerebras wafer-scale engines with models like Llama, Qwen, and others.                                                                                                                                  | `CEREBRAS_API_KEY`                                                                                                                                                                  |
 | [xAI](https://x.ai/)                                                        | Access to xAI's Grok models including grok-3, grok-3-mini, and grok-3-fast with 131,072 token context window.                                                                                                            | `XAI_API_KEY`, `XAI_HOST` (optional)                                                                                                                                                |
@@ -858,6 +859,51 @@ To set up Routstr with goose, follow these steps:
     3. Follow the prompts to choose `Routstr` as the provider.
     4. Enter your API key when prompted (and optionally override `ROUTSTR_HOST`).
     5. Select the Routstr model of your choice.
+  </TabItem>
+</Tabs>
+
+### TokenLab
+[TokenLab](https://tokenlab.sh/) provides unified access to frontier chat models through an OpenAI-compatible API. TokenLab also exposes native Responses, Anthropic Messages, and Gemini endpoints for clients that can use those provider-native protocols.
+
+TokenLab models configured in goose include:
+- **claude-fable-5** - Claude Fable 5 with a 1M context window
+- **claude-opus-4-8** - Claude Opus 4.8 with a 1M context window
+- **claude-sonnet-5** - Claude Sonnet 5 with a 1M context window
+- **gpt-5.5** - GPT-5.5 with a 1M context window
+- **gpt-5.4** and **gpt-5.4-mini** - GPT-5.4 models with 400K context windows
+- **qwen3.7-max** - Qwen3.7 Max with a 991K context window
+- **deepseek-v4-pro** and **deepseek-v4-flash** - DeepSeek V4 models with 1M context windows
+- **glm-5.2** - GLM 5.2 with a 1M context window
+- **gemini-3.5-flash** and **gemini-3.1-flash-lite** - Gemini Flash models with 1M context windows
+- **grok-4.3** and **grok-4-fast** - Grok models with large context support
+- **kimi-k2.7-code** and **minimax-m3** - coding and long-context models
+
+For the complete list of TokenLab models configured in goose, see [tokenlab.json](https://github.com/block/goose/blob/main/crates/goose-providers/src/declarative/definitions/tokenlab.json).
+
+To set up TokenLab with goose, follow these steps:
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  **To update your LLM provider and API key:**
+
+    1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar.
+    2. Click the `Settings` button on the sidebar.
+    3. Click the `Models` tab.
+    4. Click `Configure Providers`
+    5. Choose `TokenLab` as provider from the list.
+    6. Click `Configure`, enter your API key, and click `Submit`.
+    7. Select the TokenLab model of your choice.
+
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    1. Run:
+    ```sh
+    goose configure
+    ```
+    2. Select `Configure Providers` from the menu.
+    3. Follow the prompts to choose `TokenLab` as the provider.
+    4. Enter your API key when prompted.
+    5. Select the TokenLab model of your choice.
   </TabItem>
 </Tabs>
 

--- a/documentation/src/pages/index.tsx
+++ b/documentation/src/pages/index.tsx
@@ -131,8 +131,8 @@ function FeaturesSection() {
             description={
               <p>
                 Works with 15+ providers — Anthropic, OpenAI, Google, Ollama,
-                OpenRouter, Azure, Bedrock, and more. Use API keys or your
-                existing Claude, ChatGPT, or Gemini subscriptions via{" "}
+                OpenRouter, TokenLab, Azure, Bedrock, and more. Use API keys or
+                your existing Claude, ChatGPT, or Gemini subscriptions via{" "}
                 <Link to="/docs/guides/acp-providers">ACP</Link>.
               </p>
             }


### PR DESCRIPTION
## Summary
Adds TokenLab as a declarative OpenAI-compatible provider with a curated set of current chat models for goose model selection. The provider uses `TOKENLAB_API_KEY`, points at `https://api.tokenlab.sh/v1/chat/completions`, and keeps dynamic model discovery disabled so non-chat TokenLab models from `/v1/models` are not shown in the chat model picker.

The docs and README now list TokenLab, including a note that TokenLab also offers native Responses, Anthropic Messages, and Gemini endpoints for clients that use those native protocols.

### Testing
- `cargo fmt`
- `cargo fmt --check`
- `cargo test -p goose-providers all_bundled_providers_are_valid`
- `cargo test -p goose-providers expose_declarative_providers_enumerates_all_bundled_json_files`
- Parsed `tokenlab.json` locally: 16 configured models, `dynamic_models: false`, `skip_canonical_filtering: true`
- Live TokenLab `/v1/models` readback: 353 total models; all 16 configured models exist and are `chat` category
- `git diff --check`
- Attempted `npm run typecheck` in `documentation`; it currently fails on existing unrelated Docusaurus/React/recipes type errors before this change

### Related Issues
Relates to TokenLab provider support.
Discussion: N/A

### Screenshots/Demos (for UX changes)
Before: N/A

After: N/A
