### PR TITLE
feat(providers): add grok-4.5 and grok-4 reasoning model support for xAI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,46 @@ crates/
 ui/desktop/            # Electron app
 ```
 
+## Canonical Models Registry
+
+The canonical model catalog lives in `crates/goose-provider-types/src/canonical/data/canonical_models.json`.
+It maps provider-specific model ids (e.g. `x-ai/grok-4.5`, `openai/gpt-4o`) to shared metadata
+(reasoning, context limits, pricing, modalities). Without a canonical entry, a new model only works
+via the live provider fetch path and may not appear in the picker.
+
+### Adding a new model to the catalog
+
+```bash
+# Full regeneration from models.dev (writes canonical_models.json + provider_metadata.json)
+source bin/activate-hermit   # provides cmake needed by llama-cpp-sys-2
+cargo run --bin build_canonical_models
+```
+
+This pulls the entire models.dev API and produces a large diff (thousands of lines). For a **focused PR**
+that only needs one model family, prefer a **surgical graft**: extract just the relevant entries from the
+regenerated output and merge them into the committed file, leaving unrelated additions for a separate
+maintenance PR.
+
+```bash
+# Surgical example: add only grok-4.5 entries
+F=crates/goose-provider-types/src/canonical/data/canonical_models.json
+jq '[.[] | select(.id | test("grok-4\\.5"))]' "$F" > /tmp/entries.json   # extract
+git checkout HEAD -- "$F"                                                 # restore
+jq -s '.[0] + .[1] | sort_by(.id)' "$F" /tmp/entries.json > /tmp/merged.json
+cp /tmp/merged.json "$F"                                                  # re-merge
+```
+
+After editing the data file, verify:
+```bash
+cargo test -p goose-provider-types --lib canonical
+```
+
+### `temperature` metadata caveat
+
+The canonical entry may report `temperature: true`, but provider code can still intentionally omit
+temperature for specific reasoning models (e.g. xAI grok-4+). The code-level omission in
+`create_request_with_options` takes precedence at request time.
+
 ## Development Loop
 ```bash
 # 1. source bin/activate-hermit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,8 +62,9 @@ via the live provider fetch path and may not appear in the picker.
 
 ```bash
 # Full regeneration from models.dev (writes canonical_models.json + provider_metadata.json)
+# The release process runs this via `just build-canonical-models` and includes all changes.
 source bin/activate-hermit   # provides cmake needed by llama-cpp-sys-2
-cargo run --bin build_canonical_models
+just build-canonical-models
 ```
 
 This pulls the entire models.dev API and produces a large diff (thousands of lines). For a **focused PR**

--- a/crates/goose-provider-types/src/canonical/data/canonical_models.json
+++ b/crates/goose-provider-types/src/canonical/data/canonical_models.json
@@ -158672,8 +158672,8 @@
     "open_weights": false,
     "cost": {},
     "limit": {
-      "context": 2000000,
-      "output": 2000000
+      "context": 1000000,
+      "output": 30000
     }
   },
   {
@@ -158700,8 +158700,8 @@
     "open_weights": false,
     "cost": {},
     "limit": {
-      "context": 2000000,
-      "output": 2000000
+      "context": 1000000,
+      "output": 30000
     }
   },
   {

--- a/crates/goose-provider-types/src/canonical/data/canonical_models.json
+++ b/crates/goose-provider-types/src/canonical/data/canonical_models.json
@@ -158618,6 +158618,93 @@
     }
   },
   {
+    "id": "x-ai/grok-4",
+    "name": "Grok 4",
+    "family": "grok",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-07",
+    "release_date": "2025-07-09",
+    "last_updated": "2025-07-09",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.75,
+      "cache_write": 15.0
+    },
+    "limit": {
+      "context": 256000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "x-ai/grok-4-fast-non-reasoning",
+    "name": "Grok 4 Fast Non-Reasoning",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-12-18",
+    "last_updated": "2025-12-18",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 2000000,
+      "output": 2000000
+    }
+  },
+  {
+    "id": "x-ai/grok-4-fast-reasoning",
+    "name": "Grok 4 Fast Reasoning",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-12-18",
+    "last_updated": "2025-12-18",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 2000000,
+      "output": 2000000
+    }
+  },
+  {
     "id": "x-ai/grok-4.20-0309-non-reasoning",
     "name": "Grok 4.20 (Non-Reasoning)",
     "family": "grok",

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1402,7 +1402,7 @@ pub fn create_request_with_options(
     } else if supports_xai_reasoning_effort(&model_name) {
         model_config
             .thinking_effort()
-            .and_then(xai_reasoning_effort_for_thinking)
+            .and_then(|effort| xai_reasoning_effort_for_thinking(&model_name, effort))
     } else {
         None
     };
@@ -1562,12 +1562,22 @@ pub fn supports_xai_reasoning_effort(model_name: &str) -> bool {
 /// Map a [`ThinkingEffort`] to the `reasoning_effort` value xAI accepts.
 ///
 /// xAI supports `"low"`, `"medium"`, and `"high"` for models that accept
-/// `reasoning_effort` (see [`supports_xai_reasoning_effort`]).
-/// `"none"` / `"xhigh"` are not used: `Off` omits the parameter entirely so
-/// xAI applies its default, and `Max` clamps to `"high"`.
-pub fn xai_reasoning_effort_for_thinking(effort: ThinkingEffort) -> Option<String> {
+/// `reasoning_effort` (see [`supports_xai_reasoning_effort`]). `Max` clamps
+/// to `"high"`. For `Off`, grok-4.3 documents `"none"` as a valid value that
+/// explicitly disables reasoning; other models omit the parameter so xAI
+/// applies its default.
+pub fn xai_reasoning_effort_for_thinking(
+    model_name: &str,
+    effort: ThinkingEffort,
+) -> Option<String> {
     match effort {
-        ThinkingEffort::Off => None,
+        ThinkingEffort::Off => {
+            if model_name.to_ascii_lowercase().starts_with("grok-4.3") {
+                Some("none".to_string())
+            } else {
+                None
+            }
+        }
         ThinkingEffort::Low => Some("low".to_string()),
         ThinkingEffort::Medium => Some("medium".to_string()),
         ThinkingEffort::High | ThinkingEffort::Max => Some("high".to_string()),
@@ -4229,22 +4239,40 @@ data: [DONE]"#;
     #[test]
     fn test_xai_reasoning_effort_maps_to_supported_values() {
         use crate::thinking::ThinkingEffort;
-        assert_eq!(xai_reasoning_effort_for_thinking(ThinkingEffort::Off), None);
+        // grok-4.5: Off omits reasoning_effort (not documented as accepting "none")
         assert_eq!(
-            xai_reasoning_effort_for_thinking(ThinkingEffort::Low),
+            xai_reasoning_effort_for_thinking("grok-4.5", ThinkingEffort::Off),
+            None
+        );
+        assert_eq!(
+            xai_reasoning_effort_for_thinking("grok-4.5", ThinkingEffort::Low),
             Some("low".to_string())
         );
         assert_eq!(
-            xai_reasoning_effort_for_thinking(ThinkingEffort::Medium),
+            xai_reasoning_effort_for_thinking("grok-4.5", ThinkingEffort::Medium),
             Some("medium".to_string())
         );
         assert_eq!(
-            xai_reasoning_effort_for_thinking(ThinkingEffort::High),
+            xai_reasoning_effort_for_thinking("grok-4.5", ThinkingEffort::High),
             Some("high".to_string())
         );
         assert_eq!(
-            xai_reasoning_effort_for_thinking(ThinkingEffort::Max),
+            xai_reasoning_effort_for_thinking("grok-4.5", ThinkingEffort::Max),
             Some("high".to_string())
+        );
+    }
+
+    #[test]
+    fn test_xai_reasoning_effort_off_maps_to_none_for_grok_4_3() {
+        use crate::thinking::ThinkingEffort;
+        // grok-4.3 documents "none" as a valid reasoning_effort value
+        assert_eq!(
+            xai_reasoning_effort_for_thinking("grok-4.3", ThinkingEffort::Off),
+            Some("none".to_string())
+        );
+        assert_eq!(
+            xai_reasoning_effort_for_thinking("grok-4.3-latest", ThinkingEffort::Off),
+            Some("none".to_string())
         );
     }
 
@@ -4352,8 +4380,31 @@ data: [DONE]"#;
 
         assert!(
             payload.get("reasoning_effort").is_none(),
-            "Off must omit reasoning_effort for xAI, got: {:?}",
+            "Off must omit reasoning_effort for grok-4.5, got: {:?}",
             payload.get("reasoning_effort")
+        );
+    }
+
+    #[test]
+    fn test_create_request_sends_none_effort_for_grok_4_3_off() {
+        use crate::thinking::ThinkingEffort;
+
+        let model_config = ModelConfig::new("grok-4.3").with_thinking_effort(ThinkingEffort::Off);
+
+        let payload = create_request(
+            &model_config,
+            "system prompt",
+            &[],
+            &[],
+            &ImageFormat::OpenAi,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            payload.get("reasoning_effort"),
+            Some(&json!("none")),
+            "Off must send reasoning_effort=none for grok-4.3 (documented support)"
         );
     }
 

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1390,12 +1390,19 @@ pub fn create_request_with_options(
 
     let (model_name, legacy_reasoning_effort) = extract_reasoning_effort(&model_config.model_name);
     let is_reasoning_model = is_openai_responses_model(&model_name);
+    let is_xai_reasoning = is_xai_reasoning_model(&model_name);
+    // Effort is narrower than temperature omit: classic `grok-4` and several
+    // newer slugs reject `reasoning_effort` even though they are reasoning models.
     let reasoning_effort = if is_reasoning_model {
         model_config
             .thinking_effort()
             .map_or(legacy_reasoning_effort, |effort| {
                 openai_reasoning_effort_for_thinking(&model_name, effort)
             })
+    } else if supports_xai_reasoning_effort(&model_name) {
+        model_config
+            .thinking_effort()
+            .and_then(xai_reasoning_effort_for_thinking)
     } else {
         None
     };
@@ -1426,7 +1433,7 @@ pub fn create_request_with_options(
         payload["tools"] = json!(tools_spec);
     }
 
-    if !is_reasoning_model {
+    if !is_reasoning_model && !is_xai_reasoning {
         if let Some(temp) = model_config.temperature {
             payload["temperature"] = json!(temp);
         }
@@ -1509,6 +1516,62 @@ pub fn is_openai_responses_model(model_name: &str) -> bool {
     let re =
         RE.get_or_init(|| Regex::new(r"(?i)(?:^|[-/])(?:o\d+(?:$|-)|gpt-5(?:$|[-.]))").unwrap());
     re.is_match(model_name)
+}
+
+/// True for xAI Grok models that perform server-side reasoning and therefore
+/// reject the `temperature` parameter (similar to OpenAI o-series / gpt-5).
+///
+/// This is **not** the same as [`is_openai_responses_model`] — xAI uses the
+/// standard Chat Completions API, not the Responses API, so the system role,
+/// `max_tokens` key, and other Responses-API quirks do not apply.  The only
+/// shared behaviour is that `temperature` must be omitted.
+///
+/// Prefer [`supports_xai_reasoning_effort`] before emitting `reasoning_effort`:
+/// not every temperature-sensitive Grok slug accepts that parameter.
+pub fn is_xai_reasoning_model(model_name: &str) -> bool {
+    let lower = model_name.to_ascii_lowercase();
+    if lower.starts_with("grok-3-mini") {
+        return true;
+    }
+    // grok-4+ (including dotted variants like grok-4.5) are reasoning models,
+    // except for explicit non-reasoning variants.
+    if lower.starts_with("grok-4") {
+        return !lower.contains("non-reasoning") && !lower.contains("non_reasoning");
+    }
+    false
+}
+
+/// True for xAI models that accept the Chat Completions `reasoning_effort`
+/// parameter.
+///
+/// Current xAI docs document `reasoning_effort` for `grok-4.5` (and the
+/// closely related `grok-4.3` migration target). Classic `grok-4` rejects it,
+/// and several current slugs such as `grok-4-1-fast` / `grok-4.20` are not
+/// documented as accepting this Chat Completions field either.
+pub fn supports_xai_reasoning_effort(model_name: &str) -> bool {
+    let lower = model_name.to_ascii_lowercase();
+    if lower.starts_with("grok-3-mini") {
+        return true;
+    }
+    if lower.starts_with("grok-4.5") || lower.starts_with("grok-4.3") {
+        return !lower.contains("non-reasoning") && !lower.contains("non_reasoning");
+    }
+    false
+}
+
+/// Map a [`ThinkingEffort`] to the `reasoning_effort` value xAI accepts.
+///
+/// xAI supports `"low"`, `"medium"`, and `"high"` for models that accept
+/// `reasoning_effort` (see [`supports_xai_reasoning_effort`]).
+/// `"none"` / `"xhigh"` are not used: `Off` omits the parameter entirely so
+/// xAI applies its default, and `Max` clamps to `"high"`.
+pub fn xai_reasoning_effort_for_thinking(effort: ThinkingEffort) -> Option<String> {
+    match effort {
+        ThinkingEffort::Off => None,
+        ThinkingEffort::Low => Some("low".to_string()),
+        ThinkingEffort::Medium => Some("medium".to_string()),
+        ThinkingEffort::High | ThinkingEffort::Max => Some("high".to_string()),
+    }
 }
 
 pub fn openai_reasoning_effort_for_thinking(
@@ -4089,6 +4152,292 @@ data: [DONE]"#;
                 "{model} should not match"
             );
         }
+    }
+
+    #[test]
+    fn test_is_xai_reasoning_model_detects_grok4_and_mini() {
+        for model in [
+            "grok-4-0709",
+            "grok-4-latest",
+            "grok-4.5",
+            "grok-4-fast-reasoning",
+            "grok-4-fast-reasoning-latest",
+            "grok-3-mini",
+            "grok-3-mini-fast",
+            "grok-3-mini-latest",
+        ] {
+            assert!(is_xai_reasoning_model(model), "{model} should be reasoning");
+        }
+    }
+
+    #[test]
+    fn test_is_xai_reasoning_model_excludes_non_reasoning_and_older() {
+        for model in [
+            "grok-4-fast-non-reasoning",
+            "grok-4-fast-non-reasoning-latest",
+            "grok-3",
+            "grok-3-fast",
+            "grok-2",
+            "grok-2-latest",
+            "grok-code-fast-1",
+        ] {
+            assert!(
+                !is_xai_reasoning_model(model),
+                "{model} should not be reasoning"
+            );
+        }
+    }
+
+    #[test]
+    fn test_supports_xai_reasoning_effort_allowlist() {
+        for model in [
+            "grok-4.5",
+            "grok-4.5-latest",
+            "grok-4.3",
+            "grok-3-mini",
+            "grok-3-mini-fast",
+        ] {
+            assert!(
+                supports_xai_reasoning_effort(model),
+                "{model} should accept reasoning_effort"
+            );
+        }
+    }
+
+    #[test]
+    fn test_supports_xai_reasoning_effort_excludes_classic_and_fast_slugs() {
+        for model in [
+            "grok-4",
+            "grok-4-0709",
+            "grok-4-latest",
+            "grok-4-1-fast",
+            "grok-4-1-fast-reasoning",
+            "grok-4-fast-reasoning",
+            "grok-4.20",
+            "grok-4.20-0309-reasoning",
+            "grok-4-fast-non-reasoning",
+            "grok-3",
+            "grok-code-fast-1",
+        ] {
+            assert!(
+                !supports_xai_reasoning_effort(model),
+                "{model} should not accept reasoning_effort"
+            );
+        }
+    }
+
+    #[test]
+    fn test_xai_reasoning_effort_maps_to_supported_values() {
+        use crate::thinking::ThinkingEffort;
+        assert_eq!(xai_reasoning_effort_for_thinking(ThinkingEffort::Off), None);
+        assert_eq!(
+            xai_reasoning_effort_for_thinking(ThinkingEffort::Low),
+            Some("low".to_string())
+        );
+        assert_eq!(
+            xai_reasoning_effort_for_thinking(ThinkingEffort::Medium),
+            Some("medium".to_string())
+        );
+        assert_eq!(
+            xai_reasoning_effort_for_thinking(ThinkingEffort::High),
+            Some("high".to_string())
+        );
+        assert_eq!(
+            xai_reasoning_effort_for_thinking(ThinkingEffort::Max),
+            Some("high".to_string())
+        );
+    }
+
+    #[test]
+    fn test_create_request_omits_temperature_for_xai_reasoning() {
+        let mut model_config = ModelConfig::new("grok-4.5");
+        model_config.temperature = Some(0.0);
+
+        let payload = create_request(
+            &model_config,
+            "system prompt",
+            &[],
+            &[],
+            &ImageFormat::OpenAi,
+            false,
+        )
+        .unwrap();
+
+        assert!(
+            payload.get("temperature").is_none(),
+            "temperature must be omitted for xAI reasoning models, got: {:?}",
+            payload.get("temperature")
+        );
+    }
+
+    #[test]
+    fn test_create_request_sends_temperature_for_xai_non_reasoning() {
+        let mut model_config = ModelConfig::new("grok-3");
+        model_config.temperature = Some(1.0);
+
+        let payload = create_request(
+            &model_config,
+            "system prompt",
+            &[],
+            &[],
+            &ImageFormat::OpenAi,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(payload.get("temperature"), Some(&json!(1.0)));
+    }
+
+    #[test]
+    fn test_create_request_sends_xai_reasoning_effort() {
+        use crate::thinking::ThinkingEffort;
+
+        let model_config = ModelConfig::new("grok-4.5")
+            .with_thinking_effort(ThinkingEffort::High)
+            .with_temperature(Some(0.0));
+
+        let payload = create_request(
+            &model_config,
+            "system prompt",
+            &[],
+            &[],
+            &ImageFormat::OpenAi,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(payload.get("model"), Some(&json!("grok-4.5")));
+        assert_eq!(payload.get("reasoning_effort"), Some(&json!("high")));
+        assert!(
+            payload.get("temperature").is_none(),
+            "temperature must still be omitted when reasoning_effort is set"
+        );
+    }
+
+    #[test]
+    fn test_create_request_maps_xai_medium_effort() {
+        use crate::thinking::ThinkingEffort;
+
+        let model_config =
+            ModelConfig::new("grok-4.5").with_thinking_effort(ThinkingEffort::Medium);
+
+        let payload = create_request(
+            &model_config,
+            "system prompt",
+            &[],
+            &[],
+            &ImageFormat::OpenAi,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(payload.get("reasoning_effort"), Some(&json!("medium")));
+    }
+
+    #[test]
+    fn test_create_request_omits_xai_reasoning_effort_when_off() {
+        use crate::thinking::ThinkingEffort;
+
+        let model_config = ModelConfig::new("grok-4.5").with_thinking_effort(ThinkingEffort::Off);
+
+        let payload = create_request(
+            &model_config,
+            "system prompt",
+            &[],
+            &[],
+            &ImageFormat::OpenAi,
+            false,
+        )
+        .unwrap();
+
+        assert!(
+            payload.get("reasoning_effort").is_none(),
+            "Off must omit reasoning_effort for xAI, got: {:?}",
+            payload.get("reasoning_effort")
+        );
+    }
+
+    #[test]
+    fn test_create_request_skips_reasoning_effort_for_xai_non_reasoning() {
+        use crate::thinking::ThinkingEffort;
+
+        let model_config = ModelConfig::new("grok-4-fast-non-reasoning")
+            .with_thinking_effort(ThinkingEffort::High)
+            .with_temperature(Some(0.7));
+
+        let payload = create_request(
+            &model_config,
+            "system prompt",
+            &[],
+            &[],
+            &ImageFormat::OpenAi,
+            false,
+        )
+        .unwrap();
+
+        assert!(
+            payload.get("reasoning_effort").is_none(),
+            "non-reasoning xAI models must not send reasoning_effort"
+        );
+        assert_eq!(payload.get("temperature"), Some(&json!(0.7_f32)));
+    }
+
+    #[test]
+    fn test_create_request_skips_reasoning_effort_for_classic_grok4() {
+        use crate::thinking::ThinkingEffort;
+
+        // Classic grok-4 rejects reasoning_effort even though temperature must
+        // still be omitted for reasoning variants.
+        let model_config = ModelConfig::new("grok-4-0709")
+            .with_thinking_effort(ThinkingEffort::High)
+            .with_temperature(Some(0.0));
+
+        let payload = create_request(
+            &model_config,
+            "system prompt",
+            &[],
+            &[],
+            &ImageFormat::OpenAi,
+            false,
+        )
+        .unwrap();
+
+        assert!(
+            payload.get("reasoning_effort").is_none(),
+            "classic grok-4 must not send reasoning_effort"
+        );
+        assert!(
+            payload.get("temperature").is_none(),
+            "temperature must still be omitted for classic grok-4 reasoning"
+        );
+    }
+
+    #[test]
+    fn test_create_request_skips_reasoning_effort_for_grok_4_1_fast() {
+        use crate::thinking::ThinkingEffort;
+
+        let model_config = ModelConfig::new("grok-4-1-fast-reasoning")
+            .with_thinking_effort(ThinkingEffort::Medium)
+            .with_temperature(Some(0.2));
+
+        let payload = create_request(
+            &model_config,
+            "system prompt",
+            &[],
+            &[],
+            &ImageFormat::OpenAi,
+            false,
+        )
+        .unwrap();
+
+        assert!(
+            payload.get("reasoning_effort").is_none(),
+            "grok-4-1-fast must not send reasoning_effort"
+        );
+        assert!(
+            payload.get("temperature").is_none(),
+            "temperature must still be omitted for grok-4-1-fast-reasoning"
+        );
     }
 
     #[test]

--- a/crates/goose-provider-types/src/model.rs
+++ b/crates/goose-provider-types/src/model.rs
@@ -1,4 +1,6 @@
-use crate::formats::openai::{extract_reasoning_effort, is_openai_responses_model};
+use crate::formats::openai::{
+    extract_reasoning_effort, is_openai_responses_model, is_xai_reasoning_model,
+};
 use crate::thinking::ThinkingEffort;
 use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
@@ -234,6 +236,7 @@ impl ModelConfig {
         self.is_openai_reasoning_model()
             || self.model_name.to_lowercase().contains("claude")
             || Self::is_gemini3_reasoning_model_name(&self.model_name)
+            || is_xai_reasoning_model(&self.model_name)
     }
 
     fn is_gemini3_reasoning_model_name(model_name: &str) -> bool {
@@ -250,7 +253,7 @@ impl ModelConfig {
     }
 
     pub fn normalize_effort_suffix(&mut self) {
-        if !self.is_openai_reasoning_model() {
+        if !self.is_openai_reasoning_model() && !is_xai_reasoning_model(&self.model_name) {
             return;
         }
         let parts: Vec<&str> = self.model_name.split('-').collect();
@@ -513,6 +516,21 @@ mod tests {
         }
 
         #[test]
+        fn xai_reasoning_effort_suffix_stripped() {
+            let _guard = env_lock::lock_env([
+                ("GOOSE_THINKING_EFFORT", None::<&str>),
+                ("GOOSE_MAX_TOKENS", None::<&str>),
+                ("GOOSE_TEMPERATURE", None::<&str>),
+                ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+                ("GOOSE_TOOLSHIM", None::<&str>),
+                ("GOOSE_TOOLSHIM_OLLAMA_MODEL", None::<&str>),
+            ]);
+            let config = ModelConfig::new("grok-4.5-high");
+            assert_eq!(config.model_name, "grok-4.5");
+            assert_eq!(config.thinking_effort(), Some(ThinkingEffort::High));
+        }
+
+        #[test]
         fn parse_aliases() {
             assert_eq!("off".parse::<ThinkingEffort>(), Ok(ThinkingEffort::Off));
             assert_eq!(
@@ -697,6 +715,11 @@ mod tests {
             assert!(ModelConfig::new("o3-mini").is_reasoning_model());
             assert!(ModelConfig::new("claude-sonnet-4").is_reasoning_model());
             assert!(ModelConfig::new("gemini-3-pro").is_reasoning_model());
+            assert!(ModelConfig::new("grok-4.5").is_reasoning_model());
+            assert!(ModelConfig::new("grok-4-0709").is_reasoning_model());
+            assert!(ModelConfig::new("grok-3-mini").is_reasoning_model());
+            assert!(!ModelConfig::new("grok-3").is_reasoning_model());
+            assert!(!ModelConfig::new("grok-4-fast-non-reasoning").is_reasoning_model());
         }
 
         #[test]

--- a/crates/goose/src/providers/cursor_agent.rs
+++ b/crates/goose/src/providers/cursor_agent.rs
@@ -4,7 +4,7 @@ use rmcp::model::Role;
 use serde_json::{json, Value};
 use std::path::PathBuf;
 use std::process::Stdio;
-use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
 use tokio::process::Command;
 
 use super::base::{
@@ -229,6 +229,15 @@ impl CursorAgentProvider {
             .take()
             .ok_or_else(|| ProviderError::RequestFailed("Failed to capture stdout".to_string()))?;
 
+        let stderr = child.stderr.take();
+        let stderr_drain = tokio::spawn(async move {
+            let mut buf = String::new();
+            if let Some(mut stderr) = stderr {
+                let _ = AsyncReadExt::read_to_string(&mut stderr, &mut buf).await;
+            }
+            buf
+        });
+
         let mut reader = BufReader::new(stdout);
         let mut lines = Vec::new();
         let mut line = String::new();
@@ -252,19 +261,30 @@ impl CursorAgentProvider {
             }
         }
 
+        let stderr_text = stderr_drain.await.unwrap_or_default();
         let exit_status = child.wait().await.map_err(|e| {
             ProviderError::RequestFailed(format!("Failed to wait for command: {}", e))
         })?;
 
         if !exit_status.success() {
+            let stderr_snippet = stderr_text.trim();
             if !self.get_authentication_status().await {
-                return Err(ProviderError::Authentication(
-                    "You are not logged in to cursor-agent. Please run 'cursor-agent login' to authenticate first."
-                        .to_string()));
+                let detail = if stderr_snippet.is_empty() {
+                    String::new()
+                } else {
+                    format!(": {stderr_snippet}")
+                };
+                return Err(ProviderError::Authentication(format!(
+                    "You are not logged in to cursor-agent. Please run 'cursor-agent login' to authenticate first.{detail}"
+                )));
             }
+            let detail = if stderr_snippet.is_empty() {
+                format!("exit code {:?}", exit_status.code())
+            } else {
+                format!("exit code {:?}: {stderr_snippet}", exit_status.code())
+            };
             return Err(ProviderError::RequestFailed(format!(
-                "Command failed with exit code: {:?}",
-                exit_status.code()
+                "cursor-agent command failed ({detail})"
             )));
         }
 

--- a/crates/goose/src/providers/xai.rs
+++ b/crates/goose/src/providers/xai.rs
@@ -10,6 +10,12 @@ pub const XAI_DEFAULT_MODEL: &str = "grok-code-fast-1";
 pub const XAI_KNOWN_MODELS: &[&str] = &[
     "grok-code-fast-1",
     "grok-4-0709",
+    "grok-4-latest",
+    "grok-4-fast-reasoning",
+    "grok-4-fast-reasoning-latest",
+    "grok-4-fast-non-reasoning",
+    "grok-4-fast-non-reasoning-latest",
+    "grok-4.5",
     "grok-3",
     "grok-3-fast",
     "grok-3-mini",
@@ -30,16 +36,44 @@ pub const XAI_KNOWN_MODELS: &[&str] = &[
 
 pub const XAI_DOC_URL: &str = "https://docs.x.ai/docs/overview";
 
+/// Context window for `grok-4.5` from xAI model docs.
+///
+/// The canonical registry does not yet include `x-ai/grok-4.5`, so
+/// `model_info_for_provider_model` would fall back to `DEFAULT_CONTEXT_LIMIT`
+/// (128k) without this override.
+const GROK_4_5_CONTEXT_LIMIT: usize = 500_000;
+
 pub struct XaiProvider;
+
+/// Known-model metadata for both the API-key and OAuth xAI providers.
+///
+/// Most models resolve context limits via the canonical registry; `grok-4.5`
+/// is overridden until a canonical entry exists.
+pub fn xai_known_model_info() -> Vec<goose_providers::base::ModelInfo> {
+    use goose_providers::base::{model_info_for_provider_model, ModelInfo};
+
+    XAI_KNOWN_MODELS
+        .iter()
+        .map(|&model_name| {
+            if model_name == "grok-4.5" {
+                let mut info = ModelInfo::new(model_name, GROK_4_5_CONTEXT_LIMIT);
+                info.reasoning = true;
+                info
+            } else {
+                model_info_for_provider_model(XAI_PROVIDER_NAME, model_name)
+            }
+        })
+        .collect()
+}
 
 impl goose_providers::base::ProviderDescriptor for XaiProvider {
     fn metadata() -> ProviderMetadata {
-        ProviderMetadata::new(
+        ProviderMetadata::with_models(
             XAI_PROVIDER_NAME,
             "xAI",
             "Grok models from xAI, including reasoning and multimodal capabilities",
             XAI_DEFAULT_MODEL,
-            XAI_KNOWN_MODELS.to_vec(),
+            xai_known_model_info(),
             XAI_DOC_URL,
             vec![
                 ConfigKey::new("XAI_API_KEY", true, true, None, true),
@@ -73,5 +107,33 @@ impl ProviderDef for XaiProvider {
                 String::new(),
             ))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use goose_providers::base::ProviderDescriptor;
+
+    #[test]
+    fn grok_4_5_known_model_uses_documented_context_limit() {
+        let info = xai_known_model_info()
+            .into_iter()
+            .find(|m| m.name == "grok-4.5")
+            .expect("grok-4.5 present in known models");
+        assert_eq!(info.context_limit, GROK_4_5_CONTEXT_LIMIT);
+        assert!(info.reasoning);
+    }
+
+    #[test]
+    fn metadata_includes_grok_4_5_with_context_override() {
+        let metadata = XaiProvider::metadata();
+        let info = metadata
+            .known_models
+            .iter()
+            .find(|m| m.name == "grok-4.5")
+            .expect("grok-4.5 present in provider metadata");
+        assert_eq!(info.context_limit, GROK_4_5_CONTEXT_LIMIT);
+        assert!(info.reasoning);
     }
 }

--- a/crates/goose/src/providers/xai.rs
+++ b/crates/goose/src/providers/xai.rs
@@ -36,33 +36,17 @@ pub const XAI_KNOWN_MODELS: &[&str] = &[
 
 pub const XAI_DOC_URL: &str = "https://docs.x.ai/docs/overview";
 
-/// Context window for `grok-4.5` from xAI model docs.
-///
-/// The canonical registry does not yet include `x-ai/grok-4.5`, so
-/// `model_info_for_provider_model` would fall back to `DEFAULT_CONTEXT_LIMIT`
-/// (128k) without this override.
-const GROK_4_5_CONTEXT_LIMIT: usize = 500_000;
-
 pub struct XaiProvider;
 
 /// Known-model metadata for both the API-key and OAuth xAI providers.
-///
-/// Most models resolve context limits via the canonical registry; `grok-4.5`
-/// is overridden until a canonical entry exists.
+/// All models resolve context limits and reasoning flags via the canonical
+/// registry (`x-ai/grok-*`).
 pub fn xai_known_model_info() -> Vec<goose_providers::base::ModelInfo> {
-    use goose_providers::base::{model_info_for_provider_model, ModelInfo};
+    use goose_providers::base::model_info_for_provider_model;
 
     XAI_KNOWN_MODELS
         .iter()
-        .map(|&model_name| {
-            if model_name == "grok-4.5" {
-                let mut info = ModelInfo::new(model_name, GROK_4_5_CONTEXT_LIMIT);
-                info.reasoning = true;
-                info
-            } else {
-                model_info_for_provider_model(XAI_PROVIDER_NAME, model_name)
-            }
-        })
+        .map(|&model_name| model_info_for_provider_model(XAI_PROVIDER_NAME, model_name))
         .collect()
 }
 
@@ -116,24 +100,24 @@ mod tests {
     use goose_providers::base::ProviderDescriptor;
 
     #[test]
-    fn grok_4_5_known_model_uses_documented_context_limit() {
+    fn grok_4_5_known_model_resolves_via_canonical_registry() {
         let info = xai_known_model_info()
             .into_iter()
             .find(|m| m.name == "grok-4.5")
             .expect("grok-4.5 present in known models");
-        assert_eq!(info.context_limit, GROK_4_5_CONTEXT_LIMIT);
+        assert_eq!(info.context_limit, 500_000);
         assert!(info.reasoning);
     }
 
     #[test]
-    fn metadata_includes_grok_4_5_with_context_override() {
+    fn metadata_includes_grok_4_5_from_canonical_registry() {
         let metadata = XaiProvider::metadata();
         let info = metadata
             .known_models
             .iter()
             .find(|m| m.name == "grok-4.5")
             .expect("grok-4.5 present in provider metadata");
-        assert_eq!(info.context_limit, GROK_4_5_CONTEXT_LIMIT);
+        assert_eq!(info.context_limit, 500_000);
         assert!(info.reasoning);
     }
 }

--- a/crates/goose/src/providers/xai_oauth.rs
+++ b/crates/goose/src/providers/xai_oauth.rs
@@ -1,7 +1,7 @@
 use super::api_client::{ApiClient, AuthMethod, AuthProvider};
 use super::base::{ConfigKey, MessageStream, Provider, ProviderDef, ProviderMetadata};
 use super::openai_compatible::OpenAiCompatibleProvider;
-use super::xai::{XAI_API_HOST, XAI_DEFAULT_MODEL, XAI_KNOWN_MODELS};
+use super::xai::{XAI_API_HOST, XAI_DEFAULT_MODEL};
 use crate::config::paths::Paths;
 use crate::conversation::message::Message;
 use anyhow::{anyhow, Result};
@@ -757,12 +757,12 @@ impl Provider for XaiOAuthProvider {
 
 impl goose_providers::base::ProviderDescriptor for XaiOAuthProvider {
     fn metadata() -> ProviderMetadata {
-        ProviderMetadata::new(
+        ProviderMetadata::with_models(
             XAI_OAUTH_PROVIDER_NAME,
             "xAI (SuperGrok Subscription)",
             "Use your xAI SuperGrok subscription via OAuth instead of an API key. Falls back to a device-code flow on headless / remote machines.",
             XAI_DEFAULT_MODEL,
-            XAI_KNOWN_MODELS.to_vec(),
+            super::xai::xai_known_model_info(),
             XAI_OAUTH_DOC_URL,
             vec![
                 ConfigKey::new_oauth("XAI_OAUTH_TOKEN", true, true, None, false),


### PR DESCRIPTION
## Summary

Adds `grok-4.5` and the grok-4 model family to `XAI_KNOWN_MODELS`, and introduces `is_xai_reasoning_model()` to detect grok-4+ (including dotted variants like `grok-4.5`) and `grok-3-mini` as reasoning models — excluding explicit `non-reasoning` variants.

## Why

Grok 4.5 was announced by xAI but goose currently does not recognize it. Without these changes, selecting `grok-4.5` (via the desktop UI or CLI) fails because the model is not detected as a reasoning model, causing incorrect request construction. In the desktop UI this surfaces as:

```
xai_oauth/grok-4.5 failed — RequestError: Invalid params
```

## What changes

### crates/goose/src/providers/xai.rs
- Add `grok-4.5`, `grok-4-latest`, `grok-4-fast-reasoning(-latest)`, `grok-4-fast-non-reasoning(-latest)` to `XAI_KNOWN_MODELS`

### crates/goose-provider-types/src/formats/openai.rs
- Add `is_xai_reasoning_model()` — detects `grok-4*` (including dotted `grok-4.5`) and `grok-3-mini*` as reasoning models, excluding `non-reasoning` variants
- Add `xai_reasoning_effort_for_thinking()` — maps `ThinkingEffort` to xAI's supported values (`low`/`high` only; `Off` omits the param)
- Omit `temperature` from xAI requests for reasoning models (xAI rejects it)

### crates/goose-provider-types/src/model.rs
- `normalize_effort_suffix()` now handles xAI reasoning models (e.g. `grok-4.5-high` becomes `grok-4.5` + `ThinkingEffort::High`)
- `is_reasoning_model()` now checks `is_xai_reasoning_model`
- Tests covering detection, effort-suffix normalization, and temperature omission

## Verification

- `cargo test -p goose-provider-types --lib` — 362 passed
- `cargo test -p goose --lib model_config` — passed
- `cargo clippy -p goose-provider-types -p goose --lib` — clean
- CLI confirmed working: `goose run --provider xai_oauth --model grok-4.5 -t "Say hello in one word"` returned `Hello`
