### PR TITLE
fix(ui): restore pnpm 11 project configuration

### DIFF
--- a/ui/.npmrc
+++ b/ui/.npmrc
@@ -1,5 +1,0 @@
-registry=https://registry.npmjs.org/
-prefer-offline=true
-node-linker=hoisted
-supportedArchitectures.os=current,linux,darwin,win32
-supportedArchitectures.cpu=current,x64,arm64

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,17 +13,5 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1"
-  },
-  "pnpm": {
-    "overrides": {
-      "react": "^19.2.4",
-      "react-dom": "^19.2.4"
-    },
-    "onlyBuiltDependencies": [
-      "@modelcontextprotocol/ext-apps",
-      "electron",
-      "electron-winstaller",
-      "esbuild"
-    ]
   }
 }

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -812,7 +812,7 @@ packages:
     engines: {node: '>=14'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -3,3 +3,20 @@ packages:
   - 'text'
   - 'desktop'
   - 'goose-binary/*'
+
+registry: https://registry.npmjs.org/
+preferOffline: true
+nodeLinker: hoisted
+supportedArchitectures:
+  os: [current, linux, darwin, win32]
+  cpu: [current, x64, arm64]
+overrides:
+  react: ^19.2.4
+  react-dom: ^19.2.4
+allowBuilds:
+  '@modelcontextprotocol/ext-apps': true
+  electron: true
+  electron-winstaller: true
+  esbuild: true
+# Electron Forge resolves @electron/node-gyp from git.
+blockExoticSubdeps: false


### PR DESCRIPTION
## Summary

- move UI project settings to `pnpm-workspace.yaml`, where pnpm 11 reads them
- replace `onlyBuiltDependencies` with `allowBuilds` and permit Electron Forge's pinned git subdependency
- refresh the pnpm 11 lock metadata for that dependency

### Testing

- `pnpm install --lockfile-only --frozen-lockfile` with pnpm 11.11.0
- `corepack pnpm@10.30.3 install --lockfile-only --frozen-lockfile`
- `pnpm config list --location project` from `ui/desktop`
- `pnpm dlx prettier@3.8.1 --check ui/package.json`
- `git diff --check`

A full pnpm 11 install cleared the reported configuration errors and reached package linking, but this container ran out of disk while extracting platform binaries.

### Related Issues

Fixes #10382

### Screenshots/Demos

Not applicable.