### PR TITLE
fix: isolate prepare tools test state

### DIFF
--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -666,10 +666,11 @@ pub fn is_tool_visible_to_model(tool: &Tool) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::GooseMode;
+    use crate::agents::{AgentConfig, GoosePlatform};
+    use crate::config::{GooseMode, PermissionManager};
     use crate::conversation::message::{Message, SystemNotificationType};
     use crate::providers::base::Provider;
-    use crate::session::session_manager::SessionType;
+    use crate::session::{SessionManager, SessionType};
     use async_trait::async_trait;
     use goose_providers::conversation::token_usage::{ProviderStats, ProviderUsage, Usage};
     use goose_providers::model::ModelConfig;
@@ -700,11 +701,19 @@ mod tests {
 
     #[tokio::test]
     async fn prepare_tools_returns_sorted_tools_including_frontend() -> anyhow::Result<()> {
-        let agent = crate::agents::Agent::new();
+        let data_dir = tempfile::tempdir()?;
+        let data_path = data_dir.path().to_path_buf();
+        let session_manager = std::sync::Arc::new(SessionManager::new(data_path.clone()));
+        let agent = Agent::with_config(AgentConfig::new(
+            std::sync::Arc::clone(&session_manager),
+            std::sync::Arc::new(PermissionManager::new(data_path)),
+            None,
+            GooseMode::default(),
+            false,
+            GoosePlatform::GooseCli,
+        ));
 
-        let session = agent
-            .config
-            .session_manager
+        let session = session_manager
             .create_session(
                 std::env::current_dir().unwrap(),
                 "test-prepare-tools".to_string(),


### PR DESCRIPTION
## Summary

- give `prepare_tools_returns_sorted_tools_including_frontend` isolated temporary session and permission storage
- avoid the process-global session database initialized by `Agent::new()`

## Root cause

The test created its session through the global `SessionManager`. Parallel tests temporarily change `GOOSE_PATH_ROOT`, so the lazy global SQLite pool could be initialized inside a temporary directory that was deleted before this test opened `sessions.db`. This produced SQLite error 14 (`unable to open database file`) in the native-TLS CI job.

## Testing

- `cargo fmt --check`
- `cargo test -p goose --no-default-features --features native-tls,code-mode agents::reply_parts::tests::prepare_tools_returns_sorted_tools_including_frontend -- --exact`
- `cargo test -p goose --no-default-features --features native-tls,code-mode --lib` — the fixed test passed in the parallel suite; 1394 tests passed and four unrelated local environment-sensitive plugin discovery/Ollama tests failed