### PR TITLE
Fix Desktop ACP shell PATH

### DIFF
--- a/ui/desktop/src/acp/acpConnection.ts
+++ b/ui/desktop/src/acp/acpConnection.ts
@@ -74,6 +74,9 @@ async function initializeConnection(): Promise<InitializedAcpClient> {
     const initializeResponse = await withTimeout(
       client.initialize({
         protocolVersion: PROTOCOL_VERSION,
+        _meta: {
+          'goose/useLoginShellPath': true,
+        },
         clientCapabilities: {
           elicitation: { form: {} },
           _meta: {


### PR DESCRIPTION
Closes #10335.

Enables login-shell PATH recovery for Desktop ACP sessions.
