### PR TITLE
tests: add recursion_limit attribute to remaining ACP test files

### DIFF
--- a/crates/goose/tests/acp_custom_provider_methods_test.rs
+++ b/crates/goose/tests/acp_custom_provider_methods_test.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 #[allow(dead_code)]
 #[path = "acp_common_tests/mod.rs"]
 mod common_tests;

--- a/crates/goose/tests/acp_custom_requests_test.rs
+++ b/crates/goose/tests/acp_custom_requests_test.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 #[allow(dead_code)]
 #[path = "acp_common_tests/mod.rs"]
 mod common_tests;

--- a/crates/goose/tests/acp_fork_session_test.rs
+++ b/crates/goose/tests/acp_fork_session_test.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 #[allow(dead_code)]
 #[path = "acp_common_tests/mod.rs"]
 mod common_tests;

--- a/crates/goose/tests/acp_secret_cache_invalidation_test.rs
+++ b/crates/goose/tests/acp_secret_cache_invalidation_test.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 #[allow(dead_code)]
 #[path = "acp_common_tests/mod.rs"]
 mod common_tests;

--- a/crates/goose/tests/acp_server_test.rs
+++ b/crates/goose/tests/acp_server_test.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 #[allow(dead_code)]
 #[path = "acp_common_tests/mod.rs"]
 mod common_tests;

--- a/crates/goose/tests/acp_transport_auth_test.rs
+++ b/crates/goose/tests/acp_transport_auth_test.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 use std::sync::Arc;
 
 use axum::body::Body;


### PR DESCRIPTION
### Problem
Building the test binaries for the ACP integration tests fails on some rustc versions with a query-depth overflow:

```
error: queries overflow the depth limit!
  = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]`
    attribute to your crate (`acp_secret_cache_invalidation_test`)
  = note: query depth increased by 130 when computing layout of
    {async block@goose::acp::server::dispatch::<impl HandleDispatchFrom<Client>
    for GooseAcpHandler>::handle_dispatch_from::{closure#0}::{closure#11}::{closure#0}::{closure#0}}
```

Observed while packaging goose 1.43.0 for nixpkgs with rustc 1.96.1. Three test targets failed before cargo aborted (acp_secret_cache_invalidation_test, acp_custom_provider_methods_test, acp_custom_requests_test); the remaining ACP test files compile the same acp::server::dispatch code, so this PR adds the attribute uniformly rather than only to the observed failures.
### Why this doesn't reproduce in CI
The overflow is compiler-version-dependent, not code-correctness-dependent. Computing the type layout of the nested async closures in handle_dispatch_from costs a query depth right around rustc's default limit of 128 — the note above shows a single layout computation adding 130. How that depth is accounted varies between rustc releases, so the toolchain pinned in rust-toolchain.toml stays under the limit while other compiler versions (distribution packagers generally build with their own rustc rather than the pinned toolchain) go over. Any refactor that nests these closures slightly deeper could push the pinned toolchain over the edge too, so the attribute is also mild future-proofing.

### Why this fix
It's the fix rustc itself suggests, and it's already this codebase's established pattern: acp_provider_test.rs carries exactly this attribute, presumably from a previous encounter with the same limit. This PR just completes that pattern across the sibling files.
The attribute is a no-op cost-wise where the limit isn't reached — it only raises a ceiling, affecting nothing on toolchains that build fine today.
The alternative (reducing closure nesting in acp::server::dispatch) would be a behavior-adjacent refactor of production code to solve a test-compilation issue; not worth the risk.

### Context
Found while packaging goose 1.43.0 for nixpkgs, where this is currently carried as a downstream patch — upstreaming it lets us (and any other distro building with a non-pinned rustc) drop the workaround. Two related reports coming separately: a couple of lib tests that race on process-global state under parallel execution, and GOOSE_BINARY being rejected in packaged builds, which affects distro-packaged Electron apps.
The attribute treats the symptom; if the closure nesting in acp::server::dispatch keeps growing, flattening it (or boxing at the dispatch boundary) would address the cause and shrink the generated futures. Happy to file that as an issue if useful.
Disclosure: this PR description was drafted with assistance from Claude Fable 5 (Anthropic); I hit the failure, verified the fix in a real build, and reviewed everything here.