### PR TITLE
Add Nika (read-only workflow oracle) to servers.json

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -545,7 +545,8 @@
     "description": "Read-only oracle for Nika AI workflows: validate .nika.yaml files, explain findings, estimate cost before running",
     "command": "nika mcp",
     "link": "https://github.com/supernovae-st/nika",
-    "installation_notes": "Install the nika binary first (single Rust binary): brew install supernovae-st/tap/nika — the MCP server ships inside it. Release tarballs with SHA256SUMS are on GitHub for Linux.",
+    "installation_notes": "Install the nika binary first (single Rust binary): brew install supernovae-st/tap/nika — the MCP server ships inside it. Release tarballs with SHA256SUMS are on GitHub for Linux. Then add it manually with 'goose session --with-extension \"nika mcp\"' or via Settings → Extensions → Add custom extension.",
+    "show_install_link": false,
     "is_builtin": false,
     "endorsed": false,
     "environmentVariables": []

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -36,7 +36,7 @@
   {
     "id": "apify",
     "name": "Apify",
-    "description": "Extract data from any website with thousands of scrapers, crawlers, and automations on Apify Store \u26a1",
+    "description": "Extract data from any website with thousands of scrapers, crawlers, and automations on Apify Store ⚡",
     "command": "npx -y @apify/actors-mcp-server",
     "link": "https://github.com/apify/apify-mcp-server",
     "installation_notes": "Install using npx. Requires an Apify API token.",
@@ -540,6 +540,17 @@
     ]
   },
   {
+    "id": "nika",
+    "name": "Nika",
+    "description": "Read-only oracle for Nika AI workflows: validate .nika.yaml files, explain findings, estimate cost before running",
+    "command": "nika mcp",
+    "link": "https://github.com/supernovae-st/nika",
+    "installation_notes": "Install the nika binary first (single Rust binary): brew install supernovae-st/tap/nika — the MCP server ships inside it. Release tarballs with SHA256SUMS are on GitHub for Linux.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": []
+  },
+  {
     "id": "nostrbook-mcp",
     "name": "NostrBook",
     "description": "Nostr protocol integration for decentralized social",
@@ -849,7 +860,7 @@
   {
     "id": "cash-app",
     "name": "Cash App",
-    "description": "Cash App brings local food ordering into the AI era. Discover nearby sellers, browse menus with calories and allergen info, customize orders, and complete checkout\u2014all conversationally.",
+    "description": "Cash App brings local food ordering into the AI era. Discover nearby sellers, browse menus with calories and allergen info, customize orders, and complete checkout—all conversationally.",
     "type": "streamable-http",
     "url": "https://connect.squareup.com/v2/mcp/cash-app",
     "link": "",
@@ -859,26 +870,25 @@
     "environmentVariables": []
   },
   {
-  "id": "scholar-sidekick",
-  "name": "Scholar Sidekick",
-  "description": "Resolve, format, export, and verify academic citations (DOI, PMID, ISBN, arXiv) plus retraction and open-access checks",
-  "command": "npx -y scholar-sidekick-mcp@latest",
-  "link": "https://github.com/mlava/scholar-sidekick-mcp",
-  "installation_notes": "No API key required — works anonymously on a free, rate-limited tier. Optionally set SCHOLAR_API_KEY (a free first-party ssk_ key from https://scholar-sidekick.com/account) for higher limits, or RAPIDAPI_KEY for paid tiers via RapidAPI.",
-  "is_builtin": false,
-  "endorsed": false,
-  "environmentVariables": [
-    {
-      "name": "SCHOLAR_API_KEY",
-      "description": "Optional first-party API key (ssk_) from https://scholar-sidekick.com/account; raises rate limits. Sent as Authorization: Bearer.",
-      "required": false
-    },
-    {
-      "name": "RAPIDAPI_KEY",
-      "description": "Optional RapidAPI key for paid/managed tiers; routes calls through the RapidAPI gateway.",
-      "required": false
-    }
-  ]
-}
-
+    "id": "scholar-sidekick",
+    "name": "Scholar Sidekick",
+    "description": "Resolve, format, export, and verify academic citations (DOI, PMID, ISBN, arXiv) plus retraction and open-access checks",
+    "command": "npx -y scholar-sidekick-mcp@latest",
+    "link": "https://github.com/mlava/scholar-sidekick-mcp",
+    "installation_notes": "No API key required — works anonymously on a free, rate-limited tier. Optionally set SCHOLAR_API_KEY (a free first-party ssk_ key from https://scholar-sidekick.com/account) for higher limits, or RAPIDAPI_KEY for paid tiers via RapidAPI.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [
+      {
+        "name": "SCHOLAR_API_KEY",
+        "description": "Optional first-party API key (ssk_) from https://scholar-sidekick.com/account; raises rate limits. Sent as Authorization: Bearer.",
+        "required": false
+      },
+      {
+        "name": "RAPIDAPI_KEY",
+        "description": "Optional RapidAPI key for paid/managed tiers; routes calls through the RapidAPI gateway.",
+        "required": false
+      }
+    ]
+  }
 ]


### PR DESCRIPTION
Adds the **Nika** MCP server to the extensions directory.

`nika mcp` is a read-only oracle over the Nika workflow engine (single Rust binary, AGPL-3.0): agents validate `.nika.yaml` workflow files, get findings explained, and see an honest cost estimate before anything runs. No execution and no mutation over MCP by design — the threat model is documented in-repo.

It's a binary (brew/tarball), not an npx package — `installation_notes` covers it.

Disclosure: I'm the author.
