### PR TITLE
fix(telegram): contain voice file extensions

### DIFF
--- a/crates/goose/src/gateway/telegram.rs
+++ b/crates/goose/src/gateway/telegram.rs
@@ -247,19 +247,7 @@ impl TelegramGateway {
             std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))?;
         }
 
-        let ext = mime_type
-            .and_then(|m| m.rsplit('/').next())
-            .map(|sub| {
-                // Normalise common MIME sub-types to file extensions.
-                match sub {
-                    "mpeg" => "mp3",
-                    "mp4" | "x-m4a" => "m4a",
-                    "ogg" => "ogg",
-                    "wav" | "x-wav" => "wav",
-                    other => other,
-                }
-            })
-            .unwrap_or("ogg");
+        let ext = Self::voice_file_extension(mime_type);
 
         let filename = format!("voice_{}.{ext}", uuid::Uuid::new_v4());
         let path = dir.join(filename);
@@ -273,6 +261,34 @@ impl TelegramGateway {
         }
 
         Ok(path)
+    }
+
+    fn voice_file_extension(mime_type: Option<&str>) -> String {
+        let subtype = mime_type
+            .and_then(|mime| mime.split(';').next())
+            .map(str::trim)
+            .and_then(|mime| mime.strip_prefix("audio/"))
+            .map(str::to_ascii_lowercase);
+
+        let Some(subtype) = subtype else {
+            return "ogg".to_string();
+        };
+
+        match subtype.as_str() {
+            "mpeg" => "mp3".to_string(),
+            "mp4" | "x-m4a" => "m4a".to_string(),
+            "ogg" => "ogg".to_string(),
+            "wav" | "x-wav" => "wav".to_string(),
+            other
+                if other.len() <= 16
+                    && other.bytes().enumerate().all(|(index, byte)| {
+                        byte.is_ascii_alphanumeric() || (index > 0 && matches!(byte, b'-' | b'_'))
+                    }) =>
+            {
+                other.to_string()
+            }
+            _ => "ogg".to_string(),
+        }
     }
 
     /// Build the text prompt that tells Goose about a voice message file.
@@ -779,6 +795,60 @@ mod tests {
         let bytes = b"unknown format";
         let path = TelegramGateway::save_voice_file(bytes, None).unwrap();
         assert!(path.to_str().unwrap().ends_with(".ogg"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn voice_file_extension_preserves_safe_audio_formats() {
+        let cases = [
+            (Some("audio/mpeg"), "mp3"),
+            (Some("audio/mp4"), "m4a"),
+            (Some("audio/x-m4a"), "m4a"),
+            (Some("audio/ogg; codecs=opus"), "ogg"),
+            (Some("audio/x-wav"), "wav"),
+            (Some("audio/flac"), "flac"),
+            (Some("audio/WEBM"), "webm"),
+        ];
+
+        for (mime_type, expected) in cases {
+            assert_eq!(TelegramGateway::voice_file_extension(mime_type), expected);
+        }
+    }
+
+    #[test]
+    fn voice_file_extension_rejects_filename_syntax() {
+        let invalid = [
+            None,
+            Some("application/ogg"),
+            Some("audio/..\\..\\outside"),
+            Some("audio/../../outside"),
+            Some("audio/ogg:stream"),
+            Some("audio/ogg.stream"),
+            Some("audio/ogg\nnext"),
+            Some("audio/ogg; touch=outside"),
+            Some("audio/ogg$HOME"),
+            Some("audio/åudio"),
+            Some("audio/this-subtype-is-too-long"),
+        ];
+
+        for mime_type in invalid {
+            assert_eq!(TelegramGateway::voice_file_extension(mime_type), "ogg");
+        }
+    }
+
+    #[test]
+    fn save_voice_file_contains_untrusted_mime_before_pairing() {
+        let bytes = b"unpaired voice data";
+        let path = TelegramGateway::save_voice_file(bytes, Some("audio/..\\..\\outside")).unwrap();
+
+        let expected_dir = std::env::temp_dir().join("goose_voice");
+        assert_eq!(path.parent(), Some(expected_dir.as_path()));
+        let filename = path.file_name().unwrap().to_str().unwrap();
+        assert!(filename.starts_with("voice_"));
+        assert!(filename.ends_with(".ogg"));
+        assert!(!filename.chars().any(|c| matches!(c, '/' | '\\' | ':')));
+        assert_eq!(std::fs::read(&path).unwrap(), bytes);
+
         let _ = std::fs::remove_file(&path);
     }
 

--- a/crates/goose/src/gateway/telegram.rs
+++ b/crates/goose/src/gateway/telegram.rs
@@ -280,7 +280,7 @@ impl TelegramGateway {
             "mpeg" => "mp3".to_string(),
             "mp4" | "x-m4a" => "m4a".to_string(),
             "ogg" => "ogg".to_string(),
-            "wav" | "x-wav" => "wav".to_string(),
+            "wav" | "x-wav" | "vnd.wave" => "wav".to_string(),
             other
                 if other.len() <= 16
                     && other.bytes().enumerate().all(|(index, byte)| {
@@ -808,6 +808,7 @@ mod tests {
             (Some("audio/x-m4a"), "m4a"),
             (Some("audio/ogg; codecs=opus"), "ogg"),
             (Some("audio/x-wav"), "wav"),
+            (Some("audio/vnd.wave"), "wav"),
             (Some("audio/flac"), "flac"),
             (Some("audio/WEBM"), "webm"),
             (Some("Audio/MPEG"), "mp3"),

--- a/crates/goose/src/gateway/telegram.rs
+++ b/crates/goose/src/gateway/telegram.rs
@@ -264,17 +264,19 @@ impl TelegramGateway {
     }
 
     fn voice_file_extension(mime_type: Option<&str>) -> String {
-        let subtype = mime_type
+        let media_type = mime_type
             .and_then(|mime| mime.split(';').next())
             .map(str::trim)
-            .and_then(|mime| mime.strip_prefix("audio/"))
             .map(str::to_ascii_lowercase);
+        let subtype = media_type
+            .as_deref()
+            .and_then(|mime| mime.strip_prefix("audio/"));
 
         let Some(subtype) = subtype else {
             return "ogg".to_string();
         };
 
-        match subtype.as_str() {
+        match subtype {
             "mpeg" => "mp3".to_string(),
             "mp4" | "x-m4a" => "m4a".to_string(),
             "ogg" => "ogg".to_string(),
@@ -808,6 +810,8 @@ mod tests {
             (Some("audio/x-wav"), "wav"),
             (Some("audio/flac"), "flac"),
             (Some("audio/WEBM"), "webm"),
+            (Some("Audio/MPEG"), "mp3"),
+            (Some("AUDIO/WEBM"), "webm"),
         ];
 
         for (mime_type, expected) in cases {


### PR DESCRIPTION
## Summary

- derive Telegram voice filenames only from a bounded filename-safe audio subtype
- preserve common MIME aliases and safe uncommon formats while falling back to `ogg` for invalid input
- cover path separators, metacharacters, control characters, Unicode, oversized values, MIME parameters, and the pre-pairing save boundary

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p goose gateway::telegram::tests`
- `cargo build -p goose`
- `cargo clippy -p goose --all-targets -- -D warnings`
- `git diff --check`

_This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)._

