### PR TITLE
fix: preserve reasoning_content for DeepSeek thinking mode on multi-turn tool calls

### DIFF
--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -257,8 +257,8 @@ pub fn format_messages_with_options(
                 MessageContent::Thinking(t) => {
                     reasoning_text.push_str(&t.thinking);
                 }
-                MessageContent::RedactedThinking(_) => {
-                    continue;
+                MessageContent::RedactedThinking(r) => {
+                    reasoning_text.push_str(&r.data);
                 }
                 MessageContent::SystemNotification(_) => {
                     continue;

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -257,8 +257,8 @@ pub fn format_messages_with_options(
                 MessageContent::Thinking(t) => {
                     reasoning_text.push_str(&t.thinking);
                 }
-                MessageContent::RedactedThinking(r) => {
-                    reasoning_text.push_str(&r.data);
+                MessageContent::RedactedThinking(_) => {
+                    continue;
                 }
                 MessageContent::SystemNotification(_) => {
                     continue;

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2345,13 +2345,21 @@ impl Agent {
                                         )
                                     });
                                     if has_thinking {
-                                        for c in &m.content {
-                                            if matches!(
-                                                c,
-                                                MessageContent::Thinking(_)
-                                                    | MessageContent::RedactedThinking(_)
-                                            ) {
-                                                accumulated_prior.push(c.clone());
+                                        // Only accumulate thinking from messages that
+                                        // have not already been split into tool-call
+                                        // request_msg items — prior-split messages
+                                        // already carry their own thinking copy.
+                                        if !m.content.iter().any(|c| {
+                                            matches!(c, MessageContent::ToolRequest(_))
+                                        }) {
+                                            for c in &m.content {
+                                                if matches!(
+                                                    c,
+                                                    MessageContent::Thinking(_)
+                                                        | MessageContent::RedactedThinking(_)
+                                                ) {
+                                                    accumulated_prior.push(c.clone());
+                                                }
                                             }
                                         }
                                     }

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2313,27 +2313,63 @@ impl Agent {
                                     })
                                     .cloned()
                                     .collect();
-                                // When thinking arrived in an earlier stream chunk it was stored as
-                                // a standalone thinking-only message; reuse that thinking on the
-                                // tool-call messages and drop the standalone so it isn't duplicated.
-                                let response_thinking = if direct_thinking.is_empty() {
-                                    let prior = messages_to_add.messages().iter().rposition(|m| {
-                                        m.role == response.role
-                                            && !m.content.is_empty()
-                                            && m.content.iter().all(|c| {
-                                                matches!(
-                                                    c,
-                                                    MessageContent::Thinking(_)
-                                                        | MessageContent::RedactedThinking(_)
-                                                )
-                                            })
-                                    });
-                                    match prior {
-                                        Some(idx) => messages_to_add.remove(idx).content,
-                                        None => Vec::new(),
+                                // When thinking arrived in earlier stream chunks it was stored as
+                                // standalone thinking-only messages; reuse that thinking on the
+                                // tool-call messages and drop the standalone messages so the
+                                // thinking isn't duplicated.
+                                // Always accumulate ALL prior thinking — even when
+                                // direct_thinking is non-empty (reasoning arrived on the same
+                                // chunk as tool_calls) — because otherwise only the last chunk's
+                                // reasoning ends up on split tool-call messages.
+                                // Also extract thinking from mixed (thinking+text) messages,
+                                // not just pure-thinking-only ones.
+                                let mut accumulated_prior: Vec<MessageContent> = Vec::new();
+                                let mut indices_to_remove: Vec<usize> = Vec::new();
+                                for (idx, m) in messages_to_add.messages().iter().enumerate() {
+                                    if m.role != response.role || m.content.is_empty() {
+                                        continue;
                                     }
-                                } else {
+                                    let thinking_only = m.content.iter().all(|c| {
+                                        matches!(
+                                            c,
+                                            MessageContent::Thinking(_)
+                                                | MessageContent::RedactedThinking(_)
+                                        )
+                                    });
+                                    let has_thinking = m.content.iter().any(|c| {
+                                        matches!(
+                                            c,
+                                            MessageContent::Thinking(_)
+                                                | MessageContent::RedactedThinking(_)
+                                        )
+                                    });
+                                    if has_thinking {
+                                        for c in &m.content {
+                                            if matches!(
+                                                c,
+                                                MessageContent::Thinking(_)
+                                                    | MessageContent::RedactedThinking(_)
+                                            ) {
+                                                accumulated_prior.push(c.clone());
+                                            }
+                                        }
+                                    }
+                                    if thinking_only {
+                                        indices_to_remove.push(idx);
+                                    }
+                                }
+                                // Remove in reverse order to preserve indices
+                                for idx in indices_to_remove.into_iter().rev() {
+                                    messages_to_add.remove(idx);
+                                }
+                                let response_thinking = if direct_thinking.is_empty() {
+                                    accumulated_prior
+                                } else if accumulated_prior.is_empty() {
                                     direct_thinking
+                                } else {
+                                    let mut merged = accumulated_prior;
+                                    merged.extend(direct_thinking);
+                                    merged
                                 };
 
                                 for request in frontend_requests.iter().chain(remaining_requests.iter()) {

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2357,10 +2357,21 @@ impl Agent {
                                     }
                                     if thinking_only {
                                         indices_to_remove.push(idx);
-                                    } else if has_thinking {
-                                        // Strip thinking blocks from mixed messages so the same
-                                        // signed/unsigned thinking is not duplicated when it is
-                                        // carried onto the tool-call request messages below.
+                                    } else if has_thinking
+                                        && !m.content.iter().any(|c| {
+                                            matches!(c, MessageContent::ToolRequest(_))
+                                        })
+                                    {
+                                        // Strip thinking blocks from mixed text+thinking
+                                        // messages so the same signed/unsigned thinking is not
+                                        // duplicated when carried onto the tool-call request
+                                        // messages below. Messages that already contain tool
+                                        // requests are prior-split request_msg items whose
+                                        // thinking was already attached — stripping their
+                                        // thinking would leave only the last split message
+                                        // with reasoning, violating the signed-thinking
+                                        // dedup expectation that the first split message
+                                        // retains it.
                                         m.content.retain(|c| {
                                             !matches!(
                                                 c,

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2325,7 +2325,8 @@ impl Agent {
                                 // not just pure-thinking-only ones.
                                 let mut accumulated_prior: Vec<MessageContent> = Vec::new();
                                 let mut indices_to_remove: Vec<usize> = Vec::new();
-                                for (idx, m) in messages_to_add.messages().iter().enumerate() {
+                                for (idx, m) in messages_to_add.messages_mut().iter_mut().enumerate()
+                                {
                                     if m.role != response.role || m.content.is_empty() {
                                         continue;
                                     }
@@ -2356,6 +2357,17 @@ impl Agent {
                                     }
                                     if thinking_only {
                                         indices_to_remove.push(idx);
+                                    } else if has_thinking {
+                                        // Strip thinking blocks from mixed messages so the same
+                                        // signed/unsigned thinking is not duplicated when it is
+                                        // carried onto the tool-call request messages below.
+                                        m.content.retain(|c| {
+                                            !matches!(
+                                                c,
+                                                MessageContent::Thinking(_)
+                                                    | MessageContent::RedactedThinking(_)
+                                            )
+                                        });
                                     }
                                 }
                                 // Remove in reverse order to preserve indices


### PR DESCRIPTION
## Summary

Fixes four issues in thinking/reasoning preservation for DeepSeek/Kimi thinking models on multi-turn tool calls:

1. **RedactedThinking was silently dropped** in `format_messages_with_options` — `reasoning_content` was missing for signed/redacted thinking blocks.

2. **Only the last thinking-only message was used** when reasoning arrived across multiple streaming chunks. Now accumulates **ALL** prior thinking, even when `direct_thinking` is non-empty (reasoning on same chunk as tool_calls).

3. **Mixed thinking+text messages were not recognized** as a thinking source. The prior-message filter required **ALL** content to be Thinking. Now extracts thinking from **ANY** prior assistant message.

4. **Thinking from mixed messages created duplicate signed blocks** (review feedback). When thinking was cloned from a mixed (thinking+text) message onto a tool-call message, the original mixed message kept its thinking blocks. Since `fix_conversation`/`dedupe_signed_thinking` does not run between turns in the multi-turn loop, the duplicate signed blocks reached the provider on the next API call — causing a 400 rejection from Anthropic-style providers. Now thinking blocks are stripped from mixed messages after cloning.

## Changes

### `crates/goose-provider-types/src/formats/openai.rs`
- `RedactedThinking.data` is now appended to `reasoning_text` instead of being skipped

### `crates/goose/src/agents/agent.rs`
- Rewrote the thinking accumulation logic to iterate through all assistant messages, accumulate thinking from any message containing thinking blocks, remove pure-thinking-only messages, and merge accumulated prior thinking with `direct_thinking`
- Strip thinking blocks from mixed (thinking+text) messages after cloning them onto tool-call request messages, preventing duplicate signed/unsigned reasoning in the next turn

## Testing

- Existing tests pass for `format_messages` with `preserve_thinking_context`
- Tests cover: reasoning content preservation, thinking-only chunks carried to tool calls, no duplication of pending thinking, merging thinking with tool-call suffix, no cross-turn leaking, reasoning carried through text-only chunks, reasoning on all split tool calls, sequential tool calls not merged, signed thinking deduplication across split tool-call messages

## Related Issues

Closes #9397
Closes #9434
Closes #9675
Closes #9891
Closes #10012