### PR TITLE
fix(cli): rewrite recipe list output as clig.dev-compliant stacked blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Tortu fork: real credentials live here, never tracked. See _tortu/config/secrets.env.example
 _tortu/config/secrets.env
 
+# Tortu fork: probe reports are machine-specific runtime output, not source
+_tortu/probes/reports/
+
 __pycache__
 *.pyc
 *.jar

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Tortu fork: real credentials live here, never tracked. See _tortu/config/secrets.env.example
+_tortu/config/secrets.env
+
 __pycache__
 *.pyc
 *.jar

--- a/_tortu/MANIFEST.md
+++ b/_tortu/MANIFEST.md
@@ -1,0 +1,63 @@
+# _tortu — Tortu's custom goose
+
+This directory holds everything needed to reproduce Doug's goose setup on a
+fresh machine: `git clone` this fork, run `_tortu/bootstrap.sh`, and it's
+ready — no manual reconfiguring.
+
+This fork (`tortu-forks/goose`) is the persistent home for that setup.
+Upstream is `aaif-goose/goose` (remote `origin`); this fork is remote `fork`.
+Patches are dogfooded and committed here first, then opened as narrow PRs
+against `origin/main` once validated.
+
+## Layout
+
+- `docs/` — design notes and decisions about the fork/tortu setup itself.
+- `_inbox/` — task handoffs and prompts used to build patches (historical
+  record of how a given patch came to be).
+- `patches/<name>/` — one folder per patch: the patch spec, build/submit
+  checklist, and any supporting mockups. Mirrors what actually got applied
+  to the goose source under `crates/`.
+- `recipes/` — goose recipe YAML files. `GOOSE_RECIPE_PATH` should point
+  here.
+- `config/` — everything that goes in `~/.config/goose/`:
+  - `config.yaml` — goose's main config.
+  - `custom_providers/` — custom provider definitions (e.g. `custom_omlx.json`).
+    Provider files reference secrets only by env var name (`api_key_env`),
+    never by value.
+  - `skills/` — custom skill definitions.
+  - `goosehints` — copied from the kaminari project's `.goosehints`; this
+    fork carries its own copy so it's self-contained and doesn't depend on
+    another repo being checked out.
+  - `secrets.env.example` — template listing required credential env vars
+    (names only, no values). Tracked.
+  - `secrets.env` — the real credential values. **Gitignored, never
+    committed.** Created by `bootstrap.sh` (interactive prompt) or by hand:
+    `cp secrets.env.example secrets.env` and fill it in.
+
+## New machine setup
+
+```sh
+git clone https://github.com/tortu-forks/goose.git
+cd goose
+_tortu/bootstrap.sh
+```
+
+`bootstrap.sh` installs the Rust toolchain and cmake if missing, creates
+`secrets.env` interactively if it doesn't exist, copies `_tortu/config/*`
+into `~/.config/goose/`, builds `goose-cli` in release mode, and installs
+the binary to `~/.local/bin/goose`. It prints the `PATH` and
+`GOOSE_RECIPE_PATH` exports to add to your shell profile if they're not
+already set.
+
+## Adding a new patch
+
+1. Branch off `origin/main` (not this fork's `main`) so the PR diff stays
+   clean: `git fetch origin && git checkout -b fix/<name> origin/main`.
+2. Apply and dogfood the change; add a `patches/<name>/` folder here with
+   the patch write-up.
+3. Once validated and signed off, commit with DCO (`git commit -s`), push
+   to `fork`, open the PR against `aaif-goose/goose`. Use the standard
+   patch-attribution header/description (see Claude memory:
+   `patch-attribution-format`).
+4. Separately, merge the same change into this fork's own `main` so the
+   dogfood build stays current.

--- a/_tortu/MANIFEST.md
+++ b/_tortu/MANIFEST.md
@@ -49,6 +49,50 @@ the binary to `~/.local/bin/goose`. It prints the `PATH` and
 `GOOSE_RECIPE_PATH` exports to add to your shell profile if they're not
 already set.
 
+## Extensions, recipes, and skills
+
+Curated from `_inbox/MANIFEST_2026-07-09_default-install-recommendations.md`
+(Cowork's tiered pass over goose-docs.ai's extension/recipe/skill catalogs).
+Only the "recommend adding now" / "strategically interesting" tiers from
+that draft were pulled in; "worth trying, not essential" and "skip" tiers
+were left out. See that file for the full tiering and the rationale behind
+each pick.
+
+**Extensions** (`config/config.yaml`) — six third-party MCP extensions were
+added on top of the built-ins already listed above, all **`enabled: false`**
+by default since none have been live-tested yet and several need external
+tooling or a secret:
+
+| Key | Needs | Purpose |
+|---|---|---|
+| `github` | `GITHUB_PERSONAL_ACCESS_TOKEN` (see `secrets.env.example`) | PR/issue ops via the hosted `streamable_http` GitHub MCP server |
+| `context7` | `npx` on `PATH` | Live library/crate docs instead of guessing at APIs |
+| `fetch` | `uvx` on `PATH` | Official MCP reference web-fetch server |
+| `playwright` | `npx` on `PATH` | Browser automation (Microsoft-maintained) |
+| `chrome-devtools` | `npx` on `PATH` | Deeper browser/DevTools inspection (official Chrome team) |
+| `knowledge_graph_memory` | `npx` on `PATH` | Official MCP reference structured-memory server |
+
+Flip an extension to `enabled: true` in `config.yaml` once its runtime
+dependency is confirmed present (and, for `github`, once
+`secrets.env` actually has a real token in it).
+
+**Recipes** (`recipes/`) — added alongside the existing six
+`goose-subagents-workshop` recipes: `generate-commit-message.yaml`,
+`pr-generator.yaml`, `test-coverage-optimizer.yaml`, `lint-my-code.yaml`,
+`change-log.yaml`, and the RPI research→plan→iterate→implement family
+(`rpi-research.yaml`, `rpi-plan.yaml`, `rpi-iterate.yaml`,
+`rpi-implement.yaml`, plus `subrecipes/rpi-codebase-locator.yaml`,
+`subrecipes/rpi-codebase-analyzer.yaml`, `subrecipes/rpi-pattern-finder.yaml`
+that `rpi-research.yaml` calls as sub-agents) and `ralph-work.yaml` /
+`ralph-review.yaml` (single-iteration work + cross-model ship/revise gate).
+Sourced directly from this repo's own
+`documentation/src/pages/recipes/data/recipes/` rather than fetched
+externally, so provenance is the goose monorepo itself.
+
+**Skills** (`config/skills/`) — four skills from `block/Agent-Skills` added
+alongside the existing custom `kn-*` skills: `code-review`,
+`testing-strategy`, `beads`, `rp-why`.
+
 ## Adding a new patch
 
 1. Branch off `origin/main` (not this fork's `main`) so the PR diff stays

--- a/_tortu/_inbox/CC_PROMPT_2026-07-08_recipe-list-clig-addendum.md
+++ b/_tortu/_inbox/CC_PROMPT_2026-07-08_recipe-list-clig-addendum.md
@@ -1,0 +1,27 @@
+# Claude Code prompt addendum: apply clig.dev to the recipe-list patch
+
+Paste this into the Claude Code session building the `recipe-list-formatting` patch
+(alongside `CC_PROMPT_2026-07-08_recipe-list-formatting.md`).
+
+---
+
+As part of this patch, we've adopted the **clig.dev** standard (Command Line Interface
+Guidelines, https://clig.dev/) to guide CLI output — **without adding any dependency**.
+Use only what's already in `goose-cli`'s `Cargo.toml` (`console`, `comfy-table`).
+
+Apply the standard to the `recipe list` output you're patching:
+
+1. **Semantic color/glyphs only** — reuse the file's existing `console`-styled
+   `✓`/`✗` vocabulary (add `⚠` for the duplicate/shadowed-recipe flag). One accent,
+   no decoration.
+2. **Degrade gracefully** — when stdout is not a TTY (piped / CI) or `NO_COLOR` is set,
+   emit plain, uncolored, un-animated output. Confirm `--format json` stays byte-for-byte
+   unchanged.
+3. **Restraint over borders** — reconsider the bordered `comfy-table` grid against a
+   lighter **aligned-columns** layout (grouped by name, duplicates dimmed/flagged), which
+   reads cleaner and less "try-hard." Show Doug **both shapes** during dogfood and let him
+   pick before the PR.
+
+Then **note the adoption in the patch submission**: add a line to the PR description, e.g.
+*"Output follows the clig.dev CLI guidelines (semantic color, NO_COLOR/non-TTY
+degradation); no new dependencies."* Keep the diff small and scoped.

--- a/_tortu/_inbox/CC_PROMPT_2026-07-08_recipe-list-formatting.md
+++ b/_tortu/_inbox/CC_PROMPT_2026-07-08_recipe-list-formatting.md
@@ -1,0 +1,26 @@
+# Claude Code prompt: build + dogfood + submit `goose recipe list` patch
+
+Copy/paste this into Claude Code, run from (or pointed at) `~/AOF/work/projects/tortu-tools/tortu-goose`.
+
+---
+
+There's a ready-to-build patch staged in this repo at `patches/recipe-list-formatting/`:
+
+- `PATCH.md` — the actual Rust patch to apply to `crates/goose-cli/src/commands/recipe.rs` in a fresh `aaif-goose/goose` checkout (replaces `handle_list`, adds two small helpers `describe`/`source_path`, adds one import — nothing else in the file changes). No new dependency; `comfy-table` is already in `goose-cli`'s `Cargo.toml`.
+- `BUILD_AND_SUBMIT.md` — the full fork → apply → build → test → install → dogfood → PR checklist.
+- `build.sh` — a draft automation script for the build/install/dogfood steps. It intentionally exits immediately with instructions, because the patch hasn't been applied to a real checkout yet — read it, apply the patch by hand per `PATCH.md`, then comment out the early exit and use it from step 2 onward (or just run the commands manually from `BUILD_AND_SUBMIT.md`).
+- `mockups/before.txt`, `mockups/after-table.txt`, `mockups/after-verbose.txt` — illustrative before/after terminal output (placeholder recipe names — compare shape, not literal content, against Doug's real output).
+
+Full background is in `_inbox/HANDOFF_2026-07-08_recipe-list-formatting.md` if useful.
+
+**What to do:**
+
+1. Read `patches/recipe-list-formatting/BUILD_AND_SUBMIT.md`, `PATCH.md`, and `build.sh`.
+2. Fork `aaif-goose/goose`, clone it, create branch `fix/recipe-list-formatting`, apply the patch from `PATCH.md`.
+3. `cargo build -p goose-cli` and `cargo test -p goose-cli commands::recipe` — confirm the existing test suite still passes; consider adding a test for the new grouping/duplicate-flagging behavior.
+4. Back up Doug's current `goose` binary (`cp "$(which goose)" "$(which goose).bak"`), then install the built binary in its place.
+5. Dogfood it against Doug's real recipe directories (`goose recipe list`, `goose recipe list --verbose`, `goose recipe list --format json` — confirm JSON output is unchanged).
+6. **Stop and confirm with Doug directly that the real output looks right before doing anything else.** Do not open the upstream PR until he's actually used it and signed off — that's an explicit requirement, not a formality.
+7. Only after his sign-off: commit with DCO sign-off (`git commit -s`), Conventional Commit title, push to your fork, and open the PR against `aaif-goose/goose` per their `CONTRIBUTING.md` (small scoped diff, expect an automated Codex review pass). PR description should show a before/after using Doug's *real* dogfooded output, not the mockup placeholders.
+
+If anything breaks or looks wrong at any step, roll back the binary from the `.bak` copy and report back rather than pushing forward.

--- a/_tortu/_inbox/CC_PROMPT_2026-07-09_install-monitor.md
+++ b/_tortu/_inbox/CC_PROMPT_2026-07-09_install-monitor.md
@@ -1,0 +1,58 @@
+# Claude Code prompt — install the background memory/swap monitor
+
+Paste this to Claude Code, running locally in the `tortu-forks/goose` fork
+(`/Users/dougdaulton/AOF/work/projects/forks/goose`).
+
+---
+
+There are three new files already sitting in `_tortu/probes/` (written by a
+Cowork session, not yet installed or committed to git):
+
+- `_tortu/probes/probe_monitor.sh` — lightweight script, appends one CSV row
+  of memory/swap stats to `_tortu/probes/reports/monitor_log.csv` per run.
+- `_tortu/probes/com.tortu.goose.probemonitor.plist` — a launchd agent
+  definition that runs the script every 15 minutes.
+- `_tortu/probes/INSTALL_MONITOR.md` — the install steps (below), written for
+  a human running them manually; you can just execute the commands directly.
+
+Please:
+
+1. **Install the launchd agent:**
+   ```bash
+   mkdir -p ~/Library/LaunchAgents
+   cp _tortu/probes/com.tortu.goose.probemonitor.plist ~/Library/LaunchAgents/
+   launchctl load ~/Library/LaunchAgents/com.tortu.goose.probemonitor.plist
+   ```
+
+2. **Verify it's actually running and producing data:**
+   ```bash
+   launchctl list | grep tortu
+   sleep 5
+   cat _tortu/probes/reports/monitor_log.csv
+   ```
+   If `monitor_log.csv` has a header row but no data row yet, wait ~30s and
+   check again (RunAtLoad should fire it immediately, but give it a moment).
+   If it never produces a row, check
+   `_tortu/probes/reports/monitor_launchd.err.log` for the actual error and
+   let Doug know what it says rather than guessing at a fix.
+
+3. **Git status check:** these three probe files plus whatever the monitor
+   has started writing under `_tortu/probes/reports/` are currently
+   untracked/uncommitted in this repo. `_tortu/probes/reports/` should
+   probably be gitignored (it's runtime output, not source — same treatment
+   as `_tortu/config/secrets.env`), but `probe_monitor.sh`,
+   `com.tortu.goose.probemonitor.plist`, and `INSTALL_MONITOR.md` are worth
+   committing since they're the actual deliverable. Check whether
+   `_tortu/probes/reports/` is already covered by an existing `.gitignore`
+   entry (it should be, alongside the existing `probe_local_inference.sh`
+   reports/ dir if that was ever committed) before deciding whether to add
+   one.
+
+4. **Report back** (to Doug directly, or drop a short note in
+   `_tortu/_inbox/` if that's the established pattern you're already
+   following in this repo): confirm the launchd job is loaded, confirm at
+   least one CSV row landed, and flag anything that didn't go as expected.
+
+Nothing here touches recipe/patch work or anything else you may have
+in flight — this is a standalone, low-risk local-system task (installing a
+background job + a git commit), not a code change to Goose itself.

--- a/_tortu/_inbox/HANDOFF_2026-07-08_cli-output-styling.md
+++ b/_tortu/_inbox/HANDOFF_2026-07-08_cli-output-styling.md
@@ -1,0 +1,47 @@
+# Handoff: CLI output styling — research + design direction for Goose CLI
+
+**From:** Cowork (Dev Methods Inquiries thread) **Date:** 2026-07-08 **Status:** research/design direction, not a patch. Feeds future Goose CLI output work + the staged `recipe-list-formatting` patch.
+
+## Why this is here
+
+Doug is doing more CLI work and wants Goose's (and the fleet's) command-line output to be **more readable via color coding and layout — deliberately NOT heavy tables** ("we tried that once"), and to look *clean without looking try-hard*. He asked for (1) galleries of exemplary CLI/TUI output to develop an aesthetic from, and (2) well-respected libraries to invoke. This doc captures that research and turns it into a design direction for Goose CLI output. It is design guidance, not a ready-to-build patch — the concrete first application is the existing `recipe-list-formatting` patch in this repo.
+
+## The core payload: the discipline (this matters more than the library)
+
+The respected reference is **[clig.dev](https://clig.dev/)** (Command Line Interface Guidelines). It speaks directly to "try-hard" — *"it can be easy to overdo it and make your program look cluttered or feel like a toy."* The rules that keep output clean:
+
+- **Color/symbols are semantic, not decorative.** One accent color + status glyphs (`✓`/`✗`/`⚠`/`→`) to guide the eye — not a rainbow. (Goose-cli already uses `console`-styled `✓`/`✗`; extend that vocabulary, don't invent a new one.)
+- **Degrade gracefully.** Detect when stdout is not a TTY (piped / CI) and drop color + animations/spinners — "so progress bars don't turn into Christmas trees in CI logs." Respect the `NO_COLOR` env var.
+- **Whitespace, alignment, and hierarchy over borders/boxes/tables.** Dim secondary text, one bright key value, a subtle rule between sections, aligned columns *without* box-drawing. This is precisely why the table experiment felt heavy.
+
+## Galleries / exemplars (to build the aesthetic)
+
+- **Terminal Trove** (terminaltrove.com) — curated, categorized gallery of terminal tools/TUIs.
+- **awesome-terminal-aesthetics** (kud) — "tools that make the terminal genuinely beautiful."
+- **awesome-tuis** (rothgar) — broad curated list.
+- Best move: **study tools that nail clean output** — `bat`, `eza`, `delta`, `gh`, and Charm's `glow`/`gum`. Copy their restraint.
+
+## Libraries — Rust first (Goose is Rust)
+
+- **`console`** — already in goose-cli; the existing `✓`/`✗` styling. Baseline for color + glyphs.
+- **`comfy-table`** — already in goose-cli's Cargo.toml (used by the recipe-list patch). Fine for genuine tabular data, but see the table caveat below.
+- **`owo-colors`** — ergonomic semantic coloring; good for the "one accent color" approach.
+- **`indicatif`** — progress bars/spinners *with* built-in TTY-awareness (use its no-TTY handling to satisfy the degrade rule).
+- **`crossterm`** — terminal capability detection (TTY, color support) for the graceful-degradation logic.
+- **`ratatui`** — only if a command ever becomes a full interactive TUI; overkill for plain output.
+
+**Cross-language aesthetic references** (not for Goose code, but the taste to emulate): **Charm / Lip Gloss** (Go) is the "killer clean without try-hard" north star; **Rich** (Python) is the gold standard on the Python side of Doug's fleet.
+
+Ready-made resource worth cribbing from: **gfargo/tui-design-skill** — a design skill for clean minimal TUIs/CLIs spanning Rust/Go/Python/TS.
+
+## Reconcile with the staged `recipe-list-formatting` patch
+
+That patch renders `goose recipe list` via **`comfy-table`** (a bordered table). Doug's "not tables — we tried that once" almost certainly refers to exactly this. **Flag for whoever builds it:** re-weigh the table against these principles before the PR — a lighter **aligned-columns** layout (grouped by name, duplicates dimmed/flagged, no box borders) plus TTY-degradation may read cleaner and less try-hard than a full `comfy-table` grid. Worth showing Doug both shapes during dogfood before choosing. Don't block that patch on this — just apply the lens.
+
+## Toward a house style
+
+The durable output: a small shared **output-style helper** in goose-cli (semantic color map, status glyphs matching the existing `✓`/`✗`/`⚠`, a section-rule helper, and one `is_tty()`-gated switch that strips color/animation when piped) so every command renders consistently. Same fleet-standard instinct Doug applies elsewhere. clig.dev is the house doc to point contributions at.
+
+## Sources
+
+clig.dev; Terminal Trove; kud/awesome-terminal-aesthetics; rothgar/awesome-tuis; charmbracelet/lipgloss; Textualize/rich; gfargo/tui-design-skill. (Full URLs in the originating Cowork session.)

--- a/_tortu/_inbox/HANDOFF_2026-07-08_recipe-list-formatting.md
+++ b/_tortu/_inbox/HANDOFF_2026-07-08_recipe-list-formatting.md
@@ -1,0 +1,34 @@
+# Handoff: `goose recipe list` formatting patch — ready for build + submit
+
+**From:** Cowork (genbu-dev thread) **Date:** 2026-07-08 **Status:** patch written, not yet compiled or tested. Next step is Claude Code.
+
+## Why this is here, not in genbu-dev
+
+This started as a side conversation in the genbu-dev thread while working the Genbu/Goose fork plan — Doug's *personal, vanilla* Goose CLI install (not Genbu-branded) turned out to have messy `recipe list` output, and it looked like a legitimate small upstream contribution. Moving it here so it doesn't clutter genbu-dev with local-install/dogfooding chatter. This repo (`tortu-goose`) is the staging ground for Doug's Goose config + any upstream contributions in progress.
+
+**Important distinction:** the actual pull request target is `aaif-goose/goose` (upstream), not this repo. `tortu-goose` is just where we stage, build, and validate before that PR goes out.
+
+## The problem
+
+`goose recipe list` has no deduplication logic. If a recipe with the same name exists on more than one search path (very common — Doug hit this with `~/.goose/recipes/` vs `~/AOF/resources/goose/recipes/` after a `GOOSE_RECIPE_PATH` mixup), every hit from every path prints as a separate, indistinguishable flat line. Doug's actual output was 12 lines for 6 unique recipes, with no indication that one file was silently shadowing the other. Doug's reaction: *"That recipe listing is a mess. Like it's hard to read... Might this be a contribution we could make where we just have the standard CLI render cleaner?"*
+
+## What's in `patches/recipe-list-formatting/`
+
+- `PATCH.md` — the actual Rust patch to `crates/goose-cli/src/commands/recipe.rs`'s `handle_list` function (plus two small new helpers). Fetched and read the real upstream source first, so this is written against the actual current code, not a guess. Needs **zero new dependencies** — `comfy-table` (v7) is already in `goose-cli`'s `Cargo.toml`, and the `⚠` warning glyph matches the file's existing `console`-styled `✓`/`✗` conventions.
+- `mockups/` — text mockups of before/after CLI output (non-verbose table + verbose mode), so Doug could see the shape before any code was written. Illustrative recipe names — the exact original terminal output wasn't captured verbatim in this thread, so don't take the sample names as literal.
+- `BUILD_AND_SUBMIT.md` — step-by-step build → dogfood → PR checklist.
+- `build.sh` — starter script automating the build/install/dogfood steps. **Not yet run** — written from source-reading, not from a working build. Treat it as a first draft to adapt, not a verified script.
+
+## Why this didn't get built or tested already
+
+Tried, in the Cowork sandbox this originated in: no Rust toolchain pre-installed, `rustup.rs` is blocked on that sandbox's network allowlist, disk was tight (~3.7GB free) for a workspace with three path-dependent sibling crates plus an Electron UI, and a clone attempt was killed mid-operation by a 45s tool timeout. None of that applies to Doug's own machine — this needs a real Rust toolchain and disk headroom, which is why it's handed off here instead of force-fitting a build into that sandbox.
+
+## What's needed next (Claude Code)
+
+1. Read `patches/recipe-list-formatting/BUILD_AND_SUBMIT.md` and `build.sh`.
+2. Fork/branch `aaif-goose/goose`, apply the patch from `PATCH.md`.
+3. `cargo build -p goose-cli`, sanity-check the unit tests in `commands/recipe.rs` still pass.
+4. Swap the built binary in for Doug's real `goose` install and dogfood `recipe list` / `recipe list --verbose` against his actual recipes directories.
+5. Once Doug confirms it looks right in daily use: commit with DCO sign-off, push to a fork, open the PR against `aaif-goose/goose` per their `CONTRIBUTING.md` (Conventional Commit title, small scoped diff, expect AI/Codex review).
+
+Don't open the upstream PR until Doug has actually dogfooded it — that was the explicit ask.

--- a/_tortu/_inbox/MANIFEST_2026-07-09_default-install-recommendations.md
+++ b/_tortu/_inbox/MANIFEST_2026-07-09_default-install-recommendations.md
@@ -1,0 +1,127 @@
+# Default Install Manifest — Extensions, Recipes & Skills
+
+**Status:** DRAFT — for Doug's review. Nothing here has been installed, enabled, or committed.
+**Compiled by:** Cowork, 2026-07-09, from `goose-docs.ai`'s live catalogs (`servers.json`,
+`skills-manifest.json`, and the recipe cookbook source in `documentation/src/pages/recipes/data/`).
+**Scope:** what to add to the *default* tortu-forks/goose install — i.e. `_tortu/bootstrap.sh` /
+`_tortu/config/` territory — not a one-off session enable.
+
+Once Doug picks what to keep, this becomes a real handoff for Claude Code to wire into
+`bootstrap.sh` / `config.yaml` / `_tortu/recipes/`.
+
+---
+
+## 1. Extensions
+
+Goose's built-ins (Developer, Extension Manager, Todo, Summon, etc.) are already configured in
+`_tortu/config/config.yaml` — not repeated here. This is the third-party/community catalog
+(61 entries in `servers.json`), filtered to what's actually relevant to this project: dogfooding +
+upstreaming Rust patches to `aaif-goose/goose`.
+
+### Tier 1 — recommend adding now
+
+| Extension | Repo | Why |
+|---|---|---|
+| **GitHub** | [github/github-mcp-server](https://github.com/github/github-mcp-server) | Native PR/issue ops — the missing piece for the fork→PR workflow in `BUILD_AND_SUBMIT.md`. Goose-endorsed. |
+| **Context7** | [upstash/context7](https://github.com/upstash/context7) | Live library docs instead of guessing at Rust crate APIs — directly addresses the "not yet verified against the compiler" pattern seen on the recipe-list patch. Endorsed. |
+| **Fetch** | [modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch) | Official MCP reference server, lightweight web fetching for research. Endorsed. |
+| **Playwright** | [microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp) | Browser automation — useful for `ui/desktop` (Electron) testing and doc-site work. Endorsed, Microsoft-maintained. |
+| **Chrome DevTools** | [ChromeDevTools/chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp) | Same rationale as Playwright, deeper inspection. Endorsed, official Chrome team. |
+| **Knowledge Graph Memory** | [modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers/tree/main/src/memory) | Official MCP reference server; more structured than the built-in Memory extension as fork knowledge grows. Endorsed. |
+
+### Tier 2 — worth trying, not essential
+
+| Extension | Repo | Why | Note |
+|---|---|---|---|
+| **Repomix** | [yamadashy/repomix](https://github.com/yamadashy/repomix) | Repo analysis/organization — the goose monorepo (`crates/`, `ui/desktop`) is large enough to benefit beyond Developer alone. | Not endorsed, single maintainer. |
+| **Beads** | [steveyegge/beads](https://github.com/steveyegge/beads) | Git-backed issue tracker for AI agent task management — could dovetail with how patches are already tracked (`_tortu/patches/<name>/`). | Not endorsed. Pairs with the `beads` skill below. |
+| **GitMCP** | [idosal/git-mcp](https://github.com/idosal/git-mcp) | Pulls live docs/repo content for any GitHub project into context. | Not endorsed. **Same repo link as "goose Docs" below — check before installing both, may be a duplicate/pre-configured instance.** |
+| **JetBrains** | [JetBrains/mcp-jetbrains](https://github.com/JetBrains/mcp-jetbrains) | IDE integration. | Only relevant if you're actually using a JetBrains IDE for this work — otherwise skip. |
+| **Container Use** | [container-use.com](https://container-use.com) | Isolated dev environments per task; the fork already has `BUILDING_DOCKER.md`/`Dockerfile`. | Not on GitHub (own site), not verified against this repo's actual container workflow yet. |
+
+### Explicitly skip
+
+Everything finance/e-commerce/IoT-flavored (Alby, Square, Cash App, MBot, Neighborhood), niche
+domain tools (I Ching, Scholar Sidekick, NostrBook, Ophis), and DB/data-platform ones (MongoDB, Neon,
+Supabase, DataHub, OpenMetadata) unless a specific patch actually touches a database.
+
+---
+
+## 2. Recipes
+
+### Already installed (community, from Block's Goose Subagents Workshop)
+
+Already living in `_tortu/recipes/` — no action needed, listed for completeness:
+
+`code-reviewer` · `test-generator` · `doc-writer` · `codebase-analyzer` · `codebase-locator` ·
+`web-researcher` — sourced from
+[block/goose-subagents-workshop](https://github.com/block/goose-subagents-workshop).
+
+### Recommend adding, from the official cookpanel
+
+| Recipe | Why |
+|---|---|
+| **Generate Commit Message** | Matches the DCO-signed commit step already in `BUILD_AND_SUBMIT.md`. |
+| **PR Generator** | Auto-drafts PR descriptions from a local diff — could template the attribution-header + before/after PR body format directly. |
+| **Test Coverage Optimizer** | `BUILD_AND_SUBMIT.md` already flags "consider adding a test for the new grouping/duplicate-flagging behavior" as a to-do — this formalizes that step. |
+| **Lint My Code** | Codifies the `cargo clippy --all-targets -- -D warnings` habit already noted in `.goosehints`. |
+| **Generate Change Logs from Git Commits** | Fits the fork's own "merge into fork's `main`" step in `MANIFEST.md`. |
+
+### Strategically interesting — could reshape the patch workflow itself
+
+| Recipe | Why |
+|---|---|
+| **RPI family** (`rpi-research`, `rpi-plan`, `rpi-iterate`, `rpi-implement`) | A formal Research→Plan→Implement pipeline — essentially what got improvised by hand for `recipe-list-formatting` (`HANDOFF.md` → `PATCH.md` → `BUILD_AND_SUBMIT.md`). Worth trying as a way to make that repeatable. |
+| **Ralph Work / Ralph Review** | Single-iteration work + "cross-model review, returns SHIP or REVISE." A built-in quality gate before dogfooding/submitting — matches the validate-before-PR discipline already in place. |
+
+### Worth trying, lower priority
+
+| Recipe | Why |
+|---|---|
+| **Code Review Mentor** | Compare against the existing `code-reviewer` recipe — may or may not add enough to be worth running both. |
+| **Technical Debt Tracker** | Useful now that a long-lived fork is being maintained — helps spot the *next* worthwhile upstream patch. |
+| **Add MCP Server** | Meta-recipe for contributing a new MCP server to goose's own docs (`servers.json` entry + tutorial). Not needed today; keep in back pocket if Tortu ever builds one worth upstreaming. |
+| **Maverick — Behavioral Adaptation** | Adjusts Goose's pacing/tone/autonomy to your working style. Curiosity-driven, not workflow-critical. |
+
+### Skip
+
+Domain-specific cookbook recipes that don't touch this project: A/B Test Framework Generator,
+CSV/data-cleaning recipes, Kafka topic creator, OpenAPI→Locust, DataHub/OpenMetadata, Sunno song
+formatter, web accessibility auditor, and the Flutter/JS-React/PHP PR reviewers (language-specific —
+the JS one would only matter if patching `ui/desktop` rather than the Rust CLI).
+
+---
+
+## 3. Skills
+
+All sourced from [block/Agent-Skills](https://github.com/block/Agent-Skills), installed via
+`npx skills add https://github.com/block/Agent-Skills --skill <id>`. Seven exist total; recommending
+four:
+
+| Skill | Why |
+|---|---|
+| **`code-review`** | Complements the existing `code-reviewer` recipe with a standing checklist rather than an on-demand recipe run. |
+| **`testing-strategy`** | Pairs with the recommended Test Coverage Optimizer recipe above. |
+| **`beads`** | Same git-backed task-tracking concept as the Beads extension (Tier 2 above) — a skill version if the full extension feels like too much. |
+| **`rp-why`** | Analyzes session history for AI-collaboration quality (cognitive depth, tool orchestration, delegation trust). Not workflow-critical, but matches Doug's general interest in refining how agent collaboration works (Framework/BASIS+M territory) — worth trying as a curiosity. |
+
+**Situational, not default:**
+
+| Skill | Why not default |
+|---|---|
+| `frontend-design` | Only relevant if touching `ui/desktop` (the TypeScript/React Electron app) rather than the Rust CLI. |
+| `api-setup` | General-purpose, no specific tie to current work. |
+| `goose-blog-post` | Specific to writing blog posts for the `block/goose` project — situational if Doug ever writes publicly about the fork/contribution, not a default. |
+
+**Note on Tortu's own skills:** `_tortu/config/skills/` already has five custom skills
+(`kn-nas`, `kn-nrr`, `kn-nsr`, `kn-summary`, `kn-wsr`) — these are separate from the
+`block/Agent-Skills` catalog above and untouched by this manifest.
+
+---
+
+## Open questions for Doug
+
+1. GitMCP and "goose Docs" resolve to the same repo (`idosal/git-mcp`) in `servers.json` — worth
+   confirming before installing both as if they were distinct.
+2. JetBrains extension — only worth it if you're actually using a JetBrains IDE for this work.
+3. Any of the "Tier 2" / "worth trying" items you'd rather skip entirely, or promote to Tier 1?

--- a/_tortu/_inbox/from-tortu-mcp-mcp-connection-spec.md
+++ b/_tortu/_inbox/from-tortu-mcp-mcp-connection-spec.md
@@ -1,0 +1,94 @@
+# Handoff → tortu-forks/goose: how to connect to tortu-mcp
+
+**From:** tortu-mcp (Cowork session) · **Date:** 2026-07-09
+**Status:** RESPONSE to `from-cowork-goose-default-install-request.md`
+**Re:** the 5 questions on transport, auth, default tool subset, the P98 gate bug, and config
+
+## 1. Transport
+
+tortu-mcp is **not** running as a standing network server today. All 8 engines
+(blender/triage/review/build/comms/learn/roadmap/mockups) are **stdio-spawned per client**,
+via an identical bash cd-wrapper pattern already registered in Claude Desktop's config:
+
+```
+bash -lc "cd <repo> && exec <repo>/.venv/bin/python -m <engine>.mcp"
+```
+
+There's a `reboot.sh --with-http-mcp` flag that puts review on `:8766` and build on `:8768`
+over Streamable HTTP, but that flag is explicitly reserved for a not-yet-built gateway
+architecture and is off by default — every current client (Claude Code Desktop/CLI, Cowork)
+uses stdio. Recommend goose do the same rather than being the first client on HTTP: mirror
+the existing wrapper, pointed at the same repo and venv.
+
+## 2. Auth / identity
+
+No API key or token — the trust boundary is "can this process spawn the venv python
+locally." Some tools (build's git-write verbs, comms) do check a self-declared caller
+string against `owner_agent` in `~/.tortu/repos.toml`, but it's checked at write-time only,
+not cryptographically enforced.
+
+Recommend goose sessions self-identify as their own caller, e.g. `"goose"` — not
+impersonating `tortu-mcp` or another existing agent identity. That keeps audit trails and
+any future ownership-gate enforcement correctly attributed, and avoids collisions if/when
+gating gets stricter.
+
+## 3. Default tool subset
+
+Recommend **read-only on by default**, mutating tools opt-in per session:
+
+**Default-on (read-only):**
+- review: `decisions_pending`, `decisions_status`, `markup_list`, `markup_get`, `markup_stats`, `notifications`
+- learn: `learning_list`, `learning_stats`, `learning_digest`
+- comms: `comms_read`, `comms_feed`, `comms_board`, `comms_threads`
+- roadmap: `roadmap_get` (flagging below — this engine has its own registration gap right now)
+
+**Opt-in only (mutates state):**
+- review: `decisions_create`, `decisions_update`, `decisions_revise`, `decisions_amend`, `markup_comment`, `markup_resolve`, `markup_reopen`
+- build: everything — `git_commit`, `git_push`, `git_merge`, `git_switch`, `sweep_*`, `job_start`, etc.
+- comms: `comms_post`, `comms_publish`, `comms_announce`, `comms_dispatch`
+
+Same posture tortu-mcp holds internally: write ops route through decision tickets / HITL,
+not ambient default access.
+
+**Aside, not blocking:** roadmap's own MCP server (`roadmap.mcp`) has an unresolved
+registration gap in this Cowork session specifically — it's configured identically to the
+working servers but doesn't show up via tool search. Root cause not yet confirmed. Don't
+build against it assuming it's live; verify it responds before depending on `roadmap_get`.
+
+## 4. Known gate bug — still open, keep write tools off
+
+Confirmed still unresolved as of this reply — the `decisions_create` → `git_commit`/
+`git_push` permission-consumption path (P98) does not reliably unblock a gated caller on a
+resolved YES. Agreed with your instinct: goose should launch with build's write-capable
+tools **off** by default until this lands, so it isn't a second caller hitting the same
+broken gate.
+
+## 5. Config snippet
+
+Start with review only (read-only surface), stdio, mirroring the existing Desktop pattern:
+
+```yaml
+extensions:
+  tortu-review:
+    name: tortu-review
+    type: stdio
+    cmd: bash
+    args:
+      - "-lc"
+      - "cd /Users/dougdaulton/AOF/work/projects/tortu-tools/tortu-mcp && exec .venv/bin/python -m review.mcp"
+    enabled: true
+    timeout: 60
+```
+
+Add `tortu-build` (same pattern, `-m mcpbuild.mcp`) only once Doug explicitly signs off on
+enabling write tools — and even then, gate the mutating tool names above behind an
+explicit allowlist in goose's own config rather than exposing the full build surface.
+
+## 6. What's next
+
+Nothing wired on tortu-mcp's side needs to change for this — it's purely a goose-side
+config addition. Ping tortu-mcp's `_inbox/` if the roadmap-registration gap or the P98 gate
+bug becomes something goose actually needs unblocked, since both are already tracked on
+tortu-mcp's own roadmap.
+
+— tortu-mcp, 2026-07-09

--- a/_tortu/bootstrap.sh
+++ b/_tortu/bootstrap.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# _tortu/bootstrap.sh
+#
+# Stand up tortu-custom goose on a fresh machine from a clean clone of this
+# fork. Installs the toolchain, wires in _tortu/config, builds the CLI, and
+# installs it onto PATH — no manual reconfiguration required.
+#
+# Usage: _tortu/bootstrap.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TORTU_DIR="$REPO_ROOT/_tortu"
+GOOSE_CONFIG_DIR="$HOME/.config/goose"
+INSTALL_DIR="$HOME/.local/bin"
+
+echo "==> Bootstrapping tortu goose from $REPO_ROOT"
+
+# --- 1. Toolchain -----------------------------------------------------------
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "==> Installing Rust toolchain (rustup via Homebrew)"
+    brew install rustup
+    rustup-init -y --no-modify-path
+fi
+if ! command -v cmake >/dev/null 2>&1; then
+    echo "==> Installing cmake (required by llama-cpp-sys-2)"
+    brew install cmake
+fi
+
+# --- 2. Secrets --------------------------------------------------------------
+SECRETS_FILE="$TORTU_DIR/config/secrets.env"
+SECRETS_TEMPLATE="$TORTU_DIR/config/secrets.env.example"
+
+if [ ! -f "$SECRETS_FILE" ]; then
+    echo "==> No $SECRETS_FILE found. Let's create one from the template."
+    echo "    (Values are written locally only; this file is gitignored and never committed.)"
+    cp "$SECRETS_TEMPLATE" "$SECRETS_FILE"
+    # Prompt for each VAR= line in the template and fill in the real file.
+    while IFS='=' read -r key _; do
+        case "$key" in
+            ""|\#*) continue ;;
+        esac
+        read -r -p "    $key: " value
+        # Escape any '|' or '&' the user might paste; sed -e keeps this simple.
+        escaped_value=$(printf '%s' "$value" | sed -e 's/[&|]/\\&/g')
+        sed -i '' "s|^${key}=.*|${key}=${escaped_value}|" "$SECRETS_FILE"
+    done < "$SECRETS_TEMPLATE"
+    echo "==> Wrote $SECRETS_FILE"
+else
+    echo "==> Found existing $SECRETS_FILE, using it as-is"
+fi
+
+# shellcheck disable=SC1090
+set -a; source "$SECRETS_FILE"; set +a
+
+# --- 3. Goose config ----------------------------------------------------------
+echo "==> Linking _tortu/config into $GOOSE_CONFIG_DIR"
+mkdir -p "$GOOSE_CONFIG_DIR"
+cp "$TORTU_DIR/config/config.yaml" "$GOOSE_CONFIG_DIR/config.yaml"
+mkdir -p "$GOOSE_CONFIG_DIR/custom_providers"
+cp "$TORTU_DIR/config/custom_providers/"*.json "$GOOSE_CONFIG_DIR/custom_providers/" 2>/dev/null || true
+mkdir -p "$GOOSE_CONFIG_DIR/skills"
+cp -R "$TORTU_DIR/config/skills/." "$GOOSE_CONFIG_DIR/skills/" 2>/dev/null || true
+cp "$TORTU_DIR/config/goosehints" "$GOOSE_CONFIG_DIR/.goosehints"
+
+# --- 4. Build + install --------------------------------------------------------
+echo "==> Building goose-cli (release)"
+cargo build --release -p goose-cli --manifest-path "$REPO_ROOT/Cargo.toml"
+
+mkdir -p "$INSTALL_DIR"
+cp "$REPO_ROOT/target/release/goose" "$INSTALL_DIR/goose"
+echo "==> Installed goose to $INSTALL_DIR/goose"
+
+if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
+    echo "==> NOTE: $INSTALL_DIR is not on your PATH. Add this to your shell profile:"
+    echo "    export PATH=\"$INSTALL_DIR:\$PATH\""
+fi
+
+echo "==> NOTE: set GOOSE_RECIPE_PATH to $TORTU_DIR/recipes in your shell profile:"
+echo "    export GOOSE_RECIPE_PATH=\"$TORTU_DIR/recipes\""
+
+echo "==> Bootstrap complete."

--- a/_tortu/config/config.yaml
+++ b/_tortu/config/config.yaml
@@ -1,0 +1,150 @@
+OPENAI_HOST: http://127.0.0.1:8000
+OPENAI_BASE_PATH: v1/chat/completions
+extensions:
+  chatrecall:
+    enabled: false
+    type: platform
+    name: chatrecall
+    description: Search past conversations and load session summaries for contextual memory
+    display_name: Chat Recall
+    bundled: true
+    available_tools: []
+  skills:
+    enabled: true
+    type: platform
+    name: skills
+    description: Discover and provide skill instructions from filesystem and builtins
+    display_name: Skills
+    bundled: true
+    available_tools: []
+  analyze:
+    enabled: true
+    type: platform
+    name: analyze
+    description: 'Analyze code structure with tree-sitter: directory overviews, file details, symbol call graphs'
+    display_name: Analyze
+    bundled: true
+    available_tools: []
+  apps:
+    enabled: true
+    type: platform
+    name: apps
+    description: Create and manage custom Goose apps through chat. Apps are HTML/CSS/JavaScript and run in sandboxed windows.
+    display_name: Apps
+    bundled: true
+    available_tools: []
+  summon:
+    enabled: true
+    type: platform
+    name: summon
+    description: Load knowledge and delegate tasks to subagents
+    display_name: Summon
+    bundled: true
+    available_tools: []
+  summarize:
+    enabled: false
+    type: platform
+    name: summarize
+    description: Load files/directories and get an LLM summary in a single call
+    display_name: Summarize
+    bundled: true
+    available_tools: []
+  orchestrator:
+    enabled: false
+    type: platform
+    name: orchestrator
+    description: 'Manage agent sessions: list, view, start, send messages, interrupt, and stop agents'
+    display_name: Orchestrator
+    bundled: true
+    available_tools: []
+  todo:
+    enabled: true
+    type: platform
+    name: todo
+    description: Enable a todo list for goose so it can keep track of what it is doing
+    display_name: Todo
+    bundled: true
+    available_tools: []
+  extensionmanager:
+    enabled: true
+    type: platform
+    name: Extension Manager
+    description: Enable extension management tools for discovering, enabling, and disabling extensions
+    display_name: Extension Manager
+    bundled: true
+    available_tools: []
+  code_execution:
+    enabled: false
+    type: platform
+    name: code_execution
+    description: Goose will make extension calls through code execution, saving tokens
+    display_name: Code Mode
+    bundled: true
+    available_tools: []
+  developer:
+    enabled: true
+    type: platform
+    name: developer
+    description: Write and edit files, and execute shell commands
+    display_name: Developer
+    bundled: true
+    available_tools: []
+  tom:
+    enabled: true
+    type: platform
+    name: tom
+    description: Inject custom context into every turn via GOOSE_MOIM_MESSAGE_TEXT and GOOSE_MOIM_MESSAGE_FILE environment variables
+    display_name: Top Of Mind
+    bundled: true
+    available_tools: []
+  computercontroller:
+    enabled: false
+    type: builtin
+    name: computercontroller
+    description: General computer control tools that don't require you to be a developer or engineer.
+    display_name: Computer Controller
+    timeout: 300
+    bundled: true
+    available_tools: []
+  autovisualiser:
+    enabled: false
+    type: builtin
+    name: autovisualiser
+    description: Data visualization and UI generation tools
+    display_name: Auto Visualiser
+    timeout: 300
+    bundled: true
+    available_tools: []
+  memory:
+    enabled: false
+    type: builtin
+    name: memory
+    description: Teach goose your preferences as you go.
+    display_name: Memory
+    timeout: 300
+    bundled: true
+    available_tools: []
+  tutorial:
+    enabled: false
+    type: builtin
+    name: tutorial
+    description: Access interactive tutorials and guides
+    display_name: Tutorial
+    timeout: 300
+    bundled: true
+    available_tools: []
+providers:
+  openai:
+    enabled: true
+    model: granite-4.1-3b-bf16
+    configured: true
+  custom_omlx:
+    enabled: true
+    model: granite-4.1-3b-bf16
+    configured: true
+  local:
+    enabled: true
+    model: bartowski/Mistral-Small-24B-Instruct-2501-GGUF:Q4_K_M
+    configured: true
+active_provider: local
+GOOSE_TELEMETRY_ENABLED: true

--- a/_tortu/config/config.yaml
+++ b/_tortu/config/config.yaml
@@ -133,6 +133,83 @@ extensions:
     timeout: 300
     bundled: true
     available_tools: []
+  # --- Tier 1 third-party MCP extensions, added per
+  # _tortu/_inbox/MANIFEST_2026-07-09_default-install-recommendations.md.
+  # All start disabled: none have been live-tested yet, and several need
+  # npx/uvx on PATH or (github) a secret. Flip enabled: true per-extension
+  # once verified.
+  github:
+    enabled: false
+    type: streamable_http
+    name: github
+    description: GitHub repository management and operations
+    uri: https://api.githubcopilot.com/mcp/
+    env_keys:
+      - GITHUB_PERSONAL_ACCESS_TOKEN
+    headers:
+      Authorization: "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"
+    timeout: 300
+    bundled: false
+    available_tools: []
+  context7:
+    enabled: false
+    type: stdio
+    name: Context7
+    description: Context7 MCP server for up-to-date code and docs
+    cmd: npx
+    args:
+      - "-y"
+      - "@upstash/context7-mcp"
+    timeout: 300
+    bundled: false
+    available_tools: []
+  fetch:
+    enabled: false
+    type: stdio
+    name: Fetch
+    description: Web content fetching and processing capabilities
+    cmd: uvx
+    args:
+      - mcp-server-fetch
+    timeout: 300
+    bundled: false
+    available_tools: []
+  playwright:
+    enabled: false
+    type: stdio
+    name: Playwright
+    description: Modern web testing and automation
+    cmd: npx
+    args:
+      - "-y"
+      - "@playwright/mcp@latest"
+    timeout: 300
+    bundled: false
+    available_tools: []
+  chrome-devtools:
+    enabled: false
+    type: stdio
+    name: Chrome DevTools
+    description: Browser automation and web performance testing capabilities
+    cmd: npx
+    args:
+      - "-y"
+      - "chrome-devtools-mcp@latest"
+    timeout: 300
+    bundled: false
+    available_tools: []
+  knowledge_graph_memory:
+    enabled: false
+    type: stdio
+    name: Knowledge Graph Memory
+    description: Graph-based memory system for persistent knowledge storage
+    cmd: npx
+    args:
+      - "-y"
+      - "@modelcontextprotocol/server-memory"
+    timeout: 300
+    bundled: false
+    available_tools: []
 providers:
   openai:
     enabled: true

--- a/_tortu/config/config.yaml
+++ b/_tortu/config/config.yaml
@@ -210,6 +210,40 @@ extensions:
     timeout: 300
     bundled: false
     available_tools: []
+  # Read-only surface into tortu-mcp's review engine, per
+  # _tortu/_inbox/from-tortu-mcp-mcp-connection-spec.md. available_tools is
+  # populated deliberately (not left empty) so goose's own extension.rs
+  # is_tool_available() allowlist enforces read-only at both tool-listing and
+  # dispatch time -- not relying solely on review.mcp's own posture. Mutating
+  # tools (decisions_create/update/revise/amend, markup_comment/resolve/
+  # reopen) and all of tortu-build stay excluded until Doug signs off and the
+  # P98 gate bug is resolved.
+  tortu-review:
+    enabled: true
+    type: stdio
+    name: tortu-review
+    description: Read-only access to tortu-mcp's review engine (decisions, markup, learning, comms, roadmap)
+    cmd: bash
+    args:
+      - "-lc"
+      - "cd /Users/dougdaulton/AOF/work/projects/tortu-tools/tortu-mcp && exec .venv/bin/python -m review.mcp"
+    timeout: 60
+    bundled: false
+    available_tools:
+      - decisions_pending
+      - decisions_status
+      - markup_list
+      - markup_get
+      - markup_stats
+      - notifications
+      - learning_list
+      - learning_stats
+      - learning_digest
+      - comms_read
+      - comms_feed
+      - comms_board
+      - comms_threads
+      - roadmap_get
 providers:
   openai:
     enabled: true

--- a/_tortu/config/custom_providers/custom_omlx.json
+++ b/_tortu/config/custom_providers/custom_omlx.json
@@ -1,0 +1,32 @@
+{
+  "name": "custom_omlx",
+  "engine": "openai",
+  "display_name": "OMLX",
+  "description": "Custom OMLX provider",
+  "api_key_env": "CUSTOM_OMLX_API_KEY",
+  "base_url": "http://127.0.0.1:8000/v1",
+  "models": [
+    {
+      "name": "granite-4.1-3b-bf16",
+      "context_limit": 128000,
+      "input_token_cost": null,
+      "output_token_cost": null,
+      "currency": null,
+      "supports_cache_control": null,
+      "reasoning": false
+    }
+  ],
+  "headers": {},
+  "timeout_seconds": null,
+  "supports_streaming": true,
+  "requires_auth": true,
+  "catalog_provider_id": null,
+  "base_path": null,
+  "env_vars": null,
+  "dynamic_models": null,
+  "skip_canonical_filtering": false,
+  "model_doc_link": null,
+  "setup_steps": [],
+  "fast_model": null,
+  "preserves_thinking": true
+}

--- a/_tortu/config/goosehints
+++ b/_tortu/config/goosehints
@@ -1,0 +1,66 @@
+# Kaminari — Goose identity (.goosehints)
+Canonical identity: `commons/CORE.md`; rubric + exemplars:
+`commons/boundaries/guardrails/`. On Goose you CAN read those files if you
+need depth — but everything required to act is here and in the skills.
+
+## Identity
+You are Kaminari, Doug's TRD annotation assistant, running on local
+models. Doug dictates; you produce exactly-formatted annotation
+deliverables. You are a scribe and formatter — NOT an evaluator, grader,
+or scorer. Never score, rate, or evaluate YOUR OWN output. Scoring another
+SME's work is allowed only when a skill directs it (kn-nsr SME Score) or
+Doug asks.
+
+## Prime directives
+1. Deliverable only, IN CHAT, in its exact template — no meta-commentary,
+   no recaps, no scores. Never write a deliverable to a file unless Doug
+   asks.
+2. The templates are law. Formats come from the skills and the rubric.
+   Never invent a methodology, section, or field not in the skill.
+3. Local only. If a task exceeds the current model, say so and suggest
+   switching models — never route to cloud.
+4. Capture everything dictated. Every observation must appear in output.
+
+## Process glossary (the ONLY meanings)
+- NAS = New Annotation Set (dictation → annotations; ADDITIONS only)
+- NRR = New Revision Round (implement a reviewer's notes on Doug's set)
+- NSR = New SME Review (Doug's review notes on another SME's set)
+- WSR = Work Session Report (session summary)
+These map to skills kn-nas / kn-nrr / kn-nsr / kn-wsr (+ kn-summary for the
+Lightning Summary). On Goose, a skill loads when your request matches its
+description — there is no slash command. Dictation transposes acronyms:
+treat NRS=NSR, NSA=NAS, RNR=NRR; ambiguous → ask one question.
+
+#########################################
+TEXTUAL DESCRIPTION (TD) — THE THREE-PART RULE (always applies)
+#########################################
+Every textual description you WRITE is exactly three sentences on one
+line, in order — all three parts mandatory:
+  1. OPENER — the literal sentence `Unrealistic physics.` (only
+     `Unrealistic scene consistency.` instead, and only when Doug directs).
+  2. OBSERVATION — one sentence, naming the specific part ("left gripper",
+     "upper elbow link", "the orange block"). Never "robot"/"robot arm".
+  3. CLOSER — one sentence giving the physical reason, beginning
+     `This breaks physics because…` / `This is impossible because…` /
+     `This is implausible because…`.
+The observation alone is NOT a valid TD. Never drop the opener; never
+replace the closer with vague filler ("breaks the geometry of the
+system"). No hedging (appears/seems/might/possibly/somehow), no
+engineering jargon, definitive verbs. ET tag (URS/PM/UGC/UI/UA/OCE/Other)
+goes only on the `ET:` line, never inside the TD.
+
+Gold-standard TDs — match this shape exactly:
+```
+Unrealistic physics. The left forearm twists at the upper elbow link in a direction the joint cannot support. This breaks physics because the elbow link is a rigid structural component and cannot rotate without an articulated joint to enable that movement.
+```
+```
+Unrealistic physics. The silver hanger on the right side of the table slides forward toward the camera without any contact or applied force. This is impossible because an object cannot move without a force applied against it.
+```
+```
+Unrealistic physics. The closed left gripper hovers above the orange block without making contact, yet the block lifts off the table and follows the gripper upward. This breaks physics because an object cannot be supported against gravity without a secure grasp or other applied force.
+```
+
+## Communication
+Concise and direct; deliverable first; ONE short clarifying question only
+when dictation is too vague to format without inventing detail. If the
+session grows long and answers degrade, say so and recommend a fresh one.

--- a/_tortu/config/secrets.env.example
+++ b/_tortu/config/secrets.env.example
@@ -1,0 +1,17 @@
+# _tortu/config/secrets.env.example
+#
+# Template for _tortu/config/secrets.env — the real file that holds actual
+# credential values. secrets.env is gitignored and never committed; only
+# this .example file (names, no values) is tracked.
+#
+# Setup on a new machine, either:
+#   1) Run _tortu/bootstrap.sh and answer the prompts (it writes secrets.env
+#      for you), or
+#   2) Copy this file to secrets.env by hand and fill in real values:
+#        cp _tortu/config/secrets.env.example _tortu/config/secrets.env
+#
+# bootstrap.sh sources secrets.env and exports everything into the shell
+# environment before goose config/providers are wired up.
+
+# API key for the local OMLX custom provider (_tortu/config/custom_providers/custom_omlx.json)
+CUSTOM_OMLX_API_KEY=

--- a/_tortu/config/secrets.env.example
+++ b/_tortu/config/secrets.env.example
@@ -15,3 +15,11 @@
 
 # API key for the local OMLX custom provider (_tortu/config/custom_providers/custom_omlx.json)
 CUSTOM_OMLX_API_KEY=
+
+# GitHub Personal Access Token for the "github" MCP extension
+# (_tortu/config/config.yaml -> extensions.github, disabled by default).
+# Create at https://github.com/settings/personal-access-tokens — scope it to
+# only the repos/permissions this fork actually needs (PR/issue ops on
+# aaif-goose/goose and tortu-forks/goose). Referenced by name via env_keys,
+# never written into config.yaml directly.
+GITHUB_PERSONAL_ACCESS_TOKEN=

--- a/_tortu/config/skills/beads/SKILL.md
+++ b/_tortu/config/skills/beads/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: beads
+description: Use beads (bd) for persistent task tracking in coding projects. A git-backed issue tracker designed for AI agents with dependency graphs, hierarchical tasks, and multi-agent coordination.
+author: goose
+version: "1.0"
+tags:
+  - development
+  - productivity
+  - task-management
+  - workflow
+---
+
+This skill teaches effective use of **beads** (`bd`), a distributed git-backed issue tracker designed for AI agents. Use beads to track tasks, manage dependencies, and coordinate work across sessions.
+
+## Getting Started
+
+First, check if beads is available and initialized:
+
+```bash
+# Check if bd is installed
+bd version
+
+# Check if current project has beads initialized
+bd status
+```
+
+**If `bd` is not installed**, ask the user which installation method they prefer:
+- **npm:** `npm install -g @beads/bd`
+- **Homebrew:** `brew install beads` (macOS)
+- **Go:** `go install github.com/steveyegge/beads/cmd/bd@latest`
+
+Do not install without user confirmation, as these are global system packages.
+
+**If not initialized in the project**, run:
+```bash
+bd init
+```
+
+For personal use on shared projects (won't commit to repo):
+```bash
+bd init --stealth
+```
+
+For contributors on forked repos (routes to separate planning repo):
+```bash
+bd init --contributor
+```
+
+## Essential Commands
+
+| Command | Purpose |
+|---------|---------|
+| `bd ready` | List tasks with no open blockers (what to work on next) |
+| `bd create "Title" -p 1` | Create a task (priority 0-3, lower = higher priority) |
+| `bd show <id>` | View task details and dependencies |
+| `bd list` | List all open issues |
+| `bd close <id>` | Mark task as complete |
+| `bd update <id> --status in_progress` | Update task status |
+| `bd dep add <child> <parent>` | Create dependency (child blocked by parent) |
+| `bd sync` | Force immediate sync to git |
+
+**Always use `--json` flag** for machine-readable output when parsing results.
+
+## Task Hierarchy
+
+Beads supports hierarchical IDs for organizing work:
+
+- `bd-a3f8` — Epic (large feature)
+- `bd-a3f8.1` — Task under epic
+- `bd-a3f8.1.1` — Sub-task
+
+Create hierarchical tasks:
+```bash
+bd create "Epic: User Authentication" -t epic -p 1
+bd create "Implement login flow" -p 1 --parent bd-a3f8
+```
+
+## Session Workflow
+
+### Starting a Session
+
+```bash
+# See what's ready to work on
+bd ready --json
+
+# Pick a task and mark it in progress
+bd update <id> --status in_progress
+
+# View full details
+bd show <id> --json
+```
+
+### During Work
+
+```bash
+# Create new tasks as you discover them
+bd create "Fix edge case in validation" -p 2
+
+# Add dependencies
+bd dep add <new-task> <blocking-task>
+
+# Update task with notes
+bd update <id> --notes "Found issue with timezone handling"
+```
+
+### Ending a Session ("Land the Plane")
+
+When finishing work, complete ALL these steps:
+
+```bash
+# 1. File issues for remaining work
+bd create "TODO: Add integration tests" -p 2
+
+# 2. Close completed tasks
+bd close <id> --reason "Completed"
+
+# 3. Sync and push (MANDATORY)
+git pull --rebase
+bd sync
+git push
+
+# 4. Verify push succeeded
+git status  # Must show "up to date with origin"
+
+# 5. Identify next task for follow-up
+bd ready --json
+```
+
+**CRITICAL**: Always push before ending a session. Unpushed work causes coordination problems in multi-agent workflows.
+
+## Important Rules
+
+### DO use `bd update` with flags
+```bash
+bd update <id> --description "new description"
+bd update <id> --title "new title"  
+bd update <id> --design "design notes"
+bd update <id> --notes "additional notes"
+bd update <id> --acceptance "acceptance criteria"
+bd update <id> --status in_progress
+```
+
+### DO NOT use `bd edit`
+The `edit` command opens an interactive editor (`$EDITOR`) which AI agents cannot use. Always use `bd update` with flags instead.
+
+### DO sync before ending sessions
+```bash
+bd sync  # Forces immediate export, commit, and push
+```
+
+Without `bd sync`, changes sit in a 30-second debounce window and may not be committed.
+
+### DO include issue IDs in commit messages
+```bash
+git commit -m "Fix auth validation bug (bd-abc)"
+```
+
+This enables `bd doctor` to detect orphaned issues.
+
+## Dependency Types
+
+```bash
+# Hard blocker - child cannot start until parent is done
+bd dep add <child> <parent> --type blocks
+
+# Soft link - related but not blocking  
+bd dep add <issue1> <issue2> --type related
+
+# Parent-child - hierarchical relationship
+bd dep add <child> <parent> --type parent-child
+```
+
+## Handling Merge Conflicts
+
+If conflicts occur in `.beads/issues.jsonl`:
+
+```bash
+# Accept remote version
+git checkout --theirs .beads/issues.jsonl
+
+# Re-import to database
+bd import -i .beads/issues.jsonl
+
+# Continue with your work
+```
+
+## Git Hooks (Recommended)
+
+Install hooks for automatic sync:
+
+```bash
+bd hooks install
+```
+
+This prevents stale JSONL problems by auto-syncing on commit, merge, push, and checkout.
+
+## MCP Server Alternative
+
+For tighter integration, beads also offers an MCP server (`beads-mcp`) that provides tools directly to your agent. Install via:
+
+```bash
+pip install beads-mcp
+```
+
+The CLI (`bd`) and MCP server work with the same underlying database.
+
+## Quick Reference
+
+```bash
+# What should I work on?
+bd ready
+
+# Create a task
+bd create "Fix bug in login" -p 1
+
+# Start working
+bd update bd-xyz --status in_progress
+
+# Done working
+bd close bd-xyz --reason "Completed"
+bd sync
+git push
+```

--- a/_tortu/config/skills/code-review/SKILL.md
+++ b/_tortu/config/skills/code-review/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: code-review
+description: Comprehensive code review checklist for pull requests
+author: goose
+version: "1.0"
+tags:
+  - development
+  - quality
+  - review
+---
+
+# Code Review Checklist
+
+When reviewing code, check each of these areas:
+
+## Functionality
+
+- [ ] Code does what the PR description claims
+- [ ] Edge cases are handled
+- [ ] Error handling is appropriate
+
+## Code Quality
+
+- [ ] Follows project style guide
+- [ ] No hardcoded values that should be configurable
+- [ ] Functions are focused and well-named
+
+## Testing
+
+- [ ] New functionality has tests
+- [ ] Tests are meaningful, not just for coverage
+- [ ] Existing tests still pass
+
+## Security
+
+- [ ] No credentials or secrets in code
+- [ ] User input is validated
+- [ ] SQL queries are parameterized
+
+## Performance
+
+- [ ] No obvious performance issues
+- [ ] Database queries are optimized
+- [ ] No unnecessary loops or iterations
+
+## Documentation
+
+- [ ] Public APIs are documented
+- [ ] Complex logic has comments explaining "why"
+- [ ] README updated if needed

--- a/_tortu/config/skills/kn-nas/SKILL.md
+++ b/_tortu/config/skills/kn-nas/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: kn-nas
+description: "TRD New Annotation Set (NAS): turn Doug's dictated video observations into Annotation Content (Pass 2 format). Triggers: NAS, NSA (transposition of NAS), new annotation set, annotate this clip, annotate this video, here are my observations."
+version: 2.2.0
+author: Doug Daulton
+metadata:
+  hermes:
+    tags: [TRD, NAS, annotation, SME, rubric]
+---
+
+# TRD — New Annotation Set (NAS)
+
+NAS = New Annotation Set. Doug (SME) dictates observations about an
+AI-generated robot video; you structure them into annotation content.
+ADDITIONS only. This skill produces ONLY the annotation content — the
+Lightning Summary is a separate step (the kn-summary skill), produced
+later when Doug asks. Do NOT produce a summary here.
+
+Never invent your own methodology. Everything you need is in this skill and
+in SOUL — you have NO file-read tool, so do not try to open the rubric or
+exemplars; use the inline rules and the worked example below.
+
+## How it works (ONE pass)
+Doug dictates each issue with whatever timecodes he has. You produce
+Annotation Content in Pass 2 format. For any timecode he did not give,
+write `[tbd]` — he fills it in. Produce output only after he has
+actually dictated observations. If invoked with an await cue and no
+observations yet, reply with EXACTLY `Awaiting notes.` and nothing else
+(see SOUL → AWAIT STATE) — no plan, no rules, no reasoning.
+
+## Number normalization (spoken -> decimal timecode) - ALWAYS apply
+Doug dictates by voice; transcription often leaves numbers as English
+words or mis-formats them. Convert EVERY timecode to decimal seconds
+before using or echoing it. Never leave English number-words in output.
+- "point seven five" -> 0.75 ; "two point two two" -> 2.22
+- After "point", read digits individually: "one point oh four" -> 1.04 ;
+  "five point oh six seven" -> 5.067 ; "zero point four seven eight" -> 0.478
+- "two twenty-two" / "two twenty two" in timecode context -> 2.22 (NOT 222)
+- "to the end" -> 5.067 ; spelled integers: "zero"->0 ... "five"->5
+- Timecodes are ALWAYS within 0.00-5.067 (clip length). If a converted
+  value falls outside that range, do NOT guess - flag it in the readback
+  and ask Doug.
+- Surface the converted decimals in the readback so Doug can catch any
+  mis-conversion before the deliverable renders.
+
+## READBACK — required before rendering
+Before producing the formatted deliverable, list back the items you
+captured as a numbered preview (`timecode — short description`, one line
+each) and ask Doug to confirm or correct. Render the final output only
+after he confirms. Catches mis-bound or dropped items from long/multi-
+pass dictation. Skip only if Doug says "no readback".
+
+## Output — Annotation Content (one ```text block)
+One entry per observation, sorted by TS-S ascending:
+```text
+0.05:  Unrealistic physics. <observation>. <closer with reason>.
+TS-E: 5.067
+ET: URSP
+```
+- TS-S leads each entry; no item numbers.
+- `TS-E:` and `ET:` each on their own line. "To the end" = TS-E 5.067.
+- NO bounding box — the SME sets BB in the annotation tool.
+- Use `[tbd]` for any timecode or ET Doug hasn't given. Never invent one.
+
+## TD rules (every textual description) — THREE PARTS REQUIRED
+Every TD has three required parts on one line, in order:
+1. `Unrealistic physics.` — literal opener, verbatim.
+   (Only `Unrealistic scene consistency.` instead, and only when Doug
+   directs it — including cross-camera / wrist-camera inconsistencies
+   flagged as Other. Never your own call. For scene-consistency TDs,
+   the closer begins `This breaks scene consistency because…`, not
+   `This breaks physics because…`.)
+2. The observation — exactly what is seen, naming the specific part.
+   May be one or more sentences for complex errors.
+3. The closer — the physical reason this error is impossible, beginning:
+   `This breaks physics because…` / `This is implausible because…` /
+   `This is impossible because…`. Must match THIS specific error —
+   never copy a generic physics sentence from another annotation.
+
+Sentence count: aim for ~3 for simple, clear errors; longer is correct
+when the error is complex or requires additional context. Never exceed
+one short paragraph. Never pad with repetition.
+
+Both the visual observation AND the physics reason must be present.
+Observational tone, 11th-grade level, short declarative sentences,
+definitive verbs (bends, slides, intersects). No subjective adjectives
+(strange, weird, unusual). No hedging (appears to, seems to, might be,
+possibly, somehow). No "motivated cause/force". No engineering jargon
+(rigid-body dynamics, kinematic constraints). No timestamps in TD text.
+Do not use the word "indicated" in TD text.
+Never write "robot" or "robot arm" in a TD — name the specific part.
+Name specific objects ("the orange block", "the left gripper") — never
+"the gripper" or "the object" without a qualifier.
+ET tag never appears in the TD sentences — only on the `ET:` line.
+
+## ET tags — metadata (ET: line) only, NEVER the first sentence
+- URSP — robot part deformation / pose / speed / continuity / duplication
+- PM — scene object moves with no force applied (never robot parts)
+- UGC — gripper–object contact physics fail (slips jaws, acts magnetic,
+         object movement syncs with arm without contact)
+- UI — objects phase into each other (robot-into-robot = URSP, not UI)
+- UA — motion has a real cause but wrong speed/trajectory/direction
+- OCE — object permanence: occlusion, pop-in, duplication (objects only;
+         robot-part OCE-type errors → URSP)
+- Other — camera/scene errors; Doug's call; uses the scene-consistency opener
+
+## URSP triage — critical routing rules
+Use URSP (not another ET) for these specific situations:
+- Arm interpenetrates itself → URSP (not UI)
+- Arm interpenetrates the other arm → URSP
+- Gripper duplicates itself → URSP
+- Left gripper duplicates after right gripper passes in front → URSP
+- Arm moves too quickly → URSP (not UA)
+- Exception: arm moves too quickly AND hits object that then moves at
+  wrong speed → TWO separate annotations: URSP (arm) + UA (object)
+- Robot part has OCE-type error (pop-in, occlusion, duplication) → URSP
+  (not OCE — OCE is only for scene objects)
+
+## Motion Error Diagnosis (PM / UGC / UA)
+When you see unusual object motion, apply this flow:
+- Something clearly touching/pushing the object?
+  - YES, wrong speed or path → UA
+  - YES, gripper involved but acting glitchy → UGC
+  - NO, moving entirely on its own → PM
+If the object's motion syncs with or mimics the arm's movement in any
+way, that is UGC, not PM.
+
+## Combining annotations — hard limit
+Max TWO annotations of the same ET may be combined into one annotation.
+NEVER combine different ET types in one annotation if their bounding
+boxes overlap. When two ET types co-exist with overlapping BBs, create
+separate annotations for each.
+
+## Vocabulary
+- Arm: base, base joint, lower/upper shoulder link, lower/upper elbow
+  link, forearm, wrist.
+- Wrist sub-components: wrist head (top of wrist, black component);
+  end effector connector (connects wrist to gripper, usually not visible
+  in the annotation — refer to it only if it is the locus of the error);
+  wrist grip (rounded component just above end effector connector, fixed,
+  follows end effector connector movement); gripper camera (small white
+  stick off end effector connector, rotates 360° only, cannot move up/down).
+- Gripper: end effector (whole apparatus), fingers/jaws, fingertips/jaw
+  tips, fingerpads. One gripper per arm — never "grippers" for one arm.
+- Objects by attribute ("the orange block"), never "the item/object".
+- BANNED in prose: grabbers, claws, pinchers, clappers, clippers, clamps,
+  teeth, pincers, pilot, flange, indicated, numbered joints ("joint 3"),
+  timestamps, "robot arm" (name the part).
+- Left/right = CAMERA perspective, always. Specify left/right at least
+  once per annotation; do not repeat unnecessarily once established.
+
+## Never annotate
+- The operator (even if the operator appears to break physics).
+- The first frame (0.00–0.01s — recorded footage, not AI).
+- Events outside the glass-box environment.
+- Motion already underway when the clip starts (cause not visible → ET
+  unknowable).
+- An error-free task — never fabricate annotations to fill it.
+
+## Timecodes
+- Convert spoken numbers literally: "point seven five" → 0.75 ·
+  "one point oh two" → 1.02 · "two twenty three" → 2.23 · "to the end" → 5.067.
+- Echo Doug's timecodes EXACTLY — never round, shift, or drop digits.
+- Ambiguous spoken timecode → ask ONE question. Missing → `[tbd]`.
+
+## Edge handling
+- Vague dictation → ask ONE clarifying question; never guess detail.
+- "Don't act yet / just note it" → acknowledge, apply the note, defer
+  output until Doug asks for it.
+- Any tool or file read fails → STOP and report it. Never proceed as if
+  it succeeded.
+- PM is for scene objects only; a robot part moving wrong is always URSP.
+- When only a timecode changes, change only that — don't rewrite the TD.
+
+## Output mechanics
+- Put the deliverable in ONE ```text code block (real line breaks),
+  directly in chat. Never write it to a file unless Doug asks for a file.
+- Placeholders: [brackets] and {braces} in templates are NEVER literal
+  output — replace each with the real value, or omit the line if it's an
+  optional field with nothing to fill. Output containing literal bracket
+  or brace placeholder text is wrong.
+- Nothing after the deliverable: no commentary, no scores, no recap.
+
+## FINAL CHECK before sending
+1. Entries sorted by TS-S ascending.
+2. Every dictated observation is present — count them.
+3. Timecodes exactly as dictated; `[tbd]` where none was given.
+4. Each TD has all THREE parts: opener + observation (specific part named,
+   no "robot"/"robot arm", no "indicated", no timestamps) + physics closer
+   matched to THIS error. Scene-consistency TDs use correct opener and
+   `…scene consistency because…` closer.
+5. No banned vocabulary; ET only on the `ET:` line.
+6. Combining limit not violated (max 2 same ET per annotation).
+7. One ```text block; nothing trailing after it.
+
+## WORKED EXAMPLE
+Doug: "First, the left arm moves way too fast, starts at the beginning —
+call it 0.05 to the end. Second, the right gripper finger bends a way it
+shouldn't, 1.34 to 2.67, URSP. Third, a red cup slides on its own with no
+contact, 3.12 to the end, PM."
+
+Agent:
+```text
+0.05:  Unrealistic physics. The left arm moves through its task at a speed too fast for accurate manipulation. This breaks physics because an arm moving at this speed could not reliably complete a precise task.
+TS-E: 5.067
+ET: URSP
+
+1.34:  Unrealistic physics. The right gripper finger bends in a direction its joint does not support. This is impossible because gripper fingers are rigid components that can only articulate at designated joints.
+TS-E: 2.67
+ET: URSP
+
+3.12:  Unrealistic physics. The red cup slides across the table without any contact or force acting on it. This breaks physics because an object cannot move without a force applied against it.
+TS-E: 5.067
+ET: PM
+```
+When Doug later asks for the summary, that is the kn-summary skill — not
+this one.

--- a/_tortu/config/skills/kn-nrr/SKILL.md
+++ b/_tortu/config/skills/kn-nrr/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: kn-nrr
+description: "TRD New Revision Round (NRR): implement an SCR reviewer's notes on Doug's prior annotation set field-level annotation content updates. Triggers: NRR, revision round, RNR (transposition of NRR), reviewer notes, implement these review notes, revise my annotations."
+version: 2.2.0
+author: Doug Daulton
+metadata:
+  hermes:
+    tags: [TRD, NRR, revision, reviewer, annotation]
+---
+# TRD New Revision Round (NRR)
+NRR=New Revision Round. Doug pastes a reviewer's notes on his prior annotation set; you produce the annotation content updates he moves into the web app. Allowed actions: ADDITIONS, DELETIONS, EDITs, MERGES. This skill produces ONLY the annotation content the Lightning Summary is a separate step (kn-summary), produced when Doug says "NRR complete." Do NOT produce a summary here.
+
+Never invent methodology. Everything you need is in this skill and in SOUL
+(the TD three-part rule + exemplars). You have NO file-read tool — do not
+try to open the rubric or "the guidelines," and do not model your wording
+on examples you cannot see. Use the inline exemplars below.
+
+## Await state
+If invoked with an await cue and no reviewer notes yet, reply with EXACTLY
+`Awaiting reviewer notes.` and nothing else (see SOUL → AWAIT STATE) — no
+plan, no rules recap, no reasoning. Produce the annotation updates only
+after the notes arrive.
+
+## Core rules
+- Output ONLY the field(s) that changed per annotation. Never include unchanged annotations.
+- EDIT/MERGE header timecode=the ORIGINAL start time; a changed start goes on a `TS-S:` line.
+- DELETIONS rationale must be one of: invalid/subjective/covered elsewhere.
+- MERGES: header=earliest annotation's start; text covers all merged points.
+- Labels are EDITs (not "UPDATES") and ADDITIONS (not "NEW").
+- End with FINAL ACTION: exactly `Marked as complete.` or `Resubmitted for new review.`, per the reviewer's directive.
+
+## Number normalization (spoken->decimal timecode)
+- ALWAYS apply Doug dictates by voice; transcription often leaves numbers as English words or mis-formats them. Convert EVERY timecode to decimal seconds before using or echoing it. Never leave English number words in output.
+- "point seven five" -> 0.75; "two point two two" -> 2.22
+- After "point", read digits individually: "one point oh four" -> 1.04; "five point oh six seven" -> 5.067; "zero point four seven eight" -> 0.478
+- "two twenty-two" / "two twenty two" in timecode context -> 2.22 (NOT 222)
+- "to the end" -> 5.067; spelled integers: "zero" -> 0 ... "five" -> 5
+- Timecodes are ALWAYS within 0.00-5.067 (clip length). If a converted value falls outside that range, do NOT guess; flag it in the readback and ask Doug.
+- Surface the converted decimals in the readback so Doug can catch any mis-conversion before the deliverable renders.
+
+## READBACK required before rendering
+Before producing the formatted deliverable, list back the items you captured as a numbered preview (`timecode, short description`, one line each) and ask Doug to confirm or correct. Render the final output only after he confirms. Catches mis-bound or dropped items from long/multi-pass dictation. Skip only if Doug says "no readback".
+
+## Output (one ```text block, sections with items only)
+```text
+ADDITIONS
+###########################
+[timecode]: Unrealistic physics. [observation naming the part]. This breaks physics because [physical reason].
+TS-E: [end time if extended, else omit line]
+
+DELETIONS
+###########################
+[timecode]: [Original text to delete]
+Rationale: [invalid/subjective/covered elsewhere]
+
+EDITS
+###########################
+[timecode]: Unrealistic physics. [revised observation]. This breaks physics because [physical reason].
+TS-E: [end time if extended, else omit line]
+
+FINAL ACTION
+###########################
+Marked as complete.
+```
+- Top headers 27 hashes. Only include lines/fields that actually changed.
+- Any new or revised TD is the full three-part form (opener · observation
+  · closer) — see TD rules below and the worked example at the end.
+- EDITS that change ONLY a non-text field (TS, BB, ET) state just that
+  field as a directive (e.g. `1.88: ET: change Phantom Motion to URSP`) —
+  no TD needed. Only write a full TD when the text itself changed.
+
+## TD rules (any new or revised textual description) — ALL THREE PARTS REQUIRED
+Every TD you write has THREE required parts on one line, in order:
+1. `Unrealistic physics.` — the literal opener, verbatim. (Only
+   `Unrealistic scene consistency.` instead, and only when Doug directs —
+   including cross-camera / wrist-camera inconsistencies flagged as Other.
+   For scene-consistency TDs, closer begins `This breaks scene consistency
+   because…`, never `This breaks physics because…`.)
+2. The observation — what is seen, naming the specific part. May be one
+   or more sentences for complex errors.
+3. The closer — the physical reason, beginning `This breaks physics
+   because…` / `This is impossible because…` / `This is implausible
+   because…`. Must describe why THIS SPECIFIC ERROR is impossible — never
+   a copied generic physics sentence from another annotation.
+
+Sentence count: aim for ~3 for simple errors; more is correct when the
+error is complex. Never exceed one short paragraph. Never pad with
+repetition. Four or five sentences is not wrong — missing either the
+observation or the physics closer is.
+
+The observation alone is NOT a valid TD. Dropping the `Unrealistic
+physics.` opener, or replacing the closer with vague filler (\"breaks the
+geometry of the system\", \"breaks the robot design\"), is WRONG. When Doug
+hands you an observation, you still ADD the opener and WRITE the physical
+reason — you are not just echoing his words.
+- Observational tone, 11th-grade, definitive verbs. No subjective
+  adjectives, no hedging (appears/seems/might/possibly/somehow), no
+  "motivated cause/force", no engineering jargon.
+- Never write "robot" or "robot arm" in a TD — name the specific part.
+- No timestamps in TD text. Do not use the word "indicated" in TD text.
+- Name specific objects ("the orange block", "the left gripper") — never
+  "the gripper" or "the object" without a qualifier.
+- ET tag never appears in the TD sentences — only on the `ET:` line.
+
+## Vocabulary
+- Arm: base, base joint, lower/upper shoulder link, lower/upper elbow link, forearm, wrist.
+- Wrist sub-components: wrist head (top of wrist, black component);
+  end effector connector (connects wrist to gripper, usually not visible —
+  refer only if it is the locus of the error); wrist grip (rounded
+  component above end effector connector, fixed); gripper camera (small
+  white stick off end effector connector, rotates 360° only).
+- Gripper: end effector (whole apparatus), fingers/jaws, fingertip, jaw
+  tips, finger pads. One gripper per arm.
+- Objects by attribute. Left/right=CAMERA perspective.
+- BANNED: grabbers, claws, pinchers, clappers, clippers, clamps, teeth,
+  pincers, pilot, flange, indicated, numbered joints, timestamps,
+  "robot arm" (name the part).
+
+## ET tags (ET: [line only]): URSP, PM, UGC, UI, UA, OCE, Other
+(URSP=robot part errors — deformation/pose/speed/duplication/continuity;
+PM=scene object no force; UGC=gripper contact fail; UI=interpenetration
+objects only; UA=wrong speed/direction; OCE=object permanence objects only;
+Other=Doug's call, scene consistency opener.)
+
+URSP routing: arm-self-interpenetration → URSP not UI; arm–arm
+interpenetration → URSP; gripper duplication → URSP; arm too fast → URSP
+not UA. Exception: arm too fast AND object reacts at wrong speed → two
+separate annotations: URSP + UA.
+
+## Combining limit
+Max TWO annotations of the same ET per combined annotation. Never combine
+different ET types in one annotation if their bounding boxes overlap.
+
+## Timecodes & edges
+- Convert spoken numbers literally ("point seven five"=0.75; "to the end"=5.067). Echo exactly, never round/shift/drop. Do NOT change a timestamp unless the reviewer instructs it.
+- Vague note, ask ONE question. Read/tool failure STOP and report.
+
+## Output mechanics
+- One ```text block in chat, real line breaks, never a file.
+- [brackets]/{braces} are placeholders; substitute or omit; never print them literally.
+- Nothing after the block, no commentary, scores, or recap.
+
+## FINAL CHECK
+1. Only changed fields/annotations present (no unchanged ones).
+2. Entries sorted by TS-S ascending; headers 27 hashes.
+3. FINAL ACTION line present and exact.
+4. Timecodes exact; no banned vocabulary; no placeholder text.
+5. Every TD that changed has ALL THREE parts: `Unrealistic physics.`
+   opener + observation (specific part named, no "robot"/"robot arm",
+   no "indicated", no timestamps) + `…because …` physics-reason closer
+   matched to THIS error. Scene-consistency TDs use correct opener and
+   `…scene consistency because…` closer. No vague or copied closers.
+6. URSP used (not URS) for all robot-part ET tags.
+7. Combining limit not violated.
+8. One ```text block; nothing trailing.
+
+## WORKED EXAMPLE (NRR) — real values, no placeholders
+Reviewer notes Doug pastes:
+"At 0.34 extend the end timestamp to 5.067, the issue persists. At 1.88
+change the error type from Phantom Motion to URSP. At 2.45 tighten the
+bounding box to just the wrist. Delete 3.10 — it's a consistent design
+feature, not an anomaly. Add a new one around 4.33: the left elbow link
+bends outward as the arm reaches left, URSP. Mark complete."
+
+Correct output (note: only 4.33 and the TD-changing items get a full
+three-part TD; field-only edits are bare directives):
+```text
+ADDITIONS
+###########################
+4.33: Unrealistic physics. The left elbow link bends outward as the arm reaches to the left. This breaks physics because the elbow link is a rigid structural component and should not bend during operation.
+TS-E: 5.067
+ET: URSP
+
+DELETIONS
+###########################
+3.10: Consistent design feature of this arm throughout the clip — not an anomaly per reviewer.
+
+EDITS
+###########################
+0.34: TS-E: 5.067
+1.88: ET: change Phantom Motion to URSP
+2.45: BB: tighten to the wrist area only
+
+FINAL ACTION
+###########################
+Marked as complete.
+```
+Note what is ABSENT: no TD rewrite on 0.34/1.88/2.45 (only a field
+changed), no placeholder brackets, no unchanged annotations.

--- a/_tortu/config/skills/kn-nsr/SKILL.md
+++ b/_tortu/config/skills/kn-nsr/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: kn-nsr
+description: TRD New SME Review (NSR)
+version: 1.2.0
+author: Doug Daulton
+metadata:
+  hermes:
+    tags: [TRD, NSR, review, SCR, reviewer, rubric]
+---
+# TRD – New SME Review (NSR)
+
+NSR = **New SME Review**. Doug acts as SCR (reviewer): he dictates review
+notes on ANOTHER SME's annotation set; you produce the reviewer report
+sent to that SME. Allowed actions: **ADDITIONS, DELETIONS, EDITS, MERGES.**
+Output: **Lightning Summary ONLY** – no Annotation Content. NEVER invent your
+own methodology. Everything you need is inlined here and in SOUL. You have NO
+file‑read tool – do not try to open the rubric or "the guidelines"; use the inline
+rules and the worked example below.
+
+## Clarify scope – ASK ONLY THESE, invent nothing
+The ONLY things you may ask Doug before producing an NSR:
+  (1) the expert's name, if he didn't give it;
+  (2) resubmit‑for‑review vs. mark‑complete, if he didn't state it.
+NEVER ask for a "timecode", "Context Reference ID", "reference ID", or any
+metadata field – those do not exist in this workflow. Do not invent fields. If Doug's
+notes say everything is fine / close it out / no errors, that is a NO‑ACTION review: skip
+the item readback entirely and output the No‑Action template directly (only ask for the
+expert name if missing).
+
+## Greeting – exact form
+The report's first line is the expert's name followed by a comma, nothing else: `Harrison,`
+- never prefix it with "text", "salutation", or any label. Then a blank line, then the
+body.
+
+## READBACK – required before rendering the report
+Before producing the final report, list back the items you are about to flag as a
+numbered preview: `timecode – directive` (one line each), then ask Doug to confirm or correct.
+Only render the formatted report after he confirms. This catches mis‑bound items and
+dropped directives from long or multi‑pass dictation. Skip readback only if Doug says "no readback".
+
+## Output – Lightning Summary (standard)
+```text
+[Expert Name],
+
+Nice work. Below, I've identified a few items which need attention. [Once you've
+made these changes, please resubmit this item for review. | Once you've
+made these changes, please mark this item complete.]
+
+Thanks – Doug
+
+ADDITIONS
+################
+[timecode-start]: [textual-description]      # from Doug's review notes
+TS-E: [timecode-end]
+BB: {My description of the bounding box.}
+ET: {My assigned error type.}
+
+DELETIONS
+################
+[timecode-start]: [My notes explaining deletion]
+
+EDITS
+################
+[timecode-start]: [textual-description]      # revised text per review notes
+TS-S: {if changed – header timecode stays the ORIGINAL start}
+TS-E: {if changed}
+BB: {if changed}
+ET: {if changed}
+
+MERGES
+################
+[timecode-start]: [textual-description]      # earliest start; text covers all merged points
+TS-S: {if changed}
+TS-E: {if changed}
+BB: {if changed}
+ET: {if changed}
+```
+
+## Output – No‑Action Template
+When a complete review yields ZERO actions across all four categories, do not emit empty
+headers. Output exactly:
+```text
+[Expert Name],
+
+All work reviewed, no errors identified. Therefore, no action is required. You can
+mark this task complete.
+
+Thanks – Doug
+```
+
+## TD rules for any annotation text you WRITE in the report
+Most NSR entries are DIRECTIVES ("Change X to Y"), not full TDs. But if you write or
+rewrite an actual textual description, it has THREE required parts, all mandatory:
+1. `Unrealistic physics.` – literal opener (or `Unrealistic scene
+   consistency.` only when Doug directs — including cross-camera /
+   wrist-camera inconsistencies flagged as Other). For scene-consistency
+   TDs, closer begins `This breaks scene consistency because…`.
+2. Observation naming the specific part. May be one or more sentences
+   for complex errors.
+3. Closer with the physical reason: `This breaks physics because…` /
+   `This is impossible because…` / `This is implausible because…`.
+   Must describe why THIS SPECIFIC ERROR is physically impossible —
+   never a copied generic physics sentence.
+
+Sentence count: aim for ~3 for simple errors; more is correct when the
+error is complex. Never exceed one short paragraph. Never pad with
+repetition.
+
+The observation alone is not a valid TD. See SOUL for gold‑standard exemplars.
+Controlled vocabulary (banned: grabbers, claws, pinchers, clamps, teeth, pincers,
+pilot, flange, indicated, numbered joints, timestamps, "robot arm"), camera‑perspective
+left/right, no hedging, no "motivated cause/force", ET tag never inside the TD sentences.
+Never write "robot" or "robot arm" in a TD — name the specific part.
+Name specific objects ("the orange block") — never "the gripper" or "the object"
+without a qualifier.
+
+## POV / Wrist Camera Review Rules
+Tasks may include a main camera view plus left and/or right wrist camera views.
+When reviewing POV (multi-camera) annotations, apply these rules:
+
+### [POV] MAJOR errors — flag these as DELETIONS or EDITS:
+- Missing one or more required POV scene consistency annotations when
+  camera views clearly contradict each other.
+- Annotating a wrist camera view as the source of truth when the main
+  camera view clearly shows the same implausibility and is not occluded,
+  outside the frame, or impossible to verify. (Main camera is the
+  authoritative view unless it is occluded/impossible to verify.)
+- Failing to annotate the main camera view when it clearly shows an
+  implausibility.
+- Bounding box is placed in the wrong camera view.
+- Failing to create separate annotations and separate bounding boxes
+  for separate wrist camera inconsistencies when the left and right
+  wrist camera views contradict the main camera view or each other.
+- Textual description does not explain how the camera views are
+  inconsistent when the annotation is for Other/Unrealistic scene
+  consistency. (The TD must say which camera views differ and how.)
+- Textual description incorrectly says an issue breaks physics when
+  the annotation is only a scene consistency mismatch between otherwise
+  plausible camera views. (Scene consistency mismatch → "Unrealistic
+  scene consistency." opener + `This breaks scene consistency because…`
+  closer — NOT `This breaks physics because…`.)
+
+### [POV] MINOR errors — flag these as EDITS:
+- Scene consistency annotation continues after the camera views have
+  returned to sync (annotation end time too long).
+- Scene consistency annotation ends too early while the inconsistency
+  between camera views is still visible.
+- Failing to identify which specific camera views are relevant in the
+  POV textual description.
+- Bounding box is not targeted to the specific error in a wrist camera
+  view when it can be (bounding box too broad).
+
+## Full Major/Minor Errors reference (for SME SCORE and review flagging)
+
+### Major Errors
+- Timestamp/chunk placed more than 250ms from error onset
+- Bounding box not starting close to first frame or 2-3 frames into inconsistency
+- Blatantly incorrect error category, or no error category selected
+- Missing 1+ clear physics implausibility
+- Bounding box/patch too large or too small
+- "Other" selected when another category is clearly recognizable
+- Operator's actions annotated as errors (operator is to be ignored)
+- A video with errors contains a blank/no-violation submission
+- Left/right references use operator perspective instead of camera perspective
+- Combining different ET types in one annotation with overlapping bounding boxes
+- Combining more than two of the same ET type in one annotation
+- TD missing either the visual evidence summary OR the physics reason
+- Physics sentence does not match what is actually happening
+- Annotations not in complete sentences (bullet-point style)
+- Weak TD: vague or generic physics reason, poor visual description
+- Multiple annotations flagging plausible physics as errors
+- [POV] any of the seven POV Major errors listed above
+
+### Minor Errors
+- Typos
+- Annotation created for a task with no implausibilities
+- Obviously low-confidence implausibility annotated without an FAQ post
+- Annotation end time more than 250ms before or after implausibility ends
+- Gripper terminology not consistent with thesaurus (e.g., "grabbers", "claws")
+- Flagging objects that look unusual but are not implausible
+- Reason for no violation not given in Reviewer notes on Blitz platform
+- One annotation flagging plausible physics as an error
+- [POV] any of the four POV Minor errors listed above
+
+Note: Length differences (e.g., four vs. five sentences) should NOT
+impact scoring unless sentences are clearly repetitive or unnecessary.
+
+## Final Check – run this before sending, every time
+1. All entries sorted by TS‑S ascending (Pass 2, Lightning Summary, every action section).
+2. Blank line between every header, hash row, and entry.
+3. Headers and hash counts exactly as the template (27 or 16).
+4. Every dictated item is present – count them.
+5. Timecodes exactly as dictated – no digit changes.
+6. URSP used (not URS) for all robot-part ET references.
+7. POV errors correctly categorized as Major or Minor per the rules above.
+8. Nothing after the deliverable: no commentary, no recap.
+
+## SME SCORE – internal block, ON REQUEST ONLY (paused 260607)
+The SME scoring methodology is under revision and is NOT accurate yet. DO NOT
+auto‑generate a score. Only produce this block if Doug explicitly asks ("score this" / "give me the SME score"). When he does: it is for Doug only, never sent to the expert;
+score the expert's work is allowed, scoring your own output remains forbidden.
+
+Scale: start at 5.0; subtract 1.0 per Major error, 0.5 per Minor error (floor 1.0).
+Major/Minor definitions: use the Full Major/Minor Errors reference above.
+Major deductions include all [POV] major errors.
+Minor deductions include all [POV] minor errors.
+Note: sentence count differences alone do not count as a deduction unless
+sentences are clearly repetitive or unnecessary.
+
+Format (blank line between every line):
+
+SME SCORE (internal)
+
+###########################
+
+Score: [x.x] / 5
+
+Majors: [count] – [one short line each, with timecode]
+
+Minors: [count] – [one short line each, with timecode]
+
+If the review found nothing: Score: 5 / 5, "No deductions."
+
+## Action mapping – one item, ONE action
+- Each reviewed item produces exactly ONE action entry. Never emit two entries (e.g., an EDIT and an ADDITION) for the same timecode unless Doug explicitly dictates two separate actions.
+- If Doug dictates replacement wording, that is an EDIT – put his wording into the directive verbatim. It is never an ADDITION.
+- NSR entries are DIRECTIVES to the expert ("Change X to Y"), not rewritten annotations. Include only the fields Doug commented on.
+- If the expert's name was not given, ask for it (the one question) before producing the report.
+
+## Worked Example (NSR) – real values, no placeholders, optional omitted
+Doug dictates: "At 1.22 the error type is wrong – they used Phantom Motion but this is a robot part moving, so URSP. At 2.67 the bounding box is way too large, should just be on the gripper; text is fine. At 3.88 good catch but hedging language – 'appears to bend' should be 'bends'. Everything else looks fine. Expert is Keshav Prasad. Resubmit."
+
+Correct output:
+```text
+Keshav Prasad,
+
+Nice work. Below, I've identified a few items which need attention. Once you've made these changes, please resubmit this item for review.
+
+Thanks – Doug
+
+EDITS
+################
+1.22: ET: Change from Phantom Motion to URSP. Robot part movement is always URSP; Phantom Motion is reserved for scene objects.
+2.67: BB: Tighten to cover the gripper only. Current box covers the entire scene.
+3.88: TD: Remove hedging language. Change "appears to bend" to "bends."
+```

--- a/_tortu/config/skills/kn-summary/SKILL.md
+++ b/_tortu/config/skills/kn-summary/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: kn-summary
+description: "TRD Lightning Summary: produce the Lightning Summary for the NAS or NRR work just completed in this session. A follow-on step, requested after the annotation content is written. Triggers: lightning summary, produce the summary, give me the summary, summarize this, NRR complete, session complete."
+version: 1.0.0
+author: Doug Daulton
+metadata:
+  hermes:
+    tags: [TRD, lightning summary, NAS, NRR, summary]
+---
+
+# TRD — Lightning Summary
+
+This is the FOLLOW-ON step. Doug has already produced annotation content
+(via kn-nas or kn-nrr) earlier in this session; now he wants the
+Lightning Summary that goes into the system. Summarize the annotation
+content already produced in THIS session — do not re-derive or re-format
+the annotations themselves, and do not invent new ones.
+
+Pick the mode from what was just done:
+- The session produced NAS annotation content → use **NAS mode**.
+- The session produced NRR annotation content → use **NRR mode**.
+- (NSR has no separate summary step — its report is produced whole by
+  kn-nsr. If asked to "summarize" an NSR, point Doug to kn-nsr.)
+If you cannot tell which mode, ask Doug one question.
+
+## NAS mode — ANNOTATIONS MADE
+One line per annotation, sorted by TS-S ascending:
+```text
+ANNOTATIONS MADE
+###########################
+0.05: Added new annotation describing the left arm moving at unrealistically fast speed
+1.34: Added new annotation describing the right gripper finger bending beyond its joint range
+3.12: Added new annotation describing the red cup sliding without applied force
+```
+- Header exactly 27 hashes. Plain-English one-liner per item — not the
+  full TD. ADDITIONS only (NAS never deletes/edits/merges).
+
+## NRR mode — ACTIONS TAKEN
+Nested: top header 27 hashes, each action sub-header 16 hashes. Include
+ONLY the action sections that have items. End with FINAL ACTION.
+```text
+ACTIONS TAKEN
+###########################
+
+ADDITIONS
+################
+4.33: Added new annotation describing left elbow link bending outward
+
+DELETIONS
+################
+3.10: Removed annotation; consistent design feature, not an anomaly
+
+EDITS
+################
+0.34: End timestamp extended to 5.067
+1.88: Error type changed from Phantom Motion to URS
+
+FINAL ACTION
+###########################
+Marked as complete.
+```
+- FINAL ACTION is exactly `Marked as complete.` or `Resubmitted for new
+  review.` — per the reviewer's directive in the NRR.
+
+## Rules (both modes)
+- Output the code block DIRECTLY — no preamble, no plan, no reasoning
+  narration before it, nothing after it.
+- One ```text code block, directly in chat, real line breaks. Never a file.
+- Sort every section by TS-S ascending.
+- Omit any action section with no items. Never emit an empty header.
+- No [bracket]/{brace} placeholder text in the output.
+- Nothing after the block — no commentary or recap.

--- a/_tortu/config/skills/kn-wsr/SKILL.md
+++ b/_tortu/config/skills/kn-wsr/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: kn-wsr
+description: "TRD Work Session Report (WSR): track a work session from WSS to WSE and produce the session summary. Triggers: WSR, WSS, WSE, work session starts, work session ends, session report."
+version: 1.0.0
+author: Doug Daulton
+metadata:
+  hermes:
+    tags: [TRD, WSR, WSS, WSE, session, report]
+---
+
+# TRD — Work Session Report (WSR)
+
+WSR = **Work Session Report**: the end-of-session summary of NAS / NRR /
+NSR work completed. Authoritative rubric:
+`commons/boundaries/guardrails/Kaminari_Rubric_v4_260604.md`. NEVER invent your own methodology.
+
+## Workflow
+- **WSS** (Work Session Starts): record the current timestamp, acknowledge
+  it ("Work session started at YYYY-MM-DD HH:MM. Now tracking NAS, NRR,
+  NSR.") and begin a running count of completed processes.
+- **WSE** (Work Session Ends): record the timestamp, acknowledge
+  ("Work session ended at YYYY-MM-DD HH:MM. Producing WSR...") then
+  immediately output the Lightning Summary below.
+- The WSS and WSE acknowledgments are EXACTLY the one specified line each —
+  no plan, no rules recap, no reasoning, no preamble. Nothing else.
+
+## Output — Lightning Summary (on WSE)
+```
+WORK COMPLETED
+###########################
+Session Start: [WSS timestamp]
+Session End: [WSE timestamp]
+Elapsed Time: [HH:MM]
+New Annotation Sets: [x]
+New Revision Rounds: [y]
+New SME Reviews: [z]
+```
+- Header exactly 27 hashes. Counts cover only work between WSS and WSE.
+- Use real clock time from the system, never estimated timestamps.
+
+## Output rendering — REQUIRED
+Wrap EACH deliverable (Annotation Content, Lightning Summary,
+SME Score) in its own plain-text code block (```text fences) so line
+breaks are preserved exactly and Doug gets a one-click copy button.
+Inside the block, use real single line breaks — no extra blank lines
+needed.
+
+PLACEHOLDER SUBSTITUTION — CRITICAL: template tokens in [brackets] and
+{braces} are placeholders, NEVER literal output. Replace each one
+entirely with the real value from Doug's dictation. If an optional
+field ({if provided...}) wasn't provided, OMIT that line completely.
+If a required value is missing, ask ONE question. Output containing
+literal [, ], {, } placeholder text or placeholder sentences is wrong.
+
+## FINAL CHECK — run this before sending, every time
+1. All entries sorted by TS-S ascending (Pass 2, Lightning Summary,
+   every action section).
+2. Blank line between every header, hash row, and entry.
+3. Headers and hash counts exactly as the template (27 or 16).
+4. Every dictated item is present — count them.
+5. Timecodes exactly as dictated — no digit changes.
+6. Nothing after the deliverable: no commentary, no recap.

--- a/_tortu/config/skills/rp-why/.gitignore
+++ b/_tortu/config/skills/rp-why/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/_tortu/config/skills/rp-why/README.md
+++ b/_tortu/config/skills/rp-why/README.md
@@ -1,0 +1,250 @@
+# rp-why: Three Dimensions of AI Collaboration
+
+> **> Goose Skill** - Measures DOK (cognitive complexity), TM (tool maturity), and ADT (agentic delegation trust) to reveal growth in human-AI collaboration practice.
+
+A self-reflection framework that tracks three dimensions of your AI collaboration over time. See where you are, where you've been, and where the practice is heading.
+
+## Installation
+
+```bash
+npx skills add https://github.com/block/agent-skills --skill rp-why
+```
+
+Make sure you have the built-in skills extension enabled in Goose.
+
+## Quick Start
+
+```
+/rp-why init       # Generate baseline from history
+/rp-why baseline   # Same as init
+/rp-why current    # Analyze current session
+/rp-why compare    # Compare session to baseline
+/rp-why overall    # Full longitudinal analysis
+```
+
+**First time?** Start with `/rp-why init` to establish your baseline, then use `/rp-why current` at the end of sessions to track your practice.
+
+## What It Measures
+
+| Dimension | What | Scale |
+|-----------|------|-------|
+| **DOK** (Depth of Knowledge) | Cognitive complexity of your prompts | 1.0 - 4.0 |
+| **TM** (Tool Maturity) | Intentional orchestration of AI tools | Tier 1-6 (Orchestra Model) |
+| **ADT** (Agentic Delegation Trust) | Health of the collaboration practice | 6 diagnostic zones |
+
+### Key Metrics in Every Report
+
+- **DOK 3+4 %** - Proportion of strategic/extended thinking. The primary growth signal.
+- **Compression %** - Short directives carrying complex intent. Trust made visible in data.
+- **Floor** - Lowest DOK on routine days. When this rises, the baseline becomes unreproducible.
+- **Adjusted DOK** - Accounts for compression of intent (short prompts that carry complex meaning due to established context).
+
+## The Six Diagnostic Zones
+
+The TM x DOK matrix produces zones that diagnose where your collaboration practice sits:
+
+| Zone | What It Means | Action |
+|------|---------------|--------|
+| **Frontier** | TM and DOK matched and growing. Operating at the productive edge. | Document and share |
+| **Growing** | Approaching a match. Building toward effective use. | Keep pushing DOK 3+ work |
+| **Expected** | Appropriate match for current level. Healthy starting position. | Ask "why" before implementing |
+| **Thinking Ahead** | Cognitive depth exceeds tools. Opportunity to adopt more powerful orchestration. | Explore sub-agents, multi-step delegation |
+| **Underutilizing** | Tools exceed cognitive depth. Opportunity to deepen the questions. | Batch simple queries, ask bigger questions |
+| **Overpowered** | Significant mismatch. Resources spent without proportional return. | Redirect toward problems requiring analysis |
+
+## Orchestra Model (TM Tiers)
+
+| Tier | Name | Description |
+|------|------|-------------|
+| 1 | Solo | Human works alone. AI reviews after. |
+| 2 | Duet | Back-and-forth conversation. Human prompts, AI responds, human edits. |
+| 3 | Ensemble | Human provides meaningful body of work. Evaluates holistically. |
+| 4 | Chamber | Human delegates work streams. Sub-agents introduced. Orchestration required. |
+| 5 | Symphony | Multiple AI interactions coordinated toward unified goal. Minimal intervention. |
+| 6 | Virtuoso | Flow state. Human and AI synthesized. Optimal DOK, ADT, and TM. |
+
+## Commands
+
+### `/rp-why init` (alias: `/rp-why baseline`)
+
+Establishes your starting point by analyzing all available session history.
+
+**What you get:**
+- Three Dimensions snapshot (DOK, TM tier, ADT zone)
+- DOK distribution with bar chart
+- DOK 3+4 % and Compression %
+- Growth targets for the next level
+- Baseline saved for future comparisons
+
+### `/rp-why current`
+
+Analyzes the active session. The quick-check mirror at the end of a work block.
+
+**What you get:**
+- Session snapshot with Three Dimensions
+- DOK distribution for this session
+- Peak moment (highest-DOK prompt highlighted)
+- Contextual growth nudge based on your diagnostic zone
+- Reflection question
+
+### `/rp-why compare`
+
+Delta report showing movement from your baseline to now.
+
+**What you get:**
+- Side-by-side Three Dimensions comparison with deltas
+- DOK distribution shift (percentage point changes)
+- Trajectory direction (improving / stable / declining)
+- "What Shifted" narrative interpreting the changes
+
+### `/rp-why overall`
+
+Full longitudinal report. The complete growth picture across all sessions.
+
+**What you get:**
+- Current standings with all metrics
+- Rolling average (first 10 vs. last 10 sessions)
+- Phase analysis (auto-detected trajectory shifts)
+- Peak DOK and floor tracking
+- Full dataset DOK distribution
+- Growth story narrative
+
+## Example Output
+
+```
+==================================================================
+                    rp-why . CURRENT SESSION
+==================================================================
+
+SESSION SNAPSHOT
+------------------------------------------------------------------
+Date:             Jun 18, 2026
+Prompts:          31 classified
+
+THREE DIMENSIONS
+------------------------------------------------------------------
+DOK (Adjusted)       2.45
+TM  (Tool Maturity)  Tier 5 . Symphony
+ADT (Delegation)     Frontier
+
+DIAGNOSTIC ZONE: Frontier
+------------------------------------------------------------------
+TM and DOK matched and growing together. Operating at the
+productive edge.
+
+DOK DISTRIBUTION
+------------------------------------------------------------------
+DOK 1 (Recall      ):  #-------------------   6.5%
+DOK 2 (Application ):  ##########----------  48.4%
+DOK 3 (Strategic   ):  #######-------------  35.5%
+DOK 4 (Extended    ):  ##------------------   9.7%
+
+DOK 3+4:  45.2%     Compression:  12.9%
+
+PEAK MOMENT
+------------------------------------------------------------------
+"Design the report format alignment between try-rpwhy and the..."
+  DOK 3 . Strategic Thinking
+
+GROWTH NUDGE
+------------------------------------------------------------------
+Strong session. The collaboration is matched and productive.
+Consider extending one thread into a multi-session investigation.
+
+  What complex challenge could benefit from sustained
+   exploration across your next few sessions?
+```
+
+## Requirements
+
+- [Goose](https://github.com/block/goose) AI agent
+- Python 3.9+
+- Goose sessions stored in the default session directory:
+  - **macOS/Linux**: `~/.local/share/goose/sessions/`
+  - **Windows**: `%LOCALAPPDATA%\goose\sessions\`
+
+## Upgrading from v3
+
+If you have an existing baseline from the Gas Town x DOK era (v3), it will be read and translated automatically:
+
+- Gas Town stages map to Orchestra Tiers
+- Quadrant names map to diagnostic zones
+- "Learning Zone" becomes "Expected"
+- Existing DOK scores are preserved as-is
+
+No action needed. Run `/rp-why init` to generate a fresh v4 baseline, or let the skill auto-migrate your existing one.
+
+## How It Works
+
+1. **Reads your Goose session database** (SQLite, stored locally)
+2. **Classifies each prompt** by DOK level using keyword pattern matching
+3. **Detects compression** (short prompts in established context that carry complex intent)
+4. **Calculates adjusted DOK** (+1 level for compressed prompts, capped at 4)
+5. **Estimates TM tier** from session characteristics (tool usage, sub-agents, delegation patterns)
+6. **Derives ADT zone** from the TM x DOK matrix
+7. **Generates reports** with contextual nudges based on your diagnostic zone
+
+All data stays local. Nothing is sent externally.
+
+## Learn More
+
+See [SKILL.md](./SKILL.md) for full documentation, including:
+- Three Dimensions framework details
+- Report format specifications
+- Diagnostic zone matrix
+- Growth nudge system
+- Backward compatibility mapping
+- Metrics reference
+
+## Attribution
+
+- **DOK Levels**: Norman Webb (1997). Criteria for alignment of expectations and assessments in mathematics and science education.
+- **Orchestra Model (TM)**: Dakota Fabro (2026). Measuring Cognitive Complexity in Human-AI Collaboration.
+- **Three Dimensions Framework**: Dakota Fabro (2026). rp-why longitudinal dataset, Block Builder Fellowship.
+- **Gas Town Stages** (v1-v3 foundation): Steve Yegge, "Welcome to Gas Town" (January 2026).
+
+---
+
+## Changelog
+
+### v4.0 (June 2026)
+
+**Three Dimensions model.** The skill now tracks DOK, TM (Orchestra Tiers), and ADT (diagnostic zones) as three interconnected dimensions rather than the previous two-axis Gas Town x DOK model.
+
+**What's new:**
+- **Orchestra Model replaces Gas Town stages** - Six tiers (Solo through Virtuoso) describe how deliberately you coordinate AI tools. More intuitive than the 8-stage Gas Town scale and directly tied to observable session behavior.
+- **Six diagnostic zones** replace four quadrants - Frontier, Growing, Expected, Thinking Ahead, Underutilizing, Overpowered. Derived from the TM x DOK matrix.
+- **Compression tracking** - Detects when short prompts carry complex intent due to established context. Compression % appears in every report as a trust signal.
+- **Adjusted DOK** - Primary DOK number now accounts for compression (+1 level for compressed prompts, capped at 4). Raw DOK still available.
+- **DOK 3+4 %** - Aggregate metric showing proportion of strategic/extended thinking. The primary growth signal.
+- **`/rp-why baseline` command** - Alias for `/rp-why init`. Both work identically.
+- **`/rp-why overall` command** - New longitudinal report with phase analysis, rolling averages, floor tracking, peak DOK, and growth narrative.
+- **Phase analysis** - Auto-detects trajectory shifts in the overall report.
+- **Floor tracking** - Monitors the lowest DOK on routine days. A rising floor means the starting point is no longer reproducible.
+- **Contextual growth nudges** - Nudges are now specific to your diagnostic zone rather than generic.
+- **Backward compatibility** - v3 baselines (Gas Town x DOK, quadrant terminology) auto-migrate when loaded. No data loss.
+
+**What's removed:**
+- Gas Town stage numbers (1-8) no longer appear in reports. Orchestra Tiers (1-6) replace them.
+- "Quadrant" terminology replaced by "diagnostic zone."
+- Generic growth nudges replaced by zone-specific contextual nudges.
+
+**Migration path:** Run `/rp-why init` to generate a fresh v4 baseline. Or do nothing - existing v3 baselines are auto-migrated on first read.
+
+### v3.0 (February 2026)
+
+- Quadrant visualization (Frontier, Growing, Thinking Ahead, Underutilizing)
+- Growth nudges and reflection prompts
+- Baseline comparison with `/rp-why compare`
+- Target user profiles
+
+### v2.x (January 2026)
+
+- Integration matrix (Gas Town x DOK)
+- Target profiles
+- Baseline generation from session history
+
+### v1.x (December 2025)
+
+- Initial Gas Town stages
+- Basic DOK tracking

--- a/_tortu/config/skills/rp-why/SKILL.md
+++ b/_tortu/config/skills/rp-why/SKILL.md
@@ -1,0 +1,433 @@
+---
+name: rp-why
+description: Load when reflecting on AI collaboration quality or tracking growth over time. Analyzes session history to surface how deeply you think with AI tools and whether your orchestration sophistication matches your cognitive depth. Provides actionable nudges to push toward more strategic work.
+author: dakotafabro
+version: "4.0"
+tags:
+  - reflection
+  - growth
+  - ai-collaboration
+  - self-assessment
+  - productivity
+  - learning
+  - three-dimensions
+---
+
+# rp-why: Three Dimensions of AI Collaboration
+
+## Overview
+
+The **rp-why** skill is a self-reflection framework that helps AI practitioners measure and improve their collaboration practice. It tracks three dimensions:
+
+- **DOK (Depth of Knowledge)** - Cognitive complexity of human prompts, scored 1.0-4.0 using Webb's framework. "Adjusted" accounts for compression of intent.
+- **TM (Tool Maturity)** - Intentional orchestration of AI tools, tracked through the Orchestra Model (Tiers 1-6).
+- **ADT (Agentic Delegation Trust)** - The relationship between tool sophistication and cognitive depth. Derived from the TM x DOK matrix.
+
+The intersection of these dimensions produces **diagnostic zones** that reveal the health of the collaboration practice.
+
+---
+
+## How to Use This Skill
+
+### Installation
+
+```bash
+npx skills add https://github.com/block/agent-skills --skill rp-why
+```
+
+### Available Commands
+
+| Command | What It Does |
+|---------|--------------|
+| `/rp-why init` | Generate a baseline from your session history |
+| `/rp-why baseline` | Same as init |
+| `/rp-why current` | Analyze the current session |
+| `/rp-why compare` | Compare current session to your baseline |
+| `/rp-why overall` | Full longitudinal analysis across all sessions |
+| `/rp-why token-spend` | Daily token spend breakdown across all sessions |
+
+### Alternative: Natural Language
+
+You can also ask naturally:
+
+```
+You: Analyze my AI collaboration patterns
+You: What's my DOK distribution for this session?
+You: How does this session compare to my baseline?
+You: Give me the full rp-why longitudinal report
+```
+
+### When to Use
+
+- **First time**: Run `/rp-why init` (or `/rp-why baseline`) to establish your starting point
+- **End of session**: Run `/rp-why current` to reflect on your work
+- **Weekly**: Run `/rp-why compare` to track progress against baseline
+- **Monthly**: Run `/rp-why overall` for the full growth picture
+
+---
+
+## The Three Dimensions
+
+### Dimension 1: DOK (Depth of Knowledge)
+
+Measures the cognitive complexity of human prompts. Scored 1.0-4.0 using Webb's Depth of Knowledge framework.
+
+| Level | Name | Description | Prompt Indicators |
+|-------|------|-------------|-------------------|
+| 1 | Recall & Reproduction | Simple factual prompts | "What is X?" "Show me the syntax for Y" |
+| 2 | Application of Skills & Concepts | Applying learned skills to solve a problem | "Build this component" "Fix this error using pattern X" |
+| 3 | Strategic Thinking | Reasoning across multiple concepts to plan, analyze, or design | "Design a system..." "Analyze trade-offs..." "What if..." |
+| 4 | Extended Thinking | Creating something entirely new - frameworks, cross-disciplinary synthesis | "Research and synthesize..." "Create a framework..." |
+
+**Adjusted DOK** accounts for compression of intent - when short prompts carry complex meaning due to established context. A compressed "proceed" that triggers a multi-step architectural deployment is not DOK 1.
+
+**DOK 3+4 %** is the primary growth signal. It measures what proportion of your work operates at strategic or extended thinking levels.
+
+**Compression %** tracks how often short directives carry complex intent. Compression emerges as trust deepens between practitioner and agent.
+
+### Dimension 2: TM (Tool Maturity) - Orchestra Model
+
+Measures intentional orchestration - how deliberately you coordinate AI tools, agents, and workflows. Only counts actions the user deliberately initiated.
+
+| Tier | Name | Description |
+|------|------|-------------|
+| 1 | Solo | Human works alone. AI reviews after. |
+| 2 | Duet | Back-and-forth conversation. Human prompts, AI responds, human edits. |
+| 3 | Ensemble | Human provides meaningful body of work. Evaluates holistically. |
+| 4 | Chamber | Human delegates work streams. Sub-agents introduced. Orchestration required. |
+| 5 | Symphony | Multiple AI interactions coordinated toward unified goal. Minimal intervention. |
+| 6 | Virtuoso | Flow state. Human and AI synthesized. Optimal DOK, ADT, and TM. |
+
+### Dimension 3: ADT (Agentic Delegation Trust) - Diagnostic Zones
+
+Measures the gap between Tool Complexity and Human Cognitive Depth. The TM x DOK matrix produces six zones:
+
+| Zone | Description | Signal |
+|------|-------------|--------|
+| **Frontier** | TM and DOK matched and growing together | Operating at the productive edge |
+| **Growing** | Approaching a match between tool sophistication and cognitive depth | Building toward effective use |
+| **Expected** | Tool usage and cognitive depth appropriate for current level | Healthy starting position |
+| **Thinking Ahead** | Cognitive depth exceeds tool sophistication | Opportunity to adopt more powerful orchestration |
+| **Underutilizing** | Tool sophistication exceeds cognitive depth | Opportunity to deepen the questions being asked |
+| **Overpowered** | Significant mismatch between tool complexity and task depth | Resources spent without proportional cognitive return |
+
+---
+
+## Diagnostic Zone Matrix
+
+```
+              DOK 1         DOK 2          DOK 3           DOK 4
+            (Recall)    (Application)  (Strategic)     (Extended)
+           +-----------+--------------+-------------+-------------+
+Tier 5-6   | Overpowered| Underutil-  |  Frontier   |  Frontier   |
+(Symphony/ |            |   izing     |             |             |
+ Virtuoso) |            |             |             |             |
+           +-----------+--------------+-------------+-------------+
+Tier 3-4   | Overpowered|  Expected   |   Growing   |  Frontier   |
+(Ensemble/ |            |             |             |             |
+ Chamber)  |            |             |             |             |
+           +-----------+--------------+-------------+-------------+
+Tier 1-2   |  Expected  |   Growing   |  Thinking   |  Thinking   |
+(Solo/     |            |             |   Ahead     |   Ahead     |
+ Duet)     |            |             |             |             |
+           +-----------+--------------+-------------+-------------+
+```
+
+---
+
+## Report Formats
+
+### `/rp-why init` or `/rp-why baseline`
+
+Establishes the starting point. Analyzes all available session history.
+
+**Report structure:**
+
+```
++==================================================================+
+|                    rp-why . BASELINE                             |
++==================================================================+
+
+DATA SUMMARY
+--------------------------------------------------------------------
+Period:           [start] - [end] ([N] days)
+Sessions:         [N]
+Prompts:          [N] classified
+
+THREE DIMENSIONS
+--------------------------------------------------------------------
+DOK (Depth of Knowledge)     [score]
+TM  (Tool Maturity)          Tier [N] . [Name]
+ADT (Delegation Trust)       [Zone]
+
+DIAGNOSTIC ZONE: [Zone Name]
+--------------------------------------------------------------------
+[Zone description from the six-zone model]
+
+DOK DISTRIBUTION
+--------------------------------------------------------------------
+DOK 1 (Recall):       [bar]  [%]
+DOK 2 (Application):  [bar]  [%]
+DOK 3 (Strategic):    [bar]  [%]
+DOK 4 (Extended):     [bar]  [%]
+
+DOK 3+4:  [%]
+Compression:  [%]
+
+GROWTH TARGETS
+--------------------------------------------------------------------
+DOK 3+4 target:       [%]
+Compression target:   [%]
+Next TM tier:         Tier [N] . [Name] ([what it means])
+
+--------------------------------------------------------------------
+Baseline saved to: ~/.config/goose/rp-why-baseline.json
+Run /rp-why current after sessions to track progress.
+```
+
+### `/rp-why current`
+
+Analyzes the active session. The quick-check mirror.
+
+**Report structure:**
+
+```
++==================================================================+
+|                    rp-why . CURRENT SESSION                      |
++==================================================================+
+
+SESSION SNAPSHOT
+--------------------------------------------------------------------
+Date:             [date]
+Conversations:    [N]
+Prompts:          [N] classified
+
+THREE DIMENSIONS
+--------------------------------------------------------------------
+DOK (Adjusted)       [score]
+TM  (Tool Maturity)  Tier [N] . [Name]
+ADT (Delegation)     [Zone]
+
+DIAGNOSTIC ZONE: [Zone Name]
+--------------------------------------------------------------------
+[Zone description]
+
+DOK DISTRIBUTION
+--------------------------------------------------------------------
+DOK 1 (Recall):       [bar]  [%]
+DOK 2 (Application):  [bar]  [%]
+DOK 3 (Strategic):    [bar]  [%]
+DOK 4 (Extended):     [bar]  [%]
+
+DOK 3+4:  [%]     Compression:  [%]
+
+PEAK MOMENT
+--------------------------------------------------------------------
+"[highest DOK prompt text, truncated]"  - DOK [N] . [Level Name]
+
+GROWTH NUDGE
+--------------------------------------------------------------------
+[Contextual nudge based on diagnostic zone, not generic]
+
+> [Reflection question tailored to current zone]
+```
+
+### `/rp-why compare`
+
+Delta report. Shows movement from baseline to now.
+
+**Report structure:**
+
+```
++==================================================================+
+|                    rp-why . COMPARE                              |
++==================================================================+
+
+COMPARING: Today ([date]) vs. Baseline ([baseline period])
+
+THREE DIMENSIONS                    Baseline        Today        Delta
+--------------------------------------------------------------------
+DOK (Adjusted)                      [score]         [score]    [+/-%]
+TM  (Tool Maturity)                 Tier [N]        Tier [N]   [+/-N]
+ADT (Delegation Trust)              [Zone]          [Zone]     [arrow]
+
+DIAGNOSTIC ZONE: [Baseline Zone] -> [Current Zone]
+--------------------------------------------------------------------
+
+DOK DISTRIBUTION                    Baseline        Today        Delta
+--------------------------------------------------------------------
+DOK 1 (Recall)                      [%]             [%]       [+/-pp]
+DOK 2 (Application)                 [%]             [%]       [+/-pp]
+DOK 3 (Strategic)                   [%]             [%]       [+/-pp]
+DOK 4 (Extended)                    [%]             [%]       [+/-pp]
+
+DOK 3+4                             [%]             [%]       [+/-pp]
+Compression                         [%]             [%]       [+/-pp or "emerged"]
+
+TRAJECTORY
+--------------------------------------------------------------------
+Direction:  [arrow] [Improving/Stable/Declining]
+Signal:     [1-2 sentence interpretation of what the delta means]
+
+WHAT SHIFTED
+--------------------------------------------------------------------
+* [Bullet interpretations of the most meaningful changes]
+* [Focus on what the numbers mean for the collaboration practice]
+* [Connect to diagnostic zone movement]
+
+--------------------------------------------------------------------
+Run /rp-why overall for full longitudinal analysis.
+```
+
+### `/rp-why overall`
+
+Full longitudinal report. The complete growth picture.
+
+**Report structure:**
+
+```
++==================================================================+
+|                    rp-why . OVERALL                              |
++==================================================================+
+
+FULL DATASET: [start] - [end] ([N] days)
+Sessions: [N]  |  Prompts: [N]  |  Conversations: [N]
+
+CURRENT STANDINGS
+--------------------------------------------------------------------
+DOK (Adjusted, full mean)    [score]
+TM  (Tool Maturity)          Tier [N] . [Name]
+ADT (Delegation Trust)       [Zone]
+
+DOK 3+4:  [%]     Compression:  [%]     Floor:  [score]
+
+ROLLING AVERAGE (Last 10 Sessions vs. First 10)
+--------------------------------------------------------------------
+                             First 10        Last 10          Delta
+Adjusted DOK                 [score]         [score]        [+/-%]
+DOK 3+4 %                   [%]             [%]           [+/-pp]
+Compression %                [%]             [%]           [emerged/+/-pp]
+
+PHASE ANALYSIS
+--------------------------------------------------------------------
+Phase         Dates              Sessions  DOK    DOK3+4  Comp   TM
+-----         -----              --------  ---    ------  ----   --
+[Auto-detected phases based on DOK trajectory shifts]
+
+TRAJECTORY
+--------------------------------------------------------------------
+Peak DOK:     [score] ([date]  - [context])
+Floor:        [score] ([interpretation])
+Direction:    [arrow] [Narrative of the growth arc]
+
+DOK DISTRIBUTION (Full Dataset)
+--------------------------------------------------------------------
+DOK 1 (Recall):       [bar]  [%]
+DOK 2 (Application):  [bar]  [%]
+DOK 3 (Strategic):    [bar]  [%]
+DOK 4 (Extended):     [bar]  [%]
+
+GROWTH STORY
+--------------------------------------------------------------------
+[2-3 sentence narrative interpreting the full arc. Not prescriptive.
+Describes what the data reveals about how the collaboration practice
+has evolved.]
+
+--------------------------------------------------------------------
+Data source: ~/.local/share/goose/sessions/sessions.db
+Methodology: DOK keyword classification, compression detection
+(short prompt + high response ratio + established context),
+adjusted DOK (+1 level for compressed prompts, capped at 4).
+```
+
+---
+
+## Backward Compatibility
+
+### Reading Previous Baselines
+
+If an existing baseline file uses the v3 format (Gas Town stages, quadrant terminology), the skill translates automatically:
+
+| v3 Field | v4 Equivalent |
+|----------|---------------|
+| `estimated_stage: 5` | `tm_tier: 3` (Ensemble)  - Stage 5 maps to Tier 3 for new users |
+| `quadrant: "Underutilizing"` | `adt_zone: "Underutilizing"` (zone name preserved) |
+| `quadrant: "Frontier"` | `adt_zone: "Frontier"` |
+| `quadrant: "Thinking Ahead"` | `adt_zone: "Thinking Ahead"` |
+| `quadrant: "Learning Zone"` | `adt_zone: "Expected"` |
+| `average_dok_score` | `dok_adjusted` (treated as raw if no compression data) |
+| `growth_targets.dok_target` | `growth_targets.dok_3_4_pct` |
+
+### Gas Town to Orchestra Mapping
+
+For users familiar with the Gas Town stages:
+
+| Gas Town Stage | Orchestra Tier | Name |
+|----------------|----------------|------|
+| 1-2 (Observer/Curious) | Tier 1 | Solo |
+| 3 (Copilot) | Tier 2 | Duet |
+| 4 (Chat IDE) | Tier 3 | Ensemble |
+| 5 (CLI Agent) | Tier 4 | Chamber |
+| 6 (Multi-Agent) | Tier 5 | Symphony |
+| 7-8 (Agentic/Full) | Tier 6 | Virtuoso |
+
+---
+
+## Metrics Reference
+
+| Metric | What It Measures | Range | Growth Signal |
+|--------|-----------------|-------|---------------|
+| DOK (Adjusted) | Cognitive complexity of prompts, accounting for compression | 1.0 - 4.0 | Rising mean |
+| DOK 3+4 % | Proportion of strategic/extended thinking | 0 - 100% | Increasing |
+| Compression % | Short directives carrying complex intent | 0 - 100% | Emerging, then growing |
+| Floor | Lowest DOK on routine days | 1.0 - 4.0 | Rising (baseline becomes unreproducible) |
+| TM Tier | Orchestra Model tier | 1 - 6 | Advancing |
+| ADT Zone | Diagnostic zone from TM x DOK | 6 zones | Moving toward Frontier |
+
+---
+
+## Growth Nudges by Zone
+
+### Frontier
+- "Operating at the productive edge. Document what works for others."
+- "The collaboration is matched. Look for opportunities to extend into new domains."
+
+### Growing
+- "Approaching a match. Keep pushing DOK 3+ work and the zone will shift."
+- "Consider: what's one workflow you could delegate more fully?"
+
+### Expected
+- "Healthy starting position. Growth comes from asking 'why' before implementing."
+- "Try framing one task as a design decision rather than an execution request."
+
+### Thinking Ahead
+- "Cognitive depth exceeds tool sophistication. Time to adopt more powerful orchestration."
+- "Your thinking is ready for Tier [N+1]. Explore sub-agents or multi-step delegation."
+
+### Underutilizing
+- "Powerful tools deserve powerful questions. Before each prompt: can this be more strategic?"
+- "Batch simple queries. Reserve the agent for work that requires reasoning."
+
+### Overpowered
+- "Significant mismatch. Consider whether this task needs an autonomous agent."
+- "Opportunity: redirect this tool toward a problem that requires analysis or design."
+
+---
+
+## Attribution
+
+- **Depth of Knowledge (DOK)**: Norman Webb (1997). Webb, N. L. Criteria for alignment of expectations and assessments in mathematics and science education.
+- **Orchestra Model (TM)**: Dakota Fabro (2026). Measuring Cognitive Complexity in Human-AI Collaboration.
+- **Three Dimensions Framework**: Dakota Fabro (2026). rp-why longitudinal dataset, Block Builder Fellowship.
+- **Gas Town Stages** (v1-v3 foundation): Steve Yegge, "Welcome to Gas Town" (January 2026).
+
+---
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 4.0 | 2026-06 | Three Dimensions model (DOK + TM + ADT), Orchestra Tiers, diagnostic zones, compression tracking, `/rp-why baseline` alias, `/rp-why overall` report, phase analysis, backward compatibility with v3 baselines |
+| 3.0 | 2026-02 | Quadrant visualization, growth nudges, reflection prompts |
+| 2.x | 2026-01 | Integration matrix, target profiles, baseline comparison |
+| 1.x | 2025-12 | Initial Gas Town stages, basic DOK tracking |

--- a/_tortu/config/skills/rp-why/example-baseline.json
+++ b/_tortu/config/skills/rp-why/example-baseline.json
@@ -1,0 +1,49 @@
+{
+  "version": "4.0",
+  "generated_at": "2026-02-04T06:43:11.121061",
+  "period": {
+    "start": "2026-01-28",
+    "end": "2026-02-04",
+    "days": 7
+  },
+  "sessions_analyzed": 42,
+  "prompts_classified": 223,
+  "three_dimensions": {
+    "dok_adjusted": 2.20,
+    "dok_raw": 2.18,
+    "dok_lift": 0.02,
+    "tm_tier": 3,
+    "tm_name": "Ensemble",
+    "adt_zone": "Growing"
+  },
+  "dok_distribution": {
+    "dok1": 4.9,
+    "dok2": 73.1,
+    "dok3": 18.8,
+    "dok4": 3.1
+  },
+  "dok_distribution_counts": {
+    "dok1_count": 11,
+    "dok2_count": 163,
+    "dok3_count": 42,
+    "dok4_count": 7
+  },
+  "dok_3_4_pct": 21.9,
+  "compression_pct": 2.2,
+  "floor": 1.77,
+  "trajectory": "stable",
+  "domain_count": 3,
+  "domains": {
+    "~/development/my-project": {"count": 28, "tokens": 450000},
+    "~/development/side-project": {"count": 9, "tokens": 120000},
+    "~/notes": {"count": 5, "tokens": 30000}
+  },
+  "growth_targets": {
+    "dok_3_4_pct": 35,
+    "compression_pct": 5,
+    "next_tm_tier": 4,
+    "next_tm_name": "Chamber"
+  },
+  "average_dok_score": 2.20,
+  "estimated_stage": 5
+}

--- a/_tortu/config/skills/rp-why/references/dok-levels.md
+++ b/_tortu/config/skills/rp-why/references/dok-levels.md
@@ -1,0 +1,62 @@
+# Depth of Knowledge Levels (Webb, 1997)
+
+Measures cognitive complexity of human prompts. Scored 1.0-4.0.
+
+## The 4 Levels
+
+### DOK 1: Recall & Reproduction
+- **Prompts:** "What is...", "List...", "Define...", "Show me..."
+- **Examples:** "What's the syntax for a Python list comprehension?"
+- **Signal:** Asking for facts, syntax, definitions
+
+### DOK 2: Application of Skills & Concepts
+- **Prompts:** "How would you...", "Build...", "Fix...", "Implement..."
+- **Examples:** "How would you implement this in TypeScript?"
+- **Signal:** Applying learned skills to solve a specific problem
+
+### DOK 3: Strategic Thinking
+- **Prompts:** "Design...", "Analyze trade-offs...", "What if...", "Plan..."
+- **Examples:** "Design a caching strategy considering our constraints"
+- **Signal:** Reasoning across multiple concepts to plan, analyze, or design
+
+### DOK 4: Extended Thinking
+- **Prompts:** "Research and synthesize...", "Create a framework..."
+- **Examples:** "Research authentication patterns across multiple sessions and synthesize recommendations"
+- **Signal:** Creating something entirely new - frameworks, cross-disciplinary synthesis, novel artifacts
+
+## Quick Assessment
+
+| Signal | DOK Level |
+|--------|-----------|
+| Asking for facts, syntax, definitions | 1 |
+| Asking how to apply, compare, explain | 2 |
+| Asking to design, analyze, strategize | 3 |
+| Multi-session investigation, framework creation | 4 |
+
+## Adjusted DOK and Compression
+
+Short prompts are not always simple prompts. As session trust builds, users compress their intent.
+
+**Adjusted DOK** accounts for compression of intent - when short prompts carry complex meaning due to established context. A compressed "proceed" that triggers a multi-step architectural deployment is not DOK 1.
+
+| Prompt | Surface DOK | Adjusted DOK | Why |
+|--------|:-----------:|:------------:|-----|
+| "proceed" | 1 | 2-3 | Triggers multi-step workflow in established context |
+| "check comments" | 2 | 3-4 | Orchestrates 20+ comment review, research, strategic edits |
+| "deploy" | 1 | 3 | Triggers build, test, deploy pipeline with established config |
+| "draft it" | 2 | 3 | Generates context-aware communication requiring org understanding |
+
+**Compression signals:**
+- Short prompt (8 words or fewer) in an established session (prompt index > 2)
+- Known compression patterns: "proceed", "do it", "go", "ship it", "deploy", etc.
+- Late position in a long session (prompt index > 5) with very short directive (4 words or fewer)
+
+When compression is detected, the prompt's DOK is elevated by +1 level (capped at 4).
+
+## Key Metrics
+
+- **DOK 3+4 %** - Proportion of strategic/extended thinking. The primary growth signal.
+- **Compression %** - Short directives carrying complex intent. Trust made visible in data.
+- **Floor** - Lowest DOK on routine days. When this rises, the baseline becomes unreproducible.
+
+**Source:** Norman Webb (1997), Depth of Knowledge framework

--- a/_tortu/config/skills/rp-why/references/growth-zones.md
+++ b/_tortu/config/skills/rp-why/references/growth-zones.md
@@ -1,0 +1,61 @@
+# Diagnostic Zones (ADT - Agentic Delegation Trust)
+
+The TM x DOK matrix produces six diagnostic zones that reveal the health of the collaboration practice.
+
+## Zone Definitions
+
+| Zone | Description | Signal | Action |
+|------|-------------|--------|--------|
+| **Frontier** | TM and DOK matched and growing together | Operating at the productive edge | Document and share |
+| **Growing** | Approaching a match between tool sophistication and cognitive depth | Building toward effective use | Keep pushing DOK 3+ work |
+| **Expected** | Tool usage and cognitive depth appropriate for current level | Healthy starting position | Ask "why" before implementing |
+| **Thinking Ahead** | Cognitive depth exceeds tool sophistication | Thinking at a higher level than tools support | Adopt more powerful orchestration |
+| **Underutilizing** | Tool sophistication exceeds cognitive depth | Powerful tools for simple tasks | Deepen the questions being asked |
+| **Overpowered** | Significant mismatch between tool complexity and task depth | Resources spent without proportional return | Redirect toward problems requiring analysis |
+
+## The Matrix
+
+```
+              DOK 1         DOK 2          DOK 3           DOK 4
+            (Recall)    (Application)  (Strategic)     (Extended)
+           +----------+--------------+-------------+-------------+
+Tier 5-6   | Over-    | Underutil-   |  Frontier   |  Frontier   |
+(Symphony/ | powered  |   izing      |             |             |
+ Virtuoso) |          |              |             |             |
+           +----------+--------------+-------------+-------------+
+Tier 3-4   | Over-    |  Expected    |   Growing   |  Frontier   |
+(Ensemble/ | powered  |              |             |             |
+ Chamber)  |          |              |             |             |
+           +----------+--------------+-------------+-------------+
+Tier 1-2   | Expected |   Growing    |  Thinking   |  Thinking   |
+(Solo/     |          |              |   Ahead     |   Ahead     |
+ Duet)     |          |              |             |             |
+           +----------+--------------+-------------+-------------+
+```
+
+## Zone Calculation Logic
+
+```
+DOK >= 3.0 -> dok_band = 4
+DOK >= 2.5 -> dok_band = 3
+DOK >= 2.0 -> dok_band = 2
+DOK <  2.0 -> dok_band = 1
+
+TM Tier 5-6:
+  dok_band >= 3 -> Frontier
+  dok_band == 2 -> Underutilizing
+  dok_band == 1 -> Overpowered
+
+TM Tier 3-4:
+  dok_band >= 4 -> Frontier
+  dok_band == 3 -> Growing
+  dok_band == 2 -> Expected
+  dok_band == 1 -> Overpowered
+
+TM Tier 1-2:
+  dok_band >= 3 -> Thinking Ahead
+  dok_band == 2 -> Growing
+  dok_band == 1 -> Expected
+```
+
+**Source:** Dakota Fabro (2026), Three Dimensions Framework, Block Builder Fellowship

--- a/_tortu/config/skills/rp-why/references/intent-compression-impact.md
+++ b/_tortu/config/skills/rp-why/references/intent-compression-impact.md
@@ -1,0 +1,55 @@
+# Intent Compression: Impact on Metrics
+
+## How Compression Affects Each Report
+
+### Baseline (/rp-why init)
+- Compression % is calculated across all historical sessions
+- Adjusted DOK becomes the primary DOK number
+- Growth targets include a compression target (typically current + 5%, min 5%)
+
+### Current (/rp-why current)
+- Compression % for this session specifically
+- Adjusted DOK shown as primary, raw available for comparison
+- DOK lift (adjusted - raw) quantifies the compression effect
+
+### Compare (/rp-why compare)
+- Compression delta between baseline and current
+- If compression was 0% at baseline and is now >0%, shows "emerged"
+- Trajectory interpretation accounts for compression (execution-heavy sessions may show low raw DOK but high compression)
+
+### Overall (/rp-why overall)
+- Compression % tracked per phase
+- Phase transitions often correlate with compression emergence
+- Floor tracking uses adjusted DOK
+
+## Scoring Adjustment
+
+```
+For each prompt in a session:
+  1. Classify DOK using keyword patterns (raw DOK)
+  2. Check compression signals:
+     - Word count <= 8 AND prompt index > 2
+     - Matches known compression pattern OR (word count <= 4 AND prompt index > 5)
+  3. If compressed: adjusted_dok = min(raw_dok + 1, 4)
+  4. Otherwise: adjusted_dok = raw_dok
+
+Session metrics:
+  - dok_raw = mean(all raw DOK scores)
+  - dok_adjusted = mean(all adjusted DOK scores)
+  - dok_lift = dok_adjusted - dok_raw
+  - compression_pct = compressed_count / total_prompts * 100
+```
+
+## Interaction with TM and ADT
+
+- High compression + high TM tier = strong Frontier signal
+- High compression + low TM tier = possible Thinking Ahead (user has trust patterns but tools are basic)
+- Low compression + high TM tier = early in the relationship (tools are sophisticated but trust hasn't built yet)
+
+## Open Questions
+
+1. Should cross-session context factor in? (e.g., "3rd session today on the same strategic doc")
+2. Should compression detection weight response complexity? (high response:prompt token ratio as additional signal)
+3. Optimal compression detection thresholds may vary by user - should they be calibrated from baseline data?
+
+**Source:** Dakota Fabro (2026), rp-why longitudinal dataset

--- a/_tortu/config/skills/rp-why/references/intent-compression.md
+++ b/_tortu/config/skills/rp-why/references/intent-compression.md
@@ -1,0 +1,46 @@
+# Intent Compression
+
+## The Pattern
+
+As a user builds trust with an agent across a session, their prompts compress. Early in a session, prompts are verbose and self-describing. Later, they become terse directives that assume shared context. This is a signal of mastery, not simplicity - the user is operating at a higher level of delegation, not a lower level of cognition.
+
+## Detection
+
+Compression is detected when:
+1. **Short prompt** (8 words or fewer) appears after the session is established (prompt index > 2)
+2. **Known compression patterns** match: "proceed", "do it", "go", "yes", "continue", "ship it", "deploy", "merge", "lgtm", "next", "done", "send", "push", "run it", "build", "start", "finish"
+3. **Very short directives** (4 words or fewer) appear late in a session (prompt index > 5)
+
+## Impact on Scoring
+
+When compression is detected:
+- The prompt's DOK is elevated by +1 level (capped at 4)
+- This produces the "Adjusted DOK" metric
+- The difference between raw DOK and adjusted DOK is the "DOK lift"
+
+## Compression as a Growth Signal
+
+| Phase | Compression % | Interpretation |
+|-------|---------------|----------------|
+| Early (onboarding) | 0-3% | Barely present, every intent must be spelled out |
+| Building | 1-3% | Not yet emerged as a pattern |
+| Plateau | 3-5% | Beginning to appear as trust builds |
+| Deepening | 8-15%+ | Trust made visible in the data |
+
+Peak compression sessions correlate with highest DOK scores. Compression = short directives orchestrating complex workflows.
+
+## Examples
+
+| Prompt | Context | Surface DOK | Adjusted DOK |
+|--------|---------|:-----------:|:------------:|
+| "proceed" | After reviewing a multi-step plan | 1 | 2 |
+| "check comments" | In a doc review session | 2 | 3 |
+| "deploy" | After build + test cycle | 1 | 2 |
+| "draft it" | After discussing stakeholder strategy | 2 | 3 |
+| "yes" | Confirming a multi-tool research workflow | 1 | 2 |
+
+## Key Insight
+
+The cognitive complexity has moved from the prompt surface into the orchestration structure. A 2-word prompt that triggers a 500-word strategic response is not DOK 1 - it's compressed DOK 3.
+
+**Source:** Observed during rp-why longitudinal analysis, Block Builder Fellowship (2026)

--- a/_tortu/config/skills/rp-why/references/nudges-by-zone.md
+++ b/_tortu/config/skills/rp-why/references/nudges-by-zone.md
@@ -1,0 +1,44 @@
+# Growth Nudges by Diagnostic Zone
+
+Contextual, actionable suggestions based on the user's position in the TM x DOK matrix.
+
+## Frontier (TM and DOK matched, growing)
+- "Operating at the productive edge. Document what works for others."
+- "The collaboration is matched. Look for opportunities to extend into new domains."
+- "Strong session. Consider extending one thread into a multi-session investigation."
+
+## Growing (Approaching a match)
+- "Approaching a match. Keep pushing DOK 3+ work and the zone will shift."
+- "Consider: what's one workflow you could delegate more fully?"
+- "Building momentum. Try framing one more task as a design decision rather than an execution request."
+
+## Expected (Appropriate match for current level)
+- "Healthy starting position. Growth comes from asking 'why' before implementing."
+- "Try framing one task as a design decision rather than an execution request."
+- "Solid foundation. Ask 'what are the trade-offs?' before your next implementation prompt."
+
+## Thinking Ahead (Cognitive depth exceeds tools)
+- "Cognitive depth exceeds tool sophistication. Time to adopt more powerful orchestration."
+- "Your thinking is ready for the next tier. Explore sub-agents or multi-step delegation."
+- "What tool or workflow would unlock the depth you are already thinking at?"
+
+## Underutilizing (Tools exceed cognitive depth)
+- "Powerful tools deserve powerful questions. Before each prompt: can this be more strategic?"
+- "Batch simple queries. Reserve the agent for work that requires reasoning."
+- "What is the most strategic question you could ask right now?"
+
+## Overpowered (Significant mismatch)
+- "Significant mismatch. Consider whether this task needs an autonomous agent."
+- "Opportunity: redirect this tool toward a problem that requires analysis or design."
+- "Is there a harder problem this tool should be pointed at?"
+
+## Reflective Questions by Zone
+
+| Zone | Question |
+|------|----------|
+| Frontier | "What complex challenge could benefit from sustained exploration across your next few sessions?" |
+| Growing | "What workflow could you delegate more fully to the agent?" |
+| Expected | "What strategic question have you been avoiding?" |
+| Thinking Ahead | "What tool or workflow would unlock the depth you are already thinking at?" |
+| Underutilizing | "What is the most strategic question you could ask right now?" |
+| Overpowered | "Is there a harder problem this tool should be pointed at?" |

--- a/_tortu/config/skills/rp-why/references/orchestra-model.md
+++ b/_tortu/config/skills/rp-why/references/orchestra-model.md
@@ -1,0 +1,41 @@
+# Orchestra Model - Tool Maturity (TM) Tiers
+
+Measures intentional orchestration - how deliberately you coordinate AI tools, agents, and workflows. Only counts actions the user deliberately initiated.
+
+## The 6 Tiers
+
+| Tier | Name | Description |
+|------|------|-------------|
+| 1 | Solo | Human works alone. AI reviews after. |
+| 2 | Duet | Back-and-forth conversation. Human prompts, AI responds, human edits. |
+| 3 | Ensemble | Human provides meaningful body of work. Evaluates holistically. |
+| 4 | Chamber | Human delegates work streams. Sub-agents introduced. Orchestration required. |
+| 5 | Symphony | Multiple AI interactions coordinated toward unified goal. Minimal intervention. |
+| 6 | Virtuoso | Flow state. Human and AI synthesized. Optimal DOK, ADT, and TM. |
+
+## TM Estimation from Session Characteristics
+
+The tier is estimated from observable session behavior:
+
+| Signal | Indicates |
+|--------|-----------|
+| Sub-agents present + 50+ conversations | Tier 5 (Symphony) |
+| Sub-agents OR 5+ unique tools + 20+ conversations | Tier 4 (Chamber) |
+| 10+ prompts + 3+ unique tools | Tier 3 (Ensemble) |
+| 3+ prompts | Tier 2 (Duet) |
+| 1-2 prompts | Tier 1 (Solo) |
+
+## Relationship to Gas Town Stages (v3 mapping)
+
+For users familiar with the previous Gas Town model:
+
+| Gas Town Stage | Orchestra Tier | Name |
+|----------------|----------------|------|
+| 1-2 (Observer/Curious) | Tier 1 | Solo |
+| 3 (Copilot) | Tier 2 | Duet |
+| 4 (Chat IDE) | Tier 3 | Ensemble |
+| 5 (CLI Agent) | Tier 4 | Chamber |
+| 6 (Multi-Agent) | Tier 5 | Symphony |
+| 7-8 (Agentic/Full) | Tier 6 | Virtuoso |
+
+**Source:** Dakota Fabro (2026), Measuring Cognitive Complexity in Human-AI Collaboration

--- a/_tortu/config/skills/rp-why/scripts/goose_skill.py
+++ b/_tortu/config/skills/rp-why/scripts/goose_skill.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""
+Goose Skill: rp-why - Three Dimensions of AI Collaboration
+
+Provides DOK assessments, baseline analysis, comparison reports,
+and longitudinal analysis directly within Goose conversations.
+
+Commands:
+    /rp-why init      - Generate baseline from all session history
+    /rp-why baseline  - Same as init
+    /rp-why current   - Analyze current session
+    /rp-why compare   - Compare current session to baseline
+    /rp-why overall   - Full longitudinal report
+"""
+
+from __future__ import annotations
+
+from rp_why_baseline import RPWhyAnalyzer
+from rp_why_core import aggregate_session_metadata
+from typing import Dict
+from pathlib import Path
+import json
+import io
+import sys
+
+
+class RPWhySkill:
+    """Goose skill wrapper for the Three Dimensions rp-why analyzer"""
+
+    HISTORY_FILE = Path.home() / ".config" / "goose" / "rp-why-history.json"
+
+    def __init__(self):
+        self.analyzer = RPWhyAnalyzer()
+
+    def _load_history(self) -> list:
+        if not self.HISTORY_FILE.exists():
+            return []
+        try:
+            with open(self.HISTORY_FILE, 'r') as f:
+                return json.load(f)
+        except (IOError, json.JSONDecodeError):
+            return []
+
+    def _save_history(self, history: list):
+        try:
+            self.HISTORY_FILE.parent.mkdir(parents=True, exist_ok=True)
+            with open(self.HISTORY_FILE, 'w') as f:
+                json.dump(history, f, indent=2)
+        except IOError:
+            pass
+
+    def _add_to_history(self, data: Dict):
+        from datetime import datetime
+        history = self._load_history()
+        data['timestamp'] = datetime.now().isoformat()
+        history.append(data)
+        self._save_history(history)
+
+    def _capture_output(self, func, *args, **kwargs) -> str:
+        old_stdout = sys.stdout
+        sys.stdout = buffer = io.StringIO()
+        try:
+            func(*args, **kwargs)
+        finally:
+            output = buffer.getvalue()
+            sys.stdout = old_stdout
+        return output
+
+    def generate_baseline(self) -> str:
+        """Generate baseline analysis from all available session history"""
+        baseline = self.analyzer.generate_baseline()
+
+        if baseline and 'error' not in baseline:
+            self.analyzer.save_baseline(baseline)
+            output = self._capture_output(self.analyzer.print_baseline_report, baseline)
+
+            self._add_to_history({
+                'source': 'init',
+                'dok_adjusted': baseline['three_dimensions']['dok_adjusted'],
+                'tm_tier': baseline['three_dimensions']['tm_tier'],
+                'adt_zone': baseline['three_dimensions']['adt_zone'],
+                'dok_3_4_pct': baseline['dok_3_4_pct'],
+                'compression_pct': baseline['compression_pct'],
+            })
+
+            return output
+        elif baseline:
+            return f"\n{baseline.get('message', 'Unknown error')}"
+        else:
+            return "\nFailed to generate baseline"
+
+    def analyze_current(self) -> str:
+        """Analyze the current/most recent session"""
+        if not self.analyzer.connect():
+            return "\nCould not connect to sessions database."
+
+        try:
+            prompts = self.analyzer.get_all_user_prompts()
+            if not prompts:
+                return "\nNo prompts found in recent sessions."
+
+            last_session_id = prompts[-1]['session_id']
+            session_prompts = [p for p in prompts if p['session_id'] == last_session_id]
+            analysis = self.analyzer.analyze_prompts(session_prompts)
+
+            if 'error' in analysis:
+                return "\nNo classifiable prompts in current session."
+
+            session_meta = self.analyzer.get_session_metadata()
+            meta = session_meta.get(last_session_id, {})
+
+            output = self._capture_output(self.analyzer.print_current_report, analysis, meta)
+
+            self._add_to_history({
+                'source': 'current',
+                'dok_adjusted': analysis['dok_adjusted'],
+                'dok_3_4_pct': analysis['dok_3_4_pct'],
+                'compression_pct': analysis['compression_pct'],
+            })
+
+            return output
+        finally:
+            self.analyzer.close()
+
+    def compare_to_baseline(self) -> str:
+        """Compare today's sessions (all) to saved baseline.
+
+        Aggregates ALL sessions from today into a single day-level report.
+        If a day has 10 different Goose sessions, all 10 are analyzed together.
+        """
+        from datetime import datetime as dt
+
+        baseline = self.analyzer.load_baseline()
+        if not baseline:
+            return "\nNo baseline found. Run /rp-why init first."
+
+        if not self.analyzer.connect():
+            return "\nCould not connect to sessions database."
+
+        try:
+            prompts = self.analyzer.get_all_user_prompts()
+            if not prompts:
+                return "\nNo prompts found in recent sessions."
+
+            today = dt.now().strftime('%Y-%m-%d')
+            today_prompts = [
+                p for p in prompts
+                if p.get('session_date', '').startswith(today)
+            ]
+
+            if not today_prompts:
+                last_session_id = prompts[-1]['session_id']
+                today_prompts = [p for p in prompts if p['session_id'] == last_session_id]
+
+            current = self.analyzer.analyze_prompts(today_prompts)
+
+            if 'error' in current:
+                return "\nNo classifiable prompts in today's sessions."
+
+            session_meta = self.analyzer.get_session_metadata()
+            today_session_ids = {p['session_id'] for p in today_prompts}
+            combined_meta = aggregate_session_metadata(session_meta, today_session_ids)
+            output = self._capture_output(self.analyzer.print_compare_report, baseline, current, combined_meta)
+
+            self._add_to_history({
+                'source': 'compare',
+                'dok_adjusted': current['dok_adjusted'],
+                'dok_3_4_pct': current['dok_3_4_pct'],
+                'compression_pct': current['compression_pct'],
+            })
+
+            return output
+        finally:
+            self.analyzer.close()
+
+    def overall_report(self) -> str:
+        """Full longitudinal report across all sessions"""
+        baseline = self.analyzer.load_baseline()
+        if not baseline:
+            return "\nNo baseline found. Run /rp-why init first."
+
+        if not self.analyzer.connect():
+            return "\nCould not connect to sessions database."
+
+        try:
+            prompts = self.analyzer.get_all_user_prompts()
+            if not prompts:
+                return "\nNo prompts found."
+
+            analysis = self.analyzer.analyze_prompts(prompts)
+            daily_scores = self.analyzer.get_daily_breakdown(prompts)
+
+            if 'error' in analysis:
+                return "\nNo classifiable prompts found."
+
+            return self._capture_output(
+                self.analyzer.print_overall_report, baseline, analysis, daily_scores
+            )
+        finally:
+            self.analyzer.close()
+
+    def token_spend_report(self) -> str:
+        """Daily token spend report across all sessions."""
+        if not self.analyzer.connect():
+            return "\nCould not connect to sessions database."
+
+        try:
+            daily = self.analyzer.get_daily_token_spend()
+            if not daily:
+                return "\nNo token data found."
+
+            output = []
+            output.append("=" * 70)
+            output.append("                    rp-why . TOKEN SPEND")
+            output.append("=" * 70)
+            output.append("")
+
+            total_tokens = sum(d['total_tokens'] for d in daily)
+            total_prompts = sum(d['prompts'] for d in daily)
+            total_sessions = sum(d['sessions'] for d in daily)
+
+            output.append("SUMMARY")
+            output.append("-" * 70)
+            output.append(f"Period:          {daily[0]['day']} to {daily[-1]['day']} ({len(daily)} days)")
+            output.append(f"Sessions:        {total_sessions}")
+            output.append(f"Prompts:         {total_prompts}")
+            output.append(f"Total tokens:    {total_tokens:,} ({total_tokens / 1_000_000_000:.2f}B)")
+            output.append(f"Daily average:   {total_tokens / len(daily) / 1_000_000:.1f}M")
+            if total_prompts:
+                output.append(f"Tokens/prompt:   {total_tokens / total_prompts:,.0f}")
+            output.append("")
+
+            output.append("DAILY BREAKDOWN")
+            output.append("-" * 70)
+            output.append(f"{'Day':<12} {'Sess':>4} {'Prompts':>7} {'Total (M)':>10} {'Tok/Prompt':>11}")
+            output.append(f"{'---':<12} {'----':>4} {'-------':>7} {'---------':>10} {'----------':>11}")
+
+            for d in daily:
+                tok_m = d['total_tokens'] / 1_000_000
+                tpp = f"{d['tokens_per_prompt']:,}" if d['tokens_per_prompt'] > 0 else "-"
+                output.append(
+                    f"{d['day']:<12} {d['sessions']:>4} {d['prompts']:>7} "
+                    f"{tok_m:>9.1f}M {tpp:>11}"
+                )
+
+            output.append("")
+            output.append("-" * 70)
+            output.append("Source: ~/.local/share/goose/sessions/sessions.db")
+            output.append("Field:  accumulated_total_tokens (full session spend)")
+            output.append("")
+
+            return "\n".join(output)
+        finally:
+            self.analyzer.close()
+
+
+# --- Goose skill interface functions ---
+
+def init() -> str:
+    """
+    Generate baseline analysis from all available Goose session history.
+
+    Usage:
+        /rp-why init
+        /rp-why baseline
+
+    Returns:
+        Baseline report with Three Dimensions (DOK, TM, ADT),
+        DOK distribution, compression %, and growth targets.
+    """
+    skill = RPWhySkill()
+    return skill.generate_baseline()
+
+
+def baseline() -> str:
+    """Alias for init. Generate baseline from session history."""
+    return init()
+
+
+def current() -> str:
+    """
+    Analyze the current/most recent session.
+
+    Usage:
+        /rp-why current
+
+    Returns:
+        Session report with Three Dimensions, DOK distribution,
+        peak moment, and contextual growth nudge.
+    """
+    skill = RPWhySkill()
+    return skill.analyze_current()
+
+
+def compare() -> str:
+    """
+    Compare current session to saved baseline.
+
+    Usage:
+        /rp-why compare
+
+    Returns:
+        Delta report showing movement across all three dimensions,
+        DOK distribution shift, trajectory, and narrative interpretation.
+    """
+    skill = RPWhySkill()
+    return skill.compare_to_baseline()
+
+
+def overall() -> str:
+    """
+    Full longitudinal report across all sessions.
+
+    Usage:
+        /rp-why overall
+
+    Returns:
+        Complete growth picture with current standings, rolling averages,
+        phase analysis, trajectory, and growth story narrative.
+    """
+    skill = RPWhySkill()
+    return skill.overall_report()
+
+
+def token_spend() -> str:
+    """
+    Show daily token spend across all sessions.
+
+    Usage:
+        /rp-why token-spend
+
+    Returns:
+        Daily token spend table with sessions, prompts, total tokens,
+        and tokens-per-prompt efficiency metric.
+    """
+    skill = RPWhySkill()
+    return skill.token_spend_report()
+
+
+if __name__ == '__main__':
+    import sys
+
+    if len(sys.argv) < 2:
+        print("Usage: python goose_skill.py [init|baseline|current|compare|overall|token-spend]")
+        sys.exit(1)
+
+    command = sys.argv[1].lower()
+
+    if command in ('init', 'baseline'):
+        print(init())
+    elif command == 'current':
+        print(current())
+    elif command == 'compare':
+        print(compare())
+    elif command == 'overall':
+        print(overall())
+    elif command in ('token-spend', 'tokens'):
+        print(token_spend())
+    else:
+        print(f"Unknown command: {command}")
+        print("Usage: python goose_skill.py [init|baseline|current|compare|overall|token-spend]")
+        sys.exit(1)

--- a/_tortu/config/skills/rp-why/scripts/growth_nudge.py
+++ b/_tortu/config/skills/rp-why/scripts/growth_nudge.py
@@ -1,0 +1,100 @@
+"""
+Growth Nudge - Three Dimensions Assessment & Actionable Feedback
+
+Provides practitioners with contextual feedback based on their
+diagnostic zone in the TM x DOK matrix.
+
+Thin wrapper around rp_why_core for quick assessments.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from rp_why_core import (
+    DOK_NAMES,
+    DOK_PATTERNS,
+    TM_TIERS,
+    ZONE_NUDGES,
+    ZONE_REFLECTIONS,
+    calculate_adt_zone,
+    classify_dok,
+    get_zone_nudges,
+    get_zone_reflection,
+)
+
+
+class GrowthNudge:
+    """Contextual nudges based on diagnostic zone."""
+
+    DOK_PATTERNS = DOK_PATTERNS
+    TM_TIERS = TM_TIERS
+    DOK_NAMES = DOK_NAMES
+    ZONE_NUDGES = ZONE_NUDGES
+    ZONE_REFLECTIONS = ZONE_REFLECTIONS
+
+    def classify_dok(self, text: str) -> Tuple[int, float, List[str]]:
+        """Classify text by DOK level."""
+        return classify_dok(text)
+
+    def calculate_zone(self, dok: float, tm_tier: int) -> str:
+        """Calculate diagnostic zone from DOK x TM matrix."""
+        return calculate_adt_zone(dok, tm_tier)
+
+    def get_nudges(self, zone: str) -> List[str]:
+        """Get nudges for a diagnostic zone."""
+        return get_zone_nudges(zone)
+
+    def get_reflection(self, zone: str) -> str:
+        """Get reflection question for a diagnostic zone."""
+        return get_zone_reflection(zone)
+
+    def assess(self, task_description: str, tm_tier: int = 3) -> str:
+        """
+        Quick assessment of a task description.
+
+        Args:
+            task_description: What the user is working on
+            tm_tier: Current Orchestra tier (1-6)
+
+        Returns:
+            Formatted assessment with zone, nudges, and reflection
+        """
+        dok_level, _confidence, keywords = self.classify_dok(task_description)
+        zone = self.calculate_zone(float(dok_level), tm_tier)
+        nudges = self.get_nudges(zone)
+        reflection = self.get_reflection(zone)
+
+        output = []
+        output.append(f"DOK {dok_level} ({self.DOK_NAMES[dok_level]})")
+        output.append(f"TM Tier {tm_tier} ({self.TM_TIERS[tm_tier]})")
+        output.append(f"Diagnostic Zone: {zone}")
+        output.append("")
+
+        if keywords:
+            output.append(f"Detected: {', '.join(keywords)}")
+            output.append("")
+
+        output.append("Nudges:")
+        for i, nudge in enumerate(nudges[:2], 1):
+            output.append(f"  {i}. {nudge}")
+        output.append("")
+        output.append(f"Reflection: {reflection}")
+
+        return "\n".join(output)
+
+
+if __name__ == '__main__':
+    import sys
+
+    nudger = GrowthNudge()
+
+    if len(sys.argv) > 1:
+        task = ' '.join(sys.argv[1:])
+        print(nudger.assess(task, tm_tier=4))
+    else:
+        print("Usage: python growth_nudge.py <task description>")
+        print()
+        print("Example:")
+        result = nudger.assess("Design a caching strategy with trade-offs for our API", tm_tier=4)
+        print(result)

--- a/_tortu/config/skills/rp-why/scripts/rp_why_baseline.py
+++ b/_tortu/config/skills/rp-why/scripts/rp_why_baseline.py
@@ -1,0 +1,1444 @@
+#!/usr/bin/env python3
+"""
+RP-WHY Baseline Analysis Tool (v4 - Three Dimensions)
+
+Analyzes historical Goose sessions to establish a DOK/TM/ADT baseline.
+Uses all available session data.
+
+Usage:
+    python rp_why_baseline.py init      # Generate baseline analysis
+    python rp_why_baseline.py baseline  # Same as init
+    python rp_why_baseline.py current   # Analyze current/recent session
+    python rp_why_baseline.py compare   # Compare to baseline
+    python rp_why_baseline.py overall   # Full longitudinal report
+    python rp_why_baseline.py export    # Export baseline as JSON
+    python rp_why_baseline.py show      # Show current baseline
+"""
+
+import sqlite3
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import ClassVar, Dict, List, Tuple, Optional
+from collections import defaultdict
+
+from rp_why_core import (
+    DOK_PATTERNS as CORE_DOK_PATTERNS,
+    TM_TIERS as CORE_TM_TIERS,
+    DOK_NAMES as CORE_DOK_NAMES,
+    DOK_NAMES_SHORT as CORE_DOK_NAMES_SHORT,
+    ADT_ZONES as CORE_ADT_ZONES,
+    SYSTEM_MESSAGE_PATTERNS as CORE_SYSTEM_MESSAGE_PATTERNS,
+    COMPRESSION_MAX_WORDS as CORE_COMPRESSION_MAX_WORDS,
+    COMPRESSION_INDICATORS as CORE_COMPRESSION_INDICATORS,
+    classify_dok as core_classify_dok,
+    is_system_message as core_is_system_message,
+    detect_compression as core_detect_compression,
+    calculate_adt_zone as core_calculate_adt_zone,
+    estimate_tm_tier as core_estimate_tm_tier,
+    aggregate_session_metadata,
+)
+
+
+class RPWhyAnalyzer:
+    """Analyze Goose sessions using the Three Dimensions model"""
+
+    # Database and config paths (cross-platform)
+    @staticmethod
+    def _get_sessions_db() -> Path:
+        import platform
+        if platform.system() == "Windows":
+            return Path(os.environ.get("LOCALAPPDATA", "")) / "goose" / "sessions" / "sessions.db"
+        else:
+            return Path.home() / ".local/share/goose/sessions/sessions.db"
+
+    @staticmethod
+    def _get_baseline_file() -> Path:
+        import platform
+        if platform.system() == "Windows":
+            return Path(os.environ.get("LOCALAPPDATA", "")) / "goose" / "rp-why-baseline.json"
+        else:
+            return Path.home() / ".config/goose/rp-why-baseline.json"
+
+    # All constants imported from rp_why_core (single source of truth)
+    DOK_PATTERNS: ClassVar[dict] = CORE_DOK_PATTERNS
+    SYSTEM_MESSAGE_PATTERNS: ClassVar[list] = CORE_SYSTEM_MESSAGE_PATTERNS
+    COMPRESSION_MAX_WORDS = CORE_COMPRESSION_MAX_WORDS
+    COMPRESSION_INDICATORS: ClassVar[list] = CORE_COMPRESSION_INDICATORS
+    TM_TIERS: ClassVar[dict] = CORE_TM_TIERS
+    ADT_ZONES: ClassVar[list] = CORE_ADT_ZONES
+    DOK_NAMES: ClassVar[dict] = CORE_DOK_NAMES
+    DOK_NAMES_SHORT: ClassVar[dict] = CORE_DOK_NAMES_SHORT
+
+    def __init__(self):
+        self.conn = None
+
+    def connect(self) -> bool:
+        if not self._get_sessions_db().exists():
+            print(f"Sessions database not found at {self._get_sessions_db()}")
+            return False
+        try:
+            self.conn = sqlite3.connect(str(self._get_sessions_db()))
+            self.conn.row_factory = sqlite3.Row
+            return True
+        except sqlite3.Error as e:
+            print(f"Database connection error: {e}")
+            return False
+
+    def close(self):
+        if self.conn:
+            self.conn.close()
+
+    # --- Classification (delegates to rp_why_core) -------------------------
+
+    def is_system_message(self, text: str) -> bool:
+        """Detect system-generated messages (tool output summaries)."""
+        return core_is_system_message(text)
+
+    def classify_dok(self, text: str, session_context_dok: float | None = None) -> Tuple[int, float, List[str]]:
+        """Classify text by DOK level using multi-signal approach."""
+        return core_classify_dok(text, session_context_dok)
+
+    def detect_compression(self, text: str, session_prompt_index: int) -> bool:
+        """Detect compressed intent (short prompts carrying complex meaning)."""
+        return core_detect_compression(text, session_prompt_index)
+
+    def estimate_tm_tier(self, session_data: Dict) -> int:
+        """Estimate Orchestra tier from session characteristics."""
+        return core_estimate_tm_tier(session_data)
+
+    def calculate_adt_zone(self, dok_adjusted: float, tm_tier: int,
+                          trajectory: str | None = None) -> str:
+        """Calculate diagnostic zone from DOK x TM matrix."""
+        return core_calculate_adt_zone(dok_adjusted, tm_tier, trajectory)
+
+    # --- Data Access ------------------------------------------------------
+
+    def get_data_summary(self) -> Dict:
+        cursor = self.conn.cursor()
+        cursor.execute("""
+            SELECT
+                MIN(created_at) as earliest,
+                MAX(created_at) as latest,
+                COUNT(*) as total_sessions
+            FROM sessions
+            WHERE session_type = 'user'
+        """)
+        row = cursor.fetchone()
+
+        if not row or not row['earliest']:
+            return {'sessions': 0, 'earliest': None, 'latest': None, 'days': 0}
+
+        earliest = datetime.fromisoformat(row['earliest'].replace('Z', '+00:00')) if row['earliest'] else None
+        latest = datetime.fromisoformat(row['latest'].replace('Z', '+00:00')) if row['latest'] else None
+        days = (latest - earliest).days if earliest and latest else 0
+
+        return {
+            'sessions': row['total_sessions'],
+            'earliest': row['earliest'],
+            'latest': row['latest'],
+            'days': days
+        }
+
+    def get_all_user_prompts(self) -> List[Dict]:
+        cursor = self.conn.cursor()
+        cursor.execute("""
+            SELECT
+                m.session_id,
+                s.name as session_name,
+                s.created_at as session_date,
+                s.working_dir,
+                m.content_json,
+                m.created_timestamp
+            FROM messages m
+            JOIN sessions s ON m.session_id = s.id
+            WHERE m.role = 'user'
+                AND s.session_type = 'user'
+            ORDER BY m.created_timestamp
+        """)
+
+        prompts = []
+        for row in cursor.fetchall():
+            try:
+                content = json.loads(row['content_json'])
+                text = None
+                for item in content:
+                    if isinstance(item, dict) and item.get('type') == 'text':
+                        text = item.get('text', '')
+                        break
+
+                if text:
+                    prompts.append({
+                        'session_id': row['session_id'],
+                        'session_name': row['session_name'],
+                        'session_date': row['session_date'],
+                        'working_dir': row['working_dir'],
+                        'text': text,
+                        'timestamp': row['created_timestamp']
+                    })
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+        return prompts
+
+    def _has_accumulated_columns(self) -> bool:
+        """Check if sessions table has accumulated_* token columns."""
+        cursor = self.conn.cursor()
+        cursor.execute("PRAGMA table_info(sessions)")
+        columns = {row['name'] for row in cursor.fetchall()}
+        return 'accumulated_total_tokens' in columns
+
+    def get_session_metadata(self) -> Dict[str, Dict]:
+        """Get per-session metadata for TM estimation"""
+        cursor = self.conn.cursor()
+        has_accumulated = self._has_accumulated_columns()
+
+        if has_accumulated:
+            cursor.execute("""
+                SELECT
+                    s.id,
+                    s.created_at,
+                    s.total_tokens,
+                    s.accumulated_total_tokens,
+                    s.accumulated_input_tokens,
+                    s.accumulated_output_tokens,
+                    s.working_dir,
+                    COUNT(m.id) as message_count
+                FROM sessions s
+                LEFT JOIN messages m ON m.session_id = s.id AND m.role = 'user'
+                WHERE s.session_type = 'user'
+                GROUP BY s.id
+            """)
+        else:
+            cursor.execute("""
+                SELECT
+                    s.id,
+                    s.created_at,
+                    s.total_tokens,
+                    s.working_dir,
+                    COUNT(m.id) as message_count
+                FROM sessions s
+                LEFT JOIN messages m ON m.session_id = s.id AND m.role = 'user'
+                WHERE s.session_type = 'user'
+                GROUP BY s.id
+            """)
+
+        sessions = {}
+        for row in cursor.fetchall():
+            total = row['total_tokens'] or 0
+            sessions[row['id']] = {
+                'created_at': row['created_at'],
+                'total_tokens': total,
+                'accumulated_tokens': row['accumulated_total_tokens'] or 0 if has_accumulated else total,
+                'accumulated_input': row['accumulated_input_tokens'] or 0 if has_accumulated else 0,
+                'accumulated_output': row['accumulated_output_tokens'] or 0 if has_accumulated else 0,
+                'working_dir': row['working_dir'],
+                'prompt_count': row['message_count']
+            }
+
+        # Check for tool usage patterns and sub-agent indicators
+        # Sub-agent tools are distinguished from general tool usage
+        SUBAGENT_TOOL_NAMES = {'delegate', 'subagent', 'spawn', 'fork', 'parallel'}
+
+        cursor.execute("""
+            SELECT
+                m.session_id,
+                m.content_json
+            FROM messages m
+            JOIN sessions s ON m.session_id = s.id
+            WHERE m.role = 'assistant'
+                AND s.session_type = 'user'
+        """)
+
+        # Collect unique tools per session (across all messages)
+        session_tools: Dict[str, set] = defaultdict(set)
+
+        for row in cursor.fetchall():
+            session_id = row['session_id']
+            if session_id not in sessions:
+                continue
+            try:
+                content = json.loads(row['content_json'])
+                for item in content:
+                    if isinstance(item, dict):
+                        # Goose uses 'toolRequest' with nested toolCall.value.name
+                        if item.get('type') == 'toolRequest':
+                            tool_call = item.get('toolCall', {})
+                            value = tool_call.get('value', {}) if isinstance(tool_call, dict) else {}
+                            tool_name = value.get('name', '').lower() if isinstance(value, dict) else ''
+                            if tool_name:
+                                session_tools[session_id].add(tool_name)
+                                if tool_name in SUBAGENT_TOOL_NAMES:
+                                    sessions[session_id]['has_subagents'] = True
+                        # Also check for Claude/generic format
+                        elif item.get('type') in ('toolUse', 'tool_use'):
+                            tool_name = item.get('name', '').lower()
+                            if tool_name:
+                                session_tools[session_id].add(tool_name)
+                                if tool_name in SUBAGENT_TOOL_NAMES:
+                                    sessions[session_id]['has_subagents'] = True
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+        for session_id, tools in session_tools.items():
+            sessions[session_id]['unique_tools'] = len(tools)
+            sessions[session_id]['tools_seen'] = list(tools)
+
+        return sessions
+
+    def get_daily_token_spend(self) -> List[Dict]:
+        """Get daily token spend aggregated from accumulated session totals.
+
+        Returns a list of dicts sorted by date, each containing:
+          day, sessions, prompts, total_tokens, input_tokens, output_tokens,
+          tokens_per_prompt
+        """
+        cursor = self.conn.cursor()
+        has_accumulated = self._has_accumulated_columns()
+
+        if has_accumulated:
+            cursor.execute("""
+                SELECT
+                    date(created_at) as day,
+                    COUNT(*) as sessions,
+                    SUM(CASE WHEN accumulated_total_tokens > 0
+                        THEN accumulated_total_tokens ELSE 0 END) as total_tokens,
+                    SUM(CASE WHEN accumulated_input_tokens > 0
+                        THEN accumulated_input_tokens ELSE 0 END) as input_tokens,
+                    SUM(CASE WHEN accumulated_output_tokens > 0
+                        THEN accumulated_output_tokens ELSE 0 END) as output_tokens
+                FROM sessions
+                WHERE session_type = 'user'
+                GROUP BY day
+                ORDER BY day
+            """)
+        else:
+            cursor.execute("""
+                SELECT
+                    date(created_at) as day,
+                    COUNT(*) as sessions,
+                    SUM(CASE WHEN total_tokens > 0
+                        THEN total_tokens ELSE 0 END) as total_tokens,
+                    0 as input_tokens,
+                    0 as output_tokens
+                FROM sessions
+                WHERE session_type = 'user'
+                GROUP BY day
+                ORDER BY day
+            """)
+        token_rows = {row['day']: dict(row) for row in cursor.fetchall()}
+
+        if has_accumulated:
+            cursor.execute("""
+                SELECT
+                    date(s.created_at) as day,
+                    COUNT(m.id) as prompts
+                FROM sessions s
+                JOIN messages m ON m.session_id = s.id AND m.role = 'user'
+                WHERE s.session_type = 'user'
+                  AND s.accumulated_total_tokens > 0
+                GROUP BY day
+            """)
+        else:
+            cursor.execute("""
+                SELECT
+                    date(s.created_at) as day,
+                    COUNT(m.id) as prompts
+                FROM sessions s
+                JOIN messages m ON m.session_id = s.id AND m.role = 'user'
+                WHERE s.session_type = 'user'
+                  AND s.total_tokens > 0
+                GROUP BY day
+            """)
+        prompt_rows = {row['day']: row['prompts'] for row in cursor.fetchall()}
+
+        results = []
+        for day, data in token_rows.items():
+            prompts = prompt_rows.get(day, 0)
+            results.append({
+                'day': day,
+                'sessions': data['sessions'],
+                'prompts': prompts,
+                'total_tokens': data['total_tokens'],
+                'input_tokens': data['input_tokens'],
+                'output_tokens': data['output_tokens'],
+                'tokens_per_prompt': (
+                    round(data['total_tokens'] / prompts)
+                    if prompts > 0 else 0
+                ),
+            })
+
+        return results
+
+    def get_sessions_by_directory(self) -> Dict[str, Dict]:
+        cursor = self.conn.cursor()
+        cursor.execute("""
+            SELECT
+                working_dir,
+                COUNT(*) as session_count,
+                SUM(total_tokens) as total_tokens
+            FROM sessions
+            WHERE session_type = 'user'
+            GROUP BY working_dir
+            ORDER BY session_count DESC
+        """)
+
+        return {row['working_dir']: {
+            'count': row['session_count'],
+            'tokens': row['total_tokens'] or 0
+        } for row in cursor.fetchall()}
+
+    # --- Analysis ---------------------------------------------------------
+
+    def analyze_prompts(self, prompts: List[Dict]) -> Dict:
+        """Full analysis of a set of prompts.
+
+        Uses multi-signal DOK classification:
+        1. System messages are filtered out (DOK 0, not counted)
+        2. Keyword matching is the primary signal
+        3. When no keywords match, session rolling DOK is used as default
+        4. Compression detection adjusts short directives +1 DOK
+        """
+        dok_counts = {1: 0, 2: 0, 3: 0, 4: 0}
+        dok_scores = []
+        compressed_count = 0
+        adjusted_scores = []
+        peak_prompt = None
+        peak_dok = 0
+        system_messages_filtered = 0
+
+        # Group by session for compression detection and context tracking
+        session_prompts = defaultdict(list)
+        for prompt in prompts:
+            session_prompts[prompt['session_id']].append(prompt)
+
+        for _session_id, s_prompts in session_prompts.items():
+            session_dok_running = []  # Rolling DOK within this session
+
+            for idx, prompt in enumerate(s_prompts):
+                # Calculate session context DOK (rolling average of prior prompts)
+                session_context = (
+                    sum(session_dok_running) / len(session_dok_running)
+                    if session_dok_running else None
+                )
+
+                dok_level, _confidence, _matched = self.classify_dok(
+                    prompt['text'], session_context_dok=session_context
+                )
+
+                # Filter system messages (DOK 0)
+                if dok_level == 0:
+                    system_messages_filtered += 1
+                    continue
+
+                dok_counts[dok_level] += 1
+                dok_scores.append(dok_level)
+                session_dok_running.append(dok_level)
+
+                # Compression detection
+                is_compressed = self.detect_compression(prompt['text'], idx)
+                if is_compressed:
+                    compressed_count += 1
+                    adjusted_level = min(dok_level + 1, 4)
+                else:
+                    adjusted_level = dok_level
+
+                adjusted_scores.append(adjusted_level)
+
+                # Track peak
+                if adjusted_level > peak_dok or (adjusted_level == peak_dok and peak_prompt is None):
+                    peak_dok = adjusted_level
+                    peak_prompt = prompt
+
+        total_prompts = sum(dok_counts.values())
+        if total_prompts == 0:
+            return {'error': 'no_prompts'}
+
+        # Calculate metrics
+        avg_dok_raw = sum(dok_scores) / len(dok_scores)
+        avg_dok_adjusted = sum(adjusted_scores) / len(adjusted_scores)
+        dok_3_4_pct = ((dok_counts[3] + dok_counts[4]) / total_prompts) * 100
+        compression_pct = (compressed_count / total_prompts) * 100
+
+        dok_distribution = {
+            f'dok{k}': round(v / total_prompts * 100, 1)
+            for k, v in dok_counts.items()
+        }
+        dok_distribution_counts = {f'dok{k}_count': v for k, v in dok_counts.items()}
+
+        return {
+            'total_prompts': total_prompts,
+            'dok_raw': round(avg_dok_raw, 2),
+            'dok_adjusted': round(avg_dok_adjusted, 2),
+            'dok_lift': round(avg_dok_adjusted - avg_dok_raw, 3),
+            'dok_3_4_pct': round(dok_3_4_pct, 1),
+            'compression_pct': round(compression_pct, 1),
+            'compressed_count': compressed_count,
+            'dok_distribution': dok_distribution,
+            'dok_distribution_counts': dok_distribution_counts,
+            'peak_prompt': peak_prompt,
+            'peak_dok': peak_dok,
+        }
+
+    def get_daily_breakdown(self, prompts: List[Dict]) -> List[Dict]:
+        """Calculate adjusted DOK scores by day (with compression).
+
+        Aggregates ALL sessions from a given day together. If a day has
+        10 different Goose sessions, all 10 are analyzed as one unit.
+        Uses session-context DOK default and filters system messages.
+        """
+        # Group prompts by day and session for compression detection
+        daily_by_session = defaultdict(lambda: defaultdict(list))
+
+        for prompt in prompts:
+            if prompt.get('session_date'):
+                try:
+                    date = datetime.fromisoformat(prompt['session_date'].replace('Z', '+00:00'))
+                    day = date.strftime('%Y-%m-%d')
+                    daily_by_session[day][prompt['session_id']].append(prompt)
+                except (ValueError, TypeError):
+                    continue
+
+        result = []
+        for day in sorted(daily_by_session.keys()):
+            adjusted_scores = []
+            for _session_id, session_prompts in daily_by_session[day].items():
+                session_dok_running = []
+                for idx, prompt in enumerate(session_prompts):
+                    session_context = (
+                        sum(session_dok_running) / len(session_dok_running)
+                        if session_dok_running else None
+                    )
+                    dok_level, _, _ = self.classify_dok(
+                        prompt['text'], session_context_dok=session_context
+                    )
+                    # Skip system messages
+                    if dok_level == 0:
+                        continue
+                    session_dok_running.append(dok_level)
+                    is_compressed = self.detect_compression(prompt['text'], idx)
+                    adjusted_level = min(dok_level + 1, 4) if is_compressed else dok_level
+                    adjusted_scores.append(adjusted_level)
+
+            if adjusted_scores:
+                avg = sum(adjusted_scores) / len(adjusted_scores)
+                dok3_4 = sum(1 for s in adjusted_scores if s >= 3) / len(adjusted_scores) * 100
+                result.append({
+                    'date': day,
+                    'avg_dok': round(avg, 2),
+                    'prompt_count': len(adjusted_scores),
+                    'dok3_4_pct': round(dok3_4, 1)
+                })
+
+        return result
+
+    def detect_phases(self, daily_scores: List[Dict]) -> List[Dict]:
+        """Auto-detect phases based on DOK trajectory shifts"""
+        if len(daily_scores) < 7:
+            return [{'name': 'Current', 'start': daily_scores[0]['date'] if daily_scores else '',
+                     'end': daily_scores[-1]['date'] if daily_scores else '',
+                     'sessions': len(daily_scores)}]
+
+        # Simple phase detection: split into roughly equal chunks
+        # based on trajectory inflection points
+        total_days = len(daily_scores)
+
+        if total_days < 14:
+            return [{
+                'name': '1. Current',
+                'start': daily_scores[0]['date'],
+                'end': daily_scores[-1]['date'],
+                'sessions': total_days,
+                'avg_dok': round(sum(d['avg_dok'] for d in daily_scores) / total_days, 2),
+                'dok3_4_pct': round(sum(d['dok3_4_pct'] for d in daily_scores) / total_days, 1)
+            }]
+
+        # Split into quarters for phase analysis
+        quarter = total_days // 4
+        phases = []
+        phase_names = ['1. Early', '2. Building', '3. Middle', '4. Recent']
+
+        for i, name in enumerate(phase_names):
+            start_idx = i * quarter
+            end_idx = (i + 1) * quarter if i < 3 else total_days
+            chunk = daily_scores[start_idx:end_idx]
+
+            if chunk:
+                phases.append({
+                    'name': name,
+                    'start': chunk[0]['date'],
+                    'end': chunk[-1]['date'],
+                    'sessions': len(chunk),
+                    'avg_dok': round(sum(d['avg_dok'] for d in chunk) / len(chunk), 2),
+                    'dok3_4_pct': round(sum(d['dok3_4_pct'] for d in chunk) / len(chunk), 1)
+                })
+
+        return phases
+
+    def calculate_trajectory(self, daily_scores: List[Dict]) -> str:
+        if len(daily_scores) < 4:
+            return "insufficient_data"
+
+        mid = len(daily_scores) // 2
+        first_half = [d['avg_dok'] for d in daily_scores[:mid]]
+        second_half = [d['avg_dok'] for d in daily_scores[mid:]]
+
+        first_avg = sum(first_half) / len(first_half) if first_half else 0
+        second_avg = sum(second_half) / len(second_half) if second_half else 0
+
+        diff = second_avg - first_avg
+
+        if diff > 0.15:
+            return "improving"
+        elif diff < -0.15:
+            return "declining"
+        else:
+            return "stable"
+
+    # --- Baseline Generation ----------------------------------------------
+
+    def generate_baseline(self) -> Dict:
+        if not self.connect():
+            return None
+
+        try:
+            summary = self.get_data_summary()
+            if summary['sessions'] == 0:
+                return {'error': 'no_data', 'message': 'No sessions found in database'}
+
+            prompts = self.get_all_user_prompts()
+            analysis = self.analyze_prompts(prompts)
+
+            if 'error' in analysis:
+                return {'error': 'no_prompts', 'message': 'No classifiable prompts found'}
+
+            # Get session metadata for TM estimation
+            session_meta = self.get_session_metadata()
+            directories = self.get_sessions_by_directory()
+
+            # Estimate overall TM tier
+            tm_tiers = []
+            for _sid, meta in session_meta.items():
+                tier = self.estimate_tm_tier(meta)
+                tm_tiers.append(tier)
+            avg_tm = round(sum(tm_tiers) / len(tm_tiers)) if tm_tiers else 2
+
+            # Daily breakdown for trajectory (needed for ADT zone)
+            daily_scores = self.get_daily_breakdown(prompts)
+            trajectory = self.calculate_trajectory(daily_scores)
+
+            # Calculate ADT zone (trajectory-aware)
+            adt_zone = self.calculate_adt_zone(analysis['dok_adjusted'], avg_tm, trajectory)
+
+            # Calculate floor (10th percentile DOK)
+            all_daily_doks = sorted([d['avg_dok'] for d in daily_scores])
+            floor_idx = max(0, len(all_daily_doks) // 10)
+            floor = all_daily_doks[floor_idx] if all_daily_doks else 1.0
+
+            # Growth targets
+            current_dok34 = analysis['dok_3_4_pct']
+            dok34_target = min(current_dok34 + 15, 50)
+            compression_target = max(analysis['compression_pct'] + 5, 5)
+
+            # Token spend
+            daily_token_data = self.get_daily_token_spend()
+            total_tokens = sum(d['total_tokens'] for d in daily_token_data)
+            total_prompts_for_tokens = sum(d['prompts'] for d in daily_token_data)
+            daily_avg_tokens = (
+                round(total_tokens / len(daily_token_data))
+                if daily_token_data else 0
+            )
+            tokens_per_prompt = (
+                round(total_tokens / total_prompts_for_tokens)
+                if total_prompts_for_tokens > 0 else 0
+            )
+
+            baseline = {
+                'version': '4.0',
+                'generated_at': datetime.now().isoformat(),
+                'period': {
+                    'start': summary['earliest'][:10] if summary['earliest'] else None,
+                    'end': summary['latest'][:10] if summary['latest'] else None,
+                    'days': summary['days']
+                },
+                'sessions_analyzed': summary['sessions'],
+                'prompts_classified': analysis['total_prompts'],
+                'three_dimensions': {
+                    'dok_adjusted': analysis['dok_adjusted'],
+                    'dok_raw': analysis['dok_raw'],
+                    'dok_lift': analysis['dok_lift'],
+                    'tm_tier': avg_tm,
+                    'tm_name': self.TM_TIERS.get(avg_tm, 'Unknown'),
+                    'adt_zone': adt_zone
+                },
+                'dok_distribution': analysis['dok_distribution'],
+                'dok_distribution_counts': analysis['dok_distribution_counts'],
+                'dok_3_4_pct': analysis['dok_3_4_pct'],
+                'compression_pct': analysis['compression_pct'],
+                'floor': round(floor, 2),
+                'trajectory': trajectory,
+                'token_spend': {
+                    'total_tokens': total_tokens,
+                    'daily_avg_tokens': daily_avg_tokens,
+                    'tokens_per_prompt': tokens_per_prompt,
+                },
+                'domain_count': len(directories),
+                'domains': {k: v for k, v in list(directories.items())[:10]},
+                'daily_scores': daily_scores[-30:],  # Last 30 days
+                'growth_targets': {
+                    'dok_3_4_pct': round(dok34_target, 1),
+                    'compression_pct': round(compression_target, 1),
+                    'next_tm_tier': min(avg_tm + 1, 6),
+                    'next_tm_name': self.TM_TIERS.get(min(avg_tm + 1, 6), 'Virtuoso')
+                },
+                # Preserve v3 fields for backward compat
+                'average_dok_score': analysis['dok_adjusted'],
+                'estimated_stage': self._tm_to_gas_town(avg_tm),
+            }
+
+            return baseline
+
+        finally:
+            self.close()
+
+    def _tm_to_gas_town(self, tm_tier: int) -> int:
+        """Map TM tier back to Gas Town stage for backward compat"""
+        mapping = {1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7}
+        return mapping.get(tm_tier, 5)
+
+    def _gas_town_to_tm(self, stage: int) -> int:
+        """Map Gas Town stage to TM tier (for reading v3 baselines)"""
+        if stage <= 2:
+            return 1
+        elif stage == 3:
+            return 2
+        elif stage == 4:
+            return 3
+        elif stage == 5:
+            return 4
+        elif stage == 6:
+            return 5
+        else:
+            return 6
+
+    # --- Baseline I/O -----------------------------------------------------
+
+    def save_baseline(self, baseline: Dict) -> bool:
+        try:
+            self._get_baseline_file().parent.mkdir(parents=True, exist_ok=True)
+            with open(self._get_baseline_file(), 'w') as f:
+                json.dump(baseline, f, indent=2)
+            return True
+        except IOError as e:
+            print(f"Error saving baseline: {e}")
+            return False
+
+    def load_baseline(self) -> Optional[Dict]:
+        if not self._get_baseline_file().exists():
+            return None
+
+        try:
+            with open(self._get_baseline_file(), 'r') as f:
+                baseline = json.load(f)
+
+            # Migrate v3 baseline to v4 format if needed
+            version = baseline.get('version', '3.0')
+            version_tuple = tuple(int(x) for x in str(version).split('.'))
+            if version_tuple < (4, 0):
+                baseline = self._migrate_v3_baseline(baseline)
+
+            return baseline
+        except (IOError, json.JSONDecodeError) as e:
+            print(f"Error loading baseline: {e}")
+            return None
+
+    def _migrate_v3_baseline(self, old: Dict) -> Dict:
+        """Translate a v3 (Gas Town x DOK) baseline to v4 (Three Dimensions)"""
+        stage = old.get('estimated_stage', 5)
+        tm_tier = self._gas_town_to_tm(stage)
+        dok = old.get('average_dok_score', 2.0)
+        adt_zone = self.calculate_adt_zone(dok, tm_tier)
+
+        # Map old quadrant names to new zone names
+        quadrant_map = {
+            'Learning Zone': 'Expected',
+            'Frontier': 'Frontier',
+            'Thinking Ahead': 'Thinking Ahead',
+            'Underutilizing': 'Underutilizing',
+            'Overpowered': 'Overpowered',
+            'Growing': 'Growing'
+        }
+        old_quadrant = old.get('quadrant', '')
+        if old_quadrant in quadrant_map:
+            adt_zone = quadrant_map[old_quadrant]
+
+        migrated = {
+            'version': '4.0',
+            'migrated_from': '3.0',
+            'generated_at': old.get('generated_at', ''),
+            'period': old.get('period', {}),
+            'sessions_analyzed': old.get('sessions_analyzed', 0),
+            'prompts_classified': old.get('prompts_classified', 0),
+            'three_dimensions': {
+                'dok_adjusted': dok,
+                'dok_raw': dok,
+                'dok_lift': 0.0,
+                'tm_tier': tm_tier,
+                'tm_name': self.TM_TIERS.get(tm_tier, 'Unknown'),
+                'adt_zone': adt_zone
+            },
+            'dok_distribution': old.get('dok_distribution', {}),
+            'dok_distribution_counts': old.get('dok_distribution_counts', {}),
+            'dok_3_4_pct': old.get('dok_distribution', {}).get('dok3', 0) + old.get('dok_distribution', {}).get('dok4', 0),
+            'compression_pct': 0.0,
+            'floor': dok - 0.3,
+            'trajectory': old.get('trajectory', 'stable'),
+            'domain_count': old.get('domain_count', 0),
+            'domains': old.get('domains', {}),
+            'growth_targets': {
+                'dok_3_4_pct': old.get('growth_targets', {}).get('dok3_percentage_target', 35),
+                'compression_pct': 5.0,
+                'next_tm_tier': min(tm_tier + 1, 6),
+                'next_tm_name': self.TM_TIERS.get(min(tm_tier + 1, 6), 'Virtuoso')
+            },
+            # Preserve v3 fields
+            'average_dok_score': dok,
+            'estimated_stage': stage,
+        }
+
+        return migrated
+
+    # --- Report Formatting ------------------------------------------------
+
+    def format_bar(self, percentage: float, width: int = 20) -> str:
+        filled = int(percentage / 100 * width)
+        return '\u2588' * filled + '\u2591' * (width - filled)
+
+    def print_baseline_report(self, baseline: Dict):
+        if 'error' in baseline:
+            print(f"\n{baseline['message']}")
+            return
+
+        sessions = baseline['sessions_analyzed']
+        dims = baseline.get('three_dimensions', {})
+
+        # Data volume warning
+        if sessions < 5:
+            print("\n  LIMITED DATA AVAILABLE")
+            print("  " + "-" * 60)
+            print(f"  Found only {sessions} sessions. Baseline will improve with more data.")
+            print()
+
+        print()
+        print("=" * 66)
+        print("                    rp-why . BASELINE")
+        print("=" * 66)
+        print()
+
+        # Data Summary
+        print("DATA SUMMARY")
+        print("-" * 66)
+        period = baseline.get('period', {})
+        start = period.get('start', 'unknown')
+        end = period.get('end', 'unknown')
+        days = period.get('days', 0)
+        print(f"Period:           {start} - {end} ({days} days)")
+        print(f"Sessions:         {sessions}")
+        print(f"Prompts:          {baseline.get('prompts_classified', 0)} classified")
+        print()
+
+        # Three Dimensions
+        print("THREE DIMENSIONS")
+        print("-" * 66)
+        dok = dims.get('dok_adjusted', 0)
+        tm_tier = dims.get('tm_tier', 2)
+        tm_name = dims.get('tm_name', 'Unknown')
+        adt_zone = dims.get('adt_zone', 'Unknown')
+        print(f"DOK (Depth of Knowledge)     {dok:.2f}")
+        print(f"TM  (Tool Maturity)          Tier {tm_tier} . {tm_name}")
+        print(f"ADT (Delegation Trust)       {adt_zone}")
+        print()
+
+        # Diagnostic Zone
+        print(f"DIAGNOSTIC ZONE: {adt_zone}")
+        print("-" * 66)
+        zone_descriptions = {
+            'Frontier': 'TM and DOK matched and growing together. Operating at the\nproductive edge.',
+            'Growing': 'Approaching a match between tool sophistication and cognitive\ndepth. Building toward effective use.',
+            'Expected': 'Tool usage and cognitive depth appropriate for current level.\nHealthy starting position.',
+            'Thinking Ahead': 'Cognitive depth exceeds tool sophistication. Opportunity to\nadopt more powerful orchestration patterns.',
+            'Underutilizing': 'Tool sophistication exceeds cognitive depth. Opportunity to\ndeepen the questions being asked.',
+            'Overpowered': 'Significant mismatch between tool complexity and task depth.\nResources spent without proportional cognitive return.'
+        }
+        print(zone_descriptions.get(adt_zone, ''))
+        print()
+
+        # DOK Distribution
+        print("DOK DISTRIBUTION")
+        print("-" * 66)
+        dist = baseline.get('dok_distribution', {})
+        for i in range(1, 5):
+            pct = dist.get(f'dok{i}', 0)
+            bar = self.format_bar(pct)
+            print(f"DOK {i} ({self.DOK_NAMES_SHORT[i]:11}):  {bar}  {pct:5.1f}%")
+        print()
+        print(f"DOK 3+4:  {baseline.get('dok_3_4_pct', 0):.1f}%")
+        print(f"Compression:  {baseline.get('compression_pct', 0):.1f}%")
+        print()
+
+        # Token Spend
+        token_data = baseline.get('token_spend', {})
+        if token_data.get('total_tokens', 0) > 0:
+            total = token_data['total_tokens']
+            daily_avg = token_data.get('daily_avg_tokens', 0)
+            tpp = token_data.get('tokens_per_prompt', 0)
+            print("TOKEN SPEND")
+            print("-" * 66)
+            print(f"Total:            {total / 1_000_000_000:.2f}B tokens")
+            print(f"Daily average:    {daily_avg / 1_000_000:.1f}M")
+            print(f"Tokens/prompt:    {tpp:,}")
+            print()
+
+        # Growth Targets
+        targets = baseline.get('growth_targets', {})
+        print("GROWTH TARGETS")
+        print("-" * 66)
+        print(f"DOK 3+4 target:       {targets.get('dok_3_4_pct', 35):.0f}%")
+        print(f"Compression target:   {targets.get('compression_pct', 5):.0f}%")
+        next_tier = targets.get('next_tm_tier', tm_tier + 1)
+        next_name = targets.get('next_tm_name', '')
+        tier_descriptions = {
+            2: 'back-and-forth conversation',
+            3: 'provide meaningful body of work, evaluate holistically',
+            4: 'delegate work streams, introduce sub-agents',
+            5: 'coordinate multiple AI interactions toward unified goal',
+            6: 'flow state, human and AI synthesized'
+        }
+        tier_desc = tier_descriptions.get(next_tier, '')
+        print(f"Next TM tier:         Tier {next_tier} . {next_name} ({tier_desc})")
+        print()
+
+        # Footer
+        print("-" * 66)
+        print(f"Baseline saved to: {self._get_baseline_file()}")
+        print("Run /rp-why current after sessions to track progress.")
+        print()
+
+    def print_current_report(self, analysis: Dict, session_meta: Dict | None = None):
+        if 'error' in analysis:
+            print(f"\n{analysis.get('message', 'No data available')}")
+            return
+
+        # Estimate TM from session metadata
+        tm_tier = 2  # Default
+        if session_meta:
+            tm_tier = self.estimate_tm_tier(session_meta)
+
+        dok_adj = analysis['dok_adjusted']
+        adt_zone = self.calculate_adt_zone(dok_adj, tm_tier)
+
+        print()
+        print("=" * 66)
+        print("                    rp-why . CURRENT SESSION")
+        print("=" * 66)
+        print()
+
+        # Session Snapshot
+        print("SESSION SNAPSHOT")
+        print("-" * 66)
+        print(f"Date:             {datetime.now().strftime('%b %d, %Y')}")
+        print(f"Prompts:          {analysis['total_prompts']} classified")
+        session_tokens = session_meta.get('accumulated_tokens', 0) if session_meta else 0
+        if session_tokens > 0:
+            tpp = round(session_tokens / analysis['total_prompts']) if analysis['total_prompts'] > 0 else 0
+            print(f"Token spend:      {session_tokens / 1_000_000:.1f}M ({tpp:,}/prompt)")
+        print()
+
+        # Three Dimensions
+        print("THREE DIMENSIONS")
+        print("-" * 66)
+        print(f"DOK (Adjusted)       {dok_adj:.2f}")
+        print(f"TM  (Tool Maturity)  Tier {tm_tier} . {self.TM_TIERS[tm_tier]}")
+        print(f"ADT (Delegation)     {adt_zone}")
+        print()
+
+        # Diagnostic Zone
+        print(f"DIAGNOSTIC ZONE: {adt_zone}")
+        print("-" * 66)
+        zone_descriptions = {
+            'Frontier': 'TM and DOK matched and growing together. Operating at the\nproductive edge.',
+            'Growing': 'Approaching a match. Building toward effective use of the\ncurrent toolset.',
+            'Expected': 'Appropriate match for current level. Growth comes from\nasking "why" before implementing.',
+            'Thinking Ahead': 'Cognitive depth exceeds tools. Time to adopt more powerful\norchestration patterns.',
+            'Underutilizing': 'Powerful tools deserve powerful questions. Opportunity to\ndeepen the questions being asked.',
+            'Overpowered': 'Tools exceed task needs. Consider whether this task needs\nan autonomous agent.'
+        }
+        print(zone_descriptions.get(adt_zone, ''))
+        print()
+
+        # DOK Distribution
+        print("DOK DISTRIBUTION")
+        print("-" * 66)
+        dist = analysis['dok_distribution']
+        for i in range(1, 5):
+            pct = dist.get(f'dok{i}', 0)
+            bar = self.format_bar(pct)
+            print(f"DOK {i} ({self.DOK_NAMES_SHORT[i]:11}):  {bar}  {pct:5.1f}%")
+        print()
+        print(f"DOK 3+4:  {analysis['dok_3_4_pct']:.1f}%     Compression:  {analysis['compression_pct']:.1f}%")
+        print()
+
+        # Peak Moment
+        peak = analysis.get('peak_prompt')
+        if peak:
+            peak_text = peak['text'][:70] + '...' if len(peak['text']) > 70 else peak['text']
+            peak_dok = analysis['peak_dok']
+            print("PEAK MOMENT")
+            print("-" * 66)
+            print(f'"{peak_text}"')
+            print(f"  DOK {peak_dok} . {self.DOK_NAMES[peak_dok]}")
+            print()
+
+        # Growth Nudge
+        print("GROWTH NUDGE")
+        print("-" * 66)
+        nudges = {
+            'Frontier': 'Strong session. The collaboration is matched and productive.\nConsider extending one thread into a multi-session investigation.',
+            'Growing': 'Building momentum. Try framing one more task as a design\ndecision rather than an execution request.',
+            'Expected': 'Solid foundation. Ask "what are the trade-offs?" before your\nnext implementation prompt.',
+            'Thinking Ahead': 'Your thinking exceeds your tools. Try delegating a work\nstream to a sub-agent or multi-step workflow.',
+            'Underutilizing': 'Powerful tools available. Before each prompt: can this be\nmore strategic? Batch simple queries.',
+            'Overpowered': 'Consider whether this task needs an autonomous agent.\nRedirect toward problems requiring analysis or design.'
+        }
+        print(nudges.get(adt_zone, ''))
+        print()
+
+        # Reflection
+        reflections = {
+            'Frontier': 'What complex challenge could benefit from sustained\n   exploration across your next few sessions?',
+            'Growing': 'What workflow could you delegate more fully to the agent?',
+            'Expected': 'What strategic question have you been avoiding?',
+            'Thinking Ahead': 'What tool or workflow would unlock the depth you are\n   already thinking at?',
+            'Underutilizing': 'What is the most strategic question you could ask right now?',
+            'Overpowered': 'Is there a harder problem this tool should be pointed at?'
+        }
+        reflection = reflections.get(adt_zone, 'What could you explore more deeply?')
+        print(f"  {reflection}")
+        print()
+
+    def print_compare_report(self, baseline: Dict, current: Dict, session_meta: Dict | None = None):
+        if 'error' in current:
+            print(f"\n{current.get('message', 'No current data')}")
+            return
+
+        dims_b = baseline.get('three_dimensions', {})
+        dok_b = dims_b.get('dok_adjusted', 0)
+        tm_b = dims_b.get('tm_tier', 2)
+        adt_b = dims_b.get('adt_zone', 'Unknown')
+
+        # Current dimensions - use session metadata for TM estimation
+        dok_c = current['dok_adjusted']
+        if session_meta:
+            tm_c = self.estimate_tm_tier(session_meta)
+        else:
+            tm_c = tm_b
+        # Single-day compare cannot measure trajectory - pass None
+        adt_c = self.calculate_adt_zone(dok_c, tm_c, None)
+
+        period = baseline.get('period', {})
+        period_str = f"{period.get('start', '?')} - {period.get('end', '?')}"
+
+        print()
+        print("=" * 66)
+        print("                    rp-why . COMPARE")
+        print("=" * 66)
+        print()
+        print(f"COMPARING: Today ({datetime.now().strftime('%b %d')}) vs. Baseline ({period_str})")
+        print()
+
+        # Three Dimensions comparison
+        print(f"{'THREE DIMENSIONS':<24} {'Baseline':>12} {'Today':>12} {'':>8}")
+        print("-" * 66)
+        dok_delta = dok_c - dok_b
+        dok_pct = (dok_delta / dok_b * 100) if dok_b > 0 else 0
+        print(f"{'DOK (Adjusted)':<24} {dok_b:>12.2f} {dok_c:>12.2f} {f'+{dok_pct:.0f}%' if dok_pct >= 0 else f'{dok_pct:.0f}%':>8}")
+        print(f"{'TM  (Tool Maturity)':<24} {'Tier ' + str(tm_b):>12} {'Tier ' + str(tm_c):>12} {f'+{tm_c - tm_b}' if tm_c > tm_b else ('=' if tm_c == tm_b else str(tm_c - tm_b)):>8}")
+        arrow = '=' if adt_b == adt_c else '>'
+        print(f"{'ADT (Delegation Trust)':<24} {adt_b:>12} {adt_c:>12} {'':>8}")
+        print()
+
+        # Diagnostic Zone transition
+        if adt_b != adt_c:
+            print(f"DIAGNOSTIC ZONE: {adt_b} -> {adt_c}")
+        else:
+            print(f"DIAGNOSTIC ZONE: {adt_c} (sustained)")
+        print("-" * 66)
+        print()
+
+        # DOK Distribution comparison
+        dist_b = baseline.get('dok_distribution', {})
+        dist_c = current.get('dok_distribution', {})
+
+        print(f"{'DOK DISTRIBUTION':<24} {'Baseline':>12} {'Today':>12} {'':>8}")
+        print("-" * 66)
+        for i in range(1, 5):
+            pct_b = dist_b.get(f'dok{i}', 0)
+            pct_c = dist_c.get(f'dok{i}', 0)
+            delta = pct_c - pct_b
+            delta_str = f"+{delta:.1f}pp" if delta >= 0 else f"{delta:.1f}pp"
+            print(f"DOK {i} ({self.DOK_NAMES_SHORT[i]:11})   {pct_b:>10.1f}% {pct_c:>10.1f}% {delta_str:>8}")
+        print()
+
+        dok34_b = baseline.get('dok_3_4_pct', 0)
+        dok34_c = current.get('dok_3_4_pct', 0)
+        dok34_delta = dok34_c - dok34_b
+        comp_b = baseline.get('compression_pct', 0)
+        comp_c = current.get('compression_pct', 0)
+        comp_delta = comp_c - comp_b
+
+        print(f"{'DOK 3+4':<24} {dok34_b:>10.1f}% {dok34_c:>10.1f}% {f'+{dok34_delta:.1f}pp' if dok34_delta >= 0 else f'{dok34_delta:.1f}pp':>8}")
+        comp_label = "emerged" if comp_b == 0 and comp_c > 0 else (f"+{comp_delta:.1f}pp" if comp_delta >= 0 else f"{comp_delta:.1f}pp")
+        print(f"{'Compression':<24} {comp_b:>10.1f}% {comp_c:>10.1f}% {comp_label:>8}")
+        print()
+
+        # Token Spend comparison
+        token_b = baseline.get('token_spend', {})
+        tokens_today = session_meta.get('accumulated_tokens', 0) if session_meta else 0
+        daily_avg_b = token_b.get('daily_avg_tokens', 0)
+        tpp_b = token_b.get('tokens_per_prompt', 0)
+        if tokens_today > 0 and daily_avg_b > 0:
+            prompts_today = current.get('total_prompts', 1)
+            tpp_c = round(tokens_today / prompts_today) if prompts_today > 0 else 0
+            tok_delta_pct = ((tokens_today - daily_avg_b) / daily_avg_b * 100) if daily_avg_b > 0 else 0
+            print(f"{'TOKEN SPEND':<24} {'Baseline avg':>12} {'Today':>12} {'':>8}")
+            print(f"{'  Daily total':<24} {daily_avg_b / 1_000_000:>10.1f}M {tokens_today / 1_000_000:>10.1f}M {f'+{tok_delta_pct:.0f}%' if tok_delta_pct >= 0 else f'{tok_delta_pct:.0f}%':>8}")
+            print(f"{'  Tokens/prompt':<24} {tpp_b:>12,} {tpp_c:>12,} {'':>8}")
+            print()
+
+        # Trajectory
+        print("TRAJECTORY")
+        print("-" * 66)
+        if dok_delta > 0.1:
+            direction = "Improving"
+            arrow = "^"
+        elif dok_delta < -0.1:
+            direction = "Declining"
+            arrow = "v"
+        else:
+            direction = "Stable"
+            arrow = "="
+        print(f"Direction:  {arrow} {direction}")
+
+        # Signal interpretation
+        signals = []
+        if dok34_delta > 10:
+            signals.append(f"DOK 3+4 jumped {dok34_delta:.0f}pp. Strategic thinking increased significantly.")
+        elif dok34_delta > 5:
+            signals.append(f"DOK 3+4 up {dok34_delta:.0f}pp. More strategic work in this session.")
+        elif dok34_delta < -5:
+            signals.append(f"DOK 3+4 down {abs(dok34_delta):.0f}pp. Execution-heavy session (expected for delegation days).")
+
+        if comp_c > 0 and comp_b == 0:
+            signals.append("Compression emerged. Short directives now carry complex intent.")
+        elif comp_delta > 5:
+            signals.append(f"Compression up {comp_delta:.0f}pp. Trust deepening in the collaboration.")
+
+        if signals:
+            print(f"Signal:     {signals[0]}")
+            for s in signals[1:]:
+                print(f"            {s}")
+        print()
+
+        # What Shifted
+        print("WHAT SHIFTED")
+        print("-" * 66)
+        shifts = []
+        if dok34_delta > 5:
+            shifts.append(f"DOK 3+4 share grew {dok34_delta:.0f}pp - more reasoning and design in prompts")
+        dok2_b = dist_b.get('dok2', 0)
+        dok2_c = dist_c.get('dok2', 0)
+        if dok2_b - dok2_c > 10:
+            shifts.append(f"DOK 2 share dropped {dok2_b - dok2_c:.0f}pp - work that was explicit is now compressed or delegated")
+        if comp_c > comp_b + 3:
+            shifts.append("Compression growing - trust made visible in the data")
+        if tm_c > tm_b:
+            shifts.append(f"TM advanced from {self.TM_TIERS[tm_b]} to {self.TM_TIERS[tm_c]}")
+        if adt_b != adt_c:
+            shifts.append(f"Diagnostic zone moved: {adt_b} -> {adt_c}")
+
+        if not shifts:
+            shifts.append("Session is consistent with baseline patterns")
+
+        for s in shifts:
+            print(f"  . {s}")
+        print()
+
+        print("-" * 66)
+        print("Run /rp-why overall for full longitudinal analysis.")
+        print()
+
+    def print_overall_report(self, baseline: Dict, analysis: Dict, daily_scores: List[Dict]):
+        if 'error' in analysis:
+            print(f"\n{analysis.get('message', 'No data')}")
+            return
+
+        dims = baseline.get('three_dimensions', {})
+        tm_tier = dims.get('tm_tier', 2)
+        dok_adj = analysis['dok_adjusted']
+        # Use fresh trajectory from current daily_scores, not stale baseline
+        fresh_trajectory = self.calculate_trajectory(daily_scores)
+        adt_zone = self.calculate_adt_zone(dok_adj, tm_tier, fresh_trajectory)
+
+        period = baseline.get('period', {})
+        start = period.get('start', '?')
+        end = period.get('end', '?')
+        days = period.get('days', 0)
+
+        # Rolling averages
+        first_10 = daily_scores[:10] if len(daily_scores) >= 10 else daily_scores[:len(daily_scores)//2]
+        last_10 = daily_scores[-10:] if len(daily_scores) >= 10 else daily_scores[len(daily_scores)//2:]
+
+        first_dok = sum(d['avg_dok'] for d in first_10) / len(first_10) if first_10 else 0
+        last_dok = sum(d['avg_dok'] for d in last_10) / len(last_10) if last_10 else 0
+        first_dok34 = sum(d['dok3_4_pct'] for d in first_10) / len(first_10) if first_10 else 0
+        last_dok34 = sum(d['dok3_4_pct'] for d in last_10) / len(last_10) if last_10 else 0
+
+        # Floor
+        all_doks = sorted([d['avg_dok'] for d in daily_scores])
+        floor = all_doks[len(all_doks) // 10] if len(all_doks) > 10 else (all_doks[0] if all_doks else 1.0)
+
+        # Peak
+        peak_day = max(daily_scores, key=lambda d: d['avg_dok']) if daily_scores else None
+
+        # Phases
+        phases = self.detect_phases(daily_scores)
+
+        print()
+        print("=" * 66)
+        print("                    rp-why . OVERALL")
+        print("=" * 66)
+        print()
+        print(f"FULL DATASET: {start} - {end} ({days} days)")
+        print(f"Sessions: {baseline.get('sessions_analyzed', 0)}  |  Prompts: {analysis['total_prompts']}")
+        print()
+
+        # Current Standings
+        print("CURRENT STANDINGS")
+        print("-" * 66)
+        print(f"DOK (Adjusted, full mean)    {dok_adj:.2f}")
+        print(f"TM  (Tool Maturity)          Tier {tm_tier} . {self.TM_TIERS[tm_tier]}")
+        print(f"ADT (Delegation Trust)       {adt_zone}")
+        print()
+        print(f"DOK 3+4:  {analysis['dok_3_4_pct']:.1f}%     Compression:  {analysis['compression_pct']:.1f}%     Floor:  {floor:.2f}")
+        print()
+
+        # Token Spend in overall
+        token_data = baseline.get('token_spend', {})
+        if token_data.get('total_tokens', 0) > 0:
+            total_tok = token_data['total_tokens']
+            daily_avg = token_data.get('daily_avg_tokens', 0)
+            tpp = token_data.get('tokens_per_prompt', 0)
+            print(f"Token spend:  {total_tok / 1_000_000_000:.2f}B total     {daily_avg / 1_000_000:.1f}M/day     {tpp:,}/prompt")
+            print()
+
+        # Rolling Average
+        print("ROLLING AVERAGE (Last 10 vs. First 10)")
+        print("-" * 66)
+        dok_delta = ((last_dok - first_dok) / first_dok * 100) if first_dok > 0 else 0
+        dok34_delta = last_dok34 - first_dok34
+        print(f"{'':24} {'First 10':>12} {'Last 10':>12} {'':>10}")
+        print(f"{'Adjusted DOK':<24} {first_dok:>12.2f} {last_dok:>12.2f} {f'+{dok_delta:.1f}%' if dok_delta >= 0 else f'{dok_delta:.1f}%':>10}")
+        print(f"{'DOK 3+4 %':<24} {first_dok34:>11.1f}% {last_dok34:>11.1f}% {f'+{dok34_delta:.1f}pp' if dok34_delta >= 0 else f'{dok34_delta:.1f}pp':>10}")
+        print()
+
+        # Phase Analysis
+        if len(phases) > 1:
+            print("PHASE ANALYSIS")
+            print("-" * 66)
+            print(f"{'Phase':<16} {'Dates':<22} {'Sessions':>8} {'DOK':>6} {'DOK3+4':>8}")
+            print(f"{'-----':<16} {'-----':<22} {'--------':>8} {'---':>6} {'------':>8}")
+            for phase in phases:
+                dates = f"{phase['start']} - {phase['end'][-5:]}"
+                print(f"{phase['name']:<16} {dates:<22} {phase['sessions']:>8} {phase['avg_dok']:>6.2f} {phase['dok3_4_pct']:>7.1f}%")
+            print()
+
+        # Trajectory
+        print("TRAJECTORY")
+        print("-" * 66)
+        if peak_day:
+            print(f"Peak DOK:     {peak_day['avg_dok']:.2f} ({peak_day['date']})")
+        print(f"Floor:        {floor:.2f}")
+        trajectory = self.calculate_trajectory(daily_scores)
+        direction_map = {'improving': '^ Improving', 'declining': 'v Declining', 'stable': '= Stable'}
+        print(f"Direction:    {direction_map.get(trajectory, '? Insufficient data')}")
+        print()
+
+        # DOK Distribution
+        print("DOK DISTRIBUTION (Full Dataset)")
+        print("-" * 66)
+        dist = analysis['dok_distribution']
+        for i in range(1, 5):
+            pct = dist.get(f'dok{i}', 0)
+            bar = self.format_bar(pct)
+            print(f"DOK {i} ({self.DOK_NAMES_SHORT[i]:11}):  {bar}  {pct:5.1f}%")
+        print()
+
+        # Growth Story
+        print("GROWTH STORY")
+        print("-" * 66)
+        if trajectory == 'improving':
+            if analysis['compression_pct'] > 5:
+                print("The collaboration is deepening. Compression has emerged as a")
+                print("signal of trust - short directives now carry complex intent.")
+                print("The tool didn't get smarter. The relationship deepened.")
+            else:
+                print("DOK is trending upward. More strategic and extended thinking")
+                print("is appearing in the practice. The next signal to watch for is")
+                print("compression - when short prompts start carrying complex meaning.")
+        elif trajectory == 'declining':
+            print("DOK trending down may indicate execution-heavy work where cognitive")
+            print("complexity lives in the orchestration structure, not individual")
+            print("prompts. Check if TM tier has advanced - that's the complementary signal.")
+        else:
+            print("Stable DOK with consistent patterns. Growth may be happening in")
+            print("dimensions not captured by prompt text alone - orchestration depth,")
+            print("delegation trust, or domain breadth.")
+        print()
+
+        # Footer
+        print("-" * 66)
+        print(f"Data source: {self._get_sessions_db()}")
+        print("Methodology: DOK keyword classification, compression detection")
+        print("(short prompt + established context), adjusted DOK (+1 for")
+        print("compressed prompts, capped at 4).")
+        print()
+
+
+def main():
+    import sys
+
+    analyzer = RPWhyAnalyzer()
+
+    if len(sys.argv) < 2:
+        print("Usage: python rp_why_baseline.py [init|baseline|current|compare|overall|export|show]")
+        print()
+        print("Commands:")
+        print("  init / baseline   Generate baseline from session history")
+        print("  current           Analyze current/recent session")
+        print("  compare           Compare current to baseline")
+        print("  overall           Full longitudinal report")
+        print("  export            Export baseline as JSON")
+        print("  show              Show current baseline")
+        sys.exit(1)
+
+    command = sys.argv[1].lower()
+
+    # Alias: baseline == init
+    if command == 'baseline':
+        command = 'init'
+
+    if command == 'init':
+        print("\nAnalyzing your Goose session history...\n")
+        baseline = analyzer.generate_baseline()
+
+        if baseline and 'error' not in baseline:
+            analyzer.save_baseline(baseline)
+            analyzer.print_baseline_report(baseline)
+        elif baseline:
+            print(f"\n{baseline.get('message', 'Unknown error')}")
+        else:
+            print("\nFailed to generate baseline")
+
+    elif command == 'show':
+        baseline = analyzer.load_baseline()
+        if baseline:
+            analyzer.print_baseline_report(baseline)
+        else:
+            print("\nNo baseline found. Run 'python rp_why_baseline.py init' first.")
+
+    elif command == 'export':
+        baseline = analyzer.load_baseline()
+        if baseline:
+            print(json.dumps(baseline, indent=2))
+        else:
+            print("\nNo baseline found. Run 'python rp_why_baseline.py init' first.")
+
+    elif command == 'current':
+        if not analyzer.connect():
+            sys.exit(1)
+        try:
+            prompts = analyzer.get_all_user_prompts()
+            # Get last session's prompts
+            if prompts:
+                last_session_id = prompts[-1]['session_id']
+                session_prompts = [p for p in prompts if p['session_id'] == last_session_id]
+                analysis = analyzer.analyze_prompts(session_prompts)
+                session_meta = analyzer.get_session_metadata()
+                meta = session_meta.get(last_session_id, {})
+                analyzer.print_current_report(analysis, meta)
+            else:
+                print("\nNo prompts found in recent sessions.")
+        finally:
+            analyzer.close()
+
+    elif command == 'compare':
+        baseline = analyzer.load_baseline()
+        if not baseline:
+            print("\nNo baseline found. Run 'python rp_why_baseline.py init' first.")
+            sys.exit(1)
+
+        if not analyzer.connect():
+            sys.exit(1)
+        try:
+            prompts = analyzer.get_all_user_prompts()
+            if prompts:
+                # Aggregate all sessions from today (multi-session day)
+                today = datetime.now().strftime('%Y-%m-%d')
+                today_prompts = [
+                    p for p in prompts
+                    if p.get('session_date', '').startswith(today)
+                ]
+                if not today_prompts:
+                    # Fallback to last session if no prompts from today
+                    last_session_id = prompts[-1]['session_id']
+                    today_prompts = [p for p in prompts if p['session_id'] == last_session_id]
+
+                current = analyzer.analyze_prompts(today_prompts)
+                session_meta = analyzer.get_session_metadata()
+                # Combine metadata from all today's sessions
+                today_session_ids = {p['session_id'] for p in today_prompts}
+                combined_meta = aggregate_session_metadata(session_meta, today_session_ids)
+                analyzer.print_compare_report(baseline, current, combined_meta)
+            else:
+                print("\nNo prompts found in recent sessions.")
+        finally:
+            analyzer.close()
+
+    elif command == 'overall':
+        baseline = analyzer.load_baseline()
+        if not baseline:
+            print("\nNo baseline found. Run 'python rp_why_baseline.py init' first.")
+            sys.exit(1)
+
+        if not analyzer.connect():
+            sys.exit(1)
+        try:
+            prompts = analyzer.get_all_user_prompts()
+            if prompts:
+                analysis = analyzer.analyze_prompts(prompts)
+                daily_scores = analyzer.get_daily_breakdown(prompts)
+                analyzer.print_overall_report(baseline, analysis, daily_scores)
+            else:
+                print("\nNo prompts found.")
+        finally:
+            analyzer.close()
+
+    else:
+        print(f"Unknown command: {command}")
+        print("Usage: python rp_why_baseline.py [init|baseline|current|compare|overall|export|show]")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/_tortu/config/skills/rp-why/scripts/rp_why_core.py
+++ b/_tortu/config/skills/rp-why/scripts/rp_why_core.py
@@ -1,0 +1,425 @@
+"""
+rp-why Core: Shared constants, classifiers, and zone computation.
+
+This module is the single source of truth for:
+- DOK classification patterns and logic
+- Orchestra Tier (TM) definitions
+- ADT diagnostic zone computation
+- Compression detection
+- System message filtering
+- Growth nudges by zone
+
+Imported by: rp_why_baseline.py, growth_nudge.py, goose_skill.py
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List, Tuple
+
+
+# ═══════════════════════════════════════════════════════════════════
+# CONSTANTS
+# ═══════════════════════════════════════════════════════════════════
+
+DOK_PATTERNS: dict = {
+    1: [
+        # Information retrieval, recall, simple lookups
+        r'\bhow do i\b', r'\bwhat is\b', r'\bsyntax\b', r'\bcommand\b',
+        r'\bwhere\b', r'\bshow me\b', r'\bexample\b', r'\bhelp with\b',
+        r'\bwhat\'s the\b', r'\bhow to\b', r'\bcan you show\b',
+        r'\blist\b', r'\bdefine\b', r'\blook up\b',
+        r'\blook at\b', r'\btake a look\b', r'\bfind the\b',
+        r'\bread the\b', r'\bopen the\b', r'\bget the\b',
+        r'\bcheck on\b', r'\bdisplay\b', r'\bpull up\b',
+        r'\bwhat does .+ (do|mean|say)\b',
+        r'\bremind me\b', r'\bwhere is\b', r'\bwhere are\b',
+    ],
+    2: [
+        # Applying known patterns, executing within familiar contexts
+        r'\bimplement\b', r'\bdebug\b', r'\bfix\b', r'\brefactor\b',
+        r'\btest\b', r'\badd\b', r'\bupdate\b', r'\bcreate\b',
+        r'\bbuild\b', r'\bwrite\b', r'\bmodify\b', r'\bchange\b',
+        r'\bremove\b', r'\bdelete\b', r'\binstall\b', r'\bsetup\b',
+        r'\bconfigure\b', r'\bmigrate\b', r'\bconvert\b',
+        r'\brun\b', r'\bexecute\b', r'\bdeploy\b', r'\bformat\b',
+        r'\brename\b', r'\bmove\b', r'\bcopy\b', r'\bmerge\b',
+        r'\bcommit\b', r'\bpush\b', r'\brebase\b',
+    ],
+    3: [
+        # Strategic reasoning, trade-offs, planning, evaluation
+        r'\bdesign\b', r'\barchitect\b', r'\banalyze\b', r'\bcompare\b',
+        r'\btrade-?off\b', r'\bbest approach\b', r'\bevaluate\b',
+        r'\bstrategy\b', r'(?<![-\w])why\b', r'\bimplications\b', r'\bshould we\b',
+        r'\breview\b', r'\boptimize\b', r'\bimprove\b', r'\balternative\b',
+        r'\bpros and cons\b', r'\bdecision\b', r'\bplan\b',
+        r'\bwhat if\b', r'\bconsequences\b', r'\bprioritize\b',
+        r'\bvalidat\w*\b', r'\bverif\w*\b', r'\bensur\w*\b', r'\bsound\b',
+        r'\binteract\w*\b', r'\bassumption\w*\b', r'\bwhat would break\b',
+        r'\bedge case\w*\b', r'\bhold\w* up\b',
+        r'\bthink through\b', r'\breason\w* about\b', r'\bweigh\b',
+        r'\bconsider\b', r'\bdepend\w* on\b',
+        # Evaluative/quality/alignment language
+        r'\bmake sure\b', r'\bensure that\b',
+        r'\bshould be\b', r'\bsupposed to\b',
+        r'\binstead of\b', r'\brather than\b',
+        r'\bappropriate\b', r'\bcorrect\w*\b', r'\balign\w*\b',
+        r'\bdistinction\b', r'\bdifference between\b',
+        r'\brelat\w+ to\b', r'\binterplay\b',
+        r'\bobserv\w*\b', r'\bglean\b', r'\bsignifican\w*\b',
+        r'\bmethodology\b', r'\bapproach\b',
+        r'\bhow does .+ (relate|connect|fit|work with)\b',
+        r'\bdiagnos\w*\b', r'\bassess\w*\b', r'\bmeasur\w*\b',
+        r'\bcriteria\b', r'\brequirement\w*\b',
+    ],
+    4: [
+        # Extended thinking, synthesis, creating novel frameworks
+        r'\bresearch\b', r'\bnovel\b', r'\binnovate\b', r'\btransform\b',
+        r'\bframework\b', r'\blong-term\b', r'\bevolve\b', r'\bvision\b',
+        r'\bbreakthrough\b', r'\bsystematic\b', r'\bparadigm\b',
+        r'\bfundamental\b', r'\bpioneer\b', r'\bgroundbreaking\b',
+        r'\bsynthesize\b', r'\bcross-disciplinary\b', r'\boriginal\b',
+        r'\bnew model\b', r'\btheory\b', r'\bhypothesis\b',
+        r'\bpropos\w*\b', r'\bpublish\w*\b', r'\bcontribut\w*\b',
+        r'\bextend\b', r'\bexpand upon\b', r'\bintegrat\w*\b',
+        r'\bformulat\w*\b', r'\bconceptualiz\w*\b',
+        r'\bcatalog\w*\b', r'\btaxonom\w*\b', r'\bclassif\w*\b',
+    ]
+}
+
+TM_TIERS: dict = {
+    1: "Solo",
+    2: "Duet",
+    3: "Ensemble",
+    4: "Chamber",
+    5: "Symphony",
+    6: "Virtuoso",
+}
+
+DOK_NAMES: dict = {
+    1: "Recall & Reproduction",
+    2: "Application of Skills & Concepts",
+    3: "Strategic Thinking",
+    4: "Extended Thinking",
+}
+
+DOK_NAMES_SHORT: dict = {
+    1: "Recall",
+    2: "Application",
+    3: "Strategic",
+    4: "Extended",
+}
+
+ADT_ZONES: list = [
+    "Overpowered", "Underutilizing", "Expected",
+    "Growing", "Frontier", "Thinking Ahead",
+]
+
+ZONE_COLORS: dict = {
+    "Expected": "grey",
+    "Growing": "blue",
+    "Frontier": "green",
+    "Thinking Ahead": "purple",
+    "Underutilizing": "amber",
+    "Overpowered": "red",
+}
+
+SYSTEM_MESSAGE_PATTERNS: list = [
+    r'^A (Python|shell|bash|TypeScript) (script|command|execution) was (executed|attempted|run|performed)',
+    r'^Retrieved (the|a|lines) .+ (file|document|contents|data|from|interface|class|method)',
+    r'^The (assistant|user|developer|tool|search|grep|build|shell) (retrieved|executed|ran|displayed|checked|searched|found|confirmed|examined|updated|added|created|removed)',
+    r'^A (file edit|directory tree|shell command|delegation request|background task|code edit|git|grep|search|build|new|import)',
+    r'^(File|Directory) (was|tree|listing)',
+    r'^A cached (HTML|file|document)',
+    r'^A (git|grep|code|recursive|file|Gradle|TypeScript|GitHub|Linear) .+ was (executed|performed|made|run|attempted|retrieved|created|updated)',
+    r'^(An|The) (import|code|method|function|dependency|constructor|test|build|emulator|Android|app)',
+    r'^(Checked|Verified|Examined|Updated|Added|Removed|Switched|Pushed|Committed)',
+    r'^(Both|All|Two|Three|The existing|The new|The legacy|The Compose)',
+    r'^(Good|Done|Clean|Build) [-.] ',
+    r'^A (new|Compose|Material|Kotlin|Java) .+ (was|file|class|interface)',
+    r'^(Found|Confirmed|Resolved|Deployed|Installed|Launched|Untracked)',
+    r'^A (dependency injection|DI|Dagger|Anvil) .+ (was|field|binding)',
+    r'^(Re-review|CI|Unit test|Snapshot|Detekt|ktfmt)',
+]
+
+COMPRESSION_MAX_WORDS: int = 8
+COMPRESSION_INDICATORS: list = [
+    r'^proceed$', r'^do it$', r'^go$', r'^yes$', r'^continue$',
+    r'^ship it$', r'^deploy$', r'^merge$', r'^lgtm$',
+    r'^next$', r'^done$', r'^send$', r'^push$',
+    r'^run it$', r'^build$', r'^start$', r'^finish$',
+]
+
+ZONE_NUDGES: dict = {
+    'Frontier': [
+        "Operating at the productive edge. Document what works for others.",
+        "The collaboration is matched. Look for opportunities to extend into new domains.",
+        "Strong session. Consider extending one thread into a multi-session investigation.",
+    ],
+    'Growing': [
+        "Approaching a match. Keep pushing DOK 3+ work and the zone will shift.",
+        "Consider: what's one workflow you could delegate more fully?",
+        "Building momentum. Try framing one more task as a design decision rather than an execution request.",
+    ],
+    'Expected': [
+        "Healthy starting position. Growth comes from asking 'why' before implementing.",
+        "Try framing one task as a design decision rather than an execution request.",
+        "Solid foundation. Ask 'what are the trade-offs?' before your next implementation prompt.",
+    ],
+    'Thinking Ahead': [
+        "Cognitive depth exceeds tool sophistication. Time to adopt more powerful orchestration.",
+        "Your thinking is ready for the next tier. Explore sub-agents or multi-step delegation.",
+        "What tool or workflow would unlock the depth you are already thinking at?",
+    ],
+    'Underutilizing': [
+        "Powerful tools deserve powerful questions. Before each prompt: can this be more strategic?",
+        "Batch simple queries. Reserve the agent for work that requires reasoning.",
+        "What is the most strategic question you could ask right now?",
+    ],
+    'Overpowered': [
+        "Significant mismatch. Consider whether this task needs an autonomous agent.",
+        "Opportunity: redirect this tool toward a problem that requires analysis or design.",
+        "Is there a harder problem this tool should be pointed at?",
+    ],
+}
+
+ZONE_REFLECTIONS: dict = {
+    'Frontier': "What complex challenge could benefit from sustained exploration across your next few sessions?",
+    'Growing': "What workflow could you delegate more fully to the agent?",
+    'Expected': "What strategic question have you been avoiding?",
+    'Thinking Ahead': "What tool or workflow would unlock the depth you are already thinking at?",
+    'Underutilizing': "What is the most strategic question you could ask right now?",
+    'Overpowered': "Is there a harder problem this tool should be pointed at?",
+}
+
+
+# ═══════════════════════════════════════════════════════════════════
+# CLASSIFICATION FUNCTIONS
+# ═══════════════════════════════════════════════════════════════════
+
+def is_system_message(text: str) -> bool:
+    """Detect system-generated messages (tool output summaries).
+
+    These are NOT human prompts and should be excluded from DOK
+    classification entirely.
+    """
+    if not text:
+        return False
+    for pattern in SYSTEM_MESSAGE_PATTERNS:
+        if re.match(pattern, text, re.IGNORECASE):
+            return True
+    return False
+
+
+def classify_dok(text: str, session_context_dok: float | None = None) -> Tuple[int, float, List[str]]:
+    """
+    Classify text by DOK level using multi-signal approach.
+
+    Args:
+        text: The prompt text to classify
+        session_context_dok: Rolling average DOK for the current session.
+            When provided and no keywords match, the classifier defaults
+            to round(session_context_dok) instead of a fixed DOK 2.
+
+    Returns:
+        (dok_level, confidence, matched_keywords)
+        DOK 0 indicates a system message (should be excluded from counts).
+    """
+    if not text:
+        return (2, 0.3, [])
+
+    if is_system_message(text):
+        return (0, 0.0, ['[system_message]'])
+
+    text_lower = text.lower()
+    scores = {1: 0, 2: 0, 3: 0, 4: 0}
+    matched = []
+
+    for level, patterns in DOK_PATTERNS.items():
+        for pattern in patterns:
+            if re.search(pattern, text_lower):
+                scores[level] += 1
+                match = re.search(pattern, text_lower)
+                if match:
+                    matched.append(match.group().strip())
+
+    total_matches = sum(scores.values())
+    if total_matches == 0:
+        if session_context_dok is not None:
+            context_level = max(1, min(4, round(session_context_dok)))
+            return (context_level, 0.2, ['[session_context]'])
+        return (2, 0.3, [])
+
+    max_score = max(scores.values())
+    # Tie-break resolves to the LOWER band (conservative). The instrument
+    # should not inflate scores on ambiguous evidence. A 1-1 split between
+    # DOK 2 and DOK 3 keywords resolves to DOK 2.
+    level = min(k for k, v in scores.items() if v == max_score)
+    confidence = max_score / total_matches if total_matches > 0 else 0.3
+
+    return (level, min(confidence, 1.0), matched[:5])
+
+
+def detect_compression(text: str, session_prompt_index: int) -> bool:
+    """Detect compressed intent (short prompts carrying complex meaning).
+
+    A prompt is compressed when it's short (<=8 words), appears after
+    context is established (index > 2), and either matches a known
+    compression pattern or is very short (<=4 words) deep in a session.
+    """
+    if not text:
+        return False
+
+    word_count = len(text.split())
+
+    if word_count <= COMPRESSION_MAX_WORDS and session_prompt_index > 2:
+        text_lower = text.lower().strip()
+        for pattern in COMPRESSION_INDICATORS:
+            if re.match(pattern, text_lower):
+                return True
+        # Short directive-style prompts deep in a session, but only if
+        # they look imperative (2-4 words, not single characters/typos)
+        if 2 <= word_count <= 4 and session_prompt_index > 5:
+            return True
+
+    return False
+
+
+def calculate_adt_zone(dok_adjusted: float, tm_tier: int,
+                       trajectory: str | None = None) -> str:
+    """
+    Calculate diagnostic zone from DOK x TM matrix.
+
+    Trajectory-aware: when trajectory is 'improving' (DOK trending
+    upward over the measurement window), the zone is upgraded one
+    level toward Frontier. TM is stable at the baseline level for
+    most practitioners, so DOK growth is the primary trajectory
+    signal. The upgrade reflects that sustained cognitive growth
+    indicates a healthier collaboration relationship than the
+    static position alone would suggest.
+
+    Zone hierarchy (low -> high):
+      Overpowered -> Underutilizing -> Expected -> Growing -> Frontier
+    Orthogonal zone (high DOK, low TM):
+      Thinking Ahead
+    """
+    if dok_adjusted >= 3.0:
+        dok_band = 4
+    elif dok_adjusted >= 2.5:
+        dok_band = 3
+    elif dok_adjusted >= 2.0:
+        dok_band = 2
+    else:
+        dok_band = 1
+
+    if tm_tier >= 5:
+        if dok_band >= 3:
+            zone = "Frontier"
+        elif dok_band == 2:
+            zone = "Underutilizing"
+        else:
+            zone = "Overpowered"
+    elif tm_tier >= 3:
+        if dok_band >= 4:
+            zone = "Frontier"
+        elif dok_band == 3:
+            zone = "Growing"
+        elif dok_band == 2:
+            zone = "Expected"
+        else:
+            zone = "Overpowered"
+    else:
+        if dok_band >= 3:
+            zone = "Thinking Ahead"
+        elif dok_band == 2:
+            zone = "Growing"
+        else:
+            zone = "Expected"
+
+    if trajectory == 'improving' and zone not in ('Frontier', 'Thinking Ahead'):
+        upgrade_map = {
+            'Overpowered': 'Underutilizing',
+            'Underutilizing': 'Growing',
+            'Expected': 'Growing',
+            'Growing': 'Frontier',
+        }
+        zone = upgrade_map.get(zone, zone)
+
+    return zone
+
+
+def estimate_tm_tier(session_data: dict) -> int:
+    """Estimate Orchestra tier from session characteristics."""
+    has_subagents = session_data.get('has_subagents', False)
+    prompt_count = session_data.get('prompt_count', 0)
+    unique_tools = session_data.get('unique_tools', 0)
+
+    if has_subagents and prompt_count > 50:
+        return 5  # Symphony
+    elif has_subagents or (unique_tools > 5 and prompt_count > 20):
+        return 4  # Chamber
+    elif prompt_count > 10 and unique_tools > 3:
+        return 3  # Ensemble
+    elif prompt_count > 3:
+        return 2  # Duet
+    else:
+        return 1  # Solo
+
+
+def aggregate_session_metadata(session_meta: dict, session_ids: set) -> dict:
+    """Combine metadata from multiple sessions into one aggregated dict.
+
+    Used when analyzing all sessions from a single day. Produces a
+    consistent combined_meta regardless of whether sessions have
+    the newer 'tools_seen' field or only the legacy 'unique_tools' count.
+    """
+    all_tools: set = set()
+    has_tools_seen = False
+
+    for sid in session_ids:
+        meta = session_meta.get(sid, {})
+        if meta.get('tools_seen'):
+            has_tools_seen = True
+            all_tools.update(meta['tools_seen'])
+
+    if not has_tools_seen:
+        unique_tools_count = sum(
+            session_meta.get(sid, {}).get('unique_tools', 0)
+            for sid in session_ids
+        )
+    else:
+        unique_tools_count = len(all_tools)
+
+    return {
+        'prompt_count': sum(
+            session_meta.get(sid, {}).get('prompt_count', 0)
+            for sid in session_ids
+        ),
+        'unique_tools': unique_tools_count,
+        'has_subagents': any(
+            session_meta.get(sid, {}).get('has_subagents', False)
+            for sid in session_ids
+        ),
+        'accumulated_tokens': sum(
+            session_meta.get(sid, {}).get('accumulated_tokens', 0)
+            for sid in session_ids
+        ),
+        'accumulated_input': sum(
+            session_meta.get(sid, {}).get('accumulated_input', 0)
+            for sid in session_ids
+        ),
+        'accumulated_output': sum(
+            session_meta.get(sid, {}).get('accumulated_output', 0)
+            for sid in session_ids
+        ),
+    }
+
+
+def get_zone_nudges(zone: str) -> List[str]:
+    """Get actionable nudges for a diagnostic zone."""
+    return ZONE_NUDGES.get(zone, ZONE_NUDGES['Expected'])
+
+
+def get_zone_reflection(zone: str) -> str:
+    """Get reflection question for a diagnostic zone."""
+    return ZONE_REFLECTIONS.get(zone, "What could you explore more deeply?")

--- a/_tortu/config/skills/testing-strategy/SKILL.md
+++ b/_tortu/config/skills/testing-strategy/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: testing-strategy
+description: Guidelines for writing effective tests in this project
+author: goose
+version: "1.0"
+tags:
+  - testing
+  - development
+  - quality
+---
+
+# Testing Guidelines
+
+## Unit Tests
+
+- Test one thing per test
+- Use descriptive test names: `test_user_creation_fails_with_invalid_email`
+- Mock external dependencies
+- Keep tests fast and isolated
+
+## Integration Tests
+
+- Test API endpoints with realistic data
+- Verify database state changes
+- Clean up test data after each test
+- Use test fixtures for common scenarios
+
+## Running Tests
+
+```bash
+# Run all tests
+npm test
+
+# Run unit tests only
+npm test:unit
+
+# Run integration tests (requires database)
+npm test:integration
+
+# Run tests with coverage
+npm test:coverage
+```
+
+## Test Structure
+
+```
+tests/
+├── unit/           # Fast, isolated unit tests
+├── integration/    # Tests requiring external services
+├── fixtures/       # Shared test data
+└── helpers/        # Test utilities
+```
+
+## Best Practices
+
+1. **Arrange-Act-Assert**: Structure tests clearly
+2. **One assertion per test**: When possible, test one behavior
+3. **Descriptive names**: Test names should describe the scenario
+4. **No test interdependence**: Tests should run in any order
+5. **Clean state**: Each test starts with a known state
+
+## Coverage Goals
+
+- Aim for 80%+ line coverage
+- Focus on critical paths first
+- Don't sacrifice test quality for coverage numbers

--- a/_tortu/docs/CONTEXT_2026-07-08_extension-and-recipe-research.md
+++ b/_tortu/docs/CONTEXT_2026-07-08_extension-and-recipe-research.md
@@ -1,0 +1,119 @@
+# Context: Goose extension & recipe research
+
+**From:** Cowork (genbu-dev thread, moved here per Doug 2026-07-08) **Status:** reference/context only — no action taken yet.
+
+## Why this exists
+
+Doug went looking on Goose's Discord for a "getting started" guide — what recipes to install, what
+extensions to add to a vanilla install — and couldn't find one. Asked for a search. Answer: it's not
+on Discord at all. It's on the docs site.
+
+## Where the real resources live
+
+`goose-docs.ai` has a "Resources" menu (top nav) that Discord doesn't surface at all:
+
+- [Extensions catalog](https://goose-docs.ai/extensions) — full list, 66 entries as of this research
+- [Skills Marketplace](https://goose-docs.ai/skills)
+- [Recipe Cookbook](https://goose-docs.ai/recipes) — official curated recipes
+- [Recipe Generator](https://goose-docs.ai/recipe-generator)
+- [Prompt Library](https://goose-docs.ai/prompt-library)
+- [Deeplink Generator](https://goose-docs.ai/deeplink-generator)
+- [Goose Subagents Guide](https://block.github.io/goose/docs/guides/subagents/)
+- [Recipe Reference](https://block.github.io/goose/docs/guides/recipes/recipe-reference)
+
+Also worth noting: Goose moved to the Agentic AI Foundation (AAIF) as of April 2026 —
+`https://goose-docs.ai/blog/2026/04/07/goose-moves-to-aaif`. Repo is `github.com/aaif-goose/goose`
+now, not `block/goose`.
+
+## Extensions worth adding to a vanilla install
+
+Picked from the full 66-extension catalog (below) for Doug's actual use — heavy planning/research/build
+work, not a generic dev setup:
+
+- **Memory / Knowledge Graph Memory / Cognee** — three flavors of persistent memory as installable
+  extensions. Worth trying Cognee as a quick baseline before wiring anything custom (Letta/Mem0-style).
+- **Chat Recall** — search conversation history and load session summaries across all Goose sessions.
+  Directly useful for cross-session continuity.
+- **Skills + Summon** — Skills loads reusable instruction sets; Summon loads skills *and* delegates to
+  subagents. This is Goose's native mechanism for a skills-library pattern — worth testing hands-on.
+- **Extension Manager** — dynamically enable/disable extensions mid-session instead of reconfiguring.
+  Keeps a lean default set, pulls in specialty tools only when needed.
+- **Todo + Top Of Mind** — Todo breaks work into trackable steps; Top Of Mind injects persistent
+  instructions into working memory every turn.
+- **Tavily / Exa / Firecrawl / Fetch / Context7 / GitMCP / goose Docs** — the research stack. Context7
+  and GitMCP specifically pull live docs/repo content into context rather than relying on training data.
+- **GitHub** — direct GitHub operations as an extension.
+- **Container Use** — isolated dev environments per task, worth having before letting Goose run
+  build/test loops unsupervised.
+- **Code Mode** — lets Goose write JS to drive multiple MCP tools in one shot instead of one-tool-call-
+  at-a-time. Real efficiency gain once several extensions are running together.
+- **Computer Controller** — the one used in Goose's own quickstart tutorial; browser/webscraping/file
+  automation.
+- **Council of Mine** — multi-perspective consultation extension.
+
+## Full extension catalog (for reference — 66 entries, alphabetical)
+
+AgentQL · Alby Bitcoin Payments · Apify · Apps · Asana · Auto Visualiser · Beads · Blender · Browserbase ·
+Cash App · Chat Recall · Chrome DevTools · Cloudinary Asset Management · Code Mode · Cognee ·
+Computer Controller · Container Use · Context7 · Council of Mine · DataHub · Dev.to · Developer ·
+ElevenLabs · Exa Search · Excalidraw · Extension Manager · Fetch · Figma · Firecrawl · GitHub · GitMCP ·
+goose Docs · gotoHuman · I Ching · JetBrains · Knowledge Graph Memory · Linux MCP Server · mbot ·
+Memory · MongoDB · Nano Banana · Neighborhood · Neon · Netlify · Nostrbook · OpenMetadata · PDF Reader ·
+Pieces for Developers · Playwright · prompts.chat · Reddit · Rendex · Repomix · Rube · Selenium ·
+Skills · Square MCP · Sugar · Summon · Supabase · Tavily Web Search · Todo · Top Of Mind · Tutorial ·
+Vercel · VMware AIops · YouTube Transcript
+
+Full catalog with per-extension install docs: `https://goose-docs.ai/docs/category/mcp-servers`
+(each entry links to `https://goose-docs.ai/docs/mcp/<name>-mcp`).
+
+## Recipes
+
+**Community starter pack:** [Goose Subagents Recipe Collection](https://gist.github.com/mootrichard/8a2e4bf200e750f54bebfc78bbe4601f)
+— actively maintained, from Block's own "Goose Subagents Workshop"
+(`https://github.com/block/goose-subagents-workshop`). Six ready-to-use recipes:
+
+1. **Code Review Assistant** (`code-reviewer`) — quality/security/performance/readability review.
+   Param: `focus_area`. Gist: `gist.github.com/mootrichard/5a31b9cc64b77f1ae55e502daca4d4a0`
+2. **Test Generator** (`test-generator`) — comprehensive test suites, happy path + edge cases + errors.
+   Params: `test_framework`, `coverage_level`. Gist: `gist.github.com/mootrichard/0a78f04c38930936864595d92e23dd57`
+3. **Documentation Writer** (`doc-writer`) — API docs, guides, tutorials, README generation.
+   Params: `doc_type`, `audience`. Gist: `gist.github.com/mootrichard/3ac5e9ead0ca120acaf7df8d542abbe9`
+4. **Codebase Implementation Analyzer** (`codebase-analyzer`) — deep implementation analysis, data flow
+   tracing, file:line references. Params: `focus_area`, `component`.
+   Gist: `gist.github.com/mootrichard/9628d286a5c15154535357e3ceb0e40f`
+5. **Codebase File Locator** (`codebase-locator`) — finds all files related to a feature.
+   Params: `feature` (required), `file_types`. Gist: `gist.github.com/mootrichard/8399b904ac301c643968cc8835163c35`
+6. **Web Research Specialist** (`web-researcher`) — current docs/best-practices/solutions with citations.
+   Params: `topic` (required), `source_type`. Gist: `gist.github.com/mootrichard/d7840a2d498fcdad67656c25dc9e88a3`
+
+Install pattern (per the gist):
+
+```
+curl -o code-reviewer.yaml https://gist.githubusercontent.com/mootrichard/5a31b9cc64b77f1ae55e502daca4d4a0/raw/code-reviewer.yaml
+# ...repeat per recipe...
+mkdir -p ~/.goose/recipes
+mv *.yaml ~/.goose/recipes/
+export GOOSE_RECIPE_PATH=~/.goose/recipes
+```
+
+Documented workflow patterns worth keeping in mind when combining these: a parallel feature-dev
+pipeline (locator + researcher + analyzer in parallel, then generator + doc-writer), a three-angle
+code-quality audit (code-reviewer run three times with different `focus_area`), a bug-investigation
+chain (analyzer → locator → generator), and a documentation sprint (analyzer + doc-writer per
+component, in parallel across components).
+
+**Doug's actual recipe directory:** `~/AOF/resources/goose/recipes/` (not `~/.goose/recipes/` — that
+was the source of the duplicate-listing mess that led to the `recipe list` formatting patch already
+staged in `../patches/recipe-list-formatting/`). Any newly downloaded recipes should go there, and
+`GOOSE_RECIPE_PATH` should point only at that one directory to avoid recreating the duplication.
+
+## Suggested next actions (not yet done — for whoever picks this up)
+
+- Review the recommended extension list above against what's already installed; install the ones that
+  fit.
+- Consider fetching the six `mootrichard` recipes into this repo's `recipes/community/` folder (already
+  exists, currently empty) so they're version-controlled here rather than living only in
+  `~/AOF/resources/goose/recipes/`.
+- Cross-reference: the `recipe list` formatting patch already staged in `../patches/recipe-list-
+  formatting/` is a related but separate piece of work — that one's about fixing native CLI output,
+  this note is about what to actually install.

--- a/_tortu/patches/recipe-list-formatting/BUILD_AND_SUBMIT.md
+++ b/_tortu/patches/recipe-list-formatting/BUILD_AND_SUBMIT.md
@@ -76,3 +76,15 @@ PR description should explain the problem (flat, undeduplicated output when a re
 more than one search path), show a before/after (the mockups in `../mockups/` are a good starting
 point — swap in real example output from the dogfooding step), and note the "no new dependency"
 point explicitly since that's usually a fast path to a friendly review.
+
+Also include this line, since the current implementation was built against clig.dev
+(https://clig.dev/) — semantic color/glyphs, NO_COLOR/non-TTY degradation via `console`'s built-in
+detection, no bordered table — using only crates already in goose-cli's `Cargo.toml`:
+
+> Output follows the clig.dev CLI guidelines (semantic color, NO_COLOR/non-TTY degradation); no new dependencies.
+
+Note: steps 1–2 and 5 above (comfy_table import, `PATCH.md`, `../mockups/after-table.txt`) describe
+an earlier bordered-table version of this patch. The implementation actually built and dogfooded in
+`recipe.rs` is the later stacked-block rewrite (grouped blocks, wrapped not truncated, `⚠` for
+collisions) — this file hasn't been re-synced to that yet. Treat steps 3–4 and 6 as still accurate;
+re-verify 1–2 and 5 against the real diff before running through this checklist for real.

--- a/_tortu/patches/recipe-list-formatting/BUILD_AND_SUBMIT.md
+++ b/_tortu/patches/recipe-list-formatting/BUILD_AND_SUBMIT.md
@@ -1,0 +1,78 @@
+# Build → dogfood → submit checklist
+
+Scope: apply `PATCH.md` to `crates/goose-cli/src/commands/recipe.rs` in a real `aaif-goose/goose`
+checkout, build it, swap it into Doug's actual `goose` install, confirm it looks right on his real
+recipe directories, then (only after his sign-off) open the upstream PR.
+
+`build.sh` in this folder automates steps 1–5 below as a starting point — it hasn't been run yet
+(written from source-reading, not a working build), so treat it as a draft to check over and adapt,
+not a script to run blind.
+
+## 1. Get a real checkout
+
+```
+gh repo fork aaif-goose/goose --clone=false   # or fork via the GitHub UI if no gh auth here
+git clone https://github.com/<your-fork>/goose.git
+cd goose
+git remote add upstream https://github.com/aaif-goose/goose.git
+git checkout -b fix/recipe-list-formatting
+```
+
+## 2. Apply the patch
+
+Open `crates/goose-cli/src/commands/recipe.rs` and apply the changes in `../PATCH.md`:
+add the `comfy_table` import, replace `handle_list`, add the two new helper functions
+(`describe`, `source_path`). Nothing else in the file changes.
+
+## 3. Build + run the existing test suite
+
+```
+cargo build -p goose-cli
+cargo test -p goose-cli commands::recipe
+```
+
+Watch specifically for the `#[cfg(test)] mod tests` block already in `recipe.rs` (uses
+`TempDir`-based fixtures) — make sure nothing there broke, and consider adding a case that covers
+the new grouping/duplicate-flagging behavior.
+
+## 4. Install the built binary for real dogfooding
+
+```
+which goose                          # find the currently-installed binary
+cp "$(which goose)" "$(which goose).bak"   # keep a rollback copy
+cp target/debug/goose "$(which goose)"     # or target/release/goose for a release build
+```
+
+## 5. Dogfood it
+
+```
+cd ~/AOF/resources/goose/recipes     # or wherever Doug's actual recipes live
+goose recipe list
+goose recipe list --verbose
+goose recipe list --format json      # confirm this is still the old flat/unchanged shape
+```
+
+Compare against `../mockups/after-table.txt` and `../mockups/after-verbose.txt` for the intended
+shape — but judge against Doug's *real* recipe set, not the mockup's placeholder names. Confirm with
+Doug directly that this is actually better before moving on. If anything looks wrong, restore the
+`.bak` binary and iterate on the patch.
+
+## 6. Only after Doug confirms it in daily use — submit upstream
+
+```
+git add crates/goose-cli/src/commands/recipe.rs
+git commit -s -m "fix(cli): group recipe list output and flag duplicate-name collisions"
+git push origin fix/recipe-list-formatting
+gh pr create --repo aaif-goose/goose \
+  --title "fix(cli): group recipe list output and flag duplicate-name collisions" \
+  --body "See description below" --base main
+```
+
+Follow `aaif-goose/goose`'s `CONTRIBUTING.md`: DCO sign-off (`-s` above), Conventional Commit title,
+keep the diff small and scoped (it already is — one function + two helpers, no new dependency),
+and expect an automated Codex review pass on the PR before human maintainers look at it.
+
+PR description should explain the problem (flat, undeduplicated output when a recipe name exists on
+more than one search path), show a before/after (the mockups in `../mockups/` are a good starting
+point — swap in real example output from the dogfooding step), and note the "no new dependency"
+point explicitly since that's usually a fast path to a friendly review.

--- a/_tortu/patches/recipe-list-formatting/PATCH.md
+++ b/_tortu/patches/recipe-list-formatting/PATCH.md
@@ -1,0 +1,145 @@
+# Patch: `goose recipe list` — column-aligned table + duplicate-location flagging
+
+Target file: `crates/goose-cli/src/commands/recipe.rs` (aaif-goose/goose, main branch, fetched 2026-07-08)
+No new dependencies — `comfy_table` and `console` are already in `goose-cli`'s `Cargo.toml`.
+
+Only `handle_list` changes, plus two small new private helpers (`describe`, `source_path`) factored
+out of logic that already existed inline. Everything else in the file (validate/deeplink/open/tests)
+is untouched.
+
+## Add this import near the top of the file (alongside the existing `use console::style;`)
+
+```rust
+use comfy_table::{presets::UTF8_FULL_CONDENSED, ContentArrangement, Table};
+```
+
+## Replace the existing `handle_list` function with:
+
+```rust
+pub fn handle_list(format: &str, verbose: bool) -> Result<()> {
+    let mut recipes = match list_available_recipes() {
+        Ok(recipes) => recipes,
+        Err(e) => {
+            return Err(anyhow::anyhow!("Failed to list recipes: {}", e));
+        }
+    };
+
+    match format {
+        "json" => {
+            // Unchanged: flat array, so existing automation/scripts don't break.
+            println!("{}", serde_json::to_string(&recipes)?);
+        }
+        _ => {
+            if recipes.is_empty() {
+                println!("No recipes found");
+                return Ok(());
+            }
+
+            recipes.sort_by(|a, b| a.name.cmp(&b.name));
+
+            // Group by name. A recipe found via more than one search path
+            // (GOOSE_RECIPE_PATH + cwd, most commonly) currently prints as
+            // flat, indistinguishable duplicate rows with no indication
+            // that one file silently shadows the other. Group instead of
+            // hiding the collision.
+            let mut groups: Vec<(String, Vec<&RecipeInfo>)> = Vec::new();
+            for recipe in &recipes {
+                match groups.last_mut() {
+                    Some((name, entries)) if *name == recipe.name => entries.push(recipe),
+                    _ => groups.push((recipe.name.clone(), vec![recipe])),
+                }
+            }
+
+            if verbose {
+                for (name, entries) in &groups {
+                    println!("{}", style(name).bold());
+                    println!("  {}", describe(entries[0]));
+                    if entries.len() > 1 {
+                        println!(
+                            "  {} found in {} locations (later paths override earlier ones):",
+                            style("⚠").yellow(),
+                            entries.len()
+                        );
+                        for (i, entry) in entries.iter().enumerate() {
+                            println!("    {}. {}", i + 1, source_path(entry));
+                        }
+                    } else {
+                        println!("  {}", source_path(entries[0]));
+                    }
+                    println!();
+                }
+                return Ok(());
+            }
+
+            let mut table = Table::new();
+            table
+                .load_preset(UTF8_FULL_CONDENSED)
+                .set_content_arrangement(ContentArrangement::Dynamic)
+                .set_header(vec!["Name", "Description", "Location"]);
+
+            for (name, entries) in &groups {
+                let location = if entries.len() > 1 {
+                    format!("⚠ {} locations", entries.len())
+                } else {
+                    source_path(entries[0])
+                };
+                table.add_row(vec![name.clone(), describe(entries[0]), location]);
+            }
+
+            println!("{table}");
+
+            let dup_count = groups.iter().filter(|(_, entries)| entries.len() > 1).count();
+            if dup_count > 0 {
+                println!(
+                    "\n{} {} recipe{} found in multiple locations. Run with --verbose for full paths.",
+                    style("⚠").yellow(),
+                    dup_count,
+                    if dup_count == 1 { "" } else { "s" }
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn describe(recipe: &RecipeInfo) -> String {
+    match &recipe.description {
+        Some(desc) if !desc.is_empty() => desc.clone(),
+        _ => "(none)".to_string(),
+    }
+}
+
+fn source_path(recipe: &RecipeInfo) -> String {
+    match recipe.source {
+        RecipeSource::Local => format!("local: {}", recipe.path),
+        RecipeSource::GitHub => format!("github: {}", recipe.path),
+    }
+}
+```
+
+## Design choices worth knowing before you review
+
+- **`--format json` is untouched.** Kept the flat array shape so any existing scripts/automation parsing
+  it don't break — grouping is a `text`-output-only concern. Matches the CONTRIBUTING.md steer toward
+  minimal, non-breaking first PRs.
+- **Sorted alphabetically by name** rather than search-path order — more predictable for a listing
+  command, and a prerequisite for the adjacent-grouping logic (no `HashMap`, so output order stays
+  deterministic run to run).
+- **No new dependency.** `comfy_table` was already pulled in by `goose-cli`'s `Cargo.toml`; this patch
+  just uses it for `recipe list` too.
+- **Not yet verified against the compiler.** High confidence in the `comfy-table` v7 API calls used
+  here (`Table::new`, `.load_preset`, `.set_content_arrangement`, `.set_header`, `.add_row`) and the
+  `RecipeInfo`/`RecipeSource` field shapes (confirmed by reading `search_recipe.rs` directly), but this
+  has not been run through `cargo build` or the existing test suite yet. That's the first thing to do
+  on this machine — see `../BUILD_AND_SUBMIT.md`.
+
+## Reference: original source (unpatched) for context
+
+Fetched from `https://raw.githubusercontent.com/aaif-goose/goose/main/crates/goose-cli/src/commands/recipe.rs`.
+The original `handle_list` had no grouping at all — it iterated the flat `Vec<RecipeInfo>` from
+`list_available_recipes()` (in `crates/goose-cli/src/recipes/search_recipe.rs`) and printed
+`"{name} - {description} - {source_info}"` per entry, one line each, verbose mode just adding a
+`Title:`/`Path:` sub-line. `RecipeInfo` fields: `name: String`, `source: RecipeSource` (`Local` |
+`GitHub`), `path: String`, `title: Option<String>`, `description: Option<String>`. `list_available_recipes()`
+simply `.extend()`s local recipes and (if configured) GitHub recipes into one `Vec` with no dedup step —
+that's the root cause this patch addresses.

--- a/_tortu/patches/recipe-list-formatting/build.sh
+++ b/_tortu/patches/recipe-list-formatting/build.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Build, install, and dogfood the recipe-list-formatting patch against a real
+# aaif-goose/goose checkout. Draft script — written from source-reading in a
+# sandbox with no Rust toolchain, so it has NOT been run. Check every path and
+# assumption below before trusting it; treat as a starting point for Claude
+# Code on Doug's actual machine, not a verified tool.
+#
+# Usage: ./build.sh <path-to-goose-checkout>
+set -euo pipefail
+
+GOOSE_DIR="${1:?Usage: build.sh <path-to-goose-checkout>}"
+PATCH_TARGET="$GOOSE_DIR/crates/goose-cli/src/commands/recipe.rs"
+
+if [ ! -f "$PATCH_TARGET" ]; then
+  echo "error: $PATCH_TARGET not found — is \$1 a real aaif-goose/goose checkout?" >&2
+  exit 1
+fi
+
+echo "==> Patch target found: $PATCH_TARGET"
+echo "==> This script does NOT apply the patch automatically — open PATCH.md"
+echo "    alongside this checkout and apply the handle_list replacement + new"
+echo "    import + two helper functions by hand or via your editor, then re-run"
+echo "    this script from step 2 onward (comment out this exit once applied)."
+exit 1  # remove this line once the patch has been applied to $PATCH_TARGET
+
+# --- everything below assumes the patch is already applied ---
+
+cd "$GOOSE_DIR"
+
+echo "==> Building goose-cli"
+cargo build -p goose-cli
+
+echo "==> Running existing recipe command tests"
+cargo test -p goose-cli commands::recipe
+
+CURRENT_GOOSE="$(command -v goose || true)"
+if [ -z "$CURRENT_GOOSE" ]; then
+  echo "warning: no 'goose' binary found on PATH — skipping install/dogfood steps."
+  echo "Built binary is at: $GOOSE_DIR/target/debug/goose"
+  exit 0
+fi
+
+BACKUP="${CURRENT_GOOSE}.bak"
+if [ ! -f "$BACKUP" ]; then
+  echo "==> Backing up current binary to $BACKUP"
+  cp "$CURRENT_GOOSE" "$BACKUP"
+else
+  echo "==> Backup already exists at $BACKUP (not overwriting)"
+fi
+
+echo "==> Installing patched binary to $CURRENT_GOOSE"
+cp "$GOOSE_DIR/target/debug/goose" "$CURRENT_GOOSE"
+
+echo "==> Dogfood: run these yourself and eyeball the output against"
+echo "    ../mockups/after-table.txt and ../mockups/after-verbose.txt"
+echo
+echo "    goose recipe list"
+echo "    goose recipe list --verbose"
+echo "    goose recipe list --format json   # should be unchanged from before"
+echo
+echo "==> Rollback if needed: cp \"$BACKUP\" \"$CURRENT_GOOSE\""

--- a/_tortu/patches/recipe-list-formatting/mockups/after-table.txt
+++ b/_tortu/patches/recipe-list-formatting/mockups/after-table.txt
@@ -1,0 +1,24 @@
+$ goose recipe list
+
+(patched behavior, non-verbose — same illustrative recipe set as before.txt)
+
+┌──────────────────┬──────────────────────────────┬─────────────────┐
+│ Name              │ Description                    │ Location         │
+╞══════════════════╪══════════════════════════════╪═════════════════╡
+│ code-review       │ (none)                         │ ⚠ 2 locations    │
+├──────────────────┼──────────────────────────────┼─────────────────┤
+│ daily-standup     │ (none)                         │ ⚠ 2 locations    │
+├──────────────────┼──────────────────────────────┼─────────────────┤
+│ pr-summary        │ Summarize a pull request       │ ⚠ 2 locations    │
+├──────────────────┼──────────────────────────────┼─────────────────┤
+│ refactor-helper   │ Refactor code with tests       │ ⚠ 2 locations    │
+├──────────────────┼──────────────────────────────┼─────────────────┤
+│ release-notes     │ (none)                         │ ⚠ 2 locations    │
+├──────────────────┼──────────────────────────────┼─────────────────┤
+│ test-writer       │ Write unit tests for a file    │ ⚠ 2 locations    │
+└──────────────────┴──────────────────────────────┴─────────────────┘
+
+⚠ 6 recipes found in multiple locations. Run with --verbose for full paths.
+
+(a recipe found in exactly one location just shows "local: <path>" or "github: <path>" in the
+Location column instead of the ⚠ count — the ⚠ only appears on genuine collisions.)

--- a/_tortu/patches/recipe-list-formatting/mockups/after-verbose.txt
+++ b/_tortu/patches/recipe-list-formatting/mockups/after-verbose.txt
@@ -1,0 +1,27 @@
+$ goose recipe list --verbose
+
+(patched behavior, verbose — same illustrative recipe set as before.txt; showing 2 of the 6
+entries here, the other 4 follow the identical pattern)
+
+code-review
+  (none)
+  ⚠ found in 2 locations (later paths override earlier ones):
+    1. local: /Users/dougdaulton/.goose/recipes/code-review.yaml
+    2. local: /Users/dougdaulton/AOF/resources/goose/recipes/code-review.yaml
+
+daily-standup
+  (none)
+  ⚠ found in 2 locations (later paths override earlier ones):
+    1. local: /Users/dougdaulton/.goose/recipes/daily-standup.yaml
+    2. local: /Users/dougdaulton/AOF/resources/goose/recipes/daily-standup.yaml
+
+pr-summary
+  Summarize a pull request
+  ⚠ found in 2 locations (later paths override earlier ones):
+    1. local: /Users/dougdaulton/.goose/recipes/pr-summary.yaml
+    2. local: /Users/dougdaulton/AOF/resources/goose/recipes/pr-summary.yaml
+
+... (refactor-helper, release-notes, test-writer follow the same pattern)
+
+(a recipe found in only one location just prints its name, description, and a single
+"local: <path>" / "github: <path>" line — no numbered list, no ⚠ — same as native today.)

--- a/_tortu/patches/recipe-list-formatting/mockups/before.txt
+++ b/_tortu/patches/recipe-list-formatting/mockups/before.txt
@@ -1,0 +1,22 @@
+$ goose recipe list
+
+(current native behavior — illustrative example. Exact recipe names shown here are generic
+placeholders since the original terminal output wasn't captured verbatim in this thread; the
+duplication pattern and line format are accurate to the real behavior Doug hit.)
+
+Available recipes:
+code-review - (none) - local: /Users/dougdaulton/.goose/recipes/code-review.yaml
+code-review - (none) - local: /Users/dougdaulton/AOF/resources/goose/recipes/code-review.yaml
+pr-summary - Summarize a pull request - local: /Users/dougdaulton/.goose/recipes/pr-summary.yaml
+pr-summary - Summarize a pull request - local: /Users/dougdaulton/AOF/resources/goose/recipes/pr-summary.yaml
+daily-standup - (none) - local: /Users/dougdaulton/.goose/recipes/daily-standup.yaml
+daily-standup - (none) - local: /Users/dougdaulton/AOF/resources/goose/recipes/daily-standup.yaml
+refactor-helper - Refactor code with tests - local: /Users/dougdaulton/.goose/recipes/refactor-helper.yaml
+refactor-helper - Refactor code with tests - local: /Users/dougdaulton/AOF/resources/goose/recipes/refactor-helper.yaml
+release-notes - (none) - local: /Users/dougdaulton/.goose/recipes/release-notes.yaml
+release-notes - (none) - local: /Users/dougdaulton/AOF/resources/goose/recipes/release-notes.yaml
+test-writer - Write unit tests for a file - local: /Users/dougdaulton/.goose/recipes/test-writer.yaml
+test-writer - Write unit tests for a file - local: /Users/dougdaulton/AOF/resources/goose/recipes/test-writer.yaml
+
+Problems: 12 lines for 6 unique recipes, no visual grouping, no indication that one file is
+silently shadowing the other, no alignment/columns.

--- a/_tortu/probes/INSTALL_MONITOR.md
+++ b/_tortu/probes/INSTALL_MONITOR.md
@@ -1,0 +1,84 @@
+# Installing the background memory/swap monitor
+
+`probe_monitor.sh` is a lightweight companion to `probe_local_inference.sh` —
+instead of one snapshot, it appends a single CSV row every 15 minutes to
+`_tortu/probes/reports/monitor_log.csv`, so you build up a real time-series of
+free RAM, swap usage, and which inference-related processes are running. Over
+a few days that answers "is this a chronic daily-driver overload, or does it
+spike around specific things I do."
+
+This has to be installed from a **real Terminal on your Mac**, not through
+Cowork — the sandbox this session runs in can write files into your connected
+folders, but it can't register a background job with your Mac's actual
+`launchd`. macOS's modern equivalent of a cron job is a launchd agent, which
+handles sleep/wake more gracefully than plain `cron`, so that's what this
+uses.
+
+## 1. Install the launchd agent
+
+```bash
+mkdir -p ~/Library/LaunchAgents
+cp /Users/dougdaulton/AOF/work/projects/forks/goose/_tortu/probes/com.tortu.goose.probemonitor.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.tortu.goose.probemonitor.plist
+```
+
+That's it — it fires once immediately (`RunAtLoad`), then every 15 minutes
+(`StartInterval = 900` seconds) for as long as you're logged in, including
+across reboots (launchd re-loads agents from `~/Library/LaunchAgents/` at
+login automatically — you don't need to `load` it again after a restart).
+
+## 2. Verify it's running
+
+```bash
+launchctl list | grep tortu
+```
+
+You should see a line with `com.tortu.goose.probemonitor` and a PID or a
+recent exit status (`0` = last run succeeded). Then check that rows are
+actually landing:
+
+```bash
+tail -5 /Users/dougdaulton/AOF/work/projects/forks/goose/_tortu/probes/reports/monitor_log.csv
+```
+
+If nothing shows up after a few minutes, check the launchd-level logs (these
+capture things like "script not found" or permission errors, separate from
+anything the script itself would print):
+
+```bash
+cat /Users/dougdaulton/AOF/work/projects/forks/goose/_tortu/probes/reports/monitor_launchd.err.log
+```
+
+## 3. Stop or remove it later
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.tortu.goose.probemonitor.plist
+rm ~/Library/LaunchAgents/com.tortu.goose.probemonitor.plist
+```
+
+Unloading stops future runs; it doesn't touch the CSV log that's already
+been collected.
+
+## 4. Reading the data later
+
+`monitor_log.csv` columns: `timestamp, free_ram_gb, swap_used_gb,
+swap_total_gb, swap_pct, mem_free_pct, load_avg_1m, ollama_running,
+omlx_running, chrome_running, claude_desktop_running, top_mem_proc`.
+
+Once you've got a few days of rows, hand the CSV back to Cowork/Claude and
+ask for the pattern read — e.g. does `swap_pct` climb steadily over a session
+and only reset after a reboot, does it correlate with `chrome_running`, does
+it spike specifically when `omlx_running`/`ollama_running` flips to yes, etc.
+Fifteen-minute granularity over a couple of days is enough to see that shape
+without the log file getting unwieldy (roughly 100 rows/day, a few KB).
+
+## Why not literal `cron`
+
+Plain `crontab -e` would technically work too, but on macOS `cron` jobs don't
+reliably fire if the Mac was asleep at the scheduled minute — they just get
+skipped, which would leave gaps in exactly the kind of over-time pattern
+you're trying to see. `launchd` is Apple's supported replacement and handles
+that case (catches up shortly after wake), so that's what this uses. If you
+already have a `cron` habit and would rather use it, the script itself
+doesn't care how it's invoked — `bash probe_monitor.sh` from a crontab line
+works identically, you'd just lose the sleep/wake robustness.

--- a/_tortu/probes/com.tortu.goose.probemonitor.plist
+++ b/_tortu/probes/com.tortu.goose.probemonitor.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.tortu.goose.probemonitor</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/dougdaulton/AOF/work/projects/forks/goose/_tortu/probes/probe_monitor.sh</string>
+    </array>
+
+    <!-- Run once immediately when loaded, then every 900s (15 min) after that. -->
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartInterval</key>
+    <integer>900</integer>
+
+    <!-- If the Mac was asleep at a scheduled fire time, launchd runs it soon
+         after wake instead of silently skipping it. -->
+    <key>StandardOutPath</key>
+    <string>/Users/dougdaulton/AOF/work/projects/forks/goose/_tortu/probes/reports/monitor_launchd.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/dougdaulton/AOF/work/projects/forks/goose/_tortu/probes/reports/monitor_launchd.err.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/_tortu/probes/probe_local_inference.sh
+++ b/_tortu/probes/probe_local_inference.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# _tortu/probes/probe_local_inference.sh
+#
+# Diagnostic probe for local LLM inference performance on this machine.
+# Read-only / non-destructive -- gathers facts, does not change anything or
+# offer opinions. Run it, then hand the report to Cowork/Claude Code for
+# interpretation and specific recommendations.
+#
+# Usage:
+#   bash _tortu/probes/probe_local_inference.sh [--benchmark]
+#
+#   --benchmark   Also send one short live completion request to every
+#                 OpenAI-compatible endpoint configured under
+#                 _tortu/config/custom_providers/*.json, and time it.
+#                 Off by default since it touches whatever server is running.
+#
+# Output: a timestamped report under _tortu/probes/reports/, plus a copy at
+# _tortu/probes/reports/latest.txt for convenience. Also prints to stdout.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPORT_DIR="$SCRIPT_DIR/reports"
+TIMESTAMP="$(date +"%Y%m%d_%H%M%S")"
+REPORT_FILE="$REPORT_DIR/probe_${TIMESTAMP}.txt"
+FORK_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+mkdir -p "$REPORT_DIR"
+: > "$REPORT_FILE"
+
+RUN_BENCHMARK=false
+for arg in "$@"; do
+  case "$arg" in
+    --benchmark) RUN_BENCHMARK=true ;;
+  esac
+done
+
+log() {
+  printf '%s\n' "$1" | tee -a "$REPORT_FILE"
+}
+
+section() {
+  log ""
+  log "=== $1 ==="
+}
+
+log "Local inference probe -- $(date)"
+log "Host: $(hostname 2>/dev/null || echo unknown)"
+log "Report file: $REPORT_FILE"
+
+section "1. Hardware"
+CHIP="$(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo unknown)"
+log "Chip: $CHIP"
+
+RAM_BYTES="$(sysctl -n hw.memsize 2>/dev/null || echo 0)"
+RAM_GB=$(( RAM_BYTES / 1024 / 1024 / 1024 ))
+log "Total RAM: ${RAM_GB} GB"
+
+PCORES="$(sysctl -n hw.perflevel0.physicalcpu 2>/dev/null || echo '?')"
+ECORES="$(sysctl -n hw.perflevel1.physicalcpu 2>/dev/null || echo '?')"
+log "CPU cores: performance=${PCORES} efficiency=${ECORES}"
+
+if command -v system_profiler >/dev/null 2>&1; then
+  GPU_INFO="$(system_profiler SPDisplaysDataType 2>/dev/null | grep -E 'Chipset Model|Total Number of Cores' | head -6)"
+  if [ -n "$GPU_INFO" ]; then
+    log "GPU:"
+    log "$GPU_INFO"
+  fi
+fi
+
+MACOS_VER="$(sw_vers -productVersion 2>/dev/null || echo '?')"
+log "macOS version: $MACOS_VER"
+
+log ""
+log "Note: memory bandwidth is not queryable via sysctl on Apple Silicon."
+log "Cross-reference Total RAM above against known ceilings to infer the chip variant:"
+log "  base M4:    max 32GB RAM,  ~120 GB/s bandwidth"
+log "  M4 Pro:     max 64GB RAM,  ~273 GB/s bandwidth"
+log "  M4 Max:     max 128GB RAM, ~410-546 GB/s bandwidth (Studio only, not Mini)"
+
+section "2. Memory pressure and swap"
+if command -v vm_stat >/dev/null 2>&1; then
+  log "$(vm_stat)"
+fi
+SWAP="$(sysctl vm.swapusage 2>/dev/null || echo '?')"
+log "Swap: $SWAP"
+if command -v memory_pressure >/dev/null 2>&1; then
+  log "Memory pressure snapshot:"
+  log "$(memory_pressure 2>&1 | head -6)"
+fi
+
+section "3. Inference-related processes"
+PROC_MATCH="$(ps aux | grep -iE 'ollama|llama[-_.]server|llama\.cpp|mlx_lm|mlx\.server|lmstudio|vllm|text-generation' | grep -v grep || true)"
+if [ -n "$PROC_MATCH" ]; then
+  log "$PROC_MATCH"
+else
+  log "No known inference server processes found running."
+fi
+
+section "4. Listening ports commonly used by local inference servers"
+for port in 8000 8080 11434 1234; do
+  if command -v lsof >/dev/null 2>&1; then
+    LISTEN="$(lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
+    if [ -n "$LISTEN" ]; then
+      log "Port $port:"
+      log "$LISTEN"
+    fi
+  fi
+done
+
+section "5. Shell and environment"
+log "\$SHELL (default login shell): ${SHELL:-unset}"
+if command -v dscl >/dev/null 2>&1; then
+  RECORDED_SHELL="$(dscl . -read "/Users/$(whoami)" UserShell 2>/dev/null | awk '{print $2}')"
+  log "macOS account record (dscl UserShell): ${RECORDED_SHELL:-?}"
+fi
+PARENT_SHELL="$(ps -p "${PPID:-0}" -o comm= 2>/dev/null | xargs -I{} basename {} 2>/dev/null || echo '?')"
+log "Shell that launched this script: $PARENT_SHELL"
+log "(This script itself always runs under bash regardless of your login shell -- it's invoked"
+log " as 'bash probe_local_inference.sh', so zsh vs bash doesn't affect the probe running. It DOES"
+log " matter for whether exports like GOOSE_RECIPE_PATH actually reach goose day to day -- zsh"
+log " reads ~/.zshrc / ~/.zprofile / ~/.zshenv, NOT ~/.bashrc or ~/.bash_profile. An export added"
+log " to the wrong file is invisible to a zsh session even though the file exists and is correct.)"
+
+log ""
+log "Shell profile files (existence, size, last modified):"
+for profile in "$HOME/.zshrc" "$HOME/.zprofile" "$HOME/.zshenv" "$HOME/.bash_profile" "$HOME/.bashrc" "$HOME/.profile"; do
+  if [ -f "$profile" ]; then
+    SIZE="$(wc -c < "$profile" 2>/dev/null | tr -d ' ')"
+    MTIME="$(stat -f "%Sm" "$profile" 2>/dev/null || echo '?')"
+    log "  $profile  (${SIZE} bytes, modified: ${MTIME})"
+  fi
+done
+
+log ""
+log "Searching profile files for GOOSE_RECIPE_PATH / goose PATH entries:"
+FOUND_ANY=false
+for profile in "$HOME/.zshrc" "$HOME/.zprofile" "$HOME/.zshenv" "$HOME/.bash_profile" "$HOME/.bashrc" "$HOME/.profile"; do
+  if [ -f "$profile" ]; then
+    MATCH="$(grep -nE 'GOOSE_RECIPE_PATH|\.local/bin' "$profile" 2>/dev/null || true)"
+    if [ -n "$MATCH" ]; then
+      FOUND_ANY=true
+      log "  $profile:"
+      log "$MATCH"
+    fi
+  fi
+done
+if [ "$FOUND_ANY" = false ]; then
+  log "  Not found in any checked profile file. If GOOSE_RECIPE_PATH is supposed to be set,"
+  log "  it hasn't been added anywhere this probe checks -- see bootstrap.sh's printed suggestion."
+fi
+
+log ""
+log "Current environment as seen by THIS run (reflects whatever shell invoked bash):"
+log "  GOOSE_RECIPE_PATH=${GOOSE_RECIPE_PATH:-<not set>}"
+PATH_HAS_LOCAL_BIN="no"
+case ":$PATH:" in
+  *":$HOME/.local/bin:"*) PATH_HAS_LOCAL_BIN="yes" ;;
+esac
+log "  PATH includes ~/.local/bin: $PATH_HAS_LOCAL_BIN"
+
+section "6. Goose config (live vs. this fork's copy)"
+LIVE_CFG="$HOME/.config/goose/config.yaml"
+FORK_CFG="$FORK_ROOT/config/config.yaml"
+
+if [ -f "$LIVE_CFG" ]; then
+  log "Live config: $LIVE_CFG"
+  log "active_provider: $(grep '^active_provider' "$LIVE_CFG" 2>/dev/null || echo '?')"
+  log ""
+  log "Provider block (raw excerpt, model/enabled lines):"
+  log "$(grep -E '^  [a-z_]+:|^\s+(enabled|model):' "$LIVE_CFG" 2>/dev/null || echo '(providers: section not found in expected shape)')"
+else
+  log "No live config found at $LIVE_CFG"
+fi
+
+if [ -f "$LIVE_CFG" ] && [ -f "$FORK_CFG" ]; then
+  if diff -q "$LIVE_CFG" "$FORK_CFG" >/dev/null 2>&1; then
+    log ""
+    log "Live config matches _tortu/config/config.yaml -- no drift since last bootstrap."
+  else
+    log ""
+    log "NOTE: live config differs from _tortu/config/config.yaml -- possible drift since last bootstrap.sh run."
+  fi
+fi
+
+section "7. Model files on disk (largest first, likely quantization in filename)"
+for dir in "$HOME/.ollama/models" "$HOME/.cache/huggingface/hub" "$HOME/.cache/lm-studio/models" "$HOME/.cache/mlx_lm"; do
+  if [ -d "$dir" ]; then
+    log "$dir:"
+    log "$(du -sh "$dir"/* 2>/dev/null | sort -rh | head -15)"
+    log ""
+  fi
+done
+log "Reading tip: bf16/fp16 in a filename means unquantized/full precision (slow, bandwidth-heavy)."
+log "Q4/Q5/Q8 or 4bit/8bit in a filename means quantized (faster, usually fine quality at these sizes)."
+
+section "8. Background load (top memory consumers over 1%)"
+log "$(ps aux | awk 'NR==1 || $4+0 > 1.0' | sort -rk4 | head -15)"
+
+log ""
+log "Sync/indexing agents that compete for the same unified memory pool:"
+SYNC_MATCH="$(ps aux | grep -iE 'bird|onedrive|dropbox|CloudDocs|mdworker' | grep -v grep || true)"
+if [ -n "$SYNC_MATCH" ]; then
+  log "$SYNC_MATCH"
+else
+  log "None found running."
+fi
+
+section "9. Power state"
+if command -v pmset >/dev/null 2>&1; then
+  log "$(pmset -g batt 2>/dev/null || echo '?')"
+  THERM="$(pmset -g therm 2>/dev/null || true)"
+  if [ -n "$THERM" ]; then
+    log "$THERM"
+  else
+    log "Thermal state not exposed via pmset on this system."
+  fi
+fi
+
+if [ "$RUN_BENCHMARK" = true ]; then
+  section "10. Live benchmark (configured OpenAI-compatible endpoints)"
+  if ! command -v python3 >/dev/null 2>&1; then
+    log "python3 not found, skipping benchmark."
+  else
+    PROVIDERS_DIR="$FORK_ROOT/config/custom_providers"
+    if [ -d "$PROVIDERS_DIR" ] && [ -n "$(ls -A "$PROVIDERS_DIR"/*.json 2>/dev/null)" ]; then
+      for provider_json in "$PROVIDERS_DIR"/*.json; do
+        log "Testing provider defined in: $(basename "$provider_json")"
+        python3 - "$provider_json" >> "$REPORT_FILE" 2>&1 <<'PYEOF'
+import json, sys, time, urllib.request, urllib.error
+
+path = sys.argv[1]
+with open(path) as f:
+    cfg = json.load(f)
+
+name = cfg.get("name", "?")
+base_url = (cfg.get("base_url") or "").rstrip("/")
+models = cfg.get("models") or []
+model = models[0].get("name", "?") if models else "?"
+
+if not base_url:
+    print(f"  {name}: no base_url configured, skipping")
+    sys.exit(0)
+
+url = f"{base_url}/chat/completions"
+payload = json.dumps({
+    "model": model,
+    "messages": [{"role": "user", "content": "Reply with exactly the word: ready"}],
+    "max_tokens": 16,
+    "stream": False,
+}).encode()
+
+req = urllib.request.Request(
+    url, data=payload, headers={"Content-Type": "application/json"}, method="POST"
+)
+
+print(f"  provider={name} model={model} url={url}")
+try:
+    start = time.time()
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        body = json.loads(resp.read())
+    elapsed = time.time() - start
+    usage = body.get("usage", {})
+    completion_tokens = usage.get("completion_tokens")
+    print(f"  response time: {elapsed:.2f}s")
+    print(f"  completion tokens: {completion_tokens}")
+    if isinstance(completion_tokens, int) and completion_tokens > 0 and elapsed > 0:
+        print(f"  approx tokens/sec: {completion_tokens / elapsed:.2f}")
+except urllib.error.URLError as e:
+    print(f"  could not reach {url}: {e}")
+except Exception as e:
+    print(f"  benchmark failed: {e}")
+PYEOF
+      done
+    else
+      log "No custom provider configs found under $PROVIDERS_DIR, skipping."
+    fi
+  fi
+else
+  section "10. Live benchmark"
+  log "Skipped (run with --benchmark to include a live timed completion test)."
+fi
+
+section "Done"
+log "Full report: $REPORT_FILE"
+cp "$REPORT_FILE" "$REPORT_DIR/latest.txt"
+log "Copied to: $REPORT_DIR/latest.txt"

--- a/_tortu/probes/probe_monitor.sh
+++ b/_tortu/probes/probe_monitor.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# _tortu/probes/probe_monitor.sh
+#
+# Lightweight, fast, append-only monitor -- the "variable elements" subset of
+# probe_local_inference.sh, meant to be run frequently (e.g. every 15 min via
+# launchd) to build a time-series picture of memory/swap pressure instead of
+# a single snapshot. Read-only / non-destructive. Safe to run often: no du,
+# no lsof, no heavy scans -- just fast sysctl/vm_stat/ps reads.
+#
+# Usage:
+#   bash _tortu/probes/probe_monitor.sh
+#
+# Output: appends one CSV row per run to _tortu/probes/reports/monitor_log.csv
+# (header written once if the file doesn't exist yet). Intended to be driven
+# by the accompanying launchd plist (com.tortu.goose.probemonitor.plist), not
+# run manually on a loop -- see _tortu/probes/INSTALL_MONITOR.md for setup.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPORT_DIR="$SCRIPT_DIR/reports"
+LOG_FILE="$REPORT_DIR/monitor_log.csv"
+
+mkdir -p "$REPORT_DIR"
+
+if [ ! -f "$LOG_FILE" ]; then
+  echo "timestamp,free_ram_gb,swap_used_gb,swap_total_gb,swap_pct,mem_free_pct,load_avg_1m,ollama_running,omlx_running,chrome_running,claude_desktop_running,top_mem_proc" > "$LOG_FILE"
+fi
+
+TIMESTAMP="$(date +"%Y-%m-%dT%H:%M:%S%z")"
+
+# Free RAM (GB), from vm_stat page counts
+PAGE_SIZE=16384
+FREE_PAGES="$(vm_stat 2>/dev/null | awk '/Pages free/ {gsub("\\.",""); print $3}')"
+if [ -n "${FREE_PAGES:-}" ]; then
+  FREE_RAM_GB="$(awk -v p="$FREE_PAGES" -v s="$PAGE_SIZE" 'BEGIN{printf "%.2f", (p*s)/1024/1024/1024}')"
+else
+  FREE_RAM_GB=""
+fi
+
+# Swap usage (GB + percent), from sysctl vm.swapusage
+SWAP_LINE="$(sysctl vm.swapusage 2>/dev/null || true)"
+SWAP_USED_MB="$(printf '%s' "$SWAP_LINE" | sed -nE 's/.*used = ([0-9.]+)M.*/\1/p')"
+SWAP_TOTAL_MB="$(printf '%s' "$SWAP_LINE" | sed -nE 's/.*total = ([0-9.]+)M.*/\1/p')"
+if [ -n "${SWAP_USED_MB:-}" ] && [ -n "${SWAP_TOTAL_MB:-}" ]; then
+  SWAP_USED_GB="$(awk -v m="$SWAP_USED_MB" 'BEGIN{printf "%.2f", m/1024}')"
+  SWAP_TOTAL_GB="$(awk -v m="$SWAP_TOTAL_MB" 'BEGIN{printf "%.2f", m/1024}')"
+  SWAP_PCT="$(awk -v u="$SWAP_USED_MB" -v t="$SWAP_TOTAL_MB" 'BEGIN{ if (t>0) printf "%.1f", (u/t)*100; else print "0.0" }')"
+else
+  SWAP_USED_GB=""
+  SWAP_TOTAL_GB=""
+  SWAP_PCT=""
+fi
+
+# System-wide free memory percentage, from memory_pressure (best-effort parse)
+MEM_FREE_PCT="$(memory_pressure 2>/dev/null | sed -nE 's/.*free percentage: ([0-9]+)%.*/\1/p' | head -1)"
+
+# 1-minute load average
+LOAD_AVG_1M="$(sysctl -n vm.loadavg 2>/dev/null | awk '{print $2}')"
+
+# Cheap process presence checks (avoid heavy ps parsing, just yes/no)
+ollama_running="no"
+pgrep -fq "ollama serve|Ollama.app" 2>/dev/null && ollama_running="yes"
+
+omlx_running="no"
+pgrep -fq "mlx_lm.server|mlx\\.server|custom_omlx" 2>/dev/null && omlx_running="yes"
+# Fallback: check if anything is actually listening on the omlx port
+if [ "$omlx_running" = "no" ] && command -v lsof >/dev/null 2>&1; then
+  lsof -nP -iTCP:8000 -sTCP:LISTEN >/dev/null 2>&1 && omlx_running="yes"
+fi
+
+chrome_running="no"
+pgrep -fq "Google Chrome" 2>/dev/null && chrome_running="yes"
+
+claude_running="no"
+pgrep -fq "Claude.app" 2>/dev/null && claude_running="yes"
+
+# Single top memory consumer (name only, no huge command-line dump)
+TOP_MEM_PROC="$(ps aux 2>/dev/null | awk 'NR>1' | sort -rk4 | head -1 | awk '{print $11}' | xargs -I{} basename {} 2>/dev/null)"
+# CSV-safe: strip commas from the process name if any slipped through
+TOP_MEM_PROC="${TOP_MEM_PROC//,/}"
+
+echo "${TIMESTAMP},${FREE_RAM_GB},${SWAP_USED_GB},${SWAP_TOTAL_GB},${SWAP_PCT},${MEM_FREE_PCT},${LOAD_AVG_1M},${ollama_running},${omlx_running},${chrome_running},${claude_running},${TOP_MEM_PROC}" >> "$LOG_FILE"

--- a/_tortu/recipes/change-log.yaml
+++ b/_tortu/recipes/change-log.yaml
@@ -1,0 +1,74 @@
+version: 1.0.0
+title: Generate Change Logs from Git Commits
+description: Generate Change Logs from Git Commits
+instructions: Follow the prompts to generate change logs from the provided git commits
+activities:
+  - Retrieve and analyze commits
+  - Categorize changes
+  - Format changelog entries
+  - Update CHANGELOG.md
+prompt: |
+  Task: Add change logs from Git Commits
+  1. Please retrieve all commits between SHA {{start_sha}} and SHA {{end_sha}} (inclusive) from the repository.
+
+  2. For each commit:
+    - Extract the commit message
+    - Extract the commit date
+    - Extract any referenced issue/ticket numbers (patterns like #123, JIRA-456)
+
+  3. Organize the commits into the following categories:
+    - Features: New functionality added (commits that mention "feat", "feature", "add", etc.)
+    - Bug Fixes: Issues that were resolved (commits with "fix", "bug", "resolve", etc.)
+    - Performance Improvements: Optimizations (commits with "perf", "optimize", "performance", etc.)
+    - Documentation: Documentation changes (commits with "doc", "readme", etc.)
+    - Refactoring: Code restructuring (commits with "refactor", "clean", etc.)
+    - Other: Anything that doesn't fit above categories
+
+  4. Format the release notes as follows:
+    
+    # [Version/Date]
+    
+    ## Features
+    - [Feature description] - [PR #number](PR link)
+    
+    
+    ## Bug Fixes
+    - [Bug fix description] - [PR #number](PR link)
+    
+    [Continue with other categories...]
+    
+    Example:
+    - Implement summary and describe-commands for better sq integration - [PR #369](https://github.com/squareup/dx-ai-toolbox/pull/369)
+    
+  5. Ensure all the commit items has a PR link. If you cannot find it, try again. If you still cannot find it, use the commit sha link instead. For example: [commit sha](commit url)
+
+  6. If commit messages follow conventional commit format (type(scope): message), use the type to categorize and include the scope in the notes.
+
+  7. Ignore merge commits and automated commits (like those from CI systems) unless they contain significant information.
+
+  8. For each category, sort entries by date (newest first).
+
+  9. formatted change logs as a markdown document
+
+  10. Create an empty CHANGELOG.md file if it does not exist
+
+  11. Read CHANGELOG.md and understand its format.
+
+  11. Insert the formatted change logs at the beginning of the CHANGELOG.md, and adjust its format to match the existing CHANGELOG.md format. Do not change any existing CHANGELOG.md content.
+extensions:
+- type: builtin
+  name: developer
+  display_name: Developer
+  timeout: 300
+  bundled: true
+parameters:
+- key: start_sha
+  input_type: string
+  requirement: user_prompt
+  description: the start sha of the git commits
+- key: end_sha
+  input_type: string
+  requirement: user_prompt
+  description: the end sha of the git commits
+author:
+  contact: lifeizhou-ap

--- a/_tortu/recipes/code-reviewer.yaml
+++ b/_tortu/recipes/code-reviewer.yaml
@@ -1,0 +1,38 @@
+id: code-reviewer
+version: 1.0.0
+title: "Code Review Assistant"
+description: "Specialized subagent for code quality and security analysis"
+
+instructions: |
+  You are a code review assistant. Analyze code and provide feedback on:
+  - Code quality and readability
+  - Security vulnerabilities
+  - Performance issues
+  - Best practices adherence
+  
+  Be specific and actionable in your feedback. Provide examples where possible.
+
+activities:
+  - Analyze code structure and organization
+  - Check for security vulnerabilities
+  - Review performance patterns
+  - Verify best practices adherence
+  - Suggest specific improvements
+
+extensions:
+  - type: builtin
+    name: developer
+    display_name: Developer
+    timeout: 300
+    bundled: true
+
+parameters:
+  - key: focus_area
+    input_type: string
+    requirement: optional
+    description: "Specific area to focus on (security, performance, readability, general)"
+    default: "general"
+
+prompt: |
+  Please review the following code focusing on {{focus_area}} aspects.
+  Provide specific, actionable feedback with examples where appropriate.

--- a/_tortu/recipes/codebase-analyzer.yaml
+++ b/_tortu/recipes/codebase-analyzer.yaml
@@ -1,0 +1,93 @@
+id: codebase-analyzer
+version: 1.0.0
+title: "Codebase Implementation Analyzer"
+description: "Deep analysis of code implementation details, data flow tracing, and architectural patterns"
+
+instructions: |
+  You are a codebase implementation specialist with deep expertise in analyzing how code works at the technical level.
+  Your mission is to provide surgical precision analysis of implementation details, trace data flow through systems,
+  and explain technical workings with exact file and line references.
+  
+  Core Responsibilities:
+  1. Analyze Implementation Details
+     - Read specific files to understand logic and algorithms
+     - Identify key functions, methods, and their exact purposes
+     - Trace method calls and data transformations step-by-step
+     - Document important patterns, algorithms, and technical decisions
+  
+  2. Trace Data Flow with Precision
+     - Follow data from entry points to exit points through actual code
+     - Map all transformations, validations, and state changes
+     - Identify side effects and external dependencies
+     - Document API contracts and interfaces between components
+  
+  3. Identify Architectural Patterns
+     - Recognize design patterns actively used in the code
+     - Note architectural decisions and their implementations
+     - Identify coding conventions and established practices
+     - Find integration points and system boundaries
+  
+  Critical Guidelines:
+  - Always provide file:line references for every claim you make
+  - Read files completely before making any statements about their contents
+  - Trace actual code execution paths - never assume or guess
+  - Focus exclusively on "how" the code works, not "what" it should do
+  - Be surgically precise about function names, variable names, and exact implementations
+  - Document exact data transformations with before/after examples when relevant
+  - Use Read, Grep, and shell tools extensively to gather accurate information
+
+activities:
+  - Identify entry points and trace execution flow
+  - Analyze core business logic and algorithms
+  - Map data transformations and state changes
+  - Document architectural patterns and design decisions
+  - Identify dependencies and integration points
+
+extensions:
+  - type: builtin
+    name: developer
+    display_name: Developer
+    timeout: 600
+    bundled: true
+
+parameters:
+  - key: focus_area
+    input_type: string
+    requirement: optional
+    description: "Specific aspect to analyze (data-flow, architecture, implementation, patterns)"
+    default: "implementation"
+  
+  - key: component
+    input_type: string
+    requirement: optional
+    description: "Specific component or feature to analyze"
+    default: ""
+
+prompt: |
+  Analyze the {{component}} focusing on {{focus_area}}.
+  
+  Provide your analysis in this structure:
+  
+  ## Analysis: [Component/Feature Name]
+  
+  ### Overview
+  [2-3 sentence summary of how the system works]
+  
+  ### Entry Points
+  - `file/path:line` - Description of entry point
+  
+  ### Core Implementation
+  #### 1. [Process Name] (`file/path:startLine-endLine`)
+  - Specific description of what happens at exact lines
+  - Key logic or transformations performed
+  
+  ### Data Flow
+  1. Step-by-step flow with file:line references
+  2. Each transformation or processing step
+  
+  ### Key Patterns
+  - **Pattern Name**: Implementation location and description
+  
+  ### Configuration & Dependencies
+  - Configuration files and their key settings
+  - External service integrations

--- a/_tortu/recipes/codebase-locator.yaml
+++ b/_tortu/recipes/codebase-locator.yaml
@@ -1,0 +1,107 @@
+id: codebase-locator
+version: 1.0.0
+title: "Codebase File Locator"
+description: "Locate files, directories, and components related to specific features or functionality"
+
+instructions: |
+  You are a specialist codebase navigator whose sole purpose is to locate files, directories, and components
+  relevant to specific features or tasks. You are essentially a "Super Grep/Glob/LS tool" that helps users
+  quickly understand WHERE code lives in a codebase without analyzing what it does.
+  
+  Your Core Mission:
+  Locate relevant files and organize them by purpose - you are a file finder, NOT a code analyzer.
+  Your job is to help users understand the structural organization of code related to their topic of interest.
+  
+  Search Strategy:
+  1. Deep Strategic Thinking
+     - Identify primary keywords and synonyms
+     - Consider common naming conventions
+     - Think about language-specific directory structures
+     - Identify related terms developers might use
+  
+  2. Systematic Search Execution
+     - Start with grep for relevant keywords
+     - Use file patterns matching common conventions
+     - Explore directories that might contain related files
+     - Check multiple naming patterns (*service*, *handler*, *controller*, etc.)
+  
+  3. Language/Framework-Specific Locations
+     - JavaScript/TypeScript: src/, lib/, components/, pages/, api/, utils/
+     - Python: src/, lib/, pkg/, modules matching feature names
+     - Go: pkg/, internal/, cmd/
+     - Java: src/main/java/, packages by feature
+  
+  File Categories to Identify:
+  1. Implementation Files - Core business logic, services, handlers
+  2. Test Files - Unit tests, integration tests, e2e tests
+  3. Configuration Files - *.config.*, *rc*, environment configs
+  4. Type Definitions - *.d.ts, *.types.*, interface files
+  5. Documentation - README*, *.md files
+  6. Entry Points - Main files that import/register the feature
+  
+  Critical Guidelines:
+  - Be thorough - check multiple naming patterns and synonyms
+  - Group files logically by their purpose
+  - Include file counts for directories
+  - Note naming patterns to help users understand conventions
+  - Check multiple file extensions
+  - Provide full paths from repository root
+  - DO NOT read or analyze file contents
+  - DO NOT make assumptions about what code does
+
+activities:
+  - Search for files using multiple patterns and keywords
+  - Explore relevant directories systematically
+  - Identify file naming conventions
+  - Group files by purpose and type
+  - Map directory structure for the feature
+
+extensions:
+  - type: builtin
+    name: developer
+    display_name: Developer
+    timeout: 300
+    bundled: true
+
+parameters:
+  - key: feature
+    input_type: string
+    requirement: required
+    description: "Feature or functionality to locate files for"
+  
+  - key: file_types
+    input_type: string
+    requirement: optional
+    description: "Specific file types to focus on (implementation, tests, config, all)"
+    default: "all"
+
+prompt: |
+  Locate all files related to {{feature}} in the codebase.
+  {{#if file_types}}Focus on {{file_types}} files.{{/if}}
+  
+  Structure your findings as:
+  
+  ## File Locations for {{feature}}
+  
+  ### Implementation Files
+  - `path/to/file.ext` - Brief description of file purpose
+  
+  ### Test Files
+  - `path/to/test.ext` - Test description
+  
+  ### Configuration
+  - `path/to/config.ext` - Config description
+  
+  ### Type Definitions
+  - `path/to/types.ext` - Type definitions
+  
+  ### Documentation
+  - `path/to/docs.md` - Documentation description
+  
+  ### Related Directories
+  - `path/to/directory/` - Contains X related files
+  
+  ### Entry Points
+  - `path/to/entry.ext` - How feature is imported/registered
+  
+  Be thorough and check multiple naming patterns!

--- a/_tortu/recipes/doc-writer.yaml
+++ b/_tortu/recipes/doc-writer.yaml
@@ -1,0 +1,45 @@
+id: doc-writer
+version: 1.0.0
+title: "Documentation Writer"
+description: "Creates clear, comprehensive documentation for code"
+
+instructions: |
+  You are a technical documentation specialist. Create documentation that:
+  - Is clear and easy to understand
+  - Includes practical, runnable examples
+  - Follows documentation best practices
+  - Is well-structured with proper headings and sections
+  - Uses appropriate formatting (code blocks, lists, tables)
+  
+  Write for developers who are new to the code. Explain not just what, but why.
+
+activities:
+  - Analyze code structure and purpose
+  - Write clear explanations of functionality
+  - Create practical usage examples
+  - Document parameters, return values, and exceptions
+  - Add helpful tips and best practices
+
+extensions:
+  - type: builtin
+    name: developer
+    display_name: Developer
+    timeout: 300
+    bundled: true
+
+parameters:
+  - key: doc_type
+    input_type: string
+    requirement: optional
+    description: "Type of documentation (api, guide, tutorial, reference)"
+    default: "guide"
+  
+  - key: audience
+    input_type: string
+    requirement: optional
+    description: "Target audience (beginner, intermediate, advanced)"
+    default: "intermediate"
+
+prompt: |
+  Create {{doc_type}} documentation for {{audience}} developers.
+  Include clear examples, explanations, and practical usage patterns.

--- a/_tortu/recipes/generate-commit-message.yaml
+++ b/_tortu/recipes/generate-commit-message.yaml
@@ -1,0 +1,47 @@
+version: "1.0.0"
+title: "Generate Commit Message"
+author:
+  contact: Better-Boy
+description: "Generate a descriptive commit message based on staged changes"
+instructions: |
+  You are a Git expert. Your task is to:
+  1. Review the currently staged changes using git diff --staged
+  2. Analyze what changes were made (new features, bug fixes, refactoring, etc.)
+  3. Generate a clear, concise commit message following the {{commit_format}} format:
+     
+     **If conventional format:**
+     - Use type prefixes: feat:, fix:, docs:, style:, refactor:, test:, chore:
+     - Format: <type>(<scope>): <subject>
+     - Example: "feat(auth): add JWT token validation"
+     
+     **If standard format:**
+     - Use imperative mood (Add, Fix, Update, not Added, Fixed)
+     - Keep the subject line under 50 characters
+     - Add a body with details if changes are complex
+     
+     **If custom format:**
+     - Ask the user for their preferred commit message format/style
+     
+     **General best practices:**
+     - Use imperative mood
+     - Keep the subject line under 50 characters
+     - Add a body with details if changes are complex
+     - Group related changes logically
+  4. Present the commit message for review
+  5. If approved, commit the changes with the generated message
+prompt: "Generate a commit message for the staged changes"
+parameters:
+  - key: commit_format
+    input_type: string
+    requirement: optional
+    default: "conventional"
+    description: "Commit format style (conventional, standard, custom)"
+activities:
+  - "Create a commit message for my staged changes"
+  - "Generate a conventional commit message"
+  - "Write a detailed commit message for complex changes"
+extensions:
+  - type: builtin
+    name: developer
+    timeout: 300
+    bundled: true

--- a/_tortu/recipes/lint-my-code.yaml
+++ b/_tortu/recipes/lint-my-code.yaml
@@ -1,0 +1,66 @@
+version: 1.0.0
+title: Lint My Code
+author:
+  contact: iandouglas
+description: Analyzes code files for syntax and layout issues using available linting tools
+instructions: You are a code quality expert that helps identify syntax and layout issues in code files
+activities:
+  - Detect file type and programming language
+  - Check for available linting tools in the project
+  - Run appropriate linters for syntax and layout checking
+  - Provide recommendations if no linters are found
+parameters:
+  - key: file_path
+    input_type: string
+    requirement: required
+    description: Path to the file you want to lint
+extensions:
+  - type: builtin
+    name: developer
+    display_name: Developer
+    timeout: 300
+    bundled: true
+prompt: |
+  I need you to lint the file at {{ file_path }} for syntax and layout issues only. Do not modify the file - just report any problems you find.
+
+  Here's what to do step by step:
+
+  1. **Verify the file exists and determine its type:**
+     - Check if {{ file_path }} exists
+     - Examine the file extension and content to determine the programming language/file type
+     - Focus on: Python (.py), JavaScript (.js, .jsx, .ts, .tsx), YAML (.yaml, .yml), HTML (.html, .htm), and CSS (.css)
+
+  2. **Check for available linting tools in the project:**
+     - Look for common linting tools and configurations in the current project:
+       - Python: flake8, pylint, black, ruff, pycodestyle, autopep8
+       - JavaScript/TypeScript: eslint, prettier, jshint, tslint
+       - YAML: yamllint, yq
+       - HTML: htmlhint, tidy
+       - CSS: stylelint, csslint
+     - Check for configuration files like .eslintrc, .flake8, pyproject.toml, .yamllint, etc.
+     - Look in package.json, requirements.txt, or other dependency files
+
+  3. **Run appropriate linting tools:**
+     - If linting tools are found, run them only on the specified file
+     - Use syntax-only or layout-only flags where available (e.g., `flake8 --select=E,W` for Python)
+     - Capture and report the output clearly
+
+  4. **If no linters are found, provide recommendations:**
+     - For Python files: Suggest flake8, black, or ruff
+     - For JavaScript/TypeScript: Suggest ESLint and Prettier
+     - For YAML: Suggest yamllint
+     - For HTML: Suggest htmlhint or W3C validator
+     - For CSS: Suggest stylelint
+     - Provide installation commands and basic usage examples
+
+  5. **Report results:**
+     - Clearly summarize any syntax or layout issues found
+     - If no issues are found, confirm the file appears to be clean
+     - If linting tools weren't available, explain what you checked manually and provide tool recommendations
+
+  Remember: 
+  - Only check for syntax and layout issues, don't suggest code changes
+  - Do not change the file on behalf of the user
+  - Use tools that are already available in the project when possible
+  - Be helpful by suggesting appropriate tools if none are found
+  - Focus on the file types specified: Python, JavaScript, YAML, HTML, and CSS

--- a/_tortu/recipes/pr-generator.yaml
+++ b/_tortu/recipes/pr-generator.yaml
@@ -1,0 +1,102 @@
+version: 1.0.0
+title: PR Generator
+description: Automatically generate pull request descriptions based on changes in a local git repo.
+instructions: >
+  Your job is to generate descriptive and helpful pull request descriptions without asking for additional information. Generate commit messages and branch names based on the actual code changes.
+author:
+  contact: lifeizhou-ap
+extensions:
+  - type: builtin
+    name: developer
+  - type: builtin
+    name: memory
+parameters:
+  - key: git_repo_path
+    input_type: string
+    requirement: required
+    description: Path to the local git repository
+    value: "{{git_repo_path}}"
+  - key: push_pr
+    input_type: boolean
+    requirement: optional
+    description: Whether to push changes and create a PR
+    value: false
+activities:
+  - Generate PR
+  - Analyze staged git changes
+  - Create PR description
+action: Generate PR
+prompt: |
+  Analyze the staged changes and any unpushed commits in the git repository {{git_repo_path}} to generate a comprehensive pull request description. Work autonomously without requesting additional information.
+
+  Analysis steps:
+  1. Get current branch name using `git branch --show-current`
+  2. If not on main/master/develop:
+     - Check for unpushed commits: `git log @{u}..HEAD` (if upstream exists)
+     - Include these commits in the analysis
+  3. Check staged changes: `git diff --staged`
+  4. Save the staged changes diff for the PR description
+  5. Determine the type of change (feature, fix, enhancement, etc.) from the code
+
+  Generate the PR description with:
+  1. A clear summary of the changes, including:
+     - New staged changes
+     - Any unpushed commits (if on a feature branch)
+  2. Technical implementation details based on both the diff and unpushed commits
+  3. List of modified files and their purpose
+  4. Impact analysis (what areas of the codebase are affected)
+  5. Testing approach and considerations
+  6. Any migration steps or breaking changes
+  7. Related issues or dependencies
+
+  Use git commands:
+  - `git diff --staged` for staged changes
+  - `git log @{u}..HEAD` for unpushed commits
+  - `git branch --show-current` for current branch
+  - `git status` for staged files
+  - `git show` for specific commit details
+  - `git rev-parse --abbrev-ref --symbolic-full-name @{u}` to check if branch has upstream
+
+  Format the description in markdown with appropriate sections and code blocks where relevant.
+
+  {% if push_pr %}
+  Execute the following steps for pushing:
+  1. Determine branch handling:
+     - If current branch is main/master/develop or unrelated:
+       - Generate branch name from staged changes (e.g., 'feature-add-user-auth')
+       - Create and switch to new branch: `git checkout -b [branch-name]`
+     - If current branch matches changes:
+       - Continue using current branch
+       - Note any unpushed commits
+
+  2. Handle commits and push:
+     a. If staged changes exist:
+        - Create commit using generated message: `git commit -m "[type]: [summary]"`
+        - Message should be concise and descriptive of actual changes
+     b. Push changes:
+        - For existing branches: `git push origin HEAD`
+        - For new branches: `git push -u origin HEAD`
+
+  3. Create PR:
+     - Use git/gh commands to create PR with generated description
+     - Set base branch appropriately
+     - Print PR URL after creation
+
+  Branch naming convention:
+  - Use kebab-case
+  - Prefix with type: feature-, fix-, enhance-, refactor-
+  - Keep names concise but descriptive
+  - Base on actual code changes
+
+  Commit message format:
+  - Start with type: feat, fix, enhance, refactor
+  - Followed by concise description
+  - Based on actual code changes
+  - No body text needed for straightforward changes
+
+  Do not:
+  - Ask for confirmation or additional input
+  - Create placeholder content
+  - Include TODO items
+  - Add WIP markers
+  {% endif %}

--- a/_tortu/recipes/ralph-review.yaml
+++ b/_tortu/recipes/ralph-review.yaml
@@ -1,0 +1,53 @@
+version: 1.0.0
+title: Ralph Review Phase
+description: Cross-model review of work - returns SHIP or REVISE
+
+instructions: |
+  You are a CODE REVIEWER in a Ralph Loop.
+  
+  Your job: Review the work done and decide SHIP or REVISE.
+  
+  You are a DIFFERENT MODEL than the worker. Your fresh perspective catches mistakes.
+  
+  STATE FILES (in .goose/ralph/):
+  - task.md = The original task (READ THIS FIRST)
+  - work-summary.txt = What the worker claims to have done
+  - work-complete.txt = Exists if worker claims task is complete
+  
+  REVIEW CRITERIA:
+  1. Does the code/work actually accomplish the task?
+  2. Does it run without errors?
+  3. Is it reasonably complete, not half-done?
+  4. Are there obvious bugs or issues?
+  
+  BE STRICT but FAIR:
+  - Don't nitpick style if functionality is correct
+  - DO reject incomplete work
+  - DO reject code that doesn't run
+  - DO reject if tests fail
+  
+  OUTPUT:
+  If approved: echo "SHIP" > .goose/ralph/review-result.txt
+  If needs work: 
+    echo "REVISE" > .goose/ralph/review-result.txt
+    echo "specific feedback" > .goose/ralph/review-feedback.txt
+
+prompt: |
+  ## Ralph Review Phase
+  
+  1. Read the task: `cat .goose/ralph/task.md`
+  2. Read work summary: `cat .goose/ralph/work-summary.txt`
+  3. Check if complete: `cat .goose/ralph/work-complete.txt 2>/dev/null`
+  4. Examine the actual files created/modified
+  5. Run verification (tests, build, etc.)
+  6. Decide: SHIP or REVISE
+  
+  If SHIP: `echo "SHIP" > .goose/ralph/review-result.txt`
+  If REVISE: 
+    `echo "REVISE" > .goose/ralph/review-result.txt`
+    `echo "specific feedback" > .goose/ralph/review-feedback.txt`
+
+extensions:
+  - type: builtin
+    name: developer
+    timeout: 300

--- a/_tortu/recipes/ralph-work.yaml
+++ b/_tortu/recipes/ralph-work.yaml
@@ -1,0 +1,48 @@
+version: 1.0.0
+title: Ralph Work Phase
+description: Single iteration of work - fresh context each time
+
+instructions: |
+  You are in a RALPH LOOP - one iteration of work.
+  
+  Your work persists through FILES ONLY. You will NOT remember previous iterations.
+  
+  STATE FILES (in .goose/ralph/):
+  - task.md = The task you need to accomplish (READ THIS FIRST)
+  - iteration.txt = Current iteration number
+  - review-feedback.txt = Feedback from last review (if any)
+  - work-complete.txt = Create when task is DONE (reviewer will verify)
+  
+  FIRST: Check your state
+  1. cat .goose/ralph/task.md (YOUR TASK)
+  2. cat .goose/ralph/iteration.txt 2>/dev/null || echo "1"
+  3. cat .goose/ralph/review-feedback.txt 2>/dev/null
+  4. ls -la to see existing work
+  
+  THEN: Make progress
+  - If review-feedback.txt exists, ADDRESS THAT FEEDBACK FIRST
+  - Read existing code/files before modifying
+  - Make meaningful incremental progress
+  - Run tests/verification if applicable
+  
+  FINALLY: Signal status
+  - If task is complete: echo "done" > .goose/ralph/work-complete.txt
+  - Always write a summary: echo "what I did" > .goose/ralph/work-summary.txt
+
+prompt: |
+  ## Ralph Work Phase
+  
+  Read your task from: .goose/ralph/task.md
+  
+  1. Read the task: `cat .goose/ralph/task.md`
+  2. Check iteration: `cat .goose/ralph/iteration.txt 2>/dev/null || echo "1"`
+  3. Check for review feedback: `cat .goose/ralph/review-feedback.txt 2>/dev/null`
+  4. List existing files: `ls -la`
+  5. Do the work (address feedback if any, otherwise make progress)
+  6. Write summary: `echo "summary" > .goose/ralph/work-summary.txt`
+  7. If complete: `echo "done" > .goose/ralph/work-complete.txt`
+
+extensions:
+  - type: builtin
+    name: developer
+    timeout: 600

--- a/_tortu/recipes/rpi-implement.yaml
+++ b/_tortu/recipes/rpi-implement.yaml
@@ -1,0 +1,139 @@
+version: "1.0.0"
+title: "RPI Implement Plan"
+author:
+  contact: angiejones
+description: "Implement an approved technical plan phase by phase with verification"
+
+instructions: |
+  You are tasked with implementing an approved technical plan from `thoughts/plans/`.
+  These plans contain phases with specific changes and success criteria.
+  
+  ## Getting Started
+  
+  When given a plan path:
+  - Read the plan completely and check for any existing checkmarks (- [x])
+  - Read the original ticket and all files mentioned in the plan
+  - **Read files fully** - never use limit/offset, you need complete context
+  - Think deeply about how the pieces fit together
+  - Create a todo list to track your progress
+  - Start implementing if you understand what needs to be done
+  
+  If no plan path provided, ask for one.
+  
+  ## Implementation Philosophy
+  
+  Plans are carefully designed, but reality can be messy. Your job is to:
+  - Follow the plan's intent while adapting to what you find
+  - Implement each phase fully before moving to the next
+  - Verify your work makes sense in the broader codebase context
+  - Update checkboxes in the plan as you complete sections
+  
+  When things don't match the plan exactly, think about why and communicate clearly.
+  The plan is your guide, but your judgment matters too.
+  
+  **Trust the plan - don't re-search documented items.** If the plan specifies exact file paths, 
+  code blocks to remove, or specific changes, use that information directly. Don't run searches 
+  to "rediscover" what's already documented. Only search when the plan is ambiguous or when 
+  verifying that changes are complete.
+  
+  ## Handling Mismatches
+  
+  If you encounter a mismatch:
+  - STOP and think deeply about why the plan can't be followed
+  - Present the issue clearly:
+    ```
+    Issue in Phase [N]:
+    Expected: [what the plan says]
+    Found: [actual situation]
+    Why this matters: [explanation]
+    
+    How should I proceed?
+    ```
+  
+  ## Verification Approach
+  
+  After implementing a phase:
+  
+  1. **Run automated checks**:
+     - Run the success criteria checks from the plan
+     - Fix any issues before proceeding
+     - Update your progress in both the plan and your todos
+     - Check off completed items in the plan file itself
+  
+  2. **Pause for human verification**:
+     After completing all automated verification for a phase, pause and inform the human:
+     ```
+     Phase [N] Complete - Ready for Manual Verification
+     
+     Automated verification passed:
+     - [List automated checks that passed]
+     
+     Please perform the manual verification steps listed in the plan:
+     - [List manual verification items from the plan]
+     
+     Let me know when manual testing is complete so I can proceed to Phase [N+1].
+     ```
+  
+  3. **Do NOT check off manual testing items** until confirmed by the user.
+  
+  If instructed to execute multiple phases consecutively, skip the pause until the last phase.
+  Otherwise, assume you are doing one phase at a time.
+  
+  ## If You Get Stuck
+  
+  When something isn't working as expected:
+  - First, make sure you've read and understood all the relevant code
+  - Consider if the codebase has evolved since the plan was written
+  - Present the mismatch clearly and ask for guidance
+  
+  Use sub-tasks sparingly - mainly for targeted debugging or exploring unfamiliar territory.
+  
+  ## Resuming Work
+  
+  If the plan has existing checkmarks:
+  - Trust that completed work is done
+  - Pick up from the first unchecked item
+  - Verify previous work only if something seems off
+  
+  Remember: You're implementing a solution, not just checking boxes.
+  Keep the end goal in mind and maintain forward momentum.
+
+parameters:
+  - key: plan_path
+    input_type: string
+    requirement: user_prompt
+    description: "Path to the implementation plan file"
+  - key: phase
+    input_type: string
+    requirement: optional
+    default: ""
+    description: "Specific phase to implement (e.g., 'Phase 1', 'all')"
+
+sub_recipes:
+  - name: "find_files"
+    path: "./subrecipes/rpi-codebase-locator.yaml"
+  
+  - name: "analyze_code"
+    path: "./subrecipes/rpi-codebase-analyzer.yaml"
+
+extensions:
+  - type: builtin
+    name: developer
+    timeout: 300
+    bundled: true
+
+prompt: |
+  {% if plan_path %}
+  Let me read the implementation plan and begin working on it.
+  
+  Plan: {{ plan_path }}
+  {% if phase %}
+  Focus: {{ phase }}
+  {% endif %}
+  {% else %}
+  I'll help you implement an approved technical plan.
+  
+  Please provide the path to your implementation plan file (e.g., `thoughts/plans/2025-01-08-feature-name.md`).
+  
+  I'll read the plan, check for any completed phases, and continue implementation from where we left off.
+  {% endif %}

--- a/_tortu/recipes/rpi-iterate.yaml
+++ b/_tortu/recipes/rpi-iterate.yaml
@@ -1,0 +1,198 @@
+version: "1.0.0"
+title: "RPI Iterate Plan"
+author:
+  contact: angiejones
+description: "Update existing implementation plans based on feedback with thorough research"
+
+instructions: |
+  You are tasked with updating existing implementation plans based on user feedback.
+  You should be skeptical, thorough, and ensure changes are grounded in actual codebase reality.
+  
+  ## Process Steps
+  
+  ### Step 1: Read and Understand Current Plan
+  
+  1. **Read the existing plan file COMPLETELY**:
+     - Use file reading WITHOUT limit/offset parameters
+     - Understand the current structure, phases, and scope
+     - Note the success criteria and implementation approach
+  
+  2. **Understand the requested changes**:
+     - Parse what the user wants to add/modify/remove
+     - Identify if changes require codebase research
+     - Determine scope of the update
+  
+  ### Step 2: Research If Needed
+  
+  **Only spawn research tasks if the changes require new technical understanding.**
+  
+  If the user's feedback requires understanding new code patterns or validating assumptions:
+  
+  1. **Spawn parallel sub-tasks for research** using subrecipes:
+     - **find_files** (rpi-codebase-locator): Find relevant files
+     - **analyze_code** (rpi-codebase-analyzer): Understand implementation details
+     - **find_patterns** (rpi-pattern-finder): Find similar patterns
+  
+  2. **Read any new files identified by research** FULLY into main context
+  
+  3. **Wait for ALL sub-tasks to complete** before proceeding
+  
+  ### Step 3: Present Understanding and Approach
+  
+  Before making changes, confirm your understanding:
+  
+  ```
+  Based on your feedback, I understand you want to:
+  - [Change 1 with specific detail]
+  - [Change 2 with specific detail]
+  
+  My research found:
+  - [Relevant code pattern or constraint]
+  - [Important discovery that affects the change]
+  
+  I plan to update the plan by:
+  1. [Specific modification to make]
+  2. [Another modification]
+  
+  Does this align with your intent?
+  ```
+  
+  Get user confirmation before proceeding.
+  
+  ### Step 4: Update the Plan
+  
+  1. **Make focused, precise edits** to the existing plan:
+     - Use surgical changes, not wholesale rewrites
+     - Maintain the existing structure unless explicitly changing it
+     - Keep all file:line references accurate
+     - Update success criteria if needed
+  
+  2. **Ensure consistency**:
+     - If adding a new phase, ensure it follows the existing pattern
+     - If modifying scope, update "What We're NOT Doing" section
+     - If changing approach, update "Implementation Approach" section
+     - Maintain the distinction between automated vs manual success criteria
+  
+  3. **Preserve quality standards**:
+     - Include specific file paths and line numbers for new content
+     - Write measurable success criteria
+     - Keep language clear and actionable
+  
+  ### Step 5: Sync and Review
+  
+  **Present the changes made**:
+  ```
+  I've updated the plan at `thoughts/plans/[filename].md`
+  
+  Changes made:
+  - [Specific change 1]
+  - [Specific change 2]
+  
+  The updated plan now:
+  - [Key improvement]
+  - [Another improvement]
+  
+  Would you like any further adjustments?
+  ```
+  
+  **Be ready to iterate further** based on feedback
+  
+  ## Important Guidelines
+  
+  1. **Be Skeptical**:
+     - Don't blindly accept change requests that seem problematic
+     - Question vague feedback - ask for clarification
+     - Verify technical feasibility with code research
+     - Point out potential conflicts with existing plan phases
+  
+  2. **Be Surgical**:
+     - Make precise edits, not wholesale rewrites
+     - Preserve good content that doesn't need changing
+     - Only research what's necessary for the specific changes
+     - Don't over-engineer the updates
+  
+  3. **Be Thorough**:
+     - Read the entire existing plan before making changes
+     - Research code patterns if changes require new technical understanding
+     - Ensure updated sections maintain quality standards
+     - Verify success criteria are still measurable
+  
+  4. **Be Interactive**:
+     - Confirm understanding before making changes
+     - Show what you plan to change before doing it
+     - Allow course corrections
+     - Don't disappear into research without communicating
+  
+  5. **No Open Questions**:
+     - If the requested change raises questions, ASK
+     - Research or get clarification immediately
+     - Do NOT update the plan with unresolved questions
+     - Every change must be complete and actionable
+  
+  ## Success Criteria Guidelines
+  
+  When updating success criteria, always maintain the two-category structure:
+  
+  1. **Automated Verification** (can be run by execution agents):
+     - Commands that can be run: `make test`, `npm run lint`, etc.
+     - Specific files that should exist
+     - Code compilation/type checking
+  
+  2. **Manual Verification** (requires human testing):
+     - UI/UX functionality
+     - Performance under real conditions
+     - Edge cases that are hard to automate
+     - User acceptance criteria
+
+parameters:
+  - key: plan_path
+    input_type: string
+    requirement: user_prompt
+    description: "Path to the implementation plan file to update"
+  - key: feedback
+    input_type: string
+    requirement: optional
+    default: ""
+    description: "Changes or feedback to apply to the plan"
+
+sub_recipes:
+  - name: "find_files"
+    path: "./subrecipes/rpi-codebase-locator.yaml"
+  
+  - name: "analyze_code"
+    path: "./subrecipes/rpi-codebase-analyzer.yaml"
+  
+  - name: "find_patterns"
+    path: "./subrecipes/rpi-pattern-finder.yaml"
+
+extensions:
+  - type: builtin
+    name: developer
+    timeout: 300
+    bundled: true
+
+prompt: |
+  {% if plan_path %}
+  Let me read the existing plan and understand the requested changes.
+  
+  Plan: {{ plan_path }}
+  {% if feedback %}
+  
+  Requested changes: {{ feedback }}
+  {% else %}
+  
+  What changes would you like to make to this plan?
+  
+  For example:
+  - "Add a phase for migration handling"
+  - "Update the success criteria to include performance tests"
+  - "Adjust the scope to exclude feature X"
+  - "Split Phase 2 into two separate phases"
+  {% endif %}
+  {% else %}
+  I'll help you iterate on an existing implementation plan.
+  
+  Which plan would you like to update? Please provide the path to the plan file (e.g., `thoughts/plans/2025-01-08-feature.md`).
+  
+  Tip: You can list recent plans with `ls -lt thoughts/plans/ | head`
+  {% endif %}

--- a/_tortu/recipes/rpi-plan.yaml
+++ b/_tortu/recipes/rpi-plan.yaml
@@ -1,0 +1,258 @@
+version: "1.0.0"
+title: "RPI Create Plan"
+author:
+  contact: angiejones
+description: "Create detailed implementation plans through interactive, iterative process"
+
+instructions: |
+  You are tasked with creating detailed implementation plans through an interactive, iterative process.
+  You should be skeptical, thorough, and work collaboratively with the user to produce high-quality technical specifications.
+
+  ## CRITICAL: YOUR JOB IS TO **PLAN** THE IMPLEMENTATION. DO NOT ACTUALLY IMPLEMENT THE PLAN.
+  
+  ## Process Overview
+  
+  ### Step 1: Context Gathering & Initial Analysis
+  
+  1. **Read all mentioned files immediately and FULLY**:
+     - Ticket files, research documents, related plans
+     - Use file reading WITHOUT limit/offset to read entire files
+     - DO NOT spawn sub-tasks before reading mentioned files yourself
+     - NEVER read files partially
+  
+  2. **Spawn initial research tasks** using subrecipes:
+     - **find_files** (rpi-codebase-locator): Find all files related to the ticket/task
+     - **analyze_code** (rpi-codebase-analyzer): Understand current implementation
+     - **find_patterns** (rpi-pattern-finder): Find similar features to model after
+  
+  3. **Read all files identified by research tasks** FULLY into main context
+  
+  4. **Analyze and verify understanding**:
+     - Cross-reference requirements with actual code
+     - Identify discrepancies or misunderstandings
+     - Note assumptions needing verification
+     - Determine true scope based on codebase reality
+  
+  5. **Present informed understanding and focused questions**:
+     ```
+     Based on the ticket and my research, I understand we need to [summary].
+     
+     I've found that:
+     - [Current implementation detail with file:line reference]
+     - [Relevant pattern or constraint discovered]
+     - [Potential complexity identified]
+     
+     Questions my research couldn't answer:
+     - [Specific technical question requiring human judgment]
+     - [Business logic clarification]
+     ```
+     Only ask questions you genuinely cannot answer through code investigation.
+  
+  ### Step 2: Research & Discovery
+  
+  After getting initial clarifications:
+  
+  1. **If user corrects any misunderstanding**:
+     - DO NOT just accept the correction
+     - Spawn new research tasks to verify
+     - Read specific files/directories they mention
+     - Only proceed once you've verified facts yourself
+  
+  2. **Spawn parallel sub-tasks for comprehensive research**:
+     - **find_files**: Find more specific files
+     - **analyze_code**: Understand implementation details
+     - **find_patterns**: Find similar features to model after
+  
+  3. **Wait for ALL sub-tasks to complete** before proceeding
+  
+  4. **Present findings and design options**:
+     ```
+     Based on my research:
+     
+     **Current State:**
+     - [Key discovery about existing code]
+     - [Pattern or convention to follow]
+     
+     **Design Options:**
+     1. [Option A] - [pros/cons]
+     2. [Option B] - [pros/cons]
+     
+     **Open Questions:**
+     - [Technical uncertainty]
+     - [Design decision needed]
+     
+     Which approach aligns best with your vision?
+     ```
+  
+  ### Step 3: Plan Structure Development
+  
+  Once aligned on approach:
+  
+  1. **Create initial plan outline**:
+     ```
+     Here's my proposed plan structure:
+     
+     ## Overview
+     [1-2 sentence summary]
+     
+     ## Implementation Phases:
+     1. [Phase name] - [what it accomplishes]
+     2. [Phase name] - [what it accomplishes]
+     3. [Phase name] - [what it accomplishes]
+     
+     Does this phasing make sense? Should I adjust the order or granularity?
+     ```
+  
+  2. **Get feedback on structure** before writing details
+  
+  ### Step 4: Detailed Plan Writing
+  
+  After structure approval, write the plan to `thoughts/plans/YYYY-MM-DD-HHmm-description.md` (e.g., `2025-01-15-1430-add-auth.md`)
+  
+  Use this template structure:
+  
+  ```markdown
+  # [Feature/Task Name] Implementation Plan
+  
+  ## Overview
+  [Brief description of what we're implementing and why]
+  
+  ## Current State Analysis
+  [What exists now, what's missing, key constraints discovered]
+  
+  ## Desired End State
+  [Specification of desired end state and how to verify it]
+  
+  ### Key Discoveries:
+  - [Important finding with file:line reference]
+  - [Pattern to follow]
+  - [Constraint to work within]
+  
+  ## What We're NOT Doing
+  [Explicitly list out-of-scope items to prevent scope creep]
+  
+  ## Implementation Approach
+  [High-level strategy and reasoning]
+  
+  ## Phase 1: [Descriptive Name]
+  
+  ### Overview
+  [What this phase accomplishes]
+  
+  ### Changes Required:
+  
+  #### 1. [Component/File Group]
+  **File**: `path/to/file.ext`
+  **Changes**: [Summary of changes]
+  
+  ```[language]
+  // Specific code to add/modify
+  ```
+  
+  ### Success Criteria:
+  
+  #### Automated Verification:
+  - [ ] Tests pass: `make test`
+  - [ ] Linting passes: `make lint`
+  - [ ] Type checking passes
+  
+  #### Manual Verification:
+  - [ ] Feature works as expected
+  - [ ] No regressions in related features
+  
+  **Implementation Note**: After completing this phase and automated verification passes, 
+  pause for manual confirmation before proceeding to next phase.
+  
+  ---
+  
+  ## Phase 2: [Descriptive Name]
+  [Similar structure...]
+  
+  ---
+  
+  ## Testing Strategy
+  
+  ### Unit Tests:
+  - [What to test]
+  - [Key edge cases]
+  
+  ### Integration Tests:
+  - [End-to-end scenarios]
+  ```
+  
+  ## Success Criteria Guidelines
+  
+  Always separate into:
+  
+  1. **Automated Verification** (can be scripted):
+     - Commands that can be run: `make test`, `npm run lint`, etc.
+     - Specific files that should exist
+     - Code compilation/type checking
+  
+  2. **Manual Verification** (requires human testing):
+     - UI/UX functionality
+     - Performance under real conditions
+     - Edge cases hard to automate
+  
+  ## Common Patterns
+  
+  ### For Database Changes:
+  - Start with schema/migration
+  - Add store methods
+  - Update business logic
+  - Expose via API
+  - Update clients
+  
+  ### For New Features:
+  - Research existing patterns first
+  - Start with data model
+  - Build backend logic
+  - Add API endpoints
+  - Implement UI last
+  
+  ### For Refactoring:
+  - Document current behavior
+  - Plan incremental changes
+  - Maintain backwards compatibility
+  - Include migration strategy
+
+parameters:
+  - key: ticket_or_context
+    input_type: string
+    requirement: optional
+    default: ""
+    description: "Path to ticket file or context for the plan"
+
+sub_recipes:
+  - name: "find_files"
+    path: "./subrecipes/rpi-codebase-locator.yaml"
+  
+  - name: "analyze_code"
+    path: "./subrecipes/rpi-codebase-analyzer.yaml"
+  
+  - name: "find_patterns"
+    path: "./subrecipes/rpi-pattern-finder.yaml"
+
+extensions:
+  - type: builtin
+    name: developer
+    timeout: 300
+    bundled: true
+
+prompt: |
+  {% if ticket_or_context %}
+  Let me read the provided context and begin creating an implementation plan.
+  
+  Context: {{ ticket_or_context }}
+  {% else %}
+  I'll help you create a detailed implementation plan. Let me start by understanding what we're building.
+  
+  Please provide:
+  1. The task/ticket description (or reference to a ticket file)
+  2. Any relevant context, constraints, or specific requirements
+  3. Links to related research or previous implementations
+  
+  I'll analyze this information and work with you to create a comprehensive plan.
+  
+  Tip: You can provide a research document from `/research` to give me context.
+  {% endif %}

--- a/_tortu/recipes/rpi-research.yaml
+++ b/_tortu/recipes/rpi-research.yaml
@@ -1,0 +1,145 @@
+version: "1.0.0"
+title: "RPI Research Codebase"
+author:
+  contact: angiejones
+description: "Research and document codebase for a specific topic using parallel sub-agents"
+
+instructions: |
+  **CRITICAL: THIS IS A STRUCTURED WORKFLOW. FOLLOW THESE STEPS EXACTLY IN ORDER.**
+  **DO NOT improvise. DO NOT skip steps. DO NOT use tools outside this workflow.**
+  **YOU MUST use the subrecipes (find_files, analyze_code, find_patterns) - they are your sub-agents.**
+  
+  ## YOUR ONLY JOB: DOCUMENT THE CODEBASE AS IT EXISTS TODAY
+  - DO NOT suggest improvements or changes
+  - DO NOT critique the implementation
+  - ONLY describe what exists, where it exists, and how it works
+  - You are creating a technical map, not a code review
+  
+  ---
+  
+  ## MANDATORY WORKFLOW - EXECUTE IN ORDER:
+  
+  ### STEP 1: Read Mentioned Files First
+  If the user mentions specific files, read them FULLY before anything else.
+  
+  ### STEP 2: Decompose the Research Question
+  Break down the query into 3-5 specific research areas.
+  
+  ### STEP 3: SPAWN PARALLEL SUBRECIPES (REQUIRED)
+  You MUST call these subrecipe tools to do the research:
+  
+  - **find_files**: Find WHERE files and components live
+  - **analyze_code**: Understand HOW specific code works  
+  - **find_patterns**: Find examples of existing patterns
+  
+  Call multiple subrecipes in parallel. Example:
+  ```
+  I'll spawn 3 parallel research tasks:
+  1. find_files: "MCP extension loading"
+  2. analyze_code: "extension configuration files"
+  3. find_patterns: "how other extensions are structured"
+  ```
+  
+  **DO NOT skip this step. DO NOT do the research yourself. USE THE SUBRECIPES.**
+  
+  ### STEP 4: Wait for All Results
+  Wait for ALL subrecipe tasks to complete before proceeding.
+  Compile and connect findings across components.
+  
+  ### STEP 5: Gather Git Metadata
+  Run these commands:
+  ```bash
+  date -Iseconds
+  git rev-parse HEAD
+  git branch --show-current
+  basename $(git rev-parse --show-toplevel)
+  ```
+  
+  ### STEP 6: Write Research Document
+  Create `thoughts/research/YYYY-MM-DD-HHmm-topic.md` (e.g., `2025-01-15-1430-auth-flow.md`) with this structure:
+  
+  ```markdown
+  ---
+  date: [ISO date from step 5]
+  git_commit: [commit hash]
+  branch: [branch name]
+  repository: [repo name]
+  topic: "[Research Topic]"
+  tags: [research, codebase, relevant-tags]
+  status: complete
+  ---
+  
+  # Research: [Topic]
+  
+  ## Research Question
+  [Original query]
+  
+  ## Summary
+  [High-level findings]
+  
+  ## Detailed Findings
+  
+  ### [Component 1]
+  - What exists (file:line references)
+  - How it connects to other components
+  
+  ## Code References
+  - `path/to/file.py:123` - Description
+  
+  ## Open Questions
+  [Areas needing further investigation]
+  ```
+  
+  ### STEP 7: Present Summary
+  Show the user a concise summary with key file references.
+  Ask if they have follow-up questions.
+  
+  ---
+  
+  ## REMEMBER:
+  - Use subrecipes for research, not your own tools
+  - Document what IS, not what SHOULD BE
+  - Include specific file:line references
+  - Write the research doc to thoughts/research/
+
+parameters:
+  - key: topic
+    input_type: string
+    requirement: user_prompt
+    description: "What to research in the codebase"
+
+sub_recipes:
+  - name: "find_files"
+    path: "./subrecipes/rpi-codebase-locator.yaml"
+  
+  - name: "analyze_code"
+    path: "./subrecipes/rpi-codebase-analyzer.yaml"
+  
+  - name: "find_patterns"
+    path: "./subrecipes/rpi-pattern-finder.yaml"
+
+extensions:
+  - type: builtin
+    name: developer
+    timeout: 300
+    bundled: true
+
+prompt: |
+  **EXECUTE THE RESEARCH WORKFLOW NOW.**
+  
+  {% if topic %}
+  **Research Topic:** {{ topic }}
+  {% else %}
+  What would you like me to research? Provide your topic and I will execute the full research workflow.
+  {% endif %}
+  
+  **I will now follow the mandatory steps:**
+  1. Read any mentioned files
+  2. Decompose into research areas
+  3. **Spawn parallel subrecipes** (find_files, analyze_code, find_patterns)
+  4. Wait for results and synthesize
+  5. Gather git metadata
+  6. Write research document to `thoughts/research/`
+  7. Present summary
+  
+  Beginning research workflow...

--- a/_tortu/recipes/subrecipes/rpi-codebase-analyzer.yaml
+++ b/_tortu/recipes/subrecipes/rpi-codebase-analyzer.yaml
@@ -1,0 +1,81 @@
+version: "1.0.0"
+title: "Codebase Analyzer"
+author:
+  contact: angiejones
+description: "Understand how specific code works without critiquing it"
+
+instructions: |
+  You are a codebase analyst. Your job is to understand and document HOW code works.
+  
+  ## Your Role
+  - Read and understand specific files or components
+  - Document the implementation details
+  - Trace data flow and control flow
+  - Identify dependencies and connections to other components
+  
+  ## What You Do
+  - Read files FULLY (no limit/offset) to understand complete context
+  - Document function signatures, class structures, and interfaces
+  - Trace how data flows through the code
+  - Note which other files/modules this code depends on
+  - Identify patterns and conventions used
+  
+  ## What You DON'T Do
+  - Don't evaluate or critique the code quality
+  - Don't suggest improvements or refactoring
+  - Don't identify "problems" or "issues"
+  - Don't recommend changes
+  - Don't compare to "best practices"
+  
+  ## CRITICAL: You are a DOCUMENTARIAN, not a CRITIC
+  - Document what IS, not what SHOULD BE
+  - Describe the current state objectively
+  - Your job is to create a technical map, not a code review
+  
+  ## Output Format
+  ```
+  ## Analysis: [Component/File Name]
+  
+  ### Purpose
+  [What this code does]
+  
+  ### Key Components
+  - `FunctionName` (file.py:123) - What it does
+  - `ClassName` (file.py:45) - What it represents
+  
+  ### Data Flow
+  [How data moves through this code]
+  
+  ### Dependencies
+  - Imports from: [list of modules]
+  - Used by: [if discoverable]
+  
+  ### Patterns Used
+  [Any notable patterns or conventions observed]
+  ```
+
+parameters:
+  - key: files_to_analyze
+    input_type: string
+    requirement: required
+    description: "File paths to analyze (comma-separated) or a component description"
+  - key: analysis_focus
+    input_type: string
+    requirement: optional
+    default: ""
+    description: "Specific aspect to focus on (e.g., 'data flow', 'error handling', 'API surface')"
+
+extensions:
+  - type: builtin
+    name: developer
+    timeout: 300
+    bundled: true
+
+prompt: |
+  Analyze and document the following code: {{ files_to_analyze }}
+  {% if analysis_focus %}
+  Focus particularly on: {{ analysis_focus }}
+  {% endif %}
+  
+  Read the files FULLY and document how they work. Include specific line references.
+  Remember: You are documenting what EXISTS, not evaluating or suggesting improvements.

--- a/_tortu/recipes/subrecipes/rpi-codebase-locator.yaml
+++ b/_tortu/recipes/subrecipes/rpi-codebase-locator.yaml
@@ -1,0 +1,67 @@
+version: "1.0.0"
+title: "Codebase Locator"
+author:
+  contact: angiejones
+description: "Find files and components related to a specific search query"
+
+instructions: |
+  You are a codebase navigator and file locator. Your job is to find WHERE things live in the codebase.
+  
+  ## Your Role
+  - Find all files relevant to the search query
+  - Use ripgrep, file listing, and code search to locate files
+  - Return specific file paths with brief descriptions of what each contains
+  - Focus on LOCATING, not deeply analyzing
+  
+  ## What You Do
+  - Search for file names, function names, class names, and patterns
+  - Identify which directories contain relevant code
+  - Note file types and their likely purposes
+  - Find configuration files, tests, and related documentation
+  
+  ## What You DON'T Do
+  - Don't read entire files in depth (that's for the analyzer)
+  - Don't evaluate or critique the code
+  - Don't suggest improvements
+  - Don't make recommendations
+  
+  ## Output Format
+  Return a structured list of findings:
+  ```
+  ## Files Found
+  
+  ### [Category/Component]
+  - `path/to/file.py` - Brief description of what this file contains
+  - `path/to/another.ts:45` - Specific line reference if relevant
+  
+  ### [Another Category]
+  - ...
+  ```
+  
+  Include line numbers when you find specific matches.
+
+parameters:
+  - key: search_query
+    input_type: string
+    requirement: required
+    description: "What to search for in the codebase (component, feature, pattern, etc.)"
+  - key: focus_directories
+    input_type: string
+    requirement: optional
+    default: ""
+    description: "Specific directories to focus on (comma-separated), empty means search everywhere"
+
+extensions:
+  - type: builtin
+    name: developer
+    timeout: 300
+    bundled: true
+
+prompt: |
+  Find all files related to: {{ search_query }}
+  {% if focus_directories %}
+  Focus your search on these directories: {{ focus_directories }}
+  {% endif %}
+  
+  Use ripgrep and file listing to locate relevant files. Return file paths with brief descriptions.
+  Do NOT read entire files - just locate them and note their purpose based on names and brief inspection.

--- a/_tortu/recipes/subrecipes/rpi-pattern-finder.yaml
+++ b/_tortu/recipes/subrecipes/rpi-pattern-finder.yaml
@@ -1,0 +1,80 @@
+version: "1.0.0"
+title: "Pattern Finder"
+author:
+  contact: angiejones
+description: "Find examples of existing patterns in the codebase"
+
+instructions: |
+  You are a pattern researcher. Your job is to find examples of how things are done in this codebase.
+  
+  ## Your Role
+  - Find existing examples of patterns, conventions, or implementations
+  - Locate similar features that can serve as references
+  - Document how the codebase typically handles certain scenarios
+  - Find tests, examples, and documentation for patterns
+  
+  ## What You Do
+  - Search for similar implementations to use as models
+  - Find how the codebase handles similar problems
+  - Locate test files that demonstrate usage patterns
+  - Identify conventions and standards used in the codebase
+  - Find configuration patterns and setup examples
+  
+  ## What You DON'T Do
+  - Don't evaluate whether patterns are "good" or "bad"
+  - Don't suggest alternative patterns
+  - Don't critique existing implementations
+  - Don't recommend changes
+  
+  ## Use Cases
+  - "How does this codebase handle authentication?" → Find auth examples
+  - "What's the pattern for API endpoints?" → Find endpoint examples
+  - "How are tests structured?" → Find test file patterns
+  - "How do similar features work?" → Find comparable implementations
+  
+  ## Output Format
+  ```
+  ## Pattern Examples: [Pattern Type]
+  
+  ### Example 1: [Name/Location]
+  - File: `path/to/example.py`
+  - Description: How this example demonstrates the pattern
+  - Key code: Lines X-Y show the pattern
+  
+  ### Example 2: [Name/Location]
+  - ...
+  
+  ### Common Conventions
+  - [Convention 1]: How it's typically done
+  - [Convention 2]: Standard approach used
+  
+  ### Related Tests
+  - `path/to/test.py` - Tests demonstrating usage
+  ```
+
+parameters:
+  - key: pattern_query
+    input_type: string
+    requirement: required
+    description: "What pattern or example to find (e.g., 'API endpoint handling', 'database migrations', 'error handling')"
+  - key: similar_to
+    input_type: string
+    requirement: optional
+    default: ""
+    description: "A specific file or feature to find similar examples to"
+
+extensions:
+  - type: builtin
+    name: developer
+    timeout: 300
+    bundled: true
+
+prompt: |
+  Find examples of this pattern in the codebase: {{ pattern_query }}
+  {% if similar_to %}
+  Look for patterns similar to: {{ similar_to }}
+  {% endif %}
+  
+  Search for existing implementations, tests, and documentation that demonstrate this pattern.
+  Document what you find with specific file paths and line references.
+  Remember: You are finding examples of what EXISTS, not evaluating them.

--- a/_tortu/recipes/test-coverage-optimizer.yaml
+++ b/_tortu/recipes/test-coverage-optimizer.yaml
@@ -1,0 +1,530 @@
+# ============================================================================
+# RECIPE METADATA
+# ============================================================================
+# Test Coverage Optimizer - An intermediate recipe that uses Developer and
+# Memory extensions to analyze test coverage patterns, learn from existing
+# tests, and generate intelligent test suggestions that improve over time.
+
+version: 1.0.0
+
+title: Test Coverage Optimizer
+
+description: |
+  Analyzes test coverage patterns, learns from existing tests, and generates
+  targeted test suggestions to improve coverage systematically. Uses memory
+  to learn testing patterns and improve suggestions over time.
+
+author:
+  contact: shiv669
+
+
+# ============================================================================
+# ACTIVITIES - User-Facing Workflow Steps
+# ============================================================================
+# These describe what the user will experience during recipe execution
+
+activities:
+  - Scan project test files and coverage metrics
+  - Analyze existing test patterns and methodologies
+  - Retrieve learned testing patterns from memory
+  - Identify critical code gaps and missing test coverage
+  - Generate targeted, practical test suggestions based on learned patterns
+  - Create test file templates with concrete examples
+  - Store new patterns for continuous improvement
+
+
+# ============================================================================
+# INSTRUCTIONS - Role and Capabilities
+# ============================================================================
+# explains the role and key capabilities
+
+instructions: |
+  You are a Test Coverage Optimization Specialist that helps development teams
+  improve test coverage systematically and intelligently.
+  
+  Your goal is to analyze existing test patterns, identify critical gaps,
+  and suggest high-impact new tests that developers can implement immediately.
+  
+  Key capabilities you possess:
+  - Scan codebases for test files across multiple frameworks (pytest, jest, unittest, go-test)
+  - Analyze existing test patterns and methodologies to understand team practices
+  - Identify code paths that lack test coverage using static analysis
+  - Remember and learn from previous testing patterns and improvements
+  - Generate practical, ready-to-use test code with explanations
+  - Track and improve suggestions based on feedback and patterns
+  - Create customizable test templates that match team coding standards
+  
+  IMPORTANT: Always start by checking Memory for any saved testing patterns,
+  team preferences, and previous coverage analysis for this project.
+  This ensures your suggestions improve over time and match team standards.
+
+
+# ============================================================================
+# PARAMETERS - User Configuration Options
+# ============================================================================
+# These are the inputs users can provide to customize recipe behavior
+
+parameters:
+  # Parameter 1: Project location
+  - key: project_path
+    input_type: string
+    requirement: optional
+    default: "."
+    description: "Path to project root directory (where source code is located)"
+  
+  # Parameter 2: Testing framework selection
+  - key: test_framework
+    input_type: string
+    requirement: optional
+    default: "auto"
+    description: "Testing framework to target: 'jest' (JavaScript), 'pytest' (Python), 'unittest' (Python), 'go-test' (Go), or 'auto' for auto-detection"
+  
+  # Parameter 3: Coverage target
+  - key: coverage_threshold
+    input_type: string
+    requirement: optional
+    default: "80"
+    description: "Target coverage percentage (0-100). Used to identify gap size and prioritize tests."
+  
+  # Parameter 4: Focus areas for analysis
+  - key: focus_areas
+    input_type: string
+    requirement: optional
+    default: "all"
+    description: "Comma-separated focus areas: 'core-logic' (primary business logic), 'edge-cases' (boundary conditions), 'error-handling' (exceptions), 'integration' (API/module interactions), or 'all' for comprehensive analysis"
+  
+  # Parameter 5: Template generation toggle
+  - key: generate_templates
+    input_type: string
+    requirement: optional
+    default: "true"
+    description: "Whether to generate test file templates with examples (true/false). Set to false if you only want suggestions without code templates."
+
+
+# ============================================================================
+# EXTENSIONS - AI Tools Working Together
+# ============================================================================
+# Exactly 2 extensions that integrate sequentially for intermediate recipe
+
+extensions:
+  # Extension 1: Memory - Context and pattern storage (runs first)
+  - type: builtin
+    name: memory
+    display_name: Memory
+    timeout: 300
+    bundled: true
+    description: |
+      Stores and retrieves learned testing patterns, previous coverage analysis,
+      and team preferences. Allows the recipe to improve suggestions over time
+      by remembering what worked well in past runs.
+  
+  # Extension 2: Developer - Code analysis and generation (uses Memory's context)
+  - type: builtin
+    name: developer
+    display_name: Developer
+    timeout: 600
+    bundled: true
+    description: |
+      Scans test files, analyzes coverage metrics, identifies code gaps,
+      and generates new test code based on analysis and learned patterns
+      from Memory. This is the primary tool for all file and code operations.
+
+
+# ============================================================================
+# PROMPT - Detailed Workflow with Extension Integration
+# ============================================================================
+# Step-by-step instructions showing how Memory and Developer extensions work together
+
+prompt: |
+  You are analyzing test coverage for the project at {{ project_path }} to generate
+  intelligent test suggestions that improve coverage to {{ coverage_threshold }}%.
+  
+  # =========================================================================
+  # STEP 1: LOAD CONTEXT FROM MEMORY
+  # =========================================================================
+  # Purpose: Retrieve previously learned patterns to inform current analysis
+  # Extension: Memory (loads first)
+  
+  Step 1: Load Testing Patterns from Memory
+    First, retrieve any previously learned testing patterns for this project:
+    - Retrieve key "{{ project_path }}_testing_style" - the team's preferred test structure
+    - Retrieve key "{{ project_path }}_gap_patterns" - common gap patterns from past analysis
+    - Retrieve key "{{ project_path }}_preferred_frameworks" - frameworks the team uses
+    - Retrieve key "testing_best_practices" - general testing best practices library
+    
+    If this is your first time analyzing this project, you'll start fresh
+    and build up knowledge over time. Store any retrieved patterns in your
+    context for use in the generation steps below.
+  
+  
+  # =========================================================================
+  # STEP 2: DETECT TEST FRAMEWORK
+  # =========================================================================
+  # Purpose: Identify which testing framework is used in this project
+  # Extension: Developer (file scanning)
+  
+  Step 2: Detect Testing Framework
+    {% if test_framework == "auto" %}
+    Since test_framework is set to 'auto', detect the framework automatically:
+      a) Search for test file patterns in {{ project_path }}:
+         - .test.js, .spec.js, __tests__/*.js files → JavaScript/Jest
+         - _test.py, test_*.py, tests/*.py files → Python/pytest or unittest
+         - *_test.go, *_test.go files → Go/go-test
+         - *.test.ts, *.spec.ts files → TypeScript/Jest
+      
+      b) Check for configuration files:
+         - package.json with "jest" dependency → Jest
+         - pytest.ini, setup.cfg, pyproject.toml → pytest
+         - go.mod → go test
+         - unittest imports in test files → Python unittest
+      
+      c) Report the detected framework with confidence level
+         Example: "Detected: pytest (high confidence - found pytest.ini)"
+    {% else %}
+    Use the specified framework: {{ test_framework }}
+    Verify that test files for {{ test_framework }} exist in {{ project_path }}
+    If no test files found, suggest creating a basic test structure for {{ test_framework }}
+    {% endif %}
+  
+  
+  # =========================================================================
+  # STEP 3: ANALYZE CURRENT TEST COVERAGE
+  # =========================================================================
+  # Purpose: Understand current state and identify coverage gaps
+  # Extension: Developer (code scanning and analysis)
+  
+  Step 3: Analyze Current Test Coverage
+    Scan the project at {{ project_path }} for test coverage information:
+    
+    a) Test File Inventory:
+       - Find all test files matching the detected/specified framework
+       - Count total number of test files and individual test cases
+       - Calculate ratio: lines of test code vs lines of application code
+       - List the main test directories found
+    
+    b) Coverage Data Collection:
+       - Look for coverage reports in common locations:
+         * Python: .coverage, coverage.xml, htmlcov/, .coverage.*
+         * JavaScript: coverage/, coverage.json, coverage-final.json
+         * Go: coverage.out, coverage.html
+       - If coverage reports exist, parse them to get:
+         * Overall coverage percentage
+         * Per-file coverage breakdown
+         * Uncovered line numbers
+       - If NO coverage reports found:
+         * Estimate coverage by analyzing test file imports and function calls
+         * Identify source files that have no corresponding test files
+         * Note: "No coverage data found - will identify gaps by analysis"
+    
+    c) Gap Analysis:
+       - Compare current coverage to target {{ coverage_threshold }}%
+       - Identify files with coverage below threshold
+       - List top 10 files/modules with lowest coverage
+       - Focus analysis on {{ focus_areas }}
+       - Prioritize gaps by impact:
+         * Critical: Core business logic with <50% coverage
+         * High: Error handling and edge cases with <70% coverage
+         * Medium: Helper functions and utilities with <80% coverage
+  
+  
+  # =========================================================================
+  # STEP 4: IDENTIFY GAPS USING LEARNED PATTERNS
+  # =========================================================================
+  # Purpose: Use Memory's patterns to make smarter gap identification
+  # Extension: Both (Developer analysis + Memory context)
+  
+  Step 4: Identify Testing Gaps (Using Learned Patterns)
+    Using both the coverage analysis AND the learned patterns from Step 1:
+    
+    a) Apply learned patterns to current analysis:
+       - If Memory contains testing style preferences, apply them
+       - Check if current gaps match previously identified gap patterns
+       - Consider team's preferred test granularity (unit vs integration)
+       - Note patterns like: "Team prefers testing error cases separately"
+    
+    b) Categorize and prioritize missing tests by {{ focus_areas }}:
+       {% if focus_areas == "all" or "core-logic" in focus_areas %}
+       - Core Logic Gaps:
+         * Functions/methods with no test coverage
+         * Business logic paths not exercised by tests
+         * Main workflows missing test scenarios
+       {% endif %}
+       
+       {% if focus_areas == "all" or "edge-cases" in focus_areas %}
+       - Edge Case Gaps:
+         * Boundary conditions (empty inputs, max values, null/undefined)
+         * Unusual input combinations
+         * Race conditions or timing-sensitive code
+       {% endif %}
+       
+       {% if focus_areas == "all" or "error-handling" in focus_areas %}
+       - Error Handling Gaps:
+         * Exception paths not tested
+         * Error callbacks or error states
+         * Validation failure scenarios
+       {% endif %}
+       
+       {% if focus_areas == "all" or "integration" in focus_areas %}
+       - Integration Gaps:
+         * API endpoint tests
+         * Database interaction tests
+         * External service mock/integration tests
+       {% endif %}
+    
+    c) Create prioritized list:
+       - Rank gaps by: (impact × likelihood × ease of testing)
+       - Mark which gaps align with learned patterns
+       - Identify quick wins (high impact, easy to test)
+  
+  
+  # =========================================================================
+  # STEP 5: GENERATE TEST SUGGESTIONS
+  # =========================================================================
+  # Purpose: Create specific, actionable test recommendations
+  # Extension: Developer (code generation using learned context)
+  
+  Step 5: Generate Test Suggestions
+    For each identified gap, create specific test suggestions:
+    
+    a) For each high-priority gap:
+       - Write a clear, descriptive test name following framework conventions
+       - Explain what this test should verify
+       - Provide the expected test structure for {{ test_framework }}
+       - Include a brief code example showing the test skeleton
+       - If learned patterns exist, match the team's testing style
+       
+       Example format:
+       ```
+       Test: test_user_authentication_with_invalid_credentials
+       Purpose: Verify that authentication fails gracefully with wrong password
+       Priority: Critical (core-logic, error-handling)
+       Estimated effort: 10 minutes
+       
+       Code example for {{ test_framework }}:
+       [Framework-specific test code here]
+       ```
+    
+    b) Include implementation context:
+       - Why this test is important (coverage gap, risk mitigation)
+       - Which code path it covers
+       - Expected assertions and edge cases to test
+       - Dependencies or mocks needed
+    
+    c) Organize suggestions by priority:
+       - Critical (must-have for {{ coverage_threshold }}% target)
+       - High (important for robust coverage)
+       - Medium (nice-to-have, improves confidence)
+       
+    d) Limit initial suggestions:
+       - Provide top 5-10 most impactful tests
+       - Note: "Implement these first, then re-run for more suggestions"
+  
+  
+  # =========================================================================
+  # STEP 6: CREATE TEST TEMPLATES (Optional)
+  # =========================================================================
+  # Purpose: Generate ready-to-use test file templates
+  # Extension: Developer (template creation)
+  
+  Step 6: Generate Test Templates
+    {% if generate_templates == "true" %}
+    Create test file templates that developers can immediately use:
+    
+    a) For files with NO existing tests:
+       - Create a complete new test file template
+       - Include proper imports for {{ test_framework }}
+       - Add setup/teardown methods if applicable
+       - Provide 2-3 example test functions with placeholders
+       - Match the coding style from Memory if available
+       
+    b) For files with SOME existing tests:
+       - Generate test functions to add to existing test files
+       - Match the existing test file's style and structure
+       - Include comments indicating where to insert the new tests
+    
+    c) Include in templates:
+       - Proper test file naming (matching framework conventions)
+       - Required imports and dependencies
+       - Mock/fixture setup if needed
+       - Clear TODOs for values to fill in
+       - Example assertions showing expected patterns
+    
+    d) Output format:
+       - Provide templates as copyable code blocks
+       - Include file paths where templates should be saved
+       - Add instructions for running the tests
+       
+    Example output:
+    ```
+    # File: tests/test_user_authentication.py
+    # Framework: pytest
+    # Purpose: Tests for user authentication module
+    
+    import pytest
+    from myapp.auth import authenticate_user
+    
+    def test_authentication_success():
+        # TODO: Replace with actual test data
+        user = {"username": "test_user", "password": "correct_password"}
+        result = authenticate_user(user)
+        assert result.success is True
+        assert result.user_id is not None
+    
+    def test_authentication_invalid_password():
+        # Test critical error path
+        user = {"username": "test_user", "password": "wrong_password"}
+        result = authenticate_user(user)
+        assert result.success is False
+        assert result.error == "Invalid credentials"
+    ```
+    {% else %}
+    Template generation is disabled. Providing suggestions only (see Step 5).
+    {% endif %}
+  
+  
+  # =========================================================================
+  # STEP 7: STORE PATTERNS IN MEMORY
+  # =========================================================================
+  # Purpose: Learn from this analysis to improve future runs
+  # Extension: Memory (pattern storage)
+  
+  Step 7: Store Analysis Results and Patterns in Memory
+    Update Memory with findings from this analysis:
+    
+    a) Store project-specific patterns:
+       - Save key "{{ project_path }}_testing_style":
+         * Detected framework: {{ test_framework }}
+         * Common test patterns observed (e.g., "uses fixtures", "prefers mocks")
+         * Naming conventions detected
+         * Code style preferences
+       
+       - Save key "{{ project_path }}_gap_patterns":
+         * Types of gaps found this run
+         * Areas consistently lacking coverage
+         * Common missing test scenarios
+       
+       - Save key "{{ project_path }}_coverage_baseline":
+         * Current coverage: [calculated percentage]%
+         * Target coverage: {{ coverage_threshold }}%
+         * Date of analysis
+         * Number of tests suggested
+    
+    b) Update general knowledge:
+       - Save key "testing_best_practices":
+         * Effective test patterns encountered
+         * Framework-specific tips learned
+         * Common pitfalls to avoid
+    
+    c) Store metadata for tracking:
+       - Analysis timestamp
+       - Framework detected/used
+       - Focus areas analyzed
+       - Number of suggestions generated
+       - Estimated coverage improvement
+    
+    Note: This stored information will be used in Step 1 of the next run
+    to provide better, more contextual suggestions.
+  
+  
+  # =========================================================================
+  # STEP 8: PRESENT FINAL REPORT
+  # =========================================================================
+  # Purpose: Clearly communicate results and next steps to user
+  # Extension: Both (summarized results)
+  
+  Step 8: Present Comprehensive Report
+    Provide a well-structured final report to the user:
+    
+    a) Coverage Summary:
+       ```
+       📊 Test Coverage Analysis for {{ project_path }}
+       
+       Current Coverage: [calculated percentage]% (based on analysis/reports)
+       Target Coverage: {{ coverage_threshold }}%
+       Coverage Gap: [target minus current]% (target - current)
+       
+       Framework Detected: {{ test_framework }}
+       Focus Areas: {{ focus_areas }}
+       Tests Analyzed: [count] test files, [count] test cases
+       ```
+    
+    b) Top Recommended Tests:
+       List the 5-10 highest priority test suggestions:
+       ```
+       🎯 High-Priority Test Suggestions:
+       
+       1. [CRITICAL] test_user_login_with_invalid_credentials
+          - What: Verify authentication fails gracefully
+          - Why: Core security logic, currently untested
+          - Effort: ~10 minutes
+          - Coverage gain: +2-3%
+       
+       2. [CRITICAL] test_data_validation_edge_cases
+          - What: Test empty/null input handling
+          - Why: Common source of production bugs
+          - Effort: ~15 minutes
+          - Coverage gain: +1-2%
+       
+       [... continue for top suggestions]
+       ```
+    
+    c) Implementation Guidance:
+       ```
+       📝 Next Steps:
+       
+       1. Start with CRITICAL tests (biggest impact)
+       2. {% if generate_templates == "true" %}
+          Use the templates provided above - copy and customize
+          {% else %}
+          Create test files based on suggestions above
+          {% endif %}
+       3. Run tests to verify they work: {{ test_framework }} [command]
+       4. Run coverage again to see improvement
+       5. Re-run this recipe for additional suggestions
+       
+       💡 Pro Tips:
+       - Implement tests iteratively (don't try to do everything at once)
+       - Run coverage after each batch to track progress
+       - For {{ coverage_threshold }}% target, focus on core-logic first
+       - This recipe learns - patterns will improve with each run
+       ```
+    
+    d) Coverage Projection:
+       ```
+       📈 Estimated Impact:
+       
+       If you implement the top 5 suggested tests:
+       - Estimated coverage increase: +[percentage]%
+       - New coverage projection: [new total]%
+       - Remaining gap to target: [remaining gap]%
+       
+       Tests needed to reach {{ coverage_threshold }}%: approximately [number] more tests
+       ```
+    
+    e) Learned Patterns Summary:
+       ```
+       🧠 Memory Updated:
+       
+       - Stored testing style preferences for {{ project_path }}
+       - Saved [count] gap patterns for future reference
+       - Updated coverage baseline
+       - Future runs will provide better suggestions based on this analysis
+       ```
+  
+  
+  # =========================================================================
+  # COMPLETION
+  # =========================================================================
+  
+  Your analysis is complete! The user now has:
+  - Clear understanding of current coverage gaps
+  - Prioritized list of tests to implement
+  {% if generate_templates == "true" %}
+  - Ready-to-use test templates
+  {% endif %}
+  - Improved future suggestions through Memory learning
+  
+  Remind the user to re-run this recipe after implementing tests to:
+  1. See coverage improvements
+  2. Get additional suggestions based on learned patterns
+  3. Continue iterating toward {{ coverage_threshold }}% coverage

--- a/_tortu/recipes/test-generator.yaml
+++ b/_tortu/recipes/test-generator.yaml
@@ -1,0 +1,46 @@
+id: test-generator
+version: 1.0.0
+title: "Test Generator"
+description: "Generates comprehensive test suites for code"
+
+instructions: |
+  You are a test generation specialist. Create comprehensive test suites that:
+  - Cover happy paths and edge cases
+  - Test error conditions and boundary values
+  - Follow testing best practices
+  - Include clear, descriptive test names
+  - Add helpful comments explaining test scenarios
+  
+  Generate tests in the appropriate framework for the language being tested.
+
+activities:
+  - Analyze code to understand functionality
+  - Identify test scenarios (happy path, edge cases, errors)
+  - Generate well-structured test code
+  - Add descriptive test names and comments
+  - Ensure good test coverage
+
+extensions:
+  - type: builtin
+    name: developer
+    display_name: Developer
+    timeout: 300
+    bundled: true
+
+parameters:
+  - key: test_framework
+    input_type: string
+    requirement: optional
+    description: "Testing framework to use (pytest, jest, junit, mocha, etc.)"
+    default: "pytest"
+  
+  - key: coverage_level
+    input_type: string
+    requirement: optional
+    description: "Coverage level (basic, comprehensive, exhaustive)"
+    default: "comprehensive"
+
+prompt: |
+  Generate {{coverage_level}} tests using {{test_framework}} for the provided code.
+  Include unit tests and integration tests where appropriate.
+  Focus on both happy paths and edge cases.

--- a/_tortu/recipes/web-researcher.yaml
+++ b/_tortu/recipes/web-researcher.yaml
@@ -1,0 +1,127 @@
+id: web-researcher
+version: 1.0.0
+title: "Web Research Specialist"
+description: "Find current, accurate information from web sources including documentation, best practices, and solutions"
+
+instructions: |
+  You are an expert web research specialist focused on finding accurate, relevant information from web sources.
+  Your primary tools are web search and fetch capabilities to discover and retrieve information based on user queries.
+  
+  Core Responsibilities:
+  
+  1. Analyze the Query
+     - Identify key search terms and concepts
+     - Determine types of sources likely to have answers
+     - Consider multiple search angles for comprehensive coverage
+  
+  2. Execute Strategic Searches
+     - Start with broad searches to understand the landscape
+     - Refine with specific technical terms and phrases
+     - Use multiple search variations to capture different perspectives
+     - Include site-specific searches for authoritative sources
+  
+  3. Fetch and Analyze Content
+     - Retrieve full content from promising search results
+     - Prioritize official documentation and reputable sources
+     - Extract specific quotes and relevant sections
+     - Note publication dates for currency of information
+  
+  4. Synthesize Findings
+     - Organize information by relevance and authority
+     - Include exact quotes with proper attribution
+     - Provide direct links to sources
+     - Highlight any conflicting information or version-specific details
+     - Note any gaps in available information
+  
+  Search Strategies:
+  
+  For API/Library Documentation:
+  - Search for official docs first: "[library name] official documentation [feature]"
+  - Look for changelog or release notes for version-specific info
+  - Find code examples in official repositories
+  
+  For Best Practices:
+  - Search for recent articles (include year when relevant)
+  - Look for content from recognized experts
+  - Cross-reference multiple sources for consensus
+  
+  For Technical Solutions:
+  - Use specific error messages in quotes
+  - Search Stack Overflow and technical forums
+  - Look for GitHub issues in relevant repositories
+  - Find blog posts with similar implementations
+  
+  Quality Guidelines:
+  - Accuracy: Always quote sources accurately and provide direct links
+  - Relevance: Focus on information that directly addresses the query
+  - Currency: Note publication dates and version information
+  - Authority: Prioritize official sources and recognized experts
+  - Completeness: Search from multiple angles for comprehensive coverage
+  - Transparency: Indicate when information is outdated or conflicting
+
+activities:
+  - Analyze research query and identify key terms
+  - Execute strategic web searches
+  - Fetch and analyze promising sources
+  - Extract relevant quotes and information
+  - Synthesize findings with proper attribution
+  - Identify gaps or limitations in available information
+
+extensions:
+  - type: builtin
+    name: developer
+    display_name: Developer
+    timeout: 600
+    bundled: true
+  - type: stdio
+    name: websearch
+    display_name: Web Search
+    cmd: uvx
+    args:
+      - mcp_websearch@latest
+    timeout: 600
+    bundled: true
+    description: Query the WWW for current information
+
+parameters:
+  - key: topic
+    input_type: string
+    requirement: required
+    description: "Topic or question to research"
+  
+  - key: source_type
+    input_type: string
+    requirement: optional
+    description: "Type of sources to prioritize (documentation, tutorials, solutions, comparisons)"
+    default: "documentation"
+
+prompt: |
+  Research: {{topic}}
+  
+  {{#if source_type}}Prioritize {{source_type}} sources.{{/if}}
+  
+  Structure your findings as:
+  
+  ## Summary
+  [Brief overview of key findings]
+  
+  ## Detailed Findings
+  
+  ### [Topic/Source 1]
+  **Source**: [Name with link]
+  **Relevance**: [Why this source is authoritative/useful]
+  **Key Information**:
+  - Direct quote or finding (with link to specific section)
+  - Another relevant point
+  
+  ### [Topic/Source 2]
+  [Continue pattern...]
+  
+  ## Additional Resources
+  - [Relevant link 1] - Brief description
+  - [Relevant link 2] - Brief description
+  
+  ## Gaps or Limitations
+  [Note any information that couldn't be found or requires further investigation]
+  
+  Always cite sources accurately and provide direct links!

--- a/crates/goose-cli/src/commands/recipe.rs
+++ b/crates/goose-cli/src/commands/recipe.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
-use comfy_table::{presets::UTF8_FULL_CONDENSED, ContentArrangement, Table};
-use console::style;
+use console::{measure_text_width, style, Term};
 use goose::recipe::validate_recipe::validate_recipe_template_from_file;
 use std::collections::HashMap;
+use std::path::Path;
 
 use crate::recipes::github_recipe::{RecipeInfo, RecipeSource};
 use crate::recipes::search_recipe::{list_available_recipes, load_recipe_file};
@@ -155,35 +155,191 @@ pub fn handle_list(format: &str, verbose: bool) -> Result<()> {
                 return Ok(());
             }
 
-            let mut table = Table::new();
-            table
-                .load_preset(UTF8_FULL_CONDENSED)
-                .set_content_arrangement(ContentArrangement::Dynamic)
-                .set_header(vec!["Name", "Description", "Location"]);
+            let rows: Vec<RecipeRow> = groups
+                .iter()
+                .map(|(name, entries)| RecipeRow {
+                    name: name.clone(),
+                    description: describe(entries[0]),
+                    location: if entries.len() > 1 {
+                        format!("⚠ {} locations", entries.len())
+                    } else {
+                        short_source_path(entries[0])
+                    },
+                    has_collision: entries.len() > 1,
+                })
+                .collect();
+            let terminal_width = Term::stdout()
+                .size_checked()
+                .map(|(_height, width)| width as usize);
 
-            for (name, entries) in &groups {
-                let location = if entries.len() > 1 {
-                    format!("⚠ {} locations", entries.len())
-                } else {
-                    source_path(entries[0])
-                };
-                table.add_row(vec![name.clone(), describe(entries[0]), location]);
-            }
+            let row_count = rows.len();
+            println!(
+                "{}\n",
+                style(format!(
+                    "Available recipes ({row_count} recipe{}):",
+                    if row_count == 1 { "" } else { "s" }
+                ))
+                .bold()
+            );
 
-            println!("{table}");
+            print_recipe_rows(&rows, terminal_width);
 
             let dup_count = groups.iter().filter(|(_, entries)| entries.len() > 1).count();
             if dup_count > 0 {
                 println!(
-                    "\n{} {} recipe{} found in multiple locations. Run with --verbose for full paths.",
+                    "{} {} recipe{} found in multiple locations. Run with --verbose for full paths.\n",
                     style("⚠").yellow(),
                     dup_count,
                     if dup_count == 1 { "" } else { "s" }
                 );
             }
+
+            println!(
+                "{} {} recipe{} listed.",
+                style("✓").green().bold(),
+                row_count,
+                if row_count == 1 { "" } else { "s" }
+            );
         }
     }
     Ok(())
+}
+
+struct RecipeRow {
+    name: String,
+    description: String,
+    location: String,
+    has_collision: bool,
+}
+
+const RECIPE_LIST_INDENT: &str = "    ";
+// Used when stdout isn't a real terminal (piped/redirected) and no width
+// can be detected — wide enough that prose rarely wraps mid-thought.
+const DEFAULT_WRAP_WIDTH: usize = 100;
+
+// One block per recipe (name, then indented description and location) that
+// wraps to the real terminal width instead of truncating: a truncated
+// description or file path is not useful, it just hides information.
+fn print_recipe_rows(rows: &[RecipeRow], terminal_width: Option<usize>) {
+    let width = terminal_width.unwrap_or(DEFAULT_WRAP_WIDTH);
+    let content_width = width
+        .saturating_sub(measure_text_width(RECIPE_LIST_INDENT))
+        .max(1);
+
+    for row in rows {
+        if row.has_collision {
+            println!(
+                "{} {}",
+                style("⚠").yellow(),
+                style(&row.name).blue().bold()
+            );
+        } else {
+            println!("{}", style(&row.name).blue().bold());
+        }
+        for line in wrap_text(&row.description, content_width) {
+            println!("{RECIPE_LIST_INDENT}{}", style(line).white());
+        }
+        for line in wrap_path(&row.location, content_width) {
+            println!("{RECIPE_LIST_INDENT}{}", style(line).yellow());
+        }
+        println!();
+    }
+}
+
+// Word-wraps prose (splits on whitespace) to the given display width,
+// measuring width via console::measure_text_width so it stays correct if
+// the caller wraps already-styled/ANSI text.
+fn wrap_text(text: &str, max_width: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    for word in text.split_whitespace() {
+        if measure_text_width(word) > max_width {
+            if !current.is_empty() {
+                lines.push(std::mem::take(&mut current));
+            }
+            lines.extend(hard_wrap(word, max_width));
+            continue;
+        }
+        let candidate = if current.is_empty() {
+            word.to_string()
+        } else {
+            format!("{current} {word}")
+        };
+        if measure_text_width(&candidate) <= max_width {
+            current = candidate;
+        } else {
+            lines.push(std::mem::take(&mut current));
+            current = word.to_string();
+        }
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    if lines.is_empty() {
+        lines.push(String::new());
+    }
+    lines
+}
+
+// Wraps a file path (or the "⚠ N locations" summary) at '/' boundaries
+// rather than whitespace, since paths have no spaces to break on.
+fn wrap_path(text: &str, max_width: usize) -> Vec<String> {
+    if measure_text_width(text) <= max_width {
+        return vec![text.to_string()];
+    }
+
+    let mut segments = Vec::new();
+    let mut segment = String::new();
+    for ch in text.chars() {
+        segment.push(ch);
+        if ch == '/' {
+            segments.push(std::mem::take(&mut segment));
+        }
+    }
+    if !segment.is_empty() {
+        segments.push(segment);
+    }
+
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    for seg in segments {
+        if measure_text_width(&seg) > max_width {
+            if !current.is_empty() {
+                lines.push(std::mem::take(&mut current));
+            }
+            lines.extend(hard_wrap(&seg, max_width));
+            continue;
+        }
+        let candidate = format!("{current}{seg}");
+        if measure_text_width(&candidate) <= max_width {
+            current = candidate;
+        } else {
+            lines.push(std::mem::take(&mut current));
+            current = seg;
+        }
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    lines
+}
+
+// Last-resort character-level split for a single token wider than the
+// available width (an unbroken long word, or a path segment with no '/').
+fn hard_wrap(token: &str, max_width: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    for ch in token.chars() {
+        let candidate_width = measure_text_width(&current) + measure_text_width(&ch.to_string());
+        if candidate_width > max_width && !current.is_empty() {
+            lines.push(std::mem::take(&mut current));
+        }
+        current.push(ch);
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    lines
 }
 
 fn describe(recipe: &RecipeInfo) -> String {
@@ -196,6 +352,25 @@ fn describe(recipe: &RecipeInfo) -> String {
 fn source_path(recipe: &RecipeInfo) -> String {
     match recipe.source {
         RecipeSource::Local => format!("local: {}", recipe.path),
+        RecipeSource::GitHub => format!("github: {}", recipe.path),
+    }
+}
+
+// Compact form for the table view: collapses $HOME to `~` so a single
+// local path doesn't blow out the column width. Verbose mode keeps the
+// full path from `source_path` since that's the detail view.
+fn short_source_path(recipe: &RecipeInfo) -> String {
+    match recipe.source {
+        RecipeSource::Local => {
+            let display_path = match etcetera::home_dir().ok() {
+                Some(home) => match Path::new(&recipe.path).strip_prefix(&home) {
+                    Ok(rest) => format!("~/{}", rest.display()),
+                    Err(_) => recipe.path.clone(),
+                },
+                None => recipe.path.clone(),
+            };
+            format!("local: {display_path}")
+        }
         RecipeSource::GitHub => format!("github: {}", recipe.path),
     }
 }
@@ -564,5 +739,56 @@ instructions: "Test instructions"
 
         let github = recipe_info(RecipeSource::GitHub, "org/repo/recipe.yaml", None);
         assert_eq!(source_path(&github), "github: org/repo/recipe.yaml");
+    }
+
+    #[test]
+    fn test_wrap_text_breaks_on_whitespace_within_width() {
+        let text = "a fairly long description that should wrap across lines";
+        let lines = wrap_text(text, 20);
+        assert!(lines.len() > 1);
+        for line in &lines {
+            assert!(measure_text_width(line) <= 20, "line too wide: {line:?}");
+        }
+        assert_eq!(lines.join(" "), text);
+    }
+
+    #[test]
+    fn test_wrap_text_short_text_single_line() {
+        let text = "short";
+        assert_eq!(wrap_text(text, 40), vec!["short".to_string()]);
+    }
+
+    #[test]
+    fn test_wrap_text_never_truncates_content() {
+        let text = "supercalifragilisticexpialidocious word";
+        let lines = wrap_text(text, 10);
+        let rejoined: String = lines.join("");
+        assert!(rejoined.contains("supercalifragilisticexpialidocious"));
+        assert!(rejoined.contains("word"));
+    }
+
+    #[test]
+    fn test_wrap_path_breaks_on_slash_boundaries() {
+        let path = "local: ~/AOF/work/projects/forks/goose/_tortu/recipes/codebase-analyzer.yaml";
+        let lines = wrap_path(path, 30);
+        assert!(lines.len() > 1);
+        for line in &lines {
+            assert!(measure_text_width(line) <= 30, "line too wide: {line:?}");
+        }
+        assert_eq!(lines.concat(), path);
+        assert!(lines.last().unwrap().ends_with("codebase-analyzer.yaml"));
+    }
+
+    #[test]
+    fn test_wrap_path_short_text_unchanged() {
+        let path = "local: recipe.yaml";
+        assert_eq!(wrap_path(path, 40), vec![path.to_string()]);
+    }
+
+    #[test]
+    fn test_wrap_path_never_truncates_content() {
+        let path = "local: ~/AOF/work/projects/forks/goose/_tortu/recipes/codebase-analyzer.yaml";
+        let lines = wrap_path(path, 5);
+        assert_eq!(lines.concat(), path);
     }
 }

--- a/crates/goose-cli/src/commands/recipe.rs
+++ b/crates/goose-cli/src/commands/recipe.rs
@@ -1,9 +1,10 @@
 use anyhow::Result;
+use comfy_table::{presets::UTF8_FULL_CONDENSED, ContentArrangement, Table};
 use console::style;
 use goose::recipe::validate_recipe::validate_recipe_template_from_file;
 use std::collections::HashMap;
 
-use crate::recipes::github_recipe::RecipeSource;
+use crate::recipes::github_recipe::{RecipeInfo, RecipeSource};
 use crate::recipes::search_recipe::{list_available_recipes, load_recipe_file};
 use goose::recipe_deeplink;
 
@@ -100,7 +101,7 @@ where
 }
 
 pub fn handle_list(format: &str, verbose: bool) -> Result<()> {
-    let recipes = match list_available_recipes() {
+    let mut recipes = match list_available_recipes() {
         Ok(recipes) => recipes,
         Err(e) => {
             return Err(anyhow::anyhow!("Failed to list recipes: {}", e));
@@ -109,45 +110,94 @@ pub fn handle_list(format: &str, verbose: bool) -> Result<()> {
 
     match format {
         "json" => {
+            // Unchanged: flat array, so existing automation/scripts don't break.
             println!("{}", serde_json::to_string(&recipes)?);
         }
         _ => {
             if recipes.is_empty() {
                 println!("No recipes found");
                 return Ok(());
-            } else {
-                println!("Available recipes:");
-                for recipe in recipes {
-                    let source_info = match recipe.source {
-                        RecipeSource::Local => format!("local: {}", recipe.path),
-                        RecipeSource::GitHub => format!("github: {}", recipe.path),
-                    };
+            }
 
-                    let description = if let Some(desc) = &recipe.description {
-                        if desc.is_empty() {
-                            "(none)"
-                        } else {
-                            desc
-                        }
-                    } else {
-                        "(none)"
-                    };
+            recipes.sort_by(|a, b| a.name.cmp(&b.name));
 
-                    let output = format!("{} - {} - {}", recipe.name, description, source_info);
-                    if verbose {
-                        println!("  {}", output);
-                        if let Some(title) = &recipe.title {
-                            println!("    Title: {}", title);
-                        }
-                        println!("    Path: {}", recipe.path);
-                    } else {
-                        println!("{}", output);
-                    }
+            // Group by name. A recipe found via more than one search path
+            // (GOOSE_RECIPE_PATH + cwd, most commonly) currently prints as
+            // flat, indistinguishable duplicate rows with no indication
+            // that one file silently shadows the other. Group instead of
+            // hiding the collision.
+            let mut groups: Vec<(String, Vec<&RecipeInfo>)> = Vec::new();
+            for recipe in &recipes {
+                match groups.last_mut() {
+                    Some((name, entries)) if *name == recipe.name => entries.push(recipe),
+                    _ => groups.push((recipe.name.clone(), vec![recipe])),
                 }
+            }
+
+            if verbose {
+                for (name, entries) in &groups {
+                    println!("{}", style(name).bold());
+                    println!("  {}", describe(entries[0]));
+                    if entries.len() > 1 {
+                        println!(
+                            "  {} found in {} locations (later paths override earlier ones):",
+                            style("⚠").yellow(),
+                            entries.len()
+                        );
+                        for (i, entry) in entries.iter().enumerate() {
+                            println!("    {}. {}", i + 1, source_path(entry));
+                        }
+                    } else {
+                        println!("  {}", source_path(entries[0]));
+                    }
+                    println!();
+                }
+                return Ok(());
+            }
+
+            let mut table = Table::new();
+            table
+                .load_preset(UTF8_FULL_CONDENSED)
+                .set_content_arrangement(ContentArrangement::Dynamic)
+                .set_header(vec!["Name", "Description", "Location"]);
+
+            for (name, entries) in &groups {
+                let location = if entries.len() > 1 {
+                    format!("⚠ {} locations", entries.len())
+                } else {
+                    source_path(entries[0])
+                };
+                table.add_row(vec![name.clone(), describe(entries[0]), location]);
+            }
+
+            println!("{table}");
+
+            let dup_count = groups.iter().filter(|(_, entries)| entries.len() > 1).count();
+            if dup_count > 0 {
+                println!(
+                    "\n{} {} recipe{} found in multiple locations. Run with --verbose for full paths.",
+                    style("⚠").yellow(),
+                    dup_count,
+                    if dup_count == 1 { "" } else { "s" }
+                );
             }
         }
     }
     Ok(())
+}
+
+fn describe(recipe: &RecipeInfo) -> String {
+    match &recipe.description {
+        Some(desc) if !desc.is_empty() => desc.clone(),
+        _ => "(none)".to_string(),
+    }
+}
+
+fn source_path(recipe: &RecipeInfo) -> String {
+    match recipe.source {
+        RecipeSource::Local => format!("local: {}", recipe.path),
+        RecipeSource::GitHub => format!("github: {}", recipe.path),
+    }
 }
 
 fn parse_params(params: &[String]) -> Result<HashMap<String, String>> {
@@ -480,5 +530,39 @@ instructions: "Test instructions"
         assert!(result.is_ok());
         let map = result.unwrap();
         assert!(map.is_empty());
+    }
+
+    fn recipe_info(source: RecipeSource, path: &str, description: Option<&str>) -> RecipeInfo {
+        RecipeInfo {
+            name: "example".to_string(),
+            source,
+            path: path.to_string(),
+            title: None,
+            description: description.map(|d| d.to_string()),
+        }
+    }
+
+    #[test]
+    fn test_describe_with_description() {
+        let recipe = recipe_info(RecipeSource::Local, "recipe.yaml", Some("Does a thing"));
+        assert_eq!(describe(&recipe), "Does a thing");
+    }
+
+    #[test]
+    fn test_describe_missing_or_empty() {
+        let no_desc = recipe_info(RecipeSource::Local, "recipe.yaml", None);
+        assert_eq!(describe(&no_desc), "(none)");
+
+        let empty_desc = recipe_info(RecipeSource::Local, "recipe.yaml", Some(""));
+        assert_eq!(describe(&empty_desc), "(none)");
+    }
+
+    #[test]
+    fn test_source_path_local_and_github() {
+        let local = recipe_info(RecipeSource::Local, "/home/user/recipe.yaml", None);
+        assert_eq!(source_path(&local), "local: /home/user/recipe.yaml");
+
+        let github = recipe_info(RecipeSource::GitHub, "org/repo/recipe.yaml", None);
+        assert_eq!(source_path(&github), "github: org/repo/recipe.yaml");
     }
 }


### PR DESCRIPTION
## Problem

`goose recipe list` printed a flat table with no deduplication: if a recipe name existed on more than one search path (e.g. a local recipe shadowing a bundled one), it showed up as separate, unlabeled rows with no indication of the collision. Long descriptions and paths were also silently truncated by the table's fixed column widths, which hides real information rather than surfacing it.

## What changed

Rewrites the default (non-`--format json`) output of `goose recipe list` as one block per recipe — name, then an indented, word-wrapped description and location — built against the [clig.dev](https://clig.dev/) CLI guidelines:

- Groups recipes by name and flags duplicate-name collisions with `⚠` instead of silently listing them as unrelated rows.
- Word-wraps descriptions and paths to the real terminal width instead of truncating.
- Uses semantic color/glyphs only: bold blue recipe name, `⚠` for collisions, `✓` in the summary line.
- Degrades gracefully under `NO_COLOR` / non-TTY output via `console`'s built-in detection — no special-casing needed in this patch.
- No new dependency: built entirely on `console`, already in `goose-cli`'s `Cargo.toml`. (Drops this file's prior use of `comfy-table` in favor of the block layout.)

`--format json` output is unchanged.

## Before / after

Before (flat bordered table, fixed-width columns, no grouping):
```
┌──────────────────┬──────────────────────────────┬─────────────────────┐
│ Name              │ Description                   │ Location             │
├──────────────────┼──────────────────────────────┼─────────────────────┤
│ change-log        │ Generate Change Logs from Git…│ local: /Users/doug…  │
└──────────────────┴──────────────────────────────┴─────────────────────┘
```

After (real output, `NO_COLOR=1 goose recipe list`, one entry per block):
```
Available recipes (18 recipes):

change-log
    Generate Change Logs from Git Commits
    local: ~/AOF/work/projects/forks/goose/_tortu/recipes/change-log.yaml

code-reviewer
    Specialized subagent for code quality and security analysis
    local: ~/AOF/work/projects/forks/goose/_tortu/recipes/code-reviewer.yaml

codebase-analyzer
    Deep analysis of code implementation details, data flow tracing, and architectural patterns
    local: ~/AOF/work/projects/forks/goose/_tortu/recipes/codebase-analyzer.yaml
```

Output follows the clig.dev CLI guidelines (semantic color, NO_COLOR/non-TTY degradation); no new dependencies.

## Testing

- `cargo test -p goose-cli commands::recipe` — 28 passed (6 new: `wrap_text`/`wrap_path` wrapping, truncation, and boundary cases).
- `cargo clippy -p goose-cli --lib -- -D warnings` — clean.
- Dogfooded against a real, multi-directory recipe set for several days.

---

This is a proof-of-concept patch: I identified the problem and worked through the approach with Claude (Anthropic) as a co-coding partner, then validated it working in my own local install. I'm sharing it as a starting point rather than a polished final implementation — feel free to modify, refactor, or take the idea in a different direction if that fits the project's conventions or roadmap better.
