### PR TITLE
fix(cli): emit OSC 0 terminal title on session start (#10280)

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -33,11 +33,21 @@ use crate::session::{build_session, SessionBuilderConfig};
 use goose::agents::Container;
 use goose::session::session_manager::SessionType;
 use goose::session::SessionManager;
-use std::io::Read;
+use std::io::{Read, Write};
 use std::path::PathBuf;
 use tracing::warn;
 
 const GOOSE_SERVER_SECRET_KEY_ENV: &str = "GOOSE_SERVER__SECRET_KEY";
+
+/// Emit OSC 0 escape sequence to set the terminal window/tab title.
+/// Most modern terminals (WezTerm, iTerm2, Ghostty, Windows Terminal,
+/// GNOME Terminal, Alacritty, Kitty) respect this for pane identification.
+fn set_terminal_title(title: &str) {
+    // OSC 0: ESC ] 0 ; title BEL
+    // Sets both window title and terminal tab title on most terminals.
+    print!("\x1b]0;{}\x07", title);
+    std::io::stdout().flush().ok();
+}
 
 fn generate_serve_secret_key() -> String {
     use rand::distributions::{Alphanumeric, DistString};
@@ -1214,6 +1224,8 @@ async fn handle_interactive_session(
         configure_telemetry_consent_dialog()?;
     }
 
+    set_terminal_title("goose");
+
     let session_start = std::time::Instant::now();
     let session_type = if fork {
         "forked"
@@ -1464,6 +1476,8 @@ async fn handle_run_command(
         goose_mode,
     )
     .await?;
+
+    set_terminal_title("goose");
 
     let mut session = build_session(SessionBuilderConfig {
         session_id,
@@ -1763,6 +1777,8 @@ async fn handle_default_session() -> Result<()> {
 
     let goose_mode = Config::global().get_goose_mode().unwrap_or_default();
     let session_id = get_or_create_session_id(None, false, false, goose_mode).await?;
+
+    set_terminal_title("goose");
 
     let mut session = build_session(SessionBuilderConfig {
         session_id,

--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -39,14 +39,51 @@ use tracing::warn;
 
 const GOOSE_SERVER_SECRET_KEY_ENV: &str = "GOOSE_SERVER__SECRET_KEY";
 
-/// Emit OSC 0 escape sequence to set the terminal window/tab title.
+/// Push the current terminal title onto the OSC title stack and set a new title.
 /// Most modern terminals (WezTerm, iTerm2, Ghostty, Windows Terminal,
-/// GNOME Terminal, Alacritty, Kitty) respect this for pane identification.
-fn set_terminal_title(title: &str) {
-    // OSC 0: ESC ] 0 ; title BEL
-    // Sets both window title and terminal tab title on most terminals.
+/// GNOME Terminal, Alacritty, Kitty) support the OSC 22/23 stack.
+fn push_terminal_title(title: &str) {
+    // Push current title onto stack (OSC 22)
+    print!("\x1b]22;\x07");
+    // Set new title (OSC 0)
     print!("\x1b]0;{}\x07", title);
     std::io::stdout().flush().ok();
+}
+
+/// Pop the previous terminal title from the OSC title stack.
+fn pop_terminal_title() {
+    print!("\x1b]23;\x07");
+    std::io::stdout().flush().ok();
+}
+
+/// RAII guard that pushes a terminal title on construction
+/// and pops (restores) it on drop.
+struct TerminalTitleGuard;
+
+impl TerminalTitleGuard {
+    fn new(title: &str) -> Self {
+        push_terminal_title(title);
+        TerminalTitleGuard
+    }
+}
+
+impl Drop for TerminalTitleGuard {
+    fn drop(&mut self) {
+        pop_terminal_title();
+    }
+}
+
+/// Derive a meaningful terminal tab title from config and model override.
+fn goose_terminal_title(model_override: Option<&str>) -> String {
+    let model = model_override
+        .map(|s| s.to_string())
+        .or_else(|| Config::global().get_goose_model().ok())
+        .unwrap_or_default();
+    if model.is_empty() {
+        "goose".to_string()
+    } else {
+        format!("goose · {}", model)
+    }
 }
 
 fn generate_serve_secret_key() -> String {
@@ -1224,7 +1261,11 @@ async fn handle_interactive_session(
         configure_telemetry_consent_dialog()?;
     }
 
-    set_terminal_title("goose");
+    let _title_guard = if std::io::stdout().is_terminal() {
+        Some(TerminalTitleGuard::new(&goose_terminal_title(None)))
+    } else {
+        None
+    };
 
     let session_start = std::time::Instant::now();
     let session_type = if fork {
@@ -1477,7 +1518,12 @@ async fn handle_run_command(
     )
     .await?;
 
-    set_terminal_title("goose");
+    let model_name = model_opts.model.clone();
+    let _title_guard = if run_behavior.interactive && std::io::stdout().is_terminal() {
+        Some(TerminalTitleGuard::new(&goose_terminal_title(model_name.as_deref())))
+    } else {
+        None
+    };
 
     let mut session = build_session(SessionBuilderConfig {
         session_id,
@@ -1778,7 +1824,11 @@ async fn handle_default_session() -> Result<()> {
     let goose_mode = Config::global().get_goose_mode().unwrap_or_default();
     let session_id = get_or_create_session_id(None, false, false, goose_mode).await?;
 
-    set_terminal_title("goose");
+    let _title_guard = if std::io::stdout().is_terminal() {
+        Some(TerminalTitleGuard::new(&goose_terminal_title(None)))
+    } else {
+        None
+    };
 
     let mut session = build_session(SessionBuilderConfig {
         session_id,


### PR DESCRIPTION
When running goose in a terminal multiplexer (WezTerm, tmux, iTerm2, Windows Terminal, etc.), the pane/tab title stays generic. Emit the standard OSC 0 escape sequence on session start so the terminal tab reads "goose" ? matching what Claude Code, Pi, and other CLI agents do.

Fixes #10280
