### PR TITLE
Add WebAbility accessibility MCP server

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -859,26 +859,36 @@
     "environmentVariables": []
   },
   {
-  "id": "scholar-sidekick",
-  "name": "Scholar Sidekick",
-  "description": "Resolve, format, export, and verify academic citations (DOI, PMID, ISBN, arXiv) plus retraction and open-access checks",
-  "command": "npx -y scholar-sidekick-mcp@latest",
-  "link": "https://github.com/mlava/scholar-sidekick-mcp",
-  "installation_notes": "No API key required — works anonymously on a free, rate-limited tier. Optionally set SCHOLAR_API_KEY (a free first-party ssk_ key from https://scholar-sidekick.com/account) for higher limits, or RAPIDAPI_KEY for paid tiers via RapidAPI.",
-  "is_builtin": false,
-  "endorsed": false,
-  "environmentVariables": [
-    {
-      "name": "SCHOLAR_API_KEY",
-      "description": "Optional first-party API key (ssk_) from https://scholar-sidekick.com/account; raises rate limits. Sent as Authorization: Bearer.",
-      "required": false
-    },
-    {
-      "name": "RAPIDAPI_KEY",
-      "description": "Optional RapidAPI key for paid/managed tiers; routes calls through the RapidAPI gateway.",
-      "required": false
-    }
-  ]
-}
-
+    "id": "scholar-sidekick",
+    "name": "Scholar Sidekick",
+    "description": "Resolve, format, export, and verify academic citations (DOI, PMID, ISBN, arXiv) plus retraction and open-access checks",
+    "command": "npx -y scholar-sidekick-mcp@latest",
+    "link": "https://github.com/mlava/scholar-sidekick-mcp",
+    "installation_notes": "No API key required \u2014 works anonymously on a free, rate-limited tier. Optionally set SCHOLAR_API_KEY (a free first-party ssk_ key from https://scholar-sidekick.com/account) for higher limits, or RAPIDAPI_KEY for paid tiers via RapidAPI.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [
+      {
+        "name": "SCHOLAR_API_KEY",
+        "description": "Optional first-party API key (ssk_) from https://scholar-sidekick.com/account; raises rate limits. Sent as Authorization: Bearer.",
+        "required": false
+      },
+      {
+        "name": "RAPIDAPI_KEY",
+        "description": "Optional RapidAPI key for paid/managed tiers; routes calls through the RapidAPI gateway.",
+        "required": false
+      }
+    ]
+  },
+  {
+    "id": "webability",
+    "name": "WebAbility",
+    "description": "Find and fix web accessibility (WCAG 2.2 AA, ADA, Section 508, EAA, AODA) issues from your coding agent \u2014 scan (3 engines), framework-aware fixes, verify, vision audit, auditor-ready reports.",
+    "command": "npx -y -p @webability/mcp webability-mcp",
+    "link": "https://github.com/snayyar00/webability-mcp",
+    "installation_notes": "Install using npx package manager. No API key required. A remote Streamable HTTP endpoint is also available at https://mcp.webability.io/mcp. Docs: https://webability.io/docs/mcp",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": []
+  }
 ]


### PR DESCRIPTION
## Summary
- Adds an entry for [WebAbility](https://github.com/snayyar00/webability-mcp) (`@webability/mcp`) to `documentation/static/servers.json`, which powers the [Extensions directory](https://block.github.io/goose/extensions).
- WebAbility is an accessibility-testing MCP server for coding agents: scans pages with axe-core, HTML_CodeSniffer, and 60+ custom detectors, generates framework-aware fixes, verifies them, runs vision-based audits, and produces WCAG 2.2 AA / ADA / Section 508 / EAA / AODA compliance reports.
- Installed via `npx -y -p @webability/mcp webability-mcp` (stdio, no API key required). A remote Streamable HTTP endpoint (`https://mcp.webability.io/mcp`) is also available and noted in `installation_notes`.
- Docs: https://webability.io/docs/mcp · npm: https://www.npmjs.com/package/@webability/mcp

## Test plan
- [x] `python3 -m json.tool documentation/static/servers.json` — valid JSON
- [x] New entry matches the existing schema (`id`/`name`/`description`/`command`/`link`/`installation_notes`/`is_builtin`/`endorsed`/`environmentVariables`) used by neighboring stdio entries (e.g. `scholar-sidekick-mcp`, `agentql-mcp`)
- [x] Confirmed no existing `webability` entry / id collision in the directory
- [x] Diff is scoped to the single appended entry (plus a pre-existing indentation inconsistency on the previous last entry that `json.dump` normalized)