### PR TITLE
fix(recipe): reject incomplete response schemas and avoid FinalOutputTool panics

### DIFF
--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -527,9 +527,13 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
 
     let recipe = session_config.recipe.as_ref();
 
-    agent
+    if let Err(error) = agent
         .apply_recipe_components(recipe.and_then(|r| r.response.clone()), true)
-        .await;
+        .await
+    {
+        output::render_error(&format!("Failed to apply recipe response: {}", error));
+        process::exit(1);
+    }
 
     let session_id =
         resolve_session_id(&session_config, &session_manager, agent.config.goose_mode).await;

--- a/crates/goose/src/acp/server/new_session.rs
+++ b/crates/goose/src/acp/server/new_session.rs
@@ -77,7 +77,7 @@ impl GooseAcpAgent {
             .activate_acp_session(cx, &reloaded_session, HashMap::new())
             .await?;
         if let Some(recipe) = &rendered_recipe {
-            self.apply_recipe(&agent, recipe).await;
+            self.apply_recipe(&agent, recipe).await?;
         }
 
         let reloaded_session = self.reload_session(&session.id).await?;

--- a/crates/goose/src/acp/server/recipe/mod.rs
+++ b/crates/goose/src/acp/server/recipe/mod.rs
@@ -311,15 +311,23 @@ impl GooseAcpAgent {
         }
     }
 
-    pub(super) async fn apply_recipe(&self, agent: &Arc<Agent>, recipe: &Recipe) {
+    pub(super) async fn apply_recipe(
+        &self,
+        agent: &Arc<Agent>,
+        recipe: &Recipe,
+    ) -> Result<(), agent_client_protocol::Error> {
         agent
             .apply_recipe_components(recipe.response.clone(), true)
-            .await;
+            .await
+            .map_err(|error| {
+                agent_client_protocol::Error::invalid_params().data(format!("recipe: {error}"))
+            })?;
         if let Some(instructions) = recipe.instructions.clone() {
             agent
                 .extend_system_prompt("recipe".to_string(), instructions)
                 .await;
         }
+        Ok(())
     }
 
     pub(super) async fn apply_session_recipe(
@@ -332,7 +340,7 @@ impl GooseAcpAgent {
         };
 
         if session.session_type == SessionType::Scheduled {
-            self.apply_recipe(agent, recipe).await;
+            self.apply_recipe(agent, recipe).await?;
             return Ok(());
         }
 
@@ -342,7 +350,7 @@ impl GooseAcpAgent {
             &recipe_dir,
             session.user_recipe_values.clone().unwrap_or_default(),
         )? {
-            self.apply_recipe(agent, &rendered).await;
+            self.apply_recipe(agent, &rendered).await?;
         }
 
         Ok(())

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1022,8 +1022,8 @@ impl Agent {
 
     pub async fn add_final_output_tool(&self, response: Response) -> anyhow::Result<()> {
         let mut final_output_tool = self.final_output_tool.lock().await;
-        let created_final_output_tool = FinalOutputTool::new(response)
-            .map_err(|error| anyhow::anyhow!(error))?;
+        let created_final_output_tool =
+            FinalOutputTool::new(response).map_err(|error| anyhow::anyhow!(error))?;
         let final_output_system_prompt = created_final_output_tool.system_prompt();
         *final_output_tool = Some(created_final_output_tool);
         self.extend_system_prompt("final_output".to_string(), final_output_system_prompt)

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1020,25 +1020,28 @@ impl Agent {
         )
     }
 
-    pub async fn add_final_output_tool(&self, response: Response) {
+    pub async fn add_final_output_tool(&self, response: Response) -> anyhow::Result<()> {
         let mut final_output_tool = self.final_output_tool.lock().await;
-        let created_final_output_tool = FinalOutputTool::new(response);
+        let created_final_output_tool = FinalOutputTool::new(response)
+            .map_err(|error| anyhow::anyhow!(error))?;
         let final_output_system_prompt = created_final_output_tool.system_prompt();
         *final_output_tool = Some(created_final_output_tool);
         self.extend_system_prompt("final_output".to_string(), final_output_system_prompt)
             .await;
+        Ok(())
     }
 
     pub async fn apply_recipe_components(
         &self,
         response: Option<Response>,
         include_final_output: bool,
-    ) {
+    ) -> anyhow::Result<()> {
         if include_final_output {
             if let Some(response) = response {
-                self.add_final_output_tool(response).await;
+                self.add_final_output_tool(response).await?;
             }
         }
+        Ok(())
     }
 
     /// Dispatch a single tool call to the appropriate client
@@ -4063,7 +4066,7 @@ echo start >> "$PLUGIN_ROOT/hook.log"
             })),
         };
 
-        agent.add_final_output_tool(response).await;
+        agent.add_final_output_tool(response).await?;
 
         let tools = agent.list_tools("test-session-id", None).await;
         let final_output_tool = tools

--- a/crates/goose/src/agents/execute_commands.rs
+++ b/crates/goose/src/agents/execute_commands.rs
@@ -425,7 +425,7 @@ impl Agent {
         match recipe_slash_command::resolve_command(command, params_str) {
             Ok(None) => Ok(None),
             Ok(Some((response, prompt))) => {
-                self.apply_recipe_components(response, true).await;
+                self.apply_recipe_components(response, true).await?;
                 Ok(Some(Message::user().with_text(prompt)))
             }
             Err(text) => Ok(Some(Message::assistant().with_text(text))),

--- a/crates/goose/src/agents/final_output_tool.rs
+++ b/crates/goose/src/agents/final_output_tool.rs
@@ -17,9 +17,10 @@ pub struct FinalOutputTool {
 
 impl FinalOutputTool {
     pub fn new(response: Response) -> Result<Self, String> {
-        let schema = response.json_schema.as_ref().ok_or_else(|| {
-            "Cannot create FinalOutputTool: json_schema is required".to_string()
-        })?;
+        let schema = response
+            .json_schema
+            .as_ref()
+            .ok_or_else(|| "Cannot create FinalOutputTool: json_schema is required".to_string())?;
 
         if let Some(obj) = schema.as_object() {
             if obj.is_empty() {

--- a/crates/goose/src/agents/final_output_tool.rs
+++ b/crates/goose/src/agents/final_output_tool.rs
@@ -16,23 +16,26 @@ pub struct FinalOutputTool {
 }
 
 impl FinalOutputTool {
-    pub fn new(response: Response) -> Self {
-        if response.json_schema.is_none() {
-            panic!("Cannot create FinalOutputTool: json_schema is required");
-        }
-        let schema = response.json_schema.as_ref().unwrap();
+    pub fn new(response: Response) -> Result<Self, String> {
+        let schema = response.json_schema.as_ref().ok_or_else(|| {
+            "Cannot create FinalOutputTool: json_schema is required".to_string()
+        })?;
 
         if let Some(obj) = schema.as_object() {
             if obj.is_empty() {
-                panic!("Cannot create FinalOutputTool: empty json_schema is not allowed");
+                return Err(
+                    "Cannot create FinalOutputTool: empty json_schema is not allowed".to_string(),
+                );
             }
         }
 
-        jsonschema::meta::validate(schema).unwrap();
-        Self {
+        jsonschema::meta::validate(schema)
+            .map_err(|e| format!("Cannot create FinalOutputTool: invalid json_schema: {e}"))?;
+
+        Ok(Self {
             response,
             final_output: None,
-        }
+        })
     }
 
     pub fn tool(&self) -> Tool {
@@ -178,23 +181,26 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Cannot create FinalOutputTool: json_schema is required")]
     fn test_new_with_missing_schema() {
         let response = Response { json_schema: None };
-        FinalOutputTool::new(response);
+        match FinalOutputTool::new(response) {
+            Err(error) => assert!(error.contains("json_schema is required")),
+            Ok(_) => panic!("expected missing schema error"),
+        }
     }
 
     #[test]
-    #[should_panic(expected = "Cannot create FinalOutputTool: empty json_schema is not allowed")]
     fn test_new_with_empty_schema() {
         let response = Response {
             json_schema: Some(json!({})),
         };
-        FinalOutputTool::new(response);
+        match FinalOutputTool::new(response) {
+            Err(error) => assert!(error.contains("empty json_schema is not allowed")),
+            Ok(_) => panic!("expected empty schema error"),
+        }
     }
 
     #[test]
-    #[should_panic]
     fn test_new_with_invalid_schema() {
         let response = Response {
             json_schema: Some(json!({
@@ -206,7 +212,7 @@ mod tests {
                 }
             })),
         };
-        FinalOutputTool::new(response);
+        assert!(FinalOutputTool::new(response).is_err());
     }
 
     #[tokio::test]
@@ -226,7 +232,7 @@ mod tests {
             })),
         };
 
-        let mut tool = FinalOutputTool::new(response);
+        let mut tool = FinalOutputTool::new(response).unwrap();
         let tool_call =
             CallToolRequestParams::new(FINAL_OUTPUT_TOOL_NAME).with_arguments(object!({
                 "message": "Hello"  // Missing required "count" field
@@ -246,7 +252,7 @@ mod tests {
             json_schema: Some(create_complex_test_schema()),
         };
 
-        let mut tool = FinalOutputTool::new(response);
+        let mut tool = FinalOutputTool::new(response).unwrap();
         let tool_call =
             CallToolRequestParams::new(FINAL_OUTPUT_TOOL_NAME).with_arguments(object!({
                 "user": {

--- a/crates/goose/src/agents/subagent_handler.rs
+++ b/crates/goose/src/agents/subagent_handler.rs
@@ -162,7 +162,7 @@ fn get_agent_messages(params: SubagentRunParams) -> AgentMessagesFuture {
         let has_response_schema = recipe.response.is_some();
         agent
             .apply_recipe_components(recipe.response.clone(), true)
-            .await;
+            .await?;
 
         let subagent_prompt =
             build_subagent_prompt(&agent, &task_config, &session_id, system_instructions).await?;

--- a/crates/goose/src/recipe/validate_recipe.rs
+++ b/crates/goose/src/recipe/validate_recipe.rs
@@ -46,12 +46,32 @@ pub fn validate_recipe_template_from_content(
     validate_prompt_or_instructions(&recipe)?;
     validate_retry_config(&recipe)?;
     if let Some(response) = &recipe.response {
-        if let Some(json_schema) = &response.json_schema {
-            validate_json_schema(json_schema)?;
-        }
+        validate_response_config(response)?;
     }
 
     Ok(recipe)
+}
+
+fn validate_response_config(response: &crate::recipe::Response) -> Result<()> {
+    let json_schema = response.json_schema.as_ref().ok_or_else(|| {
+        anyhow::anyhow!("Recipe `response` requires a non-empty `json_schema` object")
+    })?;
+
+    match json_schema.as_object() {
+        Some(obj) if obj.is_empty() => {
+            return Err(anyhow::anyhow!(
+                "Recipe `response.json_schema` must be a non-empty JSON Schema object"
+            ));
+        }
+        Some(_) => validate_json_schema(json_schema)?,
+        None => {
+            return Err(anyhow::anyhow!(
+                "Recipe `response.json_schema` must be a JSON Schema object"
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 fn validate_retry_config(recipe: &Recipe) -> Result<()> {
@@ -224,6 +244,39 @@ parameters:
         let error = validate_recipe_template_from_content(&recipe_content, None).unwrap_err();
 
         assert_eq!(error.to_string(), "Duplicate parameter definition: value.");
+    }
+
+    #[test]
+    fn test_rejects_response_without_json_schema() {
+        let recipe_content = r#"
+version: 1.0.0
+title: Incomplete response
+description: Missing json_schema
+instructions: Say hello
+response: {}
+"#;
+
+        let error = validate_recipe_template_from_content(recipe_content, None).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("Recipe `response` requires a non-empty `json_schema` object"));
+    }
+
+    #[test]
+    fn test_rejects_response_with_empty_json_schema() {
+        let recipe_content = r#"
+version: 1.0.0
+title: Empty schema response
+description: Empty json_schema object
+instructions: Say hello
+response:
+  json_schema: {}
+"#;
+
+        let error = validate_recipe_template_from_content(recipe_content, None).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("Recipe `response.json_schema` must be a non-empty JSON Schema object"));
     }
 
     #[test]

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -3097,7 +3097,7 @@ mod tests {
                         "properties": { "result": { "type": "string" } }
                     })),
                 })
-                .await;
+                .await?;
 
             let session_config = SessionConfig {
                 id: session.id,


### PR DESCRIPTION
## Summary

Recipes that declared `response` without a usable `json_schema` could pass validation and then panic inside `FinalOutputTool::new` during apply (`goose run --recipe`, ACP, `/recipe`, etc.).

This PR validates `response.json_schema` at recipe load time and changes final-output setup to return structured errors instead of panicking.

Fixes #10491

### Testing

- `cargo test -p goose final_output_tool` — 6 passed
- `cargo test -p goose validate_recipe` — 5 passed (includes new regression tests for `response: {}` and empty `json_schema`)
- `cargo test -p goose test_add_final_output_tool` — 1 passed

### Related Issues

Fixes #10491