### PR TITLE
Trim macOS desktop entitlements

### DIFF
--- a/ui/desktop/entitlements.plist
+++ b/ui/desktop/entitlements.plist
@@ -2,19 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <key>com.apple.security.files.user-selected.read-write</key>
-    <true/>
-    <key>com.apple.security.files.downloads.read-write</key>
-    <true/>
-    <key>com.apple.security.files.documents.read-write</key>
-    <true/>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
     <key>com.apple.security.cs.allow-dyld-environment-variables</key>
-    <true/>
-    <key>com.apple.security.screen-recording</key>
     <true/>
     <key>com.apple.security.automation.apple-events</key>
     <true/>
@@ -22,13 +14,7 @@
     <true/>
     <key>com.apple.security.network.server</key>
     <true/>
-    <key>com.apple.security.device.camera</key>
-    <true/>
     <key>com.apple.security.device.audio-input</key>
-    <true/>
-    <key>com.apple.security.personal-information.calendars</key>
-    <true/>
-    <key>com.apple.security.personal-information.reminders</key>
     <true/>
   </dict>
 </plist>

--- a/ui/desktop/forge.config.ts
+++ b/ui/desktop/forge.config.ts
@@ -35,10 +35,10 @@ let cfg = {
       },
     ],
     // Usage descriptions for macOS TCC (Transparency, Consent, and Control)
-    NSCalendarsUsageDescription:
-      'Goose needs access to your calendars to help manage and query calendar events.',
-    NSRemindersUsageDescription:
-      'Goose needs access to your reminders to help manage and query reminders.',
+    NSMicrophoneUsageDescription:
+      'Goose needs access to your microphone for voice dictation.',
+    NSAppleEventsUsageDescription:
+      'Goose needs access to send Apple Events to control other apps on your behalf.',
   },
 };
 


### PR DESCRIPTION
Trim macOS desktop entitlements to those goose first-party code uses and add the missing microphone and Apple Events usage descriptions

Also adds `ui/desktop/forge.config.ts` entries for things we do need (audio input)

## Summary
We don't need all the entitlements listed in `ui/desktop/entitlements.plist` for first party goose code. Extensions may need them but from a goose perspective we have decided we don't need to declare things our first party code doesn't need.

The effect of this will be that the extensions that need this functionality will need to include tool or server descriptions that inform goose that the user will need to manually add permission (for things like Downloads, Contacts, Reminders, etc) access. goose also does a good job generally handling errors and informing the user what they need to do anyway.

### Testing
Manual/local

### Related Issues
Relates to https://github.com/aaif-goose/goose/issues/10286

### Screenshots/Demos (for UX changes)
N/A
