### PR TITLE
feat(providers): add PleumRouter declarative provider

### DIFF
--- a/crates/goose-providers/src/declarative.rs
+++ b/crates/goose-providers/src/declarative.rs
@@ -40,6 +40,7 @@ pub(crate) mod declarative_providers {
         orcarouter,
         ovhcloud,
         perplexity,
+        pleumrouter,
         routstr,
         saladcloud,
         scaleway,

--- a/crates/goose-providers/src/declarative/definitions/pleumrouter.json
+++ b/crates/goose-providers/src/declarative/definitions/pleumrouter.json
@@ -1,0 +1,30 @@
+{
+  "name": "pleumrouter",
+  "engine": "openai",
+  "display_name": "PleumRouter",
+  "description": "Korea-region OpenAI-compatible multi-provider LLM gateway — one key for OpenAI, Anthropic, Google, and more.",
+  "api_key_env": "PLEUMROUTER_API_KEY",
+  "base_url": "https://router.pleum.ai/v1",
+  "catalog_provider_id": "pleumrouter",
+  "headers": {
+    "http-referer": "https://goose-docs.ai",
+    "x-title": "goose"
+  },
+  "models": [
+    { "name": "deepseek-v4-pro", "context_limit": 1000000 },
+    { "name": "glm-5.1", "context_limit": 200000 },
+    { "name": "qwen3-max", "context_limit": 262144 },
+    { "name": "claude-sonnet-4-6", "context_limit": 1000000 },
+    { "name": "gpt-5.5", "context_limit": 1050000 },
+    { "name": "gemini-2.5-pro", "context_limit": 1000000 }
+  ],
+  "dynamic_models": true,
+  "supports_streaming": true,
+  "preserves_thinking": true,
+  "model_doc_link": "https://router.pleum.ai/docs",
+  "setup_steps": [
+    "Sign up at https://router.pleum.ai",
+    "Create an API key (starts with plm_)",
+    "Paste the key above as PLEUMROUTER_API_KEY"
+  ]
+}

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -347,7 +347,7 @@ impl OpenAiProvider {
         "ovhcloud",
     ];
 
-    const PROVIDERS_NEEDING_STANDARD_CHAT_PARAMS: &[&str] = &["nearai"];
+    const PROVIDERS_NEEDING_STANDARD_CHAT_PARAMS: &[&str] = &["nearai", "pleumrouter"];
 
     /// Providers whose reasoning models accept an OpenAI-style
     /// `reasoning_effort` field on chat-completions requests but aren't


### PR DESCRIPTION
## Summary

Adds **PleumRouter** ([router.pleum.ai](https://router.pleum.ai)) as a declarative provider.

PleumRouter is a Korea-region, OpenAI-compatible multi-provider LLM gateway (one key → many providers). KRW prepaid credits, PIPA-aware operation.

Also opts `pleumrouter` into `PROVIDERS_NEEDING_STANDARD_CHAT_PARAMS` (same as `nearai`) so `gpt-5*` selections stay on `/v1/chat/completions`.

## Who we are / why this PR

We are **Pleum AI** ([pleum.ai](https://pleum.ai)). Goose users who want a gateway today hand-edit a custom OpenAI base URL. Listing PleumRouter as a first-class declarative provider makes that a one-click provider pick — same pattern as OrcaRouter / Together / Vercel AI Gateway already in-tree.

## Follow-up to #9939

Previous PR was closed pending the Responses vs chat-completions routing fix. This rebases onto current `main` (providers now live under `crates/goose-providers/`) and includes that fix.

## Test plan

- [ ] `pleumrouter.json` deserializes / appears in fixed provider list
- [ ] With `PLEUMROUTER_API_KEY` set, provider shows in Goose setup
- [ ] Selecting `gpt-5.5` uses chat completions path (not Responses)

Made with [Cursor](https://cursor.com)