### PR TITLE
fix(nix): allow builtin fetch-git for cudaforge git dependency (#9467)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,16 @@
           version = workspaceToml.workspace.package.version;
           src = self;
 
-          cargoLock.lockFile = ./Cargo.lock;
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            # Cargo.lock pins a git dependency (cudaforge). buildRustPackage
+            # refuses to fetch git deps unless we either provide an output hash
+            # per dep or opt into builtins.fetchGit. We use the latter so the
+            # flake builds without downstream consumers having to override
+            # cargoDeps / crate fetch behavior (see issue #9467). The fetch is
+            # still reproducible because Cargo.lock pins the exact rev.
+            allowBuiltinFetchGit = true;
+          };
 
           LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
 


### PR DESCRIPTION
## Why

Fixes #9467.

The Nix flake fails when consumed as `github:aaif-goose/goose` because `Cargo.lock` pins a **git dependency**:

```
name = "cudaforge"
source = "git+https://github.com/jbg/cudaforge?rev=e7c1967340e40673db98dc9e17da0f04834a456f#..."
```

`rustPlatform.buildRustPackage` with `cargoLock.lockFile` refuses to fetch git dependencies unless you either supply a per-dep `outputHashes` entry or opt into `builtins.fetchGit`. The current `flake.nix` does neither, so `nix build` fails demanding a hash for the git dep — exactly as reported.

## What

Opt into `allowBuiltinFetchGit` on the `cargoLock` set:

```nix
cargoLock = {
  lockFile = ./Cargo.lock;
  allowBuiltinFetchGit = true;
};
```

This makes the flake build without downstream consumers having to override `cargoDeps` / crate fetch behavior. The fetch is still reproducible because `Cargo.lock` pins the exact rev.

I chose `allowBuiltinFetchGit` over a hard-coded `outputHashes` entry because the pinned cudaforge rev changes over time; an `outputHashes` map would need updating on every bump, whereas `builtins.fetchGit` derives reproducibility from the lockfile rev directly.

## Testing

⚠️ I don't have `nix` available on this machine, so I could **not** run `nix build` locally. Would appreciate a reviewer with Nix confirming:

```sh
nix build github:aaif-goose/goose#packages.<system>.default
```

Note: the reporter also mentioned crates.io API `403`s during vendoring (a `fetchurl` User-Agent issue). That is a separate, environment/nixpkgs-level concern and is not addressed here — this PR targets the primary, reproducible defect (unhashed git dependency).
