### PR TITLE
fix: enable indexmap serde support for musl builds

### DIFF
--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -187,7 +187,7 @@ schemars = { workspace = true, features = [
     "derive",
 ] }
 shellexpand = { workspace = true }
-indexmap = { version = "2.9", default-features = false, features = ["std"] }
+indexmap = { version = "2.9", default-features = false, features = ["serde", "std"] }
 ignore = { workspace = true }
 rayon = { workspace = true }
 tree-sitter = { workspace = true }


### PR DESCRIPTION
## Summary

Removing the unused `utoipa` dependency in the PR #10505 also removed its indirect activation of `indexmap`’s Serde support.

Enable `indexmap/serde` directly to fix the x86_64 and aarch64 musl builds. [Failed build ](https://github.com/aaif-goose/goose/actions/runs/29486333547/job/87581665842) 

### Testing
CI

