### PR TITLE
Add GPT-5.6 support

### DIFF
--- a/crates/goose-provider-types/src/canonical/data/canonical_models.json
+++ b/crates/goose-provider-types/src/canonical/data/canonical_models.json
@@ -2671,6 +2671,64 @@
     }
   },
   {
+    "id": "abacus/MiniMaxAI/MiniMax-M2.7",
+    "name": "MiniMax-M2.7",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2
+    },
+    "limit": {
+      "context": 204800,
+      "output": 131072
+    }
+  },
+  {
+    "id": "abacus/MiniMaxAI/MiniMax-M3",
+    "name": "MiniMax-M3",
+    "family": "minimax",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-01",
+    "last_updated": "2026-06-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
     "id": "abacus/Qwen/QwQ-32B",
     "name": "QwQ 32B",
     "family": "qwen",
@@ -2762,8 +2820,9 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-04-29",
-    "last_updated": "2025-04-29",
+    "knowledge": "2025-04",
+    "release_date": "2025-04",
+    "last_updated": "2025-04",
     "modalities": {
       "input": [
         "text"
@@ -2778,20 +2837,21 @@
       "output": 0.29
     },
     "limit": {
-      "context": 128000,
+      "context": 131072,
       "output": 8192
     }
   },
   {
-    "id": "abacus/Qwen/qwen3-coder-480b-a35b-instruct",
-    "name": "Qwen3 Coder 480B A35B Instruct",
+    "id": "abacus/Qwen/Qwen3-Coder-480B-A35B-Instruct",
+    "name": "Qwen3-Coder 480B-A35B Instruct",
     "family": "qwen",
     "attachment": false,
-    "reasoning": true,
+    "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-07-22",
-    "last_updated": "2025-07-22",
+    "knowledge": "2025-04",
+    "release_date": "2025-04",
+    "last_updated": "2025-04",
     "modalities": {
       "input": [
         "text"
@@ -2807,7 +2867,35 @@
     },
     "limit": {
       "context": 262144,
-      "output": 65536
+      "output": 16384
+    }
+  },
+  {
+    "id": "abacus/Qwen/Qwen3.6-27B",
+    "name": "Qwen3.6 27B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.32,
+      "output": 3.2
+    },
+    "limit": {
+      "context": 262144,
+      "output": 8192
     }
   },
   {
@@ -2842,6 +2930,36 @@
     }
   },
   {
+    "id": "abacus/claude-fable-5",
+    "name": "Claude Fable 5",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-09",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "abacus/claude-haiku-4.5",
     "name": "Claude Haiku 4.5",
     "family": "claude-haiku",
@@ -2855,8 +2973,7 @@
     "modalities": {
       "input": [
         "text",
-        "image",
-        "pdf"
+        "image"
       ],
       "output": [
         "text"
@@ -2940,14 +3057,13 @@
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-03-31",
+    "knowledge": "2025-05",
     "release_date": "2025-11-01",
     "last_updated": "2025-11-01",
     "modalities": {
       "input": [
         "text",
-        "image",
-        "pdf"
+        "image"
       ],
       "output": [
         "text"
@@ -2973,12 +3089,11 @@
     "temperature": true,
     "knowledge": "2025-05-31",
     "release_date": "2026-02-05",
-    "last_updated": "2026-02-05",
+    "last_updated": "2026-03-13",
     "modalities": {
       "input": [
         "text",
-        "image",
-        "pdf"
+        "image"
       ],
       "output": [
         "text"
@@ -2990,7 +3105,67 @@
       "output": 25.0
     },
     "limit": {
-      "context": 200000,
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "abacus/claude-opus-4.7",
+    "name": "Claude Opus 4.7",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-04-16",
+    "last_updated": "2026-04-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "abacus/claude-opus-4.8",
+    "name": "Claude Opus 4.8",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01",
+    "release_date": "2026-05-28",
+    "last_updated": "2026-05-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0
+    },
+    "limit": {
+      "context": 1000000,
       "output": 128000
     }
   },
@@ -3038,8 +3213,7 @@
     "modalities": {
       "input": [
         "text",
-        "image",
-        "pdf"
+        "image"
       ],
       "output": [
         "text"
@@ -3065,12 +3239,11 @@
     "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-17",
-    "last_updated": "2026-02-17",
+    "last_updated": "2026-03-13",
     "modalities": {
       "input": [
         "text",
-        "image",
-        "pdf"
+        "image"
       ],
       "output": [
         "text"
@@ -3082,7 +3255,37 @@
       "output": 15.0
     },
     "limit": {
-      "context": 200000,
+      "context": 1000000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "abacus/claude-sonnet-5",
+    "name": "Claude Sonnet 5",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0
+    },
+    "limit": {
+      "context": 1000000,
       "output": 64000
     }
   },
@@ -3171,6 +3374,66 @@
     }
   },
   {
+    "id": "abacus/deepseek-ai/DeepSeek-V4-Flash",
+    "name": "DeepSeek V4 Flash",
+    "family": "deepseek-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.03
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 32768
+    }
+  },
+  {
+    "id": "abacus/deepseek-ai/DeepSeek-V4-Pro",
+    "name": "DeepSeek V4 Pro",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.74,
+      "output": 3.48,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 32768
+    }
+  },
+  {
     "id": "abacus/deepseek/deepseek-v3.1",
     "name": "DeepSeek V3.1",
     "family": "deepseek",
@@ -3207,15 +3470,13 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-01",
-    "release_date": "2025-03-20",
-    "last_updated": "2025-06-05",
+    "release_date": "2025-06-17",
+    "last_updated": "2025-06-17",
     "modalities": {
       "input": [
         "text",
         "image",
-        "audio",
-        "video",
-        "pdf"
+        "audio"
       ],
       "output": [
         "text"
@@ -3224,11 +3485,43 @@
     "open_weights": false,
     "cost": {
       "input": 0.3,
-      "output": 2.5
+      "output": 2.5,
+      "cache_read": 0.03
     },
     "limit": {
       "context": 1048576,
       "output": 65536
+    }
+  },
+  {
+    "id": "abacus/gemini-2.5-flash-image",
+    "name": "Nano Banana",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-06",
+    "release_date": "2025-08-26",
+    "last_updated": "2025-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.3,
+      "output": 30.0
+    },
+    "limit": {
+      "context": 32768,
+      "output": 32768
     }
   },
   {
@@ -3240,15 +3533,13 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-01",
-    "release_date": "2025-03-25",
-    "last_updated": "2025-03-25",
+    "release_date": "2025-06-17",
+    "last_updated": "2025-06-17",
     "modalities": {
       "input": [
         "text",
         "image",
-        "audio",
-        "video",
-        "pdf"
+        "audio"
       ],
       "output": [
         "text"
@@ -3257,7 +3548,8 @@
     "open_weights": false,
     "cost": {
       "input": 1.25,
-      "output": 10.0
+      "output": 10.0,
+      "cache_read": 0.125
     },
     "limit": {
       "context": 1048576,
@@ -3279,9 +3571,7 @@
       "input": [
         "text",
         "image",
-        "audio",
-        "video",
-        "pdf"
+        "audio"
       ],
       "output": [
         "text"
@@ -3290,7 +3580,103 @@
     "open_weights": false,
     "cost": {
       "input": 0.5,
+      "output": 3.0,
+      "cache_read": 0.05
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "abacus/gemini-3-pro-image-preview",
+    "name": "Nano Banana Pro",
+    "family": "gemini-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-11-20",
+    "last_updated": "2025-11-20",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 12.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 65536,
+      "output": 32768
+    }
+  },
+  {
+    "id": "abacus/gemini-3.1-flash-image-preview",
+    "name": "Nano Banana 2",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-02-26",
+    "last_updated": "2026-02-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.5,
       "output": 3.0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 32768
+    }
+  },
+  {
+    "id": "abacus/gemini-3.1-flash-lite",
+    "name": "Gemini 3.1 Flash Lite",
+    "family": "gemini-flash-lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-05-07",
+    "last_updated": "2026-05-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 1.5,
+      "cache_read": 0.025
     },
     "limit": {
       "context": 1048576,
@@ -3346,9 +3732,7 @@
       "input": [
         "text",
         "image",
-        "video",
-        "audio",
-        "pdf"
+        "audio"
       ],
       "output": [
         "text"
@@ -3357,11 +3741,73 @@
     "open_weights": false,
     "cost": {
       "input": 2.0,
-      "output": 12.0
+      "output": 12.0,
+      "cache_read": 0.2
     },
     "limit": {
       "context": 1048576,
       "output": 65536
+    }
+  },
+  {
+    "id": "abacus/gemini-3.5-flash",
+    "name": "Gemini 3.5 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-05-19",
+    "last_updated": "2026-05-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 9.0,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "abacus/google/gemma-4-31b-it",
+    "name": "Gemma 4 31B IT",
+    "family": "gemma",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.14,
+      "output": 0.4
+    },
+    "limit": {
+      "context": 262144,
+      "output": 131072
     }
   },
   {
@@ -3387,7 +3833,8 @@
     "open_weights": false,
     "cost": {
       "input": 2.0,
-      "output": 8.0
+      "output": 8.0,
+      "cache_read": 0.5
     },
     "limit": {
       "context": 1047576,
@@ -3396,8 +3843,8 @@
   },
   {
     "id": "abacus/gpt-4.1-mini",
-    "name": "GPT-4.1 Mini",
-    "family": "gpt",
+    "name": "GPT-4.1 mini",
+    "family": "gpt-mini",
     "attachment": true,
     "reasoning": false,
     "tool_call": true,
@@ -3417,7 +3864,8 @@
     "open_weights": false,
     "cost": {
       "input": 0.4,
-      "output": 1.6
+      "output": 1.6,
+      "cache_read": 0.1
     },
     "limit": {
       "context": 1047576,
@@ -3426,8 +3874,8 @@
   },
   {
     "id": "abacus/gpt-4.1-nano",
-    "name": "GPT-4.1 Nano",
-    "family": "gpt",
+    "name": "GPT-4.1 nano",
+    "family": "gpt-nano",
     "attachment": true,
     "reasoning": false,
     "tool_call": true,
@@ -3447,7 +3895,8 @@
     "open_weights": false,
     "cost": {
       "input": 0.1,
-      "output": 0.4
+      "output": 0.4,
+      "cache_read": 0.025
     },
     "limit": {
       "context": 1047576,
@@ -3456,20 +3905,19 @@
   },
   {
     "id": "abacus/gpt-4o",
-    "name": "GPT-4o (2024-11-20)",
+    "name": "GPT-4o",
     "family": "gpt",
     "attachment": true,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-10",
-    "release_date": "2024-11-20",
-    "last_updated": "2024-11-20",
+    "knowledge": "2023-09",
+    "release_date": "2024-05-13",
+    "last_updated": "2024-08-06",
     "modalities": {
       "input": [
         "text",
-        "image",
-        "audio"
+        "image"
       ],
       "output": [
         "text"
@@ -3478,7 +3926,8 @@
     "open_weights": false,
     "cost": {
       "input": 2.5,
-      "output": 10.0
+      "output": 10.0,
+      "cache_read": 1.25
     },
     "limit": {
       "context": 128000,
@@ -3487,13 +3936,13 @@
   },
   {
     "id": "abacus/gpt-4o-mini",
-    "name": "GPT-4o Mini",
-    "family": "gpt",
+    "name": "GPT-4o mini",
+    "family": "gpt-mini",
     "attachment": true,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-04",
+    "knowledge": "2023-09",
     "release_date": "2024-07-18",
     "last_updated": "2024-07-18",
     "modalities": {
@@ -3538,7 +3987,8 @@
     "open_weights": false,
     "cost": {
       "input": 1.25,
-      "output": 10.0
+      "output": 10.0,
+      "cache_read": 0.125
     },
     "limit": {
       "context": 400000,
@@ -3547,8 +3997,8 @@
   },
   {
     "id": "abacus/gpt-5-codex",
-    "name": "GPT-5 Codex",
-    "family": "gpt",
+    "name": "GPT-5-Codex",
+    "family": "gpt-codex",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
@@ -3568,7 +4018,8 @@
     "open_weights": false,
     "cost": {
       "input": 1.25,
-      "output": 10.0
+      "output": 10.0,
+      "cache_read": 0.125
     },
     "limit": {
       "context": 400000,
@@ -3598,7 +4049,8 @@
     "open_weights": false,
     "cost": {
       "input": 0.25,
-      "output": 2.0
+      "output": 2.0,
+      "cache_read": 0.025
     },
     "limit": {
       "context": 400000,
@@ -3628,7 +4080,8 @@
     "open_weights": false,
     "cost": {
       "input": 0.05,
-      "output": 0.4
+      "output": 0.4,
+      "cache_read": 0.005
     },
     "limit": {
       "context": 400000,
@@ -3658,7 +4111,8 @@
     "open_weights": false,
     "cost": {
       "input": 1.25,
-      "output": 10.0
+      "output": 10.0,
+      "cache_read": 0.125
     },
     "limit": {
       "context": 400000,
@@ -3698,7 +4152,7 @@
   {
     "id": "abacus/gpt-5.1-codex",
     "name": "GPT-5.1 Codex",
-    "family": "gpt",
+    "family": "gpt-codex",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
@@ -3718,7 +4172,8 @@
     "open_weights": false,
     "cost": {
       "input": 1.25,
-      "output": 10.0
+      "output": 10.0,
+      "cache_read": 0.125
     },
     "limit": {
       "context": 400000,
@@ -3778,7 +4233,8 @@
     "open_weights": false,
     "cost": {
       "input": 1.75,
-      "output": 14.0
+      "output": 14.0,
+      "cache_read": 0.175
     },
     "limit": {
       "context": 400000,
@@ -3818,7 +4274,7 @@
   {
     "id": "abacus/gpt-5.2-codex",
     "name": "GPT-5.2 Codex",
-    "family": "gpt",
+    "family": "gpt-codex",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
@@ -3829,8 +4285,7 @@
     "modalities": {
       "input": [
         "text",
-        "image",
-        "pdf"
+        "image"
       ],
       "output": [
         "text"
@@ -3839,7 +4294,8 @@
     "open_weights": false,
     "cost": {
       "input": 1.75,
-      "output": 14.0
+      "output": 14.0,
+      "cache_read": 0.175
     },
     "limit": {
       "context": 400000,
@@ -3878,7 +4334,7 @@
   {
     "id": "abacus/gpt-5.3-codex",
     "name": "GPT-5.3 Codex",
-    "family": "gpt",
+    "family": "gpt-codex",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
@@ -3889,8 +4345,7 @@
     "modalities": {
       "input": [
         "text",
-        "image",
-        "pdf"
+        "image"
       ],
       "output": [
         "text"
@@ -3899,7 +4354,8 @@
     "open_weights": false,
     "cost": {
       "input": 1.75,
-      "output": 14.0
+      "output": 14.0,
+      "cache_read": 0.18
     },
     "limit": {
       "context": 400000,
@@ -3960,10 +4416,197 @@
     "open_weights": false,
     "cost": {
       "input": 2.5,
-      "output": 15.0
+      "output": 15.0,
+      "cache_read": 0.25
     },
     "limit": {
-      "context": 1050000,
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "abacus/gpt-5.4-mini",
+    "name": "GPT-5.4 mini",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 4.5,
+      "cache_read": 0.075
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "abacus/gpt-5.4-nano",
+    "name": "GPT-5.4 nano",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.2,
+      "output": 1.25,
+      "cache_read": 0.02
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "abacus/gpt-5.5",
+    "name": "GPT-5.5",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-12-01",
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "abacus/gpt-5.6-luna",
+    "name": "GPT-5.6 Luna",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 6.0,
+      "cache_read": 0.1
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "abacus/gpt-5.6-sol",
+    "name": "GPT-5.6 Sol",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "abacus/gpt-5.6-terra",
+    "name": "GPT-5.6 Terra",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 15.0,
+      "cache_read": 0.25
+    },
+    "limit": {
+      "context": 1000000,
       "output": 128000
     }
   },
@@ -4052,6 +4695,65 @@
     "limit": {
       "context": 2000000,
       "output": 16384
+    }
+  },
+  {
+    "id": "abacus/grok-4.3",
+    "name": "Grok 4.3",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-17",
+    "last_updated": "2026-04-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 32768
+    }
+  },
+  {
+    "id": "abacus/grok-4.5",
+    "name": "Grok 4.5",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-07-08",
+    "last_updated": "2026-07-08",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 6.0
+    },
+    "limit": {
+      "context": 500000,
+      "output": 32768
     }
   },
   {
@@ -4172,7 +4874,7 @@
   },
   {
     "id": "abacus/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
-    "name": "Llama 4 Maverick 17B 128E Instruct FP8",
+    "name": "Llama 4 Maverick 17B Instruct",
     "family": "llama",
     "attachment": true,
     "reasoning": false,
@@ -4196,8 +4898,8 @@
       "output": 0.59
     },
     "limit": {
-      "context": 1000000,
-      "output": 32768
+      "context": 1048576,
+      "output": 8192
     }
   },
   {
@@ -4257,6 +4959,128 @@
     }
   },
   {
+    "id": "abacus/meta-llama/Meta-Llama-3.3-70B-Instruct",
+    "name": "Llama-3.3-70B-Instruct",
+    "family": "llama",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-12",
+    "release_date": "2024-12-06",
+    "last_updated": "2024-12-06",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.59,
+      "output": 0.79
+    },
+    "limit": {
+      "context": 131072,
+      "output": 8192
+    }
+  },
+  {
+    "id": "abacus/mimo-v2-pro",
+    "name": "MiMo-V2-Pro",
+    "family": "mimo",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 3.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "abacus/moonshotai/Kimi-K2.6",
+    "name": "Kimi K2.6",
+    "family": "kimi-k2",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.95,
+      "output": 4.0,
+      "cache_read": 0.19
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "abacus/muse-spark-1.1",
+    "name": "Muse Spark 1.1",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-08",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 4.25,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 32000
+    }
+  },
+  {
     "id": "abacus/o3",
     "name": "o3",
     "family": "o",
@@ -4279,7 +5103,8 @@
     "open_weights": false,
     "cost": {
       "input": 2.0,
-      "output": 8.0
+      "output": 8.0,
+      "cache_read": 0.5
     },
     "limit": {
       "context": 200000,
@@ -4308,7 +5133,8 @@
     "open_weights": false,
     "cost": {
       "input": 1.1,
-      "output": 4.4
+      "output": 4.4,
+      "cache_read": 0.55
     },
     "limit": {
       "context": 200000,
@@ -4377,9 +5203,9 @@
   },
   {
     "id": "abacus/openai/gpt-oss-120b",
-    "name": "GPT-OSS 120B",
+    "name": "GPT OSS 120B",
     "family": "gpt-oss",
-    "attachment": true,
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -4387,8 +5213,7 @@
     "last_updated": "2025-08-05",
     "modalities": {
       "input": [
-        "text",
-        "image"
+        "text"
       ],
       "output": [
         "text"
@@ -4401,7 +5226,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 32768
+      "output": 16384
     }
   },
   {
@@ -4462,15 +5287,14 @@
   },
   {
     "id": "abacus/route-llm",
-    "name": "Route LLM",
+    "name": "RouteLLM",
     "family": "gpt",
     "attachment": true,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-10",
     "release_date": "2024-01-01",
-    "last_updated": "2024-01-01",
+    "last_updated": "2026-07-10",
     "modalities": {
       "input": [
         "text",
@@ -4487,17 +5311,18 @@
     },
     "limit": {
       "context": 128000,
-      "output": 16384
+      "output": 64000
     }
   },
   {
-    "id": "abacus/zai-org/glm-4.5",
+    "id": "abacus/zai-org/GLM-4.5",
     "name": "GLM-4.5",
     "family": "glm",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
+    "knowledge": "2025-04",
     "release_date": "2025-07-28",
     "last_updated": "2025-07-28",
     "modalities": {
@@ -4514,20 +5339,21 @@
       "output": 2.2
     },
     "limit": {
-      "context": 128000,
-      "output": 8192
+      "context": 131072,
+      "output": 96000
     }
   },
   {
-    "id": "abacus/zai-org/glm-4.6",
+    "id": "abacus/zai-org/GLM-4.6",
     "name": "GLM-4.6",
     "family": "glm",
     "attachment": false,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-03-01",
-    "last_updated": "2025-03-01",
+    "knowledge": "2025-04",
+    "release_date": "2025-09-30",
+    "last_updated": "2025-09-30",
     "modalities": {
       "input": [
         "text"
@@ -4542,20 +5368,21 @@
       "output": 2.2
     },
     "limit": {
-      "context": 128000,
-      "output": 8192
+      "context": 202752,
+      "output": 131072
     }
   },
   {
-    "id": "abacus/zai-org/glm-4.7",
+    "id": "abacus/zai-org/GLM-4.7",
     "name": "GLM-4.7",
     "family": "glm",
     "attachment": false,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-06-01",
-    "last_updated": "2025-06-01",
+    "knowledge": "2025-04",
+    "release_date": "2025-12-22",
+    "last_updated": "2025-12-22",
     "modalities": {
       "input": [
         "text"
@@ -4570,20 +5397,20 @@
       "output": 2.2
     },
     "limit": {
-      "context": 128000,
-      "output": 8192
+      "context": 204800,
+      "output": 131072
     }
   },
   {
-    "id": "abacus/zai-org/glm-5",
+    "id": "abacus/zai-org/GLM-5",
     "name": "GLM-5",
     "family": "glm",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-02-11",
-    "last_updated": "2026-02-11",
+    "release_date": "2026-02-12",
+    "last_updated": "2026-02-12",
     "modalities": {
       "input": [
         "text"
@@ -4599,6 +5426,64 @@
     },
     "limit": {
       "context": 204800,
+      "output": 131072
+    }
+  },
+  {
+    "id": "abacus/zai-org/GLM-5.1",
+    "name": "GLM-5.1",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-07",
+    "last_updated": "2026-04-07",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26
+    },
+    "limit": {
+      "context": 204800,
+      "output": 131072
+    }
+  },
+  {
+    "id": "abacus/zai-org/GLM-5.2",
+    "name": "GLM-5.2",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-13",
+    "last_updated": "2026-06-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26
+    },
+    "limit": {
+      "context": 1048576,
       "output": 131072
     }
   },
@@ -36565,6 +37450,997 @@
     }
   },
   {
+    "id": "empiriolabs/deepseek-v4-flash",
+    "name": "DeepSeek V4 Flash",
+    "family": "deepseek-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-06-12",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.14,
+      "output": 0.28
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 393216
+    }
+  },
+  {
+    "id": "empiriolabs/deepseek-v4-pro",
+    "name": "DeepSeek V4 Pro",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-06-12",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.65,
+      "output": 3.3
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 393216
+    }
+  },
+  {
+    "id": "empiriolabs/fugu-ultra",
+    "name": "Fugu Ultra",
+    "family": "fugu",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-06-15",
+    "last_updated": "2026-06-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 7.5,
+      "output": 45.0,
+      "cache_read": 1.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "empiriolabs/gemma-4-26b-a4b",
+    "name": "Gemma 4 26B-A4B",
+    "family": "gemma",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-02",
+    "last_updated": "2026-06-12",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.05,
+      "output": 0.29,
+      "cache_read": 0.025
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "empiriolabs/glm-4.5-flash",
+    "name": "GLM 4.5 Flash",
+    "family": "glm-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2025-07-28",
+    "last_updated": "2025-07-28",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 200000,
+      "output": 98304
+    }
+  },
+  {
+    "id": "empiriolabs/glm-4.7-flash",
+    "name": "GLM 4.7 Flash",
+    "family": "glm-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-01-19",
+    "last_updated": "2026-01-19",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 200000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "empiriolabs/glm-5.1",
+    "name": "GLM 5.1",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-07",
+    "last_updated": "2026-06-12",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.825,
+      "output": 3.301,
+      "cache_read": 0.165
+    },
+    "limit": {
+      "context": 202000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "empiriolabs/glm-5.2",
+    "name": "GLM 5.2",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-13",
+    "last_updated": "2026-06-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.4,
+      "output": 4.4
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "empiriolabs/kimi-k2-6",
+    "name": "Kimi K2.6",
+    "family": "kimi-k2",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-04-21",
+    "last_updated": "2026-06-12",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.8939,
+      "output": 3.7131,
+      "cache_read": 0.1788
+    },
+    "limit": {
+      "context": 256000,
+      "output": 16000
+    }
+  },
+  {
+    "id": "empiriolabs/kimi-k2-7-code",
+    "name": "Kimi K2.7 Code",
+    "family": "kimi-k2",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-01",
+    "release_date": "2026-06-12",
+    "last_updated": "2026-06-12",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.95,
+      "output": 4.0
+    },
+    "limit": {
+      "context": 256000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "empiriolabs/kimi-k2-7-code-highspeed",
+    "name": "Kimi K2.7 Code Highspeed",
+    "family": "kimi-k2",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-01",
+    "release_date": "2026-06-12",
+    "last_updated": "2026-06-12",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.9,
+      "output": 8.0
+    },
+    "limit": {
+      "context": 256000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "empiriolabs/mimo-v2-5",
+    "name": "MiMo V2.5",
+    "family": "mimo",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.7,
+      "output": 1.4,
+      "cache_read": 0.014
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "empiriolabs/mimo-v2-5-pro",
+    "name": "MiMo V2.5 Pro",
+    "family": "mimo",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 2.175,
+      "output": 4.35,
+      "cache_read": 0.018
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "empiriolabs/minimax-m2-7",
+    "name": "MiniMax M2.7",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.15,
+      "output": 0.6,
+      "cache_read": 0.03
+    },
+    "limit": {
+      "context": 200000,
+      "output": 32768
+    }
+  },
+  {
+    "id": "empiriolabs/minimax-m2-7-highspeed",
+    "name": "MiniMax M2.7 Highspeed",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.03
+    },
+    "limit": {
+      "context": 200000,
+      "output": 32768
+    }
+  },
+  {
+    "id": "empiriolabs/minimax-m3",
+    "name": "MiniMax M3",
+    "family": "minimax",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-01",
+    "last_updated": "2026-06-12",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.225,
+      "output": 0.9,
+      "cache_read": 0.045
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 524288
+    }
+  },
+  {
+    "id": "empiriolabs/muse-spark-1.1",
+    "name": "Muse Spark 1.1",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-08",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 4.25,
+      "cache_read": 1.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "empiriolabs/qwen3-5-122b-a10b",
+    "name": "Qwen3.5 122B-A10B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-23",
+    "last_updated": "2026-02-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.115,
+      "output": 0.917
+    },
+    "limit": {
+      "context": 256000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "empiriolabs/qwen3-5-27b",
+    "name": "Qwen3.5 27B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-23",
+    "last_updated": "2026-02-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.086,
+      "output": 0.688
+    },
+    "limit": {
+      "context": 256000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "empiriolabs/qwen3-5-35b-a3b",
+    "name": "Qwen3.5 35B-A3B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-23",
+    "last_updated": "2026-02-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.057,
+      "output": 0.459
+    },
+    "limit": {
+      "context": 256000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "empiriolabs/qwen3-5-397b-a17b",
+    "name": "Qwen3.5 397B-A17B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-15",
+    "last_updated": "2026-02-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.172,
+      "output": 1.032
+    },
+    "limit": {
+      "context": 256000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "empiriolabs/qwen3-5-4b",
+    "name": "Qwen3.5 4B",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-02",
+    "last_updated": "2026-03-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.04,
+      "output": 0.07,
+      "cache_read": 0.02
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "empiriolabs/qwen3-5-9b",
+    "name": "Qwen3.5 9B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-23",
+    "last_updated": "2026-02-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.09,
+      "output": 0.13,
+      "cache_read": 0.045
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "empiriolabs/qwen3-5-plus",
+    "name": "Qwen3.5 Plus",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-02-16",
+    "last_updated": "2026-02-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.36,
+      "output": 2.21
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "empiriolabs/qwen3-6-27b",
+    "name": "Qwen3.6 27B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.412564,
+      "output": 2.475384
+    },
+    "limit": {
+      "context": 256000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "empiriolabs/qwen3-6-flash",
+    "name": "Qwen3.6 Flash",
+    "family": "qwen3.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-27",
+    "last_updated": "2026-04-27",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 1.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "empiriolabs/qwen3-6-max-preview",
+    "name": "Qwen3.6 Max Preview",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-04-20",
+    "last_updated": "2026-04-20",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.31,
+      "output": 7.88
+    },
+    "limit": {
+      "context": 256000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "empiriolabs/qwen3-6-plus",
+    "name": "Qwen3.6 Plus",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.5,
+      "output": 3.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "empiriolabs/qwen3-7-max",
+    "name": "Qwen3.7 Max",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-05-21",
+    "last_updated": "2026-06-12",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 7.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "empiriolabs/qwen3-7-plus",
+    "name": "Qwen3.7 Plus",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-06-02",
+    "last_updated": "2026-06-12",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.4,
+      "output": 1.6
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "empiriolabs/qwen3-max",
+    "name": "Qwen3 Max",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2025-09-23",
+    "last_updated": "2025-09-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.08,
+      "output": 5.52
+    },
+    "limit": {
+      "context": 256000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "empiriolabs/step-3.5-flash",
+    "name": "Step 3.5 Flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-01-29",
+    "last_updated": "2026-02-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.1,
+      "output": 0.3,
+      "cache_read": 0.02
+    },
+    "limit": {
+      "context": 256000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "empiriolabs/step-3.7-flash",
+    "name": "Step 3.7 Flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2026-01-01",
+    "release_date": "2026-05-29",
+    "last_updated": "2026-05-29",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.2,
+      "output": 1.15,
+      "cache_read": 0.04
+    },
+    "limit": {
+      "context": 256000,
+      "output": 131072
+    }
+  },
+  {
     "id": "evroc/KBLab/kb-whisper-large",
     "name": "KB Whisper",
     "family": "whisper",
@@ -40581,7 +42457,7 @@
       "cache_read": 0.2
     },
     "limit": {
-      "context": 200000,
+      "context": 1000000,
       "output": 64000
     }
   },
@@ -40805,7 +42681,7 @@
       "cache_read": 0.25
     },
     "limit": {
-      "context": 400000,
+      "context": 1050000,
       "output": 128000
     }
   },
@@ -40899,7 +42775,103 @@
       "cache_read": 0.5
     },
     "limit": {
-      "context": 400000,
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "github-copilot/gpt-5.6-luna",
+    "name": "GPT-5.6 Luna",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 6.0,
+      "cache_read": 0.1
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "github-copilot/gpt-5.6-sol",
+    "name": "GPT-5.6 Sol",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "github-copilot/gpt-5.6-terra",
+    "name": "GPT-5.6 Terra",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 15.0,
+      "cache_read": 0.25
+    },
+    "limit": {
+      "context": 1050000,
       "output": 128000
     }
   },
@@ -60931,6 +62903,7 @@
   {
     "id": "kilo/poolside/laguna-m.1:free",
     "name": "Poolside: Laguna M.1 (free)",
+    "family": "laguna",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
@@ -60945,7 +62918,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.0,
       "output": 0.0
@@ -60958,6 +62931,7 @@
   {
     "id": "kilo/poolside/laguna-xs.2:free",
     "name": "Poolside: Laguna XS.2 (free)",
+    "family": "laguna",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
@@ -60972,7 +62946,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.0,
       "output": 0.0
@@ -65487,9 +67461,10 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 1.4,
-      "output": 4.4,
-      "cache_read": 0.26
+      "input": 1.26,
+      "output": 3.96,
+      "cache_read": 0.234,
+      "cache_write": 0.0
     },
     "limit": {
       "context": 1024000,
@@ -66417,6 +68392,105 @@
     "cost": {
       "input": 30.0,
       "output": 180.0
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "llmgateway/gpt-5.6-luna",
+    "name": "GPT-5.6 Luna",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 6.0,
+      "cache_read": 0.1,
+      "cache_write": 1.25
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "llmgateway/gpt-5.6-sol",
+    "name": "GPT-5.6 Sol",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "llmgateway/gpt-5.6-terra",
+    "name": "GPT-5.6 Terra",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 15.0,
+      "cache_read": 0.25,
+      "cache_write": 3.125
     },
     "limit": {
       "context": 1050000,
@@ -67763,6 +69837,38 @@
     "limit": {
       "context": 128000,
       "output": 16384
+    }
+  },
+  {
+    "id": "llmgateway/muse-spark-1.1",
+    "name": "Muse Spark 1.1",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-08",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 4.25,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 32000
     }
   },
   {
@@ -73194,7 +75300,8 @@
     "open_weights": false,
     "cost": {
       "input": 1.25,
-      "output": 4.25
+      "output": 4.25,
+      "cache_read": 0.15
     },
     "limit": {
       "context": 1000000,
@@ -74810,6 +76917,415 @@
     "limit": {
       "context": 204800,
       "output": 131072
+    }
+  },
+  {
+    "id": "model-oracle-ai/auto",
+    "name": "Auto",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-29",
+    "last_updated": "2026-07-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "model-oracle-ai/claude-fable-5",
+    "name": "Claude Fable 5",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-09",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "model-oracle-ai/claude-haiku-4.5",
+    "name": "Claude Haiku 4.5 (latest)",
+    "family": "claude-haiku",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-02-28",
+    "release_date": "2025-10-15",
+    "last_updated": "2025-10-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "model-oracle-ai/claude-opus-4.8",
+    "name": "Claude Opus 4.8",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01",
+    "release_date": "2026-05-28",
+    "last_updated": "2026-05-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "model-oracle-ai/claude-sonnet-5",
+    "name": "Claude Sonnet 5",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "model-oracle-ai/deepseek-v4-pro",
+    "name": "DeepSeek V4 Pro",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {},
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "model-oracle-ai/glm-5.2",
+    "name": "GLM-5.2",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-13",
+    "last_updated": "2026-06-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {},
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "model-oracle-ai/gpt-4.1",
+    "name": "GPT-4.1",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-04",
+    "release_date": "2025-04-14",
+    "last_updated": "2025-04-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 1047576,
+      "output": 32768
+    }
+  },
+  {
+    "id": "model-oracle-ai/gpt-4.1-mini",
+    "name": "GPT-4.1 mini",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-04",
+    "release_date": "2025-04-14",
+    "last_updated": "2025-04-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 1047576,
+      "output": 32768
+    }
+  },
+  {
+    "id": "model-oracle-ai/gpt-5",
+    "name": "GPT-5",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-09-30",
+    "release_date": "2025-08-07",
+    "last_updated": "2025-08-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "model-oracle-ai/gpt-5.4",
+    "name": "GPT-5.4",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-05",
+    "last_updated": "2026-03-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "model-oracle-ai/gpt-5.4-mini",
+    "name": "GPT-5.4 mini",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "model-oracle-ai/gpt-5.4-nano",
+    "name": "GPT-5.4 nano",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "model-oracle-ai/gpt-5.5",
+    "name": "GPT-5.5",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-12-01",
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "model-oracle-ai/o4-mini",
+    "name": "o4-mini",
+    "family": "o-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-05",
+    "release_date": "2025-04-16",
+    "last_updated": "2025-04-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 200000,
+      "output": 100000
     }
   },
   {
@@ -88623,11 +91139,13 @@
   {
     "id": "nano-gpt/poolside/laguna-m.1",
     "name": "Laguna M.1",
+    "family": "laguna",
     "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2026-04-29",
-    "last_updated": "2026-04-29",
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-28",
+    "last_updated": "2026-06-13",
     "modalities": {
       "input": [
         "text"
@@ -88636,24 +91154,26 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
-      "input": 0.1,
-      "output": 0.3
+      "input": 0.2,
+      "output": 0.4
     },
     "limit": {
-      "context": 128000,
+      "context": 262144,
       "output": 32768
     }
   },
   {
     "id": "nano-gpt/poolside/laguna-xs.2",
     "name": "Laguna XS.2",
+    "family": "laguna",
     "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2026-04-29",
-    "last_updated": "2026-04-29",
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-28",
+    "last_updated": "2026-06-13",
     "modalities": {
       "input": [
         "text"
@@ -88662,13 +91182,13 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
-      "input": 0.1,
-      "output": 0.3
+      "input": 0.2,
+      "output": 0.4
     },
     "limit": {
-      "context": 128000,
+      "context": 262144,
       "output": 32768
     }
   },
@@ -103742,6 +106262,39 @@
     }
   },
   {
+    "id": "openai/gpt-realtime-2.1",
+    "name": "GPT-Realtime-2.1",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-09-30",
+    "release_date": "2026-07-06",
+    "last_updated": "2026-07-06",
+    "modalities": {
+      "input": [
+        "text",
+        "audio",
+        "image"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 4.0,
+      "output": 24.0,
+      "cache_read": 0.4
+    },
+    "limit": {
+      "context": 128000,
+      "output": 32000
+    }
+  },
+  {
     "id": "openai/o1",
     "name": "o1",
     "family": "o",
@@ -106063,6 +108616,105 @@
     }
   },
   {
+    "id": "opencode/gpt-5.6-luna",
+    "name": "GPT-5.6 Luna",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 6.0,
+      "cache_read": 0.1,
+      "cache_write": 1.25
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "opencode/gpt-5.6-sol",
+    "name": "GPT-5.6 Sol",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "opencode/gpt-5.6-terra",
+    "name": "GPT-5.6 Terra",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 15.0,
+      "cache_read": 0.25,
+      "cache_write": 3.125
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
     "id": "opencode/grok-4.5",
     "name": "Grok 4.5",
     "family": "grok",
@@ -106177,7 +108829,7 @@
       "cache_read": 0.0
     },
     "limit": {
-      "context": 256000,
+      "context": 190000,
       "output": 64000
     }
   },
@@ -107385,7 +110037,7 @@
       "output": 5.0
     },
     "limit": {
-      "context": 16384,
+      "context": 32768,
       "output": 2048
     }
   },
@@ -107939,34 +110591,6 @@
     }
   },
   {
-    "id": "openrouter/arcee-ai/trinity-mini",
-    "name": "Trinity Mini",
-    "family": "trinity-mini",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-12-01",
-    "last_updated": "2025-12-01",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.045,
-      "output": 0.15
-    },
-    "limit": {
-      "context": 131072,
-      "output": 131072
-    }
-  },
-  {
     "id": "openrouter/arcee-ai/virtuoso-large",
     "name": "Virtuoso Large",
     "attachment": false,
@@ -108020,7 +110644,7 @@
       "output": 1.25
     },
     "limit": {
-      "context": 123000,
+      "context": 131072,
       "output": 16000
     }
   },
@@ -108172,6 +110796,35 @@
     "limit": {
       "context": 128000,
       "output": 2048
+    }
+  },
+  {
+    "id": "openrouter/cognitivecomputations/dolphin-mistral-24b-venice-edition",
+    "name": "Uncensored",
+    "family": "mistral",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2024-04-30",
+    "release_date": "2025-07-09",
+    "last_updated": "2025-07-09",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.2,
+      "output": 0.9
+    },
+    "limit": {
+      "context": 128000,
+      "output": 8192
     }
   },
   {
@@ -108400,7 +111053,7 @@
       "output": 0.8001
     },
     "limit": {
-      "context": 128000,
+      "context": 131072,
       "output": 16000
     }
   },
@@ -108489,7 +111142,7 @@
       "output": 2.5
     },
     "limit": {
-      "context": 64000,
+      "context": 163840,
       "output": 16000
     }
   },
@@ -108518,7 +111171,7 @@
       "output": 0.8
     },
     "limit": {
-      "context": 8192,
+      "context": 128000,
       "output": 8192
     }
   },
@@ -108573,12 +111226,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.2288,
-      "output": 0.3432,
-      "cache_read": 0.02288
+      "input": 0.2145,
+      "output": 0.32175,
+      "cache_read": 0.02145
     },
     "limit": {
-      "context": 128000,
+      "context": 131072,
       "output": 64000
     }
   },
@@ -108632,13 +111285,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.09,
-      "output": 0.18,
-      "cache_read": 0.018
+      "input": 0.084,
+      "output": 0.168,
+      "cache_read": 0.0168
     },
     "limit": {
       "context": 1048576,
-      "output": 65536
+      "output": 384000
     }
   },
   {
@@ -109206,7 +111859,7 @@
       "cache_write": 0.375
     },
     "limit": {
-      "context": 1048576,
+      "context": 1048756,
       "output": 65536
     }
   },
@@ -109449,7 +112102,7 @@
       "output": 0.0
     },
     "limit": {
-      "context": 131072,
+      "context": 262144,
       "output": 32768
     }
   },
@@ -110089,7 +112742,7 @@
       "output": 0.201
     },
     "limit": {
-      "context": 60000,
+      "context": 131072,
       "output": 60000
     }
   },
@@ -110205,7 +112858,7 @@
       "output": 0.0
     },
     "limit": {
-      "context": 65536,
+      "context": 131072,
       "output": 131072
     }
   },
@@ -110265,7 +112918,7 @@
       "output": 0.3
     },
     "limit": {
-      "context": 327680,
+      "context": 10000000,
       "output": 16384
     }
   },
@@ -110352,7 +113005,7 @@
       "output": 0.62
     },
     "limit": {
-      "context": 65535,
+      "context": 65536,
       "output": 8000
     }
   },
@@ -110526,7 +113179,7 @@
       "cache_read": 0.05
     },
     "limit": {
-      "context": 196608,
+      "context": 204800,
       "output": 196608
     }
   },
@@ -110554,7 +113207,7 @@
       "output": 0.96
     },
     "limit": {
-      "context": 196608,
+      "context": 204800,
       "output": 196608
     }
   },
@@ -110585,8 +113238,8 @@
       "cache_read": 0.06
     },
     "limit": {
-      "context": 524288,
-      "output": 512000
+      "context": 1048576,
+      "output": 131072
     }
   },
   {
@@ -111194,7 +113847,7 @@
       "cache_read": 0.203
     },
     "limit": {
-      "context": 256000,
+      "context": 262144,
       "output": 256000
     }
   },
@@ -111220,9 +113873,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.65,
+      "input": 0.66,
       "output": 3.41,
-      "cache_read": 0.14
+      "cache_read": 0.15
     },
     "limit": {
       "context": 262144,
@@ -111252,8 +113905,8 @@
     "open_weights": true,
     "cost": {
       "input": 0.72,
-      "output": 3.5,
-      "cache_read": 0.15
+      "output": 3.49,
+      "cache_read": 0.159
     },
     "limit": {
       "context": 262144,
@@ -111660,7 +114313,7 @@
       "output": 0.45
     },
     "limit": {
-      "context": 262144,
+      "context": 1000000,
       "output": 16384
     }
   },
@@ -111688,7 +114341,7 @@
       "output": 0.0
     },
     "limit": {
-      "context": 262144,
+      "context": 1000000,
       "output": 262144
     }
   },
@@ -111717,7 +114370,7 @@
       "cache_read": 0.1
     },
     "limit": {
-      "context": 262144,
+      "context": 1000000,
       "output": 16384
     }
   },
@@ -114103,12 +116756,13 @@
   {
     "id": "openrouter/poolside/laguna-m.1",
     "name": "Laguna M.1",
+    "family": "laguna",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-04-28",
-    "last_updated": "2026-04-28",
+    "last_updated": "2026-06-13",
     "modalities": {
       "input": [
         "text"
@@ -114131,12 +116785,13 @@
   {
     "id": "openrouter/poolside/laguna-m.1:free",
     "name": "Laguna M.1 (free)",
+    "family": "laguna",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-04-28",
-    "last_updated": "2026-04-28",
+    "last_updated": "2026-06-13",
     "modalities": {
       "input": [
         "text"
@@ -114158,6 +116813,7 @@
   {
     "id": "openrouter/poolside/laguna-xs-2.1",
     "name": "Laguna XS 2.1",
+    "family": "laguna",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
@@ -114186,6 +116842,7 @@
   {
     "id": "openrouter/poolside/laguna-xs-2.1:free",
     "name": "Laguna XS 2.1 (free)",
+    "family": "laguna",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
@@ -114235,7 +116892,7 @@
       "output": 0.4
     },
     "limit": {
-      "context": 32768,
+      "context": 131072,
       "output": 16384
     }
   },
@@ -114264,7 +116921,7 @@
       "output": 0.1
     },
     "limit": {
-      "context": 32768,
+      "context": 131072,
       "output": 32768
     }
   },
@@ -114293,7 +116950,7 @@
       "output": 1.0
     },
     "limit": {
-      "context": 32768,
+      "context": 128000,
       "output": 32768
     }
   },
@@ -114385,7 +117042,7 @@
       "cache_read": 0.4
     },
     "limit": {
-      "context": 128000,
+      "context": 131072,
       "output": 128000
     }
   },
@@ -114414,7 +117071,7 @@
       "output": 0.24
     },
     "limit": {
-      "context": 40960,
+      "context": 131702,
       "output": 40960
     }
   },
@@ -114472,7 +117129,7 @@
       "output": 1.495
     },
     "limit": {
-      "context": 131072,
+      "context": 262144,
       "output": 262144
     }
   },
@@ -114501,7 +117158,7 @@
       "output": 0.5
     },
     "limit": {
-      "context": 40960,
+      "context": 131072,
       "output": 16384
     }
   },
@@ -114530,7 +117187,7 @@
       "output": 0.19305
     },
     "limit": {
-      "context": 128000,
+      "context": 131072,
       "output": 32000
     }
   },
@@ -114559,7 +117216,7 @@
       "output": 1.56
     },
     "limit": {
-      "context": 81920,
+      "context": 131072,
       "output": 32768
     }
   },
@@ -114588,7 +117245,7 @@
       "output": 0.28
     },
     "limit": {
-      "context": 40960,
+      "context": 131072,
       "output": 16384
     }
   },
@@ -114646,7 +117303,7 @@
       "output": 1.8
     },
     "limit": {
-      "context": 262144,
+      "context": 1048576,
       "output": 65536
     }
   },
@@ -114795,7 +117452,7 @@
       "output": 0.0
     },
     "limit": {
-      "context": 262000,
+      "context": 1048576,
       "output": 262000
     }
   },
@@ -114941,7 +117598,7 @@
       "output": 0.78
     },
     "limit": {
-      "context": 131072,
+      "context": 262144,
       "output": 32768
     }
   },
@@ -115032,7 +117689,7 @@
       "output": 0.52
     },
     "limit": {
-      "context": 131072,
+      "context": 262144,
       "output": 32768
     }
   },
@@ -115091,7 +117748,7 @@
       "output": 0.416
     },
     "limit": {
-      "context": 131072,
+      "context": 262144,
       "output": 32768
     }
   },
@@ -115120,7 +117777,7 @@
       "output": 0.455
     },
     "limit": {
-      "context": 131072,
+      "context": 256000,
       "output": 32768
     }
   },
@@ -115149,7 +117806,7 @@
       "output": 1.365
     },
     "limit": {
-      "context": 131072,
+      "context": 256000,
       "output": 32768
     }
   },
@@ -115271,7 +117928,7 @@
       "cache_read": 0.111
     },
     "limit": {
-      "context": 131072,
+      "context": 256000,
       "output": 64000
     }
   },
@@ -115424,7 +118081,7 @@
       "cache_read": 0.15
     },
     "limit": {
-      "context": 262140,
+      "context": 262144,
       "output": 262140
     }
   },
@@ -116431,7 +119088,7 @@
       "cache_read": 0.028
     },
     "limit": {
-      "context": 32000,
+      "context": 1048576,
       "output": 131072
     }
   },
@@ -116761,7 +119418,7 @@
       "cache_read": 0.1794
     },
     "limit": {
-      "context": 200000,
+      "context": 202752,
       "output": 128000
     }
   },
@@ -116785,13 +119442,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.54,
-      "output": 1.76,
-      "cache_read": 0.1
+      "input": 0.42,
+      "output": 1.32,
+      "cache_read": 0.078
     },
     "limit": {
-      "context": 101376,
-      "output": 101376
+      "context": 1048576,
+      "output": 131072
     }
   },
   {
@@ -117043,9 +119700,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.65,
+      "input": 0.66,
       "output": 3.41,
-      "cache_read": 0.14
+      "cache_read": 0.15
     },
     "limit": {
       "context": 262144,
@@ -120665,6 +123322,2386 @@
     "limit": {
       "context": 128000,
       "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/HuggingFaceTB/SmolLM3-3B-Base",
+    "name": "SmolLM3 3B Base",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-06-30",
+    "last_updated": "2025-06-30",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.15,
+      "cache_read": 0.15,
+      "cache_write": 0.15
+    },
+    "limit": {
+      "context": 32768,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/LiquidAI/LFM2-24B-A2B",
+    "name": "LFM2 24B A2B",
+    "family": "liquid",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-01-31",
+    "last_updated": "2026-02-25",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.03,
+      "output": 0.12,
+      "cache_read": 0.03,
+      "cache_write": 0.03
+    },
+    "limit": {
+      "context": 32768,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/MiniMaxAI/MiniMax-M2.7",
+    "name": "MiniMax-M2.7",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.279,
+      "output": 1.2,
+      "cache_read": 0.279,
+      "cache_write": 0.279
+    },
+    "limit": {
+      "context": 204800,
+      "output": 131072
+    }
+  },
+  {
+    "id": "pioneer/MiniMaxAI/MiniMax-M3",
+    "name": "MiniMax-M3",
+    "family": "minimax",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-01",
+    "last_updated": "2026-06-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.06,
+      "cache_write": 0.3
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "pioneer/Qwen/Qwen3-1.7B-Base",
+    "name": "Qwen3 1.7B Base",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-03-31",
+    "last_updated": "2025-03-31",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.1,
+      "cache_read": 0.1,
+      "cache_write": 0.1
+    },
+    "limit": {
+      "context": 32768,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/Qwen/Qwen3-32B",
+    "name": "Qwen3 32B",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2025-04",
+    "last_updated": "2025-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.9,
+      "output": 0.9,
+      "cache_read": 0.9,
+      "cache_write": 0.9
+    },
+    "limit": {
+      "context": 131072,
+      "output": 16384
+    }
+  },
+  {
+    "id": "pioneer/Qwen/Qwen3-4B-Base",
+    "name": "Qwen3 4B Base",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-03-31",
+    "last_updated": "2025-03-31",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.15,
+      "cache_read": 0.15,
+      "cache_write": 0.15
+    },
+    "limit": {
+      "context": 32768,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/Qwen/Qwen3-4B-Instruct",
+    "name": "Qwen3 4B Instruct",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-07-31",
+    "last_updated": "2025-07-31",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.2,
+      "output": 0.2,
+      "cache_read": 0.2,
+      "cache_write": 0.2
+    },
+    "limit": {
+      "context": 262144,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/Qwen/Qwen3-8B",
+    "name": "Qwen3 8B",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-03-31",
+    "last_updated": "2025-04-28",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.2,
+      "output": 0.2,
+      "cache_read": 0.2,
+      "cache_write": 0.2
+    },
+    "limit": {
+      "context": 131072,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/Qwen/Qwen3.5-9B",
+    "name": "Qwen3.5 9B",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-23",
+    "last_updated": "2026-02-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.3,
+      "output": 0.3,
+      "cache_read": 0.3,
+      "cache_write": 0.3
+    },
+    "limit": {
+      "context": 32768,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/Qwen/Qwen3.6-27B",
+    "name": "Qwen3.6 27B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.6,
+      "output": 0.6,
+      "cache_read": 0.6,
+      "cache_write": 0.6
+    },
+    "limit": {
+      "context": 32768,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/Qwen/Qwen3.6-35B-A3B",
+    "name": "Qwen3.6 35B-A3B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-17",
+    "last_updated": "2026-04-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.14,
+      "output": 1.0,
+      "cache_read": 0.028,
+      "cache_write": 0.175
+    },
+    "limit": {
+      "context": 262144,
+      "output": 131072
+    }
+  },
+  {
+    "id": "pioneer/XiaomiMiMo/MiMo-V2.5",
+    "name": "MiMo-V2.5",
+    "family": "mimo",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.0028,
+      "cache_write": 0.14
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "pioneer/XiaomiMiMo/MiMo-V2.5-Pro",
+    "name": "MiMo-V2.5-Pro",
+    "family": "mimo",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.435,
+      "output": 0.87,
+      "cache_read": 0.0036,
+      "cache_write": 0.435
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "pioneer/claude-haiku-4.5",
+    "name": "Claude Haiku 4.5 (latest)",
+    "family": "claude-haiku",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-02-28",
+    "release_date": "2025-10-15",
+    "last_updated": "2025-10-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 5.0,
+      "cache_read": 0.1,
+      "cache_write": 1.25
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "pioneer/claude-opus-4.1",
+    "name": "Claude Opus 4.1 (latest)",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-03-31",
+    "release_date": "2025-08-05",
+    "last_updated": "2025-08-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 15.0,
+      "output": 75.0,
+      "cache_read": 1.5,
+      "cache_write": 18.75
+    },
+    "limit": {
+      "context": 200000,
+      "output": 32000
+    }
+  },
+  {
+    "id": "pioneer/claude-opus-4.5",
+    "name": "Claude Opus 4.5 (latest)",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2025-11-24",
+    "last_updated": "2025-11-24",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "pioneer/claude-opus-4.6",
+    "name": "Claude Opus 4.6",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05-31",
+    "release_date": "2026-02-05",
+    "last_updated": "2026-03-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "pioneer/claude-opus-4.7",
+    "name": "Claude Opus 4.7",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-04-16",
+    "last_updated": "2026-04-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "pioneer/claude-opus-4.8",
+    "name": "Claude Opus 4.8",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01",
+    "release_date": "2026-05-28",
+    "last_updated": "2026-05-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "pioneer/claude-sonnet-4.5",
+    "name": "Claude Sonnet 4.5 (latest)",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-07-31",
+    "release_date": "2025-09-29",
+    "last_updated": "2025-09-29",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "pioneer/claude-sonnet-4.6",
+    "name": "Claude Sonnet 4.6",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-02-17",
+    "last_updated": "2026-03-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "pioneer/deepseek-ai/DeepSeek-V4-Flash",
+    "name": "DeepSeek V4 Flash",
+    "family": "deepseek-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.1,
+      "output": 0.2,
+      "cache_read": 0.0197,
+      "cache_write": 0.1
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "pioneer/deepseek-ai/DeepSeek-V4-Pro",
+    "name": "DeepSeek V4 Pro",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.435,
+      "output": 0.87,
+      "cache_read": 0.003625,
+      "cache_write": 0.435
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "pioneer/fastino/gliguard-LLMGuardrails-300M",
+    "name": "GLiGuard LLM Guardrails 300M",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.15,
+      "cache_read": 0.15,
+      "cache_write": 0.15
+    },
+    "limit": {
+      "context": 8192,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/fastino/gliner2-base-v1",
+    "name": "GLiNER2 Base",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-06-30",
+    "last_updated": "2025-06-30",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.15,
+      "cache_read": 0.15,
+      "cache_write": 0.15
+    },
+    "limit": {
+      "context": 8192,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/fastino/gliner2-large-v1",
+    "name": "GLiNER2 Large",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-06-30",
+    "last_updated": "2025-06-30",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.15,
+      "cache_read": 0.15,
+      "cache_write": 0.15
+    },
+    "limit": {
+      "context": 8192,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/fastino/gliner2-multi-large-v1",
+    "name": "GLiNER2 Multi Large",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-11-30",
+    "last_updated": "2025-11-30",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.15,
+      "cache_read": 0.15,
+      "cache_write": 0.15
+    },
+    "limit": {
+      "context": 8192,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/fastino/gliner2-multi-v1",
+    "name": "GLiNER2 Multi",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-11-30",
+    "last_updated": "2025-11-30",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.15,
+      "cache_read": 0.15,
+      "cache_write": 0.15
+    },
+    "limit": {
+      "context": 8192,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/fastino/gliner2-privacy-filter-PII-multi",
+    "name": "GLiNER2 Privacy Filter PII (Multi)",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-30",
+    "last_updated": "2026-04-30",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.15,
+      "cache_read": 0.15,
+      "cache_write": 0.15
+    },
+    "limit": {
+      "context": 8192,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/gemini-3-flash",
+    "name": "Gemini 3 Flash Preview",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-12-17",
+    "last_updated": "2025-12-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.5,
+      "output": 3.0,
+      "cache_read": 0.05,
+      "cache_write": 0.083333
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65535
+    }
+  },
+  {
+    "id": "pioneer/gemini-3.1-pro",
+    "name": "Gemini 3.1 Pro Preview",
+    "family": "gemini-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-02-19",
+    "last_updated": "2026-02-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 12.0,
+      "cache_read": 0.2,
+      "cache_write": 0.375
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "pioneer/gemini-3.5-flash",
+    "name": "Gemini 3.5 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-05-19",
+    "last_updated": "2026-05-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 9.0,
+      "cache_read": 0.15,
+      "cache_write": 0.083333
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "pioneer/google/diffusiongemma-26B-A4B-it",
+    "name": "DiffusionGemma 26B-A4B IT",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-05-31",
+    "last_updated": "2026-05-31",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.5,
+      "output": 0.5,
+      "cache_read": 0.5,
+      "cache_write": 0.5
+    },
+    "limit": {
+      "context": 262144,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/google/gemma-3-4b-pt",
+    "name": "Gemma 3 4B (Pretrained)",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-02-28",
+    "last_updated": "2025-02-28",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.15,
+      "cache_read": 0.15,
+      "cache_write": 0.15
+    },
+    "limit": {
+      "context": 32768,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/google/gemma-4-12B-it",
+    "name": "Gemma 4 12B IT",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-05-31",
+    "last_updated": "2026-05-31",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 0.25,
+      "cache_read": 0.25,
+      "cache_write": 0.25
+    },
+    "limit": {
+      "context": 32768,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/google/gemma-4-31B-it",
+    "name": "Gemma 4 31B IT",
+    "family": "gemma",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.5,
+      "output": 0.5,
+      "cache_read": 0.5,
+      "cache_write": 0.5
+    },
+    "limit": {
+      "context": 32768,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/google/gemma-4-E2B-it",
+    "name": "Gemma 4 E2B IT",
+    "family": "gemma",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.1,
+      "output": 0.1,
+      "cache_read": 0.1,
+      "cache_write": 0.1
+    },
+    "limit": {
+      "context": 32768,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/google/gemma-4-E4B-it",
+    "name": "Gemma 4 E4B IT",
+    "family": "gemma",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.2,
+      "output": 0.2,
+      "cache_read": 0.2,
+      "cache_write": 0.2
+    },
+    "limit": {
+      "context": 32768,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/gpt-4.1",
+    "name": "GPT-4.1",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-04",
+    "release_date": "2025-04-14",
+    "last_updated": "2025-04-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 8.0,
+      "cache_read": 1.0,
+      "cache_write": 2.0
+    },
+    "limit": {
+      "context": 1047576,
+      "output": 32768
+    }
+  },
+  {
+    "id": "pioneer/gpt-4.1-mini",
+    "name": "GPT-4.1 mini",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-04",
+    "release_date": "2025-04-14",
+    "last_updated": "2025-04-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.4,
+      "output": 1.6,
+      "cache_read": 0.2,
+      "cache_write": 0.4
+    },
+    "limit": {
+      "context": 1047576,
+      "output": 32768
+    }
+  },
+  {
+    "id": "pioneer/gpt-4.1-nano",
+    "name": "GPT-4.1 nano",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-04",
+    "release_date": "2025-04-14",
+    "last_updated": "2025-04-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.4,
+      "cache_read": 0.05,
+      "cache_write": 0.1
+    },
+    "limit": {
+      "context": 1047576,
+      "output": 32768
+    }
+  },
+  {
+    "id": "pioneer/gpt-4o",
+    "name": "GPT-4o",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-09",
+    "release_date": "2024-05-13",
+    "last_updated": "2024-08-06",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 10.0,
+      "cache_read": 1.25,
+      "cache_write": 2.5
+    },
+    "limit": {
+      "context": 128000,
+      "output": 16384
+    }
+  },
+  {
+    "id": "pioneer/gpt-4o-mini",
+    "name": "GPT-4o mini",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-09",
+    "release_date": "2024-07-18",
+    "last_updated": "2024-07-18",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.6,
+      "cache_read": 0.075,
+      "cache_write": 0.15
+    },
+    "limit": {
+      "context": 128000,
+      "output": 16384
+    }
+  },
+  {
+    "id": "pioneer/gpt-5-mini",
+    "name": "GPT-5 Mini",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-05-30",
+    "release_date": "2025-08-07",
+    "last_updated": "2025-08-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.25,
+      "output": 2.0,
+      "cache_read": 0.025,
+      "cache_write": 0.25
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "pioneer/gpt-5-nano",
+    "name": "GPT-5 Nano",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-05-30",
+    "release_date": "2025-08-07",
+    "last_updated": "2025-08-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.05,
+      "output": 0.4,
+      "cache_read": 0.005,
+      "cache_write": 0.05
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "pioneer/gpt-5.1",
+    "name": "GPT-5.1",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2024-09-30",
+    "release_date": "2025-11-13",
+    "last_updated": "2025-11-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.125,
+      "cache_write": 1.25
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "pioneer/gpt-5.3-codex",
+    "name": "GPT-5.3 Codex",
+    "family": "gpt-codex",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-02-05",
+    "last_updated": "2026-02-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.75,
+      "output": 14.0,
+      "cache_read": 0.175,
+      "cache_write": 1.75
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "pioneer/gpt-5.4",
+    "name": "GPT-5.4",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-05",
+    "last_updated": "2026-03-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 15.0,
+      "cache_read": 0.25,
+      "cache_write": 2.5
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "pioneer/gpt-5.4-mini",
+    "name": "GPT-5.4 mini",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 4.5,
+      "cache_read": 0.075,
+      "cache_write": 0.75
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "pioneer/gpt-5.4-nano",
+    "name": "GPT-5.4 nano",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-17",
+    "last_updated": "2026-03-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.2,
+      "output": 1.25,
+      "cache_read": 0.02,
+      "cache_write": 0.2
+    },
+    "limit": {
+      "context": 1047576,
+      "output": 128000
+    }
+  },
+  {
+    "id": "pioneer/gpt-5.5",
+    "name": "GPT-5.5",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-12-01",
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5,
+      "cache_write": 5.0
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "pioneer/meta-llama/Llama-3.1-8B-Instruct",
+    "name": "Llama 3.1 8B Instruct",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-12-31",
+    "release_date": "2024-06-30",
+    "last_updated": "2024-07-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.2,
+      "output": 0.2,
+      "cache_read": 0.2,
+      "cache_write": 0.2
+    },
+    "limit": {
+      "context": 131072,
+      "output": 16384
+    }
+  },
+  {
+    "id": "pioneer/meta-llama/Llama-3.2-1B-Instruct",
+    "name": "Llama 3.2 1B Instruct",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2023-12-31",
+    "release_date": "2024-08-31",
+    "last_updated": "2024-09-25",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.1,
+      "output": 0.201,
+      "cache_read": 0.1,
+      "cache_write": 0.1
+    },
+    "limit": {
+      "context": 131072,
+      "output": 60000
+    }
+  },
+  {
+    "id": "pioneer/meta-llama/Llama-3.2-3B-Instruct",
+    "name": "Llama 3.2 3B Instruct",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2023-12-31",
+    "release_date": "2024-08-31",
+    "last_updated": "2024-09-25",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.1,
+      "output": 0.335,
+      "cache_read": 0.1,
+      "cache_write": 0.1
+    },
+    "limit": {
+      "context": 131072,
+      "output": 80000
+    }
+  },
+  {
+    "id": "pioneer/meta-llama/Llama-3.3-70B-Instruct",
+    "name": "Llama-3.3-70B-Instruct",
+    "family": "llama",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-12",
+    "release_date": "2024-12-06",
+    "last_updated": "2024-12-06",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.9,
+      "output": 0.9,
+      "cache_read": 0.9,
+      "cache_write": 0.9
+    },
+    "limit": {
+      "context": 131072,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/mistral-medium-3.5",
+    "name": "Mistral Medium 3.5",
+    "family": "mistral-medium",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-29",
+    "last_updated": "2026-04-29",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.5,
+      "output": 7.5,
+      "cache_read": 1.5,
+      "cache_write": 1.5
+    },
+    "limit": {
+      "context": 262144,
+      "output": 131072
+    }
+  },
+  {
+    "id": "pioneer/mistralai/Mistral-7B-Instruct-v0.3",
+    "name": "Mistral 7B Instruct v0.3",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2023-04-30",
+    "last_updated": "2023-04-30",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.2,
+      "output": 0.2,
+      "cache_read": 0.2,
+      "cache_write": 0.2
+    },
+    "limit": {
+      "context": 32768,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/mistralai/Mistral-Nemo-Instruct",
+    "name": "Mistral Nemo",
+    "family": "mistral-nemo",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-07",
+    "release_date": "2024-07-01",
+    "last_updated": "2024-07-01",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.02,
+      "output": 0.03,
+      "cache_read": 0.02,
+      "cache_write": 0.02
+    },
+    "limit": {
+      "context": 131072,
+      "output": 128000
+    }
+  },
+  {
+    "id": "pioneer/mistralai/Mistral-Small-4-119B",
+    "name": "Mistral Small 4",
+    "family": "mistral-small",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-06",
+    "release_date": "2026-03-16",
+    "last_updated": "2026-03-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.15,
+      "output": 0.6,
+      "cache_read": 0.015,
+      "cache_write": 0.15
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "pioneer/moonshotai/Kimi-K2.6",
+    "name": "Kimi K2.6",
+    "family": "kimi-k2",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.95,
+      "output": 4.0,
+      "cache_read": 0.34,
+      "cache_write": 0.95
+    },
+    "limit": {
+      "context": 262144,
+      "output": 131072
+    }
+  },
+  {
+    "id": "pioneer/moonshotai/Kimi-K2.7-Code",
+    "name": "Kimi K2.7 Code",
+    "family": "kimi-k2",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-01",
+    "release_date": "2026-06-12",
+    "last_updated": "2026-06-12",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.95,
+      "output": 4.0,
+      "cache_read": 0.19,
+      "cache_write": 0.95
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "pioneer/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+    "name": "Nemotron 3 Nano 30B A3B",
+    "family": "nemotron",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-12-15",
+    "last_updated": "2025-12-15",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.05,
+      "output": 0.2,
+      "cache_read": 0.05,
+      "cache_write": 0.05
+    },
+    "limit": {
+      "context": 262144,
+      "output": 131072
+    }
+  },
+  {
+    "id": "pioneer/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
+    "name": "Nemotron 3 Super 120B A12B",
+    "family": "nemotron",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-11",
+    "last_updated": "2026-03-11",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.09,
+      "output": 0.45,
+      "cache_read": 0.09,
+      "cache_write": 0.09
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 32000
+    }
+  },
+  {
+    "id": "pioneer/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16",
+    "name": "Nemotron 3 Ultra 550B A55B",
+    "family": "nemotron",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-04",
+    "last_updated": "2026-06-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.5,
+      "output": 2.5,
+      "cache_read": 0.15,
+      "cache_write": 0.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65000
+    }
+  },
+  {
+    "id": "pioneer/openai/gpt-oss-120b",
+    "name": "GPT OSS 120B",
+    "family": "gpt-oss",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-08-05",
+    "last_updated": "2025-08-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.15,
+      "output": 0.6,
+      "cache_read": 0.015,
+      "cache_write": 0.15
+    },
+    "limit": {
+      "context": 131072,
+      "output": 131072
+    }
+  },
+  {
+    "id": "pioneer/openai/gpt-oss-20b",
+    "name": "GPT OSS 20B",
+    "family": "gpt-oss",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-08-05",
+    "last_updated": "2025-08-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.07,
+      "output": 0.3,
+      "cache_read": 0.035,
+      "cache_write": 0.07
+    },
+    "limit": {
+      "context": 131072,
+      "output": 8192
+    }
+  },
+  {
+    "id": "pioneer/pioneer/auto",
+    "name": "Pioneer Auto",
+    "family": "auto",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2024-01-01",
+    "last_updated": "2025-06-29",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 1048576,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pioneer/qwen3.6-flash",
+    "name": "Qwen3.6 Flash",
+    "family": "qwen3.6",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-27",
+    "last_updated": "2026-04-27",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1875,
+      "output": 1.125,
+      "cache_read": 0.0375,
+      "cache_write": 0.234375
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "pioneer/qwen3.6-max-preview",
+    "name": "Qwen3.6 Max Preview",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-04-20",
+    "last_updated": "2026-04-20",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.04,
+      "output": 6.24,
+      "cache_read": 0.208,
+      "cache_write": 1.3
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "pioneer/qwen3.6-plus",
+    "name": "Qwen3.6 Plus",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.325,
+      "output": 1.95,
+      "cache_read": 0.065,
+      "cache_write": 0.40625
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "pioneer/qwen3.7-max",
+    "name": "Qwen3.7 Max",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-05-21",
+    "last_updated": "2026-05-21",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 3.75,
+      "cache_read": 0.25,
+      "cache_write": 1.5625
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "pioneer/qwen3.7-plus",
+    "name": "Qwen3.7 Plus",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-06-02",
+    "last_updated": "2026-06-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.32,
+      "output": 1.28,
+      "cache_read": 0.064,
+      "cache_write": 0.4
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "pioneer/sakana/fugu-ultra",
+    "name": "Fugu Ultra",
+    "family": "fugu",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-06-15",
+    "last_updated": "2026-06-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5,
+      "cache_write": 5.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "pioneer/zai-org/GLM-5.1",
+    "name": "GLM-5.1",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-07",
+    "last_updated": "2026-04-07",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.98,
+      "output": 3.08,
+      "cache_read": 0.182,
+      "cache_write": 0.98
+    },
+    "limit": {
+      "context": 202752,
+      "output": 131072
+    }
+  },
+  {
+    "id": "pioneer/zai-org/GLM-5.2",
+    "name": "GLM-5.2",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-13",
+    "last_updated": "2026-06-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26,
+      "cache_write": 1.4
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 128000
     }
   },
   {
@@ -124517,6 +129554,7 @@
   {
     "id": "poolside/poolside/laguna-m.1",
     "name": "Laguna M.1",
+    "family": "laguna",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
@@ -124531,7 +129569,37 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "poolside/poolside/laguna-xs-2.1",
+    "name": "Laguna XS 2.1",
+    "family": "laguna",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-07-02",
+    "last_updated": "2026-07-02",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
     "cost": {
       "input": 0.0,
       "output": 0.0,
@@ -124546,6 +129614,7 @@
   {
     "id": "poolside/poolside/laguna-xs.2",
     "name": "Laguna XS.2",
+    "family": "laguna",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
@@ -128989,6 +134058,99 @@
     "limit": {
       "context": 200000,
       "output": 32000
+    }
+  },
+  {
+    "id": "routing-run/gpt-5.6-luna",
+    "name": "GPT-5.6 Luna",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.7,
+      "output": 4.2
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "routing-run/gpt-5.6-sol",
+    "name": "GPT-5.6 Sol",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 15.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "routing-run/gpt-5.6-terra",
+    "name": "GPT-5.6 Terra",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 9.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
     }
   },
   {
@@ -137284,6 +142446,691 @@
     }
   },
   {
+    "id": "unorouter/claude-haiku-4.5",
+    "name": "Claude Haiku 4.5",
+    "family": "claude-haiku",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-02-28",
+    "release_date": "2025-10-15",
+    "last_updated": "2025-10-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.2,
+      "output": 6.0
+    },
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "unorouter/claude-opus-4.8",
+    "name": "Claude Opus 4.8",
+    "family": "claude-opus",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01",
+    "release_date": "2026-05-28",
+    "last_updated": "2026-05-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.425,
+      "output": 2.125
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "unorouter/claude-sonnet-5",
+    "name": "Claude Sonnet 5",
+    "family": "claude-sonnet",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-30",
+    "last_updated": "2026-06-30",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.44,
+      "output": 7.2
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "unorouter/deepseek-v4-flash",
+    "name": "DeepSeek V4 Flash",
+    "family": "deepseek-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0625,
+      "output": 0.125
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "unorouter/deepseek-v4-flash:free",
+    "name": "DeepSeek V4 Flash",
+    "family": "deepseek-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "unorouter/deepseek-v4-pro",
+    "name": "DeepSeek V4 Pro",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.8999,
+      "output": 1.7999
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "unorouter/deepseek-v4-pro:free",
+    "name": "DeepSeek V4 Pro",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "unorouter/gemini-3.5-flash",
+    "name": "Gemini 3.5 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-05-19",
+    "last_updated": "2026-05-19",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1857,
+      "output": 1.1142
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "unorouter/gemma-4-31b-it:free",
+    "name": "Gemma 4 31B IT",
+    "family": "gemma",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "unorouter/glm-4.5-flash:free",
+    "name": "GLM-4.5-Flash",
+    "family": "glm-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2025-07-28",
+    "last_updated": "2025-07-28",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 131072,
+      "output": 98304
+    }
+  },
+  {
+    "id": "unorouter/glm-5.2",
+    "name": "GLM-5.2",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-13",
+    "last_updated": "2026-06-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.6001,
+      "output": 5.0288
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "unorouter/glm-5.2:free",
+    "name": "GLM-5.2",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-13",
+    "last_updated": "2026-06-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "unorouter/gpt-5.2",
+    "name": "GPT-5.2",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2025-12-11",
+    "last_updated": "2025-12-11",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.05,
+      "output": 8.4
+    },
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "unorouter/gpt-5.4",
+    "name": "GPT-5.4",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-05",
+    "last_updated": "2026-03-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.8,
+      "output": 10.8
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "unorouter/gpt-5.4:free",
+    "name": "GPT-5.4",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-08-31",
+    "release_date": "2026-03-05",
+    "last_updated": "2026-03-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "unorouter/gpt-5.5",
+    "name": "GPT-5.5",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-12-01",
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1875,
+      "output": 1.125
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "unorouter/gpt-5.5:free",
+    "name": "GPT-5.5",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2025-12-01",
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "unorouter/kimi-k2.6",
+    "name": "Kimi K2.6",
+    "family": "kimi-k2",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2026-04-21",
+    "last_updated": "2026-04-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.2675,
+      "output": 5.3368
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "unorouter/minimax-m2.7",
+    "name": "MiniMax-M2.7",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.819,
+      "output": 3.276
+    },
+    "limit": {
+      "context": 204800,
+      "output": 131072
+    }
+  },
+  {
+    "id": "unorouter/minimax-m2.7:free",
+    "name": "MiniMax-M2.7",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 204800,
+      "output": 131072
+    }
+  },
+  {
+    "id": "unorouter/nemotron-3-ultra-550b-a55b:free",
+    "name": "Nemotron 3 Ultra 550B A55B",
+    "family": "nemotron",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-04",
+    "last_updated": "2026-06-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "unorouter/qwen3.5-397b-a17b:free",
+    "name": "Qwen3.5 397B-A17B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-15",
+    "last_updated": "2026-02-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "unorouter/step-3.7-flash:free",
+    "name": "Step 3.7 Flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2026-01-01",
+    "release_date": "2026-05-29",
+    "last_updated": "2026-05-29",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 256000,
+      "output": 256000
+    }
+  },
+  {
     "id": "upstage/solar-mini",
     "name": "solar-mini",
     "family": "solar-mini",
@@ -139074,6 +144921,198 @@
     "cost": {
       "input": 37.5,
       "output": 225.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "venice/openai-gpt-56-luna",
+    "name": "GPT-5.6 Luna",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 7.5,
+      "cache_read": 0.125,
+      "cache_write": 1.5625
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "venice/openai-gpt-56-luna-pro",
+    "name": "GPT-5.6 Luna Pro",
+    "family": "gpt-nano",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 7.5,
+      "cache_read": 0.125,
+      "cache_write": 1.5625
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "venice/openai-gpt-56-sol",
+    "name": "GPT-5.6 Sol",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 6.25,
+      "output": 37.5,
+      "cache_read": 0.625,
+      "cache_write": 7.8125
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "venice/openai-gpt-56-sol-pro",
+    "name": "GPT-5.6 Sol Pro",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 6.25,
+      "output": 37.5,
+      "cache_read": 0.625,
+      "cache_write": 7.8125
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "venice/openai-gpt-56-terra",
+    "name": "GPT-5.6 Terra",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.125,
+      "output": 18.75,
+      "cache_read": 0.3125,
+      "cache_write": 3.90625
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "venice/openai-gpt-56-terra-pro",
+    "name": "GPT-5.6 Terra Pro",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 3.125,
+      "output": 18.75,
+      "cache_read": 0.3125,
+      "cache_write": 3.90625
     },
     "limit": {
       "context": 1000000,
@@ -142326,7 +148365,7 @@
     "cost": {
       "input": 0.14,
       "output": 0.28,
-      "cache_read": 0.0028
+      "cache_read": 0.028
     },
     "limit": {
       "context": 1000000,
@@ -143837,6 +149876,37 @@
     "limit": {
       "context": 128000,
       "output": 4096
+    }
+  },
+  {
+    "id": "vercel/meta/muse-spark-1.1",
+    "name": "Muse Spark 1.1",
+    "family": "muse",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 4.25,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 1048576
     }
   },
   {
@@ -146052,6 +152122,105 @@
     }
   },
   {
+    "id": "vercel/openai/gpt-5.6-luna",
+    "name": "GPT 5.6 Luna",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.0,
+      "output": 6.0,
+      "cache_read": 0.1,
+      "cache_write": 1.25
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "vercel/openai/gpt-5.6-sol",
+    "name": "GPT 5.6 Sol",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "vercel/openai/gpt-5.6-terra",
+    "name": "GPT 5.6 Terra",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2026-02-16",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.5,
+      "output": 15.0,
+      "cache_read": 0.25,
+      "cache_write": 3.125
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
     "id": "vercel/openai/gpt-image-1",
     "name": "GPT Image 1",
     "family": "gpt-image",
@@ -146315,6 +152484,38 @@
     "limit": {
       "context": 0,
       "output": 0
+    }
+  },
+  {
+    "id": "vercel/openai/gpt-realtime-2.1",
+    "name": "gpt-realtime-2.1",
+    "family": "gpt",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2024-09-30",
+    "release_date": "2026-07-09",
+    "last_updated": "2026-07-06",
+    "modalities": {
+      "input": [
+        "text",
+        "audio"
+      ],
+      "output": [
+        "text",
+        "audio"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 4.0,
+      "output": 24.0,
+      "cache_read": 0.4
+    },
+    "limit": {
+      "context": 128000,
+      "output": 32000
     }
   },
   {

--- a/crates/goose-provider-types/src/canonical/data/provider_metadata.json
+++ b/crates/goose-provider-types/src/canonical/data/provider_metadata.json
@@ -19,7 +19,7 @@
     "env": [
       "ABACUS_API_KEY"
     ],
-    "model_count": 65
+    "model_count": 95
   },
   {
     "id": "abliteration-ai",
@@ -321,6 +321,17 @@
     "model_count": 3
   },
   {
+    "id": "empiriolabs",
+    "display_name": "EmpirioLabs AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.empiriolabs.ai/v1",
+    "doc": "https://docs.empiriolabs.ai",
+    "env": [
+      "EMPIRIOLABS_API_KEY"
+    ],
+    "model_count": 34
+  },
+  {
     "id": "evroc",
     "display_name": "evroc",
     "npm": "@ai-sdk/openai-compatible",
@@ -395,7 +406,7 @@
     "env": [
       "GITHUB_TOKEN"
     ],
-    "model_count": 25
+    "model_count": 28
   },
   {
     "id": "github-models",
@@ -582,7 +593,7 @@
     "env": [
       "LLMGATEWAY_API_KEY"
     ],
-    "model_count": 181
+    "model_count": 184
   },
   {
     "id": "llmtr",
@@ -726,6 +737,17 @@
       "MOARK_API_KEY"
     ],
     "model_count": 2
+  },
+  {
+    "id": "model-oracle-ai",
+    "display_name": "Model Oracle AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.modeloracle.com/api/v1",
+    "doc": "https://modeloracle.com/setup/",
+    "env": [
+      "MODEL_ORACLE_API_KEY"
+    ],
+    "model_count": 15
   },
   {
     "id": "modelscope",
@@ -880,7 +902,7 @@
     "env": [
       "OPENCODE_API_KEY"
     ],
-    "model_count": 76
+    "model_count": 79
   },
   {
     "id": "opencode-go",
@@ -927,6 +949,17 @@
     "model_count": 18
   },
   {
+    "id": "pioneer",
+    "display_name": "Pioneer",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.pioneer.ai/v1",
+    "doc": "https://agent.pioneer.ai/llms.txt",
+    "env": [
+      "PIONEER_API_KEY"
+    ],
+    "model_count": 76
+  },
+  {
     "id": "poe",
     "display_name": "Poe",
     "npm": "@ai-sdk/openai-compatible",
@@ -946,7 +979,7 @@
     "env": [
       "POOLSIDE_API_KEY"
     ],
-    "model_count": 2
+    "model_count": 3
   },
   {
     "id": "privatemode-ai",
@@ -1013,7 +1046,7 @@
     "env": [
       "ROUTING_RUN_API_KEY"
     ],
-    "model_count": 12
+    "model_count": 15
   },
   {
     "id": "sakana",
@@ -1235,6 +1268,17 @@
       "UMANS_AI_CODING_PLAN_API_KEY"
     ],
     "model_count": 6
+  },
+  {
+    "id": "unorouter",
+    "display_name": "UnoRouter",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.unorouter.com/v1",
+    "doc": "https://unorouter.com/models",
+    "env": [
+      "UNOROUTER_API_KEY"
+    ],
+    "model_count": 23
   },
   {
     "id": "upstage",

--- a/crates/goose-provider-types/src/formats/databricks.rs
+++ b/crates/goose-provider-types/src/formats/databricks.rs
@@ -1158,7 +1158,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_request_off_effort_preserves_none() -> anyhow::Result<()> {
+    fn test_create_request_off_effort_uses_low() -> anyhow::Result<()> {
         let mut params = std::collections::HashMap::new();
         params.insert("thinking_effort".to_string(), serde_json::json!("off"));
         let model_config = ModelConfig {
@@ -1172,7 +1172,7 @@ mod tests {
             reasoning: None,
         };
         let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
-        assert_eq!(request["reasoning_effort"], "none");
+        assert_eq!(request["reasoning_effort"], "low");
         assert!(request.get("thinking_effort").is_none());
         Ok(())
     }

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1506,13 +1506,10 @@ pub fn openai_reasoning_effort_for_thinking(
     model_name: &str,
     effort: ThinkingEffort,
 ) -> Option<String> {
-    if effort == ThinkingEffort::Off {
-        return Some("none".to_string());
-    }
-
     let supported = openai_reasoning_efforts_for_model(model_name);
+
     let preferred: &[&str] = match effort {
-        ThinkingEffort::Off => unreachable!(),
+        ThinkingEffort::Off => &["none", "low"],
         ThinkingEffort::Low => &["low", "medium", "high", "xhigh"],
         ThinkingEffort::Medium => &["medium", "high", "low", "xhigh"],
         ThinkingEffort::High => &["high", "medium", "xhigh", "low"],
@@ -1525,7 +1522,7 @@ pub fn openai_reasoning_effort_for_thinking(
         .map(|level| (*level).to_string())
 }
 
-fn openai_reasoning_efforts_for_model(model_name: &str) -> &'static [&'static str] {
+pub(crate) fn openai_reasoning_efforts_for_model(model_name: &str) -> &'static [&'static str] {
     let normalized = model_name.to_ascii_lowercase();
 
     if normalized.contains("gpt-5") {
@@ -1538,7 +1535,7 @@ fn openai_reasoning_efforts_for_model(model_name: &str) -> &'static [&'static st
             || normalized.contains("gpt-5.6")
             || normalized.contains("gpt-5-6")
         {
-            &["low", "medium", "high", "xhigh"]
+            &["none", "low", "medium", "high", "xhigh"]
         } else {
             &["low", "medium", "high"]
         }
@@ -2488,27 +2485,6 @@ mod tests {
         let obj = request.as_object().unwrap();
 
         assert_eq!(obj.get("reasoning_effort"), Some(&json!("medium")));
-        assert!(obj.get("thinking_effort").is_none());
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_create_request_o3_off_effort_preserves_none() -> anyhow::Result<()> {
-        let model_config = test_model_config("o3")
-            .with_max_tokens(Some(1024))
-            .with_thinking_effort(ThinkingEffort::Off);
-        let request = create_request(
-            &model_config,
-            "system",
-            &[],
-            &[],
-            &ImageFormat::OpenAi,
-            false,
-        )?;
-        let obj = request.as_object().unwrap();
-
-        assert_eq!(obj.get("reasoning_effort"), Some(&json!("none")));
         assert!(obj.get("thinking_effort").is_none());
 
         Ok(())

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -563,6 +563,14 @@ fn add_message_items(input_items: &mut Vec<Value>, messages: &[Message]) {
     }
 }
 
+fn is_gpt_5_6_model(model_name: &str) -> bool {
+    let normalized = model_name.to_ascii_lowercase();
+    normalized == "gpt-5.6"
+        || normalized.starts_with("gpt-5.6-")
+        || normalized == "gpt-5-6"
+        || normalized.starts_with("gpt-5-6-")
+}
+
 pub fn create_responses_request(
     model_config: &ModelConfig,
     system: &str,
@@ -590,11 +598,15 @@ pub fn create_responses_request(
     let is_reasoning_model = is_openai_responses_model(&model_name);
     let reasoning_effort = if is_reasoning_model {
         if let Some(effort) = legacy_reasoning_effort.as_deref() {
-            effort
-                .parse()
-                .ok()
-                .and_then(|effort| openai_reasoning_effort_for_thinking(&model_name, effort))
-                .or(legacy_reasoning_effort)
+            if effort.eq_ignore_ascii_case("none") {
+                legacy_reasoning_effort
+            } else {
+                effort
+                    .parse()
+                    .ok()
+                    .and_then(|effort| openai_reasoning_effort_for_thinking(&model_name, effort))
+                    .or(legacy_reasoning_effort)
+            }
         } else {
             model_config
                 .thinking_effort()
@@ -605,20 +617,43 @@ pub fn create_responses_request(
     };
 
     let store = model_config.request_param::<bool>("store").unwrap_or(false);
+    let reasoning_mode = model_config
+        .request_param::<String>("reasoning_mode")
+        .map(|mode| {
+            let normalized = mode.to_ascii_lowercase();
+            match normalized.as_str() {
+                "standard" | "pro" => Ok(normalized),
+                _ => Err(anyhow!(
+                    "Invalid reasoning_mode '{}'. Supported values are: standard, pro",
+                    mode
+                )),
+            }
+        })
+        .transpose()?;
+    if reasoning_mode.is_some() && !is_gpt_5_6_model(&model_name) {
+        return Err(anyhow!(
+            "reasoning_mode is only supported for GPT-5.6 models"
+        ));
+    }
     let mut payload = json!({
         "model": model_name,
         "input": input_items,
         "store": store,
     });
 
-    if let Some(effort) = reasoning_effort {
-        payload.as_object_mut().unwrap().insert(
-            "reasoning".to_string(),
-            json!({
-                "effort": effort,
-                "summary": "auto",
-            }),
-        );
+    if reasoning_effort.is_some() || reasoning_mode.is_some() {
+        let mut reasoning = serde_json::Map::new();
+        if let Some(effort) = reasoning_effort {
+            reasoning.insert("effort".to_string(), json!(effort));
+            reasoning.insert("summary".to_string(), json!("auto"));
+        }
+        if let Some(mode) = reasoning_mode {
+            reasoning.insert("mode".to_string(), json!(mode));
+        }
+        payload
+            .as_object_mut()
+            .unwrap()
+            .insert("reasoning".to_string(), Value::Object(reasoning));
     }
 
     if !tools.is_empty() {
@@ -650,10 +685,12 @@ pub fn create_responses_request(
         }
     }
 
-    payload.as_object_mut().unwrap().insert(
-        "max_output_tokens".to_string(),
-        json!(model_config.max_output_tokens()),
-    );
+    if let Some(max_tokens) = model_config.max_tokens {
+        payload
+            .as_object_mut()
+            .unwrap()
+            .insert("max_output_tokens".to_string(), json!(max_tokens));
+    }
 
     Ok(payload)
 }
@@ -1456,6 +1493,46 @@ mod tests {
     }
 
     #[test]
+    fn test_responses_request_supports_gpt_5_6_xhigh_effort() {
+        let model_config = ModelConfig::new("gpt-5.6-sol-xhigh");
+
+        let result = create_responses_request(&model_config, "You are helpful.", &[], &[]).unwrap();
+
+        assert_eq!(result["model"], "gpt-5.6-sol");
+        assert_eq!(result["reasoning"]["effort"], "xhigh");
+        assert_eq!(result["reasoning"]["summary"], "auto");
+    }
+
+    #[test]
+    fn test_responses_request_supports_gpt_5_6_reasoning_mode() {
+        let model_config = ModelConfig::new("gpt-5.6-sol").with_merged_request_params(
+            std::collections::HashMap::from([("reasoning_mode".to_string(), json!("pro"))]),
+        );
+
+        let result = create_responses_request(&model_config, "You are helpful.", &[], &[]).unwrap();
+
+        assert_eq!(result["reasoning"]["mode"], "pro");
+        assert!(result["reasoning"].get("effort").is_none());
+        assert!(result["reasoning"].get("summary").is_none());
+    }
+
+    #[test]
+    fn test_responses_request_rejects_reasoning_mode_for_non_gpt_5_6_model() {
+        for model_name in ["gpt-5.5", "gpt-5.60"] {
+            let model_config = ModelConfig::new(model_name).with_merged_request_params(
+                std::collections::HashMap::from([("reasoning_mode".to_string(), json!("pro"))]),
+            );
+
+            let error = create_responses_request(&model_config, "You are helpful.", &[], &[])
+                .expect_err("reasoning mode should be gated to GPT-5.6 models");
+
+            assert!(error
+                .to_string()
+                .contains("reasoning_mode is only supported for GPT-5.6 models"));
+        }
+    }
+
+    #[test]
     fn test_responses_request_without_effort_suffix_omits_reasoning() {
         for model_name in ["gpt-5.4", "o3", "gpt-5-nano"] {
             let model_config = ModelConfig {
@@ -1478,6 +1555,31 @@ mod tests {
                 "reasoning should be omitted for {model_name} without explicit effort suffix"
             );
         }
+    }
+
+    #[test]
+    fn test_responses_request_omits_default_max_output_tokens_for_unknown_model() {
+        let model_config = ModelConfig::new("gpt-5.6-sol");
+
+        let result = create_responses_request(&model_config, "You are helpful.", &[], &[]).unwrap();
+
+        assert_eq!(result["model"], "gpt-5.6-sol");
+        assert!(
+            result.get("max_output_tokens").is_none(),
+            "unknown/new models should not receive Goose's fallback max_output_tokens"
+        );
+    }
+
+    #[test]
+    fn test_responses_request_includes_canonical_max_output_tokens() {
+        let model_config = ModelConfig::new("gpt-5.4").with_canonical_limits("openai");
+
+        let result = create_responses_request(&model_config, "You are helpful.", &[], &[]).unwrap();
+
+        assert_eq!(
+            result["max_output_tokens"],
+            model_config.max_tokens.unwrap()
+        );
     }
 
     #[test]

--- a/crates/goose-provider-types/src/model.rs
+++ b/crates/goose-provider-types/src/model.rs
@@ -624,6 +624,20 @@ mod tests {
             let config = ModelConfig::new("gpt-5.4-xhigh").with_canonical_limits("openai");
             assert_eq!(config.context_limit, Some(1_050_000));
 
+            // "gpt-5.6-sol-xhigh" should resolve via "gpt-5.6-sol"
+            let config = ModelConfig::new("gpt-5.6-sol-xhigh").with_canonical_limits("openai");
+            assert_eq!(config.context_limit, Some(1_050_000));
+            assert_eq!(config.max_tokens, Some(128_000));
+            assert_eq!(config.reasoning, Some(true));
+            let canonical = crate::canonical::maybe_get_canonical_model("openai", "gpt-5.6-sol")
+                .expect("gpt-5.6-sol should have canonical metadata");
+            assert_eq!(canonical.temperature, Some(false));
+
+            let config = ModelConfig::new("gpt-5.6-sol").with_canonical_limits("chatgpt_codex");
+            assert_eq!(config.context_limit, Some(1_050_000));
+            assert_eq!(config.max_tokens, Some(128_000));
+            assert_eq!(config.reasoning, Some(true));
+
             // "gpt-5.4-nano-low" should resolve via "gpt-5.4-nano"
             let config = ModelConfig::new("gpt-5.4-nano-low").with_canonical_limits("openai");
             assert_eq!(config.context_limit, Some(400_000));

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -62,9 +62,10 @@ pub const OPEN_AI_KNOWN_MODELS: &[(&str, usize)] = &[
     ("gpt-5.4-pro", 1_050_000),
     ("gpt-5.5", 1_050_000),
     ("gpt-5.5-pro", 1_050_000),
-    ("gpt-5.6-luna", 1_050_000),
+    ("gpt-5.6", 1_050_000),
     ("gpt-5.6-sol", 1_050_000),
     ("gpt-5.6-terra", 1_050_000),
+    ("gpt-5.6-luna", 1_050_000),
 ];
 
 pub const OPEN_AI_DOC_URL: &str = "https://platform.openai.com/docs/models";
@@ -844,26 +845,6 @@ mod tests {
     use crate::api_client::AuthMethod;
     use serde_json::json;
 
-    #[test]
-    fn gpt_5_5_and_5_6_models_have_expected_context_limits() {
-        for model in [
-            "gpt-5.5",
-            "gpt-5.5-pro",
-            "gpt-5.6-luna",
-            "gpt-5.6-sol",
-            "gpt-5.6-terra",
-        ] {
-            assert_eq!(
-                OPEN_AI_KNOWN_MODELS
-                    .iter()
-                    .find(|(name, _)| *name == model)
-                    .map(|(_, limit)| *limit),
-                Some(1_050_000),
-                "unexpected context limit for {model}"
-            );
-        }
-    }
-
     fn make_provider(name: &str) -> OpenAiProvider {
         OpenAiProvider {
             api_client: ApiClient::new_with_tls(
@@ -1023,6 +1004,8 @@ mod tests {
         for (model_name, base_path, expected) in [
             ("gpt-5.4", "v1/chat/completions", true),
             ("gpt-5.4-xhigh", "v1/chat/completions", true),
+            ("gpt-5.6-sol", "v1/chat/completions", true),
+            ("gpt-5.6-terra-xhigh", "v1/chat/completions", true),
             ("gpt-5.2-pro-2025-12-11", "v1/chat/completions", true),
             ("gpt-4o", "v1/chat/completions", false),
             ("gpt-5.2-codex", "openai/v1/chat/completions", false),

--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -53,6 +53,22 @@ pub struct ChatGptCodexModelAttrs {
 
 pub const CHATGPT_CODEX_KNOWN_MODELS: &[ChatGptCodexModelAttrs] = &[
     ChatGptCodexModelAttrs {
+        name: "gpt-5.6-sol",
+        reasoning_levels: &["none", "low", "medium", "high", "xhigh"],
+    },
+    ChatGptCodexModelAttrs {
+        name: "gpt-5.6-terra",
+        reasoning_levels: &["none", "low", "medium", "high", "xhigh"],
+    },
+    ChatGptCodexModelAttrs {
+        name: "gpt-5.6-luna",
+        reasoning_levels: &["none", "low", "medium", "high", "xhigh"],
+    },
+    ChatGptCodexModelAttrs {
+        name: "gpt-5.6",
+        reasoning_levels: &["none", "low", "medium", "high", "xhigh"],
+    },
+    ChatGptCodexModelAttrs {
         name: "gpt-5.5",
         reasoning_levels: &["low", "medium", "high", "xhigh"],
     },
@@ -223,7 +239,13 @@ fn reasoning_effort_for_config(model_config: &ModelConfig) -> Option<String> {
         .map(|effort| {
             let valid_levels = reasoning_levels_for_model(&model_config.model_name);
             let preferred_levels: &[&str] = match effort {
-                ThinkingEffort::Off => return None,
+                ThinkingEffort::Off => {
+                    return Some(if valid_levels.contains(&"none") {
+                        "none".to_string()
+                    } else {
+                        "low".to_string()
+                    });
+                }
                 ThinkingEffort::Low => &["low", "medium", "high", "xhigh"],
                 ThinkingEffort::Medium => &["medium", "high", "low", "xhigh"],
                 ThinkingEffort::High => &["high", "medium", "xhigh", "low"],
@@ -1201,14 +1223,14 @@ mod tests {
     }
 
     #[test]
-    fn test_create_codex_request_off_omits_reasoning_for_codex_models() {
+    fn test_create_codex_request_off_sets_none_for_gpt_5_6_models() {
         let mut params = std::collections::HashMap::new();
         params.insert("thinking_effort".to_string(), json!("off"));
-        let mut config = ModelConfig::new("gpt-5.2-codex");
+        let mut config = ModelConfig::new("gpt-5.6-sol");
         config.request_params = Some(params);
 
         let payload = create_codex_request(&config, "sys", &[], &[]).unwrap();
-        assert!(payload.get("reasoning").is_none());
+        assert_eq!(payload["reasoning"]["effort"], "none");
         assert!(payload.get("reasoning_effort").is_none());
     }
 
@@ -1374,9 +1396,23 @@ mod tests {
         assert_eq!(claims.chatgpt_account_id.as_deref(), Some("account-1"));
     }
 
+    #[test_case("gpt-5.6-sol", &["none", "low", "medium", "high", "xhigh"]; "gpt 5.6 sol supports extended reasoning levels")]
+    #[test_case("gpt-5.6-terra", &["none", "low", "medium", "high", "xhigh"]; "gpt 5.6 terra supports extended reasoning levels")]
+    #[test_case("gpt-5.6-luna", &["none", "low", "medium", "high", "xhigh"]; "gpt 5.6 luna supports extended reasoning levels")]
+    #[test_case("gpt-5.6", &["none", "low", "medium", "high", "xhigh"]; "gpt 5.6 supports extended reasoning levels")]
     #[test_case("unknown-model", &["medium", "high"]; "unknown model gets default reasoning levels")]
     fn test_reasoning_levels_for_model(model: &str, expected: &[&str]) {
         assert_eq!(reasoning_levels_for_model(model), expected);
+    }
+
+    #[test]
+    fn test_known_model_names_include_gpt_5_6_models() {
+        let names = known_model_names();
+
+        assert!(names.contains(&"gpt-5.6-sol"));
+        assert!(names.contains(&"gpt-5.6-terra"));
+        assert!(names.contains(&"gpt-5.6-luna"));
+        assert!(names.contains(&"gpt-5.6"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Add GPT-5.6 model support for OpenAI and ChatGPT Codex, including updated reasoning effort handling, Responses API params, and regenerated canonical metadata.

Note: I ran `cargo run --bin build_canonical_models` to pull from `models.dev`, which includes the GPT-5.6 family metadata. The generated files changed more than just GPT-5.6 because there was more in the upstream models.dev since the last generation.

### Testing
Added tests:
- `test_responses_request_supports_gpt_5_6_xhigh_effort`
- `test_responses_request_omits_default_max_output_tokens_for_unknown_model`
- `test_responses_request_includes_canonical_max_output_tokens`
- `test_known_model_names_include_gpt_5_6_models`
- `test_reasoning_levels_for_model`
- `test_create_codex_request_off_sets_none_for_gpt_5_6_models`

Ran:
- `cargo test -p goose-provider-types openai`
- `cargo test -p goose-providers openai`

Issue to be addressed later: https://github.com/aaif-goose/goose/issues/10385
