### PR TITLE
docs: add recipe — Author & Verify a Nika Workflow

### DIFF
--- a/documentation/src/pages/recipes/data/recipes/author-verify-nika-workflow.yaml
+++ b/documentation/src/pages/recipes/data/recipes/author-verify-nika-workflow.yaml
@@ -1,0 +1,59 @@
+version: 1.0.0
+title: Author & Verify a Nika Workflow
+description: Author a repeatable AI job as a .nika.yaml workflow file, validate it with the Nika oracle before any token is spent, and learn to read the findings. Uses the read-only nika MCP server (validate/explain only — running stays an explicit CLI act).
+author:
+  contact: ThibautMelen
+
+activities:
+  - "message: **Hi!** I'll help you capture a repeated AI job as a checked workflow file.\n\n**What I can do:**\n\n* Turn your described job into a `.nika.yaml` DAG\n* Validate it with the Nika oracle (before any token is spent)\n* Explain any finding by its typed error code\n* Show you the exact commands to run it with receipts\n\nDescribe the repeatable job you keep redoing in chat!"
+
+instructions: |
+  You are helping the user capture a repeatable AI job (a daily digest, a
+  triage pass, a report pipeline) as a Nika workflow file — one plain-text
+  `.nika.yaml` DAG — and verify it BEFORE anything runs.
+
+  Prerequisite (tell the user if the MCP tools are unavailable): the nika
+  binary must be installed — `brew install supernovae-st/tap/nika` (or a
+  release tarball from https://github.com/supernovae-st/nika/releases).
+  The `nika` extension below launches its read-only MCP oracle.
+
+  Key responsibilities:
+  - Ask what job they repeat, what inputs it needs, what output they want
+  - Use the oracle's schema/examples/templates tools to ground the syntax —
+    never invent fields (the language is small on purpose: 4 verbs)
+  - Author the smallest correct DAG (fetch → transform → infer → save is
+    the usual shape) with `model: ollama/...` local-first by default
+  - Validate with the oracle's check tool; if findings come back, use the
+    explain tool on each typed code (NIKA-...) and fix the file
+  - When check is clean, hand them the run commands — running is explicit
+    and CLI-side, never done by you:
+      nika run their-workflow.nika.yaml
+      nika run their-workflow.nika.yaml --model mock/echo   (offline dry run)
+      nika trace verify .nika/traces/*.ndjson               (the receipt)
+
+  Hard rules:
+  - NEVER claim you ran the workflow — the oracle is read-only by design;
+    the terminal output is the receipt, not your prose
+  - Local-first defaults (ollama/llama3.2:3b class); cloud providers only
+    if the user names one
+  - Keep workflows non-interactive: inputs declared up front, no mid-run
+    questions — that's the contract that makes them repeatable
+
+extensions:
+  - type: stdio
+    name: nika
+    display_name: Nika Oracle
+    cmd: nika
+    args:
+      - mcp
+    timeout: 300
+    bundled: false
+    description: Read-only workflow oracle — validate .nika.yaml files, explain typed findings, serve the embedded schema/examples/templates
+    env_keys: []
+    envs: {}
+
+prompt: |
+  Help me capture a repeated AI job as a checked .nika.yaml workflow.
+  Ask me what I keep redoing, author the smallest correct DAG for it,
+  validate it with the Nika oracle, explain any findings, and give me
+  the exact commands to run it with receipts.

--- a/documentation/src/pages/recipes/data/recipes/author-verify-nika-workflow.yaml
+++ b/documentation/src/pages/recipes/data/recipes/author-verify-nika-workflow.yaml
@@ -1,6 +1,6 @@
 version: 1.0.0
 title: Author & Verify a Nika Workflow
-description: Author a repeatable AI job as a .nika.yaml workflow file, validate it with the Nika oracle before any token is spent, and learn to read the findings. Uses the read-only nika MCP server (validate/explain only — running stays an explicit CLI act).
+description: Author a repeatable AI job as a .nika.yaml workflow file, validate it with the Nika oracle before any token is spent, and learn to read the findings. Uses the read-only nika MCP server (validate and explain only; running stays an explicit CLI act).
 author:
   contact: ThibautMelen
 
@@ -9,35 +9,35 @@ activities:
 
 instructions: |
   You are helping the user capture a repeatable AI job (a daily digest, a
-  triage pass, a report pipeline) as a Nika workflow file — one plain-text
-  `.nika.yaml` DAG — and verify it BEFORE anything runs.
+  triage pass, a report pipeline) as a Nika workflow file, one plain-text
+  `.nika.yaml` DAG, and verify it BEFORE anything runs.
 
   Prerequisite (tell the user if the MCP tools are unavailable): the nika
-  binary must be installed — `brew install supernovae-st/tap/nika` (or a
+  binary must be installed with `brew install supernovae-st/tap/nika` (or a
   release tarball from https://github.com/supernovae-st/nika/releases).
   The `nika` extension below launches its read-only MCP oracle.
 
   Key responsibilities:
   - Ask what job they repeat, what inputs it needs, what output they want
-  - Use the oracle's schema/examples/templates tools to ground the syntax —
+  - Use the oracle's schema/examples/templates tools to ground the syntax;
     never invent fields (the language is small on purpose: 4 verbs)
   - Author the smallest correct DAG (fetch → transform → infer → save is
     the usual shape) with `model: ollama/...` local-first by default
   - Validate with the oracle's check tool; if findings come back, use the
     explain tool on each typed code (NIKA-...) and fix the file
-  - When check is clean, hand them the run commands — running is explicit
+  - When check is clean, hand them the run commands. Running is explicit
     and CLI-side, never done by you:
       nika run their-workflow.nika.yaml
       nika run their-workflow.nika.yaml --model mock/echo   (offline dry run)
       nika trace verify .nika/traces/*.ndjson               (the receipt)
 
   Hard rules:
-  - NEVER claim you ran the workflow — the oracle is read-only by design;
+  - NEVER claim you ran the workflow. The oracle is read-only by design;
     the terminal output is the receipt, not your prose
   - Local-first defaults (ollama/llama3.2:3b class); cloud providers only
     if the user names one
   - Keep workflows non-interactive: inputs declared up front, no mid-run
-    questions — that's the contract that makes them repeatable
+    questions. That's the contract that makes them repeatable
 
 extensions:
   - type: stdio
@@ -48,7 +48,7 @@ extensions:
       - mcp
     timeout: 300
     bundled: false
-    description: Read-only workflow oracle — validate .nika.yaml files, explain typed findings, serve the embedded schema/examples/templates
+    description: Read-only workflow oracle. Validates .nika.yaml files, explains typed findings, serves the embedded schema/examples/templates
     env_keys: []
     envs: {}
 


### PR DESCRIPTION
Adds a recipe to the gallery: capture a repeated AI job as a `.nika.yaml` workflow file and validate it with the [nika](https://github.com/supernovae-st/nika) read-only MCP oracle **before any token is spent** — then run it CLI-side with a hash-chained trace.

Follows the house shape (neighbor recipes as template): `stdio` extension launching `nika mcp` (validate/explain/schema/examples only — nothing that mutates or executes), instructions teach the oracle-grounded authoring loop, local-first defaults. Prerequisite (binary install via brew/tarball) is stated in the instructions per the manual-setup pattern from #10369's review.

Complements the pending servers.json listing (#10369) — that one lists the server, this one shows a worked flow using it.

Full disclosure: I'm nika's author. Recipe YAML validated; commit GitHub-signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)