### PR TITLE
Update canonical model inventory

### DIFF
--- a/crates/goose-provider-types/src/canonical/data/canonical_models.json
+++ b/crates/goose-provider-types/src/canonical/data/canonical_models.json
@@ -4860,6 +4860,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -4891,6 +4892,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -12502,6 +12504,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -12699,6 +12702,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -13082,6 +13086,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -13378,6 +13383,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -13664,6 +13670,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -15085,6 +15092,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -15671,7 +15679,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-03-31",
+    "knowledge": "2025-05",
     "release_date": "2025-11-24",
     "last_updated": "2025-11-24",
     "modalities": {
@@ -15773,6 +15781,7 @@
     "thinking_mode": "adaptive",
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -25354,6 +25363,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -28460,6 +28470,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -30620,6 +30631,1184 @@
     }
   },
   {
+    "id": "crossmodel/anthropic/claude-fable-5",
+    "name": "Claude Fable 5",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-09",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "crossmodel/anthropic/claude-haiku-4.5",
+    "name": "Claude Haiku 4.5 (latest)",
+    "family": "claude-haiku",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-02-28",
+    "release_date": "2025-10-15",
+    "last_updated": "2025-10-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 5.0,
+      "cache_read": 0.1,
+      "cache_write": 1.25
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "crossmodel/anthropic/claude-opus-4.7",
+    "name": "Claude Opus 4.7",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-04-16",
+    "last_updated": "2026-04-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "crossmodel/anthropic/claude-opus-4.8",
+    "name": "Claude Opus 4.8",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01",
+    "release_date": "2026-05-28",
+    "last_updated": "2026-05-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "crossmodel/anthropic/claude-sonnet-4.6",
+    "name": "Claude Sonnet 4.6",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-02-17",
+    "last_updated": "2026-03-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "crossmodel/anthropic/claude-sonnet-5",
+    "name": "Claude Sonnet 5",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 10.0,
+      "cache_read": 0.2,
+      "cache_write": 2.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "crossmodel/deepseek/deepseek-v4-flash",
+    "name": "DeepSeek V4 Flash",
+    "family": "deepseek-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.16,
+      "output": 0.32,
+      "cache_read": 0.004,
+      "cache_write": 0.16
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65000
+    }
+  },
+  {
+    "id": "crossmodel/deepseek/deepseek-v4-pro",
+    "name": "DeepSeek V4 Pro",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.47,
+      "output": 0.94,
+      "cache_read": 0.005,
+      "cache_write": 0.47
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65000
+    }
+  },
+  {
+    "id": "crossmodel/gemini/gemini-2.5-flash",
+    "name": "Gemini 2.5 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-06-17",
+    "last_updated": "2025-06-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 2.5,
+      "cache_read": 0.03,
+      "cache_write": 0.3
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "crossmodel/gemini/gemini-2.5-flash-lite",
+    "name": "Gemini 2.5 Flash-Lite",
+    "family": "gemini-flash-lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-06-17",
+    "last_updated": "2025-06-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.4,
+      "cache_read": 0.01,
+      "cache_write": 0.1
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "crossmodel/gemini/gemini-2.5-pro",
+    "name": "Gemini 2.5 Pro",
+    "family": "gemini-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-06-17",
+    "last_updated": "2025-06-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125,
+      "cache_write": 1.25
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "crossmodel/gemini/gemini-3-flash-preview",
+    "name": "Gemini 3 Flash Preview",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-12-17",
+    "last_updated": "2025-12-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.5,
+      "output": 3.0,
+      "cache_read": 0.05,
+      "cache_write": 0.5
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "crossmodel/gemini/gemini-3.1-pro-preview",
+    "name": "Gemini 3.1 Pro Preview",
+    "family": "gemini-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-02-19",
+    "last_updated": "2026-02-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 12.0,
+      "cache_read": 0.2,
+      "cache_write": 2.0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "crossmodel/gemini/gemini-3.5-flash",
+    "name": "Gemini 3.5 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-05-19",
+    "last_updated": "2026-05-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 9.0,
+      "cache_read": 0.15,
+      "cache_write": 1.5
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "crossmodel/minimax/minimax-m2.7",
+    "name": "MiniMax-M2.7",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.33,
+      "output": 1.32,
+      "cache_read": 0.066,
+      "cache_write": 0.42
+    },
+    "limit": {
+      "context": 204800,
+      "output": 131072
+    }
+  },
+  {
+    "id": "crossmodel/minimax/minimax-m3",
+    "name": "MiniMax-M3",
+    "family": "minimax",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-01",
+    "last_updated": "2026-06-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.33,
+      "output": 1.32,
+      "cache_read": 0.066,
+      "cache_write": 0.33
+    },
+    "limit": {
+      "context": 1024000,
+      "output": 512000
+    }
+  },
+  {
+    "id": "crossmodel/moonshot/kimi-k2.5",
+    "name": "Kimi K2.5",
+    "family": "kimi-k2",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-01",
+    "release_date": "2026-01",
+    "last_updated": "2026-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.62,
+      "output": 3.3,
+      "cache_read": 0.11,
+      "cache_write": 0.62
+    },
+    "limit": {
+      "context": 262000,
+      "output": 262000
+    }
+  },
+  {
+    "id": "crossmodel/moonshot/kimi-k2.6",
+    "name": "Kimi K2.6",
+    "family": "kimi-k2",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.0,
+      "output": 4.16,
+      "cache_read": 0.18,
+      "cache_write": 1.0
+    },
+    "limit": {
+      "context": 262000,
+      "output": 262000
+    }
+  },
+  {
+    "id": "crossmodel/moonshot/kimi-k2.7-code",
+    "name": "Kimi K2.7 Code",
+    "family": "kimi-k2",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-01",
+    "release_date": "2026-06-12",
+    "last_updated": "2026-06-12",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.0,
+      "output": 4.16,
+      "cache_read": 0.18,
+      "cache_write": 1.0
+    },
+    "limit": {
+      "context": 262000,
+      "output": 262000
+    }
+  },
+  {
+    "id": "crossmodel/openai/gpt-4o-mini",
+    "name": "GPT-4o mini",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-09",
+    "release_date": "2024-07-18",
+    "last_updated": "2024-07-18",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.6,
+      "cache_read": 0.075,
+      "cache_write": 0.15
+    },
+    "limit": {
+      "context": 128000,
+      "output": 16384
+    }
+  },
+  {
+    "id": "crossmodel/openai/gpt-5.4",
+    "name": "GPT-5.4",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-05",
+    "last_updated": "2026-03-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 15.0,
+      "cache_read": 0.25,
+      "cache_write": 2.5
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "crossmodel/openai/gpt-5.4-mini",
+    "name": "GPT-5.4 mini",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 4.5,
+      "cache_read": 0.075,
+      "cache_write": 0.75
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "crossmodel/openai/gpt-5.4-nano",
+    "name": "GPT-5.4 nano",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.2,
+      "output": 1.25,
+      "cache_read": 0.02,
+      "cache_write": 0.2
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "crossmodel/openai/gpt-5.5",
+    "name": "GPT-5.5",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-12-01",
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5,
+      "cache_write": 5.0
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "crossmodel/openai/gpt-5.5-pro",
+    "name": "GPT-5.5 Pro",
+    "family": "gpt-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-12-01",
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 30.0,
+      "output": 180.0
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "crossmodel/qwen/qwen3.6-flash",
+    "name": "Qwen3.6 Flash",
+    "family": "qwen3.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-27",
+    "last_updated": "2026-04-27",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.19,
+      "output": 1.13,
+      "cache_read": 0.019,
+      "cache_write": 0.24
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "crossmodel/qwen/qwen3.6-plus",
+    "name": "Qwen3.6 Plus",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.32,
+      "output": 1.88,
+      "cache_read": 0.032,
+      "cache_write": 0.4
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "crossmodel/qwen/qwen3.7-max",
+    "name": "Qwen3.7 Max",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-05-21",
+    "last_updated": "2026-05-21",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.88,
+      "output": 5.63,
+      "cache_read": 0.375,
+      "cache_write": 2.35
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "crossmodel/qwen/qwen3.7-plus",
+    "name": "Qwen3.7 Plus",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-06-02",
+    "last_updated": "2026-06-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.32,
+      "output": 1.25,
+      "cache_read": 0.032,
+      "cache_write": 0.4
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "crossmodel/tencent/hy3-preview",
+    "name": "Hy3 preview",
+    "family": "Hy",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-20",
+    "last_updated": "2026-04-20",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.19,
+      "output": 0.63,
+      "cache_read": 0.063,
+      "cache_write": 0.19
+    },
+    "limit": {
+      "context": 256000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "crossmodel/xiaomi/mimo-v2.5",
+    "name": "MiMo-V2.5",
+    "family": "mimo",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.16,
+      "output": 0.32,
+      "cache_read": 0.004,
+      "cache_write": 0.16
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "crossmodel/xiaomi/mimo-v2.5-pro",
+    "name": "MiMo-V2.5-Pro",
+    "family": "mimo",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.47,
+      "output": 0.94,
+      "cache_read": 0.005,
+      "cache_write": 0.47
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "crossmodel/z-ai/glm-4.7",
+    "name": "GLM-4.7",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2025-12-22",
+    "last_updated": "2025-12-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.47,
+      "output": 2.16,
+      "cache_read": 0.1,
+      "cache_write": 0.47
+    },
+    "limit": {
+      "context": 200000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "crossmodel/z-ai/glm-5",
+    "name": "GLM-5",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-12",
+    "last_updated": "2026-02-12",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.6,
+      "output": 3.0,
+      "cache_read": 0.16,
+      "cache_write": 0.6
+    },
+    "limit": {
+      "context": 200000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "crossmodel/z-ai/glm-5-turbo",
+    "name": "GLM-5-Turbo",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-16",
+    "last_updated": "2026-03-16",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.9,
+      "output": 3.7,
+      "cache_read": 0.18,
+      "cache_write": 0.9
+    },
+    "limit": {
+      "context": 200000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "crossmodel/z-ai/glm-5.1",
+    "name": "GLM-5.1",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-07",
+    "last_updated": "2026-04-07",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.0,
+      "output": 3.8,
+      "cache_read": 0.2,
+      "cache_write": 1.0
+    },
+    "limit": {
+      "context": 200000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "crossmodel/z-ai/glm-5.2",
+    "name": "GLM-5.2",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-13",
+    "last_updated": "2026-06-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.2,
+      "output": 4.4,
+      "cache_read": 0.3,
+      "cache_write": 1.2
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "databricks/databricks-claude-haiku-4.5",
     "name": "Claude Haiku 4.5 (latest)",
     "family": "claude-haiku",
@@ -30693,7 +31882,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-03-31",
+    "knowledge": "2025-05",
     "release_date": "2025-11-24",
     "last_updated": "2025-11-24",
     "modalities": {
@@ -32405,7 +33594,7 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.039,
+      "input": 0.037,
       "output": 0.17
     },
     "limit": {
@@ -35841,6 +37030,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -37788,6 +38978,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -39036,7 +40227,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-03-31",
+    "knowledge": "2025-05",
     "release_date": "2025-11-24",
     "last_updated": "2025-11-24",
     "modalities": {
@@ -39135,6 +40326,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -42058,6 +43250,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -42490,7 +43683,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-03-31",
+    "knowledge": "2025-05",
     "release_date": "2025-11-01",
     "last_updated": "2025-11-01",
     "modalities": {
@@ -42589,6 +43782,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -42885,7 +44079,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-03-31",
+    "knowledge": "2025-05",
     "release_date": "2025-11-01",
     "last_updated": "2025-11-01",
     "modalities": {
@@ -42984,6 +44178,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -44547,6 +45742,36 @@
     },
     "limit": {
       "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "google/gemini-omni-flash-preview",
+    "name": "Gemini Omni Flash Preview",
+    "family": "gemini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 17.5
+    },
+    "limit": {
+      "context": 131072,
       "output": 65536
     }
   },
@@ -52399,6 +53624,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -63001,7 +64227,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-03-31",
+    "knowledge": "2025-05",
     "release_date": "2025-11-01",
     "last_updated": "2025-11-01",
     "modalities": {
@@ -63100,6 +64326,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -63552,36 +64779,6 @@
     "limit": {
       "context": 1048576,
       "output": 65536
-    }
-  },
-  {
-    "id": "llmgateway/gemini-2.5-flash-lite-preview-09",
-    "name": "Gemini 2.5 Flash Lite Preview (09-2025)",
-    "family": "gemini",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-09-25",
-    "last_updated": "2025-09-25",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.1,
-      "output": 0.4,
-      "cache_read": 0.01
-    },
-    "limit": {
-      "context": 1048576,
-      "output": 1048576
     }
   },
   {
@@ -64045,8 +65242,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.431,
-      "output": 2.007,
+      "input": 0.55,
+      "output": 2.2,
       "cache_read": 0.11,
       "cache_write": 0.0
     },
@@ -64290,13 +65487,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 1.26,
-      "output": 3.96,
-      "cache_read": 0.234,
-      "cache_write": 0.0
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26
     },
     "limit": {
-      "context": 1000000,
+      "context": 1024000,
       "output": 131072
     }
   },
@@ -65529,6 +66725,36 @@
     }
   },
   {
+    "id": "llmgateway/grok-4.5",
+    "name": "Grok 4.5",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-07-08",
+    "last_updated": "2026-07-08",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 6.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 500000,
+      "output": 500000
+    }
+  },
+  {
     "id": "llmgateway/grok-build-0.1",
     "name": "Grok Build 0.1",
     "family": "grok-build",
@@ -65579,8 +66805,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.574,
-      "output": 2.294,
+      "input": 0.57,
+      "output": 2.3,
       "cache_read": 0.5
     },
     "limit": {
@@ -65609,9 +66835,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.574,
-      "output": 2.294,
-      "cache_read": 0.15
+      "input": 0.6,
+      "output": 2.5,
+      "cache_read": 0.06
     },
     "limit": {
       "context": 262144,
@@ -67480,8 +68706,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.5,
-      "output": 2.0
+      "input": 0.98,
+      "output": 3.95
     },
     "limit": {
       "context": 131072,
@@ -67690,6 +68916,37 @@
     "cost": {
       "input": 0.248,
       "output": 1.485
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "llmgateway/qwen3.6-flash",
+    "name": "Qwen3.6 Flash",
+    "family": "qwen3.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-27",
+    "last_updated": "2026-04-27",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.9,
+      "cache_read": 0.015
     },
     "limit": {
       "context": 262144,
@@ -69203,7 +70460,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-03-31",
+    "knowledge": "2025-05",
     "release_date": "2025-11-01",
     "last_updated": "2025-11-01",
     "modalities": {
@@ -69302,6 +70559,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -71910,6 +73168,37 @@
     "limit": {
       "context": 128000,
       "output": 4096
+    }
+  },
+  {
+    "id": "meta/muse-spark-1.1",
+    "name": "Muse Spark 1.1",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-08",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 4.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 32000
     }
   },
   {
@@ -93071,7 +94360,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-03-31",
+    "knowledge": "2025-05",
     "release_date": "2025-11-24",
     "last_updated": "2025-11-24",
     "modalities": {
@@ -93140,6 +94429,39 @@
     "knowledge": "2026-01-31",
     "release_date": "2026-04-16",
     "last_updated": "2026-04-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "neon/claude-opus-4.8",
+    "name": "Claude Opus 4.8",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01",
+    "release_date": "2026-05-28",
+    "last_updated": "2026-05-28",
     "modalities": {
       "input": [
         "text",
@@ -93466,6 +94788,70 @@
     }
   },
   {
+    "id": "neon/gemini-3.5-flash",
+    "name": "Gemini 3.5 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-05-19",
+    "last_updated": "2026-05-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 9.0,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "neon/gemma-3-12b",
+    "name": "Gemma 3 12B",
+    "family": "gemma",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-08-31",
+    "release_date": "2025-03-13",
+    "last_updated": "2025-03-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.15,
+      "output": 0.5
+    },
+    "limit": {
+      "context": 131072,
+      "output": 16384
+    }
+  },
+  {
     "id": "neon/gpt-5",
     "name": "GPT-5",
     "family": "gpt",
@@ -93482,7 +94868,8 @@
         "image"
       ],
       "output": [
-        "text"
+        "text",
+        "image"
       ]
     },
     "open_weights": false,
@@ -93513,7 +94900,8 @@
         "image"
       ],
       "output": [
-        "text"
+        "text",
+        "image"
       ]
     },
     "open_weights": false,
@@ -93544,7 +94932,8 @@
         "image"
       ],
       "output": [
-        "text"
+        "text",
+        "image"
       ]
     },
     "open_weights": false,
@@ -93575,7 +94964,8 @@
         "image"
       ],
       "output": [
-        "text"
+        "text",
+        "image"
       ]
     },
     "open_weights": false,
@@ -93583,6 +94973,70 @@
       "input": 1.25,
       "output": 10.0,
       "cache_read": 0.125
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "neon/gpt-5.1-codex-max",
+    "name": "GPT-5.1 Codex Max",
+    "family": "gpt-codex",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-09-30",
+    "release_date": "2025-11-13",
+    "last_updated": "2025-11-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "neon/gpt-5.1-codex-mini",
+    "name": "GPT-5.1 Codex mini",
+    "family": "gpt-codex",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-09-30",
+    "release_date": "2025-11-13",
+    "last_updated": "2025-11-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 2.0,
+      "cache_read": 0.025
     },
     "limit": {
       "context": 400000,
@@ -93606,7 +95060,74 @@
         "image"
       ],
       "output": [
-        "text"
+        "text",
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.75,
+      "output": 14.0,
+      "cache_read": 0.175
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "neon/gpt-5.2-codex",
+    "name": "GPT-5.2 Codex",
+    "family": "gpt-codex",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2025-12-11",
+    "last_updated": "2025-12-11",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.75,
+      "output": 14.0,
+      "cache_read": 0.175
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "neon/gpt-5.3-codex",
+    "name": "GPT-5.3 Codex",
+    "family": "gpt-codex",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-02-05",
+    "last_updated": "2026-02-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text",
+        "image"
       ]
     },
     "open_weights": false,
@@ -93638,7 +95159,8 @@
         "pdf"
       ],
       "output": [
-        "text"
+        "text",
+        "image"
       ]
     },
     "open_weights": false,
@@ -93669,7 +95191,8 @@
         "image"
       ],
       "output": [
-        "text"
+        "text",
+        "image"
       ]
     },
     "open_weights": false,
@@ -93700,7 +95223,8 @@
         "image"
       ],
       "output": [
-        "text"
+        "text",
+        "image"
       ]
     },
     "open_weights": false,
@@ -93711,38 +95235,6 @@
     },
     "limit": {
       "context": 400000,
-      "output": 128000
-    }
-  },
-  {
-    "id": "neon/gpt-5.5",
-    "name": "GPT-5.5",
-    "family": "gpt",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2025-12-01",
-    "release_date": "2026-04-23",
-    "last_updated": "2026-04-23",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 5.0,
-      "output": 30.0,
-      "cache_read": 0.5
-    },
-    "limit": {
-      "context": 1050000,
       "output": 128000
     }
   },
@@ -93800,6 +95292,151 @@
     "limit": {
       "context": 131072,
       "output": 32768
+    }
+  },
+  {
+    "id": "neon/llama-4-maverick",
+    "name": "Llama 4 Maverick 17B Instruct",
+    "family": "llama",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-08",
+    "release_date": "2025-04-05",
+    "last_updated": "2025-04-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.5,
+      "output": 1.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 16384
+    }
+  },
+  {
+    "id": "neon/meta-llama-3.1-8b-instruct",
+    "name": "Llama 3.1 8B Instruct",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-12-31",
+    "release_date": "2024-07-23",
+    "last_updated": "2024-07-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.15,
+      "output": 0.45
+    },
+    "limit": {
+      "context": 131072,
+      "output": 16384
+    }
+  },
+  {
+    "id": "neon/meta-llama-3.3-70b-instruct",
+    "name": "Llama-3.3-70B-Instruct",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-12",
+    "release_date": "2024-12-06",
+    "last_updated": "2024-12-06",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.5,
+      "output": 1.5
+    },
+    "limit": {
+      "context": 128000,
+      "output": 4096
+    }
+  },
+  {
+    "id": "neon/qwen3-next-80b-a3b-instruct",
+    "name": "Qwen3-Next 80B-A3B Instruct",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2025-09",
+    "last_updated": "2025-09",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.15,
+      "output": 1.2
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    }
+  },
+  {
+    "id": "neon/qwen35-122b-a10b",
+    "name": "Qwen3.5 122B-A10B",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-23",
+    "last_updated": "2026-02-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.22,
+      "output": 2.2
+    },
+    "limit": {
+      "context": 262144,
+      "output": 8000
     }
   },
   {
@@ -101863,6 +103500,138 @@
     }
   },
   {
+    "id": "openai/gpt-5.6",
+    "name": "GPT-5.6",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openai/gpt-5.6-luna",
+    "name": "GPT-5.6 Luna",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 6.0,
+      "cache_read": 0.1,
+      "cache_write": 1.25
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openai/gpt-5.6-sol",
+    "name": "GPT-5.6 Sol",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openai/gpt-5.6-terra",
+    "name": "GPT-5.6 Terra",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 15.0,
+      "cache_read": 0.25,
+      "cache_write": 3.125
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
     "id": "openai/gpt-image-1",
     "name": "gpt-image-1",
     "family": "gpt-image",
@@ -103167,6 +104936,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -104290,6 +106060,36 @@
     "limit": {
       "context": 1050000,
       "output": 128000
+    }
+  },
+  {
+    "id": "opencode/grok-4.5",
+    "name": "Grok 4.5",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-07-08",
+    "last_updated": "2026-07-08",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 6.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 500000,
+      "output": 500000
     }
   },
   {
@@ -105761,7 +107561,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-03-31",
+    "knowledge": "2025-05",
     "release_date": "2025-11-24",
     "last_updated": "2025-11-24",
     "modalities": {
@@ -105892,6 +107692,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -106837,7 +108638,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 16384
+      "output": 65536
     }
   },
   {
@@ -106956,41 +108757,6 @@
         "audio",
         "video",
         "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.1,
-      "output": 0.4,
-      "cache_read": 0.01,
-      "cache_write": 0.083333
-    },
-    "limit": {
-      "context": 1048576,
-      "output": 65535
-    }
-  },
-  {
-    "id": "openrouter/google/gemini-2.5-flash-lite-preview-09",
-    "name": "Gemini 2.5 Flash Lite Preview 09-2025",
-    "family": "gemini-flash-lite",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-01-31",
-    "release_date": "2025-09-25",
-    "last_updated": "2025-09-25",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf",
-        "audio",
-        "video"
       ],
       "output": [
         "text"
@@ -108095,34 +109861,6 @@
     }
   },
   {
-    "id": "openrouter/liquid/lfm-2-24b-a2b",
-    "name": "LFM2-24B-A2B",
-    "family": "liquid",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2026-02-25",
-    "last_updated": "2026-02-25",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.03,
-      "output": 0.12
-    },
-    "limit": {
-      "context": 32768,
-      "output": 32768
-    }
-  },
-  {
     "id": "openrouter/liquid/lfm-2.5-1.2b-instruct:free",
     "name": "LFM2.5-1.2B-Instruct (free)",
     "family": "liquid",
@@ -108783,8 +110521,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.12,
-      "output": 0.48
+      "input": 0.15,
+      "output": 0.9,
+      "cache_read": 0.05
     },
     "limit": {
       "context": 196608,
@@ -108811,8 +110550,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.18,
-      "output": 0.72
+      "input": 0.24,
+      "output": 0.96
     },
     "limit": {
       "context": 196608,
@@ -109481,7 +111220,7 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.66,
+      "input": 0.65,
       "output": 3.41,
       "cache_read": 0.14
     },
@@ -109512,13 +111251,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.74,
+      "input": 0.72,
       "output": 3.5,
       "cache_read": 0.15
     },
     "limit": {
       "context": 262144,
-      "output": 16384
+      "output": 262144
     }
   },
   {
@@ -111313,6 +113052,204 @@
     }
   },
   {
+    "id": "openrouter/openai/gpt-5.6-luna",
+    "name": "GPT-5.6 Luna",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 6.0,
+      "cache_read": 0.1,
+      "cache_write": 1.25
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/openai/gpt-5.6-luna-pro",
+    "name": "GPT-5.6 Luna Pro",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 6.0,
+      "cache_read": 0.1,
+      "cache_write": 1.25
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/openai/gpt-5.6-sol",
+    "name": "GPT-5.6 Sol",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/openai/gpt-5.6-sol-pro",
+    "name": "GPT-5.6 Sol Pro",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/openai/gpt-5.6-terra",
+    "name": "GPT-5.6 Terra",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 15.0,
+      "cache_read": 0.25,
+      "cache_write": 3.125
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/openai/gpt-5.6-terra-pro",
+    "name": "GPT-5.6 Terra Pro",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 15.0,
+      "cache_read": 0.25,
+      "cache_write": 3.125
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
     "id": "openrouter/openai/gpt-audio",
     "name": "GPT Audio",
     "family": "gpt",
@@ -111423,8 +113360,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.03,
-      "output": 0.15
+      "input": 0.036,
+      "output": 0.18
     },
     "limit": {
       "context": 131072,
@@ -112255,61 +114192,6 @@
     "temperature": true,
     "release_date": "2026-07-02",
     "last_updated": "2026-07-02",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 262144,
-      "output": 32768
-    }
-  },
-  {
-    "id": "openrouter/poolside/laguna-xs.2",
-    "name": "Laguna XS.2",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-04-28",
-    "last_updated": "2026-04-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.1,
-      "output": 0.2,
-      "cache_read": 0.05
-    },
-    "limit": {
-      "context": 262144,
-      "output": 32768
-    }
-  },
-  {
-    "id": "openrouter/poolside/laguna-xs.2:free",
-    "name": "Laguna XS.2 (free)",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-04-28",
-    "last_updated": "2026-04-28",
     "modalities": {
       "input": [
         "text"
@@ -114050,33 +115932,6 @@
     }
   },
   {
-    "id": "openrouter/switchpoint/router",
-    "name": "Switchpoint Router",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2025-07-11",
-    "last_updated": "2025-07-11",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.85,
-      "output": 3.4
-    },
-    "limit": {
-      "context": 131072,
-      "output": 131072
-    }
-  },
-  {
     "id": "openrouter/tencent/hunyuan-a13b-instruct",
     "name": "Hunyuan A13B Instruct",
     "family": "hunyuan",
@@ -114125,12 +115980,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.2,
-      "output": 0.8,
-      "cache_read": 0.5
+      "input": 0.14,
+      "output": 0.58,
+      "cache_read": 0.035
     },
     "limit": {
-      "context": 202752,
+      "context": 262144,
       "output": 131072
     }
   },
@@ -114486,6 +116341,37 @@
     }
   },
   {
+    "id": "openrouter/x-ai/grok-4.5",
+    "name": "Grok 4.5",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-07-08",
+    "last_updated": "2026-07-08",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 6.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 500000,
+      "output": 500000
+    }
+  },
+  {
     "id": "openrouter/x-ai/grok-build-0.1",
     "name": "Grok Build 0.1",
     "family": "grok-build",
@@ -114498,7 +116384,8 @@
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
@@ -114898,13 +116785,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.93,
-      "output": 3.0,
-      "cache_read": 0.18
+      "input": 0.54,
+      "output": 1.76,
+      "cache_read": 0.1
     },
     "limit": {
-      "context": 1048576,
-      "output": 32768
+      "context": 101376,
+      "output": 101376
     }
   },
   {
@@ -115156,7 +117043,7 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.66,
+      "input": 0.65,
       "output": 3.41,
       "cache_read": 0.14
     },
@@ -115173,7 +117060,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
-    "knowledge": "2025-12-01",
+    "knowledge": "2026-02-16",
     "release_date": "2026-04-27",
     "last_updated": "2026-04-27",
     "modalities": {
@@ -115190,7 +117077,8 @@
     "cost": {
       "input": 5.0,
       "output": 30.0,
-      "cache_read": 0.5
+      "cache_read": 0.5,
+      "cache_write": 6.25
     },
     "limit": {
       "context": 1050000,
@@ -115227,6 +117115,37 @@
     "limit": {
       "context": 400000,
       "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/~x-ai/grok",
+    "name": "Grok Latest",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-07-08",
+    "last_updated": "2026-07-08",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 6.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 500000,
+      "output": 1000000
     }
   },
   {
@@ -115336,7 +117255,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-03-31",
+    "knowledge": "2025-05",
     "release_date": "2025-11-24",
     "last_updated": "2025-11-24",
     "modalities": {
@@ -119010,6 +120929,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -126896,38 +128816,69 @@
     }
   },
   {
-    "id": "routing-run/route/deepseek-v3.2",
-    "name": "DeepSeek V3.2",
-    "family": "deepseek",
+    "id": "routing-run/claude-opus-4.8",
+    "name": "Claude Opus 4.8",
+    "family": "claude-opus",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-07",
-    "release_date": "2025-12-01",
-    "last_updated": "2025-12-01",
+    "temperature": false,
+    "knowledge": "2026-01",
+    "release_date": "2026-05-28",
+    "last_updated": "2026-05-28",
     "modalities": {
       "input": [
         "text",
         "image",
-        "video"
+        "pdf"
       ],
       "output": [
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
-      "input": 0.4928,
-      "output": 0.7392
+      "input": 5.0,
+      "output": 25.0
     },
     "limit": {
-      "context": 163840,
-      "output": 163840
+      "context": 1000000,
+      "output": 32000
     }
   },
   {
-    "id": "routing-run/route/deepseek-v4-flash",
+    "id": "routing-run/claude-sonnet-4.6",
+    "name": "Claude Sonnet 4.6",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-02-17",
+    "last_updated": "2026-03-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "routing-run/deepseek-v4-flash",
     "name": "DeepSeek V4 Flash",
     "family": "deepseek-flash",
     "attachment": false,
@@ -126947,47 +128898,16 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.4928,
-      "output": 0.7392,
-      "cache_read": 0.0028
+      "input": 0.112,
+      "output": 0.224
     },
     "limit": {
       "context": 1000000,
-      "output": 131072
+      "output": 64000
     }
   },
   {
-    "id": "routing-run/route/deepseek-v4-flash-6bit",
-    "name": "DeepSeek V4 Flash 6bit",
-    "family": "deepseek-flash",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-05",
-    "release_date": "2026-04-24",
-    "last_updated": "2026-04-24",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.4928,
-      "output": 0.7392,
-      "cache_read": 0.0028
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 131072
-    }
-  },
-  {
-    "id": "routing-run/route/deepseek-v4-pro",
+    "id": "routing-run/deepseek-v4-pro",
     "name": "DeepSeek V4 Pro",
     "family": "deepseek-thinking",
     "attachment": false,
@@ -127007,85 +128927,24 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.4928,
-      "output": 0.7392,
-      "cache_read": 0.003625
+      "input": 0.348,
+      "output": 0.696
     },
     "limit": {
       "context": 1000000,
-      "output": 131072
+      "output": 64000
     }
   },
   {
-    "id": "routing-run/route/deepseek-v4-pro-6bit",
-    "name": "DeepSeek V4 Pro 6bit",
-    "family": "deepseek-thinking",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-05",
-    "release_date": "2026-04-24",
-    "last_updated": "2026-04-24",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.4928,
-      "output": 0.7392,
-      "cache_read": 0.003625
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 131072
-    }
-  },
-  {
-    "id": "routing-run/route/gemma-4-31b-it",
-    "name": "Gemma 4 31B IT",
-    "family": "gemma",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-04-02",
-    "last_updated": "2026-04-02",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.1,
-      "output": 0.3
-    },
-    "limit": {
-      "context": 131072,
-      "output": 65536
-    }
-  },
-  {
-    "id": "routing-run/route/glm-5.1",
-    "name": "GLM 5.1",
+    "id": "routing-run/glm-5.2",
+    "name": "GLM-5.2",
     "family": "glm",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-04-07",
-    "last_updated": "2026-04-07",
+    "release_date": "2026-06-13",
+    "last_updated": "2026-06-13",
     "modalities": {
       "input": [
         "text"
@@ -127096,26 +128955,24 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 1.0,
-      "output": 3.0,
-      "cache_read": 0.26,
-      "cache_write": 0.0
+      "input": 0.8,
+      "output": 2.4
     },
     "limit": {
-      "context": 202752,
-      "output": 65536
+      "context": 200000,
+      "output": 32000
     }
   },
   {
-    "id": "routing-run/route/glm-5.1-6bit",
-    "name": "GLM 5.1 6bit",
+    "id": "routing-run/glm-5.2-nitro",
+    "name": "GLM 5.2 Nitro",
     "family": "glm",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-04-07",
-    "last_updated": "2026-04-07",
+    "release_date": "2026-06-13",
+    "last_updated": "2026-06-13",
     "modalities": {
       "input": [
         "text"
@@ -127126,50 +128983,16 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 1.0,
-      "output": 3.0,
-      "cache_read": 0.26,
-      "cache_write": 0.0
+      "input": 0.8,
+      "output": 2.4
     },
     "limit": {
-      "context": 202752,
-      "output": 65536
+      "context": 200000,
+      "output": 32000
     }
   },
   {
-    "id": "routing-run/route/kimi-k2.5",
-    "name": "Kimi K2.5",
-    "family": "kimi-k2",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2025-01",
-    "release_date": "2026-01",
-    "last_updated": "2026-01",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.462,
-      "output": 2.42,
-      "cache_read": 0.1
-    },
-    "limit": {
-      "context": 131072,
-      "output": 32768
-    }
-  },
-  {
-    "id": "routing-run/route/kimi-k2.6",
+    "id": "routing-run/kimi-k2.6",
     "name": "Kimi K2.6",
     "family": "kimi-k2",
     "attachment": true,
@@ -127191,18 +129014,17 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.462,
-      "output": 2.42,
-      "cache_read": 0.16
+      "input": 0.275,
+      "output": 1.1
     },
     "limit": {
-      "context": 262144,
-      "output": 262144
+      "context": 200000,
+      "output": 32000
     }
   },
   {
-    "id": "routing-run/route/kimi-k2.6-6bit",
-    "name": "Kimi K2.6 6bit",
+    "id": "routing-run/kimi-k2.6-nitro",
+    "name": "Kimi K2.6 Nitro",
     "family": "kimi-k2",
     "attachment": true,
     "reasoning": true,
@@ -127223,26 +129045,25 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.462,
-      "output": 2.42,
-      "cache_read": 0.16
+      "input": 0.275,
+      "output": 1.1
     },
     "limit": {
-      "context": 262144,
-      "output": 262144
+      "context": 200000,
+      "output": 32000
     }
   },
   {
-    "id": "routing-run/route/mimo-v2.5",
-    "name": "MiMo V2.5",
-    "family": "mimo",
+    "id": "routing-run/kimi-k2.7-code",
+    "name": "Kimi K2.7 Code",
+    "family": "kimi-k2",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-12",
-    "release_date": "2026-04-22",
-    "last_updated": "2026-04-22",
+    "temperature": false,
+    "knowledge": "2025-01",
+    "release_date": "2026-06-12",
+    "last_updated": "2026-06-12",
     "modalities": {
       "input": [
         "text",
@@ -127255,26 +129076,25 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.45,
-      "output": 1.35,
-      "cache_read": 0.2
+      "input": 0.275,
+      "output": 1.1
     },
     "limit": {
-      "context": 1000000,
-      "output": 262144
+      "context": 200000,
+      "output": 32000
     }
   },
   {
-    "id": "routing-run/route/mimo-v2.5-pro",
-    "name": "MiMo V2.5 Pro",
-    "family": "mimo",
+    "id": "routing-run/kimi-k2.7-code-nitro",
+    "name": "Kimi K2.7 Code Nitro",
+    "family": "kimi-k2",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-12",
-    "release_date": "2026-04-22",
-    "last_updated": "2026-04-22",
+    "temperature": false,
+    "knowledge": "2025-01",
+    "release_date": "2026-06-12",
+    "last_updated": "2026-06-12",
     "modalities": {
       "input": [
         "text",
@@ -127287,117 +129107,24 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.45,
-      "output": 1.35,
-      "cache_read": 0.2
+      "input": 0.275,
+      "output": 1.1
     },
     "limit": {
-      "context": 1000000,
-      "output": 262144
+      "context": 200000,
+      "output": 32000
     }
   },
   {
-    "id": "routing-run/route/mimo-v2.5-pro-6bit",
-    "name": "MiMo V2.5 Pro 6bit",
-    "family": "mimo",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-12",
-    "release_date": "2026-04-22",
-    "last_updated": "2026-04-22",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.45,
-      "output": 1.35,
-      "cache_read": 0.2
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 262144
-    }
-  },
-  {
-    "id": "routing-run/route/minimax-m2.5",
-    "name": "MiniMax M2.5",
-    "family": "minimax",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-02-12",
-    "last_updated": "2026-02-12",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.193,
-      "output": 1.238,
-      "cache_read": 0.03,
-      "cache_write": 0.375
-    },
-    "limit": {
-      "context": 100000,
-      "output": 131072
-    }
-  },
-  {
-    "id": "routing-run/route/minimax-m2.5-highspeed",
-    "name": "MiniMax M2.5 Highspeed",
-    "family": "minimax",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-02-13",
-    "last_updated": "2026-02-13",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.193,
-      "output": 1.238,
-      "cache_read": 0.06,
-      "cache_write": 0.375
-    },
-    "limit": {
-      "context": 100000,
-      "output": 131072
-    }
-  },
-  {
-    "id": "routing-run/route/minimax-m2.7",
-    "name": "MiniMax M2.7",
-    "family": "minimax",
+    "id": "routing-run/nemotron-3-ultra",
+    "name": "Nemotron 3 Ultra 550B A55B",
+    "family": "nemotron",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-03-18",
-    "last_updated": "2026-03-18",
+    "release_date": "2026-06-04",
+    "last_updated": "2026-06-04",
     "modalities": {
       "input": [
         "text"
@@ -127408,203 +129135,24 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.33,
-      "output": 1.32,
-      "cache_read": 0.06,
-      "cache_write": 0.375
+      "input": 0.1,
+      "output": 0.1
     },
     "limit": {
-      "context": 100000,
-      "output": 131072
+      "context": 131072,
+      "output": 32000
     }
   },
   {
-    "id": "routing-run/route/minimax-m2.7-highspeed",
-    "name": "MiniMax M2.7 Highspeed",
-    "family": "minimax",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-03-18",
-    "last_updated": "2026-03-18",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.33,
-      "output": 1.32,
-      "cache_read": 0.06,
-      "cache_write": 0.375
-    },
-    "limit": {
-      "context": 100000,
-      "output": 131072
-    }
-  },
-  {
-    "id": "routing-run/route/mistral-large-3",
-    "name": "Mistral Large 3",
-    "family": "mistral-large",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-11",
-    "release_date": "2024-11-01",
-    "last_updated": "2025-12-02",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.5,
-      "output": 1.5
-    },
-    "limit": {
-      "context": 128000,
-      "output": 32768
-    }
-  },
-  {
-    "id": "routing-run/route/mistral-medium",
-    "name": "Mistral Medium 2505",
-    "family": "mistral-medium",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-05",
-    "release_date": "2025-05-07",
-    "last_updated": "2025-05-07",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.4,
-      "output": 2.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 32768
-    }
-  },
-  {
-    "id": "routing-run/route/mistral-small",
-    "name": "Mistral Small 2503",
-    "family": "mistral-small",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-06",
-    "release_date": "2026-03-16",
-    "last_updated": "2026-03-16",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.15,
-      "output": 0.6
-    },
-    "limit": {
-      "context": 128000,
-      "output": 32768
-    }
-  },
-  {
-    "id": "routing-run/route/qwen3.6-27b",
-    "name": "Qwen3.6 27B",
+    "id": "routing-run/qwen3.5-9b",
+    "name": "Qwen3.5 9B",
     "family": "qwen",
     "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-04-22",
-    "last_updated": "2026-04-22",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 1.1,
-      "output": 3.3
-    },
-    "limit": {
-      "context": 202000,
-      "output": 32768
-    }
-  },
-  {
-    "id": "routing-run/route/qwen3.6-27b-202k",
-    "name": "Qwen3.6 27B 202K",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-04-22",
-    "last_updated": "2026-04-22",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 1.1,
-      "output": 3.3
-    },
-    "limit": {
-      "context": 202000,
-      "output": 32768
-    }
-  },
-  {
-    "id": "routing-run/route/step-3.5-flash",
-    "name": "Step 3.5 Flash",
-    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2026-01-29",
-    "last_updated": "2026-02-13",
+    "release_date": "2026-02-23",
+    "last_updated": "2026-02-23",
     "modalities": {
       "input": [
         "text"
@@ -127615,42 +129163,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.096,
-      "output": 0.288,
-      "cache_read": 0.019
+      "input": 0.16,
+      "output": 0.48
     },
     "limit": {
       "context": 262144,
-      "output": 65536
-    }
-  },
-  {
-    "id": "routing-run/route/stepfun-3.5-flash",
-    "name": "StepFun 3.5 Flash",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2026-01-29",
-    "last_updated": "2026-02-13",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.096,
-      "output": 0.288,
-      "cache_read": 0.019
-    },
-    "limit": {
-      "context": 262144,
-      "output": 65536
+      "output": 32000
     }
   },
   {
@@ -128139,6 +129657,39 @@
     }
   },
   {
+    "id": "sap-ai-core/anthropic--claude-4.8-opus",
+    "name": "anthropic--claude-4.8-opus",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01",
+    "release_date": "2026-05-28",
+    "last_updated": "2026-05-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "sap-ai-core/gemini-2.5-flash",
     "name": "gemini-2.5-flash",
     "family": "gemini-flash",
@@ -128234,6 +129785,74 @@
       "input": 1.25,
       "output": 10.0,
       "cache_read": 0.125
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "sap-ai-core/gemini-3.1-flash-lite",
+    "name": "gemini-3.1-flash-lite",
+    "family": "gemini-flash-lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-05-07",
+    "last_updated": "2026-05-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 1.5,
+      "cache_read": 0.025
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "sap-ai-core/gemini-3.5-flash",
+    "name": "gemini-3.5-flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-05-19",
+    "last_updated": "2026-05-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 9.0,
+      "cache_read": 0.15
     },
     "limit": {
       "context": 1048576,
@@ -131930,6 +133549,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -133802,7 +135422,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-05-04",
-    "last_updated": "2026-05-19",
+    "last_updated": "2026-07-06",
     "modalities": {
       "input": [
         "text",
@@ -133827,7 +135447,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-05-04",
-    "last_updated": "2026-05-19",
+    "last_updated": "2026-07-06",
     "modalities": {
       "input": [
         "text"
@@ -133839,8 +135459,8 @@
     "open_weights": false,
     "cost": {},
     "limit": {
-      "context": 128000,
-      "output": 64000
+      "context": 196608,
+      "output": 30000
     }
   },
   {
@@ -133851,7 +135471,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-05-04",
-    "last_updated": "2026-05-19",
+    "last_updated": "2026-07-06",
     "modalities": {
       "input": [
         "text"
@@ -133875,7 +135495,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-05-04",
-    "last_updated": "2026-05-19",
+    "last_updated": "2026-07-06",
     "modalities": {
       "input": [
         "text",
@@ -133900,7 +135520,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-05-04",
-    "last_updated": "2026-05-19",
+    "last_updated": "2026-07-06",
     "modalities": {
       "input": [
         "text"
@@ -133912,8 +135532,8 @@
     "open_weights": false,
     "cost": {},
     "limit": {
-      "context": 128000,
-      "output": 64000
+      "context": 196608,
+      "output": 30000
     }
   },
   {
@@ -133924,7 +135544,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-05-04",
-    "last_updated": "2026-05-19",
+    "last_updated": "2026-07-06",
     "modalities": {
       "input": [
         "text"
@@ -133948,7 +135568,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-03-24",
-    "last_updated": "2026-05-19",
+    "last_updated": "2026-07-06",
     "modalities": {
       "input": [
         "text",
@@ -133973,7 +135593,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-02-26",
-    "last_updated": "2026-05-19",
+    "last_updated": "2026-07-06",
     "modalities": {
       "input": [
         "text"
@@ -133985,7 +135605,7 @@
     "open_weights": false,
     "cost": {},
     "limit": {
-      "context": 128000,
+      "context": 196608,
       "output": 30000
     }
   },
@@ -133997,7 +135617,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-02-26",
-    "last_updated": "2026-05-19",
+    "last_updated": "2026-07-06",
     "modalities": {
       "input": [
         "text"
@@ -135865,6 +137485,60 @@
     }
   },
   {
+    "id": "venice/aion-labs-aion-3.0",
+    "name": "Aion 3.0",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-07-08",
+    "last_updated": "2026-07-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.75,
+      "output": 7.5,
+      "cache_read": 0.9375
+    },
+    "limit": {
+      "context": 128000,
+      "output": 32768
+    }
+  },
+  {
+    "id": "venice/aion-labs-aion-3.0-mini",
+    "name": "Aion 3.0 Mini",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-07-08",
+    "last_updated": "2026-07-08",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.875,
+      "output": 1.75,
+      "cache_read": 0.225
+    },
+    "limit": {
+      "context": 128000,
+      "output": 32768
+    }
+  },
+  {
     "id": "venice/claude-fable-5",
     "name": "Claude Fable 5",
     "family": "claude-fable",
@@ -135904,7 +137578,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-03-31",
+    "knowledge": "2025-05",
     "release_date": "2025-12-06",
     "last_updated": "2026-06-11",
     "modalities": {
@@ -136032,6 +137706,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-06-11",
     "modalities": {
@@ -136063,6 +137738,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-06-11",
     "modalities": {
@@ -136575,6 +138251,36 @@
     },
     "limit": {
       "context": 1000000,
+      "output": 32000
+    }
+  },
+  {
+    "id": "venice/grok-4.5",
+    "name": "Grok 4.5",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-07-07",
+    "last_updated": "2026-07-08",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.27,
+      "output": 6.8,
+      "cache_read": 0.57
+    },
+    "limit": {
+      "context": 500000,
       "output": 32000
     }
   },
@@ -139435,7 +141141,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-03-31",
+    "knowledge": "2025-05",
     "release_date": "2025-11-24",
     "last_updated": "2025-11-24",
     "modalities": {
@@ -139534,6 +141240,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {
@@ -141153,6 +142860,36 @@
     "limit": {
       "context": 0,
       "output": 0
+    }
+  },
+  {
+    "id": "vercel/google/gemini-omni-flash-preview",
+    "name": "Gemini Omni Flash Preview",
+    "family": "gemini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 9.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 57920
     }
   },
   {
@@ -145952,6 +147689,37 @@
     }
   },
   {
+    "id": "vercel/xai/grok-4.5",
+    "name": "Grok 4.5",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-07-08",
+    "last_updated": "2026-07-08",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 6.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 500000,
+      "output": 500000
+    }
+  },
+  {
     "id": "vercel/xai/grok-build-0.1",
     "name": "Grok Build 0.1",
     "family": "grok-build",
@@ -147713,43 +149481,14 @@
     }
   },
   {
-    "id": "wandb/MiniMaxAI/MiniMax-M2.5",
-    "name": "MiniMax M2.5",
-    "family": "minimax",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-02-12",
-    "last_updated": "2026-03-12",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.3,
-      "output": 1.2
-    },
-    "limit": {
-      "context": 196608,
-      "output": 196608
-    }
-  },
-  {
-    "id": "wandb/OpenPipe/Qwen3-14B-Instruct",
-    "name": "OpenPipe Qwen3 14B Instruct",
-    "family": "qwen",
+    "id": "wandb/JetBrains/Mellum2-12B-A2.5B-Instruct",
+    "name": "Mellum2 12B A2.5B",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-04-29",
-    "last_updated": "2026-03-12",
+    "release_date": "2026-06-01",
+    "last_updated": "2026-06-01",
     "modalities": {
       "input": [
         "text"
@@ -147761,7 +149500,66 @@
     "open_weights": true,
     "cost": {
       "input": 0.05,
-      "output": 0.22
+      "output": 0.1,
+      "cache_read": 0.05
+    },
+    "limit": {
+      "context": 131072,
+      "output": 131072
+    }
+  },
+  {
+    "id": "wandb/MiniMaxAI/MiniMax-M2.5",
+    "name": "MiniMax M2.5",
+    "family": "minimax-m2.5",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-12",
+    "last_updated": "2026-02-12",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.3
+    },
+    "limit": {
+      "context": 196608,
+      "output": 196608
+    }
+  },
+  {
+    "id": "wandb/OpenPipe/Qwen3-14B-Instruct",
+    "name": "Qwen3 14B Instruct",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-04-29",
+    "last_updated": "2025-04-29",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.05,
+      "output": 0.22,
+      "cache_read": 0.05
     },
     "limit": {
       "context": 32768,
@@ -147770,15 +149568,15 @@
   },
   {
     "id": "wandb/Qwen/Qwen3-235B-A22B-Instruct",
-    "name": "Qwen3 235B A22B Instruct 2507",
+    "name": "Qwen3 235B A22B-2507",
     "family": "qwen",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-04",
-    "release_date": "2025-04-28",
-    "last_updated": "2026-03-12",
+    "release_date": "2025-07-22",
+    "last_updated": "2025-07-22",
     "modalities": {
       "input": [
         "text"
@@ -147790,7 +149588,8 @@
     "open_weights": true,
     "cost": {
       "input": 0.1,
-      "output": 0.1
+      "output": 0.1,
+      "cache_read": 0.1
     },
     "limit": {
       "context": 262144,
@@ -147799,7 +149598,7 @@
   },
   {
     "id": "wandb/Qwen/Qwen3-235B-A22B-Thinking",
-    "name": "Qwen3-235B-A22B-Thinking-2507",
+    "name": "Qwen3 235B A22B Thinking-2507",
     "family": "qwen",
     "attachment": false,
     "reasoning": true,
@@ -147807,7 +149606,7 @@
     "temperature": true,
     "knowledge": "2025-04",
     "release_date": "2025-07-25",
-    "last_updated": "2026-03-12",
+    "last_updated": "2025-07-25",
     "modalities": {
       "input": [
         "text"
@@ -147819,7 +149618,8 @@
     "open_weights": true,
     "cost": {
       "input": 0.1,
-      "output": 0.1
+      "output": 0.1,
+      "cache_read": 0.1
     },
     "limit": {
       "context": 262144,
@@ -147835,7 +149635,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-07-29",
-    "last_updated": "2026-03-12",
+    "last_updated": "2025-07-29",
     "modalities": {
       "input": [
         "text"
@@ -147847,7 +149647,8 @@
     "open_weights": true,
     "cost": {
       "input": 0.1,
-      "output": 0.3
+      "output": 0.3,
+      "cache_read": 0.1
     },
     "limit": {
       "context": 262144,
@@ -147856,15 +149657,15 @@
   },
   {
     "id": "wandb/Qwen/Qwen3-Coder-480B-A35B-Instruct",
-    "name": "Qwen3-Coder-480B-A35B-Instruct",
+    "name": "Qwen3 Coder 480B A35B",
     "family": "qwen",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-04",
-    "release_date": "2025-07-23",
-    "last_updated": "2026-03-12",
+    "release_date": "2025-07-22",
+    "last_updated": "2025-07-22",
     "modalities": {
       "input": [
         "text"
@@ -147876,7 +149677,128 @@
     "open_weights": true,
     "cost": {
       "input": 1.0,
-      "output": 1.5
+      "output": 1.5,
+      "cache_read": 1.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "wandb/Qwen/Qwen3.5-27B",
+    "name": "Qwen3.5-27B",
+    "family": "qwen3.5",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-24",
+    "last_updated": "2026-02-24",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.39,
+      "output": 3.12,
+      "cache_read": 0.08
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "wandb/Qwen/Qwen3.5-35B-A3B",
+    "name": "Qwen3.5-35B-A3B",
+    "family": "qwen3.5",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-24",
+    "last_updated": "2026-02-24",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.25,
+      "output": 1.25,
+      "cache_read": 0.25
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "wandb/Qwen/Qwen3.6-27B",
+    "name": "Qwen3.6 27B",
+    "family": "qwen3.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.6,
+      "output": 3.6,
+      "cache_read": 0.12
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "wandb/Qwen/Qwen3.6-35B-A3B",
+    "name": "Qwen3.6 35B A3B",
+    "family": "qwen3.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-15",
+    "last_updated": "2026-04-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.25,
+      "output": 1.25,
+      "cache_read": 0.25
     },
     "limit": {
       "context": 262144,
@@ -147892,7 +149814,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-08-21",
-    "last_updated": "2026-03-12",
+    "last_updated": "2025-08-21",
     "modalities": {
       "input": [
         "text"
@@ -147904,7 +149826,8 @@
     "open_weights": true,
     "cost": {
       "input": 0.55,
-      "output": 1.65
+      "output": 1.65,
+      "cache_read": 0.55
     },
     "limit": {
       "context": 161000,
@@ -147912,15 +149835,16 @@
     }
   },
   {
-    "id": "wandb/meta-llama/Llama-3.1-70B-Instruct",
-    "name": "Llama 3.1 70B",
-    "family": "llama",
+    "id": "wandb/deepseek-ai/DeepSeek-V4-Flash",
+    "name": "DeepSeek V4 Flash",
+    "family": "deepseek",
     "attachment": false,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2024-07-23",
-    "last_updated": "2026-03-12",
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
     "modalities": {
       "input": [
         "text"
@@ -147931,25 +149855,26 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.8,
-      "output": 0.8
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.07
     },
     "limit": {
-      "context": 128000,
-      "output": 128000
+      "context": 1048576,
+      "output": 1048576
     }
   },
   {
-    "id": "wandb/meta-llama/Llama-3.1-8B-Instruct",
-    "name": "Meta-Llama-3.1-8B-Instruct",
-    "family": "llama",
+    "id": "wandb/deepseek-ai/DeepSeek-V4-Pro",
+    "name": "DeepSeek V4 Pro",
+    "family": "deepseek",
     "attachment": false,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2023-12",
-    "release_date": "2024-07-23",
-    "last_updated": "2026-03-12",
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
     "modalities": {
       "input": [
         "text"
@@ -147960,54 +149885,25 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.22,
-      "output": 0.22
+      "input": 1.74,
+      "output": 3.48,
+      "cache_read": 0.14
     },
     "limit": {
-      "context": 128000,
-      "output": 128000
+      "context": 1048576,
+      "output": 1048576
     }
   },
   {
-    "id": "wandb/meta-llama/Llama-3.3-70B-Instruct",
-    "name": "Llama-3.3-70B-Instruct",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
+    "id": "wandb/google/gemma-4-31B-it",
+    "name": "Gemma 4 31B",
+    "family": "gemma",
+    "attachment": true,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2023-12",
-    "release_date": "2024-12-06",
-    "last_updated": "2026-03-12",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.71,
-      "output": 0.71
-    },
-    "limit": {
-      "context": 128000,
-      "output": 128000
-    }
-  },
-  {
-    "id": "wandb/meta-llama/Llama-4-Scout-17B-16E-Instruct",
-    "name": "Llama 4 Scout 17B 16E Instruct",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-12",
-    "release_date": "2025-01-31",
-    "last_updated": "2026-03-12",
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
     "modalities": {
       "input": [
         "text",
@@ -148019,25 +149915,144 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.17,
-      "output": 0.66
+      "input": 0.12,
+      "output": 0.35,
+      "cache_read": 0.09
     },
     "limit": {
-      "context": 64000,
-      "output": 64000
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "wandb/ibm-granite/granite-4.1-8b",
+    "name": "Granite 4.1 8B",
+    "family": "granite",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-29",
+    "last_updated": "2026-04-29",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.05,
+      "output": 0.1,
+      "cache_read": 0.05
+    },
+    "limit": {
+      "context": 131072,
+      "output": 131072
+    }
+  },
+  {
+    "id": "wandb/meta-llama/Llama-3.1-70B-Instruct",
+    "name": "Llama 3.1 70B",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2024-07-23",
+    "last_updated": "2024-07-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.8,
+      "output": 0.8,
+      "cache_read": 0.8
+    },
+    "limit": {
+      "context": 128000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "wandb/meta-llama/Llama-3.1-8B-Instruct",
+    "name": "Llama 3.1 8B",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-12",
+    "release_date": "2024-07-23",
+    "last_updated": "2024-07-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.22,
+      "output": 0.22,
+      "cache_read": 0.22
+    },
+    "limit": {
+      "context": 128000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "wandb/meta-llama/Llama-3.3-70B-Instruct",
+    "name": "Llama 3.3 70B",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-12",
+    "release_date": "2024-12-01",
+    "last_updated": "2024-12-01",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.71,
+      "output": 0.71,
+      "cache_read": 0.71
+    },
+    "limit": {
+      "context": 128000,
+      "output": 128000
     }
   },
   {
     "id": "wandb/microsoft/Phi-4-mini-instruct",
-    "name": "Phi-4-mini-instruct",
+    "name": "Phi 4 Mini 3.8B",
     "family": "phi",
     "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2023-10",
-    "release_date": "2024-12-11",
-    "last_updated": "2026-03-12",
+    "release_date": "2025-02-01",
+    "last_updated": "2025-02-01",
     "modalities": {
       "input": [
         "text"
@@ -148049,7 +150064,8 @@
     "open_weights": true,
     "cost": {
       "input": 0.08,
-      "output": 0.35
+      "output": 0.35,
+      "cache_read": 0.08
     },
     "limit": {
       "context": 128000,
@@ -148064,8 +150080,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-01-27",
-    "last_updated": "2026-03-12",
+    "knowledge": "2025-01",
+    "release_date": "2026-02-02",
+    "last_updated": "2026-02-02",
     "modalities": {
       "input": [
         "text",
@@ -148077,8 +150094,71 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.5,
-      "output": 2.85
+      "input": 0.6,
+      "output": 3.0,
+      "cache_read": 0.1
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "wandb/moonshotai/Kimi-K2.6",
+    "name": "Kimi K2.6",
+    "family": "kimi-k2",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-04-20",
+    "last_updated": "2026-04-20",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.95,
+      "output": 4.0,
+      "cache_read": 0.16
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "wandb/moonshotai/Kimi-K2.7-Code",
+    "name": "Kimi K2.7 Code",
+    "family": "kimi-k2",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-06-12",
+    "last_updated": "2026-06-12",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.94,
+      "output": 4.0,
+      "cache_read": 0.19
     },
     "limit": {
       "context": 262144,
@@ -148087,14 +150167,14 @@
   },
   {
     "id": "wandb/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
-    "name": "NVIDIA Nemotron 3 Super 120B",
+    "name": "Nemotron 3 Super",
     "family": "nemotron",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-03-11",
-    "last_updated": "2026-03-12",
+    "last_updated": "2026-03-11",
     "modalities": {
       "input": [
         "text"
@@ -148106,7 +150186,37 @@
     "open_weights": true,
     "cost": {
       "input": 0.2,
-      "output": 0.8
+      "output": 0.8,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "wandb/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
+    "name": "Nemotron 3 Ultra",
+    "family": "nemotron",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-04",
+    "last_updated": "2026-06-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.75,
+      "output": 2.75,
+      "cache_read": 0.15
     },
     "limit": {
       "context": 262144,
@@ -148122,7 +150232,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-08-05",
-    "last_updated": "2026-03-12",
+    "last_updated": "2025-08-05",
     "modalities": {
       "input": [
         "text"
@@ -148131,10 +150241,11 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
-      "input": 0.15,
-      "output": 0.6
+      "input": 0.04,
+      "output": 0.14,
+      "cache_read": 0.04
     },
     "limit": {
       "context": 131072,
@@ -148150,35 +150261,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2025-08-05",
-    "last_updated": "2026-03-12",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.05,
-      "output": 0.2
-    },
-    "limit": {
-      "context": 131072,
-      "output": 131072
-    }
-  },
-  {
-    "id": "wandb/zai-org/GLM-5-FP8",
-    "name": "GLM 5",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-02-11",
-    "last_updated": "2026-03-12",
+    "last_updated": "2025-08-05",
     "modalities": {
       "input": [
         "text"
@@ -148189,17 +150272,18 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 1.0,
-      "output": 3.2
+      "input": 0.03,
+      "output": 0.13,
+      "cache_read": 0.03
     },
     "limit": {
-      "context": 200000,
-      "output": 200000
+      "context": 131072,
+      "output": 131072
     }
   },
   {
     "id": "wandb/zai-org/GLM-5.1",
-    "name": "GLM-5.1",
+    "name": "GLM 5.1",
     "family": "glm",
     "attachment": false,
     "reasoning": true,
@@ -148219,12 +150303,40 @@
     "cost": {
       "input": 1.4,
       "output": 4.4,
-      "cache_read": 0.26,
-      "cache_write": 0.0
+      "cache_read": 0.26
     },
     "limit": {
-      "context": 200000,
-      "output": 131072
+      "context": 202752,
+      "output": 202752
+    }
+  },
+  {
+    "id": "wandb/zai-org/GLM-5.2",
+    "name": "GLM 5.2",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-16",
+    "last_updated": "2026-06-16",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.39,
+      "output": 4.4,
+      "cache_read": 0.26
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
     }
   },
   {
@@ -148349,6 +150461,37 @@
     "limit": {
       "context": 1000000,
       "output": 30000
+    }
+  },
+  {
+    "id": "x-ai/grok-4.5",
+    "name": "Grok 4.5",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-07-08",
+    "last_updated": "2026-07-08",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 6.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 500000,
+      "output": 500000
     }
   },
   {
@@ -149994,6 +152137,34 @@
     }
   },
   {
+    "id": "zenifra/alibaba/qwen3.6-35b-a3b",
+    "name": "Qwen3.6 35B-A3B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-17",
+    "last_updated": "2026-04-17",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.19,
+      "output": 0.48
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
     "id": "zenmux/anthropic/claude-3.5-haiku",
     "name": "Claude 3.5 Haiku",
     "attachment": true,
@@ -150287,6 +152458,7 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
+    "knowledge": "2026-01",
     "release_date": "2026-05-28",
     "last_updated": "2026-05-28",
     "modalities": {

--- a/crates/goose-provider-types/src/canonical/data/provider_metadata.json
+++ b/crates/goose-provider-types/src/canonical/data/provider_metadata.json
@@ -254,6 +254,17 @@
     "model_count": 23
   },
   {
+    "id": "crossmodel",
+    "display_name": "CrossModel",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.crossmodel.ai/v1",
+    "doc": "https://www.crossmodel.ai/docs",
+    "env": [
+      "CROSSMODEL_API_KEY"
+    ],
+    "model_count": 37
+  },
+  {
     "id": "databricks",
     "display_name": "Databricks",
     "npm": "@ai-sdk/openai-compatible",
@@ -571,7 +582,7 @@
     "env": [
       "LLMGATEWAY_API_KEY"
     ],
-    "model_count": 180
+    "model_count": 181
   },
   {
     "id": "llmtr",
@@ -627,6 +638,17 @@
       "MEGANOVA_API_KEY"
     ],
     "model_count": 19
+  },
+  {
+    "id": "meta",
+    "display_name": "Meta",
+    "npm": "@ai-sdk/openai",
+    "api": "https://api.meta.ai/v1",
+    "doc": "https://dev.meta.ai/docs",
+    "env": [
+      "META_MODEL_API_KEY"
+    ],
+    "model_count": 1
   },
   {
     "id": "meta-llama",
@@ -792,7 +814,7 @@
       "NEON_AI_GATEWAY_BASE_URL",
       "NEON_AI_GATEWAY_TOKEN"
     ],
-    "model_count": 25
+    "model_count": 36
   },
   {
     "id": "neuralwatt",
@@ -858,7 +880,7 @@
     "env": [
       "OPENCODE_API_KEY"
     ],
-    "model_count": 75
+    "model_count": 76
   },
   {
     "id": "opencode-go",
@@ -986,12 +1008,12 @@
     "id": "routing-run",
     "display_name": "routing.run",
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://ai.routing.sh/v1",
+    "api": "https://api.routing.run/v1",
     "doc": "https://docs.routing.run/api-reference/models",
     "env": [
       "ROUTING_RUN_API_KEY"
     ],
-    "model_count": 26
+    "model_count": 12
   },
   {
     "id": "sakana",
@@ -1267,7 +1289,7 @@
     "env": [
       "WANDB_API_KEY"
     ],
-    "model_count": 18
+    "model_count": 29
   },
   {
     "id": "xiaomi",
@@ -1354,6 +1376,17 @@
     "doc": "https://docs.zeldoc.ai",
     "env": [
       "ZELDOC_API_KEY"
+    ],
+    "model_count": 1
+  },
+  {
+    "id": "zenifra",
+    "display_name": "Zenifra",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://ai.zenifra.com/v1",
+    "doc": "https://docs.zenifra.com",
+    "env": [
+      "ZENIFRA_AI_KEY"
     ],
     "model_count": 1
   },


### PR DESCRIPTION
## Summary

Refresh the generated canonical model inventory and provider metadata from models.dev. This includes the GPT-5.6 family supported by #10349.

### Testing

- Ran `just build-canonical-models` without the optional mapping checker
- Confirmed the generated inventory contains OpenAI and OpenRouter GPT-5.6 variants

### Related Issues

Follow-up to #10349

### Screenshots/Demos

Not applicable; generated model metadata only.

Generated with Goose
