### PR TITLE
feat(providers): add DaoXE multi-model gateway provider

### DIFF
--- a/crates/goose-providers/src/declarative.rs
+++ b/crates/goose-providers/src/declarative.rs
@@ -17,6 +17,7 @@ pub(crate) mod declarative_providers {
         alibaba,
         atomic_chat,
         cerebras,
+        daoxe,
         deepseek,
         empiriolabs,
         fireworks,

--- a/crates/goose-providers/src/declarative/definitions/daoxe.json
+++ b/crates/goose-providers/src/declarative/definitions/daoxe.json
@@ -1,0 +1,41 @@
+{
+  "name": "daoxe",
+  "engine": "openai",
+  "display_name": "DaoXE",
+  "description": "Multi-model multi-protocol API gateway (OpenAI Chat Completions / Responses and Anthropic Messages). Live model catalog is account-scoped; not available in mainland China.",
+  "api_key_env": "DAOXE_API_KEY",
+  "base_url": "https://daoxe.com/v1",
+  "dynamic_models": true,
+  "skip_canonical_filtering": true,
+  "models": [
+    {
+      "name": "gpt-5.5",
+      "context_limit": 400000
+    },
+    {
+      "name": "claude-sonnet-4-6",
+      "context_limit": 200000
+    },
+    {
+      "name": "gemini-3.1-pro-preview",
+      "context_limit": 1048576
+    },
+    {
+      "name": "grok-4.5",
+      "context_limit": 256000
+    },
+    {
+      "name": "kimi-k2.5",
+      "context_limit": 262144
+    }
+  ],
+  "supports_streaming": true,
+  "preserves_thinking": true,
+  "model_doc_link": "https://daoxe.com/pricing",
+  "setup_steps": [
+    "Sign in at https://daoxe.com (not available in mainland China)",
+    "Create an API key in the dashboard",
+    "Paste the key above as DAOXE_API_KEY",
+    "Prefer model IDs from your live DaoXE catalog / GET /v1/models over any seed list"
+  ]
+}

--- a/crates/goose-providers/src/declarative/definitions/daoxe.json
+++ b/crates/goose-providers/src/declarative/definitions/daoxe.json
@@ -10,7 +10,7 @@
   "models": [
     {
       "name": "gpt-5.5",
-      "context_limit": 400000
+      "context_limit": 1050000
     },
     {
       "name": "claude-sonnet-4-6",


### PR DESCRIPTION
## Summary

Add **DaoXE** as a bundled declarative OpenAI-compatible provider in goose.

- Base URL: `https://daoxe.com/v1`
- Auth env: `DAOXE_API_KEY`
- `dynamic_models: true` + `skip_canonical_filtering: true` so goose prefers live `GET /v1/models` over any seed list
- Seed model IDs are fallbacks only (aligned with public models.dev entry), not a price/catalog lock-in
- Setup steps note mainland China unavailability

DaoXE is a multi-model multi-protocol API gateway (OpenAI Chat Completions / Responses and Anthropic Messages). This PR wires the OpenAI-compatible engine path used by other gateway-style providers (e.g. OrcaRouter / Routstr / Vercel AI Gateway).

## Files

- `crates/goose-providers/src/declarative/definitions/daoxe.json` (new)
- `crates/goose-providers/src/declarative.rs` (register `daoxe` in `expose_declarative_providers!`)

## Disclosure

I am affiliated with DaoXE. DaoXE is **not available in mainland China**.

## Test plan

- [ ] `cargo test -p goose-providers expose_declarative_providers_enumerates_all_bundled_json_files`
- [ ] `cargo test -p goose-providers all_bundled_providers_are_valid`
- [ ] UI/CLI shows **DaoXE** in provider list
- [ ] With `DAOXE_API_KEY`, model list loads from live catalog (or falls back to seed IDs)