### PR TITLE
chore: remove unused utoipa ToSchema derives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5034,7 +5034,6 @@ dependencies = [
  "unicode-normalization",
  "url",
  "urlencoding",
- "utoipa 4.2.3",
  "uuid",
  "v_htmlescape",
  "webbrowser",
@@ -5117,7 +5116,6 @@ dependencies = [
  "serde",
  "tokio",
  "tracing",
- "utoipa 4.2.3",
 ]
 
 [[package]]
@@ -5152,7 +5150,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "utoipa 4.2.3",
  "uuid",
 ]
 
@@ -5212,7 +5209,6 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "unicode-normalization",
- "utoipa 4.2.3",
  "uuid",
 ]
 
@@ -5245,7 +5241,6 @@ dependencies = [
  "tracing",
  "url",
  "urlencoding",
- "utoipa 4.2.3",
  "wiremock",
 ]
 
@@ -7883,7 +7878,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "utoipa 5.5.0",
+ "utoipa",
 ]
 
 [[package]]
@@ -8380,7 +8375,6 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
  "version_check",
 ]
 
@@ -12808,18 +12802,6 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
-version = "4.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
-dependencies = [
- "indexmap 2.14.0",
- "serde",
- "serde_json",
- "utoipa-gen 4.3.1",
-]
-
-[[package]]
-name = "utoipa"
 version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
@@ -12827,19 +12809,7 @@ dependencies = [
  "indexmap 2.14.0",
  "serde",
  "serde_json",
- "utoipa-gen 5.5.0",
-]
-
-[[package]]
-name = "utoipa-gen"
-version = "4.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c24e8ab68ff9ee746aad22d39b5535601e6416d1b0feeabf78be986a5c4392"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
+ "utoipa-gen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,6 @@ tracing-appender = { version = "0.2.1", default-features = false }
 tracing-futures = { version = "0.2.4", default-features = false, features = ["futures-03", "std", "std-future"] }
 tracing-subscriber = { version = "0.3.22", default-features = false, features = ["std"] }
 urlencoding = { version = "2.1", default-features = false }
-utoipa = { version = "4.2", default-features = false }
 uuid = { version = "1.23", default-features = false, features = ["v4", "std"] }
 webbrowser = { version = "1", default-features = false }
 which = { version = "8", default-features = false, features = ["real-sys"] }

--- a/crates/goose-download-manager/Cargo.toml
+++ b/crates/goose-download-manager/Cargo.toml
@@ -18,4 +18,3 @@ reqwest = { workspace = true, features = ["stream"] }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util", "time"] }
 tracing = { workspace = true }
-utoipa = { workspace = true }

--- a/crates/goose-download-manager/src/lib.rs
+++ b/crates/goose-download-manager/src/lib.rs
@@ -5,7 +5,6 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use tokio::io::AsyncWriteExt;
 use tracing::info;
-use utoipa::ToSchema;
 
 fn partial_path_for(destination: &Path) -> PathBuf {
     destination.with_extension(
@@ -51,7 +50,7 @@ pub fn cleanup_partial_downloads(
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DownloadProgress {
     /// Model ID being downloaded
     pub model_id: String,
@@ -74,7 +73,7 @@ pub struct DownloadProgress {
     pub task_exited: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum DownloadStatus {
     Downloading,

--- a/crates/goose-local-inference/Cargo.toml
+++ b/crates/goose-local-inference/Cargo.toml
@@ -42,7 +42,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["fs", "rt-multi-thread", "sync", "time"] }
 tracing = { workspace = true }
-utoipa = { workspace = true, features = ["chrono"] }
 uuid = { workspace = true, features = ["v4", "std"] }
 tempfile = { workspace = true }
 

--- a/crates/goose-local-inference/src/hf_models.rs
+++ b/crates/goose-local-inference/src/hf_models.rs
@@ -10,8 +10,6 @@ use std::sync::{Arc, Mutex};
 
 use crate::huggingface_auth;
 
-use utoipa::ToSchema;
-
 const HF_API_BASE: &str = "https://huggingface.co/api/models";
 const HF_DOWNLOAD_BASE: &str = "https://huggingface.co";
 const LLAMACPP_BACKEND_ID: &str = "llamacpp";
@@ -20,7 +18,7 @@ const GGUF_FORMAT: &str = "gguf";
 const MLX_FORMAT: &str = "mlx-safetensors";
 const MLX_VARIANT_ID: &str = "default";
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HfModelInfo {
     pub repo_id: String,
     pub author: String,
@@ -31,7 +29,7 @@ pub struct HfModelInfo {
     pub variants: Vec<HfModelVariant>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HfModelVariant {
     pub variant_id: String,
     pub label: String,
@@ -59,7 +57,7 @@ fn default_supported() -> bool {
 }
 
 /// A single downloadable GGUF file (used internally and for downloads).
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HfGgufFile {
     pub filename: String,
     pub size_bytes: u64,
@@ -68,7 +66,7 @@ pub struct HfGgufFile {
 }
 
 /// A quantization variant — groups sharded files into one logical entry.
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HfQuantVariant {
     pub quantization: String,
     pub size_bytes: u64,

--- a/crates/goose-local-inference/src/local_model_registry.rs
+++ b/crates/goose-local-inference/src/local_model_registry.rs
@@ -4,9 +4,8 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
-use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum SamplingConfig {
     Greedy,
@@ -36,7 +35,7 @@ impl Default for SamplingConfig {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ToolCallingMode {
     #[default]
@@ -45,7 +44,7 @@ pub enum ToolCallingMode {
     ForceEmulated,
 }
 
-#[derive(Debug, Clone, Default, Hash, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Default, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ChatTemplate {
     #[serde(alias = "auto")]
@@ -59,7 +58,7 @@ pub enum ChatTemplate {
     },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelSettings {
     /// Backend implementation to use for this model. Defaults to llama.cpp.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -274,7 +273,7 @@ pub fn get_registry() -> &'static Mutex<LocalModelRegistry> {
     })
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LocalModelStorage {
     #[default]

--- a/crates/goose-provider-types/Cargo.toml
+++ b/crates/goose-provider-types/Cargo.toml
@@ -30,7 +30,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
 tracing = { workspace = true }
 unicode-normalization = { version = "0.1.22", default-features = false, features = ["std"] }
-utoipa = { workspace = true, features = ["chrono"] }
 uuid = { workspace = true, features = ["v4", "std"] }
 
 [dev-dependencies]

--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -3,7 +3,6 @@ use futures::Stream;
 use rmcp::model::Tool;
 use serde::{Deserialize, Serialize};
 use std::pin::Pin;
-use utoipa::ToSchema;
 
 use crate::{
     canonical::{map_to_canonical_model, CanonicalModelRegistry},
@@ -19,7 +18,7 @@ use crate::{
 };
 
 /// Metadata about a provider's configuration requirements and capabilities
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProviderMetadata {
     /// The unique identifier for this provider
     pub name: String,
@@ -129,7 +128,7 @@ impl ProviderMetadata {
 }
 
 /// Configuration key metadata for provider setup
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConfigKey {
     /// The name of the configuration key (e.g., "API_KEY")
     pub name: String,
@@ -218,7 +217,7 @@ impl ConfigKey {
 }
 
 /// Information about a model's capabilities
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ModelInfo {
     /// The name of the model
     pub name: String,

--- a/crates/goose-provider-types/src/canonical/catalog.rs
+++ b/crates/goose-provider-types/src/canonical/catalog.rs
@@ -70,7 +70,7 @@ fn detect_format_from_npm(npm: &str) -> Option<ProviderFormat> {
     }
 }
 
-#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ProviderCatalogEntry {
     pub id: String,
     pub name: String,
@@ -81,7 +81,7 @@ pub struct ProviderCatalogEntry {
     pub env_var: String,
 }
 
-#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ProviderTemplate {
     pub id: String,
     pub name: String,
@@ -93,7 +93,7 @@ pub struct ProviderTemplate {
     pub doc_url: String,
 }
 
-#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ModelTemplate {
     pub id: String,
     pub name: String,
@@ -102,7 +102,7 @@ pub struct ModelTemplate {
     pub deprecated: bool,
 }
 
-#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ModelCapabilities {
     pub tool_call: bool,
     pub reasoning: bool,

--- a/crates/goose-provider-types/src/conversation.rs
+++ b/crates/goose-provider-types/src/conversation.rs
@@ -4,13 +4,12 @@ use rmcp::model::{Content, Role};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use thiserror::Error;
-use utoipa::ToSchema;
 
 pub mod message;
 pub mod token_usage;
 mod tool_result_serde;
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Conversation(Vec<Message>);
 
 #[derive(Error, Debug)]

--- a/crates/goose-provider-types/src/conversation/message.rs
+++ b/crates/goose-provider-types/src/conversation/message.rs
@@ -11,10 +11,8 @@ use rmcp::model::{
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashSet;
 use std::fmt;
-use utoipa::ToSchema;
 use uuid::Uuid;
 
-#[derive(ToSchema)]
 pub enum ToolCallResult<T> {
     Success { value: T },
     Error { error: String },
@@ -79,17 +77,13 @@ pub type ToolResult<T> = Result<T, rmcp::model::ErrorData>;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(ToSchema)]
 pub struct ToolRequest {
     pub id: String,
     #[serde(with = "tool_result_serde")]
-    #[schema(value_type = Object)]
     pub tool_call: ToolResult<CallToolRequestParams>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Object)]
     pub metadata: Option<ProviderMetadata>,
     #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Object)]
     pub tool_meta: Option<serde_json::Value>,
 }
 
@@ -174,20 +168,16 @@ pub const TOOL_META_CHAIN_SUMMARY_KEY: &str = "goose.toolChain.summary";
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(ToSchema)]
 pub struct ToolResponse {
     pub id: String,
     #[serde(with = "tool_result_serde::call_tool_result")]
-    #[schema(value_type = Object)]
     pub tool_result: ToolResult<CallToolResult>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Object)]
     pub metadata: Option<ProviderMetadata>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(ToSchema)]
 pub struct ToolConfirmationRequest {
     pub id: String,
     pub tool_name: String,
@@ -195,7 +185,7 @@ pub struct ToolConfirmationRequest {
     pub prompt: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "actionType", rename_all = "camelCase")]
 pub enum ActionRequiredData {
     #[serde(rename_all = "camelCase")]
@@ -214,7 +204,6 @@ pub enum ActionRequiredData {
         id: String,
         user_data: serde_json::Value,
         #[serde(default = "default_elicitation_action")]
-        #[schema(value_type = String)]
         action: ElicitationAction,
     },
 }
@@ -223,33 +212,32 @@ fn default_elicitation_action() -> ElicitationAction {
     ElicitationAction::Accept
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ActionRequired {
     pub data: ActionRequiredData,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ThinkingContent {
     pub thinking: String,
     pub signature: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RedactedThinkingContent {
     pub data: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FrontendToolRequest {
     pub id: String,
     #[serde(with = "tool_result_serde")]
-    #[schema(value_type = Object)]
     pub tool_call: ToolResult<CallToolRequestParams>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum SystemNotificationType {
     ThinkingMessage,
@@ -258,7 +246,7 @@ pub enum SystemNotificationType {
     CreditsExhausted,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SystemNotificationContent {
     pub notification_type: SystemNotificationType,
@@ -267,7 +255,7 @@ pub struct SystemNotificationContent {
     pub data: Option<serde_json::Value>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 /// Content passed inside a message, which can be both simple content and tool content
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum MessageContent {
@@ -659,7 +647,7 @@ impl From<PromptMessage> for Message {
     }
 }
 
-#[derive(ToSchema, Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct InferenceMetadata {
     pub provider: String,
@@ -668,7 +656,7 @@ pub struct InferenceMetadata {
     pub resolved_model: Option<String>,
 }
 
-#[derive(ToSchema, Clone, PartialEq, Serialize, Deserialize, Debug, Default)]
+#[derive(Clone, PartialEq, Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct MessageUsage {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -711,7 +699,7 @@ impl MessageUsage {
     }
 }
 
-#[derive(ToSchema, Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
 /// Metadata for message visibility and model inference details
 #[serde(rename_all = "camelCase")]
 pub struct MessageMetadata {
@@ -813,7 +801,7 @@ impl MessageMetadata {
     }
 }
 
-#[derive(ToSchema, Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
 /// A message to or from an LLM
 #[serde(rename_all = "camelCase")]
 pub struct Message {
@@ -1130,7 +1118,7 @@ impl Message {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TokenState {
     pub input_tokens: i32,

--- a/crates/goose-provider-types/src/conversation/token_usage.rs
+++ b/crates/goose-provider-types/src/conversation/token_usage.rs
@@ -1,7 +1,6 @@
 use std::ops::{Add, AddAssign};
 
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProviderUsage {
@@ -15,7 +14,7 @@ pub struct ProviderUsage {
     pub cost_source: Option<CostSource>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CostSource {
     ProviderReported,
@@ -68,7 +67,7 @@ impl ProviderUsage {
 /// the cache fields are breakdown subsets of it. Parsers for providers
 /// that report cache tokens separately from input (e.g. Anthropic,
 /// Bedrock) must fold them into `input_tokens`.
-#[derive(Debug, Clone, Serialize, Deserialize, Default, Copy, PartialEq, Eq, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, Copy, PartialEq, Eq)]
 pub struct Usage {
     /// All prompt tokens, including any served from or written to cache.
     /// `cache_read_input_tokens` and `cache_write_input_tokens` are subsets of this.

--- a/crates/goose-provider-types/src/goose_mode.rs
+++ b/crates/goose-provider-types/src/goose_mode.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumMessage, EnumString, IntoStaticStr, VariantNames};
-use utoipa::ToSchema;
 
 #[derive(
     Copy,
@@ -17,7 +16,6 @@ use utoipa::ToSchema;
     EnumString,
     IntoStaticStr,
     VariantNames,
-    ToSchema,
 )]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]

--- a/crates/goose-provider-types/src/model.rs
+++ b/crates/goose-provider-types/src/model.rs
@@ -4,7 +4,6 @@ use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
-use utoipa::ToSchema;
 
 pub const DEFAULT_CONTEXT_LIMIT: usize = 128_000;
 
@@ -21,7 +20,7 @@ const INHERITED_SESSION_PARAM_KEYS: &[&str] = &[
     "preserve_unsigned_thinking",
 ];
 
-#[derive(Debug, Clone, Serialize, ToSchema)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ModelConfig {
     pub model_name: String,
     pub context_limit: Option<usize>,

--- a/crates/goose-provider-types/src/permission.rs
+++ b/crates/goose-provider-types/src/permission.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum Permission {
     AlwaysAllow,
@@ -11,7 +10,7 @@ pub enum Permission {
     AlwaysDeny,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub enum PrincipalType {
     Extension,
     Tool,

--- a/crates/goose-provider-types/src/thinking.rs
+++ b/crates/goose-provider-types/src/thinking.rs
@@ -2,7 +2,6 @@ use std::{fmt, str::FromStr, sync::LazyLock};
 
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 
 pub const GEMINI_THOUGHT_SIGNATURE_KEY: &str = "thoughtSignature";
 
@@ -273,7 +272,7 @@ fn contains_unquoted_gt(text: &str) -> bool {
     false
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ThinkingEffort {
     Off,

--- a/crates/goose-providers/Cargo.toml
+++ b/crates/goose-providers/Cargo.toml
@@ -42,7 +42,6 @@ rmcp = { workspace = true, features = ["server", "macros"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
-utoipa = { workspace = true, features = ["chrono"] }
 async-trait = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true, features = ["io-util"] }

--- a/crates/goose-providers/src/declarative.rs
+++ b/crates/goose-providers/src/declarative.rs
@@ -6,7 +6,6 @@ use std::{collections::HashMap, path::Path, str::FromStr};
 use anyhow::Result;
 use include_dir::{include_dir, Dir};
 use serde::{Deserialize, Deserializer, Serialize};
-use utoipa::ToSchema;
 
 pub static FIXED_PROVIDERS: Dir = include_dir!("$CARGO_MANIFEST_DIR/src/declarative/definitions");
 
@@ -68,7 +67,7 @@ pub fn fixed_provider_config_entries() -> Vec<(&'static str, &'static str)> {
     declarative_providers::fixed_provider_config_entries()
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EnvVarConfig {
     pub name: String,
     #[serde(default)]
@@ -82,7 +81,7 @@ pub struct EnvVarConfig {
     pub default: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ProviderEngine {
     #[serde(alias = "openai_compatible")]
@@ -106,7 +105,7 @@ impl FromStr for ProviderEngine {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeclarativeProviderConfig {
     pub name: String,
     pub engine: ProviderEngine,

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -139,7 +139,6 @@ goose-providers = { path = "../goose-providers", default-features = false }
 goose-download-manager = { path = "../goose-download-manager" }
 goose-sdk-types = { path = "../goose-sdk-types" }
 rand = { workspace = true }
-utoipa = { workspace = true, features = ["chrono"] }
 tokio-cron-scheduler = { version = "0.15", default-features = false }
 urlencoding = { workspace = true }
 v_htmlescape = { version = "0.17", default-features = false, features = ["std"] }

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -152,7 +152,7 @@ pub struct ToolCategorizeResult {
     pub filtered_response: Message,
 }
 
-#[derive(Debug, Clone, serde::Serialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct ExtensionLoadResult {
     pub name: String,
     pub success: bool,

--- a/crates/goose/src/agents/extension.rs
+++ b/crates/goose/src/agents/extension.rs
@@ -11,7 +11,6 @@ use serde::Deserializer;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::warn;
-use utoipa::ToSchema;
 
 pub use crate::agents::platform_extensions::{
     PlatformExtensionContext, PlatformExtensionDef, PLATFORM_EXTENSIONS,
@@ -58,7 +57,7 @@ pub enum ExtensionError {
 
 pub type ExtensionResult<T> = Result<T, ExtensionError>;
 
-#[derive(Debug, Clone, Serialize, Default, ToSchema, PartialEq)]
+#[derive(Debug, Clone, Serialize, Default, PartialEq)]
 pub struct Envs {
     /// A map of environment variables to set, e.g. API_KEY -> some_secret, HOST -> host
     #[serde(default)]
@@ -158,18 +157,16 @@ impl Envs {
 }
 
 /// Represents the different types of MCP extensions that can be added to the manager
-#[derive(Debug, Clone, Deserialize, Serialize, ToSchema, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "type")]
 pub enum ExtensionConfig {
     /// SSE transport is no longer supported - kept only for config file compatibility
     #[serde(rename = "sse")]
     Sse {
         #[serde(default)]
-        #[schema(required)]
         name: String,
         #[serde(default)]
         #[serde(deserialize_with = "deserialize_null_with_default")]
-        #[schema(required)]
         description: String,
         #[serde(default)]
         uri: Option<String>,
@@ -181,7 +178,6 @@ pub enum ExtensionConfig {
         name: String,
         #[serde(default)]
         #[serde(deserialize_with = "deserialize_null_with_default")]
-        #[schema(required)]
         description: String,
         cmd: String,
         args: Vec<String>,
@@ -205,7 +201,6 @@ pub enum ExtensionConfig {
         name: String,
         #[serde(default)]
         #[serde(deserialize_with = "deserialize_null_with_default")]
-        #[schema(required)]
         description: String,
         display_name: Option<String>, // needed for the UI
         timeout: Option<u64>,
@@ -222,7 +217,6 @@ pub enum ExtensionConfig {
         name: String,
         #[serde(default)]
         #[serde(deserialize_with = "deserialize_null_with_default")]
-        #[schema(required)]
         description: String,
         display_name: Option<String>,
         #[serde(default)]
@@ -238,7 +232,6 @@ pub enum ExtensionConfig {
         name: String,
         #[serde(default)]
         #[serde(deserialize_with = "deserialize_null_with_default")]
-        #[schema(required)]
         description: String,
         uri: String,
         #[serde(default)]
@@ -269,7 +262,6 @@ pub enum ExtensionConfig {
         name: String,
         #[serde(default)]
         #[serde(deserialize_with = "deserialize_null_with_default")]
-        #[schema(required)]
         description: String,
         /// The tools provided by the frontend
         tools: Vec<Tool>,
@@ -288,7 +280,6 @@ pub enum ExtensionConfig {
         name: String,
         #[serde(default)]
         #[serde(deserialize_with = "deserialize_null_with_default")]
-        #[schema(required)]
         description: String,
         /// The Python code to execute
         code: String,
@@ -581,14 +572,13 @@ where
 }
 
 /// Information about the tool used for building prompts
-#[derive(Clone, Debug, Serialize, ToSchema)]
+#[derive(Clone, Debug, Serialize)]
 pub struct ToolInfo {
     pub name: String,
     pub description: String,
     pub parameters: Vec<String>,
     pub permission: Option<PermissionLevel>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Object)]
     pub input_schema: Option<serde_json::Value>,
 }
 

--- a/crates/goose/src/agents/types.rs
+++ b/crates/goose/src/agents/types.rs
@@ -4,7 +4,6 @@ use rmcp::model::{CallToolResult, Tool};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
-use utoipa::ToSchema;
 
 /// Type alias for the tool result channel receiver
 pub type ToolResultReceiver = Arc<Mutex<mpsc::Receiver<(String, ToolResult<CallToolResult>)>>>;
@@ -19,7 +18,7 @@ pub const DEFAULT_RETRY_TIMEOUT_SECONDS: u64 = 300;
 pub const DEFAULT_ON_FAILURE_TIMEOUT_SECONDS: u64 = 600;
 
 /// Configuration for retry logic in recipe execution
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RetryConfig {
     /// Maximum number of retry attempts before giving up
     pub max_retries: u32,
@@ -62,7 +61,7 @@ impl RetryConfig {
 }
 
 /// A single success check to validate recipe completion
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum SuccessCheck {
     /// Execute a shell command and check its exit status

--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -15,7 +15,6 @@ use std::str::FromStr;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Mutex;
-use utoipa::ToSchema;
 
 pub use goose_providers::declarative::*;
 
@@ -57,7 +56,7 @@ pub fn expand_env_vars(template: &str, env_vars: &[EnvVarConfig]) -> Result<Stri
     Ok(result)
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LoadedProvider {
     pub config: DeclarativeProviderConfig,
     pub is_editable: bool,

--- a/crates/goose/src/config/extensions.rs
+++ b/crates/goose/src/config/extensions.rs
@@ -5,7 +5,6 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use serde_yaml::Mapping;
 use tracing::{info, warn};
-use utoipa::ToSchema;
 
 pub const DEFAULT_EXTENSION: &str = "developer";
 pub const DEFAULT_EXTENSION_TIMEOUT: u64 = 300;
@@ -13,7 +12,7 @@ pub const DEFAULT_EXTENSION_DESCRIPTION: &str = "";
 pub const DEFAULT_DISPLAY_NAME: &str = "Developer";
 const EXTENSIONS_CONFIG_KEY: &str = "extensions";
 
-#[derive(Debug, Deserialize, Serialize, Clone, ToSchema)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct ExtensionEntry {
     pub enabled: bool,
     #[serde(flatten)]

--- a/crates/goose/src/config/permission.rs
+++ b/crates/goose/src/config/permission.rs
@@ -6,7 +6,6 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock, RwLock};
 use tracing;
-use utoipa::ToSchema;
 
 const PERMISSION_FILE: &str = "permission.yaml";
 
@@ -14,7 +13,7 @@ static PERMISSION_MANAGER: LazyLock<Arc<PermissionManager>> =
     LazyLock::new(|| Arc::new(PermissionManager::new(Paths::config_dir())));
 
 /// Enum representing the possible permission levels for a tool.
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, ToSchema)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum PermissionLevel {
     AlwaysAllow, // Tool can always be used without prompt

--- a/crates/goose/src/dictation/providers.rs
+++ b/crates/goose/src/dictation/providers.rs
@@ -9,7 +9,6 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "local-inference")]
 use std::sync::Mutex;
 use std::time::Duration;
-use utoipa::ToSchema;
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const OPENAI_VERSIONLESS_TRANSCRIPTIONS_PATH: &str = "audio/transcriptions";
@@ -23,7 +22,7 @@ static LOCAL_TRANSCRIBER: once_cell::sync::Lazy<
 #[cfg(feature = "local-inference")]
 const WHISPER_TOKENIZER_JSON: &str = include_str!("whisper_data/tokens.json");
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize, ToSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum DictationProvider {
     OpenAI,

--- a/crates/goose/src/dictation/whisper.rs
+++ b/crates/goose/src/dictation/whisper.rs
@@ -23,7 +23,6 @@ use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;
 use symphonia::core::probe::Hint;
 use tokenizers::Tokenizer;
-use utoipa::ToSchema;
 
 // Common suppress tokens for all Whisper models
 const SUPPRESS_TOKENS: &[u32] = &[
@@ -42,7 +41,7 @@ const EOT_TOKEN: u32 = 50257;
 const TIMESTAMP_BEGIN: u32 = 50364;
 const SAMPLE_BEGIN: usize = 3;
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WhisperModel {
     /// Model identifier (e.g., "tiny", "base", "small")
     pub id: &'static str,

--- a/crates/goose/src/gateway/manager.rs
+++ b/crates/goose/src/gateway/manager.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
-use utoipa::ToSchema;
 
 use crate::config::Config;
 use crate::execution::manager::AgentManager;
@@ -34,7 +33,7 @@ pub struct GatewayInstance {
     pub handle: tokio::task::JoinHandle<()>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PairedUserInfo {
     pub platform: String,
     pub user_id: String,
@@ -43,7 +42,7 @@ pub struct PairedUserInfo {
     pub paired_at: i64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GatewayStatus {
     pub gateway_type: String,
     pub running: bool,

--- a/crates/goose/src/gateway/mod.rs
+++ b/crates/goose/src/gateway/mod.rs
@@ -8,7 +8,6 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tokio_util::sync::CancellationToken;
-use utoipa::ToSchema;
 
 use handler::GatewayHandler;
 
@@ -51,7 +50,7 @@ pub struct Attachment {
     pub data: Vec<u8>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum OutgoingMessage {
     Text { body: String },
@@ -66,7 +65,7 @@ pub enum PairingState {
     Paired { session_id: String, paired_at: i64 },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GatewayConfig {
     pub gateway_type: String,
     pub platform_config: serde_json::Value,

--- a/crates/goose/src/goose_apps/app.rs
+++ b/crates/goose/src/goose_apps/app.rs
@@ -3,11 +3,10 @@ use rmcp::model::ErrorData;
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
-use utoipa::ToSchema;
 
 use super::resource::McpAppResource;
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WindowProps {
     pub width: u32,
@@ -15,7 +14,7 @@ pub struct WindowProps {
     pub resizable: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GooseApp {
     #[serde(flatten)]

--- a/crates/goose/src/goose_apps/resource.rs
+++ b/crates/goose/src/goose_apps/resource.rs
@@ -1,9 +1,8 @@
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 
 /// Content Security Policy metadata for MCP Apps
 /// Specifies allowed domains for network connections and resource loading
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct CspMetadata {
     /// Domains allowed for connect-src (fetch, XHR, WebSocket)
@@ -23,7 +22,7 @@ pub struct CspMetadata {
 /// Sandbox permissions for MCP Apps
 /// Specifies which browser capabilities the UI needs access to.
 /// Maps to the iframe Permission Policy `allow` attribute.
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PermissionsMetadata {
     /// Request camera access (maps to Permission Policy `camera` feature)
@@ -45,7 +44,7 @@ fn is_default_permissions(p: &PermissionsMetadata) -> bool {
 }
 
 /// UI-specific metadata for MCP resources
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct UiMetadata {
     /// Content Security Policy configuration
@@ -63,7 +62,7 @@ pub struct UiMetadata {
 }
 
 /// Resource metadata containing UI configuration
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ResourceMetadata {
     /// UI-specific configuration
@@ -73,7 +72,7 @@ pub struct ResourceMetadata {
 
 /// MCP App Resource
 /// Represents a UI resource that can be rendered in an MCP App
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct McpAppResource {
     /// URI of the resource (must use ui:// scheme)

--- a/crates/goose/src/prompt_template.rs
+++ b/crates/goose/src/prompt_template.rs
@@ -50,7 +50,7 @@ static TEMPLATE_REGISTRY: &[(&str, &str)] = &[
 ];
 
 /// Information about a template including its content and customization status
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Template {
     pub name: String,
     pub description: String,

--- a/crates/goose/src/providers/base.rs
+++ b/crates/goose/src/providers/base.rs
@@ -9,13 +9,12 @@ use serde::{Deserialize, Serialize};
 pub const DEFAULT_PROVIDER_TIMEOUT_SECS: u64 = 600;
 
 use crate::config::ExtensionConfig;
-use utoipa::ToSchema;
 
 use std::path::PathBuf;
 
 pub use goose_providers::base::*;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ProviderType {
     Preferred,
     Builtin,

--- a/crates/goose/src/providers/provider_secrets.rs
+++ b/crates/goose/src/providers/provider_secrets.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 use chrono::{DateTime, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use utoipa::ToSchema;
 
 use crate::config::paths::Paths;
 use crate::config::{Config, ConfigError};
@@ -14,14 +13,14 @@ use crate::providers::huggingface_auth;
 pub const SECRET_STORE_ID_PREFIX: &str = "secret_store:";
 pub const PROVIDER_CACHE_ID_PREFIX: &str = "provider_cache:";
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ProviderSecretStorage {
     SecretStore,
     ProviderCache,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ProviderSecretStatus {
     Valid,
@@ -29,7 +28,7 @@ pub enum ProviderSecretStatus {
     Unknown,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProviderSecret {
     pub id: String,
     pub provider: String,

--- a/crates/goose/src/recipe/mod.rs
+++ b/crates/goose/src/recipe/mod.rs
@@ -11,7 +11,6 @@ use crate::recipe::yaml_format_utils::reformat_fields_with_multiline_values;
 use crate::utils::contains_unicode_tags;
 use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 
 pub mod build_recipe;
 pub mod local_recipes;
@@ -39,7 +38,7 @@ pub fn strip_error_location(error_msg: &str) -> String {
         .to_string()
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Recipe {
     // Required fields
     #[serde(default = "default_version")]
@@ -86,7 +85,7 @@ pub struct Recipe {
     pub retry: Option<RetryConfig>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Author {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub contact: Option<String>, // creator/contact information of the recipe
@@ -95,7 +94,7 @@ pub struct Author {
     pub metadata: Option<String>, // any additional metadata for the author
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Settings {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub goose_provider: Option<String>,
@@ -110,13 +109,13 @@ pub struct Settings {
     pub max_turns: Option<usize>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Response {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub json_schema: Option<serde_json::Value>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SubRecipe {
     pub name: String,
     pub path: String,
@@ -153,7 +152,7 @@ where
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum RecipeParameterRequirement {
     Required,
@@ -171,7 +170,7 @@ impl fmt::Display for RecipeParameterRequirement {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum RecipeParameterInputType {
     String,
@@ -194,7 +193,7 @@ impl fmt::Display for RecipeParameterInputType {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RecipeParameter {
     pub key: String,
     pub input_type: RecipeParameterInputType,

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -102,7 +102,7 @@ impl From<anyhow::Error> for SchedulerError {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, utoipa::ToSchema)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct ScheduledJob {
     pub id: String,
     pub source: String,

--- a/crates/goose/src/session/diagnostics.rs
+++ b/crates/goose/src/session/diagnostics.rs
@@ -7,14 +7,13 @@ use crate::session::SessionManager;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
-use utoipa::ToSchema;
 
 const LLM_LOG_MAX_BYTES: usize = 2 * 1024 * 1024;
 const CONFIG_MAX_BYTES: usize = 256 * 1024;
 const CLI_LOG_TAIL_LINES: usize = 400;
 const CLI_LOGS_TO_INCLUDE: usize = 3;
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, ToSchema, schemars::JsonSchema)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum DiagnosticsLevel {
     #[default]
@@ -22,7 +21,7 @@ pub enum DiagnosticsLevel {
     Full,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, schemars::JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct SystemInfo {
     pub app_version: String,
     pub os: String,
@@ -33,7 +32,7 @@ pub struct SystemInfo {
     pub enabled_extensions: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, schemars::JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DiagnosticsConfig {
     pub config_path: String,
@@ -41,13 +40,13 @@ pub struct DiagnosticsConfig {
     pub truncated: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, schemars::JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DiagnosticsExtensions {
     pub enabled: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, schemars::JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DiagnosticsTextFile {
     pub path: String,
@@ -55,35 +54,35 @@ pub struct DiagnosticsTextFile {
     pub truncated: bool,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema, schemars::JsonSchema)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DiagnosticsLogs {
     pub cli: Vec<DiagnosticsTextFile>,
     pub llm: Vec<DiagnosticsTextFile>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, schemars::JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DiagnosticsPrompt {
     pub name: String,
     pub content: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, schemars::JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DiagnosticsScheduledRecipe {
     pub path: String,
     pub content: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, schemars::JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DiagnosticsError {
     pub path: Option<String>,
     pub message: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, schemars::JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DiagnosticsReport {
     pub schema_version: u32,

--- a/crates/goose/src/session/extension_data.rs
+++ b/crates/goose/src/session/extension_data.rs
@@ -9,11 +9,10 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
-use utoipa::ToSchema;
 
 /// Extension data containing all extension states
 /// Keys are in format "extension_name.version" (e.g., "todo.v0")
-#[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ExtensionData {
     #[serde(flatten)]
     pub extension_states: HashMap<String, Value>,

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -22,7 +22,6 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock};
 use tracing::{info, warn};
-use utoipa::ToSchema;
 
 pub const CURRENT_SCHEMA_VERSION: i32 = 15;
 pub const SESSIONS_FOLDER: &str = "sessions";
@@ -35,7 +34,6 @@ const MILLISECOND_TIMESTAMP_THRESHOLD: i64 = 10_000_000_000;
     Copy,
     Serialize,
     Deserialize,
-    ToSchema,
     PartialEq,
     Eq,
     Default,
@@ -58,10 +56,9 @@ pub enum SessionType {
 static SESSION_STORAGE: LazyLock<Arc<SessionStorage>> =
     LazyLock::new(|| Arc::new(SessionStorage::new(Paths::data_dir())));
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
     pub id: String,
-    #[schema(value_type = String)]
     pub working_dir: PathBuf,
     #[serde(alias = "description")]
     pub name: String,
@@ -170,7 +167,7 @@ pub struct SessionUpdateBuilder<'a> {
     parent_session_id: Option<Option<String>>,
 }
 
-#[derive(Serialize, ToSchema, Debug)]
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionInsights {
     pub total_sessions: usize,


### PR DESCRIPTION
## Summary

- remove unused `utoipa::ToSchema` derives and imports
- remove the associated `#[schema(...)]` helper attributes
- remove direct `utoipa` dependencies from the workspace and affected crates

These schemas were previously consumed by the removed OpenAPI/goose-server implementation. ACP schema generation continues to use `schemars::JsonSchema`.


