### PR TITLE
ci: keep the Windows CUDA build cache warm

### DIFF
--- a/.github/workflows/warm-windows-cuda-cache.yml
+++ b/.github/workflows/warm-windows-cuda-cache.yml
@@ -1,0 +1,21 @@
+name: Warm Windows CUDA cache
+
+on:
+  schedule:
+    - cron: "17 10,19 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  warm-windows-cuda:
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/bundle-windows.yml
+    with:
+      windows_variant: cuda
+      package_cli: false
+      package_desktop: false
+      signing: false


### PR DESCRIPTION
## Summary

Add a scheduled workflow that warms the existing Windows CUDA Rust cache twice daily, before New York and Melbourne working hours.

The workflow:
- Reuses the same CUDA build and cache key as Canary and Release.
- Runs at 10:17 and 19:17 UTC.

### Why
A cold Windows CUDA build can take more than two hours. Canary is not a reliable cache warmer because a new merge can cancel an in-progress run.

The current 10 GB cache limit can evict the CUDA cache within hours. This dedicated workflow keeps the cache recently accessed so both Canary and tagged release builds can avoid cold CUDA compilation.

### Cache settings (need to update manually)

- **200 GB cache limit:** GitHub charges only for actual hourly usage above the included 10 GB.
- **One-day retention:** the current 10 GB limit already evicts caches within hours despite seven-day retention. Twice-daily warming keeps CUDA active while stale caches expire sooner.

