### PR TITLE
apply the default extension timeout to developer shell tool calls also

### DIFF
--- a/crates/goose/src/agents/platform_extensions/developer/shell.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/shell.rs
@@ -171,6 +171,12 @@ struct TruncationInfo {
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ShellParams {
     pub command: String,
+    /// Maximum time in seconds to allow the command to run before it is killed.
+    /// Use this to bound commands that may hang (test runners, servers, watchers,
+    /// commands that wait on unavailable services). If omitted, the default
+    /// extension timeout is applied (configurable via
+    /// `GOOSE_DEFAULT_EXTENSION_TIMEOUT`, defaulting to
+    /// `DEFAULT_EXTENSION_TIMEOUT` seconds).
     #[serde(default)]
     pub timeout_secs: Option<u64>,
 }
@@ -437,14 +443,10 @@ impl ShellTool {
         .collect();
 
         let is_error = if execution.timed_out {
-            if let Some(timeout_secs) = params.timeout_secs {
-                rendered.push_str(&format!(
-                    "\n\nCommand timed out after {} seconds",
-                    timeout_secs
-                ));
-            } else {
-                rendered.push_str("\n\nCommand timed out");
-            }
+            rendered.push_str(&format!(
+                "\n\nCommand timed out after {} seconds",
+                resolve_shell_timeout(params.timeout_secs)
+            ));
             true
         } else {
             execution.exit_code.unwrap_or(1) != 0
@@ -509,6 +511,22 @@ struct ExecutionOutput {
     output_collection_error: Option<String>,
 }
 
+/// Resolve the effective shell-command timeout.
+///
+/// An explicit `timeout_secs` from the tool call wins; otherwise fall back to
+/// the default extension timeout (configurable via `GOOSE_DEFAULT_EXTENSION_TIMEOUT`,
+/// defaulting to `DEFAULT_EXTENSION_TIMEOUT`). This mirrors `resolve_timeout` in
+/// the extension manager and `execution_timeout` in code-mode, so shell commands
+/// are bounded by the same default as every other tool call and can no longer
+/// hang indefinitely.
+fn resolve_shell_timeout(timeout_secs: Option<u64>) -> u64 {
+    timeout_secs.unwrap_or_else(|| {
+        crate::config::Config::global()
+            .get_goose_default_extension_timeout()
+            .unwrap_or(crate::config::DEFAULT_EXTENSION_TIMEOUT)
+    })
+}
+
 async fn run_command(
     command_line: &str,
     timeout_secs: Option<u64>,
@@ -516,6 +534,10 @@ async fn run_command(
     login_path: Option<&str>,
     cancellation_token: CancellationToken,
 ) -> Result<ExecutionOutput, String> {
+    // Fall back to the default extension timeout when the caller omits one, so a
+    // command that never exits cannot hang the session forever.
+    let timeout_secs = Some(resolve_shell_timeout(timeout_secs));
+
     let mut command = build_shell_command(command_line, working_dir, login_path);
 
     command.stdout(Stdio::piped());
@@ -1103,5 +1125,43 @@ mod tests {
             text.contains("after"),
             "should capture output after background cmd"
         );
+    }
+
+    #[test]
+    fn resolve_shell_timeout_prefers_explicit_value() {
+        assert_eq!(resolve_shell_timeout(Some(42)), 42);
+    }
+
+    #[test]
+    fn resolve_shell_timeout_falls_back_to_a_bound_when_absent() {
+        // The key behavioral guarantee: an omitted timeout no longer means
+        // "run forever" — it resolves to the default extension timeout.
+        assert!(resolve_shell_timeout(None) > 0);
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn shell_kills_hanging_command_after_explicit_timeout() {
+        let tool = ShellTool::new_for_test().unwrap();
+        let start = std::time::Instant::now();
+        let result = tool
+            .shell(ShellParams {
+                command: "sleep 30".to_string(),
+                timeout_secs: Some(1),
+            })
+            .await;
+
+        assert!(
+            start.elapsed().as_secs() < 10,
+            "shell should return shortly after the timeout, not wait for the command"
+        );
+        assert_eq!(result.is_error, Some(true));
+        let shell_output = extract_shell_output(&result);
+        assert!(shell_output.timed_out, "command should be marked timed_out");
+        assert!(
+            shell_output.exit_code.is_none(),
+            "killed process should have no exit code"
+        );
+        assert!(extract_text(&result).contains("Command timed out after 1 seconds"));
     }
 }

--- a/crates/goose/src/agents/platform_extensions/developer/shell.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/shell.rs
@@ -172,11 +172,7 @@ struct TruncationInfo {
 pub struct ShellParams {
     pub command: String,
     /// Maximum time in seconds to allow the command to run before it is killed.
-    /// Use this to bound commands that may hang (test runners, servers, watchers,
-    /// commands that wait on unavailable services). If omitted, the default
-    /// extension timeout is applied (configurable via
-    /// `GOOSE_DEFAULT_EXTENSION_TIMEOUT`, defaulting to
-    /// `DEFAULT_EXTENSION_TIMEOUT` seconds).
+    /// If omitted, defaults to DEFAULT_EXTENSION_TIMEOUT.
     #[serde(default)]
     pub timeout_secs: Option<u64>,
 }
@@ -511,14 +507,6 @@ struct ExecutionOutput {
     output_collection_error: Option<String>,
 }
 
-/// Resolve the effective shell-command timeout.
-///
-/// An explicit `timeout_secs` from the tool call wins; otherwise fall back to
-/// the default extension timeout (configurable via `GOOSE_DEFAULT_EXTENSION_TIMEOUT`,
-/// defaulting to `DEFAULT_EXTENSION_TIMEOUT`). This mirrors `resolve_timeout` in
-/// the extension manager and `execution_timeout` in code-mode, so shell commands
-/// are bounded by the same default as every other tool call and can no longer
-/// hang indefinitely.
 fn resolve_shell_timeout(timeout_secs: Option<u64>) -> u64 {
     timeout_secs.unwrap_or_else(|| {
         crate::config::Config::global()
@@ -534,8 +522,6 @@ async fn run_command(
     login_path: Option<&str>,
     cancellation_token: CancellationToken,
 ) -> Result<ExecutionOutput, String> {
-    // Fall back to the default extension timeout when the caller omits one, so a
-    // command that never exits cannot hang the session forever.
     let timeout_secs = Some(resolve_shell_timeout(timeout_secs));
 
     let mut command = build_shell_command(command_line, working_dir, login_path);


### PR DESCRIPTION
## Summary

The default extension timeout was NOT being applied to shell commands after [#7466](https://github.com/aaif-goose/goose/pull/7466). This puts it back 

### Testing

Unit + integration tests (crates/goose/src/agents/platform_extensions/developer/shell.rs):

- resolve_shell_timeout_prefers_explicit_value — an explicit `timeout_secs`
  overrides the default.
- resolve_shell_timeout_falls_back_to_a_bound_when_absent — an omitted
  `timeout_secs` now resolves to a positive bound (the default extension
  timeout) rather than running unbounded.
- shell_kills_hanging_command_after_explicit_timeout — end-to-end: `sleep 30`
  with `timeout_secs: Some(1)` returns in <10s, is marked `timed_out`, has no
  exit code (process killed), and reports "Command timed out after 1 seconds".

Full suite: `cargo test -p goose --lib agents::platform_extensions::developer::shell`
→ 18 passed, 0 failed. `cargo fmt --check` and `cargo clippy -p goose --lib`
are clean.

### Related Issues

#1428 wired the extension timeout, but #7466 ("simplify developer extension") moved developer to an in-process platform extension whose shell path bypasses the MCP-client timeout — so shell commands silently became unbounded. #10214 fixed this for code-mode; this PR closes the same gap for the shell tool.


