### PR TITLE
feat(aws_bedrock): route xAI Grok 4.3 via the Bedrock mantle endpoint

### DIFF
--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1504,10 +1504,15 @@ pub fn extract_reasoning_effort(model_name: &str) -> (String, Option<String>) {
 /// routes here. The matcher intentionally scans the full model identifier so
 /// hosted aliases like `databricks-gpt-5.4`, `goose-o3-mini`, or
 /// `headless-goose-o3-mini` work without provider-specific normalization.
+///
+/// xAI Grok is also matched: Bedrock Mantle serves it through the same
+/// OpenAI-compatible Responses API, so it shares this routing and reasoning-
+/// effort forwarding path identically.
 pub fn is_openai_responses_model(model_name: &str) -> bool {
     static RE: OnceLock<Regex> = OnceLock::new();
-    let re =
-        RE.get_or_init(|| Regex::new(r"(?i)(?:^|[-/])(?:o\d+(?:$|-)|gpt-5(?:$|[-.]))").unwrap());
+    let re = RE.get_or_init(|| {
+        Regex::new(r"(?i)(?:^|[-/])(?:o\d+(?:$|-)|gpt-5(?:$|[-.])|grok(?:$|[-.]))").unwrap()
+    });
     re.is_match(model_name)
 }
 
@@ -1533,6 +1538,11 @@ pub fn openai_reasoning_effort_for_thinking(
 
 pub(crate) fn openai_reasoning_efforts_for_model(model_name: &str) -> &'static [&'static str] {
     let normalized = model_name.to_ascii_lowercase();
+
+    // Grok 4.3 on Bedrock Mantle accepts none/low/medium/high (no xhigh).
+    if normalized.contains("grok") {
+        return &["none", "low", "medium", "high"];
+    }
 
     if normalized.contains("gpt-5") {
         if normalized.contains("-pro") || normalized.contains("/pro") {
@@ -4047,6 +4057,9 @@ data: [DONE]"#;
             "databricks-gpt-5.4",
             "goose-gpt-5.4-high",
             "headless-goose-o3-mini",
+            "grok-4.3",
+            "grok-4.3-high",
+            "xai.grok-4.3",
         ] {
             assert!(is_openai_responses_model(model), "{model} should match");
         }
@@ -4081,6 +4094,8 @@ data: [DONE]"#;
             ),
             ("databricks-o3-low", "databricks-o3", Some("low")),
             ("goose-gpt-5-high", "goose-gpt-5", Some("high")),
+            ("grok-4.3-high", "grok-4.3", Some("high")),
+            ("grok-4.3", "grok-4.3", None),
             ("gpt-4o", "gpt-4o", None),
         ] {
             let (name, effort) = extract_reasoning_effort(model);

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -1504,6 +1504,19 @@ mod tests {
     }
 
     #[test]
+    fn test_responses_request_supports_grok_effort_suffix() {
+        // Grok 4.3 rides the Responses API on Bedrock Mantle; an explicit effort
+        // suffix must surface as reasoning.effort just like the gpt-5 family.
+        let model_config = ModelConfig::new("grok-4.3-high");
+
+        let result = create_responses_request(&model_config, "You are helpful.", &[], &[]).unwrap();
+
+        assert_eq!(result["model"], "grok-4.3");
+        assert_eq!(result["reasoning"]["effort"], "high");
+        assert_eq!(result["reasoning"]["summary"], "auto");
+    }
+
+    #[test]
     fn test_responses_request_supports_gpt_5_6_reasoning_mode() {
         let model_config = ModelConfig::new("gpt-5.6-sol").with_merged_request_params(
             std::collections::HashMap::from([("reasoning_mode".to_string(), json!("pro"))]),

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -45,6 +45,7 @@ pub const BEDROCK_KNOWN_MODELS: &[&str] = &[
     "us.anthropic.claude-opus-4-1-20250805-v1:0",
     "openai.gpt-5.5",
     "openai.gpt-5.4",
+    "xai.grok-4.3",
 ];
 
 pub const BEDROCK_DEFAULT_MAX_RETRIES: usize = 6;
@@ -750,22 +751,35 @@ impl Provider for BedrockProvider {
             Some(session_id.as_str())
         };
 
-        let without_prefix = model_config
-            .model_name
-            .strip_prefix("openai.")
+        // Mantle (the OpenAI-compatible Responses endpoint) serves vendor-prefixed
+        // third-party models — OpenAI GPT-5.x and xAI Grok. anthropic.* still routes
+        // through Converse, so only these vendor prefixes are mantle candidates.
+        const MANTLE_VENDOR_PREFIXES: &[&str] = &["openai.", "xai."];
+        let mantle_prefix = MANTLE_VENDOR_PREFIXES
+            .iter()
+            .copied()
+            .find(|p| model_config.model_name.starts_with(p));
+
+        // Strip the vendor prefix so the reasoning-effort regex can normalize the
+        // bare name (e.g. `grok-4.3-high` -> `grok-4.3`), then reattach it for the
+        // known-model lookup and the outbound payload.
+        let without_prefix = mantle_prefix
+            .and_then(|p| model_config.model_name.strip_prefix(p))
             .unwrap_or(&model_config.model_name);
         let (base_name, effort) = extract_reasoning_effort(without_prefix);
-        let bedrock_model_id = format!("openai.{}", base_name);
+        let bedrock_model_id = format!("{}{}", mantle_prefix.unwrap_or(""), base_name);
 
-        let is_mantle_model = BEDROCK_KNOWN_MODELS.contains(&bedrock_model_id.as_str());
+        let is_mantle_model =
+            mantle_prefix.is_some() && BEDROCK_KNOWN_MODELS.contains(&bedrock_model_id.as_str());
 
         if is_mantle_model {
             let mut normalized_config = ModelConfig {
                 model_name: base_name,
                 ..model_config.clone()
             };
-            // `ModelConfig::new` cannot normalize the effort suffix for `openai.gpt-*` names
-            // because the `openai.` prefix breaks the reasoning-model regex. Inject it here.
+            // `ModelConfig::new` cannot normalize the effort suffix for prefixed mantle
+            // names (`openai.gpt-*`, `xai.grok-*`) because the vendor prefix breaks the
+            // reasoning-model regex. Inject it here.
             if let Some(e) = effort {
                 let params = normalized_config
                     .request_params
@@ -1129,6 +1143,70 @@ mod tests {
         assert_eq!(received.len(), 1);
         let body: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
         assert_eq!(body["model"].as_str().unwrap(), "openai.gpt-5.5");
+    }
+
+    #[tokio::test]
+    async fn test_mantle_stream_returns_text_message_grok() {
+        use futures::StreamExt;
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        let sse_body = [
+            r#"data: {"type":"response.output_text.delta","sequence_number":1,"item_id":"msg_1","output_index":0,"content_index":0,"delta":"Hello"}"#,
+            r#"data: {"type":"response.output_text.delta","sequence_number":2,"item_id":"msg_1","output_index":0,"content_index":0,"delta":" world"}"#,
+            "data: [DONE]",
+        ]
+        .join("\n");
+
+        Mock::given(method("POST"))
+            .and(path("/openai/v1/responses"))
+            .and(header("authorization", "Bearer test-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let sdk_config = aws_config::SdkConfig::builder()
+            .behavior_version(aws_config::BehaviorVersion::latest())
+            .region(aws_config::Region::new("us-east-1"))
+            .build();
+
+        let model = ModelConfig::new("xai.grok-4.3");
+        let provider = BedrockProvider {
+            client: Client::new(&sdk_config),
+            retry_config: RetryConfig::default(),
+            name: "aws_bedrock".to_string(),
+            region: Some("us-east-1".to_string()),
+            bearer_token: Some("test-token".to_string()),
+            http_client: reqwest::Client::new(),
+            mantle_base_url: Some(format!("{}/openai/v1/responses", server.uri())),
+        };
+
+        let messages = vec![crate::conversation::message::Message::user().with_text("hi")];
+        let mut stream = provider
+            .stream(&model.clone(), "", &messages, &[])
+            .await
+            .unwrap();
+
+        let mut text = String::new();
+        while let Some(item) = stream.next().await {
+            let (msg, _usage) = item.unwrap();
+            if let Some(m) = msg {
+                for c in m.content {
+                    if let MessageContent::Text(t) = c {
+                        text.push_str(&t.text);
+                    }
+                }
+            }
+        }
+
+        assert_eq!(text, "Hello world");
+
+        let received = server.received_requests().await.unwrap();
+        assert_eq!(received.len(), 1);
+        let body: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(body["model"].as_str().unwrap(), "xai.grok-4.3");
     }
 
     // ── ConverseStream event processing ──────────────────────────────────


### PR DESCRIPTION
## Summary
Routes **xAI Grok 4.3** (`xai.grok-4.3`) through the Bedrock mantle
(OpenAI-compatible Responses) endpoint with reasoning-effort forwarding —
the same auto-routing the OpenAI `gpt-5.x` models already get.

## Motivation
Grok 4.3 is served on Amazon Bedrock exclusively via the `bedrock-mantle`
OpenAI-compatible Responses API. Today it can only be reached through a manual
`provider: openai` + `host`/`base_path` passthrough, which has a side effect:
the model name fails `is_openai_responses_model`, so reasoning effort
(`GOOSE_THINKING_EFFORT` / `reasoning.effort`) is silently dropped on that path.

## What this changes
Three coordinated changes, since Grok differs from the GPT-5.x models in two ways:

1. **`bedrock.rs`** — add `xai.grok-4.3` to `BEDROCK_KNOWN_MODELS`, and generalize
   the mantle routing guard from an `openai.`-only prefix check to a vendor-prefix
   allowlist (`openai.`, `xai.`). The bare name is normalized for effort-suffix
   handling, then the vendor prefix is reattached for the known-model lookup and
   outbound payload. `anthropic.*` is unaffected and still uses Converse.

2. **`is_openai_responses_model`** — also match `grok`. Bedrock Mantle serves Grok
   through the same OpenAI-compatible Responses API, so it shares the routing and
   reasoning-effort path identically. This is the gate that was dropping effort.

3. **`openai_reasoning_efforts_for_model`** — return Grok 4.3's supported effort
   set: `none`/`low`/`medium`/`high` (no `xhigh`).

## Correctness
The mantle path is Responses-only (`bedrock.rs` targets `/openai/v1/responses`),
which is exactly what Grok 4.3 requires. `reasoning_mode` stays gated to GPT-5.6
models — Grok is unaffected by that gate.

## Testing
- `test_mantle_stream_returns_text_message_grok` — asserts `xai.grok-4.3` routes
  through the mantle endpoint with the correct outbound model id.
- `test_responses_request_supports_grok_effort_suffix` — asserts `reasoning.effort`
  is emitted for Grok.
- Extended `is_openai_responses_model` and `extract_reasoning_effort` test arrays
  with Grok cases.

## Note for the maintainer
This touches `BEDROCK_KNOWN_MODELS` adjacent to my companion PR for GPT-5.6
(Sol/Terra/Luna). Whichever merges second will have a trivial one-line conflict
in that list — no logic overlap.