### PR TITLE
Add Tap extension — authenticated browser MCP

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -774,6 +774,17 @@
     ]
   },
   {
+    "id": "tap",
+    "name": "Tap",
+    "description": "Authenticated browser MCP that drives your own logged-in Chrome so credentials stay local; compiles a task into a deterministic .plan.json program replayed at zero LLM tokens",
+    "command": "npx -y @taprun/cli mcp start",
+    "link": "https://github.com/LeonTing1010/tap",
+    "installation_notes": "Install using npx package manager. No API key required; authentication uses your own logged-in Chrome session.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": []
+  },
+  {
     "id": "tavily",
     "name": "Tavily Web Search",
     "description": "Web search capabilities powered by Tavily",


### PR DESCRIPTION
## Summary

Adds **Tap** to the extensions directory (`documentation/static/servers.json`), rendered at block.github.io/goose/extensions/.

Tap is an authenticated browser MCP that drives your own logged-in Chrome so credentials stay local; it compiles a task into a deterministic `.plan.json` program that is replayed at zero LLM tokens. Because it reuses your existing Chrome session, there is no API key and no cloud credential handoff — the own-Chrome/zero-token replay is the differentiator versus cloud browser-automation servers.

Command (stdio / command extension):

```
npx -y @taprun/cli mcp start
```

- Website: https://taprun.dev
- Repo / link: https://github.com/LeonTing1010/tap

The entry matches the exact schema of existing command-line (stdio) extensions in `servers.json` (`id`, `name`, `description`, `command` as a single string, `link`, `installation_notes`, `is_builtin: false`, `endorsed: false`, empty `environmentVariables`). No `type` field is set, consistent with other local/stdio entries (only `streamable-http` remote entries carry `type`). Inserted alphabetically before `tavily`.

### Testing

Validated that the modified `servers.json` parses as valid JSON (62 entries), confirmed no pre-existing `tap`/`taprun` entry, and verified the diff adds only the single new entry (+11 lines, 0 deletions) leaving the rest of the file byte-for-byte unchanged.

### Related Issues

N/A — new community extension submission.

### Screenshots/Demos (for UX changes)

N/A — data-only addition to the extensions directory.
