### PR TITLE
fix: updated spin to v0.9.9 as 0.9.8 is yanked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10309,9 +10309,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]


### PR DESCRIPTION
## Summary
Fix crate deny 
https://github.com/aaif-goose/goose/actions/runs/29312777755/job/87020007313

After triggering the `v1.43.0` release, I noticed that Cargo Deny failed because the release includes the recently yanked `spin 0.9.8`.

The version was yanked because of an issue affecting specific spin::Once methods that consume or drop their stored value. A yank does not remove the crate or prevent projects with an existing Cargo.lock from building.

In Goose, spin is only a transitive dependency:
goose → sqlx → sqlx-sqlite → flume → spin

It also appears through lazy_static in other transitive paths. Goose does not call spin directly. flume uses its mutex functionality, while lazy_static uses Once only for static initialization, so these paths do not appear to exercise the affected behavior. In addition, we have used this version `0.9.8` for long time. 

So v1.43.0 has low practical risk and does not require an emergency patch or recall. The upgrade to spin 0.9.9 is in this PR and will be included in next week’s release.
  

