### PR TITLE
feat(hooks): advise tier — non-blocking context injection, tool trace in Stop payload, warn decision (#10358)

### DIFF
--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -2385,6 +2385,7 @@ impl GooseAcpAgent {
         };
         if let Some(agent) = agent {
             agent.discard_pending_steers(session_id).await;
+            agent.discard_pre_tool_advisories(session_id).await;
         }
 
         if self.closed_session_ids.lock().await.contains(session_id) {

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -544,13 +544,21 @@ impl Agent {
             .unwrap_or(DEFAULT_STOP_HOOK_BLOCK_CAP)
     }
 
-    pub async fn emit_hook(&self, event: crate::hooks::HookEvent, session_id: &str) {
+    /// Fire a lifecycle hook event with no extra context (e.g. `SessionStart`,
+    /// `SessionEnd`). Returns any `additionalContext` strings the hooks emit,
+    /// so the caller can route them through the same advisory-injection path as
+    /// every other emit site instead of discarding them.
+    pub async fn emit_hook(
+        &self,
+        event: crate::hooks::HookEvent,
+        session_id: &str,
+    ) -> Vec<String> {
         if !self.hook_manager.has_hooks(event) {
-            return;
+            return Vec::new();
         }
         self.hook_manager
             .emit(event, crate::hooks::HookContext::new(event, session_id))
-            .await;
+            .await
     }
 
     fn stop_hook_context(
@@ -1724,12 +1732,19 @@ impl Agent {
             .as_ref()
             .map(|conversation| conversation.messages().is_empty())
             .unwrap_or(true);
+        // Hook advisories collected before the turn, injected together at the
+        // single point below. SessionStart used to discard its advisories; now
+        // it shares the same path as UserPromptSubmit (order preserved:
+        // SessionStart context first, then this prompt's).
+        let mut user_prompt_submit_context: Vec<String> = Vec::new();
         if is_first_turn {
-            self.emit_hook(crate::hooks::HookEvent::SessionStart, &session_config.id)
-                .await;
+            user_prompt_submit_context.extend(
+                self.emit_hook(crate::hooks::HookEvent::SessionStart, &session_config.id)
+                    .await,
+            );
         }
 
-        let user_prompt_submit_context = if self
+        if self
             .hook_manager
             .has_hooks(crate::hooks::HookEvent::UserPromptSubmit)
         {
@@ -1738,12 +1753,12 @@ impl Agent {
                 &session_config.id,
             )
             .with_message(message_text.clone());
-            self.hook_manager
-                .emit(crate::hooks::HookEvent::UserPromptSubmit, ctx)
-                .await
-        } else {
-            Vec::new()
-        };
+            user_prompt_submit_context.extend(
+                self.hook_manager
+                    .emit(crate::hooks::HookEvent::UserPromptSubmit, ctx)
+                    .await,
+            );
+        }
 
         let command_result = self
             .execute_command(&message_text, &session_config.id)
@@ -3872,6 +3887,24 @@ echo start >> "$PLUGIN_ROOT/hook.log"
             })
         }
 
+        /// Like `new`, but the SessionStart hook also advises via the
+        /// `additionalContext` shape, so tests can assert the advisory is
+        /// injected (it used to be discarded by `emit_hook`).
+        fn new_emitting_context(context: &str) -> Result<Self> {
+            let env = Self::new()?;
+            let start_sh = env.temp_dir.path().join("session-start/start.sh");
+            std::fs::write(
+                &start_sh,
+                format!(
+                    r#"#!/bin/sh
+echo start >> "$PLUGIN_ROOT/hook.log"
+printf '%s' '{{"hookSpecificOutput":{{"hookEventName":"SessionStart","additionalContext":"{context}"}}}}'
+"#,
+                ),
+            )?;
+            Ok(env)
+        }
+
         fn hook_manager(&self) -> crate::hooks::HookManager {
             crate::hooks::HookManager::from_plugins_for_test(vec![DiscoveredPlugin {
                 name: "session-start".into(),
@@ -4117,6 +4150,29 @@ echo start >> "$PLUGIN_ROOT/hook.log"
 
         assert_eq!(env.hook_invocations(), 1);
         assert_eq!(provider.call_count(), 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn emit_hook_returns_additional_context_instead_of_discarding() -> Result<()> {
+        // Regression for the review gap: emit_hook used to discard emit()'s
+        // return value, so SessionStart's additionalContext never reached the
+        // caller. It now returns the advisories, which reply() merges into the
+        // same advisory-injection path as UserPromptSubmit (line ~1857).
+        let env = SessionStartHookTestEnv::new_emitting_context("project uses tabs, not spaces")?;
+        let provider = Arc::new(CountingTextProvider::new());
+        let (agent, session_id) =
+            create_test_agent(env.data_dir(), env.hook_manager(), provider.clone()).await?;
+
+        let advisories = agent
+            .emit_hook(crate::hooks::HookEvent::SessionStart, &session_id)
+            .await;
+
+        assert_eq!(
+            advisories,
+            vec!["project uses tabs, not spaces".to_string()],
+            "emit_hook must return the SessionStart additionalContext, not discard it"
+        );
         Ok(())
     }
 

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2014,6 +2014,15 @@ impl Agent {
                 }
             };
 
+            // Any PreToolUse advisory still queued for this session is an orphan
+            // from a prior run that was cancelled or dropped before its next-turn
+            // drain — a PreToolUse advisory only lives within a single reply's
+            // loop. Clear it here, on the generic reply path (elicitation
+            // responses return early above and never reach this point), so a
+            // cancelled run on ANY driver — ACP, orchestrator, or otherwise —
+            // can't leak stale advice into this fresh turn.
+            self.discard_pre_tool_advisories(&session_config.id).await;
+
             let mut reply_stream = self.reply_internal(final_conversation, session_config, session, cancel_token).await?;
             while let Some(event) = reply_stream.next().await {
                 yield event?;
@@ -4647,6 +4656,39 @@ printf '%s' '{{"hookSpecificOutput":{{"hookEventName":"SessionStart","additional
             agent.drain_pre_tool_advisories(session_id).await.is_empty(),
             "discarding must drop PreToolUse advisories orphaned by a cancelled run"
         );
+    }
+
+    #[tokio::test]
+    async fn reply_clears_orphaned_pre_tool_advisory_before_the_turn() -> Result<()> {
+        // Regression (codex #10361): a PreToolUse advisory queued by a run that
+        // was cancelled before its drain must NOT leak into the next reply on the
+        // same session. reply() clears the buffer at entry, generically —
+        // independent of which driver (ACP, orchestrator, …) cancelled the prior
+        // run.
+        let env = SessionStartHookTestEnv::new()?; // SessionStart hook emits no advisory
+        let provider = Arc::new(CountingTextProvider::new());
+        let (agent, session_id) =
+            create_test_agent(env.data_dir(), env.hook_manager(), provider.clone()).await?;
+
+        agent
+            .queue_pre_tool_advisory(&session_id, vec!["STALE_LEAK_ADVISORY".to_string()])
+            .await;
+
+        let messages = run_stop_hook_test_turn(&agent, &session_id, "hello").await?;
+        let texts = visible_texts(&messages);
+
+        assert!(
+            !texts.iter().any(|t| t.contains("STALE_LEAK_ADVISORY")),
+            "an orphaned PreToolUse advisory must be cleared at reply entry, not injected into the next turn"
+        );
+        assert!(
+            agent
+                .drain_pre_tool_advisories(&session_id)
+                .await
+                .is_empty(),
+            "the buffer must be empty after reply cleared it at entry"
+        );
+        Ok(())
     }
 
     #[tokio::test]

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -368,6 +368,11 @@ pub struct Agent {
     goal: Mutex<Option<String>>,
     grind: Mutex<Option<String>>,
     pending_steers: Mutex<HashMap<String, VecDeque<Message>>>,
+    // PreToolUse fires mid-turn, while a tool call is already executing, so an
+    // Allow-with-advisory can't be injected into the conversation right there.
+    // Queued here and drained at the next turn boundary in `reply_internal`,
+    // the same deferral pattern as `pending_steers`.
+    pending_pre_tool_advisories: Mutex<HashMap<String, Vec<String>>>,
 }
 
 #[derive(Clone, Debug)]
@@ -518,6 +523,7 @@ impl Agent {
             goal: Mutex::new(None),
             grind: Mutex::new(None),
             pending_steers: Mutex::new(HashMap::new()),
+            pending_pre_tool_advisories: Mutex::new(HashMap::new()),
         }
     }
 
@@ -645,6 +651,30 @@ impl Agent {
             .await
             .remove(session_id)
             .map(|messages| messages.into_iter().map(Message::with_steer).collect())
+            .unwrap_or_default()
+    }
+
+    /// Queue a PreToolUse advisory for delivery at the next turn boundary.
+    /// PreToolUse fires while a tool call is already in flight, so the
+    /// advisory can't be injected into the conversation right there — it's
+    /// drained in `reply_internal` (see `drain_pre_tool_advisories`).
+    async fn queue_pre_tool_advisory(&self, session_id: &str, advisories: Vec<String>) {
+        if advisories.is_empty() {
+            return;
+        }
+        self.pending_pre_tool_advisories
+            .lock()
+            .await
+            .entry(session_id.to_string())
+            .or_default()
+            .extend(advisories);
+    }
+
+    async fn drain_pre_tool_advisories(&self, session_id: &str) -> Vec<String> {
+        self.pending_pre_tool_advisories
+            .lock()
+            .await
+            .remove(session_id)
             .unwrap_or_default()
     }
 
@@ -1221,12 +1251,11 @@ impl Agent {
                             .map(|a| serde_json::Value::Object(a.clone())),
                     )
                     .with_working_dir(session.working_dir.to_string_lossy().to_string());
-            if let crate::hooks::HookDecision::Deny { reason, plugin } = self
+            let hook_result = self
                 .hook_manager
                 .emit_blocking(crate::hooks::HookEvent::PreToolUse, ctx)
-                .await
-                .decision
-            {
+                .await;
+            if let crate::hooks::HookDecision::Deny { reason, plugin } = hook_result.decision {
                 return (
                     request_id,
                     Err(ErrorData::new(
@@ -1239,6 +1268,12 @@ impl Agent {
                     )),
                 );
             }
+            // Allow with a non-empty advisory (`warn` or `additionalContext`):
+            // the tool is about to run mid-turn, so the advisory can't be
+            // delivered to the model here — queue it for delivery at the next
+            // turn boundary instead of dropping it.
+            self.queue_pre_tool_advisory(&session.id, hook_result.advisories)
+                .await;
         }
 
         let tool_input_for_extended = tool_call
@@ -2082,6 +2117,21 @@ impl Agent {
                 }
 
                 if can_drain_pending_steers {
+                    let pre_tool_advisories = self.drain_pre_tool_advisories(&session_config.id).await;
+                    if let Some(message) = advisory_context_message(&pre_tool_advisories) {
+                        // A PreToolUse hook warned (or emitted additionalContext)
+                        // while a tool call was in flight; that advisory was
+                        // queued rather than injected on the spot. This is the
+                        // next turn boundary — deliver it now, then merge so it
+                        // doesn't leave two consecutive user-role turns for
+                        // strict providers when moim's per-turn merge is skipped
+                        // (small context limits).
+                        session_manager.add_message(&session_config.id, &message).await?;
+                        conversation.push(message.clone());
+                        yield AgentEvent::Message(message);
+                        conversation = merge_injected_advisory(conversation);
+                    }
+
                     let mut injected_advisory = false;
                     for message in self.drain_pending_steers(&session_config.id).await {
                         let message_text = message.as_concat_text();
@@ -2919,6 +2969,12 @@ impl Agent {
                                     session_manager.add_message(&session_config.id, &message).await?;
                                     conversation.push(message.clone());
                                     yield AgentEvent::Message(message);
+                                    // Same accounting as the Deny retry: an in-turn warn
+                                    // correction must not consume a turn, or a low
+                                    // `max_turns` (e.g. 1) can trip the max-turns check
+                                    // below before the provider is re-invoked with the
+                                    // advisory.
+                                    retrying_after_stop_hook_denial = true;
                                     // Do NOT break and do NOT set
                                     // stop_hook_handled_for_exit: falling through
                                     // continues the loop, which re-invokes the
@@ -4182,6 +4238,89 @@ printf '%s' '{{"hookSpecificOutput":{{"hookEventName":"SessionStart","additional
         Ok(())
     }
 
+    struct CapturingTextProvider {
+        call_count: AtomicUsize,
+        last_messages: tokio::sync::Mutex<Vec<Message>>,
+    }
+
+    impl CapturingTextProvider {
+        fn new() -> Self {
+            Self {
+                call_count: AtomicUsize::new(0),
+                last_messages: tokio::sync::Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::providers::base::Provider for CapturingTextProvider {
+        async fn stream(
+            &self,
+            _model_config: &goose_providers::model::ModelConfig,
+            _system_prompt: &str,
+            messages: &[Message],
+            _tools: &[Tool],
+        ) -> Result<MessageStream, ProviderError> {
+            let call = self.call_count.fetch_add(1, Ordering::SeqCst);
+            *self.last_messages.lock().await = messages.to_vec();
+            let message = Message::assistant().with_text(format!("provider response {call}"));
+            let usage = ProviderUsage::new("mock-model".to_string(), Usage::default());
+            Ok(stream_from_single_message(message, usage))
+        }
+
+        fn get_name(&self) -> &str {
+            "capturing-text"
+        }
+    }
+
+    #[tokio::test]
+    async fn session_start_advisory_keeps_provider_roles_alternating_in_small_context_sessions(
+    ) -> Result<()> {
+        // System-level invariant guard. The review (#10361) worried that the
+        // SessionStart/UserPromptSubmit advisory injection could leave two
+        // consecutive user-role turns for strict providers in a small-context
+        // session, where moim's per-turn merge (`inject_moim` ->
+        // `fix_conversation`) is skipped entirely (`should_skip_moim`). It can't:
+        // `prepare_reply_context` unconditionally runs `fix_conversation` on the
+        // incoming conversation at the top of every `reply_internal` call,
+        // independent of moim — so the role-alternation invariant already holds
+        // at this injection point, and no extra merge is needed at the call site.
+        // This test proves it end-to-end by asserting on exactly what the
+        // provider receives (via `CapturingTextProvider`), not on persisted
+        // session history (`fix_conversation` only reshapes the in-flight
+        // conversation, never persisted per-message visibility).
+        let env = SessionStartHookTestEnv::new_emitting_context("project uses tabs, not spaces")?;
+        let provider = Arc::new(CapturingTextProvider::new());
+        let (agent, session_id) =
+            create_test_agent(env.data_dir(), env.hook_manager(), provider.clone()).await?;
+
+        let small_context_limit = 8_000;
+        assert!(
+            crate::agents::moim::should_skip_moim(Some(small_context_limit)),
+            "sub-32k context limit must skip moim for this repro to be meaningful"
+        );
+        agent
+            .update_provider(
+                provider.clone(),
+                goose_providers::model::ModelConfig::new("mock-model")
+                    .with_context_limit(Some(small_context_limit)),
+                &session_id,
+            )
+            .await?;
+
+        run_stop_hook_test_turn(&agent, &session_id, "hello").await?;
+
+        let sent_messages = provider.last_messages.lock().await.clone();
+        let sent_conversation = Conversation::new_unvalidated(sent_messages);
+        assert!(
+            !has_adjacent_same_role_agent_visible(&sent_conversation),
+            "the SessionStart advisory must be merged into the in-flight conversation so the \
+             provider never sees two consecutive user-role turns when moim is skipped"
+        );
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn stop_hook_block_cap_allows_configured_consecutive_blocks_then_overrides() -> Result<()>
     {
@@ -4427,6 +4566,269 @@ printf '%s' '{{"hookSpecificOutput":{{"hookEventName":"SessionStart","additional
             "discarding must drop steers orphaned by a cancelled run so they cannot leak into a later prompt"
         );
         assert!(agent.drain_pending_steers(session_id).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn queue_pre_tool_advisory_is_drained_once() {
+        let agent = Agent::new();
+        let session_id = "session-pre-tool-advisory";
+
+        agent
+            .queue_pre_tool_advisory(session_id, vec!["be careful".to_string()])
+            .await;
+        agent
+            .queue_pre_tool_advisory(session_id, vec!["double check".to_string()])
+            .await;
+
+        assert_eq!(
+            agent.drain_pre_tool_advisories(session_id).await,
+            vec!["be careful".to_string(), "double check".to_string()],
+            "advisories queued from separate PreToolUse calls must accumulate in order"
+        );
+        assert!(
+            agent.drain_pre_tool_advisories(session_id).await.is_empty(),
+            "draining must remove the queued advisories so they are not delivered twice"
+        );
+    }
+
+    struct PreToolUseHookTestEnv {
+        temp_dir: TempDir,
+        hook_log: PathBuf,
+    }
+
+    impl PreToolUseHookTestEnv {
+        /// A PreToolUse hook that always warns (Allow + advisory) via the
+        /// `{"decision":"warn",...}` shape, without denying the tool call.
+        fn new_warning(reason: &str) -> Result<Self> {
+            let temp_dir = tempfile::tempdir()?;
+            let plugin_dir = temp_dir.path().join("pre-tool-warn");
+            std::fs::create_dir_all(plugin_dir.join("hooks"))?;
+            std::fs::write(
+                plugin_dir.join("hooks/hooks.json"),
+                r#"{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          { "type": "command", "command": "sh ${PLUGIN_ROOT}/warn.sh" }
+        ]
+      }
+    ]
+  }
+}
+"#,
+            )?;
+            std::fs::write(
+                plugin_dir.join("warn.sh"),
+                format!(
+                    r#"#!/bin/sh
+echo warned >> "$PLUGIN_ROOT/hook.log"
+printf '%s' '{{"decision":"warn","reason":"{reason}"}}'
+"#,
+                ),
+            )?;
+
+            Ok(Self {
+                temp_dir,
+                hook_log: plugin_dir.join("hook.log"),
+            })
+        }
+
+        fn hook_manager(&self) -> crate::hooks::HookManager {
+            crate::hooks::HookManager::from_plugins_for_test(vec![DiscoveredPlugin {
+                name: "pre-tool-warn".into(),
+                root: self.temp_dir.path().join("pre-tool-warn"),
+                scope: PluginScope::Project,
+            }])
+        }
+
+        fn data_dir(&self) -> PathBuf {
+            self.temp_dir.path().join("data")
+        }
+
+        fn hook_invocations(&self) -> usize {
+            std::fs::read_to_string(&self.hook_log)
+                .unwrap_or_default()
+                .lines()
+                .count()
+        }
+    }
+
+    fn final_output_response_schema() -> Response {
+        Response {
+            json_schema: Some(serde_json::json!({
+                "type": "object",
+                "properties": { "result": { "type": "string" } }
+            })),
+        }
+    }
+
+    #[tokio::test]
+    async fn pre_tool_use_warn_is_queued_by_dispatch_tool_call() -> Result<()> {
+        // Tight unit test for the exact code path Fix 1 changes:
+        // `dispatch_tool_call`'s PreToolUse handling used to project to just
+        // `.decision`, discarding `.advisories` on an Allow. It must now queue
+        // a non-empty advisory instead of dropping it. This calls the real
+        // `dispatch_tool_call` directly rather than driving it through the
+        // full `reply()` loop, since PreToolUse only fires once a tool call
+        // is already being dispatched (see the end-to-end test below for
+        // that full path).
+        let env = PreToolUseHookTestEnv::new_warning("double-check this tool call")?;
+        let provider = Arc::new(CountingTextProvider::new());
+        let (agent, session_id) =
+            create_test_agent(env.data_dir(), env.hook_manager(), provider).await?;
+
+        agent
+            .add_final_output_tool(final_output_response_schema())
+            .await;
+
+        let session = agent
+            .config
+            .session_manager
+            .get_session(&session_id, true)
+            .await?;
+
+        let mut arguments = serde_json::Map::new();
+        arguments.insert("result".to_string(), Value::String("done".to_string()));
+        let tool_call = CallToolRequestParams::new(FINAL_OUTPUT_TOOL_NAME.to_string())
+            .with_arguments(arguments);
+
+        let (_request_id, result) = agent
+            .dispatch_tool_call(tool_call, "req-1".to_string(), None, &session)
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "a warn decision is Allow, not Deny: the tool call must still execute"
+        );
+        assert_eq!(env.hook_invocations(), 1);
+        assert_eq!(
+            agent.drain_pre_tool_advisories(&session_id).await,
+            vec!["double-check this tool call".to_string()],
+            "the warn advisory must be queued for the next turn boundary, not dropped"
+        );
+
+        Ok(())
+    }
+
+    struct FinalOutputToolCallProvider {
+        call_count: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::providers::base::Provider for FinalOutputToolCallProvider {
+        async fn stream(
+            &self,
+            _model_config: &goose_providers::model::ModelConfig,
+            _system_prompt: &str,
+            _messages: &[Message],
+            _tools: &[Tool],
+        ) -> Result<MessageStream, ProviderError> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            let mut arguments = serde_json::Map::new();
+            arguments.insert("result".to_string(), Value::String("done".to_string()));
+            let message = Message::assistant().with_tool_request(
+                "call-1",
+                Ok(
+                    CallToolRequestParams::new(FINAL_OUTPUT_TOOL_NAME.to_string())
+                        .with_arguments(arguments),
+                ),
+            );
+            let usage = ProviderUsage::new("mock-model".to_string(), Usage::default());
+            Ok(stream_from_single_message(message, usage))
+        }
+
+        fn get_name(&self) -> &str {
+            "final-output-tool-call"
+        }
+    }
+
+    #[tokio::test]
+    async fn pre_tool_use_warn_advisory_reaches_next_turn_end_to_end() -> Result<()> {
+        // End-to-end: the model calls a tool, PreToolUse warns while that
+        // tool call is being dispatched, and the advisory must show up as an
+        // agent-visible message once the loop reaches the next turn boundary
+        // (here, the same iteration that notices `final_output` was set) —
+        // not be silently dropped.
+        let env = PreToolUseHookTestEnv::new_warning("verify this before finishing")?;
+        let provider = Arc::new(FinalOutputToolCallProvider {
+            call_count: AtomicUsize::new(0),
+        });
+        let (agent, session_id) =
+            create_test_agent(env.data_dir(), env.hook_manager(), provider.clone()).await?;
+
+        agent
+            .add_final_output_tool(final_output_response_schema())
+            .await;
+
+        let messages = run_stop_hook_test_turn(&agent, &session_id, "go").await?;
+        let texts = visible_texts(&messages);
+
+        assert_eq!(
+            provider.call_count.load(Ordering::SeqCst),
+            1,
+            "only one provider call is needed: the tool call resolves final_output directly"
+        );
+        assert!(
+            texts
+                .iter()
+                .any(|text| text.contains("verify this before finishing")),
+            "the PreToolUse warn advisory must reach the conversation, not be dropped: {texts:?}"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stop_hook_warn_retry_does_not_trip_max_turns() -> Result<()> {
+        // Fix 3 regression: the warn loopback arm used to fall through to
+        // continue the loop without setting `retrying_after_stop_hook_denial`,
+        // so with a low `max_turns` the turns_taken accounting (which the Deny
+        // retry is exempted from via that same flag) would trip the
+        // max-turns check and break BEFORE the provider was re-invoked with
+        // the warn advisory.
+        let env = StopHookTestEnv::new(WARN_ONCE_THEN_ALLOW_SCRIPT)?;
+        let (agent, session_id, provider) = create_stop_hook_test_agent(&env, 2).await?;
+
+        let session_config = SessionConfig {
+            id: session_id,
+            schedule_id: None,
+            max_turns: Some(1),
+            retry_config: None,
+        };
+        let reply_stream = agent
+            .reply(Message::user().with_text("hello"), session_config, None)
+            .await?;
+        tokio::pin!(reply_stream);
+
+        let mut messages = Vec::new();
+        while let Some(event) = reply_stream.next().await {
+            if let AgentEvent::Message(message) = event? {
+                messages.push(message);
+            }
+        }
+        let texts = visible_texts(&messages);
+
+        assert_eq!(
+            provider.call_count(),
+            2,
+            "the in-turn warn retry must not consume a turn: with max_turns=1 the provider \
+             must still be re-invoked once with the advisory, exactly as it would with a \
+             generous max_turns"
+        );
+        assert_eq!(env.hook_invocations(), 2);
+        assert!(
+            texts
+                .iter()
+                .any(|text| text.contains("double-check before finishing")),
+            "the warn reason must be injected as advisory context: {texts:?}"
+        );
+        assert!(
+            !texts.iter().any(|text| text == MAX_TURNS_MESSAGE),
+            "the warn retry must not trip max_turns before the provider is re-invoked: {texts:?}"
+        );
+
+        Ok(())
     }
 
     #[test]

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -637,6 +637,17 @@ impl Agent {
         self.pending_steers.lock().await.remove(session_id);
     }
 
+    /// Drop any PreToolUse advisory queued for this session but not yet drained.
+    /// Called from the same abort/cleanup path as `discard_pending_steers` so a
+    /// run cancelled between a PreToolUse hook queuing advice and the next turn
+    /// boundary can't leak that advice into a later, unrelated prompt.
+    pub async fn discard_pre_tool_advisories(&self, session_id: &str) {
+        self.pending_pre_tool_advisories
+            .lock()
+            .await
+            .remove(session_id);
+    }
+
     async fn has_pending_steers(&self, session_id: &str) -> bool {
         self.pending_steers
             .lock()
@@ -2964,7 +2975,19 @@ impl Agent {
                                 // can't loop forever — and because this is still
                                 // Allow, hitting the cap ends the turn regardless, so
                                 // warn can NEVER re-gate/deadlock the way block does.
-                                Some(message) if stop_hook_warn_loops < stop_hook_block_cap => {
+                                //
+                                // Gated on `hook_result.warned`: only an explicit
+                                // `warn` decision loops back. A hook that passively
+                                // emits `additionalContext` on every Stop (no warn)
+                                // also lands its text in `advisories`, but must NOT
+                                // trigger a retry — otherwise a purely observational
+                                // context hook would fire up to the block cap extra
+                                // model calls each turn. Those fall through to the
+                                // inject-once arm below.
+                                Some(message)
+                                    if hook_result.warned
+                                        && stop_hook_warn_loops < stop_hook_block_cap =>
+                                {
                                     stop_hook_warn_loops += 1;
                                     session_manager.add_message(&session_config.id, &message).await?;
                                     conversation.push(message.clone());
@@ -3835,6 +3858,14 @@ printf '%s' '{"decision":"warn","reason":"verify the claim against the tool trac
 exit 0
 "#;
 
+    // Passively emits `additionalContext` on every Stop (exit 0, no `decision`).
+    // The context must be injected but must NOT loop the model — unlike a `warn`.
+    const ALWAYS_ADDITIONAL_CONTEXT_SCRIPT: &str = r#"#!/bin/sh
+echo ctx >> "$PLUGIN_ROOT/hook.log"
+printf '%s' '{"hookSpecificOutput":{"hookEventName":"Stop","additionalContext":"repo has an uncommitted migration"}}'
+exit 0
+"#;
+
     // Warns on the first invocation, then plain-allows on every later one.
     const WARN_ONCE_THEN_ALLOW_SCRIPT: &str = r#"#!/bin/sh
 count_file="$PLUGIN_ROOT/count"
@@ -4457,6 +4488,37 @@ printf '%s' '{{"hookSpecificOutput":{{"hookEventName":"SessionStart","additional
     }
 
     #[tokio::test]
+    async fn stop_hook_additional_context_injects_once_without_looping() -> Result<()> {
+        // Regression (codex #10361): a Stop hook that only emits
+        // `additionalContext` (no `warn` decision) lands its text in
+        // `advisories` after the emit_blocking unify, but must be treated as a
+        // plain allow — inject the context once and END the turn. It must NOT
+        // loop the model the way `warn` does; otherwise a purely observational
+        // context hook would fire up to the block cap extra provider calls.
+        let env = StopHookTestEnv::new(ALWAYS_ADDITIONAL_CONTEXT_SCRIPT)?;
+        let (agent, session_id, provider) = create_stop_hook_test_agent(&env, 2).await?;
+
+        let messages = run_stop_hook_test_turn(&agent, &session_id, "hello").await?;
+        let texts = visible_texts(&messages);
+
+        assert_eq!(
+            provider.call_count(),
+            1,
+            "additionalContext-only must inject once and end the turn — no loop-back \
+             (contrast ALWAYS_WARN_SCRIPT, which reaches the cap at 3)"
+        );
+        assert_eq!(env.hook_invocations(), 1);
+        assert!(
+            texts
+                .iter()
+                .any(|text| text.contains("repo has an uncommitted migration")),
+            "the additionalContext must still be injected as advisory context"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn stop_hook_payload_includes_streamed_assistant_reply_text() -> Result<()> {
         let env = StopHookTestEnv::new(RECORD_PAYLOAD_SCRIPT)?;
         let provider = Arc::new(ChunkedTextProvider);
@@ -4566,6 +4628,25 @@ printf '%s' '{{"hookSpecificOutput":{{"hookEventName":"SessionStart","additional
             "discarding must drop steers orphaned by a cancelled run so they cannot leak into a later prompt"
         );
         assert!(agent.drain_pending_steers(session_id).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn discard_pre_tool_advisories_clears_queued_advice() {
+        // Regression (codex #10361): a PreToolUse advisory queued but not yet
+        // drained when a run is cancelled must be cleared on the same cleanup
+        // path as steers, or it leaks into a later unrelated prompt.
+        let agent = Agent::new();
+        let session_id = "session-discard-pretool";
+
+        agent
+            .queue_pre_tool_advisory(session_id, vec!["tool policy note".to_string()])
+            .await;
+        agent.discard_pre_tool_advisories(session_id).await;
+
+        assert!(
+            agent.drain_pre_tool_advisories(session_id).await.is_empty(),
+            "discarding must drop PreToolUse advisories orphaned by a cancelled run"
+        );
     }
 
     #[tokio::test]

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2051,6 +2051,7 @@ impl Agent {
             let mut stop_hook_handled_for_exit = false;
             let mut retrying_after_stop_hook_denial = false;
             let mut consecutive_stop_hook_blocks = 0u32;
+            let mut stop_hook_warn_loops = 0u32;
             let stop_hook_block_cap = self.stop_hook_block_cap();
             let mut can_drain_pending_steers = false;
 
@@ -2872,13 +2873,40 @@ impl Agent {
                         .await;
                     match hook_result.decision {
                         crate::hooks::HookDecision::Allow => {
-                            if let Some(message) = advisory_context_message(&hook_result.advisories) {
-                                session_manager.add_message(&session_config.id, &message).await?;
-                                conversation.push(message.clone());
-                                yield AgentEvent::Message(message);
+                            match advisory_context_message(&hook_result.advisories) {
+                                // A `warn` decision advises without denying: inject
+                                // the reason and loop back so the model can correct
+                                // the claim IN THIS turn (the provider is re-invoked
+                                // with the advisory now in `conversation`). Bounded
+                                // by the block cap so a hook that warns every time
+                                // can't loop forever — and because this is still
+                                // Allow, hitting the cap ends the turn regardless, so
+                                // warn can NEVER re-gate/deadlock the way block does.
+                                Some(message) if stop_hook_warn_loops < stop_hook_block_cap => {
+                                    stop_hook_warn_loops += 1;
+                                    session_manager.add_message(&session_config.id, &message).await?;
+                                    conversation.push(message.clone());
+                                    yield AgentEvent::Message(message);
+                                    // Do NOT break and do NOT set
+                                    // stop_hook_handled_for_exit: falling through
+                                    // continues the loop, which re-invokes the
+                                    // provider with the advisory now in
+                                    // `conversation` (`exit_chat` is re-initialized
+                                    // to false at the top of the next iteration).
+                                }
+                                // Plain allow (no advisory), or the warn cap is
+                                // reached: inject any pending advisory once, then end
+                                // the turn. This always terminates.
+                                maybe_message => {
+                                    if let Some(message) = maybe_message {
+                                        session_manager.add_message(&session_config.id, &message).await?;
+                                        conversation.push(message.clone());
+                                        yield AgentEvent::Message(message);
+                                    }
+                                    stop_hook_handled_for_exit = true;
+                                    break;
+                                }
                             }
-                            stop_hook_handled_for_exit = true;
-                            break;
                         }
                         crate::hooks::HookDecision::Deny { reason, plugin } => {
                             consecutive_stop_hook_blocks += 1;
@@ -3712,6 +3740,29 @@ cat > "$PLUGIN_ROOT/payload.json"
 exit 0
 "#;
 
+    // Always emits a non-blocking `warn` advisory on stdout.
+    const ALWAYS_WARN_SCRIPT: &str = r#"#!/bin/sh
+echo warned >> "$PLUGIN_ROOT/hook.log"
+printf '%s' '{"decision":"warn","reason":"verify the claim against the tool trace"}'
+exit 0
+"#;
+
+    // Warns on the first invocation, then plain-allows on every later one.
+    const WARN_ONCE_THEN_ALLOW_SCRIPT: &str = r#"#!/bin/sh
+count_file="$PLUGIN_ROOT/count"
+count=0
+if [ -f "$count_file" ]; then
+  count=$(cat "$count_file")
+fi
+count=$((count + 1))
+echo "$count" > "$count_file"
+echo "$count" >> "$PLUGIN_ROOT/hook.log"
+if [ "$count" -eq 1 ]; then
+  printf '%s' '{"decision":"warn","reason":"double-check before finishing"}'
+fi
+exit 0
+"#;
+
     struct StopHookTestEnv {
         temp_dir: TempDir,
         hook_log: PathBuf,
@@ -4119,6 +4170,75 @@ echo start >> "$PLUGIN_ROOT/hook.log"
                 .iter()
                 .any(|text| text.contains("overriding and ending turn")),
             "non-consecutive Stop hook blocks should not trip the cap warning"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stop_hook_warn_advises_and_lets_model_correct_in_turn() -> Result<()> {
+        let env = StopHookTestEnv::new(WARN_ONCE_THEN_ALLOW_SCRIPT)?;
+        let (agent, session_id, provider) = create_stop_hook_test_agent(&env, 2).await?;
+
+        let messages = run_stop_hook_test_turn(&agent, &session_id, "hello").await?;
+        let texts = visible_texts(&messages);
+
+        assert_eq!(
+            provider.call_count(),
+            2,
+            "warn should NOT end the turn: the loop re-invokes the provider once with the advisory in context, then the follow-up allow ends it"
+        );
+        assert_eq!(
+            env.hook_invocations(),
+            2,
+            "Stop hook runs for the first response (warn) and the in-turn correction (allow)"
+        );
+        assert!(
+            texts
+                .iter()
+                .any(|text| text.contains("double-check before finishing")),
+            "the warn reason must be injected as advisory context"
+        );
+        assert!(
+            texts.iter().any(|text| text == "provider response 1"),
+            "the model must produce a second response after the advisory — the in-turn correction"
+        );
+        assert!(
+            !texts
+                .iter()
+                .any(|text| text.contains("overriding and ending turn")),
+            "warn is not a denial and must never trip the block-cap override"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stop_hook_warn_is_capped_and_cannot_loop_forever() -> Result<()> {
+        let env = StopHookTestEnv::new(ALWAYS_WARN_SCRIPT)?;
+        let (agent, session_id, provider) = create_stop_hook_test_agent(&env, 2).await?;
+
+        let messages = run_stop_hook_test_turn(&agent, &session_id, "hello").await?;
+        let texts = visible_texts(&messages);
+
+        // cap=2: two warn loop-backs (after responses 0 and 1), then the third
+        // warn hits the cap and the turn ends — 3 provider calls total. max_turns
+        // is 10, so hitting 3 proves the WARN cap (not max_turns) is the limiter.
+        assert_eq!(
+            provider.call_count(),
+            3,
+            "an always-warn hook must terminate at the warn cap, not loop forever"
+        );
+        assert_eq!(env.hook_invocations(), 3);
+        assert!(
+            !texts.iter().any(|text| text == MAX_TURNS_MESSAGE),
+            "the warn cap, not max_turns, should terminate the loop"
+        );
+        assert!(
+            !texts
+                .iter()
+                .any(|text| text.contains("overriding and ending turn")),
+            "warn is Allow, so it must never emit the block-cap override warning"
         );
 
         Ok(())

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -447,19 +447,21 @@ impl Agent {
     fn stop_hook_context(
         session_id: &str,
         last_assistant_message: &str,
+        working_dir: &str,
     ) -> crate::hooks::HookContext {
         crate::hooks::HookContext::new(crate::hooks::HookEvent::Stop, session_id)
             .with_last_assistant_message(last_assistant_message.to_string())
+            .with_working_dir(working_dir.to_string())
     }
 
-    async fn emit_stop_hook(&self, session_id: &str, last_assistant_message: &str) {
+    async fn emit_stop_hook(&self, session_id: &str, last_assistant_message: &str, working_dir: &str) {
         if !self.hook_manager.has_hooks(crate::hooks::HookEvent::Stop) {
             return;
         }
         self.hook_manager
             .emit(
                 crate::hooks::HookEvent::Stop,
-                Self::stop_hook_context(session_id, last_assistant_message),
+                Self::stop_hook_context(session_id, last_assistant_message, working_dir),
             )
             .await;
     }
@@ -468,11 +470,12 @@ impl Agent {
         &self,
         session_id: &str,
         last_assistant_message: &str,
+        working_dir: &str,
     ) -> crate::hooks::HookDecision {
         self.hook_manager
             .emit_blocking(
                 crate::hooks::HookEvent::Stop,
-                Self::stop_hook_context(session_id, last_assistant_message),
+                Self::stop_hook_context(session_id, last_assistant_message, working_dir),
             )
             .await
     }
@@ -1956,7 +1959,7 @@ impl Agent {
                     conversation.push(message);
 
                     match self
-                        .emit_stop_hook_blocking(&session_config.id, &last_assistant_text)
+                        .emit_stop_hook_blocking(&session_config.id, &last_assistant_text, &session.working_dir.to_string_lossy())
                         .await
                     {
                         crate::hooks::HookDecision::Allow => {
@@ -2705,7 +2708,7 @@ impl Agent {
 
                 if exit_chat {
                     match self
-                        .emit_stop_hook_blocking(&session_config.id, &last_assistant_text)
+                        .emit_stop_hook_blocking(&session_config.id, &last_assistant_text, &session.working_dir.to_string_lossy())
                         .await
                     {
                         crate::hooks::HookDecision::Allow => {
@@ -2738,7 +2741,7 @@ impl Agent {
             }
 
             if !stop_hook_handled_for_exit {
-                self.emit_stop_hook(&session_config.id, &last_assistant_text).await;
+                self.emit_stop_hook(&session_config.id, &last_assistant_text, &session.working_dir.to_string_lossy()).await;
             }
         }.instrument(reply_stream_span));
         Ok(inner)

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -204,6 +204,20 @@ fn build_tool_trace(conversation: &Conversation, pre_turn_tool_count: usize) -> 
     }
 }
 
+/// Collapse adjacent agent-visible messages that share a role, so an injected
+/// advisory placed immediately after a steer (both user-role) is not sent to
+/// the provider as two consecutive user turns — providers require alternating
+/// roles. The usual per-turn merge happens inside `moim::inject_moim` via
+/// `fix_conversation`, but moim is skipped entirely when the context limit is
+/// below `MIN_CONTEXT_FOR_MOIM` (e.g. a small `GOOSE_CONTEXT_LIMIT`); role
+/// alternation is a correctness invariant that must hold regardless of context
+/// size. `fix_conversation` scopes its merge to agent-visible messages, so
+/// persisted per-message visibility metadata in the session is untouched — this
+/// only reshapes the in-flight conversation handed toward the provider.
+fn merge_injected_advisory(conversation: Conversation) -> Conversation {
+    fix_conversation(conversation).0
+}
+
 /// Build the agent-visible-only message that injects hook advisory text
 /// (non-blocking `additionalContext`, or a `warn` decision's reason) into the
 /// conversation. Returns `None` if there's nothing to inject, so callers can
@@ -2046,6 +2060,7 @@ impl Agent {
                 }
 
                 if can_drain_pending_steers {
+                    let mut injected_advisory = false;
                     for message in self.drain_pending_steers(&session_config.id).await {
                         let message_text = message.as_concat_text();
                         let additional_context = if self
@@ -2070,7 +2085,18 @@ impl Agent {
                             session_manager.add_message(&session_config.id, &context_message).await?;
                             conversation.push(context_message.clone());
                             yield AgentEvent::Message(context_message);
+                            injected_advisory = true;
                         }
+                    }
+                    // A steer and its injected advisory are both user-role, so
+                    // pushing them back-to-back leaves two consecutive user
+                    // turns. moim's per-turn merge normally fixes this, but it's
+                    // skipped for small context limits — merge here so the
+                    // provider never sees non-alternating roles. Only runs when
+                    // an advisory was actually injected, so the non-hook path is
+                    // byte-for-byte unchanged.
+                    if injected_advisory {
+                        conversation = merge_injected_advisory(conversation);
                     }
                 }
 
@@ -3451,6 +3477,78 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tempfile::TempDir;
+
+    /// Provider view of a conversation: agent-visible messages only, mapped to
+    /// their effective role (what `stream_response_from_provider` sends after
+    /// `is_agent_visible` filtering). Returns true iff two adjacent entries
+    /// share a role — the shape providers reject with "roles must alternate".
+    fn has_adjacent_same_role_agent_visible(conversation: &Conversation) -> bool {
+        let roles: Vec<String> = conversation
+            .messages()
+            .iter()
+            .filter(|m| m.is_agent_visible())
+            .map(crate::conversation::effective_role)
+            .collect();
+        roles.windows(2).any(|w| w[0] == w[1])
+    }
+
+    #[test]
+    fn injected_advisory_after_steer_keeps_provider_roles_alternating() {
+        // Repro for the advise-tier steer-drain bug: a small GOOSE_CONTEXT_LIMIT
+        // makes moim (and thus its per-turn role-merge) skip, so the injected
+        // advisory must be merged locally or it reaches the provider as two
+        // consecutive user turns.
+        assert!(
+            crate::agents::moim::should_skip_moim(Some(8_000)),
+            "sub-32k context limit must skip moim for this repro to be meaningful"
+        );
+
+        // What the steer-drain path pushes: a user-visible steer immediately
+        // followed by the agent-visible-only advisory the hook returned.
+        let steer = Message::user()
+            .with_text("also check the logs")
+            .with_steer();
+        let advisory =
+            advisory_context_message(&["remember to run the tests".to_string()]).unwrap();
+        let conversation = Conversation::new_unvalidated([
+            Message::assistant().with_text("all done"),
+            steer,
+            advisory,
+        ]);
+
+        // Without the fix (raw conversation as pushed): two adjacent user turns.
+        assert!(
+            has_adjacent_same_role_agent_visible(&conversation),
+            "precondition: raw steer+advisory must be non-alternating"
+        );
+
+        // With the fix the steer-drain path applies before streaming:
+        let fixed = merge_injected_advisory(conversation);
+        assert!(
+            !has_adjacent_same_role_agent_visible(&fixed),
+            "after merge, provider-bound roles must alternate"
+        );
+    }
+
+    #[test]
+    fn multiple_steers_with_advisories_keep_roles_alternating() {
+        // Draining several steers, each firing a hook, appends
+        // [steer1, adv1, steer2, adv2, ...] — all user-role. A single merge
+        // after the loop must still leave alternating roles.
+        assert!(crate::agents::moim::should_skip_moim(Some(8_000)));
+
+        let conversation = Conversation::new_unvalidated([
+            Message::assistant().with_text("done"),
+            Message::user().with_text("steer one").with_steer(),
+            advisory_context_message(&["advice one".to_string()]).unwrap(),
+            Message::user().with_text("steer two").with_steer(),
+            advisory_context_message(&["advice two".to_string()]).unwrap(),
+        ]);
+
+        assert!(has_adjacent_same_role_agent_visible(&conversation));
+        let fixed = merge_injected_advisory(conversation);
+        assert!(!has_adjacent_same_role_agent_visible(&fixed));
+    }
 
     #[test]
     fn resolve_use_login_shell_path_defaults_by_platform() {

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2118,6 +2118,17 @@ impl Agent {
                         .await;
                     match hook_result.decision {
                         crate::hooks::HookDecision::Allow => {
+                            // SCOPE: on this structured-output (`final_output` tool)
+                            // exit path a `warn` advisory is injected as next-turn
+                            // context and the turn ends here — it does NOT loop back
+                            // to let the model correct in-turn. In-turn warn
+                            // correction is implemented only on the conversational
+                            // exit path (see the `exit_chat` Stop-hook arm below).
+                            // Extending in-turn warn to this path is a deferred
+                            // follow-up (it needs different plumbing around the
+                            // structured-output completion). `block` and the
+                            // additionalContext injection behave identically on both
+                            // paths; only in-turn `warn` differs.
                             if let Some(message) = advisory_context_message(&hook_result.advisories) {
                                 session_manager.add_message(&session_config.id, &message).await?;
                                 conversation.push(message.clone());

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -131,6 +131,101 @@ fn stop_hook_block_cap_warning(plugin: &str, cap: u32) -> Message {
     )
 }
 
+/// Truncate `s` to at most `max_chars` characters, appending `...` if cut.
+fn truncate_str(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max_chars).collect();
+        format!("{truncated}...")
+    }
+}
+
+/// Build a compact summary of this turn's tool calls + results for the Stop
+/// hook payload (see `HookContext::tool_trace`): tool name, a short rendering
+/// of its arguments, and ok/err with a truncated result snippet. Only tool
+/// requests made after `pre_turn_tool_count` prior requests are included, so
+/// earlier turns' tool calls are excluded. Overall size is capped by
+/// `HookContext::with_tool_trace`.
+fn build_tool_trace(conversation: &Conversation, pre_turn_tool_count: usize) -> Option<String> {
+    let mut seen_requests = 0usize;
+    let mut this_turn_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut lines: Vec<String> = Vec::new();
+
+    for message in conversation.messages() {
+        for content in &message.content {
+            match content {
+                MessageContent::ToolRequest(req) => {
+                    seen_requests += 1;
+                    if seen_requests > pre_turn_tool_count {
+                        this_turn_ids.insert(req.id.clone());
+                        let call_desc = match &req.tool_call {
+                            Ok(call) => format!(
+                                "{}({})",
+                                call.name,
+                                call.arguments
+                                    .as_ref()
+                                    .map(|a| serde_json::Value::Object(a.clone()).to_string())
+                                    .unwrap_or_default()
+                            ),
+                            Err(e) => format!("<invalid tool call: {e}>"),
+                        };
+                        lines.push(format!("-> {}", truncate_str(&call_desc, 200)));
+                    }
+                }
+                MessageContent::ToolResponse(resp) if this_turn_ids.contains(&resp.id) => {
+                    let outcome = match &resp.tool_result {
+                        Ok(result) => {
+                            let text = result
+                                .content
+                                .iter()
+                                .filter_map(|c| c.as_text().map(|t| t.text.to_string()))
+                                .collect::<Vec<_>>()
+                                .join(" ");
+                            if text.is_empty() {
+                                "ok".to_string()
+                            } else {
+                                format!("ok: {}", truncate_str(&text, 200))
+                            }
+                        }
+                        Err(e) => format!("err: {}", truncate_str(&e.to_string(), 200)),
+                    };
+                    lines.push(format!("<- {outcome}"));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    if lines.is_empty() {
+        None
+    } else {
+        Some(lines.join("\n"))
+    }
+}
+
+/// Build the agent-visible-only message that injects hook advisory text
+/// (non-blocking `additionalContext`, or a `warn` decision's reason) into the
+/// conversation. Returns `None` if there's nothing to inject, so callers can
+/// skip adding an empty message — backward compatible with hooks that don't
+/// use this shape.
+fn advisory_context_message(texts: &[String]) -> Option<Message> {
+    let joined = texts
+        .iter()
+        .filter(|t| !t.is_empty())
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    if joined.is_empty() {
+        return None;
+    }
+    Some(
+        Message::user()
+            .with_text(format!("Context from a hook:\n\n{joined}"))
+            .with_visibility(false, true),
+    )
+}
+
 /// Context needed for the reply function
 pub struct ReplyContext {
     pub conversation: Conversation,
@@ -448,22 +543,36 @@ impl Agent {
         session_id: &str,
         last_assistant_message: &str,
         working_dir: &str,
+        tool_trace: Option<&str>,
     ) -> crate::hooks::HookContext {
-        crate::hooks::HookContext::new(crate::hooks::HookEvent::Stop, session_id)
+        let ctx = crate::hooks::HookContext::new(crate::hooks::HookEvent::Stop, session_id)
             .with_last_assistant_message(last_assistant_message.to_string())
-            .with_working_dir(working_dir.to_string())
+            .with_working_dir(working_dir.to_string());
+        match tool_trace {
+            Some(trace) => ctx.with_tool_trace(trace.to_string()),
+            None => ctx,
+        }
     }
 
-    async fn emit_stop_hook(&self, session_id: &str, last_assistant_message: &str, working_dir: &str) {
+    /// Fire the non-blocking Stop hook. Returns any `additionalContext`
+    /// strings emitted by hooks (see `HookManager::emit`) so the caller can
+    /// inject them into the model's context for the next turn.
+    async fn emit_stop_hook(
+        &self,
+        session_id: &str,
+        last_assistant_message: &str,
+        working_dir: &str,
+        tool_trace: Option<&str>,
+    ) -> Vec<String> {
         if !self.hook_manager.has_hooks(crate::hooks::HookEvent::Stop) {
-            return;
+            return Vec::new();
         }
         self.hook_manager
             .emit(
                 crate::hooks::HookEvent::Stop,
-                Self::stop_hook_context(session_id, last_assistant_message, working_dir),
+                Self::stop_hook_context(session_id, last_assistant_message, working_dir, tool_trace),
             )
-            .await;
+            .await
     }
 
     async fn emit_stop_hook_blocking(
@@ -471,11 +580,12 @@ impl Agent {
         session_id: &str,
         last_assistant_message: &str,
         working_dir: &str,
-    ) -> crate::hooks::HookDecision {
+        tool_trace: Option<&str>,
+    ) -> crate::hooks::HookBlockingResult {
         self.hook_manager
             .emit_blocking(
                 crate::hooks::HookEvent::Stop,
-                Self::stop_hook_context(session_id, last_assistant_message, working_dir),
+                Self::stop_hook_context(session_id, last_assistant_message, working_dir, tool_trace),
             )
             .await
     }
@@ -1087,6 +1197,7 @@ impl Agent {
                 .hook_manager
                 .emit_blocking(crate::hooks::HookEvent::PreToolUse, ctx)
                 .await
+                .decision
             {
                 return (
                     request_id,
@@ -1604,7 +1715,7 @@ impl Agent {
                 .await;
         }
 
-        if self
+        let user_prompt_submit_context = if self
             .hook_manager
             .has_hooks(crate::hooks::HookEvent::UserPromptSubmit)
         {
@@ -1615,8 +1726,10 @@ impl Agent {
             .with_message(message_text.clone());
             self.hook_manager
                 .emit(crate::hooks::HookEvent::UserPromptSubmit, ctx)
-                .await;
-        }
+                .await
+        } else {
+            Vec::new()
+        };
 
         let command_result = self
             .execute_command(&message_text, &session_config.id)
@@ -1726,6 +1839,13 @@ impl Agent {
                     .await?;
             }
         }
+
+        if let Some(message) = advisory_context_message(&user_prompt_submit_context) {
+            session_manager
+                .add_message(&session_config.id, &message)
+                .await?;
+        }
+
         let session = session_manager
             .get_session(&session_config.id, true)
             .await?;
@@ -1928,7 +2048,7 @@ impl Agent {
                 if can_drain_pending_steers {
                     for message in self.drain_pending_steers(&session_config.id).await {
                         let message_text = message.as_concat_text();
-                        if self
+                        let additional_context = if self
                             .hook_manager
                             .has_hooks(crate::hooks::HookEvent::UserPromptSubmit)
                         {
@@ -1939,11 +2059,18 @@ impl Agent {
                             .with_message(message_text);
                             self.hook_manager
                                 .emit(crate::hooks::HookEvent::UserPromptSubmit, ctx)
-                                .await;
-                        }
+                                .await
+                        } else {
+                            Vec::new()
+                        };
                         session_manager.add_message(&session_config.id, &message).await?;
                         conversation.push(message.clone());
                         yield AgentEvent::Message(message);
+                        if let Some(context_message) = advisory_context_message(&additional_context) {
+                            session_manager.add_message(&session_config.id, &context_message).await?;
+                            conversation.push(context_message.clone());
+                            yield AgentEvent::Message(context_message);
+                        }
                     }
                 }
 
@@ -1958,11 +2085,17 @@ impl Agent {
                     session_manager.add_message(&session_config.id, &message).await?;
                     conversation.push(message);
 
-                    match self
-                        .emit_stop_hook_blocking(&session_config.id, &last_assistant_text, &session.working_dir.to_string_lossy())
-                        .await
-                    {
+                    let tool_trace = build_tool_trace(&conversation, pre_turn_tool_count);
+                    let hook_result = self
+                        .emit_stop_hook_blocking(&session_config.id, &last_assistant_text, &session.working_dir.to_string_lossy(), tool_trace.as_deref())
+                        .await;
+                    match hook_result.decision {
                         crate::hooks::HookDecision::Allow => {
+                            if let Some(message) = advisory_context_message(&hook_result.advisories) {
+                                session_manager.add_message(&session_config.id, &message).await?;
+                                conversation.push(message.clone());
+                                yield AgentEvent::Message(message);
+                            }
                             stop_hook_handled_for_exit = true;
                             break;
                         }
@@ -2707,11 +2840,17 @@ impl Agent {
                 }
 
                 if exit_chat {
-                    match self
-                        .emit_stop_hook_blocking(&session_config.id, &last_assistant_text, &session.working_dir.to_string_lossy())
-                        .await
-                    {
+                    let tool_trace = build_tool_trace(&conversation, pre_turn_tool_count);
+                    let hook_result = self
+                        .emit_stop_hook_blocking(&session_config.id, &last_assistant_text, &session.working_dir.to_string_lossy(), tool_trace.as_deref())
+                        .await;
+                    match hook_result.decision {
                         crate::hooks::HookDecision::Allow => {
+                            if let Some(message) = advisory_context_message(&hook_result.advisories) {
+                                session_manager.add_message(&session_config.id, &message).await?;
+                                conversation.push(message.clone());
+                                yield AgentEvent::Message(message);
+                            }
                             stop_hook_handled_for_exit = true;
                             break;
                         }
@@ -2741,7 +2880,15 @@ impl Agent {
             }
 
             if !stop_hook_handled_for_exit {
-                self.emit_stop_hook(&session_config.id, &last_assistant_text, &session.working_dir.to_string_lossy()).await;
+                let tool_trace = build_tool_trace(&conversation, pre_turn_tool_count);
+                let additional_context = self
+                    .emit_stop_hook(&session_config.id, &last_assistant_text, &session.working_dir.to_string_lossy(), tool_trace.as_deref())
+                    .await;
+                if let Some(message) = advisory_context_message(&additional_context) {
+                    session_manager.add_message(&session_config.id, &message).await?;
+                    conversation.push(message.clone());
+                    yield AgentEvent::Message(message);
+                }
             }
         }.instrument(reply_stream_span));
         Ok(inner)

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -548,11 +548,7 @@ impl Agent {
     /// `SessionEnd`). Returns any `additionalContext` strings the hooks emit,
     /// so the caller can route them through the same advisory-injection path as
     /// every other emit site instead of discarding them.
-    pub async fn emit_hook(
-        &self,
-        event: crate::hooks::HookEvent,
-        session_id: &str,
-    ) -> Vec<String> {
+    pub async fn emit_hook(&self, event: crate::hooks::HookEvent, session_id: &str) -> Vec<String> {
         if !self.hook_manager.has_hooks(event) {
             return Vec::new();
         }
@@ -592,7 +588,12 @@ impl Agent {
         self.hook_manager
             .emit(
                 crate::hooks::HookEvent::Stop,
-                Self::stop_hook_context(session_id, last_assistant_message, working_dir, tool_trace),
+                Self::stop_hook_context(
+                    session_id,
+                    last_assistant_message,
+                    working_dir,
+                    tool_trace,
+                ),
             )
             .await
     }
@@ -607,7 +608,12 @@ impl Agent {
         self.hook_manager
             .emit_blocking(
                 crate::hooks::HookEvent::Stop,
-                Self::stop_hook_context(session_id, last_assistant_message, working_dir, tool_trace),
+                Self::stop_hook_context(
+                    session_id,
+                    last_assistant_message,
+                    working_dir,
+                    tool_trace,
+                ),
             )
             .await
     }

--- a/crates/goose/src/agents/moim.rs
+++ b/crates/goose/src/agents/moim.rs
@@ -129,7 +129,7 @@ pub async fn inject_moim(
     fixed
 }
 
-fn should_skip_moim(context_limit: Option<usize>) -> bool {
+pub(crate) fn should_skip_moim(context_limit: Option<usize>) -> bool {
     context_limit.is_some_and(|limit| limit < MIN_CONTEXT_FOR_MOIM)
 }
 

--- a/crates/goose/src/hooks/mod.rs
+++ b/crates/goose/src/hooks/mod.rs
@@ -505,6 +505,18 @@ impl HookManager {
                     }
                     None => {}
                 }
+
+                // Unify parsing with `emit`: a hook may advise via the
+                // `{"hookSpecificOutput":{"additionalContext":...}}` shape on a
+                // blocking event too (a `warn` reason and an `additionalContext`
+                // can even coexist). Without this, `additionalContext` is
+                // silently dropped on `Stop`'s primary (non-deny) exit paths.
+                // Guarded on success to match `emit`, which skips failed hooks.
+                if output.status.success() {
+                    if let Some(context) = additional_context_from_output(&output) {
+                        advisories.push(context);
+                    }
+                }
             }
         }
 
@@ -951,6 +963,34 @@ mod tests {
         assert_eq!(
             result.advisories,
             vec!["claim not verified by tool trace".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn emit_blocking_surfaces_additional_context_on_a_blocking_event() {
+        // A hook that advises via the `additionalContext` shape (no `decision`)
+        // on a blocking event (Stop) must have its context surfaced, exactly
+        // like `emit` does — not silently dropped on the non-deny exit path.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = write_plugin(
+            tmp.path(),
+            "p",
+            r#"{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"Stop\",\"additionalContext\":\"remember to run tests\"}}'"}]}]}}"#,
+        );
+        let mgr = make_manager(vec![DiscoveredPlugin {
+            name: "p".into(),
+            root,
+            scope: PluginScope::User,
+        }]);
+
+        let result = mgr
+            .emit_blocking(HookEvent::Stop, HookContext::new(HookEvent::Stop, "s"))
+            .await;
+
+        assert_eq!(result.decision, HookDecision::Allow);
+        assert_eq!(
+            result.advisories,
+            vec!["remember to run tests".to_string()]
         );
     }
 

--- a/crates/goose/src/hooks/mod.rs
+++ b/crates/goose/src/hooks/mod.rs
@@ -169,7 +169,18 @@ pub struct HookContext {
     pub last_assistant_message: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub working_dir: Option<String>,
+    /// Compact summary of the turn's tool calls + results (tool name, short
+    /// args, ok/err or a truncated result), populated on `Stop` so a hook can
+    /// verify the assistant's claims against what actually ran. Capped at
+    /// [`MAX_TOOL_TRACE_BYTES`] by [`Self::with_tool_trace`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_trace: Option<String>,
 }
+
+/// Hard cap on `tool_trace` length. Hook scripts receive this over stdin;
+/// keeping it bounded avoids passing pathologically large payloads to child
+/// processes.
+const MAX_TOOL_TRACE_BYTES: usize = 16 * 1024;
 
 impl HookContext {
     pub fn new(event: HookEvent, session_id: impl Into<String>) -> Self {
@@ -183,6 +194,7 @@ impl HookContext {
             message: None,
             last_assistant_message: None,
             working_dir: None,
+            tool_trace: None,
         }
     }
 
@@ -218,12 +230,40 @@ impl HookContext {
         self.working_dir = Some(dir.into());
         self
     }
+
+    /// Attach a compact tool-execution trace for this turn, truncating to
+    /// [`MAX_TOOL_TRACE_BYTES`] (on a UTF-8 boundary) if needed.
+    pub fn with_tool_trace(mut self, trace: impl Into<String>) -> Self {
+        let trace = trace.into();
+        let capped = if trace.len() > MAX_TOOL_TRACE_BYTES {
+            let mut end = MAX_TOOL_TRACE_BYTES;
+            while end > 0 && !trace.is_char_boundary(end) {
+                end -= 1;
+            }
+            format!("{}...[truncated]", &trace[..end])
+        } else {
+            trace
+        };
+        self.tool_trace = Some(capped);
+        self
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HookDecision {
     Allow,
     Deny { reason: String, plugin: String },
+}
+
+/// Result of [`HookManager::emit_blocking`]: the allow/deny decision, plus any
+/// advisory text collected along the way — from a `{"decision":"warn",...}`
+/// response — that should be injected into the model's context (via the same
+/// path as [`HookManager::emit`]'s `additionalContext`) when the turn is
+/// allowed to proceed. A warn never denies; it's advise-and-continue.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookBlockingResult {
+    pub decision: HookDecision,
+    pub advisories: Vec<String>,
 }
 
 /// Loads and executes plugin hooks.
@@ -292,19 +332,27 @@ impl HookManager {
     /// Fire all rules whose matcher matches the event context. Errors from
     /// individual hooks are logged but never propagated — a misbehaving hook
     /// MUST NOT crash the host tool.
-    pub async fn emit(&self, event: HookEvent, ctx: HookContext) {
+    ///
+    /// Returns any non-empty `additionalContext` strings emitted by hooks via
+    /// `{"hookSpecificOutput": {"additionalContext": "..."}}` on stdout, so
+    /// callers can inject them into the model's context. This is purely
+    /// additive: hooks that print nothing, or stdout that doesn't match this
+    /// shape, yield nothing here and behave exactly as before.
+    pub async fn emit(&self, event: HookEvent, ctx: HookContext) -> Vec<String> {
+        let mut injected = Vec::new();
+
         let Some(rules) = self.rules.get(&event) else {
-            return;
+            return injected;
         };
         if rules.is_empty() {
-            return;
+            return injected;
         }
 
         let payload = match serde_json::to_string(&ctx) {
             Ok(s) => s,
             Err(err) => {
                 warn!(event = %event, error = %err, "Failed to serialize hook context");
-                return;
+                return injected;
             }
         };
 
@@ -324,7 +372,7 @@ impl HookManager {
                     command = %command,
                     "Running plugin hook",
                 );
-                let res = run_command_hook(
+                let output = match run_command_hook(
                     command,
                     &rule.plugin_root,
                     &payload,
@@ -332,45 +380,67 @@ impl HookManager {
                     self.use_login_shell_path,
                 )
                 .await
-                .and_then(|o| {
-                    if o.status.success() {
-                        Ok(())
-                    } else {
-                        anyhow::bail!(
-                            "hook `{command}` exited with {:?}: {}",
-                            o.status.code(),
-                            String::from_utf8_lossy(&o.stderr).trim()
-                        )
+                {
+                    Ok(o) => o,
+                    Err(err) => {
+                        warn!(
+                            plugin = %rule.plugin_name,
+                            event = %event,
+                            command = %command,
+                            error = %err,
+                            "Plugin hook failed",
+                        );
+                        continue;
                     }
-                });
-                if let Err(err) = res {
+                };
+
+                if !output.status.success() {
                     warn!(
                         plugin = %rule.plugin_name,
                         event = %event,
                         command = %command,
-                        error = %err,
+                        status = ?output.status.code(),
+                        stderr = %String::from_utf8_lossy(&output.stderr).trim(),
                         "Plugin hook failed",
                     );
+                    continue;
+                }
+
+                if let Some(context) = additional_context_from_output(&output) {
+                    injected.push(context);
                 }
             }
         }
+
+        injected
     }
 
     /// Like [`Self::emit`], but stops at the first rule that denies the event
     /// and returns the denial. A hook denies by exiting with status code 2
     /// (reason on stderr) or by printing `{"decision":"block","reason":"..."}`
-    /// to stdout. All other failures (spawn, timeout, other non-zero exits)
-    /// are logged and treated as Allow — a misbehaving hook MUST NOT block.
-    pub async fn emit_blocking(&self, event: HookEvent, ctx: HookContext) -> HookDecision {
+    /// to stdout. A hook may instead *advise* without denying by printing
+    /// `{"decision":"warn","reason":"..."}`: the reason is collected into
+    /// `advisories` and the turn proceeds. All other failures (spawn,
+    /// timeout, other non-zero exits) are logged and treated as Allow — a
+    /// misbehaving hook MUST NOT block.
+    pub async fn emit_blocking(&self, event: HookEvent, ctx: HookContext) -> HookBlockingResult {
+        let mut advisories = Vec::new();
+
         let Some(rules) = self.rules.get(&event) else {
-            return HookDecision::Allow;
+            return HookBlockingResult {
+                decision: HookDecision::Allow,
+                advisories,
+            };
         };
 
         let payload = match serde_json::to_string(&ctx) {
             Ok(s) => s,
             Err(err) => {
                 warn!(event = %event, error = %err, "Failed to serialize hook context");
-                return HookDecision::Allow;
+                return HookBlockingResult {
+                    decision: HookDecision::Allow,
+                    advisories,
+                };
             }
         };
 
@@ -406,33 +476,58 @@ impl HookManager {
                     }
                 };
 
-                if let Some(reason) = deny_reason(&output) {
-                    info!(
-                        plugin = %rule.plugin_name,
-                        event = %event,
-                        command = %command,
-                        reason = %reason,
-                        "Plugin hook denied tool call",
-                    );
-                    return HookDecision::Deny {
-                        reason,
-                        plugin: rule.plugin_name.clone(),
-                    };
+                match hook_response(&output) {
+                    Some(HookResponse::Deny(reason)) => {
+                        info!(
+                            plugin = %rule.plugin_name,
+                            event = %event,
+                            command = %command,
+                            reason = %reason,
+                            "Plugin hook denied tool call",
+                        );
+                        return HookBlockingResult {
+                            decision: HookDecision::Deny {
+                                reason,
+                                plugin: rule.plugin_name.clone(),
+                            },
+                            advisories,
+                        };
+                    }
+                    Some(HookResponse::Warn(reason)) => {
+                        info!(
+                            plugin = %rule.plugin_name,
+                            event = %event,
+                            command = %command,
+                            reason = %reason,
+                            "Plugin hook advised (warn)",
+                        );
+                        advisories.push(reason);
+                    }
+                    None => {}
                 }
             }
         }
 
-        HookDecision::Allow
+        HookBlockingResult {
+            decision: HookDecision::Allow,
+            advisories,
+        }
     }
 }
 
-fn deny_reason(output: &std::process::Output) -> Option<String> {
+/// A hook's parsed stdout decision: either a denial or a non-blocking advisory.
+enum HookResponse {
+    Deny(String),
+    Warn(String),
+}
+
+fn hook_response(output: &std::process::Output) -> Option<HookResponse> {
     const DEFAULT: &str = "denied by plugin hook";
     let non_empty = |s: String| if s.is_empty() { DEFAULT.into() } else { s };
 
     if output.status.code() == Some(2) {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        return Some(non_empty(stderr));
+        return Some(HookResponse::Deny(non_empty(stderr)));
     }
 
     #[derive(Deserialize)]
@@ -447,8 +542,46 @@ fn deny_reason(output: &std::process::Output) -> Option<String> {
         return None;
     }
     let parsed: Resp = serde_json::from_str(trimmed).ok()?;
-    (parsed.decision.as_deref() == Some("block"))
-        .then(|| non_empty(parsed.reason.unwrap_or_default()))
+    match parsed.decision.as_deref() {
+        Some("block") => Some(HookResponse::Deny(non_empty(parsed.reason.unwrap_or_default()))),
+        Some("warn") => {
+            let reason = parsed.reason.unwrap_or_default();
+            if reason.is_empty() {
+                None
+            } else {
+                Some(HookResponse::Warn(reason))
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Parses a hook's stdout for the non-blocking `additionalContext` shape:
+/// `{"hookSpecificOutput": {"hookEventName": "...", "additionalContext": "..."}}`.
+/// Empty or malformed stdout (including plain, non-JSON output) yields `None`.
+fn additional_context_from_output(output: &std::process::Output) -> Option<String> {
+    #[derive(Deserialize)]
+    struct HookSpecificOutput {
+        #[serde(default, rename = "additionalContext")]
+        additional_context: Option<String>,
+    }
+
+    #[derive(Deserialize)]
+    struct Resp {
+        #[serde(default, rename = "hookSpecificOutput")]
+        hook_specific_output: Option<HookSpecificOutput>,
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let trimmed = stdout.trim();
+    if !trimmed.starts_with('{') {
+        return None;
+    }
+    let parsed: Resp = serde_json::from_str(trimmed).ok()?;
+    parsed
+        .hook_specific_output
+        .and_then(|h| h.additional_context)
+        .filter(|s| !s.is_empty())
 }
 
 fn load_hooks_file(
@@ -761,17 +894,111 @@ mod tests {
             scope: PluginScope::User,
         }]);
 
-        let decision = mgr
+        let result = mgr
             .emit_blocking(HookEvent::Stop, HookContext::new(HookEvent::Stop, "s"))
             .await;
 
         assert_eq!(
-            decision,
+            result.decision,
             HookDecision::Deny {
                 reason: "say something first".into(),
                 plugin: "p".into(),
             }
         );
+        assert!(result.advisories.is_empty());
+    }
+
+    #[tokio::test]
+    async fn emit_returns_additional_context_from_hook_stdout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = write_plugin(
+            tmp.path(),
+            "p",
+            r#"{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"Stop\",\"additionalContext\":\"remember to run tests\"}}'"}]}]}}"#,
+        );
+        let mgr = make_manager(vec![DiscoveredPlugin {
+            name: "p".into(),
+            root,
+            scope: PluginScope::User,
+        }]);
+
+        let injected = mgr
+            .emit(HookEvent::Stop, HookContext::new(HookEvent::Stop, "s"))
+            .await;
+
+        assert_eq!(injected, vec!["remember to run tests".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn emit_blocking_warn_decision_is_not_a_denial() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = write_plugin(
+            tmp.path(),
+            "p",
+            r#"{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"printf '%s' '{\"decision\":\"warn\",\"reason\":\"claim not verified by tool trace\"}'"}]}]}}"#,
+        );
+        let mgr = make_manager(vec![DiscoveredPlugin {
+            name: "p".into(),
+            root,
+            scope: PluginScope::User,
+        }]);
+
+        let result = mgr
+            .emit_blocking(HookEvent::Stop, HookContext::new(HookEvent::Stop, "s"))
+            .await;
+
+        assert_eq!(result.decision, HookDecision::Allow);
+        assert_eq!(
+            result.advisories,
+            vec!["claim not verified by tool trace".to_string()]
+        );
+    }
+
+    #[test]
+    fn tool_trace_round_trips_through_hook_context_serialization() {
+        let ctx = HookContext::new(HookEvent::Stop, "s").with_tool_trace("-> shell(ls)\n<- ok: file.txt");
+        let json = serde_json::to_value(&ctx).unwrap();
+        assert_eq!(
+            json.get("tool_trace").and_then(|v| v.as_str()),
+            Some("-> shell(ls)\n<- ok: file.txt")
+        );
+
+        let long_trace = "x".repeat(MAX_TOOL_TRACE_BYTES + 100);
+        let capped = HookContext::new(HookEvent::Stop, "s").with_tool_trace(long_trace);
+        let trace = capped.tool_trace.unwrap();
+        assert!(trace.len() <= MAX_TOOL_TRACE_BYTES + "...[truncated]".len());
+        assert!(trace.ends_with("...[truncated]"));
+    }
+
+    #[tokio::test]
+    async fn malformed_or_empty_stdout_yields_no_injection_and_allows() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = write_plugin(
+            tmp.path(),
+            "p",
+            r#"{"hooks":{
+                "Stop":[
+                    {"hooks":[{"type":"command","command":"printf '%s' 'not json'"}]},
+                    {"hooks":[{"type":"command","command":"true"}]}
+                ]
+            }}"#,
+        );
+        let mgr = make_manager(vec![DiscoveredPlugin {
+            name: "p".into(),
+            root,
+            scope: PluginScope::User,
+        }]);
+
+        let injected = mgr
+            .emit(HookEvent::Stop, HookContext::new(HookEvent::Stop, "s"))
+            .await;
+        assert!(injected.is_empty());
+
+        let result = mgr
+            .emit_blocking(HookEvent::Stop, HookContext::new(HookEvent::Stop, "s"))
+            .await;
+        assert_eq!(result.decision, HookDecision::Allow);
+        assert!(result.advisories.is_empty());
     }
 
     #[test]

--- a/crates/goose/src/hooks/mod.rs
+++ b/crates/goose/src/hooks/mod.rs
@@ -555,7 +555,9 @@ fn hook_response(output: &std::process::Output) -> Option<HookResponse> {
     }
     let parsed: Resp = serde_json::from_str(trimmed).ok()?;
     match parsed.decision.as_deref() {
-        Some("block") => Some(HookResponse::Deny(non_empty(parsed.reason.unwrap_or_default()))),
+        Some("block") => Some(HookResponse::Deny(non_empty(
+            parsed.reason.unwrap_or_default(),
+        ))),
         Some("warn") => {
             let reason = parsed.reason.unwrap_or_default();
             if reason.is_empty() {
@@ -988,15 +990,13 @@ mod tests {
             .await;
 
         assert_eq!(result.decision, HookDecision::Allow);
-        assert_eq!(
-            result.advisories,
-            vec!["remember to run tests".to_string()]
-        );
+        assert_eq!(result.advisories, vec!["remember to run tests".to_string()]);
     }
 
     #[test]
     fn tool_trace_round_trips_through_hook_context_serialization() {
-        let ctx = HookContext::new(HookEvent::Stop, "s").with_tool_trace("-> shell(ls)\n<- ok: file.txt");
+        let ctx =
+            HookContext::new(HookEvent::Stop, "s").with_tool_trace("-> shell(ls)\n<- ok: file.txt");
         let json = serde_json::to_value(&ctx).unwrap();
         assert_eq!(
             json.get("tool_trace").and_then(|v| v.as_str()),

--- a/crates/goose/src/hooks/mod.rs
+++ b/crates/goose/src/hooks/mod.rs
@@ -257,13 +257,21 @@ pub enum HookDecision {
 
 /// Result of [`HookManager::emit_blocking`]: the allow/deny decision, plus any
 /// advisory text collected along the way — from a `{"decision":"warn",...}`
-/// response — that should be injected into the model's context (via the same
-/// path as [`HookManager::emit`]'s `additionalContext`) when the turn is
-/// allowed to proceed. A warn never denies; it's advise-and-continue.
+/// reason or a `{"hookSpecificOutput":{"additionalContext":...}}` shape — that
+/// should be injected into the model's context (via the same path as
+/// [`HookManager::emit`]'s `additionalContext`) when the turn is allowed to
+/// proceed. A warn never denies; it's advise-and-continue.
+///
+/// `warned` records whether any hook returned an explicit `warn` *decision* (as
+/// opposed to only passively emitting `additionalContext`). Callers that treat
+/// `warn` as a request to re-invoke the model in-turn (the conversational Stop
+/// path) must gate that retry on `warned`, so a passive context-only hook that
+/// fires every turn does not trigger repeated model calls.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HookBlockingResult {
     pub decision: HookDecision,
     pub advisories: Vec<String>,
+    pub warned: bool,
 }
 
 /// Loads and executes plugin hooks.
@@ -425,11 +433,13 @@ impl HookManager {
     /// misbehaving hook MUST NOT block.
     pub async fn emit_blocking(&self, event: HookEvent, ctx: HookContext) -> HookBlockingResult {
         let mut advisories = Vec::new();
+        let mut warned = false;
 
         let Some(rules) = self.rules.get(&event) else {
             return HookBlockingResult {
                 decision: HookDecision::Allow,
                 advisories,
+                warned,
             };
         };
 
@@ -440,6 +450,7 @@ impl HookManager {
                 return HookBlockingResult {
                     decision: HookDecision::Allow,
                     advisories,
+                    warned,
                 };
             }
         };
@@ -491,6 +502,7 @@ impl HookManager {
                                 plugin: rule.plugin_name.clone(),
                             },
                             advisories,
+                            warned,
                         };
                     }
                     Some(HookResponse::Warn(reason)) => {
@@ -502,6 +514,7 @@ impl HookManager {
                             "Plugin hook advised (warn)",
                         );
                         advisories.push(reason);
+                        warned = true;
                     }
                     None => {}
                 }
@@ -523,6 +536,7 @@ impl HookManager {
         HookBlockingResult {
             decision: HookDecision::Allow,
             advisories,
+            warned,
         }
     }
 }


### PR DESCRIPTION
Implements the "advise tier" for hooks, closing the gap identified in #10358 (and enabling #9708's ground-truth completion gate to work as a *gate*, not a wall).

Builds on #10296 (`working_dir` in the Stop context) — this branch is stacked on it; please merge #10296 first, after which its commit drops out of this diff.

## Why

goose hooks today can **block** (`{"decision":"block"}` / `exit 2`) or **observe** (output discarded) — but never **advise**: feed a finding into the model's next turn without blocking. I hit this building the #9708 completion gate as a real `Stop`-hook verifier: wired as a *blocking* hook it deadlocks (the agent re-claims → re-blocked, forever, because it often can't produce the demanded receipt in-turn; a wall is the wrong answer to "unverified"). In one live run against a cheap agentic model it ran 70 consecutive blocks with zero progress. The right response to an unverified claim is "here's what's unverified — address it or say so," which is advisory. Both Claude Code and OpenAI Codex already ship this advise-and-let-it-correct tier on Stop; goose was the outlier. Full context in #10358.

## What (three additive, backward-compatible primitives)

1. **Non-blocking `additionalContext` injection.** `emit()` now parses each hook's stdout for `{"hookSpecificOutput":{"additionalContext":"..."}}` and injects the string into the model's conversation (via goose's existing invisible-context idiom, `Message::user().with_visibility(false, true)`) on `UserPromptSubmit` and `Stop`. Non-blocking; the turn proceeds.
2. **Tool-execution trace in the `Stop` payload.** New `tool_trace` on `HookContext`, populated at Stop with the turn's tool calls/results (capped, UTF-8-safe) — what #9708's gate needs to verify success claims against actual execution.
3. **`warn` decision.** `emit_blocking` now recognizes `{"decision":"warn","reason":"..."}`: surfaces the reason to the model (same injection path) without denying the turn.

Backward compatible: hooks that only block or observe are unaffected; new behavior only fires on the new output shapes. `emit()`/`emit_blocking()` return types changed; all in-crate callers updated.

## Tests

New `hooks` unit tests (additionalContext parsed & returned; `warn` is not a denial; `tool_trace` round-trips; malformed/empty stdout → no injection, no panic, Allow) plus two `agent` tests guarding provider role-alternation for the injected advisory even when the moim merge is context-gate-skipped (`GOOSE_CONTEXT_LIMIT < 32000`). `cargo test -p goose --lib hooks::` + the new agent tests pass (14 total); `cargo build -p goose --tests` clean.

---
**Update (review addressed):** `warn` now corrects **in-turn** on the conversational exit path — it injects the advisory and loops back once (capped, never re-gates, so no deadlock), letting the model fix the unverified claim before finishing. On the structured-output (`final_output`) exit path `warn` remains next-turn context for now (deferred follow-up); `block` and `additionalContext` injection are identical on both paths. See c9ba877 (role-alternation fix), 9a4ce05 (in-turn warn), 7b3b563 (scope note).
