### PR TITLE
feat(aws_bedrock): route OpenAI GPT-5.6 (sol/terra/luna) via Bedrock …

### DIFF
--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -45,6 +45,9 @@ pub const BEDROCK_KNOWN_MODELS: &[&str] = &[
     "us.anthropic.claude-opus-4-1-20250805-v1:0",
     "openai.gpt-5.5",
     "openai.gpt-5.4",
+    "openai.gpt-5.6-sol",
+    "openai.gpt-5.6-terra",
+    "openai.gpt-5.6-luna",
 ];
 
 pub const BEDROCK_DEFAULT_MAX_RETRIES: usize = 6;
@@ -1129,6 +1132,70 @@ mod tests {
         assert_eq!(received.len(), 1);
         let body: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
         assert_eq!(body["model"].as_str().unwrap(), "openai.gpt-5.5");
+    }
+
+    #[tokio::test]
+    async fn test_mantle_stream_returns_text_message_gpt_5_6() {
+        use futures::StreamExt;
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        let sse_body = [
+            r#"data: {"type":"response.output_text.delta","sequence_number":1,"item_id":"msg_1","output_index":0,"content_index":0,"delta":"Hello"}"#,
+            r#"data: {"type":"response.output_text.delta","sequence_number":2,"item_id":"msg_1","output_index":0,"content_index":0,"delta":" world"}"#,
+            "data: [DONE]",
+        ]
+        .join("\n");
+
+        Mock::given(method("POST"))
+            .and(path("/openai/v1/responses"))
+            .and(header("authorization", "Bearer test-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let sdk_config = aws_config::SdkConfig::builder()
+            .behavior_version(aws_config::BehaviorVersion::latest())
+            .region(aws_config::Region::new("us-east-1"))
+            .build();
+
+        let model = ModelConfig::new("openai.gpt-5.6-terra");
+        let provider = BedrockProvider {
+            client: Client::new(&sdk_config),
+            retry_config: RetryConfig::default(),
+            name: "aws_bedrock".to_string(),
+            region: Some("us-east-1".to_string()),
+            bearer_token: Some("test-token".to_string()),
+            http_client: reqwest::Client::new(),
+            mantle_base_url: Some(format!("{}/openai/v1/responses", server.uri())),
+        };
+
+        let messages = vec![crate::conversation::message::Message::user().with_text("hi")];
+        let mut stream = provider
+            .stream(&model.clone(), "", &messages, &[])
+            .await
+            .unwrap();
+
+        let mut text = String::new();
+        while let Some(item) = stream.next().await {
+            let (msg, _usage) = item.unwrap();
+            if let Some(m) = msg {
+                for c in m.content {
+                    if let MessageContent::Text(t) = c {
+                        text.push_str(&t.text);
+                    }
+                }
+            }
+        }
+
+        assert_eq!(text, "Hello world");
+
+        let received = server.received_requests().await.unwrap();
+        assert_eq!(received.len(), 1);
+        let body: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(body["model"].as_str().unwrap(), "openai.gpt-5.6-terra");
     }
 
     // ── ConverseStream event processing ──────────────────────────────────


### PR DESCRIPTION
## Summary
Adds the OpenAI GPT-5.6 family — `openai.gpt-5.6-sol`, `openai.gpt-5.6-terra`,
`openai.gpt-5.6-luna` — to `BEDROCK_KNOWN_MODELS`, so they auto-route through the
Bedrock provider's mantle path, exactly like the existing `gpt-5.4`/`gpt-5.5`.

## Motivation
GPT-5.6 (Sol/Terra/Luna) went GA on Amazon Bedrock on 2026-07-13. These models are
exclusive to the `bedrock-mantle` endpoint and are served **only** via the OpenAI
Responses API — they do not support the classic Invoke/Converse path.

Today, reaching them through Goose requires a manual `provider: openai` +
`host`/`base_path` passthrough. That workaround has a side effect: the
`openai.`-prefixed model name fails `is_openai_responses_model`, so reasoning
effort (`GOOSE_THINKING_EFFORT` / `reasoning.effort`) is silently dropped on that path.

## What this changes
Adding the three IDs to `BEDROCK_KNOWN_MODELS` makes `is_mantle_model` match, which
routes the request through `create_responses_request` + `post_mantle_streaming` — the
Bedrock mantle path that already targets `.../openai/v1/responses`. Because that path
strips and re-adds the `openai.` prefix, and `gpt-5.6-*` is already recognized by the
reasoning-effort machinery, users get **both** auto-routing (no manual passthrough) and
correct `reasoning.effort` forwarding for free. No new endpoint logic is introduced.

## Correctness
The mantle path is Responses-only (`bedrock.rs` hardcodes `/openai/v1/responses`), which
is exactly what GPT-5.6 requires — identical to how 5.4/5.5 already work.

## Testing
Adds `test_mantle_stream_returns_text_message_gpt_5_6`, mirroring the existing
`gpt-5.5` mantle-routing test (drives `stream()`, asserts the outbound payload model).