### PR TITLE
fix: avoid local inference Metal teardown crash

### DIFF
--- a/crates/goose-local-inference/src/lib.rs
+++ b/crates/goose-local-inference/src/lib.rs
@@ -39,7 +39,7 @@ use rmcp::model::Tool;
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex as StdMutex};
+use std::sync::{Arc, Mutex as StdMutex, Weak};
 use tokio::sync::{Mutex, Notify};
 use uuid::Uuid;
 
@@ -96,17 +96,17 @@ pub fn builtin_chat_template_names() -> Vec<String> {
     llamacpp::builtin_chat_template_names()
 }
 
-static RUNTIME: StdMutex<Option<Arc<InferenceRuntime>>> = StdMutex::new(None);
+static RUNTIME: StdMutex<Weak<InferenceRuntime>> = StdMutex::new(Weak::new());
 
 fn current_runtime() -> Option<Arc<InferenceRuntime>> {
-    RUNTIME.lock().expect("runtime lock poisoned").clone()
+    RUNTIME.lock().expect("runtime lock poisoned").upgrade()
 }
 
 impl InferenceRuntime {
     pub fn get_or_init() -> Result<Arc<Self>> {
         let mut guard = RUNTIME.lock().expect("runtime lock poisoned");
-        if let Some(runtime) = guard.as_ref() {
-            return Ok(runtime.clone());
+        if let Some(runtime) = guard.upgrade() {
+            return Ok(runtime);
         }
         let llamacpp_backend: Arc<dyn LocalInferenceBackend> = Arc::new(LlamaCppBackend::new()?);
         let mlx_backend: Arc<dyn LocalInferenceBackend> = Arc::new(MlxBackend::new());
@@ -118,7 +118,7 @@ impl InferenceRuntime {
             cold_load_lock: Mutex::new(()),
             backends,
         });
-        *guard = Some(runtime.clone());
+        *guard = Arc::downgrade(&runtime);
         Ok(runtime)
     }
 


### PR DESCRIPTION
## Summary
- store the shared local inference runtime as a Weak reference again
- avoid keeping llama.cpp/Metal-backed runtime alive until process finalization

## Test
- cargo fmt --package goose-local-inference
- cargo build -p goose-cli --features local-inference --bin goose
- GOOSE_PROVIDER=local GOOSE_MODEL='unsloth/Qwen3-0.6B-GGUF:Q4_K_XL' target/debug/goose run --text hello
