### PR TITLE
Add SitesPlaced remote MCP extension to servers directory

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -36,7 +36,7 @@
   {
     "id": "apify",
     "name": "Apify",
-    "description": "Extract data from any website with thousands of scrapers, crawlers, and automations on Apify Store \u26a1",
+    "description": "Extract data from any website with thousands of scrapers, crawlers, and automations on Apify Store ⚡",
     "command": "npx -y @apify/actors-mcp-server",
     "link": "https://github.com/apify/apify-mcp-server",
     "installation_notes": "Install using npx. Requires an Apify API token.",
@@ -648,6 +648,18 @@
     "environmentVariables": []
   },
   {
+    "id": "sitesplaced-mcp",
+    "name": "SitesPlaced",
+    "description": "Build, edit, and publish websites and online stores by chatting",
+    "url": "https://sitesplaced.com/api/mcp",
+    "link": "https://sitesplaced.com/developers/mcp",
+    "installation_notes": "Hosted remote MCP server. Sign in with your SitesPlaced account via OAuth when prompted - no API keys required.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [],
+    "type": "streamable-http"
+  },
+  {
     "id": "square-mcp",
     "name": "Square",
     "description": "Square API for payments and business management",
@@ -774,7 +786,7 @@
   {
     "id": "cash-app",
     "name": "Cash App",
-    "description": "Cash App brings local food ordering into the AI era. Discover nearby sellers, browse menus with calories and allergen info, customize orders, and complete checkout\u2014all conversationally.",
+    "description": "Cash App brings local food ordering into the AI era. Discover nearby sellers, browse menus with calories and allergen info, customize orders, and complete checkout—all conversationally.",
     "type": "streamable-http",
     "url": "https://connect.squareup.com/v2/mcp/cash-app",
     "link": "",
@@ -784,26 +796,25 @@
     "environmentVariables": []
   },
   {
-  "id": "scholar-sidekick",
-  "name": "Scholar Sidekick",
-  "description": "Resolve, format, export, and verify academic citations (DOI, PMID, ISBN, arXiv) plus retraction and open-access checks",
-  "command": "npx -y scholar-sidekick-mcp@latest",
-  "link": "https://github.com/mlava/scholar-sidekick-mcp",
-  "installation_notes": "No API key required — works anonymously on a free, rate-limited tier. Optionally set SCHOLAR_API_KEY (a free first-party ssk_ key from https://scholar-sidekick.com/account) for higher limits, or RAPIDAPI_KEY for paid tiers via RapidAPI.",
-  "is_builtin": false,
-  "endorsed": false,
-  "environmentVariables": [
-    {
-      "name": "SCHOLAR_API_KEY",
-      "description": "Optional first-party API key (ssk_) from https://scholar-sidekick.com/account; raises rate limits. Sent as Authorization: Bearer.",
-      "required": false
-    },
-    {
-      "name": "RAPIDAPI_KEY",
-      "description": "Optional RapidAPI key for paid/managed tiers; routes calls through the RapidAPI gateway.",
-      "required": false
-    }
-  ]
-}
-
+    "id": "scholar-sidekick",
+    "name": "Scholar Sidekick",
+    "description": "Resolve, format, export, and verify academic citations (DOI, PMID, ISBN, arXiv) plus retraction and open-access checks",
+    "command": "npx -y scholar-sidekick-mcp@latest",
+    "link": "https://github.com/mlava/scholar-sidekick-mcp",
+    "installation_notes": "No API key required — works anonymously on a free, rate-limited tier. Optionally set SCHOLAR_API_KEY (a free first-party ssk_ key from https://scholar-sidekick.com/account) for higher limits, or RAPIDAPI_KEY for paid tiers via RapidAPI.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [
+      {
+        "name": "SCHOLAR_API_KEY",
+        "description": "Optional first-party API key (ssk_) from https://scholar-sidekick.com/account; raises rate limits. Sent as Authorization: Bearer.",
+        "required": false
+      },
+      {
+        "name": "RAPIDAPI_KEY",
+        "description": "Optional RapidAPI key for paid/managed tiers; routes calls through the RapidAPI gateway.",
+        "required": false
+      }
+    ]
+  }
 ]


### PR DESCRIPTION
Adds **SitesPlaced** to `documentation/static/servers.json` as a remote `streamable-http` extension (inserted alphabetically after selenium-mcp).

- **What it is:** official hosted MCP server for [SitesPlaced](https://sitesplaced.com), a website + online-store builder — create, edit, and publish real sites and stores by chatting
- **Endpoint:** `https://sitesplaced.com/api/mcp` (Streamable HTTP)
- **Auth:** OAuth 2.1 + PKCE with dynamic client registration — Goose's OAuth flow handles sign-in; no API keys or env vars needed (`environmentVariables: []`)
- **Also published:** Official MCP Registry as `com.sitesplaced/sitesplaced`
- **Docs:** https://sitesplaced.com/developers/mcp

Followed the existing remote-entry pattern (`type: streamable-http` + `url`, e.g. the dev.to entry). `endorsed` left `false` for maintainers to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)