### PR TITLE
feat(installer): detect Termux and select musl portable build

### DIFF
--- a/BUILDING_LINUX.md
+++ b/BUILDING_LINUX.md
@@ -27,17 +27,27 @@ sudo dnf install dpkg-dev fakeroot gcc gcc-c++ make libxcb-devel vulkan-headers 
 sudo zypper install dpkg fakeroot gcc gcc-c++ make vulkan-headers vulkan-loader glslc
 ```
 
-**android / termux:**
+**Android / Termux:**
 
-goose is not officially support termux build yet, you need some minor patch to fix build issues.
-We will publish goose (block-goose) into termux-packages. <!-- NOTE: package name kept for backwards compat -->
-If you want to try there is a non-official build, https://github.com/shawn111/goose/releases/download/termux/goose-termux-aarch64.tar.bz2
-For more details, see: https://github.com/aaif-goose/goose/pull/3890
+The `download_cli.sh` installer detects Termux and automatically selects the
+musl portable build (`GOOSE_LINUX_VARIANT=musl`). To install:
 
 ```bash
-pkg install rust
-pkg install cmake protobuf clang build-essential
+curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh | bash
 ```
+
+To build from source in Termux:
+
+```bash
+pkg install rust cmake protobuf clang build-essential
+cargo build --release -p goose-cli --bin goose --no-default-features --features portable-default
+```
+
+> **Note:** The musl/portable build disables `local-inference` (V8) and
+> `system-keyring` (D-Bus SecretService) since neither is available on Android.
+
+Community builds: https://github.com/shawn111/goose/releases/download/termux/goose-termux-aarch64.tar.bz2
+Original PR: https://github.com/aaif-goose/goose/pull/3890
 
 ### Development Tools
 

--- a/BUILDING_LINUX.md
+++ b/BUILDING_LINUX.md
@@ -46,7 +46,6 @@ cargo build --release -p goose-cli --bin goose --no-default-features --features 
 > **Note:** The musl/portable build disables `local-inference` (V8) and
 > `system-keyring` (D-Bus SecretService) since neither is available on Android.
 
-Community builds: https://github.com/shawn111/goose/releases/download/termux/goose-termux-aarch64.tar.bz2
 Original PR: https://github.com/aaif-goose/goose/pull/3890
 
 ### Development Tools

--- a/download_cli.sh
+++ b/download_cli.sh
@@ -7,7 +7,7 @@ set -eu
 # This script downloads the latest stable 'goose' CLI binary from GitHub releases
 # and installs it to your system.
 #
-# Supported OS: macOS (darwin), Linux, Windows (MSYS2/Git Bash/WSL)
+# Supported OS: macOS (darwin), Linux, Windows (MSYS2/Git Bash/WSL), Android (Termux)
 # Supported Architectures: x86_64, arm64
 #
 # Usage:
@@ -152,6 +152,12 @@ detect_linux_musl() {
 
   return 1
 }
+
+# Termux on Android: the musl portable build is the best fit (no system-keyring, no local-inference).
+if [ "$OS" = "linux" ] && [ -n "${TERMUX_VERSION:-}" ] && [ -z "$GOOSE_LINUX_VARIANT" ]; then
+  echo "Termux detected (v$TERMUX_VERSION). Using musl portable build."
+  GOOSE_LINUX_VARIANT="musl"
+fi
 
 if [ "$OS" = "linux" ] && [ -z "$GOOSE_LINUX_VARIANT" ]; then
   if detect_linux_musl; then

--- a/download_cli.sh
+++ b/download_cli.sh
@@ -98,6 +98,10 @@ else
   # If explicit Windows-like shells/variables are present (MSYS/Cygwin), treat as windows.
   if [[ "${WINDIR:-}" ]] || [[ "${windir:-}" ]] || [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
     OS="windows"
+  elif [[ -n "${TERMUX_VERSION:-}" ]]; then
+    # Termux on Android: treat as Linux before the Windows mount heuristic,
+    # since /d may exist on Android and would incorrectly match as Windows.
+    OS="linux"
   elif [[ -f "/proc/version" ]] && grep -q "Microsoft\|WSL" /proc/version 2>/dev/null; then
     # WSL is a Linux environment regardless of the current working directory.
     # The PWD (e.g. /mnt/c/) does not change the kernel — always install Linux.
@@ -248,7 +252,7 @@ if ! curl -sLf "$DOWNLOAD_URL" --output "$FILE"; then
 fi
 
 # Create a temporary directory for extraction
-TMP_DIR="/tmp/goose_install_$RANDOM"
+TMP_DIR="${TMPDIR:-/tmp}/goose_install_$RANDOM"
 if ! mkdir -p "$TMP_DIR"; then
   echo "Error: Could not create temporary extraction directory"
   exit 1


### PR DESCRIPTION
## Summary

 now detects Termux via $TERMUX_VERSION and defaults to the **musl portable build** instead of standard glibc. This is the only viable build on Android (no D-Bus SecretService, no V8).

## Changes

- ****: Auto-selects `GOOSE_LINUX_VARIANT=musl` when Termux is detected
- ****: Rewrote Android/Termux section with one-liner install and build-from-source instructions

## Notes

The musl/portable build disables `local-inference` (V8) and `system-keyring` (D-Bus SecretService) since neither is available on Android. No new CI jobs or feature flags added — this is the lowest-maintenance path.

Related: #3890