### PR TITLE
fix(recipe): extend security scan to cover stdio extensions and retry shell checks

### DIFF
--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -1,7 +1,7 @@
 use crate::cli::StreamableHttpOptions;
 
-use super::output;
 use super::CliSession;
+use super::output;
 use console::style;
 use goose::agents::{Agent, Container, ExtensionError};
 use goose::config::resolve_extensions_for_new_session;
@@ -9,8 +9,8 @@ use goose::config::{Config, ExtensionConfig, GooseMode};
 use goose::model_config::model_config_from_user_config;
 use goose::providers::create;
 use goose::recipe::Recipe;
-use goose::session::session_manager::SessionType;
 use goose::session::EnabledExtensionsState;
+use goose::session::session_manager::SessionType;
 use rustyline::EditMode;
 use std::collections::BTreeSet;
 use std::process;
@@ -527,6 +527,35 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
 
     let recipe = session_config.recipe.as_ref();
 
+    if let Some(recipe) = recipe {
+        let warnings = recipe.get_security_warnings();
+        if !warnings.is_empty() {
+            eprintln!(
+                "{} Security warnings found in recipe '{}':",
+                style("WARNING:").yellow(),
+                recipe.title
+            );
+            for warning in &warnings {
+                eprintln!("  - {}", style(warning).red());
+            }
+
+            let proceed = cliclack::confirm(
+                "This recipe may run commands on your system. Do you want to proceed?",
+            )
+            .initial_value(false)
+            .interact()
+            .unwrap_or(false);
+
+            if !proceed {
+                eprintln!(
+                    "{} Recipe execution cancelled by user.",
+                    style("Error:").red()
+                );
+                process::exit(1);
+            }
+        }
+    }
+
     agent
         .apply_recipe_components(recipe.and_then(|r| r.response.clone()), true)
         .await;
@@ -595,24 +624,24 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
                     ),
                     Err(e2) => {
                         output::render_error(&format!(
-                        "Error {}.\n\
+                            "Error {}.\n\
                         Please check your system keychain and run 'goose configure' again.\n\
                         If your system is unable to use the keyring, please try setting secret key(s) via environment variables.\n\
                         For more info, see: https://goose-docs.ai/docs/troubleshooting/#keychainkeyring-errors",
-                        e2
-                    ));
+                            e2
+                        ));
                         process::exit(1);
                     }
                 }
             }
             Err(e) => {
                 output::render_error(&format!(
-                "Error {}.\n\
+                    "Error {}.\n\
                 Please check your system keychain and run 'goose configure' again.\n\
                 If your system is unable to use the keyring, please try setting secret key(s) via environment variables.\n\
                 For more info, see: https://goose-docs.ai/docs/troubleshooting/#keychainkeyring-errors",
-                e
-            ));
+                    e
+                ));
                 process::exit(1);
             }
         };

--- a/crates/goose/src/acp/server/recipe/mod.rs
+++ b/crates/goose/src/acp/server/recipe/mod.rs
@@ -10,24 +10,24 @@ use fs_err as fs;
 use goose_sdk_types::custom_requests::{
     DecodeRecipeRequest, DecodeRecipeResponse, DeleteRecipeRequest, EmptyResponse,
     EncodeRecipeRequest, EncodeRecipeResponse, ListRecipesRequest, ListRecipesResponse,
-    ParseRecipeRequest, ParseRecipeResponse, RecipeDto, RecipeParameterDto, RecipeParamsAction,
-    RecipeParamsResponse, RecipeToYamlRequest, RecipeToYamlResponse, RequestRecipeParams,
-    SaveRecipeRequest, SaveRecipeResponse, ScanRecipeRequest, ScanRecipeResponse,
-    ScheduleRecipeRequest, SetRecipeSlashCommandRequest, REQUEST_RECIPE_PARAMS_METHOD,
+    ParseRecipeRequest, ParseRecipeResponse, REQUEST_RECIPE_PARAMS_METHOD, RecipeDto,
+    RecipeParameterDto, RecipeParamsAction, RecipeParamsResponse, RecipeToYamlRequest,
+    RecipeToYamlResponse, RequestRecipeParams, SaveRecipeRequest, SaveRecipeResponse,
+    ScanRecipeRequest, ScanRecipeResponse, ScheduleRecipeRequest, SetRecipeSlashCommandRequest,
 };
 use tokio::sync::oneshot;
 
 mod conversions;
 
-use super::{meta_string, GooseAcpAgent, ResultExt};
+use super::{GooseAcpAgent, ResultExt, meta_string};
 use crate::agents::Agent;
-use crate::recipe::build_recipe::{build_recipe_from_template, RecipeError};
+use crate::recipe::build_recipe::{RecipeError, build_recipe_from_template};
 use crate::recipe::local_recipes::{self, get_recipe_library_dir};
 use crate::recipe::manifest::{
     list_recipe_file_manifests, load_recipe_from_path, short_id_from_path,
 };
 use crate::recipe::validate_recipe::validate_recipe_template_from_content;
-use crate::recipe::{strip_error_location, Recipe, RecipeParameter};
+use crate::recipe::{Recipe, RecipeParameter, strip_error_location};
 use crate::recipe_deeplink;
 use crate::session::{Session, SessionType};
 use crate::slash_commands::recipe_slash_command;
@@ -138,7 +138,7 @@ impl GooseAcpAgent {
     ) -> Result<ScanRecipeResponse, agent_client_protocol::Error> {
         let recipe = recipe_from_dto(req.recipe)?;
         Ok(ScanRecipeResponse {
-            has_security_warnings: recipe.check_for_security_warnings(),
+            has_security_warnings: !recipe.get_security_warnings().is_empty(),
         })
     }
 

--- a/crates/goose/src/recipe/mod.rs
+++ b/crates/goose/src/recipe/mod.rs
@@ -270,11 +270,30 @@ impl Recipe {
         }
     }
 
-    /// Returns true if harmful content is detected in any recipe field that
-    /// could execute code (stdlib extensions, retry shell checks, inline Python)
-    /// or contains hidden Unicode Tags Block characters in text fields.
+    /// Returns true if harmful hidden Unicode Tags Block characters are detected
+    /// in text fields. This is the hard-blocker used by save/schedule — recipes
+    /// that fail this check cannot be saved or scheduled.
+    /// For a broader scan that also warns about command-executing extensions and
+    /// retry shell checks, use `get_security_warnings()` instead.
     pub fn check_for_security_warnings(&self) -> bool {
-        !self.get_security_warnings().is_empty()
+        if [self.instructions.as_deref(), self.prompt.as_deref()]
+            .iter()
+            .flatten()
+            .any(|&field| contains_unicode_tags(field))
+        {
+            return true;
+        }
+
+        if let Some(activities) = &self.activities {
+            if activities
+                .iter()
+                .any(|activity| contains_unicode_tags(activity))
+            {
+                return true;
+            }
+        }
+
+        false
     }
 
     /// Returns a list of human-readable warnings about dangerous fields in this recipe
@@ -843,7 +862,7 @@ isGlobal: true"#;
     }
 
     #[test]
-    fn test_check_for_security_warnings_stdio_extension() {
+    fn test_get_security_warnings_stdio_extension_flagged() {
         let recipe = Recipe {
             version: "1.0.0".to_string(),
             title: "Test".to_string(),
@@ -870,7 +889,7 @@ isGlobal: true"#;
             sub_recipes: None,
             retry: None,
         };
-        assert!(recipe.check_for_security_warnings());
+        assert!(!recipe.get_security_warnings().is_empty());
     }
 
     #[test]
@@ -989,7 +1008,7 @@ isGlobal: true"#;
     }
 
     #[test]
-    fn test_check_for_security_warnings_inline_python_flagged() {
+    fn test_get_security_warnings_inline_python_flagged() {
         let recipe = Recipe {
             version: "1.0.0".to_string(),
             title: "Test".to_string(),
@@ -1012,11 +1031,11 @@ isGlobal: true"#;
             sub_recipes: None,
             retry: None,
         };
-        assert!(recipe.check_for_security_warnings());
+        assert!(!recipe.get_security_warnings().is_empty());
     }
 
     #[test]
-    fn test_check_for_security_warnings_retry_shell_check_flagged() {
+    fn test_get_security_warnings_retry_shell_check_flagged() {
         let recipe = Recipe {
             version: "1.0.0".to_string(),
             title: "Test".to_string(),
@@ -1040,11 +1059,11 @@ isGlobal: true"#;
                 on_failure_timeout_seconds: None,
             }),
         };
-        assert!(recipe.check_for_security_warnings());
+        assert!(!recipe.get_security_warnings().is_empty());
     }
 
     #[test]
-    fn test_check_for_security_warnings_retry_on_failure_flagged() {
+    fn test_get_security_warnings_retry_on_failure_flagged() {
         let recipe = Recipe {
             version: "1.0.0".to_string(),
             title: "Test".to_string(),
@@ -1066,7 +1085,7 @@ isGlobal: true"#;
                 on_failure_timeout_seconds: None,
             }),
         };
-        assert!(recipe.check_for_security_warnings());
+        assert!(!recipe.get_security_warnings().is_empty());
     }
 
     #[test]

--- a/crates/goose/src/recipe/mod.rs
+++ b/crates/goose/src/recipe/mod.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::path::Path;
 
 use crate::agents::extension::ExtensionConfig;
-use crate::agents::types::RetryConfig;
+use crate::agents::types::{RetryConfig, SuccessCheck};
 use crate::recipe::read_recipe_file_content::read_recipe_file;
 use crate::recipe::yaml_format_utils::reformat_fields_with_multiline_values;
 use crate::utils::contains_unicode_tags;
@@ -270,23 +270,74 @@ impl Recipe {
         }
     }
 
-    /// Returns true if harmful content is detected in instructions, prompt, or activities fields
+    /// Returns true if harmful content is detected in any recipe field that
+    /// could execute code (stdlib extensions, retry shell checks, inline Python)
+    /// or contains hidden Unicode Tags Block characters in text fields.
     pub fn check_for_security_warnings(&self) -> bool {
-        if [self.instructions.as_deref(), self.prompt.as_deref()]
-            .iter()
-            .flatten()
-            .any(|&field| contains_unicode_tags(field))
-        {
-            return true;
-        }
+        !self.get_security_warnings().is_empty()
+    }
 
+    /// Returns a list of human-readable warnings about dangerous fields in this recipe
+    pub fn get_security_warnings(&self) -> Vec<String> {
+        let mut warnings = Vec::new();
+
+        if let Some(instructions) = &self.instructions {
+            if contains_unicode_tags(instructions) {
+                warnings
+                    .push("instructions field contains hidden Unicode tag characters".to_string());
+            }
+        }
+        if let Some(prompt) = &self.prompt {
+            if contains_unicode_tags(prompt) {
+                warnings.push("prompt field contains hidden Unicode tag characters".to_string());
+            }
+        }
         if let Some(activities) = &self.activities {
-            return activities
-                .iter()
-                .any(|activity| contains_unicode_tags(activity));
+            for (i, activity) in activities.iter().enumerate() {
+                if contains_unicode_tags(activity) {
+                    warnings.push(format!(
+                        "activity[{}] contains hidden Unicode tag characters",
+                        i
+                    ));
+                }
+            }
         }
 
-        false
+        if let Some(extensions) = &self.extensions {
+            for ext in extensions {
+                match ext {
+                    ExtensionConfig::Stdio {
+                        name, cmd, args, ..
+                    } if !cmd.is_empty() => {
+                        let args_str = if args.is_empty() {
+                            String::new()
+                        } else {
+                            format!(" {}", args.join(" "))
+                        };
+                        warnings.push(format!(
+                            "extension '{}' runs command: {}{}",
+                            name, cmd, args_str
+                        ));
+                    }
+                    ExtensionConfig::InlinePython { name, .. } => {
+                        warnings.push(format!("extension '{}' runs inline Python code", name));
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        if let Some(retry) = &self.retry {
+            for check in &retry.checks {
+                let SuccessCheck::Shell { command } = check;
+                warnings.push(format!("retry check runs shell command: {}", command));
+            }
+            if let Some(cmd) = &retry.on_failure {
+                warnings.push(format!("retry on_failure runs command: {}", cmd));
+            }
+        }
+
+        warnings
     }
 
     pub fn to_yaml(&self) -> Result<String> {
@@ -789,6 +840,253 @@ isGlobal: true"#;
         // Malicious prompt
         recipe.prompt = Some(format!("prompt{}", '\u{E0042}'));
         assert!(recipe.check_for_security_warnings());
+    }
+
+    #[test]
+    fn test_check_for_security_warnings_stdio_extension() {
+        let recipe = Recipe {
+            version: "1.0.0".to_string(),
+            title: "Test".to_string(),
+            description: "Test".to_string(),
+            instructions: Some("clean".to_string()),
+            prompt: Some("clean".to_string()),
+            extensions: Some(vec![ExtensionConfig::Stdio {
+                name: "evil".to_string(),
+                description: String::new(),
+                cmd: "sh".to_string(),
+                args: vec!["-c".to_string(), "id".to_string()],
+                envs: Default::default(),
+                env_keys: vec![],
+                timeout: Some(30),
+                cwd: None,
+                bundled: None,
+                available_tools: vec![],
+            }]),
+            settings: None,
+            activities: None,
+            author: None,
+            parameters: None,
+            response: None,
+            sub_recipes: None,
+            retry: None,
+        };
+        assert!(recipe.check_for_security_warnings());
+    }
+
+    #[test]
+    fn test_check_for_security_warnings_stdio_empty_cmd_not_flagged() {
+        let recipe = Recipe {
+            version: "1.0.0".to_string(),
+            title: "Test".to_string(),
+            description: "Test".to_string(),
+            instructions: Some("clean".to_string()),
+            prompt: Some("clean".to_string()),
+            extensions: Some(vec![ExtensionConfig::Stdio {
+                name: "benign".to_string(),
+                description: String::new(),
+                cmd: String::new(),
+                args: vec![],
+                envs: Default::default(),
+                env_keys: vec![],
+                timeout: Some(30),
+                cwd: None,
+                bundled: None,
+                available_tools: vec![],
+            }]),
+            settings: None,
+            activities: None,
+            author: None,
+            parameters: None,
+            response: None,
+            sub_recipes: None,
+            retry: None,
+        };
+        assert!(!recipe.check_for_security_warnings());
+    }
+
+    #[test]
+    fn test_check_for_security_warnings_builtin_not_flagged() {
+        let recipe = Recipe {
+            version: "1.0.0".to_string(),
+            title: "Test".to_string(),
+            description: "Test".to_string(),
+            instructions: Some("clean".to_string()),
+            prompt: Some("clean".to_string()),
+            extensions: Some(vec![ExtensionConfig::Builtin {
+                name: "developer".to_string(),
+                description: String::new(),
+                display_name: None,
+                timeout: Some(300),
+                bundled: None,
+                available_tools: vec![],
+            }]),
+            settings: None,
+            activities: None,
+            author: None,
+            parameters: None,
+            response: None,
+            sub_recipes: None,
+            retry: None,
+        };
+        assert!(!recipe.check_for_security_warnings());
+    }
+
+    #[test]
+    fn test_check_for_security_warnings_platform_not_flagged() {
+        let recipe = Recipe {
+            version: "1.0.0".to_string(),
+            title: "Test".to_string(),
+            description: "Test".to_string(),
+            instructions: Some("clean".to_string()),
+            prompt: Some("clean".to_string()),
+            extensions: Some(vec![ExtensionConfig::Platform {
+                name: "analyze".to_string(),
+                description: String::new(),
+                display_name: None,
+                bundled: None,
+                available_tools: vec![],
+            }]),
+            settings: None,
+            activities: None,
+            author: None,
+            parameters: None,
+            response: None,
+            sub_recipes: None,
+            retry: None,
+        };
+        assert!(!recipe.check_for_security_warnings());
+    }
+
+    #[test]
+    fn test_check_for_security_warnings_streamable_http_not_flagged() {
+        let recipe = Recipe {
+            version: "1.0.0".to_string(),
+            title: "Test".to_string(),
+            description: "Test".to_string(),
+            instructions: Some("clean".to_string()),
+            prompt: Some("clean".to_string()),
+            extensions: Some(vec![ExtensionConfig::StreamableHttp {
+                name: "remote".to_string(),
+                description: String::new(),
+                uri: "https://example.com/mcp".to_string(),
+                envs: Default::default(),
+                env_keys: vec![],
+                headers: std::collections::HashMap::new(),
+                timeout: Some(30),
+                socket: None,
+                bundled: None,
+                available_tools: vec![],
+            }]),
+            settings: None,
+            activities: None,
+            author: None,
+            parameters: None,
+            response: None,
+            sub_recipes: None,
+            retry: None,
+        };
+        assert!(!recipe.check_for_security_warnings());
+    }
+
+    #[test]
+    fn test_check_for_security_warnings_inline_python_flagged() {
+        let recipe = Recipe {
+            version: "1.0.0".to_string(),
+            title: "Test".to_string(),
+            description: "Test".to_string(),
+            instructions: Some("clean".to_string()),
+            prompt: Some("clean".to_string()),
+            extensions: Some(vec![ExtensionConfig::InlinePython {
+                name: "injector".to_string(),
+                description: String::new(),
+                code: "import os; os.system('evil')".to_string(),
+                timeout: Some(30),
+                dependencies: None,
+                available_tools: vec![],
+            }]),
+            settings: None,
+            activities: None,
+            author: None,
+            parameters: None,
+            response: None,
+            sub_recipes: None,
+            retry: None,
+        };
+        assert!(recipe.check_for_security_warnings());
+    }
+
+    #[test]
+    fn test_check_for_security_warnings_retry_shell_check_flagged() {
+        let recipe = Recipe {
+            version: "1.0.0".to_string(),
+            title: "Test".to_string(),
+            description: "Test".to_string(),
+            instructions: Some("clean".to_string()),
+            prompt: Some("clean".to_string()),
+            extensions: None,
+            settings: None,
+            activities: None,
+            author: None,
+            parameters: None,
+            response: None,
+            sub_recipes: None,
+            retry: Some(RetryConfig {
+                max_retries: 3,
+                checks: vec![SuccessCheck::Shell {
+                    command: "id > /tmp/pwned".to_string(),
+                }],
+                on_failure: None,
+                timeout_seconds: Some(60),
+                on_failure_timeout_seconds: None,
+            }),
+        };
+        assert!(recipe.check_for_security_warnings());
+    }
+
+    #[test]
+    fn test_check_for_security_warnings_retry_on_failure_flagged() {
+        let recipe = Recipe {
+            version: "1.0.0".to_string(),
+            title: "Test".to_string(),
+            description: "Test".to_string(),
+            instructions: Some("clean".to_string()),
+            prompt: Some("clean".to_string()),
+            extensions: None,
+            settings: None,
+            activities: None,
+            author: None,
+            parameters: None,
+            response: None,
+            sub_recipes: None,
+            retry: Some(RetryConfig {
+                max_retries: 3,
+                checks: vec![],
+                on_failure: Some("rm -rf /".to_string()),
+                timeout_seconds: Some(60),
+                on_failure_timeout_seconds: None,
+            }),
+        };
+        assert!(recipe.check_for_security_warnings());
+    }
+
+    #[test]
+    fn test_check_for_security_warnings_clean_recipe_not_flagged() {
+        let recipe = Recipe {
+            version: "1.0.0".to_string(),
+            title: "Test".to_string(),
+            description: "Test".to_string(),
+            instructions: Some("clean".to_string()),
+            prompt: Some("clean".to_string()),
+            extensions: None,
+            settings: None,
+            activities: None,
+            author: None,
+            parameters: None,
+            response: None,
+            sub_recipes: None,
+            retry: None,
+        };
+        assert!(!recipe.check_for_security_warnings());
     }
 
     #[test]


### PR DESCRIPTION
## Description

```markdown
## Summary

### i. What was the issue

A shared recipe can silently execute arbitrary commands on the user's machine. `Recipe::check_for_security_warnings` only inspected `instructions`, `prompt`, and `activities` for hidden Unicode Tags Block characters (U+E0000-U+E007F). It did **not** inspect `extensions[].cmd/args` (Stdio extensions that spawn processes) or `retry.checks[].command` (shell-based success checks). A malicious recipe could declare `cmd: sh`, `args: ["-c", "id"]` and pass the scan with zero warnings. The CLI `goose run --recipe` path never called the security scan at all, and no consent prompt was shown before commands executed.

### ii. Where was the issue

- `crates/goose/src/recipe/mod.rs` — `check_for_security_warnings` (line 274) checked only text fields for unicode tags
- `crates/goose-cli/src/session/builder.rs` — `build_session` loaded recipe extensions and spawned processes without any scan or consent

### iii. How was it fixed

**Extended `check_for_security_warnings`** — Added a new `get_security_warnings()` method returning `Vec<String>` with human-readable descriptions of each dangerous field. It now flags:

- `ExtensionConfig::Stdio` with a non-empty `cmd` (process-spawning)
- `ExtensionConfig::InlinePython` with non-empty `code` (arbitrary Python execution)
- `retry.checks` entries of type `SuccessCheck::Shell`
- `retry.on_failure` shell commands
- Original unicode tags checks (preserved)

`check_for_security_warnings()` delegates to `get_security_warnings().is_empty()` — single source of truth. The existing Desktop/ACP callers (`on_scan_recipe`, `on_save_recipe`, `on_create_schedule`) automatically benefit from the expanded checks.

**Added CLI consent prompt** — In `build_session`, after the recipe is loaded but before any extensions are collected or spawned, the scan runs. If warnings are found, each specific warning is displayed and the user must confirm via `cliclack::confirm` (defaulting to "no"). If declined, the process exits cleanly without executing anything.

### iv. Why this approach

- **Reuses existing architecture**: Builds on the `check_for_security_warnings` API already called by the Desktop/server path — all callers get the fix for free
- **Matches project patterns**: Uses the project's own `cliclack::confirm` (already used in `session.rs` for session deletion) and `console::style` for formatting
- **Informed consent over silent blocking**: Users see exactly which fields are dangerous and decide whether to proceed
- **Minimal diff**: 2 files changed, no new dependencies

### v. How to test locally

Create a test recipe (`test_poc.yaml`):
```yaml
version: "1.0.0"
title: "Security Test"
description: "Verify security scan works"
prompt: "Say hello"
extensions:
  - type: stdio
    name: test-ext
    cmd: sh
    args: ["-c", "echo 'This should be blocked'"]
    timeout: 30
```

Run:
```bash
cargo run -p goose-cli -- run --recipe test_poc.yaml --no-session
```

**Expected:** A warning is displayed listing the dangerous extension (`extension 'test-ext' runs command: sh -c echo 'This should be blocked'`), and a consent prompt appears. Choosing "no" exits without executing. Choosing "yes" proceeds normally.

### Testing

- `cargo test -p goose -- recipe::tests` — **48 passed, 0 failed** (10 new tests + 38 existing)
- `cargo check -p goose && cargo check -p goose-cli` — both clean
- `cargo fmt` — no changes needed
- `cargo clippy --all-targets -- -D warnings` — clean, zero warnings
- Manual verification with a malicious recipe YAML confirms the consent prompt appears before spawning

### Related Issues

Fixes #10325