### PR TITLE
chore: remove unavailable models from cerebras catalog

### DIFF
--- a/crates/goose-providers/src/declarative/definitions/cerebras.json
+++ b/crates/goose-providers/src/declarative/definitions/cerebras.json
@@ -7,15 +7,7 @@
   "base_url": "https://api.cerebras.ai/v1/chat/completions",
   "models": [
     {
-      "name": "llama3.1-8b",
-      "context_limit": 131072
-    },
-    {
       "name": "gpt-oss-120b",
-      "context_limit": 131072
-    },
-    {
-      "name": "qwen-3-235b-a22b-instruct-2507",
       "context_limit": 131072
     },
     {


### PR DESCRIPTION
Removes llama3.1-8b and qwen-3-235b-a22b-instruct-2507 from Cerebras definitions as they are no longer available on the platform.

Addresses one part of #10406 

<img width="1119" height="248" alt="Screenshot 2026-07-12 at 8 09 35 PM" src="https://github.com/user-attachments/assets/2394f4b3-9fca-46d7-9683-20555b925bb9" />
