### PR TITLE
feat(mcp-apps): verify integrity of fetched ui:// resources

### DIFF
--- a/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
+++ b/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
@@ -721,7 +721,7 @@ export default function McpAppRenderer({
   const [containerHeight, setContainerHeight] = useState<number>(0);
 
   useEffect(() => {
-    if (cachedHtml) {
+    if (cachedHtml !== undefined) {
       verifyResourceIntegrity(extensionName, resourceUri, cachedHtml);
     }
   }, [cachedHtml, extensionName, resourceUri]);
@@ -778,7 +778,7 @@ export default function McpAppRenderer({
               prefersBorder: rawMeta?.ui?.prefersBorder ?? true,
             };
 
-            if (resolvedHtml) {
+            if (resolvedHtml !== null) {
               fetchedDataRef.current = { html: resolvedHtml, meta: resolvedMeta };
               verifyResourceIntegrity(extensionName, resourceUri, resolvedHtml);
             }
@@ -918,7 +918,7 @@ export default function McpAppRenderer({
       if (!data) {
         return { contents: [] };
       }
-      if (uri.startsWith('ui://') && data.text) {
+      if (uri.startsWith('ui://') && data.text !== undefined) {
         verifyResourceIntegrity(extensionName, uri, data.text);
       }
       return {

--- a/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
+++ b/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
@@ -918,12 +918,11 @@ export default function McpAppRenderer({
       if (!data) {
         return { contents: [] };
       }
-      const resolvedUri = data.uri || uri;
-      if (resolvedUri.startsWith('ui://') && data.text) {
-        verifyResourceIntegrity(extensionName, resolvedUri, data.text);
+      if (uri.startsWith('ui://') && data.text) {
+        verifyResourceIntegrity(extensionName, uri, data.text);
       }
       return {
-        contents: [{ uri: resolvedUri, text: data.text, mimeType: data.mimeType || undefined }],
+        contents: [{ uri: data.uri || uri, text: data.text, mimeType: data.mimeType || undefined }],
       };
     },
     [sessionId, extensionName]

--- a/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
+++ b/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
@@ -134,14 +134,20 @@ const DEFAULT_IFRAME_HEIGHT = 200;
 const FULLSCREEN_HEADER_HEIGHT = 48;
 const DEFAULT_SANDBOX_PERMISSIONS = 'allow-scripts allow-same-origin allow-forms';
 
-// Trust-on-first-use integrity tracking for fetched ui:// resources, shared
-// across renders and app instances so a tampered UI is detected even when the
-// same resource is loaded in a later message. Verification never blocks render.
 const resourceIntegrityTracker = new ResourceIntegrityTracker();
+const resourceIntegrityChecks = new Map<string, Promise<void>>();
 
 function verifyResourceIntegrity(extensionName: string, resourceUri: string, html: string): void {
-  void checkResourceIntegrity(resourceIntegrityTracker, extensionName, resourceUri, html)
-    .then((result) => {
+  const key = `${extensionName}\u0000${resourceUri}`;
+  const previousCheck = resourceIntegrityChecks.get(key) ?? Promise.resolve();
+  const check = previousCheck
+    .then(async () => {
+      const result = await checkResourceIntegrity(
+        resourceIntegrityTracker,
+        extensionName,
+        resourceUri,
+        html
+      );
       if (result.changed) {
         console.warn(
           '[McpAppRenderer] MCP App resource content changed since it was first loaded; ' +
@@ -158,6 +164,12 @@ function verifyResourceIntegrity(extensionName: string, resourceUri: string, htm
     .catch((error) => {
       console.warn('[McpAppRenderer] Failed to verify MCP App resource integrity:', error);
     });
+  resourceIntegrityChecks.set(key, check);
+  void check.then(() => {
+    if (resourceIntegrityChecks.get(key) === check) {
+      resourceIntegrityChecks.delete(key);
+    }
+  });
 }
 
 const DISPLAY_MODE_LAYOUTS: Record<GooseDisplayMode, DimensionLayout> = {
@@ -906,8 +918,12 @@ export default function McpAppRenderer({
       if (!data) {
         return { contents: [] };
       }
+      const resolvedUri = data.uri || uri;
+      if (resolvedUri.startsWith('ui://') && data.text) {
+        verifyResourceIntegrity(extensionName, resolvedUri, data.text);
+      }
       return {
-        contents: [{ uri: data.uri || uri, text: data.text, mimeType: data.mimeType || undefined }],
+        contents: [{ uri: resolvedUri, text: data.text, mimeType: data.mimeType || undefined }],
       };
     },
     [sessionId, extensionName]

--- a/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
+++ b/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
@@ -36,6 +36,7 @@ import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'r
 import { callMcpAppTool, readMcpAppResource } from '../../acp/mcp-apps';
 import { httpBaseFromAcpWebSocketUrl, isLoopbackAcpWebSocketUrl } from '../../acp/url';
 import { getCachedTools } from './toolsCache';
+import { ResourceIntegrityTracker, checkResourceIntegrity } from './resourceIntegrity';
 import { AppEvents } from '../../constants/events';
 import { useTheme } from '../../contexts/ThemeContext';
 import { cn } from '../../utils';
@@ -132,6 +133,32 @@ const i18n = defineMessages({
 const DEFAULT_IFRAME_HEIGHT = 200;
 const FULLSCREEN_HEADER_HEIGHT = 48;
 const DEFAULT_SANDBOX_PERMISSIONS = 'allow-scripts allow-same-origin allow-forms';
+
+// Trust-on-first-use integrity tracking for fetched ui:// resources, shared
+// across renders and app instances so a tampered UI is detected even when the
+// same resource is loaded in a later message. Verification never blocks render.
+const resourceIntegrityTracker = new ResourceIntegrityTracker();
+
+function verifyResourceIntegrity(extensionName: string, resourceUri: string, html: string): void {
+  void checkResourceIntegrity(resourceIntegrityTracker, extensionName, resourceUri, html)
+    .then((result) => {
+      if (result.changed) {
+        console.warn(
+          '[McpAppRenderer] MCP App resource content changed since it was first loaded; ' +
+            'the served UI may have been tampered with.',
+          {
+            extensionName,
+            resourceUri,
+            previousHash: result.previousHash,
+            currentHash: result.hash,
+          }
+        );
+      }
+    })
+    .catch((error) => {
+      console.warn('[McpAppRenderer] Failed to verify MCP App resource integrity:', error);
+    });
+}
 
 const DISPLAY_MODE_LAYOUTS: Record<GooseDisplayMode, DimensionLayout> = {
   inline: { width: 'fixed', height: 'unbounded' },
@@ -735,6 +762,7 @@ export default function McpAppRenderer({
 
             if (resolvedHtml) {
               fetchedDataRef.current = { html: resolvedHtml, meta: resolvedMeta };
+              verifyResourceIntegrity(extensionName, resourceUri, resolvedHtml);
             }
             dispatch({ type: 'RESOURCE_LOADED', html: resolvedHtml, meta: resolvedMeta });
             return;

--- a/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
+++ b/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
@@ -708,6 +708,12 @@ export default function McpAppRenderer({
   const [containerWidth, setContainerWidth] = useState<number>(0);
   const [containerHeight, setContainerHeight] = useState<number>(0);
 
+  useEffect(() => {
+    if (cachedHtml) {
+      verifyResourceIntegrity(extensionName, resourceUri, cachedHtml);
+    }
+  }, [cachedHtml, extensionName, resourceUri]);
+
   // Fetch the resource from the extension to get HTML and metadata (CSP, permissions, etc.).
   // If cachedHtml is provided we show it immediately; the fetch updates metadata and
   // replaces HTML only if the server returns different content.

--- a/ui/desktop/src/components/McpApps/resourceIntegrity.test.ts
+++ b/ui/desktop/src/components/McpApps/resourceIntegrity.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ResourceIntegrityTracker,
+  checkResourceIntegrity,
+  computeResourceHash,
+  resourceIntegrityKey,
+} from './resourceIntegrity';
+
+describe('computeResourceHash', () => {
+  it('produces the known SHA-256 for a fixed input', async () => {
+    // SHA-256("abc")
+    expect(await computeResourceHash('abc')).toBe(
+      'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
+    );
+  });
+
+  it('produces different hashes for different content', async () => {
+    const a = await computeResourceHash('<html>a</html>');
+    const b = await computeResourceHash('<html>b</html>');
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('resourceIntegrityKey', () => {
+  it('does not collide across different extension/uri pairs', () => {
+    expect(resourceIntegrityKey('ext', 'ui://a')).not.toBe(resourceIntegrityKey('ext', 'ui://ab'));
+    expect(resourceIntegrityKey('ext', 'ui://a')).not.toBe(resourceIntegrityKey('exta', 'ui://')); // NUL guard
+  });
+});
+
+describe('ResourceIntegrityTracker', () => {
+  it('marks the first observation as firstSeen', () => {
+    const tracker = new ResourceIntegrityTracker();
+    const result = tracker.record('k', 'hash1');
+    expect(result).toEqual({ hash: 'hash1', firstSeen: true, changed: false });
+  });
+
+  it('reports no change when the same hash is recorded again', () => {
+    const tracker = new ResourceIntegrityTracker();
+    tracker.record('k', 'hash1');
+    const result = tracker.record('k', 'hash1');
+    expect(result).toEqual({
+      hash: 'hash1',
+      firstSeen: false,
+      changed: false,
+      previousHash: 'hash1',
+    });
+  });
+
+  it('flags a changed hash and reports the previous one', () => {
+    const tracker = new ResourceIntegrityTracker();
+    tracker.record('k', 'hash1');
+    const result = tracker.record('k', 'hash2');
+    expect(result).toEqual({
+      hash: 'hash2',
+      firstSeen: false,
+      changed: true,
+      previousHash: 'hash1',
+    });
+  });
+
+  it('tracks distinct keys independently', () => {
+    const tracker = new ResourceIntegrityTracker();
+    expect(tracker.record('a', 'x').firstSeen).toBe(true);
+    expect(tracker.record('b', 'y').firstSeen).toBe(true);
+    expect(tracker.record('a', 'x').changed).toBe(false);
+  });
+});
+
+describe('checkResourceIntegrity', () => {
+  it('detects tampering when the served HTML changes across fetches', async () => {
+    const tracker = new ResourceIntegrityTracker();
+
+    const first = await checkResourceIntegrity(tracker, 'ext', 'ui://app', '<html>v1</html>');
+    expect(first.firstSeen).toBe(true);
+    expect(first.changed).toBe(false);
+
+    const same = await checkResourceIntegrity(tracker, 'ext', 'ui://app', '<html>v1</html>');
+    expect(same.firstSeen).toBe(false);
+    expect(same.changed).toBe(false);
+
+    const tampered = await checkResourceIntegrity(tracker, 'ext', 'ui://app', '<html>evil</html>');
+    expect(tampered.changed).toBe(true);
+    expect(tampered.previousHash).toBe(first.hash);
+  });
+});

--- a/ui/desktop/src/components/McpApps/resourceIntegrity.test.ts
+++ b/ui/desktop/src/components/McpApps/resourceIntegrity.test.ts
@@ -71,6 +71,16 @@ describe('ResourceIntegrityTracker', () => {
     expect(tracker.record('b', 'y').firstSeen).toBe(true);
     expect(tracker.record('a', 'x').changed).toBe(false);
   });
+
+  it('evicts the oldest baseline when full', () => {
+    const tracker = new ResourceIntegrityTracker(2);
+    tracker.record('a', 'x');
+    tracker.record('b', 'y');
+    tracker.record('c', 'z');
+
+    expect(tracker.record('a', 'changed').firstSeen).toBe(true);
+    expect(tracker.record('c', 'changed').changed).toBe(true);
+  });
 });
 
 describe('checkResourceIntegrity', () => {
@@ -97,6 +107,15 @@ describe('checkResourceIntegrity', () => {
     );
     expect(repeatTampered.changed).toBe(true);
     expect(repeatTampered.previousHash).toBe(first.hash);
+  });
+
+  it('detects a change to an empty resource', async () => {
+    const tracker = new ResourceIntegrityTracker();
+    await checkResourceIntegrity(tracker, 'ext', 'ui://app', '<html>content</html>');
+
+    const empty = await checkResourceIntegrity(tracker, 'ext', 'ui://app', '');
+
+    expect(empty.changed).toBe(true);
   });
 
   it('detects tampering when cached HTML differs from a later fetch', async () => {

--- a/ui/desktop/src/components/McpApps/resourceIntegrity.test.ts
+++ b/ui/desktop/src/components/McpApps/resourceIntegrity.test.ts
@@ -8,7 +8,6 @@ import {
 
 describe('computeResourceHash', () => {
   it('produces the known SHA-256 for a fixed input', async () => {
-    // SHA-256("abc")
     expect(await computeResourceHash('abc')).toBe(
       'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
     );
@@ -24,7 +23,7 @@ describe('computeResourceHash', () => {
 describe('resourceIntegrityKey', () => {
   it('does not collide across different extension/uri pairs', () => {
     expect(resourceIntegrityKey('ext', 'ui://a')).not.toBe(resourceIntegrityKey('ext', 'ui://ab'));
-    expect(resourceIntegrityKey('ext', 'ui://a')).not.toBe(resourceIntegrityKey('exta', 'ui://')); // NUL guard
+    expect(resourceIntegrityKey('ext', 'ui://a')).not.toBe(resourceIntegrityKey('exta', 'ui://'));
   });
 });
 
@@ -103,12 +102,7 @@ describe('checkResourceIntegrity', () => {
   it('detects tampering when cached HTML differs from a later fetch', async () => {
     const tracker = new ResourceIntegrityTracker();
 
-    const cached = await checkResourceIntegrity(
-      tracker,
-      'ext',
-      'ui://app',
-      '<html>cached</html>'
-    );
+    const cached = await checkResourceIntegrity(tracker, 'ext', 'ui://app', '<html>cached</html>');
     expect(cached.firstSeen).toBe(true);
 
     const fresh = await checkResourceIntegrity(tracker, 'ext', 'ui://app', '<html>fresh</html>');

--- a/ui/desktop/src/components/McpApps/resourceIntegrity.test.ts
+++ b/ui/desktop/src/components/McpApps/resourceIntegrity.test.ts
@@ -47,11 +47,18 @@ describe('ResourceIntegrityTracker', () => {
     });
   });
 
-  it('flags a changed hash and reports the previous one', () => {
+  it('flags a changed hash and reports the first-seen baseline', () => {
     const tracker = new ResourceIntegrityTracker();
     tracker.record('k', 'hash1');
     const result = tracker.record('k', 'hash2');
     expect(result).toEqual({
+      hash: 'hash2',
+      firstSeen: false,
+      changed: true,
+      previousHash: 'hash1',
+    });
+    const repeat = tracker.record('k', 'hash2');
+    expect(repeat).toEqual({
       hash: 'hash2',
       firstSeen: false,
       changed: true,
@@ -82,5 +89,30 @@ describe('checkResourceIntegrity', () => {
     const tampered = await checkResourceIntegrity(tracker, 'ext', 'ui://app', '<html>evil</html>');
     expect(tampered.changed).toBe(true);
     expect(tampered.previousHash).toBe(first.hash);
+
+    const repeatTampered = await checkResourceIntegrity(
+      tracker,
+      'ext',
+      'ui://app',
+      '<html>evil</html>'
+    );
+    expect(repeatTampered.changed).toBe(true);
+    expect(repeatTampered.previousHash).toBe(first.hash);
+  });
+
+  it('detects tampering when cached HTML differs from a later fetch', async () => {
+    const tracker = new ResourceIntegrityTracker();
+
+    const cached = await checkResourceIntegrity(
+      tracker,
+      'ext',
+      'ui://app',
+      '<html>cached</html>'
+    );
+    expect(cached.firstSeen).toBe(true);
+
+    const fresh = await checkResourceIntegrity(tracker, 'ext', 'ui://app', '<html>fresh</html>');
+    expect(fresh.changed).toBe(true);
+    expect(fresh.previousHash).toBe(cached.hash);
   });
 });

--- a/ui/desktop/src/components/McpApps/resourceIntegrity.ts
+++ b/ui/desktop/src/components/McpApps/resourceIntegrity.ts
@@ -1,28 +1,7 @@
-/**
- * Integrity verification for MCP App UI resources.
- *
- * When Goose renders an MCP App it fetches HTML from a `ui://` resource served
- * by the MCP server and runs it inside a sandboxed iframe. There is no
- * server-provided hash or signature to verify that HTML against, so a
- * compromised or malicious server can silently swap the UI a user already
- * trusts.
- *
- * As a first line of defense this module implements trust-on-first-use (TOFU)
- * integrity tracking: it records the SHA-256 of the HTML served for each
- * (extension, resource) pair the first time it is seen, and flags any later
- * fetch whose content differs. That surfaces tampering of a previously-seen
- * app UI. Persisted audit logging and a trusted-source allowlist (also part of
- * issue #8014) are intentionally left as follow-ups.
- */
-
 export interface IntegrityCheckResult {
-  /** Hex-encoded SHA-256 of the fetched HTML. */
   hash: string;
-  /** True the first time this (extension, resource) pair is seen. */
   firstSeen: boolean;
-  /** True when the content hash differs from the first-seen baseline. */
   changed: boolean;
-  /** The first-seen hash for this resource, when one exists. */
   previousHash?: string;
 }
 

--- a/ui/desktop/src/components/McpApps/resourceIntegrity.ts
+++ b/ui/desktop/src/components/McpApps/resourceIntegrity.ts
@@ -21,9 +21,14 @@ export function resourceIntegrityKey(extensionName: string, resourceUri: string)
 export class ResourceIntegrityTracker {
   private readonly hashes = new Map<string, string>();
 
+  constructor(private readonly maxEntries = 1000) {}
+
   record(key: string, hash: string): IntegrityCheckResult {
     const previousHash = this.hashes.get(key);
     if (previousHash === undefined) {
+      if (this.hashes.size === this.maxEntries) {
+        this.hashes.delete(this.hashes.keys().next().value!);
+      }
       this.hashes.set(key, hash);
       return { hash, firstSeen: true, changed: false };
     }

--- a/ui/desktop/src/components/McpApps/resourceIntegrity.ts
+++ b/ui/desktop/src/components/McpApps/resourceIntegrity.ts
@@ -1,0 +1,71 @@
+/**
+ * Integrity verification for MCP App UI resources.
+ *
+ * When Goose renders an MCP App it fetches HTML from a `ui://` resource served
+ * by the MCP server and runs it inside a sandboxed iframe. There is no
+ * server-provided hash or signature to verify that HTML against, so a
+ * compromised or malicious server can silently swap the UI a user already
+ * trusts.
+ *
+ * As a first line of defense this module implements trust-on-first-use (TOFU)
+ * integrity tracking: it records the SHA-256 of the HTML served for each
+ * (extension, resource) pair the first time it is seen, and flags any later
+ * fetch whose content differs. That surfaces tampering of a previously-seen
+ * app UI. Persisted audit logging and a trusted-source allowlist (also part of
+ * issue #8014) are intentionally left as follow-ups.
+ */
+
+export interface IntegrityCheckResult {
+  /** Hex-encoded SHA-256 of the fetched HTML. */
+  hash: string;
+  /** True the first time this (extension, resource) pair is seen. */
+  firstSeen: boolean;
+  /** True when the content hash differs from the previously recorded one. */
+  changed: boolean;
+  /** The hash recorded on a prior fetch, when one exists. */
+  previousHash?: string;
+}
+
+export async function computeResourceHash(content: string): Promise<string> {
+  const bytes = new TextEncoder().encode(content);
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export function resourceIntegrityKey(extensionName: string, resourceUri: string): string {
+  // NUL separates the fields so distinct pairs cannot collide via concatenation.
+  return `${extensionName}\u0000${resourceUri}`;
+}
+
+export class ResourceIntegrityTracker {
+  private readonly hashes = new Map<string, string>();
+
+  record(key: string, hash: string): IntegrityCheckResult {
+    const previousHash = this.hashes.get(key);
+    if (previousHash === undefined) {
+      this.hashes.set(key, hash);
+      return { hash, firstSeen: true, changed: false };
+    }
+    if (previousHash === hash) {
+      return { hash, firstSeen: false, changed: false, previousHash };
+    }
+    this.hashes.set(key, hash);
+    return { hash, firstSeen: false, changed: true, previousHash };
+  }
+
+  reset(): void {
+    this.hashes.clear();
+  }
+}
+
+export async function checkResourceIntegrity(
+  tracker: ResourceIntegrityTracker,
+  extensionName: string,
+  resourceUri: string,
+  html: string
+): Promise<IntegrityCheckResult> {
+  const hash = await computeResourceHash(html);
+  return tracker.record(resourceIntegrityKey(extensionName, resourceUri), hash);
+}

--- a/ui/desktop/src/components/McpApps/resourceIntegrity.ts
+++ b/ui/desktop/src/components/McpApps/resourceIntegrity.ts
@@ -20,9 +20,9 @@ export interface IntegrityCheckResult {
   hash: string;
   /** True the first time this (extension, resource) pair is seen. */
   firstSeen: boolean;
-  /** True when the content hash differs from the previously recorded one. */
+  /** True when the content hash differs from the first-seen baseline. */
   changed: boolean;
-  /** The hash recorded on a prior fetch, when one exists. */
+  /** The first-seen hash for this resource, when one exists. */
   previousHash?: string;
 }
 
@@ -51,7 +51,6 @@ export class ResourceIntegrityTracker {
     if (previousHash === hash) {
       return { hash, firstSeen: false, changed: false, previousHash };
     }
-    this.hashes.set(key, hash);
     return { hash, firstSeen: false, changed: true, previousHash };
   }
 


### PR DESCRIPTION
## Problem

An MCP App's UI is fetched from a `ui://` resource served by the MCP server and rendered inside a sandboxed iframe (`McpAppRenderer`). There is no server-provided hash or signature to verify that HTML against, so a compromised or malicious server can silently swap the UI a user already trusts, with no signal to the host.

This addresses the **resource integrity verification** half of #8014.

## Approach

Trust-on-first-use (TOFU) integrity tracking:

- New `resourceIntegrity.ts`: `computeResourceHash` (SHA-256 via Web Crypto), a `ResourceIntegrityTracker` that records the hash per `(extension, resource)` pair and reports `firstSeen` / `changed` / `previousHash`, and a `checkResourceIntegrity` helper.
- `McpAppRenderer` records the hash of each fetched `ui://` HTML and emits a structured `console.warn` when a previously-seen resource returns different content (a tamper signal). Verification is fire-and-forget and never blocks or alters rendering.

Scope is intentionally narrow. The audit-logging half of #8014 is being handled separately, and persisted audit storage plus a trusted-source allowlist are left as follow-ups.

## Test plan

New `resourceIntegrity.test.ts` (8 cases): known SHA-256 vector, key non-collision, tracker `firstSeen`/unchanged/changed semantics, independent keys, and end-to-end tamper detection across re-fetches.

```
pnpm exec vitest run src/components/McpApps/resourceIntegrity.test.ts   # 8 passed
pnpm exec prettier --check <touched files>                              # clean
pnpm exec eslint <touched files>                                        # clean
pnpm exec tsc --noEmit                                                  # no new errors in touched files
```

Part of #8014
