### PR TITLE
fix(ui): hide nested config values in Configuration Editor

### DIFF
--- a/ui/desktop/src/components/settings/config/ConfigSettings.tsx
+++ b/ui/desktop/src/components/settings/config/ConfigSettings.tsx
@@ -192,6 +192,12 @@ export default function ConfigSettings() {
           return false;
         }
 
+        // skip nested structures - they can't be edited as a single-line string
+        const value: unknown = configValues[key];
+        if (typeof value === 'object' && value !== null) {
+          return false;
+        }
+
         // Only show provider-specific entries for the current provider
         const providerSpecific = allProviderPrefixes.some((prefix: string) =>
           key.startsWith(prefix)


### PR DESCRIPTION
## Summary

The Configuration Editor (Settings → Configuration → Edit Configuration)
rendered nested config values like the `providers:` section as the literal
text `[object Object]`, because every value is coerced into the text input
with `String(...)`. Worse, clicking save on such a row overwrote the
structured YAML in `config.yaml` with that literal string.

This change skips non-scalar values (objects/arrays) in the `configEntries`
filter in `ConfigSettings.tsx`, the same way `extensions` is already
excluded. Nested structures no longer appear as editable single-line fields,
so they can't be displayed incorrectly or corrupted on save. Scalar entries
(model, host, timeout, etc.) are unaffected.

### Testing

- `tsc --noEmit` (`pnpm run typecheck`) passes in `ui/desktop`
- Manual: with a `providers:` map (and a synthetic `my_test_setting:` nested
  map) in `~/.config/goose/config.yaml`, opened the Configuration Editor —
  nested rows no longer appear
- Manual: edited and saved a scalar entry (e.g. `GOOSE_MODEL`) to confirm
  normal editing still works

### Related Issues
Fixes #10389

Before
<img width="2562" height="784" alt="image" src="https://github.com/user-attachments/assets/97296829-9061-429d-9d4e-28f10b653a80" />

After
Nested rows no longer appear

