### PR TITLE
fix(google): include thinking tokens in usage output_tokens

### DIFF
--- a/crates/goose-provider-types/src/formats/google.rs
+++ b/crates/goose-provider-types/src/formats/google.rs
@@ -339,10 +339,26 @@ pub fn get_usage(data: &Value) -> Result<Usage> {
             .get("promptTokenCount")
             .and_then(|v| v.as_u64())
             .map(|v| v as i32);
-        let output_tokens = usage_meta_data
+        // `candidatesTokenCount` is the visible output; thinking models
+        // (Gemini 2.5/3) report reasoning tokens separately in
+        // `thoughtsTokenCount`, and per the API spec `totalTokenCount` =
+        // prompt + thoughts + candidates. Fold thoughts into `output_tokens` so
+        // the record reconciles (input + output == total) and cost, which
+        // Google bills at the output rate, is correct -- matching the OpenAI
+        // (completion_tokens includes reasoning) and Anthropic (output_tokens
+        // includes thinking) adapters.
+        let candidates_tokens = usage_meta_data
             .get("candidatesTokenCount")
-            .and_then(|v| v.as_u64())
-            .map(|v| v as i32);
+            .and_then(|v| v.as_u64());
+        let thoughts_tokens = usage_meta_data
+            .get("thoughtsTokenCount")
+            .and_then(|v| v.as_u64());
+        let output_tokens = match (candidates_tokens, thoughts_tokens) {
+            (None, None) => None,
+            (candidates, thoughts) => {
+                Some((candidates.unwrap_or(0) + thoughts.unwrap_or(0)) as i32)
+            }
+        };
         let total_tokens = usage_meta_data
             .get("totalTokenCount")
             .and_then(|v| v.as_u64())
@@ -742,6 +758,33 @@ mod tests {
         assert_eq!(usage.total_tokens, Some(120));
         assert_eq!(usage.cache_read_input_tokens, Some(80));
         assert_eq!(usage.cache_write_input_tokens, None);
+    }
+
+    #[test]
+    fn test_get_usage_includes_thinking_tokens() {
+        // Gemini thinking models (2.5/3, the goose defaults) report reasoning
+        // tokens separately in `thoughtsTokenCount`, and per the API spec
+        // `totalTokenCount` = prompt + thoughts + candidates. `output_tokens`
+        // must include thoughts so the record reconciles (input + output ==
+        // total) and cost, which Google bills at the output rate, is correct --
+        // matching the OpenAI (completion_tokens includes reasoning) and
+        // Anthropic (output_tokens includes thinking) adapters.
+        let data = json!({
+            "usageMetadata": {
+                "promptTokenCount": 100,
+                "candidatesTokenCount": 50,
+                "thoughtsTokenCount": 200,
+                "totalTokenCount": 350
+            }
+        });
+        let usage = get_usage(&data).unwrap();
+        assert_eq!(usage.input_tokens, Some(100));
+        assert_eq!(usage.output_tokens, Some(250));
+        assert_eq!(usage.total_tokens, Some(350));
+        assert_eq!(
+            usage.input_tokens.unwrap() + usage.output_tokens.unwrap(),
+            usage.total_tokens.unwrap(),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`get_usage` in `crates/goose-provider-types/src/formats/google.rs` sets `output_tokens = candidatesTokenCount` and takes `total_tokens = totalTokenCount` verbatim. For Gemini thinking models (2.5/3, the current defaults) the API reports reasoning tokens separately in `thoughtsTokenCount`, and per the [spec](https://ai.google.dev/api/generate-content#UsageMetadata) `totalTokenCount = promptTokenCount + thoughtsTokenCount + candidatesTokenCount`.

So on a thinking response:

- `output_tokens` undercounts generated output by the entire thinking-token amount, and Google bills thoughts at the output rate, so any cost derived from `output_tokens` is low.
- The record is self-inconsistent: `input_tokens + output_tokens = total_tokens - thoughtsTokenCount < total_tokens`.

This also diverges from goose's own OpenAI adapter (`output_tokens = completion_tokens`, which includes `reasoning_tokens`) and Anthropic adapter (`output_tokens` includes thinking) - Google is the only provider that drops the reasoning tokens. The Vertex path (`gcpvertexai.rs`) delegates to this function too.

## Fix

Fold `thoughtsTokenCount` into `output_tokens`. When neither `candidatesTokenCount` nor `thoughtsTokenCount` is present, `output_tokens` stays `None`, so non-thinking responses are unchanged. This restores `input + output == total`.

## Verification

`cargo test -p goose-provider-types formats::google::tests`: the new `test_get_usage_includes_thinking_tokens` fails on `main` (`output_tokens == Some(50)`) and passes with the fix (`Some(250)`); all existing google-format tests (which carry no `thoughtsTokenCount`) still pass, so non-thinking responses are unaffected. `cargo fmt` and `cargo clippy -p goose-provider-types` are clean.