### PR TITLE
feat(providers): Add Cerebras Reasoning Support

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -944,12 +944,16 @@ pub async fn configure_provider_dialog() -> anyhow::Result<bool> {
     };
 
     {
-        let supports_thinking = match temp_provider.fetch_model_info(&model).await {
-            Ok(model_info) => model_info.reasoning,
-            Err(_) => goose_providers::base::Reasoning::Enabled(
-                goose_providers::model::ModelConfig::new(&model).is_reasoning_model(),
-            ),
-        };
+        let supports_thinking = temp_provider
+            .fetch_model_info(&model)
+            .await
+            .ok()
+            .and_then(|info| info.reasoning)
+            .unwrap_or_else(|| {
+                goose_providers::base::Reasoning::Enabled(
+                    goose_providers::model::ModelConfig::new(&model).is_reasoning_model(),
+                )
+            });
 
         if supports_thinking.is_enabled() {
             let effort: ThinkingEffort = cliclack::select("Select thinking effort:")

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -946,7 +946,9 @@ pub async fn configure_provider_dialog() -> anyhow::Result<bool> {
     {
         let supports_thinking = match temp_provider.fetch_model_info(&model).await {
             Ok(model_info) => model_info.reasoning,
-            Err(_) => goose_providers::base::Reasoning::Enabled(goose_providers::model::ModelConfig::new(&model).is_reasoning_model()),
+            Err(_) => goose_providers::base::Reasoning::Enabled(
+                goose_providers::model::ModelConfig::new(&model).is_reasoning_model(),
+            ),
         };
 
         if supports_thinking.is_enabled() {

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -946,10 +946,10 @@ pub async fn configure_provider_dialog() -> anyhow::Result<bool> {
     {
         let supports_thinking = match temp_provider.fetch_model_info(&model).await {
             Ok(model_info) => model_info.reasoning,
-            Err(_) => goose_providers::model::ModelConfig::new(&model).is_reasoning_model(),
+            Err(_) => goose_providers::base::Reasoning::Enabled(goose_providers::model::ModelConfig::new(&model).is_reasoning_model()),
         };
 
-        if supports_thinking {
+        if supports_thinking.is_enabled() {
             let effort: ThinkingEffort = cliclack::select("Select thinking effort:")
                 .item("off", "Off - No extended thinking", "")
                 .item("low", "Low - Better latency, lighter reasoning", "")

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -2583,7 +2583,7 @@ mod tests {
                 "anthropic_beta".to_string(),
                 serde_json::json!(["output-128k-2025-02-19"]),
             )])),
-            reasoning: Some(false),
+            reasoning: Some(goose_providers::base::Reasoning::Enabled(false)),
         };
 
         let switched =

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -2573,6 +2573,7 @@ mod tests {
         ]);
 
         let current_model_config = goose_providers::model::ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "gpt-4o".to_string(),
             context_limit: Some(128_000),
             temperature: Some(0.25),

--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -251,7 +251,7 @@ pub struct ReasoningConfig {
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq)]
 #[serde(untagged)]
 pub enum Reasoning {
-    /// Legacy/simple boolean flag
+    /// Simple enablement flag
     Enabled(bool),
     /// Advanced reasoning configuration block
     ReasoningConfig(ReasoningConfig),

--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -264,6 +264,37 @@ impl Reasoning {
             Self::ReasoningConfig(config) => config.enabled,
         }
     }
+
+    /// Merges provider-specific declarative configuration into the user's requested reasoning state.
+    pub fn with_provider_defaults(self, provider_defaults: Option<&Reasoning>) -> Self {
+        let Some(Self::ReasoningConfig(provider_rc)) = provider_defaults else {
+            return self;
+        };
+
+        match self {
+            Self::Enabled(enabled) => {
+                // Upgrade to ReasoningConfig with provider defaults, but keep user's enabled flag
+                let mut merged = provider_rc.clone();
+                merged.enabled = enabled;
+                Self::ReasoningConfig(merged)
+            }
+            Self::ReasoningConfig(mut config) => {
+                if config.thinking_preservation_format.is_none() {
+                    config.thinking_preservation_format = provider_rc.thinking_preservation_format;
+                }
+                if config.reasoning_property.is_none() {
+                    config.reasoning_property = provider_rc.reasoning_property.clone();
+                }
+                if config.effort_mapping.is_none() {
+                    config.effort_mapping = provider_rc.effort_mapping.clone();
+                }
+                if config.extra_body.is_none() {
+                    config.extra_body = provider_rc.extra_body.clone();
+                }
+                Self::ReasoningConfig(config)
+            }
+        }
+    }
 }
 
 impl Default for Reasoning {
@@ -839,5 +870,45 @@ mod tests {
             })
         );
         assert!(!reasoning_struct_false.is_enabled());
+    }
+
+    #[test]
+    fn test_reasoning_with_provider_defaults() {
+        let provider_config = Reasoning::ReasoningConfig(ReasoningConfig {
+            enabled: true,
+            thinking_preservation_format: Some(ThinkingPreservationFormat::ContentPrepend),
+            reasoning_property: Some("thinking_effort".to_string()),
+            effort_mapping: None,
+            extra_body: Some(serde_json::json!({"custom": "value"})),
+        });
+
+        // 1. User specified simple Enabled(false), should upgrade to ReasoningConfig keeping enabled=false
+        let user_req = Reasoning::Enabled(false);
+        let merged = user_req.with_provider_defaults(Some(&provider_config));
+        match merged {
+            Reasoning::ReasoningConfig(c) => {
+                assert!(!c.enabled);
+                assert_eq!(c.thinking_preservation_format, Some(ThinkingPreservationFormat::ContentPrepend));
+                assert_eq!(c.reasoning_property.as_deref(), Some("thinking_effort"));
+                assert_eq!(c.extra_body, Some(serde_json::json!({"custom": "value"})));
+            }
+            _ => panic!("Expected ReasoningConfig"),
+        }
+
+        // 2. User has explicit ReasoningConfig without some fields
+        let user_req = Reasoning::ReasoningConfig(ReasoningConfig {
+            enabled: true,
+            reasoning_property: Some("override_property".to_string()),
+            ..Default::default()
+        });
+        let merged = user_req.with_provider_defaults(Some(&provider_config));
+        match merged {
+            Reasoning::ReasoningConfig(c) => {
+                assert!(c.enabled);
+                assert_eq!(c.reasoning_property.as_deref(), Some("override_property"));
+                assert_eq!(c.thinking_preservation_format, Some(ThinkingPreservationFormat::ContentPrepend));
+            }
+            _ => panic!("Expected ReasoningConfig"),
+        }
     }
 }

--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -322,8 +322,8 @@ pub struct ModelInfo {
     /// Whether this model supports cache control
     pub supports_cache_control: Option<bool>,
     /// Whether this model supports reasoning/thinking controls
-    #[serde(default)]
-    pub reasoning: Reasoning,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<Reasoning>,
 }
 
 impl ModelInfo {
@@ -337,7 +337,7 @@ impl ModelInfo {
             output_token_cost: None,
             currency: None,
             supports_cache_control: None,
-            reasoning: Reasoning::default(),
+            reasoning: None,
         }
     }
 
@@ -356,7 +356,7 @@ impl ModelInfo {
             output_token_cost: Some(output_cost),
             currency: Some("$".to_string()),
             supports_cache_control: None,
-            reasoning: Reasoning::default(),
+            reasoning: None,
         }
     }
 }
@@ -408,7 +408,7 @@ pub fn model_info_for_provider_model(provider_name: &str, model_name: &str) -> M
         output_token_cost: None,
         currency: None,
         supports_cache_control: None,
-        reasoning,
+        reasoning: Some(reasoning),
     }
 }
 
@@ -794,7 +794,7 @@ mod tests {
             output_token_cost: None,
             currency: None,
             supports_cache_control: None,
-            reasoning: Reasoning::default(),
+            reasoning: None,
         };
         assert_eq!(info.context_limit, 1000);
 
@@ -807,7 +807,7 @@ mod tests {
             output_token_cost: None,
             currency: None,
             supports_cache_control: None,
-            reasoning: Reasoning::default(),
+            reasoning: None,
         };
         assert_eq!(info, info2);
 
@@ -820,7 +820,7 @@ mod tests {
             output_token_cost: None,
             currency: None,
             supports_cache_control: None,
-            reasoning: Reasoning::default(),
+            reasoning: None,
         };
         assert_ne!(info, info3);
     }

--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -888,7 +888,10 @@ mod tests {
         match merged {
             Reasoning::ReasoningConfig(c) => {
                 assert!(!c.enabled);
-                assert_eq!(c.thinking_preservation_format, Some(ThinkingPreservationFormat::ContentPrepend));
+                assert_eq!(
+                    c.thinking_preservation_format,
+                    Some(ThinkingPreservationFormat::ContentPrepend)
+                );
                 assert_eq!(c.reasoning_property.as_deref(), Some("thinking_effort"));
                 assert_eq!(c.extra_body, Some(serde_json::json!({"custom": "value"})));
             }
@@ -906,7 +909,10 @@ mod tests {
             Reasoning::ReasoningConfig(c) => {
                 assert!(c.enabled);
                 assert_eq!(c.reasoning_property.as_deref(), Some("override_property"));
-                assert_eq!(c.thinking_preservation_format, Some(ThinkingPreservationFormat::ContentPrepend));
+                assert_eq!(
+                    c.thinking_preservation_format,
+                    Some(ThinkingPreservationFormat::ContentPrepend)
+                );
             }
             _ => panic!("Expected ReasoningConfig"),
         }

--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -822,7 +822,10 @@ mod tests {
         let reasoning_struct_true: Reasoning = serde_json::from_str(json_struct_true).unwrap();
         assert_eq!(
             reasoning_struct_true,
-            Reasoning::ReasoningConfig(ReasoningConfig { enabled: true, ..Default::default() })
+            Reasoning::ReasoningConfig(ReasoningConfig {
+                enabled: true,
+                ..Default::default()
+            })
         );
         assert!(reasoning_struct_true.is_enabled());
 
@@ -830,7 +833,10 @@ mod tests {
         let reasoning_struct_false: Reasoning = serde_json::from_str(json_struct_false).unwrap();
         assert_eq!(
             reasoning_struct_false,
-            Reasoning::ReasoningConfig(ReasoningConfig { enabled: false, ..Default::default() })
+            Reasoning::ReasoningConfig(ReasoningConfig {
+                enabled: false,
+                ..Default::default()
+            })
         );
         assert!(!reasoning_struct_false.is_enabled());
     }

--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -232,11 +232,19 @@ pub enum ThinkingPreservationFormat {
 /// Configuration block for models that require advanced reasoning parameters
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Default)]
 pub struct ReasoningConfig {
-    /// Whether reasoning is enabled
+    #[serde(default)]
     pub enabled: bool,
-    /// How to format reasoning content when returning it in message history
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thinking_preservation_format: Option<ThinkingPreservationFormat>,
+    /// The property name for configuring reasoning effort (e.g. "thinking_effort" or "reasoning_effort")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_property: Option<String>,
+    /// A mapping from standard effort levels ("low", "medium", "high") to provider-specific effort levels
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effort_mapping: Option<serde_json::Value>,
+    /// Any extra JSON fields to merge into the provider payload when reasoning is enabled
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra_body: Option<serde_json::Value>,
 }
 
 /// Reasoning support configuration

--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -218,7 +218,7 @@ impl ConfigKey {
 
 /// Controls how reasoning/thinking content is preserved and formatted when returned to a provider.
 /// Providers like Cerebras may crash if `reasoning_content` is passed back in the message history.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum ThinkingPreservationFormat {
     /// Prepend the reasoning content to the normal content response as plain text.
@@ -230,7 +230,7 @@ pub enum ThinkingPreservationFormat {
 }
 
 /// Configuration block for models that require advanced reasoning parameters
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct ReasoningConfig {
     #[serde(default)]
     pub enabled: bool,
@@ -248,7 +248,7 @@ pub struct ReasoningConfig {
 }
 
 /// Reasoning support configuration
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum Reasoning {
     /// Simple enablement flag

--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -216,11 +216,27 @@ impl ConfigKey {
     }
 }
 
+/// Controls how reasoning/thinking content is preserved and formatted when returned to a provider.
+/// Providers like Cerebras may crash if `reasoning_content` is passed back in the message history.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ThinkingPreservationFormat {
+    /// Prepend the reasoning content to the normal content response as plain text.
+    ContentPrepend,
+    /// Wrap the reasoning content in XML tags (e.g., `<think>...</think>`) and embed it in the normal content response.
+    ContentXml,
+    /// Pass the reasoning content directly in the `reasoning_content` field (standard OpenAI-compatible behavior).
+    ReasoningContent,
+}
+
 /// Configuration block for models that require advanced reasoning parameters
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Default)]
 pub struct ReasoningConfig {
     /// Whether reasoning is enabled
     pub enabled: bool,
+    /// How to format reasoning content when returning it in message history
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking_preservation_format: Option<ThinkingPreservationFormat>,
 }
 
 /// Reasoning support configuration
@@ -798,7 +814,7 @@ mod tests {
         let reasoning_struct_true: Reasoning = serde_json::from_str(json_struct_true).unwrap();
         assert_eq!(
             reasoning_struct_true,
-            Reasoning::ReasoningConfig(ReasoningConfig { enabled: true })
+            Reasoning::ReasoningConfig(ReasoningConfig { enabled: true, ..Default::default() })
         );
         assert!(reasoning_struct_true.is_enabled());
 
@@ -806,7 +822,7 @@ mod tests {
         let reasoning_struct_false: Reasoning = serde_json::from_str(json_struct_false).unwrap();
         assert_eq!(
             reasoning_struct_false,
-            Reasoning::ReasoningConfig(ReasoningConfig { enabled: false })
+            Reasoning::ReasoningConfig(ReasoningConfig { enabled: false, ..Default::default() })
         );
         assert!(!reasoning_struct_false.is_enabled());
     }

--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -216,6 +216,38 @@ impl ConfigKey {
     }
 }
 
+/// Configuration block for models that require advanced reasoning parameters
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Default)]
+pub struct ReasoningConfig {
+    /// Whether reasoning is enabled
+    pub enabled: bool,
+}
+
+/// Reasoning support configuration
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq)]
+#[serde(untagged)]
+pub enum Reasoning {
+    /// Legacy/simple boolean flag
+    Enabled(bool),
+    /// Advanced reasoning configuration block
+    ReasoningConfig(ReasoningConfig),
+}
+
+impl Reasoning {
+    pub fn is_enabled(&self) -> bool {
+        match self {
+            Self::Enabled(enabled) => *enabled,
+            Self::ReasoningConfig(config) => config.enabled,
+        }
+    }
+}
+
+impl Default for Reasoning {
+    fn default() -> Self {
+        Self::Enabled(false)
+    }
+}
+
 /// Information about a model's capabilities
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ModelInfo {
@@ -236,7 +268,7 @@ pub struct ModelInfo {
     pub supports_cache_control: Option<bool>,
     /// Whether this model supports reasoning/thinking controls
     #[serde(default)]
-    pub reasoning: bool,
+    pub reasoning: Reasoning,
 }
 
 impl ModelInfo {
@@ -250,7 +282,7 @@ impl ModelInfo {
             output_token_cost: None,
             currency: None,
             supports_cache_control: None,
-            reasoning: false,
+            reasoning: Reasoning::default(),
         }
     }
 
@@ -269,7 +301,7 @@ impl ModelInfo {
             output_token_cost: Some(output_cost),
             currency: Some("$".to_string()),
             supports_cache_control: None,
-            reasoning: false,
+            reasoning: Reasoning::default(),
         }
     }
 }
@@ -302,7 +334,14 @@ pub fn model_info_for_provider_model(provider_name: &str, model_name: &str) -> M
     let reasoning = canonical
         .as_ref()
         .and_then(|model| model.reasoning)
-        .unwrap_or_else(|| ModelConfig::new(model_name).is_reasoning_model());
+        .map(Reasoning::Enabled)
+        .unwrap_or_else(|| {
+            if ModelConfig::new(model_name).is_reasoning_model() {
+                Reasoning::Enabled(true)
+            } else {
+                Reasoning::Enabled(false)
+            }
+        });
 
     ModelInfo {
         name: model_name.to_string(),
@@ -700,7 +739,7 @@ mod tests {
             output_token_cost: None,
             currency: None,
             supports_cache_control: None,
-            reasoning: false,
+            reasoning: Reasoning::default(),
         };
         assert_eq!(info.context_limit, 1000);
 
@@ -713,7 +752,7 @@ mod tests {
             output_token_cost: None,
             currency: None,
             supports_cache_control: None,
-            reasoning: false,
+            reasoning: Reasoning::default(),
         };
         assert_eq!(info, info2);
 
@@ -726,7 +765,7 @@ mod tests {
             output_token_cost: None,
             currency: None,
             supports_cache_control: None,
-            reasoning: false,
+            reasoning: Reasoning::default(),
         };
         assert_ne!(info, info3);
     }
@@ -739,5 +778,36 @@ mod tests {
         assert_eq!(info.input_token_cost, Some(0.0000025));
         assert_eq!(info.output_token_cost, Some(0.00001));
         assert_eq!(info.currency, Some("$".to_string()));
+    }
+
+    #[test]
+    fn test_reasoning_deserialization() {
+        // Test basic boolean deserialization
+        let json_bool_true = "true";
+        let reasoning_bool_true: Reasoning = serde_json::from_str(json_bool_true).unwrap();
+        assert_eq!(reasoning_bool_true, Reasoning::Enabled(true));
+        assert!(reasoning_bool_true.is_enabled());
+
+        let json_bool_false = "false";
+        let reasoning_bool_false: Reasoning = serde_json::from_str(json_bool_false).unwrap();
+        assert_eq!(reasoning_bool_false, Reasoning::Enabled(false));
+        assert!(!reasoning_bool_false.is_enabled());
+
+        // Test struct deserialization
+        let json_struct_true = r#"{"enabled": true}"#;
+        let reasoning_struct_true: Reasoning = serde_json::from_str(json_struct_true).unwrap();
+        assert_eq!(
+            reasoning_struct_true,
+            Reasoning::ReasoningConfig(ReasoningConfig { enabled: true })
+        );
+        assert!(reasoning_struct_true.is_enabled());
+
+        let json_struct_false = r#"{"enabled": false}"#;
+        let reasoning_struct_false: Reasoning = serde_json::from_str(json_struct_false).unwrap();
+        assert_eq!(
+            reasoning_struct_false,
+            Reasoning::ReasoningConfig(ReasoningConfig { enabled: false })
+        );
+        assert!(!reasoning_struct_false.is_enabled());
     }
 }

--- a/crates/goose-provider-types/src/formats/anthropic.rs
+++ b/crates/goose-provider-types/src/formats/anthropic.rs
@@ -59,9 +59,11 @@ impl AnthropicFormatOptions {
             .request_param::<bool>("preserve_unsigned_thinking")
             .unwrap_or(self.preserve_unsigned_thinking)
             || preserve_thinking_context;
-        let thinking_disabled =
-            model_config.reasoning.as_ref().is_some_and(|r| !r.is_enabled())
-                || model_config.thinking_effort() == Some(ThinkingEffort::Off);
+        let thinking_disabled = model_config
+            .reasoning
+            .as_ref()
+            .is_some_and(|r| !r.is_enabled())
+            || model_config.thinking_effort() == Some(ThinkingEffort::Off);
 
         Self {
             preserve_unsigned_thinking,
@@ -92,10 +94,9 @@ pub fn thinking_type(model_config: &ModelConfig) -> ThinkingType {
 
 pub fn thinking_type_for_provider(provider_name: &str, model_config: &ModelConfig) -> ThinkingType {
     let mode = canonical_thinking_mode(provider_name, &model_config.model_name);
-    let reasoning = model_config
-        .reasoning
-        .clone()
-        .or_else(|| canonical_reasoning(provider_name, model_config).map(crate::base::Reasoning::Enabled));
+    let reasoning = model_config.reasoning.clone().or_else(|| {
+        canonical_reasoning(provider_name, model_config).map(crate::base::Reasoning::Enabled)
+    });
 
     if !reasoning.is_some_and(|r| r.is_enabled()) {
         return ThinkingType::Disabled;

--- a/crates/goose-provider-types/src/formats/anthropic.rs
+++ b/crates/goose-provider-types/src/formats/anthropic.rs
@@ -59,8 +59,9 @@ impl AnthropicFormatOptions {
             .request_param::<bool>("preserve_unsigned_thinking")
             .unwrap_or(self.preserve_unsigned_thinking)
             || preserve_thinking_context;
-        let thinking_disabled = model_config.reasoning == Some(false)
-            || model_config.thinking_effort() == Some(ThinkingEffort::Off);
+        let thinking_disabled =
+            model_config.reasoning.as_ref().is_some_and(|r| !r.is_enabled())
+                || model_config.thinking_effort() == Some(ThinkingEffort::Off);
 
         Self {
             preserve_unsigned_thinking,
@@ -93,9 +94,10 @@ pub fn thinking_type_for_provider(provider_name: &str, model_config: &ModelConfi
     let mode = canonical_thinking_mode(provider_name, &model_config.model_name);
     let reasoning = model_config
         .reasoning
-        .or_else(|| canonical_reasoning(provider_name, model_config));
+        .clone()
+        .or_else(|| canonical_reasoning(provider_name, model_config).map(crate::base::Reasoning::Enabled));
 
-    if reasoning != Some(true) {
+    if !reasoning.is_some_and(|r| r.is_enabled()) {
         return ThinkingType::Disabled;
     }
 

--- a/crates/goose-provider-types/src/formats/databricks.rs
+++ b/crates/goose-provider-types/src/formats/databricks.rs
@@ -1063,6 +1063,7 @@ mod tests {
     fn test_create_request_gpt_4o() -> anyhow::Result<()> {
         // Test default medium reasoning effort for O3 model
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "gpt-4o".to_string(),
             context_limit: Some(4096),
             temperature: None,
@@ -1097,6 +1098,7 @@ mod tests {
         let mut params = std::collections::HashMap::new();
         params.insert("thinking_effort".to_string(), serde_json::json!("high"));
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "o3-mini".to_string(),
             context_limit: Some(4096),
             temperature: None,
@@ -1116,6 +1118,7 @@ mod tests {
         let mut params = std::collections::HashMap::new();
         params.insert("thinking_effort".to_string(), serde_json::json!("off"));
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "databricks-o3-mini".to_string(),
             context_limit: Some(4096),
             temperature: None,
@@ -1136,6 +1139,7 @@ mod tests {
         let mut params = std::collections::HashMap::new();
         params.insert("thinking_effort".to_string(), serde_json::json!("max"));
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "databricks-gpt-5.2-pro".to_string(),
             context_limit: Some(4096),
             temperature: None,
@@ -1154,6 +1158,7 @@ mod tests {
     #[test]
     fn test_create_request_reasoning_effort_xhigh() -> anyhow::Result<()> {
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "o3-xhigh".to_string(),
             context_limit: Some(4096),
             temperature: None,
@@ -1172,6 +1177,7 @@ mod tests {
     #[test]
     fn test_create_request_reasoning_effort_none() -> anyhow::Result<()> {
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "o3-none".to_string(),
             context_limit: Some(4096),
             temperature: None,
@@ -1190,6 +1196,7 @@ mod tests {
     #[test]
     fn test_create_request_reasoning_effort_for_prefixed_gpt5_model() -> anyhow::Result<()> {
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "databricks-gpt-5.4-high".to_string(),
             context_limit: Some(4096),
             temperature: None,
@@ -1679,6 +1686,7 @@ mod tests {
     #[test]
     fn test_create_request_claude_has_cache_control() -> anyhow::Result<()> {
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "databricks-claude-sonnet-4".to_string(),
             context_limit: Some(200000),
             temperature: None,
@@ -1731,6 +1739,7 @@ mod tests {
     #[test]
     fn test_create_request_non_claude_no_cache_control() -> anyhow::Result<()> {
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "gpt-4o".to_string(),
             context_limit: Some(128000),
             temperature: None,

--- a/crates/goose-provider-types/src/formats/google.rs
+++ b/crates/goose-provider-types/src/formats/google.rs
@@ -541,7 +541,10 @@ fn get_thinking_config(
     model_config: &ModelConfig,
     thinking_budget: Option<i32>,
 ) -> Option<ThinkingConfig> {
-    if model_config.reasoning.as_ref().is_some_and(|r| !r.is_enabled())
+    if model_config
+        .reasoning
+        .as_ref()
+        .is_some_and(|r| !r.is_enabled())
         || model_config.thinking_effort() == Some(ThinkingEffort::Off)
     {
         // Gemini 2.5 Flash defaults to dynamic thinking; only an explicit budget

--- a/crates/goose-provider-types/src/formats/google.rs
+++ b/crates/goose-provider-types/src/formats/google.rs
@@ -541,7 +541,7 @@ fn get_thinking_config(
     model_config: &ModelConfig,
     thinking_budget: Option<i32>,
 ) -> Option<ThinkingConfig> {
-    if model_config.reasoning == Some(false)
+    if model_config.reasoning.as_ref().is_some_and(|r| !r.is_enabled())
         || model_config.thinking_effort() == Some(ThinkingEffort::Off)
     {
         // Gemini 2.5 Flash defaults to dynamic thinking; only an explicit budget

--- a/crates/goose-provider-types/src/formats/ollama.rs
+++ b/crates/goose-provider-types/src/formats/ollama.rs
@@ -24,7 +24,8 @@ use std::borrow::Cow;
 use uuid::Uuid;
 
 pub use crate::formats::openai::{
-    create_request, format_messages, format_tools, get_usage, validate_tool_schemas,
+    create_request, create_request_with_options, format_messages, format_tools, get_usage,
+    validate_tool_schemas, OpenAiFormatOptions,
 };
 
 /// Parse XML-style tool calls from content (Ollama/Qwen3-coder fallback format).

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -4343,8 +4343,11 @@ data: [DONE]"#;
             ),
         };
 
-        let result =
-            format_messages_with_options(std::slice::from_ref(&msg), &ImageFormat::OpenAi, options_prepend);
+        let result = format_messages_with_options(
+            std::slice::from_ref(&msg),
+            &ImageFormat::OpenAi,
+            options_prepend,
+        );
         assert_eq!(result.len(), 1);
         let content = result[0]["content"].as_str().unwrap();
         assert_eq!(content, "Thinking process\n\nHello");
@@ -4355,8 +4358,11 @@ data: [DONE]"#;
             thinking_preservation_format: Some(crate::base::ThinkingPreservationFormat::ContentXml),
         };
 
-        let result =
-            format_messages_with_options(std::slice::from_ref(&msg), &ImageFormat::OpenAi, options_xml);
+        let result = format_messages_with_options(
+            std::slice::from_ref(&msg),
+            &ImageFormat::OpenAi,
+            options_xml,
+        );
         assert_eq!(result.len(), 1);
         let content = result[0]["content"].as_str().unwrap();
         assert_eq!(content, "<think>\nThinking process\n</think>\n\nHello");
@@ -4369,8 +4375,11 @@ data: [DONE]"#;
             ),
         };
 
-        let result =
-            format_messages_with_options(std::slice::from_ref(&msg), &ImageFormat::OpenAi, options_reasoning);
+        let result = format_messages_with_options(
+            std::slice::from_ref(&msg),
+            &ImageFormat::OpenAi,
+            options_reasoning,
+        );
         assert_eq!(result.len(), 1);
         let content = result[0]["content"].as_str().unwrap();
         assert_eq!(content, "Hello");

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1469,10 +1469,9 @@ pub fn create_request_with_options(
             .map_or(legacy_reasoning_effort.map(|s| json!(s)), |effort| {
                 if let Some(mapping) = effort_mapping {
                     let effort_str = effort.to_string();
-                    mapping
-                        .get(&effort_str)
-                        .cloned()
-                        .or_else(|| openai_reasoning_effort_for_thinking(&model_name, effort).map(|s| json!(s)))
+                    mapping.get(&effort_str).cloned().or_else(|| {
+                        openai_reasoning_effort_for_thinking(&model_name, effort).map(|s| json!(s))
+                    })
                 } else {
                     openai_reasoning_effort_for_thinking(&model_name, effort).map(|s| json!(s))
                 }
@@ -2652,8 +2651,8 @@ mod tests {
         let mut model_config = test_model_config("my-custom-model")
             .with_max_tokens(Some(1024))
             .with_thinking_effort(ThinkingEffort::High);
-        
-        let mut reasoning = crate::base::ReasoningConfig {
+
+        let reasoning = crate::base::ReasoningConfig {
             enabled: true,
             reasoning_property: Some("custom_effort_property".to_string()),
             effort_mapping: Some(json!({
@@ -2676,9 +2675,12 @@ mod tests {
             false,
         )?;
         let obj = request.as_object().unwrap();
-        
+
         assert_eq!(obj.get("custom_effort_property"), Some(&json!(0.8)));
-        assert_eq!(obj.get("stream_options"), Some(&json!({ "include_usage": true })));
+        assert_eq!(
+            obj.get("stream_options"),
+            Some(&json!({ "include_usage": true }))
+        );
         assert!(obj.get("reasoning_effort").is_none());
         assert!(obj.get("thinking_effort").is_none());
 
@@ -3354,7 +3356,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
-            ..Default::default()
+                ..Default::default()
             },
         );
 
@@ -3413,7 +3415,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: false,
-            ..Default::default()
+                ..Default::default()
             },
         );
 
@@ -3466,7 +3468,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
-            ..Default::default()
+                ..Default::default()
             },
         );
 
@@ -3497,7 +3499,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
-            ..Default::default()
+                ..Default::default()
             },
         );
 
@@ -3526,7 +3528,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
-            ..Default::default()
+                ..Default::default()
             },
         );
 
@@ -3551,7 +3553,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
-            ..Default::default()
+                ..Default::default()
             },
         );
 
@@ -3588,7 +3590,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
-            ..Default::default()
+                ..Default::default()
             },
         );
 
@@ -3647,7 +3649,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
-            ..Default::default()
+                ..Default::default()
             },
         );
 
@@ -3695,7 +3697,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
-            ..Default::default()
+                ..Default::default()
             },
         );
 
@@ -3966,7 +3968,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
-            ..Default::default()
+                ..Default::default()
             },
         );
         assert_eq!(spec.len(), 1);
@@ -4001,7 +4003,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
-            ..Default::default()
+                ..Default::default()
             },
         );
         assert_eq!(spec.len(), 1);
@@ -4330,14 +4332,19 @@ data: [DONE]"#;
 
     #[test]
     fn test_thinking_preservation_format() {
-        let msg = Message::assistant().with_text("Hello").with_thinking("Thinking process", "");
+        let msg = Message::assistant()
+            .with_text("Hello")
+            .with_thinking("Thinking process", "");
 
         let options_prepend = OpenAiFormatOptions {
             preserve_thinking_context: true,
-            thinking_preservation_format: Some(crate::base::ThinkingPreservationFormat::ContentPrepend),
+            thinking_preservation_format: Some(
+                crate::base::ThinkingPreservationFormat::ContentPrepend,
+            ),
         };
 
-        let result = format_messages_with_options(&[msg.clone()], &ImageFormat::OpenAi, options_prepend);
+        let result =
+            format_messages_with_options(std::slice::from_ref(&msg), &ImageFormat::OpenAi, options_prepend);
         assert_eq!(result.len(), 1);
         let content = result[0]["content"].as_str().unwrap();
         assert_eq!(content, "Thinking process\n\nHello");
@@ -4348,7 +4355,8 @@ data: [DONE]"#;
             thinking_preservation_format: Some(crate::base::ThinkingPreservationFormat::ContentXml),
         };
 
-        let result = format_messages_with_options(&[msg.clone()], &ImageFormat::OpenAi, options_xml);
+        let result =
+            format_messages_with_options(std::slice::from_ref(&msg), &ImageFormat::OpenAi, options_xml);
         assert_eq!(result.len(), 1);
         let content = result[0]["content"].as_str().unwrap();
         assert_eq!(content, "<think>\nThinking process\n</think>\n\nHello");
@@ -4356,10 +4364,13 @@ data: [DONE]"#;
 
         let options_reasoning = OpenAiFormatOptions {
             preserve_thinking_context: true,
-            thinking_preservation_format: Some(crate::base::ThinkingPreservationFormat::ReasoningContent),
+            thinking_preservation_format: Some(
+                crate::base::ThinkingPreservationFormat::ReasoningContent,
+            ),
         };
 
-        let result = format_messages_with_options(&[msg.clone()], &ImageFormat::OpenAi, options_reasoning);
+        let result =
+            format_messages_with_options(std::slice::from_ref(&msg), &ImageFormat::OpenAi, options_reasoning);
         assert_eq!(result.len(), 1);
         let content = result[0]["content"].as_str().unwrap();
         assert_eq!(content, "Hello");

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -59,6 +59,7 @@ fn is_reserved_request_param_key(key: &str) -> bool {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct OpenAiFormatOptions {
     pub preserve_thinking_context: bool,
+    pub thinking_preservation_format: Option<crate::base::ThinkingPreservationFormat>,
 }
 
 fn merge_reasoning_text(prefix: &str, suffix: &str) -> String {
@@ -191,6 +192,7 @@ pub fn format_messages(messages: &[Message], image_format: &ImageFormat) -> Vec<
         image_format,
         OpenAiFormatOptions {
             preserve_thinking_context: true,
+            ..Default::default()
         },
     )
 }
@@ -493,7 +495,40 @@ pub fn format_messages_with_options(
         // Include reasoning_content only when non-empty. Kimi rejects empty
         // reasoning_content (""), so we must omit it entirely.
         if options.preserve_thinking_context && !reasoning_text.is_empty() {
-            converted["reasoning_content"] = json!(reasoning_text);
+            let mut format_as_content = false;
+            let mut formatted_text = String::new();
+
+            if let Some(format) = &options.thinking_preservation_format {
+                match format {
+                    crate::base::ThinkingPreservationFormat::ContentPrepend => {
+                        format_as_content = true;
+                        formatted_text = format!("{}\n\n", reasoning_text);
+                    }
+                    crate::base::ThinkingPreservationFormat::ContentXml => {
+                        format_as_content = true;
+                        formatted_text = format!("<think>\n{}\n</think>\n\n", reasoning_text);
+                    }
+                    crate::base::ThinkingPreservationFormat::ReasoningContent => {}
+                }
+            }
+
+            if format_as_content {
+                if let Some(content) = converted.get_mut("content") {
+                    if content.is_string() {
+                        let s = content.as_str().unwrap();
+                        *content = json!(format!("{}{}", formatted_text, s));
+                    } else if content.is_array() {
+                        let arr = content.as_array_mut().unwrap();
+                        arr.insert(0, json!({ "type": "text", "text": formatted_text }));
+                    } else if content.is_null() {
+                        *content = json!(formatted_text.trim_end());
+                    }
+                } else {
+                    converted["content"] = json!(formatted_text.trim_end());
+                }
+            } else {
+                converted["reasoning_content"] = json!(reasoning_text);
+            }
         }
 
         if has_message_payload {
@@ -1393,6 +1428,7 @@ pub fn create_request(
         for_streaming,
         OpenAiFormatOptions {
             preserve_thinking_context: true,
+            ..Default::default()
         },
     )
 }
@@ -3251,6 +3287,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
+            ..Default::default()
             },
         );
 
@@ -3309,6 +3346,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: false,
+            ..Default::default()
             },
         );
 
@@ -3361,6 +3399,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
+            ..Default::default()
             },
         );
 
@@ -3391,6 +3430,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
+            ..Default::default()
             },
         );
 
@@ -3419,6 +3459,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
+            ..Default::default()
             },
         );
 
@@ -3443,6 +3484,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
+            ..Default::default()
             },
         );
 
@@ -3479,6 +3521,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
+            ..Default::default()
             },
         );
 
@@ -3537,6 +3580,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
+            ..Default::default()
             },
         );
 
@@ -3584,6 +3628,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
+            ..Default::default()
             },
         );
 
@@ -3854,6 +3899,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
+            ..Default::default()
             },
         );
         assert_eq!(spec.len(), 1);
@@ -3888,6 +3934,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
+            ..Default::default()
             },
         );
         assert_eq!(spec.len(), 1);
@@ -4212,5 +4259,44 @@ data: [DONE]"#;
                 _ => {}
             }
         }
+    }
+
+    #[test]
+    fn test_thinking_preservation_format() {
+        let msg = Message::assistant().with_text("Hello").with_thinking("Thinking process", "");
+
+        let options_prepend = OpenAiFormatOptions {
+            preserve_thinking_context: true,
+            thinking_preservation_format: Some(crate::base::ThinkingPreservationFormat::ContentPrepend),
+        };
+
+        let result = format_messages_with_options(&[msg.clone()], &ImageFormat::OpenAi, options_prepend);
+        assert_eq!(result.len(), 1);
+        let content = result[0]["content"].as_str().unwrap();
+        assert_eq!(content, "Thinking process\n\nHello");
+        assert!(result[0].get("reasoning_content").is_none());
+
+        let options_xml = OpenAiFormatOptions {
+            preserve_thinking_context: true,
+            thinking_preservation_format: Some(crate::base::ThinkingPreservationFormat::ContentXml),
+        };
+
+        let result = format_messages_with_options(&[msg.clone()], &ImageFormat::OpenAi, options_xml);
+        assert_eq!(result.len(), 1);
+        let content = result[0]["content"].as_str().unwrap();
+        assert_eq!(content, "<think>\nThinking process\n</think>\n\nHello");
+        assert!(result[0].get("reasoning_content").is_none());
+
+        let options_reasoning = OpenAiFormatOptions {
+            preserve_thinking_context: true,
+            thinking_preservation_format: Some(crate::base::ThinkingPreservationFormat::ReasoningContent),
+        };
+
+        let result = format_messages_with_options(&[msg.clone()], &ImageFormat::OpenAi, options_reasoning);
+        assert_eq!(result.len(), 1);
+        let content = result[0]["content"].as_str().unwrap();
+        assert_eq!(content, "Hello");
+        let reasoning = result[0]["reasoning_content"].as_str().unwrap();
+        assert_eq!(reasoning, "Thinking process");
     }
 }

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1465,9 +1465,15 @@ pub fn create_request_with_options(
         _ => (None, None, None),
     };
 
-    let property_key = reasoning_property.unwrap_or("reasoning_effort");
+    let property_key = reasoning_property.or_else(|| {
+        if is_openai_model {
+            Some("reasoning_effort")
+        } else {
+            None
+        }
+    });
 
-    let reasoning_effort = if is_reasoning_model {
+    let reasoning_effort = if is_reasoning_model && property_key.is_some() {
         model_config
             .thinking_effort()
             .map_or(legacy_reasoning_effort.map(|s| json!(s)), |effort| {
@@ -1502,8 +1508,8 @@ pub fn create_request_with_options(
         "messages": messages_array
     });
 
-    if let Some(effort) = reasoning_effort {
-        payload[property_key] = effort;
+    if let (Some(effort), Some(key)) = (reasoning_effort, property_key) {
+        payload[key] = effort;
     }
 
     if let Some(extra) = extra_body {

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1457,11 +1457,17 @@ pub fn create_request_with_options(
     let is_reasoning_model = model_config.is_reasoning_model();
 
     let (reasoning_property, effort_mapping, extra_body) = match &model_config.reasoning {
-        Some(crate::base::Reasoning::ReasoningConfig(c)) if c.enabled => (
-            c.reasoning_property.as_deref(),
-            c.effort_mapping.as_ref(),
-            c.extra_body.as_ref(),
-        ),
+        Some(crate::base::Reasoning::ReasoningConfig(c))
+            if c.enabled
+                && (is_openai_model
+                    || model_config.thinking_effort() != Some(ThinkingEffort::Off)) =>
+        {
+            (
+                c.reasoning_property.as_deref(),
+                c.effort_mapping.as_ref(),
+                c.extra_body.as_ref(),
+            )
+        }
         _ => (None, None, None),
     };
 

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1454,7 +1454,7 @@ pub fn create_request_with_options(
 
     let (model_name, legacy_reasoning_effort) = extract_reasoning_effort(&model_config.model_name);
     let is_openai_model = is_openai_responses_model(&model_name);
-    let is_reasoning_model = model_config.is_reasoning_model() || is_openai_model;
+    let is_reasoning_model = model_config.is_reasoning_model();
 
     let (reasoning_property, effort_mapping, extra_body) = match &model_config.reasoning {
         Some(crate::base::Reasoning::ReasoningConfig(c)) if c.enabled => (

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1526,7 +1526,7 @@ pub fn create_request_with_options(
     // lmstudio) sending the historic 4096 default truncates non-trivial
     // responses; omitting the field lets the server use its own max.
     if let Some(max_tokens) = model_config.max_tokens {
-        let key = if is_reasoning_model {
+        let key = if is_openai_model {
             "max_completion_tokens"
         } else {
             "max_tokens"
@@ -2683,6 +2683,8 @@ mod tests {
         );
         assert!(obj.get("reasoning_effort").is_none());
         assert!(obj.get("thinking_effort").is_none());
+        assert_eq!(obj.get("max_tokens"), Some(&json!(1024)));
+        assert!(obj.get("max_completion_tokens").is_none());
 
         Ok(())
     }

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1553,7 +1553,10 @@ pub fn create_request_with_options(
 
     if for_streaming {
         payload["stream"] = json!(true);
-        if let Some(stream_opts) = payload.get_mut("stream_options").and_then(|v| v.as_object_mut()) {
+        if let Some(stream_opts) = payload
+            .get_mut("stream_options")
+            .and_then(|v| v.as_object_mut())
+        {
             stream_opts.insert("include_usage".to_string(), json!(true));
         } else {
             payload["stream_options"] = json!({"include_usage": true});

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -495,40 +495,7 @@ pub fn format_messages_with_options(
         // Include reasoning_content only when non-empty. Kimi rejects empty
         // reasoning_content (""), so we must omit it entirely.
         if options.preserve_thinking_context && !reasoning_text.is_empty() {
-            let mut format_as_content = false;
-            let mut formatted_text = String::new();
-
-            if let Some(format) = &options.thinking_preservation_format {
-                match format {
-                    crate::base::ThinkingPreservationFormat::ContentPrepend => {
-                        format_as_content = true;
-                        formatted_text = format!("{}\n\n", reasoning_text);
-                    }
-                    crate::base::ThinkingPreservationFormat::ContentXml => {
-                        format_as_content = true;
-                        formatted_text = format!("<think>\n{}\n</think>\n\n", reasoning_text);
-                    }
-                    crate::base::ThinkingPreservationFormat::ReasoningContent => {}
-                }
-            }
-
-            if format_as_content {
-                if let Some(content) = converted.get_mut("content") {
-                    if content.is_string() {
-                        let s = content.as_str().unwrap();
-                        *content = json!(format!("{}{}", formatted_text, s));
-                    } else if content.is_array() {
-                        let arr = content.as_array_mut().unwrap();
-                        arr.insert(0, json!({ "type": "text", "text": formatted_text }));
-                    } else if content.is_null() {
-                        *content = json!(formatted_text.trim_end());
-                    }
-                } else {
-                    converted["content"] = json!(formatted_text.trim_end());
-                }
-            } else {
-                converted["reasoning_content"] = json!(reasoning_text);
-            }
+            converted["reasoning_content"] = json!(reasoning_text);
         }
 
         if has_message_payload {
@@ -539,6 +506,43 @@ pub fn format_messages_with_options(
     }
 
     merge_split_tool_call_messages(&mut messages_spec);
+
+    // After tool calls are merged (using reasoning_content to identify split messages),
+    // apply the requested preservation format.
+    if let Some(format) = &options.thinking_preservation_format {
+        if *format != crate::base::ThinkingPreservationFormat::ReasoningContent {
+            for msg in &mut messages_spec {
+                if let Some(reasoning) = msg.get("reasoning_content").and_then(|v| v.as_str()) {
+                    let formatted_text = match format {
+                        crate::base::ThinkingPreservationFormat::ContentPrepend => {
+                            format!("{}\n\n", reasoning)
+                        }
+                        crate::base::ThinkingPreservationFormat::ContentXml => {
+                            format!("<think>\n{}\n</think>\n\n", reasoning)
+                        }
+                        _ => unreachable!(),
+                    };
+
+                    if let Some(content) = msg.get_mut("content") {
+                        if content.is_string() {
+                            let s = content.as_str().unwrap();
+                            *content = json!(format!("{}{}", formatted_text, s));
+                        } else if content.is_array() {
+                            let arr = content.as_array_mut().unwrap();
+                            arr.insert(0, json!({ "type": "text", "text": formatted_text }));
+                        } else if content.is_null() {
+                            *content = json!(formatted_text.trim_end());
+                        }
+                    } else {
+                        msg["content"] = json!(formatted_text.trim_end());
+                    }
+
+                    msg.as_object_mut().unwrap().remove("reasoning_content");
+                }
+            }
+        }
+    }
+
     messages_spec
 }
 
@@ -1453,7 +1457,7 @@ pub fn create_request_with_options(
     let is_reasoning_model = model_config.is_reasoning_model() || is_openai_model;
 
     let (reasoning_property, effort_mapping, extra_body) = match &model_config.reasoning {
-        Some(crate::base::Reasoning::ReasoningConfig(c)) => (
+        Some(crate::base::Reasoning::ReasoningConfig(c)) if c.enabled => (
             c.reasoning_property.as_deref(),
             c.effort_mapping.as_ref(),
             c.extra_body.as_ref(),

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1541,11 +1541,6 @@ pub fn create_request_with_options(
             .insert(key.to_string(), json!(max_tokens));
     }
 
-    if for_streaming {
-        payload["stream"] = json!(true);
-        payload["stream_options"] = json!({"include_usage": true});
-    }
-
     if let Some(params) = &model_config.request_params {
         if let Some(obj) = payload.as_object_mut() {
             for (key, value) in params {
@@ -1553,6 +1548,15 @@ pub fn create_request_with_options(
                     obj.insert(key.clone(), value.clone());
                 }
             }
+        }
+    }
+
+    if for_streaming {
+        payload["stream"] = json!(true);
+        if let Some(stream_opts) = payload.get_mut("stream_options").and_then(|v| v.as_object_mut()) {
+            stream_opts.insert("include_usage".to_string(), json!(true));
+        } else {
+            payload["stream_options"] = json!({"include_usage": true});
         }
     }
 
@@ -2689,6 +2693,39 @@ mod tests {
         assert!(obj.get("thinking_effort").is_none());
         assert_eq!(obj.get("max_tokens"), Some(&json!(1024)));
         assert!(obj.get("max_completion_tokens").is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_request_preserves_stream_options_from_extra_body() -> anyhow::Result<()> {
+        let mut model_config = test_model_config("my-custom-model");
+
+        let reasoning = crate::base::ReasoningConfig {
+            enabled: true,
+            extra_body: Some(json!({
+                "stream_options": { "foo": "bar" }
+            })),
+            ..Default::default()
+        };
+        model_config.reasoning = Some(crate::base::Reasoning::ReasoningConfig(reasoning));
+
+        // Use `true` for streaming
+        let request = create_request(
+            &model_config,
+            "system",
+            &[],
+            &[],
+            &ImageFormat::OpenAi,
+            true,
+        )?;
+        let obj = request.as_object().unwrap();
+
+        // `include_usage: true` should have been merged into `stream_options`
+        assert_eq!(
+            obj.get("stream_options"),
+            Some(&json!({ "foo": "bar", "include_usage": true }))
+        );
 
         Ok(())
     }

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1449,19 +1449,40 @@ pub fn create_request_with_options(
     }
 
     let (model_name, legacy_reasoning_effort) = extract_reasoning_effort(&model_config.model_name);
-    let is_reasoning_model = is_openai_responses_model(&model_name);
+    let is_openai_model = is_openai_responses_model(&model_name);
+    let is_reasoning_model = model_config.is_reasoning_model() || is_openai_model;
+
+    let (reasoning_property, effort_mapping, extra_body) = match &model_config.reasoning {
+        Some(crate::base::Reasoning::ReasoningConfig(c)) => (
+            c.reasoning_property.as_deref(),
+            c.effort_mapping.as_ref(),
+            c.extra_body.as_ref(),
+        ),
+        _ => (None, None, None),
+    };
+
+    let property_key = reasoning_property.unwrap_or("reasoning_effort");
+
     let reasoning_effort = if is_reasoning_model {
         model_config
             .thinking_effort()
-            .map_or(legacy_reasoning_effort, |effort| {
-                openai_reasoning_effort_for_thinking(&model_name, effort)
+            .map_or(legacy_reasoning_effort.map(|s| json!(s)), |effort| {
+                if let Some(mapping) = effort_mapping {
+                    let effort_str = effort.to_string();
+                    mapping
+                        .get(&effort_str)
+                        .cloned()
+                        .or_else(|| openai_reasoning_effort_for_thinking(&model_name, effort).map(|s| json!(s)))
+                } else {
+                    openai_reasoning_effort_for_thinking(&model_name, effort).map(|s| json!(s))
+                }
             })
     } else {
         None
     };
 
     let system_message = json!({
-        "role": if is_reasoning_model { "developer" } else { "system" },
+        "role": if is_openai_model { "developer" } else { "system" },
         "content": system
     });
 
@@ -1479,14 +1500,22 @@ pub fn create_request_with_options(
     });
 
     if let Some(effort) = reasoning_effort {
-        payload["reasoning_effort"] = json!(effort);
+        payload[property_key] = effort;
+    }
+
+    if let Some(extra) = extra_body {
+        if let (Some(payload_obj), Some(extra_obj)) = (payload.as_object_mut(), extra.as_object()) {
+            for (k, v) in extra_obj {
+                payload_obj.insert(k.clone(), v.clone());
+            }
+        }
     }
 
     if !tools_spec.is_empty() {
         payload["tools"] = json!(tools_spec);
     }
 
-    if !is_reasoning_model {
+    if !is_openai_model {
         if let Some(temp) = model_config.temperature {
             payload["temperature"] = json!(temp);
         }
@@ -2613,6 +2642,44 @@ mod tests {
         let obj = request.as_object().unwrap();
 
         assert_eq!(obj.get("reasoning_effort"), Some(&json!("xhigh")));
+        assert!(obj.get("thinking_effort").is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_request_custom_reasoning_config() -> anyhow::Result<()> {
+        let mut model_config = test_model_config("my-custom-model")
+            .with_max_tokens(Some(1024))
+            .with_thinking_effort(ThinkingEffort::High);
+        
+        let mut reasoning = crate::base::ReasoningConfig {
+            enabled: true,
+            reasoning_property: Some("custom_effort_property".to_string()),
+            effort_mapping: Some(json!({
+                "high": 0.8,
+                "low": 0.2
+            })),
+            extra_body: Some(json!({
+                "stream_options": { "include_usage": true }
+            })),
+            ..Default::default()
+        };
+        model_config.reasoning = Some(crate::base::Reasoning::ReasoningConfig(reasoning));
+
+        let request = create_request(
+            &model_config,
+            "system",
+            &[],
+            &[],
+            &ImageFormat::OpenAi,
+            false,
+        )?;
+        let obj = request.as_object().unwrap();
+        
+        assert_eq!(obj.get("custom_effort_property"), Some(&json!(0.8)));
+        assert_eq!(obj.get("stream_options"), Some(&json!({ "include_usage": true })));
+        assert!(obj.get("reasoning_effort").is_none());
         assert!(obj.get("thinking_effort").is_none());
 
         Ok(())

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1457,17 +1457,11 @@ pub fn create_request_with_options(
     let is_reasoning_model = model_config.is_reasoning_model();
 
     let (reasoning_property, effort_mapping, extra_body) = match &model_config.reasoning {
-        Some(crate::base::Reasoning::ReasoningConfig(c))
-            if c.enabled
-                && (is_openai_model
-                    || model_config.thinking_effort() != Some(ThinkingEffort::Off)) =>
-        {
-            (
-                c.reasoning_property.as_deref(),
-                c.effort_mapping.as_ref(),
-                c.extra_body.as_ref(),
-            )
-        }
+        Some(crate::base::Reasoning::ReasoningConfig(c)) if c.enabled => (
+            c.reasoning_property.as_deref(),
+            c.effort_mapping.as_ref(),
+            c.extra_body.as_ref(),
+        ),
         _ => (None, None, None),
     };
 

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1465,13 +1465,7 @@ pub fn create_request_with_options(
         _ => (None, None, None),
     };
 
-    let property_key = reasoning_property.or_else(|| {
-        if is_openai_model {
-            Some("reasoning_effort")
-        } else {
-            None
-        }
-    });
+    let property_key = reasoning_property.or(is_openai_model.then_some("reasoning_effort"));
 
     let reasoning_effort = if is_reasoning_model && property_key.is_some() {
         model_config

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -1322,6 +1322,7 @@ mod tests {
     #[test]
     fn test_history_preserves_chronological_order() {
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "gpt-5.2-codex".to_string(),
             context_limit: None,
             temperature: None,
@@ -1413,6 +1414,7 @@ mod tests {
     #[test]
     fn test_responses_tools_include_strict_false() {
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "gpt-5.4".to_string(),
             context_limit: None,
             temperature: None,
@@ -1456,6 +1458,7 @@ mod tests {
             ("databricks-o3-none", "databricks-o3", "none"),
         ] {
             let model_config = ModelConfig {
+            reasoning_is_explicit: false,
                 model_name: model_name.to_string(),
                 context_limit: None,
                 temperature: None,
@@ -1536,6 +1539,7 @@ mod tests {
     fn test_responses_request_without_effort_suffix_omits_reasoning() {
         for model_name in ["gpt-5.4", "o3", "gpt-5-nano"] {
             let model_config = ModelConfig {
+            reasoning_is_explicit: false,
                 model_name: model_name.to_string(),
                 context_limit: None,
                 temperature: None,
@@ -1586,6 +1590,7 @@ mod tests {
     fn test_responses_request_non_reasoning_model_ignores_global_thinking_effort() {
         let _guard = env_lock::lock_env([("GOOSE_THINKING_EFFORT", Some("high"))]);
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "gpt-4o".to_string(),
             context_limit: None,
             temperature: None,
@@ -1608,6 +1613,7 @@ mod tests {
     #[test]
     fn test_request_params_override_store() {
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "o3".to_string(),
             context_limit: None,
             temperature: None,
@@ -1635,6 +1641,7 @@ mod tests {
             .with_image("aW1hZ2VkYXRh", "image/png")];
 
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
             temperature: None,
@@ -1681,6 +1688,7 @@ mod tests {
         ))];
 
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
             temperature: None,
@@ -1717,6 +1725,7 @@ mod tests {
         )];
 
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
             temperature: None,
@@ -1748,6 +1757,7 @@ mod tests {
             .with_tool_request("call_1", Ok(CallToolRequestParams::new("noop")))];
 
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
             temperature: None,
@@ -1778,6 +1788,7 @@ mod tests {
             )];
 
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
             temperature: None,
@@ -1812,6 +1823,7 @@ mod tests {
                 ))];
 
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
             temperature: None,
@@ -1848,6 +1860,7 @@ mod tests {
         ))];
 
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
             temperature: None,
@@ -1873,6 +1886,7 @@ mod tests {
         let messages = vec![Message::user().with_image("aW1n", "image/png")];
 
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
             temperature: None,
@@ -1904,6 +1918,7 @@ mod tests {
             .with_image("img2", "image/jpeg")];
 
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
             temperature: None,
@@ -1935,6 +1950,7 @@ mod tests {
         let messages = vec![Message::assistant().with_text("hello")];
 
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
             temperature: None,
@@ -2077,6 +2093,7 @@ mod tests {
         ];
 
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
             temperature: None,
@@ -2117,6 +2134,7 @@ mod tests {
         ];
 
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
             temperature: None,
@@ -2154,6 +2172,7 @@ mod tests {
         )];
 
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
             temperature: None,
@@ -2191,6 +2210,7 @@ mod tests {
         )];
 
         let model_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
             temperature: None,

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -1458,7 +1458,7 @@ mod tests {
             ("databricks-o3-none", "databricks-o3", "none"),
         ] {
             let model_config = ModelConfig {
-            reasoning_is_explicit: false,
+                reasoning_is_explicit: false,
                 model_name: model_name.to_string(),
                 context_limit: None,
                 temperature: None,
@@ -1539,7 +1539,7 @@ mod tests {
     fn test_responses_request_without_effort_suffix_omits_reasoning() {
         for model_name in ["gpt-5.4", "o3", "gpt-5-nano"] {
             let model_config = ModelConfig {
-            reasoning_is_explicit: false,
+                reasoning_is_explicit: false,
                 model_name: model_name.to_string(),
                 context_limit: None,
                 temperature: None,

--- a/crates/goose-provider-types/src/model.rs
+++ b/crates/goose-provider-types/src/model.rs
@@ -1,6 +1,6 @@
+use crate::base::Reasoning;
 use crate::formats::openai::{extract_reasoning_effort, is_openai_responses_model};
 use crate::thinking::ThinkingEffort;
-use crate::base::Reasoning;
 use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/crates/goose-provider-types/src/model.rs
+++ b/crates/goose-provider-types/src/model.rs
@@ -34,6 +34,8 @@ pub struct ModelConfig {
     pub request_params: Option<HashMap<String, Value>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<Reasoning>,
+    #[serde(skip)]
+    pub reasoning_is_explicit: bool,
 }
 
 impl<'de> Deserialize<'de> for ModelConfig {
@@ -56,6 +58,7 @@ impl<'de> Deserialize<'de> for ModelConfig {
         }
 
         let raw = RawModelConfig::deserialize(deserializer)?;
+        let reasoning_is_explicit = raw.reasoning.is_some();
         let mut config = Self {
             model_name: raw.model_name,
             context_limit: raw.context_limit,
@@ -65,6 +68,7 @@ impl<'de> Deserialize<'de> for ModelConfig {
             toolshim_model: raw.toolshim_model,
             request_params: raw.request_params,
             reasoning: raw.reasoning,
+            reasoning_is_explicit,
         };
         config.normalize_effort_suffix();
         Ok(config)
@@ -82,9 +86,16 @@ impl ModelConfig {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            reasoning_is_explicit: false,
         };
         config.normalize_effort_suffix();
         config
+    }
+
+    pub fn with_reasoning(mut self, reasoning: Reasoning) -> Self {
+        self.reasoning = Some(reasoning);
+        self.reasoning_is_explicit = true;
+        self
     }
 
     pub fn with_canonical_limits(mut self, provider_name: &str) -> Self {

--- a/crates/goose-provider-types/src/model.rs
+++ b/crates/goose-provider-types/src/model.rs
@@ -1,5 +1,6 @@
 use crate::formats::openai::{extract_reasoning_effort, is_openai_responses_model};
 use crate::thinking::ThinkingEffort;
+use crate::base::Reasoning;
 use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -32,7 +33,7 @@ pub struct ModelConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub request_params: Option<HashMap<String, Value>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub reasoning: Option<bool>,
+    pub reasoning: Option<Reasoning>,
 }
 
 impl<'de> Deserialize<'de> for ModelConfig {
@@ -51,7 +52,7 @@ impl<'de> Deserialize<'de> for ModelConfig {
             #[serde(default, skip_serializing_if = "Option::is_none")]
             request_params: Option<HashMap<String, Value>>,
             #[serde(default, skip_serializing_if = "Option::is_none")]
-            reasoning: Option<bool>,
+            reasoning: Option<Reasoning>,
         }
 
         let raw = RawModelConfig::deserialize(deserializer)?;
@@ -114,7 +115,7 @@ impl ModelConfig {
                     .map(|output| output as i32);
             }
             if self.reasoning.is_none() {
-                self.reasoning = canonical.reasoning;
+                self.reasoning = canonical.reasoning.map(Reasoning::Enabled);
             }
         }
 
@@ -226,8 +227,8 @@ impl ModelConfig {
     }
 
     pub fn is_reasoning_model(&self) -> bool {
-        if let Some(reasoning) = self.reasoning {
-            return reasoning;
+        if let Some(reasoning) = &self.reasoning {
+            return reasoning.is_enabled();
         }
 
         self.is_openai_reasoning_model()
@@ -538,7 +539,7 @@ mod tests {
 
             assert_eq!(config.context_limit, Some(128_000));
             assert_eq!(config.max_tokens, Some(16_384));
-            assert_eq!(config.reasoning, Some(false));
+            assert_eq!(config.reasoning, Some(Reasoning::Enabled(false)));
         }
 
         #[test]
@@ -591,7 +592,7 @@ mod tests {
 
             assert_eq!(config.context_limit, Some(1_000_000));
             assert_eq!(config.max_tokens, Some(128_000));
-            assert_eq!(config.reasoning, Some(true));
+            assert_eq!(config.reasoning, Some(Reasoning::Enabled(true)));
         }
 
         #[test]
@@ -716,11 +717,11 @@ mod tests {
         fn uses_explicit_metadata_first() {
             let _guard = env_lock::lock_env(ENV_LOCK_KEYS);
             let mut config = ModelConfig::new("provider-alias");
-            config.reasoning = Some(true);
+            config.reasoning = Some(Reasoning::Enabled(true));
             assert!(config.is_reasoning_model());
 
             let mut config = ModelConfig::new("claude-sonnet-4");
-            config.reasoning = Some(false);
+            config.reasoning = Some(Reasoning::Enabled(false));
             assert!(!config.is_reasoning_model());
         }
     }

--- a/crates/goose-provider-types/src/model.rs
+++ b/crates/goose-provider-types/src/model.rs
@@ -639,7 +639,10 @@ mod tests {
             let config = ModelConfig::new("gpt-5.6-sol-xhigh").with_canonical_limits("openai");
             assert_eq!(config.context_limit, Some(1_050_000));
             assert_eq!(config.max_tokens, Some(128_000));
-            assert_eq!(config.reasoning, Some(crate::base::Reasoning::Enabled(true)));
+            assert_eq!(
+                config.reasoning,
+                Some(crate::base::Reasoning::Enabled(true))
+            );
             let canonical = crate::canonical::maybe_get_canonical_model("openai", "gpt-5.6-sol")
                 .expect("gpt-5.6-sol should have canonical metadata");
             assert_eq!(canonical.temperature, Some(false));
@@ -647,7 +650,10 @@ mod tests {
             let config = ModelConfig::new("gpt-5.6-sol").with_canonical_limits("chatgpt_codex");
             assert_eq!(config.context_limit, Some(1_050_000));
             assert_eq!(config.max_tokens, Some(128_000));
-            assert_eq!(config.reasoning, Some(crate::base::Reasoning::Enabled(true)));
+            assert_eq!(
+                config.reasoning,
+                Some(crate::base::Reasoning::Enabled(true))
+            );
 
             // "gpt-5.4-nano-low" should resolve via "gpt-5.4-nano"
             let config = ModelConfig::new("gpt-5.4-nano-low").with_canonical_limits("openai");

--- a/crates/goose-provider-types/src/model.rs
+++ b/crates/goose-provider-types/src/model.rs
@@ -639,7 +639,7 @@ mod tests {
             let config = ModelConfig::new("gpt-5.6-sol-xhigh").with_canonical_limits("openai");
             assert_eq!(config.context_limit, Some(1_050_000));
             assert_eq!(config.max_tokens, Some(128_000));
-            assert_eq!(config.reasoning, Some(true));
+            assert_eq!(config.reasoning, Some(crate::base::Reasoning::Enabled(true)));
             let canonical = crate::canonical::maybe_get_canonical_model("openai", "gpt-5.6-sol")
                 .expect("gpt-5.6-sol should have canonical metadata");
             assert_eq!(canonical.temperature, Some(false));
@@ -647,7 +647,7 @@ mod tests {
             let config = ModelConfig::new("gpt-5.6-sol").with_canonical_limits("chatgpt_codex");
             assert_eq!(config.context_limit, Some(1_050_000));
             assert_eq!(config.max_tokens, Some(128_000));
-            assert_eq!(config.reasoning, Some(true));
+            assert_eq!(config.reasoning, Some(crate::base::Reasoning::Enabled(true)));
 
             // "gpt-5.4-nano-low" should resolve via "gpt-5.4-nano"
             let config = ModelConfig::new("gpt-5.4-nano-low").with_canonical_limits("openai");

--- a/crates/goose-provider-types/src/model.rs
+++ b/crates/goose-provider-types/src/model.rs
@@ -34,7 +34,7 @@ pub struct ModelConfig {
     pub request_params: Option<HashMap<String, Value>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<Reasoning>,
-    #[serde(skip)]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub reasoning_is_explicit: bool,
 }
 
@@ -55,10 +55,14 @@ impl<'de> Deserialize<'de> for ModelConfig {
             request_params: Option<HashMap<String, Value>>,
             #[serde(default, skip_serializing_if = "Option::is_none")]
             reasoning: Option<Reasoning>,
+            #[serde(default)]
+            reasoning_is_explicit: Option<bool>,
         }
 
         let raw = RawModelConfig::deserialize(deserializer)?;
-        let reasoning_is_explicit = raw.reasoning.is_some();
+        let reasoning_is_explicit = raw
+            .reasoning_is_explicit
+            .unwrap_or_else(|| raw.reasoning.is_some());
         let mut config = Self {
             model_name: raw.model_name,
             context_limit: raw.context_limit,

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -313,8 +313,12 @@ impl Provider for AnthropicProvider {
             .as_ref()
             .and_then(|models| models.iter().find(|m| m.name == model_config.model_name))
         {
+            let default_info = goose_provider_types::base::model_info_for_provider_model(
+                self.get_name(),
+                &model_config.model_name,
+            );
             patched_model_config.reasoning = match patched_model_config.reasoning {
-                Some(crate::base::Reasoning::Enabled(false)) => m.reasoning.clone(),
+                Some(ref r) if Some(r.clone()) == default_info.reasoning => m.reasoning.clone(),
                 Some(r) => Some(r.with_provider_defaults(m.reasoning.as_ref())),
                 None => m.reasoning.clone(),
             };

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -266,9 +266,11 @@ impl Provider for AnthropicProvider {
         tools: &[Tool],
     ) -> Result<MessageStream, ProviderError> {
         let mut patched_model_config = model_config.clone();
-        if let Some(m) = self.custom_models.as_ref().and_then(|models| {
-            models.iter().find(|m| m.name == model_config.model_name)
-        }) {
+        if let Some(m) = self
+            .custom_models
+            .as_ref()
+            .and_then(|models| models.iter().find(|m| m.name == model_config.model_name))
+        {
             patched_model_config.reasoning = Some(
                 patched_model_config
                     .reasoning

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -314,6 +314,7 @@ impl Provider for AnthropicProvider {
             .and_then(|models| models.iter().find(|m| m.name == model_config.model_name))
         {
             patched_model_config.reasoning = match patched_model_config.reasoning {
+                Some(crate::base::Reasoning::Enabled(false)) => m.reasoning.clone(),
                 Some(r) => Some(r.with_provider_defaults(m.reasoning.as_ref())),
                 None => m.reasoning.clone(),
             };

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -271,12 +271,13 @@ impl Provider for AnthropicProvider {
             .as_ref()
             .and_then(|models| models.iter().find(|m| m.name == model_config.model_name))
         {
-            patched_model_config.reasoning = Some(
-                patched_model_config
-                    .reasoning
-                    .unwrap_or_default()
-                    .with_provider_defaults(Some(&m.reasoning)),
-            );
+            patched_model_config.reasoning = match patched_model_config.reasoning {
+                Some(r) => Some(r.with_provider_defaults(Some(&m.reasoning))),
+                None => match &m.reasoning {
+                    goose_provider_types::base::Reasoning::Enabled(false) => None,
+                    _ => Some(m.reasoning.clone()),
+                },
+            };
         }
         let model_config = &patched_model_config;
         let mut payload = create_request(

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -263,31 +263,41 @@ impl Provider for AnthropicProvider {
         let mut model_infos = Vec::new();
 
         for model_name in models {
+            let default_info = goose_provider_types::base::model_info_for_provider_model(
+                self.get_name(),
+                &model_name,
+            );
+
             if let Some(custom_models) = &self.custom_models {
                 if let Some(model_info) = custom_models.iter().find(|m| m.name == model_name) {
-                    model_infos.push(model_info.clone());
+                    let mut info = model_info.clone();
+                    if let goose_provider_types::base::Reasoning::Enabled(false) = info.reasoning {
+                        info.reasoning = default_info.reasoning.clone();
+                    }
+                    model_infos.push(info);
                     continue;
                 }
             }
-            model_infos.push(goose_provider_types::base::model_info_for_provider_model(
-                self.get_name(),
-                &model_name,
-            ));
+            model_infos.push(default_info);
         }
 
         Ok(model_infos)
     }
 
     async fn fetch_model_info(&self, model_name: &str) -> Result<ModelInfo, ProviderError> {
+        let default_info =
+            goose_provider_types::base::model_info_for_provider_model(self.get_name(), model_name);
+
         if let Some(custom_models) = &self.custom_models {
             if let Some(model_info) = custom_models.iter().find(|m| m.name == model_name) {
-                return Ok(model_info.clone());
+                let mut info = model_info.clone();
+                if let goose_provider_types::base::Reasoning::Enabled(false) = info.reasoning {
+                    info.reasoning = default_info.reasoning.clone();
+                }
+                return Ok(info);
             }
         }
-        Ok(goose_provider_types::base::model_info_for_provider_model(
-            self.get_name(),
-            model_name,
-        ))
+        Ok(default_info)
     }
 
     async fn stream(
@@ -474,5 +484,30 @@ mod tests {
         // Standard heuristics would default this to non-reasoning
         let info_not_found = provider.fetch_model_info("other-model").await.unwrap();
         assert!(!info_not_found.reasoning.is_enabled());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_model_info_preserves_reasoning_heuristics_for_custom_models() {
+        // claude-3-7-sonnet is a known reasoning model
+        let custom_model = ModelInfo::new("claude-3-7-sonnet-20250219", 4096);
+        // Reasoning is Enabled(false) by default when unconfigured
+
+        let provider = AnthropicProviderBuilder::new(
+            crate::api_client::ApiClient::new_with_tls(
+                "http://localhost:11434".into(),
+                crate::api_client::AuthMethod::NoAuth,
+                None,
+            )
+            .unwrap(),
+        )
+        .custom_models(Some(vec![custom_model.clone()]))
+        .build();
+
+        // The fallback heuristic should kick in and return true for claude-3-7-sonnet
+        let info = provider
+            .fetch_model_info("claude-3-7-sonnet-20250219")
+            .await
+            .unwrap();
+        assert!(info.reasoning.is_enabled());
     }
 }

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -314,7 +314,7 @@ impl Provider for AnthropicProvider {
             .and_then(|models| models.iter().find(|m| m.name == model_config.model_name))
         {
             patched_model_config.reasoning = match patched_model_config.reasoning {
-                Some(_) if !model_config.reasoning_is_explicit => m.reasoning.clone(),
+                Some(r) if !model_config.reasoning_is_explicit => m.reasoning.clone().or(Some(r)),
                 Some(r) => Some(r.with_provider_defaults(m.reasoning.as_ref())),
                 None => m.reasoning.clone(),
             };

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -258,6 +258,38 @@ impl Provider for AnthropicProvider {
         self.fetch_models_from_api().await
     }
 
+    async fn fetch_supported_model_info(&self) -> Result<Vec<ModelInfo>, ProviderError> {
+        let models = self.fetch_supported_models().await?;
+        let mut model_infos = Vec::new();
+
+        for model_name in models {
+            if let Some(custom_models) = &self.custom_models {
+                if let Some(model_info) = custom_models.iter().find(|m| m.name == model_name) {
+                    model_infos.push(model_info.clone());
+                    continue;
+                }
+            }
+            model_infos.push(goose_provider_types::base::model_info_for_provider_model(
+                self.get_name(),
+                &model_name,
+            ));
+        }
+
+        Ok(model_infos)
+    }
+
+    async fn fetch_model_info(&self, model_name: &str) -> Result<ModelInfo, ProviderError> {
+        if let Some(custom_models) = &self.custom_models {
+            if let Some(model_info) = custom_models.iter().find(|m| m.name == model_name) {
+                return Ok(model_info.clone());
+            }
+        }
+        Ok(goose_provider_types::base::model_info_for_provider_model(
+            self.get_name(),
+            model_name,
+        ))
+    }
+
     async fn stream(
         &self,
         model_config: &ModelConfig,
@@ -408,4 +440,39 @@ pub fn from_declarative_config(
         .dynamic_models(config.dynamic_models)
         .skip_canonical_filtering(config.skip_canonical_filtering)
         .format_options(format_options))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use goose_provider_types::base::ModelInfo;
+
+    #[tokio::test]
+    async fn test_fetch_model_info_returns_custom_model_config() {
+        let mut custom_model = ModelInfo::new("my-custom-model", 4096);
+        custom_model.reasoning = goose_provider_types::base::Reasoning::ReasoningConfig(
+            goose_provider_types::base::ReasoningConfig {
+                enabled: true,
+                ..Default::default()
+            },
+        );
+
+        let provider = AnthropicProviderBuilder::new(
+            crate::api_client::ApiClient::new_with_tls(
+                "http://localhost:11434".into(),
+                crate::api_client::AuthMethod::NoAuth,
+                None,
+            )
+            .unwrap(),
+        )
+        .custom_models(Some(vec![custom_model.clone()]))
+        .build();
+
+        let info = provider.fetch_model_info("my-custom-model").await.unwrap();
+        assert!(info.reasoning.is_enabled());
+
+        // Standard heuristics would default this to non-reasoning
+        let info_not_found = provider.fetch_model_info("other-model").await.unwrap();
+        assert!(!info_not_found.reasoning.is_enabled());
+    }
 }

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -313,12 +313,8 @@ impl Provider for AnthropicProvider {
             .as_ref()
             .and_then(|models| models.iter().find(|m| m.name == model_config.model_name))
         {
-            let default_info = goose_provider_types::base::model_info_for_provider_model(
-                self.get_name(),
-                &model_config.model_name,
-            );
             patched_model_config.reasoning = match patched_model_config.reasoning {
-                Some(ref r) if Some(r.clone()) == default_info.reasoning => m.reasoning.clone(),
+                Some(_) if !model_config.reasoning_is_explicit => m.reasoning.clone(),
                 Some(r) => Some(r.with_provider_defaults(m.reasoning.as_ref())),
                 None => m.reasoning.clone(),
             };

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -265,6 +265,18 @@ impl Provider for AnthropicProvider {
         messages: &[Message],
         tools: &[Tool],
     ) -> Result<MessageStream, ProviderError> {
+        let mut patched_model_config = model_config.clone();
+        if let Some(m) = self.custom_models.as_ref().and_then(|models| {
+            models.iter().find(|m| m.name == model_config.model_name)
+        }) {
+            patched_model_config.reasoning = Some(
+                patched_model_config
+                    .reasoning
+                    .unwrap_or_default()
+                    .with_provider_defaults(Some(&m.reasoning)),
+            );
+        }
+        let model_config = &patched_model_config;
         let mut payload = create_request(
             ANTHROPIC_PROVIDER_NAME,
             model_config,

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -271,7 +271,7 @@ impl Provider for AnthropicProvider {
             if let Some(custom_models) = &self.custom_models {
                 if let Some(model_info) = custom_models.iter().find(|m| m.name == model_name) {
                     let mut info = model_info.clone();
-                    if let goose_provider_types::base::Reasoning::Enabled(false) = info.reasoning {
+                    if info.reasoning.is_none() {
                         info.reasoning = default_info.reasoning.clone();
                     }
                     model_infos.push(info);
@@ -291,7 +291,7 @@ impl Provider for AnthropicProvider {
         if let Some(custom_models) = &self.custom_models {
             if let Some(model_info) = custom_models.iter().find(|m| m.name == model_name) {
                 let mut info = model_info.clone();
-                if let goose_provider_types::base::Reasoning::Enabled(false) = info.reasoning {
+                if info.reasoning.is_none() {
                     info.reasoning = default_info.reasoning.clone();
                 }
                 return Ok(info);
@@ -314,11 +314,8 @@ impl Provider for AnthropicProvider {
             .and_then(|models| models.iter().find(|m| m.name == model_config.model_name))
         {
             patched_model_config.reasoning = match patched_model_config.reasoning {
-                Some(r) => Some(r.with_provider_defaults(Some(&m.reasoning))),
-                None => match &m.reasoning {
-                    goose_provider_types::base::Reasoning::Enabled(false) => None,
-                    _ => Some(m.reasoning.clone()),
-                },
+                Some(r) => Some(r.with_provider_defaults(m.reasoning.as_ref())),
+                None => m.reasoning.clone(),
             };
         }
         let model_config = &patched_model_config;
@@ -460,12 +457,12 @@ mod tests {
     #[tokio::test]
     async fn test_fetch_model_info_returns_custom_model_config() {
         let mut custom_model = ModelInfo::new("my-custom-model", 4096);
-        custom_model.reasoning = goose_provider_types::base::Reasoning::ReasoningConfig(
+        custom_model.reasoning = Some(goose_provider_types::base::Reasoning::ReasoningConfig(
             goose_provider_types::base::ReasoningConfig {
                 enabled: true,
                 ..Default::default()
             },
-        );
+        ));
 
         let provider = AnthropicProviderBuilder::new(
             crate::api_client::ApiClient::new_with_tls(
@@ -479,11 +476,11 @@ mod tests {
         .build();
 
         let info = provider.fetch_model_info("my-custom-model").await.unwrap();
-        assert!(info.reasoning.is_enabled());
+        assert!(info.reasoning.unwrap().is_enabled());
 
         // Standard heuristics would default this to non-reasoning
         let info_not_found = provider.fetch_model_info("other-model").await.unwrap();
-        assert!(!info_not_found.reasoning.is_enabled());
+        assert!(!info_not_found.reasoning.unwrap().is_enabled());
     }
 
     #[tokio::test]
@@ -508,6 +505,6 @@ mod tests {
             .fetch_model_info("claude-3-7-sonnet-20250219")
             .await
             .unwrap();
-        assert!(info.reasoning.is_enabled());
+        assert!(info.reasoning.unwrap().is_enabled());
     }
 }

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -56,7 +56,7 @@ pub struct AnthropicProvider {
     api_client: ApiClient,
     supports_streaming: bool,
     name: String,
-    custom_models: Option<Vec<String>>,
+    custom_models: Option<Vec<ModelInfo>>,
     dynamic_models: Option<bool>,
     skip_canonical_filtering: bool,
     #[serde(skip)]
@@ -73,7 +73,7 @@ pub struct AnthropicProviderBuilder {
     api_client: ApiClient,
     supports_streaming: bool,
     name: String,
-    custom_models: Option<Vec<String>>,
+    custom_models: Option<Vec<ModelInfo>>,
     dynamic_models: Option<bool>,
     skip_canonical_filtering: bool,
     format_options: AnthropicFormatOptions,
@@ -120,7 +120,7 @@ impl AnthropicProviderBuilder {
         self
     }
 
-    pub fn custom_models(mut self, custom_models: Option<Vec<String>>) -> Self {
+    pub fn custom_models(mut self, custom_models: Option<Vec<ModelInfo>>) -> Self {
         self.custom_models = custom_models;
         self
     }
@@ -239,7 +239,7 @@ impl Provider for AnthropicProvider {
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         if let Some(custom_models) = &self.custom_models {
             if self.dynamic_models == Some(false) {
-                return Ok(custom_models.clone());
+                return Ok(custom_models.iter().map(|m| m.name.clone()).collect());
             }
             match self.fetch_models_from_api().await {
                 Ok(models) => return Ok(models),
@@ -249,7 +249,7 @@ impl Provider for AnthropicProvider {
                         self.name,
                         e
                     );
-                    return Ok(custom_models.clone());
+                    return Ok(custom_models.iter().map(|m| m.name.clone()).collect());
                 }
                 Err(e) => return Err(e),
             }
@@ -322,13 +322,7 @@ pub fn from_declarative_config(
     key_resolver: impl KeyResolver,
 ) -> Result<AnthropicProviderBuilder> {
     let custom_models = if !config.models.is_empty() {
-        Some(
-            config
-                .models
-                .iter()
-                .map(|m| m.name.clone())
-                .collect::<Vec<String>>(),
-        )
+        Some(config.models.clone())
     } else {
         None
     };

--- a/crates/goose-providers/src/databricks.rs
+++ b/crates/goose-providers/src/databricks.rs
@@ -468,7 +468,7 @@ impl DatabricksProvider {
             output_token_cost: None,
             currency: None,
             supports_cache_control: None,
-            reasoning,
+            reasoning: goose_provider_types::base::Reasoning::Enabled(reasoning),
         }
     }
 
@@ -801,7 +801,7 @@ mod tests {
             model_info.resolved_model.as_deref(),
             Some("claude-opus-4.6")
         );
-        assert!(model_info.reasoning);
+        assert!(model_info.reasoning.is_enabled());
     }
 
     #[test]

--- a/crates/goose-providers/src/databricks.rs
+++ b/crates/goose-providers/src/databricks.rs
@@ -468,7 +468,7 @@ impl DatabricksProvider {
             output_token_cost: None,
             currency: None,
             supports_cache_control: None,
-            reasoning: goose_provider_types::base::Reasoning::Enabled(reasoning),
+            reasoning: Some(goose_provider_types::base::Reasoning::Enabled(reasoning)),
         }
     }
 
@@ -801,7 +801,7 @@ mod tests {
             model_info.resolved_model.as_deref(),
             Some("claude-opus-4.6")
         );
-        assert!(model_info.reasoning.is_enabled());
+        assert!(model_info.reasoning.unwrap().is_enabled());
     }
 
     #[test]

--- a/crates/goose-providers/src/declarative/definitions/cerebras.json
+++ b/crates/goose-providers/src/declarative/definitions/cerebras.json
@@ -29,10 +29,7 @@
         "thinking_preservation_format": "content_xml",
         "reasoning_property": "reasoning_effort",
         "effort_mapping": {
-          "off": "none",
-          "low": "low",
-          "medium": "medium",
-          "high": "high"
+          "off": "none"
         },
         "extra_body": {
           "reasoning_format": "parsed"

--- a/crates/goose-providers/src/declarative/definitions/cerebras.json
+++ b/crates/goose-providers/src/declarative/definitions/cerebras.json
@@ -41,6 +41,7 @@
       "context_limit": 131072,
       "reasoning": {
         "enabled": true,
+        "thinking_preservation_format": "content_prepend",
         "reasoning_property": "reasoning_effort",
         "effort_mapping": {
           "off": "none"

--- a/crates/goose-providers/src/declarative/definitions/cerebras.json
+++ b/crates/goose-providers/src/declarative/definitions/cerebras.json
@@ -8,11 +8,25 @@
   "models": [
     {
       "name": "gpt-oss-120b",
-      "context_limit": 131072
+      "context_limit": 131072,
+      "reasoning": {
+        "enabled": true,
+        "thinking_preservation_format": "content_prepend",
+        "extra_body": {
+          "reasoning_format": "parsed"
+        }
+      }
     },
     {
       "name": "zai-glm-4.7",
-      "context_limit": 131072
+      "context_limit": 131072,
+      "reasoning": {
+        "enabled": true,
+        "thinking_preservation_format": "content_xml",
+        "extra_body": {
+          "reasoning_format": "parsed"
+        }
+      }
     }
   ],
   "supports_streaming": true

--- a/crates/goose-providers/src/declarative/definitions/cerebras.json
+++ b/crates/goose-providers/src/declarative/definitions/cerebras.json
@@ -14,10 +14,7 @@
         "thinking_preservation_format": "content_prepend",
         "reasoning_property": "reasoning_effort",
         "effort_mapping": {
-          "off": "none",
-          "low": "low",
-          "medium": "medium",
-          "high": "high"
+          "off": "none"
         },
         "extra_body": {
           "reasoning_format": "parsed"

--- a/crates/goose-providers/src/declarative/definitions/cerebras.json
+++ b/crates/goose-providers/src/declarative/definitions/cerebras.json
@@ -5,6 +5,7 @@
   "description": "Fast inference on Cerebras wafer-scale engines",
   "api_key_env": "CEREBRAS_API_KEY",
   "base_url": "https://api.cerebras.ai/v1/chat/completions",
+  "preserves_thinking": true,
   "models": [
     {
       "name": "gpt-oss-120b",

--- a/crates/goose-providers/src/declarative/definitions/cerebras.json
+++ b/crates/goose-providers/src/declarative/definitions/cerebras.json
@@ -41,7 +41,6 @@
       "context_limit": 131072,
       "reasoning": {
         "enabled": true,
-        "thinking_preservation_format": "content_prepend",
         "reasoning_property": "reasoning_effort",
         "effort_mapping": {
           "off": "none"

--- a/crates/goose-providers/src/declarative/definitions/cerebras.json
+++ b/crates/goose-providers/src/declarative/definitions/cerebras.json
@@ -13,6 +13,12 @@
         "enabled": true,
         "thinking_preservation_format": "content_prepend",
         "reasoning_property": "reasoning_effort",
+        "effort_mapping": {
+          "off": "none",
+          "low": "low",
+          "medium": "medium",
+          "high": "high"
+        },
         "extra_body": {
           "reasoning_format": "parsed"
         }
@@ -25,6 +31,12 @@
         "enabled": true,
         "thinking_preservation_format": "content_xml",
         "reasoning_property": "reasoning_effort",
+        "effort_mapping": {
+          "off": "none",
+          "low": "low",
+          "medium": "medium",
+          "high": "high"
+        },
         "extra_body": {
           "reasoning_format": "parsed"
         }

--- a/crates/goose-providers/src/declarative/definitions/cerebras.json
+++ b/crates/goose-providers/src/declarative/definitions/cerebras.json
@@ -13,11 +13,6 @@
         "enabled": true,
         "thinking_preservation_format": "content_prepend",
         "reasoning_property": "reasoning_effort",
-        "effort_mapping": {
-          "low": "low",
-          "medium": "medium",
-          "high": "high"
-        },
         "extra_body": {
           "reasoning_format": "parsed"
         }
@@ -30,11 +25,6 @@
         "enabled": true,
         "thinking_preservation_format": "content_xml",
         "reasoning_property": "reasoning_effort",
-        "effort_mapping": {
-          "low": "low",
-          "medium": "medium",
-          "high": "high"
-        },
         "extra_body": {
           "reasoning_format": "parsed"
         }

--- a/crates/goose-providers/src/declarative/definitions/cerebras.json
+++ b/crates/goose-providers/src/declarative/definitions/cerebras.json
@@ -12,6 +12,12 @@
       "reasoning": {
         "enabled": true,
         "thinking_preservation_format": "content_prepend",
+        "reasoning_property": "reasoning_effort",
+        "effort_mapping": {
+          "low": "low",
+          "medium": "medium",
+          "high": "high"
+        },
         "extra_body": {
           "reasoning_format": "parsed"
         }
@@ -23,6 +29,12 @@
       "reasoning": {
         "enabled": true,
         "thinking_preservation_format": "content_xml",
+        "reasoning_property": "reasoning_effort",
+        "effort_mapping": {
+          "low": "low",
+          "medium": "medium",
+          "high": "high"
+        },
         "extra_body": {
           "reasoning_format": "parsed"
         }

--- a/crates/goose-providers/src/declarative/definitions/cerebras.json
+++ b/crates/goose-providers/src/declarative/definitions/cerebras.json
@@ -35,6 +35,21 @@
           "reasoning_format": "parsed"
         }
       }
+    },
+    {
+      "name": "gemma-4-31b",
+      "context_limit": 131072,
+      "reasoning": {
+        "enabled": true,
+        "thinking_preservation_format": "content_prepend",
+        "reasoning_property": "reasoning_effort",
+        "effort_mapping": {
+          "off": "none"
+        },
+        "extra_body": {
+          "reasoning_format": "parsed"
+        }
+      }
     }
   ],
   "supports_streaming": true

--- a/crates/goose-providers/src/ollama.rs
+++ b/crates/goose-providers/src/ollama.rs
@@ -405,6 +405,20 @@ impl Provider for OllamaProvider {
         messages: &[Message],
         tools: &[Tool],
     ) -> Result<MessageStream, ProviderError> {
+        let mut patched_model_config = model_config.clone();
+        if let Some(m) = self
+            .custom_models
+            .as_ref()
+            .and_then(|models| models.iter().find(|m| m.name == model_config.model_name))
+        {
+            patched_model_config.reasoning = match patched_model_config.reasoning {
+                Some(crate::base::Reasoning::Enabled(false)) => m.reasoning.clone(),
+                Some(r) => Some(r.with_provider_defaults(m.reasoning.as_ref())),
+                None => m.reasoning.clone(),
+            };
+        }
+        let model_config = &patched_model_config;
+
         let mut payload = create_request(
             model_config,
             system,

--- a/crates/goose-providers/src/ollama.rs
+++ b/crates/goose-providers/src/ollama.rs
@@ -430,12 +430,14 @@ impl Provider for OllamaProvider {
             true,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
-                thinking_preservation_format: model_config.reasoning.as_ref().and_then(|r| match r {
-                    goose_provider_types::base::Reasoning::ReasoningConfig(c) => {
-                        c.thinking_preservation_format
-                    }
-                    _ => None,
-                }),
+                thinking_preservation_format: model_config.reasoning.as_ref().and_then(
+                    |r| match r {
+                        goose_provider_types::base::Reasoning::ReasoningConfig(c) => {
+                            c.thinking_preservation_format
+                        }
+                        _ => None,
+                    },
+                ),
             },
         )?;
         apply_ollama_options(&mut payload, &self.options, model_config);

--- a/crates/goose-providers/src/ollama.rs
+++ b/crates/goose-providers/src/ollama.rs
@@ -7,7 +7,9 @@ use crate::base::ProviderDescriptor;
 use crate::conversation::message::Message;
 use crate::declarative::{DeclarativeProviderConfig, KeyResolver};
 use crate::errors::ProviderError;
-use crate::formats::ollama::{create_request, response_to_streaming_message_ollama};
+use crate::formats::ollama::{
+    create_request_with_options, response_to_streaming_message_ollama, OpenAiFormatOptions,
+};
 use crate::images::ImageFormat;
 use crate::model::ModelConfig;
 use crate::request_log::{start_log, LoggerHandleExt, RequestLogHandle};
@@ -419,13 +421,22 @@ impl Provider for OllamaProvider {
         }
         let model_config = &patched_model_config;
 
-        let mut payload = create_request(
+        let mut payload = create_request_with_options(
             model_config,
             system,
             messages,
             tools,
             &ImageFormat::OpenAi,
             true,
+            OpenAiFormatOptions {
+                preserve_thinking_context: true,
+                thinking_preservation_format: model_config.reasoning.as_ref().and_then(|r| match r {
+                    goose_provider_types::base::Reasoning::ReasoningConfig(c) => {
+                        c.thinking_preservation_format
+                    }
+                    _ => None,
+                }),
+            },
         )?;
         apply_ollama_options(&mut payload, &self.options, model_config);
         let mut log = start_log(model_config, &payload)?;

--- a/crates/goose-providers/src/ollama.rs
+++ b/crates/goose-providers/src/ollama.rs
@@ -1,5 +1,5 @@
 use super::api_client::ApiClient;
-use super::base::{ConfigKey, MessageStream, Provider, ProviderMetadata};
+use super::base::{ConfigKey, MessageStream, ModelInfo, Provider, ProviderMetadata};
 use super::openai_compatible::handle_status;
 use super::retry::{ProviderRetry, RetryConfig};
 use crate::api_client::{AuthMethod, TlsConfig};
@@ -82,7 +82,7 @@ pub struct OllamaProvider {
     #[serde(skip)]
     api_client: ApiClient,
     name: String,
-    custom_models: Option<Vec<String>>,
+    custom_models: Option<Vec<ModelInfo>>,
     dynamic_models: Option<bool>,
     skip_canonical_filtering: bool,
     options: OllamaOptions,
@@ -91,7 +91,7 @@ pub struct OllamaProvider {
 pub struct OllamaProviderBuilder {
     api_client: ApiClient,
     name: String,
-    custom_models: Option<Vec<String>>,
+    custom_models: Option<Vec<ModelInfo>>,
     dynamic_models: Option<bool>,
     skip_canonical_filtering: bool,
     options: OllamaOptions,
@@ -132,7 +132,7 @@ impl OllamaProviderBuilder {
         self
     }
 
-    pub fn custom_models(mut self, custom_models: Option<Vec<String>>) -> Self {
+    pub fn custom_models(mut self, custom_models: Option<Vec<ModelInfo>>) -> Self {
         self.custom_models = custom_models;
         self
     }
@@ -273,13 +273,7 @@ pub fn from_declarative_config(
     key_resolver: impl KeyResolver,
 ) -> Result<OllamaProviderBuilder> {
     let custom_models = if !config.models.is_empty() {
-        Some(
-            config
-                .models
-                .iter()
-                .map(|m| m.name.clone())
-                .collect::<Vec<String>>(),
-        )
+        Some(config.models.clone())
     } else {
         None
     };
@@ -440,7 +434,7 @@ impl Provider for OllamaProvider {
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         if let Some(custom_models) = &self.custom_models {
             if self.dynamic_models == Some(false) {
-                return Ok(custom_models.clone());
+                return Ok(custom_models.iter().map(|m| m.name.clone()).collect());
             }
 
             match self.fetch_models_from_api().await {
@@ -451,7 +445,7 @@ impl Provider for OllamaProvider {
                         self.name,
                         e
                     );
-                    return Ok(custom_models.clone());
+                    return Ok(custom_models.iter().map(|m| m.name.clone()).collect());
                 }
                 Err(e) => return Err(e),
             }

--- a/crates/goose-providers/src/ollama.rs
+++ b/crates/goose-providers/src/ollama.rs
@@ -412,7 +412,7 @@ impl Provider for OllamaProvider {
             .and_then(|models| models.iter().find(|m| m.name == model_config.model_name))
         {
             patched_model_config.reasoning = match patched_model_config.reasoning {
-                Some(_) if !model_config.reasoning_is_explicit => m.reasoning.clone(),
+                Some(r) if !model_config.reasoning_is_explicit => m.reasoning.clone().or(Some(r)),
                 Some(r) => Some(r.with_provider_defaults(m.reasoning.as_ref())),
                 None => m.reasoning.clone(),
             };

--- a/crates/goose-providers/src/ollama.rs
+++ b/crates/goose-providers/src/ollama.rs
@@ -453,6 +453,18 @@ impl Provider for OllamaProvider {
 
         self.fetch_models_from_api().await
     }
+
+    async fn fetch_model_info(&self, model_name: &str) -> Result<ModelInfo, ProviderError> {
+        let info = self
+            .custom_models
+            .as_ref()
+            .and_then(|models| models.iter().find(|m| m.name == model_name).cloned())
+            .unwrap_or_else(|| {
+                crate::base::model_info_for_provider_model(self.get_name(), model_name)
+            });
+
+        Ok(info)
+    }
 }
 
 /// Default per-chunk timeout for Ollama streaming responses (seconds).
@@ -754,5 +766,34 @@ mod tests {
             payload.get("stream_options").is_none(),
             "stream_options should be removed when OLLAMA_STREAM_USAGE=false"
         );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_model_info_preserves_custom_reasoning() {
+        let mut model1 = ModelInfo::new("reasoning-model", 4096);
+        model1.reasoning = Some(crate::base::Reasoning::Enabled(true));
+        let mut model2 = ModelInfo::new("non-reasoning-model", 4096);
+        model2.reasoning = Some(crate::base::Reasoning::Enabled(false));
+        let models = vec![model1, model2];
+
+        let provider = from_declarative_config(
+            ollama_config(None, models),
+            None,
+            crate::declarative::EnvKeyResolver,
+        )
+        .unwrap()
+        .build();
+
+        let info = provider.fetch_model_info("reasoning-model").await.unwrap();
+        assert_eq!(info.reasoning, Some(crate::base::Reasoning::Enabled(true)));
+
+        let info = provider
+            .fetch_model_info("non-reasoning-model")
+            .await
+            .unwrap();
+        assert_eq!(info.reasoning, Some(crate::base::Reasoning::Enabled(false)));
+
+        let info = provider.fetch_model_info("unknown-model").await.unwrap();
+        assert_eq!(info.reasoning, Some(crate::base::Reasoning::Enabled(false)));
     }
 }

--- a/crates/goose-providers/src/ollama.rs
+++ b/crates/goose-providers/src/ollama.rs
@@ -411,12 +411,8 @@ impl Provider for OllamaProvider {
             .as_ref()
             .and_then(|models| models.iter().find(|m| m.name == model_config.model_name))
         {
-            let default_info = goose_provider_types::base::model_info_for_provider_model(
-                self.get_name(),
-                &model_config.model_name,
-            );
             patched_model_config.reasoning = match patched_model_config.reasoning {
-                Some(ref r) if Some(r.clone()) == default_info.reasoning => m.reasoning.clone(),
+                Some(_) if !model_config.reasoning_is_explicit => m.reasoning.clone(),
                 Some(r) => Some(r.with_provider_defaults(m.reasoning.as_ref())),
                 None => m.reasoning.clone(),
             };

--- a/crates/goose-providers/src/ollama.rs
+++ b/crates/goose-providers/src/ollama.rs
@@ -411,8 +411,12 @@ impl Provider for OllamaProvider {
             .as_ref()
             .and_then(|models| models.iter().find(|m| m.name == model_config.model_name))
         {
+            let default_info = goose_provider_types::base::model_info_for_provider_model(
+                self.get_name(),
+                &model_config.model_name,
+            );
             patched_model_config.reasoning = match patched_model_config.reasoning {
-                Some(crate::base::Reasoning::Enabled(false)) => m.reasoning.clone(),
+                Some(ref r) if Some(r.clone()) == default_info.reasoning => m.reasoning.clone(),
                 Some(r) => Some(r.with_provider_defaults(m.reasoning.as_ref())),
                 None => m.reasoning.clone(),
             };

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -638,6 +638,38 @@ impl Provider for OpenAiProvider {
         self.fetch_models_from_api().await
     }
 
+    async fn fetch_supported_model_info(&self) -> Result<Vec<ModelInfo>, ProviderError> {
+        let models = self.fetch_supported_models().await?;
+        let mut model_infos = Vec::new();
+
+        for model_name in models {
+            if let Some(custom_models) = &self.custom_models {
+                if let Some(model_info) = custom_models.iter().find(|m| m.name == model_name) {
+                    model_infos.push(model_info.clone());
+                    continue;
+                }
+            }
+            model_infos.push(goose_provider_types::base::model_info_for_provider_model(
+                self.get_name(),
+                &model_name,
+            ));
+        }
+
+        Ok(model_infos)
+    }
+
+    async fn fetch_model_info(&self, model_name: &str) -> Result<ModelInfo, ProviderError> {
+        if let Some(custom_models) = &self.custom_models {
+            if let Some(model_info) = custom_models.iter().find(|m| m.name == model_name) {
+                return Ok(model_info.clone());
+            }
+        }
+        Ok(goose_provider_types::base::model_info_for_provider_model(
+            self.get_name(),
+            model_name,
+        ))
+    }
+
     async fn stream(
         &self,
         model_config: &ModelConfig,
@@ -1334,5 +1366,35 @@ mod tests {
     fn derive_base_path_does_not_treat_v_word_as_version() {
         let r = derive_base_path("/api/voice");
         assert_eq!(r, "api/voice/v1/chat/completions");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_model_info_returns_custom_model_config() {
+        let mut custom_model = ModelInfo::new("my-custom-model", 4096);
+        custom_model.reasoning = goose_provider_types::base::Reasoning::ReasoningConfig(
+            goose_provider_types::base::ReasoningConfig {
+                enabled: true,
+                ..Default::default()
+            },
+        );
+
+        let provider = OpenAiProviderBuilder::new(
+            crate::api_client::ApiClient::new_with_tls(
+                "http://localhost".into(),
+                crate::api_client::AuthMethod::NoAuth,
+                None,
+            )
+            .unwrap(),
+        )
+        .custom_models(Some(vec![custom_model.clone()]))
+        .build();
+
+        let info = provider.fetch_model_info("my-custom-model").await.unwrap();
+
+        assert!(info.reasoning.is_enabled());
+
+        // Standard heuristics would default this to non-reasoning
+        let info_not_found = provider.fetch_model_info("other-model").await.unwrap();
+        assert!(!info_not_found.reasoning.is_enabled());
     }
 }

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -694,7 +694,7 @@ impl Provider for OpenAiProvider {
             .and_then(|models| models.iter().find(|m| m.name == model_config.model_name))
         {
             patched_model_config.reasoning = match patched_model_config.reasoning {
-                Some(_) if !model_config.reasoning_is_explicit => m.reasoning.clone(),
+                Some(r) if !model_config.reasoning_is_explicit => m.reasoning.clone().or(Some(r)),
                 Some(r) => Some(r.with_provider_defaults(m.reasoning.as_ref())),
                 None => m.reasoning.clone(),
             };

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -651,7 +651,7 @@ impl Provider for OpenAiProvider {
             if let Some(custom_models) = &self.custom_models {
                 if let Some(model_info) = custom_models.iter().find(|m| m.name == model_name) {
                     let mut info = model_info.clone();
-                    if let goose_provider_types::base::Reasoning::Enabled(false) = info.reasoning {
+                    if info.reasoning.is_none() {
                         info.reasoning = default_info.reasoning.clone();
                     }
                     model_infos.push(info);
@@ -671,7 +671,7 @@ impl Provider for OpenAiProvider {
         if let Some(custom_models) = &self.custom_models {
             if let Some(model_info) = custom_models.iter().find(|m| m.name == model_name) {
                 let mut info = model_info.clone();
-                if let goose_provider_types::base::Reasoning::Enabled(false) = info.reasoning {
+                if info.reasoning.is_none() {
                     info.reasoning = default_info.reasoning.clone();
                 }
                 return Ok(info);
@@ -694,11 +694,8 @@ impl Provider for OpenAiProvider {
             .and_then(|models| models.iter().find(|m| m.name == model_config.model_name))
         {
             patched_model_config.reasoning = match patched_model_config.reasoning {
-                Some(r) => Some(r.with_provider_defaults(Some(&m.reasoning))),
-                None => match &m.reasoning {
-                    goose_provider_types::base::Reasoning::Enabled(false) => None,
-                    _ => Some(m.reasoning.clone()),
-                },
+                Some(r) => Some(r.with_provider_defaults(m.reasoning.as_ref())),
+                None => m.reasoning.clone(),
             };
         }
         let model_config = &patched_model_config;
@@ -1381,12 +1378,12 @@ mod tests {
     #[tokio::test]
     async fn test_fetch_model_info_returns_custom_model_config() {
         let mut custom_model = ModelInfo::new("my-custom-model", 4096);
-        custom_model.reasoning = goose_provider_types::base::Reasoning::ReasoningConfig(
+        custom_model.reasoning = Some(goose_provider_types::base::Reasoning::ReasoningConfig(
             goose_provider_types::base::ReasoningConfig {
                 enabled: true,
                 ..Default::default()
             },
-        );
+        ));
 
         let provider = OpenAiProviderBuilder::new(
             crate::api_client::ApiClient::new_with_tls(
@@ -1401,11 +1398,11 @@ mod tests {
 
         let info = provider.fetch_model_info("my-custom-model").await.unwrap();
 
-        assert!(info.reasoning.is_enabled());
+        assert!(info.reasoning.unwrap().is_enabled());
 
         // Standard heuristics would default this to non-reasoning
         let info_not_found = provider.fetch_model_info("other-model").await.unwrap();
-        assert!(!info_not_found.reasoning.is_enabled());
+        assert!(!info_not_found.reasoning.unwrap().is_enabled());
     }
 
     #[tokio::test]
@@ -1427,6 +1424,6 @@ mod tests {
 
         // The fallback heuristic should kick in and return true for o3
         let info = provider.fetch_model_info("o3").await.unwrap();
-        assert!(info.reasoning.is_enabled());
+        assert!(info.reasoning.unwrap().is_enabled());
     }
 }

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -645,6 +645,19 @@ impl Provider for OpenAiProvider {
         messages: &[Message],
         tools: &[Tool],
     ) -> Result<MessageStream, ProviderError> {
+        let mut patched_model_config = model_config.clone();
+        if let Some(m) = self.custom_models.as_ref().and_then(|models| {
+            models.iter().find(|m| m.name == model_config.model_name)
+        }) {
+            patched_model_config.reasoning = Some(
+                patched_model_config
+                    .reasoning
+                    .unwrap_or_default()
+                    .with_provider_defaults(Some(&m.reasoning)),
+            );
+        }
+        let model_config = &patched_model_config;
+
         if self.should_use_responses_api_for_provider(&model_config.model_name) {
             let mut payload = create_responses_request(model_config, system, messages, tools)?;
             payload["stream"] = serde_json::Value::Bool(self.supports_streaming);
@@ -712,29 +725,14 @@ impl Provider for OpenAiProvider {
                 self.supports_streaming,
                 OpenAiFormatOptions {
                     preserve_thinking_context: self.preserve_thinking_context,
-                    thinking_preservation_format: {
-                        let config_format = model_config.reasoning.as_ref().and_then(|r| match r {
+                    thinking_preservation_format: model_config.reasoning.as_ref().and_then(|r| {
+                        match r {
                             goose_provider_types::base::Reasoning::ReasoningConfig(c) => {
                                 c.thinking_preservation_format
                             }
                             _ => None,
-                        });
-
-                        let provider_format = self
-                            .custom_models
-                            .as_ref()
-                            .and_then(|models| {
-                                models.iter().find(|m| m.name == model_config.model_name)
-                            })
-                            .and_then(|m| match &m.reasoning {
-                                goose_provider_types::base::Reasoning::ReasoningConfig(c) => {
-                                    c.thinking_preservation_format
-                                }
-                                _ => None,
-                            });
-
-                        config_format.or(provider_format)
-                    },
+                        }
+                    }),
                 },
             )?;
             let payload = self.sanitize_request_for_compat(payload, model_config);

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -693,8 +693,12 @@ impl Provider for OpenAiProvider {
             .as_ref()
             .and_then(|models| models.iter().find(|m| m.name == model_config.model_name))
         {
+            let default_info = goose_provider_types::base::model_info_for_provider_model(
+                self.get_name(),
+                &model_config.model_name,
+            );
             patched_model_config.reasoning = match patched_model_config.reasoning {
-                Some(crate::base::Reasoning::Enabled(false)) => m.reasoning.clone(),
+                Some(ref r) if Some(r.clone()) == default_info.reasoning => m.reasoning.clone(),
                 Some(r) => Some(r.with_provider_defaults(m.reasoning.as_ref())),
                 None => m.reasoning.clone(),
             };

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -694,6 +694,7 @@ impl Provider for OpenAiProvider {
             .and_then(|models| models.iter().find(|m| m.name == model_config.model_name))
         {
             patched_model_config.reasoning = match patched_model_config.reasoning {
+                Some(crate::base::Reasoning::Enabled(false)) => m.reasoning.clone(),
                 Some(r) => Some(r.with_provider_defaults(m.reasoning.as_ref())),
                 None => m.reasoning.clone(),
             };

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -646,9 +646,11 @@ impl Provider for OpenAiProvider {
         tools: &[Tool],
     ) -> Result<MessageStream, ProviderError> {
         let mut patched_model_config = model_config.clone();
-        if let Some(m) = self.custom_models.as_ref().and_then(|models| {
-            models.iter().find(|m| m.name == model_config.model_name)
-        }) {
+        if let Some(m) = self
+            .custom_models
+            .as_ref()
+            .and_then(|models| models.iter().find(|m| m.name == model_config.model_name))
+        {
             patched_model_config.reasoning = Some(
                 patched_model_config
                     .reasoning

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -693,12 +693,8 @@ impl Provider for OpenAiProvider {
             .as_ref()
             .and_then(|models| models.iter().find(|m| m.name == model_config.model_name))
         {
-            let default_info = goose_provider_types::base::model_info_for_provider_model(
-                self.get_name(),
-                &model_config.model_name,
-            );
             patched_model_config.reasoning = match patched_model_config.reasoning {
-                Some(ref r) if Some(r.clone()) == default_info.reasoning => m.reasoning.clone(),
+                Some(_) if !model_config.reasoning_is_explicit => m.reasoning.clone(),
                 Some(r) => Some(r.with_provider_defaults(m.reasoning.as_ref())),
                 None => m.reasoning.clone(),
             };

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -759,6 +759,14 @@ impl Provider for OpenAiProvider {
                 Ok(super::base::stream_from_single_message(message, usage))
             }
         } else {
+            let thinking_preservation_format =
+                model_config.reasoning.as_ref().and_then(|r| match r {
+                    goose_provider_types::base::Reasoning::ReasoningConfig(c) => {
+                        c.thinking_preservation_format
+                    }
+                    _ => None,
+                });
+
             let payload = create_request_with_options(
                 model_config,
                 system,
@@ -767,15 +775,9 @@ impl Provider for OpenAiProvider {
                 &ImageFormat::OpenAi,
                 self.supports_streaming,
                 OpenAiFormatOptions {
-                    preserve_thinking_context: self.preserve_thinking_context,
-                    thinking_preservation_format: model_config.reasoning.as_ref().and_then(|r| {
-                        match r {
-                            goose_provider_types::base::Reasoning::ReasoningConfig(c) => {
-                                c.thinking_preservation_format
-                            }
-                            _ => None,
-                        }
-                    }),
+                    preserve_thinking_context: self.preserve_thinking_context
+                        || thinking_preservation_format.is_some(),
+                    thinking_preservation_format,
                 },
             )?;
             let payload = self.sanitize_request_for_compat(payload, model_config);

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -643,31 +643,41 @@ impl Provider for OpenAiProvider {
         let mut model_infos = Vec::new();
 
         for model_name in models {
+            let default_info = goose_provider_types::base::model_info_for_provider_model(
+                self.get_name(),
+                &model_name,
+            );
+
             if let Some(custom_models) = &self.custom_models {
                 if let Some(model_info) = custom_models.iter().find(|m| m.name == model_name) {
-                    model_infos.push(model_info.clone());
+                    let mut info = model_info.clone();
+                    if let goose_provider_types::base::Reasoning::Enabled(false) = info.reasoning {
+                        info.reasoning = default_info.reasoning.clone();
+                    }
+                    model_infos.push(info);
                     continue;
                 }
             }
-            model_infos.push(goose_provider_types::base::model_info_for_provider_model(
-                self.get_name(),
-                &model_name,
-            ));
+            model_infos.push(default_info);
         }
 
         Ok(model_infos)
     }
 
     async fn fetch_model_info(&self, model_name: &str) -> Result<ModelInfo, ProviderError> {
+        let default_info =
+            goose_provider_types::base::model_info_for_provider_model(self.get_name(), model_name);
+
         if let Some(custom_models) = &self.custom_models {
             if let Some(model_info) = custom_models.iter().find(|m| m.name == model_name) {
-                return Ok(model_info.clone());
+                let mut info = model_info.clone();
+                if let goose_provider_types::base::Reasoning::Enabled(false) = info.reasoning {
+                    info.reasoning = default_info.reasoning.clone();
+                }
+                return Ok(info);
             }
         }
-        Ok(goose_provider_types::base::model_info_for_provider_model(
-            self.get_name(),
-            model_name,
-        ))
+        Ok(default_info)
     }
 
     async fn stream(
@@ -1396,5 +1406,27 @@ mod tests {
         // Standard heuristics would default this to non-reasoning
         let info_not_found = provider.fetch_model_info("other-model").await.unwrap();
         assert!(!info_not_found.reasoning.is_enabled());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_model_info_preserves_reasoning_heuristics_for_custom_models() {
+        // o3 is a known reasoning model
+        let custom_model = ModelInfo::new("o3", 4096);
+        // Reasoning is Enabled(false) by default when unconfigured
+
+        let provider = OpenAiProviderBuilder::new(
+            crate::api_client::ApiClient::new_with_tls(
+                "http://localhost".into(),
+                crate::api_client::AuthMethod::NoAuth,
+                None,
+            )
+            .unwrap(),
+        )
+        .custom_models(Some(vec![custom_model.clone()]))
+        .build();
+
+        // The fallback heuristic should kick in and return true for o3
+        let info = provider.fetch_model_info("o3").await.unwrap();
+        assert!(info.reasoning.is_enabled());
     }
 }

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -140,12 +140,12 @@ pub struct OpenAiProvider {
     custom_headers: Option<HashMap<String, String>>,
     supports_streaming: bool,
     name: String,
-    custom_models: Option<Vec<String>>,
     dynamic_models: Option<bool>,
     skip_canonical_filtering: bool,
     preserve_thinking_context: bool,
     #[serde(skip)]
     n_ctx_cache: Arc<Mutex<HashMap<String, Option<usize>>>>,
+    custom_models: Option<Vec<ModelInfo>>,
 }
 
 /// Builder for [`OpenAiProvider`].
@@ -161,7 +161,7 @@ pub struct OpenAiProviderBuilder {
     custom_headers: Option<HashMap<String, String>>,
     supports_streaming: bool,
     name: String,
-    custom_models: Option<Vec<String>>,
+    custom_models: Option<Vec<ModelInfo>>,
     dynamic_models: Option<bool>,
     skip_canonical_filtering: bool,
     preserve_thinking_context: bool,
@@ -232,7 +232,7 @@ impl OpenAiProviderBuilder {
         self
     }
 
-    pub fn custom_models(mut self, custom_models: Option<Vec<String>>) -> Self {
+    pub fn custom_models(mut self, custom_models: Option<Vec<ModelInfo>>) -> Self {
         self.custom_models = custom_models;
         self
     }
@@ -619,7 +619,7 @@ impl Provider for OpenAiProvider {
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         if let Some(custom_models) = &self.custom_models {
             if self.dynamic_models == Some(false) {
-                return Ok(custom_models.clone());
+                return Ok(custom_models.iter().map(|m| m.name.clone()).collect());
             }
             match self.fetch_models_from_api().await {
                 Ok(models) => return Ok(models),
@@ -629,7 +629,7 @@ impl Provider for OpenAiProvider {
                         self.name,
                         e
                     );
-                    return Ok(custom_models.clone());
+                    return Ok(custom_models.iter().map(|m| m.name.clone()).collect());
                 }
                 Err(e) => return Err(e),
             }
@@ -712,14 +712,29 @@ impl Provider for OpenAiProvider {
                 self.supports_streaming,
                 OpenAiFormatOptions {
                     preserve_thinking_context: self.preserve_thinking_context,
-                    thinking_preservation_format: model_config.reasoning.as_ref().and_then(|r| {
-                        match r {
+                    thinking_preservation_format: {
+                        let config_format = model_config.reasoning.as_ref().and_then(|r| match r {
                             goose_provider_types::base::Reasoning::ReasoningConfig(c) => {
                                 c.thinking_preservation_format
                             }
                             _ => None,
-                        }
-                    }),
+                        });
+
+                        let provider_format = self
+                            .custom_models
+                            .as_ref()
+                            .and_then(|models| {
+                                models.iter().find(|m| m.name == model_config.model_name)
+                            })
+                            .and_then(|m| match &m.reasoning {
+                                goose_provider_types::base::Reasoning::ReasoningConfig(c) => {
+                                    c.thinking_preservation_format
+                                }
+                                _ => None,
+                            });
+
+                        config_format.or(provider_format)
+                    },
                 },
             )?;
             let payload = self.sanitize_request_for_compat(payload, model_config);
@@ -773,13 +788,7 @@ pub fn from_declarative_config(
     key_resolver: impl KeyResolver,
 ) -> Result<OpenAiProviderBuilder> {
     let custom_models = if !config.models.is_empty() {
-        Some(
-            config
-                .models
-                .iter()
-                .map(|m| m.name.clone())
-                .collect::<Vec<String>>(),
-        )
+        Some(config.models.clone())
     } else {
         None
     };

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -712,9 +712,13 @@ impl Provider for OpenAiProvider {
                 self.supports_streaming,
                 OpenAiFormatOptions {
                     preserve_thinking_context: self.preserve_thinking_context,
-                    thinking_preservation_format: model_config.reasoning.as_ref().and_then(|r| match r {
-                        goose_provider_types::base::Reasoning::ReasoningConfig(c) => c.thinking_preservation_format,
-                        _ => None,
+                    thinking_preservation_format: model_config.reasoning.as_ref().and_then(|r| {
+                        match r {
+                            goose_provider_types::base::Reasoning::ReasoningConfig(c) => {
+                                c.thinking_preservation_format
+                            }
+                            _ => None,
+                        }
                     }),
                 },
             )?;

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -651,12 +651,13 @@ impl Provider for OpenAiProvider {
             .as_ref()
             .and_then(|models| models.iter().find(|m| m.name == model_config.model_name))
         {
-            patched_model_config.reasoning = Some(
-                patched_model_config
-                    .reasoning
-                    .unwrap_or_default()
-                    .with_provider_defaults(Some(&m.reasoning)),
-            );
+            patched_model_config.reasoning = match patched_model_config.reasoning {
+                Some(r) => Some(r.with_provider_defaults(Some(&m.reasoning))),
+                None => match &m.reasoning {
+                    goose_provider_types::base::Reasoning::Enabled(false) => None,
+                    _ => Some(m.reasoning.clone()),
+                },
+            };
         }
         let model_config = &patched_model_config;
 

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -712,6 +712,10 @@ impl Provider for OpenAiProvider {
                 self.supports_streaming,
                 OpenAiFormatOptions {
                     preserve_thinking_context: self.preserve_thinking_context,
+                    thinking_preservation_format: model_config.reasoning.as_ref().and_then(|r| match r {
+                        goose_provider_types::base::Reasoning::ReasoningConfig(c) => c.thinking_preservation_format,
+                        _ => None,
+                    }),
                 },
             )?;
             let payload = self.sanitize_request_for_compat(payload, model_config);

--- a/crates/goose-sdk/src/bindings.rs
+++ b/crates/goose-sdk/src/bindings.rs
@@ -101,7 +101,9 @@ impl ProviderModelConfig {
             config = config.with_merged_request_params(request_params);
         }
 
-        config.reasoning = self.reasoning;
+        config.reasoning = self
+            .reasoning
+            .map(goose_providers::base::Reasoning::Enabled);
         Ok(config)
     }
 }

--- a/crates/goose-sdk/src/bindings.rs
+++ b/crates/goose-sdk/src/bindings.rs
@@ -101,9 +101,9 @@ impl ProviderModelConfig {
             config = config.with_merged_request_params(request_params);
         }
 
-        config.reasoning = self
-            .reasoning
-            .map(goose_providers::base::Reasoning::Enabled);
+        if let Some(r) = self.reasoning {
+            config = config.with_reasoning(goose_providers::base::Reasoning::Enabled(r));
+        }
         Ok(config)
     }
 }

--- a/crates/goose/src/acp/response_builder.rs
+++ b/crates/goose/src/acp/response_builder.rs
@@ -696,7 +696,7 @@ mod tests {
             ModelConfig::new("gpt-4").with_merged_request_params(std::collections::HashMap::from(
                 [("thinking_effort".to_string(), serde_json::json!("high"))],
             ));
-        model_config.reasoning = Some(false);
+        model_config.reasoning = Some(goose_providers::base::Reasoning::Enabled(false));
 
         let options = build_config_options(
             &mode_state,

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1860,7 +1860,7 @@ impl Agent {
             tool_call_cut_off,
             goose_mode,
             initial_messages,
-            model_config,
+            mut model_config,
         } = context;
 
         if let Some(project_addendum) = self.load_project_instructions(&session).await {
@@ -1872,10 +1872,16 @@ impl Agent {
         let provider = self.provider().await?;
         let provider_name = provider.get_name().to_string();
         let requested_model = model_config.model_name.clone();
-        let inference = provider
-            .fetch_model_info(&requested_model)
-            .await
-            .ok()
+
+        let model_info_opt = provider.fetch_model_info(&requested_model).await.ok();
+
+        if let Some(info) = &model_info_opt {
+            if model_config.reasoning.is_none() {
+                model_config.reasoning = info.reasoning.clone();
+            }
+        }
+
+        let inference = model_info_opt
             .and_then(|model_info| model_info.resolved_model)
             .map(|resolved_model| InferenceMetadata {
                 provider: provider_name,

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2972,12 +2972,18 @@ impl Agent {
         // backfill `context_limit` from their known models before the config is
         // persisted as the session source of truth; otherwise auto-compaction
         // would fall back to DEFAULT_CONTEXT_LIMIT.
-        let model_config = match crate::providers::get_from_registry(&provider_name).await {
+        let mut model_config = match crate::providers::get_from_registry(&provider_name).await {
             Ok(entry) => entry
                 .normalize_model_config(model_config.clone())
                 .unwrap_or(model_config),
             Err(_) => model_config,
         };
+
+        if let Ok(info) = provider.fetch_model_info(&model_config.model_name).await {
+            if model_config.reasoning.is_none() {
+                model_config.reasoning = info.reasoning.clone();
+            }
+        }
 
         let mut current_provider = self.provider.lock().await;
         *current_provider = Some(provider);

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1876,7 +1876,7 @@ impl Agent {
         let model_info_opt = provider.fetch_model_info(&requested_model).await.ok();
 
         if let Some(info) = &model_info_opt {
-            if model_config.reasoning.is_none() {
+            if model_config.reasoning.is_none() || !model_config.reasoning_is_explicit {
                 model_config.reasoning = info.reasoning.clone();
             }
         }
@@ -2980,7 +2980,7 @@ impl Agent {
         };
 
         if let Ok(info) = provider.fetch_model_info(&model_config.model_name).await {
-            if model_config.reasoning.is_none() {
+            if model_config.reasoning.is_none() || !model_config.reasoning_is_explicit {
                 model_config.reasoning = info.reasoning.clone();
             }
         }

--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -548,7 +548,7 @@ mod tests {
                 output_token_cost: None,
                 currency: None,
                 supports_cache_control: None,
-                reasoning: goose_providers::base::Reasoning::Enabled(false),
+                reasoning: Some(goose_providers::base::Reasoning::Enabled(false)),
             }],
             headers: None,
             timeout_seconds: None,

--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -548,7 +548,7 @@ mod tests {
                 output_token_cost: None,
                 currency: None,
                 supports_cache_control: None,
-                reasoning: false,
+                reasoning: goose_providers::base::Reasoning::Enabled(false),
             }],
             headers: None,
             timeout_seconds: None,

--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -636,6 +636,7 @@ mod tests {
             Self {
                 message,
                 config: ModelConfig {
+            reasoning_is_explicit: false,
                     model_name: "test".to_string(),
                     context_limit: Some(context_limit),
                     temperature: None,

--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -636,7 +636,7 @@ mod tests {
             Self {
                 message,
                 config: ModelConfig {
-            reasoning_is_explicit: false,
+                    reasoning_is_explicit: false,
                     model_name: "test".to_string(),
                     context_limit: Some(context_limit),
                     temperature: None,

--- a/crates/goose/src/model_config.rs
+++ b/crates/goose/src/model_config.rs
@@ -171,6 +171,7 @@ fn apply_openai_request_params(mut model: ModelConfig) -> ModelConfig {
 fn base_model_config_from_user_config(model_name: &str) -> Result<ModelConfig> {
     let config = Config::global();
     let mut model = ModelConfig {
+            reasoning_is_explicit: false,
         model_name: model_name.to_string(),
         context_limit: None,
         temperature: get_goose_temperature(config)?,

--- a/crates/goose/src/model_config.rs
+++ b/crates/goose/src/model_config.rs
@@ -171,7 +171,7 @@ fn apply_openai_request_params(mut model: ModelConfig) -> ModelConfig {
 fn base_model_config_from_user_config(model_name: &str) -> Result<ModelConfig> {
     let config = Config::global();
     let mut model = ModelConfig {
-            reasoning_is_explicit: false,
+        reasoning_is_explicit: false,
         model_name: model_name.to_string(),
         context_limit: None,
         temperature: get_goose_temperature(config)?,

--- a/crates/goose/src/providers/anthropic_def.rs
+++ b/crates/goose/src/providers/anthropic_def.rs
@@ -133,14 +133,8 @@ mod tests {
         let provider = make_provider_with_server(
             &server.uri(),
             Some(vec![
-                ModelInfo {
-                    name: "m1".to_string(),
-                    ..Default::default()
-                },
-                ModelInfo {
-                    name: "m2".to_string(),
-                    ..Default::default()
-                },
+                ModelInfo::new("m1", 8192),
+                ModelInfo::new("m2", 8192),
             ]),
             Some(false),
         );

--- a/crates/goose/src/providers/anthropic_def.rs
+++ b/crates/goose/src/providers/anthropic_def.rs
@@ -132,10 +132,7 @@ mod tests {
 
         let provider = make_provider_with_server(
             &server.uri(),
-            Some(vec![
-                ModelInfo::new("m1", 8192),
-                ModelInfo::new("m2", 8192),
-            ]),
+            Some(vec![ModelInfo::new("m1", 8192), ModelInfo::new("m2", 8192)]),
             Some(false),
         );
 

--- a/crates/goose/src/providers/anthropic_def.rs
+++ b/crates/goose/src/providers/anthropic_def.rs
@@ -76,7 +76,7 @@ mod tests {
 
     fn make_provider_with_server(
         server_uri: &str,
-        custom_models: Option<Vec<String>>,
+        custom_models: Option<Vec<ModelInfo>>,
         dynamic_models: Option<bool>,
     ) -> AnthropicProvider {
         let auth = AuthMethod::ApiKey {
@@ -132,7 +132,16 @@ mod tests {
 
         let provider = make_provider_with_server(
             &server.uri(),
-            Some(vec!["m1".to_string(), "m2".to_string()]),
+            Some(vec![
+                ModelInfo {
+                    name: "m1".to_string(),
+                    ..Default::default()
+                },
+                ModelInfo {
+                    name: "m2".to_string(),
+                    ..Default::default()
+                },
+            ]),
             Some(false),
         );
 

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -761,7 +761,7 @@ impl Provider for BedrockProvider {
 
         if is_mantle_model {
             let mut normalized_config = ModelConfig {
-            reasoning_is_explicit: false,
+                reasoning_is_explicit: false,
                 model_name: base_name,
                 ..model_config.clone()
             };
@@ -934,7 +934,7 @@ mod tests {
                 mantle_base_url: None,
             },
             ModelConfig {
-            reasoning_is_explicit: false,
+                reasoning_is_explicit: false,
                 model_name: model_name.to_string(),
                 context_limit: None,
                 temperature: None,

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -761,6 +761,7 @@ impl Provider for BedrockProvider {
 
         if is_mantle_model {
             let mut normalized_config = ModelConfig {
+            reasoning_is_explicit: false,
                 model_name: base_name,
                 ..model_config.clone()
             };
@@ -933,6 +934,7 @@ mod tests {
                 mantle_base_url: None,
             },
             ModelConfig {
+            reasoning_is_explicit: false,
                 model_name: model_name.to_string(),
                 context_limit: None,
                 temperature: None,

--- a/crates/goose/src/providers/formats/bedrock.rs
+++ b/crates/goose/src/providers/formats/bedrock.rs
@@ -80,7 +80,7 @@ fn bedrock_anthropic_thinking_type(model_config: &ModelConfig) -> ThinkingType {
     };
 
     let anthropic_config = ModelConfig {
-            reasoning_is_explicit: false,
+        reasoning_is_explicit: false,
         model_name: strip_bedrock_version_suffix(anthropic_model),
         ..model_config.clone()
     };

--- a/crates/goose/src/providers/formats/bedrock.rs
+++ b/crates/goose/src/providers/formats/bedrock.rs
@@ -80,6 +80,7 @@ fn bedrock_anthropic_thinking_type(model_config: &ModelConfig) -> ThinkingType {
     };
 
     let anthropic_config = ModelConfig {
+            reasoning_is_explicit: false,
         model_name: strip_bedrock_version_suffix(anthropic_model),
         ..model_config.clone()
     };
@@ -139,6 +140,7 @@ pub fn bedrock_inference_config(model_config: &ModelConfig) -> bedrock::Inferenc
 fn bedrock_model_supports_temperature(model_config: &ModelConfig) -> bool {
     if let Some((_, anthropic_model)) = model_config.model_name.rsplit_once("anthropic.") {
         let anthropic_config = ModelConfig {
+            reasoning_is_explicit: false,
             model_name: strip_bedrock_version_suffix(anthropic_model),
             ..model_config.clone()
         };

--- a/crates/goose/src/providers/formats/bedrock.rs
+++ b/crates/goose/src/providers/formats/bedrock.rs
@@ -618,7 +618,7 @@ mod tests {
         params.insert("thinking_effort".to_string(), json!("low"));
         let mut config = ModelConfig::new("us.anthropic.claude-3-7-sonnet-20250219-v1:0");
         config.request_params = Some(params);
-        config.reasoning = Some(true);
+        config.reasoning = Some(goose_providers::base::Reasoning::Enabled(true));
 
         let fields = bedrock_anthropic_thinking_fields(&config).expect("thinking fields");
         assert_eq!(
@@ -641,7 +641,7 @@ mod tests {
         params.insert("thinking_effort".to_string(), json!("low"));
         let mut config = ModelConfig::new("us.anthropic.claude-3-7-sonnet-20250219-v1:0");
         config.request_params = Some(params);
-        config.reasoning = Some(true);
+        config.reasoning = Some(goose_providers::base::Reasoning::Enabled(true));
         config.max_tokens = Some(3000);
 
         let fields = bedrock_anthropic_thinking_fields(&config).expect("thinking fields");
@@ -664,7 +664,7 @@ mod tests {
         params.insert("thinking_effort".to_string(), json!("low"));
         let mut config = ModelConfig::new("us.anthropic.claude-3-7-sonnet-20250219-v1:0");
         config.request_params = Some(params);
-        config.reasoning = Some(true);
+        config.reasoning = Some(goose_providers::base::Reasoning::Enabled(true));
         config.max_tokens = Some(1500);
 
         assert!(bedrock_anthropic_thinking_fields(&config).is_none());
@@ -673,7 +673,7 @@ mod tests {
     #[test]
     fn test_bedrock_anthropic_thinking_fields_disabled() {
         let mut config = ModelConfig::new("us.anthropic.claude-3-7-sonnet-20250219-v1:0");
-        config.reasoning = Some(true);
+        config.reasoning = Some(goose_providers::base::Reasoning::Enabled(true));
         config.request_params = Some(HashMap::from([(
             "thinking_effort".to_string(),
             json!("off"),
@@ -685,7 +685,7 @@ mod tests {
     #[test]
     fn test_bedrock_anthropic_thinking_fields_always_on_adaptive() {
         let mut config = ModelConfig::new("global.anthropic.claude-fable-5");
-        config.reasoning = Some(true);
+        config.reasoning = Some(goose_providers::base::Reasoning::Enabled(true));
         config.request_params = Some(HashMap::from([(
             "thinking_effort".to_string(),
             json!("off"),
@@ -704,7 +704,7 @@ mod tests {
     #[test]
     fn test_bedrock_anthropic_thinking_fields_adaptive_with_effort() {
         let mut config = ModelConfig::new("us.anthropic.claude-opus-4.7");
-        config.reasoning = Some(true);
+        config.reasoning = Some(goose_providers::base::Reasoning::Enabled(true));
         config.request_params = Some(HashMap::from([(
             "thinking_effort".to_string(),
             json!("low"),
@@ -723,7 +723,7 @@ mod tests {
     #[test]
     fn test_bedrock_anthropic_thinking_fields_adaptive_with_version_suffix() {
         let mut config = ModelConfig::new("us.anthropic.claude-opus-4-7-20251101-v1:0");
-        config.reasoning = Some(true);
+        config.reasoning = Some(goose_providers::base::Reasoning::Enabled(true));
         config.request_params = Some(HashMap::from([(
             "thinking_effort".to_string(),
             json!("low"),
@@ -742,7 +742,7 @@ mod tests {
     #[test]
     fn test_bedrock_thinking_fields_skipped_for_non_anthropic() {
         let mut config = ModelConfig::new("us.deepseek.r1-v1:0");
-        config.reasoning = Some(true);
+        config.reasoning = Some(goose_providers::base::Reasoning::Enabled(true));
         config.request_params = Some(HashMap::from([(
             "thinking_effort".to_string(),
             json!("low"),

--- a/crates/goose/src/providers/formats/openrouter.rs
+++ b/crates/goose/src/providers/formats/openrouter.rs
@@ -234,7 +234,7 @@ mod tests {
         // Reasoning-capable model (per canonical) with thinking explicitly off, as a
         // fast-model config is built: OpenRouter must still emit the disable object.
         let mut model_config = ModelConfig::new("google/gemini-2.5-flash");
-        model_config.reasoning = Some(true);
+        model_config.reasoning = Some(goose_providers::base::Reasoning::Enabled(true));
         let mut params = HashMap::new();
         params.insert("thinking_effort".to_string(), json!("off"));
         model_config.request_params = Some(params);
@@ -254,7 +254,7 @@ mod tests {
         let mut params = HashMap::new();
         params.insert("thinking_effort".to_string(), json!("high"));
         model_config.request_params = Some(params);
-        model_config.reasoning = Some(true);
+        model_config.reasoning = Some(goose_providers::base::Reasoning::Enabled(true));
 
         apply_reasoning_config(&mut payload, &model_config);
 
@@ -287,7 +287,7 @@ mod tests {
         let mut params = HashMap::new();
         params.insert("thinking_effort".to_string(), json!("high"));
         model_config.request_params = Some(params);
-        model_config.reasoning = Some(false);
+        model_config.reasoning = Some(goose_providers::base::Reasoning::Enabled(false));
 
         apply_reasoning_config(&mut payload, &model_config);
 
@@ -304,7 +304,7 @@ mod tests {
         let mut params = HashMap::new();
         params.insert("thinking_effort".to_string(), json!("off"));
         model_config.request_params = Some(params);
-        model_config.reasoning = Some(true);
+        model_config.reasoning = Some(goose_providers::base::Reasoning::Enabled(true));
 
         apply_reasoning_config(&mut payload, &model_config);
 

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -361,6 +361,7 @@ mod tests {
 
     fn model_config(model_name: &str) -> ModelConfig {
         ModelConfig {
+            reasoning_is_explicit: false,
             model_name: model_name.to_string(),
             context_limit: None,
             temperature: None,

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -239,7 +239,7 @@ impl ProviderRegistry {
                 output_token_cost: m.output_token_cost,
                 currency: m.currency.clone(),
                 supports_cache_control: Some(m.supports_cache_control.unwrap_or(false)),
-                reasoning: m.reasoning,
+                reasoning: m.reasoning.clone(),
             })
             .collect();
 

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -1640,6 +1640,7 @@ mod tests {
                 &ImageFormat::OpenAi,
                 OpenAiFormatOptions {
                     preserve_thinking_context: true,
+                    ..Default::default()
                 },
             );
             let has_reasoning_on_tool_call = spec.iter().any(|m| {
@@ -1978,6 +1979,7 @@ mod tests {
                 &ImageFormat::OpenAi,
                 OpenAiFormatOptions {
                     preserve_thinking_context: true,
+                    ..Default::default()
                 },
             );
 


### PR DESCRIPTION
This PR introduces flexible reasoning support for providers that use non-standard parameters, starting with **[Cerebras](https://inference-docs.cerebras.ai/capabilities/reasoning)**. 

It adds a new `ReasoningConfig` that lets models declare:
- Which property name to use for reasoning in requests
- How to map reasoning effort levels (`low` / `medium` / `high`) to provider-specific values via `effort_mapping`
- Optional `extra_body` JSON that gets merged into the request when reasoning is enabled

The primary goal was to unblock reliable multi-turn usage with Cerebras models. The design is intentionally provider-agnostic so future models can adapt requests to their specific requirements without changing core logic.

```mermaid
flowchart TD
    A[Model declares ReasoningConfig] --> B{Reasoning enabled?}
    B -->|No| C[Omit reasoning params]
    B -->|Yes| D[Apply effort_mapping]
    D --> E[Merge extra_body if present]
    E --> F[Send request to provider<br/>e.g. Cerebras]
    F --> G[Receive response with thinking]
    G --> H[Apply ThinkingPreservationFormat<br/>to message history]
```

## Problem

Prior to this change, any multi-turn conversation with a Cerebras model that had thinking/reasoning enabled would fail with:

**Before**

https://github.com/user-attachments/assets/632873a3-46c3-4450-aa5e-9c794b0a0c6c

**After**

https://github.com/user-attachments/assets/4de90f45-dff4-4202-8268-857a89a77aad

Fixes [#10406](https://github.com/aaif-goose/goose/issues/10406)