### PR TITLE
fix: canary build with new release flow

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -106,6 +106,9 @@ jobs:
   bundle-windows:
     needs: [prepare-version]
     uses: ./.github/workflows/bundle-windows.yml
+    permissions:
+      contents: read
+      id-token: write
     with:
       version: ${{ needs.prepare-version.outputs.version }}
       package_cli: true
@@ -115,6 +118,9 @@ jobs:
   bundle-windows-cuda:
     needs: [prepare-version]
     uses: ./.github/workflows/bundle-windows.yml
+    permissions:
+      contents: read
+      id-token: write
     with:
       version: ${{ needs.prepare-version.outputs.version }}
       package_cli: true


### PR DESCRIPTION
## Summary
The bundle-windows.yml workflow needs id_token: write, so the caller canary.yml needs to pass this in too.

### Testing
CI

