### PR TITLE
fix(flatpak): bundle git so hermit can clone its package registry

### DIFF
--- a/ui/desktop/forge.config.ts
+++ b/ui/desktop/forge.config.ts
@@ -143,6 +143,15 @@ module.exports = {
                 'ln -s $(find /usr/lib -name "libbz2.so.1" | head -n 1) /app/lib/libbz2.so.1.0',
               ],
             },
+            {
+              name: 'git',
+              buildsystem: 'simple',
+              'build-commands': [
+                'mkdir -p /app/bin /app/libexec/git-core',
+                'cp /usr/bin/git /app/bin/git',
+                'cp /usr/libexec/git-core/git-remote-https /app/libexec/git-core/git-remote-https 2>/dev/null || true',
+              ],
+            },
           ],
           finishArgs: [
             '--share=ipc',

--- a/ui/desktop/forge.config.ts
+++ b/ui/desktop/forge.config.ts
@@ -165,6 +165,7 @@ module.exports = {
             '--socket=system-bus',
             // This ensures the app looks in our shim folder first
             '--env=LD_LIBRARY_PATH=/app/lib',
+            '--env=GIT_EXEC_PATH=/app/libexec/git-core',
           ],
         },
       },


### PR DESCRIPTION
Fixes #10497

## Summary

Hermit needs git to clone the hermit-packages registry from GitHub when installing MCP extensions. The Flatpak sandbox does not expose git by default, so copy the git binary and git-remote-https helper from the SDK into /app/bin during the Flatpak build.

### Testing
manual - still appreciate testing form a linux user 

