### PR TITLE
fix: retry transient stream startup failures

### DIFF
--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -424,7 +424,7 @@ pub trait Provider: Send + Sync {
 
     /// Whether it is safe to replay a streaming request that fails before its
     /// first item. Providers with local or external side effects must not opt in.
-    fn supports_stream_start_retry(&self) -> bool {
+    fn supports_stream_start_retry(&self, _model_config: &ModelConfig) -> bool {
         false
     }
 

--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -422,6 +422,12 @@ pub trait Provider: Send + Sync {
         RetryConfig::default()
     }
 
+    /// Whether it is safe to replay a streaming request that fails before its
+    /// first item. Providers with local or external side effects must not opt in.
+    fn supports_stream_start_retry(&self) -> bool {
+        false
+    }
+
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         Ok(vec![])
     }

--- a/crates/goose-provider-types/src/model.rs
+++ b/crates/goose-provider-types/src/model.rs
@@ -305,11 +305,45 @@ impl ModelConfig {
             .and_then(|params| params.get(request_key))
             .and_then(|v| serde_json::from_value(v.clone()).ok())
     }
+
+    /// Whether the effective request may persist a response server-side.
+    /// Unknown values fail closed so replay safety never depends on permissive parsing.
+    pub fn stores_responses(&self) -> bool {
+        match self
+            .request_params
+            .as_ref()
+            .and_then(|params| params.get("store"))
+        {
+            None | Some(Value::Bool(false)) => false,
+            Some(_) => true,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn stores_responses_fails_closed() {
+        assert!(!ModelConfig::new("test-model").stores_responses());
+
+        for value in [
+            serde_json::json!(true),
+            serde_json::json!(null),
+            serde_json::json!("true"),
+        ] {
+            let config = ModelConfig::new("test-model")
+                .with_merged_request_params(HashMap::from([("store".to_string(), value)]));
+            assert!(config.stores_responses());
+        }
+
+        let config = ModelConfig::new("test-model").with_merged_request_params(HashMap::from([(
+            "store".to_string(),
+            serde_json::json!(false),
+        )]));
+        assert!(!config.stores_responses());
+    }
 
     #[test]
     fn request_headers_never_serialize_into_bodies() {

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -233,7 +233,7 @@ impl Provider for AnthropicProvider {
     }
 
     fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
-        !model_config.request_param::<bool>("store").unwrap_or(false)
+        !model_config.stores_responses()
     }
 
     fn skip_canonical_filtering(&self) -> bool {

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -232,6 +232,10 @@ impl Provider for AnthropicProvider {
         &self.name
     }
 
+    fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
+        !model_config.request_param::<bool>("store").unwrap_or(false)
+    }
+
     fn skip_canonical_filtering(&self) -> bool {
         self.skip_canonical_filtering
     }

--- a/crates/goose-providers/src/databricks.rs
+++ b/crates/goose-providers/src/databricks.rs
@@ -515,6 +515,10 @@ impl Provider for DatabricksProvider {
         &self.name
     }
 
+    fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
+        !model_config.request_param::<bool>("store").unwrap_or(false)
+    }
+
     fn retry_config(&self) -> RetryConfig {
         self.retry_config.clone()
     }

--- a/crates/goose-providers/src/databricks.rs
+++ b/crates/goose-providers/src/databricks.rs
@@ -516,7 +516,7 @@ impl Provider for DatabricksProvider {
     }
 
     fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
-        !model_config.request_param::<bool>("store").unwrap_or(false)
+        !model_config.stores_responses()
     }
 
     fn retry_config(&self) -> RetryConfig {

--- a/crates/goose-providers/src/databricks_v2.rs
+++ b/crates/goose-providers/src/databricks_v2.rs
@@ -332,7 +332,7 @@ impl Provider for DatabricksV2Provider {
     }
 
     fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
-        !model_config.request_param::<bool>("store").unwrap_or(false)
+        !model_config.stores_responses()
     }
 
     fn retry_config(&self) -> RetryConfig {

--- a/crates/goose-providers/src/databricks_v2.rs
+++ b/crates/goose-providers/src/databricks_v2.rs
@@ -331,6 +331,10 @@ impl Provider for DatabricksV2Provider {
         &self.name
     }
 
+    fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
+        !model_config.request_param::<bool>("store").unwrap_or(false)
+    }
+
     fn retry_config(&self) -> RetryConfig {
         self.retry_config.clone()
     }

--- a/crates/goose-providers/src/declarative.rs
+++ b/crates/goose-providers/src/declarative.rs
@@ -541,6 +541,38 @@ mod tests {
         assert_eq!(provider.get_name(), "test-provider");
     }
 
+    #[test]
+    fn bundled_sakana_provider_supports_safe_stream_start_retry() {
+        #[derive(Debug)]
+        struct TestKeyResolverError;
+
+        impl std::fmt::Display for TestKeyResolverError {
+            fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("test key resolver failed")
+            }
+        }
+
+        impl std::error::Error for TestKeyResolverError {}
+
+        struct TestKeyResolver;
+
+        impl KeyResolver for TestKeyResolver {
+            type Error = TestKeyResolverError;
+
+            fn resolve_key(&self, _key: &str) -> std::result::Result<String, Self::Error> {
+                Ok("test-key".to_string())
+            }
+        }
+
+        let json = declarative_providers::fixed_provider_config_entries()
+            .into_iter()
+            .find_map(|(name, json)| (name == "sakana.json").then_some(json))
+            .expect("bundled Sakana provider should exist");
+        let provider = from_json(json, None, TestKeyResolver).unwrap();
+
+        assert!(provider.supports_stream_start_retry(&crate::model::ModelConfig::new("fugu")));
+    }
+
     #[tokio::test]
     async fn from_json_ollama_returns_static_models_when_dynamic_models_false() {
         let json = json!({

--- a/crates/goose-providers/src/google.rs
+++ b/crates/goose-providers/src/google.rs
@@ -143,6 +143,10 @@ impl Provider for GoogleProvider {
         &self.name
     }
 
+    fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
+        !model_config.request_param::<bool>("store").unwrap_or(false)
+    }
+
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         let response = self
             .api_client

--- a/crates/goose-providers/src/google.rs
+++ b/crates/goose-providers/src/google.rs
@@ -144,7 +144,7 @@ impl Provider for GoogleProvider {
     }
 
     fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
-        !model_config.request_param::<bool>("store").unwrap_or(false)
+        !model_config.stores_responses()
     }
 
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {

--- a/crates/goose-providers/src/ollama.rs
+++ b/crates/goose-providers/src/ollama.rs
@@ -391,7 +391,7 @@ impl Provider for OllamaProvider {
     }
 
     fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
-        !model_config.request_param::<bool>("store").unwrap_or(false)
+        !model_config.stores_responses()
     }
 
     fn skip_canonical_filtering(&self) -> bool {

--- a/crates/goose-providers/src/ollama.rs
+++ b/crates/goose-providers/src/ollama.rs
@@ -390,6 +390,10 @@ impl Provider for OllamaProvider {
         &self.name
     }
 
+    fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
+        !model_config.request_param::<bool>("store").unwrap_or(false)
+    }
+
     fn skip_canonical_filtering(&self) -> bool {
         self.skip_canonical_filtering
     }

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -575,6 +575,10 @@ impl Provider for OpenAiProvider {
         &self.name
     }
 
+    fn supports_stream_start_retry(&self) -> bool {
+        true
+    }
+
     fn skip_canonical_filtering(&self) -> bool {
         self.skip_canonical_filtering
     }

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -576,7 +576,7 @@ impl Provider for OpenAiProvider {
     }
 
     fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
-        !model_config.request_param::<bool>("store").unwrap_or(false)
+        !model_config.stores_responses()
     }
 
     fn skip_canonical_filtering(&self) -> bool {

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -575,8 +575,8 @@ impl Provider for OpenAiProvider {
         &self.name
     }
 
-    fn supports_stream_start_retry(&self) -> bool {
-        true
+    fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
+        !model_config.request_param::<bool>("store").unwrap_or(false)
     }
 
     fn skip_canonical_filtering(&self) -> bool {
@@ -912,6 +912,21 @@ mod tests {
             preserve_thinking_context: false,
             n_ctx_cache: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    #[test]
+    fn stream_start_retry_is_enabled_by_default() {
+        let provider = make_provider(OPEN_AI_PROVIDER_NAME);
+        assert!(provider.supports_stream_start_retry(&ModelConfig::new("gpt-5.4")));
+    }
+
+    #[test]
+    fn stream_start_retry_is_disabled_when_responses_are_stored() {
+        let provider = make_provider(OPEN_AI_PROVIDER_NAME);
+        let model_config = ModelConfig::new("gpt-5.4")
+            .with_merged_request_params(HashMap::from([("store".to_string(), json!(true))]));
+
+        assert!(!provider.supports_stream_start_retry(&model_config));
     }
 
     #[test]

--- a/crates/goose-providers/src/openai_compatible.rs
+++ b/crates/goose-providers/src/openai_compatible.rs
@@ -76,7 +76,7 @@ impl Provider for OpenAiCompatibleProvider {
     }
 
     fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
-        !model_config.request_param::<bool>("store").unwrap_or(false)
+        !model_config.stores_responses()
     }
 
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {

--- a/crates/goose-providers/src/openai_compatible.rs
+++ b/crates/goose-providers/src/openai_compatible.rs
@@ -75,6 +75,10 @@ impl Provider for OpenAiCompatibleProvider {
         &self.name
     }
 
+    fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
+        !model_config.request_param::<bool>("store").unwrap_or(false)
+    }
+
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         let response = self
             .api_client

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2031,15 +2031,31 @@ impl Agent {
                     max_turns,
                 ).await;
 
-                let mut stream = Self::stream_response_from_provider(
-                    self.provider().await?,
-                    model_config.clone(),
-                    &session_config.id,
-                    &system_prompt,
-                    conversation_with_moim.messages(),
-                    &tools,
-                    &toolshim_tools,
-                ).await?;
+                let stream_result = {
+                    let stream_future = Self::stream_response_from_provider(
+                        self.provider().await?,
+                        model_config.clone(),
+                        &session_config.id,
+                        &system_prompt,
+                        conversation_with_moim.messages(),
+                        &tools,
+                        &toolshim_tools,
+                    );
+                    tokio::pin!(stream_future);
+                    if let Some(token) = cancel_token.as_ref() {
+                        tokio::select! {
+                            biased;
+                            _ = token.cancelled() => None,
+                            result = &mut stream_future => Some(result),
+                        }
+                    } else {
+                        Some(stream_future.as_mut().await)
+                    }
+                };
+                let Some(stream_result) = stream_result else {
+                    break;
+                };
+                let mut stream = stream_result?;
                 last_assistant_text.clear();
 
                 let current_turn_tool_count = conversation.messages().iter()
@@ -3860,6 +3876,32 @@ echo start >> "$PLUGIN_ROOT/hook.log"
         }
     }
 
+    struct PendingFirstItemProvider;
+
+    #[async_trait::async_trait]
+    impl crate::providers::base::Provider for PendingFirstItemProvider {
+        async fn stream(
+            &self,
+            _model_config: &goose_providers::model::ModelConfig,
+            _system_prompt: &str,
+            _messages: &[Message],
+            _tools: &[Tool],
+        ) -> Result<MessageStream, ProviderError> {
+            Ok(Box::pin(futures::stream::pending()))
+        }
+
+        fn supports_stream_start_retry(
+            &self,
+            _model_config: &goose_providers::model::ModelConfig,
+        ) -> bool {
+            true
+        }
+
+        fn get_name(&self) -> &str {
+            "pending-first-item"
+        }
+    }
+
     struct ChunkedTextProvider;
 
     #[async_trait::async_trait]
@@ -3911,6 +3953,47 @@ echo start >> "$PLUGIN_ROOT/hook.log"
         fn get_name(&self) -> &str {
             "refusing"
         }
+    }
+
+    #[tokio::test]
+    async fn cancellation_interrupts_pending_first_provider_item() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let hook_manager = crate::hooks::HookManager::from_plugins_for_test(vec![]);
+        let (agent, session_id) = create_test_agent(
+            temp_dir.path().join("data"),
+            hook_manager,
+            Arc::new(PendingFirstItemProvider),
+        )
+        .await?;
+        let cancel_token = CancellationToken::new();
+        let session_config = SessionConfig {
+            id: session_id,
+            schedule_id: None,
+            max_turns: Some(1),
+            retry_config: None,
+        };
+        let reply_stream = agent
+            .reply(
+                Message::user().with_text("hi"),
+                session_config,
+                Some(cancel_token.clone()),
+            )
+            .await?;
+        tokio::pin!(reply_stream);
+
+        let cancel = cancel_token.clone();
+        tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            cancel.cancel();
+        });
+
+        let next =
+            tokio::time::timeout(std::time::Duration::from_secs(1), reply_stream.next()).await;
+        assert!(next.is_ok(), "cancellation should stop first-item polling");
+        if let Some(event) = next.unwrap() {
+            event?;
+        }
+        Ok(())
     }
 
     #[tokio::test]

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -23,8 +23,75 @@ use crate::providers::toolshim::{
 };
 use goose_providers::conversation::token_usage::{CostSource, ProviderStats, ProviderUsage, Usage};
 use goose_providers::model::ModelConfig;
+use goose_providers::retry::should_retry;
 use rmcp::model::Tool;
 use tracing::warn;
+
+async fn open_provider_stream(
+    provider: &dyn Provider,
+    model_config: &ModelConfig,
+    system_prompt: &str,
+    messages: &[Message],
+    tools: &[Tool],
+) -> Result<MessageStream, ProviderError> {
+    let retry_config = provider.retry_config().transient_only();
+    let mut attempts = 0;
+
+    loop {
+        debug!("WAITING_LLM_STREAM_START");
+        let stream_result = provider
+            .stream(model_config, system_prompt, messages, tools)
+            .await;
+        debug!("WAITING_LLM_STREAM_END");
+
+        let mut stream = stream_result?;
+        match stream.next().await {
+            Some(Ok(first_item)) => {
+                return Ok(Box::pin(try_stream! {
+                    yield first_item;
+                    while let Some(result) = stream.next().await {
+                        yield result?;
+                    }
+                }));
+            }
+            Some(Err(error))
+                if provider.supports_stream_start_retry()
+                    && should_retry(&error, &retry_config)
+                    && attempts < retry_config.max_retries() =>
+            {
+                attempts += 1;
+                tracing::warn!(
+                    "Stream failed before yielding output, retrying ({}/{}): {:?}",
+                    attempts,
+                    retry_config.max_retries(),
+                    error
+                );
+
+                let delay = match &error {
+                    ProviderError::RateLimitExceeded {
+                        retry_delay: Some(provider_delay),
+                        ..
+                    } => *provider_delay,
+                    _ => retry_config.delay_for_attempt(attempts),
+                };
+
+                let skip_backoff = std::env::var("GOOSE_PROVIDER_SKIP_BACKOFF")
+                    .unwrap_or_default()
+                    .parse::<bool>()
+                    .unwrap_or(false);
+
+                if skip_backoff {
+                    tracing::info!("Skipping backoff due to GOOSE_PROVIDER_SKIP_BACKOFF");
+                } else {
+                    tracing::info!("Backing off for {:?} before stream retry", delay);
+                    tokio::time::sleep(delay).await;
+                }
+            }
+            Some(Err(error)) => return Err(error),
+            None => return Ok(Box::pin(futures::stream::empty())),
+        }
+    }
+}
 
 async fn enhance_model_error(
     error: ProviderError,
@@ -313,15 +380,13 @@ impl Agent {
         let toolshim_tools = toolshim_tools.to_owned();
         let provider = provider.clone();
 
-        // Capture errors during stream creation and return them as part of the stream
-        // so they can be handled by the existing error handling logic in the agent
         let model_config =
             model_config.with_default_thinking_effort(Config::global().get_goose_thinking_effort());
         let request_started = std::time::Instant::now();
-        debug!("WAITING_LLM_STREAM_START");
         let stream_result = crate::session_context::with_session_id(
             Some(session_id.to_string()),
-            provider.stream(
+            open_provider_stream(
+                provider.as_ref(),
                 &model_config,
                 system_prompt.as_str(),
                 messages_for_provider.messages(),
@@ -329,9 +394,7 @@ impl Agent {
             ),
         )
         .await;
-        debug!("WAITING_LLM_STREAM_END");
 
-        // If there was an error creating the stream, return a stream that yields that error
         let mut stream = match stream_result {
             Ok(s) => s,
             Err(e) => {
@@ -681,22 +744,37 @@ mod tests {
     use crate::config::{GooseMode, PermissionManager};
     use crate::conversation::message::{Message, SystemNotificationType};
     use crate::providers::base::Provider;
+    use crate::providers::RetryConfig;
     use crate::session::{SessionManager, SessionType};
     use async_trait::async_trait;
     use goose_providers::conversation::token_usage::{ProviderStats, ProviderUsage, Usage};
     use goose_providers::model::ModelConfig;
     use rmcp::model::{AnnotateAble, RawTextContent, Role, ToolAnnotations};
     use rmcp::object;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;
     use std::time::{Duration, Instant};
 
     #[derive(Clone)]
-    struct MockProvider;
+    struct MockProvider {
+        attempts: Option<Arc<AtomicUsize>>,
+        first_error: Option<ProviderError>,
+        fail_after_output: bool,
+        supports_stream_start_retry: bool,
+    }
 
     #[async_trait]
     impl Provider for MockProvider {
         fn get_name(&self) -> &str {
             "mock"
+        }
+
+        fn retry_config(&self) -> RetryConfig {
+            RetryConfig::new(2, 1, 1.0, 1)
+        }
+
+        fn supports_stream_start_retry(&self) -> bool {
+            self.supports_stream_start_retry
         }
 
         async fn stream(
@@ -706,9 +784,29 @@ mod tests {
             _messages: &[Message],
             _tools: &[Tool],
         ) -> Result<MessageStream, ProviderError> {
+            let attempt = self
+                .attempts
+                .as_ref()
+                .map(|attempts| attempts.fetch_add(1, Ordering::SeqCst))
+                .unwrap_or(0);
+
+            if attempt == 0 {
+                if let Some(error) = self.first_error.clone() {
+                    return Ok(Box::pin(futures::stream::once(async move { Err(error) })));
+                }
+            }
+
             let message = Message::assistant().with_text("ok");
             let usage = ProviderUsage::new("mock".to_string(), Usage::default());
-            Ok(stream_from_single_message(message, usage))
+            let first_item = Ok((Some(message), Some(usage)));
+            if self.fail_after_output {
+                let error = Err(ProviderError::NetworkError(
+                    "stream failed after output".to_string(),
+                ));
+                Ok(Box::pin(futures::stream::iter([first_item, error])))
+            } else {
+                Ok(Box::pin(futures::stream::once(async move { first_item })))
+            }
         }
     }
 
@@ -891,7 +989,12 @@ mod tests {
             .await?;
 
         let model_config = ModelConfig::new("test-model");
-        let provider = std::sync::Arc::new(MockProvider);
+        let provider = std::sync::Arc::new(MockProvider {
+            attempts: None,
+            first_error: None,
+            fail_after_output: false,
+            supports_stream_start_retry: false,
+        });
         agent
             .update_provider(provider, model_config, &session.id)
             .await?;
@@ -939,6 +1042,109 @@ mod tests {
         assert_eq!(names, sorted);
 
         Ok(())
+    }
+
+    async fn test_provider_stream(provider: &MockProvider) -> MessageStream {
+        open_provider_stream(
+            provider,
+            &ModelConfig::new("test-model"),
+            "system",
+            &[],
+            &[],
+        )
+        .await
+        .unwrap()
+    }
+
+    fn stream_decode_error() -> ProviderError {
+        ProviderError::NetworkError("Stream decode error: error decoding response body".to_string())
+    }
+
+    #[tokio::test]
+    async fn retries_transient_stream_error_before_output_for_opted_in_provider() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let provider = MockProvider {
+            attempts: Some(attempts.clone()),
+            first_error: Some(stream_decode_error()),
+            fail_after_output: false,
+            supports_stream_start_retry: true,
+        };
+
+        let mut stream = test_provider_stream(&provider).await;
+        let (message, usage) = stream.next().await.unwrap().unwrap();
+        assert_eq!(message.unwrap().as_concat_text(), "ok");
+        assert!(usage.is_some());
+        assert!(stream.next().await.is_none());
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_stream_error_for_provider_without_opt_in() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let provider = MockProvider {
+            attempts: Some(attempts.clone()),
+            first_error: Some(stream_decode_error()),
+            fail_after_output: false,
+            supports_stream_start_retry: false,
+        };
+
+        let error = open_provider_stream(
+            &provider,
+            &ModelConfig::new("test-model"),
+            "system",
+            &[],
+            &[],
+        )
+        .await
+        .err()
+        .unwrap();
+        assert_eq!(error, stream_decode_error());
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_non_transient_stream_error() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let error = ProviderError::RequestFailed("invalid request".to_string());
+        let provider = MockProvider {
+            attempts: Some(attempts.clone()),
+            first_error: Some(error.clone()),
+            fail_after_output: false,
+            supports_stream_start_retry: true,
+        };
+
+        let actual = open_provider_stream(
+            &provider,
+            &ModelConfig::new("test-model"),
+            "system",
+            &[],
+            &[],
+        )
+        .await
+        .err()
+        .unwrap();
+        assert_eq!(actual, error);
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_stream_error_after_first_output() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let provider = MockProvider {
+            attempts: Some(attempts.clone()),
+            first_error: None,
+            fail_after_output: true,
+            supports_stream_start_retry: true,
+        };
+
+        let mut stream = test_provider_stream(&provider).await;
+        let (message, _) = stream.next().await.unwrap().unwrap();
+        assert_eq!(message.unwrap().as_concat_text(), "ok");
+        assert_eq!(
+            stream.next().await.unwrap().unwrap_err(),
+            ProviderError::NetworkError("stream failed after output".to_string())
+        );
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -1173,7 +1173,16 @@ mod tests {
             .await?;
         let model_config = ModelConfig::new("test-model").with_toolshim(true);
         agent
-            .update_provider(Arc::new(MockProvider), model_config, &session.id)
+            .update_provider(
+                Arc::new(MockProvider {
+                    attempts: None,
+                    first_error: None,
+                    fail_after_output: false,
+                    supports_stream_start_retry: false,
+                }),
+                model_config,
+                &session.id,
+            )
             .await?;
         agent
             .add_extension(

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -55,7 +55,7 @@ async fn open_provider_stream(
                 }));
             }
             Some(Err(error))
-                if provider.supports_stream_start_retry()
+                if provider.supports_stream_start_retry(model_config)
                     && should_retry(&error, &retry_config)
                     && attempts < retry_config.max_retries() =>
             {
@@ -773,7 +773,7 @@ mod tests {
             RetryConfig::new(2, 1, 1.0, 1)
         }
 
-        fn supports_stream_start_retry(&self) -> bool {
+        fn supports_stream_start_retry(&self, _model_config: &ModelConfig) -> bool {
             self.supports_stream_start_retry
         }
 

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -728,6 +728,10 @@ impl Provider for BedrockProvider {
         &self.name
     }
 
+    fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
+        !model_config.request_param::<bool>("store").unwrap_or(false)
+    }
+
     fn retry_config(&self) -> RetryConfig {
         self.retry_config.clone()
     }

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -729,7 +729,7 @@ impl Provider for BedrockProvider {
     }
 
     fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
-        !model_config.request_param::<bool>("store").unwrap_or(false)
+        !model_config.stores_responses()
     }
 
     fn retry_config(&self) -> RetryConfig {

--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -980,6 +980,10 @@ impl Provider for ChatGptCodexProvider {
         &self.name
     }
 
+    fn supports_stream_start_retry(&self, _model_config: &ModelConfig) -> bool {
+        true
+    }
+
     async fn stream(
         &self,
         model_config: &ModelConfig,

--- a/crates/goose/src/providers/claude_code.rs
+++ b/crates/goose/src/providers/claude_code.rs
@@ -1535,6 +1535,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cli_result_error_is_propagated_without_retry_opt_in() {
+        use futures::StreamExt;
+
+        let (provider, mut stream, _stdin_reader) = stream_with_canned_stdout(&[
+            r#"{"type":"control_response","response":{"subtype":"success","request_id":"req_0"}}"#,
+            r#"{"type":"result","is_error":true,"subtype":"error_during_execution","error":"process failed"}"#,
+        ])
+        .await;
+
+        assert!(!provider.supports_stream_start_retry(&ModelConfig::new(CLAUDE_CODE_DEFAULT_MODEL)));
+        assert_eq!(
+            stream.next().await.unwrap().unwrap_err(),
+            ProviderError::RequestFailed(
+                "Claude CLI error: error_during_execution: process failed".to_string()
+            )
+        );
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
     async fn test_pending_permissions_cleaned_on_new_stream() {
         use futures::StreamExt;
 

--- a/crates/goose/src/providers/gcpvertexai.rs
+++ b/crates/goose/src/providers/gcpvertexai.rs
@@ -600,7 +600,7 @@ impl Provider for GcpVertexAIProvider {
     }
 
     fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
-        !model_config.request_param::<bool>("store").unwrap_or(false)
+        !model_config.stores_responses()
     }
 
     fn retry_config(&self) -> RetryConfig {

--- a/crates/goose/src/providers/gcpvertexai.rs
+++ b/crates/goose/src/providers/gcpvertexai.rs
@@ -603,6 +603,10 @@ impl Provider for GcpVertexAIProvider {
         !model_config.request_param::<bool>("store").unwrap_or(false)
     }
 
+    fn retry_config(&self) -> RetryConfig {
+        self.retry_config.clone()
+    }
+
     /// Completes a model interaction by sending a request and processing the response.
     ///
     /// # Arguments

--- a/crates/goose/src/providers/gcpvertexai.rs
+++ b/crates/goose/src/providers/gcpvertexai.rs
@@ -599,6 +599,10 @@ impl Provider for GcpVertexAIProvider {
         &self.name
     }
 
+    fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
+        !model_config.request_param::<bool>("store").unwrap_or(false)
+    }
+
     /// Completes a model interaction by sending a request and processing the response.
     ///
     /// # Arguments

--- a/crates/goose/src/providers/gemini_oauth.rs
+++ b/crates/goose/src/providers/gemini_oauth.rs
@@ -961,6 +961,10 @@ impl Provider for GeminiOAuthProvider {
         &self.name
     }
 
+    fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
+        !model_config.request_param::<bool>("store").unwrap_or(false)
+    }
+
     async fn configure_oauth(&self) -> Result<(), ProviderError> {
         self.token_provider
             .get_valid_setup()

--- a/crates/goose/src/providers/gemini_oauth.rs
+++ b/crates/goose/src/providers/gemini_oauth.rs
@@ -962,7 +962,7 @@ impl Provider for GeminiOAuthProvider {
     }
 
     fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
-        !model_config.request_param::<bool>("store").unwrap_or(false)
+        !model_config.stores_responses()
     }
 
     async fn configure_oauth(&self) -> Result<(), ProviderError> {

--- a/crates/goose/src/providers/githubcopilot.rs
+++ b/crates/goose/src/providers/githubcopilot.rs
@@ -559,7 +559,7 @@ impl Provider for GithubCopilotProvider {
     }
 
     fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
-        !model_config.request_param::<bool>("store").unwrap_or(false)
+        !model_config.stores_responses()
     }
 
     async fn complete(

--- a/crates/goose/src/providers/githubcopilot.rs
+++ b/crates/goose/src/providers/githubcopilot.rs
@@ -558,6 +558,10 @@ impl Provider for GithubCopilotProvider {
         &self.name
     }
 
+    fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
+        !model_config.request_param::<bool>("store").unwrap_or(false)
+    }
+
     async fn complete(
         &self,
         model_config: &ModelConfig,

--- a/crates/goose/src/providers/huggingface.rs
+++ b/crates/goose/src/providers/huggingface.rs
@@ -133,6 +133,10 @@ impl Provider for HuggingFaceProvider {
         self.inner.get_name()
     }
 
+    fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
+        self.inner.supports_stream_start_retry(model_config)
+    }
+
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         if let Some(custom_models) = &self.custom_models {
             if self.dynamic_models == Some(false) {

--- a/crates/goose/src/providers/kimicode.rs
+++ b/crates/goose/src/providers/kimicode.rs
@@ -378,6 +378,10 @@ impl Provider for KimiCodeProvider {
         &self.name
     }
 
+    fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
+        !model_config.request_param::<bool>("store").unwrap_or(false)
+    }
+
     async fn stream(
         &self,
         model_config: &ModelConfig,

--- a/crates/goose/src/providers/kimicode.rs
+++ b/crates/goose/src/providers/kimicode.rs
@@ -379,7 +379,7 @@ impl Provider for KimiCodeProvider {
     }
 
     fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
-        !model_config.request_param::<bool>("store").unwrap_or(false)
+        !model_config.stores_responses()
     }
 
     async fn stream(

--- a/crates/goose/src/providers/nanogpt.rs
+++ b/crates/goose/src/providers/nanogpt.rs
@@ -119,7 +119,7 @@ impl Provider for NanoGptProvider {
     }
 
     fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
-        !model_config.request_param::<bool>("store").unwrap_or(false)
+        !model_config.stores_responses()
     }
 
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {

--- a/crates/goose/src/providers/nanogpt.rs
+++ b/crates/goose/src/providers/nanogpt.rs
@@ -118,6 +118,10 @@ impl Provider for NanoGptProvider {
         &self.name
     }
 
+    fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
+        !model_config.request_param::<bool>("store").unwrap_or(false)
+    }
+
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         let response = self
             .api_client

--- a/crates/goose/src/providers/ollama_cloud.rs
+++ b/crates/goose/src/providers/ollama_cloud.rs
@@ -167,6 +167,10 @@ impl Provider for OllamaCloudProvider {
         self.inner.get_name()
     }
 
+    fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
+        self.inner.supports_stream_start_retry(model_config)
+    }
+
     async fn stream(
         &self,
         model_config: &ModelConfig,

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -233,6 +233,10 @@ impl Provider for OpenRouterProvider {
         &self.name
     }
 
+    fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
+        !model_config.request_param::<bool>("store").unwrap_or(false)
+    }
+
     /// Fetch supported models from OpenRouter API (only models with tool support)
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         let response = self

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -186,6 +186,17 @@ fn merge_openrouter_parameters(model: &mut ModelConfig, params: HashMap<String, 
     merge_request_params(&mut model.request_params, params);
 }
 
+fn stores_responses(
+    model_config: &ModelConfig,
+    configured_parameters: Option<&HashMap<String, Value>>,
+) -> bool {
+    configured_parameters
+        .and_then(|params| params.get("store"))
+        .and_then(Value::as_bool)
+        .or_else(|| model_config.request_param::<bool>("store"))
+        .unwrap_or(false)
+}
+
 impl goose_providers::base::ProviderDescriptor for OpenRouterProvider {
     fn metadata() -> ProviderMetadata {
         ProviderMetadata::new(
@@ -234,7 +245,7 @@ impl Provider for OpenRouterProvider {
     }
 
     fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
-        !model_config.request_param::<bool>("store").unwrap_or(false)
+        !stores_responses(model_config, self.configured_parameters.as_ref())
     }
 
     /// Fetch supported models from OpenRouter API (only models with tool support)
@@ -377,6 +388,28 @@ mod tests {
             reasoning: None,
             request_headers: None,
         }
+    }
+
+    #[test]
+    fn configured_store_setting_controls_stream_start_retry() {
+        let model = model_config("openai/gpt-5");
+
+        assert!(!stores_responses(&model, None));
+        assert!(stores_responses(
+            &model,
+            Some(&HashMap::from([("store".to_string(), json!(true))]))
+        ));
+    }
+
+    #[test]
+    fn configured_store_overrides_model_request_param() {
+        let mut model = model_config("openai/gpt-5");
+        model.request_params = Some(HashMap::from([("store".to_string(), json!(true))]));
+
+        assert!(!stores_responses(
+            &model,
+            Some(&HashMap::from([("store".to_string(), json!(false))]))
+        ));
     }
 
     #[test]

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -186,15 +186,15 @@ fn merge_openrouter_parameters(model: &mut ModelConfig, params: HashMap<String, 
     merge_request_params(&mut model.request_params, params);
 }
 
-fn stores_responses(
+fn effective_model_config(
     model_config: &ModelConfig,
     configured_parameters: Option<&HashMap<String, Value>>,
-) -> bool {
-    configured_parameters
-        .and_then(|params| params.get("store"))
-        .and_then(Value::as_bool)
-        .or_else(|| model_config.request_param::<bool>("store"))
-        .unwrap_or(false)
+) -> ModelConfig {
+    let mut effective = model_config.clone();
+    if let Some(params) = configured_parameters {
+        merge_openrouter_parameters(&mut effective, params.clone());
+    }
+    effective
 }
 
 impl goose_providers::base::ProviderDescriptor for OpenRouterProvider {
@@ -245,7 +245,8 @@ impl Provider for OpenRouterProvider {
     }
 
     fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
-        !stores_responses(model_config, self.configured_parameters.as_ref())
+        !effective_model_config(model_config, self.configured_parameters.as_ref())
+            .stores_responses()
     }
 
     /// Fetch supported models from OpenRouter API (only models with tool support)
@@ -305,14 +306,9 @@ impl Provider for OpenRouterProvider {
     ) -> Result<MessageStream, ProviderError> {
         let session_id = crate::session_context::current_session_id().unwrap_or_default();
 
-        let mut merged_model;
-        let model_config = if let Some(params) = &self.configured_parameters {
-            merged_model = model_config.clone();
-            merge_openrouter_parameters(&mut merged_model, params.clone());
-            &merged_model
-        } else {
-            model_config
-        };
+        let effective_model =
+            effective_model_config(model_config, self.configured_parameters.as_ref());
+        let model_config = &effective_model;
 
         let mut payload = create_request(
             model_config,
@@ -394,11 +390,12 @@ mod tests {
     fn configured_store_setting_controls_stream_start_retry() {
         let model = model_config("openai/gpt-5");
 
-        assert!(!stores_responses(&model, None));
-        assert!(stores_responses(
+        assert!(!effective_model_config(&model, None).stores_responses());
+        assert!(effective_model_config(
             &model,
             Some(&HashMap::from([("store".to_string(), json!(true))]))
-        ));
+        )
+        .stores_responses());
     }
 
     #[test]
@@ -406,10 +403,22 @@ mod tests {
         let mut model = model_config("openai/gpt-5");
         model.request_params = Some(HashMap::from([("store".to_string(), json!(true))]));
 
-        assert!(!stores_responses(
+        assert!(!effective_model_config(
             &model,
             Some(&HashMap::from([("store".to_string(), json!(false))]))
-        ));
+        )
+        .stores_responses());
+    }
+
+    #[test]
+    fn malformed_configured_store_fails_closed() {
+        let model = model_config("openai/gpt-5");
+
+        assert!(effective_model_config(
+            &model,
+            Some(&HashMap::from([("store".to_string(), json!("true"))]))
+        )
+        .stores_responses());
     }
 
     #[test]

--- a/crates/goose/src/providers/tetrate.rs
+++ b/crates/goose/src/providers/tetrate.rs
@@ -131,7 +131,7 @@ impl Provider for TetrateProvider {
     }
 
     fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
-        !model_config.request_param::<bool>("store").unwrap_or(false)
+        !model_config.stores_responses()
     }
 
     async fn stream(

--- a/crates/goose/src/providers/tetrate.rs
+++ b/crates/goose/src/providers/tetrate.rs
@@ -130,6 +130,10 @@ impl Provider for TetrateProvider {
         &self.name
     }
 
+    fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
+        !model_config.request_param::<bool>("store").unwrap_or(false)
+    }
+
     async fn stream(
         &self,
         model_config: &ModelConfig,

--- a/crates/goose/src/providers/xai_oauth.rs
+++ b/crates/goose/src/providers/xai_oauth.rs
@@ -701,6 +701,10 @@ impl Provider for XaiOAuthProvider {
         self.inner.get_name()
     }
 
+    fn supports_stream_start_retry(&self, model_config: &ModelConfig) -> bool {
+        self.inner.supports_stream_start_retry(model_config)
+    }
+
     async fn stream(
         &self,
         model_config: &ModelConfig,


### PR DESCRIPTION
## Context

Provider streams can fail while decoding their initial response body even after the request itself was opened successfully. Goose previously surfaced these transient failures immediately, despite not having consumed any stream output yet.

## Summary

Retry transient inference-provider stream failures only while replaying the request remains safe.

## Changes

- Adds a centralized provider stream-opening wrapper.
- Retries typed transient failures before the first stream item is yielded.
- Requires an explicit provider opt-in and enables it for stateless in-process inference providers, including declarative providers using those engines.
- Keeps stateful ACP, CLI, and external-agent providers opted out to avoid replaying side effects.
- Disables replay when request parameters enable stored responses.
- Preserves existing behavior after any output is yielded, avoiding duplicate assistant output or tool calls.
- Reuses existing provider retry/backoff behavior and `GOOSE_PROVIDER_SKIP_BACKOFF`.
- Adds coverage for opt-in, opt-out, stored-response, declarative-provider, non-transient, and post-output failure cases.

## Validation

```bash
GOOSE_PROVIDER_SKIP_BACKOFF=true cargo test -p goose stream_error --no-default-features
cargo test -p goose-providers stream_start_retry
cargo test -p goose-providers bundled_sakana_provider_supports_safe_stream_start_retry
cargo fmt --all --check
```

Observed: 8 stream-error tests, 3 provider capability tests, and formatting passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
