### PR TITLE
fix(developer): expose AGENT_SESSION_ID to shell commands

### DIFF
--- a/crates/goose/src/acp/fs.rs
+++ b/crates/goose/src/acp/fs.rs
@@ -453,13 +453,13 @@ mod tests {
 
     #[test]
     fn terminal_request_includes_agent_session_id() {
-        let session_id = SessionId::new("session-123");
+        let session_id = SessionId::new("acp-session");
         let params = ShellParams {
             command: "echo test".to_string(),
             timeout_secs: None,
         };
         let ctx = ToolCallContext::new(
-            "session-123".to_string(),
+            "agent-session".to_string(),
             Some(std::path::PathBuf::from("/tmp/worktree")),
             None,
         );
@@ -468,7 +468,7 @@ mod tests {
 
         assert_eq!(
             request.env,
-            vec![EnvVariable::new("AGENT_SESSION_ID", "session-123")]
+            vec![EnvVariable::new("AGENT_SESSION_ID", "agent-session")]
         );
         assert_eq!(request.cwd, Some(std::path::PathBuf::from("/tmp/worktree")));
     }

--- a/crates/goose/src/acp/fs.rs
+++ b/crates/goose/src/acp/fs.rs
@@ -6,10 +6,10 @@ use crate::agents::platform_extensions::developer::edit::{
 use crate::agents::platform_extensions::developer::shell::{ShellParams, OUTPUT_LIMIT_BYTES};
 use crate::agents::platform_extensions::developer::DeveloperClient;
 use agent_client_protocol::schema::v1::{
-    CreateTerminalRequest, Diff, KillTerminalRequest, ReadTextFileRequest, ReleaseTerminalRequest,
-    SessionId, SessionNotification, SessionUpdate, Terminal, TerminalOutputRequest,
-    ToolCallContent, ToolCallId, ToolCallLocation, ToolCallUpdate, ToolCallUpdateFields, ToolKind,
-    WaitForTerminalExitRequest, WriteTextFileRequest,
+    CreateTerminalRequest, Diff, EnvVariable, KillTerminalRequest, ReadTextFileRequest,
+    ReleaseTerminalRequest, SessionId, SessionNotification, SessionUpdate, Terminal,
+    TerminalOutputRequest, ToolCallContent, ToolCallId, ToolCallLocation, ToolCallUpdate,
+    ToolCallUpdateFields, ToolKind, WaitForTerminalExitRequest, WriteTextFileRequest,
 };
 use agent_client_protocol::{Client, ConnectionTo};
 use agent_client_protocol_schema::v1::TerminalId;
@@ -67,6 +67,17 @@ pub(crate) struct AcpTools {
     pub(crate) fs_read: bool,
     pub(crate) fs_write: bool,
     pub(crate) terminal: bool,
+}
+
+fn create_terminal_request(
+    session_id: &SessionId,
+    params: &ShellParams,
+    ctx: &crate::agents::ToolCallContext,
+) -> CreateTerminalRequest {
+    CreateTerminalRequest::new(session_id.clone(), &params.command)
+        .env(vec![EnvVariable::new("AGENT_SESSION_ID", &ctx.session_id)])
+        .cwd(ctx.working_dir.clone())
+        .output_byte_limit(OUTPUT_LIMIT_BYTES as u64)
 }
 
 fn error_result(msg: impl std::fmt::Display) -> CallToolResult {
@@ -250,11 +261,7 @@ impl AcpTools {
 
         let create_res = self
             .cx
-            .send_request(
-                CreateTerminalRequest::new(self.session_id.clone(), &params.command)
-                    .cwd(ctx.working_dir.clone())
-                    .output_byte_limit(OUTPUT_LIMIT_BYTES as u64),
-            )
+            .send_request(create_terminal_request(&self.session_id, &params, ctx))
             .block_task()
             .await
             .map_err(|e| {
@@ -436,5 +443,33 @@ impl McpClientTrait for AcpTools {
 
     fn get_info(&self) -> Option<&rmcp::model::InitializeResult> {
         self.inner.get_info()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agents::ToolCallContext;
+
+    #[test]
+    fn terminal_request_includes_agent_session_id() {
+        let session_id = SessionId::new("session-123");
+        let params = ShellParams {
+            command: "echo test".to_string(),
+            timeout_secs: None,
+        };
+        let ctx = ToolCallContext::new(
+            "session-123".to_string(),
+            Some(std::path::PathBuf::from("/tmp/worktree")),
+            None,
+        );
+
+        let request = create_terminal_request(&session_id, &params, &ctx);
+
+        assert_eq!(
+            request.env,
+            vec![EnvVariable::new("AGENT_SESSION_ID", "session-123")]
+        );
+        assert_eq!(request.cwd, Some(std::path::PathBuf::from("/tmp/worktree")));
     }
 }

--- a/crates/goose/src/agents/platform_extensions/developer/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/mod.rs
@@ -350,7 +350,7 @@ mod tests {
                 &ctx,
                 "shell",
                 Some(object!({
-                    "command": "printf '%s' \"$AGENT_SESSION_ID\""
+                    "command": "printenv AGENT_SESSION_ID"
                 })),
                 CancellationToken::new(),
             )

--- a/crates/goose/src/agents/platform_extensions/developer/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/mod.rs
@@ -199,7 +199,7 @@ impl McpClientTrait for DeveloperClient {
             "shell" => match Self::parse_args::<ShellParams>(arguments) {
                 Ok(params) => Ok(self
                     .shell_tool
-                    .shell_with_cwd(params, working_dir, cancel_token)
+                    .shell_with_cwd(params, working_dir, Some(&ctx.session_id), cancel_token)
                     .await),
                 Err(error) => Ok(ShellTool::error_result(&format!("Error: {error}"), None)),
             },
@@ -336,6 +336,29 @@ mod tests {
             fs::read_to_string(cwd.join("notes.txt")).unwrap(),
             "updated line"
         );
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn developer_client_passes_session_id_to_shell_tool() {
+        let temp = tempfile::tempdir().unwrap();
+        let client = DeveloperClient::new(test_context(temp.path().join("sessions"))).unwrap();
+        let ctx = ToolCallContext::new("session-789".to_owned(), None, None);
+
+        let result = client
+            .call_tool(
+                &ctx,
+                "shell",
+                Some(object!({
+                    "command": "printf '%s' \"$AGENT_SESSION_ID\""
+                })),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(false));
+        assert_eq!(first_text(&result), "session-789");
     }
 
     #[cfg(not(windows))]

--- a/crates/goose/src/agents/platform_extensions/developer/shell.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/shell.rs
@@ -912,67 +912,49 @@ mod tests {
     }
 
     #[test]
-    fn session_environment_is_scoped_to_the_shell_command() {
-        let mut command = tokio::process::Command::new("ignored");
+    fn session_environment_is_set_or_removed() {
+        for (session_id, expected) in [
+            (
+                Some("session-123"),
+                Some(Some(std::ffi::OsStr::new("session-123"))),
+            ),
+            (None, Some(None)),
+        ] {
+            let mut command = tokio::process::Command::new("ignored");
+            command.env("AGENT_SESSION_ID", "stale-session");
 
-        apply_session_environment(&mut command, Some("session-123"));
+            apply_session_environment(&mut command, session_id);
 
-        assert_eq!(
-            command.as_std().get_envs().find_map(|(key, value)| {
-                (key == "AGENT_SESSION_ID").then(|| value.unwrap().to_owned())
-            }),
-            Some(std::ffi::OsString::from("session-123"))
-        );
-    }
-
-    #[test]
-    fn session_environment_removes_stale_id_without_context() {
-        let mut command = tokio::process::Command::new("ignored");
-        command.env("AGENT_SESSION_ID", "stale-session");
-
-        apply_session_environment(&mut command, None);
-
-        assert_eq!(
-            command
-                .as_std()
-                .get_envs()
-                .find_map(|(key, value)| (key == "AGENT_SESSION_ID").then_some(value)),
-            Some(None)
-        );
+            assert_eq!(
+                command
+                    .as_std()
+                    .get_envs()
+                    .find_map(|(key, value)| (key == "AGENT_SESSION_ID").then_some(value)),
+                expected
+            );
+        }
     }
 
     #[cfg(not(windows))]
     #[test]
-    fn flatpak_session_environment_is_forwarded_to_host() {
-        let mut command = tokio::process::Command::new("flatpak-spawn");
+    fn flatpak_session_environment_is_set_or_unset() {
+        for (session_id, expected) in [
+            (Some("session-123"), "--env=AGENT_SESSION_ID=session-123"),
+            (None, "--unset-env=AGENT_SESSION_ID"),
+        ] {
+            let mut command = tokio::process::Command::new("flatpak-spawn");
 
-        apply_flatpak_session_environment(&mut command, Some("session-123"));
+            apply_flatpak_session_environment(&mut command, session_id);
 
-        assert_eq!(
-            command
-                .as_std()
-                .get_args()
-                .map(|arg| arg.to_string_lossy().into_owned())
-                .collect::<Vec<_>>(),
-            vec!["--env=AGENT_SESSION_ID=session-123"]
-        );
-    }
-
-    #[cfg(not(windows))]
-    #[test]
-    fn flatpak_session_environment_removes_stale_id_without_context() {
-        let mut command = tokio::process::Command::new("flatpak-spawn");
-
-        apply_flatpak_session_environment(&mut command, None);
-
-        assert_eq!(
-            command
-                .as_std()
-                .get_args()
-                .map(|arg| arg.to_string_lossy().into_owned())
-                .collect::<Vec<_>>(),
-            vec!["--unset-env=AGENT_SESSION_ID"]
-        );
+            assert_eq!(
+                command
+                    .as_std()
+                    .get_args()
+                    .map(|arg| arg.to_string_lossy().into_owned())
+                    .collect::<Vec<_>>(),
+                vec![expected]
+            );
+        }
     }
 
     #[cfg(not(windows))]

--- a/crates/goose/src/agents/platform_extensions/developer/shell.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/shell.rs
@@ -668,6 +668,7 @@ fn build_shell_command(
             if let Some(path) = login_path {
                 command.arg(format!("--env=PATH={}", path));
             }
+            apply_flatpak_session_environment(&mut command, session_id);
             command
                 .arg(&shell)
                 .args(unix_shell_command_args(command_line));
@@ -681,10 +682,12 @@ fn build_shell_command(
             if let Some(path) = login_path {
                 command.env("PATH", path);
             }
+            apply_session_environment(&mut command, session_id);
             command
         }
     };
 
+    #[cfg(windows)]
     apply_session_environment(&mut command, session_id);
     command.set_no_window();
     command
@@ -695,6 +698,18 @@ fn apply_session_environment(command: &mut tokio::process::Command, session_id: 
         command.env("AGENT_SESSION_ID", session_id);
     } else {
         command.env_remove("AGENT_SESSION_ID");
+    }
+}
+
+#[cfg(not(windows))]
+fn apply_flatpak_session_environment(
+    command: &mut tokio::process::Command,
+    session_id: Option<&str>,
+) {
+    if let Some(session_id) = session_id.filter(|id| !id.is_empty()) {
+        command.arg(format!("--env=AGENT_SESSION_ID={session_id}"));
+    } else {
+        command.arg("--unset-env=AGENT_SESSION_ID");
     }
 }
 
@@ -923,6 +938,40 @@ mod tests {
                 .get_envs()
                 .find_map(|(key, value)| (key == "AGENT_SESSION_ID").then_some(value)),
             Some(None)
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn flatpak_session_environment_is_forwarded_to_host() {
+        let mut command = tokio::process::Command::new("flatpak-spawn");
+
+        apply_flatpak_session_environment(&mut command, Some("session-123"));
+
+        assert_eq!(
+            command
+                .as_std()
+                .get_args()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            vec!["--env=AGENT_SESSION_ID=session-123"]
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn flatpak_session_environment_removes_stale_id_without_context() {
+        let mut command = tokio::process::Command::new("flatpak-spawn");
+
+        apply_flatpak_session_environment(&mut command, None);
+
+        assert_eq!(
+            command
+                .as_std()
+                .get_args()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            vec!["--unset-env=AGENT_SESSION_ID"]
         );
     }
 

--- a/crates/goose/src/agents/platform_extensions/developer/shell.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/shell.rs
@@ -348,7 +348,7 @@ impl ShellTool {
     }
 
     pub async fn shell(&self, params: ShellParams) -> CallToolResult {
-        self.shell_with_cwd(params, None, CancellationToken::new())
+        self.shell_with_cwd(params, None, None, CancellationToken::new())
             .await
     }
 
@@ -356,6 +356,7 @@ impl ShellTool {
         &self,
         params: ShellParams,
         working_dir: Option<&std::path::Path>,
+        session_id: Option<&str>,
         cancellation_token: CancellationToken,
     ) -> CallToolResult {
         if params.command.trim().is_empty() {
@@ -374,6 +375,7 @@ impl ShellTool {
             params.timeout_secs,
             working_dir,
             login_path_ref,
+            session_id,
             cancellation_token,
         )
         .await
@@ -520,11 +522,12 @@ async fn run_command(
     timeout_secs: Option<u64>,
     working_dir: Option<&std::path::Path>,
     login_path: Option<&str>,
+    session_id: Option<&str>,
     cancellation_token: CancellationToken,
 ) -> Result<ExecutionOutput, String> {
     let timeout_secs = Some(resolve_shell_timeout(timeout_secs));
 
-    let mut command = build_shell_command(command_line, working_dir, login_path);
+    let mut command = build_shell_command(command_line, working_dir, login_path, session_id);
 
     command.stdout(Stdio::piped());
     command.stderr(Stdio::piped());
@@ -599,8 +602,8 @@ async fn run_command(
         }
         Err(_) => {
             tracing::debug!(
-                    "output drain timed out after {OUTPUT_DRAIN_TIMEOUT_MILLIS}ms (backgrounded process?)"
-                );
+                "output drain timed out after {OUTPUT_DRAIN_TIMEOUT_MILLIS}ms (backgrounded process?)"
+            );
             abort_handle.abort();
             true
         }
@@ -625,6 +628,7 @@ fn build_shell_command(
     command_line: &str,
     working_dir: Option<&std::path::Path>,
     login_path: Option<&str>,
+    session_id: Option<&str>,
 ) -> tokio::process::Command {
     #[cfg(windows)]
     let mut command = {
@@ -681,8 +685,17 @@ fn build_shell_command(
         }
     };
 
+    apply_session_environment(&mut command, session_id);
     command.set_no_window();
     command
+}
+
+fn apply_session_environment(command: &mut tokio::process::Command, session_id: Option<&str>) {
+    if let Some(session_id) = session_id.filter(|id| !id.is_empty()) {
+        command.env("AGENT_SESSION_ID", session_id);
+    } else {
+        command.env_remove("AGENT_SESSION_ID");
+    }
 }
 
 /// Split tagged lines into (stdout, stderr, interleaved) strings.
@@ -872,6 +885,7 @@ mod tests {
                     timeout_secs: None,
                 },
                 Some(dir.path()),
+                None,
                 CancellationToken::new(),
             )
             .await;
@@ -880,6 +894,36 @@ mod tests {
         let observed = std::fs::canonicalize(extract_text(&result)).unwrap();
         let expected = std::fs::canonicalize(dir.path()).unwrap();
         assert_eq!(observed, expected);
+    }
+
+    #[test]
+    fn session_environment_is_scoped_to_the_shell_command() {
+        let mut command = tokio::process::Command::new("ignored");
+
+        apply_session_environment(&mut command, Some("session-123"));
+
+        assert_eq!(
+            command.as_std().get_envs().find_map(|(key, value)| {
+                (key == "AGENT_SESSION_ID").then(|| value.unwrap().to_owned())
+            }),
+            Some(std::ffi::OsString::from("session-123"))
+        );
+    }
+
+    #[test]
+    fn session_environment_removes_stale_id_without_context() {
+        let mut command = tokio::process::Command::new("ignored");
+        command.env("AGENT_SESSION_ID", "stale-session");
+
+        apply_session_environment(&mut command, None);
+
+        assert_eq!(
+            command
+                .as_std()
+                .get_envs()
+                .find_map(|(key, value)| (key == "AGENT_SESSION_ID").then_some(value)),
+            Some(None)
+        );
     }
 
     #[cfg(not(windows))]
@@ -901,6 +945,7 @@ mod tests {
                     command: "sleep 30".to_string(),
                     timeout_secs: None,
                 },
+                None,
                 None,
                 token,
             )


### PR DESCRIPTION
## Context

This is a bug fix for Goose's documented `AGENT_SESSION_ID` contract. Goose exposes the session ID to STDIO extensions and documents it for Developer extension shell commands, but the Developer shell and supported delegated execution paths omit it. Session-isolated workflows therefore see an empty or stale value from shell steps.

## Summary

This PR restores `AGENT_SESSION_ID` across every Developer shell execution path. The value is scoped to each tool call so concurrent sessions in a shared Goose server do not leak identifiers into one another.

## Changes

- Passes `ToolCallContext.session_id` to each in-process Developer shell invocation.
- Sets or clears `AGENT_SESSION_ID` on spawned commands to prevent stale inherited values.
- Forwards the variable to Flatpak host shells with `flatpak-spawn --env` and clears it with `--unset-env` when no session context exists.
- Includes `AGENT_SESSION_ID` in ACP `CreateTerminalRequest.env` when the client owns terminal execution.
- Covers direct Developer shell execution, environment scoping, Flatpak forwarding, and ACP terminal request construction.

## Reviewer-reproducible examples

The reproduction calls `DeveloperClient::call_tool` with session `session-789`, executes `printenv AGENT_SESSION_ID` through the real Developer shell path, and asserts that the command returns `session-789`.

### Red: `main` returns no session ID

From a clean checkout of `main`, copy the test `developer_client_passes_session_id_to_shell_tool` from this PR into `crates/goose/src/agents/platform_extensions/developer/mod.rs`, then run:

```bash
env -u AGENT_SESSION_ID cargo test -p goose --lib agents::platform_extensions::developer::tests::developer_client_passes_session_id_to_shell_tool -- --exact --nocapture
```

Output excerpt:

```text
assertion `left == right` failed
  left: Some(true)
 right: Some(false)
test agents::platform_extensions::developer::tests::developer_client_passes_session_id_to_shell_tool ... FAILED

test result: FAILED. 0 passed; 1 failed
```

### Green: this branch returns the tool-call session ID

From a clean checkout of this branch, run the same test:

```bash
env -u AGENT_SESSION_ID cargo test -p goose --lib agents::platform_extensions::developer::tests::developer_client_passes_session_id_to_shell_tool -- --exact --nocapture
```

Output excerpt:

```text
running 1 test
test agents::platform_extensions::developer::tests::developer_client_passes_session_id_to_shell_tool ... ok

test result: ok. 1 passed; 0 failed
```

Supporting checks:

```bash
cargo test -p goose --lib terminal_request_includes_agent_session_id -q
cargo test -p goose --lib session_environment_ -q
cargo test -p goose --lib flatpak_session_environment_ -q
cargo fmt --check
```

These checks passed. The Flatpak path and an external ACP client terminal were not available for live execution in this environment, so focused command and request-construction tests cover those platform-specific paths.

