### PR TITLE
Add GPT-5.6 family support

### DIFF
--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1535,6 +1535,8 @@ fn openai_reasoning_efforts_for_model(model_name: &str) -> &'static [&'static st
             || normalized.contains("gpt-5-4")
             || normalized.contains("gpt-5.5")
             || normalized.contains("gpt-5-5")
+            || normalized.contains("gpt-5.6")
+            || normalized.contains("gpt-5-6")
         {
             &["low", "medium", "high", "xhigh"]
         } else {
@@ -2507,6 +2509,27 @@ mod tests {
         let obj = request.as_object().unwrap();
 
         assert_eq!(obj.get("reasoning_effort"), Some(&json!("none")));
+        assert!(obj.get("thinking_effort").is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_request_gpt56_max_effort_uses_xhigh() -> anyhow::Result<()> {
+        let model_config = test_model_config("gpt-5.6-luna")
+            .with_max_tokens(Some(1024))
+            .with_thinking_effort(ThinkingEffort::Max);
+        let request = create_request(
+            &model_config,
+            "system",
+            &[],
+            &[],
+            &ImageFormat::OpenAi,
+            false,
+        )?;
+        let obj = request.as_object().unwrap();
+
+        assert_eq!(obj.get("reasoning_effort"), Some(&json!("xhigh")));
         assert!(obj.get("thinking_effort").is_none());
 
         Ok(())

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -60,6 +60,8 @@ pub const OPEN_AI_KNOWN_MODELS: &[(&str, usize)] = &[
     ("gpt-5.4-mini", 400_000),
     ("gpt-5.4-nano", 400_000),
     ("gpt-5.4-pro", 1_050_000),
+    ("gpt-5.5", 1_050_000),
+    ("gpt-5.5-pro", 1_050_000),
     ("gpt-5.6-luna", 1_050_000),
     ("gpt-5.6-sol", 1_050_000),
     ("gpt-5.6-terra", 1_050_000),
@@ -841,6 +843,26 @@ mod tests {
     use super::*;
     use crate::api_client::AuthMethod;
     use serde_json::json;
+
+    #[test]
+    fn gpt_5_5_and_5_6_models_have_expected_context_limits() {
+        for model in [
+            "gpt-5.5",
+            "gpt-5.5-pro",
+            "gpt-5.6-luna",
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+        ] {
+            assert_eq!(
+                OPEN_AI_KNOWN_MODELS
+                    .iter()
+                    .find(|(name, _)| *name == model)
+                    .map(|(_, limit)| *limit),
+                Some(1_050_000),
+                "unexpected context limit for {model}"
+            );
+        }
+    }
 
     fn make_provider(name: &str) -> OpenAiProvider {
         OpenAiProvider {

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -60,6 +60,9 @@ pub const OPEN_AI_KNOWN_MODELS: &[(&str, usize)] = &[
     ("gpt-5.4-mini", 400_000),
     ("gpt-5.4-nano", 400_000),
     ("gpt-5.4-pro", 1_050_000),
+    ("gpt-5.6-luna", 1_050_000),
+    ("gpt-5.6-sol", 1_050_000),
+    ("gpt-5.6-terra", 1_050_000),
 ];
 
 pub const OPEN_AI_DOC_URL: &str = "https://platform.openai.com/docs/models";


### PR DESCRIPTION
## Summary
- register `gpt-5.6-luna`, `gpt-5.6-sol`, and `gpt-5.6-terra` with their 1,050,000-token context windows
- add the missing GPT-5.5 and GPT-5.5 Pro static context metadata
- recognize GPT-5.6 models as supporting `xhigh` reasoning effort
- add focused tests for model context metadata and reasoning effort handling

## Verification
- Probed the OpenAI API: all three GPT-5.6 models report a 922,000-token input limit, consistent with 1,050,000 total context minus 128,000 max output tokens
- Probed `reasoning.effort: xhigh`: all three GPT-5.6 models accepted it
- `cargo test -p goose-provider-types test_create_request_gpt56_max_effort_uses_xhigh`
- `cargo test -p goose-providers gpt_5_5_and_5_6_models_have_expected_context_limits`
- `cargo clippy -p goose-provider-types -p goose-providers --all-targets -- -D warnings`
- `cargo fmt --all`