### PR TITLE
fix(providers): refresh Vercel AI Gateway models

### DIFF
--- a/crates/goose-providers/src/declarative.rs
+++ b/crates/goose-providers/src/declarative.rs
@@ -365,6 +365,14 @@ mod tests {
         assert!(!config.preserves_thinking);
     }
 
+    #[test]
+    fn vercel_ai_gateway_json_enables_dynamic_model_discovery() {
+        let config = deserialize_provider_config(crate::vercel_ai_gateway::JSON)
+            .expect("vercel_ai_gateway.json should parse");
+
+        assert_eq!(config.dynamic_models, Some(true));
+    }
+
     fn placeholder_var_names(template: &str) -> Vec<String> {
         template
             .split("${")

--- a/crates/goose-providers/src/declarative/definitions/vercel_ai_gateway.json
+++ b/crates/goose-providers/src/declarative/definitions/vercel_ai_gateway.json
@@ -9,6 +9,7 @@
     "http-referer": "https://goose-docs.ai",
     "x-title": "goose"
   },
+  "dynamic_models": true,
   "models": [
     {
       "name": "anthropic/claude-sonnet-4.6",


### PR DESCRIPTION
## Summary
- enable dynamic model discovery for Vercel AI Gateway
- retain the bundled model list as the existing fallback when /v1/models returns 404
- add a regression test for the declarative configuration

## Test plan
- cargo test -p goose-providers vercel_ai_gateway_json_enables_dynamic_model_discovery