### PR TITLE
Add Unstructured Transform extension (remote MCP over streamable HTTP)

### DIFF
--- a/documentation/docs/mcp/unstructured-transform-mcp.md
+++ b/documentation/docs/mcp/unstructured-transform-mcp.md
@@ -36,6 +36,8 @@ An OAuth window will open in your browser when goose first connects to the exten
 
 The extension provides the tools goose drives end to end for a parse: `request_file_upload_url`, `start_transform_job`, `check_job_status`, and `get_job_results`. Uploads and result downloads use pre-signed URLs, which goose handles with its built-in shell tools.
 
+It also provides two tools for structured data extraction, which returns named fields as JSON rather than converting a whole document: `suggest_extraction_schema_for_file` drafts a schema from a parsed document, and `start_extraction_job` runs the extraction against a schema. Both reuse `check_job_status` and `get_job_results`.
+
 ## Configuration
 
 <Tabs groupId="interface">
@@ -95,7 +97,21 @@ goose requests a pre-signed upload URL, uploads the file with its shell tools, s
 
 The upload and download URLs are pre-signed and reject requests that carry an `Authorization` header, which is why the example prompt calls it out.
 
-Parsing requests have the following limits, which the server also reports back to goose through its tool responses:
+### Extracting Structured Data
+
+To pull named fields out of a document instead of converting the whole thing, ask goose for an extraction:
+
+```
+Use the unstructured-transform tools to extract the vendor, invoice number, line items, and total from ./invoice.pdf as JSON. Suggest a schema first and show it to me before running the extraction.
+```
+
+Extraction runs on the element JSON that a parse produces, not on the raw file, so goose parses the document first and then extracts from the `output_ref` that `get_job_results` returns for it. That means two jobs run back to back, so an extraction takes longer than a parse alone. If you have no schema, goose can draft one with `suggest_extraction_schema_for_file` and show it to you before extracting; if you describe the fields you want, it can write the schema itself.
+
+Results come back inline rather than behind a download URL, one object per file, wrapped with the source filename, file type, timestamp, and the element JSON reference they were taken from. Keep that wrapper if you save the results, since it is what ties each record back to its document.
+
+Extraction can only surface what the parse captured, so if a result comes back sparse or empty the parse is usually the cause rather than the schema. Ask goose to re-parse the file at higher fidelity and extract again. For prompt patterns, see [Structured data extraction](https://docs.unstructured.io/transform/sde).
+
+Parsing and extraction requests have the following limits, which the server also reports back to goose through its tool responses:
 
 - Each file must be 50 MB or less in size.
 - Each request must have 10 files or fewer.

--- a/documentation/docs/mcp/unstructured-transform-mcp.md
+++ b/documentation/docs/mcp/unstructured-transform-mcp.md
@@ -32,7 +32,7 @@ An OAuth window will open in your browser when goose first connects to the exten
 
 ## What is Unstructured Transform?
 
-[Unstructured Transform](https://unstructured.io) is a hosted service that parses documents into structured output ready for LLMs, RAG pipelines, and agents. It partitions files into typed elements, then optionally enriches, chunks, and embeds them. The Transform MCP server is fully remote, so there is nothing to install or run locally.
+[Unstructured Transform](https://unstructured.io) is a hosted service that turns raw documents into agent-ready data: clean, structured output that agents, LLMs, and RAG pipelines can act on directly instead of wrestling with file formats. It partitions files into typed elements, then optionally enriches, chunks, and embeds them, so the output arrives ready for retrieval and reasoning. The Transform MCP server is fully remote, so there is nothing to install or run locally.
 
 The extension provides four tools that goose drives end to end: `request_file_upload_url`, `transform_files`, `check_transform_status`, and `get_transform_results`. Uploads and result downloads use pre-signed URLs, which goose handles with its built-in shell tools.
 

--- a/documentation/docs/mcp/unstructured-transform-mcp.md
+++ b/documentation/docs/mcp/unstructured-transform-mcp.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
 import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 
-This tutorial covers how to add [Unstructured Transform](https://unstructured.io) as a goose extension to turn documents (PDF, DOCX, PPTX, XLSX, HTML, EML, images, and roughly 70 other formats) into clean, structured, LLM-ready output such as Markdown, Element JSON, HTML, or plain text.
+This tutorial covers how to add [Unstructured Transform](https://unstructured.io) as a goose extension to turn documents (PDF, DOCX, PPTX, XLSX, HTML, EML, images, and roughly 70 other formats) into clean, structured, LLM-ready output such as Markdown, Element JSON, HTML, or plain text. You will need goose [installed](/docs/getting-started/installation) with a model provider configured.
 
 :::tip Quick Install
 <Tabs groupId="interface">
@@ -27,7 +27,7 @@ This tutorial covers how to add [Unstructured Transform](https://unstructured.io
 :::
 
 :::info OAUTH FLOW
-An OAuth window will open in your browser the first time you use the Transform tools. Follow the prompts to sign in to Unstructured. To authenticate with an API key instead (for example, for headless or CI use), see [Authentication](#authentication) below.
+An OAuth window will open in your browser when goose first connects to the extension (at the start of your next session or chat). Follow the prompts to sign in to Unstructured. Quick Install and the deeplink use OAuth only; to authenticate with an API key instead (for example, for headless or CI use), skip Quick Install and see [Authentication](#authentication) below.
 :::
 
 ## What is Unstructured Transform?
@@ -55,7 +55,7 @@ The extension provides four tools that goose drives end to end: `request_file_up
       type="http"
       url="https://mcp.transform.unstructured.io"
       timeout={300}
-      infoNote="OAuth authentication will happen automatically in your browser when you first use the Transform tools"
+      commandNote="OAuth authentication happens automatically in your browser when goose first connects to the extension"
     />
   </TabItem>
 </Tabs>
@@ -64,7 +64,7 @@ The extension provides four tools that goose drives end to end: `request_file_up
 
 Unstructured Transform supports two authentication methods:
 
-- **OAuth (default)**: With no additional configuration, a browser window opens the first time you use the Transform tools. Sign in to Unstructured and goose stores and refreshes the tokens for you.
+- **OAuth (default)**: With no additional configuration, a browser window opens when goose first connects to the extension. Sign in to Unstructured and goose stores and refreshes the tokens for you.
 - **API key**: For headless or CI use, send an Unstructured API key as a bearer token instead. [Get an API key](https://transform.unstructured.io/get-started), then add a request header to the extension. In `~/.config/goose/config.yaml`:
 
   ```yaml
@@ -76,20 +76,24 @@ Unstructured Transform supports two authentication methods:
       uri: https://mcp.transform.unstructured.io
       headers:
         Authorization: Bearer ${UNSTRUCTURED_API_KEY}
+      env_keys:
+        - UNSTRUCTURED_API_KEY
       timeout: 300
   ```
 
-  The `${UNSTRUCTURED_API_KEY}` reference is substituted from the environment at connection time, so the key stays out of the config file. Export the variable in any shell that runs goose.
+  The `env_keys` entry is required: goose substitutes `${UNSTRUCTURED_API_KEY}` only from keys it resolves through `env_keys`, which reads the `UNSTRUCTURED_API_KEY` environment variable (falling back to a secret stored in goose's keyring). Export the variable in the shell that runs goose, or put the literal key in the header value instead.
 
 ## Example Usage
 
 Ask goose to transform a local document:
 
 ```
-Use the unstructured-transform tools to transform ./quarterly-report.pdf into markdown and give me the element count and a preview of the output.
+Use the unstructured-transform tools to transform ./quarterly-report.pdf into markdown. Upload the file bytes yourself with a plain HTTP PUT to the pre-signed upload URL, without an Authorization header on that request. Then give me the element count and a preview of the output.
 ```
 
-goose requests a pre-signed upload URL, uploads the file with its shell tools, starts the transform job, polls until the job completes, and downloads the finished Markdown. Transforms take from about 10 seconds to several minutes, depending on page count.
+goose requests a pre-signed upload URL, uploads the file with its shell tools, starts the transform job, polls until the job completes, and downloads the finished Markdown. goose shows the result inline by default; ask it to save the output to a file if you want it on disk. Transforms take from about 10 seconds to several minutes, depending on page count.
+
+The upload and download URLs are pre-signed and reject requests that carry an `Authorization` header, which is why the example prompt calls it out.
 
 Parsing requests have the following limits, which the server also reports back to goose through its tool responses:
 

--- a/documentation/docs/mcp/unstructured-transform-mcp.md
+++ b/documentation/docs/mcp/unstructured-transform-mcp.md
@@ -34,7 +34,7 @@ An OAuth window will open in your browser when goose first connects to the exten
 
 [Unstructured Transform](https://unstructured.io) is a hosted service that turns raw documents into agent-ready data: clean, structured output that agents, LLMs, and RAG pipelines can act on directly instead of wrestling with file formats. It partitions files into typed elements, then optionally enriches, chunks, and embeds them, so the output arrives ready for retrieval and reasoning. The Transform MCP server is fully remote, so there is nothing to install or run locally.
 
-The extension provides four tools that goose drives end to end: `request_file_upload_url`, `transform_files`, `check_transform_status`, and `get_transform_results`. Uploads and result downloads use pre-signed URLs, which goose handles with its built-in shell tools.
+The extension provides the tools goose drives end to end for a parse: `request_file_upload_url`, `start_transform_job`, `check_job_status`, and `get_job_results`. Uploads and result downloads use pre-signed URLs, which goose handles with its built-in shell tools.
 
 ## Configuration
 

--- a/documentation/docs/mcp/unstructured-transform-mcp.md
+++ b/documentation/docs/mcp/unstructured-transform-mcp.md
@@ -64,7 +64,7 @@ The extension provides four tools that goose drives end to end: `request_file_up
 
 Unstructured Transform supports two authentication methods:
 
-- **OAuth (default)**: With no additional configuration, a browser window opens when goose first connects to the extension. Sign in to Unstructured and goose stores and refreshes the tokens for you.
+- **OAuth (default)**: With no additional configuration, a browser window opens when goose first connects to the extension. Sign in to Unstructured once; goose stores the tokens in your system keychain and refreshes them automatically, so later sessions connect without the browser.
 - **API key**: For headless or CI use, send an Unstructured API key as a bearer token instead. [Get an API key](https://transform.unstructured.io/get-started), then add a request header to the extension. In `~/.config/goose/config.yaml`:
 
   ```yaml

--- a/documentation/docs/mcp/unstructured-transform-mcp.md
+++ b/documentation/docs/mcp/unstructured-transform-mcp.md
@@ -1,0 +1,98 @@
+---
+title: Unstructured Transform Extension
+description: Add Unstructured Transform as a goose Extension to turn documents into clean, LLM-ready Markdown
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+
+This tutorial covers how to add [Unstructured Transform](https://unstructured.io) as a goose extension to turn documents (PDF, DOCX, PPTX, XLSX, HTML, EML, images, and roughly 70 other formats) into clean, structured, LLM-ready output such as Markdown, Element JSON, HTML, or plain text.
+
+:::tip Quick Install
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+    [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Fmcp.transform.unstructured.io&id=unstructured-transform&name=Unstructured%20Transform&description=Turn%20documents%20into%20clean%2C%20structured%2C%20LLM-ready%20Markdown%2C%20JSON%2C%20HTML%2C%20or%20text&timeout=300)
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    Use `goose configure` to add a `Remote Extension (Streamable HTTP)` extension type with:
+
+    **Endpoint URL**
+    ```
+    https://mcp.transform.unstructured.io
+    ```
+  </TabItem>
+</Tabs>
+:::
+
+:::info OAUTH FLOW
+An OAuth window will open in your browser the first time you use the Transform tools. Follow the prompts to sign in to Unstructured. To authenticate with an API key instead (for example, for headless or CI use), see [Authentication](#authentication) below.
+:::
+
+## What is Unstructured Transform?
+
+[Unstructured Transform](https://unstructured.io) is a hosted service that parses documents into structured output ready for LLMs, RAG pipelines, and agents. It partitions files into typed elements, then optionally enriches, chunks, and embeds them. The Transform MCP server is fully remote, so there is nothing to install or run locally.
+
+The extension provides four tools that goose drives end to end: `request_file_upload_url`, `transform_files`, `check_transform_status`, and `get_transform_results`. Uploads and result downloads use pre-signed URLs, which goose handles with its built-in shell tools.
+
+## Configuration
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+    <GooseDesktopInstaller
+      extensionId="unstructured-transform"
+      extensionName="Unstructured Transform"
+      description="Turn documents into clean, structured, LLM-ready Markdown, JSON, HTML, or text"
+      type="http"
+      url="https://mcp.transform.unstructured.io"
+    />
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    <CLIExtensionInstructions
+      name="unstructured-transform"
+      description="Turn documents into clean, structured, LLM-ready Markdown, JSON, HTML, or text"
+      type="http"
+      url="https://mcp.transform.unstructured.io"
+      timeout={300}
+      infoNote="OAuth authentication will happen automatically in your browser when you first use the Transform tools"
+    />
+  </TabItem>
+</Tabs>
+
+## Authentication
+
+Unstructured Transform supports two authentication methods:
+
+- **OAuth (default)**: With no additional configuration, a browser window opens the first time you use the Transform tools. Sign in to Unstructured and goose stores and refreshes the tokens for you.
+- **API key**: For headless or CI use, send an Unstructured API key as a bearer token instead. [Get an API key](https://transform.unstructured.io/get-started), then add a request header to the extension. In `~/.config/goose/config.yaml`:
+
+  ```yaml
+  extensions:
+    unstructured-transform:
+      enabled: true
+      type: streamable_http
+      name: unstructured-transform
+      uri: https://mcp.transform.unstructured.io
+      headers:
+        Authorization: Bearer ${UNSTRUCTURED_API_KEY}
+      timeout: 300
+  ```
+
+  The `${UNSTRUCTURED_API_KEY}` reference is substituted from the environment at connection time, so the key stays out of the config file. Export the variable in any shell that runs goose.
+
+## Example Usage
+
+Ask goose to transform a local document:
+
+```
+Use the unstructured-transform tools to transform ./quarterly-report.pdf into markdown and give me the element count and a preview of the output.
+```
+
+goose requests a pre-signed upload URL, uploads the file with its shell tools, starts the transform job, polls until the job completes, and downloads the finished Markdown. Transforms take from about 10 seconds to several minutes, depending on page count.
+
+Parsing requests have the following limits, which the server also reports back to goose through its tool responses:
+
+- Each file must be 50 MB or less in size.
+- Each request must have 10 files or fewer.
+- Only 5 requests can be running at a time.

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -880,5 +880,24 @@
     }
   ]
 }
-
+,
+  {
+  "id": "unstructured-transform",
+  "name": "Unstructured Transform",
+  "description": "Turn documents into clean, structured, LLM-ready Markdown, JSON, HTML, or text",
+  "url": "https://mcp.transform.unstructured.io",
+  "type": "streamable-http",
+  "link": "https://unstructured.io",
+  "installation_notes": "This is a remote extension. Authentication happens through an OAuth browser window on first use. Alternatively, send an Unstructured API key from https://transform.unstructured.io/get-started as a request header, e.g. Authorization: Bearer <YOUR_UNSTRUCTURED_API_KEY>, which suits headless or CI use.",
+  "is_builtin": false,
+  "endorsed": false,
+  "environmentVariables": [],
+  "headers": [
+    {
+      "name": "Authorization",
+      "description": "Optional: Bearer <YOUR_UNSTRUCTURED_API_KEY>. Omit to authenticate through the OAuth browser flow instead.",
+      "required": false
+    }
+  ]
+  }
 ]

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -879,8 +879,7 @@
       "required": false
     }
   ]
-}
-,
+},
   {
   "id": "unstructured-transform",
   "name": "Unstructured Transform",
@@ -888,7 +887,7 @@
   "url": "https://mcp.transform.unstructured.io",
   "type": "streamable-http",
   "link": "https://unstructured.io",
-  "installation_notes": "This is a remote extension. Authentication happens through an OAuth browser window on first use. Alternatively, send an Unstructured API key from https://transform.unstructured.io/get-started as a request header, e.g. Authorization: Bearer <YOUR_UNSTRUCTURED_API_KEY>, which suits headless or CI use.",
+  "installation_notes": "This is a remote extension. Authentication happens through an OAuth browser window when goose first connects. Alternatively, send an Unstructured API key from https://transform.unstructured.io/get-started as a request header, e.g. Authorization: Bearer <YOUR_UNSTRUCTURED_API_KEY>, which suits headless or CI use.",
   "is_builtin": false,
   "endorsed": false,
   "environmentVariables": [],


### PR DESCRIPTION
## Summary

Adds Unstructured Transform, a hosted document parsing service, to the extensions directory as a remote streamable HTTP extension, along with a tutorial page.

- `documentation/static/servers.json`: new `unstructured-transform` entry (remote, `https://mcp.transform.unstructured.io`). Same shape as the other remote entries with an optional Authorization header, since the server supports both OAuth and API key bearer auth.
- `documentation/docs/mcp/unstructured-transform-mcp.md`: tutorial page modeled on the other remote extension pages (rube-mcp), with Quick Install deeplink, Desktop and CLI configuration, both auth methods, and an example prompt.

I work at Unstructured; the endpoint is our production server. It serves MCP at the root URL with no path, which is why the entry has no `/mcp` suffix.

### Testing

- `docusaurus build` passes with the new page; the tutorial link resolves from the directory detail view (`unstructured-transform` maps to `unstructured-transform-mcp`).
- Connection and tool discovery verified against the production server with goose CLI 1.41.0 for both auth methods. OAuth: one-time browser sign-in on first connect, silent reconnects afterward on cached tokens. API key: bearer header with `env_keys`, confirmed via logs that no OAuth fallback was involved.
- Full end-to-end run through goose: a six-file batch (PDF, DOCX, HTML, Markdown, CSV, EML) in a single `transform_files` call, pre-signed uploads and downloads handled by goose's shell tools, job completed in about 20 seconds with correct per-format output.
- The config example includes `env_keys` because header `${VAR}` substitution resolves only through the extension's env map, not the process environment. Verified against the v1.41.0 source and confirmed with a negative test.

### Related Issues

None.