### PR TITLE
ci: drop non-existent goose-server crate from TLS matrix job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,6 @@ jobs:
           export CARGO_INCREMENTAL=0
           cargo test -p goose --no-default-features --features ${{ matrix.tls-feature }},code-mode
           cargo test -p goose-providers --no-default-features --features ${{ matrix.tls-feature }}
-          cargo test -p goose-server --no-default-features --features ${{ matrix.tls-feature }},code-mode
           cargo test -p goose-cli --no-default-features --features ${{ matrix.tls-feature }},code-mode -- --skip scenario_tests::scenarios::tests
           cargo test -p goose-cli --no-default-features --features ${{ matrix.tls-feature }},code-mode --jobs 1 scenario_tests::scenarios::tests
         env:


### PR DESCRIPTION
## Problem

The `rust-build-and-test-tls` job added in #10148 fails with:

```
error: cannot specify features for packages outside of workspace
```

(e.g. https://github.com/aaif-goose/goose/actions/runs/29354955233/job/87160196883)

## Root cause

The job runs:

```bash
cargo test -p goose-server --no-default-features --features ${{ matrix.tls-feature }},code-mode
```

but there is **no `goose-server` crate** in this workspace. The members are `goose`, `goose-cli`, `goose-providers`, `goose-mcp`, etc. Passing `--features` for a package that isn't a workspace member makes cargo error out, breaking both the `rustls-tls` and `native-tls` matrix builds.

## Fix

Minimal change — remove the single invalid line. The remaining targets (`goose`, `goose-providers`, `goose-cli`) are real workspace members and resolve features correctly for both TLS backends (verified locally with `--no-run`).

## Note

Because `goose-server` never existed in this workspace, the server-side code was never actually being exercised by this matrix. If server/HTTP coverage under the TLS matrix is desired, that should be a follow-up pointing at the correct crate.