### PR TITLE
feat: tab completion and switch provider for `model`

### DIFF
--- a/crates/goose-cli/src/session/completion.rs
+++ b/crates/goose-cli/src/session/completion.rs
@@ -146,30 +146,19 @@ impl GooseCompleter {
         Ok((pos, candidates))
     }
 
-    /// Complete model names (and providers) for the /model command.
-    ///
-    /// Handles these completion contexts:
-    ///   /model <TAB>                  → models for the current provider
-    ///   /model --p<TAB>               → the --provider flag
-    ///   /model --provider <TAB>       → provider names
-    ///   /model --provider <p> <TAB>   → models for provider <p>
     fn complete_model_names(&self, line: &str) -> Result<(usize, Vec<Pair>)> {
         let after_cmd = line.strip_prefix("/model").unwrap_or("").trim_start();
 
-        // Case: --provider flag (partial or complete)
         if after_cmd == "--provider" || after_cmd.starts_with("--provider ") {
             let flag_rest = after_cmd.strip_prefix("--provider").unwrap_or("").trim();
             if after_cmd == "--provider" {
-                // Just the flag, no space yet — user might type more of the flag or space
                 return Ok((line.len(), vec![]));
             }
 
-            // We have "--provider <rest>" — split into provider + optional model
             let parts: Vec<&str> = flag_rest.split_whitespace().collect();
             let trailing_space = after_cmd.ends_with(' ');
 
             if parts.is_empty() || (parts.len() == 1 && !trailing_space) {
-                // Completing the provider name
                 let partial = if parts.is_empty() { "" } else { parts[0] };
                 let cache = self.completion_cache.read().unwrap();
                 let candidates: Vec<Pair> = cache
@@ -185,7 +174,6 @@ impl GooseCompleter {
                 return Ok((pos, candidates));
             }
 
-            // Provider is selected, completing model name
             let provider_name = parts[0];
             let partial = if parts.len() > 1 && !trailing_space {
                 parts[1]
@@ -195,7 +183,6 @@ impl GooseCompleter {
             return self.models_completion_from_cache(provider_name, partial, line);
         }
 
-        // Case: partial --provider flag (e.g. "/model --p")
         if after_cmd.starts_with("--") {
             let flag_partial = &after_cmd;
             if "--provider".starts_with(flag_partial) {
@@ -210,7 +197,6 @@ impl GooseCompleter {
             return Ok((line.len(), vec![]));
         }
 
-        // Case: completing a model name for the current session provider
         let current_provider = {
             let cache = self.completion_cache.read().unwrap();
             if cache.current_session_provider.is_empty() {
@@ -222,7 +208,6 @@ impl GooseCompleter {
         self.models_completion_from_cache(&current_provider, after_cmd, line)
     }
 
-    /// Build completion candidates for model names of a given provider from the cache.
     fn models_completion_from_cache(
         &self,
         provider_name: &str,
@@ -651,7 +636,6 @@ mod tests {
             .prompt_info
             .insert("other_prompt".to_string(), other_prompt_info);
 
-        // Add test provider/model data for /model tab-completion
         cache.provider_names = vec![
             "anthropic".to_string(),
             "openai".to_string(),
@@ -715,7 +699,6 @@ mod tests {
         let cache = create_test_cache();
         let completer = GooseCompleter::new(cache);
 
-        // /model --provider <TAB> → completes provider names
         let (pos, candidates) = completer
             .complete_model_names("/model --provider ")
             .unwrap();
@@ -725,7 +708,6 @@ mod tests {
         assert!(candidates.iter().any(|c| c.display == "openai"));
         assert!(candidates.iter().any(|c| c.display == "zai"));
 
-        // /model --provider a<TAB> → partial provider name
         let (pos, candidates) = completer
             .complete_model_names("/model --provider a")
             .unwrap();
@@ -733,7 +715,6 @@ mod tests {
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].display, "anthropic");
 
-        // /model --provider anthropic <TAB> → models for anthropic
         let (pos, candidates) = completer
             .complete_model_names("/model --provider anthropic ")
             .unwrap();
@@ -741,7 +722,6 @@ mod tests {
         assert_eq!(candidates.len(), 2);
         assert!(candidates.iter().any(|c| c.display == "claude-sonnet-4"));
 
-        // /model --provider anthropic claude-s<TAB> → partial model name
         let (pos, candidates) = completer
             .complete_model_names("/model --provider anthropic claude-s")
             .unwrap();
@@ -749,7 +729,6 @@ mod tests {
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].display, "claude-sonnet-4");
 
-        // /model --p<TAB> → completes --provider flag
         let (pos, candidates) = completer.complete_model_names("/model --p").unwrap();
         assert_eq!(pos, "/model ".len());
         assert_eq!(candidates.len(), 1);
@@ -761,7 +740,6 @@ mod tests {
         let cache = create_test_cache();
         let completer = GooseCompleter::new(cache);
 
-        // /model --provider z<TAB> → only "zai" matches
         let (pos, candidates) = completer
             .complete_model_names("/model --provider z")
             .unwrap();
@@ -769,7 +747,6 @@ mod tests {
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].display, "zai");
 
-        // /model --provider zai <TAB> → single model for zai
         let (pos, candidates) = completer
             .complete_model_names("/model --provider zai ")
             .unwrap();
@@ -777,37 +754,28 @@ mod tests {
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].display, "glm-4.5");
 
-        // /model --provider nonexistent <TAB> → unknown provider, no models
         let (_pos, candidates) = completer
             .complete_model_names("/model --provider nonexistent ")
             .unwrap();
         assert!(candidates.is_empty());
 
-        // /model --provider anthropic nonexistent_model<TAB> → no model matches
         let (_pos, candidates) = completer
             .complete_model_names("/model --provider anthropic nonexistent_model")
             .unwrap();
         assert!(candidates.is_empty());
 
-        // /model --xyz → unknown flag → no candidates
         let (_pos, candidates) = completer.complete_model_names("/model --xyz").unwrap();
         assert!(candidates.is_empty());
 
-        // /model --provider nosuchprovider<TAB> → partial provider, no match
         let (_pos, candidates) = completer
             .complete_model_names("/model --provider nosuchprovider")
             .unwrap();
         assert!(candidates.is_empty());
 
-        // /model <TAB> → completes models for the current session provider (anthropic),
-        // not the global config provider. Regression test: previously this read
-        // Config::global() which could differ from the session provider after a
-        // /model --provider switch or session resume.
         let (_pos, candidates) = completer.complete_model_names("/model ").unwrap();
         assert!(candidates.iter().any(|c| c.display == "claude-sonnet-4"));
         assert!(candidates.iter().any(|c| c.display == "claude-haiku-4"));
 
-        // /model claude-s<TAB> → partial model for the session provider
         let (pos, candidates) = completer.complete_model_names("/model claude-s").unwrap();
         assert_eq!(pos, "/model ".len());
         assert_eq!(candidates.len(), 1);

--- a/crates/goose-cli/src/session/completion.rs
+++ b/crates/goose-cli/src/session/completion.rs
@@ -808,9 +808,7 @@ mod tests {
         assert!(candidates.iter().any(|c| c.display == "claude-haiku-4"));
 
         // /model claude-s<TAB> → partial model for the session provider
-        let (pos, candidates) = completer
-            .complete_model_names("/model claude-s")
-            .unwrap();
+        let (pos, candidates) = completer.complete_model_names("/model claude-s").unwrap();
         assert_eq!(pos, "/model ".len());
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].display, "claude-sonnet-4");

--- a/crates/goose-cli/src/session/completion.rs
+++ b/crates/goose-cli/src/session/completion.rs
@@ -1,5 +1,5 @@
 use goose::agents::execute_commands::list_commands;
-use goose::config::GooseMode;
+use goose::config::{Config, GooseMode};
 use rustyline::completion::{Completer, FilenameCompleter, Pair};
 use rustyline::highlight::{CmdKind, Highlighter};
 use rustyline::hint::Hinter;

--- a/crates/goose-cli/src/session/completion.rs
+++ b/crates/goose-cli/src/session/completion.rs
@@ -784,9 +784,7 @@ mod tests {
         assert!(candidates.is_empty());
 
         // /model --xyz → unknown flag → no candidates
-        let (_pos, candidates) = completer
-            .complete_model_names("/model --xyz")
-            .unwrap();
+        let (_pos, candidates) = completer.complete_model_names("/model --xyz").unwrap();
         assert!(candidates.is_empty());
 
         // /model --provider nosuchprovider<TAB> → partial provider, no match

--- a/crates/goose-cli/src/session/completion.rs
+++ b/crates/goose-cli/src/session/completion.rs
@@ -146,9 +146,99 @@ impl GooseCompleter {
         Ok((pos, candidates))
     }
 
-    /// Complete model names for the /model command.
+    /// Complete model names (and providers) for the /model command.
+    ///
+    /// Handles these completion contexts:
+    ///   /model <TAB>                  → models for the current provider
+    ///   /model --p<TAB>               → the --provider flag
+    ///   /model --provider <TAB>       → provider names
+    ///   /model --provider <p> <TAB>   → models for provider <p>
     fn complete_model_names(&self, line: &str) -> Result<(usize, Vec<Pair>)> {
-        Ok((line.len(), vec![]))
+        let after_cmd = line.strip_prefix("/model").unwrap_or("").trim_start();
+
+        // Case: --provider flag (partial or complete)
+        if after_cmd == "--provider" || after_cmd.starts_with("--provider ") {
+            let flag_rest = after_cmd.strip_prefix("--provider").unwrap_or("").trim();
+            if after_cmd == "--provider" {
+                // Just the flag, no space yet — user might type more of the flag or space
+                return Ok((line.len(), vec![]));
+            }
+
+            // We have "--provider <rest>" — split into provider + optional model
+            let parts: Vec<&str> = flag_rest.split_whitespace().collect();
+            let trailing_space = after_cmd.ends_with(' ');
+
+            if parts.is_empty() || (parts.len() == 1 && !trailing_space) {
+                // Completing the provider name
+                let partial = if parts.is_empty() { "" } else { parts[0] };
+                let cache = self.completion_cache.read().unwrap();
+                let candidates: Vec<Pair> = cache
+                    .provider_names
+                    .iter()
+                    .filter(|name| name.starts_with(partial))
+                    .map(|name| Pair {
+                        display: name.clone(),
+                        replacement: format!("{} ", name),
+                    })
+                    .collect();
+                let pos = line.len() - partial.len();
+                return Ok((pos, candidates));
+            }
+
+            // Provider is selected, completing model name
+            let provider_name = parts[0];
+            let partial = if parts.len() > 1 && !trailing_space {
+                parts[1]
+            } else {
+                ""
+            };
+            return self.models_completion_from_cache(provider_name, partial, line);
+        }
+
+        // Case: partial --provider flag (e.g. "/model --p")
+        if after_cmd.starts_with("--") {
+            let flag_partial = &after_cmd;
+            if "--provider".starts_with(flag_partial) {
+                return Ok((
+                    line.len() - flag_partial.len(),
+                    vec![Pair {
+                        display: "--provider".to_string(),
+                        replacement: "--provider ".to_string(),
+                    }],
+                ));
+            }
+            return Ok((line.len(), vec![]));
+        }
+
+        // Case: completing a model name for the current provider
+        let current_provider = goose::config::Config::global()
+            .get_goose_provider()
+            .unwrap_or_default();
+        self.models_completion_from_cache(&current_provider, after_cmd, line)
+    }
+
+    /// Build completion candidates for model names of a given provider from the cache.
+    fn models_completion_from_cache(
+        &self,
+        provider_name: &str,
+        partial: &str,
+        full_line: &str,
+    ) -> Result<(usize, Vec<Pair>)> {
+        let cache = self.completion_cache.read().unwrap();
+        let models = cache.provider_models.get(provider_name);
+        let candidates: Vec<Pair> = match models {
+            Some(names) if !names.is_empty() => names
+                .iter()
+                .filter(|name| name.starts_with(partial))
+                .map(|name| Pair {
+                    display: name.clone(),
+                    replacement: format!("{} ", name),
+                })
+                .collect(),
+            _ => vec![],
+        };
+        let pos = full_line.len() - partial.len();
+        Ok((pos, candidates))
     }
 
     /// Complete slash commands
@@ -556,6 +646,24 @@ mod tests {
             .prompt_info
             .insert("other_prompt".to_string(), other_prompt_info);
 
+        // Add test provider/model data for /model tab-completion
+        cache.provider_names = vec![
+            "anthropic".to_string(),
+            "openai".to_string(),
+            "zai".to_string(),
+        ];
+        cache.provider_models.insert(
+            "anthropic".to_string(),
+            vec!["claude-sonnet-4".to_string(), "claude-haiku-4".to_string()],
+        );
+        cache.provider_models.insert(
+            "openai".to_string(),
+            vec!["gpt-4.1".to_string(), "gpt-4.1-mini".to_string()],
+        );
+        cache
+            .provider_models
+            .insert("zai".to_string(), vec!["glm-4.5".to_string()]);
+
         Arc::new(RwLock::new(cache))
     }
 
@@ -601,13 +709,45 @@ mod tests {
         let cache = create_test_cache();
         let completer = GooseCompleter::new(cache);
 
-        let (pos, candidates) = completer.complete_model_names("/model ").unwrap();
-        assert_eq!(pos, "/model ".len());
-        assert!(candidates.is_empty());
+        // /model --provider <TAB> → completes provider names
+        let (pos, candidates) = completer
+            .complete_model_names("/model --provider ")
+            .unwrap();
+        assert_eq!(pos, "/model --provider ".len());
+        assert!(candidates.len() >= 3);
+        assert!(candidates.iter().any(|c| c.display == "anthropic"));
+        assert!(candidates.iter().any(|c| c.display == "openai"));
+        assert!(candidates.iter().any(|c| c.display == "zai"));
 
-        let (pos, candidates) = completer.complete_model_names("/model gpt").unwrap();
-        assert_eq!(pos, "/model gpt".len());
-        assert!(candidates.is_empty());
+        // /model --provider a<TAB> → partial provider name
+        let (pos, candidates) = completer
+            .complete_model_names("/model --provider a")
+            .unwrap();
+        assert_eq!(pos, "/model --provider ".len());
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].display, "anthropic");
+
+        // /model --provider anthropic <TAB> → models for anthropic
+        let (pos, candidates) = completer
+            .complete_model_names("/model --provider anthropic ")
+            .unwrap();
+        assert_eq!(pos, "/model --provider anthropic ".len());
+        assert_eq!(candidates.len(), 2);
+        assert!(candidates.iter().any(|c| c.display == "claude-sonnet-4"));
+
+        // /model --provider anthropic claude-s<TAB> → partial model name
+        let (pos, candidates) = completer
+            .complete_model_names("/model --provider anthropic claude-s")
+            .unwrap();
+        assert_eq!(pos, "/model --provider anthropic ".len());
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].display, "claude-sonnet-4");
+
+        // /model --p<TAB> → completes --provider flag
+        let (pos, candidates) = completer.complete_model_names("/model --p").unwrap();
+        assert_eq!(pos, "/model ".len());
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].display, "--provider");
     }
 
     #[test]

--- a/crates/goose-cli/src/session/completion.rs
+++ b/crates/goose-cli/src/session/completion.rs
@@ -210,10 +210,15 @@ impl GooseCompleter {
             return Ok((line.len(), vec![]));
         }
 
-        // Case: completing a model name for the current provider
-        let current_provider = goose::config::Config::global()
-            .get_goose_provider()
-            .unwrap_or_default();
+        // Case: completing a model name for the current session provider
+        let current_provider = {
+            let cache = self.completion_cache.read().unwrap();
+            if cache.current_session_provider.is_empty() {
+                Config::global().get_goose_provider().unwrap_or_default()
+            } else {
+                cache.current_session_provider.clone()
+            }
+        };
         self.models_completion_from_cache(&current_provider, after_cmd, line)
     }
 
@@ -652,6 +657,7 @@ mod tests {
             "openai".to_string(),
             "zai".to_string(),
         ];
+        cache.current_session_provider = "anthropic".to_string();
         cache.provider_models.insert(
             "anthropic".to_string(),
             vec!["claude-sonnet-4".to_string(), "claude-haiku-4".to_string()],
@@ -792,6 +798,22 @@ mod tests {
             .complete_model_names("/model --provider nosuchprovider")
             .unwrap();
         assert!(candidates.is_empty());
+
+        // /model <TAB> → completes models for the current session provider (anthropic),
+        // not the global config provider. Regression test: previously this read
+        // Config::global() which could differ from the session provider after a
+        // /model --provider switch or session resume.
+        let (_pos, candidates) = completer.complete_model_names("/model ").unwrap();
+        assert!(candidates.iter().any(|c| c.display == "claude-sonnet-4"));
+        assert!(candidates.iter().any(|c| c.display == "claude-haiku-4"));
+
+        // /model claude-s<TAB> → partial model for the session provider
+        let (pos, candidates) = completer
+            .complete_model_names("/model claude-s")
+            .unwrap();
+        assert_eq!(pos, "/model ".len());
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].display, "claude-sonnet-4");
     }
 
     #[test]

--- a/crates/goose-cli/src/session/completion.rs
+++ b/crates/goose-cli/src/session/completion.rs
@@ -751,6 +751,52 @@ mod tests {
     }
 
     #[test]
+    fn test_complete_model_names_edge_cases() {
+        let cache = create_test_cache();
+        let completer = GooseCompleter::new(cache);
+
+        // /model --provider z<TAB> → only "zai" matches
+        let (pos, candidates) = completer
+            .complete_model_names("/model --provider z")
+            .unwrap();
+        assert_eq!(pos, "/model --provider ".len());
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].display, "zai");
+
+        // /model --provider zai <TAB> → single model for zai
+        let (pos, candidates) = completer
+            .complete_model_names("/model --provider zai ")
+            .unwrap();
+        assert_eq!(pos, "/model --provider zai ".len());
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].display, "glm-4.5");
+
+        // /model --provider nonexistent <TAB> → unknown provider, no models
+        let (_pos, candidates) = completer
+            .complete_model_names("/model --provider nonexistent ")
+            .unwrap();
+        assert!(candidates.is_empty());
+
+        // /model --provider anthropic nonexistent_model<TAB> → no model matches
+        let (_pos, candidates) = completer
+            .complete_model_names("/model --provider anthropic nonexistent_model")
+            .unwrap();
+        assert!(candidates.is_empty());
+
+        // /model --xyz → unknown flag → no candidates
+        let (_pos, candidates) = completer
+            .complete_model_names("/model --xyz")
+            .unwrap();
+        assert!(candidates.is_empty());
+
+        // /model --provider nosuchprovider<TAB> → partial provider, no match
+        let (_pos, candidates) = completer
+            .complete_model_names("/model --provider nosuchprovider")
+            .unwrap();
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
     fn test_complete_prompt_names() {
         let cache = create_test_cache();
         let completer = GooseCompleter::new(cache);

--- a/crates/goose-cli/src/session/input.rs
+++ b/crates/goose-cli/src/session/input.rs
@@ -23,7 +23,7 @@ pub enum InputResult {
     ListPrompts(Option<String>),
     PromptCommand(PromptCommandOptions),
     GooseMode(String),
-    Model(Option<String>),
+    Model(ModelCommandOptions),
     Plan(PlanCommandOptions),
     EndPlan,
     Clear,
@@ -45,6 +45,12 @@ pub struct PromptCommandOptions {
 #[derive(Debug)]
 pub struct PlanCommandOptions {
     pub message_text: String,
+}
+
+#[derive(Debug, Default)]
+pub struct ModelCommandOptions {
+    pub provider: Option<String>,
+    pub model: Option<String>,
 }
 
 struct CtrlCHandler {
@@ -295,17 +301,30 @@ fn handle_slash_command(input: &str) -> Option<InputResult> {
         s if s.starts_with(CMD_MODE) => Some(InputResult::GooseMode(
             s.get(CMD_MODE.len()..).unwrap_or("").to_string(),
         )),
-        s if s == CMD_MODEL => Some(InputResult::Model(None)),
+        s if s == CMD_MODEL => Some(InputResult::Model(ModelCommandOptions::default())),
         s if s.starts_with(CMD_MODEL_WITH_SPACE) => {
-            let model = s
+            let rest = s
                 .get(CMD_MODEL_WITH_SPACE.len()..)
                 .unwrap_or("")
                 .trim()
                 .to_string();
-            if model.is_empty() {
-                Some(InputResult::Model(None))
+            if rest.is_empty() {
+                Some(InputResult::Model(ModelCommandOptions::default()))
+            } else if let Some(after_flag) = rest.strip_prefix("--provider ") {
+                let parts: Vec<&str> = after_flag.split_whitespace().collect();
+                let provider = parts.first().map(|s| s.to_string());
+                let model = parts.get(1).map(|s| s.to_string());
+                Some(InputResult::Model(ModelCommandOptions { provider, model }))
+            } else if rest == "--provider" {
+                Some(InputResult::Model(ModelCommandOptions {
+                    provider: Some(String::new()),
+                    model: None,
+                }))
             } else {
-                Some(InputResult::Model(Some(model)))
+                Some(InputResult::Model(ModelCommandOptions {
+                    provider: None,
+                    model: Some(rest),
+                }))
             }
         }
         s if s.starts_with(CMD_PLAN) => {
@@ -454,6 +473,7 @@ fn help_text() -> String {
 /prompt <n> [--info] [key=value...] - Get prompt info or execute a prompt
 /mode <name> - Set the goose mode to use ({modes})
 /model [name] - Show the current model, or switch models for this session while keeping the same provider
+/model --provider <name> [model] - Switch to a different provider (optionally specifying a model)
 /plan <message_text> -  Enters 'plan' mode with optional message. Create a plan based on the current messages and asks user if they want to act on it.
                         If user acts on the plan, goose mode is set to 'auto' and returns to 'normal' goose mode.
                         To warm up goose before using '/plan', we recommend setting '/mode approve' & putting appropriate context into goose.
@@ -574,16 +594,45 @@ mod tests {
         // Test model command
         assert!(matches!(
             handle_slash_command("/model"),
-            Some(InputResult::Model(None))
+            Some(InputResult::Model(ModelCommandOptions {
+                provider: None,
+                model: None
+            }))
         ));
         assert!(matches!(
             handle_slash_command("/model   "),
-            Some(InputResult::Model(None))
+            Some(InputResult::Model(ModelCommandOptions {
+                provider: None,
+                model: None
+            }))
         ));
-        if let Some(InputResult::Model(Some(model))) = handle_slash_command("/model gpt-4.1") {
-            assert_eq!(model, "gpt-4.1");
+        if let Some(InputResult::Model(ModelCommandOptions { provider, model })) =
+            handle_slash_command("/model gpt-4.1")
+        {
+            assert_eq!(model.as_deref(), Some("gpt-4.1"));
+            assert!(provider.is_none());
         } else {
             panic!("Expected Model");
+        }
+
+        // Test /model --provider <name> (provider only)
+        if let Some(InputResult::Model(ModelCommandOptions { provider, model })) =
+            handle_slash_command("/model --provider anthropic")
+        {
+            assert_eq!(provider.as_deref(), Some("anthropic"));
+            assert!(model.is_none());
+        } else {
+            panic!("Expected Model with provider");
+        }
+
+        // Test /model --provider <name> <model> (both provider and model)
+        if let Some(InputResult::Model(ModelCommandOptions { provider, model })) =
+            handle_slash_command("/model --provider anthropic claude-sonnet-4")
+        {
+            assert_eq!(provider.as_deref(), Some("anthropic"));
+            assert_eq!(model.as_deref(), Some("claude-sonnet-4"));
+        } else {
+            panic!("Expected Model with provider and model");
         }
 
         // Test unknown commands

--- a/crates/goose-cli/src/session/input.rs
+++ b/crates/goose-cli/src/session/input.rs
@@ -635,6 +635,36 @@ mod tests {
             panic!("Expected Model with provider and model");
         }
 
+        // Test /model --provider (bare flag, no value yet)
+        if let Some(InputResult::Model(ModelCommandOptions { provider, model })) =
+            handle_slash_command("/model --provider")
+        {
+            assert_eq!(provider.as_deref(), Some(""));
+            assert!(model.is_none());
+        } else {
+            panic!("Expected Model with empty provider");
+        }
+
+        // Test /model --provider (trailing space, same as bare flag after trim)
+        if let Some(InputResult::Model(ModelCommandOptions { provider, model })) =
+            handle_slash_command("/model --provider ")
+        {
+            assert_eq!(provider.as_deref(), Some(""));
+            assert!(model.is_none());
+        } else {
+            panic!("Expected Model with empty provider (trailing space)");
+        }
+
+        // Test extra whitespace between provider and model args
+        if let Some(InputResult::Model(ModelCommandOptions { provider, model })) =
+            handle_slash_command("/model --provider   anthropic    claude-sonnet-4")
+        {
+            assert_eq!(provider.as_deref(), Some("anthropic"));
+            assert_eq!(model.as_deref(), Some("claude-sonnet-4"));
+        } else {
+            panic!("Expected Model with extra whitespace handled");
+        }
+
         // Test unknown commands
         assert!(handle_slash_command("/unknown").is_none());
     }

--- a/crates/goose-cli/src/session/input.rs
+++ b/crates/goose-cli/src/session/input.rs
@@ -313,7 +313,10 @@ fn handle_slash_command(input: &str) -> Option<InputResult> {
             } else if let Some(after_flag) = rest.strip_prefix("--provider ") {
                 let parts: Vec<&str> = after_flag.split_whitespace().collect();
                 let provider = parts.first().map(|s| s.to_string());
-                let model = parts.get(1).map(|s| s.to_string());
+                let model = parts
+                    .get(1..)
+                    .filter(|parts| !parts.is_empty())
+                    .map(|parts| parts.join(" "));
                 Some(InputResult::Model(ModelCommandOptions { provider, model }))
             } else if rest == "--provider" {
                 Some(InputResult::Model(ModelCommandOptions {
@@ -615,7 +618,6 @@ mod tests {
             panic!("Expected Model");
         }
 
-        // Test /model --provider <name> (provider only)
         if let Some(InputResult::Model(ModelCommandOptions { provider, model })) =
             handle_slash_command("/model --provider anthropic")
         {
@@ -625,7 +627,6 @@ mod tests {
             panic!("Expected Model with provider");
         }
 
-        // Test /model --provider <name> <model> (both provider and model)
         if let Some(InputResult::Model(ModelCommandOptions { provider, model })) =
             handle_slash_command("/model --provider anthropic claude-sonnet-4")
         {
@@ -635,7 +636,6 @@ mod tests {
             panic!("Expected Model with provider and model");
         }
 
-        // Test /model --provider (bare flag, no value yet)
         if let Some(InputResult::Model(ModelCommandOptions { provider, model })) =
             handle_slash_command("/model --provider")
         {
@@ -645,7 +645,6 @@ mod tests {
             panic!("Expected Model with empty provider");
         }
 
-        // Test /model --provider (trailing space, same as bare flag after trim)
         if let Some(InputResult::Model(ModelCommandOptions { provider, model })) =
             handle_slash_command("/model --provider ")
         {
@@ -655,7 +654,6 @@ mod tests {
             panic!("Expected Model with empty provider (trailing space)");
         }
 
-        // Test extra whitespace between provider and model args
         if let Some(InputResult::Model(ModelCommandOptions { provider, model })) =
             handle_slash_command("/model --provider   anthropic    claude-sonnet-4")
         {

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -46,7 +46,10 @@ use rmcp::model::{ErrorCode, ErrorData};
 use strum::VariantNames;
 
 use goose::config::paths::Paths;
+use goose::config::providers;
 use goose::conversation::message::{ActionRequiredData, Message, MessageContent};
+use goose::providers::inventory::ProviderInventoryService;
+use goose::session::SessionManager;
 use rustyline::EditMode;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -1680,6 +1683,39 @@ impl CliSession {
         let prompts = self.agent.list_extension_prompts(&self.session_id).await;
         let all_providers = goose::providers::providers().await;
 
+        // Fetch inventory-fetched models (dynamically discovered via API refresh)
+        // to supplement the static known_models list.
+        let provider_ids: Vec<String> =
+            all_providers.iter().map(|(m, _)| m.name.clone()).collect();
+        let inventory_models: HashMap<String, Vec<String>> = {
+            let storage = SessionManager::instance().storage().clone();
+            let inventory = ProviderInventoryService::new(storage);
+            inventory
+                .entries(&provider_ids)
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .map(|entry| {
+                    let model_ids: Vec<String> =
+                        entry.models.iter().map(|m| m.id.clone()).collect();
+                    (entry.provider_id, model_ids)
+                })
+                .collect()
+        };
+
+        // Fetch configured model per provider from config so the user's
+        // currently-selected model always appears in completion, even if it
+        // is not in the static or inventory model lists.
+        let config = Config::global();
+        let configured_models: HashMap<String, String> = all_providers
+            .iter()
+            .filter_map(|(m, _)| {
+                providers::get_provider_entry(config, &m.name)
+                    .map(|entry| (m.name.clone(), entry.model))
+                    .filter(|(_, model)| !model.is_empty())
+            })
+            .collect();
+
         // Update the cache with write lock
         let mut cache = self.completion_cache.write().unwrap();
         cache.prompts.clear();
@@ -1702,15 +1738,31 @@ impl CliSession {
             }
         }
 
-        // Populate provider/model data for /model tab-completion
+        // Populate provider/model data for /model tab-completion.
+        // Models are merged from three sources, deduplicated:
+        //   1. Static known_models from provider metadata (curated list)
+        //   2. Inventory-fetched models (dynamically discovered via API refresh)
+        //   3. The user's currently-configured model for each provider
         cache.provider_names = all_providers.iter().map(|(m, _)| m.name.clone()).collect();
         cache.provider_models.clear();
         for (metadata, _) in &all_providers {
-            let models: Vec<String> = metadata
-                .known_models
-                .iter()
-                .map(|m| m.name.clone())
-                .collect();
+            let mut models: Vec<String> =
+                metadata.known_models.iter().map(|m| m.name.clone()).collect();
+
+            if let Some(inv_models) = inventory_models.get(&metadata.name) {
+                for model_id in inv_models {
+                    if !models.contains(model_id) {
+                        models.push(model_id.clone());
+                    }
+                }
+            }
+
+            if let Some(model) = configured_models.get(&metadata.name) {
+                if !models.contains(model) {
+                    models.push(model.clone());
+                }
+            }
+
             cache.provider_models.insert(metadata.name.clone(), models);
         }
 

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -868,6 +868,12 @@ impl CliSession {
             .filter(|s| !s.is_empty());
         let target_provider_name = requested_provider.unwrap_or(&current_provider_name);
 
+        // Reject a bare --provider flag with no value
+        if options.provider.is_some() && requested_provider.is_none() {
+            output::render_error("Provider name is required after '--provider'.");
+            return Ok(());
+        }
+
         // Validate that the target provider exists in the registry
         let target_entry = match goose::providers::get_from_registry(target_provider_name).await {
             Ok(entry) => entry,
@@ -888,22 +894,7 @@ impl CliSession {
             return Ok(());
         }
 
-        if requested_provider.is_some() {
-            // Provider switching path — we don't have a Provider instance for the
-            // target yet, so check whether it's known to manage its own context.
-            if target_entry
-                .metadata()
-                .config_keys
-                .iter()
-                .any(|k| k.name == "manages_own_context")
-            {
-                output::render_error(&format!(
-                    "Session provider switching is not supported for '{}' because it manages its own conversation context.",
-                    target_provider_name
-                ));
-                return Ok(());
-            }
-        } else if provider.manages_own_context() {
+        if requested_provider.is_none() && provider.manages_own_context() {
             output::render_error(&format!(
                 "Session model switching is not supported for provider '{}' because it manages its own conversation context.",
                 current_provider_name
@@ -992,6 +983,14 @@ impl CliSession {
                 return Ok(());
             }
         };
+
+        if new_provider.manages_own_context() {
+            output::render_error(&format!(
+                "Session provider switching is not supported for '{}' because it manages its own conversation context.",
+                target_provider_name
+            ));
+            return Ok(());
+        }
 
         self.agent
             .update_provider(new_provider, new_model_config, &self.session_id)

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -896,9 +896,9 @@ impl CliSession {
             return Ok(());
         }
 
-        if requested_provider.is_none() && provider.manages_own_context() {
+        if provider.manages_own_context() {
             output::render_error(&format!(
-                "Session model switching is not supported for provider '{}' because it manages its own conversation context.",
+                "Session model or provider switching is not supported for provider '{}' because it manages its own conversation context.",
                 current_provider_name
             ));
             return Ok(());
@@ -908,18 +908,21 @@ impl CliSession {
         let target_model_name = match options.model.as_deref().map(str::trim) {
             Some(m) if !m.is_empty() => m.to_string(),
             _ => {
-                // Provider-only switch: keep current model if valid for the new
-                // provider, otherwise fall back to the new provider's default.
-                let known: Vec<&str> = target_entry
-                    .metadata()
-                    .known_models
-                    .iter()
-                    .map(|m| m.name.as_str())
-                    .collect();
-                if known.contains(&current_model_name.as_str()) {
+                // Provider-only switch (no model specified).
+                if target_provider_name == current_provider_name {
                     current_model_name.clone()
                 } else {
-                    target_entry.metadata().default_model.clone()
+                    let known: Vec<&str> = target_entry
+                        .metadata()
+                        .known_models
+                        .iter()
+                        .map(|m| m.name.as_str())
+                        .collect();
+                    if known.contains(&current_model_name.as_str()) {
+                        current_model_name.clone()
+                    } else {
+                        target_entry.metadata().default_model.clone()
+                    }
                 }
             }
         };
@@ -934,7 +937,7 @@ impl CliSession {
         let configured_effort = Config::global().get_goose_thinking_effort();
         let new_effort = new_model_config.thinking_effort().or(configured_effort);
         let current_effort = current_model_config.thinking_effort().or(configured_effort);
-        let provider_unchanged = requested_provider.is_none();
+        let provider_unchanged = target_provider_name == current_provider_name;
         if provider_unchanged
             && new_model_config.model_name == current_model_config.model_name
             && new_effort == current_effort

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -208,6 +208,8 @@ pub enum HintStatus {
 pub struct CompletionCache {
     pub prompts: HashMap<String, Vec<String>>,
     pub prompt_info: HashMap<String, output::PromptInfo>,
+    pub provider_names: Vec<String>,
+    pub provider_models: HashMap<String, Vec<String>>,
     pub last_updated: Instant,
     pub hint_status: HintStatus,
 }
@@ -217,6 +219,8 @@ impl CompletionCache {
         Self {
             prompts: HashMap::new(),
             prompt_info: HashMap::new(),
+            provider_names: Vec::new(),
+            provider_models: HashMap::new(),
             last_updated: Instant::now(),
             hint_status: HintStatus::Default,
         }
@@ -641,9 +645,9 @@ impl CliSession {
                 history.save(editor);
                 self.handle_goose_mode(&mode).await?;
             }
-            InputResult::Model(model) => {
+            InputResult::Model(options) => {
                 history.save(editor);
-                self.handle_model(model.as_deref()).await?;
+                self.handle_model(options).await?;
             }
             InputResult::Plan(options) => {
                 self.handle_plan_mode(options).await?;
@@ -834,7 +838,7 @@ impl CliSession {
         Ok(())
     }
 
-    async fn handle_model(&self, model: Option<&str>) -> Result<()> {
+    async fn handle_model(&mut self, options: input::ModelCommandOptions) -> Result<()> {
         let provider = self.agent.provider().await?;
         let current_provider_name = provider.get_name().to_string();
         let current_model_config = self
@@ -843,28 +847,60 @@ impl CliSession {
             .await?;
         let current_model_name = current_model_config.model_name.clone();
 
-        if model.is_none() {
+        // No args → show current state with a helpful hint
+        if options.provider.is_none() && options.model.is_none() {
             output::goose_mode_message(&format!(
-                "Current session model: '{}' (provider '{}')",
+                "Current session model: '{}' (provider '{}')\n\
+                 Tip: use '/model <name>' to switch model, or '/model --provider <name> [model]' to switch provider.",
                 current_model_name, current_provider_name
             ));
             return Ok(());
         }
 
-        let model_name = model.unwrap_or_default().trim();
-        if model_name.is_empty() {
-            output::render_error("Model name cannot be empty");
-            return Ok(());
-        }
+        // Determine the target provider
+        let requested_provider = options
+            .provider
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+        let target_provider_name = requested_provider.unwrap_or(&current_provider_name);
 
-        if current_provider_name.ends_with("-acp") {
+        // Validate that the target provider exists in the registry
+        let target_entry = match goose::providers::get_from_registry(target_provider_name).await {
+            Ok(entry) => entry,
+            Err(_) => {
+                output::render_error(&format!(
+                    "Unknown provider '{}'. Use tab-completion to see available providers.",
+                    target_provider_name
+                ));
+                return Ok(());
+            }
+        };
+
+        // Guard: ACP and self-managing-context providers
+        if target_provider_name.ends_with("-acp") {
             output::render_error(
                 "Session model switching is not supported for ACP providers in the CLI.",
             );
             return Ok(());
         }
 
-        if provider.manages_own_context() {
+        if requested_provider.is_some() {
+            // Provider switching path — we don't have a Provider instance for the
+            // target yet, so check whether it's known to manage its own context.
+            if target_entry
+                .metadata()
+                .config_keys
+                .iter()
+                .any(|k| k.name == "manages_own_context")
+            {
+                output::render_error(&format!(
+                    "Session provider switching is not supported for '{}' because it manages its own conversation context.",
+                    target_provider_name
+                ));
+                return Ok(());
+            }
+        } else if provider.manages_own_context() {
             output::render_error(&format!(
                 "Session model switching is not supported for provider '{}' because it manages its own conversation context.",
                 current_provider_name
@@ -872,13 +908,39 @@ impl CliSession {
             return Ok(());
         }
 
-        let new_model_config =
-            build_switched_model_config(&current_provider_name, model_name, &current_model_config)?;
+        // Determine the target model name
+        let target_model_name = match options.model.as_deref().map(str::trim) {
+            Some(m) if !m.is_empty() => m.to_string(),
+            _ => {
+                // Provider-only switch: keep current model if valid for the new
+                // provider, otherwise fall back to the new provider's default.
+                let known: Vec<&str> = target_entry
+                    .metadata()
+                    .known_models
+                    .iter()
+                    .map(|m| m.name.as_str())
+                    .collect();
+                if known.contains(&current_model_name.as_str()) {
+                    current_model_name.clone()
+                } else {
+                    target_entry.metadata().default_model.clone()
+                }
+            }
+        };
 
+        let new_model_config = build_switched_model_config(
+            target_provider_name,
+            &target_model_name,
+            &current_model_config,
+        )?;
+
+        // No-op check
         let configured_effort = Config::global().get_goose_thinking_effort();
         let new_effort = new_model_config.thinking_effort().or(configured_effort);
         let current_effort = current_model_config.thinking_effort().or(configured_effort);
-        if new_model_config.model_name == current_model_config.model_name
+        let provider_unchanged = requested_provider.is_none();
+        if provider_unchanged
+            && new_model_config.model_name == current_model_config.model_name
             && new_effort == current_effort
         {
             output::goose_mode_message(&format!(
@@ -888,10 +950,45 @@ impl CliSession {
             return Ok(());
         }
 
+        // Warn if the new model has a smaller context window than the current one
+        if let Some(model_info) = target_entry
+            .metadata()
+            .known_models
+            .iter()
+            .find(|m| m.name == target_model_name)
+        {
+            if model_info.context_limit < current_model_config.context_limit.unwrap_or(0) {
+                eprintln!(
+                    "{}",
+                    console::style(format!(
+                        "Warning: '{}' has a smaller context window ({} tokens) than the current session ({} tokens). \
+                        You may need to use /compact.",
+                        target_model_name,
+                        model_info.context_limit,
+                        current_model_config.context_limit.unwrap_or(0)
+                    ))
+                    .yellow()
+                );
+            }
+        }
+
+        // Create the new provider, preserving session extensions
         let extensions = self.agent.get_extension_configs().await;
-        let new_provider = goose::providers::create(&current_provider_name, extensions)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to create provider: {e}"))?;
+        let new_provider = match goose::providers::create(target_provider_name, extensions).await {
+            Ok(p) => p,
+            Err(e) => {
+                // Don't kill the session — connect to the lesson from #9491.
+                // Missing API keys and credential errors are common when switching
+                // providers in segregated environments.
+                output::render_error(&format!(
+                        "Cannot switch to provider '{}': {}\n\
+                         Set credentials via `goose configure` or the appropriate environment variable.\n\
+                         Session continues with current provider '{}'.",
+                        target_provider_name, e, current_provider_name
+                    ));
+                return Ok(());
+            }
+        };
 
         self.agent
             .update_provider(new_provider, new_model_config, &self.session_id)
@@ -899,10 +996,21 @@ impl CliSession {
 
         let mode = self.agent.goose_mode().await;
         self.agent.update_goose_mode(mode, &self.session_id).await?;
-        output::goose_mode_message(&format!(
-            "Session model switched from '{}' to '{}' for provider '{}'",
-            current_model_name, model_name, current_provider_name
-        ));
+
+        // Refresh completion cache so model tab-completion reflects the new provider
+        self.update_completion_cache().await?;
+
+        if provider_unchanged {
+            output::goose_mode_message(&format!(
+                "Session model switched from '{}' to '{}' for provider '{}'",
+                current_model_name, target_model_name, current_provider_name
+            ));
+        } else {
+            output::goose_mode_message(&format!(
+                "Session switched from provider '{}' / model '{}' to provider '{}' / model '{}'",
+                current_provider_name, current_model_name, target_provider_name, target_model_name
+            ));
+        }
         Ok(())
     }
 
@@ -1568,8 +1676,9 @@ impl CliSession {
     /// Update the completion cache with fresh data
     /// This should be called before the interactive session starts
     pub async fn update_completion_cache(&mut self) -> Result<()> {
-        // Get fresh data
+        // Fetch all async data before acquiring the write lock
         let prompts = self.agent.list_extension_prompts(&self.session_id).await;
+        let all_providers = goose::providers::providers().await;
 
         // Update the cache with write lock
         let mut cache = self.completion_cache.write().unwrap();
@@ -1591,6 +1700,18 @@ impl CliSession {
                     },
                 );
             }
+        }
+
+        // Populate provider/model data for /model tab-completion
+        cache.provider_names = all_providers.iter().map(|(m, _)| m.name.clone()).collect();
+        cache.provider_models.clear();
+        for (metadata, _) in &all_providers {
+            let models: Vec<String> = metadata
+                .known_models
+                .iter()
+                .map(|m| m.name.clone())
+                .collect();
+            cache.provider_models.insert(metadata.name.clone(), models);
         }
 
         cache.last_updated = Instant::now();

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -852,7 +852,6 @@ impl CliSession {
             .await?;
         let current_model_name = current_model_config.model_name.clone();
 
-        // No args → show current state with a helpful hint
         if options.provider.is_none() && options.model.is_none() {
             output::goose_mode_message(&format!(
                 "Current session model: '{}' (provider '{}')\n\
@@ -862,7 +861,6 @@ impl CliSession {
             return Ok(());
         }
 
-        // Determine the target provider
         let requested_provider = options
             .provider
             .as_deref()
@@ -870,13 +868,11 @@ impl CliSession {
             .filter(|s| !s.is_empty());
         let target_provider_name = requested_provider.unwrap_or(&current_provider_name);
 
-        // Reject a bare --provider flag with no value
         if options.provider.is_some() && requested_provider.is_none() {
             output::render_error("Provider name is required after '--provider'.");
             return Ok(());
         }
 
-        // Validate that the target provider exists in the registry
         let target_entry = match goose::providers::get_from_registry(target_provider_name).await {
             Ok(entry) => entry,
             Err(_) => {
@@ -888,7 +884,6 @@ impl CliSession {
             }
         };
 
-        // Guard: ACP and self-managing-context providers
         if target_provider_name.ends_with("-acp") {
             output::render_error(
                 "Session model switching is not supported for ACP providers in the CLI.",
@@ -904,11 +899,18 @@ impl CliSession {
             return Ok(());
         }
 
-        // Determine the target model name
+        if options
+            .model
+            .as_deref()
+            .is_some_and(|model| model.split_whitespace().count() > 1)
+        {
+            output::render_error("Unexpected arguments after model name.");
+            return Ok(());
+        }
+
         let target_model_name = match options.model.as_deref().map(str::trim) {
             Some(m) if !m.is_empty() => m.to_string(),
             _ => {
-                // Provider-only switch (no model specified).
                 if target_provider_name == current_provider_name {
                     current_model_name.clone()
                 } else {
@@ -933,7 +935,6 @@ impl CliSession {
             &current_model_config,
         )?;
 
-        // No-op check
         let configured_effort = Config::global().get_goose_thinking_effort();
         let new_effort = new_model_config.thinking_effort().or(configured_effort);
         let current_effort = current_model_config.thinking_effort().or(configured_effort);
@@ -949,7 +950,6 @@ impl CliSession {
             return Ok(());
         }
 
-        // Warn if the new model has a smaller context window than the current one
         if let Some(model_info) = target_entry
             .metadata()
             .known_models
@@ -971,20 +971,16 @@ impl CliSession {
             }
         }
 
-        // Create the new provider, preserving session extensions
         let extensions = self.agent.get_extension_configs().await;
         let new_provider = match goose::providers::create(target_provider_name, extensions).await {
             Ok(p) => p,
             Err(e) => {
-                // Don't kill the session — connect to the lesson from #9491.
-                // Missing API keys and credential errors are common when switching
-                // providers in segregated environments.
                 output::render_error(&format!(
-                        "Cannot switch to provider '{}': {}\n\
+                    "Cannot switch to provider '{}': {}\n\
                          Set credentials via `goose configure` or the appropriate environment variable.\n\
                          Session continues with current provider '{}'.",
-                        target_provider_name, e, current_provider_name
-                    ));
+                    target_provider_name, e, current_provider_name
+                ));
                 return Ok(());
             }
         };
@@ -1004,7 +1000,6 @@ impl CliSession {
         let mode = self.agent.goose_mode().await;
         self.agent.update_goose_mode(mode, &self.session_id).await?;
 
-        // Refresh completion cache so model tab-completion reflects the new provider
         self.update_completion_cache().await?;
 
         if provider_unchanged {
@@ -1680,16 +1675,11 @@ impl CliSession {
         Ok(())
     }
 
-    /// Update the completion cache with fresh data
-    /// This should be called before the interactive session starts
     pub async fn update_completion_cache(&mut self) -> Result<()> {
-        // Fetch all async data before acquiring the write lock
         let prompts = self.agent.list_extension_prompts(&self.session_id).await;
         let all_providers = goose::providers::providers().await;
         let session_provider = self.agent.provider().await?.get_name().to_string();
 
-        // Fetch inventory-fetched models (dynamically discovered via API refresh)
-        // to supplement the static known_models list.
         let provider_ids: Vec<String> = all_providers.iter().map(|(m, _)| m.name.clone()).collect();
         let inventory_models: HashMap<String, Vec<String>> = {
             let storage = SessionManager::instance().storage().clone();
@@ -1707,9 +1697,6 @@ impl CliSession {
                 .collect()
         };
 
-        // Fetch configured model per provider from config so the user's
-        // currently-selected model always appears in completion, even if it
-        // is not in the static or inventory model lists.
         let config = Config::global();
         let configured_models: HashMap<String, String> = all_providers
             .iter()
@@ -1720,7 +1707,6 @@ impl CliSession {
             })
             .collect();
 
-        // Update the cache with write lock
         let mut cache = self.completion_cache.write().unwrap();
         cache.prompts.clear();
         cache.prompt_info.clear();
@@ -1742,11 +1728,6 @@ impl CliSession {
             }
         }
 
-        // Populate provider/model data for /model tab-completion.
-        // Models are merged from three sources, deduplicated:
-        //   1. Static known_models from provider metadata (curated list)
-        //   2. Inventory-fetched models (dynamically discovered via API refresh)
-        //   3. The user's currently-configured model for each provider
         cache.provider_names = all_providers.iter().map(|(m, _)| m.name.clone()).collect();
         cache.current_session_provider = session_provider;
         cache.provider_models.clear();

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -213,6 +213,7 @@ pub struct CompletionCache {
     pub prompt_info: HashMap<String, output::PromptInfo>,
     pub provider_names: Vec<String>,
     pub provider_models: HashMap<String, Vec<String>>,
+    pub current_session_provider: String,
     pub last_updated: Instant,
     pub hint_status: HintStatus,
 }
@@ -224,6 +225,7 @@ impl CompletionCache {
             prompt_info: HashMap::new(),
             provider_names: Vec::new(),
             provider_models: HashMap::new(),
+            current_session_provider: String::new(),
             last_updated: Instant::now(),
             hint_status: HintStatus::Default,
         }
@@ -1681,6 +1683,7 @@ impl CliSession {
         // Fetch all async data before acquiring the write lock
         let prompts = self.agent.list_extension_prompts(&self.session_id).await;
         let all_providers = goose::providers::providers().await;
+        let session_provider = self.agent.provider().await?.get_name().to_string();
 
         // Fetch inventory-fetched models (dynamically discovered via API refresh)
         // to supplement the static known_models list.
@@ -1742,6 +1745,7 @@ impl CliSession {
         //   2. Inventory-fetched models (dynamically discovered via API refresh)
         //   3. The user's currently-configured model for each provider
         cache.provider_names = all_providers.iter().map(|(m, _)| m.name.clone()).collect();
+        cache.current_session_provider = session_provider;
         cache.provider_models.clear();
         for (metadata, _) in &all_providers {
             let mut models: Vec<String> = metadata

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -1685,8 +1685,7 @@ impl CliSession {
 
         // Fetch inventory-fetched models (dynamically discovered via API refresh)
         // to supplement the static known_models list.
-        let provider_ids: Vec<String> =
-            all_providers.iter().map(|(m, _)| m.name.clone()).collect();
+        let provider_ids: Vec<String> = all_providers.iter().map(|(m, _)| m.name.clone()).collect();
         let inventory_models: HashMap<String, Vec<String>> = {
             let storage = SessionManager::instance().storage().clone();
             let inventory = ProviderInventoryService::new(storage);
@@ -1746,8 +1745,11 @@ impl CliSession {
         cache.provider_names = all_providers.iter().map(|(m, _)| m.name.clone()).collect();
         cache.provider_models.clear();
         for (metadata, _) in &all_providers {
-            let mut models: Vec<String> =
-                metadata.known_models.iter().map(|m| m.name.clone()).collect();
+            let mut models: Vec<String> = metadata
+                .known_models
+                .iter()
+                .map(|m| m.name.clone())
+                .collect();
 
             if let Some(inv_models) = inventory_models.get(&metadata.name) {
                 for model_id in inv_models {

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -1031,12 +1031,15 @@ impl SessionStorage {
         .execute(&mut *tx)
         .await?;
 
-        tx.commit().await?;
+        // Inventory tables must be created inside the same transaction so that
+        // a concurrent SessionStorage instance cannot observe
+        // schema_version = CURRENT_SCHEMA_VERSION without them.  Running them
+        // after the commit opened a window where another pool() call would skip
+        // migrations (version already current) and then fail with "no such
+        // table: provider_inventory_entries".
+        crate::providers::inventory::create_tables_in_tx(&mut tx).await?;
 
-        // The inventory tables already use `CREATE TABLE IF NOT EXISTS`
-        // and run on the shared pool, so they don't need to be inside
-        // the same transaction.
-        crate::providers::inventory::create_tables(pool).await?;
+        tx.commit().await?;
 
         Ok(())
     }

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -1025,12 +1025,6 @@ impl SessionStorage {
         .execute(&mut *tx)
         .await?;
 
-        // Inventory tables must be created inside the same transaction so that
-        // a concurrent SessionStorage instance cannot observe
-        // schema_version = CURRENT_SCHEMA_VERSION without them.  Running them
-        // after the commit opened a window where another pool() call would skip
-        // migrations (version already current) and then fail with "no such
-        // table: provider_inventory_entries".
         crate::providers::inventory::create_tables(&mut tx).await?;
 
         tx.commit().await?;


### PR DESCRIPTION
## Summary
Tab completion for the `/model` command and possibility to switch provider in the middle of the session.

### Testing
Manual test + added unit tests

### Related Issues
Relates to #9412


