### PR TITLE
fix(config): tighten existing secrets file permissions

### DIFF
--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -19,14 +19,16 @@ use thiserror::Error;
 fn write_secrets_file(path: &Path, content: &str) -> std::io::Result<()> {
     #[cfg(unix)]
     {
-        use std::os::unix::fs::OpenOptionsExt;
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
         let mut file = OpenOptions::new()
             .write(true)
             .create(true)
-            .truncate(true)
+            .truncate(false)
             .mode(0o600)
             .open(path)?;
 
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        file.set_len(0)?;
         file.write_all(content.as_bytes())
     }
 
@@ -2062,6 +2064,28 @@ mod tests {
         let config = Config::new_with_file_secrets(config_file.path(), &secrets_path)?;
         config.set_secret("key", &"value")?;
 
+        let mode = std::fs::metadata(&secrets_path)?.permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_existing_secrets_file_permissions_tightened_on_write() -> Result<(), ConfigError> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        let config_file = NamedTempFile::new().unwrap();
+        let secrets_path = dir.path().join("secrets.yaml");
+        std::fs::write(&secrets_path, "existing: old\n")?;
+        std::fs::set_permissions(&secrets_path, std::fs::Permissions::from_mode(0o644))?;
+
+        let config = Config::new_with_file_secrets(config_file.path(), &secrets_path)?;
+        config.set_secret("key", &"value")?;
+
+        let value: String = config.get_secret("key")?;
+        assert_eq!(value, "value");
         let mode = std::fs::metadata(&secrets_path)?.permissions().mode() & 0o777;
         assert_eq!(mode, 0o600);
 


### PR DESCRIPTION
## Summary

- enforce owner-only permissions whenever an existing Unix secrets file is rewritten
- repair permissions before truncating the file so failures preserve existing contents
- add regression coverage for permissive existing files while retaining fresh-file coverage

## Validation

- `cargo test -p goose test_existing_secrets_file_permissions_tightened_on_write`
- `cargo test -p goose test_secrets_file_created_with_restricted_permissions`
- `cargo build -p goose`
- `cargo clippy -p goose --all-targets -- -D warnings`

_This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)._
