### PR TITLE
feat(ovhcloud): add Qwen3.6-27B model (262K context, \$0.47/\$3.19 pe…

### DIFF
--- a/crates/goose-providers/src/declarative/definitions/ovhcloud.json
+++ b/crates/goose-providers/src/declarative/definitions/ovhcloud.json
@@ -14,6 +14,13 @@
       "currency": "USD"
     },
     {
+      "name": "Qwen3.6-27B",
+      "context_limit": 262144,
+      "input_token_cost": 0.00000047,
+      "output_token_cost": 0.00000319,
+      "currency": "USD"
+    },
+    {
       "name": "Qwen2.5-VL-72B-Instruct",
       "context_limit": 32768,
       "input_token_cost": 0.00000101,


### PR DESCRIPTION
````markdown
## Summary

When using Goose Desktop 1.41 with the OVHCloud provider, the model `Qwen3.6-27B` is not handled correctly.

The OVH OpenAI-compatible `/v1/models` endpoint reports:

```json
{
  "id": "Qwen3.6-27B",
  "context_length": 262144,
  "max_completion_tokens": 262144
}
````

However:

* Goose Desktop displays a 128k context window instead of 262k.
* Selecting `Qwen3.6-27B` from the UI results in an **"Invalid params"** error.
* The model only works when manually configured in `config.yaml`.
* Other OVHCloud models (e.g. `gpt-oss-120b`) are detected correctly and their context window is displayed properly. [\[github.com\]](https://github.com/aaif-goose/goose/issues/4357), [\[github.com\]](https://github.com/aaif-goose/goose)

## Root Cause

It appears that `Qwen3.6-27B` is either missing from the model recognition/mapping logic or is not correctly matched by the OVHCloud provider implementation.

As a result, Goose falls back to the default 128k context limit instead of using the `context_length` value returned by the OVH endpoint. [\[github.com\]](https://github.com/aaif-goose/goose/releases), [\[github.com\]](https://github.com/aaif-goose/goose/tree/main/documentation), [\[github.com\]](https://github.com/aaif-goose/goose/issues/4357)

## Proposed Fix

Add support for `Qwen3.6-27B` in the model mapping logic and use the advertised context window:

```json
"context_length": 262144
```

This should allow:

* Correct context window display (262k).
* Successful model selection from the UI.
* Consistent behavior with other OVHCloud-hosted models. [\[github.com\]](https://github.com/aaif-goose/goose/issues/4357), [\[github.com\]](https://github.com/aaif-goose/goose/tree/main/documentation)

