### PR TITLE
fix(acp): keep loadSession usable when recipe hydration fails

### DIFF
--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -210,6 +210,8 @@ impl GooseAcpAgent {
         let (agent, extension_results) = self.prepare_acp_session_agent(cx, &session).await?;
         // Historical sessions must remain loadable when stored recipe metadata no longer validates.
         if let Err(e) = self.apply_session_recipe(&agent, &session).await {
+            // Cached agents may still hold recipe prompt/tooling from an earlier successful load.
+            self.clear_recipe(&agent).await;
             tracing::warn!(
                 sid = %sid,
                 error = ?e,

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -208,10 +208,10 @@ impl GooseAcpAgent {
             self.supports_goose_custom_notifications(),
         )?;
         let (agent, extension_results) = self.prepare_acp_session_agent(cx, &session).await?;
-        // Historical sessions must remain loadable when stored recipe metadata no longer validates.
+        // Cached agents can retain recipe prompt/tooling from an earlier successful load.
+        // Clear first so soft-fail and MissingParams (Ok without apply) both leave no recipe context.
+        self.clear_recipe(&agent).await;
         if let Err(e) = self.apply_session_recipe(&agent, &session).await {
-            // Cached agents may still hold recipe prompt/tooling from an earlier successful load.
-            self.clear_recipe(&agent).await;
             tracing::warn!(
                 sid = %sid,
                 error = ?e,

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -209,7 +209,7 @@ impl GooseAcpAgent {
         )?;
         let (agent, extension_results) = self.prepare_acp_session_agent(cx, &session).await?;
         // Cached agents can retain recipe prompt/tooling from an earlier successful load.
-        // Clear first so soft-fail and MissingParams (Ok without apply) both leave no recipe context.
+        // Clear before rehydrate so Err soft-fail and MissingParams (Ok without apply) leave no recipe context.
         self.clear_recipe(&agent).await;
         if let Err(e) = self.apply_session_recipe(&agent, &session).await {
             tracing::warn!(

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -208,7 +208,14 @@ impl GooseAcpAgent {
             self.supports_goose_custom_notifications(),
         )?;
         let (agent, extension_results) = self.prepare_acp_session_agent(cx, &session).await?;
-        self.apply_session_recipe(&agent, &session).await?;
+        // Historical sessions must remain loadable when stored recipe metadata no longer validates.
+        if let Err(e) = self.apply_session_recipe(&agent, &session).await {
+            tracing::warn!(
+                sid = %sid,
+                error = ?e,
+                "recipe hydration failed during load_session; loading the session without recipe context"
+            );
+        }
         self.register_acp_session(session_id_str.clone(), agent.clone(), replay_tool_requests)
             .await;
 

--- a/crates/goose/src/acp/server/recipe/mod.rs
+++ b/crates/goose/src/acp/server/recipe/mod.rs
@@ -322,6 +322,10 @@ impl GooseAcpAgent {
         }
     }
 
+    pub(super) async fn clear_recipe(&self, agent: &Arc<Agent>) {
+        agent.clear_recipe_context().await;
+    }
+
     pub(super) async fn apply_session_recipe(
         &self,
         agent: &Arc<Agent>,

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1041,6 +1041,13 @@ impl Agent {
         }
     }
 
+    /// Drop recipe instructions and final-output tooling from a reused agent.
+    pub async fn clear_recipe_context(&self) {
+        self.remove_system_prompt_extra("recipe").await;
+        self.remove_system_prompt_extra("final_output").await;
+        *self.final_output_tool.lock().await = None;
+    }
+
     /// Dispatch a single tool call to the appropriate client
     #[instrument(skip(self, tool_call, request_id, cancellation_token, session), fields(input, output, session.id = %session.id))]
     pub async fn dispatch_tool_call(
@@ -4085,6 +4092,38 @@ echo start >> "$PLUGIN_ROOT/hook.log"
         let final_output_tool_system_prompt =
             final_output_tool_ref.as_ref().unwrap().system_prompt();
         assert!(system_prompt.contains(&final_output_tool_system_prompt));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_clear_recipe_context_removes_stale_prompt_and_tool() -> Result<()> {
+        let agent = Agent::new();
+        agent
+            .extend_system_prompt("recipe".to_string(), "follow the recipe".to_string())
+            .await;
+        agent
+            .add_final_output_tool(Response {
+                json_schema: Some(serde_json::json!({
+                    "type": "object",
+                    "properties": { "result": {"type": "string"} }
+                })),
+            })
+            .await;
+
+        agent.clear_recipe_context().await;
+
+        assert!(agent.final_output_tool.lock().await.is_none());
+        let tools = agent.list_tools("test-session-id", None).await;
+        assert!(tools.iter().all(|tool| tool.name != FINAL_OUTPUT_TOOL_NAME));
+
+        let system_prompt = agent
+            .prompt_manager
+            .lock()
+            .await
+            .builder()
+            .with_goose_mode(GooseMode::default())
+            .build();
+        assert!(!system_prompt.contains("follow the recipe"));
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- ACP `loadSession` no longer fails hard when `apply_session_recipe` rejects a stored recipe.
- After the transcript is replayed and the session runtime is prepared, recipe hydration failures are logged and ignored so historical sessions stay loadable.
- Scoped to problem 1 from #10113. Persistence/trust follow-ups (problems 2-4) are left for later work.

## Test plan
- [x] `cargo fmt`
- [x] `cargo check -p goose`
- [x] `cargo clippy -p goose --all-targets -- -D warnings`
- [ ] CI on this PR
- [ ] Manual: load an ACP session whose stored recipe has an obsolete parameter definition and confirm the transcript still loads

Fixes #10113
