### PR TITLE
fix(desktop): prevent recipe parameter form from reloading the app on Enter

### DIFF
--- a/ui/desktop/src/components/ParameterInputModal.tsx
+++ b/ui/desktop/src/components/ParameterInputModal.tsx
@@ -94,7 +94,8 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
     setInputValues((prevValues: Record<string, string>) => ({ ...prevValues, [name]: value }));
   };
 
-  const handleSubmit = (): void => {
+  const handleSubmit = (e: React.SyntheticEvent): void => {
+    e.preventDefault();
     setValidationErrors({});
 
     const requiredParams: Parameter[] = parameters.filter(needsUserValue);

--- a/ui/desktop/src/components/__tests__/ParameterInputModal.test.tsx
+++ b/ui/desktop/src/components/__tests__/ParameterInputModal.test.tsx
@@ -80,6 +80,30 @@ describe('ParameterInputModal', () => {
       });
     });
 
+    it('prevents the default form submission when Enter is pressed in a parameter field', async () => {
+      const user = userEvent.setup();
+      renderWithIntl(<ParameterInputModal {...defaultProps} />);
+
+      let submitFired = false;
+      let defaultPrevented: boolean | undefined;
+      const captureSubmit = (event: Event) => {
+        submitFired = true;
+        // Read before suppressing, otherwise this listener would mask the result
+        defaultPrevented = event.defaultPrevented;
+        event.preventDefault();
+      };
+      document.addEventListener('submit', captureSubmit);
+
+      try {
+        await user.type(screen.getByLabelText(/test parameter 1/i), 'test value{Enter}');
+      } finally {
+        document.removeEventListener('submit', captureSubmit);
+      }
+
+      expect(submitFired).toBe(true);
+      expect(defaultPrevented).toBe(true);
+    });
+
     it('shows validation errors for required parameters', async () => {
       const user = userEvent.setup();
       renderWithIntl(<ParameterInputModal {...defaultProps} />);


### PR DESCRIPTION
## Summary
In the recipe parameter dialog, pressing Enter in a parameter field starts the recipe **and** reloads the renderer, discarding app state.

`ParameterInputModal` renders its fields inside `<form onSubmit={handleSubmit}>`, but `handleSubmit` took no event and never called `preventDefault()`. Both buttons are `type="button"` and sit outside the `</form>`, so the form has no submit button — which is exactly when HTML implicit submission applies: a form with no submit button submits on Enter when it has exactly one field that blocks implicit submission. `<select>` does not block, so any recipe with a single text/number parameter (plus any number of select/boolean ones) hits it. The submit event fires, `handleSubmit` runs, and because the default is never prevented the browser performs the form's default GET submission and replaces the document.

Fix: accept the event and `preventDefault()`. Enter still submits the recipe — it just no longer reloads the app.

### Testing
Added a regression test to the existing `ParameterInputModal.test.tsx`. No mocks were needed: the existing `mockParameters` fixture (one string + one select + one boolean) is already the exact shape that triggers implicit submission. The test asserts the submit event fires and that its default is prevented — it fails on `main` and passes with the fix.

Also verified outside jsdom, with the real component mounted in Chromium: before the fix the document navigates to `<url>?` and all page state is lost; after it, the document is untouched and `onSubmit` still runs. Checked the boundary as well — with two text parameters implicit submission does not fire, so only single-text-field recipes are affected.

`pnpm run lint:check`, `pnpm run typecheck` and `pnpm run test:run` (565 passed) all pass.

### Related Issues
None — self-found while auditing the desktop renderer.
