### PR TITLE
Add MLX multimodal inference support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9368,9 +9368,9 @@ dependencies = [
 
 [[package]]
 name = "safemlx-lm"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52d380397b98a382399a0a8754d81c52b2d65d9310c64fb634307396f5a084d"
+checksum = "10021db1789b1707952ae7e952c81eafd5b7b2a81e34eb47719f2a182671d4db"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2954,16 +2954,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
@@ -2977,20 +2967,6 @@ name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
  "fnv",
  "ident_case",
@@ -3020,17 +2996,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core 0.21.3",
  "quote",
  "syn 2.0.118",
 ]
@@ -5136,6 +5101,7 @@ dependencies = [
  "goose-provider-types",
  "goose-sdk-types",
  "hf-hub",
+ "image 0.25.10",
  "include_dir",
  "llama-cpp-2",
  "llama-cpp-sys-2",
@@ -5988,12 +5954,23 @@ dependencies = [
  "byteorder-lite",
  "color_quant",
  "gif 0.14.2",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png 0.18.1",
  "tiff 0.11.3",
  "zune-core",
  "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -6173,6 +6150,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -9343,14 +9329,14 @@ checksum = "3944826ff8fa8093089aba3acb4ef44b9446a99a16f3bf4e74af3f77d340ab7d"
 
 [[package]]
 name = "safemlx"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f501c4f9748dfe9ccc905e7e13ae88873d96a00735268c69258e158da07a777f"
+checksum = "ba126836f374feaa7d6842fe4666fa249b364622ba3c1806b493ce0d5461998f"
 dependencies = [
  "bytemuck",
  "dyn-clone",
  "half",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "libc",
  "mach-sys",
  "num-complex",
@@ -9361,20 +9347,20 @@ dependencies = [
  "safemlx-internal-macros",
  "safemlx-macros",
  "safemlx-sys",
- "safetensors 0.6.2",
+ "safetensors 0.8.0",
  "smallvec",
- "strum 0.27.2",
+ "strum 0.28.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "safemlx-internal-macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9708b1312176963a4ea6412859e6655e56a83fe6ab936142715aa0e9fd662fe5"
+checksum = "6169d5cd6a9b565bc3b0db7d91a9bbfe19999839b23c92e991fd823835d8edbd"
 dependencies = [
- "darling 0.21.3",
- "itertools 0.14.0",
+ "darling 0.23.0",
+ "itertools 0.15.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -9382,43 +9368,44 @@ dependencies = [
 
 [[package]]
 name = "safemlx-lm"
-version = "0.1.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f450654386009003b745adfdae7af2c7f44ae749d75621a2a0b07607945e9f"
+checksum = "d52d380397b98a382399a0a8754d81c52b2d65d9310c64fb634307396f5a084d"
 dependencies = [
  "anyhow",
  "clap",
  "idna_adapter",
+ "image 0.25.10",
  "minijinja",
  "safemlx",
  "safemlx-lm-utils",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "tokenizers 0.22.2",
+ "tokenizers 0.23.1",
 ]
 
 [[package]]
 name = "safemlx-lm-utils"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583d39124dae0b4a93ac7528d16d543f5e717c21365e6b034a8a74d8e1b4eb3a"
+checksum = "1af6547ba76673530921074ad4e7608240526f30335048b7bac077dee5d392a5"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "tokenizers 0.22.2",
+ "tokenizers 0.23.1",
 ]
 
 [[package]]
 name = "safemlx-macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d549c5fdbe69b904ef84c5cf352add203de1093b3c636e8133d94c24cfc33ce0"
+checksum = "6deae4f49d22783e05805575e4b676e203fcc4e4e6ad57fbb5001abdb405e257"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -9426,9 +9413,9 @@ dependencies = [
 
 [[package]]
 name = "safemlx-sys"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552285b007dab687890f5c49382e52e69a3bb1359bb2c8f2c2743743509af071"
+checksum = "5240fd4c15ee5c0ff377757f8643e2a555378b4fbd5d0ab1a810efc06f8fcd6c"
 dependencies = [
  "cc",
  "cmake",
@@ -9439,16 +9426,6 @@ name = "safetensors"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44560c11236a6130a46ce36c836a62936dc81ebf8c36a37947423571be0e55b6"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "safetensors"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172dd94c5a87b5c79f945c863da53b2ebc7ccef4eca24ac63cca66a41aab2178"
 dependencies = [
  "serde",
  "serde_json",

--- a/crates/goose-local-inference/Cargo.toml
+++ b/crates/goose-local-inference/Cargo.toml
@@ -47,7 +47,7 @@ uuid = { workspace = true, features = ["v4", "std"] }
 tempfile = { workspace = true }
 
 safemlx = { default-features = false, features = ["accelerate", "metal", "safetensors"], optional = true, version = "0.1.3" }
-safemlx-lm = { optional = true, version = "0.4.0", features = ["image-processing"] }
+safemlx-lm = { optional = true, version = "0.4.1", features = ["image-processing"] }
 safemlx-lm-utils = { optional = true, version = "0.1.4" }
 image = { version = "0.25.10", default-features = false, features = ["png", "jpeg", "gif", "webp"], optional = true }
 

--- a/crates/goose-local-inference/Cargo.toml
+++ b/crates/goose-local-inference/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 default = []
 cuda = ["llama-cpp-2/cuda"]
 vulkan = ["llama-cpp-2/vulkan"]
-mlx = ["dep:safemlx", "dep:safemlx-lm", "dep:safemlx-lm-utils"]
+mlx = ["dep:safemlx", "dep:safemlx-lm", "dep:safemlx-lm-utils", "dep:image"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -46,9 +46,10 @@ utoipa = { workspace = true, features = ["chrono"] }
 uuid = { workspace = true, features = ["v4", "std"] }
 tempfile = { workspace = true }
 
-safemlx = { default-features = false, features = ["accelerate", "metal", "safetensors"], optional = true, version = "0.1.2" }
-safemlx-lm = { optional = true, version = "0.1.5" }
-safemlx-lm-utils = { optional = true, version = "0.1.2" }
+safemlx = { default-features = false, features = ["accelerate", "metal", "safetensors"], optional = true, version = "0.1.3" }
+safemlx-lm = { optional = true, version = "0.4.0", features = ["image-processing"] }
+safemlx-lm-utils = { optional = true, version = "0.1.4" }
+image = { version = "0.25.10", default-features = false, features = ["png", "jpeg", "gif", "webp"], optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 llama-cpp-2 = { workspace = true, features = ["sampler", "metal", "mtmd"] }

--- a/crates/goose-local-inference/src/hf_models.rs
+++ b/crates/goose-local-inference/src/hf_models.rs
@@ -1114,6 +1114,42 @@ mod tests {
     }
 
     #[test]
+    fn mlx_processor_support_rejects_qwen_multimodal_without_preprocessor() {
+        let config = Some(serde_json::json!({
+            "model_type": "qwen3_5_moe",
+            "vision_config": {},
+            "image_token_id": 42
+        }));
+
+        let reason = mlx_processor_support(&config, &mlx_siblings(&["tokenizer.json"]));
+
+        assert_eq!(
+            reason.as_deref(),
+            Some("MLX multimodal Qwen models require preprocessor_config.json")
+        );
+    }
+
+    #[test]
+    fn mlx_processor_support_accepts_qwen_multimodal_with_preprocessor() {
+        let config = Some(serde_json::json!({
+            "model_type": "qwen3_5_moe",
+            "vision_config": {},
+            "image_token_id": 42
+        }));
+        let mut siblings = mlx_siblings(&["tokenizer.json"]);
+        siblings.push(sibling("preprocessor_config.json"));
+
+        assert!(mlx_processor_support(&config, &siblings).is_none());
+    }
+
+    #[test]
+    fn mlx_processor_support_ignores_text_only_models() {
+        let config = Some(serde_json::json!({ "model_type": "llama" }));
+
+        assert!(mlx_processor_support(&config, &mlx_siblings(&["tokenizer.json"])).is_none());
+    }
+
+    #[test]
     fn mlx_download_filenames_include_fp8_snapshot_metadata() {
         let siblings = [
             "config.json",
@@ -1743,17 +1779,17 @@ fn mlx_variants_from_model_info(
         size_bytes,
         filename: None,
         download_url: None,
-        description: mlx_variant_description(mlx_config),
+        description: mlx_variant_description(mlx_config, siblings),
         quality_rank: 91,
         sharded: siblings
             .iter()
             .filter(|s| s.rfilename.ends_with(".safetensors"))
             .count()
             > 1,
-        supported: is_mlx_runtime_supported(mlx_config)
+        supported: is_mlx_runtime_supported(mlx_config, siblings)
             && cfg!(target_os = "macos")
             && cfg!(feature = "mlx"),
-        unsupported_reason: mlx_unsupported_reason(mlx_config),
+        unsupported_reason: mlx_unsupported_reason(mlx_config, siblings),
     }]
 }
 
@@ -1824,11 +1860,14 @@ fn mlx_model_type(config: &Option<serde_json::Value>) -> Option<&str> {
         .and_then(|value| value.as_str())
 }
 
-fn is_mlx_runtime_supported(config: &Option<serde_json::Value>) -> bool {
-    mlx_config_support(config).is_none()
+fn is_mlx_runtime_supported(config: &Option<serde_json::Value>, siblings: &[RepoSibling]) -> bool {
+    mlx_config_support(config).is_none() && mlx_processor_support(config, siblings).is_none()
 }
 
-fn mlx_unsupported_reason(config: &Option<serde_json::Value>) -> Option<String> {
+fn mlx_unsupported_reason(
+    config: &Option<serde_json::Value>,
+    siblings: &[RepoSibling],
+) -> Option<String> {
     if !cfg!(target_os = "macos") {
         return Some("MLX requires macOS".to_string());
     }
@@ -1836,12 +1875,51 @@ fn mlx_unsupported_reason(config: &Option<serde_json::Value>) -> Option<String> 
         return Some("MLX support was not compiled in".to_string());
     }
 
-    mlx_config_support(config)
+    mlx_config_support(config).or_else(|| mlx_processor_support(config, siblings))
 }
 
 fn mlx_config_support(config: &Option<serde_json::Value>) -> Option<String> {
     let config = config.as_ref()?;
     mlx_config_support_for_value(config)
+}
+
+fn mlx_processor_support(
+    config: &Option<serde_json::Value>,
+    siblings: &[RepoSibling],
+) -> Option<String> {
+    let config = config.as_ref()?;
+    if !is_qwen_mlx_multimodal_config(config) {
+        return None;
+    }
+    if siblings
+        .iter()
+        .any(|s| s.rfilename == "preprocessor_config.json")
+    {
+        None
+    } else {
+        Some("MLX multimodal Qwen models require preprocessor_config.json".to_string())
+    }
+}
+
+fn is_qwen_mlx_multimodal_config(config: &serde_json::Value) -> bool {
+    let effective_type = config
+        .get("text_config")
+        .and_then(|value| value.get("model_type"))
+        .and_then(|value| value.as_str())
+        .or_else(|| config.get("model_type").and_then(|value| value.as_str()));
+    if !matches!(effective_type, Some("qwen3_5_moe" | "qwen3_5_moe_text")) {
+        return false;
+    }
+
+    config_has_key(config, "vision_config")
+        || config_has_key(config, "image_token_id")
+        || config
+            .get("text_config")
+            .is_some_and(|text_config| config_has_key(text_config, "image_token_id"))
+}
+
+fn config_has_key(config: &serde_json::Value, key: &str) -> bool {
+    config.get(key).is_some_and(|value| !value.is_null())
 }
 
 #[cfg(feature = "mlx")]
@@ -1856,8 +1934,8 @@ fn mlx_config_support_for_value(_config: &serde_json::Value) -> Option<String> {
     None
 }
 
-fn mlx_variant_description(config: &Option<serde_json::Value>) -> String {
-    match mlx_unsupported_reason(config) {
+fn mlx_variant_description(config: &Option<serde_json::Value>, siblings: &[RepoSibling]) -> String {
+    match mlx_unsupported_reason(config, siblings) {
         None => "MLX safetensors snapshot".to_string(),
         Some(reason) => format!("MLX safetensors snapshot ({reason})"),
     }

--- a/crates/goose-local-inference/src/mlx.rs
+++ b/crates/goose-local-inference/src/mlx.rs
@@ -6,7 +6,14 @@ mod imp {
     use safemlx::transforms::eval;
     use safemlx::{random, Array, Device, DeviceType, Stream};
     use safemlx_lm::gemma4_mtp::generate_gemma4_mtp;
-    use safemlx_lm::models::{gemma4_assistant::load_gemma4_assistant_model, LoadedModel, Model};
+    use safemlx_lm::models::{
+        gemma4_assistant::load_gemma4_assistant_model,
+        input::{InputPart, ModelInput},
+        LoadedModel, Model,
+    };
+    use safemlx_lm::processor::{
+        MediaInput as MlxMediaInput, PreparedModelInput, ProcessorInput, RgbImageView,
+    };
     use safemlx_lm_utils::tokenizer::{Chat, Conversation, Role, Tokenizer};
     use serde_json::json;
 
@@ -105,11 +112,19 @@ mod imp {
                     },
                 }
             };
+            let media_prompt = mlx_media_prompt(&loaded.model, request.messages)?;
+            let has_media = media_prompt.has_media();
+            ensure_mlx_image_support(
+                loaded.model.model_type(),
+                has_media,
+                loaded.model.has_processor(),
+            )?;
+            let effective_messages = media_prompt.messages.as_deref().unwrap_or(request.messages);
             let prompt = build_prompt(
                 &mut loaded.model,
                 &request.model_name,
                 request.system,
-                request.messages,
+                effective_messages,
                 request.tools,
                 tool_mode,
             )?;
@@ -121,6 +136,25 @@ mod imp {
                 )));
             }
 
+            let prepared_input = if has_media {
+                let decoded_images = decode_mlx_images(&media_prompt.images)?;
+                let media = mlx_media_inputs(&decoded_images)?;
+                let marker = mlx_image_marker(loaded.model.model_type()).ok_or_else(|| {
+                    mlx_error(format!(
+                        "MLX model type '{}' does not define an image marker",
+                        loaded.model.model_type()
+                    ))
+                })?;
+                let processor_input = mlx_processor_inputs(&prompt, marker, &media)?;
+                Some(
+                    loaded
+                        .model
+                        .prepare_input(&processor_input)
+                        .map_err(mlx_error)?,
+                )
+            } else {
+                None
+            };
             let prompt_array = loaded
                 .model
                 .encode_to_array(&prompt, false, &stream)
@@ -143,7 +177,7 @@ mod imp {
                 time_to_first_token_ms,
                 streamed_response,
             } = if let Some(draft_model_path) = &request.draft_model_path {
-                if matches!(loaded.model.model_mut(), Model::Gemma4(_)) {
+                if !has_media && matches!(loaded.model.model_mut(), Model::Gemma4(_)) {
                     let weights_stream = Stream::new_with_device(&Device::new(DeviceType::Cpu, 0));
                     let mut assistant =
                         load_gemma4_assistant_model(draft_model_path, &stream, &weights_stream)
@@ -184,7 +218,7 @@ mod imp {
                     generate_single_model(
                         &mut loaded.model,
                         &loaded.tokenizer,
-                        &prompt_array,
+                        mlx_generation_input(&prompt_array, prepared_input.as_ref()),
                         &eos_token_ids,
                         max_tokens,
                         temp,
@@ -204,7 +238,7 @@ mod imp {
                 generate_single_model(
                     &mut loaded.model,
                     &loaded.tokenizer,
-                    &prompt_array,
+                    mlx_generation_input(&prompt_array, prepared_input.as_ref()),
                     &eos_token_ids,
                     max_tokens,
                     temp,
@@ -266,6 +300,28 @@ mod imp {
         fn available_memory_bytes(&self) -> u64 {
             0
         }
+    }
+
+    struct MlxMediaPrompt {
+        images: Vec<crate::multimodal::ExtractedImage>,
+        messages: Option<Vec<Message>>,
+    }
+
+    impl MlxMediaPrompt {
+        fn has_media(&self) -> bool {
+            !self.images.is_empty()
+        }
+    }
+
+    struct MlxDecodedImage {
+        pixels: Vec<u8>,
+        width: u32,
+        height: u32,
+    }
+
+    enum MlxPromptInput<'a> {
+        Text(&'a Array),
+        Prepared(&'a PreparedModelInput),
     }
 
     #[derive(Clone, Copy)]
@@ -344,6 +400,122 @@ mod imp {
             .unwrap_or_default()
     }
 
+    fn mlx_media_prompt(
+        model: &LoadedModel,
+        messages: &[Message],
+    ) -> Result<MlxMediaPrompt, ProviderError> {
+        let Some(marker) = mlx_image_marker(model.model_type()) else {
+            return Ok(MlxMediaPrompt {
+                images: Vec::new(),
+                messages: None,
+            });
+        };
+        Ok(mlx_media_prompt_with_marker(messages, marker))
+    }
+
+    fn mlx_media_prompt_with_marker(messages: &[Message], marker: &str) -> MlxMediaPrompt {
+        let (images, messages) = crate::multimodal::extract_images_from_messages(messages, marker);
+        MlxMediaPrompt {
+            messages: (!images.is_empty()).then_some(messages),
+            images,
+        }
+    }
+
+    fn ensure_mlx_image_support(
+        model_type: &str,
+        has_media: bool,
+        has_processor: bool,
+    ) -> Result<(), ProviderError> {
+        if has_media && !has_processor {
+            return Err(ProviderError::ExecutionError(format!(
+                "MLX model type '{}' does not support image input. Select a multimodal MLX model with processor metadata.",
+                model_type
+            )));
+        }
+        Ok(())
+    }
+
+    fn mlx_image_marker(model_type: &str) -> Option<&'static str> {
+        match model_type {
+            "gemma4" | "gemma4_text" | "gemma4_unified" | "gemma4_unified_text" => Some("<|image>"),
+            "qwen3_5_moe" | "qwen3_5_moe_text" => Some("<|image_pad|>"),
+            _ => None,
+        }
+    }
+
+    fn decode_mlx_images(
+        images: &[crate::multimodal::ExtractedImage],
+    ) -> Result<Vec<MlxDecodedImage>, ProviderError> {
+        images
+            .iter()
+            .map(|image| {
+                let decoded = image::load_from_memory(&image.bytes)
+                    .map_err(|error| mlx_error(format!("failed to decode image: {error}")))?
+                    .to_rgb8();
+                let (width, height) = decoded.dimensions();
+                Ok(MlxDecodedImage {
+                    pixels: decoded.into_raw(),
+                    width,
+                    height,
+                })
+            })
+            .collect()
+    }
+
+    fn mlx_media_inputs(
+        images: &[MlxDecodedImage],
+    ) -> Result<Vec<MlxMediaInput<'_>>, ProviderError> {
+        images
+            .iter()
+            .map(|image| {
+                RgbImageView::packed(&image.pixels, image.width, image.height)
+                    .map(MlxMediaInput::image_rgb8)
+                    .map_err(mlx_error)
+            })
+            .collect()
+    }
+
+    fn mlx_processor_inputs<'a>(
+        prompt: &'a str,
+        marker: &str,
+        media: &'a [MlxMediaInput<'a>],
+    ) -> Result<Vec<ProcessorInput<'a>>, ProviderError> {
+        let mut inputs = Vec::with_capacity(media.len().saturating_mul(2).saturating_add(1));
+        let mut rest = prompt;
+        for item in media {
+            let Some((before, after)) = rest.split_once(marker) else {
+                return Err(mlx_error(format!(
+                    "MLX prompt contains fewer image markers than attached images: expected {}",
+                    media.len()
+                )));
+            };
+            if !before.is_empty() {
+                inputs.push(ProcessorInput::Text(before));
+            }
+            inputs.push(ProcessorInput::Media(*item));
+            rest = after;
+        }
+        if rest.contains(marker) {
+            return Err(mlx_error(
+                "MLX prompt contains more image markers than attached images",
+            ));
+        }
+        if !rest.is_empty() {
+            inputs.push(ProcessorInput::Text(rest));
+        }
+        Ok(inputs)
+    }
+
+    fn mlx_generation_input<'a>(
+        prompt_array: &'a Array,
+        prepared_input: Option<&'a PreparedModelInput>,
+    ) -> MlxPromptInput<'a> {
+        match prepared_input {
+            Some(prepared_input) => MlxPromptInput::Prepared(prepared_input),
+            None => MlxPromptInput::Text(prompt_array),
+        }
+    }
+
     fn build_prompt(
         model: &mut LoadedModel,
         model_name: &str,
@@ -419,7 +591,7 @@ mod imp {
     fn generate_single_model(
         model: &mut LoadedModel,
         tokenizer: &Tokenizer,
-        prompt_array: &Array,
+        prompt_input: MlxPromptInput<'_>,
         eos_token_ids: &[u32],
         max_tokens: usize,
         temp: f32,
@@ -435,30 +607,77 @@ mod imp {
         let stream_generation = emitter.can_stream();
         let mut decode_stream = tokenizer.decode_stream(true);
         {
-            let generator = model
-                .generate_with_cache(&mut cache, temp, prompt_array, prng_key, stream)
-                .take(max_tokens);
-            for token in generator {
-                let token = token.map_err(mlx_error)?;
-                eval([&token]).map_err(mlx_error)?;
-                let token_id = token.item::<u32>(stream);
-                time_to_first_token_ms.get_or_insert_with(|| {
-                    u64::try_from(generation_started.elapsed().as_millis()).unwrap_or(u64::MAX)
-                });
-                if eos_token_ids.contains(&token_id) {
-                    break;
-                }
-                generated_ids.push(token_id);
-                if stream_generation {
-                    if let Some(piece) = decode_stream.step(token_id).map_err(mlx_error)? {
-                        if !piece.is_empty() {
-                            let should_continue = emitter.push_text(&piece)?;
-                            streamed_text.push_str(&piece);
-                            if !should_continue {
-                                break;
+            match prompt_input {
+                MlxPromptInput::Text(prompt_array) => {
+                    let prompt_part = InputPart::text_token_ids(prompt_array);
+                    let input_parts = [prompt_part];
+                    let generator = model
+                        .generate_input_with_cache(
+                            &mut cache,
+                            temp,
+                            ModelInput::new(&input_parts),
+                            prng_key,
+                            stream,
+                        )
+                        .take(max_tokens);
+                    for token in generator {
+                        let token = token.map_err(mlx_error)?;
+                        eval([&token]).map_err(mlx_error)?;
+                        let token_id = token.item::<u32>(stream);
+                        time_to_first_token_ms.get_or_insert_with(|| {
+                            u64::try_from(generation_started.elapsed().as_millis())
+                                .unwrap_or(u64::MAX)
+                        });
+                        if eos_token_ids.contains(&token_id) {
+                            break;
+                        }
+                        generated_ids.push(token_id);
+                        if stream_generation {
+                            if let Some(piece) = decode_stream.step(token_id).map_err(mlx_error)? {
+                                if !piece.is_empty() {
+                                    let should_continue = emitter.push_text(&piece)?;
+                                    streamed_text.push_str(&piece);
+                                    if !should_continue {
+                                        break;
+                                    }
+                                }
                             }
                         }
                     }
+                }
+                MlxPromptInput::Prepared(prepared_input) => {
+                    prepared_input.with_model_input(|input| {
+                        let generator = model
+                            .generate_input_with_cache(&mut cache, temp, input, prng_key, stream)
+                            .take(max_tokens);
+                        for token in generator {
+                            let token = token.map_err(mlx_error)?;
+                            eval([&token]).map_err(mlx_error)?;
+                            let token_id = token.item::<u32>(stream);
+                            time_to_first_token_ms.get_or_insert_with(|| {
+                                u64::try_from(generation_started.elapsed().as_millis())
+                                    .unwrap_or(u64::MAX)
+                            });
+                            if eos_token_ids.contains(&token_id) {
+                                break;
+                            }
+                            generated_ids.push(token_id);
+                            if stream_generation {
+                                if let Some(piece) =
+                                    decode_stream.step(token_id).map_err(mlx_error)?
+                                {
+                                    if !piece.is_empty() {
+                                        let should_continue = emitter.push_text(&piece)?;
+                                        streamed_text.push_str(&piece);
+                                        if !should_continue {
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        Ok::<(), ProviderError>(())
+                    })?;
                 }
             }
         }
@@ -908,9 +1127,13 @@ mod imp {
     #[cfg(test)]
     mod tests {
         use super::{
-            final_stream_suffix, mlx_max_tokens, split_generated_thinking, token_id_or_ids,
+            ensure_mlx_image_support, final_stream_suffix, mlx_max_tokens,
+            mlx_media_prompt_with_marker, mlx_processor_inputs, split_generated_thinking,
+            token_id_or_ids, MlxMediaInput, RgbImageView,
         };
         use crate::local_model_registry::ModelSettings;
+        use goose_provider_types::conversation::message::{Message, MessageContent};
+        use safemlx_lm::processor::ProcessorInput;
         use serde_json::json;
 
         #[test]
@@ -968,6 +1191,79 @@ mod imp {
         #[test]
         fn final_stream_suffix_rejects_rewritten_streamed_prefix() {
             assert!(final_stream_suffix("corrected response", "stale prefix").is_err());
+        }
+
+        #[test]
+        fn media_prompt_replaces_images_without_reordering_text() {
+            let messages = vec![Message::user()
+                .with_text("before")
+                .with_image("aGVsbG8=", "image/png")
+                .with_text("after")];
+
+            let prompt = mlx_media_prompt_with_marker(&messages, "<|image>");
+
+            assert_eq!(prompt.images.len(), 1);
+            let rewritten = prompt.messages.unwrap();
+            assert_eq!(rewritten.len(), 1);
+            assert!(matches!(
+                &rewritten[0].content[..],
+                [
+                    MessageContent::Text(before),
+                    MessageContent::Text(marker),
+                    MessageContent::Text(after)
+                ] if before.text == "before" && marker.text == "<|image>" && after.text == "after"
+            ));
+        }
+
+        #[test]
+        fn media_prompt_leaves_text_only_messages_unmodified() {
+            let messages = vec![Message::user().with_text("just text")];
+
+            let prompt = mlx_media_prompt_with_marker(&messages, "<|image>");
+
+            assert!(prompt.images.is_empty());
+            assert!(prompt.messages.is_none());
+        }
+
+        #[test]
+        fn image_support_requires_loaded_processor_when_media_is_present() {
+            assert!(ensure_mlx_image_support("gemma4", false, false).is_ok());
+            assert!(ensure_mlx_image_support("gemma4", true, true).is_ok());
+
+            let error = ensure_mlx_image_support("gemma4", true, false).unwrap_err();
+            assert!(error.to_string().contains("processor metadata"));
+        }
+
+        #[test]
+        fn processor_inputs_interleave_prompt_text_and_media() {
+            let pixels = vec![255u8, 0, 0];
+            let image = RgbImageView::packed(&pixels, 1, 1).unwrap();
+            let media = [MlxMediaInput::image_rgb8(image)];
+
+            let inputs = mlx_processor_inputs("before<|image>after", "<|image>", &media).unwrap();
+
+            assert!(matches!(
+                &inputs[..],
+                [
+                    ProcessorInput::Text("before"),
+                    ProcessorInput::Media(_),
+                    ProcessorInput::Text("after")
+                ]
+            ));
+        }
+
+        #[test]
+        fn processor_inputs_require_marker_count_to_match_media_count() {
+            let pixels = vec![255u8, 0, 0];
+            let image = RgbImageView::packed(&pixels, 1, 1).unwrap();
+            let media = [MlxMediaInput::image_rgb8(image)];
+
+            let missing = mlx_processor_inputs("no marker", "<|image>", &media).unwrap_err();
+            assert!(missing.to_string().contains("fewer image markers"));
+
+            let extra =
+                mlx_processor_inputs("one<|image>two<|image>", "<|image>", &media).unwrap_err();
+            assert!(extra.to_string().contains("more image markers"));
         }
 
         #[test]


### PR DESCRIPTION
## Summary

- update the safemlx dependency family to the latest compatible releases
- enable image processing for MLX models and route ordered image/text inputs through model processors
- preserve text-only generation and disable draft-model generation when media is present
- require processor metadata when advertising supported multimodal MLX repositories
- add focused coverage for prompt ordering, processor requirements, marker validation, and text-only behavior

## Why

Recent safemlx releases add multimodal model processors and change prepared-input generation APIs. Goose needs to use those APIs so MLX vision models receive decoded image data alongside the rendered prompt while text-only models continue using the existing token input path.

## Validation

- `cargo fmt`
- `cargo check -p goose-local-inference --features mlx`
- `cargo test -p goose-local-inference --features mlx` (130 tests passed)
- `cargo check -p goose-local-inference`