### PR TITLE
fix(acp): wire current_mode_update notification to session state

### DIFF
--- a/ui/desktop/src/acp/__tests__/sessionNotificationAdapter.test.ts
+++ b/ui/desktop/src/acp/__tests__/sessionNotificationAdapter.test.ts
@@ -633,4 +633,18 @@ describe('createAcpSessionNotificationAdapter', () => {
       });
     });
   });
+
+  describe('current_mode_update', () => {
+    it('returns a sessionInfo change with the new mode', () => {
+      const adapter = createAcpSessionNotificationAdapter();
+      const changes = adapter.apply(
+        acpUpdate({
+          sessionUpdate: 'current_mode_update',
+          currentModeId: 'approve',
+        })
+      );
+
+      expect(changes).toEqual([{ type: 'sessionInfo', gooseMode: 'approve' }]);
+    });
+  });
 });

--- a/ui/desktop/src/acp/__tests__/sessionNotificationAdapter.test.ts
+++ b/ui/desktop/src/acp/__tests__/sessionNotificationAdapter.test.ts
@@ -655,8 +655,8 @@ describe('createAcpSessionNotificationAdapter', () => {
         acpUpdate({
           sessionUpdate: 'config_option_update',
           configOptions: [
-            { id: 'model', type: 'select', currentValue: 'gpt-4o', options: [] },
-            { id: 'mode', type: 'select', currentValue: 'smart_approve', options: [] },
+            { id: 'model', name: 'Model', type: 'select', currentValue: 'gpt-4o', options: [] },
+            { id: 'mode', name: 'Mode', type: 'select', currentValue: 'smart_approve', options: [] },
           ],
         })
       );
@@ -669,7 +669,7 @@ describe('createAcpSessionNotificationAdapter', () => {
       const changes = adapter.apply(
         acpUpdate({
           sessionUpdate: 'config_option_update',
-          configOptions: [{ id: 'model', type: 'select', currentValue: 'gpt-4o', options: [] }],
+          configOptions: [{ id: 'model', name: 'Model', type: 'select', currentValue: 'gpt-4o', options: [] }],
         })
       );
 

--- a/ui/desktop/src/acp/__tests__/sessionNotificationAdapter.test.ts
+++ b/ui/desktop/src/acp/__tests__/sessionNotificationAdapter.test.ts
@@ -647,4 +647,33 @@ describe('createAcpSessionNotificationAdapter', () => {
       expect(changes).toEqual([{ type: 'sessionInfo', gooseMode: 'approve' }]);
     });
   });
+
+  describe('config_option_update', () => {
+    it('extracts gooseMode from the mode config option', () => {
+      const adapter = createAcpSessionNotificationAdapter();
+      const changes = adapter.apply(
+        acpUpdate({
+          sessionUpdate: 'config_option_update',
+          configOptions: [
+            { id: 'model', type: 'select', currentValue: 'gpt-4o', options: [] },
+            { id: 'mode', type: 'select', currentValue: 'smart_approve', options: [] },
+          ],
+        })
+      );
+
+      expect(changes).toEqual([{ type: 'sessionInfo', gooseMode: 'smart_approve' }]);
+    });
+
+    it('returns empty when no mode config option is present', () => {
+      const adapter = createAcpSessionNotificationAdapter();
+      const changes = adapter.apply(
+        acpUpdate({
+          sessionUpdate: 'config_option_update',
+          configOptions: [{ id: 'model', type: 'select', currentValue: 'gpt-4o', options: [] }],
+        })
+      );
+
+      expect(changes).toEqual([]);
+    });
+  });
 });

--- a/ui/desktop/src/acp/adapter/shared.ts
+++ b/ui/desktop/src/acp/adapter/shared.ts
@@ -10,6 +10,7 @@ export type AcpChatStateChange =
       type: 'sessionInfo';
       name?: string;
       activeRunId?: string | null;
+      gooseMode?: string;
     }
   | { type: 'localSteerConfirmed'; messageId: string }
   | { type: 'notification'; notification: NotificationEvent };

--- a/ui/desktop/src/acp/chatSessionStore.ts
+++ b/ui/desktop/src/acp/chatSessionStore.ts
@@ -4,7 +4,7 @@ import type { RequestPermissionRequest, SessionNotification } from '@agentclient
 import type { TokenState } from '../types/chat';
 import { ChatState } from '../types/chatState';
 import type { Message, NotificationEvent } from '../types/message';
-import type { Session } from '../types/session';
+import type { GooseMode, Session } from '../types/session';
 import {
   createAcpSessionNotificationAdapter,
   type AcpChatStateChange,
@@ -603,6 +603,9 @@ function applyChatStateChanges(entry: StoreEntry, changes: AcpChatStateChange[])
         }
         if (change.activeRunId !== undefined) {
           entry.activeRunId = change.activeRunId;
+        }
+        if (change.gooseMode && entry.session) {
+          entry.session = { ...entry.session, goose_mode: change.gooseMode as GooseMode };
         }
         break;
       case 'localSteerConfirmed':

--- a/ui/desktop/src/acp/sessionNotificationAdapter.ts
+++ b/ui/desktop/src/acp/sessionNotificationAdapter.ts
@@ -91,6 +91,8 @@ function applyAcpSessionNotification(
         },
       ];
     }
+    case 'current_mode_update':
+      return [{ type: 'sessionInfo', gooseMode: update.currentModeId }];
     case 'usage_update':
       return [];
     default:

--- a/ui/desktop/src/acp/sessionNotificationAdapter.ts
+++ b/ui/desktop/src/acp/sessionNotificationAdapter.ts
@@ -93,9 +93,25 @@ function applyAcpSessionNotification(
     }
     case 'current_mode_update':
       return [{ type: 'sessionInfo', gooseMode: update.currentModeId }];
+    case 'config_option_update': {
+      const gooseMode = extractModeFromConfigOptions(update.configOptions);
+      return gooseMode ? [{ type: 'sessionInfo', gooseMode }] : [];
+    }
     case 'usage_update':
       return [];
     default:
       return [];
   }
+}
+
+function extractModeFromConfigOptions(configOptions: unknown): string | undefined {
+  if (!Array.isArray(configOptions)) return undefined;
+  for (const option of configOptions) {
+    if (!option || typeof option !== 'object') continue;
+    if (!('id' in option) || option.id !== 'mode') continue;
+    if ('type' in option && option.type === 'select' && 'currentValue' in option) {
+      return typeof option.currentValue === 'string' ? option.currentValue : undefined;
+    }
+  }
+  return undefined;
 }


### PR DESCRIPTION
## Summary

The adapter dropped current_mode_update without processing it, so session.goose_mode stayed frozen at the initial value whenever the agent changed its mode mid-session.

Add a handler that maps the notification to a sessionInfo change carrying the new gooseMode, and apply it in chatSessionStore so session.goose_mode is always current.

### Testing
manaul 

