### PR TITLE
docs(extensions): add Latchshot MCP server

### DIFF
--- a/documentation/docs/mcp/latchshot-mcp.md
+++ b/documentation/docs/mcp/latchshot-mcp.md
@@ -1,0 +1,105 @@
+---
+title: Latchshot Extension
+description: Add Latchshot as a goose Extension for guarded public-webpage screenshots and PDFs
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+
+This tutorial covers how to add [Latchshot](https://github.com/BaiqingL/latchshot-mcp) as a goose extension to capture public webpages as PNG, JPEG, or PDF artifacts. The hosted browser accepts only public HTTP or HTTPS targets on ports 80 and 443, applies bounded render options, and counts only successful captures against quota.
+
+:::tip Quick Install
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Flatchshot.fly.dev%2Fmcp&id=latchshot&name=Latchshot&description=Capture%20public%20webpages%20as%20PNG%2C%20JPEG%2C%20or%20PDF%20with%20bounded%20options%20and%20network%20guardrails&header=Authorization%3DBearer%20YOUR_LATCHSHOT_API_KEY)
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+  Add a `Remote Extension (Streamable HTTP)` extension type with:
+
+  **Endpoint URL**
+  ```
+  https://latchshot.fly.dev/mcp
+  ```
+
+  **Custom Request Header**
+  ```
+  Authorization: Bearer <YOUR_LATCHSHOT_API_KEY>
+  ```
+  </TabItem>
+</Tabs>
+:::
+
+## Configuration
+
+Get a [recurring Free-plan API key](https://latchshot.fly.dev/?intent=goose#trial), then configure the remote extension:
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+    <GooseDesktopInstaller
+      extensionId="latchshot"
+      extensionName="Latchshot"
+      description="Capture public webpages as PNG, JPEG, or PDF with bounded options and network guardrails"
+      type="http"
+      url="https://latchshot.fly.dev/mcp"
+      envVars={[
+        { name: "Authorization", label: "Bearer YOUR_LATCHSHOT_API_KEY" }
+      ]}
+      apiKeyLink="https://latchshot.fly.dev/?intent=goose#trial"
+      apiKeyLinkText="Latchshot API key"
+    />
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    <CLIExtensionInstructions
+      name="Latchshot"
+      description="Capture public webpages as PNG, JPEG, or PDF with bounded options and network guardrails"
+      type="http"
+      url="https://latchshot.fly.dev/mcp"
+      timeout={300}
+      envVars={[
+        { key: "Authorization", value: "Bearer ls_live_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" }
+      ]}
+      infoNote={
+        <>
+          Get a <a href="https://latchshot.fly.dev/?intent=goose#trial" target="_blank" rel="noopener noreferrer">Latchshot API key</a> and paste it after <code>Bearer</code>. The recurring Free plan includes 100 successful renders per UTC calendar month and requires no credit card.
+        </>
+      }
+    />
+  </TabItem>
+</Tabs>
+
+Latchshot exposes two tools:
+
+- `capture_page` returns an inline PNG or JPEG image, or an embedded PDF resource, plus render and quota diagnostics.
+- `get_usage` reads the current plan, successful-render quota, reset time, and remaining allowance without consuming render quota.
+
+## Example Usage
+
+Ask goose to capture a public page and summarize the diagnostics:
+
+### goose Prompt
+
+```
+Use Latchshot to capture https://example.com as an 800 by 450 PNG. Then report the byte count, render time, navigation state, fonts state, scripts state, and remaining quota.
+```
+
+### goose Output
+
+```
+The byte count for the captured page is 15155.
+The render time was 450 ms.
+The navigation state is "complete".
+The fonts state is "original".
+The scripts state is "active".
+The remaining quota is 1.
+```
+
+This output was observed in a live goose 1.43.0 validation run. Artifact size and render time vary with the target page and selected options.
+
+## Boundaries
+
+- Targets must resolve entirely to public network addresses; credentials in target URLs and private, loopback, link-local, or metadata addresses are rejected.
+- The tools do not expose payment or plan-upgrade actions.
+- Failed direct captures do not consume quota, and automatic overages are disabled.
+- Review the target site's terms and obtain permission before automating captures.

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -397,6 +397,26 @@
     "environmentVariables": []
   },
   {
+    "id": "latchshot",
+    "name": "Latchshot",
+    "description": "Capture public webpages as PNG, JPEG, or PDF with bounded options and network guardrails",
+    "url": "https://latchshot.fly.dev/mcp",
+    "type": "streamable-http",
+    "link": "https://github.com/BaiqingL/latchshot-mcp",
+    "documentation": "https://latchshot.fly.dev/guides/screenshot-mcp-server.html",
+    "installation_notes": "This is a remote extension that requires a Latchshot API key from https://latchshot.fly.dev/?intent=goose#trial as a request header, e.g. Authorization: Bearer <YOUR_LATCHSHOT_API_KEY>. The recurring Free plan includes 100 successful renders per UTC calendar month with no credit card; only public HTTP/HTTPS targets are supported.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [],
+    "headers": [
+      {
+        "name": "Authorization",
+        "description": "Bearer <YOUR_LATCHSHOT_API_KEY>",
+        "required": true
+      }
+    ]
+  },
+  {
     "id": "linux-mcp-server",
     "name": "Linux MCP Server",
     "description": "Tools to allow LLM clients to interact with Linux systems remotely",

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -403,7 +403,6 @@
     "url": "https://latchshot.fly.dev/mcp",
     "type": "streamable-http",
     "link": "https://github.com/BaiqingL/latchshot-mcp",
-    "documentation": "https://latchshot.fly.dev/guides/screenshot-mcp-server.html",
     "installation_notes": "This is a remote extension that requires a Latchshot API key from https://latchshot.fly.dev/?intent=goose#trial as a request header, e.g. Authorization: Bearer <YOUR_LATCHSHOT_API_KEY>. The recurring Free plan includes 100 successful renders per UTC calendar month with no credit card; only public HTTP/HTTPS targets are supported.",
     "is_builtin": false,
     "endorsed": false,

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -413,7 +413,8 @@
         "description": "Bearer <YOUR_LATCHSHOT_API_KEY>",
         "required": true
       }
-    ]
+    ],
+    "show_install_command": false
   },
   {
     "id": "linux-mcp-server",


### PR DESCRIPTION
## Summary

- add Latchshot to the goose extensions directory as a remote Streamable HTTP MCP server
- add the matching Latchshot setup page used by the directory details route
- declare the required Bearer authorization header and recurring Free-plan key path
- document the public-webpage boundary, two-tool contract, and successful-render allowance

The contribution follows the existing remote authenticated extension and tutorial patterns.

## Validation

- jq empty passes for documentation/static/servers.json
- verified exactly one latchshot ID and no duplicate IDs
- verified the goose installer deeplink fields and balanced MDX code fences
- all linked production, docs, and repository URLs return HTTP 200
- unauthenticated MCP initialization returns HTTP 401
- live goose 1.43.0 run authenticated, discovered get_usage and capture_page, and captured https://example.com once as an 800 by 450 PNG
- goose received a 15,155-byte artifact with 450 ms render time, complete navigation, original fonts, active scripts, and quota moving from 2 to 1
- the bounded QA key was revoked after the run and now returns HTTP 401
- applicable CI and quarantine checks pass

## Disclosure

I maintain Latchshot. This is a community extension submission; endorsed remains false.