### PR TITLE
fix(acp): allow custom model as default for non-local providers

### DIFF
--- a/crates/goose/src/acp/server/config.rs
+++ b/crates/goose/src/acp/server/config.rs
@@ -214,14 +214,22 @@ impl GooseAcpAgent {
                 .data(format!("Provider is not configured: {provider_id}")));
         }
 
-        if let Some(model_id) = model_id.as_deref() {
-            let model_exists = entry.default_model == model_id
-                || entry.models.iter().any(|model| model.id == model_id)
-                || (provider_id == "local" && local_inference_model_exists(model_id)?);
-            if !model_exists {
-                return Err(agent_client_protocol::Error::invalid_params().data(format!(
-                    "Model '{model_id}' is not available for provider '{provider_id}'"
-                )));
+        // Custom/unlisted model entry is always allowed (#7255), matching the CLI
+        // and in-session model-selection paths, so a model that is simply absent
+        // from the provider's (often non-exhaustive) inventory must still be
+        // accepted as the default here. Local inference is the exception: its
+        // models cannot be fetched on demand, so they are validated against the
+        // inventory or the on-disk registry.
+        if provider_id == "local" {
+            if let Some(model_id) = model_id.as_deref() {
+                let model_exists = entry.default_model == model_id
+                    || entry.models.iter().any(|model| model.id == model_id)
+                    || local_inference_model_exists(model_id)?;
+                if !model_exists {
+                    return Err(agent_client_protocol::Error::invalid_params().data(format!(
+                        "Model '{model_id}' is not available for provider '{provider_id}'"
+                    )));
+                }
             }
         }
 

--- a/crates/goose/tests/acp_custom_requests_test.rs
+++ b/crates/goose/tests/acp_custom_requests_test.rs
@@ -901,6 +901,47 @@ fn test_custom_defaults_read() {
     });
 }
 
+// Regression test for #10401: a custom model that is not present in a provider's
+// (non-exhaustive) inventory must still be accepted when saved as the default from
+// a brand-new chat, matching the CLI and in-session model-selection paths where
+// custom/unlisted model entry is always allowed (#7255).
+#[test]
+#[serial]
+fn test_custom_defaults_save_allows_unlisted_model() {
+    let _env = env_lock::lock_env([("ANTHROPIC_API_KEY", Some("test-key"))]);
+    let config_dir = write_acp_global_config(
+        "GOOSE_MODEL: claude-3-5-haiku-latest\nGOOSE_PROVIDER: anthropic\n",
+    );
+
+    run_test(async move {
+        let openai = OpenAiFixture::new(vec![], Arc::new(EnforceSessionId::default())).await;
+        let config = TestConnectionConfig {
+            data_root: config_dir,
+            ..Default::default()
+        };
+        let conn = AcpServerConnection::new(config, openai).await;
+
+        let response = send_custom(
+            conn.cx(),
+            "_goose/unstable/defaults/save",
+            serde_json::json!({
+                "providerId": "anthropic",
+                "modelId": "custom-unlisted-model",
+            }),
+        )
+        .await
+        .expect("saving an unlisted custom model as the default should succeed");
+
+        assert_eq!(
+            response,
+            serde_json::json!({
+                "providerId": "anthropic",
+                "modelId": "custom-unlisted-model",
+            })
+        );
+    });
+}
+
 #[test]
 #[serial]
 fn test_custom_dictation_secret_save_delete() {


### PR DESCRIPTION
## Summary

Picking a custom OpenRouter model that isn't in the prefilled dropdown (e.g. `google/gemini-3.5-flash`) for a brand-new chat fails right away with `RequestError: Invalid params`. The same model works if you set it from inside an already-active chat, or from the CLI. It started in v1.41.0 and reproduces on Windows, macOS and Ubuntu (three reporters in #10401).

## Root cause

When you pick a model for a new chat (no active session yet), the desktop saves it as the global default through the ACP `defaults/save` handler — `on_defaults_save` in `crates/goose/src/acp/server/config.rs`. That handler rejects any model that isn't already in the provider's inventory:

```rust
let model_exists = entry.default_model == model_id
    || entry.models.iter().any(|model| model.id == model_id)
    || (provider_id == "local" && local_inference_model_exists(model_id)?);
if !model_exists {
    return Err(agent_client_protocol::Error::invalid_params().data(format!(
        "Model '{model_id}' is not available for provider '{provider_id}'"
    )));
}
```

`Error::invalid_params()` is JSON-RPC `-32602`, which the desktop shows as `RequestError: Invalid params`. OpenRouter's inventory is a static, non-exhaustive 10-model list (`OPENROUTER_KNOWN_MODELS`, `supports_refresh = false`), so any custom model gets rejected — that's the same "10 seemingly random models" a commenter mentioned; the dropdown is that same static list.

The in-session path (`set_session_config_option` → `apply_model_if_changed`) and the CLI don't do this inventory check, which is why they still take custom models. The divergence only showed up in v1.41.0 because #10081 ("UI connect to ACP directly instead of goosed") routed the desktop's default-model save through this ACP handler; before that it went through goosed, which didn't validate.

The intended behavior was already set in #7255 ("remove `allows_unlisted_models` flag, always allow custom model entry") and #6761 ("enable custom model entry for OpenRouter provider"). The inventory check in `on_defaults_save`, added later by the provider-first onboarding work, ended up re-restricting what #7255 had opened up.

## Fix

Only run the inventory check in `on_defaults_save` for the `local` provider, whose models can't be fetched on demand and so have to exist on disk or in the inventory. Every other provider allows custom/unlisted models, which matches the in-session and CLI paths. No behavior change for `local`, no new config.

## Testing

- Added `test_custom_defaults_save_allows_unlisted_model` in `crates/goose/tests/acp_custom_requests_test.rs`, following the existing `test_custom_defaults_read` / `test_provider_switching_updates_session_state` tests: it configures a provider and checks that saving a model that isn't in the inventory as the default now succeeds (it used to return `Invalid params`).
- The `local`-provider check is untouched.
- `cargo test -p goose --test acp_custom_requests_test test_custom_defaults`.

## Related Issues

Fixes #10401. Restores the intended behavior from #7255 and #6761.
