### PR TITLE
fix(desktop): gate quit on backend cleanup so goosed is not orphaned

### DIFF
--- a/ui/desktop/src/gooseServeLeaseRegistry.test.ts
+++ b/ui/desktop/src/gooseServeLeaseRegistry.test.ts
@@ -93,6 +93,43 @@ describe('GooseServeLeaseRegistry', () => {
     expect(store.getSecretKey(2)).toBeNull();
   });
 
+  it('settles in-flight cleanups started by a fire-and-forget releaseWindow', async () => {
+    let resolveCleanup: () => void = () => undefined;
+    const cleanupStarted = vi.fn();
+    const cleanup = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          cleanupStarted();
+          resolveCleanup = resolve;
+        })
+    );
+    const store = new GooseServeLeaseRegistry(createLogger());
+    const lease = store.create(createGooseServeResult({ cleanup }), 'local-secret');
+    store.attachWindow(1, lease);
+
+    // Fire-and-forget, exactly how main.ts releases a lease on window close.
+    void store.releaseWindow(1);
+    await Promise.resolve();
+
+    // The lease is already gone from the registry, so a naive quit check that
+    // relies on activeLeaseCount() would see nothing to clean up...
+    expect(store.activeLeaseCount()).toBe(0);
+    expect(cleanupStarted).toHaveBeenCalledTimes(1);
+
+    // ...but settlePendingCleanups() must still wait for the running cleanup.
+    let settled = false;
+    const settlePromise = store.settlePendingCleanups().then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    resolveCleanup();
+    await settlePromise;
+    expect(settled).toBe(true);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
   it('creates an external ACP lease without process cleanup', async () => {
     const store = new GooseServeLeaseRegistry(createLogger());
     const lease = store.createExternal('wss://example.com/goose/acp?token=test', 'external-secret');

--- a/ui/desktop/src/gooseServeLeaseRegistry.ts
+++ b/ui/desktop/src/gooseServeLeaseRegistry.ts
@@ -16,6 +16,7 @@ export interface GooseServeLease {
 
 export class GooseServeLeaseRegistry {
   private leasesByWindowId = new Map<number, GooseServeLease>();
+  private pendingCleanups = new Set<Promise<void>>();
 
   constructor(private readonly logger: Logger) {}
 
@@ -143,10 +144,23 @@ export class GooseServeLeaseRegistry {
     }
     lease.windowIds.clear();
 
+    // Track the in-flight cleanup so shutdown can await it. releaseWindow() is
+    // invoked fire-and-forget on window close, and it removes the lease from the
+    // registry before this async cleanup finishes. Without this tracking, a quit
+    // that races the cleanup sees activeLeaseCount() === 0, skips cleanupAll(),
+    // and exits while goosed is still being terminated -- orphaning the process.
+    const task = (async () => {
+      try {
+        await lease.cleanup();
+      } catch (error) {
+        this.logger.error('Failed to cleanup goose serve backend:', error);
+      }
+    })();
+    this.pendingCleanups.add(task);
     try {
-      await lease.cleanup();
-    } catch (error) {
-      this.logger.error('Failed to cleanup goose serve backend:', error);
+      await task;
+    } finally {
+      this.pendingCleanups.delete(task);
     }
   }
 
@@ -156,6 +170,28 @@ export class GooseServeLeaseRegistry {
 
   async cleanupAll() {
     await Promise.all(this.uniqueLeases().map((lease) => this.cleanupLease(lease)));
+    await this.settlePendingCleanups();
+  }
+
+  /**
+   * Whether any lease cleanup started fire-and-forget (e.g. by releaseWindow()
+   * on window close) is still running. Lets the quit path decide whether it must
+   * hold the app open until backend termination finishes.
+   */
+  hasPendingCleanups(): boolean {
+    return this.pendingCleanups.size > 0;
+  }
+
+  /**
+   * Await any in-flight lease cleanups started fire-and-forget (e.g. by
+   * releaseWindow() on window close). Call this during app shutdown so the
+   * process does not exit and orphan a goosed backend that is still being
+   * terminated.
+   */
+  async settlePendingCleanups(): Promise<void> {
+    while (this.pendingCleanups.size > 0) {
+      await Promise.all([...this.pendingCleanups]);
+    }
   }
 
   private uniqueLeases(): GooseServeLease[] {

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -3107,11 +3107,52 @@ async function getAllowList(): Promise<string[]> {
   }
 }
 
-app.on('will-quit', async () => {
-  const gooseServeLeaseCount = gooseServeLeases.activeLeaseCount();
-  if (gooseServeLeaseCount > 0) {
-    log.info(`App quitting, cleaning up ${gooseServeLeaseCount} backend lease(s)`);
-    await gooseServeLeases.cleanupAll();
+// Electron does NOT await async `will-quit` listeners: once the synchronous
+// portion of the handler returns, the runtime proceeds to terminate. To finish
+// backend cleanup before exit we must hold the quit open synchronously with
+// event.preventDefault(), run the async cleanup, then re-issue the quit.
+let backendCleanupComplete = false;
+let backendCleanupStarted = false;
+
+app.on('will-quit', (event) => {
+  if (!backendCleanupComplete) {
+    // A previous will-quit already kicked off cleanup; keep blocking until it
+    // completes and re-issues the quit.
+    if (backendCleanupStarted) {
+      event.preventDefault();
+      return;
+    }
+
+    const gooseServeLeaseCount = gooseServeLeases.activeLeaseCount();
+    // Closing a window triggers releaseWindow() fire-and-forget, which starts an
+    // async backend cleanup and removes the lease from the registry immediately.
+    // So by quit time activeLeaseCount() may already be 0 while a cleanup that
+    // terminates goosed is still running -- hasPendingCleanups() catches that.
+    const needsCleanup = gooseServeLeaseCount > 0 || gooseServeLeases.hasPendingCleanups();
+
+    if (needsCleanup) {
+      event.preventDefault();
+      backendCleanupStarted = true;
+      if (gooseServeLeaseCount > 0) {
+        log.info(`App quitting, cleaning up ${gooseServeLeaseCount} backend lease(s)`);
+      }
+      void (async () => {
+        try {
+          await gooseServeLeases.cleanupAll();
+          await gooseServeLeases.settlePendingCleanups();
+        } catch (error) {
+          log.error('Error cleaning up goose backends during quit:', error);
+        } finally {
+          backendCleanupComplete = true;
+          // Re-issue the quit; the next will-quit short-circuits past the gate
+          // and runs the synchronous teardown below before the app terminates.
+          app.quit();
+        }
+      })();
+      return;
+    }
+
+    backendCleanupComplete = true;
   }
 
   for (const [windowId, blockerId] of windowPowerSaveBlockers.entries()) {


### PR DESCRIPTION
## Summary

Fixes #10063. `goosed.exe` is left running as an orphan after the last Goose Desktop window closes.

Closing a window calls `gooseServeLeases.releaseWindow(windowId)` fire-and-forget (`void ...` in `main.ts`). `releaseWindow()` removes the lease from the registry map **synchronously**, then starts an asynchronous cleanup that terminates the `goosed` backend (`taskkill`/`SIGTERM`).

Two things combined to orphan the backend (reported as 100% reproducible on Windows):

1. **The lease is gone before quit checks for it.** `will-quit` guards its cleanup on `activeLeaseCount()`, which is already `0` because the entry was deleted in `releaseWindow()`. So `cleanupAll()` was skipped and the in-flight cleanup was awaited nowhere.
2. **Electron does not await async `will-quit` listeners.** Even the pre-existing `await cleanupAll()` did not actually hold the process open. Once the synchronous portion of an `async` `will-quit`/`before-quit` handler returns, Electron proceeds to terminate. Anything after the first `await` races the process teardown. To delay exit you must call `event.preventDefault()` **synchronously**.

## Fix

- `GooseServeLeaseRegistry` tracks in-flight cleanups in a `pendingCleanups` set and exposes `settlePendingCleanups()` (await them) and `hasPendingCleanups()` (check them). `cleanupAll()` also settles pending cleanups.
- `will-quit` now gates the quit **synchronously**: if a lease is still registered or a cleanup is pending, it calls `event.preventDefault()`, runs `cleanupAll()` + `settlePendingCleanups()`, then re-issues `app.quit()`. A `backendCleanupStarted` / `backendCleanupComplete` guard pair prevents re-entrancy and double-cleanup, and lets the second `will-quit` pass fall through to the existing synchronous teardown (power-save blockers, global shortcuts) before the app terminates. When there is nothing to clean up, quit proceeds immediately as before.

Existing lease semantics are unchanged: a lease is still removed from the registry as soon as its last window is released.

## Testing

Verified without Electron (the repo's full `pnpm install` is blocked here by an unrelated supply-chain policy on an electron-forge git subdep):

- **Registry (`gooseServeLeaseRegistry.test.ts`, in this PR):** added a regression test that releases a window fire-and-forget with a slow cleanup, asserts the registry already reports `activeLeaseCount() === 0`, and verifies `settlePendingCleanups()` blocks until the in-flight cleanup resolves. Fails without the tracking, passes with it. All existing registry tests still pass.
- **Quit gating:** verified against a faithful, line-for-line replica of the `will-quit` handler driven by a mock Electron `app` that models Electron's semantics (synchronous `will-quit` emit; terminate unless `preventDefault()` was called synchronously). Three cases pass: holds the quit open until an in-flight cleanup finishes then terminates; terminates immediately when nothing is pending; keeps blocking without double-cleanup if `will-quit` re-fires mid-cleanup. All three **fail** against the previous non-gating `async` handler, confirming it did not actually delay exit. (This replica lives in my local test harness, not in the PR, since `main.ts`'s handler isn't currently exported for unit testing and the repo has no `main.ts` tests; happy to refactor the handler into an exported, testable function if you'd like in-repo coverage.)
- `tsc --strict --noEmit` is clean on the changed registry source and the replicated handler logic.

**Not yet verified:** an end-to-end run of the packaged Desktop app on Windows confirming zero orphaned `goosed.exe`. I couldn't build/run Electron in this environment. The gating pattern is standard Electron (`preventDefault` + re-quit) and the logic is unit-verified, but a real Windows run by a maintainer would be the final confirmation.

### Related Issues
Relates to #10063
