### PR TITLE
docs: add Agentcard to the MCP servers registry

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "agentcard",
+    "name": "Agentcard",
+    "description": "Prepaid virtual cards for AI agents with spend caps and human approvals",
+    "type": "streamable-http",
+    "url": "https://mcp.agentcard.sh/mcp",
+    "link": "https://agentcard.sh",
+    "installation_notes": "Streamable HTTP extension with OAuth 2.0 browser authentication to your Agentcard account.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": []
+  },
+  {
     "id": "agentql-mcp",
     "name": "AgentQL",
     "description": "Transform unstructured web content into structured data",


### PR DESCRIPTION
## Summary
Adds **Agentcard** to the MCP servers registry (`documentation/static/servers.json`) so it appears in the goose extensions directory.

Agentcard issues prepaid virtual cards for AI agents: fund a wallet, set spend caps and human approvals, and the agent mints a one-time virtual card for each purchase. It runs as a remote **streamable HTTP** MCP server with OAuth 2.0 browser sign-in, so no API key or env vars are required.

- Endpoint: `https://mcp.agentcard.sh/mcp`
- Website: https://agentcard.sh
- Type: `streamable-http`, OAuth 2.0 (dynamic client registration)

Entry added alphabetically at the top of the array, matching the existing remote (`streamable-http`) entries such as Neon.

### Testing
Validated `servers.json` parses as JSON after the change (62 entries). No code paths modified; this is a registry data addition.

### Related Issues
None.

### Screenshots/Demos (for UX changes)
N/A (registry data only).