### PR TITLE
docs(extensions): add Nora MCP server to the registry

### DIFF
--- a/documentation/docs/mcp/nora-mcp.md
+++ b/documentation/docs/mcp/nora-mcp.md
@@ -1,0 +1,108 @@
+---
+title: Nora Extension
+description: Add the Nora MCP Server as a goose Extension
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+
+This tutorial covers how to add the [Nora MCP Server](https://github.com/solomon2773/nora/tree/master/mcp-server) as a goose extension to inspect and operate a self-hosted Nora agent fleet.
+
+:::tip Quick Install
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+    [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40noraai%2Fmcp-server&id=nora&name=Nora&description=Operate%20a%20self-hosted%20Nora%20agent%20fleet%20from%20goose.&env=NORA_API_URL%3Dhttps%3A%2F%2Fnora.example.com&env=NORA_API_KEY%3Dnora_xxxxxxxx&env=NORA_MCP_ALLOW_DESTRUCTIVE%3Dfalse)
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    **Command**
+    ```sh
+    npx -y @noraai/mcp-server
+    ```
+  </TabItem>
+</Tabs>
+
+**Environment variables**
+
+```
+NORA_API_URL=https://nora.example.com
+NORA_API_KEY=nora_xxxxxxxx
+NORA_MCP_ALLOW_DESTRUCTIVE=false
+```
+
+:::
+
+## Configuration
+
+:::info
+You'll need [Node.js 20 or later](https://nodejs.org/) to run the server with `npx`. Create a workspace API key in Nora under **Workspace → API Keys**. See the [Nora MCP guide](https://noradocs.solomontsao.com/guides/mcp-server) for required scopes and configuration details.
+:::
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+    <GooseDesktopInstaller
+      extensionId="nora"
+      extensionName="Nora"
+      description="Operate a self-hosted Nora agent fleet from goose."
+      type="stdio"
+      command="npx"
+      args={["-y", "@noraai/mcp-server"]}
+      envVars={[
+        { name: "NORA_API_URL", label: "https://nora.example.com" },
+        { name: "NORA_API_KEY", label: "nora_xxxxxxxx" },
+        { name: "NORA_MCP_ALLOW_DESTRUCTIVE", label: "false" }
+      ]}
+      apiKeyLink="https://noradocs.solomontsao.com/guides/mcp-server"
+      apiKeyLinkText="Nora API credentials"
+    />
+  </TabItem>
+
+  <TabItem value="cli" label="goose CLI">
+    <CLIExtensionInstructions
+      name="Nora"
+      description="Operate a self-hosted Nora agent fleet from goose."
+      type="stdio"
+      command="npx -y @noraai/mcp-server"
+      timeout={300}
+      envVars={[
+        { key: "NORA_API_URL", value: "https://nora.example.com" },
+        { key: "NORA_API_KEY", value: "nora_xxxxxxxx" },
+        { key: "NORA_MCP_ALLOW_DESTRUCTIVE", value: "false" }
+      ]}
+      infoNote={
+        <>
+          Enter the URL of your Nora deployment and a workspace API key. Keep <code>NORA_MCP_ALLOW_DESTRUCTIVE</code> set to <code>false</code> unless you explicitly want to register tools such as <code>delete_agent</code>. See the <a href="https://noradocs.solomontsao.com/guides/mcp-server" target="_blank" rel="noopener noreferrer">Nora MCP guide</a> for details.
+        </>
+      }
+    />
+  </TabItem>
+</Tabs>
+
+## Example Usage
+
+After configuration, ask goose for a read-only fleet summary:
+
+### goose Prompt
+
+```
+Show me the current Nora fleet status and list any agents that are not running.
+```
+
+### goose Output
+
+:::note Desktop
+
+goose calls Nora's `get_fleet_status` and `list_agents` tools, then summarizes the live response from your control plane. Agent names, states, and counts depend on your Nora deployment.
+
+:::
+
+## Safety
+
+The server exposes read tools for fleet status, metrics, monitoring events, and cost data. Lifecycle tools require an API key with `agents:write`. The `delete_agent` tool is registered only when `NORA_MCP_ALLOW_DESTRUCTIVE=true`.
+
+## Resources
+
+- [Nora repository](https://github.com/solomon2773/nora)
+- [Nora MCP guide](https://noradocs.solomontsao.com/guides/mcp-server)
+- [`@noraai/mcp-server` on npm](https://www.npmjs.com/package/@noraai/mcp-server)

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -540,6 +540,33 @@
     ]
   },
   {
+    "id": "nora",
+    "name": "Nora",
+    "description": "Operate a self-hosted AI agent fleet from goose",
+    "command": "npx -y @noraai/mcp-server",
+    "link": "https://github.com/solomon2773/nora",
+    "installation_notes": "Install using npx. Requires a Nora backend URL and workspace API key. Destructive tools are disabled by default.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [
+      {
+        "name": "NORA_API_URL",
+        "description": "Base URL of your Nora backend API",
+        "required": true
+      },
+      {
+        "name": "NORA_API_KEY",
+        "description": "Nora workspace API key",
+        "required": true
+      },
+      {
+        "name": "NORA_MCP_ALLOW_DESTRUCTIVE",
+        "description": "Set to true to register destructive tools such as delete_agent",
+        "required": false
+      }
+    ]
+  },
+  {
     "id": "nostrbook-mcp",
     "name": "NostrBook",
     "description": "Nostr protocol integration for decentralized social",


### PR DESCRIPTION
## Summary

Adds [Nora](https://github.com/solomon2773/nora) to the goose extensions registry and includes a focused setup tutorial for its published stdio MCP package, [`@noraai/mcp-server`](https://www.npmjs.com/package/@noraai/mcp-server).

The entry documents the required Nora backend URL and workspace API key, keeps destructive tools disabled by default, and provides matching Desktop and CLI configuration.

## Testing

- Parsed `documentation/static/servers.json` and verified one unique `nora` entry
- Verified the registry command and environment variables match the tutorial
- Verified the static quick-install deeplink matches `GooseDesktopInstaller` output
- Confirmed `@noraai/mcp-server@0.1.3` is the npm `latest` version with SLSA provenance
- Completed a clean public-package MCP initialize/list-tools handshake through `npx -y @noraai/mcp-server@0.1.3` from an empty directory and fresh npm cache (server 0.1.3, 15 safe tools)
- Verified the corrected package was published by Nora workflow run 29171838525 and listed by MCP Registry run 29171914329
- Ran `npm run build` in `documentation/` successfully
- Ran `git diff --check`

Source: https://github.com/solomon2773/nora/tree/master/mcp-server
Package: https://www.npmjs.com/package/@noraai/mcp-server