### PR TITLE
Add declarative Sakana AI provider for the OpenAI-compatible Fugu API

### DIFF
--- a/crates/goose-providers/src/declarative.rs
+++ b/crates/goose-providers/src/declarative.rs
@@ -40,6 +40,7 @@ pub(crate) mod declarative_providers {
         ovhcloud,
         perplexity,
         routstr,
+        sakana,
         saladcloud,
         scaleway,
         tanzu,

--- a/crates/goose-providers/src/declarative/definitions/sakana.json
+++ b/crates/goose-providers/src/declarative/definitions/sakana.json
@@ -1,0 +1,31 @@
+{
+  "name": "sakana",
+  "engine": "openai",
+  "display_name": "Sakana AI",
+  "description": "Sakana Fugu multi-agent system delivered as one OpenAI-compatible model API",
+  "api_key_env": "SAKANA_API_KEY",
+  "base_url": "https://api.sakana.ai/v1",
+  "models": [
+    {
+      "name": "fugu",
+      "context_limit": 1000000,
+      "input_token_cost": null,
+      "output_token_cost": null,
+      "currency": null,
+      "supports_cache_control": null
+    },
+    {
+      "name": "fugu-ultra",
+      "context_limit": 1000000,
+      "input_token_cost": null,
+      "output_token_cost": null,
+      "currency": null,
+      "supports_cache_control": null
+    }
+  ],
+  "headers": null,
+  "timeout_seconds": null,
+  "model_doc_link": "https://console.sakana.ai/models",
+  "preserves_thinking": true,
+  "supports_streaming": true
+}


### PR DESCRIPTION
## Summary
Simple one. Adds https://sakana.ai which is one I have been testing out, as a declarative provider.

### Testing
Manual test

### Related Issues
N/A

### Screenshots/Demos (for UX changes)
<img width="1840" height="1117" alt="Screenshot 2026-07-09 at 5 10 30 PM" src="https://github.com/user-attachments/assets/faa0396a-ae24-48b0-9581-fec566c24cb5" />
