### PR TITLE
fix(hints): keep subdirectory hints resume-safe

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -1664,7 +1664,20 @@ async fn handle_interactive_session(
                 let conversation = original
                     .conversation
                     .ok_or_else(|| anyhow::anyhow!("session has no messages to edit"))?;
-                let edited = crate::session::editor::edit_conversation(&conversation)?;
+                let hidden_hints = conversation
+                    .iter()
+                    .filter(|message| goose::hints::contains_subdirectory_hint_marker(message))
+                    .cloned()
+                    .collect::<Vec<_>>();
+                let editable = goose::conversation::Conversation::new_unvalidated(
+                    conversation
+                        .iter()
+                        .filter(|message| !goose::hints::contains_subdirectory_hint_marker(message))
+                        .cloned()
+                        .collect::<Vec<_>>(),
+                );
+                let mut edited = crate::session::editor::edit_conversation(&editable)?;
+                edited.extend(hidden_hints);
                 session_manager
                     .replace_conversation(&target_id, &edited)
                     .await?;

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -241,7 +241,7 @@ pub async fn handle_session_export(
             ));
         }
     }
-    .into_user_visible_export();
+    .into_share_safe_export();
 
     let output = match format.as_str() {
         "json" => serde_json::to_string_pretty(&session)?,

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -370,6 +370,10 @@ fn export_session_to_markdown(
     session_name: &String,
 ) -> String {
     let mut markdown_output = String::new();
+    let messages: Vec<_> = messages
+        .into_iter()
+        .filter(|message| message.metadata.user_visible)
+        .collect();
 
     markdown_output.push_str(&format!("# Session Export: {}\n\n", session_name));
 
@@ -485,5 +489,33 @@ pub async fn prompt_interactive_session_selection(
         Ok(session.id.clone())
     } else {
         Err(anyhow::anyhow!("Invalid selection"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use goose::conversation::message::Message;
+
+    #[test]
+    fn markdown_export_omits_hidden_messages() {
+        let session_name = "test session".to_string();
+        let messages = vec![
+            Message::user().with_text("visible request"),
+            Message::user()
+                .with_text(
+                    "GOOSE_SUBDIRECTORY_HINT_MARKER=subdir_hints:/tmp/project/sub\nsecret hint",
+                )
+                .with_visibility(false, true),
+            Message::assistant().with_text("visible answer"),
+        ];
+
+        let output = export_session_to_markdown(messages, &session_name);
+
+        assert!(output.contains("visible request"));
+        assert!(output.contains("visible answer"));
+        assert!(output.contains("*Total messages: 2*"));
+        assert!(!output.contains("GOOSE_SUBDIRECTORY_HINT_MARKER"));
+        assert!(!output.contains("secret hint"));
     }
 }

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -240,7 +240,8 @@ pub async fn handle_session_export(
                 e
             ));
         }
-    };
+    }
+    .into_user_visible_export();
 
     let output = match format.as_str() {
         "json" => serde_json::to_string_pretty(&session)?,

--- a/crates/goose-cli/src/commands/term.rs
+++ b/crates/goose-cli/src/commands/term.rs
@@ -248,6 +248,14 @@ pub async fn handle_term_log(command: String) -> Result<()> {
     Ok(())
 }
 
+fn trailing_user_messages(messages: &[Message]) -> Vec<&Message> {
+    messages
+        .iter()
+        .rev()
+        .take_while(|message| message.role == Role::User)
+        .collect()
+}
+
 pub async fn handle_term_run(prompt: Vec<String>) -> Result<()> {
     let prompt = prompt.join(" ");
     let session_id = std::env::var("AGENT_SESSION_ID").map_err(|_| {
@@ -268,18 +276,13 @@ pub async fn handle_term_run(prompt: Vec<String>) -> Result<()> {
         .await?;
 
     let session = session_manager.get_session(&session_id, true).await?;
-    let user_messages_after_last_assistant: Vec<&Message> =
-        if let Some(conv) = &session.conversation {
-            conv.messages()
-                .iter()
-                .rev()
-                .take_while(|m| m.role != Role::Assistant)
-                .collect()
-        } else {
-            Vec::new()
-        };
+    let trailing_user_messages: Vec<&Message> = if let Some(conv) = &session.conversation {
+        trailing_user_messages(conv.messages())
+    } else {
+        Vec::new()
+    };
 
-    if let Some(oldest_user) = user_messages_after_last_assistant.last() {
+    if let Some(oldest_user) = trailing_user_messages.last() {
         if let Some(message_id) = oldest_user.id.as_deref() {
             session_manager
                 .truncate_conversation_from_message(&session_id, message_id)
@@ -291,10 +294,15 @@ pub async fn handle_term_run(prompt: Vec<String>) -> Result<()> {
         }
     }
 
-    let prompt_with_context = if user_messages_after_last_assistant.is_empty() {
+    let trailing_user_visible_messages = trailing_user_messages
+        .into_iter()
+        .filter(|message| message.is_user_visible())
+        .collect::<Vec<_>>();
+
+    let prompt_with_context = if trailing_user_visible_messages.is_empty() {
         prompt
     } else {
-        let history = user_messages_after_last_assistant
+        let history = trailing_user_visible_messages
             .iter()
             .rev() // back to chronological order
             .map(|m| m.as_concat_text())
@@ -378,6 +386,35 @@ pub async fn handle_term_info() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn trailing_shell_history_excludes_hidden_user_messages_without_mutating_history() {
+        let messages = vec![
+            Message::assistant().with_text("previous response"),
+            Message::user().with_text("visible prompt one"),
+            Message::user()
+                .with_text(goose::hints::format_subdirectory_hint_message_text(
+                    "subdir_hints:/workspace/subdirectory",
+                    "hidden subdirectory hint",
+                ))
+                .with_visibility(false, true),
+            Message::user().with_text("visible prompt two"),
+        ];
+        let original_messages = messages.clone();
+
+        let trailing_messages = trailing_user_messages(&messages);
+        let truncation_boundary = trailing_messages.last().copied();
+        let history = trailing_messages
+            .iter()
+            .filter(|message| message.is_user_visible())
+            .rev()
+            .map(|message| message.as_concat_text())
+            .collect::<Vec<_>>();
+
+        assert_eq!(history, ["visible prompt one", "visible prompt two"]);
+        assert_eq!(truncation_boundary, messages.get(1));
+        assert_eq!(messages, original_messages);
+    }
 
     #[test]
     fn render_term_init_script_includes_nushell_hooks() {

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -1561,18 +1561,19 @@ impl CliSession {
 
     /// Render all past messages from the session history
     pub fn render_message_history(&self) {
-        if self.messages.is_empty() {
+        let visible_messages = user_visible_history(&self.messages);
+        if visible_messages.is_empty() {
             return;
         }
 
         println!(
             "\n  {} {}",
             console::style("↻").cyan(),
-            console::style(format!("{} messages restored", self.messages.len())).dim()
+            console::style(format!("{} messages restored", visible_messages.len())).dim()
         );
 
         // Render each message
-        for message in self.messages.iter() {
+        for message in visible_messages {
             output::render_message(message, self.debug);
         }
 
@@ -1755,6 +1756,13 @@ impl CliSession {
     fn push_message(&mut self, message: Message) {
         self.messages.push(message);
     }
+}
+
+fn user_visible_history(messages: &Conversation) -> Vec<&Message> {
+    messages
+        .iter()
+        .filter(|message| message.is_user_visible())
+        .collect()
 }
 
 fn message_has_text(message: &Message) -> bool {
@@ -2325,6 +2333,25 @@ mod tests {
     use std::collections::HashMap;
     use std::time::Duration;
     use test_case::test_case;
+
+    #[test]
+    fn replay_history_excludes_hidden_messages() {
+        let messages = Conversation::new_unvalidated(vec![
+            Message::user().with_text("visible request"),
+            Message::user()
+                .with_text("hidden hint")
+                .with_visibility(false, true),
+            Message::assistant().with_text("visible response"),
+        ]);
+
+        assert_eq!(
+            user_visible_history(&messages)
+                .into_iter()
+                .map(Message::as_concat_text)
+                .collect::<Vec<_>>(),
+            vec!["visible request", "visible response"]
+        );
+    }
 
     #[test]
     fn test_format_elapsed_time_under_60_seconds() {

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -520,9 +520,8 @@ impl CliSession {
         loop {
             self.display_context_usage().await?;
 
-            let conversation_strings: Vec<String> = self
-                .messages
-                .iter()
+            let conversation_strings: Vec<String> = user_visible_history(&self.messages)
+                .into_iter()
                 .map(|msg| {
                     let role = match msg.role {
                         rmcp::model::Role::User => "User",
@@ -1311,9 +1310,9 @@ impl CliSession {
                                 if interactive { output::hide_thinking() };
                                 let _ = progress_bars.hide();
 
-                                if is_stream_json_mode {
+                                if is_stream_json_mode && message.is_user_visible() {
                                     emit_stream_event(&StreamEvent::Message { message: message.clone() });
-                                } else if !is_json_mode {
+                                } else if !is_json_mode && message.is_user_visible() {
                                     output::render_message_streaming(&message, &mut markdown_buffer, &mut thinking_header_shown, self.debug);
                                     maybe_open_credits_top_up_url(
                                         &message,
@@ -1405,7 +1404,10 @@ impl CliSession {
                 },
             };
             let json_output = JsonOutput {
-                messages: self.messages.messages().to_vec(),
+                messages: user_visible_history(&self.messages)
+                    .into_iter()
+                    .cloned()
+                    .collect(),
                 metadata,
             };
             println!("{}", serde_json::to_string_pretty(&json_output)?);

--- a/crates/goose-provider-types/src/conversation.rs
+++ b/crates/goose-provider-types/src/conversation.rs
@@ -495,7 +495,10 @@ pub fn merge_consecutive_messages(messages: Vec<Message>) -> (Vec<Message>, Vec<
     for message in messages {
         if let Some(last) = merged_messages.last_mut() {
             let effective = effective_role(&message);
-            if effective_role(last) == effective {
+            if effective_role(last) == effective
+                && last.metadata.user_visible == message.metadata.user_visible
+                && last.metadata.agent_visible == message.metadata.agent_visible
+            {
                 last.content.extend(message.content);
                 issues.push(format!("Merged consecutive {} messages", effective));
                 continue;
@@ -667,9 +670,30 @@ pub fn debug_conversation_fix(
 #[cfg(test)]
 mod tests {
     use crate::conversation::message::Message;
-    use crate::conversation::{debug_conversation_fix, fix_conversation, Conversation};
+    use crate::conversation::{
+        debug_conversation_fix, fix_conversation, merge_consecutive_messages, Conversation,
+    };
     use rmcp::model::{CallToolRequestParams, Role};
     use rmcp::object;
+
+    #[test]
+    fn merge_consecutive_messages_keeps_different_visibility_separate() {
+        let hidden_hint = Message::user()
+            .with_text("hidden hint")
+            .with_visibility(false, true);
+        let visible_prompt = Message::user().with_text("visible prompt");
+
+        let (messages, issues) = merge_consecutive_messages(vec![hidden_hint, visible_prompt]);
+
+        assert_eq!(messages.len(), 2);
+        assert!(!messages[0].is_user_visible());
+        assert!(messages[0].is_agent_visible());
+        assert_eq!(messages[0].as_concat_text(), "hidden hint");
+        assert!(messages[1].is_user_visible());
+        assert!(messages[1].is_agent_visible());
+        assert_eq!(messages[1].as_concat_text(), "visible prompt");
+        assert!(issues.is_empty());
+    }
 
     macro_rules! assert_has_issues_unordered {
         ($fixed:expr, $issues:expr, $($expected:expr),+ $(,)?) => {

--- a/crates/goose-provider-types/src/formats/google.rs
+++ b/crates/goose-provider-types/src/formats/google.rs
@@ -34,6 +34,7 @@ pub fn get_thought_signature(metadata: &Option<ProviderMetadata>) -> Option<&str
 
 fn is_user_loop_boundary(message: &Message) -> bool {
     message.role == Role::User
+        && message.is_user_visible()
         && message
             .content
             .iter()
@@ -1108,6 +1109,39 @@ mod tests {
         assert!(
             final_native_no_sig.content[0].as_text().is_some(),
             "Text without signature is regular text"
+        );
+    }
+
+    #[test]
+    fn test_agent_only_user_message_preserves_active_tool_loop_signatures() {
+        const SIG: &str = "thought_sig_abc";
+
+        let user_prompt = set_up_text_message("List files", Role::User);
+        let assistant = response_to_message(google_response(vec![json!({
+            "functionCall": {"name": "shell", "args": {"cmd": "ls"}},
+            "thoughtSignature": SIG
+        })]))
+        .unwrap();
+        let request = assistant.content[0]
+            .as_tool_request()
+            .expect("assistant tool request");
+        let mut tool_response = Message::user();
+        tool_response.add_tool_response_with_metadata(
+            request.id.clone(),
+            Ok(tool_result("output")),
+            request.metadata.as_ref(),
+        );
+        let hidden_hint = Message::user()
+            .with_text("agent-only subdirectory hint")
+            .with_visibility(false, true);
+
+        let formatted = format_messages(&[user_prompt, assistant, tool_response, hidden_hint]);
+
+        assert_eq!(formatted[1]["parts"][0]["thoughtSignature"], SIG);
+        assert_eq!(formatted[2]["parts"][0]["thoughtSignature"], SIG);
+        assert_eq!(
+            formatted[3]["parts"][0]["text"],
+            "agent-only subdirectory hint"
         );
     }
 

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1824,6 +1824,11 @@ impl Agent {
         session: Session,
         cancel_token: Option<CancellationToken>,
     ) -> Result<BoxStream<'_, Result<AgentEvent>>> {
+        self.prompt_manager
+            .lock()
+            .await
+            .record_loaded_subdirectory_hints(conversation.messages());
+
         let context = self
             .prepare_reply_context(&session.id, conversation, session.working_dir.as_path())
             .await?;
@@ -2539,16 +2544,13 @@ impl Agent {
                         self.prepare_tools_and_prompt(&session_config.id, &session.working_dir).await?;
                 }
 
+                for message in self
+                    .prompt_manager
+                    .lock()
+                    .await
+                    .load_subdirectory_hints(&working_dir)
                 {
-                    let has_new_hints = self
-                        .prompt_manager
-                        .lock()
-                        .await
-                        .load_subdirectory_hints(&working_dir);
-                    if has_new_hints && !tools_updated {
-                        (tools, toolshim_tools, system_prompt, _) =
-                            self.prepare_tools_and_prompt(&session_config.id, &session.working_dir).await?;
-                    }
+                    messages_to_add.push(message);
                 }
 
                 if no_tools_called && !exit_chat {

--- a/crates/goose/src/agents/platform_extensions/chatrecall.rs
+++ b/crates/goose/src/agents/platform_extensions/chatrecall.rs
@@ -92,7 +92,12 @@ impl ChatRecallClient {
                         ))]);
                     }
 
-                    let msgs = conversation.unwrap().messages();
+                    let msgs: Vec<_> = conversation
+                        .unwrap()
+                        .messages()
+                        .iter()
+                        .filter(|msg| msg.metadata.user_visible)
+                        .collect();
                     let total = msgs.len();
 
                     if total == 0 {

--- a/crates/goose/src/agents/platform_extensions/orchestrator.rs
+++ b/crates/goose/src/agents/platform_extensions/orchestrator.rs
@@ -263,7 +263,8 @@ impl OrchestratorClient {
             .session_manager
             .get_session(&session_id, true)
             .await
-            .map_err(|e| format!("Session '{}' not found: {}", session_id, e))?;
+            .map_err(|e| format!("Session '{}' not found: {}", session_id, e))?
+            .into_share_safe_export();
 
         let manager = self.get_agent_manager().await?;
         let is_busy = manager.is_session_busy(&session_id).await;

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -255,7 +255,10 @@ impl PromptManager {
             .into_iter()
             .map(|(key, content)| {
                 Message::user()
-                    .with_text(format_subdirectory_hint_message_text(&key, &content))
+                    .with_text(format_subdirectory_hint_message_text(
+                        &key,
+                        &sanitize_unicode_tags(&content),
+                    ))
                     .with_visibility(false, true)
             })
             .collect()
@@ -393,7 +396,7 @@ mod tests {
         std::fs::create_dir_all(&subdir).unwrap();
         std::fs::write(
             subdir.join(".goosehints"),
-            "Prefer subdirectory local rules",
+            "Prefer\u{E0041} subdirectory local rules",
         )
         .unwrap();
 
@@ -419,6 +422,7 @@ mod tests {
         assert!(hint_messages[0]
             .as_concat_text()
             .contains("Prefer subdirectory local rules"));
+        assert!(!hint_messages[0].as_concat_text().contains('\u{E0041}'));
 
         let mut resumed = PromptManager::new();
         resumed.record_loaded_subdirectory_hints(&hint_messages);

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -255,9 +255,8 @@ impl PromptManager {
             .into_iter()
             .map(|(key, content)| {
                 Message::user()
-                    .with_text(format_subdirectory_hint_message_text(
-                        &key,
-                        &sanitize_unicode_tags(&content),
+                    .with_text(sanitize_unicode_tags(
+                        &format_subdirectory_hint_message_text(&key, &content),
                     ))
                     .with_visibility(false, true)
             })
@@ -392,7 +391,8 @@ mod tests {
     #[test]
     fn test_subdirectory_hints_are_agent_only_and_resume_deduped() {
         let workdir = tempfile::tempdir().unwrap();
-        let subdir = workdir.path().join("sub");
+        let subdir_name = "sub\u{E0041}";
+        let subdir = workdir.path().join(subdir_name);
         std::fs::create_dir_all(&subdir).unwrap();
         std::fs::write(
             subdir.join(".goosehints"),
@@ -403,7 +403,7 @@ mod tests {
         let mut args = serde_json::Map::new();
         args.insert(
             "path".to_string(),
-            serde_json::Value::String("sub/file.rs".to_string()),
+            serde_json::Value::String(format!("{subdir_name}/file.rs")),
         );
 
         let mut manager = PromptManager::new();

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -8,9 +8,13 @@ use std::collections::HashMap;
 
 use crate::agents::{extension::ExtensionInfo, moim};
 use crate::hints::load_hints::build_gitignore;
-use crate::hints::{get_context_filenames, load_hint_files, SubdirectoryHintTracker};
+use crate::hints::{
+    format_subdirectory_hint_message_text, get_context_filenames, load_hint_files,
+    SubdirectoryHintTracker,
+};
 use crate::{
     config::{Config, GooseMode},
+    conversation::message::Message,
     prompt_template,
     utils::sanitize_unicode_tags,
 };
@@ -240,13 +244,21 @@ impl PromptManager {
             .record_tool_arguments(arguments, working_dir);
     }
 
-    pub fn load_subdirectory_hints(&mut self, working_dir: &Path) -> bool {
+    pub fn record_loaded_subdirectory_hints(&mut self, messages: &[Message]) {
+        self.subdirectory_hint_tracker
+            .record_loaded_hints_from_messages(messages);
+    }
+
+    pub fn load_subdirectory_hints(&mut self, working_dir: &Path) -> Vec<Message> {
         let new_hints = self.subdirectory_hint_tracker.load_new_hints(working_dir);
-        let has_new = !new_hints.is_empty();
-        for (key, content) in new_hints {
-            self.system_prompt_extras.insert(key, content);
-        }
-        has_new
+        new_hints
+            .into_iter()
+            .map(|(key, content)| {
+                Message::user()
+                    .with_text(format_subdirectory_hint_message_text(&key, &content))
+                    .with_visibility(false, true)
+            })
+            .collect()
     }
 
     /// Override the system prompt with custom text
@@ -372,6 +384,50 @@ mod tests {
         assert!(result.contains("🌍"));
         assert!(result.contains("Instruction with"));
         assert!(result.contains("emojis"));
+    }
+
+    #[test]
+    fn test_subdirectory_hints_are_agent_only_and_resume_deduped() {
+        let workdir = tempfile::tempdir().unwrap();
+        let subdir = workdir.path().join("sub");
+        std::fs::create_dir_all(&subdir).unwrap();
+        std::fs::write(
+            subdir.join(".goosehints"),
+            "Prefer subdirectory local rules",
+        )
+        .unwrap();
+
+        let mut args = serde_json::Map::new();
+        args.insert(
+            "path".to_string(),
+            serde_json::Value::String("sub/file.rs".to_string()),
+        );
+
+        let mut manager = PromptManager::new();
+        manager.record_tool_arguments(&Some(args.clone()), workdir.path());
+        let hint_messages = manager.load_subdirectory_hints(workdir.path());
+
+        assert_eq!(hint_messages.len(), 1);
+        assert!(
+            !hint_messages[0].is_user_visible(),
+            "subdirectory hints should not be replayed into the visible transcript"
+        );
+        assert!(
+            hint_messages[0].is_agent_visible(),
+            "subdirectory hints must remain visible to the next model call"
+        );
+        assert!(hint_messages[0]
+            .as_concat_text()
+            .contains("Prefer subdirectory local rules"));
+
+        let mut resumed = PromptManager::new();
+        resumed.record_loaded_subdirectory_hints(&hint_messages);
+        resumed.record_tool_arguments(&Some(args), workdir.path());
+
+        assert!(
+            resumed.load_subdirectory_hints(workdir.path()).is_empty(),
+            "resume should rebuild the loaded directory set from prior hint marker messages"
+        );
     }
 
     #[test]

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -246,7 +246,7 @@ impl PromptManager {
 
     pub fn record_loaded_subdirectory_hints(&mut self, messages: &[Message]) {
         self.subdirectory_hint_tracker
-            .record_loaded_hints_from_messages(messages);
+            .sync_loaded_hints_from_messages(messages);
     }
 
     pub fn load_subdirectory_hints(&mut self, working_dir: &Path) -> Vec<Message> {

--- a/crates/goose/src/agents/schedule_tool.rs
+++ b/crates/goose/src/agents/schedule_tool.rs
@@ -442,7 +442,7 @@ impl Agent {
             .get_session(session_id, true)
             .await
         {
-            Ok(metadata) => metadata,
+            Ok(metadata) => metadata.into_share_safe_export(),
             Err(e) => {
                 return Err(ErrorData::new(
                     ErrorCode::INTERNAL_ERROR,

--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -1,6 +1,7 @@
 use crate::conversation::message::{ActionRequiredData, MessageMetadata};
 use crate::conversation::message::{Message, MessageContent};
 use crate::conversation::{merge_consecutive_messages, Conversation};
+use crate::hints::is_subdirectory_hint_message;
 use crate::prompt_template::render_template;
 use crate::providers::base::Provider;
 #[cfg(test)]
@@ -140,7 +141,9 @@ pub async fn compact_messages(
     let mut final_messages = Vec::new();
 
     for (idx, msg) in messages_to_compact.iter().enumerate() {
-        let updated_metadata = if is_most_recent
+        let updated_metadata = if is_subdirectory_hint_message(msg) {
+            msg.metadata.clone()
+        } else if is_most_recent
             && idx == messages_to_compact.len() - 1
             && preserved_user_message.is_some()
         {
@@ -602,6 +605,8 @@ mod tests {
     use async_trait::async_trait;
     use goose_providers::conversation::token_usage::Usage;
     use rmcp::model::{AnnotateAble, CallToolRequestParams, RawContent, Tool};
+    use std::fs;
+    use tempfile::TempDir;
 
     fn create_tool_pair(
         call_id: &str,
@@ -740,13 +745,23 @@ mod tests {
     async fn test_hidden_user_messages_are_not_promoted_by_compaction() {
         let response_message = Message::assistant().with_text("<mock summary>");
         let provider = MockProvider::new(response_message, 1);
-        let hidden_hint =
-            "GOOSE_SUBDIRECTORY_HINT_MARKER=subdir_hints:/tmp/project/sub\nSecret hint";
+        let workdir = TempDir::new().unwrap();
+        let subdir = workdir.path().join("sub");
+        fs::create_dir_all(&subdir).unwrap();
+        fs::write(
+            subdir.join(crate::hints::GOOSE_HINTS_FILENAME),
+            "Secret hint",
+        )
+        .unwrap();
+        let hidden_hint = crate::hints::format_subdirectory_hint_message_text(
+            &format!("subdir_hints:{}", subdir.display()),
+            "Secret hint",
+        );
         let basic_conversation = vec![
             Message::user().with_text("visible task"),
             Message::assistant().with_text("assistant context"),
             Message::user()
-                .with_text(hidden_hint)
+                .with_text(&hidden_hint)
                 .with_visibility(false, true),
         ];
 
@@ -783,6 +798,27 @@ mod tests {
                 .any(|text| text.contains("GOOSE_SUBDIRECTORY_HINT_MARKER")
                     || text.contains("Secret hint")),
             "hidden agent instructions must not become user-visible after compaction"
+        );
+
+        let preserved_hint = compacted_conversation
+            .messages()
+            .iter()
+            .find(|message| is_subdirectory_hint_message(message))
+            .expect("compaction should retain the subdirectory hint marker");
+        assert!(!preserved_hint.is_user_visible());
+        assert!(preserved_hint.is_agent_visible());
+
+        let mut resumed_tracker = crate::hints::SubdirectoryHintTracker::new();
+        resumed_tracker.record_loaded_hints_from_messages(compacted_conversation.messages());
+        let mut args = serde_json::Map::new();
+        args.insert(
+            "path".to_string(),
+            serde_json::Value::String("sub/file.rs".to_string()),
+        );
+        resumed_tracker.record_tool_arguments(&Some(args), workdir.path());
+        assert!(
+            resumed_tracker.load_new_hints(workdir.path()).is_empty(),
+            "the preserved marker should prevent duplicate hint injection after resume"
         );
     }
 

--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -301,7 +301,7 @@ async fn do_compact(
 ) -> Result<(Message, ProviderUsage), anyhow::Error> {
     let agent_visible_messages: Vec<Message> = messages
         .iter()
-        .filter(|msg| msg.is_agent_visible())
+        .filter(|msg| msg.is_agent_visible() && !is_subdirectory_hint_message(msg))
         .map(|msg| msg.agent_visible_content())
         .collect();
 
@@ -636,6 +636,7 @@ mod tests {
         message: Message,
         config: ModelConfig,
         max_tool_responses: Option<usize>,
+        forbidden_system_text: Option<String>,
     }
 
     impl MockProvider {
@@ -653,11 +654,17 @@ mod tests {
                     reasoning: None,
                 },
                 max_tool_responses: None,
+                forbidden_system_text: None,
             }
         }
 
         fn with_max_tool_responses(mut self, max: usize) -> Self {
             self.max_tool_responses = Some(max);
+            self
+        }
+
+        fn without_system_text(mut self, text: impl Into<String>) -> Self {
+            self.forbidden_system_text = Some(text.into());
             self
         }
     }
@@ -671,10 +678,16 @@ mod tests {
         async fn stream(
             &self,
             _model_config: &ModelConfig,
-            _system: &str,
+            system: &str,
             messages: &[Message],
             _tools: &[Tool],
         ) -> Result<MessageStream, ProviderError> {
+            if let Some(forbidden) = &self.forbidden_system_text {
+                assert!(
+                    !system.contains(forbidden),
+                    "compaction system prompt unexpectedly contained {forbidden:?}"
+                );
+            }
             // If max_tool_responses is set, fail if we have too many
             if let Some(max) = self.max_tool_responses {
                 let tool_response_count = messages
@@ -744,7 +757,7 @@ mod tests {
     #[tokio::test]
     async fn test_hidden_user_messages_are_not_promoted_by_compaction() {
         let response_message = Message::assistant().with_text("<mock summary>");
-        let provider = MockProvider::new(response_message, 1);
+        let provider = MockProvider::new(response_message, 1).without_system_text("Secret hint");
         let workdir = TempDir::new().unwrap();
         let subdir = workdir.path().join("sub");
         fs::create_dir_all(&subdir).unwrap();

--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -112,7 +112,8 @@ pub async fn compact_messages(
     // Find and preserve the most recent user message for non-manual compacts
     let (preserved_user_message, is_most_recent) = if !manual_compact {
         let found_msg = messages.iter().enumerate().rev().find(|(_, msg)| {
-            msg.is_agent_visible()
+            msg.is_user_visible()
+                && msg.is_agent_visible()
                 && matches!(msg.role, rmcp::model::Role::User)
                 && has_text_only(msg)
         });
@@ -733,6 +734,56 @@ mod tests {
 
         let _ = Conversation::new(agent_conversation)
             .expect("compaction should produce a valid conversation");
+    }
+
+    #[tokio::test]
+    async fn test_hidden_user_messages_are_not_promoted_by_compaction() {
+        let response_message = Message::assistant().with_text("<mock summary>");
+        let provider = MockProvider::new(response_message, 1);
+        let hidden_hint =
+            "GOOSE_SUBDIRECTORY_HINT_MARKER=subdir_hints:/tmp/project/sub\nSecret hint";
+        let basic_conversation = vec![
+            Message::user().with_text("visible task"),
+            Message::assistant().with_text("assistant context"),
+            Message::user()
+                .with_text(hidden_hint)
+                .with_visibility(false, true),
+        ];
+
+        let conversation = Conversation::new_unvalidated(basic_conversation);
+        let model_config = provider.config.clone();
+        let (compacted_conversation, _usage) = compact_messages(
+            &provider,
+            &model_config,
+            "test-session-id",
+            &conversation,
+            false,
+        )
+        .await
+        .unwrap();
+
+        let visible_text = compacted_conversation
+            .messages()
+            .iter()
+            .filter(|message| message.is_user_visible())
+            .flat_map(|message| message.content.iter())
+            .filter_map(|content| match content {
+                MessageContent::Text(text) => Some(text.text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert!(
+            visible_text.contains(&"visible task"),
+            "compaction should preserve the last visible user text"
+        );
+        assert!(
+            !visible_text
+                .iter()
+                .any(|text| text.contains("GOOSE_SUBDIRECTORY_HINT_MARKER")
+                    || text.contains("Secret hint")),
+            "hidden agent instructions must not become user-visible after compaction"
+        );
     }
 
     #[tokio::test]

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -7,6 +7,7 @@ use std::{
 use crate::config::paths::Paths;
 use crate::conversation::message::{Message, MessageContent};
 use crate::hints::import_files::read_referenced_files;
+use crate::utils::sanitize_unicode_tags;
 
 pub const GOOSE_HINTS_FILENAME: &str = ".goosehints";
 pub const AGENTS_MD_FILENAME: &str = "AGENTS.md";
@@ -85,7 +86,8 @@ impl SubdirectoryHintTracker {
             if !dir.starts_with(&working_dir) || dir == working_dir {
                 continue;
             }
-            if self.loaded_dirs.contains(&dir) {
+            let identity = normalize_hint_identity(&dir);
+            if self.loaded_dirs.contains(&identity) {
                 continue;
             }
             if let Some(content) =
@@ -94,7 +96,7 @@ impl SubdirectoryHintTracker {
                 let key = subdirectory_hint_key(&dir);
                 results.push((key, content));
             }
-            self.loaded_dirs.insert(dir);
+            self.loaded_dirs.insert(identity);
         }
         results
     }
@@ -140,7 +142,16 @@ pub fn contains_subdirectory_hint_marker(message: &Message) -> bool {
 }
 
 fn subdirectory_hint_key(dir: &Path) -> String {
-    format!("{SUBDIRECTORY_HINT_KEY_PREFIX}{}", dir.display())
+    format!(
+        "{SUBDIRECTORY_HINT_KEY_PREFIX}{}",
+        normalize_hint_identity(dir).display()
+    )
+}
+
+fn normalize_hint_identity(path: &Path) -> PathBuf {
+    PathBuf::from(sanitize_unicode_tags(
+        &normalize_dir(path).to_string_lossy(),
+    ))
 }
 
 fn subdirectory_hint_dir_from_text(text: &str) -> Option<PathBuf> {

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -116,6 +116,11 @@ impl SubdirectoryHintTracker {
             }
         }
     }
+
+    pub fn sync_loaded_hints_from_messages(&mut self, messages: &[Message]) {
+        self.loaded_dirs.clear();
+        self.record_loaded_hints_from_messages(messages);
+    }
 }
 
 pub fn format_subdirectory_hint_message_text(key: &str, content: &str) -> String {
@@ -460,6 +465,42 @@ mod tests {
             resumed_tracker.load_new_hints(workdir.path()).len(),
             1,
             "fully invisible archived markers should not suppress a fresh hint load"
+        );
+    }
+
+    #[test]
+    fn subdirectory_hint_tracker_syncs_loaded_dirs_to_replaced_history() {
+        let workdir = TempDir::new().unwrap();
+        let subdir = workdir.path().join("sub");
+        fs::create_dir_all(&subdir).unwrap();
+        fs::write(subdir.join(GOOSE_HINTS_FILENAME), "Subdirectory rule").unwrap();
+
+        let mut args = serde_json::Map::new();
+        args.insert(
+            "path".to_string(),
+            serde_json::Value::String("sub/file.rs".to_string()),
+        );
+
+        let mut tracker = SubdirectoryHintTracker::new();
+        tracker.record_tool_arguments(&Some(args.clone()), workdir.path());
+        let (key, content) = tracker.load_new_hints(workdir.path()).remove(0);
+        let marker = Message::user()
+            .with_text(format_subdirectory_hint_message_text(&key, &content))
+            .with_visibility(false, true);
+
+        tracker.sync_loaded_hints_from_messages(&[]);
+        tracker.record_tool_arguments(&Some(args.clone()), workdir.path());
+        assert_eq!(
+            tracker.load_new_hints(workdir.path()).len(),
+            1,
+            "clearing history should allow its removed subdirectory hint to load again"
+        );
+
+        tracker.sync_loaded_hints_from_messages(&[marker]);
+        tracker.record_tool_arguments(&Some(args), workdir.path());
+        assert!(
+            tracker.load_new_hints(workdir.path()).is_empty(),
+            "replacing history with a retained marker should keep suppressing duplicates"
         );
     }
 

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -127,6 +127,10 @@ pub fn is_subdirectory_hint_message(message: &Message) -> bool {
     {
         return false;
     }
+    contains_subdirectory_hint_marker(message)
+}
+
+pub fn contains_subdirectory_hint_marker(message: &Message) -> bool {
     message.content.iter().any(|content| {
         let MessageContent::Text(text) = content else {
             return false;

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -5,10 +5,13 @@ use std::{
 };
 
 use crate::config::paths::Paths;
+use crate::conversation::message::{Message, MessageContent};
 use crate::hints::import_files::read_referenced_files;
 
 pub const GOOSE_HINTS_FILENAME: &str = ".goosehints";
 pub const AGENTS_MD_FILENAME: &str = "AGENTS.md";
+const SUBDIRECTORY_HINT_KEY_PREFIX: &str = "subdir_hints:";
+const SUBDIRECTORY_HINT_MARKER_PREFIX: &str = "GOOSE_SUBDIRECTORY_HINT_MARKER=";
 
 pub fn get_context_filenames() -> Vec<String> {
     use crate::config::Config;
@@ -75,24 +78,65 @@ impl SubdirectoryHintTracker {
             return Vec::new();
         }
 
+        let working_dir = normalize_dir(working_dir);
         let mut results = Vec::new();
         for dir in pending {
-            if !dir.starts_with(working_dir) || dir == working_dir {
+            let dir = normalize_dir(&dir);
+            if !dir.starts_with(&working_dir) || dir == working_dir {
                 continue;
             }
             if self.loaded_dirs.contains(&dir) {
                 continue;
             }
             if let Some(content) =
-                load_hints_from_directory(&dir, working_dir, &self.hints_filenames)
+                load_hints_from_directory(&dir, &working_dir, &self.hints_filenames)
             {
-                let key = format!("subdir_hints:{}", dir.display());
+                let key = subdirectory_hint_key(&dir);
                 results.push((key, content));
             }
             self.loaded_dirs.insert(dir);
         }
         results
     }
+
+    pub fn record_loaded_hints_from_messages(&mut self, messages: &[Message]) {
+        for message in messages {
+            if message.is_user_visible() || !message.is_agent_visible() {
+                continue;
+            }
+            for content in &message.content {
+                let MessageContent::Text(text) = content else {
+                    continue;
+                };
+                if let Some(dir) = subdirectory_hint_dir_from_text(&text.text) {
+                    self.loaded_dirs.insert(dir);
+                }
+            }
+        }
+    }
+}
+
+pub fn format_subdirectory_hint_message_text(key: &str, content: &str) -> String {
+    format!("{SUBDIRECTORY_HINT_MARKER_PREFIX}{key}\n{content}")
+}
+
+fn subdirectory_hint_key(dir: &Path) -> String {
+    format!("{SUBDIRECTORY_HINT_KEY_PREFIX}{}", dir.display())
+}
+
+fn subdirectory_hint_dir_from_text(text: &str) -> Option<PathBuf> {
+    let key = text
+        .lines()
+        .find_map(|line| line.strip_prefix(SUBDIRECTORY_HINT_MARKER_PREFIX))?;
+    let dir = key.strip_prefix(SUBDIRECTORY_HINT_KEY_PREFIX)?;
+    if dir.is_empty() {
+        return None;
+    }
+    Some(normalize_dir(Path::new(dir)))
+}
+
+fn normalize_dir(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
 }
 
 fn resolve_to_parent_dir(token: &str, working_dir: &Path) -> Option<PathBuf> {
@@ -325,6 +369,68 @@ mod tests {
         let hints = load_hint_files(dir.path(), &[GOOSE_HINTS_FILENAME.to_string()], &gitignore);
 
         assert!(hints.contains("Test hint content"));
+    }
+
+    #[test]
+    fn subdirectory_hint_tracker_rehydrates_loaded_dirs_from_messages() {
+        let workdir = TempDir::new().unwrap();
+        let subdir = workdir.path().join("sub");
+        fs::create_dir_all(&subdir).unwrap();
+        fs::write(subdir.join(GOOSE_HINTS_FILENAME), "Subdirectory rule").unwrap();
+
+        let mut args = serde_json::Map::new();
+        args.insert(
+            "path".to_string(),
+            serde_json::Value::String("sub/file.rs".to_string()),
+        );
+
+        let mut tracker = SubdirectoryHintTracker::new();
+        tracker.record_tool_arguments(&Some(args.clone()), workdir.path());
+        let loaded = tracker.load_new_hints(workdir.path());
+        assert_eq!(loaded.len(), 1);
+
+        let (key, content) = loaded.into_iter().next().unwrap();
+        let message = Message::user()
+            .with_text(format_subdirectory_hint_message_text(&key, &content))
+            .with_visibility(false, true);
+
+        let mut resumed_tracker = SubdirectoryHintTracker::new();
+        resumed_tracker.record_loaded_hints_from_messages(&[message]);
+        resumed_tracker.record_tool_arguments(&Some(args), workdir.path());
+
+        assert!(
+            resumed_tracker.load_new_hints(workdir.path()).is_empty(),
+            "a resumed tracker should not reinject a directory already marked in conversation history"
+        );
+    }
+
+    #[test]
+    fn subdirectory_hint_tracker_ignores_fully_invisible_markers() {
+        let workdir = TempDir::new().unwrap();
+        let subdir = workdir.path().join("sub");
+        fs::create_dir_all(&subdir).unwrap();
+        fs::write(subdir.join(GOOSE_HINTS_FILENAME), "Subdirectory rule").unwrap();
+
+        let mut args = serde_json::Map::new();
+        args.insert(
+            "path".to_string(),
+            serde_json::Value::String("sub/file.rs".to_string()),
+        );
+
+        let key = subdirectory_hint_key(&subdir);
+        let message = Message::user()
+            .with_text(format_subdirectory_hint_message_text(&key, "Archived hint"))
+            .with_visibility(false, false);
+
+        let mut resumed_tracker = SubdirectoryHintTracker::new();
+        resumed_tracker.record_loaded_hints_from_messages(&[message]);
+        resumed_tracker.record_tool_arguments(&Some(args), workdir.path());
+
+        assert_eq!(
+            resumed_tracker.load_new_hints(workdir.path()).len(),
+            1,
+            "fully invisible archived markers should not suppress a fresh hint load"
+        );
     }
 
     #[test]

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -120,6 +120,21 @@ pub fn format_subdirectory_hint_message_text(key: &str, content: &str) -> String
     format!("{SUBDIRECTORY_HINT_MARKER_PREFIX}{key}\n{content}")
 }
 
+pub fn is_subdirectory_hint_message(message: &Message) -> bool {
+    if message.role != rmcp::model::Role::User
+        || message.is_user_visible()
+        || !message.is_agent_visible()
+    {
+        return false;
+    }
+    message.content.iter().any(|content| {
+        let MessageContent::Text(text) = content else {
+            return false;
+        };
+        subdirectory_hint_dir_from_text(&text.text).is_some()
+    })
+}
+
 fn subdirectory_hint_key(dir: &Path) -> String {
     format!("{SUBDIRECTORY_HINT_KEY_PREFIX}{}", dir.display())
 }

--- a/crates/goose/src/hints/mod.rs
+++ b/crates/goose/src/hints/mod.rs
@@ -2,6 +2,6 @@ mod import_files;
 pub mod load_hints;
 
 pub use load_hints::{
-    build_gitignore, get_context_filenames, load_hint_files, SubdirectoryHintTracker,
-    AGENTS_MD_FILENAME, GOOSE_HINTS_FILENAME,
+    build_gitignore, format_subdirectory_hint_message_text, get_context_filenames, load_hint_files,
+    SubdirectoryHintTracker, AGENTS_MD_FILENAME, GOOSE_HINTS_FILENAME,
 };

--- a/crates/goose/src/hints/mod.rs
+++ b/crates/goose/src/hints/mod.rs
@@ -2,7 +2,7 @@ mod import_files;
 pub mod load_hints;
 
 pub use load_hints::{
-    build_gitignore, format_subdirectory_hint_message_text, get_context_filenames,
-    is_subdirectory_hint_message, load_hint_files, SubdirectoryHintTracker, AGENTS_MD_FILENAME,
-    GOOSE_HINTS_FILENAME,
+    build_gitignore, contains_subdirectory_hint_marker, format_subdirectory_hint_message_text,
+    get_context_filenames, is_subdirectory_hint_message, load_hint_files, SubdirectoryHintTracker,
+    AGENTS_MD_FILENAME, GOOSE_HINTS_FILENAME,
 };

--- a/crates/goose/src/hints/mod.rs
+++ b/crates/goose/src/hints/mod.rs
@@ -2,6 +2,7 @@ mod import_files;
 pub mod load_hints;
 
 pub use load_hints::{
-    build_gitignore, format_subdirectory_hint_message_text, get_context_filenames, load_hint_files,
-    SubdirectoryHintTracker, AGENTS_MD_FILENAME, GOOSE_HINTS_FILENAME,
+    build_gitignore, format_subdirectory_hint_message_text, get_context_filenames,
+    is_subdirectory_hint_message, load_hint_files, SubdirectoryHintTracker, AGENTS_MD_FILENAME,
+    GOOSE_HINTS_FILENAME,
 };

--- a/crates/goose/src/session/chat_history_search.rs
+++ b/crates/goose/src/session/chat_history_search.rs
@@ -160,6 +160,7 @@ impl<'a> ChatHistorySearch<'a> {
             r#"
                 )
             )
+            AND COALESCE(json_extract(m.metadata_json, '$.userVisible'), 1) != 0
         "#,
         );
 

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -373,6 +373,7 @@ fn message_keyword_clause(keyword_count: usize) -> String {
             SELECT 1
             FROM messages mq
             WHERE mq.session_id = s.id
+              AND COALESCE(json_extract(mq.metadata_json, '$.userVisible'), 1) != 0
               AND EXISTS (
                   SELECT 1
                   FROM json_each(mq.content_json)
@@ -3365,6 +3366,66 @@ mod tests {
 
         assert_eq!(ids, vec![target]);
         assert!(page.next_cursor.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_session_list_paged_keyword_ignores_agent_only_messages() {
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+        let session_id = create_session_for_list_with_message(
+            &sm,
+            "/tmp/session-list",
+            "Visible session content",
+        )
+        .await;
+        sm.add_message(
+            &session_id,
+            &Message::user()
+                .with_text("private-subdirectory-marker")
+                .with_visibility(false, true),
+        )
+        .await
+        .unwrap();
+
+        let types = [SessionType::User];
+        let hidden_page = sm
+            .list_sessions_paged(SessionListPageQuery {
+                filters: SessionListFilters {
+                    types: Some(&types),
+                    keyword: Some("private-subdirectory-marker"),
+                    only_sessions_with_messages: true,
+                    ..Default::default()
+                },
+                cursor: None,
+                page_size: 10,
+                include_last_message_snippet: false,
+            })
+            .await
+            .unwrap();
+        assert!(hidden_page.sessions.is_empty());
+
+        let visible_page = sm
+            .list_sessions_paged(SessionListPageQuery {
+                filters: SessionListFilters {
+                    types: Some(&types),
+                    keyword: Some("visible"),
+                    only_sessions_with_messages: true,
+                    ..Default::default()
+                },
+                cursor: None,
+                page_size: 10,
+                include_last_message_snippet: false,
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            visible_page
+                .sessions
+                .iter()
+                .map(|session| session.id.as_str())
+                .collect::<Vec<_>>(),
+            vec![session_id.as_str()]
+        );
     }
 
     #[tokio::test]

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -104,7 +104,7 @@ impl Session {
             let messages = conversation
                 .messages()
                 .iter()
-                .filter(|message| !crate::hints::is_subdirectory_hint_message(message))
+                .filter(|message| !crate::hints::contains_subdirectory_hint_marker(message))
                 .cloned()
                 .collect::<Vec<_>>();
             self.message_count = messages.len();
@@ -3793,6 +3793,17 @@ mod tests {
 
         sm.add_message(
             &original.id,
+            &Message::user()
+                .with_text(
+                    "GOOSE_SUBDIRECTORY_HINT_MARKER=subdir_hints:/tmp/test/archived\nlegacy instruction",
+                )
+                .with_visibility(false, false),
+        )
+        .await
+        .unwrap();
+
+        sm.add_message(
+            &original.id,
             &Message::assistant()
                 .with_text("compaction summary")
                 .with_visibility(false, true),
@@ -3803,6 +3814,7 @@ mod tests {
         let exported = sm.export_session(&original.id).await.unwrap();
         assert!(!exported.contains("GOOSE_SUBDIRECTORY_HINT_MARKER"));
         assert!(!exported.contains("secret"));
+        assert!(!exported.contains("legacy instruction"));
         assert!(exported.contains("compaction summary"));
         let imported = sm.import_session(&exported, None).await.unwrap();
 

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -98,6 +98,22 @@ pub struct Session {
     pub last_message_snippet: Option<String>,
 }
 
+impl Session {
+    pub fn into_user_visible_export(mut self) -> Self {
+        if let Some(conversation) = self.conversation.take() {
+            let messages = conversation
+                .messages()
+                .iter()
+                .filter(|message| message.is_user_visible())
+                .cloned()
+                .collect::<Vec<_>>();
+            self.message_count = messages.len();
+            self.conversation = Some(Conversation::new_unvalidated(messages));
+        }
+        self
+    }
+}
+
 impl From<&Session> for TokenState {
     fn from(session: &Session) -> Self {
         Self {
@@ -2264,7 +2280,7 @@ impl SessionStorage {
     }
 
     async fn export_session(&self, id: &str) -> Result<String> {
-        let session = self.get_session(id, true).await?;
+        let session = self.get_session(id, true).await?.into_user_visible_export();
         serde_json::to_string_pretty(&session).map_err(Into::into)
     }
 
@@ -3766,7 +3782,18 @@ mod tests {
         .await
         .unwrap();
 
+        sm.add_message(
+            &original.id,
+            &Message::user()
+                .with_text("GOOSE_SUBDIRECTORY_HINT_MARKER=subdir_hints:/tmp/test/sub\nsecret")
+                .with_visibility(false, true),
+        )
+        .await
+        .unwrap();
+
         let exported = sm.export_session(&original.id).await.unwrap();
+        assert!(!exported.contains("GOOSE_SUBDIRECTORY_HINT_MARKER"));
+        assert!(!exported.contains("secret"));
         let imported = sm.import_session(&exported, None).await.unwrap();
 
         assert_ne!(imported.id, original.id);

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -99,12 +99,12 @@ pub struct Session {
 }
 
 impl Session {
-    pub fn into_user_visible_export(mut self) -> Self {
+    pub fn into_share_safe_export(mut self) -> Self {
         if let Some(conversation) = self.conversation.take() {
             let messages = conversation
                 .messages()
                 .iter()
-                .filter(|message| message.is_user_visible())
+                .filter(|message| !crate::hints::is_subdirectory_hint_message(message))
                 .cloned()
                 .collect::<Vec<_>>();
             self.message_count = messages.len();
@@ -2280,7 +2280,7 @@ impl SessionStorage {
     }
 
     async fn export_session(&self, id: &str) -> Result<String> {
-        let session = self.get_session(id, true).await?.into_user_visible_export();
+        let session = self.get_session(id, true).await?.into_share_safe_export();
         serde_json::to_string_pretty(&session).map_err(Into::into)
     }
 
@@ -3791,9 +3791,19 @@ mod tests {
         .await
         .unwrap();
 
+        sm.add_message(
+            &original.id,
+            &Message::assistant()
+                .with_text("compaction summary")
+                .with_visibility(false, true),
+        )
+        .await
+        .unwrap();
+
         let exported = sm.export_session(&original.id).await.unwrap();
         assert!(!exported.contains("GOOSE_SUBDIRECTORY_HINT_MARKER"));
         assert!(!exported.contains("secret"));
+        assert!(exported.contains("compaction summary"));
         let imported = sm.import_session(&exported, None).await.unwrap();
 
         assert_ne!(imported.id, original.id);
@@ -3801,12 +3811,24 @@ mod tests {
         assert_eq!(imported.working_dir, PathBuf::from("/tmp/test"));
         assert_eq!(imported.usage, usage);
         assert_eq!(imported.accumulated_usage, accumulated_usage);
-        assert_eq!(imported.message_count, 2);
+        assert_eq!(imported.message_count, 3);
 
         let conversation = imported.conversation.unwrap();
-        assert_eq!(conversation.messages().len(), 2);
-        assert_eq!(conversation.messages()[0].role, Role::User);
-        assert_eq!(conversation.messages()[1].role, Role::Assistant);
+        assert_eq!(conversation.messages().len(), 3);
+        assert!(conversation
+            .messages()
+            .iter()
+            .any(|message| message.role == Role::User && message.as_concat_text() == USER_MESSAGE));
+        assert!(conversation.messages().iter().any(|message| {
+            message.role == Role::Assistant && message.as_concat_text() == ASSISTANT_MESSAGE
+        }));
+        let summary = conversation
+            .messages()
+            .iter()
+            .find(|message| message.as_concat_text() == "compaction summary")
+            .expect("agent-only compaction summary should survive export and import");
+        assert!(!summary.is_user_visible());
+        assert!(summary.is_agent_visible());
     }
 
     #[tokio::test]

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -3019,6 +3019,68 @@ mod tests {
         assert_eq!(results.results[0].messages.len(), 2);
     }
 
+    #[tokio::test]
+    async fn test_search_chat_history_ignores_hidden_messages() {
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+
+        let session = sm
+            .create_session(
+                PathBuf::from("/tmp/search-test"),
+                "Hidden search content".to_string(),
+                SessionType::User,
+                GooseMode::default(),
+            )
+            .await
+            .unwrap();
+
+        sm.add_message(
+            &session.id,
+            &Message::user().with_text("visible public anchor"),
+        )
+        .await
+        .unwrap();
+        sm.add_message(
+            &session.id,
+            &Message::user()
+                .with_text("GOOSE_SUBDIRECTORY_HINT_MARKER=subdir_hints:/tmp/project/sub\nultrasecretmarker")
+                .with_visibility(false, true),
+        )
+        .await
+        .unwrap();
+
+        let hidden_results = sm
+            .search_chat_history(
+                "ultrasecretmarker",
+                Some(10),
+                None,
+                None,
+                None,
+                vec![SessionType::User],
+            )
+            .await
+            .unwrap();
+        assert_eq!(hidden_results.total_matches, 0);
+        assert!(hidden_results.results.is_empty());
+
+        let visible_results = sm
+            .search_chat_history(
+                "visible public anchor",
+                Some(10),
+                None,
+                None,
+                None,
+                vec![SessionType::User],
+            )
+            .await
+            .unwrap();
+        assert_eq!(visible_results.total_matches, 1);
+        assert_eq!(visible_results.results[0].session_id, session.id);
+        assert!(!visible_results.results[0].messages[0]
+            .content
+            .contains("ultrasecretmarker"));
+    }
+
     async fn expected_session_list_ids(sm: &SessionManager, session_ids: &[String]) -> Vec<String> {
         let mut sessions = Vec::new();
         for session_id in session_ids {

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -605,7 +605,7 @@ impl SessionManager {
         let user_message_count = conversation
             .messages()
             .iter()
-            .filter(|m| matches!(m.role, Role::User))
+            .filter(|m| matches!(m.role, Role::User) && m.is_user_visible())
             .count();
 
         if user_message_count <= MSG_COUNT_FOR_SESSION_NAME_GENERATION {

--- a/crates/goose/src/session/session_naming.rs
+++ b/crates/goose/src/session/session_naming.rs
@@ -75,7 +75,7 @@ fn extract_short_title(text: &str) -> String {
 fn get_initial_user_messages(messages: &Conversation) -> Vec<String> {
     messages
         .iter()
-        .filter(|m| m.role == rmcp::model::Role::User)
+        .filter(|m| m.role == rmcp::model::Role::User && m.is_user_visible())
         .take(MSG_COUNT_FOR_SESSION_NAME_GENERATION)
         .map(|m| {
             m.content
@@ -251,6 +251,22 @@ mod tests {
                 "lots of reasoning here about what to call it\nList current folder files"
             ),
             "List current folder files"
+        );
+    }
+
+    #[test]
+    fn initial_user_messages_exclude_hidden_hints() {
+        let conversation = Conversation::new_unvalidated(vec![
+            Message::user().with_text("visible request"),
+            Message::user()
+                .with_text("GOOSE_SUBDIRECTORY_HINT_MARKER=subdir_hints:/tmp/sub\nprivate hint")
+                .with_visibility(false, true),
+            Message::user().with_text("visible follow-up"),
+        ]);
+
+        assert_eq!(
+            get_initial_user_messages(&conversation),
+            vec!["visible request", "visible follow-up"]
         );
     }
 }


### PR DESCRIPTION
## Summary
- persist newly discovered subdirectory hints as hidden agent-visible messages instead of mutating the system prompt after a turn
- rehydrate the subdirectory hint tracker from prior hidden marker messages when a session resumes
- prevent hidden hint messages from being promoted into visible transcript text during compaction
- keep hidden hint text out of Chat Recall search/load results and markdown transcript export

Fixes #10330

## Tests
- cargo fmt --package goose --package goose-cli -- --check
- git diff --check
- cargo test -p goose context_mgmt::tests::test_hidden_user_messages_are_not_promoted_by_compaction
- cargo test -p goose hints::load_hints::tests
- cargo test -p goose test_subdirectory_hints_are_agent_only_and_resume_deduped
- cargo test -p goose session::session_manager::tests::test_search_chat_history_ignores_hidden_messages
- cargo test -p goose session::session_manager::tests::test_search_chat_history_preserves_message_limited_behavior
- cargo test -p goose-cli --no-default-features --features rustls-tls commands::session::tests::markdown_export_omits_hidden_messages
- cargo test -p goose --features code-mode agents::prompt_manager::tests::test_all_platform_extensions