### PR TITLE
Add macOS Contacts and Apple Events entitlements to desktop app

### DIFF
--- a/ui/desktop/entitlements.plist
+++ b/ui/desktop/entitlements.plist
@@ -30,5 +30,7 @@
     <true/>
     <key>com.apple.security.personal-information.reminders</key>
     <true/>
+    <key>com.apple.security.personal-information.addressbook</key>
+    <true/>
   </dict>
 </plist>

--- a/ui/desktop/forge.config.ts
+++ b/ui/desktop/forge.config.ts
@@ -39,6 +39,10 @@ let cfg = {
       'Goose needs access to your calendars to help manage and query calendar events.',
     NSRemindersUsageDescription:
       'Goose needs access to your reminders to help manage and query reminders.',
+    NSContactsUsageDescription:
+      'Goose needs access to your contacts to help manage and query contact information.',
+    NSAppleEventsUsageDescription:
+      'Goose needs access to send Apple Events to control other apps, such as Contacts, on your behalf.',
   },
 };
 


### PR DESCRIPTION
Closes #10286

## The problem

The desktop app's `forge.config.ts` and `entitlements.plist` declare Info.plist usage descriptions and sandbox entitlements for Calendars and Reminders, but never added the matching ones for Contacts.

Without `NSContactsUsageDescription`, macOS won't even show the permission prompt, it just fails silently. Same for `NSAppleEventsUsageDescription`, needed for any Apple Events automation of another app (for example, driving Contacts.app to edit a contact's notes field, which isn't exposed through the regular Contacts API). `com.apple.security.automation.apple-events` was already present in `entitlements.plist`, it was just missing its Info.plist usage-description counterpart, so that half of the permission never worked either.

I hit this the same way the issue reporter did: an extension that reads/edits Contacts silently fails on the desktop app with no permission prompt ever shown.

## The fix

Added both Info.plist keys to `forge.config.ts` and the one missing sandbox entitlement to `entitlements.plist`, following the exact pattern already used for the Calendars/Reminders keys in the same files. No other code paths touch these files (checked, nothing in `src/` references the entitlement/usage-description strings), so this is a self-contained config change.
