### PR TITLE
fix: reasoning_content Error (Related to Deepseek and Kimi Models)

### DIFF
--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -487,6 +487,17 @@ pub fn format_messages_with_options(
             converted["reasoning_content"] = json!(reasoning_text);
         }
 
+        // DeepSeek thinking mode requires reasoning_content on every tool-call
+        // assistant message. Ensure the field is present even when there is no
+        // reasoning to report — null signals "no reasoning" to the API without
+        // triggering Kimi's rejection of the empty string.
+        if options.preserve_thinking_context
+            && reasoning_text.is_empty()
+            && converted.get("tool_calls").is_some()
+        {
+            converted["reasoning_content"] = json!(null);
+        }
+
         if has_message_payload {
             output.insert(0, converted);
         }

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -526,7 +526,10 @@ fn merge_split_tool_call_messages(messages: &mut Vec<Value>) {
                 .is_some_and(|a| !a.is_empty());
         let base_reasoning = messages[i].get("reasoning_content");
 
-        if !is_assistant_tool_call || base_reasoning.is_none() {
+        if !is_assistant_tool_call
+            || base_reasoning.is_none()
+            || base_reasoning.is_some_and(|v| v.is_null())
+        {
             i += 1;
             continue;
         }
@@ -3366,7 +3369,11 @@ data: [DONE]"#;
         assert_eq!(spec.len(), 2);
         assert_eq!(spec[0]["role"], "user");
         assert_eq!(spec[1]["role"], "assistant");
-        assert!(spec[1].get("reasoning_content").is_none());
+        // reasoning_content is set to null on tool-call-only messages so
+        // DeepSeek thinking mode doesn't reject the request (the field must
+        // be present). It does NOT carry the stale thinking from the previous
+        // assistant message.
+        assert!(spec[1].get("reasoning_content").is_none_or(|v| v.is_null()));
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
I haven't been able to use any Deepseek model in Goose. API calls always fail no matter what the prompt is:

> Ran into this error: Request failed: Bad request (400): The reasoning_content in the thinking mode must be passed back to the API.

This happens because of how Deepseek API works in thinking mode. When the assistant thinks before answering, it sends back `reasoning_content` field alongside the regular response. Goose doesn't include `reasoning_content` field if it is empty. But Deepseek's API requires this field to be present in every subsequent request.

**The fixes**
1. If there is no thinking text, but the assistant message has tool call, set `reasoning_content` field to `null`. This signals "no reasoning" without triggering Deepseek's rejection.
2. Since we've added `null reasoning_content` to all tool-call messages, the `merge_split_tool_call_messages` function may try to merge unrelated tool-call messages because they both have the same `null` value for `reasoning_content`. So I've added a guard to skip merging when reasoning_content is null. 
### Testing
These changes have been tested with unit/integration tests.

### Related Issues
solves #9632 and #10012 