### PR TITLE
Add RunComfy MCP extension

### DIFF
--- a/documentation/docs/mcp/runcomfy-mcp.md
+++ b/documentation/docs/mcp/runcomfy-mcp.md
@@ -10,7 +10,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 
 This tutorial covers how to add the [RunComfy MCP Server](https://github.com/runcomfy-com/runcomfy-mcp) as a goose extension, enabling goose to manage RunComfy Serverless (ComfyUI) GPU deployments and run async image/video inference.
 
-RunComfy MCP is a remote, hosted server at `https://mcp.runcomfy.com/mcp`. goose connects to it through the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridge.
+RunComfy MCP is a remote, hosted server at `https://mcp.runcomfy.com/mcp`. goose connects to it natively as a **Streamable HTTP** extension — no local Node.js required.
 
 :::tip Quick Install
 <Tabs groupId="interface">
@@ -18,10 +18,7 @@ RunComfy MCP is a remote, hosted server at `https://mcp.runcomfy.com/mcp`. goose
   Add it from **Settings → Extensions → Add**, or use the goose CLI command.
   </TabItem>
   <TabItem value="cli" label="goose CLI">
-  **Command**
-  ```sh
-  npx -y mcp-remote https://mcp.runcomfy.com/mcp --header Authorization:${RUNCOMFY_AUTH}
-  ```
+  Run `goose configure` → **Add Extension** → **Remote Extension (Streamable HTTP)**, URL `https://mcp.runcomfy.com/mcp`, with header `Authorization: Bearer <YOUR_RUNCOMFY_TOKEN>`.
   </TabItem>
 </Tabs>
 :::
@@ -29,7 +26,7 @@ RunComfy MCP is a remote, hosted server at `https://mcp.runcomfy.com/mcp`. goose
 ## Configuration
 
 :::info
-You'll need [Node.js](https://nodejs.org/) installed on your system to run this command, as it uses `npx`. You'll also need a RunComfy API token — get one from your [RunComfy Profile](https://www.runcomfy.com/profile). Set `RUNCOMFY_AUTH` to your token as a Bearer credential, e.g. `Bearer <YOUR_RUNCOMFY_TOKEN>`.
+No local runtime required — RunComfy is a native Streamable HTTP extension. You'll need a RunComfy API token — get one from your [RunComfy Profile](https://www.runcomfy.com/profile) — and send it as an `Authorization: Bearer <YOUR_RUNCOMFY_TOKEN>` request header.
 :::
 
 <Tabs groupId="interface">
@@ -38,26 +35,26 @@ You'll need [Node.js](https://nodejs.org/) installed on your system to run this 
         extensionId="runcomfy"
         extensionName="RunComfy"
         description="Manage RunComfy Serverless (ComfyUI) GPU deployments and run async image/video inference"
-        command="npx"
-        args={["-y", "mcp-remote", "https://mcp.runcomfy.com/mcp", "--header", "Authorization:${RUNCOMFY_AUTH}"]}
-        cliCommand="npx -y mcp-remote https://mcp.runcomfy.com/mcp --header Authorization:${RUNCOMFY_AUTH}"
+        type="http"
+        url="https://mcp.runcomfy.com/mcp"
         timeout={300}
         envVars={[
-          { name: "RUNCOMFY_AUTH", label: "RunComfy API token as a Bearer credential, e.g. 'Bearer <YOUR_RUNCOMFY_TOKEN>'" }
+          { name: "Authorization", label: "Bearer <YOUR_RUNCOMFY_TOKEN>" }
         ]}
         apiKeyLink="https://www.runcomfy.com/profile"
         apiKeyLinkText="RunComfy API token"
-        note="Requires Node.js. RunComfy is a remote server reached via mcp-remote."
+        note="Remote Streamable HTTP server — no Node.js required. Provide your RunComfy token as an Authorization header."
     />
   </TabItem>
   <TabItem value="cli" label="goose CLI">
       <CLIExtensionInstructions
         name="RunComfy"
         description="Manage RunComfy Serverless (ComfyUI) GPU deployments and run async image/video inference"
-        command="npx -y mcp-remote https://mcp.runcomfy.com/mcp --header Authorization:${RUNCOMFY_AUTH}"
+        type="http"
+        url="https://mcp.runcomfy.com/mcp"
         timeout={300}
         envVars={[
-          { key: "RUNCOMFY_AUTH", value: "Bearer <YOUR_RUNCOMFY_TOKEN>" }
+          { key: "Authorization", value: "Bearer <YOUR_RUNCOMFY_TOKEN>" }
         ]}
         infoNote="Get your RunComfy API token from https://www.runcomfy.com/profile"
       />

--- a/documentation/docs/mcp/runcomfy-mcp.md
+++ b/documentation/docs/mcp/runcomfy-mcp.md
@@ -53,13 +53,13 @@ You'll need [Node.js](https://nodejs.org/) installed on your system to run this 
   <TabItem value="cli" label="goose CLI">
       <CLIExtensionInstructions
         name="RunComfy"
+        description="Manage RunComfy Serverless (ComfyUI) GPU deployments and run async image/video inference"
         command="npx -y mcp-remote https://mcp.runcomfy.com/mcp --header Authorization:${RUNCOMFY_AUTH}"
         timeout={300}
         envVars={[
-          { name: "RUNCOMFY_AUTH", label: "RunComfy API token as a Bearer credential, e.g. 'Bearer <YOUR_RUNCOMFY_TOKEN>'" }
+          { key: "RUNCOMFY_AUTH", value: "Bearer <YOUR_RUNCOMFY_TOKEN>" }
         ]}
-        apiKeyLink="https://www.runcomfy.com/profile"
-        apiKeyLinkText="RunComfy API token"
+        infoNote="Get your RunComfy API token from https://www.runcomfy.com/profile"
       />
   </TabItem>
 </Tabs>

--- a/documentation/docs/mcp/runcomfy-mcp.md
+++ b/documentation/docs/mcp/runcomfy-mcp.md
@@ -1,0 +1,100 @@
+---
+title: RunComfy Extension
+description: Add RunComfy MCP Server as a goose Extension
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+
+This tutorial covers how to add the [RunComfy MCP Server](https://github.com/runcomfy-com/runcomfy-mcp) as a goose extension, enabling goose to manage RunComfy Serverless (ComfyUI) GPU deployments and run async image/video inference.
+
+RunComfy MCP is a remote, hosted server at `https://mcp.runcomfy.com/mcp`. goose connects to it through the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridge.
+
+:::tip Quick Install
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  Add it from **Settings → Extensions → Add**, or use the goose CLI command.
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+  **Command**
+  ```sh
+  npx -y mcp-remote https://mcp.runcomfy.com/mcp --header Authorization:${RUNCOMFY_AUTH}
+  ```
+  </TabItem>
+</Tabs>
+:::
+
+## Configuration
+
+:::info
+You'll need [Node.js](https://nodejs.org/) installed on your system to run this command, as it uses `npx`. You'll also need a RunComfy API token — get one from your [RunComfy Profile](https://www.runcomfy.com/profile). Set `RUNCOMFY_AUTH` to your token as a Bearer credential, e.g. `Bearer <YOUR_RUNCOMFY_TOKEN>`.
+:::
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+    <GooseDesktopInstaller
+        extensionId="runcomfy"
+        extensionName="RunComfy"
+        description="Manage RunComfy Serverless (ComfyUI) GPU deployments and run async image/video inference"
+        command="npx"
+        args={["-y", "mcp-remote", "https://mcp.runcomfy.com/mcp", "--header", "Authorization:${RUNCOMFY_AUTH}"]}
+        cliCommand="npx -y mcp-remote https://mcp.runcomfy.com/mcp --header Authorization:${RUNCOMFY_AUTH}"
+        timeout={300}
+        envVars={[
+          { name: "RUNCOMFY_AUTH", label: "RunComfy API token as a Bearer credential, e.g. 'Bearer <YOUR_RUNCOMFY_TOKEN>'" }
+        ]}
+        apiKeyLink="https://www.runcomfy.com/profile"
+        apiKeyLinkText="RunComfy API token"
+        note="Requires Node.js. RunComfy is a remote server reached via mcp-remote."
+    />
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+      <CLIExtensionInstructions
+        name="RunComfy"
+        command="npx -y mcp-remote https://mcp.runcomfy.com/mcp --header Authorization:${RUNCOMFY_AUTH}"
+        timeout={300}
+        envVars={[
+          { name: "RUNCOMFY_AUTH", label: "RunComfy API token as a Bearer credential, e.g. 'Bearer <YOUR_RUNCOMFY_TOKEN>'" }
+        ]}
+        apiKeyLink="https://www.runcomfy.com/profile"
+        apiKeyLinkText="RunComfy API token"
+      />
+  </TabItem>
+</Tabs>
+
+## Available Tools
+
+The RunComfy MCP server exposes 10 tools mapping 1:1 to the [RunComfy Serverless API (ComfyUI)](https://docs.runcomfy.com/serverless):
+
+- **Deployment management**: `list_deployments`, `get_deployment`, `create_deployment`, `update_deployment`, `delete_deployment`
+- **Inference**: `submit_request`, `get_request_status`, `get_request_result`, `cancel_request`
+- **Advanced**: `call_instance_proxy`
+
+## Example Usage
+
+#### Prompt
+
+```
+List my RunComfy deployments, submit an inference request to the first one, and give me the output image URL when it's done.
+```
+
+#### goose Output
+
+```
+I'll list your RunComfy deployments, then submit a request.
+
+─── list_deployments | runcomfy ──────────────────────────
+Found 2 deployment(s).
+
+─── submit_request | runcomfy ──────────────────────────
+deployment_id: 6f3a1b...
+Submitted request req_abc123.
+
+─── get_request_status | runcomfy ──────────────────────────
+Request req_abc123: completed.
+
+Here is your generated image:
+https://output.runcomfy.net/.../result.png
+```

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -884,15 +884,17 @@
     "id": "runcomfy",
     "name": "RunComfy",
     "description": "Manage RunComfy Serverless (ComfyUI) GPU deployments and run async image/video inference",
-    "command": "npx -y mcp-remote https://mcp.runcomfy.com/mcp --header Authorization:${RUNCOMFY_AUTH}",
+    "type": "streamable-http",
+    "url": "https://mcp.runcomfy.com/mcp",
     "link": "https://www.runcomfy.com",
-    "installation_notes": "Requires Node.js. Source: https://github.com/runcomfy-com/runcomfy-mcp . Get your API token from https://www.runcomfy.com/profile and set RUNCOMFY_AUTH to 'Bearer <YOUR_RUNCOMFY_TOKEN>'.",
+    "installation_notes": "Remote Streamable HTTP extension \u2014 no local Node required. Requires a RunComfy API token as a Request Header, e.g. Authorization: Bearer <YOUR_RUNCOMFY_TOKEN>. Get it from https://www.runcomfy.com/profile . Source: https://github.com/runcomfy-com/runcomfy-mcp",
     "is_builtin": false,
     "endorsed": false,
-    "environmentVariables": [
+    "environmentVariables": [],
+    "headers": [
       {
-        "name": "RUNCOMFY_AUTH",
-        "description": "RunComfy API token as a Bearer credential, e.g. 'Bearer <YOUR_RUNCOMFY_TOKEN>' (from https://www.runcomfy.com/profile)",
+        "name": "Authorization",
+        "description": "Bearer <YOUR_RUNCOMFY_TOKEN>",
         "required": true
       }
     ]

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -885,8 +885,8 @@
     "name": "RunComfy",
     "description": "Manage RunComfy Serverless (ComfyUI) GPU deployments and run async image/video inference",
     "command": "npx -y mcp-remote https://mcp.runcomfy.com/mcp --header Authorization:${RUNCOMFY_AUTH}",
-    "link": "https://github.com/runcomfy-com/runcomfy-mcp",
-    "installation_notes": "Requires Node.js. Get your API token from https://www.runcomfy.com/profile and set RUNCOMFY_AUTH to 'Bearer <YOUR_RUNCOMFY_TOKEN>'.",
+    "link": "https://www.runcomfy.com",
+    "installation_notes": "Requires Node.js. Source: https://github.com/runcomfy-com/runcomfy-mcp . Get your API token from https://www.runcomfy.com/profile and set RUNCOMFY_AUTH to 'Bearer <YOUR_RUNCOMFY_TOKEN>'.",
     "is_builtin": false,
     "endorsed": false,
     "environmentVariables": [

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -879,6 +879,22 @@
       "required": false
     }
   ]
-}
-
+},
+  {
+    "id": "runcomfy",
+    "name": "RunComfy",
+    "description": "Manage RunComfy Serverless (ComfyUI) GPU deployments and run async image/video inference",
+    "command": "npx -y mcp-remote https://mcp.runcomfy.com/mcp --header Authorization:${RUNCOMFY_AUTH}",
+    "link": "https://github.com/runcomfy-com/runcomfy-mcp",
+    "installation_notes": "Requires Node.js. Get your API token from https://www.runcomfy.com/profile and set RUNCOMFY_AUTH to 'Bearer <YOUR_RUNCOMFY_TOKEN>'.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [
+      {
+        "name": "RUNCOMFY_AUTH",
+        "description": "RunComfy API token as a Bearer credential, e.g. 'Bearer <YOUR_RUNCOMFY_TOKEN>' (from https://www.runcomfy.com/profile)",
+        "required": true
+      }
+    ]
+  }
 ]


### PR DESCRIPTION
Adds **RunComfy** as a goose extension — the official remote MCP server for the [RunComfy Serverless API (ComfyUI)](https://docs.runcomfy.com/serverless).

- Adds `documentation/docs/mcp/runcomfy-mcp.md` (tutorial with Desktop + CLI install paths)
- Adds an entry to `documentation/static/servers.json`
- Remote server reached via the `mcp-remote` bridge: `https://mcp.runcomfy.com/mcp` (Bearer auth)
- 10 tools: manage GPU deployments + run async ComfyUI (image/video) inference
- Also published to the official MCP registry as `io.github.runcomfy-com/runcomfy-mcp`

Signed-off-by: kalvinrv <58277734+kalvinrv@users.noreply.github.com>