### PR TITLE
Skip hook loading and lifecycle events for subagents

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -535,6 +535,14 @@ impl CliSession {
 
     /// Start an interactive session, optionally with an initial message
     pub async fn interactive(&mut self, prompt: Option<String>) -> Result<()> {
+        let banners = self
+            .agent
+            .emit_hook_with_banners(goose::hooks::HookEvent::SessionStart, &self.session_id)
+            .await;
+        if !banners.is_empty() {
+            output::display_banner(&banners);
+        }
+
         let result = self.run_interactive(prompt).await;
 
         self.agent

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -514,6 +514,14 @@ impl CliSession {
 
     /// Start an interactive session, optionally with an initial message
     pub async fn interactive(&mut self, prompt: Option<String>) -> Result<()> {
+        let banners = self
+            .agent
+            .emit_hook_with_banners(goose::hooks::HookEvent::SessionStart, &self.session_id)
+            .await;
+        if !banners.is_empty() {
+            output::display_banner(&banners);
+        }
+
         let result = self.run_interactive(prompt).await;
 
         self.agent

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -1435,6 +1435,14 @@ fn set_terminal_title() {
     let _ = std::io::stdout().flush();
 }
 
+pub fn display_banner(banners: &[String]) {
+    for banner in banners {
+        for line in banner.lines() {
+            println!("{}", line);
+        }
+    }
+}
+
 pub fn display_context_usage(total_tokens: usize, context_limit: usize) {
     use console::style;
 

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -1376,6 +1376,14 @@ fn set_terminal_title() {
     let _ = std::io::stdout().flush();
 }
 
+pub fn display_banner(banners: &[String]) {
+    for banner in banners {
+        for line in banner.lines() {
+            println!("{}", line);
+        }
+    }
+}
+
 pub fn display_context_usage(total_tokens: usize, context_limit: usize) {
     use console::style;
 

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -470,6 +470,19 @@ impl Agent {
             .await;
     }
 
+    pub async fn emit_hook_with_banners(
+        &self,
+        event: crate::hooks::HookEvent,
+        session_id: &str,
+    ) -> Vec<String> {
+        if !self.hook_manager.has_hooks(event) {
+            return Vec::new();
+        }
+        self.hook_manager
+            .emit_collecting_banners(event, crate::hooks::HookContext::new(event, session_id))
+            .await
+    }
+
     fn stop_hook_context(
         session_id: &str,
         last_assistant_message: &str,

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
@@ -267,6 +268,7 @@ pub struct Agent {
     pub(super) retry_manager: RetryManager,
     pub(super) tool_inspection_manager: ToolInspectionManager,
     pub(super) hook_manager: crate::hooks::HookManager,
+    session_start_emitted: AtomicBool,
     #[cfg(test)]
     pub(super) stop_hook_block_cap_override: Option<u32>,
     container: Mutex<Option<Container>>,
@@ -436,6 +438,7 @@ impl Agent {
                     use_login_shell_path,
                 )
             },
+            session_start_emitted: AtomicBool::new(false),
             #[cfg(test)]
             stop_hook_block_cap_override: None,
             container: Mutex::new(None),
@@ -482,6 +485,9 @@ impl Agent {
         event: crate::hooks::HookEvent,
         session_id: &str,
     ) -> Vec<String> {
+        if event == crate::hooks::HookEvent::SessionStart {
+            self.session_start_emitted.store(true, Ordering::Release);
+        }
         if !self.hook_manager.has_hooks(event) {
             return Vec::new();
         }
@@ -1927,7 +1933,7 @@ impl Agent {
             return Ok(Box::pin(futures::stream::empty()));
         }
 
-        if is_first_agent_turn {
+        if is_first_agent_turn && !self.session_start_emitted.swap(true, Ordering::AcqRel) {
             self.emit_hook(crate::hooks::HookEvent::SessionStart, &session_config.id)
                 .await;
         }

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -195,6 +195,7 @@ pub struct AgentConfig {
     pub mcp_host_info: Option<GooseMcpHostInfo>,
     pub session_name_update_tx: Option<mpsc::UnboundedSender<SessionNameUpdate>>,
     pub use_login_shell_path: Option<bool>,
+    pub is_subagent: bool,
 }
 
 impl AgentConfig {
@@ -216,6 +217,7 @@ impl AgentConfig {
             mcp_host_info: None,
             session_name_update_tx: None,
             use_login_shell_path: None,
+            is_subagent: false,
         }
     }
 
@@ -399,6 +401,7 @@ impl Agent {
         let inspection_session_manager = Arc::clone(&config.session_manager);
         let permission_manager = Arc::clone(&config.permission_manager);
         let use_login_shell_path = config.resolve_use_login_shell_path();
+        let is_subagent = config.is_subagent;
         Self {
             provider: provider.clone(),
             config,
@@ -425,10 +428,14 @@ impl Agent {
                 provider.clone(),
                 inspection_session_manager,
             ),
-            hook_manager: crate::hooks::HookManager::load(
-                std::env::current_dir().ok().as_deref(),
-                use_login_shell_path,
-            ),
+            hook_manager: if is_subagent {
+                crate::hooks::HookManager::default()
+            } else {
+                crate::hooks::HookManager::load(
+                    std::env::current_dir().ok().as_deref(),
+                    use_login_shell_path,
+                )
+            },
             #[cfg(test)]
             stop_hook_block_cap_override: None,
             container: Mutex::new(None),

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -186,6 +186,7 @@ pub struct AgentConfig {
     pub mcp_host_info: Option<GooseMcpHostInfo>,
     pub session_name_update_tx: Option<mpsc::UnboundedSender<SessionNameUpdate>>,
     pub use_login_shell_path: Option<bool>,
+    pub is_subagent: bool,
 }
 
 impl AgentConfig {
@@ -207,6 +208,7 @@ impl AgentConfig {
             mcp_host_info: None,
             session_name_update_tx: None,
             use_login_shell_path: None,
+            is_subagent: false,
         }
     }
 
@@ -386,6 +388,7 @@ impl Agent {
         let inspection_session_manager = Arc::clone(&config.session_manager);
         let permission_manager = Arc::clone(&config.permission_manager);
         let use_login_shell_path = config.resolve_use_login_shell_path();
+        let is_subagent = config.is_subagent;
         Self {
             provider: provider.clone(),
             config,
@@ -411,10 +414,14 @@ impl Agent {
                 provider.clone(),
                 inspection_session_manager,
             ),
-            hook_manager: crate::hooks::HookManager::load(
-                std::env::current_dir().ok().as_deref(),
-                use_login_shell_path,
-            ),
+            hook_manager: if is_subagent {
+                crate::hooks::HookManager::default()
+            } else {
+                crate::hooks::HookManager::load(
+                    std::env::current_dir().ok().as_deref(),
+                    use_login_shell_path,
+                )
+            },
             #[cfg(test)]
             stop_hook_block_cap_override: None,
             container: Mutex::new(None),

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -456,6 +456,19 @@ impl Agent {
             .await;
     }
 
+    pub async fn emit_hook_with_banners(
+        &self,
+        event: crate::hooks::HookEvent,
+        session_id: &str,
+    ) -> Vec<String> {
+        if !self.hook_manager.has_hooks(event) {
+            return Vec::new();
+        }
+        self.hook_manager
+            .emit_collecting_banners(event, crate::hooks::HookContext::new(event, session_id))
+            .await
+    }
+
     fn stop_hook_context(
         session_id: &str,
         last_assistant_message: &str,

--- a/crates/goose/src/agents/platform_extensions/summon.rs
+++ b/crates/goose/src/agents/platform_extensions/summon.rs
@@ -1291,7 +1291,7 @@ impl SummonClient {
         // Subagents must use Auto until get_agent_messages forwards
         // ActionRequired messages to the parent. Until then, any mode
         // that requires approval will hang on the subagent's confirmation_rx.
-        let agent_config = AgentConfig::new(
+        let mut agent_config = AgentConfig::new(
             self.context.session_manager.clone(),
             crate::config::permission::PermissionManager::instance(),
             None,
@@ -1300,6 +1300,7 @@ impl SummonClient {
             crate::agents::GoosePlatform::GooseCli,
         )
         .with_use_login_shell_path(self.context.use_login_shell_path);
+        agent_config.is_subagent = true;
 
         let subagent_session = self
             .create_subagent_session(&task_config, "Delegated task".to_string())
@@ -1847,7 +1848,7 @@ impl SummonClient {
         // Subagents must use Auto until get_agent_messages forwards
         // ActionRequired messages to the parent. Until then, any mode
         // that requires approval will hang on the subagent's confirmation_rx.
-        let agent_config = AgentConfig::new(
+        let mut agent_config = AgentConfig::new(
             self.context.session_manager.clone(),
             crate::config::permission::PermissionManager::instance(),
             None,
@@ -1856,6 +1857,7 @@ impl SummonClient {
             crate::agents::GoosePlatform::GooseCli,
         )
         .with_use_login_shell_path(self.context.use_login_shell_path);
+        agent_config.is_subagent = true;
 
         let subagent_session = self
             .create_subagent_session(&task_config, description.clone())

--- a/crates/goose/src/agents/platform_extensions/summon.rs
+++ b/crates/goose/src/agents/platform_extensions/summon.rs
@@ -1291,7 +1291,7 @@ impl SummonClient {
         // Subagents must use Auto until get_agent_messages forwards
         // ActionRequired messages to the parent. Until then, any mode
         // that requires approval will hang on the subagent's confirmation_rx.
-        let agent_config = AgentConfig::new(
+        let mut agent_config = AgentConfig::new(
             self.context.session_manager.clone(),
             crate::config::permission::PermissionManager::instance(),
             None,
@@ -1300,6 +1300,7 @@ impl SummonClient {
             crate::agents::GoosePlatform::GooseCli,
         )
         .with_use_login_shell_path(self.context.use_login_shell_path);
+        agent_config.is_subagent = true;
 
         let subagent_session = self
             .create_subagent_session(&task_config, "Delegated task".to_string())
@@ -1820,7 +1821,7 @@ impl SummonClient {
         // Subagents must use Auto until get_agent_messages forwards
         // ActionRequired messages to the parent. Until then, any mode
         // that requires approval will hang on the subagent's confirmation_rx.
-        let agent_config = AgentConfig::new(
+        let mut agent_config = AgentConfig::new(
             self.context.session_manager.clone(),
             crate::config::permission::PermissionManager::instance(),
             None,
@@ -1829,6 +1830,7 @@ impl SummonClient {
             crate::agents::GoosePlatform::GooseCli,
         )
         .with_use_login_shell_path(self.context.use_login_shell_path);
+        agent_config.is_subagent = true;
 
         let subagent_session = self
             .create_subagent_session(&task_config, description.clone())

--- a/crates/goose/src/hooks/mod.rs
+++ b/crates/goose/src/hooks/mod.rs
@@ -391,6 +391,86 @@ impl HookManager {
         }
     }
 
+    /// Like [`Self::emit`], but collects banner lines from hook stdout.
+    ///
+    /// If a hook exits successfully and its stdout contains valid JSON with a
+    /// `"banner"` field, that string is collected. Multiple hooks can each
+    /// contribute banner lines. Non-JSON stdout or missing `"banner"` field
+    /// is silently ignored (backwards compatible).
+    pub async fn emit_collecting_banners(&self, event: HookEvent, ctx: HookContext) -> Vec<String> {
+        let mut banners = Vec::new();
+        let Some(rules) = self.rules.get(&event) else {
+            return banners;
+        };
+        if rules.is_empty() {
+            return banners;
+        }
+
+        let payload = match serde_json::to_string(&ctx) {
+            Ok(s) => s,
+            Err(err) => {
+                warn!(event = %event, error = %err, "Failed to serialize hook context");
+                return banners;
+            }
+        };
+
+        for rule in rules {
+            if let Some(matcher) = &rule.matcher {
+                let target = ctx.matcher_context.as_deref().unwrap_or("");
+                if !matcher.is_match(target) {
+                    continue;
+                }
+            }
+
+            for action in &rule.actions {
+                let LoadedAction::Command { command, timeout } = action;
+                debug!(
+                    plugin = %rule.plugin_name,
+                    event = %event,
+                    command = %command,
+                    "Running plugin hook (banner-collecting)",
+                );
+                match run_command_hook(
+                    command,
+                    &rule.plugin_root,
+                    &payload,
+                    *timeout,
+                    self.use_login_shell_path,
+                )
+                .await
+                {
+                    Ok(output) if output.status.success() => {
+                        let stdout = String::from_utf8_lossy(&output.stdout);
+                        if let Some(banner) = extract_banner(stdout.trim()) {
+                            banners.push(banner);
+                        }
+                    }
+                    Ok(output) => {
+                        warn!(
+                            plugin = %rule.plugin_name,
+                            event = %event,
+                            command = %command,
+                            "hook exited with {:?}: {}",
+                            output.status.code(),
+                            String::from_utf8_lossy(&output.stderr).trim(),
+                        );
+                    }
+                    Err(err) => {
+                        warn!(
+                            plugin = %rule.plugin_name,
+                            event = %event,
+                            command = %command,
+                            error = %err,
+                            "Plugin hook failed",
+                        );
+                    }
+                }
+            }
+        }
+
+        banners
+    }
+
     /// Like [`Self::emit`], but stops at the first rule that denies the event
     /// and returns the denial. A hook denies by exiting with status code 2
     /// (reason on stderr) or by printing `{"decision":"block","reason":"..."}`
@@ -454,6 +534,20 @@ impl HookManager {
 
         HookDecision::Allow
     }
+}
+
+fn extract_banner(stdout: &str) -> Option<String> {
+    if !stdout.starts_with('{') {
+        return None;
+    }
+
+    #[derive(Deserialize)]
+    struct BannerResp {
+        banner: Option<String>,
+    }
+
+    let parsed: BannerResp = serde_json::from_str(stdout).ok()?;
+    parsed.banner.filter(|b| !b.is_empty())
 }
 
 fn deny_reason(output: &std::process::Output) -> Option<String> {
@@ -897,5 +991,71 @@ mod tests {
         )
         .await;
         assert!(marker.exists());
+    }
+
+    #[test]
+    fn extract_banner_from_json() {
+        assert_eq!(
+            extract_banner(r#"{"banner":"  🌱 hello"}"#),
+            Some("  🌱 hello".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_banner_ignores_non_json() {
+        assert_eq!(extract_banner("just some text"), None);
+    }
+
+    #[test]
+    fn extract_banner_ignores_json_without_banner_field() {
+        assert_eq!(extract_banner(r#"{"decision":"allow"}"#), None);
+    }
+
+    #[test]
+    fn extract_banner_ignores_empty_banner() {
+        assert_eq!(extract_banner(r#"{"banner":""}"#), None);
+    }
+
+    #[tokio::test]
+    async fn emit_collecting_banners_returns_banner_lines() {
+        let tmp = tempfile::tempdir().unwrap();
+        let hooks = r#"{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"printf '{\"banner\":\"  🌱 test banner\"}'" }]}]}}"#;
+        let root = write_plugin(tmp.path(), "p", hooks);
+        let mgr = make_manager(vec![DiscoveredPlugin {
+            name: "p".into(),
+            root,
+            scope: PluginScope::User,
+        }]);
+
+        let banners = mgr
+            .emit_collecting_banners(
+                HookEvent::SessionStart,
+                HookContext::new(HookEvent::SessionStart, "s"),
+            )
+            .await;
+
+        assert_eq!(banners, vec!["  🌱 test banner"]);
+    }
+
+    #[tokio::test]
+    async fn emit_collecting_banners_skips_non_json_output() {
+        let tmp = tempfile::tempdir().unwrap();
+        let hooks =
+            r#"{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"echo hello"}]}]}}"#;
+        let root = write_plugin(tmp.path(), "p", hooks);
+        let mgr = make_manager(vec![DiscoveredPlugin {
+            name: "p".into(),
+            root,
+            scope: PluginScope::User,
+        }]);
+
+        let banners = mgr
+            .emit_collecting_banners(
+                HookEvent::SessionStart,
+                HookContext::new(HookEvent::SessionStart, "s"),
+            )
+            .await;
+
+        assert!(banners.is_empty());
     }
 }

--- a/crates/goose/src/hooks/mod.rs
+++ b/crates/goose/src/hooks/mod.rs
@@ -356,6 +356,86 @@ impl HookManager {
         }
     }
 
+    /// Like [`Self::emit`], but collects banner lines from hook stdout.
+    ///
+    /// If a hook exits successfully and its stdout contains valid JSON with a
+    /// `"banner"` field, that string is collected. Multiple hooks can each
+    /// contribute banner lines. Non-JSON stdout or missing `"banner"` field
+    /// is silently ignored (backwards compatible).
+    pub async fn emit_collecting_banners(&self, event: HookEvent, ctx: HookContext) -> Vec<String> {
+        let mut banners = Vec::new();
+        let Some(rules) = self.rules.get(&event) else {
+            return banners;
+        };
+        if rules.is_empty() {
+            return banners;
+        }
+
+        let payload = match serde_json::to_string(&ctx) {
+            Ok(s) => s,
+            Err(err) => {
+                warn!(event = %event, error = %err, "Failed to serialize hook context");
+                return banners;
+            }
+        };
+
+        for rule in rules {
+            if let Some(matcher) = &rule.matcher {
+                let target = ctx.matcher_context.as_deref().unwrap_or("");
+                if !matcher.is_match(target) {
+                    continue;
+                }
+            }
+
+            for action in &rule.actions {
+                let LoadedAction::Command { command, timeout } = action;
+                debug!(
+                    plugin = %rule.plugin_name,
+                    event = %event,
+                    command = %command,
+                    "Running plugin hook (banner-collecting)",
+                );
+                match run_command_hook(
+                    command,
+                    &rule.plugin_root,
+                    &payload,
+                    *timeout,
+                    self.use_login_shell_path,
+                )
+                .await
+                {
+                    Ok(output) if output.status.success() => {
+                        let stdout = String::from_utf8_lossy(&output.stdout);
+                        if let Some(banner) = extract_banner(stdout.trim()) {
+                            banners.push(banner);
+                        }
+                    }
+                    Ok(output) => {
+                        warn!(
+                            plugin = %rule.plugin_name,
+                            event = %event,
+                            command = %command,
+                            "hook exited with {:?}: {}",
+                            output.status.code(),
+                            String::from_utf8_lossy(&output.stderr).trim(),
+                        );
+                    }
+                    Err(err) => {
+                        warn!(
+                            plugin = %rule.plugin_name,
+                            event = %event,
+                            command = %command,
+                            error = %err,
+                            "Plugin hook failed",
+                        );
+                    }
+                }
+            }
+        }
+
+        banners
+    }
+
     /// Like [`Self::emit`], but stops at the first rule that denies the event
     /// and returns the denial. A hook denies by exiting with status code 2
     /// (reason on stderr) or by printing `{"decision":"block","reason":"..."}`
@@ -424,6 +504,20 @@ impl HookManager {
 
         HookDecision::Allow
     }
+}
+
+fn extract_banner(stdout: &str) -> Option<String> {
+    if !stdout.starts_with('{') {
+        return None;
+    }
+
+    #[derive(Deserialize)]
+    struct BannerResp {
+        banner: Option<String>,
+    }
+
+    let parsed: BannerResp = serde_json::from_str(stdout).ok()?;
+    parsed.banner.filter(|b| !b.is_empty())
 }
 
 fn deny_reason(output: &std::process::Output) -> Option<String> {
@@ -867,5 +961,71 @@ mod tests {
         )
         .await;
         assert!(marker.exists());
+    }
+
+    #[test]
+    fn extract_banner_from_json() {
+        assert_eq!(
+            extract_banner(r#"{"banner":"  🌱 hello"}"#),
+            Some("  🌱 hello".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_banner_ignores_non_json() {
+        assert_eq!(extract_banner("just some text"), None);
+    }
+
+    #[test]
+    fn extract_banner_ignores_json_without_banner_field() {
+        assert_eq!(extract_banner(r#"{"decision":"allow"}"#), None);
+    }
+
+    #[test]
+    fn extract_banner_ignores_empty_banner() {
+        assert_eq!(extract_banner(r#"{"banner":""}"#), None);
+    }
+
+    #[tokio::test]
+    async fn emit_collecting_banners_returns_banner_lines() {
+        let tmp = tempfile::tempdir().unwrap();
+        let hooks = r#"{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"printf '{\"banner\":\"  🌱 test banner\"}'" }]}]}}"#;
+        let root = write_plugin(tmp.path(), "p", hooks);
+        let mgr = make_manager(vec![DiscoveredPlugin {
+            name: "p".into(),
+            root,
+            scope: PluginScope::User,
+        }]);
+
+        let banners = mgr
+            .emit_collecting_banners(
+                HookEvent::SessionStart,
+                HookContext::new(HookEvent::SessionStart, "s"),
+            )
+            .await;
+
+        assert_eq!(banners, vec!["  🌱 test banner"]);
+    }
+
+    #[tokio::test]
+    async fn emit_collecting_banners_skips_non_json_output() {
+        let tmp = tempfile::tempdir().unwrap();
+        let hooks =
+            r#"{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"echo hello"}]}]}}"#;
+        let root = write_plugin(tmp.path(), "p", hooks);
+        let mgr = make_manager(vec![DiscoveredPlugin {
+            name: "p".into(),
+            root,
+            scope: PluginScope::User,
+        }]);
+
+        let banners = mgr
+            .emit_collecting_banners(
+                HookEvent::SessionStart,
+                HookContext::new(HookEvent::SessionStart, "s"),
+            )
+            .await;
+
+        assert!(banners.is_empty());
     }
 }


### PR DESCRIPTION
## Problem

When goose delegates a task to a subagent, the subagent creates a fresh `Agent` instance that loads the full hook lifecycle - discovering plugins, parsing `hooks.json`, compiling matchers, and firing `SessionStart`. This means every delegate triggers events meant for user-facing sessions: banner scripts execute mid-conversation, session-tracking plugins log phantom sessions, and any plugin subscribing to lifecycle events receives signals that violate the hook contract.

## How this was discovered

While building [goose-banner](https://github.com/dakotafabro/goose-banner) - a plugin that replaces the default "goose is ready" message with useful session context (active threads, token spend, project state) - the banner scripts were firing every time a delegate spun up. This surfaced the broader issue: the hook system's `SessionStart` event doesn't actually mean "a user started a session" - it fires for subagents too, which breaks the contract plugins rely on.

## Benefit

**Hook contract correctness.** `SessionStart` fires exactly once per user-facing session. Subagents no longer trigger lifecycle events. Plugin authors can trust the signals they receive without building their own "am I a subagent?" guards.

**Ecosystem scalability.** As the plugin ecosystem grows (permission gates, audit logging, compliance checks, session tracking), every new plugin multiplies the per-delegate overhead today. After this fix, the cost of adding plugins stays zero for subagents permanently.

**No more mid-session noise.** Banner output, session counters, and state initialization no longer fire during delegates. The terminal stays clean. Plugins that track session state don't log phantom sessions.

**Foundation for plugin trust.** Plugins like [goose-banner](https://github.com/dakotafabro/goose-banner) and [spore](https://github.com/dakotafabro/spore) (retrieval tracking, interoception) rely on `SessionStart` to initialize per-session state. Without this fix, subagent-triggered `SessionStart` overwrites the parent session's state mid-conversation.

## Fix (two mechanisms)

### 1. Skip hooks for subagents

Adds `is_subagent: bool` to `AgentConfig` (defaults `false`). When `true`, `Agent::with_config` assigns an empty `HookManager::default()` instead of calling `HookManager::load()`. Both delegate paths in `summon.rs` (sync and async) set `is_subagent = true`.

### 2. Prevent double-emission in the parent

Adds an `AtomicBool` guard (`session_start_emitted`) to `Agent`. The CLI banner path sets it via `emit_hook_with_banners`, and `reply()` uses an atomic `swap` to skip if already fired. Non-CLI paths (gateway, ACP server, scheduler) that only go through `reply()` still emit exactly once via the same guard.

## What this does NOT affect

- **Extension loading (MCP servers)** - completely separate system, untouched. Each subagent still spins up its own independent MCP client processes.
- **Extension cleanup** - subagent destruction relies on Rust's ownership/drop semantics. Fully intact.
- **`SessionEnd` hooks** - were never fired for subagents even before this change.
- **Provider configuration** - untouched
- **Session management** - untouched
- **Parent session hooks** - still fire normally

## Performance (real but secondary)

Per-delegate overhead eliminated:

| Operation | Before (per delegate) | After |
|---|---|---|
| Plugin filesystem scan | ~2-5ms | 0 |
| hooks.json parse + regex compile | ~1-2ms per plugin | 0 |
| SessionStart script execution | ~50-200ms (process fork + I/O) | 0 |
| Hook matcher evaluation per tool call | ~0.1ms per call per plugin | 0 |

Savings are marginal today (~50s/week for a heavy user with 3 plugins), but compound as the plugin ecosystem grows.

## Commits

1. **feat: session banner hooks** - adds `emit_hook_with_banners` to the CLI path so plugins can surface context at session startup (the feature that exposed the bug)
2. **Skip hook loading for subagents** - `is_subagent` flag on `AgentConfig`, empty `HookManager` for delegates
3. **Prevent duplicate emission** - `AtomicBool` guard ensures `SessionStart` fires at most once per `Agent` instance regardless of code path