### PR TITLE
fix(ui): clear stale pending ACP connection after terminal recovery failure

### DIFF
--- a/ui/desktop/src/acp/__tests__/acpConnection.test.ts
+++ b/ui/desktop/src/acp/__tests__/acpConnection.test.ts
@@ -136,6 +136,29 @@ describe('ACP connection ownership', () => {
     expect(getAcpUrl).toHaveBeenCalledOnce();
   });
 
+  it('does not cache terminal recovery failures across caller retries', async () => {
+    const { getAcpClient } = await import('../acpConnection');
+    await getAcpClient();
+
+    const getAcpUrl = vi
+      .fn()
+      .mockRejectedValue(
+        new Error(`Error invoking remote method 'get-acp-url': ${GOOSE_SERVE_EXITED_USER_MESSAGE}`)
+      );
+    window.electron.getAcpUrl = getAcpUrl;
+    sdk.instances[0].resolveClosed();
+    await Promise.resolve();
+
+    const failedRecovery = expect(getAcpClient()).rejects.toThrow(GOOSE_SERVE_EXITED_USER_MESSAGE);
+    await vi.advanceTimersByTimeAsync(250);
+    await failedRecovery;
+
+    await expect(getAcpClient()).rejects.toThrow(GOOSE_SERVE_EXITED_USER_MESSAGE);
+
+    expect(getAcpUrl).toHaveBeenCalledTimes(2);
+    expect(sdk.instances).toHaveLength(1);
+  });
+
   it('reconnects immediately after system resume', async () => {
     const { getAcpClient, reconnectAcpAfterSystemResume } = await import('../acpConnection');
     await getAcpClient();

--- a/ui/desktop/src/acp/acpConnection.ts
+++ b/ui/desktop/src/acp/acpConnection.ts
@@ -96,6 +96,9 @@ function recoverConnection(immediate: boolean): void {
       }
     },
     () => {
+      if (pendingConnection === recoveryAttempt) {
+        pendingConnection = null;
+      }
       if (generation === connectionGeneration) {
         setRecovering(false);
       }


### PR DESCRIPTION
Fixes #10551.

`recoverConnection()` cached the recovery attempt in `pendingConnection` but never cleared it when the attempt rejected terminally, so after a failed recovery every `getConnection()` call returned the same rejected promise and no fresh connection was ever attempted until system resume or app restart. This clears `pendingConnection` in the recovery attempt's rejection handler, mirroring the cleanup `getConnection()` already performs for failed initial attempts.

Adds a unit test covering caller retry after a terminal recovery failure: with the fix stashed it fails (the retry re-throws the stale "backend stopped" error even though `getAcpUrl` is healthy again), with the fix it passes. Full `ui/desktop` suite: 569/569, lint clean.
