### PR TITLE
fix(desktop): scroll chat to the latest reply on session resume

### DIFF
--- a/ui/desktop/src/components/ui/scroll-area.tsx
+++ b/ui/desktop/src/components/ui/scroll-area.tsx
@@ -192,7 +192,9 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
       if (!viewport || !content || typeof ResizeObserver === 'undefined') return;
 
       const observer = new ResizeObserver(() => {
-        if (isFollowing && !userScrolledUpRef.current) {
+        // Mirror the [children] effect's guards, including isActivelyScrolling, so
+        // the re-pin doesn't fight a user scrolling up while content is still growing.
+        if (isFollowing && !userScrolledUpRef.current && !isActivelyScrollingRef.current) {
           viewport.scrollTo({ top: viewport.scrollHeight, behavior: 'auto' });
         }
       });

--- a/ui/desktop/src/components/ui/scroll-area.tsx
+++ b/ui/desktop/src/components/ui/scroll-area.tsx
@@ -39,6 +39,7 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
     const rootRef = React.useRef<React.ElementRef<typeof ScrollAreaPrimitive.Root>>(null);
     const viewportRef = React.useRef<HTMLDivElement>(null);
     const viewportEndRef = React.useRef<HTMLDivElement>(null);
+    const contentRef = React.useRef<HTMLDivElement>(null);
     const [isFollowing, setIsFollowing] = React.useState(true);
     const [isScrolled, setIsScrolled] = React.useState(false);
     const userScrolledUpRef = React.useRef(false);
@@ -60,9 +61,12 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
 
     const scrollToBottom = React.useCallback(() => {
       if (viewportRef.current) {
+        // Jump instantly rather than animating: a smooth programmatic scroll
+        // emits intermediate scroll events that handleScroll mistakes for a
+        // manual scroll-up, which disables auto-follow mid-animation.
         viewportRef.current.scrollTo({
           top: viewportRef.current.scrollHeight,
-          behavior: 'smooth',
+          behavior: 'auto',
         });
         // When explicitly scrolling to bottom, reset the following state
         setIsFollowing(true);
@@ -169,7 +173,7 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
           if (viewportRef.current && !isActivelyScrollingRef.current) {
             viewportRef.current.scrollTo({
               top: viewportRef.current.scrollHeight,
-              behavior: 'smooth',
+              behavior: 'auto',
             });
           }
         });
@@ -177,6 +181,24 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
 
       lastScrollHeightRef.current = currentScrollHeight;
     }, [children, autoScroll, isFollowing]);
+
+    // Keep pinned to the bottom when content grows from async media (images,
+    // syntax highlighting) that resizes after paint without a React re-render,
+    // so it isn't covered by the [children] effect above.
+    React.useEffect(() => {
+      if (!autoScroll) return;
+      const viewport = viewportRef.current;
+      const content = contentRef.current;
+      if (!viewport || !content || typeof ResizeObserver === 'undefined') return;
+
+      const observer = new ResizeObserver(() => {
+        if (isFollowing && !userScrolledUpRef.current) {
+          viewport.scrollTo({ top: viewport.scrollHeight, behavior: 'auto' });
+        }
+      });
+      observer.observe(content);
+      return () => observer.disconnect();
+    }, [autoScroll, isFollowing]);
 
     // Add scroll event listener
     React.useEffect(() => {
@@ -204,7 +226,10 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
           ref={viewportRef}
           className="h-full w-full rounded-[inherit] [&>div]:!block"
         >
-          <div className={cn(paddingX ? `px-${paddingX}` : '', paddingY ? `py-${paddingY}` : '')}>
+          <div
+            ref={contentRef}
+            className={cn(paddingX ? `px-${paddingX}` : '', paddingY ? `py-${paddingY}` : '')}
+          >
             {children}
             {autoScroll && <div ref={viewportEndRef} style={{ height: '1px' }} />}
           </div>


### PR DESCRIPTION
## Summary
On session resume the chat could load scrolled to an earlier point in the conversation instead of the latest reply (#10483).

Root cause: `scrollToBottom` in `ScrollArea` animated with `behavior: 'smooth'`. A smooth programmatic scroll emits intermediate `scroll` events where the viewport isn't at the bottom yet, and `handleScroll` can't tell that from the user scrolling up — so it sets `isFollowing = false` / `userScrolledUp = true` mid-animation. Content that grows *after* the first paint (images, syntax-highlighted code) then isn't followed, because that late growth resizes the DOM without a React re-render, so the `[children]` auto-scroll effect never fires. The view stays parked above the bottom.

Fix:
- Use `behavior: 'auto'` for programmatic auto-scroll (resume + follow), so there are no intermediate frames to misread as a manual scroll-up.
- Add a `ResizeObserver` on the scroll content that re-pins to the bottom while following, covering async height growth the `[children]` effect can't see.

Manual scroll-up still disables auto-follow (unchanged): the resize re-pin is gated on `isFollowing && !userScrolledUp`.

Trade-off for maintainers: this makes programmatic auto-scroll instant rather than animated (resume and the follow-during-streaming path). For resume it avoids animating on every open. If you'd rather keep the smooth animation, the alternative is to guard the scroll handler against in-flight programmatic scrolls so a smooth `scrollToBottom` isn't misread as a scroll-up — I can switch to that.

### Testing
Verified in Chromium against the real `ScrollArea` component (standalone Playwright harness): after late content growth the resume scenario ends at the bottom (`distanceFromBottom = 0`); before the fix it parked ~800px above the bottom. A user-scroll-up check confirms the view stays where the user left it when content later grows.
`pnpm run lint:check`, `pnpm run typecheck`, and `pnpm run test:run` (564 passed) all pass.
This is layout/timing behaviour the jsdom unit tests can't exercise (no layout) and the Electron `tests/e2e` suite isn't a natural fit; I can share the standalone reproduction or add an e2e test if there's a preferred pattern.

### Related Issues
Closes #10483
