### PR TITLE
feat: session banner hooks - let plugins surface context at startup

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -485,9 +485,12 @@ impl Agent {
         event: crate::hooks::HookEvent,
         session_id: &str,
     ) -> Vec<String> {
+<<<<<<< HEAD
         if event == crate::hooks::HookEvent::SessionStart {
             self.session_start_emitted.store(true, Ordering::Release);
         }
+=======
+>>>>>>> 13096fd60 (feat: session banner hooks - let plugins surface context at startup)
         if !self.hook_manager.has_hooks(event) {
             return Vec::new();
         }


### PR DESCRIPTION
## Summary

SessionStart hooks can now return `{"banner":"..."}` on stdout to contribute lines to the CLI startup banner. Multiple plugins can each provide banner content, printed between "goose is ready" and the context usage bar.

## Motivation

Plugins like session-continuity tools, project dashboards, and reminder systems have information the user needs *before* they type their first prompt. Currently there's no way to surface this without:

1. The agent making a tool call on first turn (wastes tokens, adds latency)
2. Writing to `/dev/tty` directly (works but is a hack, not portable)
3. Using `tom` to inject into agent context (agent sees it, user doesn't)
4. Wrapping the `goose` binary in a shell function (works but fragile)

## What it looks like

```
    __( O)>  ● resuming · databricks goose-claude-4-6-opus
   \____)    20260718_15 · /Users/you
     L L     goose is ready
  🌱 spore | 120 sessions | 8.3M tokens | 47 retrievals
  🌱 today | 6 sessions | 180k tokens
  🍄 3 thread(s) active | work
  🍄  api-refactor
  🍄    ↳ Migrate v1 endpoints to new response format
  🍄  onboarding-flow
  🍄    ↳ Add email verification step before account creation
  🍄  perf-investigation
  🍄    ↳ Dashboard load time regression after deploy #847
  ━╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ 5% 45k/1.0M
```

The banner surfaces session stats and active work threads so you can re-orient instantly - especially useful for developers managing multiple workstreams or resuming after context switches.

This example uses [goose-banner](https://github.com/dakotafabro/goose-banner), a companion plugin that orchestrates multiple banner providers via a `banner.d/` script directory. The 🌱 lines come from [spore](https://github.com/dakotafabro/spore) (biomimetic agent memory with decay and proximity-based retrieval) and the 🍄 lines come from [hyphae](https://github.com/dakotafabro/hyphae) (session continuity across machines). Both are currently in development and scheduled for public release by end of August 2026.

## Changes

- **`crates/goose/src/hooks/mod.rs`**: Added `emit_collecting_banners()` method and `extract_banner()` helper. Hooks that output valid JSON with a `banner` field have that content collected. 6 new tests.
- **`crates/goose/src/agents/agent.rs`**: Added `emit_hook_with_banners()` public method on Agent.
- **`crates/goose-cli/src/session/mod.rs`**: Calls banner-collecting variant at session start in `interactive()`, prints results before the input loop.
- **`crates/goose-cli/src/session/output.rs`**: Added `display_banner()` function.

## Hook Protocol

A SessionStart hook script that wants to contribute banner lines outputs JSON on stdout:

```json
{"banner": "  🌱 spore | 120 sessions | 8.3M tokens\\n  🍄 3 active threads"}
```

If stdout is not valid JSON or lacks a `banner` field, behavior is unchanged (fully backwards compatible).

## Design Notes

**Timing:** The existing `SessionStart` hook fires inside the agent's `reply()` method on the first turn - too late for banner placement. This PR adds a separate banner-collecting emit in the CLI's `interactive()` method, which runs before the input loop. This means SessionStart hooks fire twice for interactive sessions (once for banner collection, once from the agent). Hooks should be idempotent. A follow-up could deduplicate by having the agent skip its internal emit when the CLI already fired it.

**Backwards compatibility:** Hooks that don't output JSON or output JSON without a `banner` field behave exactly as before. The banner-collecting path only extracts content from hooks that explicitly opt in via the JSON protocol.

## Testing

- `extract_banner_from_json` - parses banner from valid JSON
- `extract_banner_ignores_non_json` - non-JSON stdout ignored
- `extract_banner_ignores_json_without_banner_field` - unrelated JSON ignored
- `extract_banner_ignores_empty_banner` - empty string filtered
- `emit_collecting_banners_returns_banner_lines` - end-to-end hook execution
- `emit_collecting_banners_skips_non_json_output` - graceful fallback

All existing hook tests continue to pass. `cargo clippy` clean.

## Companion Plugin

[goose-banner](https://github.com/dakotafabro/goose-banner) - provides the `banner.d/` orchestration layer for users who want to compose multiple banner providers. Drop executable scripts into `~/.config/goose/banner.d/` and their output appears at session startup. Includes examples for git status, reminders, time context, and session stats.