### PR TITLE
fix(acp): forward image content chunks to client during live session

### DIFF
--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1434,6 +1434,18 @@ impl GooseAcpAgent {
                 }
                 ActionRequiredData::ElicitationResponse { .. } => {}
             },
+            MessageContent::Image(image) => {
+                let chunk = ContentChunk::new(ContentBlock::Image(ImageContent::new(
+                    image.data.clone(),
+                    image.mime_type.clone(),
+                )))
+                .meta(message_update_meta(message_id, message_created, steer));
+                let update = match role {
+                    Role::User => SessionUpdate::UserMessageChunk(chunk),
+                    Role::Assistant => SessionUpdate::AgentMessageChunk(chunk),
+                };
+                cx.send_notification(SessionNotification::new(session_id.clone(), update))?;
+            }
             MessageContent::SystemNotification(notification) => {
                 send_status_message_update(
                     cx,

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1435,11 +1435,25 @@ impl GooseAcpAgent {
                 ActionRequiredData::ElicitationResponse { .. } => {}
             },
             MessageContent::Image(image) => {
-                let chunk = ContentChunk::new(ContentBlock::Image(ImageContent::new(
-                    image.data.clone(),
-                    image.mime_type.clone(),
-                )))
-                .meta(message_update_meta(message_id, message_created, steer));
+                let mut image_content =
+                    ImageContent::new(image.data.clone(), image.mime_type.clone());
+                if let Some(audience) = image.audience() {
+                    image_content = image_content.annotations(
+                        Annotations::new().audience(
+                            audience
+                                .iter()
+                                .map(|r| match r {
+                                    Role::Assistant => {
+                                        agent_client_protocol::schema::v1::Role::Assistant
+                                    }
+                                    Role::User => agent_client_protocol::schema::v1::Role::User,
+                                })
+                                .collect::<Vec<_>>(),
+                        ),
+                    );
+                }
+                let chunk = ContentChunk::new(ContentBlock::Image(image_content))
+                    .meta(message_update_meta(message_id, message_created, steer));
                 let update = match role {
                     Role::User => SessionUpdate::UserMessageChunk(chunk),
                     Role::Assistant => SessionUpdate::AgentMessageChunk(chunk),


### PR DESCRIPTION
## Summary

handle_message_content had a _ => {} that silently dropped MessageContent::Image during live streaming. The session-replay path (load_session.rs) already handles images correctly — this adds the missing arm to match it.

### Testing
Manual : The fix is defensive, no built-in Goose extension currently triggers this path (Auto Visualiser uses HTML, Computer Controller uses file paths). To trigger it: connect a third-party MCP server that returns Content::Image from a tool call, run it in a live session, and verify the image renders inline. Pre-fix: silently dropped. Post-fix: image chunk reaches the UI.

